### PR TITLE
Fix scoped timer unit test when timers disabled.

### DIFF
--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -66,8 +66,10 @@ TEST_CASE("test_timer_scoped", "[utilities]")
   {
     ScopedTimer st(t1);
   }
+#if ENABLE_TIMERS
   REQUIRE(t1->get_total() == Approx(1.0));
   REQUIRE(t1->get_num_calls() == 1);
+#endif
 }
 
 TEST_CASE("test_timer_flat_profile", "[utilities]")


### PR DESCRIPTION
Should fix a unit test failures in unit_test_utilities when timers are not enabled.