### PR TITLE
Lattice analyzer multi-precision bugfix 

### DIFF
--- a/src/Lattice/LatticeAnalyzer.h
+++ b/src/Lattice/LatticeAnalyzer.h
@@ -314,7 +314,9 @@ inline bool found_shorter_base(TinyVector<TinyVector<T,3>,3>& rb)
 template<typename T>
 inline void find_reduced_basis(TinyVector<TinyVector<T,3>,3>& rb)
 {
-  do
+  int maxIter=10000;
+ 
+  for(int count=0; count<maxIter; count++)
   {
     TinyVector<TinyVector<T,3>,3> saved(rb);
     bool changed=false;
@@ -329,7 +331,7 @@ inline void find_reduced_basis(TinyVector<TinyVector<T,3>,3>& rb)
     if(!changed && !found_shorter_base(rb))
       return;
   }
-  while(1);
+  
 }
 
 }

--- a/src/Lattice/LatticeAnalyzer.h
+++ b/src/Lattice/LatticeAnalyzer.h
@@ -279,7 +279,7 @@ struct LatticeAnalyzer<T,1>
 template<typename T>
 inline bool found_shorter_base(TinyVector<TinyVector<T,3>,3>& rb)
 {
-  const T eps=10.0*std::numeric_limits<float>::epsilon();
+  const T eps=10.0*std::numeric_limits<T>::epsilon();
   int imax=0;
   T r2max=dot(rb[0],rb[0]);
   for(int i=1; i<3; i++)
@@ -291,6 +291,10 @@ inline bool found_shorter_base(TinyVector<TinyVector<T,3>,3>& rb)
       imax=i;
     }
   }
+
+  T rmax = sqrt(r2max);
+  T tol = 2.0*rmax*eps; //Error propagation for x^2
+
   TinyVector<TinyVector<T,3>,4> rb_new;
   rb_new[0]=rb[0]+rb[1]-rb[2];
   rb_new[1]=rb[0]+rb[2]-rb[1];
@@ -299,7 +303,7 @@ inline bool found_shorter_base(TinyVector<TinyVector<T,3>,3>& rb)
   for(int i=0; i<4; ++i)
   {
     T r2=dot(rb_new[i],rb_new[i]);
-    if((r2-r2max) < -eps)
+    if((r2-r2max) < -tol)
     {
       rb[imax]=rb_new[i];
       return true;


### PR DESCRIPTION
This pull request addresses bugs in LatticeAnalyzer::find_shorter_base() and secondarily removes the do...while loop in LaticeAnalyzer::find_reduced_basis(), which in conjunction with the bugs in find_shorter_base(), can lead to an infinite loop.  This infinite loop was found using multi-precision and the following unit cell:

`<parameter name="lattice" units="bohr">
        7.37924194        2.76721573        2.76721573
        2.76721573        7.37924194        2.76721573
        2.76721573        2.76721573        7.37924194
  </parameter>` 

**Bug fixes in LatticeAnalyzer::find_shorter_base()**
1.)  Changes the definition of eps tolerance to reference the floating point type used in the definition of the lattice vectors, and not "float".  
2.)  For the lattice vector replacement condition ((r2-r2max) < -eps), replace eps with tol=2*sqrt(r2max)*eps, which is the correct propagation of errors in the expression x^2.  

**Improvement in LatticeAnalyzer::find_reduced_basis()**
a.)  I changed the do...while(1) loop to a loop over some hardcoded maximum iteration (maxIter=10000) for now.  I figure if QMCPACK can't find a reduced cell by then, the user should check their unit cell or contact a developer.  
