### PR TITLE
Rename EstimatorManager EstimatorManagerBase.  

### DIFF
--- a/src/Estimators/EstimatorManagerBase.cpp
+++ b/src/Estimators/EstimatorManagerBase.cpp
@@ -1,0 +1,594 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Bryan Clark, bclark@Princeton.edu, Princeton University
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Raymond Clay III, j.k.rofling@gmail.com, Lawrence Livermore National Laboratory
+//                    Cynthia Gu, zg1@ornl.gov, Oak Ridge National Laboratory
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+    
+    
+
+
+
+#include "Particle/MCWalkerConfiguration.h"
+#include "Estimators/EstimatorManagerBase.h"
+#include "QMCHamiltonians/QMCHamiltonian.h"
+#include "Message/Communicate.h"
+#include "Message/CommOperators.h"
+#include "Message/CommUtilities.h"
+#include "Estimators/LocalEnergyEstimator.h"
+#include "Estimators/LocalEnergyOnlyEstimator.h"
+#include "Estimators/RMCLocalEnergyEstimator.h"
+#include "Estimators/CollectablesEstimator.h"
+#include "QMCDrivers/SimpleFixedNodeBranch.h"
+#include "Utilities/IteratorUtility.h"
+#include "Numerics/HDFNumericAttrib.h"
+#include "OhmmsData/HDFStringAttrib.h"
+#include "HDFVersion.h"
+#include "OhmmsData/AttributeSet.h"
+#include "Estimators/CSEnergyEstimator.h"
+//#define QMC_ASYNC_COLLECT
+//leave it for serialization debug
+//#define DEBUG_ESTIMATOR_ARCHIVE
+
+namespace qmcplusplus
+{
+
+/** enumeration for EstimatorManagerBase.Options
+ */
+enum {COLLECT=0,
+      MANAGE,
+      RECORD,
+      POSTIRECV,
+      APPEND
+     };
+
+//initialize the name of the primary estimator
+EstimatorManagerBase::EstimatorManagerBase(Communicate* c)
+  : RecordCount(0),h_file(-1), FieldWidth(20)
+  , MainEstimatorName("LocalEnergy"), Archive(0), DebugArchive(0)
+  , myComm(0), MainEstimator(0), Collectables(0)
+  , max4ascii(8), pendingRequests(0)
+{
+  setCommunicator(c);
+}
+
+EstimatorManagerBase::EstimatorManagerBase(EstimatorManagerBase& em)
+  : RecordCount(0),h_file(-1), FieldWidth(20)
+  , MainEstimatorName(em.MainEstimatorName), Options(em.Options), Archive(0), DebugArchive(0)
+  , myComm(0), MainEstimator(0), Collectables(0)
+  , EstimatorMap(em.EstimatorMap), max4ascii(em.max4ascii), pendingRequests(0)
+{
+  //inherit communicator
+  setCommunicator(em.myComm);
+  for(int i=0; i<em.Estimators.size(); i++)
+    Estimators.push_back(em.Estimators[i]->clone());
+  MainEstimator=Estimators[EstimatorMap[MainEstimatorName]];
+  if(em.Collectables)
+    Collectables=em.Collectables->clone();
+}
+
+EstimatorManagerBase::~EstimatorManagerBase()
+{
+  delete_iter(Estimators.begin(), Estimators.end());
+  delete_iter(RemoteData.begin(), RemoteData.end());
+  delete_iter(h5desc.begin(), h5desc.end());
+  if(Collectables)
+    delete Collectables;
+}
+
+void EstimatorManagerBase::setCommunicator(Communicate* c)
+{
+  if(myComm && myComm == c)
+    return;
+  myComm = c ? c:OHMMS::Controller;
+  //set the default options
+  Options.set(COLLECT,myComm->size()>1);
+  Options.set(MANAGE,myComm->rank() == 0);
+  myRequest.resize(2);
+  if(Options[COLLECT] && Options[MANAGE])
+    myRequest.resize(myComm->size()-1);
+  if(RemoteData.empty())
+  {
+#if defined(QMC_ASYNC_COLLECT)
+    for(int i=0; i<myComm->size(); i++)
+      RemoteData.push_back(new BufferType);
+#else
+    RemoteData.push_back(new BufferType);
+    RemoteData.push_back(new BufferType);
+#endif
+  }
+}
+
+/** set CollectSum
+ * @param collect if true, global sum is done over the values
+ */
+void EstimatorManagerBase::setCollectionMode(bool collect)
+{
+  if(!myComm)
+    setCommunicator(0);
+  Options.set(COLLECT,(myComm->size() == 1)? false:collect);
+  //force to be false for serial runs
+  //CollectSum = (myComm->size() == 1)? false:collect;
+}
+
+/** reset names of the properties
+ *
+ * The number of estimators and their order can vary from the previous state.
+ * Clear properties before setting up a new BlockAverage data list.
+ */
+void EstimatorManagerBase::reset()
+{
+  weightInd = BlockProperties.add("BlockWeight");
+  cpuInd = BlockProperties.add("BlockCPU");
+  acceptInd = BlockProperties.add("AcceptRatio");
+  BlockAverages.clear();//cleaup the records
+  for(int i=0; i<Estimators.size(); i++)
+    Estimators[i]->add2Record(BlockAverages);
+  max4ascii+=BlockAverages.size();
+  if(Collectables)
+    Collectables->add2Record(BlockAverages);
+}
+
+void EstimatorManagerBase::resetTargetParticleSet(ParticleSet& p)
+{
+}
+
+void EstimatorManagerBase::addHeader(std::ostream& o)
+{
+  o.setf(std::ios::scientific, std::ios::floatfield);
+  o.setf(std::ios::left,std::ios::adjustfield);
+  o.precision(10);
+  for (int i=0; i<BlockAverages.size(); i++)
+    FieldWidth = std::max(FieldWidth, BlockAverages.Names[i].size()+2);
+  for (int i=0; i<BlockProperties.size(); i++)
+    FieldWidth = std::max(FieldWidth, BlockProperties.Names[i].size()+2);
+  int maxobjs=std::min(BlockAverages.size(),max4ascii);
+  o << "#   index    ";
+  for(int i=0; i<maxobjs; i++)
+    o << std::setw(FieldWidth) << BlockAverages.Names[i];
+  for(int i=0; i<BlockProperties.size(); i++)
+    o << std::setw(FieldWidth) << BlockProperties.Names[i];
+  o << std::endl;
+  o.setf(std::ios::right,std::ios::adjustfield);
+}
+
+void EstimatorManagerBase::start(int blocks, bool record)
+{
+  for(int i=0; i<Estimators.size(); i++)
+    Estimators[i]->setNumberOfBlocks(blocks);
+  reset();
+  RecordCount=0;
+  energyAccumulator.clear();
+  varAccumulator.clear();
+  int nc=(Collectables)?Collectables->size():0;
+  BlockAverages.setValues(0.0);
+  AverageCache.resize(BlockAverages.size()+nc);
+  SquaredAverageCache.resize(BlockAverages.size()+nc);
+  PropertyCache.resize(BlockProperties.size());
+  //count the buffer size for message
+  BufferSize=2*AverageCache.size()+PropertyCache.size();
+#if defined(QMC_ASYNC_COLLECT)
+  int sources=myComm->size();
+#else
+  int sources=2;
+#endif
+  //allocate buffer for data collection
+  if(RemoteData.empty())
+    for(int i=0; i<sources; ++i)
+      RemoteData.push_back(new BufferType(BufferSize));
+  else
+    for(int i=0; i<RemoteData.size(); ++i)
+      RemoteData[i]->resize(BufferSize);
+#if defined(DEBUG_ESTIMATOR_ARCHIVE)
+  if(record && DebugArchive ==0)
+  {
+    char fname[128];
+    sprintf(fname,"%s.p%03d.scalar.dat",myComm->getName().c_str(), myComm->rank());
+    DebugArchive = new std::ofstream(fname);
+    addHeader(*DebugArchive);
+  }
+#endif
+  //set Options[RECORD] to enable/disable output
+  Options.set(RECORD,record&&Options[MANAGE]);
+  if(Options[RECORD])
+  {
+    if(Archive)
+      delete Archive;
+    std::string fname(myComm->getName());
+    fname.append(".scalar.dat");
+    Archive = new std::ofstream(fname.c_str());
+    addHeader(*Archive);
+    if(h5desc.size())
+    {
+      delete_iter(h5desc.begin(),h5desc.end());
+      h5desc.clear();
+    }
+    fname=myComm->getName()+".stat.h5";
+    h_file= H5Fcreate(fname.c_str(),H5F_ACC_TRUNC,H5P_DEFAULT,H5P_DEFAULT);
+    for(int i=0; i<Estimators.size(); i++)
+      Estimators[i]->registerObservables(h5desc,h_file);
+    if(Collectables)
+      Collectables->registerObservables(h5desc,h_file);
+#if defined(QMC_ASYNC_COLLECT)
+    if(Options[COLLECT])
+    {
+      //issue a irecv
+      pendingRequests=0;
+      for(int i=1,is=0; i<myComm->size(); i++,is++)
+      {
+        myRequest[is]=myComm->irecv(i,i,*RemoteData[i]);//request only has size-1
+        pendingRequests++;
+      }
+    }
+#endif
+  }
+}
+
+void EstimatorManagerBase::stop(const std::vector<EstimatorManagerBase*> est)
+{
+  int num_threads=est.size();
+  //normalize by the number of threads per node
+  RealType tnorm=1.0/static_cast<RealType>(num_threads);
+  //add averages and divide them by the number of threads
+  AverageCache=est[0]->AverageCache;
+  for(int i=1; i<num_threads; i++)
+    AverageCache+=est[i]->AverageCache;
+  AverageCache*=tnorm;
+  SquaredAverageCache=est[0]->SquaredAverageCache;
+  for(int i=1; i<num_threads; i++)
+    SquaredAverageCache+=est[i]->SquaredAverageCache;
+  SquaredAverageCache*=tnorm;
+  //add properties and divide them by the number of threads except for the weight
+  PropertyCache=est[0]->PropertyCache;
+  for(int i=1; i<num_threads; i++)
+    PropertyCache+=est[i]->PropertyCache;
+  for(int i=1; i<PropertyCache.size(); i++)
+    PropertyCache[i] *= tnorm;
+  stop();
+}
+
+/** Stop a run
+ *
+ * Collect data in Cache and print out data into hdf5 and ascii file.
+ * This should not be called in a OpenMP parallel region or should
+ * be guarded by master/single.
+ * Keep the ascii output for now
+ */
+void EstimatorManagerBase::stop()
+{
+  //clean up pending messages
+  if(pendingRequests)
+  {
+    cancel(myRequest);
+    pendingRequests=0;
+  }
+  //close any open files
+  if(Archive)
+  {
+    delete Archive;
+    Archive=0;
+  } 
+  if (h_file != -1)
+  {
+    H5Fclose(h_file);
+    h_file = -1;
+  }
+}
+
+
+void EstimatorManagerBase::startBlock(int steps)
+{
+  MyTimer.restart();
+  BlockWeight=0.0;
+}
+
+/** take statistics of a block
+ * @param accept acceptance rate of this block
+ * @param collectall if true, need to gather data over MPI tasks
+ */
+void EstimatorManagerBase::stopBlock(RealType accept, bool collectall)
+{
+  //take block averages and update properties per block
+  PropertyCache[weightInd]=BlockWeight;
+  PropertyCache[cpuInd] = MyTimer.elapsed();
+  PropertyCache[acceptInd] = accept;
+  for(int i=0; i<Estimators.size(); i++)
+    Estimators[i]->takeBlockAverage(AverageCache.begin(),SquaredAverageCache.begin());
+  if(Collectables)
+  {
+    Collectables->takeBlockAverage(AverageCache.begin(),SquaredAverageCache.begin());
+  }
+  if(collectall)
+    collectBlockAverages(1);
+}
+
+void EstimatorManagerBase::stopBlock(const std::vector<EstimatorManagerBase*>& est)
+{
+  //normalized it by the thread
+  int num_threads=est.size();
+  RealType tnorm=1.0/num_threads;
+  AverageCache=est[0]->AverageCache;
+  for(int i=1; i<num_threads; i++)
+    AverageCache +=est[i]->AverageCache;
+  AverageCache *= tnorm;
+  SquaredAverageCache=est[0]->SquaredAverageCache;
+  for(int i=1; i<num_threads; i++)
+    SquaredAverageCache +=est[i]->SquaredAverageCache;
+  SquaredAverageCache *= tnorm;
+  PropertyCache=est[0]->PropertyCache;
+  for(int i=1; i<num_threads; i++)
+    PropertyCache+=est[i]->PropertyCache;
+  for(int i=1; i<PropertyCache.size(); i++)
+    PropertyCache[i] *= tnorm;
+  //for(int i=0; i<num_threads; ++i)
+  //varAccumulator(est[i]->varAccumulator.mean());
+  collectBlockAverages(num_threads);
+}
+
+
+void EstimatorManagerBase::collectBlockAverages(int num_threads)
+{
+  if(Options[COLLECT])
+  {
+    //copy cached data to RemoteData[0]
+    int n1=AverageCache.size();
+    int n2=n1+AverageCache.size();
+    int n3=n2+PropertyCache.size();
+    {
+      BufferType::iterator cur(RemoteData[0]->begin());
+      copy(AverageCache.begin(),AverageCache.end(),cur);
+      copy(SquaredAverageCache.begin(),SquaredAverageCache.end(),cur+n1);
+      copy(PropertyCache.begin(),PropertyCache.end(),cur+n2);
+    }
+#if defined(QMC_ASYNC_COLLECT)
+    if(Options[MANAGE])
+    {
+      //wait all the message but we can choose to wait one-by-one with a timer
+      wait_all(myRequest.size(),&myRequest[0]);
+      for(int is=1; is<myComm->size(); is++)
+        accumulate_elements(RemoteData[is]->begin(),RemoteData[is]->end(), RemoteData[0]->begin());
+    }
+    else //not a master, pack and send the data
+      myRequest[0]=myComm->isend(0,myComm->rank(),*RemoteData[0]);
+#else
+    myComm->reduce(*RemoteData[0]);
+#endif
+    if(Options[MANAGE])
+    {
+      BufferType::iterator cur(RemoteData[0]->begin());
+      copy(cur,cur+n1, AverageCache.begin());
+      copy(cur+n1,cur+n2, SquaredAverageCache.begin());
+      copy(cur+n2,cur+n3, PropertyCache.begin());
+      RealType nth=1.0/static_cast<RealType>(myComm->size());
+      AverageCache *= nth;
+      SquaredAverageCache *= nth;
+      //do not weight weightInd
+      for(int i=1; i<PropertyCache.size(); i++)
+        PropertyCache[i] *= nth;
+    }
+  }
+  //add the block average to summarize
+  energyAccumulator(AverageCache[0]);
+  varAccumulator(SquaredAverageCache[0]-AverageCache[0]*AverageCache[0]);
+  if(Archive)
+  {
+    *Archive << std::setw(10) << RecordCount;
+    int maxobjs=std::min(BlockAverages.size(),max4ascii);
+    for(int j=0; j<maxobjs; j++)
+      *Archive << std::setw(FieldWidth) << AverageCache[j];
+    for(int j=0; j<PropertyCache.size(); j++)
+      *Archive << std::setw(FieldWidth) << PropertyCache[j];
+    *Archive << std::endl;
+    for(int o=0; o<h5desc.size(); ++o)
+      h5desc[o]->write(AverageCache.data(),SquaredAverageCache.data());
+    H5Fflush(h_file,H5F_SCOPE_LOCAL);
+  }
+  RecordCount++;
+}
+
+/** accumulate Local energies and collectables
+ * @param W ensemble
+ */
+void EstimatorManagerBase::accumulate(MCWalkerConfiguration& W)
+{
+  BlockWeight += W.getActiveWalkers();
+  RealType norm=1.0/W.getGlobalNumWalkers();
+  for(int i=0; i< Estimators.size(); i++)
+    Estimators[i]->accumulate(W,W.begin(),W.end(),norm);
+  if(Collectables)//collectables are normalized by QMC drivers
+    Collectables->accumulate_all(W.Collectables,1.0);
+}
+
+void EstimatorManagerBase::accumulate(MCWalkerConfiguration& W
+                                  , MCWalkerConfiguration::iterator it, MCWalkerConfiguration::iterator it_end)
+{
+  BlockWeight += it_end-it;
+  RealType norm=1.0/W.getGlobalNumWalkers();
+  for(int i=0; i< Estimators.size(); i++)
+    Estimators[i]->accumulate(W,it,it_end,norm);
+  if(Collectables)
+    Collectables->accumulate_all(W.Collectables,1.0);
+}
+
+void EstimatorManagerBase::getEnergyAndWeight(RealType& e, RealType& w, RealType& var)
+{
+  if(Options[COLLECT])//need to broadcast the value
+  {
+    RealType tmp[3];
+    tmp[0]= energyAccumulator.result();
+    tmp[1]= energyAccumulator.count();
+    tmp[2]= varAccumulator.mean();
+    myComm->bcast(tmp,3);
+    e=tmp[0];
+    w=tmp[1];
+    var=tmp[2];
+  }
+  else
+  {
+    e= energyAccumulator.result();
+    w= energyAccumulator.count();
+    var= varAccumulator.mean();
+  }
+}
+
+void EstimatorManagerBase::getCurrentStatistics(MCWalkerConfiguration& W
+    , RealType& eavg, RealType& var)
+{
+  LocalEnergyOnlyEstimator energynow;
+  energynow.clear();
+  energynow.accumulate(W,W.begin(),W.end(),1.0);
+  std::vector<RealType> tmp(3);
+  tmp[0]= energynow.scalars[0].result();
+  tmp[1]= energynow.scalars[0].result2();
+  tmp[2]= energynow.scalars[0].count();
+  myComm->allreduce(tmp);
+  eavg=tmp[0]/tmp[2];
+  var=tmp[1]/tmp[2]-eavg*eavg;
+}
+
+EstimatorManagerBase::EstimatorType* EstimatorManagerBase::getMainEstimator()
+{
+  if(MainEstimator==0)
+    add(new LocalEnergyOnlyEstimator(),MainEstimatorName);
+  return MainEstimator;
+}
+
+EstimatorManagerBase::EstimatorType* EstimatorManagerBase::getEstimator(const std::string& a)
+{
+  std::map<std::string,int>::iterator it = EstimatorMap.find(a);
+  if(it == EstimatorMap.end())
+    return 0;
+  else
+    return Estimators[(*it).second];
+}
+
+/** This should be moved to branch engine */
+bool EstimatorManagerBase::put(MCWalkerConfiguration& W, QMCHamiltonian& H, xmlNodePtr cur)
+{
+  std::vector<std::string> extra;
+  cur = cur->children;
+  while(cur != NULL)
+  {
+    std::string cname((const char*)(cur->name));
+    if(cname == "estimator")
+    {
+      std::string est_name(MainEstimatorName);
+      std::string use_hdf5("yes");
+      OhmmsAttributeSet hAttrib;
+      hAttrib.add(est_name, "name");
+      hAttrib.add(use_hdf5, "hdf5");
+      hAttrib.put(cur);
+      if( (est_name == MainEstimatorName) || (est_name=="elocal") )
+      {
+        max4ascii=H.sizeOfObservables()+3;
+        add(new LocalEnergyEstimator(H,use_hdf5=="yes"),MainEstimatorName);
+      }
+      else
+        if (est_name=="RMC")
+        {
+          int nobs(20);
+          OhmmsAttributeSet hAttrib;
+          hAttrib.add(nobs, "nobs");
+          hAttrib.put(cur);
+          max4ascii=nobs*H.sizeOfObservables()+3;
+          add(new RMCLocalEnergyEstimator(H,nobs),MainEstimatorName);
+        }
+        else if ( est_name=="CSLocalEnergy" )
+        {
+          OhmmsAttributeSet hAttrib;
+          int nPsi=1;
+          hAttrib.add(nPsi, "nPsi");
+          hAttrib.put(cur);	      
+	      add(new CSEnergyEstimator(H,nPsi), MainEstimatorName);
+	       app_log() << "  Adding a default LocalEnergyEstimator for the MainEstimator " << std::endl;
+	    }
+        else  
+          extra.push_back(est_name);
+    }
+    cur = cur->next;
+  }
+  if(Estimators.empty())
+  {
+    app_log() << "  Adding a default LocalEnergyEstimator for the MainEstimator " << std::endl;
+    max4ascii=H.sizeOfObservables()+3;
+    add(new LocalEnergyEstimator(H,true),MainEstimatorName);
+  }
+  //Collectables is special and should not be added to Estimators
+  if(Collectables == 0 && H.sizeOfCollectables())
+  {
+    app_log() << "  Using CollectablesEstimator for collectables, e.g. sk, gofr, density " << std::endl;
+    Collectables=new CollectablesEstimator(H);
+  }
+  return true;
+}
+
+int EstimatorManagerBase::add(EstimatorType* newestimator, const std::string& aname)
+{
+  std::map<std::string,int>::iterator it = EstimatorMap.find(aname);
+  int n =  Estimators.size();
+  if(it == EstimatorMap.end())
+  {
+    Estimators.push_back(newestimator);
+    EstimatorMap[aname] = n;
+  }
+  else
+  {
+    n=(*it).second;
+    app_log() << "  EstimatorManagerBase::add replace " << aname << " estimator." << std::endl;
+    delete Estimators[n];
+    Estimators[n]=newestimator;
+  }
+  //check the name and set the MainEstimator
+  if(aname == MainEstimatorName)
+    MainEstimator=newestimator;
+  return n;
+}
+
+int EstimatorManagerBase::addObservable(const char* aname)
+{
+  int mine = BlockAverages.add(aname);
+  int add = TotalAverages.add(aname);
+  if(mine < Block2Total.size())
+    Block2Total[mine] = add;
+  else
+    Block2Total.push_back(add);
+  return mine;
+}
+
+void EstimatorManagerBase::getData(int i, std::vector<RealType>& values)
+{
+  int entries = TotalAveragesData.rows();
+  values.resize(entries);
+  for (int a=0; a<entries; a++)
+    values[a] = TotalAveragesData(a,Block2Total[i]);
+}
+
+//void EstimatorManagerBase::updateRefEnergy()
+//{
+//  CumEnergy[0]+=1.0;
+//  RealType et=AverageCache(RecordCount-1,0);
+//  CumEnergy[1]+=et;
+//  CumEnergy[2]+=et*et;
+//  CumEnergy[3]+=std::sqrt(MainEstimator->d_variance);
+
+//  RealType wgtnorm=1.0/CumEnergy[0];
+//  RefEnergy[0]=CumEnergy[1]*wgtnorm;
+//  RefEnergy[1]=CumEnergy[2]*wgtnorm-RefEnergy[0]*RefEnergy[0];
+//  if(CumEnergy[0]>1)
+//    RefEnergy[2]=std::sqrt(RefEnergy[1]*wgtnorm/(CumEnergy[0]-1.0));
+//  RefEnergy[3]=CumEnergy[3]*wgtnorm;//average block variance
+//}
+
+}
+

--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -1,0 +1,319 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Bryan Clark, bclark@Princeton.edu, Princeton University
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+    
+    
+
+
+/** @file EstimatorManager.h
+ * @brief Manager class of scalar estimators
+ */
+#ifndef QMCPLUSPLUS_ESTIMATORMANAGERBASE_H
+#define QMCPLUSPLUS_ESTIMATORMANAGERBASE_H
+
+#include "Configuration.h"
+#include "Utilities/Timer.h"
+#include "Utilities/PooledData.h"
+#include "Message/Communicate.h"
+#include "Estimators/ScalarEstimatorBase.h"
+#include "OhmmsPETE/OhmmsVector.h"
+#include "OhmmsData/HDFAttribIO.h"
+#include <bitset>
+
+namespace qmcplusplus
+{
+
+class MCWalkerConifugration;
+class QMCHamiltonian;
+class CollectablesEstimator;
+
+/**Class to manage a set of ScalarEstimators */
+class EstimatorManagerBase
+{
+
+public:
+
+  typedef QMCTraits::EstimatorRealType  RealType;
+  typedef ScalarEstimatorBase           EstimatorType;
+  typedef std::vector<RealType>              BufferType;
+  //enum { WEIGHT_INDEX=0, BLOCK_CPU_INDEX, ACCEPT_RATIO_INDEX, TOTAL_INDEX};
+
+  ///name of the primary estimator name
+  std::string MainEstimatorName;
+  ///the root file name
+  std::string RootName;
+  ///energy
+  TinyVector<RealType,4> RefEnergy;
+  // //Cummulative energy, weight and variance
+  // TinyVector<RealType,4>  EPSum;
+  ///default constructor
+  EstimatorManagerBase(Communicate* c=0);
+  ///copy constructor
+  EstimatorManagerBase(EstimatorManagerBase& em);
+  ///destructor
+  virtual ~EstimatorManagerBase();
+
+  /** set the communicator */
+  void setCommunicator(Communicate* c);
+
+  /** return the communicator
+   */
+  Communicate* getCommunicator()
+  {
+    return myComm;
+  }
+
+  /** return true if the rank == 0
+   */
+  inline bool is_manager() const
+  {
+    return !myComm->rank();
+  }
+
+  ///return the number of ScalarEstimators
+  inline int size() const
+  {
+    return Estimators.size();
+  }
+
+  /** add a property with a name
+   * @param aname name of the column
+   * @return the property index so that its value can be set by setProperty(i)
+   *
+   * Append a named column. BlockProperties do not contain any meaning data
+   * but manages the name to index map for PropertyCache.
+   */
+  inline int addProperty(const char* aname)
+  {
+    return BlockProperties.add(aname);
+  }
+
+  /** set the value of the i-th column with a value v
+   * @param i column index
+   * @param v value
+   */
+  inline void setProperty(int i, RealType v)
+  {
+    PropertyCache[i]=v;
+  }
+
+  inline RealType getProperty(int i) const
+  {
+    return PropertyCache[i];
+  }
+
+  int addObservable(const char* aname);
+
+  inline RealType getObservable(int i) const
+  {
+    return  TotalAverages[i];
+  }
+
+  void getData(int i, std::vector<RealType>& values);
+
+  /** add an Estimator
+   * @param newestimator New Estimator
+   * @param aname name of the estimator
+   * @return locator of newestimator
+   */
+  int add(EstimatorType* newestimator, const std::string& aname);
+  //int add(CompositeEstimatorBase* newestimator, const std::string& aname);
+
+  /** add a main estimator
+   * @param newestimator New Estimator
+   * @return locator of newestimator
+   */
+  int add(EstimatorType* newestimator)
+  {
+    return add(newestimator,MainEstimatorName);
+  }
+
+  ///return a pointer to the estimator aname
+  EstimatorType* getEstimator(const std::string& a);
+
+  ///return a pointer to the estimator
+  EstimatorType* getMainEstimator();
+
+  ///return the average for estimator i
+  inline RealType average(int i) const
+  {
+    return Estimators[i]->average();
+  }
+
+  ///returns a variance for estimator i
+  inline RealType variance(int i) const
+  {
+    return Estimators[i]->variance();
+  }
+
+  void setCollectionMode(bool collect);
+  //void setAccumulateMode (bool setAccum) {AccumulateBlocks = setAccum;};
+
+  ///process xml tag associated with estimators
+  //bool put(xmlNodePtr cur);
+  bool put(MCWalkerConfiguration& W, QMCHamiltonian& H, xmlNodePtr cur);
+
+  void resetTargetParticleSet(ParticleSet& p);
+
+  /** reset the estimator
+   */
+  void reset();
+
+  /** start a run
+   * @param blocks number of blocks
+   * @param record if true, will write to a file
+   *
+   * Replace reportHeader and reset functon.
+   */
+  void start(int blocks, bool record=true);
+  /** stop a qmc run
+   *
+   * Replace finalize();
+   */
+  void stop();
+  /** stop a qmc run
+   */
+  void stop(const std::vector<EstimatorManagerBase*> m);
+
+
+  /** start  a block
+   * @param steps number of steps in a block
+   */
+  void startBlock(int steps);
+
+  void setNumberOfBlocks(int blocks)
+  {
+    for(int i=0; i<Estimators.size(); i++)
+      Estimators[i]->setNumberOfBlocks(blocks);
+  }
+
+  /** stop a block
+   * @param accept acceptance rate of this block
+   */
+  void stopBlock(RealType accept, bool collectall=true);
+  /** stop a block
+   * @param m list of estimator which has been collecting data independently
+   */
+  void stopBlock(const std::vector<EstimatorManagerBase*>& m);
+
+  /** accumulate the measurements
+   * @param W walkers
+   */
+  void accumulate(MCWalkerConfiguration& W);
+
+  /** accumulate the measurements for a subset of walkers [it,it_end)
+   * @param W walkers
+   * @param it first walker
+   * @param it_end last walker
+   */
+  void accumulate(MCWalkerConfiguration& W, MCWalkerConfiguration::iterator it,
+                  MCWalkerConfiguration::iterator it_end);
+
+//     /** accumulate the FW observables
+//      */
+//     void accumulate(HDF5_FW_observables& OBS, HDF5_FW_weights& WGTS, std::vector<int>& Dims);
+
+  ///** set the cummulative energy and weight
+  void getEnergyAndWeight(RealType& e, RealType& w, RealType& var);
+
+  void getCurrentStatistics(MCWalkerConfiguration& W, RealType& eavg, RealType& var);
+
+  template<class CT>
+  void write(CT& anything, bool doappend)
+  {
+    anything.write(h_file,doappend);
+  }
+
+protected:
+  ///use bitset to handle options
+  std::bitset<8> Options;
+  ///size of the message buffer
+  int BufferSize;
+  ///number of records in a block
+  int RecordCount;
+  ///index for the block weight PropertyCache(weightInd)
+  int weightInd;
+  ///index for the block cpu PropertyCache(cpuInd)
+  int cpuInd;
+  ///index for the acceptance rate PropertyCache(acceptInd)
+  int acceptInd;
+  ///hdf5 handler
+  hid_t h_file;
+  ///total weight accumulated in a block
+  RealType BlockWeight;
+  ///file handler to write data
+  std::ofstream* Archive;
+  ///file handler to write data for debugging
+  std::ofstream* DebugArchive;
+  ///communicator to handle communication
+  Communicate* myComm;
+  /** pointer to the primary ScalarEstimatorBase
+   */
+  ScalarEstimatorBase* MainEstimator;
+  /** pointer to the CollectablesEstimator
+   *
+   * Do not need to clone: owned by the master thread
+   */
+  CollectablesEstimator* Collectables;
+  /** accumulator for the energy
+   *
+   * @todo expand it for all the scalar observables to report the final results
+   */
+  ScalarEstimatorBase::accumulator_type energyAccumulator;
+  /** accumulator for the variance **/
+  ScalarEstimatorBase::accumulator_type varAccumulator;
+  ///cached block averages of the values
+  Vector<RealType> AverageCache;
+  ///cached block averages of the squared values
+  Vector<RealType> SquaredAverageCache;
+  ///cached block averages of properties, e.g. BlockCPU
+  Vector<RealType> PropertyCache;
+  ///manager of scalar data
+  RecordNamedProperty<RealType> BlockAverages;
+  ///manager of property data
+  RecordNamedProperty<RealType> BlockProperties;
+  ///block averages: name to value
+  RecordNamedProperty<RealType> TotalAverages;
+  ///data accumulated over the blocks
+  Matrix<RealType> TotalAveragesData;
+  ///index mapping between BlockAverages and TotalAverages
+  std::vector<int> Block2Total;
+  ///column map
+  std::map<std::string,int> EstimatorMap;
+  ///estimators of simple scalars
+  std::vector<EstimatorType*> Estimators;
+  ///convenient descriptors for hdf5
+  std::vector<observable_helper*> h5desc;
+  /////estimators of composite data
+  //CompositeEstimatorSet* CompEstimators;
+  ///Timer
+  Timer MyTimer;
+private:
+  ///number of maximum data for a scalar.dat
+  int max4ascii;
+  ///number of requests
+  int pendingRequests;
+  //Data for communication
+  std::vector<BufferType*> RemoteData;
+  //storage for MPI_Request
+  std::vector<Communicate::request> myRequest;
+  ///collect data and write
+  void collectBlockAverages(int num_threads);
+  ///add header to an std::ostream
+  void addHeader(std::ostream& o);
+  size_t FieldWidth;
+};
+}
+#endif

--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -17,7 +17,7 @@
     
 
 
-/** @file EstimatorManager.h
+/** @file EstimatorManagerBase.h
  * @brief Manager class of scalar estimators
  */
 #ifndef QMCPLUSPLUS_ESTIMATORMANAGERBASE_H

--- a/src/Estimators/tests/test_manager.cpp
+++ b/src/Estimators/tests/test_manager.cpp
@@ -17,7 +17,7 @@
 #include "Utilities/OhmmsInfo.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 #include "Estimators/ScalarEstimatorBase.h"
 
 
@@ -39,13 +39,13 @@ class FakeEstimator : public ScalarEstimatorBase
   virtual ScalarEstimatorBase* clone() { return new FakeEstimator; }
 };
 
-TEST_CASE("EstimatorManager", "[estimators]")
+TEST_CASE("EstimatorManagerBase", "[estimators]")
 {
   OHMMS::Controller->initialize(0, NULL);
   Communicate *c = OHMMS::Controller;
   OhmmsInfo("testlogfile");
 
-  EstimatorManager em(c);
+  EstimatorManagerBase em(c);
 
   REQUIRE(em.size() == 0);
 
@@ -60,7 +60,7 @@ TEST_CASE("EstimatorManager", "[estimators]")
   REQUIRE(fake_est2 == fake_est);
 
   // Check the copy constructor
-  EstimatorManager em2(em);
+  EstimatorManagerBase em2(em);
   REQUIRE(em.size() == 1);
 
   em.start(2, true);

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -56,7 +56,8 @@ SET(QMCDRIVERS
   ../Estimators/LocalEnergyEstimator.cpp
   ../Estimators/RMCLocalEnergyEstimator.cpp
   ../Estimators/LocalEnergyEstimatorHDF.cpp
-  ../Estimators/EstimatorManager.cpp
+  ../Estimators/EstimatorManagerBase.cpp
+#  ../Estimators/EstimatorManager.cpp
   ../Estimators/MultipleEnergyEstimator.cpp
   ../Estimators/CollectablesEstimator.cpp
 )

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -82,7 +82,7 @@ protected:
 //     ///update engines
 //     std::vector<QMCRenyiUpdateBase*> RenyiMovers;
   ///estimator managers
-  std::vector<EstimatorManager*> estimatorClones;
+  std::vector<EstimatorManagerBase*> estimatorClones;
   ///trace managers
   std::vector<TraceManager*> traceClones;
   ///Branch engines

--- a/src/QMCDrivers/CorrelatedSampling/CSRMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSRMC.cpp
@@ -54,7 +54,7 @@ bool CSVMC::put(xmlNodePtr q)
   Estimators = branchEngine->getEstimatorManager();
   if(Estimators == 0)
   {
-    Estimators = new EstimatorManager(myComm);
+    Estimators = new EstimatorManagerBase(myComm);
     multiEstimator = new CSEnergyEstimator(H,nPsi);
     Estimators->add(multiEstimator,Estimators->MainEstimatorName);
     branchEngine->setEstimatorManager(Estimators);

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -247,7 +247,7 @@ void CSVMC::resetRun()
     for(int ip=0; ip<NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]= new EstimatorManager(*Estimators);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/DMC/DMCOMP.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.cpp
@@ -85,7 +85,7 @@ void DMCOMP::resetComponents(xmlNodePtr cur)
     delete Movers[ip];
     delete estimatorClones[ip];
     delete branchClones[ip];
-    estimatorClones[ip]= new EstimatorManager(*Estimators);
+    estimatorClones[ip]= new EstimatorManagerBase(*Estimators);
     estimatorClones[ip]->setCollectionMode(false);
     branchClones[ip] = new BranchEngineType(*branchEngine);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -159,7 +159,7 @@ void DMCOMP::resetUpdateEngines()
     #pragma omp parallel for
     for(int ip=0; ip<NumThreads; ++ip)
     {
-      estimatorClones[ip]= new EstimatorManager(*Estimators);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();

--- a/src/QMCDrivers/DMC/DMCOMP.master.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.master.cpp
@@ -63,7 +63,7 @@ void DMCOMP::resetUpdateEngines()
       int ip = omp_get_thread_num();
       if(ip)
         hClones[ip]->add2WalkerProperty(*wClones[ip]);
-      estimatorClones[ip]= new ScalarEstimatorManager(*Estimators,*hClones[ip]);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators,*hClones[ip]);
       Rng[ip]=new RandomGenerator_t();
       Rng[ip]->init(ip,NumThreads,-1);
       hClones[ip]->setRandomGenerator(Rng[ip]);

--- a/src/QMCDrivers/DMC/DMCOMPOPT.cpp
+++ b/src/QMCDrivers/DMC/DMCOMPOPT.cpp
@@ -178,7 +178,7 @@ void DMCOMPOPT::resetUpdateEngines()
     #pragma omp parallel for
     for(int ip=0; ip<NumThreads; ++ip)
     {
-      estimatorClones[ip]= new EstimatorManager(*Estimators);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators);
       estimatorClones[ip]->setCollectionMode(false);
       Rng[ip]=new RandomGenerator_t(*RandomNumberControl::Children[ip]);
       hClones[ip]->setRandomGenerator(Rng[ip]);

--- a/src/QMCDrivers/Experimental/DMCMoveAll.cpp
+++ b/src/QMCDrivers/Experimental/DMCMoveAll.cpp
@@ -36,7 +36,7 @@ DMCMoveAll::DMCMoveAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHami
   m_param.add(NonLocalMove,"nonlocalmoves","string");
   //create a ScalarEstimator and add DMCEnergyEstimator
 //     if (Estimators) delete Estimators;
-  Estimators = new ScalarEstimatorManager(H);
+  Estimators = new EstimatorManagerBase(H);
   Estimators->add(new DMCEnergyEstimator,"elocal");
 }
 

--- a/src/QMCDrivers/Experimental/DMCPbyP.cpp
+++ b/src/QMCDrivers/Experimental/DMCPbyP.cpp
@@ -40,7 +40,7 @@ DMCPbyP::DMCPbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonia
   m_param.add(NonLocalMove,"nonlocalmove","string");
   m_param.add(NonLocalMove,"nonlocalmoves","string");
   //create a ScalarEstimator and add DMCEnergyEstimator
-  Estimators = new ScalarEstimatorManager(H);
+  Estimators = new EstimatorManagerBase(H);
   Estimators->add(new DMCEnergyEstimator,"elocal");
 }
 

--- a/src/QMCDrivers/Experimental/GSLOptimize.cpp
+++ b/src/QMCDrivers/Experimental/GSLOptimize.cpp
@@ -56,7 +56,7 @@ GSLOptimize::GSLOptimize(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHa
   H_KE.add(H.getHamiltonian("Kinetic"),"Kinetic");
   //create an etimator with H_KE
   if(Estimators == 0)
-    Estimators =new ScalarEstimatorManager(H_KE);
+    Estimators =new EstimatorManagerBase(H_KE);
   H_KE.add2WalkerProperty(W);
 }
 

--- a/src/QMCDrivers/Experimental/VMCMultiple.cpp
+++ b/src/QMCDrivers/Experimental/VMCMultiple.cpp
@@ -64,7 +64,7 @@ bool VMCMultiple::put(xmlNodePtr q)
   Estimators = branchEngine->getEstimatorManager();
   if(Estimators == 0)
   {
-    Estimators = new EstimatorManager(H);
+    Estimators = new EstimatorManagerBase(H);
     multiEstimator = new MultipleEnergyEstimator(H,nPsi);
     Estimators->add(multiEstimator,Estimators->MainEstimatorName);
     branchEngine->setEstimatorManager(Estimators);

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -197,7 +197,7 @@ void QMCDriver::process(xmlNodePtr cur)
   Estimators = branchEngine->getEstimatorManager();
   if(Estimators==0)
   {
-    Estimators = new EstimatorManager(myComm);
+    Estimators = new EstimatorManagerBase(myComm);
     branchEngine->setEstimatorManager(Estimators);
     branchEngine->read(h5FileRoot);
   }
@@ -309,7 +309,7 @@ void QMCDriver::adiosCheckpoint(int block)
 #ifdef HAVE_ADIOS
   int64_t adios_handle;
   uint64_t adios_groupsize, adios_totalsize;
-  EstimatorManager* myEstimator = branchEngine->getEstimatorManager();
+  EstimatorManagerBase* myEstimator = branchEngine->getEstimatorManager();
   if (sizeof(OHMMS_PRECISION) == sizeof(double))
   {
     adios_open(&adios_handle, "checkpoint_double", (getRotationName(RootName) + ".config.bp").c_str(), "w", myComm->getMPI());

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -29,7 +29,7 @@
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCApp/WaveFunctionPool.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 #include "Utilities/OhmmsInfo.h"
 #include "QMCDrivers/SimpleFixedNodeBranch.h"
 #include "QMCDrivers/BranchIO.h"
@@ -202,7 +202,7 @@ public:
   //virtual std::vector<RandomGenerator_t*>& getRng() {}
 
   ///Observables manager
-  EstimatorManager* Estimators;
+  EstimatorManagerBase* Estimators;
 
   ///Traces manager
   TraceManager* Traces;

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -90,7 +90,7 @@ bool QMCUpdateBase::put(xmlNodePtr cur)
   return s;
 }
 
-void QMCUpdateBase::resetRun(BranchEngineType* brancher, EstimatorManager* est)
+void QMCUpdateBase::resetRun(BranchEngineType* brancher, EstimatorManagerBase* est)
 {
   Estimators=est;
   branchEngine=brancher;
@@ -121,7 +121,7 @@ void QMCUpdateBase::resetRun(BranchEngineType* brancher, EstimatorManager* est)
 }
 
 
-void QMCUpdateBase::resetRun(BranchEngineType* brancher, EstimatorManager* est, TraceManager* traces)
+void QMCUpdateBase::resetRun(BranchEngineType* brancher, EstimatorManagerBase* est, TraceManager* traces)
 {
   resetRun(brancher,est);
   Traces = traces;

--- a/src/QMCDrivers/QMCUpdateBase.h
+++ b/src/QMCDrivers/QMCUpdateBase.h
@@ -28,7 +28,7 @@
 #include "QMCDrivers/SimpleFixedNodeBranch.h"
 //#define ENABLE_COMPOSITE_ESTIMATOR
 //#include "Estimators/CompositeEstimators.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 namespace qmcplusplus
 {
 
@@ -92,9 +92,9 @@ public:
    *
    * Update time-step variables to move walkers
    */
-  void resetRun(BranchEngineType* brancher, EstimatorManager* est);
+  void resetRun(BranchEngineType* brancher, EstimatorManagerBase* est);
 
-  void resetRun(BranchEngineType* brancher, EstimatorManager* est, TraceManager* traces);
+  void resetRun(BranchEngineType* brancher, EstimatorManagerBase* est, TraceManager* traces);
 
   inline RealType getTau()
   {
@@ -281,7 +281,7 @@ protected:
   ///branch engine
   BranchEngineType* branchEngine;
   ///estimator
-  EstimatorManager* Estimators;
+  EstimatorManagerBase* Estimators;
   ///parameters
   ParameterSet myParams;
   ///1/Mass per species

--- a/src/QMCDrivers/RMC/RMCSingleOMP.cpp
+++ b/src/QMCDrivers/RMC/RMCSingleOMP.cpp
@@ -265,7 +265,7 @@ namespace qmcplusplus
 	for (int ip = 0; ip < NumThreads; ++ip)
 	  {
 	    std::ostringstream os;
-	    estimatorClones[ip] = new EstimatorManager (*Estimators);	//,*hClones[ip]);
+	    estimatorClones[ip] = new EstimatorManagerBase (*Estimators);	//,*hClones[ip]);
 	    estimatorClones[ip]->resetTargetParticleSet (*wClones[ip]);
 	    estimatorClones[ip]->setCollectionMode (false);
 	    Rng[ip] =

--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -24,7 +24,7 @@
 #include "OhmmsData/FileUtility.h"
 #include "Utilities/RandomGenerator.h"
 #include "QMCDrivers/WalkerControlBase.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 //#include "Estimators/DMCEnergyEstimator.h"
 #include "QMCDrivers/BranchIO.h"
 #include "Particle/Reptile.h"

--- a/src/QMCDrivers/SimpleFixedNodeBranch.h
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.h
@@ -39,7 +39,7 @@ namespace qmcplusplus
 {
 
 class WalkerControlBase;
-class EstimatorManager;
+class EstimatorManagerBase;
 
 /** Manages the state of QMC sections and handles population control for DMCs
  *
@@ -133,7 +133,7 @@ struct SimpleFixedNodeBranch: public QMCTraits
   ///Backup WalkerController for mixed DMC
   WalkerControlBase* BackupWalkerController;
   ///EstimatorManager
-  EstimatorManager*  MyEstimator;
+  EstimatorManagerBase*  MyEstimator;
   ///a simple accumulator for energy
   accumulator_set<EstimatorRealType> EnergyHist;
   ///a simple accumulator for variance
@@ -200,7 +200,7 @@ struct SimpleFixedNodeBranch: public QMCTraits
   }
 
   /** get the EstimatorManager */
-  EstimatorManager* getEstimatorManager()
+  EstimatorManagerBase* getEstimatorManager()
   {
     return MyEstimator;
   }
@@ -208,7 +208,7 @@ struct SimpleFixedNodeBranch: public QMCTraits
   /** set the EstimatorManager
    * @param est estimator created by the first QMCDriver
    * */
-  void setEstimatorManager(EstimatorManager* est)
+  void setEstimatorManager(EstimatorManagerBase* est)
   {
     MyEstimator=est;
   }

--- a/src/QMCDrivers/VMC/VMCLinearOptOMP.cpp
+++ b/src/QMCDrivers/VMC/VMCLinearOptOMP.cpp
@@ -495,7 +495,7 @@ void VMCLinearOptOMP::resetRun()
     for (int ip=0; ip<NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]= new EstimatorManager(*Estimators);//,*hClones[ip]);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators);//,*hClones[ip]);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/VMC/VMCMultipleWarp.cpp
+++ b/src/QMCDrivers/VMC/VMCMultipleWarp.cpp
@@ -107,7 +107,7 @@ bool VMCMultipleWarp::put(xmlNodePtr q)
   //  H1[ipsi]->add2WalkerProperty(W);
   if(Estimators == 0)
   {
-    Estimators = new EstimatorManager(myComm);
+    Estimators = new EstimatorManagerBase(myComm);
     multiEstimator = new MultipleEnergyEstimator(H,nPsi);
     Estimators->add(multiEstimator,"elocal");
   }

--- a/src/QMCDrivers/VMC/VMCPbyPMultiWarp.cpp
+++ b/src/QMCDrivers/VMC/VMCPbyPMultiWarp.cpp
@@ -450,7 +450,7 @@ VMCPbyPMultiWarp::put(xmlNodePtr q)
   Estimators = branchEngine->getEstimatorManager();
   if(Estimators == 0)
   {
-    Estimators = new EstimatorManager(myComm);
+    Estimators = new EstimatorManagerBase(myComm);
     multiEstimator = new MultipleEnergyEstimator(H,nPsi);
     Estimators->add(multiEstimator,"elocal");
   }

--- a/src/QMCDrivers/VMC/VMCPbyPMultiple.cpp
+++ b/src/QMCDrivers/VMC/VMCPbyPMultiple.cpp
@@ -332,7 +332,7 @@ VMCPbyPMultiple::put(xmlNodePtr q)
     H1[ipsi]->add2WalkerProperty(W);
   if(Estimators == 0)
   {
-    Estimators = new EstimatorManager(H);
+    Estimators = new EstimatorManagerBase(H);
     multiEstimator = new MultipleEnergyEstimator(H,nPsi);
     Estimators->add(multiEstimator,"elocal");
   }

--- a/src/QMCDrivers/VMC/VMCSingleOMP.cpp
+++ b/src/QMCDrivers/VMC/VMCSingleOMP.cpp
@@ -151,7 +151,7 @@ void VMCSingleOMP::resetRun()
     for(int ip=0; ip<NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip]= new EstimatorManager(*Estimators);//,*hClones[ip]);
+      estimatorClones[ip]= new EstimatorManagerBase(*Estimators);//,*hClones[ip]);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -28,7 +28,7 @@
 #include "QMCWaveFunctions/ConstantOrbital.h"
 #include "QMCWaveFunctions/LinearOrbital.h"
 #include "QMCHamiltonians/BareKineticEnergy.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 #include "Estimators/TraceManager.h"
 #include "QMCDrivers/DMC/DMCUpdatePbyP.h"
 
@@ -101,7 +101,7 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
   DMCUpdatePbyPWithRejectionFast dmc(elec, *psi, h, rg);
-  EstimatorManager EM;
+  EstimatorManagerBase EM;
   double tau = 0.1;
   SimpleFixedNodeBranch branch(tau, 1);
   TraceManager TM;
@@ -203,7 +203,7 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dm
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
   DMCUpdatePbyPWithRejectionFast dmc(elec, *psi, h, rg);
-  EstimatorManager EM;
+  EstimatorManagerBase EM;
   double tau = 0.1;
   SimpleFixedNodeBranch branch(tau, 1);
   TraceManager TM;

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -28,7 +28,7 @@
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/ConstantOrbital.h"
 #include "QMCHamiltonians/BareKineticEnergy.h"
-#include "Estimators/EstimatorManager.h"
+#include "Estimators/EstimatorManagerBase.h"
 #include "Estimators/TraceManager.h"
 #include "QMCDrivers/VMC/VMCUpdatePbyP.h"
 
@@ -101,7 +101,7 @@ TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
   VMCUpdatePbyP vmc(elec, psi, h, rg);
-  EstimatorManager EM;
+  EstimatorManagerBase EM;
   SimpleFixedNodeBranch branch(0.1, 1);
   TraceManager TM;
   vmc.resetRun(&branch, &EM, &TM);


### PR DESCRIPTION
This is pull request 1/3 to resolve issue #214.  This renames EstimatorManager to EstimatorManagerBase, and updates all references to EstimatorManager in the code to EstimatorManagerBase.  While just a rename for now, the next pull request will split current functionality between a derived class EstimatorManager and EstimatorManagerBase.