### PR TITLE
Fix divided by zero issue in CUDA noMPI build.

### DIFF
--- a/src/Message/CommOperatorsSingle.h
+++ b/src/Message/CommOperatorsSingle.h
@@ -46,7 +46,10 @@ Communicate::send(int dest, int tag, T&) { }
 
 template<typename T> inline void Communicate::gather(T& sb, T& rb, int dest) { }
 
-template<typename T> inline void Communicate::allgather(T& sb, T& rb, int count) { }
+template<typename T> inline void Communicate::allgather(T& sb, T& rb, int count)
+{
+  for(size_t i=0; i<count; i++) rb[i]=sb[i];
+}
 
 template<typename T> inline void Communicate::scatter(T& sb, T& rb, int dest) { }
 


### PR DESCRIPTION
During the MPI and device matching step, allgather is called. In no MPI build, all gather was not implemented and caused a float point exception (divided by zero).