### PR TITLE
Coverage - mark lines from files not in unit tests correctly

### DIFF
--- a/tests/coverage/compare_gcov.py
+++ b/tests/coverage/compare_gcov.py
@@ -124,13 +124,16 @@ def mark_as_uncovered(gcov_base):
   for line in gcov_base.line_info.iterkeys():
     base_line = gcov_base.line_info[line]
     Uncov_norm= '#####'
+    Nocode = '-'
 
     diff_count = base_line.count
     try:
       base_count = int(base_line.count)
       diff_count = Uncov_norm
     except ValueError:
-      pass
+      if base_line.count == Uncov_norm:
+        diff_count = Nocode
+
 
     diff_line_info[line] = read_gcov.LineInfo(diff_count, line, base_line.src)
 


### PR DESCRIPTION
For files that are completely untouched in the unit tests, but have some execution
in the the base tests, the behavior was to mark all the executed lines as uncovered.
This would incorrectly handle lines that are not executed (uncovered) in the base.
These lines should be marked as 'no-code' (not counted in coverage) in the output
directory.

This was most obvious in the case of formic/utils/lmyengine/engine_timing.cpp.
Even though the new optimizer is not called by the base test, there are some static
initializers that get called.   All the executable lines of the file were marked
as uncovered in the output, which was incorrect.  After the fix, only the lines
called by the static initializers are marked as uncovered.

With this fix the percentage coverage rises to 67% locally (probably will vary
some from that on the official test system)