### PR TITLE
Add output to DMC CPU driver.  Indicates status of t-moves

### DIFF
--- a/src/QMCDrivers/DMC/DMCOMP.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.cpp
@@ -164,6 +164,12 @@ void DMCOMP::resetUpdateEngines()
         o << "\n  Walkers are killed when a node crossing is detected";
       else
         o << "\n  DMC moves are rejected when a node crossing is detected";
+  
+      if(NonLocalMove == "yes")
+        o << "\n  Non-local T-moves are enabled.";
+      else
+        o << "\n  Non-local T-moves are disabled.";
+
       app_log() << o.str() << std::endl;
     }
 #if !defined(BGP_BUG)

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -77,9 +77,9 @@ bool DMCcuda::run()
   bool NLmove = NonLocalMove == "yes";
   bool scaleweight = ScaleWeight == "yes";
   if (NLmove)
-    app_log() << "  Using Casula nonlocal moves in DMCcuda.\n";
+    app_log() << "  Using Non-local T-moves in DMCcuda.\n";
   if (scaleweight)
-    app_log() << "  Scaling weight per Umrigar/Nightengale.\n";
+    app_log() << "  Scaling weight per Umrigar/Nightingale.\n";
   resetRun();
   Mover->MaxAge = 1;
   IndexType block = 0;


### PR DESCRIPTION
Oddly, DMCOMP doesn't display status of non-local moves, whereas DMC_CUDA does.  This writes a line of output to standard out.