### PR TITLE
Add timer for startup time.

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -182,6 +182,13 @@ bool QMCMain::execute()
   }
 #endif
 
+  NewTimer *t2 = new NewTimer("Total", timer_level_coarse);
+  TimerManager.addTimer(t2);
+  t2->start();
+
+  NewTimer *t3 = new NewTimer("Startup", timer_level_coarse);
+  TimerManager.addTimer(t3);
+  t3->start();
 
   //validate the input file
   bool success = validateXML();
@@ -205,10 +212,8 @@ bool QMCMain::execute()
     app_log() << "  dryrun == 1 Ignore qmc/loop elements " << std::endl;
     APP_ABORT("QMCMain::execute");
   }
+  t3->stop();
   Timer t1;
-  NewTimer *t2 = new NewTimer("Total", timer_level_coarse);
-  TimerManager.addTimer(t2);
-  t2->start();
   curMethod = std::string("invalid");
   qmc_common.qmc_counter=0;
   for(int qa=0; qa<m_qmcaction.size(); qa++)

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -63,6 +63,9 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 #else
   std::string useGPU="no";
 #endif
+  NewTimer* spo_timer = new NewTimer("einspline::CreateSPOSetFromXML", timer_level_medium);
+  TimerManager.addTimer(spo_timer);
+  spo_timer->start();
 
   {
     OhmmsAttributeSet a;
@@ -427,6 +430,7 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     OrbitalSet->initGPU();
   }
 #endif
+  spo_timer->stop();
   return OrbitalSet;
 }
 


### PR DESCRIPTION
For the smaller NiO benchmarks, the startup time dominates the run time, but
was missed by the timers.  Now the startup time is captured and present
in the total time.