### PR TITLE
Update documentation.

### DIFF
--- a/manual/bibliography.bib
+++ b/manual/bibliography.bib
@@ -184,3 +184,10 @@ keywords = "QMCPACK",
 keywords = "Quantum Espresso",
 keywords = "VASP "
 }
+
+@article{IPCC_SC17,
+title = "Embracing a new era of highly efficient and productive quantum Monte Carlo simulations",
+author = "Mathuriya, Amrita and Luo, Ye and Clay, Raymond C. III and Benali, Anouar and  Shulenburger, Luke and Kim, Jeongnim",
+note = "arXiv:1708.02645",
+year = {2017},
+}

--- a/manual/features.tex
+++ b/manual/features.tex
@@ -1,0 +1,60 @@
+\chapter{Features of QMCPACK}
+\label{chap:features}
+\section{Features in production}
+\begin{itemize}
+\item Variational Monte Carlo
+\item Diffusion Monte Carlo
+\item Reptation Monte Carlo
+\item Single and multi-determinant Slater Jastrow wavefunctions
+\item Wavefunction updates using optimized multi-determinant algorithm of Clark et al.
+\item Backflow wavefunctions
+\item One, two, and three-body Jastrow factors
+\item Excited state calculations via flexible occupancy assignment of Slater determinants
+\item All electron and non-local pseudopotential calculations
+\item Casula T-moves for variational evaluation of non-local pseudopotentials
+\item Wavefunction optimization using the ``linear method'' of Umrigar and co-workers, with arbitrary mix of variance and energy in the objective function
+\item Gaussian, Slater, plane-wave and real-space spline basis sets for orbitals
+\item Interface and conversion utilities for plane-wave wavefunctions from Quantum Espresso (PWSCF)
+\item Interface and conversion utilities for Gaussian-basis wavefunctions from GAMESS
+\item Easy extension and interfacing to other electronic structure codes via standardized XML and HDF5 inputs
+\item MPI parallelism
+\item Fully threaded using OpenMP
+\item GPU (CUDA) implementation (limited functionality)
+\item HDF5 input/output for large data
+\item Nexus: advanced workflow tool to automate all aspects of QMC calculation from initial DFT calculations through to final analysis
+\item Analysis tools for minimal environments (perl only) through to python-based with graphs produced via matplotlib.
+\end{itemize}
+
+\subsection{Supported GPU features}
+
+\begin{itemize}
+
+  \item VMC, wavefunction optimization, DMC are supported
+  \item Periodic and open boundary conditions are fully supported. Mixed boundary conditions are not yet supported.
+  \item Wavefunctions:
+    \begin{enumerate}
+        \item Single Slater determinants with 3D B-spline orbitals. Twist-averaged boundary conditions and complex wavefunctions are fully supported. Gaussian type orbitals are not supported yet.
+        \item Mixed basis representation in which orbitals are represented as 1D splines times spherical harmonics in spherical regions (muffin tins) around atoms, and 3D B-splines in the interstitial region.
+        \item One-body and two-body Jastrows represented as 1D B-splines are supported.
+    \end{enumerate}
+  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and Model periodic Coulomb (MPC) interaction are all supported.
+\end{itemize}
+
+\section{Features in beta test}
+This section describes developmental features in QMCPACK that might be ready for production, but require additional testing, features or documentation to be ready for general use. We describe them here because they offer significant benefits and are well tested in specific cases.
+
+\subsection{CPU SoA optimization}
+SoA stands for Structure-of-Arrays which is a data layout facilitating vectorization on modern CPUs with wide SIMD units. The SoA optimization for CPUs significantly boost the performance of QMCPACK. Meanwhile, the memory footprint is dramatically reduced by introducing compute-on-the-fly algorithms. To get all the benefit, compilers support OpenMP 4.0 SIMD are recommended. \textbf{Users should check what we specifically test on cdash/ctest and to make specific requests to expand the functionality that they need.}
+
+SoA code path currently supports:
+\begin{itemize}
+  \item VMC, wavefunction optimization, DMC, RMC are all supported
+  \item Periodic, open and mixed boundary conditions are fully supported.
+  \item Wavefunctions:
+    \begin{enumerate}
+      \item Single and multiple Slater determinants with 3D B-spline orbitals. Twist-averaged boundary conditions and complex wavefunctions are fully supported. Gaussian type orbitals are not supported yet.
+      \item Hybrid representation, to be ready soon.
+      \item One-body and two-body Jastrows represented as 1D B-splines and three-body Jastrow represented as polynomials are supported.
+    \end{enumerate}
+  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and MPC are all supported.
+\end{itemize}

--- a/manual/features.tex
+++ b/manual/features.tex
@@ -44,7 +44,7 @@
 This section describes developmental features in QMCPACK that might be ready for production, but require additional testing, features or documentation to be ready for general use. We describe them here because they offer significant benefits and are well tested in specific cases.
 
 \subsection{CPU SoA optimization}
-SoA stands for Structure-of-Arrays which is a data layout facilitating vectorization on modern CPUs with wide SIMD units. The SoA optimization for CPUs significantly boost the performance of QMCPACK. Meanwhile, the memory footprint is dramatically reduced by introducing compute-on-the-fly algorithms. To get all the benefit, compilers support OpenMP 4.0 SIMD are recommended. \textbf{Users should check what we specifically test on cdash/ctest and to make specific requests to expand the functionality that they need.}
+SoA stands for Structure-of-Arrays which is a data layout facilitating vectorization on modern CPUs with wide SIMD units. The SoA optimization \cite{IPCC_SC17} for CPUs significantly boost the performance of QMCPACK. Meanwhile, the memory footprint is dramatically reduced by introducing compute-on-the-fly algorithms. To get all the benefit, compilers support OpenMP 4.0 SIMD are recommended. \textbf{Users should check what we specifically test on cdash/ctest and to make specific requests to expand the functionality that they need.}
 
 SoA code path currently supports:
 \begin{itemize}

--- a/manual/features.tex
+++ b/manual/features.tex
@@ -1,6 +1,11 @@
 \chapter{Features of QMCPACK}
 \label{chap:features}
 \section{Features in production}
+The following lists the main production level features of QMCPACK. If
+you do not see a specific feature that you are interested in listed,
+see the remainder of this manual and ask to see if specific feature is
+available or can be made full production level quickly.
+
 \begin{itemize}
 \item Variational Monte Carlo
 \item Diffusion Monte Carlo
@@ -11,15 +16,19 @@
 \item One, two, and three-body Jastrow factors
 \item Excited state calculations via flexible occupancy assignment of Slater determinants
 \item All electron and non-local pseudopotential calculations
-\item Casula T-moves for variational evaluation of non-local pseudopotentials
-\item Wavefunction optimization using the ``linear method'' of Umrigar and co-workers, with arbitrary mix of variance and energy in the objective function
+\item Casula T-moves for variational evaluation of non-local
+  pseudopotentials (non-size consistent)
+\item Wavefunction optimization using the ``linear method'' of Umrigar
+  and co-workers, with arbitrary mix of variance and energy in the
+  objective function
+\item Blocked, low memory adaptive shift optimizer of Zhao and Neuscamman. 
 \item Gaussian, Slater, plane-wave and real-space spline basis sets for orbitals
 \item Interface and conversion utilities for plane-wave wavefunctions from Quantum Espresso (PWSCF)
 \item Interface and conversion utilities for Gaussian-basis wavefunctions from GAMESS
 \item Easy extension and interfacing to other electronic structure codes via standardized XML and HDF5 inputs
 \item MPI parallelism
 \item Fully threaded using OpenMP
-\item GPU (CUDA) implementation (limited functionality)
+\item GPU (NVIDIA CUDA) implementation (limited functionality)
 \item HDF5 input/output for large data
 \item Nexus: advanced workflow tool to automate all aspects of QMC calculation from initial DFT calculations through to final analysis
 \item Analysis tools for minimal environments (perl only) through to python-based with graphs produced via matplotlib.
@@ -27,34 +36,61 @@
 
 \subsection{Supported GPU features}
 
-\begin{itemize}
+The GPU implementation supports multiple GPUs per node, with MPI tasks assigned
+in a round-robin order to the GPUs. Currently, for large runs, 1 MPI task should
+be used per GPU per node. For smaller calculations, use of multiple
+MPI tasks per GPU may yield improved performance.
 
-  \item VMC, wavefunction optimization, DMC are supported
-  \item Periodic and open boundary conditions are fully supported. Mixed boundary conditions are not yet supported.
+\begin{itemize}
+  \item VMC, wavefunction optimization, DMC.
+  \item Periodic and open boundary conditions. Mixed boundary conditions are not yet supported.
   \item Wavefunctions:
     \begin{enumerate}
         \item Single Slater determinants with 3D B-spline orbitals. Twist-averaged boundary conditions and complex wavefunctions are fully supported. Gaussian type orbitals are not supported yet.
-        \item Mixed basis representation in which orbitals are represented as 1D splines times spherical harmonics in spherical regions (muffin tins) around atoms, and 3D B-splines in the interstitial region.
-        \item One-body and two-body Jastrows represented as 1D B-splines are supported.
+        \item Hybrid Mixed basis representation in which orbitals are represented as 1D splines times spherical harmonics in spherical regions (muffin tins) around atoms, and 3D B-splines in the interstitial region.
+        \item One-body and two-body Jastrows represented as 1D
+          B-splines are supported. Threee-body jastrow functions are
+          not yet supported.
     \end{enumerate}
-  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and Model periodic Coulomb (MPC) interaction are all supported.
+  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and Model periodic Coulomb (MPC) interaction.
 \end{itemize}
 
-\section{Features in beta test}
-This section describes developmental features in QMCPACK that might be ready for production, but require additional testing, features or documentation to be ready for general use. We describe them here because they offer significant benefits and are well tested in specific cases.
+\section{Beta test teatures}
 
-\subsection{CPU SoA optimization}
-SoA stands for Structure-of-Arrays which is a data layout facilitating vectorization on modern CPUs with wide SIMD units. The SoA optimization \cite{IPCC_SC17} for CPUs significantly boost the performance of QMCPACK. Meanwhile, the memory footprint is dramatically reduced by introducing compute-on-the-fly algorithms. To get all the benefit, compilers support OpenMP 4.0 SIMD are recommended. \textbf{Users should check what we specifically test on cdash/ctest and to make specific requests to expand the functionality that they need.}
+This section describes developmental features in QMCPACK that might be
+ready for production, but require additional testing, features or
+documentation to be ready for general use. We describe them here
+because they offer significant benefits and are well tested in
+specific cases.
+
+\subsection{High performance CPU SoA optimizations}
+The Structure-of-Arrays (SoA) optimizations \cite{IPCC_SC17} are a set
+of improved data layouts facilitating vectorization on modern CPUs
+with wide SIMD units. \textbf{For many calculations and architectures, the SoA
+  implementation at least doubles the speed of the code.}  Meanwhile,
+the memory footprint is dramatically reduced by better algorithms,
+similar to the existing GPU implementation. For full benefit, modern
+compilers supporting OpenMP 4.0 SIMD are recommended, e.g. GCC version
+$\ge$4.9 and Intel compiler versions $\ge 15.0$. \textbf{Users should
+  check what is currently tested on cdash/ctest and make specific
+  requests to expand the functionality that they need.}
+
+As described in \ref{sec:cmakeoptions}, to enable the SoA
+implementation, QMCPACK should be configured with \texttt{-DENABLE\_SOA=1}.
 
 SoA code path currently supports:
 \begin{itemize}
-  \item VMC, wavefunction optimization, DMC, RMC are all supported
-  \item Periodic, open and mixed boundary conditions are fully supported.
+  \item VMC, wavefunction optimization, DMC, RMC.
+  \item Periodic, open and mixed boundary conditions.
   \item Wavefunctions:
     \begin{enumerate}
-      \item Single and multiple Slater determinants with 3D B-spline orbitals. Twist-averaged boundary conditions and complex wavefunctions are fully supported. Gaussian type orbitals are not supported yet.
-      \item Hybrid representation, to be ready soon.
-      \item One-body and two-body Jastrows represented as 1D B-splines and three-body Jastrow represented as polynomials are supported.
+      \item Single and multiple Slater determinants with 3D B-spline
+        orbitals. Twist-averaged boundary conditions and complex
+        wavefunctions are fully supported. Gaussian type orbitals are
+        not supported yet.
+      \item One-body and two-body Jastrows represented as 1D B-splines and three-body Jastrow represented as polynomials.
     \end{enumerate}
-  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and MPC are all supported.
+  \item Semilocal (nonlocal and local) pseudopotentials, Coulomb interaction (electron-electron, electron-ion) and MPC.
 \end{itemize}
+
+

--- a/manual/hamiltonianobservable.tex
+++ b/manual/hamiltonianobservable.tex
@@ -170,7 +170,7 @@ When periodic boundary conditions are selected, Ewald summation is used automati
 \end{align}
 The sum indexed by $L$ is over all non-zero simulation cell lattice vectors.  In practice, the Ewald sum is broken into short and long ranged parts in a manner optimized for efficiency (see Ref. \cite{Natoli1995}) for details. 
 
-For information on how to set the boundary conditions, consult Sec. \ref{sec:simulationcell}.
+For information on how to set the boundary conditions, consult Sec. \ref{chap:simulationcell}.
 
 
 \FloatBarrier

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -260,7 +260,7 @@ MPIEXEC_NUMPROC_FLAG   Specify the number of mpi processes flag, e.g. "-n", "-np
 \end{itemize}
 
 \subsection{Configure and build using cmake and make}
-To configure and build QMPACK, move to build directory, run cmake and make
+To configure and build QMCPACK, move to build directory, run cmake and make
 \begin{verbatim}
 cd build
 cmake ..
@@ -371,7 +371,7 @@ QMCPACK tried to do its best with CMake to facilitate cross-compiling.
 
 \begin{itemize}
   \item On a machine using Cray programming environment, we reply on
-      compiler wrappers provied by Cray to set architecture specific flags
+      compiler wrappers provided by Cray to set architecture specific flags
   \item If not on a Cray machine, we assume default building for the host.
     With Intel compiler, -xHost is added for Intel compiler
     and -march=native is added for GNU/Clang compilers.
@@ -545,7 +545,7 @@ cmake -DCMAKE_C_COMPILER=/usr/local/bin/mpicc \
       -DCMAKE_CXX_COMPILER=/usr/local/bin/mpicxx ..
 make -j 12
 \end{verbatim}
-\item Run the short tests. When mpich is used for the first time, OS
+\item Run the short tests. When MPICH is used for the first time, OS
   X will request approval of the network connection.
 \begin{verbatim}
 ctest -R short
@@ -560,7 +560,7 @@ Due to the fact that the login nodes and the compute nodes have different proces
 cross-compiling is required on this platform. See details about using Blue Gene/Q at \url{http://www.alcf.anl.gov/user-guides/compiling-linking}.
 On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang and +cmake in \$HOME/.soft.
 In order to build QMCPACK, a toolchain file is provided for setting up CMake and the cmake command should be executed twice.
-\textbf{XL C/C++ compiler no more builds QMCPACK due to the lack of C++11 support but BGClang can produce correct binary with good peroformance.}
+\textbf{XL C/C++ compiler no more builds QMCPACK due to the lack of C++11 support but BGClang can produce correct binary with good performance.}
 
 \begin{verbatim}
 cd build
@@ -569,8 +569,6 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../config/BGQ_Clang++11_ToolChain.cmake ..
 make -j 16
 ls -l bin/qmcpack
 \end{verbatim}
-
-During the make, you can use make VERBOSE=1 to print all the build commands.
 
 \subsection{Installing on ALCF Theta, Cray XC40}
 Theta is a 9.65 petaflops system manufactured by Cray with 3624 compute nodes.
@@ -934,7 +932,7 @@ You can test the whole pw$\to$pw2qmcpack$\to$qmcpack workflow by
 ctest -R qe
 \end{verbatim}
 This provides a very solid test of the entire QMC
-toolchain for planewave generated wavefunctions.
+toolchain for plane wave generated wavefunctions.
 
 \subsection{Performance tests}
 \label{sec:perftests}
@@ -943,7 +941,7 @@ tests/performance directory. They can be used for benchmarking, comparing machin
 performance, or assessing optimizations. This is in
 contrast to the majority of the conventional integration tests where the particle
 counts are too small to be representative. Care is still needed to
-remove initiallization, I/O, and compute a representative performance
+remove initialization, I/O, and compute a representative performance
 measure.
 
 The ctest integration is sufficient to run the benchmarks and measure
@@ -968,7 +966,7 @@ will need to set ``-DQMC\_DATA=YOUR\_DATA\_FOLDER -DENABLE\_TIMERS=1''
 when running cmake as
 described in the README.
 
-Two sets of wavefunction are tested: splined orbitals with a one and
+Two sets of wavefunction are tested: spline orbitals with a one and
 two body Jastrow functions, and a more complex form with an additional
 three body Jastrow function. The Jastrows are the same for each run
 and are not reoptimized, as might be done for research purposes.  Runs
@@ -1003,7 +1001,7 @@ You can locate the failing tests by searching for the key word `Fail'.
 
 \subsection{Slow testing with OpenMPI}
 OpenMPI has a default binding policy making all the threads running on a single core during testing when there are two or fewer MPI ranks.
-This significantly increases the testing time. If you are authorized to change the default setting, you can just add `hwloc\_base\_binding\_policy none' in /etc/openmpi/openmpi-mca-params.conf.
+This significantly increases the testing time. If you are authorized to change the default setting, you can just add `hwloc\_base\_binding\_policy=none' in /etc/openmpi/openmpi-mca-params.conf.
 
 \section{Automated testing of QMCPACK}
 
@@ -1057,7 +1055,7 @@ the following combinations nightly (workstations) and weekly (supercomputers):
 \label{sec:buildppconvert}
 QMCPACK includes a utility, ppconvert, to convert between different
 pseudopotential formats. Examples include effective core potential
-formats (in gaussians), the UPF format used by Quantum ESPRESSO, and
+formats (in Gaussians), the UPF format used by Quantum ESPRESSO, and
 the XML format used by QMCPACK itself. The utility also enables the
 atomic orbitals to recomputed via a numerical density functional
 calculation if they need to be reconstructed for use in an

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -204,8 +204,8 @@ QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
                     The GPU support is quite mature.
                     Use always double for host side base and full precision
                     and use float and double for CUDA base and full precision.
-ENABLE_SOA          Enable CPU optimization based on Structure-of-Array (SoA)
-                    datatypes (1:yes, 0:no (default)).\cite{IPCC_SC17}
+ENABLE_SOA          (Experimental) Enable CPU optimization based on Structure-
+                    of-Array (SoA) datatypes (1:yes, 0:no (default)).\cite{IPCC_SC17}
 
 \end{verbatim}
   \item General build options
@@ -1006,7 +1006,9 @@ This significantly increases the testing time. If you are authorized to change t
 \section{Automated testing of QMCPACK}
 
 The QMCPACK developers run automatic tests of QMCPACK on several
-different computer systems,  many on a continuous basis. We currently test
+different computer systems,  many on a continuous basis. See reports at
+\url{https://cdash.qmcpack.org/CDash/index.php?project=QMCPACK}.
+We currently test
 the following combinations nightly (workstations) and weekly (supercomputers):
 
 \begin{itemize}

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -87,8 +87,7 @@ strongly encouraged}, but not absolutely essential. Generally newer versions are
 Section \ref{sec:buildperformance} for performance suggestions.
 
 \begin{itemize}
-\item C/C++ compilers such as GNU, Intel, IBM XL. LLVM-based compilers
-  are supported only on a preliminary basis. C++ compilers are required to support C++11 standard.
+\item C/C++ compilers such as GNU, Clang, Intel, IBM XL. C++ compilers are required to support C++11 standard.
 \item MPI library such at OpenMPI \url{http://open-mpi.org}
 \item BLAS/LAPACK, numerical and linear algebra libraries. Use
   platform-optimized libraries where available, such as Intel MKL.

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -87,8 +87,11 @@ strongly encouraged}, but not absolutely essential. Generally newer versions are
 Section \ref{sec:buildperformance} for performance suggestions.
 
 \begin{itemize}
-\item C/C++ compilers such as GNU, Clang, Intel, IBM XL. C++ compilers are required to support C++11 standard.
-\item MPI library such at OpenMPI \url{http://open-mpi.org}
+\item C/C++ compilers such as GNU, Clang, Intel, IBM XL. C++ compilers
+  are required to support C++11 standard. Use of recent (``current
+  year version'') compilers is strongly encouraged.
+\item MPI library such as OpenMPI \url{http://open-mpi.org} or vendor
+  optimized MPI.
 \item BLAS/LAPACK, numerical and linear algebra libraries. Use
   platform-optimized libraries where available, such as Intel MKL.
   ATLAS or other optimized open-source libraries may also be used
@@ -364,19 +367,27 @@ MKLROOT is the directory containing the MKL binary, examples, and lib
 directories (etc.) and is often /opt/intel/mkl 
 
 \subsection{Cross compiling}
-Cross-compiling is always difficult but often needed on supercomputers
-with distinct host and compute processors from different generations and even architectures.
+Cross-compiling is often difficult but is required on supercomputers
+with distinct host and compute processor generations or architectures.
 QMCPACK tried to do its best with CMake to facilitate cross-compiling.
 
 \begin{itemize}
-  \item On a machine using Cray programming environment, we reply on
-      compiler wrappers provided by Cray to set architecture specific flags
-  \item If not on a Cray machine, we assume default building for the host.
-    With Intel compiler, -xHost is added for Intel compiler
+  \item On a machine using Cray programming environment, we rely on
+      compiler wrappers provided by Cray to set architecture specific
+      flags correctly. The CMake configure log should indicate that a
+      Cray machine was detected.
+  \item If not on a Cray machine, by default we assume building for
+    the host architecture. e.g. -xHost is added for the Intel compiler
     and -march=native is added for GNU/Clang compilers.
   \item If -x/-ax or -march is specified by the user in CMAKE\_C\_FLAGS and CMAKE\_CXX\_FLAGS,
     we respect user's intention and do not add any architecture specific flags.
 \end{itemize}
+
+The general strategy for cross-compiling should therefore be to
+manually set CMAKE\_C\_FLAGS and CMAKE\_CXX\_FLAGS for the target
+archicture. Using \texttt{make VERBOSE=1} is a useful way to check the
+final compilation options.  If on a Cray machine, selection of the
+appropriate programming environment should be sufficient.
 
 \section{Installation instructions for common workstations and
   supercomputers}

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -204,7 +204,7 @@ QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
                     Use always double for host side base and full precision
                     and use float and double for CUDA base and full precision.
 ENABLE_SOA          (Experimental) Enable CPU optimization based on Structure-
-                    of-Array (SoA) datatypes (1:yes, 0:no (default)).\cite{IPCC_SC17}
+                    of-Array (SoA) datatypes (1:yes, 0:no (default)).
 
 \end{verbatim}
   \item General build options
@@ -761,7 +761,7 @@ Currently Loaded Modulefiles:
  14) xpmem/0.1-2.0502.64982.5.3.ari        28) boost/1.59
 \end{verbatim}
 
-\subsection{Installing on NERSC Cori, Xeon Phi KNL Knight's Landing partition, Cray XC40}
+\subsection{Installing on NERSC Cori, Xeon Phi KNL partition, Cray XC40}
 The second phase of NERSC's Cori uses Intel
 Xeon Phi Knight's Landing (KNL) nodes. Substantive optimizations for QMCPACK on KNL will
 be forthcoming. The following build recipe ensures that the code

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -87,8 +87,8 @@ strongly encouraged}, but not absolutely essential. Generally newer versions are
 Section \ref{sec:buildperformance} for performance suggestions.
 
 \begin{itemize}
-\item C/C++ compilers such as GCC, Intel, IBM XLC. LLVM-based compilers
-  are supported only on a preliminary basis.
+\item C/C++ compilers such as GNU, Intel, IBM XL. LLVM-based compilers
+  are supported only on a preliminary basis. C++ compilers are required to support C++11 standard.
 \item MPI library such at OpenMPI \url{http://open-mpi.org}
 \item BLAS/LAPACK, numerical and linear algebra libraries. Use
   platform-optimized libraries where available, such as Intel MKL.
@@ -96,7 +96,7 @@ Section \ref{sec:buildperformance} for performance suggestions.
   \url{http://math-atlas.sourceforge.net}
 \item CMake, build utility, \url{http://www.cmake.org}
 \item Libxml2, XML parser, \url{http://xmlsoft.org}
-\item HDF5, portable I/O library, \url{http://www.hdfgroup.org/HDF5/}
+\item HDF5, portable I/O library, \url{http://www.hdfgroup.org/HDF5/}. Good performance at large scale requires parallel version $>=$ 1.10.
 \item BOOST, peer-reviewed portable C++ source libraries, \url{http://www.boost.org}
 \item FFTW, FFT library, \url{http://www.fftw.org/}
 \end{itemize}
@@ -204,6 +204,9 @@ QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
                     The GPU support is quite mature.
                     Use always double for host side base and full precision
                     and use float and double for CUDA base and full precision.
+ENABLE_SOA          Enable CPU optimization based on Structure-of-Array (SoA)
+                    datatypes (1:yes, 0:no (default)).\cite{IPCC_SC17}
+
 \end{verbatim}
   \item General build options
 \begin{verbatim}
@@ -234,10 +237,14 @@ QMC_BUILD_STATIC    Add -static flags to build
 QMC_DATA            Specify data directory for QMCPACK (currently
                     unused, but likely to be used for future performance tests)
 \end{verbatim}
-\item libxml related
+\item libxml2 related
 \begin{verbatim}
 Libxml2_INCLUDE_DIRS  Specify include directories for libxml2
 Libxml2_LIBRARY_DIRS  Specify library directories for libxml2
+\end{verbatim}
+ \item HDF5 related
+\begin{verbatim}
+ENABLE_PHDF5    1(default)/0, enables/disable parallel collective IO.
 \end{verbatim}
  \item FFTW related
 \begin{verbatim}
@@ -357,6 +364,20 @@ cmake \
 MKLROOT is the directory containing the MKL binary, examples, and lib
 directories (etc.) and is often /opt/intel/mkl 
 
+\subsection{Cross compiling}
+Cross-compiling is always difficult but often needed on supercomputers
+with distinct host and compute processors from different generations and even architectures.
+QMCPACK tried to do its best with CMake to facilitate cross-compiling.
+
+\begin{itemize}
+  \item On a machine using Cray programming environment, we reply on
+      compiler wrappers provied by Cray to set architecture specific flags
+  \item If not on a Cray machine, we assume default building for the host.
+    With Intel compiler, -xHost is added for Intel compiler
+    and -march=native is added for GNU/Clang compilers.
+  \item If -x/-ax or -march is specified by the user in CMAKE\_C\_FLAGS and CMAKE\_CXX\_FLAGS,
+    we respect user's intention and do not add any architecture specific flags.
+\end{itemize}
 
 \section{Installation instructions for common workstations and
   supercomputers}
@@ -533,7 +554,13 @@ ctest -R short
 
 \subsection{Installing on ANL ALCF Mira/Cetus IBM Blue Gene/Q}
 \label{sec:buildbgq}
-Mira/Cetus is a Blue Gene/Q supercomputer at Argonne National Laboratory's Argonne Leadership Computing Facility (ANL ALCF). Mira has 49152 compute nodes and each node has a 16-core PowerPC A2 processor with 16 GB DDR3 memory. Due to the fact that the login nodes and the compute nodes have different processors with distinct instruction sets, cross-compiling is required on this platform. See details about using Blue Gene/Q at \url{http://www.alcf.anl.gov/user-guides/compiling-linking}. On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-xl and +cmake in \$HOME/.soft. In order to build QMCPACK, a toolchain file is provided for setting up CMake and the cmake command should be executed twice.
+Mira/Cetus is a Blue Gene/Q supercomputer at Argonne National Laboratory's Argonne Leadership Computing Facility (ANL ALCF).
+Mira has 49152 compute nodes and each node has a 16-core PowerPC A2 processor with 16 GB DDR3 memory.
+Due to the fact that the login nodes and the compute nodes have different processors with distinct instruction sets,
+cross-compiling is required on this platform. See details about using Blue Gene/Q at \url{http://www.alcf.anl.gov/user-guides/compiling-linking}.
+On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang and +cmake in \$HOME/.soft.
+In order to build QMCPACK, a toolchain file is provided for setting up CMake and the cmake command should be executed twice.
+\textbf{XL C/C++ compiler no more builds QMCPACK due to the lack of C++11 support but BGClang can produce correct binary with good peroformance.}
 
 \begin{verbatim}
 cd build
@@ -543,9 +570,20 @@ make -j 16
 ls -l bin/qmcpack
 \end{verbatim}
 
-In addition, adding a very useful cmake option
--DCMAKE\_VERBOSE\_MAKEFILE=TRUE allows printing all the build commands
-during the make step. Alternatively you can use make VERBOSE=1.
+During the make, you can use make VERBOSE=1 to print all the build commands.
+
+\subsection{Installing on ALCF Theta, Cray XC40}
+Theta is a 9.65 petaflops system manufactured by Cray with 3624 compute nodes.
+Each node features a second-generation Intel Xeon Phi 7230 processor and 192 GB DDR4 RAM.
+
+\begin{verbatim}
+module unload cray-libsci
+module load cray-hdf5-parallel
+export BOOST_ROOT=/soft/libraries/boost/1.64.0/intel
+cmake ..
+make -j 24
+ls -l bin/qmcpack
+\end{verbatim}
 
 \subsection{Installing on ORNL OLCF Titan Cray XK7 (NVIDIA GPU
   accelerated)}
@@ -962,6 +1000,10 @@ ctest reports briefly pass or fail of tests in printout and also collects all th
 If the ctest execution is completed, look at \texttt{Testing/Temporary/LastTest.log}.
 If you manually stop the testing (ctrl+c), look at \texttt{Testing/Temporary/LastTest.log.tmp}.
 You can locate the failing tests by searching for the key word `Fail'.
+
+\subsection{Slow testing with OpenMPI}
+OpenMPI has a default binding policy making all the threads running on a single core during testing when there are two or fewer MPI ranks.
+This significantly increases the testing time. If you are authorized to change the default setting, you can just add `hwloc\_base\_binding\_policy none' in /etc/openmpi/openmpi-mca-params.conf.
 
 \section{Automated testing of QMCPACK}
 

--- a/manual/qmcpack_manual.tex
+++ b/manual/qmcpack_manual.tex
@@ -141,6 +141,7 @@
 \newpage
 
 \input{introduction}
+\input{features}
 \input{installation}
 \input{running}
 

--- a/manual/running.tex
+++ b/manual/running.tex
@@ -105,47 +105,6 @@ propagated in parallel. In each GPU kernel, loops over electrons,
 atomic cores or orbitals are further vectorized to exploit an
 additional level of parallelism and to allow coalesced memory access.
 
-%---------------------------------------------------------------------------%
-
-\subsubsection{Supported GPU features}
-
-\begin{enumerate}
-
-  \item Quantum Monte Carlo methods:
-
-    \begin{enumerate}
-	\item Variational Monte Carlo (VMC).
-	\item Diffusion Monte Carlo (DMC).
-	%\item Limited support for wavefunction optimization.
-	\item Wavefunction optimization.
-    \end{enumerate}
-
-  \item Boundary conditions:
-
-    \begin{enumerate}
-	\item Periodic and open boundary conditions are fully supported.
-	\item Twist-averaged boundary conditions and complex wavefunctions are fully supported. \courier{QMC\_COMPLEX=1}
-	\item Mixed boundary conditions are not yet supported.
-    \end{enumerate}
-
-  \item Wavefunctions:
-
-    \begin{enumerate}
-	\item Single Slater determinants with 3D B-spline orbitals. Only real-valued wavefunctions is supported, but tiling complex orbitals to supercells is supported as long as each k-point is a multiple of half a G-vector of the supercell.
-	\item Mixed basis representation in which orbitals are represented as 1D splines times spherical harmonics in spherical regions (muffin tins) around atoms, and 3D B-splines in the interstitial region.
-	\item One-body and two-body Jastrows represented as 1D B-splines are supported.
-    \end{enumerate}
-
-  \item Interaction types:
-
-    \begin{enumerate}
-	\item Semilocal (nonlocal and local) pseudopotentials.
-	\item Coulomb interaction (electron-electron, electron-ion).
-	\item Model periodic Coulomb (MPC) interaction.
-    \end{enumerate}
-
-\end{enumerate}
-
 %----------------------------------------------------------------------------%
 
 \subsubsection{Performance consideration}

--- a/manual/running.tex
+++ b/manual/running.tex
@@ -124,7 +124,7 @@ additional level of parallelism and to allow coalesced memory access.
 
     \begin{enumerate}
 	\item Periodic and open boundary conditions are fully supported.
-	\item Twist-averaged boundary conditions and complex wavefunctions are fully supported.
+	\item Twist-averaged boundary conditions and complex wavefunctions are fully supported. \courier{QMC\_COMPLEX=1}
 	\item Mixed boundary conditions are not yet supported.
     \end{enumerate}
 
@@ -133,7 +133,7 @@ additional level of parallelism and to allow coalesced memory access.
     \begin{enumerate}
 	\item Single Slater determinants with 3D B-spline orbitals. Only real-valued wavefunctions is supported, but tiling complex orbitals to supercells is supported as long as each k-point is a multiple of half a G-vector of the supercell.
 	\item Mixed basis representation in which orbitals are represented as 1D splines times spherical harmonics in spherical regions (muffin tins) around atoms, and 3D B-splines in the interstitial region.
-	\item One-body and two-body Jastrows represented as 1D B-splines are supported. %% Note that only single-precision arithmetic is fully functional at the time of writing.
+	\item One-body and two-body Jastrows represented as 1D B-splines are supported.
     \end{enumerate}
 
   \item Interaction types:
@@ -143,84 +143,6 @@ additional level of parallelism and to allow coalesced memory access.
 	\item Coulomb interaction (electron-electron, electron-ion).
 	\item Model periodic Coulomb (MPC) interaction.
     \end{enumerate}
-
-\end{enumerate}
-
-%---------------------------------------------------------------------------%
-
-\subsubsection{Compiling the GPU code}
-
-To build the executable \courier{qmcpack} with GPU support, follow
-these steps:
-
-\begin{enumerate}
-
-  \item  Make sure NVIDIA's CUDA compiler, nvcc, is in the search
-    path. In most cases, CMake should be able to locate the nvcc
-    compiler on the system automatically.
-  \item
-    \begin{enumerate}
-      \item Run CMake with the argument \courier{QMC\_CUDA} switched on: \\
-               \courier{
-           	cd build \\
-           	cmake -D QMC\_CUDA=1 .. \\
-           	make}
-
-       \item[] \hspace{-0.27in} or
-
-       \item If a CMake toolchain file is used, switch on \courier{QMC\_CUDA} by
-         including this line in the toolchain file: \\
-               \courier{SET (QMC\_CUDA 1)} \\
-                Then compile the code as before: \\
-                \courier{
-         	cd build \\
-        	cmake -D CMAKE\_TOOLCHAIN\_FILE=[toolchain name] .. \\
-         	make \\}
-    \end{enumerate}
-
-\end{enumerate}
-
-%---------------------------------------------------------------------------%
-
-\subsubsection{CMake variables for adjusting CUDA code build features}
-
-These values can be changed by passing them as CMake's command line
-options with the \courier{-D} flag, or using a toolchain file to
-overwrite the default values. \\
-
-\begin{enumerate}
-
-\item \courier{QMC\_CUDA}
-
-\begin{tabular}{l@{: }p{4.5in}}
-\courier{=0} (default) & no GPU support, build QMCPACK as a CPU code \\
-\courier{=1}               & build QMCPACK with GPU support \\
-\end{tabular} \\
-
-\item \courier{QMC\_COMPLEX}
-
-\begin{tabular}{l@{: }p{4.5in}}
-\courier{=0} (default) & as per the CPU code, build the real version \\
-\courier{=1}               & build the complex (general twist/k-point) version \\
-\end{tabular} \\
-
-\item \courier{QMC\_MIXED\_PRECISION} (when \courier{QMC\_CUDA=1})
-
-\begin{tabular}{l@{: }p{4in}}
-\courier{=1} (default) & internally set \courier{CUDA\_PRECISION=float} \\
-\courier{=0}          & internally set \courier{CUDA\_PRECISION=double} \\
-\end{tabular}
-
-
-\item \courier{CUDA\_PRECISION} (deprecated, use \courier{QMC\_MIXED\_PRECISION} instead)
-
-\begin{tabular}{l@{: }p{4in}}
-\courier{=float} (default) & single precision arithmetics and data
-                             types will be used for most GPU kernels.
-                             Several precision critical kernels are always in double precision. \\
-\courier{=double}          & double precision arithmetics and data
-                             types will be used for all the GPU kernels. \\
-\end{tabular}
 
 \end{enumerate}
 

--- a/manual/simulationcell.tex
+++ b/manual/simulationcell.tex
@@ -1,5 +1,5 @@
 \section{Specifying the simulation cell}
-\label{sec:simulationcell}
+\label{chap:simulationcell}
 
 The \texttt{simulationcell} block specifies the geometry of the cell, how the boundary conditions should be handled, and how ewald summation should be broken up.
 

--- a/src/miniapps/README.md
+++ b/src/miniapps/README.md
@@ -1,0 +1,15 @@
+QMCPACK miniapps
+================
+
+Add `-DQMC_BUILD_LEVEL=5` in CMake to build the miniapps in this folder.
+Optionally using `-DQMC_MIXED_PRECISION=1` to access mixed precision (most of the element values are single).
+Assume that the mixed precision is sufficient to evaluate the algorithms, implementations and performance.
+
+
+# checkpoint/restart miniapp
+Its source and binary file are src/miniapps/restart.cpp and bin/restart.
+It dumps walker configurations and random number seeds to the HDF5 files and then reads them in and check the correctness.
+Pass or Fail will be printed at the end of the standard output.
+
+Parallel Collective I/O is implemented via parallel HDF5. It is enabled by default when parallel HDF5 library is available.
+To have good performance at large scale, version 1.10 is needed.

--- a/src/miniapps/miniapps.md
+++ b/src/miniapps/miniapps.md
@@ -1,8 +1,0 @@
-QMCPACK miniapps
-================
-
-Build with
-`-DQMC_BUILD_LEVEL=5 -DQMC_MIXED_PRECISION=1`
-
-Assume that the mixed precision (most of the element values are single) is
-sufficient to evaluate the algorithms, implementations and performance.


### PR DESCRIPTION
1) SOA switch
2) cross compiling
3) parallel HDF5
4) update ALCF Mira Theta build recipe
5) restart miniapp
6) Remove "Compiling the GPU code" in the running chapter. All the info are the same as the installation chapter.

address #299

I need a bit help
1) I can't make the \cite working installation.tex
2) I would like to add a list of available features in SoA but I didn't find a good entry.