### PR TITLE
HTTPS required for cdash submissions

### DIFF
--- a/CMake/ctest_script.cmake
+++ b/CMake/ctest_script.cmake
@@ -291,7 +291,7 @@ ENDIF()
 
 
 # Submit the results to oblivion
-SET( CTEST_DROP_METHOD "http" )
+SET( CTEST_DROP_METHOD "https" )
 SET( CTEST_DROP_SITE "cdash.qmcpack.org" )
 SET( CTEST_DROP_LOCATION "/CDash/submit.php?project=QMCPACK" )
 SET( CTEST_DROP_SITE_CDASH TRUE )


### PR DESCRIPTION
Use SSL for cdash submissions.