### PR TITLE
Fixes to build with GCC 7.

### DIFF
--- a/src/AFQMC/Numerics/SparseMatrixOperations.h
+++ b/src/AFQMC/Numerics/SparseMatrixOperations.h
@@ -307,7 +307,7 @@ inline T product_SpVSpVc(const int n1,const  int* indx1, const T* A1, const int 
       else if( *(indx2+j) < *(indx1+i) )
         ++j;
       else {
-        res += *(A1+i) * (std::conj(*(A2+j)));
+        res += *(A1+i) * (myconj(*(A2+j)));
         ++i;++j;
       }
     }

--- a/src/Lattice/UniformCartesianGrid.h
+++ b/src/Lattice/UniformCartesianGrid.h
@@ -150,7 +150,7 @@ public:
   */
   inline int key(int i, int j, int k) const
   {
-    return CellKey(k+NP[2]*(j+NP[1]*i));
+    return CellKey[k+NP[2]*(j+NP[1]*i)];
   }
 
   /**get a index of a domain(i,j,k)
@@ -487,7 +487,7 @@ public:
   */
   inline int key(int i, int j) const
   {
-    return CellKey(j+NP[1]*i);
+    return CellKey[j+NP[1]*i];
   }
 
   /**get a index of a domain(i,j)


### PR DESCRIPTION
The GCC 7 compiler is stricter about checking template code.
Ill-formed constructs are rejected immediately, rather than waiting for instantiation.
See https://gcc.gnu.org/gcc-7/porting_to.html

The change in AFQMC resides inside a if-check for the type.  This branch is only executed for complex types, but still needs to compile for non-complex types.   std::conj always returns a complex type, but 'myconj' will return the input type.