### PR TITLE
Add empty build directory.

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Two users trying to build code from manual instructions are flummoxed by lack of a "build" directory, which is referenced in manual.  Either we add an empty "build" directory, or we rewrite the incorrect sections of the manual.  