### PR TITLE
Add ctests for RMC.  Also eliminate multithread chatter from RMCUpdate

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -286,8 +286,8 @@ ENDFUNCTION()
 
 FUNCTION(QMC_RUN_AND_CHECK BASE_NAME BASE_DIR PREFIX INPUT_FILE PROCS THREADS SCALAR_VALUES SERIES SHOULD_SUCCEED)
     # Map from name of check to appropriate flag for check_scalars.py
-    LIST(APPEND SCALAR_CHECK_TYPE "kinetic" "totenergy" "eeenergy" "samples" "potential" "ionion" "localecp" "nonlocalecp" "flux")
-    LIST(APPEND CHECK_SCALAR_FLAG "--ke"    "--le"      "--ee"     "--ts"    "--lp"      "--ii"       "--lpp"    "--nlpp"      "--fl")
+    LIST(APPEND SCALAR_CHECK_TYPE "kinetic" "totenergy" "eeenergy" "samples" "potential" "ionion" "localecp" "nonlocalecp" "flux" "kinetic_mixed" "kinetic_pure" "eeenergy_mixed" "eeenergy_pure" "potential_pure")
+    LIST(APPEND CHECK_SCALAR_FLAG "--ke"    "--le"      "--ee"     "--ts"    "--lp"      "--ii"       "--lpp"    "--nlpp" "--fl" "--ke_m" "--ke_p" "--ee_m" "--ee_p" "--lp_p")
 
     SET( TEST_ADDED FALSE )
     SET( FULL_NAME "${BASE_NAME}-${PROCS}-${THREADS}" )

--- a/src/QMCDrivers/RMC/RMCUpdateAll.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.cpp
@@ -83,22 +83,26 @@ namespace qmcplusplus
     if (driftoption)
       {
 	scaleDrift = true;
-	app_log () << "  Using Umrigar scaled drift\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using Umrigar scaled drift\n";
 	// H.rejectedMove(W,thisWalker);
       }
     else
       {
-	app_log () << "  Using non-scaled drift\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using non-scaled drift\n";
       }
 
     if (action == "DMC")
       {
 	actionType = DMC_ACTION;
-	app_log () << "  Using DMC link-action\n";
+	if (omp_get_thread_num()==0)
+          app_log () << "  Using DMC link-action\n";
       }
     else
       {
-	app_log () << "  Using Symmetrized Link-Action\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using Symmetrized Link-Action\n";
       }
 
     return true;

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -124,21 +124,25 @@ namespace qmcplusplus
 
     if (usedrift == true)
       {
-	app_log () << "  Using Umrigar scaled drift\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using Umrigar scaled drift\n";
       }
     else
       {
-	app_log () << "  Using non-scaled drift\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using non-scaled drift\n";
       }
 
     if (action == "DMC")
       {
 	actionType = DMC_ACTION;
-	app_log () << "  Using DMC link-action\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using DMC link-action\n";
       }
     else
       {
-	app_log () << "  Using Symmetrized Link-Action\n";
+        if (omp_get_thread_num()==0)
+	  app_log () << "  Using Symmetrized Link-Action\n";
       }
 
     return true;

--- a/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_rmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_rmc.in.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_long_vmc_rmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.77945227        0.00000000        0.00000000
+                 -0.00000000        3.77945227        0.00000000
+                 -0.00000000       -0.00000000        3.77945227
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="H" size="2" mass="1837.36221934">
+            <parameter name="charge"              >    1                     </parameter>
+            <parameter name="valence"             >    1                     </parameter>
+            <parameter name="atomicnumber"        >    1                     </parameter>
+            <parameter name="mass"                >    1837.36221934            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.88972614        1.88972614        1.88972614
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="H" size="8" cusp="1.0">
+               <coefficients id="eH" type="Array">                  
+0.00206602038 -0.002841926986 0.0036266191 -0.001913930279 8.457152991e-06 
+0.0007380321824 3.635172529e-05 0.0001299635851
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.4253416809 0.3693526685 0.2834952374 0.1923310728 0.1153317679 0.06112792407 
+0.02863622256 0.01185687423
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.5954603818 0.5062051797 0.3746940461 0.2521010502 0.1440163317 0.07796688253 
+0.03804420551 0.01449320872
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+
+    <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  0.3 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="rmc" move="pbyp" checkpoint="-1">
+     <estimator name="RMC" hdf5="no"/>
+     <parameter name="warmupSteps">  40000 </parameter>
+     <parameter name="timestep">  0.008 </parameter>
+     <parameter name="beads"> 400 </parameter>
+     <parameter name="steps">   10000 </parameter>
+     <parameter name="blocks">  1000 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+   
+</simulation>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_rmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_rmc.in.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short_vmc_rmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.77945227        0.00000000        0.00000000
+                 -0.00000000        3.77945227        0.00000000
+                 -0.00000000       -0.00000000        3.77945227
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="H" size="2" mass="1837.36221934">
+            <parameter name="charge"              >    1                     </parameter>
+            <parameter name="valence"             >    1                     </parameter>
+            <parameter name="atomicnumber"        >    1                     </parameter>
+            <parameter name="mass"                >    1837.36221934            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.88972614        1.88972614        1.88972614
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="H" size="8" cusp="1.0">
+               <coefficients id="eH" type="Array">                  
+0.00206602038 -0.002841926986 0.0036266191 -0.001913930279 8.457152991e-06 
+0.0007380321824 3.635172529e-05 0.0001299635851
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.4253416809 0.3693526685 0.2834952374 0.1923310728 0.1153317679 0.06112792407 
+0.02863622256 0.01185687423
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.5954603818 0.5062051797 0.3746940461 0.2521010502 0.1440163317 0.07796688253 
+0.03804420551 0.01449320872
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+
+    <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  0.3 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="rmc" move="pbyp" checkpoint="-1">
+     <estimator name="RMC" hdf5="no"/>
+     <parameter name="warmupSteps">  2000 </parameter>
+     <parameter name="timestep">  0.008 </parameter>
+     <parameter name="beads"> 400 </parameter>
+     <parameter name="steps">   400 </parameter>
+     <parameter name="blocks">  200 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+   
+</simulation>

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -272,7 +272,27 @@ ENDIF()
                     1 # DMC
                     TRUE)
 
+  LIST(APPEND BCC_H_RMC_SCALARS "totenergy" "-1.8420 0.0011")
+  #check RMC on 16 cores.  1 MPI
+  QMC_RUN_AND_CHECK(short-bccH_1x1x1_ae-rmc_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae"
+                    qmc_short_vmc_rmc
+                    qmc_short_vmc_rmc.in.xml
+                    1 16
+                    BCC_H_RMC_SCALARS
+                    1 #series# 
+                    TRUE)
+  #check RMC on 4 cores, 4 mpi
+  QMC_RUN_AND_CHECK(short-bccH_1x1x1_ae-rmc_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae"
+                    qmc_short_vmc_rmc
+                    qmc_short_vmc_rmc.in.xml
+                    4 4
+                    BCC_H_RMC_SCALARS
+                    1 #series#
+                    TRUE)
 
+                     
 # Plane wave test of bccH (no pp, so faster than typical solids)
 # Reduced number of blocks and samples compared to other short bccH tests
   LIST(APPEND BCC_H_PW_SCALARS "totenergy" "-1.834032 0.001")
@@ -431,8 +451,23 @@ ENDIF()
                     1 # DMC
                     TRUE)
 
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "totenergy" "-1.84150 0.00011")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "potential" "-2.01964 0.00072")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "potential_pure" "-2.01907 0.00085")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "kinetic_mixed" "0.17814 0.00073")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "kinetic_pure" "0.17063 0.00086")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "eeenergy_mixed" "-0.77991 0.00016")
+  LIST(APPEND LONG_BCC_H_RMC_SCALARS "eeenergy_pure" "-0.78335 0.00019")
+  QMC_RUN_AND_CHECK(long-bccH_1x1x1_ae-rmc_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae"
+                    qmc_long_vmc_rmc
+                    qmc_long_vmc_rmc.in.xml
+                    1 16
+                    LONG_BCC_H_RMC_SCALARS
+                    1 # DMC
+                    TRUE)
 
-
+ 
   LIST(APPEND LONG_DIAMOND_SCALARS "totenergy" "-10.491445 0.000065")
   LIST(APPEND LONG_DIAMOND_SCALARS "samples" "122880000 0.0")
   LIST(APPEND LONG_DIAMOND_SCALARS "flux" "0.0 0.03")

--- a/utils/check_scalars.py
+++ b/utils/check_scalars.py
@@ -171,6 +171,12 @@ def read_command_line():
             bw   = 'BlockWeight',
             ts   = 'TotalSamples',
             fl   = 'Flux',
+#now for some RMC estimators
+            ke_m = "Kinetic_m",
+            ke_p = "Kinetic_p",
+            ee_m = "ElecElec_m",
+            ee_p = "ElecElec_p",
+            lp_p = "LocalPotential_pure"
             )
 
         for qshort in sorted(quantities.keys()):


### PR DESCRIPTION
I've added ctests for bccH_1x1x1_ae.  Summary:
1.)  Short test that checks the local energy estimate (mixed).  
2.)  Long test that checks:
  a.) LocalEnergy.
  b.) Potential Energy (mixed and pure)
  c.) Kinetic Energy (mixed and pure)
  d.) Electron-electron energy (mixed and pure).  

On my system, RMC agrees with DMC, and the ctests reflect this (hallelujah).

As for chatter, RMC propagator info is now printed from OMP thread 0.  