### PR TITLE
Manual updates cmake flags

### DIFF
--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -248,6 +248,7 @@ FFTW_LIBRARY_DIRS   Specify library directories for FFTW
 \begin{verbatim}
 MPIEXEC   Specify the mpi wrapper, e.g. srun, aprun, mpirun, etc.
 MPIEXEC_NUMPROC_FLAG   Specify the number of mpi processes flag, e.g. "-n", "-np", etc.
+
 \end{verbatim}
 \end{itemize}
 

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -36,7 +36,7 @@ only supports wavefunctions that can be made real. If you run a
 calculation that needs the complex version, QMCPACK will stop and inform you.
 
 \section{Obtaining the latest release version}
-\label{sec:obrelease} 
+\label{sec:obrelease}
 Major releases of QMCPACK are distributed from
 \url{http://www.qmcpack.org}. These releases undergo the most testing. Unless there are
 specific reasons we encourage all production calculations to use the
@@ -56,7 +56,7 @@ git repository, similar to obtaining the development version (Sec. \ref{sec:obde
 
 \section{Obtaining the latest development version}
 \label{sec:obdevelopment}
-The most recent development version of QMCPACK can be obtained anonymously via 
+The most recent development version of QMCPACK can be obtained anonymously via
 \begin{verbatim}
 git clone https://github.com/QMCPACK/qmcpack.git
 \end{verbatim}
@@ -197,7 +197,7 @@ the path to the source directory.
 \begin{verbatim}
 QMC_CUDA            Enable CUDA and GPU acceleration (1:yes, 0:no)
 QMC_COMPLEX         Build the complex (general twist/k-point) version (1:yes, 0:no)
-QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version 
+QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
                     (1:yes (GPU default), 0:no (CPU default)).
                     The CPU support is experimental.
                     Use float and double for base and full precision.
@@ -209,7 +209,7 @@ QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
 \begin{verbatim}
 CMAKE_BUILD_TYPE   A variable which controls the type of build
                    (defaults to Release). Possible values are:
-                   None (Do not set debug/optmize flags, use 
+                   None (Do not set debug/optmize flags, use
                    CMAKE_C_FLAGS or CMAKE_CXX_FLAGS)
                    Debug (create a debug build)
                    Release (create a release/optimized build)
@@ -244,6 +244,11 @@ Libxml2_LIBRARY_DIRS  Specify library directories for libxml2
 FFTW_INCLUDE_DIRS   Specify include directories for FFTW
 FFTW_LIBRARY_DIRS   Specify library directories for FFTW
 \end{verbatim}
+ \item CTest related
+\begin{verbatim}
+MPIEXEC   Specify the mpi wrapper, e.g. srun, aprun, mpirun, etc.
+MPIEXEC_NUMPROC_FLAG   Specify the number of mpi processes flag, e.g. "-n", "-np", etc.
+\end{verbatim}
 \end{itemize}
 
 \subsection{Configure and build using cmake and make}
@@ -263,7 +268,7 @@ build versions with different settings (e.g. QMC\_COMPLEX) and
 different compiler settings. The build directory does not have to be
 called build - use something descriptive such as build\_machinename or
 build\_complex. The ``..'' in the cmake line refers to the directory
-containing CMakeLists.txt. Update the ``..'' for other build 
+containing CMakeLists.txt. Update the ``..'' for other build
 directory locations.
 
 \subsection{Example configure and build}
@@ -380,7 +385,7 @@ production a platform optimized BLAS should be used.
 sudo yum install make cmake gcc gcc-c++ openmpi openmpi-devel fftw fftw-devel \
                   boost boost-devel libxml2 libxml2-devel
 sudo yum install blas-devel lapack-devel atlas-devel
-module load mpi 
+module load mpi
 \end{verbatim}
 
 To setup repoforge as a source for the HDF5 package, go to
@@ -391,7 +396,7 @@ CentOS 7 in 2016, but use CentOS 7 versions when they become
 available.
 
 \begin{verbatim}
-sudo yum install hdf5 hdf5-devel 
+sudo yum install hdf5 hdf5-devel
 \end{verbatim}
 
 To build QMCPACK
@@ -402,7 +407,7 @@ which mpirun
 export CXX=mpiCC
 cd build
 cmake ..
-make -j 8  
+make -j 8
 ls -l bin/qmcpack
 \end{verbatim}
 
@@ -425,7 +430,7 @@ Follow the Macports install instructions \url{https://www.macports.org/}
 
 Install the required tools:
 
-\begin{verbatim} 
+\begin{verbatim}
 sudo port install gcc6
 sudo port select gcc mp-gcc6
 sudo port install openmpi-devel-gcc6
@@ -438,7 +443,7 @@ sudo post install boost +gcc6
 sudo port install hdf5 +gcc6
 
 sudo port select --set python python27
-sudo port install py27-numpy +gcc6 
+sudo port install py27-numpy +gcc6
 sudo port install py27-matplotlib  #For graphical plots with qmca
 \end{verbatim}
 
@@ -447,7 +452,7 @@ QMCPACK build:
 cd build
 cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpiCXX ..
 make -j 6 # Adjust for available core count
-ls -l bin/qmcpack 
+ls -l bin/qmcpack
 \end{verbatim}
 
 Cmake should pickup the versions of HDF5, libxml (etc.) installed in
@@ -469,7 +474,7 @@ source to use the brew-provided gcc instead of Apple CLANG.
 \begin{enumerate}
 \item Install Homebrew from \url{http://brew.sh/}
 \begin{verbatim}
-/usr/bin/ruby -e "$(curl -fsSL 
+/usr/bin/ruby -e "$(curl -fsSL
     https://raw.githubusercontent.com/Homebrew/install/master/install)"
 \end{verbatim}
 
@@ -482,7 +487,7 @@ brew install mpich2 --build-from-source
 # Build from source required to use homebrew compiled compilers as
 # opposed to Apple CLANG. Check "mpicc -v" indicates Homebrew gcc 5.x.x
 brew install cmake
-brew install fftw 
+brew install fftw
 brew install boost
 brew install homebrew/science/hdf5
 #Note: Libxml2 is not required via brew since OS X already includes it.
@@ -527,7 +532,7 @@ available, with libraries accessed via modules. The only extra
 settings required to build the GPU version are the cudatoolkit module
 and specifying -DQMC\_CUDA=1 on the cmake configure line.
 
-Note that on Crays the compiler wrappers ``CC'' and ``cc'' are 
+Note that on Crays the compiler wrappers ``CC'' and ``cc'' are
 used. The build system checks for these and does not (should not) use
 the compilers directly.
 
@@ -543,7 +548,7 @@ mkdir build_titan_gpu
 cd build_titan_gpu
 cmake -DQMC_CUDA=1 ..             # Must enable CUDA capabilities
 make -j 8
-ls -l bin/qmcpack 
+ls -l bin/qmcpack
 \end{verbatim}
 
 \subsection{Installing on ORNL OLCF Titan Cray XK7 (CPU version)}
@@ -561,8 +566,8 @@ module load boost
 mkdir build_titan_cpu
 cd build_titan_cpu
 cmake ..
-make -j 8  
-ls -l bin/qmcpack 
+make -j 8
+ls -l bin/qmcpack
 \end{verbatim}
 
 \subsection{Installing on ORNL OLCF Eos Cray XC30}
@@ -579,8 +584,8 @@ module load boost
 mkdir build_eos
 cd build_eos
 cmake ..
-make -j 8 
-ls -l bin/qmcpack 
+make -j 8
+ls -l bin/qmcpack
 \end{verbatim}
 
 \subsection{Installing on ORNL OLCF SummitDev}
@@ -616,7 +621,7 @@ export LD_LIBARY_PATH="$MYSOFTWARE_PATH/lib64:$MYSOFTWARE_PATH/lib:$LD_LIBRARY_P
 Now QMCPACK can be build with the following commands:
 \begin{verbatim}
 module load essl
-module load netlib-lapack 
+module load netlib-lapack
 module load hdf5/1.8.18
 module load fftw
 export FFTW_HOME=$OLCF_FFTW_ROOT
@@ -634,13 +639,13 @@ cmake -DCMAKE_C_COMPILER="mpicc" \
       -DCUDA_NVCC_FLAGS="-arch=sm_60;-Drestrict=__restrict__;-DNO_CUDA_MAIN;-O3" \
       ..
 make -j 8
-ls -l bin/qmcpack 
+ls -l bin/qmcpack
 \end{verbatim}
 
 \subsection{Installing on NERSC Edison Cray XC30}
 
-Edison is a Cray XC30 with dual 12-core Intel "Ivy Bridge" nodes 
-installed at NERSC. The build settings are identical to eos. 
+Edison is a Cray XC30 with dual 12-core Intel "Ivy Bridge" nodes
+installed at NERSC. The build settings are identical to eos.
 
 \begin{verbatim}
 module load cray-hdf5
@@ -651,33 +656,33 @@ module load boost
 mkdir build_edison
 cd build_edison
 cmake ..
-make -j 8  
-ls -l bin/qmcpack 
+make -j 8
+ls -l bin/qmcpack
 \end{verbatim}
 When the above was tested on 1 February 2016, the following module and
 software versions were present:
 \begin{verbatim}
 qmcpack@edison04:trunk> module list
 Currently Loaded Modulefiles:
-  1) modules/3.2.10.3                        16) alps/5.2.3-2.0502.9295.14.14.ari      
-  2) nsg/1.2.0                               17) rca/1.0.0-2.0502.57212.2.56.ari       
-  3) eswrap/1.1.0-1.020200.1130.0            18) atp/1.8.3                             
-  4) switch/1.0-1.0502.57058.1.58.ari        19) PrgEnv-intel/5.2.56                   
-  5) craype-network-aries                    20) craype-ivybridge                      
-  6) craype/2.5.0                            21) cray-shmem/7.3.0                      
-  7) intel/15.0.1.133                        22) cray-mpich/7.3.0                     
-  8) cray-libsci/13.3.0                      23) slurm/edison                         
-  9) udreg/2.3.2-1.0502.9889.2.20.ari        24) altd/2.0                             
- 10) ugni/6.0-1.0502.10245.9.9.ari           25) darshan/2.3.0                        
- 11) pmi/5.0.10-1.0000.11050.0.0.ari         26) subversion/1.7.9                     
- 12) dmapp/7.0.1-1.0502.10246.8.47.ari       27) cray-hdf5/1.8.14                     
- 13) gni-headers/4.0-1.0502.10317.9.2.ari    28) cmake/2.8.11.2                       
- 14) xpmem/0.1-2.0502.57015.1.15.ari         29) fftw/3.3.4.6                         
- 15) dvs/2.5_0.9.0-1.0502.1958.2.55.ari      30) boost/1.54                           
+  1) modules/3.2.10.3                        16) alps/5.2.3-2.0502.9295.14.14.ari
+  2) nsg/1.2.0                               17) rca/1.0.0-2.0502.57212.2.56.ari
+  3) eswrap/1.1.0-1.020200.1130.0            18) atp/1.8.3
+  4) switch/1.0-1.0502.57058.1.58.ari        19) PrgEnv-intel/5.2.56
+  5) craype-network-aries                    20) craype-ivybridge
+  6) craype/2.5.0                            21) cray-shmem/7.3.0
+  7) intel/15.0.1.133                        22) cray-mpich/7.3.0
+  8) cray-libsci/13.3.0                      23) slurm/edison
+  9) udreg/2.3.2-1.0502.9889.2.20.ari        24) altd/2.0
+ 10) ugni/6.0-1.0502.10245.9.9.ari           25) darshan/2.3.0
+ 11) pmi/5.0.10-1.0000.11050.0.0.ari         26) subversion/1.7.9
+ 12) dmapp/7.0.1-1.0502.10246.8.47.ari       27) cray-hdf5/1.8.14
+ 13) gni-headers/4.0-1.0502.10317.9.2.ari    28) cmake/2.8.11.2
+ 14) xpmem/0.1-2.0502.57015.1.15.ari         29) fftw/3.3.4.6
+ 15) dvs/2.5_0.9.0-1.0502.1958.2.55.ari      30) boost/1.54
 \end{verbatim}
 
 \subsection{Installing on NERSC Cori, Haswell Partition, Cray XC40}
-Cori is a Cray XC40 with 16-core Intel "Haswell" nodes 
+Cori is a Cray XC40 with 16-core Intel "Haswell" nodes
 installed at NERSC. The build settings are similar to eos at OLCF, but
 a workround is needed for the newer Cray OS which does not include a static
 libXml2 library. A NERSC installed version and its dependencies are used:
@@ -688,12 +693,12 @@ module load cmake
 module load fftw
 export FFTW_HOME=$FFTW_DIR/..
 module load boost
-export LIBXML2_HOME=/usr/common/software/libxml2/2.9.3/hsw 
+export LIBXML2_HOME=/usr/common/software/libxml2/2.9.3/hsw
 mkdir build_cori
 cd build_cori
 cmake -DQMC_EXTRA_LIBS=/usr/common/software/liblzma/20160630/hsw/lib/liblzma.a ..
-make -j 8  
-ls -l bin/qmcpack 
+make -j 8
+ls -l bin/qmcpack
 \end{verbatim}
 
 When the above was tested on 15 July 2016, the following module and
@@ -702,20 +707,20 @@ software versions were present:
 \begin{verbatim}
 qmcpack@cori05:trunk> module list
 Currently Loaded Modulefiles:
-  1) nsg/1.2.0                             15) dvs/2.5_0.9.0-1.0502.2188.1.116.ari            
-  2) modules/3.2.10.3                      16) alps/5.2.4-2.0502.9774.31.11.ari               
-  3) eswrap/1.1.0-1.020200.1231.0          17) rca/1.0.0-2.0502.60530.1.62.ari                
-  4) switch/1.0-1.0502.60522.1.61.ari      18) atp/1.8.3                                      
-  5) intel/16.0.0.109                      19) PrgEnv-intel/5.2.82                            
-  6) craype-network-aries                  20) craype-haswell                                 
-  7) craype/2.4.2                          21) cray-shmem/7.2.5                               
-  8) cray-libsci/13.2.0                    22) cray-mpich/7.2.5                               
-  9) udreg/2.3.2-1.0502.10518.2.17.ari     23) slurm/cori                                     
- 10) ugni/6.0-1.0502.10863.8.29.ari        24) cray-hdf5/1.8.14                               
- 11) pmi/5.0.9-1.0000.10911.0.0.ari        25) gcc/5.1.0                                      
- 12) dmapp/7.0.1-1.0502.11080.8.76.ari     26) cmake/3.3.2                                    
- 13) gni-headers/4.0-1.0502.10859.7.8.ari  27) fftw/3.3.4.5                                   
- 14) xpmem/0.1-2.0502.64982.5.3.ari        28) boost/1.59                                     
+  1) nsg/1.2.0                             15) dvs/2.5_0.9.0-1.0502.2188.1.116.ari
+  2) modules/3.2.10.3                      16) alps/5.2.4-2.0502.9774.31.11.ari
+  3) eswrap/1.1.0-1.020200.1231.0          17) rca/1.0.0-2.0502.60530.1.62.ari
+  4) switch/1.0-1.0502.60522.1.61.ari      18) atp/1.8.3
+  5) intel/16.0.0.109                      19) PrgEnv-intel/5.2.82
+  6) craype-network-aries                  20) craype-haswell
+  7) craype/2.4.2                          21) cray-shmem/7.2.5
+  8) cray-libsci/13.2.0                    22) cray-mpich/7.2.5
+  9) udreg/2.3.2-1.0502.10518.2.17.ari     23) slurm/cori
+ 10) ugni/6.0-1.0502.10863.8.29.ari        24) cray-hdf5/1.8.14
+ 11) pmi/5.0.9-1.0000.10911.0.0.ari        25) gcc/5.1.0
+ 12) dmapp/7.0.1-1.0502.11080.8.76.ari     26) cmake/3.3.2
+ 13) gni-headers/4.0-1.0502.10859.7.8.ari  27) fftw/3.3.4.5
+ 14) xpmem/0.1-2.0502.64982.5.3.ari        28) boost/1.59
 \end{verbatim}
 
 \subsection{Installing on NERSC Cori, Xeon Phi KNL Knight's Landing partition, Cray XC40}
@@ -735,7 +740,7 @@ module swap craype-haswell craype-mic-knl
 cmake -DQMC_EXTRA_LIBS=/usr/common/software/liblzma/20160630/hsw/lib/liblzma.a \
        -DCMAKE_CXX_FLAGS="-xMIC-AVX512" -DCMAKE_C_FLAGS="-xMIC-AVX512" ..
 make -j 16
-ls -l bin/qmcpack 
+ls -l bin/qmcpack
 \end{verbatim}
 
 When the above was tested on 21 December 2016, the following module and
@@ -763,7 +768,7 @@ Open a bash shell and follow the install directions for Ubuntu in Section \ref{s
 \label{sec:testing}
 We \textbf{strongly encourage} running the included tests each time
 QMCPACK is built. These compare the results from the executable with
-known-good mean-field, quantum chemical, and other QMC results. 
+known-good mean-field, quantum chemical, and other QMC results.
 
 The tests included with QMCPACK currently mainly test the VMC code with
 single determinant wavefunction and simple spline Jastrow
@@ -835,7 +840,7 @@ electrons, the performance is not representative of larger
 calculations. For example, while the calculations might fit in cache,
 there will be essentially no vectorization due to the small electron
 counts. \textbf{These tests should therefore not be used for any benchmarking or
-performance analysis}. 
+performance analysis}.
 
 Example runs that can be used for testing performance are described in
 Sec. \ref{sec:perftests}
@@ -879,7 +884,7 @@ See Chapter \ref{chap:unit_testing} for more details about unit tests.
 As described in Sec. \ref{sec:buildqe}, it is possible to test entire
 workflows of trial wavefunction generation, conversion, and eventual
 QMC calculation. A patched QE must be installed so that the
-pw2qmcpack converter is available. 
+pw2qmcpack converter is available.
 
 By adding \texttt{-D QE\_BIN=your\_QE\_binary\_path} in the cmake command line when building your QMCPACK,
 tests named with ``qe-'' prefix will be included in the test set of your build.
@@ -888,7 +893,7 @@ You can test the whole pw$\to$pw2qmcpack$\to$qmcpack workflow by
 ctest -R qe
 \end{verbatim}
 This provides a very solid test of the entire QMC
-toolchain for planewave generated wavefunctions.  
+toolchain for planewave generated wavefunctions.
 
 \subsection{Performance tests}
 \label{sec:perftests}
@@ -911,7 +916,7 @@ developers if you are unsure of what is a fair change.
 
 \subsubsection{NiO performance tests}
 
-Follow the instructions in tests/performance/NiO/README to 
+Follow the instructions in tests/performance/NiO/README to
 enable and run the NiO tests.
 
 The NiO tests are for bulk supercells of varying size. The QMC runs consist of short blocks of (i) VMC
@@ -920,8 +925,8 @@ constant population. The tests use spline wavefunctions that must be
 downloaded as described in the README due to their large size. You
 will need to set ``-DQMC\_DATA=YOUR\_DATA\_FOLDER -DENABLE\_TIMERS=1''
 when running cmake as
-described in the README. 
- 
+described in the README.
+
 Two sets of wavefunction are tested: splined orbitals with a one and
 two body Jastrow functions, and a more complex form with an additional
 three body Jastrow function. The Jastrows are the same for each run
@@ -934,12 +939,12 @@ future machines and require very large memory.
 \begin{center}
 \begin{tabular}{|c|c|c|c|}
 \hline
-\bfseries Name&  \bfseries Atoms& \bfseries Electrons&  \bfseries Electrons per spin \\ 
+\bfseries Name&  \bfseries Atoms& \bfseries Electrons&  \bfseries Electrons per spin \\
 \hline
- S8  &  32  &    384  &   192 \\ 
-S16 &   64  &    768  &  384 \\  
+ S8  &  32  &    384  &   192 \\
+S16 &   64  &    768  &  384 \\
 S32  & 128  &   1536 &           768 \\
-S64  & 256  &   3072 &     1536 \\ 
+S64  & 256  &   3072 &     1536 \\
 S128  & 512  &   6144 &      3072 \\
 S256  & 1024 & 12288 &  6144 \\
 \hline
@@ -958,11 +963,11 @@ the following combinations nightly (workstations) and weekly (supercomputers):
 \begin{itemize}
 \item On a Linux Intel Xeon workstation:
   \begin{itemize}
-  \item GCC 4.8.2 with OpenMPI and CUDA 7.0 (GPU build, run on NVIDIA K40s) 
+  \item GCC 4.8.2 with OpenMPI and CUDA 7.0 (GPU build, run on NVIDIA K40s)
   \item GCC 4.8.2 with OpenMPI with netlib BLAS
   \item GCC 4.8.2 with OpenMPI with Intel MKL
   \item Intel 2017 with Intel MPI and MKL
-  \item Intel 2015 with Intel MPI and MKL and CUDA 7.0 (GPU build, run on NVIDIA K40s) 
+  \item Intel 2015 with Intel MPI and MKL and CUDA 7.0 (GPU build, run on NVIDIA K40s)
   \item Intel 2015 with Intel MPI  and MKL
   \end{itemize}
 \item On a Linux Intel Knight's Landing workstation:
@@ -977,8 +982,8 @@ the following combinations nightly (workstations) and weekly (supercomputers):
 
 \item On Titan, a Cray XK7 CPU+GPU machine:
   \begin{itemize}
-  \item The GCC programming environment and compiler with Cray MPI and CUDA 
-  \item The GCC programming environment and compiler with Cray MPI 
+  \item The GCC programming environment and compiler with Cray MPI and CUDA
+  \item The GCC programming environment and compiler with Cray MPI
   \end{itemize}
 \item On Cetus, an IBM Blue Gene Q:
 \begin{itemize}
@@ -1084,7 +1089,7 @@ Some tips to help troubleshoot installations of QMCPACK:
   tools. You can compare the results of cmake and QMCPACK on this
   system with any more difficult systems you encounter.
 \item Use up to date development software, particularly a recent
-  CMake. 
+  CMake.
 \item Verify that the compilers and libraries that you expect are
   being configured. It is common to have multiple versions
   installed. The configure system will stop at the first version it


### PR DESCRIPTION
Added CMake optional arguments MPIEXEC and MPIEXEC_NUMPROCS_FLAG to the manual under the installation section.