### PR TITLE
Add unit tests for DMC walker propagation

### DIFF
--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME unit_test_${SRC_DIR})
 
 
-ADD_EXECUTABLE(${UTEST_EXE} test_vmc.cpp)
+ADD_EXECUTABLE(${UTEST_EXE} test_vmc.cpp test_dmc.cpp)
 USE_FAKE_RNG(${UTEST_EXE})
 TARGET_LINK_LIBRARIES(${UTEST_EXE} qmc qmcdriver_unit qmcham qmcwfs qmcbase qmcutil qmcfakerng ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -1,0 +1,233 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov, Argonne National Laboratory 
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "Utilities/RandomGenerator.h"
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Utilities/OhmmsInfo.h"
+#include "Lattice/ParticleBConds.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
+#include "Particle/SymmetricDistanceTableData.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "QMCApp/ParticleSetPool.h"
+#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/TrialWaveFunction.h"
+#include "QMCWaveFunctions/ConstantOrbital.h"
+#include "QMCWaveFunctions/LinearOrbital.h"
+#include "QMCHamiltonians/BareKineticEnergy.h"
+#include "Estimators/EstimatorManager.h"
+#include "Estimators/TraceManager.h"
+#include "QMCDrivers/DMC/DMCUpdatePbyP.h"
+
+
+#include <stdio.h>
+#include <string>
+
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][dmc]")
+{
+
+  Communicate *c;
+  OHMMS::Controller->initialize(0, NULL);
+  c = OHMMS::Controller;
+  OhmmsInfo("testlogfile");
+
+  ParticleSet ions;
+  MCWalkerConfiguration elec;
+
+  ions.setName("ion");
+  ions.create(1);
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  elec.setName("elec");
+  elec.setBoundBox(false);
+  std::vector<int> agroup(1);
+  agroup[0] = 2;
+  elec.create(agroup);
+  elec.R[0][0] = 1.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+  elec.R[1][0] = 0.0;
+  elec.R[1][1] = 0.0;
+  elec.R[1][2] = 1.0;
+  elec.createWalkers(1);
+  elec.WalkerList[0]->DataSet.resize(9);
+
+
+  SpeciesSet &tspecies =  elec.getSpeciesSet();
+  int upIdx = tspecies.addSpecies("u");
+  int downIdx = tspecies.addSpecies("d");
+  int chargeIdx = tspecies.addAttribute("charge");
+  int massIdx = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(chargeIdx, downIdx) = -1;
+  tspecies(massIdx, upIdx) = 1.0;
+  tspecies(massIdx, downIdx) = 1.0;
+
+  elec.addTable(ions);
+  elec.update();
+
+
+  TrialWaveFunction *psi = new TrialWaveFunction(c);
+  ConstantOrbital *orb = new ConstantOrbital;
+  psi->addOrbital(orb, "Constant");
+
+  FakeRandom rg;
+
+  QMCHamiltonian h;
+  h.addOperator(new BareKineticEnergy<double>(elec),"Kinetic");
+  h.addObservables(elec); // get double free error on 'h.Observables' w/o this
+
+  elec.resetWalkerProperty(); // get memory corruption w/o this
+
+  DMCUpdatePbyPWithRejectionFast dmc(elec, *psi, h, rg);
+  EstimatorManager EM;
+  double tau = 0.1;
+  SimpleFixedNodeBranch branch(tau, 1);
+  TraceManager TM;
+  dmc.resetRun(&branch, &EM, &TM);
+  dmc.startBlock(1);
+
+  DMCUpdatePbyPWithRejectionFast::WalkerIter_t begin = elec.begin();
+  DMCUpdatePbyPWithRejectionFast::WalkerIter_t end = elec.end();
+  dmc.advanceWalkers(begin, end, true);
+
+  // With the constant wavefunction, no moves should be rejected
+  REQUIRE(dmc.nReject == 0);
+  REQUIRE(dmc.nAccept == 2);
+
+  // Each electron moved sqrt(tau)*gaussian_rng()
+  //  See ParticleBase/tests/test_random_seq.cpp for the gaussian random numbers
+  REQUIRE(elec.R[0][0] == Approx(0.6276702589209545));
+  REQUIRE(elec.R[0][1] == Approx(0.0));
+  REQUIRE(elec.R[0][2] == Approx(-0.3723297410790455));
+
+  REQUIRE(elec.R[1][0] == Approx(0.0));
+  REQUIRE(elec.R[1][1] == Approx(-0.3723297410790455));
+  REQUIRE(elec.R[1][2] == Approx(1.0));
+
+
+  // Check rejection in case of node-crossing
+
+  orb->FakeGradRatio = -1.0;
+
+  dmc.advanceWalkers(begin, end, true);
+#ifdef QMC_COMPLEX
+  REQUIRE(dmc.nReject == 0);
+  REQUIRE(dmc.nAccept == 4);
+#else
+  // Should be rejected
+  REQUIRE(dmc.nReject == 2);
+  REQUIRE(dmc.nAccept == 2);
+#endif
+
+}
+
+TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dmc]")
+
+{
+
+  Communicate *c;
+  OHMMS::Controller->initialize(0, NULL);
+  c = OHMMS::Controller;
+  OhmmsInfo("testlogfile");
+
+  ParticleSet ions;
+  MCWalkerConfiguration elec;
+
+  ions.setName("ion");
+  ions.create(1);
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  elec.setName("elec");
+  elec.setBoundBox(false);
+  std::vector<int> agroup(1);
+  agroup[0] = 2;
+  elec.create(agroup);
+  elec.R[0][0] = 1.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+  elec.R[1][0] = 0.0;
+  elec.R[1][1] = 0.0;
+  elec.R[1][2] = 1.0;
+  elec.createWalkers(1);
+  elec.WalkerList[0]->DataSet.resize(9);
+
+
+  SpeciesSet &tspecies =  elec.getSpeciesSet();
+  int upIdx = tspecies.addSpecies("u");
+  int downIdx = tspecies.addSpecies("d");
+  int chargeIdx = tspecies.addAttribute("charge");
+  int massIdx = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(chargeIdx, downIdx) = -1;
+  tspecies(massIdx, upIdx) = 1.0;
+  tspecies(massIdx, downIdx) = 1.0;
+
+  elec.addTable(ions);
+  elec.update();
+
+
+  TrialWaveFunction *psi = new TrialWaveFunction(c);
+  LinearOrbital *orb = new LinearOrbital;
+  psi->addOrbital(orb, "Linear");
+
+  FakeRandom rg;
+
+  QMCHamiltonian h;
+  h.addOperator(new BareKineticEnergy<double>(elec),"Kinetic");
+  h.addObservables(elec); // get double free error on 'h.Observables' w/o this
+
+  elec.resetWalkerProperty(); // get memory corruption w/o this
+
+  DMCUpdatePbyPWithRejectionFast dmc(elec, *psi, h, rg);
+  EstimatorManager EM;
+  double tau = 0.1;
+  SimpleFixedNodeBranch branch(tau, 1);
+  TraceManager TM;
+  dmc.resetRun(&branch, &EM, &TM);
+  dmc.startBlock(1);
+
+  DMCUpdatePbyPWithRejectionFast::WalkerIter_t begin = elec.begin();
+  DMCUpdatePbyPWithRejectionFast::WalkerIter_t end = elec.end();
+  dmc.advanceWalkers(begin, end, true);
+
+  REQUIRE(dmc.nReject == 0);
+  REQUIRE(dmc.nAccept == 2);
+
+  // Each electron moved sqrt(tau)*gaussian_rng()
+  //  See ParticleBase/tests/test_random_seq.cpp for the gaussian random numbers
+  //  See DMC_propagator notebook for computation of these values
+  REQUIRE(elec.R[0][0] == Approx(0.695481606677082));
+  REQUIRE(elec.R[0][1] == Approx(0.135622695565971));
+  REQUIRE(elec.R[0][2] == Approx(-0.168895697756948));
+
+  REQUIRE(elec.R[1][0] == Approx(0.0678113477829853));
+  REQUIRE(elec.R[1][1] == Approx(-0.236707045539933));
+  REQUIRE(elec.R[1][2] == Approx(1.20343404334896));
+
+}
+}
+

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -2,24 +2,27 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
 //
-// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory 
 //
-// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
-#ifndef QMCPLUSPLUS_CONSTANTORBITAL_H
-#define QMCPLUSPLUS_CONSTANTORBITAL_H
+
+
+#ifndef QMCPLUSPLUS_LINEARORBITAL_H
+#define QMCPLUSPLUS_LINEARORBITAL_H
 
 #include "QMCWaveFunctions/OrbitalBase.h"
 
 namespace qmcplusplus
 {
 
+// Only for testing - has constant gradient and zero laplacian
+// phi = coeff[0]*x + coeff[1]*y + coeff[2]*z
 
-class ConstantOrbital: public OrbitalBase
+
+class LinearOrbital: public OrbitalBase
 {
 public:
   virtual void checkInVariables(opt_variables_type &active) {}
@@ -28,24 +31,32 @@ public:
   virtual void reportStatus(std::ostream& os) {}
   virtual void resetTargetParticleSet(ParticleSet& P) {}
 
-  ValueType FakeGradRatio;
+  TinyVector<ValueType,3> coeff;
 
-  ConstantOrbital() : FakeGradRatio(1.0) {}
+  LinearOrbital() {coeff[0]=1.0; coeff[1]= 2.0; coeff[2]=3.0;}
 
   virtual ValueType
   evaluate(ParticleSet& P,
            ParticleSet::ParticleGradient_t& G,
            ParticleSet::ParticleLaplacian_t& L)
   {
-    G = 0.0;
+    APP_ABORT("LinearOrbital. evaluate");
+    ValueType v = 0.0;
+    for (int i = 0; i < P.R.size(); i++) {
+      for (int d = 0; d < OHMMS_DIM; d++) {
+        v += coeff[d]*P.R[i][d];
+      }
+      G[i] = coeff;
+    }
     L = 0.0;
-    return 1.0;
+    return v;
   }
 
   virtual RealType
   evaluateLog(ParticleSet& P,
               ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
+    APP_ABORT("LinearOrbital. evaluateLog");
     G = 0.0;
     L = 0.0;
     return 0.0;
@@ -55,9 +66,14 @@ public:
                           ParticleSet::ParticleGradient_t& dG,
                           ParticleSet::ParticleLaplacian_t& dL)
   {
-    dG = 0.0;
+    ValueType v = 0.0;
+    APP_ABORT("LinearOrbital. ratio");
+    for (int d = 0; d < OHMMS_DIM; d++) {
+      v += coeff[d]*P.R[iat][d];
+    }
+    dG = 1.0;
     dL = 0.0;
-    return 1.0;
+    return v;
   }
 
   virtual void acceptMove(ParticleSet& P, int iat) {}
@@ -74,23 +90,25 @@ public:
                       ParticleSet::ParticleLaplacian_t& dL,
                       int iat)
   {
+    APP_ABORT("LinearOrbital. update");
     dG = 0.0;
     dL = 0.0;
   }
 
   virtual RealType evaluateLog(ParticleSet& P,BufferType& buf)
   {
+    APP_ABORT("LinearOrbital. evaluteLogbuffer");
     return 0.0;
   }
 
   virtual GradType evalGrad(ParticleSet &P, int iat)
   {
-    return GradType(0.0);
+    return GradType(coeff);
   }
 
   virtual ValueType ratioGrad(ParticleSet &P, int iat, GradType& grad_iat)
   {
-    return FakeGradRatio;
+    return 1.0;
   }
 
   virtual RealType registerData(ParticleSet& P, BufferType& buf) {return 0.0;}


### PR DESCRIPTION
Use some simplified wavefunctions for testing - constant orbital (gradient is zero)
and linear orbital (gradient is constant).

The methods in LinearOrbital contain abort statements so only the ones strictly
needed for the unit tests are added.  There is some implementation in 'evaluate',
but since it's not called by these tests, it may not be completely correct.

Move return statements in ConstantOrbital to the end of the function.

The Jupyter notebook that generates the values is here: https://github.com/markdewing/qmc_algorithms/blob/master/Diffusion/DMC_propagator.ipynb
