### PR TITLE
move to threaded Li2STO/HEG tests, update ctest doc

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -276,6 +276,7 @@ ENDFUNCTION()
 
 
 # Add a test run and associated scalar checks
+# ---required inputs---
 # BASE_NAME - name of test (number of MPI processes, number of threads, and value to check (if applicable)
 #             will be appended to get the full test name)
 # BASE_DIR - source location of test input files
@@ -283,12 +284,16 @@ ENDFUNCTION()
 # INPUT_FILE - XML input file to QMCPACK
 # PROCS - number of MPI processes
 # THREADS - number of OpenMP threads
+# SHOULD_SUCCEED - whether the test is expected to pass or fail.  Expected failing tests will not have
+#                  the scalar tests added.
+# ---optional inputs---
+# ---any number of SERIES/SCALAR_VALUES list pairs can be provided
+# ---input pairs beyond the first result in the series number being added to the test name
+# ---support for this functionality is provided through the ARGN catch-all input list
+# SERIES - series index to compute
 # SCALAR_VALUES - list of output values to check with check_scalars.py
 #                 The list entries alternate between the value name and the value (usually a string with the
 #                 both the average and error).
-# SERIES - series index to compute
-# SHOULD_SUCCEED - whether the test is expected to pass or fail.  Expected failing tests will not have
-#                  the scalar tests added.
 
 FUNCTION(QMC_RUN_AND_CHECK BASE_NAME BASE_DIR PREFIX INPUT_FILE PROCS THREADS SHOULD_SUCCEED)
     # Map from name of check to appropriate flag for check_scalars.py

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -76,7 +76,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_NI
                     heg-short-NI.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GSNI_SCALARS
                     )
@@ -91,7 +91,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_NI_dmc
                     heg-short-NI-dmc.xml
-                    16 1
+                    1 16
                     TRUE
                     1 HEG14GSNI_DMC_SCALARS # DMC
                     )
@@ -106,7 +106,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_HF
                     heg-short-HF.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GSHF_SCALARS # VMC
                     )
@@ -121,7 +121,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_SJ
                     heg-short-SJ.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GSSJ_SCALARS # VMC
                     )
@@ -136,7 +136,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_SJ_new
                     heg-short-SJ-new.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GSSJ_NEW_SCALARS # VMC
                     )
@@ -152,7 +152,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_SJB
                     heg-short-SJB.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GSSJB_SCALARS # VMC
                     )
@@ -185,7 +185,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_SJ_dmc
                     heg-short-SJ-dmc.xml
-                    16 1
+                    1 16
                     TRUE
                     2 HEG14GSSJ_DMC_SCALARS # DMC
                     )
@@ -204,7 +204,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_NI
                     heg-long-NI.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GLNI_SCALARS # VMC
                     )
@@ -219,7 +219,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_NI_dmc
                     heg-long-NI-dmc.xml
-                    16 1
+                    1 16
                     TRUE
                     1 HEG14GLNI_DMC_SCALARS # DMC
                     )
@@ -234,7 +234,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_HF
                     heg-long-HF.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GLHF_SCALARS # VMC
                     )
@@ -249,7 +249,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_SJ
                     heg-long-SJ.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GLSJ_SCALARS # VMC
                     )
@@ -264,7 +264,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_SJ_new
                     heg-long-SJ-new.xml
-                    16 1
+                    1 16
                     TRUE
                     0 HEG14GLSJ_NEW_SCALARS # VMC
                     )
@@ -313,7 +313,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_long_SJ_dmc
                     heg-long-SJ-dmc.xml
-                    16 1
+                    1 16
                     TRUE
                     2 HEG14GLSJ_DMC_SCALARS # DMC
                     )
@@ -345,7 +345,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/molecules/Li2_STO_ae"
                     Li2.STO.short
                     Li2.STO.short.in.xml
-                    16 1
+                    1 16
                     TRUE
                     0 LI2STOSJS_VMC_SCALARS # VMC
                     2 LI2STOSJS_DMC_SCALARS # DMC
@@ -371,7 +371,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/molecules/Li2_STO_ae"
                     Li2.STO.long
                     Li2.STO.long.in.xml
-                    16 1
+                    1 16
                     TRUE
                     0 LI2STOSJL_VMC_SCALARS # VMC
                     2 LI2STOSJL_DMC_SCALARS # DMC

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -152,7 +152,7 @@ IF (NOT QMC_COMPLEX)
                     "${CMAKE_SOURCE_DIR}/tests/heg/heg_14_gamma"
                     heg_short_SJB
                     heg-short-SJB.xml
-                    1 16
+                    16 1
                     TRUE
                     0 HEG14GSSJB_SCALARS # VMC
                     )


### PR DESCRIPTION
Revisits #403 as requested.  HEG and Li2 STO tests now in place for 1x16 mpi/threads rather than 16x1 mpi/threads.  In text documentation for QMC_RUN_AND_CHECK has been updated to reflect the change in input order and the addition of an arbitrary number of optional series/checklist pairs.

Once this PR is accepted, issue #394 can be closed.