### PR TITLE
Improvements to timer code.

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -130,6 +130,8 @@ bool QMCMain::execute()
 
 #ifdef BUILD_AFQMC
   if(simulationType == "afqmc") {
+    NewTimer *t2 = TimerManager.createTimer("Total", timer_level_coarse);
+    ScopedTimer t2_scope(t2);
     app_log() << std::endl << "/*************************************************\n"
                       << " ********  This is an AFQMC calculation   ********\n"
                       << " *************************************************" <<std::endl;
@@ -182,12 +184,10 @@ bool QMCMain::execute()
   }
 #endif
 
-  NewTimer *t2 = new NewTimer("Total", timer_level_coarse);
-  TimerManager.addTimer(t2);
+  NewTimer *t2 = TimerManager.createTimer("Total", timer_level_coarse);
   t2->start();
 
-  NewTimer *t3 = new NewTimer("Startup", timer_level_coarse);
-  TimerManager.addTimer(t3);
+  NewTimer *t3 = TimerManager.createTimer("Startup", timer_level_coarse);
   t3->start();
 
   //validate the input file
@@ -623,8 +623,7 @@ bool QMCMain::runQMC(xmlNodePtr cur)
     qmcDriver->process(cur);
     OhmmsInfo::flush();
     Timer qmcTimer;
-    NewTimer *t1 = new NewTimer(qmcDriver->getEngineName(), timer_level_coarse);
-    TimerManager.addTimer(t1);
+    NewTimer *t1 = TimerManager.createTimer(qmcDriver->getEngineName(), timer_level_coarse);
     t1->start();
     qmcDriver->run();
     t1->stop();

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -100,33 +100,18 @@ TrialWaveFunction::addOrbital(OrbitalBase* aterm, const std::string& aname, bool
 
   if (aterm->RecomputeNeedsDistanceTable) RecomputeNeedsDistanceTable = true;
 
-//#if defined(QMC_CUDA)
-  char name1[64],name2[64],name3[64],name4[64], name5[64], name6[64];
-  sprintf(name1,"WaveFunction::%s_V",aname.c_str());
-  sprintf(name2,"WaveFunction::%s_VGL",aname.c_str());
-  sprintf(name3,"WaveFunction::%s_accept",aname.c_str());
-  sprintf(name4,"WaveFunction::%s_NLratio",aname.c_str());
-  sprintf(name5,"WaveFunction::%s_recompute",aname.c_str());
-  sprintf(name6,"WaveFunction::%s_derivs",aname.c_str());
-  NewTimer *vtimer=new NewTimer(name1);
-  NewTimer *vgltimer=new NewTimer(name2);
-  NewTimer *accepttimer=new NewTimer(name3);
-  NewTimer *NLtimer=new NewTimer(name4);
-  NewTimer *recomputetimer=new NewTimer(name5);
-  NewTimer *derivstimer=new NewTimer(name6);
-  myTimers.push_back(vtimer);
-  myTimers.push_back(vgltimer);
-  myTimers.push_back(accepttimer);
-  myTimers.push_back(NLtimer);
-  myTimers.push_back(recomputetimer);
-  myTimers.push_back(derivstimer);
-  TimerManager.addTimer(vtimer);
-  TimerManager.addTimer(vgltimer);
-  TimerManager.addTimer(accepttimer);
-  TimerManager.addTimer(NLtimer);
-  TimerManager.addTimer(recomputetimer);
-  TimerManager.addTimer(derivstimer);
-//#endif
+  std::vector<std::string> suffixes(6);
+  suffixes[0] = "_V";
+  suffixes[1] = "_VGL";
+  suffixes[2] = "_accept";
+  suffixes[3] = "_NLratio";
+  suffixes[4] = "_recompute";
+  suffixes[5] = "_derivs";
+  for (int i = 0; i < suffixes.size(); i++)
+  {
+    std::string name = "WaveFunction::" + aname + suffixes[i];
+    myTimers.push_back(TimerManager.createTimer(name));
+  }
 }
 
 

--- a/src/Utilities/NewTimer.cpp
+++ b/src/Utilities/NewTimer.cpp
@@ -70,6 +70,14 @@ void TimerManagerClass::addTimer(NewTimer* t)
   }
 }
 
+NewTimer *TimerManagerClass::createTimer(const std::string& myname, timer_levels mytimer)
+{
+  NewTimer *t = new NewTimer(myname, mytimer);
+  addTimer(t);
+  return t;
+}
+
+
 void TimerManagerClass::reset()
 {
   for (int i=0; i<TimerList.size(); i++)

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -140,6 +140,7 @@ public:
   TimerManagerClass():timer_threshold(timer_level_coarse),max_timer_id(1),
     max_timers_exceeded(false) {}
   void addTimer (NewTimer* t);
+  NewTimer *createTimer(const std::string& myname, timer_levels mytimer = timer_level_fine);
 
   void push_timer(NewTimer *t)
   {
@@ -398,6 +399,23 @@ public:
 #endif
 };
 
+// Wrapper for timer that starts on construction and stops on destruction
+class ScopedTimer
+{
+public:
+  ScopedTimer(NewTimer *t) : timer(t)
+  {
+    if (timer) timer->start();
+  }
+
+  ~ScopedTimer()
+  {
+    if (timer) timer->stop();
+  }
+private:
+  NewTimer *timer;
+};
+
 struct TimerComparator
 {
   inline bool operator()(const NewTimer *a, const NewTimer *b)
@@ -405,6 +423,7 @@ struct TimerComparator
     return a->get_name() < b->get_name();
   }
 };
+
 
 }
 

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -48,16 +48,26 @@ TEST_CASE("test_timer_stack", "[utilities]")
   // Use a local version rather than the global TimerManager, otherwise
   //  changes will persist from test to test.
   TimerManagerClass tm;
-  NewTimer t1("timer1", timer_level_coarse);
-  tm.addTimer(&t1);
+  NewTimer *t1 = tm.createTimer("timer1", timer_level_coarse);
 #if ENABLE_TIMERS
 #ifdef USE_STACK_TIMERS
-  t1.start();
-  REQUIRE(tm.current_timer() == &t1);
-  t1.stop();
+  t1->start();
+  REQUIRE(tm.current_timer() == t1);
+  t1->stop();
   REQUIRE(tm.current_timer() == NULL);
 #endif
 #endif
+}
+
+TEST_CASE("test_timer_scoped", "[utilities]")
+{
+  TimerManagerClass tm;
+  NewTimer *t1 = tm.createTimer("timer1", timer_level_coarse);
+  {
+    ScopedTimer st(t1);
+  }
+  REQUIRE(t1->get_total() == Approx(1.0));
+  REQUIRE(t1->get_num_calls() == 1);
 }
 
 TEST_CASE("test_timer_flat_profile", "[utilities]")


### PR DESCRIPTION
Add a method to create a timer and add it to the timer manager in one step.
This shortens the code at timer creation sites, updated in a few places.

Add a convenience wrapper to use scoping to start/stop the timer.

Measure the total AFQMC run time. 

I know the branch name says afqmc_timers - this is preliminary work before adding AFQMC timers.