### PR TITLE
Test VMC with drift at non-gamma twist that real code can still run

### DIFF
--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="hf_vmc_LiH-x-drift" series="0">
+  </project>
+  <!--random seed="49154"/-->
+
+  <qmcsystem>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+  <qmc method="vmc" move="pbyp" gpu="yes">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    16 </parameter>
+    <parameter name="substeps">  5 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="steps">  100 </parameter>
+    <parameter name="blocks">  1000 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   yes </parameter>
+  </qmc>
+
+</simulation>

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -211,6 +211,15 @@ ENDIF()
                     0 # VMC
                     TRUE)
 
+  QMC_RUN_AND_CHECK(short-LiH_solid_1x1x1_pp-x-drift-vmc_hf_noj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+                    hf_vmc_LiH-x-drift
+                    hf_vmc_LiH-x-drift.xml
+                    1 16
+                    LIH_X_SCALARS
+                    0 # VMC
+                    TRUE)
+
 
 # Arbitrary k-point requires complex build to run. Ensure fails with real/non-complex build
   LIST(APPEND LIH_ARB_SCALARS "kinetic" "7.4201207734399359 0.024")


### PR DESCRIPTION
Missing from our testing and added due to the issue found while checking #219. Currently we test gamma (too easy) and an arbitrary twist that only the complex code can run. This test should run successfully with the real code as well as the complex code.
