### PR TITLE
Kspacejastrow

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.cpp
@@ -73,7 +73,6 @@ void LRTwoBodyJastrow::checkOutVariables(const opt_variables_type& active)
 
 void LRTwoBodyJastrow::resetParameters(const opt_variables_type& active)
 {
-//     if(handler) resetByHandler();
 }
 
 void LRTwoBodyJastrow::reportStatus(std::ostream& os)
@@ -82,14 +81,7 @@ void LRTwoBodyJastrow::reportStatus(std::ostream& os)
 
 void LRTwoBodyJastrow::resetTargetParticleSet(ParticleSet& P)
 {
-  // update handler as well, should there also be a reset?
   skRef=P.SK;
-  //Do not update handler and breakup
-  //if(handler)
-  //{
-  //  handler->initBreakup(P);
-  //  resetInternals();
-  //}
 }
 
 LRTwoBodyJastrow::RealType
@@ -99,7 +91,6 @@ LRTwoBodyJastrow::evaluateLog(ParticleSet& P,
 {
   RealType sum(0.0);
 #if defined(USE_REAL_STRUCT_FACTOR)
- // APP_ABORT("LRTwoBodyJastrow::evaluateLog ");
   std::copy(P.SK->rhok_r[0],P.SK->rhok_r[0]+MaxK,Rhok_r.data());
   std::copy(P.SK->rhok_i[0],P.SK->rhok_i[0]+MaxK,Rhok_i.data());
   
@@ -114,12 +105,6 @@ LRTwoBodyJastrow::evaluateLog(ParticleSet& P,
   for(int spec1=1; spec1<NumSpecies; spec1++)
     accumulate_elements(P.SK->rhok[spec1],P.SK->rhok[spec1]+MaxK,Rhok.data());
 #endif
-  //Rhok=0.0;
-  //for(int spec1=0; spec1<NumSpecies; spec1++)
-  //{
-  //  const ComplexType* restrict rhok(P.SK->rhok[spec1]);
-  //  for(int ki=0; ki<MaxK; ki++) Rhok[ki] += rhok[ki];
-  //}
   const KContainer::VContainer_t& Kcart(P.SK->KLists.kpts_cart);
   for(int iat=0; iat<NumPtcls; iat++)
   {
@@ -167,7 +152,6 @@ LRTwoBodyJastrow::evaluateLog(ParticleSet& P,
     L[iat]+=(d2U[iat]=l);
   }
   return 0.5*sum;
-  //return sum;
 }
 
 
@@ -180,7 +164,6 @@ LRTwoBodyJastrow::ratio(ParticleSet& P, int iat)
   //restore, if called should do nothing
   NeedToRestore=false;
 #if defined(USE_REAL_STRUCT_FACTOR)
-  //APP_ABORT("LRTwoBodyJastrow::ratio(ParticleSet& P, int iat)");
   const KContainer::VContainer_t& kpts(P.SK->KLists.kpts_cart);
   
   const RealType* restrict eikr_r_ptr(P.SK->eikr_r[iat]);
@@ -224,7 +207,6 @@ LRTwoBodyJastrow::ratio(ParticleSet& P, int iat)
       dd += c*(c+(*rhok_ptr).real()-(*eikr_ptr).real())
             + s*(s+(*rhok_ptr).imag()-(*eikr_ptr).imag());
     }
-    //DEBUG
     curVal += Fk_symm[ks]*dd;
   }
 #endif
@@ -309,7 +291,6 @@ LRTwoBodyJastrow::logRatio(ParticleSet& P, int iat,
       l += 1.0-rr;
       g += ii*kpts[ki];
     }
-    //debug
     curVal = Fk_symm[ks]*v;
     curGrad = Fk_symm[ks]*g;
     curLap = FkbyKK[ks]*l;
@@ -568,7 +549,6 @@ LRTwoBodyJastrow::registerData(ParticleSet& P, PooledData<RealType>& buf)
 {
   LogValue=evaluateLog(P,P.G,P.L);
 #if defined(USE_REAL_STRUCT_FACTOR)
-//  APP_ABORT("LRTwoBodyJastrow::registerData");
   eikr_r.resize(NumPtcls,MaxK);
   eikr_i.resize(NumPtcls,MaxK);
   eikr_new_r.resize(MaxK);
@@ -605,7 +585,6 @@ LRTwoBodyJastrow::updateBuffer(ParticleSet& P, PooledData<RealType>& buf,
 {
   LogValue=evaluateLog(P,P.G,P.L);
 #if defined(USE_REAL_STRUCT_FACTOR)
-//  APP_ABORT("LRTwoBodyJastrow::updateBuffer");
   for(int iat=0; iat<NumPtcls; iat++)
   {
     std::copy(P.SK->eikr_r[iat],P.SK->eikr_r[iat]+MaxK,eikr_r[iat]);
@@ -636,7 +615,6 @@ void LRTwoBodyJastrow::copyFromBuffer(ParticleSet& P, PooledData<RealType>& buf)
   buf.get(d2U.first_address(), d2U.last_address());
   buf.get(FirstAddressOfdU,LastAddressOfdU);
 #if defined(USE_REAL_STRUCT_FACTOR)
-//  APP_ABORT("LRTwoBodyJastrow::copyFromBuffer");
   for(int iat=0; iat<NumPtcls; iat++)
   {  
     std::copy(P.SK->eikr_r[iat],P.SK->eikr_r[iat]+MaxK,eikr_r[iat]);
@@ -687,7 +665,7 @@ void LRTwoBodyJastrow::resetByHandler(HandlerType* handler)
   int ish=0;
   while(ish<MaxKshell && ki<NumKpts)
   {
-    Fk_symm[ish]=Fk[ki];//-1.0*handler->Fk[ki];
+    Fk_symm[ish]=Fk[ki];
     FkbyKK[ish]=Fk_symm[ish]*skRef->KLists.ksq[ki];
     for(; ki<skRef->KLists.kshell[ish+1]; ki++)
       Fk[ki]=Fk_symm[ish];

--- a/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
@@ -57,7 +57,6 @@ class LRTwoBodyJastrow: public OrbitalBase
   RealType *LastAddressOfdU;
   StructFact* skRef;
   // handler used to do evalFk
-  //typedef RPALRHandler<RealType>::HandlerType HandlerType;
   typedef LRHandlerBase HandlerType;
   HandlerType* handler;
 
@@ -72,7 +71,6 @@ class LRTwoBodyJastrow: public OrbitalBase
   Vector<RealType> Rhok_r;
   Vector<RealType> Rhok_i;
 
-  ////Matrix<ComplexType> rhok;
   Matrix<RealType> eikr_r;
   Matrix<RealType> eikr_i;
   Vector<RealType> eikr_new_r;
@@ -84,14 +82,12 @@ class LRTwoBodyJastrow: public OrbitalBase
   Matrix<ComplexType> rokbyF;
   Vector<ComplexType> Rhok;
 
-  ////Matrix<ComplexType> rhok;
   Matrix<ComplexType> eikr;
   Vector<ComplexType> eikr_new;
   Vector<ComplexType> delta_eikr;
 #endif
   std::vector<int> Kshell;
   std::vector<RealType> FkbyKK;
-  //vector<PosType>  Kcart;
 
   void resetInternals();
   void resize();
@@ -141,7 +137,7 @@ public:
     while(ksh<maxshell)
     {
       if(kk[ik]>kcsq)
-        break; //exit
+        break; 
       ik=skRef->KLists.kshell[++ksh];
     }
     MaxKshell=ksh;
@@ -155,7 +151,7 @@ public:
     RealType u0 = -4.0*M_PI/CellVolume;
     for(ksh=0,ik=0; ksh<MaxKshell; ksh++, ik++)
     {
-      RealType v=u0*uk(kk[ik]);//rpa=u0/kk[ik];
+      RealType v=u0*uk(kk[ik]);
       Fk_symm[ksh]=v;
       FkbyKK[ksh]=kk[ik]*v;
       for(; ik<skRef->KLists.kshell[ksh+1]; ik++)

--- a/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
@@ -126,7 +126,7 @@ public:
     while(ksh<maxshell)
     {
       if(kk[ik]>kcsq)
-        break; //exit
+        break; 
       ik=skRef->KLists.kshell[++ksh];
     }
     MaxKshell=ksh;
@@ -140,7 +140,7 @@ public:
     RealType u0 = -4.0*M_PI/CellVolume;
     for(ksh=0,ik=0; ksh<MaxKshell; ksh++, ik++)
     {
-      RealType v=u0*uk(kk[ik]);//rpa=u0/kk[ik];
+      RealType v=u0*uk(kk[ik]);
       Fk_symm[ksh]=v;
       FkbyKK[ksh]=kk[ik]*v;
       for(; ik<skRef->KLists.kshell[ksh+1]; ik++)

--- a/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
@@ -66,6 +66,21 @@ class LRTwoBodyJastrow: public OrbitalBase
   Vector<RealType> offU, offd2U;
   Vector<PosType> offdU;
 
+#if defined(USE_REAL_STRUCT_FACTOR)
+  Matrix<RealType> rokbyF_r;
+  Matrix<RealType> rokbyF_i;
+  Vector<RealType> Rhok_r;
+  Vector<RealType> Rhok_i;
+
+  ////Matrix<ComplexType> rhok;
+  Matrix<RealType> eikr_r;
+  Matrix<RealType> eikr_i;
+  Vector<RealType> eikr_new_r;
+  Vector<RealType> eikr_new_i;
+  Vector<RealType> delta_eikr_r;
+  Vector<RealType> delta_eikr_i;
+
+#else
   Matrix<ComplexType> rokbyF;
   Vector<ComplexType> Rhok;
 
@@ -73,7 +88,7 @@ class LRTwoBodyJastrow: public OrbitalBase
   Matrix<ComplexType> eikr;
   Vector<ComplexType> eikr_new;
   Vector<ComplexType> delta_eikr;
-
+#endif
   std::vector<int> Kshell;
   std::vector<RealType> FkbyKK;
   //vector<PosType>  Kcart;
@@ -126,7 +141,7 @@ public:
     while(ksh<maxshell)
     {
       if(kk[ik]>kcsq)
-        break; 
+        break; //exit
       ik=skRef->KLists.kshell[++ksh];
     }
     MaxKshell=ksh;
@@ -140,7 +155,7 @@ public:
     RealType u0 = -4.0*M_PI/CellVolume;
     for(ksh=0,ik=0; ksh<MaxKshell; ksh++, ik++)
     {
-      RealType v=u0*uk(kk[ik]);
+      RealType v=u0*uk(kk[ik]);//rpa=u0/kk[ik];
       Fk_symm[ksh]=v;
       FkbyKK[ksh]=kk[ik]*v;
       for(; ik<skRef->KLists.kshell[ksh+1]; ik++)
@@ -166,9 +181,13 @@ public:
     return std::exp(logRatio(P,iat,dG,dL));
   }
 
+  ValueType ratioGrad(ParticleSet& P, int iat, GradType & g);
+
   ValueType logRatio(ParticleSet& P, int iat,
                      ParticleSet::ParticleGradient_t& dG,
                      ParticleSet::ParticleLaplacian_t& dL);
+
+  GradType evalGrad(ParticleSet& P, int iat);
 
   void restore(int iat);
   void acceptMove(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/Jastrow/LRBreakupUtilities.h"
 #include "QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h"
 #include "QMCWaveFunctions/Jastrow/SplineFunctors.h"
+#include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "LongRange/LRHandlerTemp.h"
 #include "LongRange/LRRPAHandlerTemp.h"
 #include "Utilities/IteratorUtility.h"
@@ -67,6 +68,7 @@ bool RPAJastrow::put(xmlNodePtr cur)
   params.add(Rs,"rs","double");
   params.add(Kc,"kc","double");
   params.put(cur);
+  app_log()<<"!!!KC = "<<Kc<<"\n";
   buildOrbital(MyName, useL, useS, rpafunc, Rs, Kc);
 //     app_log() << std::endl<<"   LongRangeForm is "<<rpafunc<< std::endl;
 //
@@ -168,21 +170,22 @@ void RPAJastrow::buildOrbital(const std::string& name, const std::string& UL
   {
     myHandler= new LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
   }
+  else if (rpafunc=="rpa")
+  {
+    myHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
+  }
+  else if (rpafunc=="dyukawa")
+  {
+    myHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
+  }
+  else if (rpafunc=="drpa")
+  {
+    myHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
+  }
   else
-    if (rpafunc=="rpa")
-    {
-      myHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(targetPtcl,Kc);
-    }
-    else
-      if (rpafunc=="dyukawa")
-      {
-        myHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
-      }
-      else
-        if (rpafunc=="drpa")
-        {
-          myHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(targetPtcl,Kc);
-        }
+  {
+    APP_ABORT("RPAJastrowBuilder::buildOrbital:  Unrecognized rpa function type.\n");
+  }
   myHandler->Breakup(targetPtcl,Rs);
   app_log() << "  Maximum K shell " << myHandler->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << myHandler->Fk.size() << std::endl;
@@ -207,33 +210,51 @@ void RPAJastrow::makeLongRange()
 
 void RPAJastrow::makeShortRange()
 {
-//     app_log()<< "  Adding Short Range part of RPA function"<< std::endl;
+     app_log()<< "  Adding Short Range part of RPA function"<< std::endl;
   //short-range uses realHandler
   Rcut = myHandler->get_rc()-0.1;
-  myGrid = new GridType;
-  int npts=static_cast<int>(Rcut/0.01)+1;
-  myGrid->set(0,Rcut,npts);
-  //create the numerical functor
+  //create numerical functor
   nfunc = new FuncType;
   SRA = new ShortRangePartAdapter<RealType>(myHandler);
   SRA->setRmax(Rcut);
-  nfunc->initialize(SRA, myGrid);
-  //Do not write the table
-  //static  int counter=0;
-  //if(IsManager && counter==0)
-  //{
-  //  char fname[32];
-  //  sprintf(fname,"%s.%d.dat",MyName.c_str(),counter++);
-  //  std::ofstream fout(fname);
-  //  for (int i = 0; i < myGrid->size(); i++) {
-  //    RealType r=(*myGrid)(i);
-  //    fout << r << "   " << nfunc->evaluate(r) << "   "
-  //      << myHandler->evaluate(r,1.0/r) << " "
-  //      << myHandler->evaluateLR(r) << std::endl;
-  //  }
-  //}
-  TwoBodyJastrowOrbital<FuncType> *j2 = new TwoBodyJastrowOrbital<FuncType>(targetPtcl,IsManager);
+//This #if is from the SoA branch.  However, I'm going to force using the new Bspline forms unless
+//a good excuse exists.  I've commented out the if/else macros for future uncommenting.  
+//#if defined(USE_BSPLINE_FUNCTOR)
+ // For when SoA branch gets merged.  
+ // J2OrbitalSoA<BsplineFunctor<RealType> > *j2 = new J2OrbitalSoA<BsplineFunctor<RealType> >(targetPtcl,IsManager);
+  TwoBodyJastrowOrbital<BsplineFunctor<RealType> > *j2 = new TwoBodyJastrowOrbital<BsplineFunctor<RealType> >(targetPtcl,IsManager);
+  size_t npts=12;
+  RealType delta=Rcut/static_cast<double>(npts);
+  std::vector<RealType> X(npts+1),Y(npts+1);
+  for(size_t i=0; i<npts; ++i)
+  {
+    X[i]=i*delta;
+    Y[i]=SRA->evaluate(X[i]);
+  }
+  X[npts]=npts*delta;
+  Y[npts]=0.0;
+  std::string functype="rpa";
+  std::string useit="no";
+  nfunc->initialize(npts,X,Y,SRA->df(0),Rcut,functype,useit);
+  for(size_t i=0; i<npts; ++i)
+  {
+    X[i]=i*delta;
+    Y[i]=SRA->evaluate(X[i]);
+    app_log()<<X[i]<<" "<<Y[i]<<" "<<nfunc->evaluate(X[i])<<"\n";
+  }
+//#else 
+//  int npts=static_cast<int>(Rcut/0.01)+1;
+//  myGrid = new GridType;
+//  myGrid->set(0,Rcut,npts);
+//  nfunc->initialize(SRA, myGrid);
+  //create the numerical functor
+
+//  TwoBodyJastrowOrbital<FuncType> *j2 = new TwoBodyJastrowOrbital<FuncType>(targetPtcl,IsManager);
+//  app_log()<<"RPAJastrow:  Made a short range functor for RPA.\n";
+//#endif
   j2->addFunc(0,0,nfunc);
+ // j2->addFunc(1,1,nfunc);
+//  j2->addFunc(0,1,nfunc);
   ShortRangeRPA=j2;
   Psi.push_back(ShortRangeRPA);
 }
@@ -285,8 +306,15 @@ RPAJastrow::evaluateLog(ParticleSet& P,
                         ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
 {
   LogValue=0.0;
+//  app_log()<<"RPAJastrow.  Calling evaluateLog!\n";
   for(int i=0; i<Psi.size(); i++)
+  {
+//    app_log()<<"   "<<i<<" "<<LogValue<<"\n";
     LogValue += Psi[i]->evaluateLog(P,G,L);
+  }
+//    app_log()<<" Final : "<<LogValue<<"\n";
+//  app_log()<<"RPAJastrow.  Calling evaluateLog!\n";
+//  app_log()<<"  LogValue="<<LogValue<<"\n";
   return LogValue;
 }
 
@@ -298,6 +326,7 @@ RPAJastrow::ratio(ParticleSet& P, int iat,
   ValueType r(1.0);
   for(int i=0; i<Psi.size(); i++)
     r *= Psi[i]->ratio(P,iat,dG,dL);
+//  app_log()<<"RPAJastrow.  Calling ratio PGL!\n";
   return r;
 }
 
@@ -307,9 +336,32 @@ RPAJastrow::ratio(ParticleSet& P, int iat)
   ValueType r(1.0);
   for(int i=0; i<Psi.size(); i++)
     r *= Psi[i]->ratio(P,iat);
+//  app_log()<<"RPAJastrow.  Calling ratio!\n";
+//  app_log()<<"  ratio="<<r<<"\n";
   return r;
 }
 
+RPAJastrow::ValueType
+RPAJastrow::ratioGrad(ParticleSet &P, int iat, GradType& g)
+{
+  ValueType r(1.0);
+  for(int i=0; i<Psi.size(); i++)
+  {
+    r*=Psi[i]->ratioGrad(P,iat,g);
+  }
+//  app_log()<<"RPAJastrow.  Calling ratioGrad!\n";
+  return r;
+}
+
+RPAJastrow::GradType
+RPAJastrow::evalGrad(ParticleSet &P, int iat)
+{
+  GradType g(0.0);
+  for(int i=0; i<Psi.size(); i++)
+    g+=Psi[i]->evalGrad(P,iat);
+//  app_log()<<"RPAJastrow.  Calling evalGrad!\n";
+  return g;
+}
 //RPAJastrow::ValueType
 //  RPAJastrow::logRatio(ParticleSet& P, int iat,
 //      ParticleSet::ParticleGradient_t& dG,
@@ -372,6 +424,7 @@ RPAJastrow::evaluateLog(ParticleSet& P,BufferType& buf)
   LogValue=0.0;
   for(int i=0; i<Psi.size(); i++)
     LogValue += Psi[i]->evaluateLog(P,buf);
+//  app_log()<<"RPAJastrow:  evaluateLog (buffer)\n";
   return LogValue;
 }
 
@@ -382,21 +435,19 @@ OrbitalBase* RPAJastrow::makeClone(ParticleSet& tpq) const
   {
     tempHandler= new LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRHandlerTemp<YukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
   }
-  else
-    if (rpafunc=="rpa")
-    {
-      tempHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-    }
-    else
-      if (rpafunc=="dyukawa")
-      {
-        tempHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-      }
-      else
-        if (rpafunc=="drpa")
-        {
-          tempHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
-        }
+  else if (rpafunc=="rpa")
+  {
+    tempHandler= new LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>(dynamic_cast<const LRRPAHandlerTemp<RPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+  else if (rpafunc=="dyukawa")
+  {
+    tempHandler= new LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRHandlerTemp<DerivYukawaBreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+  else if (rpafunc=="drpa")
+  {
+    tempHandler= new LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis >(dynamic_cast<const LRRPAHandlerTemp<DerivRPABreakup<RealType>,LPQHIBasis>& > (*myHandler),tpq);
+  }
+
   RPAJastrow* myClone = new RPAJastrow(tpq,IsManager);
   myClone->setHandler(tempHandler);
   if(!DropLongRange)

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -49,6 +49,10 @@ RPAJastrow::~RPAJastrow()
 bool RPAJastrow::put(xmlNodePtr cur)
 {
   ReportEngine PRE("RPAJastrow","put");
+  app_log()<<"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+  app_log()<<"!!!  WARNING:  RPAJastrow is not fully tested for production !!!\n";
+  app_log()<<"!!!      level calculations.  Use at your own risk!          !!!\n";
+  app_log()<<"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
   xmlNodePtr myNode=xmlCopyNode(cur,1);
   //capture attribute jastrow/@name
   MyName="RPA_Jee";

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -36,8 +36,6 @@ struct RPAJastrow: public OrbitalBase
 {
   typedef LRHandlerBase HandlerType;
   typedef BsplineFunctor<RealType> FuncType;
-//  typedef CubicBspline<RealType,LINEAR_1DGRID,FIRSTDERIV_CONSTRAINTS> SplineEngineType;
-//  typedef CubicSplineSingle<RealType,SplineEngineType> FuncType;
   typedef LinearGrid<RealType> GridType;
 
   RPAJastrow(ParticleSet& target, bool is_manager);

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -18,6 +18,7 @@
 
 #include "QMCWaveFunctions/OrbitalBase.h"
 #include "LongRange/LRHandlerBase.h"
+#include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "QMCWaveFunctions/Jastrow/SplineFunctors.h"
 #include "QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h"
 #include "QMCWaveFunctions/Jastrow/LRBreakupUtilities.h"
@@ -34,8 +35,9 @@ namespace qmcplusplus
 struct RPAJastrow: public OrbitalBase
 {
   typedef LRHandlerBase HandlerType;
-  typedef CubicBspline<RealType,LINEAR_1DGRID,FIRSTDERIV_CONSTRAINTS> SplineEngineType;
-  typedef CubicSplineSingle<RealType,SplineEngineType> FuncType;
+  typedef BsplineFunctor<RealType> FuncType;
+//  typedef CubicBspline<RealType,LINEAR_1DGRID,FIRSTDERIV_CONSTRAINTS> SplineEngineType;
+//  typedef CubicSplineSingle<RealType,SplineEngineType> FuncType;
   typedef LinearGrid<RealType> GridType;
 
   RPAJastrow(ParticleSet& target, bool is_manager);
@@ -88,6 +90,10 @@ struct RPAJastrow: public OrbitalBase
                   ParticleSet::ParticleLaplacian_t& dL);
 
   ValueType ratio(ParticleSet& P, int iat);
+
+  ValueType ratioGrad(ParticleSet& P, int iat, GradType & g);
+
+  GradType evalGrad(ParticleSet& P, int iat);
 
   void acceptMove(ParticleSet& P, int iat);
 


### PR DESCRIPTION
Revive RPA Jastrow.  Accomplished by doing the following:
1.)  Implementing evalGrad, ratioGrad, and evaluateLog to make evaluation consistent with current releases. 
2.)  Add redundant code to LRTwoBodyJastrow and StructFact.cpp to handle the "USE_REAL_STRUCT_FACTOR" use case.
