### PR TITLE
Fix allp move with MP. No need for recomputePsi.

### DIFF
--- a/src/QMCDrivers/DMC/DMCOMP.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.cpp
@@ -299,7 +299,7 @@ bool DMCOMP::run()
         if(QMCDriverMode[QMC_UPDATE_MODE] && now%updatePeriod == 0)
           Movers[ip]->updateWalkers(wit, wit_end);
         // recompute the accuracy critical part of Psi at the end of the last step.
-        if ( step+1 == nSteps && nBlocksBetweenRecompute && (1+block)%nBlocksBetweenRecompute == 0 )
+        if ( step+1 == nSteps && nBlocksBetweenRecompute && (1+block)%nBlocksBetweenRecompute == 0 && QMCDriverMode[QMC_UPDATE_MODE] )
           Movers[ip]->recomputePsi(wit,wit_end);
       }
 

--- a/src/QMCDrivers/VMC/VMCSingleOMP.cpp
+++ b/src/QMCDrivers/VMC/VMCSingleOMP.cpp
@@ -94,7 +94,7 @@ bool VMCSingleOMP::run()
 //           if(storeConfigs && (now_loc%storeConfigs == 0))
 //             ForwardWalkingHistory.storeConfigsForForwardWalking(*wClones[ip]);
       }
-      if ( nBlocksBetweenRecompute && (1+block)%nBlocksBetweenRecompute == 0 )
+      if ( nBlocksBetweenRecompute && (1+block)%nBlocksBetweenRecompute == 0 && QMCDriverMode[QMC_UPDATE_MODE] )
         Movers[ip]->recomputePsi(wit,wit_end);
       Movers[ip]->stopBlock(false);
     }//end-of-parallel for


### PR DESCRIPTION
Address the nightly test failure.