### PR TITLE
Update timer for BG/Q.

### DIFF
--- a/src/Utilities/Clock.h
+++ b/src/Utilities/Clock.h
@@ -23,10 +23,6 @@
 #include <sys/time.h>
 #include <stddef.h>
 
-#if defined(__bgp__)
-#include <dcmf.h>
-#endif
-
 namespace qmcplusplus
 {
 #if defined(USE_FAKE_CLOCK)
@@ -39,38 +35,23 @@ double fake_cpu_clock()
 }
 #define cpu_clock fake_cpu_clock
 #else
-#if defined(__bgp__)
+#if defined(__bgq__)
+__inline__ unsigned long long getticks(void)
+{
+  unsigned long long int result=0;
+  __asm__ volatile(
+    "\tmfspr   %0,268           \n"
+    : "=r"(result)
+    );
+  return result;
+}
 
 inline double cpu_clock()
 {
-  return DCMF_Timer();
+  //BG/Q node - using 1.6e9 ticks per second
+  const double SEC_PER_TICKS=6.25e-10;
+  return static_cast<double>(getticks())*SEC_PER_TICKS;
 }
-//  __inline__ unsigned long long getticks(void)
-//  {
-//    unsigned long long int result=0;
-//    unsigned long int upper, lower,tmp;
-//    __asm__ volatile(
-//        "0:                  \n"
-//        "\tmftbu   %0           \n"
-//        "\tmftb    %1           \n"
-//        "\tmftbu   %2           \n"
-//        "\tcmpw    %2,%0        \n"
-//        "\tbne     0b         \n"
-//        : "=r"(upper),"=r"(lower),"=r"(tmp)
-//        );
-//    result = upper;
-//    result = result<<32;
-//    result = result|lower;
-//
-//    return(result);
-//  }
-//
-//  inline double cpu_clock()
-//  {
-//    //using 512e6 ticks per second
-//    const double SEC_PER_TICKS=1.953125e-9;
-//    return static_cast<double>(getticks())*SEC_PER_TICKS;
-//  }
 
 #else
 #if defined(ENABLE_OPENMP)


### PR DESCRIPTION
Read directly from the time base register for a low-overhead timer.
This assumes a 1.6 GHz processor clock.

Remove the Blue Gene / P timer code - I assume no one is using one of these anymore.