### PR TITLE
Fix non-MPI checkpoint and update manual

### DIFF
--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -34,7 +34,7 @@
    &   \texttt{sigmaBound          } &  double  & $\ge 0$  & 10   & parameter to cutoff large weights  \\
    &   \texttt{killnode            } &  string  & yes/other & no   & kill or reject walkers that cross nodes  \\
   % &   \texttt{benchmark           } &  string  & $\ge 0$ & 0   & number of sample \\
-   &   \texttt{reconfiguration     } &  string  & yes/pure/other & no   & fixed population t:qechnique  \\
+   &   \texttt{reconfiguration     } &  string  & yes/pure/other & no   & fixed population technique  \\
    &   \texttt{branchInterval      } &  integer  & $\ge 0$ & 1   & branching interval \\
    &   \texttt{substeps            } &  integer  & $\ge 0$ & 1   & branching interval \\
    &   \texttt{nonlocalmoves       } &  string  & yes/other & no   & run with tmoves  \\
@@ -79,7 +79,7 @@ where $N$ is the current population.
 
 \item \texttt{refEnergy}. The default reference energy is taken from the VMC run that precedes the DMC run. This value is updated to the current mean whenever branching happens.
 
-\item \texttt{feedback}. Variable used to determine how strong to react to population fluctutations when doing population control.  See the equation in energyUpdateInterval for more details.
+\item \texttt{feedback}. Variable used to determine how strong to react to population fluctuations when doing population control.  See the equation in energyUpdateInterval for more details.
 
 \item \texttt{useBareTau}. The same time step is used whether a move is rejected to not. The default is to use an effective time step when a move is rejected.
 
@@ -98,7 +98,7 @@ where $N$ is the current population.
 \item \texttt{substeps}.  Same as BranchInterval.
 
 
-\item \texttt{nonlocalmoves}. DMC driver for running Hamiltonians with non-local moves.  An typical usage is to simulate Hamitonians with non-local psuedopotentials with T-Moves.  Setting this equal to false will impose the locality approximation.
+\item \texttt{nonlocalmoves}. DMC driver for running Hamiltonians with non-local moves.  An typical usage is to simulate Hamiltonians with non-local psuedopotentials with T-Moves.  Setting this equal to false will impose the locality approximation.
 
 \item \texttt{scaleweight}. Scaling weight per Umrigar/Nightengale.  CUDA only.
 
@@ -160,22 +160,22 @@ on diffusion Monte Carlo.
 
 
 \begin{lstlisting}[caption=The following is an example of running a simulation that can be restarted . ]
-  <qmc method="dmc" move="pbyp"  checkpoint="0" dumpconfig="5">
+  <qmc method="dmc" move="pbyp"  checkpoint="0">
     <parameter name="timestep">         0.004  </parameter>
     <parameter name="blocks">           100   </parameter>
     <parameter name="steps">            400    </parameter>
   </qmc>
 \end{lstlisting}
-The flags checkpoint and dumpconfig instructs qmcpack to output walker configurations.  This also
-works in variational Monte Carlo.  This will output an h5 file with the name "projectid"."run-number".config.h5.
+The checkpoint flag instructs qmcpack to output walker configurations.  This also
+works in Variational Monte Carlo.  This will output an h5 file with the name "projectid"."run-number".config.h5.
 Check that this file exists before attempting a restart.
 To read in this file for a continuation run, specify the following:
-\begin{lstlisting}[caption=Restart (read wakers from previous run) ]
+\begin{lstlisting}[caption=Restart (read walkers from previous run) ]
  <mcwalkerset fileroot="BH.s002" version="0 6" collected="yes"/>
 \end{lstlisting}
-where, BH is the project id and s002 is the calculation number to read in the walkers from the previous run.\\
+BH is the project id and s002 is the calculation number to read in the walkers from the previous run.\\
 
-Combining VMC and DMC in a single run (and wave function optimization can be combined in this way too) is the standard way in which QMCPACK is typical run.   There is no need to run two separate jobs, as method sections can be stacked, and walkers are transfered between them.
+Combining VMC and DMC in a single run (and wave function optimization can be combined in this way too) is the standard way in which QMCPACK is typical run.   There is no need to run two separate jobs, as method sections can be stacked, and walkers are transferred between them.
 
 \begin{lstlisting}[caption=Combined VMC and DMC run ]
   <qmc method="vmc" move="pbyp" target="e">

--- a/manual/methods.tex
+++ b/manual/methods.tex
@@ -24,8 +24,8 @@
    &   \texttt{move}          &  text              &   pbyp, alle     & pbyp              & method used to move electrons \\
    &   \texttt{gpu}           &  text              &   yes, no        & dep.              & use the GPU\\
    &   \texttt{trace}         &  text              &                  & no                & ???                      \\
-   &   \texttt{checkpoints}   &  integer           &   -1, 0, n       & -1                & checkpoint frequency \\
-   &   \texttt{dumpconfig}    &  integer           &   n              & -1                & dump configuration every n step  \\
+   &   \texttt{checkpoint}   &  integer           &   -1, 0, n       & -1                & checkpoint frequency \\
+   &   \texttt{record}      &  integer           &   n              & 0                & save configuration every n steps  \\
    &   \texttt{target}        &  text              &                  &                   & ???  \\
    &   \texttt{completed}     &  text              &                  &                   & ???  \\
    &   \texttt{append}        &  text              &   yes, no        & yes               & ???  \\
@@ -39,38 +39,59 @@
 
 Additional information:
 \begin{itemize}
-\item \texttt{move}. There are two ways implemented to move electrons. The more used method is the particle-by-particle move. In this method, only one electron is moved for acception or rejection. The other method is the all-electron move, namely all the electrons are moved once for testing acception or rejection.
+\item \texttt{move}. There are two ways implemented to move electrons. The more used method is the particle-by-particle move. In this method, only one electron is moved for acceptance or rejection. The other method is the all-electron move, namely all the electrons are moved once for testing acceptance or rejection.
 
 \item \texttt{gpu}. When the executable is compiled with CUDA, the target computing device can be chosen by this switch. With a regular CPU only compilation, this option is not effective.
 
-\item \texttt{checkpoints}. If Checkpoint=``-1'' no checkpoint will be done (default setting). If Checkpoint=``0'' dump after the completion of a qmc section. When dumconfig=``n'' is present with Checkpoint=``0'', the configurations will be dumped at the end of the run (due to Checkpoint=``0''), but also at every n block. If Checkpoint=``n'', configurations will be dump every n block. 
+\item \texttt{checkpoint}.
+Enable or disable checkpointing and specify the frequency of output.  Possible values are:
+\begin{description}
+\item [-1] No checkpoint (default setting).
+\item [0] Dump after the completion of a qmc section.
+\item [n] Dump after every $n$ blocks.  Also dump at the end of the run.
+\end{description}
+%\item  ``-1'' No checkpoint (default setting).
+%\item ``0'' Dump after the completion of a qmc section.
+%\item ``n'' Dump after every $n$ blocks.  Also dump at the end of the run.
+%\end{itemize}
+%If Checkpoint=``-1'' no checkpoint will be done (default setting). If Checkpoint=``0'' dump after the completion of a qmc section. When dumconfig=``n'' is present with Checkpoint=``0'', the configurations will be dumped at the end of the run (due to Checkpoint=``0''), but also at every n block. If Checkpoint=``n'', configurations will be dump every n block. 
 
-All the dumped data will be written in a *.config.h5. The config.h5 file will contain the state of a population to continue a run including the random number sequences; the list of what is included in the .config.h5 is: number of walkers, status of the run, branch mode, energy dataset, ratio to accepted moves, ratio to proposed moves, variance dataset, vParam\{tau, taueff. E\_trial, E\_ref, Branch\_Max, BranchCutOff, BranchFilter, Sigma, Accepted\_Energy, Accepted\_Samples\}, IParam{warmumSteps, Energy\_Update\_Interval, Counter, targetwalkers, Maxwalkers, MinWalkers, Branching Interval}, Walker coordinates, Random number size, Random number sequence, version of the code.
+% TODO: Fill in more information about checkpoint/restart
+
+The particle configurations will be written to a \texttt{.config.h5} file.
+
+%Other sections of data needed for
+%restart include the random generator state, written to a \texttt{.random.xml} file.
+
+
+
+
+% I think this description refers to a previous version of the config.h5 file.  See HDFWalkerInput0.cpp.
+%All the dumped data will be written in a \texttt{*.config.h5} file. The \texttt{config.h5} file will contain the state of a population to continue a run. The list of what is included in the .config.h5 is: number of walkers, status of the run, branch mode, energy dataset, ratio to accepted moves, ratio to proposed moves, variance dataset, vParam\{tau, taueff. E\_trial, E\_ref, Branch\_Max, BranchCutOff, BranchFilter, Sigma, Accepted\_Energy, Accepted\_Samples\}, IParam{warmumSteps, Energy\_Update\_Interval, Counter, targetwalkers, Maxwalkers, MinWalkers, Branching Interval}, Walker coordinates, Random number size, Random number sequence, version of the code.
 
 \begin{lstlisting}[caption=The following is an example of running a simulation that can be restarted . ]
-  <qmc method="dmc" move="pbyp"  checkpoint="0" dumpconfig="5">
+  <qmc method="dmc" move="pbyp"  checkpoint="0"">
     <parameter name="timestep">         0.004  </parameter>
     <parameter name="blocks">           100   </parameter>
     <parameter name="steps">            400    </parameter>
   </qmc>
 \end{lstlisting}
 
-In this case, the there will be 
-The flags checkpoint and dumpconfig instructs qmcpack to output walker configurations.  This also
-works in variational Monte Carlo.  This will output an h5 file with the name "projectid"."run-number".config.h5.
+The checkpoint flag instructs qmcpack to output walker configurations.  This also
+works in Variational Monte Carlo.  This will output an h5 file with the name "projectid"."run-number".config.h5.
 Check that this file exists before attempting a restart.
 
-To continue a run, specify the following before your VM/DMC block:
-\begin{lstlisting}[caption=Restart (read wakers from previous run) ]
+To continue a run, specify the \texttt{mcwalkerset} element before your VMC/DMC block:
+\begin{lstlisting}[caption=Restart (read walkers from previous run) ]
  <mcwalkerset fileroot="BH.s002" version="0 6" collected="yes"/>
-  <qmc method="dmc" move="pbyp"  checkpoint="0" dumpconfig="5">
+  <qmc method="dmc" move="pbyp"  checkpoint="0">
     <parameter name="timestep">         0.004  </parameter>
     <parameter name="blocks">           100   </parameter>
     <parameter name="steps">            400    </parameter>
   </qmc>
 \end{lstlisting}
-where, BH is the project id and s002 is the calculation number to read in the walkers from the previous run.
+BH is the project id and s002 is the calculation number to read in the walkers from the previous run.
 
-In the project id section, make sure that the series number is different than any existing one to avoid rewriting on it. 
+In the project id section, make sure that the series number is different than any existing one to avoid overwriting it. 
 
 \end{itemize}

--- a/manual/output_overview.tex
+++ b/manual/output_overview.tex
@@ -60,3 +60,14 @@ This file contains information from the trial wavefunction about the band struct
 including the available $k$-points. This can
 be helpful in constructing trial wavefunctions.
 
+
+\section{Checkpoint and restart files}
+\subsection{The .cont.xml file}
+This file enables continuation of the run.  It is mostly a copy of the input XML file with the series number incremented, and the \texttt{mcwalkerset} element added to read the walkers from a config file.   The \texttt{.cont.xml} file is always created, but other files it depends on are only present if checkpointing is enabled.
+
+\subsection{The .config.h5 file}
+This file contains stored walker configurations.
+
+\subsection{The .random.xml file}
+This file contains the state of the random number generator to allow restarts.
+

--- a/src/Particle/tests/CMakeLists.txt
+++ b/src/Particle/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME unit_test_${SRC_DIR})
 
 
-ADD_EXECUTABLE(${UTEST_EXE} test_particle.cpp test_distance_table.cpp)
+ADD_EXECUTABLE(${UTEST_EXE} test_particle.cpp test_distance_table.cpp test_walker.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcbase qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 
 #ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")

--- a/src/Particle/tests/test_walker.cpp
+++ b/src/Particle/tests/test_walker.cpp
@@ -1,0 +1,108 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "Configuration.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "Particle/HDFWalkerOutput.h"
+#include "Particle/HDFWalkerInput_0_4.h"
+
+
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+
+typedef Walker<QMCTraits, PtclOnLatticeTraits> Walker_t;
+
+TEST_CASE("walker", "[particle]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  OhmmsInfo("testlogfile");
+
+  Walker_t w(1);
+  REQUIRE(w.R.size() == 1);
+  w.R[0] = 1.0;
+
+  REQUIRE(w.R[0][0] == Approx(1.0));
+}
+
+
+TEST_CASE("walker HDF read and write", "[particle]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate *c = OHMMS::Controller;
+  OhmmsInfo("testlogfile");
+
+  Walker_t w1(1);
+  w1.R[0] = 1.0;
+
+  Walker_t w2(1);
+  w2.R[0] = 0.5;
+
+  MCWalkerConfiguration W;
+
+
+  W.setName("electrons");
+
+  W.create(1);
+  W.R[0][0] = 0.0;
+  W.R[0][1] = 1.0;
+  W.R[0][2] = 2.0;
+
+  // This method sets ownership to false so class does not attempt to
+  // free the walker elements.
+  W.copyWalkerRefs(&w1,&w2);
+
+  REQUIRE(W.getActiveWalkers() == 2);
+
+  std::vector<int> walker_offset(c->size()+1);
+
+  walker_offset[0] = 0;
+  int offset = 2;
+  for (int i = 0; i < c->size(); i++)
+  {
+    walker_offset[i+1] = offset;
+    offset += 2;
+  }
+
+  W.setWalkerOffsets(walker_offset);
+
+  c->setName("walker_test");
+  HDFWalkerOutput hout(W, "this string apparently does nothing", c);
+  hout.dump(W, 0);
+
+  c->barrier();
+
+  MCWalkerConfiguration W2;
+  W2.setName("electrons");
+  W2.create(1);
+
+  HDFVersion version(0,4);
+  HDFWalkerInput_0_4 hinp(W2, c, version);
+  bool okay = hinp.read_hdf5("walker_test");
+  REQUIRE(okay);
+
+  REQUIRE(W2.getActiveWalkers() == 2);
+  for (int i = 0; i < 3; i++)
+  {
+    REQUIRE(W2[0]->R[0][i] == w1.R[0][i]);
+    REQUIRE(W2[1]->R[0][i] == w2.R[0][i]);
+  }
+}
+
+}

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -252,6 +252,12 @@ int WalkerControlBase::branch(int iter, MCWalkerConfiguration& W, RealType trigg
   }
   //set the global number of walkers
   W.setGlobalNumWalkers(nw_tot);
+  // Update offsets in non-MPI case, needed to ensure checkpoint outputs the correct
+  // number of configurations.
+  if (W.WalkerOffsets.size() == 2)
+  {
+    W.WalkerOffsets[1] = nw_tot;
+  }
   return nw_tot;
 }
 


### PR DESCRIPTION
Fix issue #155 
Add a unit test for write/read of .config.h5 files.  It would not have caught the previous issue, but it's a start.   This unit test also works under MPI with mpirun.

Update checkpoint-related parts of the manual to reflect the current code.