### PR TITLE
nexus: fix for net_spin="low" in generate_physical_system

### DIFF
--- a/nexus/library/physical_system.py
+++ b/nexus/library/physical_system.py
@@ -694,7 +694,9 @@ def generate_physical_system(**kwargs):
         if extensive:
             ncells = int(round(structure.volume()/folded_structure.volume()))
             net_charge = ncells*net_charge
-            net_spin   = ncells*net_spin
+            if not isinstance(net_spin,str):
+                net_spin   = ncells*net_spin
+            #end if
         #end if
         if tiled_spin!=None:
             net_spin = tiled_spin

--- a/nexus/library/structure.py
+++ b/nexus/library/structure.py
@@ -5387,6 +5387,9 @@ def generate_crystal_structure(lattice=None,cell=None,centering=None,
         if kgrid!=None:
             structure.add_kmesh(kgrid,kshift)
         #end if        
+        if tiling!=None:
+            structure = structure.tile(tiling)
+        #end if
         return structure
     #end if
 


### PR DESCRIPTION
Very small change to correct a bug in tiled systems w/ requested low spin.  Useful for systems such as Al, which have a single atom in the primitive cell (necessarily spin polarized with integer electrons), but are spin unpolarized in supercells.