### PR TITLE
AFQMC - add sparse matrix multiply

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,10 +516,9 @@ IF(CXX11_NEEDED)
   ENDIF()
 ENDIF(CXX11_NEEDED)
 
-# AFQMC requires MKL sparse
+# AFQMC requires MKL sparse for good performance (roughly a factor of 2x)
 IF (BUILD_AFQMC AND NOT MKL_FOUND)
-  MESSAGE(STATUS "AFQMC requires MKL sparse libraries. Disabling AFQMC")
-  SET (BUILD_AFQMC 0)
+  MESSAGE(WARNING "AFQMC - MKL not found, using simple sparse matrix routines.  Link with MKL sparse libraries for better performance.")
 ENDIF()
 
 # AFQMC requires MPI

--- a/src/AFQMC/CMakeLists.txt
+++ b/src/AFQMC/CMakeLists.txt
@@ -34,5 +34,6 @@ ADD_LIBRARY(afqmc ${AFQMC_SRCS})
 IF (BUILD_UNIT_TESTS)
   INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/external_codes/catch)
   SUBDIRS(Matrix/tests)
+  SUBDIRS(Numerics/tests)
 ENDIF()
 

--- a/src/AFQMC/CMakeLists.txt
+++ b/src/AFQMC/CMakeLists.txt
@@ -31,3 +31,8 @@ SET (AFQMC_SRCS
 INCLUDE_DIRECTORIES(/usr/gapps/qmc/libs/INTEL/eigen-eigen-10219c95fe65/)
 ADD_LIBRARY(afqmc ${AFQMC_SRCS})
 
+IF (BUILD_UNIT_TESTS)
+  INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/external_codes/catch)
+  SUBDIRS(Matrix/tests)
+ENDIF()
+

--- a/src/AFQMC/Matrix/SparseMatrix.h
+++ b/src/AFQMC/Matrix/SparseMatrix.h
@@ -37,15 +37,15 @@ class SparseMatrix
   typedef typename std::vector<T>::const_iterator const_iterator;
   typedef SparseMatrix<T>  This_t;
 
-  SparseMatrix<T>():vals(),colms(),myrows(),rowIndex(),nr(0),nc(0),compressed(false),zero_based(true)
+  SparseMatrix<T>():vals(),colms(),myrows(),rowIndex(),nr(0),nc(0),compressed(false),zero_based(true),storage_format(0)
   {
   }
 
-  SparseMatrix<T>(int n):vals(),colms(),myrows(),rowIndex(),nr(n),nc(n),compressed(false),zero_based(true)
+  SparseMatrix<T>(int n):vals(),colms(),myrows(),rowIndex(),nr(n),nc(n),compressed(false),zero_based(true),storage_format(0)
   {
   }
 
-  SparseMatrix<T>(int n,int m):vals(),colms(),myrows(),rowIndex(),nr(n),nc(m),compressed(false),zero_based(true) 
+  SparseMatrix<T>(int n,int m):vals(),colms(),myrows(),rowIndex(),nr(n),nc(m),compressed(false),zero_based(true),storage_format(0)
   {
   }
 
@@ -63,6 +63,7 @@ class SparseMatrix
     myrows=rhs.myrows;
     colms=rhs.colms;
     rowIndex=rhs.rowIndex;
+    storage_format=rhs.storage_format;
   }
 
   inline void reserve(int n)
@@ -182,15 +183,23 @@ class SparseMatrix
   }  
 
   inline int find_element(int i, int j) {
-    return 0;
+    for (int k = rowIndex[i]; k < rowIndex[i+1]; k++) {
+      if (colms[k] == j) return k;
+    }
+    return -1;
   }
 
+  // DANGER: This returns a reference, which could allow changes to the stored value.
+  // If a zero element is changed, it will change zero everywhere in the matrix.
+  // For now this method is only used for testing so it should not be a problem.
   inline Type_t& operator()(int i, int j)
   {
 #ifdef ASSERT_SPARSEMATRIX
     assert(i>=0 && i<nr && j>=0 && j<nc && compressed); 
 #endif
-    return vals[find_element(i,j)]; 
+    int idx = find_element(i,j);
+    if (idx == -1) return zero;
+    return vals[idx];
   }
 
   inline Type_t operator()( int i, int j) const
@@ -198,7 +207,9 @@ class SparseMatrix
 #ifdef ASSERT_SPARSEMATRIX
     assert(i>=0 && i<nr && j>=0 && j<nc && compressed); 
 #endif
-    return vals[find_element(i,j)]; 
+    int idx = find_element(i,j);
+    if (idx == -1) return 0;
+    return vals[idx];
   }
 
   inline void add(const int i, const int j, const T& v, bool dummy=false) 
@@ -421,11 +432,7 @@ class SparseMatrix
     rowIndex.resize(nr+1);
     rowIndex[0]=0;
     for(int i=0; i<V.size(); i++) {
-      if( std::is_same<T,std::complex<double> >::value  ) {
-        vals[i] = std::complex<double>(std::get<1>(V[i]),0.0);
-      } else {
-       vals[i] = static_cast<T>(std::get<1>(V[i]));
-      }
+      vals[i] = static_cast<T>(std::get<1>(V[i]));
       myrows[i] = 0; 
       colms[i] = std::get<0>(V[i]); 
 #ifdef ASSERT_SPARSEMATRIX
@@ -505,8 +512,10 @@ class SparseMatrix
         for(int i=old+1; i<=curr; i++) rowIndex[i] = n;
       }
     }
-    for(int i=myrows.back()+1; i<rowIndex.size(); i++)
-      rowIndex[i] = vals.size();
+    if (myrows.size() > 0) {
+      for(int i=myrows.back()+1; i<rowIndex.size(); i++)
+        rowIndex[i] = vals.size();
+    }
     compressed=true;
   }
 
@@ -525,11 +534,7 @@ class SparseMatrix
     colms.resize(nnz);
     rowIndex.resize(nr+1);
     for(int i=0; i<V.size(); i++) {
-      if( std::is_same<T,std::complex<double> >::value  ) {
-        vals[i] = std::complex<double>(std::get<2>(V[i]),0.0);
-      } else {
-       vals[i] = static_cast<T>(std::get<2>(V[i]));
-      }
+      vals[i] = static_cast<T>(std::get<2>(V[i]));
       myrows[i] = std::get<0>(V[i]);
       colms[i] = std::get<1>(V[i]);
 #ifdef ASSERT_SPARSEMATRIX
@@ -545,8 +550,10 @@ class SparseMatrix
         for(int i=old+1; i<=curr; i++) rowIndex[i] = n;
       }
     }
-    for(int i=myrows.back()+1; i<rowIndex.size(); i++)
-      rowIndex[i] = vals.size();
+    if (myrows.size() > 0) {
+      for(int i=myrows.back()+1; i<rowIndex.size(); i++)
+        rowIndex[i] = vals.size();
+    }
     compressed=true;
   }
 
@@ -673,6 +680,7 @@ class SparseMatrix
   bool zero_based;
   int storage_format; // 0: CSR, 1: Compressed Matrix (ESSL) 
   int max_in_row;
+  Type_t zero; // zero for return value
 
   _mySort_snD_ my_sort;
 

--- a/src/AFQMC/Matrix/tests/CMakeLists.txt
+++ b/src/AFQMC/Matrix/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+#//
+#// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+#//////////////////////////////////////////////////////////////////////////////////////
+
+MESSAGE("Adding this unit test")
+
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
+
+SET(SRC_DIR afqmc_matrix)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME unit_test_${SRC_DIR})
+
+
+ADD_EXECUTABLE(${UTEST_EXE} test_sparse_matrix.cpp)
+#TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS})
+
+#ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit;afqmc")
+

--- a/src/AFQMC/Matrix/tests/sparse_matrix_helpers.h
+++ b/src/AFQMC/Matrix/tests/sparse_matrix_helpers.h
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef AFQMC_SPARSE_MATRIX_HELPER_H
+#define AFQMC_SPARSE_MATRIX_HELPER_H
+
+#include "AFQMC/Matrix/SparseMatrix.h"
+
+#include <stdio.h>
+#include <string>
+#include <complex>
+
+using std::string;
+using std::complex;
+
+namespace qmcplusplus
+{
+
+template<typename T> void output_data(T *data, int size)
+{
+  std::cout << "[ ";
+  for (int i= 0; i < size; i++)
+  {
+    std::cout << data[i] << " ";
+  }
+  std::cout << "]" << std::endl;
+}
+
+template<typename T> void output_matrix(SparseMatrix<T> &M)
+{
+  std::cout << "Colms = ";
+  output_data(M.column_data(), M.size());
+  std::cout << "Row index = ";
+  output_data(M.row_index(), M.rows()+1);
+  std::cout << "Values = ";
+  output_data(M.values(), M.size());
+}
+
+template <typename T> double realPart(T &a) { REQUIRE(false); return 0.0; }
+
+template<> double realPart(const double &a)
+{
+  return a;
+}
+
+template<> double realPart(double &a)
+{
+  return a;
+}
+
+template<> double realPart(const complex<double> &a)
+{
+  return a.real();
+}
+
+template<> double realPart(complex<double> &a)
+{
+  return a.real();
+}
+
+}
+
+#endif

--- a/src/AFQMC/Matrix/tests/test_sparse_matrix.cpp
+++ b/src/AFQMC/Matrix/tests/test_sparse_matrix.cpp
@@ -1,0 +1,197 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+#include "Configuration.h"
+#include "AFQMC/Matrix/SparseMatrix.h"
+
+#include "AFQMC/Matrix/tests/sparse_matrix_helpers.h"
+#include <stdio.h>
+#include <string>
+#include <complex>
+
+
+using std::string;
+using std::complex;
+
+namespace qmcplusplus
+{
+
+template<typename T> void test_init_one_D()
+{
+  SparseMatrix<T> M(1,1);
+
+  // s1D is tuple<uint32_t, T>
+  std::vector< s1D<T> > I;
+  I.push_back(s1D<T>(0, 1.0));
+  M.initFroms1D(I,true);
+
+  int idx = M.find_element(0, 0);
+  REQUIRE(idx == 0);
+  const T &val = M(0,0);
+  REQUIRE(realPart(val) == Approx(1.0));
+}
+
+TEST_CASE("sparse_matrix_init_one_D", "[sparse_matrix]")
+{
+  test_init_one_D<double>();
+  test_init_one_D<complex<double>>();
+}
+
+template<typename T> void test_init_one_D_4()
+{
+  SparseMatrix<T> M(1,4);
+
+  // s1D is tuple<uint32_t, T>
+  std::vector< s1D<T> > I;
+  I.push_back(s1D<T>(1, 4.0));
+  I.push_back(s1D<T>(2, 2.0));
+  M.initFroms1D(I,true);
+
+  //output_matrix(M);
+
+  int idx = M.find_element(0, 0);
+  REQUIRE(idx == -1);
+  idx = M.find_element(0, 1);
+  REQUIRE(idx == 0);
+  idx = M.find_element(0, 2);
+  REQUIRE(idx == 1);
+  idx = M.find_element(0, 3);
+  REQUIRE(idx == -1);
+
+  const T &val0 = M(0,0);
+  REQUIRE(realPart(val0) == Approx(0.0));
+  const T &val1 = M(0,1);
+  REQUIRE(realPart(val1) == Approx(4.0));
+  const T &val2 = M(0,2);
+  REQUIRE(realPart(val2) == Approx(2.0));
+  const T &val3 = M(0,3);
+  REQUIRE(realPart(val3) == Approx(0.0));
+}
+
+TEST_CASE("sparse_matrix_init_one_D_4", "[sparse_matrix]")
+{
+  test_init_one_D_4<double>();
+  test_init_one_D_4<complex<double> >();
+}
+
+
+template<typename T> void test_init_two_D_4()
+{
+  SparseMatrix<T> M(1,4);
+
+  // s2D is tuple<uint32_t, T>
+  std::vector< s2D<T> > I;
+  I.push_back(s2D<T>(0, 0, 4.0));
+  M.initFroms2D(I,true);
+
+  //output_matrix(M);
+
+  int idx = M.find_element(0, 0);
+  REQUIRE(idx == 0);
+
+  T val0 = M(0,0);
+  REQUIRE(realPart(val0) == Approx(4.0));
+}
+
+TEST_CASE("sparse_matrix_init_two_D_4", "[sparse_matrix]")
+{
+  test_init_two_D_4<double>();
+  test_init_two_D_4<complex<double>>();
+}
+
+template<typename T> void test_matrix_init_two_D_22()
+{
+  SparseMatrix<T> M(2,2);
+
+  // s1D is tuple<uint32_t, uint32_t, T>
+  std::vector< s2D<T> > I;
+  I.push_back(s2D<T>(0, 1, 4.0));
+  I.push_back(s2D<T>(1, 1, 2.0));
+  M.initFroms2D(I,true);
+
+  //output_matrix(M);
+
+  int idx = M.find_element(0, 0);
+  REQUIRE(idx == -1);
+  idx = M.find_element(0, 1);
+  REQUIRE(idx == 0);
+  idx = M.find_element(1, 0);
+  REQUIRE(idx == -1);
+  idx = M.find_element(1, 1);
+  REQUIRE(idx == 1);
+
+  T &val0 = M(0,0);
+  REQUIRE(realPart(val0) == Approx(0.0));
+  T &val1 = M(0,1);
+  REQUIRE(realPart(val1) == Approx(4.0));
+  T &val2 = M(1,0);
+  REQUIRE(realPart(val2) == Approx(0.0));
+  T &val3 = M(1,1);
+  REQUIRE(realPart(val3) == Approx(2.0));
+}
+
+TEST_CASE("sparse_matrix_init_two_D_2x2", "[sparse_matrix]")
+{
+  test_matrix_init_two_D_22<double>();
+  test_matrix_init_two_D_22<complex<double>>();
+}
+
+
+template<typename T> void test_matrix_invariant()
+{
+  for (int m = 1; m < 4; m++) {
+    for (int n = 1; n < 4; n++) {
+      std::vector< s2D<T> > I;
+      T *A = new T[m*n];
+      for (int i = 0; i < m; i++) {
+        for (int j = 0; j < n; j++) {
+          // Should use random selection of zero elements
+          if ((i+j)%3 == 0)
+          //if (false) // all non-zero (dense)
+          {
+            A[i*n+j] = 0;
+          } else {
+            T val = 1.0*(i+j+1);
+            I.push_back(s2D<T>(i, j, val));
+            A[i*n+j] = val;
+          }
+        }
+      }
+      SparseMatrix<T> M(m,n);
+      M.initFroms2D(I,true);
+#if 0
+      printf("m = %d  n = %d\n",m,n);
+      output_data(A, m*n);
+      printf("CSR:\n");
+      output_matrix(M);
+      printf("\n");
+#endif
+
+      for (int i = 0; i < m; i++) {
+        for (int j = 0; j < n; j++) {
+          REQUIRE(M(i,j) == A[i*n+j]);
+        }
+      }
+    }
+  }
+}
+
+TEST_CASE("sparse_matrix_invariant", "[sparse_matrix]")
+{
+  test_matrix_invariant<double>();
+  test_matrix_invariant<complex<double>>();
+}
+
+}
+

--- a/src/AFQMC/Numerics/SparseMatrixOperations.cpp
+++ b/src/AFQMC/Numerics/SparseMatrixOperations.cpp
@@ -105,8 +105,9 @@ void product_SpMatV(const int M, const int K,
     const int* rows = A.row_index();
     for(int nr=0; nr<M; nr++,C++,rows++) {
       *C*=beta;
-      for(int i=*rows; i<*(rows+1); i++,val++,cols++)
+      for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
         *C += alpha * (*val) * ( *( B + (*cols) + disp) );
+      }
     }
   } else  {  // EESL: Compressed Matrix 
 
@@ -167,7 +168,14 @@ void product_SpMatV(const int M, const int K,
   matdes[3] = 'C';
   mkl_dcsrmv( &trans, &M, &K, &alpha, matdes, val , col,  row ,  row+1, B, &beta, C );
 #else
-APP_ABORT("ERROR: product_SpMatV only implemented with MKL. \n");
+  const int* cols = col;
+  int disp = 0;
+  const int* rows = row;
+  for(int nr=0; nr<M; nr++,C++,rows++) {
+    *C*=beta;
+    for(int i=*rows; i<*(rows+1); i++,val++,cols++)
+      *C += alpha * (*val) * ( *( B + (*cols) + disp) );
+  }
 #endif
 }
 
@@ -187,7 +195,14 @@ void product_SpMatV(const int M, const int K,
   matdes[3] = 'C';
   mkl_zcsrmv( &trans, &M, &K, &alpha, matdes, val , col,  row ,  row+1, B, &beta, C );
 #else
-APP_ABORT("ERROR: product_SpMatV only implemented with MKL. \n");
+  const int* cols = col;
+  int disp = 0;
+  const int* rows = row;
+  for(int nr=0; nr<M; nr++,C++,rows++) {
+    *C*=beta;
+    for(int i=*rows; i<*(rows+1); i++,val++,cols++)
+      *C += alpha * (*val) * ( *( B + (*cols) + disp) );
+  }
 #endif
 }
 
@@ -207,7 +222,18 @@ void product_SpMatTV(const int M, const int K,
   matdes[3] = 'C';
   mkl_zcsrmv( &trans, &M, &K, &alpha, matdes, val , col,  row ,  row+1, B, &beta, C );
 #else
-APP_ABORT("ERROR: product_SpMatV only implemented with MKL. \n");
+  const int* cols = col;
+  int disp = 0;
+  const int* rows = row;
+  for(int nr=0; nr<K; nr++)
+  {
+    C[nr] *= beta;
+  }
+  for(int nr=0; nr<M; nr++,rows++,B++) {
+    for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
+      *(C + (*cols) + disp) += alpha * (*val) *  (*B);
+    }
+  }
 #endif
 }
 
@@ -229,17 +255,19 @@ void product_SpMatTV(const int M, const int K,
 
 #else
 
-APP_ABORT("ERROR: product_SpMatTV only implemented with MKL. \n");
   ComplexType zero = ComplexType(0,0);
   const ComplexType* val = A.values();
   const int* cols = A.column_data();
   int disp = (A.zero_base())?0:-1;
   if( A.format() == 0) {  // CSR
     const int* rows = A.row_index();
-    for(int nr=0; nr<M; nr++,C++,rows++) {
-      *C*=beta;
-      for(int i=*rows; i<*(rows+1); i++,val++,cols++)
-        *C += alpha * (*val) * ( *( B + (*cols) + disp) );
+    for(int nr=0; nr<K; nr++) {
+      C[nr] *= beta;
+    }
+    for(int nr=0; nr<M; nr++,rows++,B++) {
+      for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
+        *(C + (*cols) + disp) += alpha * (*val) *  (*B);
+      }
     }
   } else  {  // EESL: Compressed Matrix 
 
@@ -265,7 +293,27 @@ void product_SpMatM(const int M, const int N, const int K,
 
 #else
 
-APP_ABORT("ERROR: product_SpMatM only implemented with MKL. \n");
+  ComplexType zero = ComplexType(0,0);
+  const ComplexType* val = A.values();
+  const int* cols = A.column_data();
+  int disp = (A.zero_base())?0:-1;
+  if( A.format() == 0) {  // CSR
+    const int* rows = A.row_index();
+    ComplexType *baseC = C;
+    const ComplexType *baseB = B;
+    for(int nr=0; nr<M; nr++,rows++,C+=ldc) {
+      for(int nn=0; nn<N; nn++) {
+        C[nn] *= beta;
+      }
+      for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
+        for(int nn=0; nn<N; nn++) {
+          C[nn] += alpha*(*val) * ( *( B + nn + (*cols)*ldb + disp) );
+        }
+      }
+    }
+  } else  {  // EESL: Compressed Matrix
+
+  }
 
 #endif
 }
@@ -287,7 +335,24 @@ void product_SpMatM(const int M, const int N, const int K,
 
 #else
 
-APP_ABORT("ERROR: product_SpMatM only implemented with MKL. \n");
+  const RealType* val = A.values();
+  const int* cols = A.column_data();
+  int disp = (A.zero_base())?0:-1;
+  if( A.format() == 0) {  // CSR
+    const int* rows = A.row_index();
+    for(int nr=0; nr<M; nr++,rows++,C+=ldc) {
+      for(int nn=0; nn<N; nn++) {
+        C[nn] *= beta;
+      }
+      for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
+        for(int nn=0; nn<N; nn++) {
+          C[nn] += alpha*(*val) * ( *( B + nn + (*cols)*ldb + disp) );
+        }
+      }
+    }
+  } else  {  // EESL: Compressed Matrix
+
+  }
 
 #endif
 }
@@ -309,7 +374,24 @@ void product_SpMatM(const int M, const int N, const int K,
 
 #else
 
-APP_ABORT("ERROR: product_SpMatM only implemented with MKL. \n");
+  const float* val = A.values();
+  const int* cols = A.column_data();
+  int disp = (A.zero_base())?0:-1;
+  if( A.format() == 0) {  // CSR
+    const int* rows = A.row_index();
+    for(int nr=0; nr<M; nr++,rows++,C+=ldc) {
+      for(int nn=0; nn<N; nn++) {
+        C[nn] *= beta;
+      }
+      for(int i=*rows; i<*(rows+1); i++,val++,cols++) {
+        for(int nn=0; nn<N; nn++) {
+          C[nn] += alpha*(*val) * ( *( B + nn + (*cols)*ldb + disp) );
+        }
+      }
+    }
+  } else  {  // EESL: Compressed Matrix
+
+  }
 
 #endif
 }
@@ -583,7 +665,7 @@ bool sparseEigenSystem(ComplexSpMat &A, int& m0, RealType *eigval, ComplexType* 
   return true;
 
 #else
-APP_ABORT("Error: sparseEigenSystem only implemented with MKL library. n");
+//APP_ABORT("Error: sparseEigenSystem only implemented with MKL library. n");
   return false;
 #endif
 
@@ -591,9 +673,15 @@ APP_ABORT("Error: sparseEigenSystem only implemented with MKL library. n");
 
 
 template
-void product_SpMatV<ComplexSpMat>(const int nrows, const ComplexSpMat& A, const ComplexType* B, ComplexType* C);
+void product_SpMatV<ComplexSpMat>(int nrows,
+                                  const ComplexSpMat &,
+                                  const ComplexType* B,
+                                  ComplexType* C);
 template
-void product_SpMatV<ComplexSMSpMat>(const int nrows, const ComplexSMSpMat& A, const ComplexType* B, ComplexType* C);
+void product_SpMatV<ComplexSMSpMat>(int nrows,
+                                    const ComplexSMSpMat& A,
+                                    const ComplexType* B,
+                                    ComplexType* C);
 
 template
 void product_SpMatV<ComplexSpMat>(const int M, const int K,

--- a/src/AFQMC/Numerics/SparseMatrixOperations.h
+++ b/src/AFQMC/Numerics/SparseMatrixOperations.h
@@ -27,8 +27,8 @@ void product_SD(const IndexType K,
 
 template<class T>
 void product_SpMatV(int nrows,
-             T& A, 
-             ComplexType* B, 
+             const T& A,
+             const ComplexType* B,
              ComplexType* C );
 
 template<class T>

--- a/src/AFQMC/Numerics/tests/CMakeLists.txt
+++ b/src/AFQMC/Numerics/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+#//
+#// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+#//////////////////////////////////////////////////////////////////////////////////////
+
+MESSAGE("Adding this unit test")
+
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
+
+SET(SRC_DIR afqmc_numerics)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME unit_test_${SRC_DIR})
+
+
+ADD_EXECUTABLE(${UTEST_EXE} test_sparse_ops.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} ${QMC_UTIL_LIBS} afqmc)
+
+#ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit;afqmc")
+

--- a/src/AFQMC/Numerics/tests/gensparse.py
+++ b/src/AFQMC/Numerics/tests/gensparse.py
@@ -1,0 +1,146 @@
+
+# Generate sparse matrix multiply test cases
+
+import numpy as np
+import scipy.sparse as sps
+
+
+def flatten(a):
+  '''Flatten a nested list'''
+  return [item for d in a for item in d]
+
+def string_elements(a):
+  '''Convert elements of a list to strings'''
+  return [str(item) for item in a]
+
+def matrix_vector_mult():
+  A = np.eye(3)
+  X = np.ones((3,1))
+  Y = np.ones((3,1))
+  alpha = 1.0
+  beta = 2.0
+
+  output = generate_case(A, X, Y, alpha, beta, type='double')
+  output += generate_case(A, X, Y, alpha, beta, type='complex<double>')
+
+  A = np.eye(3)
+  A[1,2] = 2.0
+  X = np.arange(0,6).reshape(3,2)
+  Y = np.arange(0,6).reshape(3,2)
+  alpha = 1.0
+  beta = 2.0
+
+  output += '\n'
+  output += generate_case(A, X, Y, alpha, beta, type='double')
+  output += generate_case(A, X, Y, alpha, beta, type='complex<double>')
+
+  A = np.eye(3)
+  A[1,1] = 0.0
+  A[1,2] = 1.0
+  X = np.arange(0,9).reshape(3,3)
+  Y = np.arange(0,9).reshape(3,3)
+  alpha = 1.0
+  beta = 2.0
+
+  output += '\n'
+  output += generate_case(A, X, Y, alpha, beta, type='double')
+  output += generate_case(A, X, Y, alpha, beta, type='complex<double>')
+
+  A = np.eye(2)
+  A[0,1] = 1.0
+  X = np.arange(0,6).reshape(2,3)
+  Y = np.arange(0,6).reshape(2,3)
+  alpha = 1.0
+  beta = 2.0
+
+  output += '\n'
+  output += generate_case(A, X, Y, alpha, beta, type='double')
+  output += generate_case(A, X, Y, alpha, beta, type='complex<double>')
+
+  with open('sparse_mult_cases.cpp', 'w') as f:
+    f.write(output)
+
+
+case_id = 1
+def generate_case(A, X, Y, alpha, beta, type='double'):
+  global case_id
+
+  b = alpha*(A.dot(X)) + beta*Y
+
+  init_list = []
+  for k,v in sps.dok_matrix(A).iteritems():
+    init_list.append("s2Dd({i},{j},{v})".format(i=k[0],j=k[1],v=v))
+
+  x_init_list = flatten(X.tolist())
+  y_init_list = flatten(Y.tolist())
+  ans_init_list = flatten(b.tolist())
+
+  out = '''
+TEST_CASE("sparse_matrix_{test_case}", "[sparse_matrix]")
+{{
+  typedef s2D<{type}> s2Dd;
+
+  const int M = {M};
+  const int N = {N};
+  const int K = {K};
+
+  std::vector<s2Dd> I = {{{init_list}}};
+  SparseMatrix<{type}> A(M,K);
+  A.initFroms2D(I,false);
+
+  {type} B[K*N] = {{{x_init_list}}};
+  {type} C[K*N] = {{{y_init_list}}};
+  {type} alpha = {alpha};
+  {type} beta = {beta};
+
+  {type} finalC[K*N] = {{{ans_init_list}}};
+
+  int ldb = N;
+  int ldc = N;
+  SparseMatrixOperators::product_SpMatM(M, N, K, alpha, A, B, ldb, beta, C, ldc);
+
+  for (int i = 0; i < M; i++)
+  {{
+    for (int j = 0; j < N; j++)
+    {{
+      //printf("%d %d %g %g\\n",i,j,C[i*N + j],finalC[i*N + j]);
+      REQUIRE(realPart(C[i*N + j]) == Approx(realPart(finalC[i*N + j])));
+    }}
+  }}
+}}
+  '''.format(M=A.shape[0],
+             N=Y.shape[1],
+             K=A.shape[1],
+             init_list = ',\n    '.join(init_list),
+             test_case = str(case_id),
+             x_init_list = ','.join(string_elements(x_init_list)),
+             y_init_list = ','.join(string_elements(y_init_list)),
+             alpha = 1.0,
+             beta = 2.0,
+             ans_init_list = ','.join(string_elements(ans_init_list)),
+             type = type
+           )
+
+  case_id += 1
+
+  return out
+
+
+if False:
+  # Some experiments with CSR matrix format in scipy.sparse
+  # Could potentially generate tests for generation of CSR matrices
+  z = np.zeros((1,3))
+  print z
+  z[0,0] = 1.0
+  z[0,1] = 2.0
+  z[0,2] = 3.0
+
+  M = sps.csr_matrix(z)
+
+  print 'nnz = ', M.nnz
+  print 'colums = ',M.indices
+  print 'indptr = ',M.indptr
+  print 'values = ',M.data
+
+matrix_vector_mult()
+

--- a/src/AFQMC/Numerics/tests/sparse_mult_cases.cpp
+++ b/src/AFQMC/Numerics/tests/sparse_mult_cases.cpp
@@ -1,0 +1,2 @@
+
+// Run gensparse.py to create this file with content

--- a/src/AFQMC/Numerics/tests/test_sparse_ops.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_ops.cpp
@@ -1,0 +1,390 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+#include "Configuration.h"
+
+// Always test the fallback code, regardless of MKL definition
+#undef HAVE_MKL
+
+// Avoid the need to link with other libraries just to get APP_ABORT
+#undef APP_ABORT
+#define APP_ABORT(x) std::cout << x; exit(0);
+
+#include "AFQMC/Matrix/SparseMatrix.h"
+#include "AFQMC/Matrix/tests/sparse_matrix_helpers.h"
+
+// Include the templates directly so all the needed types get instantiated
+//  and so the undef of HAVE_MKL has an effect
+#include "AFQMC/Numerics/SparseMatrixOperations.cpp"
+
+#include <stdio.h>
+#include <string>
+#include <complex>
+
+using std::string;
+using std::complex;
+using std::cout;
+
+
+namespace qmcplusplus
+{
+template<typename T> void test_matrix_mult_1_1()
+{
+  SparseMatrix<T> A(1,1);
+
+  std::vector<s1D<T>> I;
+  I.push_back(s1D<T>(0, 1.0));
+  A.initFroms1D(I,true);
+
+  T *B = new T[1];
+  T *C = new T[1];
+  B[0] = 1.0;
+  C[0] = 0.0;
+  int nrows = 1;
+  SparseMatrixOperators::product_SpMatV(nrows, A, B, C);
+
+  REQUIRE(realPart(C[0]) == Approx(1.0));
+}
+
+TEST_CASE("sparse_matrix_mult", "[sparse_matrix]")
+{
+  test_matrix_mult_1_1<complex<double>>();
+}
+
+TEST_CASE("sparse_matrix_mult_2x2", "[sparse_matrix]")
+{
+
+  SparseMatrix<complex<double>> A(2,2);
+
+  std::vector< s2D<complex<double>> > I;
+  I.push_back(s2D<complex<double>>(0,0, 2.0));
+  I.push_back(s2D<complex<double>>(0,1, 4.0));
+  // [[2.0 4.0]
+  //  [0.0 0.0]]
+  A.initFroms2D(I,true);
+
+
+  complex<double> *B = new complex<double>[2];
+  complex<double> *C = new complex<double>[2];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  C[0] = 0.0;
+  C[1] = 0.0;
+  int nrows = 1;
+  SparseMatrixOperators::product_SpMatV(nrows, A, B, C);
+
+  REQUIRE(C[0].real() == Approx(20.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+
+  REQUIRE(C[1].real() == Approx(0.0));
+  REQUIRE(C[1].imag() == Approx(0.0));
+}
+
+TEST_CASE("sparse_matrix_axpy_1x1", "[sparse_matrix]")
+{
+
+  SparseMatrix<complex<double>> A(1,1);
+
+  std::vector< s1D<complex<double>> > I;
+  I.push_back(s1D<complex<double>>(0, 1.0));
+  A.initFroms1D(I,true);
+
+  //output_matrix(A);
+
+  complex<double> *B = new complex<double>[1];
+  complex<double> *C = new complex<double>[1];
+  B[0] = 1.0;
+  C[0] = 3.0;
+  int nrows = 1;
+  double alpha = 2.0;
+  double beta = 2.0;
+  SparseMatrixOperators::product_SpMatV(nrows, nrows, alpha, A.values(), A.column_data(), A.row_index(), B, beta, C);
+
+  REQUIRE(C[0].real() == Approx(8.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+}
+
+TEST_CASE("sparse_matrix_zaxpy_2x2", "[sparse_matrix]")
+{
+
+  SparseMatrix<complex<double>> A(2,2);
+
+  std::vector< s2D<complex<double>> > I;
+  I.push_back(s2D<complex<double>>(0,0, 2.0));
+  I.push_back(s2D<complex<double>>(0,1, 4.0));
+  // [[2.0 4.0]
+  //  [0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  complex<double> *B = new complex<double>[2];
+  complex<double> *C = new complex<double>[2];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  C[0] = 2.0;
+  C[1] = 1.3;
+  int nrows = 2;
+  double alpha = 2.0;
+  double beta = 2.0;
+  SparseMatrixOperators::product_SpMatV(nrows, nrows, alpha, A.values(), A.column_data(), A.row_index(), B, beta, C);
+
+  REQUIRE(C[0].real() == Approx(44.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+
+  REQUIRE(C[1].real() == Approx(2.6));
+  REQUIRE(C[1].imag() == Approx(0.0));
+}
+
+TEST_CASE("sparse_matrix_daxpy_2x2", "[sparse_matrix]")
+{
+
+  SparseMatrix<double> A(2,2);
+
+  std::vector< s2D<double> > I;
+  I.push_back(s2D<double>(0,0, 2.0));
+  I.push_back(s2D<double>(0,1, 4.0));
+  // [[2.0 4.0]
+  //  [0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  double *B = new double[2];
+  double *C = new double[2];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  C[0] = 2.0;
+  C[1] = 1.3;
+  int nrows = 2;
+  double alpha = 2.0;
+  double beta = 2.0;
+  SparseMatrixOperators::product_SpMatV(nrows, nrows, alpha, A.values(), A.column_data(), A.row_index(), B, beta, C);
+
+  REQUIRE(C[0] == Approx(44.0));
+  REQUIRE(C[1] == Approx(2.6));
+}
+
+TEST_CASE("sparse_matrix_zaxpy_T_2x2", "[sparse_matrix]")
+{
+
+  SparseMatrix<complex<double>> A(2,2);
+
+  std::vector< s2D<complex<double>> > I;
+  I.push_back(s2D<complex<double>>(0,0, 2.0));
+  I.push_back(s2D<complex<double>>(0,1, 4.0));
+  // [[2.0 4.0]
+  //  [0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  complex<double> *B = new complex<double>[2];
+  complex<double> *C = new complex<double>[2];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  C[0] = 2.0;
+  C[1] = 1.3;
+  int nrows = 2;
+  double alpha = 2.0;
+  double beta = 2.0;
+  SparseMatrixOperators::product_SpMatTV(nrows, nrows, alpha, A, B, beta, C);
+
+  for (int i = 0; i < nrows; i++) {
+    cout << C[i] << std::endl;
+  }
+
+  REQUIRE(C[0].real() == Approx(20.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+
+  REQUIRE(C[1].real() == Approx(34.6));
+  REQUIRE(C[1].imag() == Approx(0.0));
+
+  C[0] = 2.0;
+  C[1] = 1.3;
+  SparseMatrixOperators::product_SpMatTV(nrows, nrows, alpha, A.values(), A.column_data(), A.row_index(), B, beta, C);
+
+  REQUIRE(C[0].real() == Approx(20.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+
+  REQUIRE(C[1].real() == Approx(34.6));
+  REQUIRE(C[1].imag() == Approx(0.0));
+
+}
+
+TEST_CASE("sparse_matrix_mm_2x2", "[sparse_matrix]")
+{
+
+  SparseMatrix<complex<double>> A(2,2);
+
+  std::vector< s2D<complex<double>> > I;
+  I.push_back(s2D<complex<double>>(0,0, 2.0));
+  I.push_back(s2D<complex<double>>(0,1, 4.0));
+  // [[2.0 4.0]
+  //  [0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  complex<double> *B = new complex<double>[4];
+  complex<double> *C = new complex<double>[4];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  B[2] = 1.0;
+  B[3] = 5.0;
+
+  C[0] = 2.0;
+  C[1] = 1.3;
+  C[2] = 1.3;
+  C[3] = 1.3;
+  int nrows = 2;
+  double alpha = 2.0;
+  double beta = 2.0;
+  SparseMatrixOperators::product_SpMatM(nrows, nrows, nrows, alpha, A, B, nrows, beta, C, nrows);
+
+  //std::cout << C[0] << std::endl;
+  //std::cout << C[1] << std::endl;
+  //std::cout << C[2] << std::endl;
+  //std::cout << C[3] << std::endl;
+
+  REQUIRE(C[0].real() == Approx(28.0));
+  REQUIRE(C[0].imag() == Approx(0.0));
+
+  REQUIRE(C[1].real() == Approx(54.6));
+  REQUIRE(C[1].imag() == Approx(0.0));
+
+  REQUIRE(C[2].real() == Approx(2.6));
+  REQUIRE(C[2].imag() == Approx(0.0));
+
+  REQUIRE(C[3].real() == Approx(2.6));
+  REQUIRE(C[3].imag() == Approx(0.0));
+}
+
+TEST_CASE("sparse_matrix_real_mm_2x2", "[sparse_matrix]")
+{
+
+  const int N = 2; // nrows of A
+  const int M = 3; // ncols of C
+  const int K = 4; // ncols of A
+  // A is MxK
+  // B is KxN
+  // C is MxN
+  SparseMatrix<double> A(M,K);
+
+  std::vector< s2D<double> > I;
+  I.push_back(s2D<double>(0,0, 2.0));
+  I.push_back(s2D<double>(0,1, 4.0));
+  I.push_back(s2D<double>(1,2, 5.0));
+  I.push_back(s2D<double>(2,1, 1.0));
+  // [[2.0 4.0 0.0 0.0]
+  //  [0.0 0.0 5.0 0.0]
+  //  [1.0 0.0 0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  double *B = new double[K*N];
+  double *C = new double[M*N];
+  B[0] = 4.0;
+  B[1] = 3.0;
+  B[2] = 1.0;
+  B[3] = 5.0;
+
+  C[0] = 2.0;
+  C[1] = 1.3;
+  C[2] = 1.3;
+  C[3] = 1.3;
+  double alpha = 2.0;
+  double beta = 2.0;
+  int ldb = N;
+  int ldc = N;
+  SparseMatrixOperators::product_SpMatM(M, N, K, alpha, A, B, ldb, beta, C, ldc);
+
+  //for (int i = 0; i < M*N; i++)
+  //{
+  //  std::cout << C[i] << std::endl;
+  //}
+
+  REQUIRE(C[0] == Approx(28.0));
+  REQUIRE(C[1] == Approx(54.6));
+  REQUIRE(C[2] == Approx(2.6));
+  REQUIRE(C[3] == Approx(2.6));
+  REQUIRE(C[4] == Approx(2.0));
+  REQUIRE(C[5] == Approx(10.0));
+
+}
+
+
+TEST_CASE("sparse_matrix_float_mm_2x2", "[sparse_matrix]")
+{
+
+  const int N = 2; // nrows of A
+  const int M = 3; // ncols of C
+  const int K = 4; // ncols of A
+  // A is MxK
+  // B is KxN
+  // C is MxN
+  SparseMatrix<float> A(M,K);
+
+  std::vector< s2D<double> > I;
+  I.push_back(s2D<double>(0,0, 2.0));
+  I.push_back(s2D<double>(0,1, 4.0));
+  I.push_back(s2D<double>(0,3, 1.0));
+  I.push_back(s2D<double>(1,2, 5.0));
+  I.push_back(s2D<double>(2,1, 1.0));
+  // [[2.0 4.0 0.0 1.0]
+  //  [0.0 0.0 5.0 0.0]
+  //  [1.0 0.0 0.0 0.0]]
+  A.initFroms2D(I,true);
+
+  //output_matrix(A);
+
+  float *B = new float[K*N];
+  float *C = new float[M*N];
+  for (int i = 0; i < K*N; i++) B[i] = 0;
+  for (int i = 0; i < M*N; i++) C[i] = 0;
+  B[0] = 4.0;
+  B[1] = 3.0;
+  B[2] = 1.0;
+  B[3] = 5.0;
+  B[6] = 1.0;
+
+  C[0] = 2.0;
+  C[1] = 1.3;
+  C[2] = 1.3;
+  C[3] = 1.3;
+  float alpha = 2.0;
+  float beta = 2.0;
+  int ldb = N;
+  int ldc = N;
+  SparseMatrixOperators::product_SpMatM(M, N, K, alpha, A, B, ldb, beta, C, ldc);
+
+  //for (int i = 0; i < M*N; i++)
+  //{
+  //  std::cout << C[i] << std::endl;
+  //}
+
+  REQUIRE(C[0] == Approx(30.0));
+  REQUIRE(C[1] == Approx(54.6));
+  REQUIRE(C[2] == Approx(2.6));
+  REQUIRE(C[3] == Approx(2.6));
+  REQUIRE(C[4] == Approx(2.0));
+  REQUIRE(C[5] == Approx(10.0));
+
+}
+
+#include "sparse_mult_cases.cpp"
+
+}
+


### PR DESCRIPTION
Add sparse matrix-vector and matrix-matrix multiply routines so AFQMC can be built without MKL.

Also add unit testing for the sparse matrix class and the sparse matrix multiplies.