### PR TITLE
Add approximate testing for complex values.

### DIFF
--- a/external_codes/catch/catch.hpp
+++ b/external_codes/catch/catch.hpp
@@ -10443,5 +10443,7 @@ int main (int argc, char * const argv[]) {
 
 using Catch::Detail::Approx;
 
+#include "complex_approx.hpp"
+
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
 

--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -1,0 +1,69 @@
+#ifndef CATCH_COMPLEX_APPROX
+#define CATCH_COMPLEX_APPROX
+
+#include <complex>
+
+// Copy and modify the Approx class to handle complex numbers
+
+namespace Catch {
+class ComplexApprox
+{
+public:
+    ComplexApprox(std::complex<double> value) : m_value(value), m_compare_real_only(false) {}
+    std::complex<double> m_value;
+    bool m_compare_real_only;
+
+    friend bool operator == (double const& lhs, ComplexApprox const& rhs)
+    {
+        bool is_equal = Approx(lhs) == rhs.m_value.real();
+        if (!rhs.m_compare_real_only)
+        {
+          is_equal &= Approx(0.0) == rhs.m_value.imag();
+        }
+        return is_equal;
+    }
+
+    friend bool operator == (ComplexApprox const& lhs, double const &rhs)
+    {
+        return operator==( rhs, lhs );
+    }
+
+    friend bool operator == (std::complex<double>& lhs, ComplexApprox const& rhs)
+    {
+        bool is_equal = Approx(lhs.real()) == rhs.m_value.real();
+        if (!rhs.m_compare_real_only)
+        {
+          is_equal &= Approx(lhs.imag()) == rhs.m_value.imag();
+        }
+        return is_equal;
+    }
+
+    friend bool operator == (ComplexApprox const &lhs, std::complex<double>& rhs)
+    {
+        return operator==( rhs, lhs );
+    }
+
+    ComplexApprox &compare_real_only()
+    {
+      m_compare_real_only = true;
+      return *this;
+    }
+
+
+    std::string toString() const {
+        std::ostringstream oss;
+        oss <<"ComplexApprox( " << m_value << " )";
+        return oss.str();
+    }
+
+};
+
+template<>
+inline std::string toString<ComplexApprox>( ComplexApprox const& value ) {
+    return value.toString();
+}
+}
+
+using Catch::ComplexApprox;
+
+#endif

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -160,6 +160,16 @@ inline std::ostream& app_debug()
   return OhmmsInfo::Debug->getStream();
 }
 
+// For unit tests
+//  Check if we are compiling with Catch defined.  Could use other symbols if needed.
+#ifdef TEST_CASE
+#ifdef QMC_COMPLEX
+typedef ComplexApprox ValueApprox;
+#else
+typedef Approx ValueApprox;
+#endif
+#endif
+
 }
 
 #endif

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -145,11 +145,7 @@ const char *particles =
   SPOSetBase::ValueVector_t orbs(orbSize);
   spo->evaluate(elec, 0, orbs);
 
-#ifdef QMC_COMPLEX
-  REQUIRE(orbs[0].real() == Approx(-1.2473558998));
-#else
-  REQUIRE(orbs[0] == Approx(-1.2473558998));
-#endif
+  REQUIRE(orbs[0] == ComplexApprox(-1.2473558998).compare_real_only());
 
 #if 0
   // Dump values of the orbitals
@@ -304,11 +300,7 @@ const char *particles =
   SPOSetBase::ValueVector_t orbs(orbSize);
   spo->evaluate(elec, 0, orbs);
 
-#ifdef QMC_COMPLEX
-  REQUIRE(orbs[0].real() == Approx(-14.3744302974));
-#else
-  REQUIRE(orbs[0] == Approx(-14.3744302974));
-#endif
+  REQUIRE(orbs[0] == ComplexApprox(-14.3744302974).compare_real_only());
 
 #if 0
   // Dump values of the orbitals


### PR DESCRIPTION
Create a ComplexApprox class that acts similar to the Approx class in Catch.
It will compare the real and imaginary parts separately. It can also test just
the real part if compare_real_only is set.
The epsilon and scale values settings are not exposed, but it would be easy
to add them.
Also create a ValueApprox typedef for testing ValueType with the appropriate
real or complex setting.   It's not used in this PR, but it will be used in a future PR.