### PR TITLE
Added chapter to the manual about output files.

### DIFF
--- a/manual/output_overview.tex
+++ b/manual/output_overview.tex
@@ -1,0 +1,58 @@
+\chapter{Output overview}
+\label{chap:output_overview}
+
+%% Detail contents of output files.
+QMCPACK writes several output files which report information about the simulation (e.g. the physical properties such as the energy), as well as information about the computational aspects of the simulation, checkpoints, and restarts.
+The types of output files generated depend on the details of a calculation. The list below is not meant to be exhaustive, but rather to highlight some salient features of the more common filetypes. Further detail can be found in the description of the the estimator one is interested in computing.
+
+
+\section{The .scalar.dat file}
+\label{sec:scalardat_file}
+The most important output file is the \texttt{.scalar.dat} file. This file contains the output of block averaged properties of the system such as the local energy and other estimators.
+Each line corresponds to an average over $N_{walkers}*N_{steps}$ samples.
+By default, the quantities reported in the \texttt{.scalar.dat} file include:
+
+\begin{description}
+\item[LocalEnergy] The local energy.
+\item[LocalEnergy\_sq] The local energy squared.
+\item[LocalPotential] The local potential energy.
+\item[Kinetic] The kinetic energy.
+\item[ElecElec] The electron-electron potential energy.
+\item[IonIon] The ion-ion potential energy.
+\item[LocalECP] The energy due to the pseudopotential/effective core potential.
+\item[NonLocalECP] The non-local energy due to the pseudopotential/effective core potential.
+\item[MPC] The modified periodic coulomb potential energy.
+\item[BlockWeight] The number of MC samples in the block.
+\item[BlockCPU] The number of seconds to compute the block.
+\item[AcceptRatio] The acceptance ratio.
+\end{description}
+
+\section{The .opt.xml file}
+\label{sec:optxml_file}
+This file is generated after a VMC wave function optimization, and stores the optimized jastrow.
+Conveniently, this file is already formatted in .xml, so it can easily be incorporated into a DMC input file.
+
+\section{The .qmc file}
+\label{sec:qmc_file}
+This file contains information about the computational aspects of the simulation, for example, which parts of the code are being executed when.
+
+\section{The .dmc.dat file}
+\label{sec:dmc_file}
+This file contains information similar to the \texttt{.scalar.dat} file, but also includes extra information about the details of a DMC calculation. For example, information about the walker population.
+
+\begin{description}
+\item[Index] The block number.
+\item[LocalEnergy] The local energy.
+\item[Variance] The variance.
+\item[Weight] The number of samples in the block.
+\item[NumOfWalkers] The number of walkers times the number of steps.
+\item[AvgSentWalkers] The average number of walkers sent. During a DMC simulation walkers may be created or destroyed. At every step, QMCPACK will do some load balancing to ensure that the walkers are evenly distributed across nodes.
+\item[TrialEnergy] The trial energy. See \ref{sec:dmc} for an explanation of the trial energy.
+\item[DiffEff] The ratio of the number of accepted moves to the number of proposed moves.
+\item[LivingFraction] The fraction of the walker population from the previous step that survived to the current step.
+\end{description}
+
+
+\section{The .bandinfo.dat file}
+\label{sec:bandinfo_file}
+This file contains information about the band structure of the system, including the $k$-points in the irreducible Brillouin zone.

--- a/manual/qmcpack_manual.tex
+++ b/manual/qmcpack_manual.tex
@@ -157,6 +157,7 @@
 \input{dmc}
 \input{reptation}
 
+\input{output_overview}
 \input{analysis}
 
 \input{examples}

--- a/manual/running.tex
+++ b/manual/running.tex
@@ -45,25 +45,7 @@ option is disabled.
 The input is one or more XML file(s), documented in section~\ref{chap:input_overview}.
 
 \section{Output files}
-QMCPACK generates multiple files which have the following suffixes:
-\label{sec:outputs}
-\begin{description}
-\item[\texttt{scalar.dat}]{ This file contains information about
-  the simulation such as the energy, variance, MC acceptance ratio, etc..
-  In many situations, this is the main output file you should use to process
-  the results of the simulation. QMCPACK includes a useful tool for easy
-  processing of these files, called \texttt{qmca}. It is located in the
-  \texttt{qmcpack/nexus/executables} directory.}
-\item[\texttt{dmc.dat}]{ This file contains information similar to the
-  \texttt{scalar.dat} file, but also includes extra information about the
-  details of a DMC calculation. For example, information about the
-  walker population. }
-\item[\texttt{stat.h5}]{ This file contains some of the information used to
-  generate the \texttt{scalar.dat} file.}
-\item[\texttt{config.h5}]{ This file contains the walker configurations.
-  Used for checkpointing.}
-  \item[\texttt{cont.xml}]{ This file is a copy of the input xml file. }
-\end{description}
+QMCPACK generates multiple files, documented in section~\ref{chap:output_overview}.
 
 \section{Running in parallel}
 \label{sec:parallelrunning}


### PR DESCRIPTION
Added chapter to the manual detailing some of the output files (e.g. the scalar.dat file). Changes contained in new file manual/output_overview.tex