### PR TITLE
Clean up git-rev-tmp.h after each build.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,11 @@ SET(GITREV_BARE_TMP git-rev-tmp.h)
 SET(GITREV_FILE ${CMAKE_BINARY_DIR}/src/${GITREV_BARE_FILE})
 SET(GITREV_TMP ${CMAKE_BINARY_DIR}/src/${GITREV_BARE_TMP})
 
+# Always clean up git-rev-tmp.h file when cmake is run
+EXECUTE_PROCESS(
+  COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_TMP}
+)
+
 IF (GIT_FOUND AND IS_GIT_PROJECT)
   # The following custom command picks up changes to the git revision information
   # every time the project is rebuilt. Even if the repositiory is updated (git pull)

--- a/src/QMCApp/CMakeLists.txt
+++ b/src/QMCApp/CMakeLists.txt
@@ -53,6 +53,11 @@ ELSE()
   ADD_EXECUTABLE(${p} ${p}.cpp) 
 ENDIF()
 
+# Clean up git-rev-tmp.h after the build is finished
+ADD_CUSTOM_COMMAND(TARGET qmcpack
+                   POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_TMP})
+
   TARGET_LINK_LIBRARIES(${p} qmc qmcdriver qmcham qmcwfs qmcbase qmcutil adios_config)
 
   IF(BUILD_AFQMC)


### PR DESCRIPTION
This should ensure the commands to build git-rev.h are triggered on the next build.
This might help with some of the Spack issues.