### PR TITLE
Clean up unused fillOverlapHamiltonianMatrices.

### DIFF
--- a/src/QMCDrivers/QMCCSLinearOptimizeWFmanagerOMP.h
+++ b/src/QMCDrivers/QMCCSLinearOptimizeWFmanagerOMP.h
@@ -46,8 +46,7 @@ public:
   void startOptimization();
   void resetPsi(bool final_reset=false);
   void GradCost(std::vector<Return_t>& PGradient, const std::vector<Return_t>& PM, Return_t FiniteDiff=0) {};
-  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& H2, Matrix<Return_t>& Hamiltonian
-                                          , Matrix<Return_t>& Variance, Matrix<Return_t>& Overlap)
+  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right)
   {
     return 0.0;
   }

--- a/src/QMCDrivers/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/QMCCostFunctionBase.h
@@ -163,12 +163,7 @@ public:
   bool lineoptimization(const std::vector<Return_t>& x0, const std::vector<Return_t>& gr, Return_t val0,
                         Return_t& dl, Return_t& val_proj, Return_t& lambda_max);
 
-  virtual Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& H2, Matrix<Return_t>& Hamiltonian, Matrix<Return_t>& Variance, Matrix<Return_t>& Overlap)=0;
-  virtual Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right, Matrix<Return_t>& Overlap)
-  {
-    APP_ABORT("NOT IMPLEMENTED");
-    return 1;
-  }
+  virtual Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right)=0;
 
 #ifdef HAVE_LMY_ENGINE
   Return_t LMYEngineCost(const bool needDeriv, cqmc::engine::LMYEngine * EngineObj);

--- a/src/QMCDrivers/QMCCostFunctionCUDA.h
+++ b/src/QMCDrivers/QMCCostFunctionCUDA.h
@@ -47,10 +47,7 @@ public:
   void checkConfigurations();
   void resetWalkers();   
   void GradCost(std::vector<Return_t>& PGradient, const std::vector<Return_t>& PM, Return_t FiniteDiff=0);
-  Return_t fillOverlapHamiltonianMatrices
-  (Matrix<Return_t>& H2, Matrix<Return_t>& Hamiltonian, Matrix<Return_t>& Variance, Matrix<Return_t>& Overlap);
   Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right);
-  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right, Matrix<Return_t>& Overlap);
 
 protected:
   Matrix<Return_t> Records;

--- a/src/QMCDrivers/QMCCostFunctionOMP.cpp
+++ b/src/QMCDrivers/QMCCostFunctionOMP.cpp
@@ -843,88 +843,9 @@ QMCCostFunctionOMP::Return_t QMCCostFunctionOMP::correlatedSampling(bool needGra
   return SumValue[SUM_WGT]*SumValue[SUM_WGT]/SumValue[SUM_WGTSQ];
 }
 
-QMCCostFunctionOMP::Return_t QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& H2, Matrix<Return_t>& Hamiltonian, Matrix<Return_t>& Variance, Matrix<Return_t>& Overlap)
-{
-  //     resetPsi();
-  //     Return_t NWE = NumWalkersEff=correlatedSampling(true);
-  curAvg_w = SumValue[SUM_E_WGT]/SumValue[SUM_WGT];
-  Return_t curAvg2_w = SumValue[SUM_ESQ_WGT]/SumValue[SUM_WGT];
-  std::vector<Return_t> D_avg(NumParams(),0);
-  Return_t wgtinv = 1.0/SumValue[SUM_WGT];
-  for (int ip=0; ip<NumThreads; ip++)
-  {
-    int nw=wClones[ip]->getActiveWalkers();
-    for (int iw=0; iw<nw; iw++)
-    {
-      const Return_t* restrict saved = (*RecordsOnNode[ip])[iw];
-      Return_t weight=saved[REWEIGHT]*wgtinv;
-      const Return_t* Dsaved= (*DerivRecords[ip])[iw];
-      for (int pm=0; pm<NumParams(); pm++)
-      {
-        D_avg[pm]+= Dsaved[pm]*weight;
-      }
-    }
-  }
-  myComm->allreduce(D_avg);
-  ///zero out matrices before we start
-  for (int pm=0; pm<NumParams()+1; pm++)
-  {
-    for (int pm2=0; pm2<NumParams()+1; pm2++)
-    {
-      Overlap(pm,pm2)=0;
-      Hamiltonian(pm,pm2)=0;
-      H2(pm,pm2)=0;
-      Variance(pm,pm2)=0;
-    }
-  }
-  for (int ip=0; ip<NumThreads; ip++)
-  {
-    int nw=wClones[ip]->getActiveWalkers();
-    for (int iw=0; iw<nw; iw++)
-    {
-      const Return_t* restrict saved = (*RecordsOnNode[ip])[iw];
-      Return_t weight=saved[REWEIGHT]*wgtinv;
-      Return_t eloc_new=saved[ENERGY_NEW];
-      const Return_t* Dsaved= (*DerivRecords[ip])[iw];
-      const Return_t* HDsaved= (*HDerivRecords[ip])[iw];
-      for (int pm=0; pm<NumParams(); pm++)
-      {
-        Return_t wfe = (HDsaved[pm] + Dsaved[pm]*(eloc_new - curAvg_w) )*weight;
-        Return_t wfm = (HDsaved[pm] - 2.0*Dsaved[pm]*(eloc_new - curAvg_w) )*weight;
-        Return_t wfd = (Dsaved[pm]-D_avg[pm])*weight;
-        H2(0,pm+1) += wfe*(eloc_new);
-        H2(pm+1,0) += wfe*(eloc_new);
-        Return_t vterm = HDsaved[pm]*(eloc_new-curAvg_w)+(eloc_new*eloc_new-curAvg2_w)*Dsaved[pm]-2.0*curAvg_w*Dsaved[pm]*(eloc_new - curAvg_w);
-        Variance(0,pm+1) += vterm*weight;
-        Variance(pm+1,0) += vterm*weight;
-        Hamiltonian(0,pm+1) += wfe;
-        Hamiltonian(pm+1,0) += wfd*(eloc_new-curAvg_w);
-        for (int pm2=0; pm2<NumParams(); pm2++)
-        {
-          H2(pm+1,pm2+1) += wfe*(HDsaved[pm2]+ Dsaved[pm2]*(eloc_new - curAvg_w));
-          Hamiltonian(pm+1,pm2+1) += wfd*(HDsaved[pm2]+ Dsaved[pm2]*(eloc_new-curAvg_w));
-          Variance(pm+1,pm2+1) += wfm*(HDsaved[pm2] - 2.0*Dsaved[pm2]*(eloc_new - curAvg_w));
-          Overlap(pm+1,pm2+1) += wfd*(Dsaved[pm2]-D_avg[pm2]);
-        }
-      }
-    }
-  }
-  myComm->allreduce(Hamiltonian);
-  myComm->allreduce(Overlap);
-  myComm->allreduce(Variance);
-  myComm->allreduce(H2);
-  Hamiltonian(0,0) = curAvg_w;
-  Overlap(0,0) = 1.0;
-  H2(0,0) = curAvg2_w;
-  Variance(0,0) = curAvg2_w - curAvg_w*curAvg_w;
-  for (int pm=1; pm<NumParams()+1; pm++)
-    for (int pm2=1; pm2<NumParams()+1; pm2++)
-      Variance(pm,pm2) += Variance(0,0)*Overlap(pm,pm2);
-  return 1.0;
-}
 
 QMCCostFunctionOMP::Return_t
-QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right, Matrix<Return_t>& Overlap)
+QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right)
 {
   RealType b1,b2;
   if (GEVType=="H2")
@@ -940,7 +861,6 @@ QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matri
 
   Right=0.0;
   Left=0.0;
-  Overlap=0.0;
 
   //     resetPsi();
   //     Return_t NWE = NumWalkersEff=correlatedSampling(true);
@@ -1002,7 +922,6 @@ QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matri
           //                Overlap
           RealType ovlij=wfd*(Dsaved[pm2]-D_avg[pm2]);
           Right(pm+1,pm2+1) += ovlij;
-          Overlap(pm+1,pm2+1) += ovlij;
           //                Variance
           RealType varij=weight*(HDsaved[pm] - 2.0*(Dsaved[pm]-D_avg[pm])*eloc_new)*(HDsaved[pm2] - 2.0*(Dsaved[pm2]-D_avg[pm2])*eloc_new);
           //                  RealType varij=weight*(HDsaved[pm] +(Dsaved[pm]-D_avg[pm])*eloc_new-curAvg_w)*
@@ -1016,9 +935,8 @@ QMCCostFunctionOMP::fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matri
   }
   myComm->allreduce(Right);
   myComm->allreduce(Left);
-  myComm->allreduce(Overlap);
   Left(0,0) = (1-b2)*curAvg_w + b2*V_avg;
-  Overlap(0,0) = Right(0,0) = 1.0+b1*H2_avg*V_avg;
+  Right(0,0) = 1.0+b1*H2_avg*V_avg;
   if (GEVType=="H2")
     return H2_avg;
 

--- a/src/QMCDrivers/QMCCostFunctionOMP.h
+++ b/src/QMCDrivers/QMCCostFunctionOMP.h
@@ -49,8 +49,7 @@ public:
   void resetPsi(bool final_reset=false);
   void resetWalkers();   
   void GradCost(std::vector<Return_t>& PGradient, const std::vector<Return_t>& PM, Return_t FiniteDiff=0);
-  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& H2, Matrix<Return_t>& Hamiltonian, Matrix<Return_t>& Variance, Matrix<Return_t>& Overlap);
-  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right, Matrix<Return_t>& Overlap);
+  Return_t fillOverlapHamiltonianMatrices(Matrix<Return_t>& Left, Matrix<Return_t>& Right);
 
 protected:
   std::vector<QMCHamiltonian*> H_KE_Node;


### PR DESCRIPTION
In QMCCostFunctionXXX, fillOverlapHamiltonianMatrices with 2 or 4 arguments are removed.
They were not used and probably not maintained. Contents were basically the same as 3 argument version.
3 argument version is simplified to use only 2 arguments. 2nd and 3rd matrices was identical.
In OneShiftOnly, add a small value to the overlap matrix before inversion to avoid ill-condition.