### PR TITLE
Fix LiH x-point bug.

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -347,6 +347,7 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     else
       temp_OrbitalSet = new EinsplineSetExtended<double>;
     MixedSplineReader->export_MultiSpline(&(temp_OrbitalSet->MultiSpline));
+    //set the flags for anti periodic boundary conditions
     temp_OrbitalSet->HalfG = dynamic_cast<SplineAdoptorBase<double,3> *>(OrbitalSet)->HalfG;
     new_OrbitalSet = temp_OrbitalSet;
   }

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -157,12 +157,12 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   else
     NewOcc=false;
 #if defined(QMC_CUDA)
-  app_log() << "\t  QMC_CUDA=1 Overwriting the precision of the einspline storage on the host.\n";
+  app_log() << "\t  QMC_CUDA=1 Overwriting the einspline storage on the host to double precision.\n";
   spo_prec="double"; //overwrite
   truncate="no"; //overwrite
 #endif
 #if defined(MIXED_PRECISION)
-  app_log() << "\t  MIXED_PRECISION=1 Overwriting the precision of the einspline storage.\n";
+  app_log() << "\t  MIXED_PRECISION=1 Overwriting the einspline storage to single precision.\n";
   spo_prec="single"; //overwrite
 #endif
   H5OrbSet aset(H5FileName, spinSet, numOrbs);
@@ -347,6 +347,7 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     else
       temp_OrbitalSet = new EinsplineSetExtended<double>;
     MixedSplineReader->export_MultiSpline(&(temp_OrbitalSet->MultiSpline));
+    temp_OrbitalSet->HalfG = dynamic_cast<SplineAdoptorBase<double,3> *>(OrbitalSet)->HalfG;
     new_OrbitalSet = temp_OrbitalSet;
   }
   else


### PR DESCRIPTION
This bug affects non-supercell calculations on non-gamma twists using real valued orbitals with the real code but does not affect the complex code.
Related to part of the short-LiH-x issue #219 @prckent reported.
**It affects both VMC and DMC but VMC short tests didn't complain due to small statistics and large error bar.**
Now all the LiH DMC tests pass.

Some validation VMC runs
Each CPU run generates 3276800000 samples.
Each GPU run generates 409600000 samples.

                            LocalEnergy               Variance           ratio
arb-cpu-cplx/hf_vmc_LiH-arb  series 0  -8.383875 +/- 0.000051   1.600102 +/- 0.007014   0.1909
arb-gpu-cplx/hf_vmc_LiH-arb  series 0  -8.383593 +/- 0.000146   1.594170 +/- 0.011175   0.1902
gamma-cpu-cplx/hf_vmc_LiH-gamma  series 0  -8.481005 +/- 0.000050   1.623379 +/- 0.006308   0.1914
gamma-cpu-real/hf_vmc_LiH-gamma  series 0  -8.481042 +/- 0.000051   1.620302 +/- 0.005031   0.1910
gamma-gpu-cplx/hf_vmc_LiH-gamma  series 0  -8.480816 +/- 0.000139   1.619718 +/- 0.014977   0.1910
gamma-gpu-real/hf_vmc_LiH-gamma  series 0  -8.480948 +/- 0.000150   1.716451 +/- 0.097850   0.2024
x-cpu-cplx/hf_vmc_LiH-x  series 0  -8.240201 +/- 0.000047   1.559897 +/- 0.003813   0.1893
x-cpu-real/hf_vmc_LiH-x  series 0  -8.240103 +/- 0.000045   1.583906 +/- 0.016596   0.1922
x-gpu-cplx/hf_vmc_LiH-x  series 0  -8.240127 +/- 0.000140   1.555000 +/- 0.006831   0.1887
x-gpu-real/hf_vmc_LiH-x  series 0  -8.240113 +/- 0.000135   1.569071 +/- 0.012415   0.1904

arb-cpu-cplx/hf_vmc_LiH-arb  series 0  Kinetic               =  7.420353 +/- 0.000521
arb-gpu-cplx/hf_vmc_LiH-arb  series 0  Kinetic               =  7.420494 +/- 0.001682
gamma-cpu-cplx/hf_vmc_LiH-gamma  series 0  Kinetic               =  7.414736 +/- 0.000562
gamma-cpu-real/hf_vmc_LiH-gamma  series 0  Kinetic               =  7.414941 +/- 0.000504
gamma-gpu-cplx/hf_vmc_LiH-gamma  series 0  Kinetic               =  7.411374 +/- 0.001602
gamma-gpu-real/hf_vmc_LiH-gamma  series 0  Kinetic               =  7.414454 +/- 0.001474
x-cpu-cplx/hf_vmc_LiH-x  series 0  Kinetic               =  7.377165 +/- 0.000504
x-cpu-real/hf_vmc_LiH-x  series 0  Kinetic               =  7.377636 +/- 0.000509
x-gpu-cplx/hf_vmc_LiH-x  series 0  Kinetic               =  7.375528 +/- 0.001621
x-gpu-real/hf_vmc_LiH-x  series 0  Kinetic               =  7.376071 +/- 0.001520

arb-cpu-cplx/hf_vmc_LiH-arb  series 0  LocalECP              =  -11.615491 +/- 0.000560
arb-gpu-cplx/hf_vmc_LiH-arb  series 0  LocalECP              =  -11.615429 +/- 0.001819
gamma-cpu-cplx/hf_vmc_LiH-gamma  series 0  LocalECP              =  -11.719009 +/- 0.000607
gamma-cpu-real/hf_vmc_LiH-gamma  series 0  LocalECP              =  -11.719251 +/- 0.000544
gamma-gpu-cplx/hf_vmc_LiH-gamma  series 0  LocalECP              =  -11.715358 +/- 0.001729
gamma-gpu-real/hf_vmc_LiH-gamma  series 0  LocalECP              =  -11.718657 +/- 0.001584
x-cpu-cplx/hf_vmc_LiH-x  series 0  LocalECP              =  -11.414297 +/- 0.000541
x-cpu-real/hf_vmc_LiH-x  series 0  LocalECP              =  -11.414749 +/- 0.000546
x-gpu-cplx/hf_vmc_LiH-x  series 0  LocalECP              =  -11.412509 +/- 0.001736
x-gpu-real/hf_vmc_LiH-x  series 0  LocalECP              =  -11.413091 +/- 0.001628