### PR TITLE
Added more general GPU initialization code.

### DIFF
--- a/src/Platforms/devices.h
+++ b/src/Platforms/devices.h
@@ -31,28 +31,8 @@
 
 #define MAX_GPU_SPLINE_SIZE_MB 81920
 
-inline int get_device_num()
-{
-  const int MAX_LEN = 200;
-  int size = OHMMS::Controller->size();
-  int rank = OHMMS::Controller->rank();
-  std::vector<char> myname(MAX_LEN);
-  gethostname(&myname[0], MAX_LEN);
-  std::vector<char> host_list(MAX_LEN*size);
-  for (int i=0; i<MAX_LEN; i++)
-    host_list[rank*MAX_LEN+i] = myname[i];
-  OHMMS::Controller->allgather(myname, host_list, MAX_LEN);
-  std::vector<std::string> hostnames;
-  for (int i=0; i<size; i++)
-    hostnames.push_back(&(host_list[i*MAX_LEN]));
-  std::string myhostname = &myname[0];
-  int devnum = 0;
-  for (int i=0; i<rank; i++)
-    if (hostnames[i] == myhostname)
-      devnum++;
-  return devnum;
-}
-
+/** Obtains the number of appropriate Cuda devices on the current MPI rank's node
+ */
 inline int get_num_appropriate_devices()
 {
   int deviceCount;
@@ -69,11 +49,66 @@ inline int get_num_appropriate_devices()
   return num_appropriate;
 }
 
+/** First determines the current MPI rank's relative number on its node,
+ *  then returns which Cuda device to use.
+ */
+inline int get_device_num()
+{
+  const int MAX_LEN = 200;
+  int size = OHMMS::Controller->size(); // how many MPI ranks
+  int rank = OHMMS::Controller->rank(); // current MPI rank number
+  std::vector<char> myname(MAX_LEN);
+  gethostname(&myname[0], MAX_LEN);
+  std::vector<char> host_list(MAX_LEN*size);
+  // copy current MPI rank's hostname to (shared) host_list
+  for (int i=0; i<MAX_LEN; i++)
+    host_list[rank*MAX_LEN+i] = myname[i];
+  OHMMS::Controller->allgather(myname, host_list, MAX_LEN); // wait till every rank finishes
+  // copy host_list to hostnames vector
+  std::vector<std::string> hostnames;
+  for (int i=0; i<size; i++)
+    hostnames.push_back(&(host_list[i*MAX_LEN]));
+  std::string myhostname = &myname[0];
+  // calculate how many MPI ranks are ahead of the current one on the current node
+  int number_ranks = 0;
+  int curr_ranknum = 0;
+  for (int i=0; i<size; i++) // loop over all ranks
+  {
+    if (hostnames[i] == myhostname)
+    {
+      number_ranks++; // count all ranks with the same host name as the current one
+      if (i<rank)
+        curr_ranknum++; // count only the ones schedule before the current one
+    }
+  }
+  int num_cuda_devices=get_num_appropriate_devices();
+  if (curr_ranknum==0) // output some information if we're the first rank on a node
+  {
+    std::cerr << number_ranks << " MPI ranks on node " << myhostname << " with " << num_cuda_devices << " appropriate CUDA devices." << std::endl;
+    if(number_ranks<num_cuda_devices)
+    {
+      std::cerr << "WARNING: Less MPI ranks than Cuda devices. Some Cuda devices (device # >= " << number_ranks << ") will not be used." << std::endl;
+    }
+    else
+    {
+      if(number_ranks%num_cuda_devices) // is only true (>0) when number of MPI ranks is not a multiple of Cuda device number
+        std::cerr << "WARNING: Number of MPI ranks is not a multiple of the number of Cuda devices." << std::endl;
+    }
+  }
+  // return Cuda device number based on how many appropriate ones exist on the current rank's node
+  int devnum=curr_ranknum % num_cuda_devices;
+  return devnum;
+}
+
+/** Sets the Cuda device of the current MPI rank from the pool of appropriate Cuda devices
+ * @param num requested Cuda device number
+ */
 inline void set_appropriate_device_num(int num)
 {
   int deviceCount;
   cudaGetDeviceCount(&deviceCount);
   int num_appropriate=0, device=0;
+  bool set_cuda_device=false;
   for (device = 0; device < deviceCount; ++device)
   {
     cudaDeviceProp deviceProp;
@@ -83,8 +118,18 @@ inline void set_appropriate_device_num(int num)
     {
       num_appropriate++;
       if (num_appropriate == num+1)
+      {
         cudaSetDevice (device);
+        set_cuda_device=true;
+        std::cerr << "<- Rank " << OHMMS::Controller->rank() << " has acquired CUDA device #" << device << std::endl;
+        break; // the device is set, nothing more to do here
+      }
     }
+  }
+  // This is a fail-safe that should never be triggered
+  if(!set_cuda_device)
+  {
+    APP_ABORT("Failure to obtain requested CUDA device.");
   }
 }
 
@@ -96,41 +141,24 @@ inline void Finalize_CUDA()
   cudaDeviceReset();
 }
 
-inline void Init_CUDA(int rank, int size)
+/** Initialize Cuda device on current MPI rank
+ */
+inline void Init_CUDA()
 {
   int devNum = get_device_num();
-  std::ostringstream o;
-  o << "Rank = " << rank
-       << "  My device number = " << devNum << std::endl;
-  std::cerr << o.str();
-  int num_appropriate = get_num_appropriate_devices();
-  if (devNum >= num_appropriate)
-  {
-    std::cerr << "Not enough double-precision capable GPUs for MPI rank "
-         << rank << ".\n";
-    abort();
-  }
-  set_appropriate_device_num (devNum);
+  set_appropriate_device_num(devNum);
   cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 1024 * 1024 * 50);
+  gpu::rank=OHMMS::Controller->rank();
   gpu::initCUDAStreams();
   gpu::initCUDAEvents();
   gpu::initCublas();
   gpu::MaxGPUSpineSizeMB = MAX_GPU_SPLINE_SIZE_MB;
-  gpu::rank=rank;
-  if(!rank) std::cerr << "Default MAX_GPU_SPLINE_SIZE_MB is " << gpu::MaxGPUSpineSizeMB << " MB." << std::endl;
+  // Output maximum spline buffer size for first MPI rank
+  if(gpu::rank==0) std::cerr << "Default MAX_GPU_SPLINE_SIZE_MB is " << gpu::MaxGPUSpineSizeMB << " MB." << std::endl;
   return;
-  int numGPUs;
-  cudaGetDeviceCount(&numGPUs);
-  std::cerr << "There are " << numGPUs << " GPUs.";
-  std::cerr << "Size = " << size << std::endl;
-  int chunk = size/numGPUs;
-  //  int device_num = rank % numGPUs;
-  int device_num = rank * numGPUs / size;
-  std::cerr << "My device number is " << device_num << std::endl;
-  cudaSetDevice (device_num);
 }
 #else
-inline void Init_CUDA(int rank, int size)
+inline void Init_CUDA()
 {
   std::cerr << "Flag \"--gpu\" was used, but QMCPACK was built without "
        << "GPU code.\nPlease use cmake -DQMC_CUDA=1.\n";

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
     return 1;
   }
   if (useGPU)
-    Init_CUDA(OHMMS::Controller->rank(), OHMMS::Controller->size());
+    Init_CUDA();
   //safe to move on
   Communicate* qmcComm=OHMMS::Controller;
   if(inputs.size()>1)


### PR DESCRIPTION
This code allows multiple MPI ranks on a given node to access the same GPU device. Here is a short list of changes:

- code was added to allow treatment of the previously failing case where more MPI ranks are placed on  a node than GPU devices, the new behavior is to "overdrive" the existing GPU devices by cycling through them (e.g. 4 MPI ranks and 2 GPUs leads to rank 0,2 and 1,3 to request GPU device 0 and 1, respectively) 
- care was taken to provide transparent information to the user without adding too many lines of output (typically, only one additional line per node to inform about how many ranks and GPUs are on it is added over the old output)
- removed the redundantly passed parameters to Init_Cuda (the class that stores the values passed is accessible in the scope of Init_Cuda),
- clean up of the current initialization code,
- comments were added to improve readability.

Changes are mostly located in Platforms/devices.h and there is a minor change to QMCApp/qmcapp.cpp.
