### PR TITLE
Add unit tests for OhmmsPETE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -311,6 +311,7 @@ else()
     #Unit test directories
     INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/external_codes/catch)
     INCLUDE(${PROJECT_SOURCE_DIR}/CMake/unit_test.cmake)
+    SUBDIRS(OhmmsPETE/tests)
     SUBDIRS(Numerics/tests)
     SUBDIRS(Utilities/tests)
     SUBDIRS(einspline/tests)

--- a/src/OhmmsPETE/tests/CMakeLists.txt
+++ b/src/OhmmsPETE/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+#//
+#// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+#//////////////////////////////////////////////////////////////////////////////////////
+
+
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
+
+SET(SRC_DIR ohmmspete)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME unit_test_${SRC_DIR})
+
+
+ADD_EXECUTABLE(${UTEST_EXE} test_vector.cpp test_matrix.cpp test_tinyvector.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} ${QMC_UTIL_LIBS})
+
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit")
+

--- a/src/OhmmsPETE/tests/test_matrix.cpp
+++ b/src/OhmmsPETE/tests/test_matrix.cpp
@@ -1,0 +1,61 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "OhmmsPETE/OhmmsMatrix.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+
+TEST_CASE("matrix", "[OhmmsPETE]")
+{
+  typedef Matrix<double> mat_t;
+  mat_t A(3,3);
+  mat_t B(3,3);
+  mat_t C(3,3);
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      B(i,j) = (i+j)*2.1;
+    }
+  }
+
+  // Assign to all elements
+  A = 1.0;
+
+  // Assignment.   This eventually generates a call to 'evaluate' in OhmmsVector.h
+  C = A;
+
+  // *= operator in OhmmMatrixOperators.h
+  A *= 3.1;
+
+  // iterator
+  mat_t::iterator ia = A.begin();
+  for (; ia != A.end(); ia++) {
+    REQUIRE(*ia == Approx(3.1));
+  }
+
+  // copy constructor and copy method
+  mat_t D(C);
+  REQUIRE(D.rows() == 3);
+  REQUIRE(D.cols() == 3);
+
+}
+
+}

--- a/src/OhmmsPETE/tests/test_tinyvector.cpp
+++ b/src/OhmmsPETE/tests/test_tinyvector.cpp
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "OhmmsPETE/TinyVector.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+
+bool pass = true;
+namespace qmcplusplus
+{
+
+template<unsigned int D>
+void test_tiny_vector()
+{
+  typedef TinyVector<double, D> vec_t;
+
+  vec_t v1;
+  // default constructor sets elements to zero
+  for (int i = 0; i < D; i++) {
+    REQUIRE(v1[i] == Approx(0.0));
+  }
+
+  vec_t v2(1.0);
+  // single constructor sets all the elements to that value
+  for (int i = 0; i < D; i++) {
+    REQUIRE(v2[i] == Approx(1.0));
+  }
+
+  if (D > 1) {
+    vec_t v3(1.0, 2.0);
+    REQUIRE(v3[0] == Approx(1.0));
+    REQUIRE(v3[1] == Approx(2.0));
+    // problem: elements past those explicitly set are undefined
+    // in this case, vectors with D > 2 will have undefined elements.
+  }
+
+  // TODO: add optional bounds checks to element access methods
+  vec_t v4;
+  double sum = 0;
+  for (int i = 0; i < D; i++) {
+    sum += 1.0*i;
+    v4[i] = 1.0*i;
+  }
+
+  // Dot product
+  double dotp = dot(v2, v4);
+  REQUIRE(sum == Approx(dotp));
+}
+
+
+TEST_CASE("tiny vector", "[OhmmsPETE]")
+{
+  test_tiny_vector<1>();
+  test_tiny_vector<2>();
+  test_tiny_vector<3>();
+  test_tiny_vector<4>();
+}
+
+}

--- a/src/OhmmsPETE/tests/test_vector.cpp
+++ b/src/OhmmsPETE/tests/test_vector.cpp
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "OhmmsPETE/OhmmsVector.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+
+TEST_CASE("vector", "[OhmmsPETE]")
+{
+  typedef Vector<double> vec_t;
+  vec_t A(3);
+  vec_t B(3);
+
+  // iterator
+  vec_t::iterator ia = A.begin();
+  for (; ia != A.end(); ia++) {
+    *ia = 1.0;
+  }
+
+  // Assignment.   This eventually generates a call to 'evaluate' in OhmmsVector.h
+  //  To do: pointer to tutorial on expression template techniques
+  B = A;
+
+  // *= operator in OhmmVectorOperators.h
+  B *= 3.1;
+
+  REQUIRE(B[0] == Approx(3.1));
+  REQUIRE(B[1] == Approx(3.1));
+  REQUIRE(B[2] == Approx(3.1));
+
+}
+
+
+}


### PR DESCRIPTION
The particular code tested was driven by code coverage results.  Relative to the current base test, the OhmmsPETE and PETE directories should be covered by unit tests.

No tests for TinyMatrix added because it doesn't appear to be used in the code.