### PR TITLE
Resolve Issue #172

### DIFF
--- a/src/ParticleIO/ESHDFParticleParser.cpp
+++ b/src/ParticleIO/ESHDFParticleParser.cpp
@@ -109,7 +109,6 @@ bool ESHDFIonsParser::put(xmlNodePtr cur)
 
 void ESHDFIonsParser::readESHDF()
 {
-  app_log()<<"Uh Oh.  Made it to readESHDF\n";
   int nspecies=0;
   {
     HDFAttribIO<int> a(nspecies);

--- a/src/ParticleIO/ESHDFParticleParser.cpp
+++ b/src/ParticleIO/ESHDFParticleParser.cpp
@@ -53,7 +53,7 @@ bool ESHDFIonsParser::put(xmlNodePtr cur)
   int iatnumber= tspecies.addAttribute(atomic_number_tag);
   int membersize= tspecies.addAttribute("membersize");
   int massind= tspecies.addAttribute(mass_tag);
-  if(myComm->rank()==0 && hfile_id>=-1)
+  if(myComm->rank()==0 && hfile_id>=0)
     readESHDF();
   if(myComm->size()==1)
     return true;
@@ -109,6 +109,7 @@ bool ESHDFIonsParser::put(xmlNodePtr cur)
 
 void ESHDFIonsParser::readESHDF()
 {
+  app_log()<<"Uh Oh.  Made it to readESHDF\n";
   int nspecies=0;
   {
     HDFAttribIO<int> a(nspecies);

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -271,8 +271,23 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur,
     }
     //initialize ions from hdf5
     hid_t h5=-1;
+    //Rather than turn off all H5errors, we're going to
+    //temporarily disable it.
+    //
+    //old_func:  function pointer to current function that
+    //           displays when H5 encounters error.
+
+    herr_t (*old_func)(void*);
+    //old_client_data:  null pointer to associated error stream.
+    void *old_client_data;
+    //Grab the current handler info.
+    H5Eget_auto(&old_func,&old_client_data);
+    //Now kill error notifications.
+    H5Eset_auto(NULL,NULL);
     if(myComm->rank()==0)
       h5 = H5Fopen(h5name.c_str(),H5F_ACC_RDONLY,H5P_DEFAULT);
+    //and restore to defaults.  
+    H5Eset_auto(old_func, old_client_data);
     if (h5 < 0)
     {
       app_error() << "Could not open HDF5 file \"" << h5name

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -291,7 +291,9 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur,
     if (h5 < 0)
     {
       app_error() << "Could not open HDF5 file \"" << h5name
-                  << "\" in ParticleSetPool::createESParticleSet.  Aborting.\n";
+                  << "\" in ParticleSetPool::createESParticleSet.  Aborting.\n"
+                  << "(Please ensure that your path is correct, the file exists, and that "
+                  << "you have read permissions.)\n";
       APP_ABORT("ParticleSetPool::createESParticleSet");
     }
     ESHDFIonsParser ap(*ions,h5,myComm);

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -273,6 +273,12 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur,
     hid_t h5=-1;
     if(myComm->rank()==0)
       h5 = H5Fopen(h5name.c_str(),H5F_ACC_RDONLY,H5P_DEFAULT);
+    if (h5 < 0)
+    {
+      app_error() << "Could not open HDF5 file \"" << h5name
+                  << "\" in ParticleSetPool::createESParticleSet.  Aborting.\n";
+      APP_ABORT("ParticleSetPool::createESParticleSet");
+    }
     ESHDFIonsParser ap(*ions,h5,myComm);
     ap.put(cur);
     ap.expand(eshdf_tilematrix);


### PR DESCRIPTION
This should gracefully exit in the event that an h5 file is not found for particleset initialization.  Also eliminates H5 chatter, in line with Mark's suggestion.  