### PR TITLE
nexus: improve optimal_tilematrix routine

### DIFF
--- a/nexus/library/nexus.py
+++ b/nexus/library/nexus.py
@@ -25,6 +25,7 @@
 import os
 
 from generic import obj
+from developer import error
 
 from nexus_base      import NexusCore,nexus_core,nexus_noncore,nexus_core_noncore
 from machines        import Job,job,Machine,Supercomputer,get_machine
@@ -386,3 +387,36 @@ def run_project(*args,**kwargs):
     pm.add_simulations(*args,**kwargs)
     pm.run_project()
 #end def run_project
+
+
+
+
+
+
+
+
+# read input function
+#   place here for now as it depends on all other input functions
+def read_input(filepath,format=None):
+    if not os.path.exists(filepath):
+        error('cannot read input file\nfile does not exist: {0}'.format(filepath),'read_input')
+    #end if
+    if format is None:
+        if filepath.endswith('in.xml'):
+            format = 'qmcpack'
+        else:
+            error('cannot identify file format\nplease provide format for file: {0}'.format(filepath))
+        #end if
+    #end if
+    format = format.lower()
+    if format=='qmcpack':
+        input = QmcpackInput(filepath)
+    elif format=='pwscf':
+        input = PwscfInput(filepath)
+    elif format=='gamess':
+        input = GamessInput(filepath)
+    else:
+        error('cannot read input file\nfile format "{0}" is unsupported'.format(format))
+    #end if
+    return input
+#end def read_input

--- a/nexus/library/plotting.py
+++ b/nexus/library/plotting.py
@@ -13,13 +13,13 @@
 
 from developer import unavailable
 try:
-    from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
+    from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,yticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
     rcParams.update(params)
 except (ImportError,RuntimeError):
-   figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+   figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,yticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','yticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
 #end try
 
 

--- a/nexus/library/qmcpack.py
+++ b/nexus/library/qmcpack.py
@@ -106,7 +106,9 @@ class Qmcpack(Simulation):
 
     def pre_write_inputs(self,save_image):
         # fix to make twist averaged input file under generate_only
-        if nexus_core.generate_only:
+        if self.system is None:
+            self.should_twist_average = False
+        elif nexus_core.generate_only:
             twistnums = range(len(self.system.structure.kpoints))
             if self.should_twist_average:
                 self.twist_average(twistnums)

--- a/nexus/library/qmcpack_input.py
+++ b/nexus/library/qmcpack_input.py
@@ -517,7 +517,8 @@ class QIxml(Names):
             attr_types  = None,
             precision   = None,
             defaults    = obj(),
-            collection_id = None
+            collection_id = None,
+            exp_names   = None,
             )
         for v in ['attributes','elements','parameters','attribs','costs','h5tags']:
             names = cls.class_get(v)
@@ -535,6 +536,9 @@ class QIxml(Names):
             #end if
         #end for
         cls.plurals = cls.plurals_inv.inverse()
+        if cls.exp_names is not None:
+            cls.expanded_names = obj(Names.expanded_names,cls.exp_names)
+        #end if
     #end def init_class
 
 
@@ -1958,6 +1962,7 @@ class coefficients(QIxml):
     attributes = ['id','type','optimize','state','size','cusp','rcut']
     text       = 'coeff'
     write_types= obj(optimize=yesno)
+    exp_names  = obj(array='Array')
 #end class coefficients
 
 class coefficient(QIxml):  # this is bad!!! coefficients/coefficient
@@ -2187,6 +2192,12 @@ class gofr(QIxml):
     identifier = 'name'
 #end class gofr
 
+class flux(QIxml):
+    tag = 'estimator'
+    attributes = ['type','name']
+    identifier = 'name'
+#end class flux
+    
 estimator = QIxmlFactory(
     name  = 'estimator',
     types = dict(localenergy         = localenergy,
@@ -2206,6 +2217,7 @@ estimator = QIxmlFactory(
                  sk                  = sk,
                  skall               = skall,
                  gofr                = gofr,
+                 flux                = flux,
                  ),
     typekey  = 'type',
     typekey2 = 'name'
@@ -2435,7 +2447,7 @@ classes = [   #standard classes
     multideterminant,detlist,ci,mcwalkerset,csf,det,
     optimize,cg_optimizer,flex_optimizer,optimize_qmc,wftest,kspace_jastrow,
     header,local,force,forwardwalking,observable,record,rmc,pressure,dmccorrection,
-    nofk,mpc_est,distancetable,cpp,element,spline,setparams,
+    nofk,mpc_est,flux,distancetable,cpp,element,spline,setparams,
     backflow,transformation,cubicgrid,molecular_orbital_builder,cmc,sk,skall,gofr,
     host,date,user,
     ]
@@ -2510,7 +2522,7 @@ Names.set_expanded_names(
     elecelec         = 'ElecElec',
     pseudopot        = 'PseudoPot',
     posarray         = 'posArray',
-    array            = 'Array',
+    #array            = 'Array',  # handle separately, namespace collision
     atomicbasisset   = 'atomicBasisSet',
     basisgroup       = 'basisGroup',
     expandylm        = 'expandYlm',
@@ -4041,21 +4053,6 @@ def generate_particlesets(electrons = 'e',
     net_charge = system.net_charge
     net_spin   = system.net_spin
 
-    # not ordered consistently
-    #structure.group_atoms()
-    #elem = structure.elem
-    #pos  = structure.pos
-    #
-    #elns = particles.get_electrons()
-    #ions = particles.get_ions()
-    #eup  = elns.up_electron
-    #edn  = elns.down_electron
-
-    # maintain consistent order
-    ion_species,ion_counts = structure.order_by_species()
-    elem = structure.elem
-    pos  = structure.pos
-
     elns = particles.get_electrons()
     ions = particles.get_ions()
     eup  = elns.up_electron
@@ -4072,6 +4069,10 @@ def generate_particlesets(electrons = 'e',
         )
     particlesets.append(eps)
     if len(ions)>0:
+        # maintain consistent order
+        ion_species,ion_counts = structure.order_by_species()
+        elem = structure.elem
+        pos  = structure.pos
         if randomsrc:
             eps.randomsrc = iname
         #end if
@@ -4514,6 +4515,12 @@ def generate_hamiltonian(name         = 'h0',
                 #end if
             elif not isinstance(estimator,QIxml):
                 QmcpackInput.class_error('generate_hamiltonian received an invalid estimator\n  an estimator must either be a name or a QIxml object\n  inputted estimator type: {0}\n  inputted estimator contents: {1}'.format(estimator.__class__.__name__,estimator))
+            elif isinstance(estimator,energydensity):
+                est.set_optional(
+                    type = 'EnergyDensity',
+                    dynamic = ename,
+                    static  = iname,
+                    )
             elif isinstance(estimator,dm1b):
                 dm = estimator
                 reuse = False
@@ -5049,6 +5056,122 @@ def count_jastrow_params(jastrows):
 #end def count_jastrow_params
 
 
+def generate_energydensity(
+        name      = None,
+        dynamic   = None,
+        static    = None,
+        coord     = None,
+        grid      = None,
+        scale     = None,
+        ion_grids = None,
+        system    = None,
+        ):
+    type = 'EnergyDensity'
+    if dynamic is None:
+        dynamic = 'e'
+    #end if
+    if static is None:
+        static = 'ion0'
+    #end if
+    refp = None
+    sg = []
+    if coord is None:
+        QmcpackInput.class_error('coord must be provided','generate_energydensity')
+    elif coord=='voronoi':
+        if name is None:
+            name = 'EDvoronoi'
+        #end if
+        sg.append(spacegrid(coord=coord))
+    elif coord=='cartesian':
+        if name is None:
+            name = 'EDcell'
+        #end if
+        if grid is None:
+            QmcpackInput.class_error('grid must be provided for cartesian coordinates','generate_energydensity')
+        #end if
+        axes = [
+            axis(p1='a1',scale='.5',label='x'),
+            axis(p1='a2',scale='.5',label='y'),
+            axis(p1='a3',scale='.5',label='z'),
+            ]
+        n=0
+        for ax in axes:
+           ax.grid = '-1 ({0}) 1'.format(grid[n])
+           n+=1
+        #end for
+        sg.append(spacegrid(coord=coord,origin=origin(p1='zero'),axes=axes))
+    elif coord=='spherical':
+        if name is None:
+            name = 'EDatom'
+        #end if
+        if ion_grids is None:
+            QmcpackInput.class_error('ion_grids must be provided for spherical coordinates','generate_energydensity')
+        #end if
+        refp = reference_points(coord='cartesian',points='\nr1 1 0 0\nr2 0 1 0\nr3 0 0 1\n')
+        if system is None:
+            i=1
+            for scale,g1,g2,g3 in ion_grids:
+                grid = g1,g2,g3
+                axes = [
+                    axis(p1='r1',scale=scale,label='r'),
+                    axis(p1='r2',scale=scale,label='phi'),
+                    axis(p1='r3',scale=scale,label='theta'),
+                    ]
+                n=0
+                for ax in axes:
+                    ax.grid = '0 ({0}) 1'.format(grid[n])
+                    n+=1
+                #end for
+                sg.append(spacegrid(coord=coord,origin=origin(p1=static+str(i)),axes=axes))
+                i+=1
+            #end for
+        else:
+            ig = ion_grids
+            ion_grids = obj()
+            for e,s,g1,g2,g3 in ig:
+                ion_grids[e] = s,(g1,g2,g3)
+            #end for
+            missing = set(ion_grids.keys())
+            i=1
+            for e in system.structure.elem:
+                if e in ion_grids:
+                    scale,grid = ion_grids[e]
+                    axes = [
+                        axis(p1='r1',scale=scale,label='r'),
+                        axis(p1='r2',scale=scale,label='phi'),
+                        axis(p1='r3',scale=scale,label='theta'),
+                        ]
+                    n=0
+                    for ax in axes:
+                        ax.grid = '0 ({0}) 1'.format(grid[n])
+                        n+=1
+                    #end for
+                    sg.append(spacegrid(coord=coord,origin=origin(p1=static+str(i)),axes=axes))
+                    if e in missing:
+                        missing.remove(e)
+                    #end if
+                #end if
+                i+=1
+            #end for
+            if len(missing)>0:
+                QmcpackInput.class_error('ion species not found for spherical grid\nspecies not found: {0}\nspecies present: {1}'.format(sorted(missing),sorted(set(list(system.structure.elem)))),'generate_energydensity')
+            #end if
+        #end if
+    else:
+        QmcpackInput.class_error('unsupported coord type\ncoord type provided: {0}\nsupported coord types: voronoi, cartesian, spherical'.format(coord),'generate_energydensity')
+    #end if
+    ed = energydensity(
+        type       = 'EnergyDensity',
+        name       = name,
+        dynamic    = dynamic,
+        static     = static,
+        spacegrids = sg,
+        )
+    if refp is not None:
+        ed.reference_points = refp
+    #end if
+    return ed
+#end def generate_energydensity
 
 
 opt_map = dict(linear=linear,cslinear=cslinear)

--- a/nexus/library/qmcpack_input.py
+++ b/nexus/library/qmcpack_input.py
@@ -5066,7 +5066,6 @@ def generate_energydensity(
         ion_grids = None,
         system    = None,
         ):
-    type = 'EnergyDensity'
     if dynamic is None:
         dynamic = 'e'
     #end if

--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -292,6 +292,16 @@ class Simulation(NexusCore):
         inp_args = obj()
         sim_args.transfer_from(kwargs,sim_kw)
         inp_args.transfer_from(kwargs,inp_kw)
+        if 'system' in inp_args:
+            system = inp_args.system
+            if not isinstance(system,PhysicalSystem):
+                extra=''
+                if not isinstance(extra,obj):
+                    extra = '\nwith value: {0}'.format(system)
+                #end if
+                cls.class_error('invalid input for variable "system"\nsystem object must be of type PhysicalSystem\nyou provided type: {0}'.format(system.__class__.__name__)+extra)
+            #end if
+        #end if
         if 'pseudos' in inp_args and inp_args.pseudos!=None:
             pseudos = inp_args.pseudos
             # support ppset labels
@@ -320,9 +330,6 @@ class Simulation(NexusCore):
             #end if
             if 'system' in inp_args:
                 system = inp_args.system
-                if not isinstance(system,PhysicalSystem):
-                    cls.class_error('system object must be of type PhysicalSystem')
-                #end if
                 species_labels,species = system.structure.species(symbol=True)
                 pseudopotentials = nexus_core.pseudopotentials
                 for ppfile in pseudos:
@@ -417,6 +424,8 @@ class Simulation(NexusCore):
     def init_job(self):
         if self.job==None:
             self.error('job not provided.  Input field job must be set to a Job object.')
+        elif not isinstance(self.job,Job):
+            self.error('Input field job must be set to a Job object\nyou provided an object of type: {0}\nwith value: {1}'.format(self.job.__class__.__name__,self.job))
         #end if
         self.job = self.job.copy()
         self.job.initialize(self)

--- a/nexus/library/structure.py
+++ b/nexus/library/structure.py
@@ -5208,7 +5208,7 @@ def generate_structure(type='crystal',*args,**kwargs):
     elif type=='basic':
         s = Structure(*args,**kwargs)
     else:
-        Structure.class_error(str(type)+' is not a valid structure type\n  options are crystal, defect, atom, dimer, trimer, jellium, empty, or basic')
+        Structure.class_error(str(type)+' is not a valid structure type\noptions are crystal, defect, atom, dimer, trimer, jellium, empty, or basic')
     #end if
     return s
 #end def generate_structure
@@ -5530,15 +5530,19 @@ def read_structure(filepath,elem=None,format=None):
 
 
 if __name__=='__main__':
-    a = convert(5.639,'A','B')
-
-    large = generate_structure('diamond','fcc','Ge',(2,2,2),a)
-    small = generate_structure('diamond','fcc','Ge',(1,1,1),a)
-
-    large.add_kmesh((1,1,1))
-
-    kmap = large.fold(small)
+    large = generate_structure(
+        type      = 'crystal',
+        structure = 'diamond',
+        cell      = 'fcc',
+        atoms     = 'Ge',
+        constants = 5.639,
+        units     = 'A',
+        tiling    = (2,2,2),
+        kgrid     = (1,1,1),
+        kshift    = (0,0,0),
+        )
+    
+    small = large.folded_structure
 
     print small.kpoints_unit()
-
 #end if


### PR DESCRIPTION
optimal_tilematrix (structure.py) is improved in the following ways:
1) Accelerated computation of candidate tilematrix determinants for target volume matching.
2) Ability to use a mask array to restrict form of tilematrix search, e.g. only look for tilings of the form:
  x x 0
  x x 0
  0 0 x
3) Use of wigner radius to select among cells w/ equivalent inscribing radius.
4) Use of devation of cubic shape (as judged by face diagonals) to select among cells w/ equivalent wigner radius.
5) Prioritization of certain tile matrix aesthetics (diagonal, symmetric, etc) to select among cells w/ equivalent cubicity

Changes result in speedup of ~5x and superior cell selection for typical problem sets over the original algorithm.


Other minor updates include a fix for when the user provides no PhysicalSystem to a generate simulation function, the addition of a function to read an arbitrary input file and return the appropriate SimulationInput object, improved handling namespaces for qmcpack xml elements, and the ability to generate energy density xml elements with a more succinct UI.  