### PR TITLE
Fix AFQMC unit test for 'numerics'

### DIFF
--- a/src/AFQMC/Numerics/tests/test_sparse_ops.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_ops.cpp
@@ -81,7 +81,7 @@ TEST_CASE("sparse_matrix_mult_2x2", "[sparse_matrix]")
   B[1] = 3.0;
   C[0] = 0.0;
   C[1] = 0.0;
-  int nrows = 1;
+  int nrows = 2;
   SparseMatrixOperators::product_SpMatV(nrows, A, B, C);
 
   REQUIRE(C[0].real() == Approx(20.0));
@@ -300,11 +300,17 @@ TEST_CASE("sparse_matrix_real_mm_2x2", "[sparse_matrix]")
   B[1] = 3.0;
   B[2] = 1.0;
   B[3] = 5.0;
+  B[4] = 0.0;
+  B[5] = 0.0;
+  B[6] = 0.0;
+  B[7] = 0.0;
 
   C[0] = 2.0;
   C[1] = 1.3;
   C[2] = 1.3;
   C[3] = 1.3;
+  C[4] = 0.0;
+  C[5] = 0.0;
   double alpha = 2.0;
   double beta = 2.0;
   int ldb = N;


### PR DESCRIPTION
Need to correctly set the number of rows in the matrix in one test, and fully initialize all the input values in another.