### PR TITLE
nexus: add makov payne correction, make plotting robust

### DIFF
--- a/nexus/executables/qmca
+++ b/nexus/executables/qmca
@@ -1372,15 +1372,31 @@ def convert(value,source_unit,target_unit):
 
 
 
+success = False
 try:
+    import matplotlib
+    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
+    for gui in gui_envs:
+        try:
+            matplotlib.use(gui,warn=False, force=True)
+            from matplotlib import pyplot
+            success = True
+            break
+        except:
+            continue
+        #end try
+    #end for
     from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
     rcParams.update(params)
 except (ImportError,RuntimeError):
-   figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+    success = False
 #end try
+if not success:
+    figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+#end if
 
 
 def sigfig_round(some_float, nsigfig):

--- a/nexus/executables/qmcfit
+++ b/nexus/executables/qmcfit
@@ -12,6 +12,17 @@ except ImportError:
     print 'tsfit error: scipy is not present on your machine\n  please install scipy and retry'
 #end try
 try:
+    import matplotlib
+    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
+    for gui in gui_envs:
+        try:
+            matplotlib.use(gui,warn=False, force=True)
+            from matplotlib import pyplot
+            break
+        except:
+            continue
+        #end try
+    #end for
     from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
@@ -1432,7 +1443,7 @@ def timestep_fit():
                       )
 
     options,args = parser.parse_args()
-    scalar_files = args[1:]
+    scalar_files = list(sorted(args[1:]))
     opt = obj(**options.__dict__)
 
     if len(scalar_files)==0:

--- a/nexus/library/plotting.py
+++ b/nexus/library/plotting.py
@@ -12,15 +12,33 @@
 
 
 from developer import unavailable
+success = False
 try:
+    import matplotlib
+    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
+    for gui in gui_envs:
+        try:
+            matplotlib.use(gui,warn=False, force=True)
+            from matplotlib import pyplot
+            success = True
+            break
+        except:
+            continue
+        #end try
+    #end for
     from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,yticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
     rcParams.update(params)
 except (ImportError,RuntimeError):
-   figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,yticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','yticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+    success = False
 #end try
+if not success:
+    figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,yticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','yticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+    pyplot     = unavailable('matplotlib','pyplot')
+    matplotlib = unavailable('matplotlib')
+#end if
 
 
 # savefig(savefile,format='png',bbox_inches ='tight',pad_inches=.3)


### PR DESCRIPTION
Add ability to calculate the first order Makov-Payne correction for any cell.  Supported in new function 'makov_payne' in structure.py.

Also improve robustness of plotting generally, including tools like qmca.  Previously plots would fail in some environments (e.g. Titan at OLCF) due to default backend issues.  This is now fixed.  Fix contributed by Kayahan Saritas.