### PR TITLE
Add tolerance to Jastrow rcut.

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -378,7 +378,15 @@ struct BsplineFunctor: public OptimizableFunctorBase
     else
       if (periodic && radius > cutoff_radius)
       {
-        APP_ABORT("  The Jastrow cutoff specified should not be larger than Wigner-Seitz radius.");
+        if (radius - cutoff_radius > 1e-4)
+        {
+          APP_ABORT( "  The Jastrow cutoff specified should not be larger than Wigner-Seitz radius.");
+        }
+        else
+        {
+          app_log() << "  The Jastrow cutoff specified is slightly larger than the Wigner-Seitz radius.";
+          app_log() << "  Setting to Wigner-Seitz radius = " << cutoff_radius << ".\n";
+        }
       }
       else
         cutoff_radius = radius;

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -63,16 +63,27 @@ bool eeI_JastrowBuilder::putkids (xmlNodePtr kids, J3type &J3)
       functor->put (kids);
       if (sourcePtcl->Lattice.SuperCellEnum != SUPERCELL_OPEN)
       {
-        if (functor->cutoff_radius > sourcePtcl->Lattice.WignerSeitzRadius)
+        const RealType WSRadius = sourcePtcl->Lattice.WignerSeitzRadius;
+        if (functor->cutoff_radius > WSRadius)
         {
-          APP_ABORT("  The eeI Jastrow cutoff specified should not be larger than Wigner-Seitz radius.");
+          if ( functor->cutoff_radius - WSRadius > 1e-4 )
+          {
+            APP_ABORT("  The eeI Jastrow cutoff specified should not be larger than Wigner-Seitz radius.");
+          }
+          else
+          {
+            app_log() << "  The eeI Jastrow cutoff specified is slightly larger than the Wigner-Seitz radius.";
+            app_log() << "  Setting to Wigner-Seitz radius = " << WSRadius << ".\n";
+            functor->cutoff_radius = WSRadius;
+            functor->reset();
+          }
         }
         if (functor->cutoff_radius < 1.0e-6)
         {
           app_log()  << "  eeI functor rcut is currently zero.\n"
                      << "  Setting to Wigner-Seitz radius = "
-                     << sourcePtcl->Lattice.WignerSeitzRadius << std::endl;
-          functor->cutoff_radius = sourcePtcl->Lattice.WignerSeitzRadius;
+                     << WSRadius << std::endl;
+          functor->cutoff_radius = WSRadius;
           functor->reset();
         }
       }


### PR DESCRIPTION
1) If rcut > Wigner-Seitz radius + 1e-4, abort
2) If rcut > Wigner-Seitz radius and rcut <= Wigner-Seitz radius + 1e-4, overwrite to Wigner-Seitz radius
3) If rcut <= Wigner-Seitz, respect user input.

Addressing issue #291 