### PR TITLE
Limit the length of ParticleSet output.

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -328,10 +328,19 @@ bool ParticleSet::get(std::ostream& os) const
   for (int i=0; i<SubPtcl.size(); i++)
     os << SubPtcl[i] << " ";
   os <<"\n\n    " << LocalNum << "\n\n";
-  for (int i=0; i<LocalNum; i++)
+  const int maxParticlesToPrint = 10;
+  int numToPrint = std::min(LocalNum, maxParticlesToPrint);
+
+  for (int i=0; i<numToPrint; i++)
   {
     os << "    " << mySpecies.speciesName[GroupID[i]]  << R[i] << std::endl;
   }
+
+  if (numToPrint < LocalNum)
+  {
+    os << "    (... and " << (LocalNum-numToPrint) << " more particle positions ...)" << std::endl;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
As systems get larger, the particle position list in the output file gets longer.  At some point, it really takes up too much space in a file that should focus on human readability.
If needed, a record of the initial particle positions should be output some other way - either a separate text file, an XML file, or an HDF file.

Sample truncated output:
<pre>
 Summary of QMC systems
=========================================================
ParticleSetPool has:

  ParticleSet e : 0 192 384

    384

    u -4.6770436966e+00  1.0864074410e+01  2.9280799943e+00
    u  3.0882453042e+00  4.1204692880e+00  2.6269004106e+00
    u  3.8803048685e+00  5.1818523897e+00  4.9100902982e+00
    u -6.3915893400e+00  8.0251400115e+00  1.1326594491e+01
    u -7.1743533760e+00  8.4448055289e+00  1.0530443287e+01
    u -6.5275662801e+00  8.6735184183e+00  1.1665160359e+01
    u -1.3110805190e-01  3.4213514839e+00  6.3986314277e+00
    u  1.2396308992e+00  4.7594129539e+00  7.3545563789e+00
    u -1.3299681474e+00  4.4449426153e+00  8.5602482200e+00
    u  1.4246503451e+00  7.9806726590e+00  3.2735221385e+00
    (... and 374 more particle positions ...)

  ParticleSet i : 0 16 32

    32

    O  3.9405500000e+00  3.9405500000e+00  3.9405500000e+00
    O  0.0000000000e+00  0.0000000000e+00  1.1821650000e+01
    O  0.0000000000e+00  3.9405500000e+00  7.8811000000e+00
    O  0.0000000000e+00  7.8811000000e+00  3.9405500000e+00
    O  3.9405500000e+00  7.8811000000e+00  0.0000000000e+00
    O -3.9405500000e+00  3.9405500000e+00  1.1821650000e+01
    O -3.9405500000e+00  7.8811000000e+00  7.8811000000e+00
    O  0.0000000000e+00  1.1821650000e+01  0.0000000000e+00
    O  0.0000000000e+00  0.0000000000e+00  3.9405500000e+00
    O  0.0000000000e+00  3.9405500000e+00  0.0000000000e+00
    (... and 22 more particle positions ...)

</pre>