### PR TITLE
Initialize is_open value in ReadFileBuffer.

### DIFF
--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -54,12 +54,12 @@ bool ECPComponentBuilder::parse(const std::string& fname, xmlNodePtr cur)
   return read_pp_file(fname);
 }
 
-int get_file_length(std::ifstream *fin)
+int ReadFileBuffer::get_file_length(std::ifstream *f)
 {
-    fin->seekg (0, std::ios::end);
-    int length = fin->tellg();
-    fin->seekg (0, std::ios::beg);
-    return length;
+    f->seekg (0, std::ios::end);
+    int len = f->tellg();
+    f->seekg (0, std::ios::beg);
+    return len;
 }
 
 bool ReadFileBuffer::open_file(const std::string &fname)
@@ -104,13 +104,13 @@ bool ECPComponentBuilder::read_pp_file(const std::string &fname)
   bool okay = buf.open_file(fname);
   if(!okay)
   {
-    APP_ABORT("ECPComponentBuilder::parse  Missing PP file " + fname +"\n");
+    APP_ABORT("ECPComponentBuilder::read_pp_file  Missing PP file " + fname +"\n");
   }
 
   okay = buf.read_contents();
   if(!okay)
   {
-    APP_ABORT("ECPComponentBuilder::parse Unable to read PP file " + fname +"\n");
+    APP_ABORT("ECPComponentBuilder::read_pp_file Unable to read PP file " + fname +"\n");
   }
 
   xmlDocPtr m_doc = xmlReadMemory(buf.contents(),buf.length,NULL,NULL,0);
@@ -118,7 +118,7 @@ bool ECPComponentBuilder::read_pp_file(const std::string &fname)
   if (m_doc == NULL)
   {
     xmlFreeDoc(m_doc);
-    APP_ABORT("ECPComponentBuilder::parse xml file "+fname+" is invalid");
+    APP_ABORT("ECPComponentBuilder::read_pp_file xml file "+fname+" is invalid");
   }
   // Check the document is of the right kind
   xmlNodePtr cur = xmlDocGetRootElement(m_doc);

--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -54,7 +54,7 @@ bool ECPComponentBuilder::parse(const std::string& fname, xmlNodePtr cur)
   return read_pp_file(fname);
 }
 
-int ReadFileBuffer::get_file_length(std::ifstream *f)
+int ReadFileBuffer::get_file_length(std::ifstream *f) const
 {
     f->seekg (0, std::ios::end);
     int len = f->tellg();
@@ -62,8 +62,27 @@ int ReadFileBuffer::get_file_length(std::ifstream *f)
     return len;
 }
 
+void ReadFileBuffer::reset()
+{
+  if (is_open)
+  {
+    if(myComm == NULL || myComm->rank() == 0)
+    {
+      delete fin;
+      fin = NULL;
+    }
+    delete[] cbuffer;
+    cbuffer = NULL;
+    is_open = false;
+    length = 0;
+  }
+}
+
 bool ReadFileBuffer::open_file(const std::string &fname)
 {
+
+  reset();
+
   if (myComm == NULL || myComm->rank() == 0)
   {
     fin = new std::ifstream(fname.c_str());

--- a/src/QMCHamiltonians/ECPComponentBuilder.h
+++ b/src/QMCHamiltonians/ECPComponentBuilder.h
@@ -86,10 +86,12 @@ class ReadFileBuffer
   char *cbuffer;
   std::ifstream *fin;
   Communicate *myComm;
+  int get_file_length(std::ifstream *f);
+
 public:
   bool is_open;
   int length;
-  ReadFileBuffer(Communicate *c) : cbuffer(NULL), fin(NULL), myComm(c), length(0) {}
+  ReadFileBuffer(Communicate *c) : cbuffer(NULL), fin(NULL), myComm(c), is_open(false), length(0) {}
   bool open_file(const std::string &fname);
   bool read_contents();
   char *contents() { return cbuffer; }

--- a/src/QMCHamiltonians/ECPComponentBuilder.h
+++ b/src/QMCHamiltonians/ECPComponentBuilder.h
@@ -86,7 +86,7 @@ class ReadFileBuffer
   char *cbuffer;
   std::ifstream *fin;
   Communicate *myComm;
-  int get_file_length(std::ifstream *f);
+  int get_file_length(std::ifstream *f) const;
 
 public:
   bool is_open;
@@ -95,6 +95,7 @@ public:
   bool open_file(const std::string &fname);
   bool read_contents();
   char *contents() { return cbuffer; }
+  void reset();
 
   ~ReadFileBuffer() {
       delete[] cbuffer;

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -96,5 +96,26 @@ TEST_CASE("ReadFileBuffer_ecp","[hamiltonian]")
   // TODO: add more checks that pseudopotential file was read correctly
 }
 
+TEST_CASE("ReadFileBuffer_reopen","[hamiltonian]")
+{
+  // Initializing with no Communicate pointer under MPI,
+  //   this will read the file on every node.  Should be okay
+  //   for testing purposes.
+  ReadFileBuffer buf(NULL);
+  bool open_okay = buf.open_file("simple.txt");
+  REQUIRE(open_okay == true);
+
+  bool read_okay = buf.read_contents();
+  REQUIRE(read_okay);
+  REQUIRE(buf.length == 14);
+
+  open_okay = buf.open_file("C.BFD.xml");
+  REQUIRE(open_okay == true);
+
+  read_okay = buf.read_contents();
+  REQUIRE(read_okay);
+  REQUIRE(buf.length > 14);
+}
+
 }
 


### PR DESCRIPTION
Address comments in issue #253.
 - initialize the value of is_open to false by default
 - Update the filename in the APP_ABORT messages
 - change get_file_length to be a member function.