### PR TITLE
Add example prefix to He examples.

### DIFF
--- a/examples/molecules/He/CMakeLists.txt
+++ b/examples/molecules/He/CMakeLists.txt
@@ -4,7 +4,7 @@ IF(NOT QMC_CUDA AND NOT QMC_COMPLEX)
 
   LIST(APPEND HE_SIMPLE_VMC_SCALARS "totenergy" "-2.83 .006") # total energy
 
-  QMC_RUN_AND_CHECK(He_simple
+  QMC_RUN_AND_CHECK(example_He_simple
                     "${CMAKE_SOURCE_DIR}/examples/molecules/He"
                     He 
                     he_simple.xml
@@ -15,7 +15,7 @@ IF(NOT QMC_CUDA AND NOT QMC_COMPLEX)
 
   LIST(APPEND HE_SIMPLE_DMC_SCALARS "totenergy" "-2.902 .002") # total energy
 
-  QMC_RUN_AND_CHECK(He_simple_dmc
+  QMC_RUN_AND_CHECK(example_He_simple_dmc
                     "${CMAKE_SOURCE_DIR}/examples/molecules/He"
                     He 
                     he_simple_dmc.xml
@@ -26,7 +26,7 @@ IF(NOT QMC_CUDA AND NOT QMC_COMPLEX)
 
   LIST(APPEND HE_SIMPLE_OPT_SCALARS "totenergy" "-2.88 .004") # total energy
 
-  QMC_RUN_AND_CHECK(He_simple_opt
+  QMC_RUN_AND_CHECK(example_He_simple_opt
                     "${CMAKE_SOURCE_DIR}/examples/molecules/He"
                     He 
                     he_simple_opt.xml
@@ -37,7 +37,7 @@ IF(NOT QMC_CUDA AND NOT QMC_COMPLEX)
 
   LIST(APPEND HE_FROM_GAMESS_SCALARS "totenergy" "-2.872 .003") # total energy
 
-  QMC_RUN_AND_CHECK(He_from_gamess
+  QMC_RUN_AND_CHECK(example_He_from_gamess
                     "${CMAKE_SOURCE_DIR}/examples/molecules/He"
                     He 
                     he_from_gamess.xml
@@ -51,7 +51,7 @@ IF(NOT QMC_CUDA AND NOT QMC_COMPLEX)
 # but the final VMC is far off.
 #  LIST(APPEND HE_BSPLINE_OPT_SCALARS "totenergy" "-2.879 .003") # total energy
 #
-#  QMC_RUN_AND_CHECK(He_bspline_opt
+#  QMC_RUN_AND_CHECK(example_He_bspline_opt
 #                    "${CMAKE_SOURCE_DIR}/examples/molecules/He"
 #                    He 
 #                    he_bspline_jastrow.xml


### PR DESCRIPTION
Add the prefix "example_" to the He example test names to make it easier to
include or exclude tests that come from the examples.

The example tests are exceptionally slow on KNL, so it would be useful to easily exclude them from test runs.