### PR TITLE
Use symbolic links for *.h5 files in the tests

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -20,11 +20,13 @@ ENDFUNCTION()
 
 # Copy files, but symlink the *.h5 files (which are the large ones)
 FUNCTION( COPY_DIRECTORY_SYMLINK_H5 SRC_DIR DST_DIR)
-    # Copy everything but *.h5 files
-    FILE(COPY "${SRC_DIR}/" DESTINATION "${DST_DIR}" PATTERN "*.h5" EXCLUDE)
+    # Copy everything but *.h5 files and pseudopotential files
+    FILE(COPY "${SRC_DIR}/" DESTINATION "${DST_DIR}"
+         PATTERN "*.h5" EXCLUDE
+         PATTERN "*.BFD.xml" EXCLUDE)
 
-    # Now find and symlink the *.h5 files
-    FILE(GLOB_RECURSE H5 "${SRC_DIR}/*.h5")
+    # Now find and symlink the *.h5 files and psuedopotential files
+    FILE(GLOB_RECURSE H5 "${SRC_DIR}/*.h5" "${SRC_DIR}/*.BFD.xml")
     FOREACH(F IN LISTS H5)
       FILE(RELATIVE_PATH R "${SRC_DIR}" "${F}")
       #MESSAGE("Creating symlink from  ${SRC_DIR}/${R} to ${DST_DIR}/${R}")

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -8,6 +8,34 @@ FUNCTION( COPY_DIRECTORY SRC_DIR DST_DIR )
     EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E copy_directory "${SRC_DIR}" "${DST_DIR}" )
 ENDFUNCTION()
 
+# Function to copy a directory using symlinks for the files. This saves storage
+# space with large test files.
+# SRC_DIR must be an absolute path
+# The -s flag copies using symlinks
+# The -T ${DST_DIR} ensures the destination is copied as the directory, and not
+#  placed as a subdirectory if the destination already exists.
+FUNCTION( COPY_DIRECTORY_USING_SYMLINK SRC_DIR DST_DIR )
+    EXECUTE_PROCESS( COMMAND cp -as --remove-destination "${SRC_DIR}" -T "${DST_DIR}" )
+ENDFUNCTION()
+
+# Control copy vs. symlink with top-level variable
+FUNCTION( COPY_DIRECTORY_MAYBE_USING_SYMLINK SRC_DIR DST_DIR )
+  IF (QMC_SYMLINK_TEST_FILES)
+    COPY_DIRECTORY_USING_SYMLINK("${SRC_DIR}" "${DST_DIR}")
+  ELSE()
+    COPY_DIRECTORY("${SRC_DIR}" "${DST_DIR}")
+  ENDIF()
+ENDFUNCTION()
+
+# Symlink or copy an individual file
+FUNCTION(MAYBE_SYMLINK SRC_DIR DST_DIR)
+  IF (QMC_SYMLINK_TEST_FILES)
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink "${SRC_DIR}" "${DST_DIR}")
+  ELSE()
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy "${SRC_DIR}" "${DST_DIR}")
+  ENDIF()
+ENDFUNCTION()
+
 
 # Macro to add the dependencies and libraries to an executable
 MACRO( ADD_QMC_EXE_DEP EXE )
@@ -196,8 +224,7 @@ ENDMACRO()
 # Runs qmcpack
 #  Note that TEST_ADDED is an output variable
 FUNCTION( RUN_QMC_APP TESTNAME SRC_DIR PROCS THREADS TEST_ADDED ${ARGN} )
-    COPY_DIRECTORY( "${SRC_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}" )
-    EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E copy_directory "${SRC_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}" )
+    COPY_DIRECTORY_MAYBE_USING_SYMLINK( "${SRC_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}" )
     #MESSAGE("RUN_QMC_APP2: TESTNAME = ${TESTNAME} SRC_DIR=${SRC_DIR} PROCS = ${PROCS} THREADS = ${THREADS}")
     MATH( EXPR TOT_PROCS "${PROCS} * ${THREADS}" )
     SET( QMC_APP "${qmcpack_BINARY_DIR}/bin/qmcpack" )

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -18,10 +18,25 @@ FUNCTION( COPY_DIRECTORY_USING_SYMLINK SRC_DIR DST_DIR )
     EXECUTE_PROCESS( COMMAND cp -as --remove-destination "${SRC_DIR}" -T "${DST_DIR}" )
 ENDFUNCTION()
 
+# Copy files, but symlink the *.h5 files (which are the large ones)
+FUNCTION( COPY_DIRECTORY_SYMLINK_H5 SRC_DIR DST_DIR)
+    # Copy everything but *.h5 files
+    FILE(COPY "${SRC_DIR}/" DESTINATION "${DST_DIR}" PATTERN "*.h5" EXCLUDE)
+
+    # Now find and symlink the *.h5 files
+    FILE(GLOB_RECURSE H5 "${SRC_DIR}/*.h5")
+    FOREACH(F IN LISTS H5)
+      FILE(RELATIVE_PATH R "${SRC_DIR}" "${F}")
+      #MESSAGE("Creating symlink from  ${SRC_DIR}/${R} to ${DST_DIR}/${R}")
+      EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink "${SRC_DIR}/${R}" "${DST_DIR}/${R}")
+    ENDFOREACH()
+ENDFUNCTION()
+
 # Control copy vs. symlink with top-level variable
 FUNCTION( COPY_DIRECTORY_MAYBE_USING_SYMLINK SRC_DIR DST_DIR )
   IF (QMC_SYMLINK_TEST_FILES)
-    COPY_DIRECTORY_USING_SYMLINK("${SRC_DIR}" "${DST_DIR}")
+    #COPY_DIRECTORY_USING_SYMLINK("${SRC_DIR}" "${DST_DIR}")
+    COPY_DIRECTORY_SYMLINK_H5("${SRC_DIR}" "${DST_DIR}" )
   ELSE()
     COPY_DIRECTORY("${SRC_DIR}" "${DST_DIR}")
   ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ INCLUDE( CTest )
 
 SET( QMC_SYMLINK_TEST_FILES TRUE CACHE BOOL "Use symbolic links for test files to save space.  Set to false to copy files instead.")
 
+
+IF (QMC_SYMLINK_TEST_FILES)
+  SET(SYMLINK_MSG "Using symbolic links for large test files may cause test failures if the build is installed on a separate filesystem from the source.  For example, Titan at OLCF.")
+ELSE()
+  SET(SYMLINK_MSG "Copying large test files uses more disk space than using symbolic links.")
+ENDIF()
+MESSAGE(STATUS "QMC_SYMLINK_TEST_FILES = ${QMC_SYMLINK_TEST_FILES}.  ${SYMLINK_MSG}")
+
 ######################################################################
 # Build level
 ######################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ SET( DART_TESTING_TIMEOUT 3600 CACHE STRING "Maximum time for one test")
 ENABLE_TESTING()
 INCLUDE( CTest )
 
+SET( QMC_SYMLINK_TEST_FILES TRUE CACHE BOOL "Use symbolic links for test files to save space.  Set to false to copy files instead.")
+
 ######################################################################
 # Build level
 ######################################################################

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -10,6 +10,7 @@
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
     
+INCLUDE("${qmcpack_SOURCE_DIR}/CMake/macros.cmake")
     
 
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
@@ -25,14 +26,12 @@ SET(UTEST_HDF_INPUT2 ${qmcpack_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae/pwscf.pwsc
 SET(UTEST_HDF_INPUT3 ${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp/LiH-arb.pwscf.h5)
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy ${UTEST_HDF_INPUT} ${UTEST_DIR})
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy ${UTEST_HDF_INPUT2} ${UTEST_DIR}/bccH.pwscf.h5)
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy ${UTEST_HDF_INPUT3} ${UTEST_DIR}/LiH-arb.pwscf.h5)
+MAYBE_SYMLINK(${UTEST_HDF_INPUT} ${UTEST_DIR}/pwscf.pwscf.h5)
+MAYBE_SYMLINK(${UTEST_HDF_INPUT2} ${UTEST_DIR}/bccH.pwscf.h5)
+MAYBE_SYMLINK(${UTEST_HDF_INPUT3} ${UTEST_DIR}/LiH-arb.pwscf.h5)
 
 ADD_EXECUTABLE(${UTEST_EXE} test_wf.cpp test_bspline_jastrow.cpp test_einset.cpp test_pw.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} qmc qmcwfs qmcbase qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 
-#ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}" WORKING_DIRECTORY ${UTEST_DIR})
-#SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit")
 ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
 SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit" WORKING_DIRECTORY ${UTEST_DIR})


### PR DESCRIPTION
Set QMC_SYMLINK_TEST_FILES to 'true' (the default) to soft-link the *.h5 files in the tests (saves space).
Set QMC_SYMLINK_TEST_FILES to 'false' to actually copy the files (previous behavior).

In the first commit in this PR, all the test files were soft-linked.  That was changed in the next commit, but the code for that behavior is still present - adjust COPY_DIRECTORY_MAYBE_USING_SYMLINK in CMake/macros.cmake.

This fixes issue #58 
Tested on Vesta and Titan.