### PR TITLE
Change behavior for the DMC CPU time limit.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,7 @@ ENDIF(HAVE_OOMPI)
     Utilities/OhmmsInform.cpp 
     Utilities/OhmmsInfo.cpp 
     Utilities/NewTimer.cpp
+    Utilities/RunTimeManager.cpp
     Utilities/ProgressReportEngine.cpp
     Utilities/unit_conversion.cpp
     OhmmsData/Libxml2Doc.cpp

--- a/src/Utilities/RunTimeManager.cpp
+++ b/src/Utilities/RunTimeManager.cpp
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file RunTimeManager.cpp
+ *  @brief Class for determining elapsed run time enabling simulations to adjust to time limits.
+
+ */
+#include <Utilities/RunTimeManager.h>
+
+
+namespace qmcplusplus
+{
+
+RunTimeManagerClass RunTimeManager;
+
+double
+LoopTimer::get_time_per_iteration() {
+  if (nloop > 0)
+  {
+    return total_time/nloop;
+  }
+  return 0.0;
+}
+
+}

--- a/src/Utilities/RunTimeManager.h
+++ b/src/Utilities/RunTimeManager.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file RunTimeManager.h
+ * @brief Class for determining elapsed run time enabling simulations to adjust to time limits.
+ */
+#ifndef QMCPLUSPLUS_RUNTIME_MANAGER_H
+#define QMCPLUSPLUS_RUNTIME_MANAGER_H
+
+#include <Utilities/Clock.h>
+
+
+namespace qmcplusplus
+{
+
+class RunTimeManagerClass
+{
+public:
+  void start()  { start_time = cpu_clock(); }
+  double elapsed() { return cpu_clock() - start_time; }
+  // Initialize the start time at static class initialization time
+  RunTimeManagerClass() { start(); }
+private:
+  double start_time;
+};
+
+extern RunTimeManagerClass RunTimeManager;
+
+class LoopTimer
+{
+public:
+  void start() { start_time = cpu_clock(); }
+  void stop() { nloop++; total_time += cpu_clock() - start_time; }
+  double get_time_per_iteration();
+
+  LoopTimer() : nloop(0), start_time(0.0), total_time(0.0) {}
+private:
+  int nloop;
+  double start_time;
+  double total_time;
+};
+
+}
+#endif


### PR DESCRIPTION
The time limit is set with the MaxCPUSecs parameter.

Previously, the time limit was measured from the beginning of the
DMC portion of the run, and continued until the set time runs out.
To effectively set this parameter, the user would need to know how much
time is spent prior to the DMC section, and the duration of each block,
in order to leave enough time for the simulation to shut down cleanly.

The new behavior measures the time elapsed from the beginning of the
run (captured during static initialization of the RunTimeManager object).
The time per DMC block is tracked and used to estimate if there is sufficient
time to run another block.

The time reserved to finish the next block is computed from the existing
average with some margin (to handle variations in block to block time) and
a fixed amount (to cover the time to end the simulation cleanly).


This addresses issue #300 
Potential issues
- It silently changes the behavior of MaxCPUSecs.   I'm not sure if anyone depends on the current behavior?
- the margin time (10%) and fixed padding (10s) are arbitrarily chosen, and most likely incorrect.
- The decision to stop is made on every MPI node independently.  There is a chance that one node may decide to exit and other nodes continue, and this would cause problems (especially if the exit path need global reductions or parallel HDF IO).    However, the new code is no worse than the old code in this regard.

