### PR TITLE
Fix AFQMC unit test with Intel compiler.

### DIFF
--- a/src/AFQMC/Matrix/tests/test_sparse_matrix.cpp
+++ b/src/AFQMC/Matrix/tests/test_sparse_matrix.cpp
@@ -180,7 +180,9 @@ template<typename T> void test_matrix_invariant()
 
       for (int i = 0; i < m; i++) {
         for (int j = 0; j < n; j++) {
-          REQUIRE(M(i,j) == A[i*n+j]);
+          T tmp_M = M(i,j);
+          T tmp_A = A[i*n+j];
+          REQUIRE(tmp_M == tmp_A);
         }
       }
     }


### PR DESCRIPTION
The problem occurs on an empty 1x1 sparse matrix.

The problem seems to afflict the Intel compiler version 17.0.1 20161005 in release mode.
Any access to the A or M variables (to print them, for example) makes the problem disappear.
The workaround is to assign the array elements to temporary variables before testing them.