### PR TITLE
Bugfix: Long diamond test was using short inputs

### DIFF
--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -656,8 +656,8 @@ ENDIF(ENABLE_SOA)
   LIST(APPEND LONG_DIAMOND_DMC_SCALARS "totenergy" "-10.531583 0.000815")
   QMC_RUN_AND_CHECK(long-diamondC_1x1x1_pp-dmc_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
-                    qmc_short_vmc_dmc
-                    qmc_short_vmc_dmc.in.xml
+                    qmc_long_vmc_dmc
+                    qmc_long_vmc_dmc.in.xml
                     1 16
                     LONG_DIAMOND_DMC_SCALARS
                     1 # DMC


### PR DESCRIPTION
Closes #334 

Explains too frequent test failures: expected error bar was for long test but only short statistics were being computed.
