### PR TITLE
nexus: forbid bundling sims that depend on each other

### DIFF
--- a/nexus/library/bundle.py
+++ b/nexus/library/bundle.py
@@ -110,11 +110,36 @@ class SimulationBundle(Simulation):
 
     def bundle_dependencies(self):
         deps = []
+        sim_ids = set()
+        depsim_ids = set()
         for sim in self.sims:
+            sim_ids.add(sim.simid)
+            depsim_ids |= sim.downstream_simids()
             for d in sim.dependencies:
                 deps.append((d.sim,'other'))
             #end for
         #end for
+        # guard against dependencies within the bundle
+        internal_deps = sim_ids & depsim_ids
+        if len(internal_deps)>0:
+            sims = dict()
+            for sim in self.sims:
+                sims[sim.simid]=sim
+            #end for
+            msg = 'attempted to bundle simulations that depend on each other\nsimulations can only be bundled if they can be executed simultaneously\nbundle identifier, simid, and directory:\n  {0:<8} {1:>4} {2}\n'.format(self.identifier,self.simid,self.locdir)
+            msg+='sims in the bundle that can remain:\n'
+            for simid in sorted(sim_ids-internal_deps):
+                sim = sims[simid]
+                msg +='  {0:<8} {1:>4} {2}\n'.format(sim.identifier,sim.simid,sim.locdir)
+            #end for
+            msg+='sims in the bundle that need to be removed:\n'
+            for simid in sorted(internal_deps):
+                sim = sims[simid]
+                msg +='  {0:<8} {1:>4} {2}\n'.format(sim.identifier,sim.simid,sim.locdir)
+            #end for
+            msg+='please remove the necessary sims from the bundle and try again\nthe excluded sims can likely be bundled separately'
+            self.error(msg,'bundle')
+        #end if
         self.depends(*deps)
     #end def bundle_dependencies
 

--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -828,6 +828,18 @@ class Simulation(NexusCore):
     #end def get_dependencies
         
 
+    def downstream_simids(self,simids=None):
+        if simids is None:
+            simids = set()
+        #end if
+        for sim in self.dependents:
+            simids.add(sim.simid)
+            sim.downstream_simids(simids)
+        #end for
+        return simids
+    #end def downstream_simids
+
+
     def copy_file(self,sourcefile,dest):
         src = os.path.dirname(os.path.abspath(sourcefile))
         dst = os.path.abspath(dest)


### PR DESCRIPTION
Users attempting to bundle jobs/simulations together that depend on each other causes Nexus to hang.  An example situation: attempting to bundle together SCF and DMC runs.  Put a guard in place (error trap) to ensure that only simulations capable of simultaneous execution (i.e. in a single job) are bundled together.