### PR TITLE
Add tests for Nexus examples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,6 +861,7 @@ SUBDIRS(src)
 IF(NOT(QMC_BUILD_LEVEL GREATER 4))
   SUBDIRS(tests)
   SUBDIRS(examples)
+  SUBDIRS(nexus/examples)
 ENDIF()
 
 #ADD_CUSTOM_TARGET(print_settings ALL

--- a/nexus/examples/CMakeLists.txt
+++ b/nexus/examples/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+# Add tests for Nexus examples
+
+
+FUNCTION(ADD_EXAMPLE_TEST test_name test_dir nexus_file)
+    #MESSAGE("Adding Nexus test ${test_name}")
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/${test_dir}" "${CMAKE_CURRENT_BINARY_DIR}/${test_dir}")
+    ADD_TEST(NAME nexus_example_${test_name} COMMAND python nexus_example_test.py "${CMAKE_CURRENT_BINARY_DIR}/${test_dir}" --nexus-file "${nexus_file}" --nexus-path "${CMAKE_CURRENT_SOURCE_DIR}/../library")
+    SET_TESTS_PROPERTIES(nexus_example_${test_name} PROPERTIES TIMEOUT 240)
+    SET_TESTS_PROPERTIES(nexus_example_${test_name} PROPERTIES LABELS "nexus")
+
+ENDFUNCTION()
+
+MESSAGE("Adding Nexus example tests")
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/nexus_example_test.py" "${CMAKE_CURRENT_BINARY_DIR}")
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/qmcpack/pseudopotentials" "${CMAKE_CURRENT_BINARY_DIR}/qmcpack/pseudopotentials")
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/quantum_espresso/pseudopotentials" "${CMAKE_CURRENT_BINARY_DIR}/quantum_espresso/pseudopotentials")
+ADD_EXAMPLE_TEST(c20 qmcpack/c20 c20.py)
+ADD_EXAMPLE_TEST(diamond qmcpack/diamond diamond.py)
+ADD_EXAMPLE_TEST(diamond_vacancy qmcpack/diamond diamond_vacancy.py)
+ADD_EXAMPLE_TEST(graphene qmcpack/graphene graphene.py)
+ADD_EXAMPLE_TEST(H2O qmcpack/H2O H2O.py)
+ADD_EXAMPLE_TEST(LiH qmcpack/LiH LiH.py)
+ADD_EXAMPLE_TEST(oxygen_dimer qmcpack/oxygen_dimer oxygen_dimer.py)
+ADD_EXAMPLE_TEST(relax_Ge_T_vs_kpoints    quantum_espresso/relax_Ge_T_vs_kpoints relax_vs_kpoints_example.py)

--- a/nexus/examples/nexus_example_test.py
+++ b/nexus/examples/nexus_example_test.py
@@ -1,0 +1,67 @@
+#from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+def run_one_nexus_test(nexus_file):
+  okay = True
+  g = dict()
+
+  g['override_generate_only_setting'] = True
+  try:
+    execfile(nexus_file, g)
+  except Exception as e:
+    print('Error ',type(e),e)
+    okay = False
+  except SystemExit:
+    print('system exit called')
+    okay = False
+
+  if okay:
+    print("  pass")
+  else:
+    print("  FAIL")
+
+  return okay
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Test Nexus examples')
+  parser.add_argument('test_dir',
+                      help='Directory of test to run')
+  parser.add_argument('--nexus-file',
+                     help='Name of Nexus file for this example')
+  parser.add_argument('--nexus-path',
+                      help='Path to Nexus library (for setting PYTHONPATH)')
+  args = parser.parse_args()
+
+  test_dir = args.test_dir
+  if not os.path.exists(test_dir):
+    print("Test not found: ", test_dir)
+    sys.exit(1)
+
+  curr_dir = os.getcwd()
+  os.chdir(test_dir)
+
+
+  nexus_path = args.nexus_path
+  if nexus_path:
+    if not os.path.exists(nexus_path):
+      print("Nexus path not found: ", nexus_path)
+      sys.exit(1)
+    sys.path.append(nexus_path)
+
+  nexus_file = args.nexus_file
+  if not os.path.exists(nexus_file):
+      print("Nexus file not found: ", nexus_file)
+      sys.exit(1)
+
+  ret = run_one_nexus_test(args.nexus_file)
+
+  os.chdir(curr_dir)
+
+  if ret:
+    sys.exit(0)
+  sys.exit(1)
+

--- a/nexus/examples/qmcpack/H2O/H2O.py
+++ b/nexus/examples/qmcpack/H2O/H2O.py
@@ -9,11 +9,14 @@ from nexus import generate_qmcpack,vmc,loop,linear,dmc
 
 # General Settings (Directories For I/O, Machine Type, etc.)
 settings(
-    pseudo_dir      = 'pseudopotentials',
+    pseudo_dir      = '../pseudopotentials',
     runs            = 'runs',
     results         = 'results',
     sleep           = 3,
-    generate_only   = 0,
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     status_only     = 0,
     machine         = 'ws1',
     )

--- a/nexus/examples/qmcpack/LiH/LiH.py
+++ b/nexus/examples/qmcpack/LiH/LiH.py
@@ -13,7 +13,11 @@ settings(
     runs            = 'runs',
     results         = 'results',
     sleep           = 3,
-    generate_only   = 0,
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
+
     status_only     = 0,
     machine         = 'ws1',
     )

--- a/nexus/examples/qmcpack/c20/c20.py
+++ b/nexus/examples/qmcpack/c20/c20.py
@@ -12,7 +12,10 @@ from nexus import loop,linear,vmc,dmc
 settings(
     pseudo_dir    = '../pseudopotentials',# directory with all pseudopotentials
     sleep         = 3,                    # check on runs every 'sleep' seconds
-    generate_only = 0,                    # only make input files
+    #generate_only = 0,                    # only make input files
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     status_only   = 0,                    # only show status of runs
     machine       = 'ws16',               # local machine is 16 core workstation
     )

--- a/nexus/examples/qmcpack/diamond/diamond.py
+++ b/nexus/examples/qmcpack/diamond/diamond.py
@@ -9,7 +9,10 @@ from nexus import generate_qmcpack,vmc
 settings(
     pseudo_dir    = '../pseudopotentials',
     status_only   = 0,
-    generate_only = 0,
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     sleep         = 3,
     machine       = 'ws16'
     )

--- a/nexus/examples/qmcpack/diamond/diamond_vacancy.py
+++ b/nexus/examples/qmcpack/diamond/diamond_vacancy.py
@@ -5,7 +5,10 @@ from nexus import *
 settings(
     pseudo_dir    = '../pseudopotentials',
     status_only   = 0,
-    generate_only = 0,
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     sleep         = 3,
     machine       = 'ws16'
     )

--- a/nexus/examples/qmcpack/graphene/graphene.py
+++ b/nexus/examples/qmcpack/graphene/graphene.py
@@ -12,7 +12,10 @@ from nexus import loop,linear,vmc,dmc
 settings(
     pseudo_dir    = '../pseudopotentials',# directory with all pseudopotentials
     sleep         = 3,                    # check on runs every 'sleep' seconds
-    generate_only = 0,                    # only make input files
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     status_only   = 0,                    # only show status of runs
     machine       = 'ws16',               # local machine is 16 core workstation
     )

--- a/nexus/examples/qmcpack/oxygen_dimer/oxygen_dimer.py
+++ b/nexus/examples/qmcpack/oxygen_dimer/oxygen_dimer.py
@@ -14,7 +14,10 @@ settings(
     runs          = '',
     results       = '',
     status_only   = 0,
-    generate_only = 0,
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
     sleep         = 3,
     machine       = 'ws16',
     ) 

--- a/nexus/examples/qmcpack/pseudopotentials/H.BFD.upf
+++ b/nexus/examples/qmcpack/pseudopotentials/H.BFD.upf
@@ -1,0 +1,1 @@
+../../../../pseudopotentials/BFD/H.BFD.upf

--- a/nexus/examples/qmcpack/pseudopotentials/H.BFD.xml
+++ b/nexus/examples/qmcpack/pseudopotentials/H.BFD.xml
@@ -1,0 +1,1 @@
+../../../../pseudopotentials/BFD/H.BFD.xml

--- a/nexus/examples/quantum_espresso/relax_Ge_T_vs_kpoints/relax_vs_kpoints_example.py
+++ b/nexus/examples/quantum_espresso/relax_Ge_T_vs_kpoints/relax_vs_kpoints_example.py
@@ -10,7 +10,11 @@ from nexus import run_project
 # set global parameters of nexus
 settings(
     pseudo_dir    = '../pseudopotentials',# directory with pseudopotentials
-    generate_only = 0,                    # only generate input files, T/F
+    #generate_only   = False,
+    # Complicated setting only so examples can be run in test harness.
+    # For real runs, use the plain setting of 'generate_only' above.
+    generate_only   = globals().get('override_generate_only_setting',False),
+
     status_only   = 0,                    # only show run status, T/F
     machine       = 'ws16'                # local machine is 16 core workstation
     )


### PR DESCRIPTION
Nexus scripts are run with 'generate_only' set to True.
This will at least test the Nexus API and catch breaking changes.

Currently the LiH test fails:
 QmcpackInput error:
    pseudo does not have the following attributes/elements:
        l-local

The 'generate_only' setting is changed in the script by setting a particular value in the globals prior to exec'ing the Nexus script.    It does require a change to the Nexus script being tested.
It would be nice to be able to check this inside of Nexus, rather than requiring each example script to check it.    The modification of the globals only affects the exec'ed file, and does not propagate to the files imported from that file.
Another option would be to set an environment variable, and check that from inside Nexus, but I'm not sure where to insert that check.