### PR TITLE
Add tolerance to compares for estimators unit test

### DIFF
--- a/src/Estimators/tests/test_accumulator.cpp
+++ b/src/Estimators/tests/test_accumulator.cpp
@@ -112,10 +112,10 @@ void test_real_accumulator()
   REQUIRE(a.variance() == Approx(4.625));
 
   std::pair<T, T> mv = a.mean_and_variance();
-  REQUIRE(mv.first == a.mean());
-  REQUIRE(mv.second == a.variance());
+  REQUIRE(mv.first == Approx(a.mean()));
+  REQUIRE(mv.second == Approx(a.variance()));
 
-  REQUIRE(mean(a) == a.mean());
+  REQUIRE(mean(a) == Approx(a.mean()));
 
   // check that this doesn't crash
   std::stringstream o;
@@ -149,8 +149,8 @@ void test_real_accumulator_weights()
   REQUIRE(a.variance() == Approx(5.1909181302));
 
   std::pair<T, T> mv = a.mean_and_variance();
-  REQUIRE(mv.first == a.mean());
-  REQUIRE(mv.second == a.variance());
+  REQUIRE(mv.first == Approx(a.mean()));
+  REQUIRE(mv.second == Approx(a.variance()));
 }
 
 TEST_CASE("accumulator with weights float", "[estimators]")


### PR DESCRIPTION
Addresses #290

mean() and mean_and_variance() duplicate the formulas and can have slight differences as a result (divide vs. reciprocal and multiply).   An better eventual fix would be to use identical formulas in both methods.

