### PR TITLE
do not reset 'feedback' parameter

### DIFF
--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -533,6 +533,7 @@ void SimpleFixedNodeBranch::reset()
     {
       //logN = Feedback*std::log(static_cast<RealType>(iParam[B_TARGETWALKERS]));
       logN = std::log(static_cast<EstimatorRealType>(iParam[B_TARGETWALKERS]));
+      if (vParam[B_FEEDBACK]==0.0) vParam[B_FEEDBACK] = 1.0;
     }
     else
     {
@@ -639,7 +640,7 @@ int SimpleFixedNodeBranch::resetRun(xmlNodePtr cur)
     if(BranchMode[B_POPCONTROL])
     {
       vParam[B_ETRIAL]=vParam[B_EREF];
-      vParam[B_FEEDBACK]=1.0;
+      if (vParam[B_FEEDBACK]==0.0) vParam[B_FEEDBACK]=1.0;
     }
   }
 

--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -533,7 +533,6 @@ void SimpleFixedNodeBranch::reset()
     {
       //logN = Feedback*std::log(static_cast<RealType>(iParam[B_TARGETWALKERS]));
       logN = std::log(static_cast<EstimatorRealType>(iParam[B_TARGETWALKERS]));
-      vParam[B_FEEDBACK]=1.0;
     }
     else
     {


### PR DESCRIPTION
The DMC population feedback parameter should be controlled by the input
as stated by the manual. It is currently forced to be 1.0.