### PR TITLE
Add merging of gcov files.

### DIFF
--- a/tests/coverage/merge_gcov.py
+++ b/tests/coverage/merge_gcov.py
@@ -1,0 +1,148 @@
+
+import read_gcov
+import argparse
+from collections import OrderedDict
+import sys
+
+def merge_gcov_files(fnames, output_fname):
+  gcovs = [read_gcov.read_gcov(f) for f in fnames]
+  source_names = [g.tags['Source'] for g in gcovs]
+  for source in source_names[1:]:
+    if source_names[0] != source:
+      print 'Source file names do not match',source_names[0],source
+      return
+
+  gcov_out = merge_gcovs(gcovs)
+
+  out_f = sys.stdout
+  if output_fname:
+    out_f = open(output_fname, 'w')
+  read_gcov.write_gcov(gcov_out, out_f)
+
+
+def merge_gcovs(gcovs):
+  output_line_info = OrderedDict()
+
+  for line in gcovs[0].line_info.iterkeys():
+      lines = [g.line_info[line] for g in gcovs]
+
+      Uncov_norm= '#####'
+      Uncov_throw= '====='
+      Uncov = [Uncov_norm, Uncov_throw]
+      Nocode = '-'
+
+      output_count = None
+
+      lines_count = []
+      for lc in lines:
+        line_count = 0
+        try:
+          line_count = int(lc.count)
+        except:
+          pass
+        lines_count.append(line_count)
+
+      any_lines_covered = reduce(lambda x,y:x or y, [a > 0 for a in lines_count])
+      any_lines_uncovered = reduce(lambda x,y:x or y, [a.count in Uncov for a in lines])
+      all_lines_nocode = reduce(lambda x,y:x and y, [a.count == Nocode for a in lines])
+
+      if any_lines_covered:
+        output_count = sum(lines_count)
+      elif any_lines_uncovered:
+        output_count = Uncov_norm
+      elif all_lines_nocode:
+        output_count = Nocode
+
+      #if line1_count > 0 or line2_count > 0:
+
+      #  output_count = line1_count + line2_count
+      #elif line1.count == Uncov_norm or line2.count == Uncov_norm:
+      #  output_count = Uncov_norm
+      #elif line1.count == Nocode and line2.count == Nocode:
+      #  output_count = Nocode
+
+      if output_count is None:
+        print 'Unhandled situation:'
+        for idx,line in enumerate(lines):
+          print '  line %d: '%idx,line
+
+      output_line_info[line] = read_gcov.LineInfo(str(output_count), line, lines[0].src)
+
+  return read_gcov.GcovFile(gcovs[0].fname, gcovs[0].tags, output_line_info, None, None, None, gcovs[0].func_ranges)
+
+
+# this function was replaced by the more general merge_gcov_files that can
+#  merge an arbitrary number of files.  However, it's easier to understand
+# the logic for two files, so this function is left here.
+def merge_two_gcov_files(fname1, fname2, output_fname):
+  gcov1 = read_gcov.read_gcov(fname1)
+  gcov2 = read_gcov.read_gcov(fname2)
+
+  source_file1 = gcov1.tags['Source']
+  source_file2 = gcov2.tags['Source']
+  if source_file1 != source_file2:
+    print 'Source files do not match',source_file1,source_file2
+    return
+
+  gcov_out = merge_two_gcovs(gcov1, gcov2)
+
+  out_f = sys.stdout
+  if output_fname:
+    out_f = open(output_fname, 'w')
+  read_gcov.write_gcov(gcov_out, out_f)
+
+
+def merge_two_gcovs(gcov1, gcov2):
+  output_line_info = OrderedDict()
+
+  for line in gcov1.line_info.iterkeys():
+      line1 = gcov1.line_info[line]
+      line2 = gcov2.line_info[line]
+
+      Uncov_norm= '#####'
+      Nocode = '-'
+
+      output_count = None
+
+      line1_count = 0
+      try:
+        line1_count = int(line1.count)
+      except:
+        pass
+
+      line2_count = 0
+      try:
+        line2_count = int(line2.count)
+      except:
+        pass
+
+      if line1_count > 0 or line2_count > 0:
+        output_count = line1_count + line2_count
+      elif line1.count == Uncov_norm or line2.count == Uncov_norm:
+        output_count = Uncov_norm
+      elif line1.count == Nocode and line2.count == Nocode:
+        output_count = Nocode
+
+      if output_count is None:
+        print 'Unhandled situation:'
+        print '  line1: ',line1
+        print '  line2: ',line2
+
+      output_line_info[line] = read_gcov.LineInfo(str(output_count), line, line1.src)
+
+  return read_gcov.GcovFile(gcov1.fname, gcov1.tags, output_line_info, None, None, None, gcov1.func_ranges)
+
+
+if __name__ == '__main__':
+  desc = """
+  Merge different gcov files corresponding to the same source
+  """
+
+  parser = argparse.ArgumentParser(description=desc)
+  parser.add_argument('input_files',nargs='*')
+  parser.add_argument('-o','--output')
+
+  args = parser.parse_args()
+
+  #merge_two_gcov_files(args.input_files[0], args.input_files[1], args.output)
+  merge_gcov_files(args.input_files, args.output)

--- a/tests/coverage/run_coverage.sh
+++ b/tests/coverage/run_coverage.sh
@@ -22,16 +22,25 @@ echo "Running base coverage"
 
 ctest -L coverage
 
+raw_base_dir="cov_base_raw"
+if [ ! -d $raw_base_dir ]; then
+  mkdir $raw_base_dir
+fi
+
 base_dir="cov_base"
 if [ ! -d $base_dir ]; then
   mkdir $base_dir
 fi
 
-cd $base_dir
-find `pwd`/.. -name \*.gcda | xargs -i gcov -b -p {}
+cd $raw_base_dir
+find `pwd`/.. -name \*.gcda | xargs -i gcov -b -p -l {}
 
 # Filter out unwanted files
 python ${SRC_ROOT}/tests/coverage/compare_gcov.py -a process --base-dir .
+
+cd ../$base_dir
+# Combine different gcov files corresponding to the same source
+python ${SRC_ROOT}/tests/coverage/compare_gcov.py -a merge --base-dir ../$raw_base_dir
 
 
 # If gcovr is present, create an html report
@@ -56,14 +65,24 @@ ${SRC_ROOT}/tests/coverage/clean_gcda.sh
 echo "Running unit test coverage"
 ctest -L unit
 
-unit_dir="cov_unit"
+raw_unit_dir="cov_unit_raw"
+if [ ! -d $raw_unit_dir ]; then
+  mkdir $raw_unit_dir
+fi
 
+unit_dir="cov_unit"
 if [ ! -d $unit_dir ]; then
   mkdir $unit_dir
 fi
 
-cd $unit_dir
-find `pwd`/.. -name \*.gcda | xargs -i gcov -b -p {}
+cd $raw_unit_dir
+find `pwd`/.. -name \*.gcda | xargs -i gcov -b -p -l {}
+
+cd ../$unit_dir
+
+# Combine different gcov files corresponding to the same source
+python ${SRC_ROOT}/tests/coverage/compare_gcov.py -a merge --base-dir ../$raw_unit_dir
+
 
 # Filter out unwanted files
 python ${SRC_ROOT}/tests/coverage/compare_gcov.py -a process --base-dir .


### PR DESCRIPTION
Fixes because include files do not get coverage handled correctly for unit tests.  Only the coverage information corresponding to one executable is included, the coverage information from all the others is overwritten.  The coverage information should be combined.

There are two types of files produced for coverage:
  .gcno - produced at compile-time, contains notes for translating basic blocks to source lines
  .gcda - produced at run-time, contains the counts for basic blocks and arcs between then (for branch coverage)

The .gcda files can be merged, but only for multiple runs of the same executable.
(The .gcda files get automatically merged at run time, and newer versions of gcc have a 'gcov-tool' that can merge .gcda files)
This works fine for the system tests, since they all run 'qmcpack'.
For the unit tests, they cannot be merged because they come from different executables.

CMake puts object files for different executables in different directories (even for the same source file), and the .gcno and .gcda files follow, so nothing gets overwritten during collection.

However, while running 'gcov', these files get processed into files with the '.gcov' suffix, and these can get overwritten.  It's particularly bad for include files, because they don't even have a separate .gcno/.gcda file. (The collected data for one object file can generate multiple .gcov files, usually for included files)

Gcov has a -l (--long-file-names) switch to help with this.  The .gcov filename has two parts, separated by '##'.  The first part contains the cpp.gcda file the gcov file originated from, and the second part contains the usual source file name.
The -p (--preserve-paths) option keeps all the path components, separated by '#'.
Combining the -l and -p options with the CMake directory layout, the (long!) gcov file name is unique.

The next step is to combine the data at the .gcov file level.  This is the purpose of merge_gcov.py.   Lines are combined based on the priority: covered > uncovered > no code.

The collection script is modified to first put the .gcov files in a 'raw' directory where files have the two-part name.  Then those files are merged and put into the previously used directory (with a one-part name), and the processing proceeds as before.

This commit only fixes the standalone coverage script.  The coverage processing for the nightly runs will be a future commit.