### PR TITLE
Recover RPA Jastrow 

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/Jastrow/LRBreakupUtilities.h"
 #include "QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h"
 #include "QMCWaveFunctions/Jastrow/SplineFunctors.h"
+#include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "LongRange/LRHandlerTemp.h"
 #include "LongRange/LRRPAHandlerTemp.h"
 #include "Utilities/IteratorUtility.h"
@@ -67,6 +68,7 @@ bool RPAJastrow::put(xmlNodePtr cur)
   params.add(Rs,"rs","double");
   params.add(Kc,"kc","double");
   params.put(cur);
+  app_log()<<"!!!KC = "<<Kc<<"\n";
   buildOrbital(MyName, useL, useS, rpafunc, Rs, Kc);
 //     app_log() << std::endl<<"   LongRangeForm is "<<rpafunc<< std::endl;
 //
@@ -168,21 +170,22 @@ void RPAJastrow::buildOrbital(const std::string& name, const std::string& UL
   {
     myHandler= new LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
   }
+  else if (rpafunc=="rpa")
+  {
+    myHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
+  }
+  else if (rpafunc=="dyukawa")
+  {
+    myHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
+  }
+  else if (rpafunc=="drpa")
+  {
+    myHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
+  }
   else
-    if (rpafunc=="rpa")
-    {
-      myHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
-    }
-    else
-      if (rpafunc=="dyukawa")
-      {
-        myHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
-      }
-      else
-        if (rpafunc=="drpa")
-        {
-          myHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
-        }
+  {
+    APP_ABORT("RPAJastrowBuilder::buildOrbital:  Unrecognized rpa function type.\n");
+  }
   myHandler->Breakup(targetPtcl,Rs);
   app_log() << "  Maximum K shell " << myHandler->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << myHandler->Fk.size() << std::endl;
@@ -207,33 +210,51 @@ void RPAJastrow::makeLongRange()
 
 void RPAJastrow::makeShortRange()
 {
-//     app_log()<< "  Adding Short Range part of RPA function"<< std::endl;
+     app_log()<< "  Adding Short Range part of RPA function"<< std::endl;
   //short-range uses realHandler
   Rcut = myHandler->get_rc()-0.1;
-  myGrid = new GridType;
-  int npts=static_cast<int>(Rcut/0.01)+1;
-  myGrid->set(0,Rcut,npts);
-  //create the numerical functor
+  //create numerical functor
   nfunc = new FuncType;
   SRA = new ShortRangePartAdapter<RealType>(myHandler);
   SRA->setRmax(Rcut);
-  nfunc->initialize(SRA, myGrid);
-  //Do not write the table
-  //static  int counter=0;
-  //if(IsManager && counter==0)
-  //{
-  //  char fname[32];
-  //  sprintf(fname,"%s.%d.dat",MyName.c_str(),counter++);
-  //  std::ofstream fout(fname);
-  //  for (int i = 0; i < myGrid->size(); i++) {
-  //    RealType r=(*myGrid)(i);
-  //    fout << r << "   " << nfunc->evaluate(r) << "   "
-  //      << myHandler->evaluate(r,1.0/r) << " "
-  //      << myHandler->evaluateLR(r) << std::endl;
-  //  }
-  //}
-  TwoBodyJastrowOrbital<FuncType> *j2 = new TwoBodyJastrowOrbital<FuncType>(targetPtcl,IsManager);
+//This #if is from the SoA branch.  However, I'm going to force using the new Bspline forms unless
+//a good excuse exists.  I've commented out the if/else macros for future uncommenting.  
+//#if defined(USE_BSPLINE_FUNCTOR)
+ // For when SoA branch gets merged.  
+ // J2OrbitalSoA<BsplineFunctor<RealType> > *j2 = new J2OrbitalSoA<BsplineFunctor<RealType> >(targetPtcl,IsManager);
+  TwoBodyJastrowOrbital<BsplineFunctor<RealType> > *j2 = new TwoBodyJastrowOrbital<BsplineFunctor<RealType> >(targetPtcl,IsManager);
+  size_t npts=12;
+  RealType delta=Rcut/static_cast<double>(npts);
+  std::vector<RealType> X(npts+1),Y(npts+1);
+  for(size_t i=0; i<npts; ++i)
+  {
+    X[i]=i*delta;
+    Y[i]=SRA->evaluate(X[i]);
+  }
+  X[npts]=npts*delta;
+  Y[npts]=0.0;
+  std::string functype="rpa";
+  std::string useit="no";
+  nfunc->initialize(npts,X,Y,SRA->df(0),Rcut,functype,useit);
+  for(size_t i=0; i<npts; ++i)
+  {
+    X[i]=i*delta;
+    Y[i]=SRA->evaluate(X[i]);
+    app_log()<<X[i]<<" "<<Y[i]<<" "<<nfunc->evaluate(X[i])<<"\n";
+  }
+//#else 
+//  int npts=static_cast<int>(Rcut/0.01)+1;
+//  myGrid = new GridType;
+//  myGrid->set(0,Rcut,npts);
+//  nfunc->initialize(SRA, myGrid);
+  //create the numerical functor
+
+//  TwoBodyJastrowOrbital<FuncType> *j2 = new TwoBodyJastrowOrbital<FuncType>(targetPtcl,IsManager);
+//  app_log()<<"RPAJastrow:  Made a short range functor for RPA.\n";
+//#endif
   j2->addFunc(0,0,nfunc);
+ // j2->addFunc(1,1,nfunc);
+//  j2->addFunc(0,1,nfunc);
   ShortRangeRPA=j2;
   Psi.push_back(ShortRangeRPA);
 }
@@ -285,8 +306,15 @@ RPAJastrow::evaluateLog(ParticleSet& P,
                         ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
 {
   LogValue=0.0;
+//  app_log()<<"RPAJastrow.  Calling evaluateLog!\n";
   for(int i=0; i<Psi.size(); i++)
+  {
+//    app_log()<<"   "<<i<<" "<<LogValue<<"\n";
     LogValue += Psi[i]->evaluateLog(P,G,L);
+  }
+//    app_log()<<" Final : "<<LogValue<<"\n";
+//  app_log()<<"RPAJastrow.  Calling evaluateLog!\n";
+//  app_log()<<"  LogValue="<<LogValue<<"\n";
   return LogValue;
 }
 
@@ -298,6 +326,7 @@ RPAJastrow::ratio(ParticleSet& P, int iat,
   ValueType r(1.0);
   for(int i=0; i<Psi.size(); i++)
     r *= Psi[i]->ratio(P,iat,dG,dL);
+//  app_log()<<"RPAJastrow.  Calling ratio PGL!\n";
   return r;
 }
 
@@ -307,9 +336,32 @@ RPAJastrow::ratio(ParticleSet& P, int iat)
   ValueType r(1.0);
   for(int i=0; i<Psi.size(); i++)
     r *= Psi[i]->ratio(P,iat);
+//  app_log()<<"RPAJastrow.  Calling ratio!\n";
+//  app_log()<<"  ratio="<<r<<"\n";
   return r;
 }
 
+RPAJastrow::ValueType
+RPAJastrow::ratioGrad(ParticleSet &P, int iat, GradType& g)
+{
+  ValueType r(1.0);
+  for(int i=0; i<Psi.size(); i++)
+  {
+    r*=Psi[i]->ratioGrad(P,iat,g);
+  }
+//  app_log()<<"RPAJastrow.  Calling ratioGrad!\n";
+  return r;
+}
+
+RPAJastrow::GradType
+RPAJastrow::evalGrad(ParticleSet &P, int iat)
+{
+  GradType g(0.0);
+  for(int i=0; i<Psi.size(); i++)
+    g+=Psi[i]->evalGrad(P,iat);
+//  app_log()<<"RPAJastrow.  Calling evalGrad!\n";
+  return g;
+}
 //RPAJastrow::ValueType
 //  RPAJastrow::logRatio(ParticleSet& P, int iat,
 //      ParticleSet::ParticleGradient_t& dG,
@@ -372,6 +424,7 @@ RPAJastrow::evaluateLog(ParticleSet& P,BufferType& buf)
   LogValue=0.0;
   for(int i=0; i<Psi.size(); i++)
     LogValue += Psi[i]->evaluateLog(P,buf);
+//  app_log()<<"RPAJastrow:  evaluateLog (buffer)\n";
   return LogValue;
 }
 
@@ -382,21 +435,19 @@ OrbitalBase* RPAJastrow::makeClone(ParticleSet& tpq) const
   {
     tempHandler= new LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
   }
-  else
-    if (rpafunc=="rpa")
-    {
-      tempHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-    }
-    else
-      if (rpafunc=="dyukawa")
-      {
-        tempHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-      }
-      else
-        if (rpafunc=="drpa")
-        {
-          tempHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-        }
+  else if (rpafunc=="rpa")
+  {
+    tempHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+  else if (rpafunc=="dyukawa")
+  {
+    tempHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+  else if (rpafunc=="drpa")
+  {
+    tempHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+
   RPAJastrow* myClone = new RPAJastrow(tpq,IsManager);
   myClone->setHandler(tempHandler);
   if(!DropLongRange)

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -18,6 +18,7 @@
 
 #include "QMCWaveFunctions/OrbitalBase.h"
 #include "LongRange/LRHandlerBase.h"
+#include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "QMCWaveFunctions/Jastrow/SplineFunctors.h"
 #include "QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h"
 #include "QMCWaveFunctions/Jastrow/LRBreakupUtilities.h"
@@ -34,8 +35,9 @@ namespace qmcplusplus
 struct RPAJastrow: public OrbitalBase
 {
   typedef LRHandlerBase HandlerType;
-  typedef CubicBspline<RealType,LINEAR_1DGRID,FIRSTDERIV_CONSTRAINTS> SplineEngineType;
-  typedef CubicSplineSingle<RealType,SplineEngineType> FuncType;
+  typedef BsplineFunctor<RealType> FuncType;
+//  typedef CubicBspline<RealType,LINEAR_1DGRID,FIRSTDERIV_CONSTRAINTS> SplineEngineType;
+//  typedef CubicSplineSingle<RealType,SplineEngineType> FuncType;
   typedef LinearGrid<RealType> GridType;
 
   RPAJastrow(ParticleSet& target, bool is_manager);
@@ -88,6 +90,10 @@ struct RPAJastrow: public OrbitalBase
                   ParticleSet::ParticleLaplacian_t& dL);
 
   ValueType ratio(ParticleSet& P, int iat);
+
+  ValueType ratioGrad(ParticleSet& P, int iat, GradType & g);
+
+  GradType evalGrad(ParticleSet& P, int iat);
 
   void acceptMove(ParticleSet& P, int iat);
 


### PR DESCRIPTION
This recovers the old RPA Jastrow code.  Achieved by 
1.) implementing evalGrad, ratioGrad, and evaluateLog for compatibility with recent releases (in recent memory).  
2.) Adding somewhat redundant code to handle default "USE_REAL_STRUCT_FACTOR" use case.

This passes finite-diff and ratio tests.  This is an initial staging for a more generalized RPA jastrow.  