### PR TITLE
Lower stack timer overhead using fixed-size key.

### DIFF
--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -143,7 +143,6 @@ public:
 
   void push_timer(NewTimer *t)
   {
-    #pragma omp master
     {
       CurrentTimerStack.push_back(t);
     }
@@ -151,7 +150,6 @@ public:
 
   void pop_timer()
   {
-    #pragma omp master
     {
       CurrentTimerStack.pop_back();
     }
@@ -160,7 +158,6 @@ public:
   NewTimer *current_timer()
   {
     NewTimer *current = NULL;
-    # pragma omp critical
     if (CurrentTimerStack.size() > 0)
     {
        current = CurrentTimerStack.back();


### PR DESCRIPTION
The map for collecting the per-stack timer data used a string representation
of the stack as a key.  Some of the overhead comes from managing these strings.

The new key assigns a small integer timer id to each timer and constructs
the stack in a fixed-size array.
An additional hack to increase performance treats a chunk of timers as a larger
data type for the comparisons needed by the map data structure.

Current settings use 8 bits for the timer id (giving up to 254 timers), and
two 64 bit ints for the stack (16 stack levels).  If these are exceeded, warnings
are printed to the screen and in the .info.xml file.

Use of a hash table (unordered_map) gave roughly the same performance.