### PR TITLE
Add code coverage scripts for GCOV format

### DIFF
--- a/CMake/compareGCOV.cmake
+++ b/CMake/compareGCOV.cmake
@@ -1,0 +1,68 @@
+
+# Heavily inspired by the CTestCoverageCollectGCOV CMake module.
+# Functions for handling coverage data
+#  - create gcov files
+#  - compare multiple runs
+#  - create tar file for CDash upload
+
+# Generate gcov files from gcda and gcno files
+# Create the data.json file cdash expects
+FUNCTION(GENERATE_GCOV BINARY_DIR OUTPUT_DIR OUTPUT_BASE)
+  FILE(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+  FILE(GLOB_RECURSE GCDA_FILES "${BINARY_DIR}/*.gcda")
+
+  FOREACH(GCDA_FILE ${GCDA_FILES})
+    EXECUTE_PROCESS(COMMAND gcov -b -p ${GCDA_FILE} WORKING_DIRECTORY ${OUTPUT_DIR} OUTPUT_VARIABLE out)
+  ENDFOREACH()
+
+  FILE(WRITE ${OUTPUT_DIR}/data.json
+      "{
+        \"Source\":\"${CTEST_SOURCE_DIRECTORY}\",
+        \"Binary\":\"${CTEST_BINARY_DIRECTORY}\"
+}")
+
+ENDFUNCTION()
+
+
+# Create tar file of gcov files
+FUNCTION(CREATE_GCOV_TAR BINARY_DIRECTORY OUTPUT_DIR)
+  EXECUTE_PROCESS(COMMAND tar cfj gcov_${OUTPUT_DIR}.tar
+                  "--mtime=1970-01-01 0:0:0 UTC"
+                  ${OUTPUT_DIR}
+                  WORKING_DIRECTORY ${BINARY_DIRECTORY})
+ENDFUNCTION()
+
+
+# Clear the coverage data files in preparation for another run
+FUNCTION(CLEAR_GCDA BINARY_DIRECTORY)
+  FILE(GLOB_RECURSE GCDA_FILES "${BINARY_DIRECTORY}/*.gcda")
+  FOREACH(GCDA_FILE ${GCDA_FILES})
+    FILE(REMOVE ${GCDA_FILE})
+  ENDFOREACH()
+ENDFUNCTION()
+
+
+# Compare two coverage runs
+FUNCTION(COMPARE_GCOV BASE_DIR UNIT_DIR OUTPUT_DIR REL_OUTPUT_DIR)
+  FILE(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+  EXECUTE_PROCESS(COMMAND python ${CTEST_SOURCE_DIRECTORY}/tests/coverage/compare_gcov.py --action compare --base-dir ${BASE_DIR} --unit-dir ${UNIT_DIR} --output-dir ${OUTPUT_DIR})
+
+
+  FILE(WRITE ${OUTPUT_DIR}/data.json
+      "{
+        \"Source\":\"${CTEST_SOURCE_DIRECTORY}\",
+        \"Binary\":\"${CTEST_BINARY_DIRECTORY}\"
+}")
+
+  #FILE(RELATIVE_PATH REL_OUTPUT_DIR ${CTEST_BINARY_DIRECTORY} ${OUTPUT_DIR})
+  ##MESSAGE("*** Relative output dir = ${REL_OUTPUT_DIR}")
+
+  EXECUTE_PROCESS(COMMAND tar cfj gcov.tar
+                  "--mtime=1970-01-01 0:0:0 UTC"
+                  ${REL_OUTPUT_DIR}
+                  WORKING_DIRECTORY ${CTEST_BINARY_DIRECTORY})
+
+ENDFUNCTION()
+

--- a/CMake/ctest_script.cmake
+++ b/CMake/ctest_script.cmake
@@ -1,6 +1,6 @@
 # ctest script for building, running, and submitting the test results 
 # Usage:  ctest -s script,build
-#   build = debug / optimized / valgrind
+#   build = debug / optimized / valgrind / coverage
 # Note: this test will use use the number of processors defined in the variable N_PROCS,
 #   the enviornmental variable N_PROCS, or the number of processors availible (if not specified)
 
@@ -99,8 +99,6 @@ IF( NOT CTEST_SCRIPT_ARG )
     MESSAGE(FATAL_ERROR "No build specified: ctest -S /path/to/script,build (debug/optimized/valgrind")
 ELSEIF( ${CTEST_SCRIPT_ARG} STREQUAL "debug" )
     SET( CMAKE_BUILD_TYPE "Debug" )
-    SET( CTEST_COVERAGE_COMMAND ${COVERAGE_COMMAND} )
-    SET( ENABLE_GCOV "true" )
     SET( USE_VALGRIND FALSE )
     SET( USE_VALGRIND_MATLAB FALSE )
 ELSEIF( (${CTEST_SCRIPT_ARG} STREQUAL "optimized") OR (${CTEST_SCRIPT_ARG} STREQUAL "opt") OR (${CTEST_SCRIPT_ARG} STREQUAL "release") )
@@ -116,6 +114,18 @@ ELSEIF( ${CTEST_SCRIPT_ARG} STREQUAL "valgrind" )
     SET( USE_VALGRIND TRUE )
     SET( USE_VALGRIND_MATLAB FALSE )
     SET( USE_MATLAB 0 )
+ELSEIF( ${CTEST_SCRIPT_ARG} STREQUAL "coverage" )
+    SET( CMAKE_BUILD_TYPE "Debug" )
+    SET( CTEST_COVERAGE_COMMAND "gcov" )
+    SET( ENABLE_GCOV "true" )
+    SET( COVERAGE_OPTIONS
+  "-DCMAKE_CXX_FLAGS=--coverage"
+  "-DCMAKE_C_FLAGS=--coverage"
+  "-DCMAKE_EXE_LINKER_FLAGS=--coverage"
+  "-DCMAKE_SHARED_LINKER_FLAGS=--coverage"
+    )
+    SET( CTEST_BUILD_NAME "${CTEST_BUILD_NAME}-coverage" )
+
 ELSE()
     MESSAGE(FATAL_ERROR "Invalid build (${CTEST_SCRIPT_ARG}): ctest -S /path/to/script,build (debug/opt/valgrind")
 ENDIF()
@@ -234,6 +244,10 @@ IF ( QMC_OPTIONS )
     SET( CTEST_OPTIONS "${CTEST_OPTIONS};${QMC_OPTIONS}" )
 ENDIF()
 
+IF ( COVERAGE_OPTIONS )
+    SET( CTEST_OPTIONS "${CTEST_OPTIONS};${COVERAGE_OPTIONS}" )
+ENDIF()
+
 MESSAGE("Configure options:")
 MESSAGE("   ${CTEST_OPTIONS}")
 
@@ -250,6 +264,7 @@ CTEST_CONFIGURE(
     OPTIONS "${CTEST_OPTIONS}"
 )
 
+
 IF ( DEFINED CMAKE_TOOLCHAIN_FILE )
 #need to trigger the cmake configuration twice
 CTEST_CONFIGURE(
@@ -263,6 +278,8 @@ ENDIF()
 CTEST_BUILD()
 IF ( USE_VALGRIND )
     CTEST_MEMCHECK( EXCLUDE procs   PARALLEL_LEVEL ${N_PROCS} )
+ELSEIF (CTEST_COVERAGE_COMMAND)
+  # Skip the normal tests when doing coverage
 ELSE()
 #    CTEST_TEST( INCLUDE short PARALLEL_LEVEL ${N_PROCS} )
     IF( DEFINED TEST_PARALLEL_LEVEL )
@@ -270,9 +287,6 @@ ELSE()
     ELSE()
          CTEST_TEST( PARALLEL_LEVEL ${N_PROCS} )
     ENDIF()
-ENDIF()
-IF( CTEST_COVERAGE_COMMAND )
-    CTEST_COVERAGE()
 ENDIF()
 
 
@@ -284,6 +298,66 @@ SET( CTEST_DROP_SITE_CDASH TRUE )
 SET( DROP_SITE_CDASH TRUE )
 CTEST_SUBMIT()
 
+IF( CTEST_COVERAGE_COMMAND )
+  EXECUTE_PROCESS(COMMAND "pwd" OUTPUT_VARIABLE CURRENT_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+  #MESSAGE("Using new code coverage path in ${CTEST_SOURCE_DIRECTORY}")
+  #MESSAGE("Using new code coverage path bin: ${CTEST_BINARY_DIRECTORY}")
+  INCLUDE("${CTEST_SOURCE_DIRECTORY}/CMake/compareGCOV.cmake")
+  # Base test
+  CLEAR_GCDA(${CTEST_BINARY_DIRECTORY})
+  CTEST_TEST(INCLUDE_LABEL coverage)
+  FILE(REMOVE_RECURSE ${CTEST_BINARY_DIRECTORY}/tgcov_base)
+  GENERATE_GCOV(${CTEST_BINARY_DIRECTORY} ${CTEST_BINARY_DIRECTORY}/tgcov_base tgcov_base)
+  # Generate gcov
+  CLEAR_GCDA(${CTEST_BINARY_DIRECTORY})
+  # Remove gcda files
+  CTEST_TEST(INCLUDE_LABEL unit)
+  # Generate gcov
+  FILE(REMOVE_RECURSE ${CTEST_BINARY_DIRECTORY}/tgcov_unit)
+  GENERATE_GCOV(${CTEST_BINARY_DIRECTORY} ${CTEST_BINARY_DIRECTORY}/tgcov_unit tgcov_unit)
+  # Generate diff
+  FILE(REMOVE_RECURSE ${CTEST_BINARY_DIRECTORY}/tgcov_diff)
+  COMPARE_GCOV(${CTEST_BINARY_DIRECTORY}/tgcov_base
+               ${CTEST_BINARY_DIRECTORY}/tgcov_unit
+               ${CTEST_BINARY_DIRECTORY}/tgcov_diff
+               tgcov_diff)
+
+  # create tar file
+  CREATE_GCOV_TAR(${CTEST_BINARY_DIRECTORY} tgcov_unit)
+  CREATE_GCOV_TAR(${CTEST_BINARY_DIRECTORY} tgcov_base)
+
+  FILE(GLOB DIFF_GCOV_FILES ${CTEST_BINARY_DIRECTORY}/tgcov_diff/*.gcov)
+
+
+  SET( CTEST_BUILD_NAME_ORIGINAL "${CTEST_BUILD_NAME}")
+  SET( CTEST_BUILD_NAME "${CTEST_BUILD_NAME_ORIGINAL}-diff" )
+  CTEST_START(${CTEST_DASHBOARD})
+  IF(EXISTS "${CTEST_BINARY_DIRECTORY}/gcov.tar")
+    MESSAGE("submitting ${CTEST_BINARY_DIRECTORY}/gcov.tar")
+    CTEST_SUBMIT(CDASH_UPLOAD "${CTEST_BINARY_DIRECTORY}/gcov.tar"
+      CDASH_UPLOAD_TYPE GcovTar)
+  ENDIF()
+
+  SET( CTEST_BUILD_NAME "${CTEST_BUILD_NAME_ORIGINAL}-base" )
+  CTEST_START(${CTEST_DASHBOARD})
+
+  IF(EXISTS "${CTEST_BINARY_DIRECTORY}/gcov_tgcov_base.tar")
+    MESSAGE("submitting ${CTEST_BINARY_DIRECTORY}/gcov_tgcov_base.tar")
+    CTEST_SUBMIT(CDASH_UPLOAD "${CTEST_BINARY_DIRECTORY}/gcov_tgcov_base.tar"
+      CDASH_UPLOAD_TYPE GcovTar)
+  ENDIF()
+
+  SET( CTEST_BUILD_NAME "${CTEST_BUILD_NAME_ORIGINAL}-unit" )
+  CTEST_START(${CTEST_DASHBOARD})
+
+
+  IF(EXISTS "${CTEST_BINARY_DIRECTORY}/gcov_tgcov_unit.tar")
+    MESSAGE("submitting ${CTEST_BINARY_DIRECTORY}/gcov_tgcov_unit.tar")
+    CTEST_SUBMIT(CDASH_UPLOAD "${CTEST_BINARY_DIRECTORY}/gcov_tgcov_unit.tar"
+      CDASH_UPLOAD_TYPE GcovTar)
+  ENDIF()
+
+ENDIF()
 
 # Clean up
 # exec_program("make distclean")

--- a/tests/coverage/compare_gcov.py
+++ b/tests/coverage/compare_gcov.py
@@ -1,0 +1,507 @@
+
+import argparse
+from collections import OrderedDict, namedtuple, defaultdict
+import glob
+import os
+import sys
+import demangle
+import read_gcov
+
+def get_gcov_files(dir_name):
+  """
+    Get list of *.gcov files in a directory.  Returns list of bare filenames.
+  """
+  fs = glob.glob(os.path.join(dir_name,'*.gcov'))
+  fs = [os.path.basename(f) for f in fs]
+  return fs
+
+
+def keep_file(gcov):
+  """
+      Some files should not be considered in coverage.
+      Files to skip include system files (in /usr), the unit tests themselves
+      (in tests/ directories) and the unit test infrastructure (in external_codes/)
+  """
+  source_file = gcov.tags['Source']
+
+  path_elements = source_file.split('/')
+
+  # Only looking at specific depths of directories. This might need
+  # to be expanded, for example if unit test directories contain
+  # subdirectories.
+  try:
+    if path_elements[-2] == 'tests':
+      #print 'Unit test, skipping'
+      return False
+    if path_elements[-3] == 'external_codes':
+      #print 'External code, skipping'
+      return False
+  except IndexError:
+    pass
+
+  if source_file.startswith('/usr/'):
+    return False
+
+  return True
+
+def remove_unwanted_file(gcov, fname, dir_base):
+  if keep_file(gcov):
+    return True
+
+  if fname.endswith('.gcov'):
+    os.unlink(os.path.join(dir_base,fname))
+  else:
+    print 'Filter error, attempting to remove a non-gcov file: ',fname
+  return False
+
+# There are two locations for the source filename associated with each gcov
+# file.  First, the actual filename, without the '.gcov' suffix. If the -p
+# option to gcov is used, the full path is contained in the filename, with
+# the directory separator replaced with '#'.
+# The second location is the 'Source:' tag inside the gcov file.
+
+
+def read_and_filter_gcov_files(fnames, directory):
+  new_fnames = set()
+  gcov_map = dict()
+  for fname in fnames:
+    gcov = read_gcov.read_gcov(os.path.join(directory, fname))
+    keep = remove_unwanted_file(gcov, fname, directory)
+    if keep:
+      source_file = gcov.tags['Source']
+      new_fnames.add(fname)
+      gcov_map[fname] = gcov
+
+  return new_fnames, gcov_map
+
+
+def compare_gcov_dirs(dir_base, dir_unit):
+  base = set(get_gcov_files(dir_base))
+  unit = set(get_gcov_files(dir_unit))
+
+  base_names, base_gcov_map = read_and_filter_gcov_files(base, dir_base)
+  unit_names, unit_gcov_map = read_and_filter_gcov_files(unit, dir_unit)
+
+  both = unit.intersection(base_names)
+  only_base = base_names.difference(unit_names)
+  only_unit = unit_names.difference(base_names)
+
+  print 'Files in both: ',len(both)
+  print 'Files only in base: ',len(only_base)
+  print 'Files only in unit: ',len(only_unit)
+
+  return both, only_base, only_unit, base_gcov_map, unit_gcov_map
+
+
+def compare_gcov_files(both, only_base, only_unit, base_gcov_map, unit_gcov_map, dir_unit, dir_diff):
+  for fname in both:
+    gcov_base = base_gcov_map[fname]
+    gcov_unit = unit_gcov_map[fname]
+    gcov_diff = compute_gcov_diff(gcov_base, gcov_unit)
+    out_fname = os.path.join(dir_diff, fname)
+    if gcov_diff:
+      read_gcov.write_gcov(gcov_diff, open(out_fname, 'w'))
+
+  # completely uncovered in unit tests
+  # Assign all to unit tests
+  # Assign to diff only if some coverage in base
+  for fname in only_base:
+    gcov_base = base_gcov_map[fname]
+    handle_uncovered(gcov_base, fname, dir_diff)
+    handle_uncovered(gcov_base, fname, dir_unit, always_copy=True)
+
+def handle_uncovered(gcov_base, fname, dir_diff, always_copy=False):
+  # Need to see if there are any covered lines in the file
+  file_coverage = get_total_covered_lines(gcov_base)
+  if always_copy or file_coverage.covered > 0:
+    gcov_diff = mark_as_uncovered(gcov_base)
+    out_fname = os.path.join(dir_diff, fname)
+    if gcov_diff:
+      read_gcov.write_gcov(gcov_diff, open(out_fname, 'w'))
+
+def mark_as_uncovered(gcov_base):
+  diff_line_info = OrderedDict()
+  for line in gcov_base.line_info.iterkeys():
+    base_line = gcov_base.line_info[line]
+    Uncov_norm= '#####'
+
+    diff_count = base_line.count
+    try:
+      base_count = int(base_line.count)
+      diff_count = Uncov_norm
+    except ValueError:
+      pass
+
+    diff_line_info[line] = read_gcov.LineInfo(diff_count, line, base_line.src)
+
+  return read_gcov.GcovFile(gcov_base.fname, gcov_base.tags, diff_line_info, None, None, None, gcov_base.func_ranges)
+
+
+class FileCoverage:
+  def __init__(self, covered=0, uncovered=0, total=0):
+    self.covered = covered
+    self.uncovered = uncovered
+    self.total = total
+
+  def __add__(self, o):
+    return FileCoverage(self.covered + o.covered, self.uncovered + o.uncovered, self.total + o.total)
+
+
+class CompareCoverage:
+  def __init__(self, base=FileCoverage(), unit=FileCoverage(), rel=FileCoverage()):
+    self.base = base
+    self.unit = unit
+    self.rel = rel
+
+  def __add__(self, o):
+    return CompareCoverage(self.base + o.base, self.unit + o.unit, self.rel + o.rel)
+
+
+def get_total_covered_lines(gcov):
+  if not keep_file(gcov):
+    return 0
+
+  total_covered_lines = 0
+  total_uncovered_lines = 0
+  total_lines = 0
+
+  Nocode = '-'
+
+  for line in gcov.line_info.iterkeys():
+    base_line = gcov.line_info[line]
+
+    if base_line != Nocode:
+      total_lines += 1
+
+    base_count = 0
+    try:
+      base_count = int(base_line.count)
+    except ValueError:
+      pass
+
+    if gcov.func_ranges:
+      funcs = gcov.func_ranges.find_func(line)
+      for func_name in funcs:
+        if func_name:
+          if func_name.startswith("_GLOBAL__"):
+            base_count = 0
+          if 'static_initialization_and_destruction' in func_name:
+            base_count = 0
+
+    if base_count == 0:
+      total_uncovered_lines += 1
+    else:
+      total_covered_lines += 1
+
+  return FileCoverage(total_covered_lines, total_uncovered_lines, total_lines)
+
+
+def compute_gcov_diff(gcov_base, gcov_unit, print_diff=False, print_diff_summary=False, coverage_stats=None):
+  diff_line_info = OrderedDict()
+  if print_diff or print_diff_summary:
+    print 'file ',gcov_base.tags['Source']
+
+  total_base_count = 0
+
+  base_totals_total = 0
+  base_totals_covered = 0
+  base_totals_uncovered = 0
+
+  unit_totals_total = 0
+  unit_totals_covered = 0
+  unit_totals_uncovered = 0
+  unit_totals_rel_covered = 0
+  unit_totals_rel_uncovered = 0
+
+  for line in gcov_base.line_info.iterkeys():
+    if line not in gcov_unit.line_info:
+      print 'error, line not present: %d ,line=%s'%(line, gcov_base.line_info[line])
+    base_line = gcov_base.line_info[line]
+    unit_line = gcov_unit.line_info[line]
+
+    Uncov_norm = '#####'
+    Uncov_exp  = '====='
+    Uncov = [Uncov_norm, Uncov_exp]
+    Nocode = '-'
+    diff_count = None
+    base_count = 0
+    try:
+      base_count = int(base_line.count)
+    except ValueError:
+      pass
+
+    unit_count = 0
+    try:
+      unit_count = int(unit_line.count)
+    except ValueError:
+      pass
+
+    # Skip some compiler-added functions
+    #  Assuming base and unit are the same
+    if gcov_base.func_ranges:
+      funcs = gcov_base.func_ranges.find_func(line)
+      for func_name in funcs:
+        if func_name:
+          if func_name.startswith("_GLOBAL__"):
+            base_count = 0
+            unit_count = 0
+          if 'static_initialization_and_destruction' in func_name:
+            base_count = 0
+            unit_count = 0
+
+    total_base_count += base_count
+
+
+    if base_line.count != Nocode:
+      base_totals_total += 1
+    if base_line.count in Uncov:
+      base_totals_uncovered += 1
+    if base_count > 0:
+      base_totals_covered += 1
+
+    if unit_line.count != Nocode:
+      unit_totals_total += 1
+    if unit_line.count in Uncov:
+      unit_totals_uncovered += 1
+    if unit_count > 0:
+      unit_totals_covered += 1
+
+    line_has_diff = False
+
+    if base_line.count == Nocode and unit_line.count == Nocode:
+      diff_count = Nocode
+
+    # doesn't work well if one side is nocode and the other has count 0
+    #elif base_line.count == Nocode and unit_line.count != Nocode:
+    #  diff_count = Nocode
+    #  line_has_diff = True
+    #elif base_line.count != Nocode and unit_line.count == Nocode:
+    #  diff_count = Nocode
+    #  line_has_diff = True
+
+    elif base_line.count == Nocode and unit_count == 0:
+      diff_count = Nocode
+    elif base_count == 0 and unit_line.count == Nocode:
+      diff_count = Nocode
+
+    elif base_line.count in Uncov and unit_line.count in Uncov:
+      #diff_count = 9999   # special count to indicate uncovered in base?
+      diff_count = Nocode  # Not sure of the right solution
+
+    elif base_count != 0 and unit_count == 0:
+      diff_count = Uncov_norm
+      unit_totals_rel_uncovered += 1
+      line_has_diff = True
+    elif base_count == 0 and unit_count != 0:
+      diff_count = unit_count
+      line_has_diff = True
+    elif base_count != 0 and unit_count != 0:
+      diff_count = unit_count
+      unit_totals_rel_covered += 1
+    elif base_count == 0 and unit_count == 0:
+      diff_count = 0
+
+    if print_diff and line_has_diff:
+      if gcov_base.line_info[line].src.strip() != gcov_unit.line_info[line].src.strip():
+        print 'line diff, base: ',gcov_base.line_info[line]
+        print '     unit: ',gcov_unit.line_info[line]
+      print '%9s  %9s %6d : %s'%(base_line.count, unit_line.count, line, gcov_unit.line_info[line].src)
+    if diff_count is None:
+      print 'Unhandled case: ',line,diff_count,base_line.count,unit_line.count
+
+    diff_line_info[line] = read_gcov.LineInfo(diff_count, line, base_line.src)
+
+  if print_diff_summary:
+    print 'Base        Unit'
+    print '%4d/%-4d   %4d/%-4d  covered lines'%(base_totals_covered, base_totals_total, unit_totals_covered, unit_totals_total)
+    print '%4d/%-4d   %4d/%-4d  uncovered lines'%(base_totals_uncovered, base_totals_total, unit_totals_uncovered, unit_totals_total)
+    print '            %4d/%-4d  uncovered lines relative to base'%(unit_totals_rel_uncovered, (unit_totals_rel_uncovered+unit_totals_rel_covered))
+
+
+  if coverage_stats is not None:
+    base_coverage = FileCoverage(base_totals_covered, base_totals_uncovered, base_totals_total)
+    unit_coverage = FileCoverage(unit_totals_covered, unit_totals_uncovered, unit_totals_total)
+    rel_coverage = FileCoverage(unit_totals_rel_covered, unit_totals_rel_uncovered, unit_totals_rel_covered + unit_totals_rel_uncovered)
+
+    cc = CompareCoverage(base_coverage, unit_coverage, rel_coverage)
+    coverage_stats[gcov_base.tags['Source']] = cc
+
+  if total_base_count == 0:
+    return None
+
+  return read_gcov.GcovFile(gcov_base.fname, gcov_base.tags, diff_line_info, None, None, None, gcov_base.func_ranges)
+
+
+FunctionCoverageInfo = namedtuple('FunctionCoverageInfo',['uncovered','total','names'])
+
+def compute_gcov_func_diff(gcov_base, gcov_unit, print_diff=False, print_diff_summary=False, func_coverage_stats=None):
+  if print_diff or print_diff_summary:
+    print 'file ',gcov_base.tags['Source']
+
+  uncovered_funcs = []
+  nfunc = 0
+  for func_line in gcov_base.function_info.keys():
+    base_func = gcov_base.function_info[func_line]
+    unit_func = gcov_unit.function_info[func_line]
+
+    nfunc += len(base_func)
+
+    if len(unit_func) == 0 :
+      for idx in range(len(base_func)):
+        uncovered_funcs.append(base_func[idx].name)
+      # function summary not even printed.  Seems to be an issue with templates
+      continue
+    for idx in range(min(len(base_func), len(unit_func))):
+      if base_func[idx].called_count > 0 and unit_func[idx].called_count == 0:
+        uncovered_funcs.append(gcov_base.function_info[func_line][idx].name)
+
+  nfunc_uncovered = len(uncovered_funcs)
+  if func_coverage_stats is not None:
+    func_coverage_stats[gcov_base.tags['Source']] = FunctionCoverageInfo(nfunc_uncovered,nfunc,uncovered_funcs)
+
+
+def print_function_coverage(func_coverage):
+  print 'Function coverage'
+  for name,fc in func_coverage.iteritems():
+    print name,fc.total,fc.uncovered
+    for func in demangle.demangle(fc.names):
+      print '  ',func
+
+def by_uncovered(x,y):
+  if x[1].uncovered == y[1].uncovered:
+    return 0;
+  if x[1].uncovered > y[1].uncovered:
+    return -1
+  return 1
+
+
+def print_coverage_summary(coverage_stats):
+  sorted_keys = sorted(coverage_stats.iteritems(), cmp=by_uncovered)
+
+  for source,stats in sorted_keys:
+    percent = 0
+
+    if stats.total > 0:
+      percent = 100.0*stats.covered/stats.total
+    print source,'%4d/%-4d'%(stats.covered,stats.total),stats.uncovered,'%.2f'%percent
+
+def summarize_coverage_summary(coverage_stats):
+    by_dirs = defaultdict(FileCoverage)
+    for source, stats in coverage_stats.iteritems():
+      src = source
+      while True:
+        dirname = os.path.dirname(src)
+        if stats.total > 0:
+          #by_dirs[dirname] += stats
+          by_dirs[dirname] += stats
+        if dirname == '':
+          break
+        if os.path.basename(src) in ['src','/','build']:
+          break
+        if src == '/':
+          break
+        src = dirname
+
+    print '\n by Dir \n'
+    ordered = OrderedDict()
+    for k in sorted(by_dirs.keys()):
+      ordered[k] = by_dirs[k]
+    print_coverage_summary(ordered)
+
+def compare_gcov(fname, dir_base, dir_unit, dir_diff=None):
+  gcov_base = read_gcov.read_gcov(os.path.join(dir_base, fname))
+  gcov_unit = read_gcov.read_gcov(os.path.join(dir_unit, fname))
+  gcov_diff = compute_gcov_diff(gcov_base, gcov_unit)
+  if dir_diff and gcov_diff:
+    out_fname = os.path.join(dir_diff, fname)
+    read_gcov.write_gcov(gcov_diff, open(out_fname, 'w'))
+
+def print_gcov_diff(both, only_base, only_unit, base_gcov_map, unit_gcov_map):
+  coverage_summary = dict()
+  func_coverage_summary = dict()
+  for fname in both:
+    gcov_base = base_gcov_map[fname]
+    gcov_unit = unit_gcov_map[fname]
+    compute_gcov_diff(gcov_base, gcov_unit, print_diff_summary=False, print_diff=False, coverage_stats=coverage_summary)
+
+    #print 'Function Info'
+    compute_gcov_func_diff(gcov_base, gcov_unit, print_diff=False, func_coverage_stats=func_coverage_summary)
+
+  print '\nCompletely uncovered files (relative to base)\n'
+  for fname in only_base:
+    gcov_base = base_gcov_map[fname]
+    base_coverage = get_total_covered_lines(gcov_base)
+    if base_coverage.covered > 0:
+      unit_coverage = FileCoverage(0, 0, 0)
+      rel_coverage = FileCoverage(0, base_coverage.covered, base_coverage.covered)
+      src_name = gcov_base.tags['Source']
+      if True:
+        print src_name,'%4d/%-4d'%(base_coverage.covered, base_coverage.total)
+
+      coverage_summary[src_name] = CompareCoverage(base_coverage, unit_coverage, rel_coverage)
+
+  rel_coverage_summary = {src_name:x.rel for src_name,x in coverage_summary.iteritems()}
+  print_coverage_summary(rel_coverage_summary)
+  summarize_coverage_summary(rel_coverage_summary)
+
+
+  func_coverage_summary2 = {src_name:FileCoverage(x.total-x.uncovered, x.uncovered, x.total) for src_name,x in func_coverage_summary.iteritems()}
+  print_function_coverage(func_coverage_summary)
+  summarize_coverage_summary(func_coverage_summary2)
+
+
+
+if __name__ ==  '__main__':
+  parser = argparse.ArgumentParser(description="Compare GCOV files")
+
+  # Compare gcov files in base and unit directories and write results to output directory
+  # This is used to generate the gcov files for the CDash report
+  compare_action = ['compare','c']
+
+  # Just delete unwanted files from directory
+  process_action = ['process','p']
+
+  # Compare gcov files in base and unit directories and print results
+  diff_action = ['diff','d']
+
+  actions = compare_action + process_action + diff_action
+
+  parser.add_argument('-a','--action',default='compare',choices=actions)
+  parser.add_argument('--base-dir',
+                      required=True,
+                      help="Directory containing the input base gcov files")
+  parser.add_argument('--unit-dir',
+                      help="Directory containing the input unit test (target) gcov files")
+  parser.add_argument('--output-dir',
+                      help="Directory to write the difference gcov files")
+  parser.add_argument('-f','--file',
+                      help="Limit analysis to single file")
+  args = parser.parse_args()
+
+  if args.action in compare_action:
+    if not args.unit_dir:
+      print '--unit-dir required for compare'
+      sys.exit(1)
+
+    if not args.output_dir:
+      print '--output-dir required for compare'
+      sys.exit(1)
+
+    both, only_base, only_unit, base_gcov_map, unit_gcov_map = compare_gcov_dirs(args.base_dir, args.unit_dir)
+    compare_gcov_files(both, only_base, only_unit, base_gcov_map, unit_gcov_map, args.unit_dir, args.output_dir)
+
+  if args.action in process_action:
+    base = set(get_gcov_files(args.base_dir))
+    read_and_filter_gcov_files(base, args.base_dir)
+
+  if args.action in diff_action:
+    if not args.unit_dir:
+      print '--unit-dir required for diff'
+      sys.exit(1)
+
+    if args.file:
+      compare_gcov(args.file, args.base_dir, args.unit_dir)
+    else:
+      both, only_base, only_unit, base_gcov_map, unit_gcov_map = compare_gcov_dirs(args.base_dir, args.unit_dir)
+
+      print_gcov_diff(both, only_base, only_unit, base_gcov_map, unit_gcov_map)

--- a/tests/coverage/demangle.py
+++ b/tests/coverage/demangle.py
@@ -1,0 +1,21 @@
+
+from subprocess import *
+import sys
+
+
+def demangle(names):
+  """Run c++filt on a list of mangled C++ names.  Returns a list of unmangled names."""
+  cmd = ['c++filt']
+
+  p = Popen(cmd, stdin=PIPE,stdout=PIPE,stderr=PIPE)
+  inp = '\n'.join(names)
+  stdout, stderr = p.communicate(inp)
+  if stderr:
+    print 'stderr:',stderr
+
+  lines = stdout.split('\n')
+  return lines
+
+if __name__ == '__main__':
+  plain = demangle(sys.argv[1:])
+  print plain

--- a/tests/coverage/read_gcov.py
+++ b/tests/coverage/read_gcov.py
@@ -1,0 +1,431 @@
+
+import argparse
+from collections import namedtuple, defaultdict, OrderedDict
+import difflib
+import glob
+import json
+import os.path
+import StringIO
+import sys
+
+# See https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html or the gcov man page
+# for information on the gcov file format.
+
+FunctionSummary = namedtuple('FunctionSummary', ['name','called_count','returned','blocks_exe'])
+# name - function name (mangled if C++)
+# called_count - number of calls.  Zero if uncovered.
+# returned - percentage of calls returned - usually 0% or 100%
+# blocks_exe - percentage of basic blocks executed
+
+CallInfo = namedtuple('CallInfo', ['type','returned'])
+# Basic block exits due to calls
+
+BranchInfo = namedtuple('BranchInfo', ['type','taken','is_executed','is_fallthrough','is_throw'])
+# Basic block exits due to branches
+
+LineInfo = namedtuple('LineInfo', ['count','lineno','src'])
+# count - number of times the line was executed.
+#         Also '-' for non-executable code or '#####' or '=====' for unexecuted code
+# lineno - line number in source file
+# src - source line contents
+
+# --- Return from read_gcov
+GcovFile = namedtuple('GcovFile', ['fname', 'tags', 'line_info', 'function_info', 'call_branch_info', 'branch_info','func_ranges'])
+# fname - gcov file name
+# tags - dict mapping tag name to value (tags['Source'] is the original source file)
+# line_info - ordered dict mapping line num to LineInfo
+# function_info - dict mapping line number to list of FunctionSummary
+# call_branch_info -
+# branch_info -
+# func_ranges -  FunctionRange object that maps line numbers to function name
+
+# --- Return from summarize_all_files ---
+CoverageSummary = namedtuple('CoverageSummary', ['covered_files','uncovered_files','total_files','covered_functions','uncovered_functions', 'total_functions'])
+
+
+
+# map line #'s ranges to function
+class FunctionRange(object):
+  def __init__(self):
+    self.ranges = []
+
+  def set_range(self, func, start, end):
+    self.ranges.append( (start,end,func))
+
+  def find_func(self, line):
+    funcs = []
+    for start,end,func in self.ranges:
+      if line >= start and line <= end:
+        funcs.append(func)
+    return funcs
+
+
+def get_keyword_value(kw, pos, parts):
+    """
+        Match expected keyword to a position in an array.
+        The array 'parts' is most likely generated from splitting a line.
+        Returns the item in parts after the keyword.
+        Some keywords can have spaces, which means they occupy multiple slots in the
+        parts array.
+    """
+
+    if len(parts) < pos:
+        print 'Not enough parts in line for kw %s'%kw
+        print '   line parts: %s'%parts
+        return ''
+
+    kws = kw.split()
+    offset = len(kws)
+    for i,kw in enumerate(kws):
+        if parts[pos+i] != kw:
+            print 'error, keyword expected:%s, found: %s'%(kw, parts[pos+i])
+            print '   line parts: %s'%parts
+            return ''
+
+    if len(parts) < pos+offset:
+        print 'Not enough parts to line for kw value %s'%kw
+        print '   line parts: %s'%parts
+        return ''
+
+    return parts[pos+offset]
+
+
+
+def get_percent(s):
+    '''Convert strings of the form '<x>%' to integer'''
+
+    if len(s) == 0:
+        print 'get_percent empty string'
+        return 0
+
+    if not s.endswith('%'):
+        print 'not percent: %s'%s
+        return int(s)
+
+    if len(s) == 1:
+        return 0
+
+    return int(s[:-1])
+
+
+def read_gcov(fname):
+    with open(fname, 'r') as f:
+        line_info = OrderedDict()
+        func_info = dict()
+        func_location = defaultdict(list)  # which line does the function info follow?
+        #call_branch_location = defaultdict(list)
+        branch_location = defaultdict(list)
+        tags = OrderedDict()
+        lines_with_info = set()
+        current_src_line = 0
+        current_function = None
+        func_ranges = FunctionRange()
+        prev_function_start_line = 0
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith('function'):
+                parts = line.split()
+                func_name = get_keyword_value('function', 0, parts)
+                called_count = int(get_keyword_value('called', 2, parts))
+                ret_percent = get_percent(get_keyword_value('returned', 4, parts))
+                block_exe_percent = get_percent(get_keyword_value('blocks executed', 6, parts))
+
+                prev_function_end_line = current_src_line
+                if current_function:
+                  # Empty functions, like static initializers
+                  tmp_end = prev_function_end_line
+                  if prev_function_end_line < prev_function_start_line:
+                    tmp_end = prev_function_start_line
+                  func_ranges.set_range(current_function, prev_function_start_line, tmp_end)
+
+                current_function = func_name
+                prev_function_start_line = current_src_line + 1
+
+                fs = FunctionSummary(func_name, called_count, ret_percent, block_exe_percent)
+                func_info[func_name] = fs
+                func_location[current_src_line].append(fs)
+                lines_with_info.add(current_src_line)
+                continue
+
+            if line.startswith('call'):
+                parts = line.split()
+                exed = 0
+                if 'returned' in line:
+                    exed = get_percent(get_keyword_value('returned', 2, parts))
+                elif 'never executed' not in line:
+                    print "Unexpected value in call branch info: %s"%parts
+
+                lines_with_info.add(current_src_line)
+                branch_location[current_src_line].append(CallInfo('call', exed))
+
+                continue
+
+            if line.startswith('branch'):
+                parts = line.split()
+                taken = 0
+                is_executed = True
+                is_fallthrough = 'fallthrough' in line
+                is_throw = 'throw' in line
+                if 'taken' in line:
+                    taken = get_percent(get_keyword_value('taken', 2, parts))
+                elif 'never executed' in line:
+                    is_executed = False
+                else:
+                    print "Unexpected value in branch info: %s"%parts
+
+                lines_with_info.add(current_src_line)
+                branch_location[current_src_line].append(BranchInfo('branch', taken, is_executed, is_fallthrough, is_throw))
+                continue
+
+            parts = line.split(':')
+            exe_count = parts[0]
+
+#  Lines in .gcov files:
+#  Normal tag line (marked by line number is zero)
+#        -:    0:Source:sample.cpp
+#  Error message in tags
+#        -:    0:Source is newer than graph
+#  Normal line
+#        1:   26:  int j = 0;
+
+            if len(parts) > 1:
+                line_no = int(parts[1])
+                if line_no == 0:
+                    if parts[2] == 'Source is newer than graph':
+                      tag = 'error'
+                      value = parts[2]
+                    else:
+                      tag = parts[2]
+                      value = parts[3]
+                    tags[tag] = value
+                else:
+                    parts = line.split(':',2)
+                    current_src_line = line_no
+                    line_info[line_no] = LineInfo(exe_count, line_no, parts[2])
+            else:
+                print 'Unhandled line: ',parts
+
+    # Last function in the file
+    if current_function:
+      func_ranges.set_range(current_function, prev_function_start_line, current_src_line+1)
+
+    return GcovFile(fname, tags, line_info, func_location, None, branch_location, func_ranges)
+
+def write_gcov(gcov, f=sys.stdout):
+    for t,v in gcov.tags.iteritems():
+        if t == 'error':
+          print >>f, '%8s-:%5d:%s'%(' ', 0, v)
+        else:
+          print >>f, '%8s-:%5d:%s:%s'%(' ', 0, t, v)
+
+    for line_no, line_info in gcov.line_info.iteritems():
+        assert(line_no == line_info.lineno)
+        print >>f, '%9s:%5d:%s'%(line_info.count, line_no, line_info.src)
+        #if line_no in gcov.call_branch_info:
+        #    for i,cb in enumerate(gcov.call_branch_info[line_no]):
+        #        if cb.returned == 0:
+        #            print 'call    %d never executed'%i
+        #        else:
+        #            print 'call    %d returned %d%%'%(i, cb.returned)
+
+        if gcov.branch_info and line_no in gcov.branch_info:
+            for i,br in enumerate(gcov.branch_info[line_no]):
+                if br.type == 'call':
+                    if br.returned == 0:
+                        print >>f, 'call    %d never executed'%i
+                    else:
+                        print >>f, 'call    %d returned %d%%'%(i, br.returned)
+                elif br.type == 'branch':
+                    if not br.is_executed:
+                        print >>f, 'branch  %d never executed'%i
+                    else:
+                        ft = ''
+                        if br.is_fallthrough:
+                            ft = ' (fallthrough)'
+                        if br.is_throw:
+                            ft = ' (throw)'
+                        print >>f, 'branch  %d taken %d%%%s'%(i, br.taken, ft)
+                else:
+                    print 'unknown branch info type: ',br.type
+
+        if gcov.function_info and line_no in gcov.function_info:
+            for f1 in gcov.function_info[line_no]:
+                print >>f, 'function %s called %d returned %d%% blocks executed %d%%'%(f1.name, f1.called_count, f1.returned, f1.blocks_exe)
+
+def read_gcov_files_glob(target_dir):
+    flist = glob.glob(os.path.join(target_dir,'*.gcov'))
+    return read_gcov_files(flist)
+
+
+def read_gcov_files(flist):
+    all_files = dict()
+    for fname in flist:
+        #func_info, tags, line_info = read_gcov(fname)
+        gcov = read_gcov(fname)
+        source = gcov.tags['Source']
+        all_files[source] = gcov
+
+    return all_files
+
+
+def summarize_all_files(all_files):
+    covered_file = set()
+    uncovered_file = set()
+    covered_func = set()
+    uncovered_func = set()
+    total_files = 0
+    total_func = 0
+    for fname, val in all_files.iteritems():
+        total_files += 1
+        file_touched = False
+        for f_line_no,func_infos in val.function_info.iteritems():
+            for func_info in func_infos:
+                total_func += 1
+                if func_info.called_count == 0:
+                    if func_info.name not in covered_func:
+                        uncovered_func.add(func_info.name)
+                else:
+                    if func_info.name in uncovered_func:
+                        uncovered_func.discard(func_info.name)
+
+                    covered_func.add(func_info.name)
+                    file_touched = True
+
+        if file_touched:
+            covered_file.add(fname)
+        else:
+            uncovered_file.add(fname)
+
+    return CoverageSummary(covered_file, uncovered_file, total_files, covered_func, uncovered_func, total_func)
+
+def print_summary(cov_sum):
+    print 'Total files: %d Touched files: %d  Uncovered files:%d'% \
+            (cov_sum.total_files, len(cov_sum.covered_files), len(cov_sum.uncovered_files))
+    print 'Total func: %d  Touched func: %d   Uncovered func:%d'% \
+            (cov_sum.total_functions, len(cov_sum.covered_functions), len(cov_sum.uncovered_functions))
+
+
+def export_as_json(all_files, export_name='export.json'):
+    """
+        Write JSON in same format as llvm-cov export.
+        Only works for function summaries.
+        No source ranges.
+    """
+    root = dict()
+    root['version'] = '2.0.0'
+    root['type'] = 'convert.gcov.json.export'
+
+    file_list = []
+    func_list = []
+    for fname, gcov in all_files.iteritems():
+        file_entry = dict()
+        file_entry['filename'] = fname
+        file_entry['expansions'] = []
+        file_entry['segments'] = []
+
+        count = 0
+        covered = 0
+        func_entry = dict()
+        for func, called in gcov.function_info.iteritems():
+            func_entry['name'] = func
+            func_entry['count'] = called
+            func_entry['filenames'] = [fname]
+            func_entry['regions'] = []
+            count += 1
+            if called > 0:
+                covered += 1
+
+        percent_covered = 0
+        if count > 0:
+            percent_covered = 100*covered/count
+        func_summary = {'count':count,'covered':covered, 'percent':percent_covered}
+
+        file_entry['summary'] = {'functions':func_summary}
+        file_list.append(file_entry)
+
+        func_list.append(func_entry)
+
+    root['data'] = [{'files':file_list, 'functions':func_list}]
+    fout = open(export_name, 'w')
+    json.dump(root, fout, indent=2)
+    fout.close()
+
+if __name__ == '__main__':
+
+    desc = """
+    Read gcov files.
+
+    The --action (-a) option specifies what action to take:
+      summarize (s) - print summary of covered/uncovered lines and functions (default)
+      write (w)     - write gcov file to <input_base>.out.gcov
+      test (t)      - compare initial gcov file with file after read/write to ensure idempotency
+      export (e)    - export to json file (unfinished)
+      dump (d)      - Print sections of file to stdout
+    """
+    parser = argparse.ArgumentParser(description=desc,formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    summarize_action = ['summarize','s']
+    write_action = ['write','w']
+    export_action = ['export','e']
+    dump_action = ['dump','d']
+    test_action = ['test','t']
+    actions = summarize_action + write_action + export_action + dump_action + test_action
+    parser.add_argument('input_files',nargs='*')
+    parser.add_argument('-a','--action',default='summarize',choices=actions)
+    parser.add_argument('-o','--output')
+    args = parser.parse_args()
+
+    print 'input files = ', args.input_files
+    if args.action in summarize_action:
+        all_files = read_gcov_files(args.input_files)
+        cov_sum = summarize_all_files(all_files)
+        print_summary(cov_sum)
+
+    if args.action in export_action:
+        export_file = 'export.json'
+        if args.output:
+          export_file = args.output
+        all_files = read_gcov_files(args.input_files)
+        export_as_json(all_files, export_file)
+
+    if args.action in write_action:
+        output = '.out'
+        if args.output:
+          output = args.output
+
+        for input_file in args.input_files:
+          gcov = read_gcov(input_file)
+          output_name = input_file.replace('.gcov',output + '.gcov')
+          if input_file == output_name:
+            print 'Would overwrite input file, skipping:',input_file
+          else:
+            write_gcov(gcov, open(output_name, 'w'))
+
+    if args.action in test_action:
+        for input_file in args.input_files:
+          gcov = read_gcov(input_file)
+          output_buf = StringIO.StringIO()
+          write_gcov(gcov, output_buf)
+          #output_buf.write('extra')  # how to test the diff
+          output_buf.seek(0)
+          output_name = input_file.replace('.gcov','out.gcov')
+          input_buf = open(input_file,'r')
+          diff = difflib.context_diff(input_buf.readlines(), output_buf.readlines(),input_file,output_name)
+          for d in diff:
+            print d,
+
+    if args.action in dump_action:
+        fname = args.input_files[0]
+        gcov = read_gcov(fname)
+        print '** File tags **'
+        for k,v in gcov.tags.iteritems():
+            print k,v
+        print '** Function info **'
+        for f,c in gcov.function_info.iteritems():
+            print f,c
+        print '** line info **'
+        for lineno, c in gcov.line_info.iteritems():
+            print lineno, c
+

--- a/tests/coverage/sample.cpp
+++ b/tests/coverage/sample.cpp
@@ -1,0 +1,99 @@
+
+
+// Code to create coverage example
+/* Steps to compare a single file
+   1. g++ -O0 --coverage sample.cpp
+      This should create sample.cpp.gcno (and a.out)
+   2. Run a.out
+      This should create sample.cpp.gcda
+   3. Run gcov -b sample.cpp.gcda
+      This should create sample.cpp.gcov
+   4. Run python read-gcov.py -a test sample.cpp.gcov to ensure that read/write
+      of gcov files works correctly.
+
+   Steps to create a unit-test-like file and compare
+   1. Make directories base/, unit/, and diff/
+   2. Move previous sample.cpp.gcov file to base/ directory
+   3. Remove sample.cpp.gcda
+   4. g++ -O0 -DUNIT --coverage sample.cpp -o sample_unit
+   5. Run sample_unit
+   6. Run gcov -b sample.cpp.gcda
+   7. Move sample.cpp to unit/ directory
+   8. Use the 'diff' action to generate text-based comparisons and summaries:
+        python compare_gcov.py --action diff --base-dir base --unit-dir unit
+
+   9. Use the 'compare' action to create comparison gcov files:
+        python compare_gcov.py --action compare --base-dir base --unit-dir unit --output-dir diff
+       Now there should be sample.cpp.gcov in the diff/ directory.
+       The code in func5 (and the call site) should be listed as uncovered.
+*/
+
+
+// Should be listed as unexecutable code
+#if 0
+int unused_func()
+{
+  int i = 1;
+  return i;
+}
+#endif
+
+int func1()
+{
+  int j = 0;
+  int k = 0;
+  for (int i = 0; i < 10; i++) {
+    if (i < 5) { // branch coverage
+      j += 4;
+    }
+    k += i;
+  }
+  return k;
+}
+
+// Should be uncovered
+void func2()
+{
+  int i = 1;
+  int j = i+2;
+}
+
+int func3(bool should_throw)
+{
+  if (should_throw) {
+    throw  "An exception";
+  }
+  return 3;
+}
+
+void func4(int i)
+{
+  int j = 0;
+  try {
+    j = func3(false);
+  } catch (...) {
+    j = 3;
+  }
+
+}
+
+// covered in base, uncovered in unit
+void func5(int i)
+{
+  int j = i+1;
+}
+
+
+int main()
+{
+  int k = func1();
+  // Should not be executed, so func2 is uncovered
+  if (k < 0) {
+    func2();
+  }
+  func4(0);
+#ifndef UNIT
+  func5(1);
+#endif
+  return 0;
+}

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_coverage.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_coverage.in.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short_vmc_dmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    16 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="targetwalkers"> 16 </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  10 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   10 </parameter>
+     <parameter name="blocks">  10 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+
+</simulation>

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -329,6 +329,20 @@ ENDIF()
                     1 # DMC
                     TRUE)
 
+# Coverage test - shorter version of dmc test
+  SET(FULL_NAME "coverage-diamondC_1x1x1_pp-vmc_sdj-1-1")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+              1 1
+              TEST_ADDED
+              "qmc_short_vmc_dmc_coverage.in.xml")
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY LABELS "coverage")
+  ENDIF()
+
+
   LIST(APPEND DIAMOND2_SCALARS "totenergy" "-21.668293 0.007")
   LIST(APPEND DIAMOND2_SCALARS "kinetic" "20.065151 0.044")
   LIST(APPEND DIAMOND2_SCALARS "potential" "-41.733377 0.045")


### PR DESCRIPTION
The code coverage model measures unit test coverage relative to a baseline
run (or runs).  There are three relevant runs:
  base - the baseline run (a typical run activating features to test against)
  unit - the unit test run
  diff - the results from the scripts comparing the coverage of unit relative to base

A test using a shortened diamondC_1x1x1_pp case is used for the base.
The added test has the label 'coverage'.  It should be possible to add more tests
with the 'coverage' label and automatically expand the baseline. (The compiler
coverage code automatically accumulates data from multiple runs)

Running with more than one MPI process will have race conditions when writing the coverage
data, and will likely corrupt it.  There might be ways to address this later.

Scripts in the tests/coverage directory:
 - read_gcov.py - read and write GCOV files
                - This can test that reading and writing is idempotent (produces the same file)
                  'python read_gcov.py --action test <gcov file>' will run that test.
 - demangle.py - call c++filt to demangle function names
 - compare_gcov.py - compare gcov files from two runs and produce the relative output
                   - It can also produce text output and summary of uncovered lines and
                      uncovered functions.  The output from this needs to be cleaned up more.
 - sample.cpp - a sample file for testing coverage scripts.  Directions in the code comments.

Still to come are scripts to integrate this with CTest.