### PR TITLE
Add check for python modules for estimator tests.

### DIFF
--- a/CMake/python.cmake
+++ b/CMake/python.cmake
@@ -1,0 +1,29 @@
+# Support functions for handling python scripts
+
+# Test whether a python modules is present
+#   MODULE_NAME - input, name of module to test for
+#   MODULE_PRESENT - output - True/False based on success of the import
+FUNCTION (TEST_PYTHON_MODULE MODULE_NAME MODULE_PRESENT)
+  EXECUTE_PROCESS(
+    COMMAND python ${qmcpack_SOURCE_DIR}/utils/test_import.py ${MODULE_NAME}
+    OUTPUT_VARIABLE TMP_OUTPUT_VAR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  SET(${MODULE_PRESENT} ${TMP_OUTPUT_VAR} PARENT_SCOPE)
+ENDFUNCTION()
+
+# Test python module prerequisites for a particular test script
+#   module_list - input - list of module names
+#   test_name - input - name of test (used for missing module message)
+#   add_test - output - true if all modules are present, false otherwise
+FUNCTION(CHECK_PYTHON_REQS module_list test_name add_test)
+  set(${add_test} true PARENT_SCOPE)
+  foreach(python_module IN LISTS ${module_list})
+    TEST_PYTHON_MODULE(${python_module} has_python_module)
+    if (NOT(has_python_module))
+      MESSAGE("Missing python module ${python_module}, not adding test ${test_name}")
+      set(${add_test} false PARENT_SCOPE)
+    endif()
+  endforeach()
+ENDFUNCTION()
+

--- a/tests/estimator/CMakeLists.txt
+++ b/tests/estimator/CMakeLists.txt
@@ -2,11 +2,13 @@
 # Add tests to ctest
 #############################################################
 
+INCLUDE("${qmcpack_SOURCE_DIR}/CMake/python.cmake")
+
 message("Adding estimator tests for QMCPACK")
 
 IF (NOT TEST_MAX_PROCS )
-SET ( TEST_MAX_PROCS 16 )
-message ("TEST_MAX_PROCS was unset. Set to 16")
+  SET ( TEST_MAX_PROCS 16 )
+  message ("TEST_MAX_PROCS was unset. Set to 16")
 ENDIF ()
 
 set(QMCAPP_ERR "")
@@ -21,16 +23,26 @@ else()
   INCLUDE( "${qmcpack_SOURCE_DIR}/CMake/macros.cmake" )
 endif()
 
-SIMPLE_RUN_AND_CHECK(estimator-skinetic
-  "${CMAKE_SOURCE_DIR}/tests/estimator/skinetic"
-  vmc.xml
-  1 16
-  skinetic_check.py
-)
+set(skinetic_python_reqs numpy;h5py)
+CHECK_PYTHON_REQS(skinetic_python_reqs estimator-skinetic add_test)
 
-SIMPLE_RUN_AND_CHECK(estimator-latdev
-  "${CMAKE_SOURCE_DIR}/tests/estimator/latdev"
-  vmc.xml
-  1 16
-  latdev_check.py
-)
+if (add_test)
+  SIMPLE_RUN_AND_CHECK(estimator-skinetic
+    "${CMAKE_SOURCE_DIR}/tests/estimator/skinetic"
+    vmc.xml
+    1 16
+    skinetic_check.py
+  )
+endif()
+
+set(latdev_python_reqs numpy;pandas;h5py)
+CHECK_PYTHON_REQS(latdev_python_reqs estimator-latdev add_test)
+
+if (add_test)
+  SIMPLE_RUN_AND_CHECK(estimator-latdev
+    "${CMAKE_SOURCE_DIR}/tests/estimator/latdev"
+    vmc.xml
+    1 16
+    latdev_check.py
+  )
+endif()

--- a/utils/test_import.py
+++ b/utils/test_import.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+import sys
+
+# Test for existence of module in python install
+
+if len(sys.argv) < 2:
+  print('Usage: test_import.py <module>')
+  sys.exit(1)
+
+module_to_test = sys.argv[1]
+#print('testing ',module_to_test)
+try:
+  mod = __import__(module_to_test)
+  print('True')
+except ImportError:
+  print('False')


### PR DESCRIPTION
Check a list of python modules to ensure they are installed before adding the estimator tests.
The test for module installation is based on whether the module successully imports or not.
If needed, additional tests of module functionality could be added.