### PR TITLE
Add DMC tests and reference data for LiH solid at Gamma/X/Arb twists

### DIFF
--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_short_LiH-arb" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_short_LiH-gamma" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_short_LiH-x" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_short_LiH-arb" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_short_LiH-gamma" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_short_LiH-x" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  400 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.out
@@ -1,0 +1,511 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 52170 MB
+  Input file(s): hf_vmc_dmc_ref_LiH-arb.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmc_ref_LiH-arb.xml
+
+  Project = hf_vmc_dmc_ref_LiH-arb
+  date    = 2017-05-23 10:36:15 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 223
+  Random number offset = 223  seeds = 1427-1523
+        1427        1429        1433        1439        1447        1451        1453        1459
+        1471        1481        1483        1487        1489        1493        1499        1511
+        1523        1531
+  Random seeds Node = 0:        1429        1433        1439        1447        1451        1453        1459        1471        1481        1483        1487        1489        1493        1499        1511        1523
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.001378059387
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 1.907348633e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [  -0.10000  -0.20000  -0.30000 ]
+  Using supercell twist 0:  [  -0.10000  -0.20000  -0.30000]
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineC2CPackedAdoptor
+  Using complex einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (68, 68, 68)
+Maxmimum number of Gvecs 14397
+  Using meshsize=                68                68                68
+  vs input meshsize=                68                68                68
+  SplineAdoptorReader initialize_spline_pio 0.08211684227 sec
+MEMORY increase 10 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 10 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.09370803833
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013083e-15
+   Constant of PBCAB 0.3037585421
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906612
+   PBCAA total constant -7.633785883
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762645
+   PBCAA total constant -3.144641916
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -5.0712042786e+00  4.0905078696e+00  4.8068604060e+00
+    u -4.0980128020e+00  3.0520254919e+00  3.2169967681e+00
+    d -4.0586179677e+00  4.7077035505e+00  3.8591194634e+00
+    d -2.2179221692e+00  3.1601219032e+00  4.6132602315e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmc_ref_LiH-arb.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 182 in base precision, in total 1456 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.45994
+    reference variance = 0.850283
+====================================================
+  QMC Execution time = 3.4481e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmc_ref_LiH-arb.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.4599e+00
+  reference energy = -8.4599e+00
+  Feedback = 1.0000e+00
+  reference variance = 8.5028e-01
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -8.45141
+  Energy Variance = 0.868799
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 1.7045e-02 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9962e-04
+ TauEff/Tau = 9.9962e-01
+  Etrial     = -8.2950e+00
+ Running average of energy = -8.3713e+00
+                  Variance = 1.3218e+00
+branch cutoff = 1.3218e+01 1.9826e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999573
+    trial energy                  = -8.48851
+    reference energy              = -8.45396
+    reference variance            = 1.32175
+    target walkers                = 256
+    branch cutoff                 = 13.2175 19.8263
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 4.6710e+03 secs 
+  Total Execution time = 4.6713e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmc_ref_LiH-arb.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmc_ref_LiH-arb  series 1 
+  LocalEnergy           =          -8.45401 +/-          0.00070 
+  Variance              =            1.3947 +/-           0.0054 
+  Kinetic               =            7.4989 +/-           0.0070 
+  LocalPotential        =          -15.9529 +/-           0.0071 
+  ElecElec              =           -0.5540 +/-           0.0013 
+  LocalECP              =          -11.7096 +/-           0.0080 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.175 +/-            0.015 
+  LocalEnergy_sq        =            72.867 +/-            0.012 
+  BlockWeight           =          25533.65 +/-            43.43 
+  BlockCPU              =             0.468 +/-            0.015 
+  AcceptRatio           =        0.99975115 +/-       0.00000049 
+  Efficiency            =             62.26 +/-             0.00 
+  TotalTime             =           4662.72 +/-             0.00 
+  TotalSamples          =         254647058 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_ref_LiH-arb" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.out
@@ -1,0 +1,515 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 52152 MB
+  Input file(s): hf_vmc_dmc_ref_LiH-gamma.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmc_ref_LiH-gamma.xml
+
+  Project = hf_vmc_dmc_ref_LiH-gamma
+  date    = 2017-05-23 10:36:01 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 209
+  Random number offset = 209  seeds = 1297-1433
+        1297        1301        1303        1307        1319        1321        1327        1361
+        1367        1373        1381        1399        1409        1423        1427        1429
+        1433        1439
+  Random seeds Node = 0:        1301        1303        1307        1319        1321        1327        1361        1367        1373        1381        1399        1409        1423        1427        1429        1433
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.001571178436
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 1.907348633e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [   0.00000   0.00000   0.00000 ]
+  Using supercell twist 0:  [   0.00000   0.00000   0.00000]
+Using 1 copies of twist angle [-0.000, -0.000, -0.000]
+Using real orbitals.
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineR2RAdoptor
+  Using real einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+  TwistIndex = 0 TwistAngle                 -0                -0                -0
+   HalfG =                  0                 0                 0
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (64, 64, 64)
+Maxmimum number of Gvecs 14331
+  Using meshsize=                64                64                64
+  vs input meshsize=                64                64                64
+  SplineAdoptorReader initialize_spline_pio 0.03134799004 sec
+MEMORY increase 4 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 4 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.03696799278
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013083e-15
+   Constant of PBCAB 0.3037585421
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906612
+   PBCAA total constant -7.633785883
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762645
+   PBCAA total constant -3.144641916
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -1.3545486323e+00  3.2945553807e+00  1.9781308978e+00
+    u -3.6854969532e+00  1.2486384236e+00  3.9898929646e+00
+    d -1.1074679098e+00  2.6464707989e+00  2.4355454420e+00
+    d -5.5548376958e+00  6.6840493442e+00  5.1394935251e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmc_ref_LiH-gamma.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 94 in base precision, in total 752 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.46599
+    reference variance = 0.925102
+====================================================
+  QMC Execution time = 2.3437e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmc_ref_LiH-gamma.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.4660e+00
+  reference energy = -8.4660e+00
+  Feedback = 1.0000e+00
+  reference variance = 9.2510e-01
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -8.49334
+  Energy Variance = 0.88746
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 1.8623e-02 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9964e-04
+ TauEff/Tau = 9.9964e-01
+  Etrial     = -8.4462e+00
+ Running average of energy = -8.4534e+00
+                  Variance = 1.1970e+00
+branch cutoff = 1.1970e+01 1.7954e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999554
+    trial energy                  = -8.58278
+    reference energy              = -8.54823
+    reference variance            = 1.19697
+    target walkers                = 256
+    branch cutoff                 = 11.9697 17.9545
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 4.5134e+03 secs 
+  Total Execution time = 4.5137e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmc_ref_LiH-gamma.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmc_ref_LiH-gamma  series 1 
+  LocalEnergy           =          -8.54823 +/-          0.00068 
+  Variance              =            1.4423 +/-           0.0089 
+  Kinetic               =            7.4825 +/-           0.0077 
+  LocalPotential        =          -16.0308 +/-           0.0078 
+  ElecElec              =           -0.5397 +/-           0.0013 
+  LocalECP              =          -11.8018 +/-           0.0087 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.156 +/-            0.016 
+  LocalEnergy_sq        =            74.516 +/-            0.013 
+  BlockWeight           =          25589.70 +/-            42.26 
+  BlockCPU              =            0.4519 +/-           0.0060 
+  AcceptRatio           =        0.99973808 +/-       0.00000055 
+  Efficiency            =             68.14 +/-             0.00 
+  TotalTime             =           4508.06 +/-             0.00 
+  TotalSamples          =         255257238 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_ref_LiH-gamma" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.out
@@ -1,0 +1,515 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 52123 MB
+  Input file(s): hf_vmc_dmc_ref_LiH-x.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmc_ref_LiH-x.xml
+
+  Project = hf_vmc_dmc_ref_LiH-x
+  date    = 2017-05-23 10:35:53 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 201
+  Random number offset = 201  seeds = 1237-1367
+        1237        1249        1259        1277        1279        1283        1289        1291
+        1297        1301        1303        1307        1319        1321        1327        1361
+        1367        1373
+  Random seeds Node = 0:        1249        1259        1277        1279        1283        1289        1291        1297        1301        1303        1307        1319        1321        1327        1361        1367
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.002048015594
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 2.145767212e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [   0.50000   0.00000   0.00000 ]
+  Using supercell twist 0:  [   0.50000   0.00000   0.00000]
+Using 1 copies of twist angle [-0.500, -0.000, -0.000]
+Using real orbitals.
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineR2RAdoptor
+  Using real einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+  TwistIndex = 0 TwistAngle               -0.5                -0                -0
+   HalfG =                  1                 0                 0
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (68, 64, 64)
+Maxmimum number of Gvecs 14398
+  Using meshsize=                68                64                64
+  vs input meshsize=                68                64                64
+  SplineAdoptorReader initialize_spline_pio 0.03115296364 sec
+MEMORY increase 4 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 4 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.03869009018
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013083e-15
+   Constant of PBCAB 0.3037585421
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906612
+   PBCAA total constant -7.633785883
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762645
+   PBCAA total constant -3.144641916
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -5.1401720307e+00  3.2655546486e+00  3.2890720527e+00
+    u -4.1723138263e+00  4.3099056186e+00  5.2747139539e+00
+    d -5.1381911437e-01  9.0355491088e-01  7.8695397134e-01
+    d -3.8507027502e+00  8.2148141109e-01  4.0451218609e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmc_ref_LiH-x.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 94 in base precision, in total 752 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.3155
+    reference variance = 0.897079
+====================================================
+  QMC Execution time = 1.0493e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmc_ref_LiH-x.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.3155e+00
+  reference energy = -8.3155e+00
+  Feedback = 1.0000e+00
+  reference variance = 8.9708e-01
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -8.32819
+  Energy Variance = 0.849687
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 1.7071e-02 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9942e-04
+ TauEff/Tau = 9.9942e-01
+  Etrial     = -8.3823e+00
+ Running average of energy = -8.3221e+00
+                  Variance = 9.4379e-01
+branch cutoff = 1.0000e+01 1.5000e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999567
+    trial energy                  = -8.22853
+    reference energy              = -8.31412
+    reference variance            = 0.943793
+    target walkers                = 256
+    branch cutoff                 = 10 15
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 4.6183e+03 secs 
+  Total Execution time = 4.6184e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmc_ref_LiH-x.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmc_ref_LiH-x  series 1 
+  LocalEnergy           =          -8.31413 +/-          0.00072 
+  Variance              =            1.3709 +/-           0.0074 
+  Kinetic               =            7.4514 +/-           0.0073 
+  LocalPotential        =          -15.7655 +/-           0.0075 
+  ElecElec              =           -0.5756 +/-           0.0013 
+  LocalECP              =          -11.5007 +/-           0.0084 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.149 +/-            0.017 
+  LocalEnergy_sq        =            70.498 +/-            0.013 
+  BlockWeight           =          25626.46 +/-            43.96 
+  BlockCPU              =            0.4618 +/-           0.0096 
+  AcceptRatio           =        0.99974544 +/-       0.00000053 
+  Efficiency            =             58.25 +/-             0.00 
+  TotalTime             =           4617.98 +/-             0.00 
+  TotalSamples          =         256264608 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmc_ref_LiH-x" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  no </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.out
@@ -1,0 +1,511 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 51179 MB
+  Input file(s): hf_vmc_dmcnl_ref_LiH-arb.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmcnl_ref_LiH-arb.xml
+
+  Project = hf_vmc_dmcnl_ref_LiH-arb
+  date    = 2017-05-23 13:08:34 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 146
+  Random number offset = 146  seeds = 857-971
+         857         859         863         877         881         883         887         907
+         911         919         929         937         941         947         953         967
+         971         977
+  Random seeds Node = 0:         859         863         877         881         883         887         907         911         919         929         937         941         947         953         967         971
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.002062797546
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 2.861022949e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [  -0.10000  -0.20000  -0.30000 ]
+  Using supercell twist 0:  [  -0.10000  -0.20000  -0.30000]
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineC2CPackedAdoptor
+  Using complex einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (68, 68, 68)
+Maxmimum number of Gvecs 14397
+  Using meshsize=                68                68                68
+  vs input meshsize=                68                68                68
+  SplineAdoptorReader initialize_spline_pio 0.0450861454 sec
+MEMORY increase 10 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 10 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.0551700592
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013083e-15
+   Constant of PBCAB 0.3037585421
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906612
+   PBCAA total constant -7.633785883
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762645
+   PBCAA total constant -3.144641916
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -7.0991804504e-01  2.1328016329e+00  2.6713754337e+00
+    u -5.5391970288e+00  5.1420485122e+00  3.9349013284e+00
+    d -4.1144859879e+00  3.4317717198e+00  4.9457725273e+00
+    d -2.4046629691e+00  2.7225824081e+00  1.7904119716e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmcnl_ref_LiH-arb.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 182 in base precision, in total 1456 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.41197
+    reference variance = 0.95091
+====================================================
+  QMC Execution time = 1.0817e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmcnl_ref_LiH-arb.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.4120e+00
+  reference energy = -8.4120e+00
+  Feedback = 1.0000e+00
+  reference variance = 9.5091e-01
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -8.36262
+  Energy Variance = 1.41128
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 1.2088e-02 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9963e-04
+ TauEff/Tau = 9.9963e-01
+  Etrial     = -8.3869e+00
+ Running average of energy = -8.4510e+00
+                  Variance = 1.0809e+00
+branch cutoff = 1.0809e+01 1.6214e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999574
+    trial energy                  = -8.44422
+    reference energy              = -8.45207
+    reference variance            = 1.08091
+    target walkers                = 256
+    branch cutoff                 = 10.8091 16.2137
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 1.0619e+03 secs 
+  Total Execution time = 1.0620e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmcnl_ref_LiH-arb.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmcnl_ref_LiH-arb  series 1 
+  LocalEnergy           =          -8.45207 +/-          0.00068 
+  Variance              =            1.3982 +/-           0.0064 
+  Kinetic               =            7.4968 +/-           0.0069 
+  LocalPotential        =          -15.9489 +/-           0.0070 
+  ElecElec              =           -0.5526 +/-           0.0012 
+  LocalECP              =          -11.7071 +/-           0.0079 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.166 +/-            0.014 
+  LocalEnergy_sq        =            72.838 +/-            0.011 
+  BlockWeight           =          25605.48 +/-            39.27 
+  BlockCPU              =           0.10617 +/-          0.00041 
+  AcceptRatio           =        0.99975147 +/-       0.00000050 
+  Efficiency            =            286.50 +/-             0.00 
+  TotalTime             =           1061.73 +/-             0.00 
+  TotalSamples          =         256054796 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_ref_LiH-arb" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.out
@@ -1,0 +1,515 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 52110 MB
+  Input file(s): hf_vmc_dmcnl_ref_LiH-gamma.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmcnl_ref_LiH-gamma.xml
+
+  Project = hf_vmc_dmcnl_ref_LiH-gamma
+  date    = 2017-05-23 10:36:32 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 240
+  Random number offset = 240  seeds = 1531-1627
+        1531        1543        1549        1553        1559        1567        1571        1579
+        1583        1597        1601        1607        1609        1613        1619        1621
+        1627        1637
+  Random seeds Node = 0:        1543        1549        1553        1559        1567        1571        1579        1583        1597        1601        1607        1609        1613        1619        1621        1627
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.006498098373
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 1.907348633e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [   0.00000   0.00000   0.00000 ]
+  Using supercell twist 0:  [   0.00000   0.00000   0.00000]
+Using 1 copies of twist angle [-0.000, -0.000, -0.000]
+Using real orbitals.
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineR2RAdoptor
+  Using real einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+  TwistIndex = 0 TwistAngle                 -0                -0                -0
+   HalfG =                  0                 0                 0
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (64, 64, 64)
+Maxmimum number of Gvecs 14331
+  Using meshsize=                64                64                64
+  vs input meshsize=                64                64                64
+  SplineAdoptorReader initialize_spline_pio 0.07819795609 sec
+MEMORY increase 4 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 4 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.08834886551
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013083e-15
+   Constant of PBCAB 0.3037585421
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906612
+   PBCAA total constant -7.633785883
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762645
+   PBCAA total constant -3.144641916
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -4.5753948679e+00  3.3755326255e+00  2.1485913018e+00
+    u -4.0907388941e+00  4.5672874633e+00  2.4005653188e+00
+    d -4.7844569169e+00  6.2893915009e+00  4.2582913078e+00
+    d -1.1614035672e+00  3.0587864452e+00  3.6106299438e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmcnl_ref_LiH-gamma.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 94 in base precision, in total 752 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.58902
+    reference variance = 0.838085
+====================================================
+  QMC Execution time = 3.9352e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmcnl_ref_LiH-gamma.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.5890e+00
+  reference energy = -8.5890e+00
+  Feedback = 1.0000e+00
+  reference variance = 8.3809e-01
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -8.54645
+  Energy Variance = 0.870977
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 8.9591e-03 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9961e-04
+ TauEff/Tau = 9.9961e-01
+  Etrial     = -8.4752e+00
+ Running average of energy = -8.4400e+00
+                  Variance = 1.8332e+00
+branch cutoff = 1.8332e+01 2.7498e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999553
+    trial energy                  = -8.56141
+    reference energy              = -8.54976
+    reference variance            = 1.8332
+    target walkers                = 256
+    branch cutoff                 = 18.332 27.498
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 4.5115e+03 secs 
+  Total Execution time = 4.5119e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmcnl_ref_LiH-gamma.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmcnl_ref_LiH-gamma  series 1 
+  LocalEnergy           =          -8.54979 +/-          0.00068 
+  Variance              =            1.4285 +/-           0.0075 
+  Kinetic               =            7.4955 +/-           0.0068 
+  LocalPotential        =          -16.0453 +/-           0.0069 
+  ElecElec              =           -0.5398 +/-           0.0012 
+  LocalECP              =          -11.8163 +/-           0.0077 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.179 +/-            0.015 
+  LocalEnergy_sq        =            74.529 +/-            0.012 
+  BlockWeight           =          25589.55 +/-            43.83 
+  BlockCPU              =            0.4512 +/-           0.0070 
+  AcceptRatio           =        0.99973761 +/-       0.00000053 
+  Efficiency            =             68.05 +/-             0.00 
+  TotalTime             =           4498.73 +/-             0.00 
+  TotalSamples          =         255153407 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_ref_LiH-gamma" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.out
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.out
@@ -1,0 +1,515 @@
+nohup: ignoring input
+Rank =    0  Free Memory = 52070 MB
+  Input file(s): hf_vmc_dmcnl_ref_LiH-x.xml 
+
+=====================================================
+                    QMCPACK 3.0.0 
+
+  (c) Copyright 2003-  QMCPACK developers            
+
+  Git branch: more_LiH_tests
+  Last git commit: e0622832930abea4a56885a9a29b862cf51e27df
+  Last commit date: Mon May 22 12:05:22 2017 -0500
+=====================================================
+  Global options 
+  async_swap=0 : using blocking send/recv for walker swaps 
+
+  MPI Nodes            = 1
+  MPI Nodes per group  = 1
+  MPI Group ID         = 0
+  OMP_NUM_THREADS      = 16
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = hf_vmc_dmcnl_ref_LiH-x.xml
+
+  Project = hf_vmc_dmcnl_ref_LiH-x
+  date    = 2017-05-23 10:36:44 EDT
+  host    = oxygen.ornl.gov
+
+  DO NOT READ DENSITY
+  Offset for the random number seeds based on time 252
+  Random number offset = 252  seeds = 1609-1733
+        1609        1613        1619        1621        1627        1637        1657        1663
+        1667        1669        1693        1697        1699        1709        1721        1723
+        1733        1741
+  Random seeds Node = 0:        1613        1619        1621        1627        1637        1657        1663        1667        1669        1693        1697        1699        1709        1721        1723        1733
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.04959; kc = 7.31852
+
+	WignerSeitzRadius = 2.51023
+
+	SimulationCellRadius = 2.04959
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  Simulation cell radius = 2.049593456
+  Wigner-Seitz    radius = 2.510229073
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+	WignerSeitzRadius = 2.510229073
+
+	SimulationCellRadius = 2.049593456
+
+--------------------------------------- 
+<unitcell>
+<parameter name="lattice">
+             -3.55                 0              3.55
+                 0              3.55              3.55
+             -3.55              3.55                 0
+</parameter>
+<parameter name="bconds">  p  p  p </parameter>
+<note>
+Volume (A^3) = 89.47775
+Reciprocal vectors without 2*pi.
+g_1 =      -0.1408450704     -0.1408450704      0.1408450704
+g_2 =       0.1408450704      0.1408450704      0.1408450704
+g_3 =      -0.1408450704      0.1408450704     -0.1408450704
+Metric tensor in real-space.
+h_1 = 25.205 12.6025 12.6025 
+h_2 = 12.6025 25.205 12.6025 
+h_3 = 12.6025 12.6025 25.205 
+Metric tensor in g-space.
+h_1 = 2.349439651 -0.7831465504 -0.7831465504 
+h_2 = -0.7831465504 2.349439651 -0.7831465504 
+h_3 = -0.7831465504 -0.7831465504 2.349439651 
+</note>
+<note>
+	Long-range breakup parameters:
+	rc*kc = 15; rc = 2.049593456; kc = 7.318524539
+
+</note>
+</unitcell>
+--------------------------------------- 
+
+  Creating Structure Factor for periodic systems 7.318524539
+  KContainer initialised with cutoff 7.318524539
+   # of K-shell  = 25
+   # of K points = 608
+  All the species have the same mass 1
+Particles are grouped. Safe to use groups 
+ Adding WavefunctionFactory for psi0
+EinsplineSetBuilder:  using libeinspline for B-spline orbitals.
+Built BasisSetBuilder "einspline" of type einspline
+ Building SPOset  with  basis set.
+TOKEN=0 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  Distance table for AA: source/target = e
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 e_e
+  Distance table for AB: source = i target = e
+    PBC=bulk Orthorhombic=no  Using AsymmetricDTD<T,D,PPPG> 7
+    Setting Rmax = 2.04959 Using bonding box/reduced coordinates 
+  ... ParticleSet::addTable Create Table #1 i_e
+  TileMatrix = 
+ [  1  0  0
+    0  1  0
+    0  0  1 ]
+  Reading 2 orbitals from HDF5 file.
+TOKEN=1 ReadOrbitalInfo /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp 37
+  HDF5 orbital file version 2.1.0
+TOKEN=2 ReadOrbitalInfo_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 49
+  Reading orbital file in ESHDF format.
+  ESHDF orbital file version 2.1.0
+  Lattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+TOKEN=3 CheckLattice /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 102
+  SuperLattice = 
+    [ -3.550000  0.000000  3.550000
+       0.000000  3.550000  3.550000
+      -3.550000  3.550000  0.000000 ]
+bands=6, elecs=4, spins=1, twists=1, muffin tins=0, core states=0
+atomic orbital=0
+Atom type(0) = 3
+Atom type(1) = 1
+   Skip initialization of the density
+TIMER  EinsplineSetBuilder::ReadOrbitalInfo 0.01110005379
+TIMER  EinsplineSetBuilder::BroadcastOrbitalInfo 2.145767212e-06
+Found 1 distinct supercell twists.
+number of things
+1
+1
+Super twist #0:  [   0.50000   0.00000   0.00000 ]
+  Using supercell twist 0:  [   0.50000   0.00000   0.00000]
+Using 1 copies of twist angle [-0.500, -0.000, -0.000]
+Using real orbitals.
+TOKEN=4 OccupyBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 768
+TOKEN=5 OccupyBands_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp 323
+Sorting the bands now:
+We will read 2 distinct orbitals.
+There are 0 core states and 2 valence states.
+TOKEN=6 TileIons /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp 294
+Rcut = 0
+dilation = 1
+TOKEN=7 bcastSortBands /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/einspline_helper.hpp 345
+BandInfoGroup::selectBands bigspace has 6 distinct orbitals 
+BandInfoGroup::selectBands using distinct orbitals [0,2)
+  Number of distinct bands 2
+  First Band index 0
+  First SPO index 0
+  Size of SPOs 2
+  AdoptorName = SplineR2RAdoptor
+  Using real einspline table
+NumDistinctOrbitals 2 numOrbs = 2
+  TwistIndex = 0 TwistAngle               -0.5                -0                -0
+   HalfG =                  1                 0                 0
+TOKEN=8 ReadGvectors_ESHDF /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp 671
+B-spline mesh factor is 1
+B-spline mesh size is (68, 64, 64)
+Maxmimum number of Gvecs 14398
+  Using meshsize=                68                64                64
+  vs input meshsize=                68                64                64
+  SplineAdoptorReader initialize_spline_pio 0.1160209179 sec
+MEMORY increase 4 MB BsplineSetReader
+  MEMORY allocated SplineAdoptorReader 4 MB
+TIMER  EinsplineSetBuilder::ReadBands 0.1419539452
+   Using Identity for the LCOrbitalSet 
+Reuse BasisSetBuilder "einspline" type einspline
+ Building SPOset  with  basis set.
+TOKEN=9 createSPOSetFromXML /home/pk7/projects/qmc/git_QMCPACK_prckent/qmcpack/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp 48
+  ... ParticleSet::addTable Reuse Table #1 i_e
+SPOSet parameters match in EinsplineSetBuilder:  cloning EinsplineSet object.
+   Using Identity for the LCOrbitalSet 
+  Creating a determinant updet group=0 sposet=updet
+  Reusing a SPO set updet
+
+  Creating a determinant downdet group=1 sposet=downdet
+  Reusing a SPO set downdet
+
+  FermionWF=SlaterDet
+  QMCHamiltonian::addOperator Kinetic to H, physical Hamiltonian 
+
+  ECPotential builder for pseudopotential 
+
+  Adding pseudopotential for Li
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=7.02434e-05
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+
+  Adding pseudopotential for H
+   Linear grid  ri=0 rf=10 npts = 10001
+    ECPComponentBuilder::buildSemiLocalAndLocal 
+    Assuming Hartree unit
+    Only one vps is found. Set the local component=0
+   Number of angular momentum channels 1
+   Maximum angular momentum channel 0
+   Creating a Linear Grid Rmax=0.000101308
+  Using global grid with delta = 0.001
+   Making L=0 a local potential with a radial cutoff of 9.999
+  ... ParticleSet::addTable Reuse Table #1 i_e
+  ... ParticleSet::addTable Reuse Table #1 i_e
+
+  Creating CoulombHandler with the optimal breakup. 
+  KContainer initialised with cutoff 42.14338718
+   # of K-shell  = 759
+   # of K points = 113394
+  NUMBER OF OPT_BREAK KVECS = -748125351
+ finding kc:  7.318524539 , -1
+  LRBreakp parameter Kc =7.318524539
+    Continuum approximation in k = [42.14338718,2927.409816)
+
+   LR Breakup chi^2 = 1.026013082e-15
+   Constant of PBCAB 0.3037585441
+  Maximum K shell 24
+  Number of k vectors 608
+    CoulombPBCAB::add 
+ Setting a linear grid=[0,2.049593456) number of grid =2050
+    Creating the short-range pseudopotential for species 0
+    Creating the short-range pseudopotential for species 1
+  QMCHamiltonian::addOperator LocalECP to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type pseudo named PseudoPot
+  Distance table for AA: source/target = i
+    PBC=bulk Orthorhombic=no   Using SymmetricDTD<T,D,PPPG> 7
+
+    Setting Rmax = 2.04959 Using bounding box/reduced coordinates with 
+  ... ParticleSet::addTable Create Table #0 i_i
+  ... ParticleSet::addTable Reuse Table #0 i_i
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -7.481906587
+   PBCAA total constant -7.633785859
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for i
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =-3.689226845
+  QMCHamiltonian::addOperator IonIon to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named IonIon
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  ... ParticleSet::addTable Reuse Table #0 e_e
+  Clone CoulombHandler. 
+   PBCAA self-interaction term -2.992762635
+   PBCAA total constant -3.144641907
+  Maximum K shell 24
+  Number of k vectors 608
+  Fixed Coulomb potential for e
+    e-e Madelung Const. =-0.3133851583
+    Vtot     =0
+  QMCHamiltonian::addOperator ElecElec to H, physical Hamiltonian 
+QMCHamiltonian::addOperatorType added type coulomb named ElecElec
+  QMCHamiltonian::addOperator Flux to auxH 
+QMCHamiltonian::addOperatorType added type flux named Flux
+
+  QMCHamiltonian::add2WalkerProperty added
+    5 to P::PropertyList 
+    0 to P::Collectables 
+    starting Index of the observables in P::PropertyList = 9
+  Hamiltonian disables VirtualMoves
+ParticleSetPool::randomize 
+=========================================================
+ Summary of QMC systems 
+=========================================================
+ParticleSetPool has: 
+
+  ParticleSet e : 0 2 4 
+
+    4
+
+    u -4.3963930707e+00  5.5888275812e+00  3.5236619254e+00
+    u -5.2773610731e+00  4.9657496486e+00  4.7542762270e+00
+    d -3.5090280371e+00  1.3356326154e+00  4.5929011331e+00
+    d -1.5178871788e+00  2.9768212490e+00  1.5225039406e+00
+
+  ParticleSet i : 0 1 2 
+
+    2
+
+    Li  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+    H -3.5500000000e+00  3.5500000000e+00  3.5500000000e+00
+
+  Hamiltonian h0
+  Kinetic         Kinetic energy
+  LocalECP        CoulombPBCAB potential source: i
+  IonIon          CoulombPBCAA potential: i_i
+  ElecElec        CoulombPBCAA potential: e_e
+
+=========================================================
+  Start VMCSingleOMP
+  File Root hf_vmc_dmcnl_ref_LiH-x.s000 append = no 
+=========================================================
+  Adding 256 walkers to 0 existing sets
+  Total number of walkers: 2.5600000000e+02
+  Total weight: 2.5600000000e+02
+  Resetting Properties of the walkers 1 x 14
+
+<vmc function="put">
+  qmc_counter=0  my_counter=0
+  time step      = 1.0000000000e+00
+  blocks         = 1
+  steps          = 1
+  substeps       = 1
+  current        = 0
+  target samples = 0.0000000000e+00
+  walkers/mpi    = 256
+
+  stepsbetweensamples = 2
+<parameter name="blocks" condition="int">1</parameter>
+<parameter name="blocks_between_recompute" condition="int">0</parameter>
+<parameter name="check_properties" condition="int">100</parameter>
+<parameter name="checkproperties" condition="int">100</parameter>
+<parameter name="current" condition="int">0</parameter>
+<parameter name="dmcwalkersperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="maxcpusecs" condition="real">3.6000000000e+05</parameter>
+<parameter name="record_configs" condition="int">0</parameter>
+<parameter name="record_walkers" condition="int">2</parameter>
+<parameter name="recordconfigs" condition="int">0</parameter>
+<parameter name="recordwalkers" condition="int">2</parameter>
+<parameter name="rewind" condition="int">0</parameter>
+<parameter name="samples" condition="real">0.0000000000e+00</parameter>
+<parameter name="samplesperthread" condition="real">0.0000000000e+00</parameter>
+<parameter name="steps" condition="int">1</parameter>
+<parameter name="stepsbetweensamples" condition="int">2</parameter>
+<parameter name="store_configs" condition="int">0</parameter>
+<parameter name="storeconfigs" condition="int">0</parameter>
+<parameter name="sub_steps" condition="int">1</parameter>
+<parameter name="substeps" condition="int">1</parameter>
+<parameter name="tau" condition="au">1.0000000000e+00</parameter>
+<parameter name="time_step" condition="au">1.0000000000e+00</parameter>
+<parameter name="timestep" condition="au">1.0000000000e+00</parameter>
+<parameter name="use_drift" condition="string">no</parameter>
+<parameter name="usedrift" condition="string">no</parameter>
+<parameter name="walkers" condition="int">256</parameter>
+<parameter name="warmup_steps" condition="int">100</parameter>
+<parameter name="warmupsteps" condition="int">100</parameter>
+  DumpConfig==false Nothing (configurations, state) will be saved.
+  Walker Samples are dumped every 2 steps.
+</vmc>
+  CloneManager::makeClones makes 16 clones for W/Psi/H.
+  Cloning methods for both Psi and H are used
+  Initial partition of walkers 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  PbyP moves with |psi^2|, using VMCUpdatePbyP
+
+  Total Sample Size   =0
+  Walker distribution on root = 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Anonymous Buffer size per walker : 94 in base precision, in total 752 bytes.
+MEMORY increase 0 MB VMCSingleOMP::resetRun
+====================================================
+  SimpleFixedNodeBranch::finalize after a VMC block
+    QMC counter        = 0
+    time step          = 1
+    reference energy   = -8.02784
+    reference variance = 1.78934
+====================================================
+  QMC Execution time = 4.7814e-01 secs 
+Creating DMCMP for the qmc driver
+
+=========================================================
+  Start DMCOMP
+  File Root hf_vmc_dmcnl_ref_LiH-x.s001 append = no 
+=========================================================
+Using existing walkers 
+  Resetting Properties of the walkers 1 x 14
+  EstimatorManager::add replace LocalEnergy estimator.
+  Cannot make clones again. Use existing 16 clones
+  Total number of walkers: 2.5600e+02
+  Total weight: 2.5600e+02
+  Creating WalkerController: target  number of walkers = 256
+  Using WalkerControlBase for dynamic population control.
+  START ALL OVER 
+  WalkerControlBase parameters 
+    maxCopy = 2
+   Max Walkers per node 513
+   Min Walkers per node 52
+  QMC counter      = 1
+  time step        = 1.0000e-03
+  effective time step = 1.0000e-03
+  trial energy     = -8.0278e+00
+  reference energy = -8.0278e+00
+  Feedback = 1.0000e+00
+  reference variance = 1.7893e+00
+  target walkers = 256
+  branch cutoff = 5.0000e+01 7.5000e+01
+  Max and mimum walkers per node= 513 52
+  QMC Status (BranchMode) = 0000001101
+  Initial partition of walkers on a node: 0 16 32 48 64 80 96 112 128 144 160 176 192 208 224 240 256 
+  Updates by particle-by-particle moves using fast gradient version 
+  DMC moves are rejected when a node crossing is detected
+SimpleFixedNodeBranch::checkParameters 
+  Average Energy of a population  = -7.81686
+  Energy Variance = 4.59641
+
+  Fluctuating population
+  Persistent walkers are killed after 1 MC sweeps
+  BranchInterval = 1
+  Steps per block = 100
+  Number of blocks = 10000
+
+  DMC Engine Initialization = 2.3253e-02 secs 
+
+ Warmup is completed after 100
+
+  TauEff     = 9.9939e-04
+ TauEff/Tau = 9.9939e-01
+  Etrial     = -8.2519e+00
+ Running average of energy = -8.2148e+00
+                  Variance = 1.4741e+00
+branch cutoff = 1.4741e+01 2.2112e+01
+====================================================
+  SimpleFixedNodeBranch::finalize after a DMC block
+    QMC counter                   = 1
+    time step                     = 0.001
+    effective time step           = 0.000999567
+    trial energy                  = -8.2408
+    reference energy              = -8.31371
+    reference variance            = 1.47413
+    target walkers                = 256
+    branch cutoff                 = 14.7413 22.1119
+    Max and mimum walkers per node= 513 52
+    Feedback                      = 1
+    QMC Status (BranchMode)       = 0000001111
+====================================================
+  QMC Execution time = 4.6218e+03 secs 
+  Total Execution time = 4.6223e+03 secs
+
+=========================================================
+  A new xml input file : hf_vmc_dmcnl_ref_LiH-x.s001.cont.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.s001.qmca
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.s001.qmca
@@ -1,0 +1,17 @@
+
+hf_vmc_dmcnl_ref_LiH-x  series 1 
+  LocalEnergy           =          -8.31369 +/-          0.00072 
+  Variance              =            1.3662 +/-           0.0086 
+  Kinetic               =            7.4559 +/-           0.0071 
+  LocalPotential        =          -15.7696 +/-           0.0072 
+  ElecElec              =           -0.5738 +/-           0.0013 
+  LocalECP              =          -11.5065 +/-           0.0080 
+  IonIon                =             -3.69 +/-             0.00 
+  Flux                  =            -0.163 +/-            0.014 
+  LocalEnergy_sq        =            70.486 +/-            0.013 
+  BlockWeight           =          25564.30 +/-            43.46 
+  BlockCPU              =             0.462 +/-            0.014 
+  AcceptRatio           =        0.99974566 +/-       0.00000055 
+  Efficiency            =             58.82 +/-             0.00 
+  TotalTime             =           4614.42 +/-             0.00 
+  TotalSamples          =         255259530 +/-                0 

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_dmcnl_ref_LiH-x" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+   <qmc method="vmc" move="pbyp">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    256 </parameter>
+    <parameter name="substeps">  1 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  1 </parameter>
+    <parameter name="blocks">  1 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+  <qmc method="dmc" move="pbyp" checkpoint="-1">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="targetwalkers"> 256 </parameter>
+    <parameter name="reconfiguration">   no </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="timestep">  0.001 </parameter>
+    <parameter name="steps">   100 </parameter>
+    <parameter name="blocks">  10000 </parameter>
+    <parameter name="nonlocalmoves">  yes </parameter>
+  </qmc>
+   
+
+</simulation>

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -244,6 +244,69 @@ ENDIF()
                     0 # VMC
                     ${LIH_ARB_SUCCEED})
 
+# DMC tests for LiH, locality and non-local (t-moves) variants
+
+  LIST(APPEND LIH_GAMMA_DMC_SCALARS "totenergy" "-8.54823 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-gamma-dmc-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmc_short_LiH-gamma
+                    hf_vmc_dmc_short_LiH-gamma.xml
+                    1 16
+                    LIH_GAMMA_DMC_SCALARS
+                    1 # DMC
+                    TRUE)
+
+  LIST(APPEND LIH_X_DMC_SCALARS "totenergy" "-8.31413 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-x-dmc-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmc_short_LiH-x
+                    hf_vmc_dmc_short_LiH-x.xml
+                    1 16
+                    LIH_X_DMC_SCALARS
+                    1 # DMC
+                    TRUE)
+
+  LIST(APPEND LIH_ARB_DMC_SCALARS "totenergy" "-8.45401 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-arb-dmc-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmc_short_LiH-arb
+                    hf_vmc_dmc_short_LiH-arb.xml
+                    1 16
+                    LIH_ARB_DMC_SCALARS
+                    1 # DMC
+                    ${LIH_ARB_SUCCEED})
+
+  LIST(APPEND LIH_GAMMA_DMCNL_SCALARS "totenergy" "-8.54979 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-gamma-dmcnl-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmcnl_short_LiH-gamma
+                    hf_vmc_dmcnl_short_LiH-gamma.xml
+                    1 16
+                    LIH_GAMMA_DMCNL_SCALARS
+                    1 # DMC
+                    TRUE)
+
+  LIST(APPEND LIH_X_DMCNL_SCALARS "totenergy" "-8.31369 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-x-dmcnl-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmcnl_short_LiH-x
+                    hf_vmc_dmcnl_short_LiH-x.xml
+                    1 16
+                    LIH_X_DMCNL_SCALARS
+                    1 # DMC
+                    TRUE)
+
+  LIST(APPEND LIH_ARB_DMCNL_SCALARS "totenergy" "-8.45174 0.004")
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-arb-dmcnl-hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_dmcnl_short_LiH-arb
+                    hf_vmc_dmcnl_short_LiH-arb.xml
+                    1 16
+                    LIH_ARB_DMCNL_SCALARS
+                    1 # DMC
+                    ${LIH_ARB_SUCCEED})
+
+
 #
 # Short tests, about 2-3 seconds on 16 cores
 #


### PR DESCRIPTION
and using locality and t-moves approximations.

Note that the locality approximation is small enough in LiH that this is not a strong test of the t-moves scheme, but it should be sensitive to major bugs.

Reference data produced with current git version of QMCPACK. Only the analysis from qmca is included to keep overall file sizes small.
