### PR TITLE
Align two body Jastrow input behavior.

### DIFF
--- a/src/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/ParticleIO/ParticleLayoutIO.cpp
@@ -103,6 +103,7 @@ bool LatticeParser::put(xmlNodePtr cur)
       }
       else if(aname == "rs")
       {
+        lattice_defined=true;
         OhmmsAttributeSet rAttrib;
         rAttrib.add(nptcl,"condition");
         rAttrib.add(pol,"polarized");

--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -67,22 +67,36 @@ public:
 
   void addFunc(int ia, int ib, FT* j)
   {
-    if (ia==ib)
+    // make all pair terms equal to uu initially
+    //   in case some terms are not provided explicitly
+    if(ia==ib)
     {
-      if (ia==0)//first time, assign everything
+      if(ia==0)//first time, assign everything
       {
         int ij=0;
-        for (int ig=0; ig<NumGroups; ++ig)
-          for (int jg=0; jg<NumGroups; ++jg, ++ij)
-            if (F[ij]==0)
-              F[ij]=j;
+        for(int ig=0; ig<NumGroups; ++ig)
+          for(int jg=0; jg<NumGroups; ++jg, ++ij)
+            if(F[ij]==nullptr) F[ij]=j;
       }
+      else
+        F[ia*NumGroups+ib]=j;
     }
     else
     {
-      F[ia*NumGroups+ib]=j;
-      if (ia<ib)
+      if(NumPtcls==2)
+      {
+        // a very special case, 1 up + 1 down
+        // uu/dd was prevented by the builder
+        for(int ig=0; ig<NumGroups; ++ig)
+          for(int jg=0; jg<NumGroups; ++jg)
+            F[ig*NumGroups+jg]=j;
+      }
+      else
+      {
+        // generic case
+        F[ia*NumGroups+ib]=j;
         F[ib*NumGroups+ia]=j;
+      }
     }
     std::stringstream aname;
     aname<<ia<<ib;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -336,6 +336,8 @@ void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
         for(int jg=0; jg<NumGroups; ++jg, ++ij)
           if(F[ij]==nullptr) F[ij]=j;
     }
+    else
+      F[ia*NumGroups+ib]=j;
   }
   else
   {
@@ -351,8 +353,7 @@ void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
     {
       // generic case
       F[ia*NumGroups+ib]=j;
-      if(ia<ib)
-        F[ib*NumGroups+ia]=j;
+      F[ib*NumGroups+ia]=j;
     }
   }
   std::stringstream aname;

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -65,7 +65,6 @@ protected:
   ParticleSet *PtclRef;
   bool FirstTime;
   RealType KEcorr;
-  bool first_addFunc;
 
 public:
 
@@ -80,7 +79,6 @@ public:
     PtclRef = &p;
     init(p);
     FirstTime = true;
-    first_addFunc = true;
     OrbitalName = "TwoBodyJastrow";
   }
 
@@ -117,23 +115,37 @@ public:
 
   void addFunc(int ia, int ib, FT* j)
   {
-    // make all pair terms equal to the first one initially
+    // make all pair terms equal to uu initially
     //   in case some terms are not provided explicitly
-    if(first_addFunc)
+    if(ia==ib)
     {
-      int ij=0;
-      for(int ig=0; ig<NumGroups; ++ig)
-	for(int jg=0; jg<NumGroups; ++jg, ++ij)
-	  if(F[ij]==0)
-	    F[ij]=j;
-      first_addFunc = false;
+      if(ia==0)//first time, assign everything
+      {
+        int ij=0;
+        for(int ig=0; ig<NumGroups; ++ig)
+          for(int jg=0; jg<NumGroups; ++jg, ++ij)
+            if(F[ij]==nullptr) F[ij]=j;
+      }
+      else
+        F[ia*NumGroups+ib]=j;
     }
-    // add the pair function
-    F[ia*NumGroups+ib]=j;
-    // enforce exchange symmetry
-    if(ia!=ib)
-      F[ib*NumGroups+ia]=j;
-
+    else
+    {
+      if(N==2)
+      {
+        // a very special case, 1 up + 1 down
+        // uu/dd was prevented by the builder
+        for(int ig=0; ig<NumGroups; ++ig)
+          for(int jg=0; jg<NumGroups; ++jg)
+            F[ig*NumGroups+jg]=j;
+      }
+      else
+      {
+        // generic case
+        F[ia*NumGroups+ib]=j;
+        F[ib*NumGroups+ia]=j;
+      }
+    }
     std::stringstream aname;
     aname<<ia<<ib;
     J2Unique[aname.str()]=j;

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.cpp
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.cpp
@@ -78,6 +78,8 @@ TwoBodyJastrowOrbitalBspline::addFunc(int ia, int ib, FT* j)
         for(int jg=0; jg<NumGroups; ++jg, ++ij)
           if(GPUSplines[ij]==0) GPUSplines[ij]=newSpline;
     }
+    else
+      GPUSplines[ia*NumGroups+ib]=newSpline;
   }
   else
   {

--- a/src/QMCWaveFunctions/tests/test_wf.cpp
+++ b/src/QMCWaveFunctions/tests/test_wf.cpp
@@ -66,7 +66,8 @@ TEST_CASE("Pade Jastrow", "[wavefunction]")
     ions_.R[0][2] = 0.0;
 
     elec_.setName("elec");
-    elec_.create(2);
+    std::vector<int> ud(2); ud[0]=2; ud[1]=0;
+    elec_.create(ud);
     elec_.R[0][0] = -0.28;
     elec_.R[0][1] = 0.0225;
     elec_.R[0][2] = -2.709;


### PR DESCRIPTION
For issue #282 #20 
1) uu, ud(du) : uu=dd, ud=du
2) uu : uu=dd=ud=du
3) ud(du) : only justified for 1 up + 1 down case, uu=dd=ud=du, uu/dd are not used in the calculation.
4) uu, ud(du), dd : uu, dd, ud=du

I may miss some useful cases.

checked uu, ud, dd case, optimization is correct.