### PR TITLE
fixed VMCUpdateAll with drift

### DIFF
--- a/src/QMCDrivers/DriftOperators.h
+++ b/src/QMCDrivers/DriftOperators.h
@@ -279,7 +279,8 @@ inline void assignDrift(T tau_au, const std::vector<T>& massinv,
   for(int iat=0; iat<massinv.size(); ++iat)
   {
     T tau=tau_au*massinv[iat];
-    drift[iat]=qf[iat]*T1(tau);
+    // naive drift "tau/mass*qf" can diverge
+    getScaledDrift(tau,qf[iat],drift[iat]);
   }
 }
 


### PR DESCRIPTION
scaled drift needed for stable VMC

naive drift can diverge and lead to a precipitous drop in acceptance
rate as time step is increased