### PR TITLE
Fix reconfiguration="yes" by updating UnitZeta each generation.

### DIFF
--- a/src/QMCDrivers/DMC/WalkerReconfiguration.cpp
+++ b/src/QMCDrivers/DMC/WalkerReconfiguration.cpp
@@ -7,6 +7,7 @@
 // File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Andrew D. Baczewski, adbacze@sandia.gov, Sandia National Laboratories
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -27,7 +28,6 @@ using namespace qmcplusplus;
 WalkerReconfiguration::WalkerReconfiguration(Communicate* c) :WalkerControlBase(c)
 {
   SwapMode=1;
-  UnitZeta=Random();
   //ofstream fout("check.dat");
 }
 
@@ -64,6 +64,7 @@ int WalkerReconfiguration::getIndexPermutation(MCWalkerConfiguration& W)
   curData[R2ACCEPTED_INDEX]=r2_accepted;
   curData[R2PROPOSED_INDEX]=r2_proposed;
   RealType nwInv=1.0/static_cast<RealType>(nw);
+  UnitZeta=Random();
   RealType dstep=UnitZeta*nwInv;
   for(int iw=0; iw<nw; iw++)
   {

--- a/src/QMCDrivers/DMC/WalkerReconfigurationMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerReconfigurationMPI.cpp
@@ -7,6 +7,7 @@
 // File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Andrew D. Baczewski, adbacze@sandia.gov, Sandia National Laboratories
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -28,9 +29,6 @@ WalkerReconfigurationMPI::WalkerReconfigurationMPI(Communicate* c):
   WalkerControlBase(c), TotalWalkers(0)
 {
   SwapMode=1;
-  UnitZeta=Random();
-  myComm->bcast(UnitZeta);
-  app_log() << "  First weight [0,1) for reconfiguration =" << UnitZeta << std::endl;
 }
 
 int
@@ -68,13 +66,15 @@ int WalkerReconfigurationMPI::swapWalkers(MCWalkerConfiguration& W)
     LastWalker=FirstWalker+nw;
     TotalWalkers = nw*NumContexts;
     nwInv = 1.0/static_cast<RealType>(TotalWalkers);
-    DeltaStep = UnitZeta*nwInv;
     ncopy_w.resize(nw);
     wConf.resize(nw);
     //wSum.resize(NumContexts);
     wOffset.resize(NumContexts+1);
     dN.resize(NumContexts+4);
   }
+  UnitZeta=Random();
+  myComm->bcast(UnitZeta);
+  DeltaStep=UnitZeta*nwInv;
   //std::fill(wSum.begin(),wSum.end(),0.0);
   MCWalkerConfiguration::iterator it(W.begin()), it_end(W.end());
   int iw=0;

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_reconf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_reconf.in.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_long_vmc_dmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  6.74632230        6.74632230        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="4" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+                     3.37316115        3.37316115        0.00000000
+                     5.05974172        5.05974172        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <slaterdeterminant>
+               <determinant id="updet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.137281409 -0.1032026175 -0.0857843003 -0.07105398747 -0.05719926375 
+-0.04090373292 -0.0259365816 -0.01321962532
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2969700506 0.2407083361 0.1830009217 0.1355563432 0.09514725057 0.06112611044 
+0.03450633959 0.01532305926
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4704510359 0.3531940571 0.2579420961 0.1820538307 0.1211946391 0.07487030513 
+0.04028963542 0.01742251234
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="targetwalkers"> 256 </parameter>
+     <parameter name="reconfiguration">   yes </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   100 </parameter>
+     <parameter name="blocks">  250 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+
+</simulation>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_reconf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_reconf.in.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short_vmc_dmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  6.74632230        6.74632230        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="4" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+                     3.37316115        3.37316115        0.00000000
+                     5.05974172        5.05974172        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <slaterdeterminant>
+               <determinant id="updet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.137281409 -0.1032026175 -0.0857843003 -0.07105398747 -0.05719926375 
+-0.04090373292 -0.0259365816 -0.01321962532
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2969700506 0.2407083361 0.1830009217 0.1355563432 0.09514725057 0.06112611044 
+0.03450633959 0.01532305926
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4704510359 0.3531940571 0.2579420961 0.1820538307 0.1211946391 0.07487030513 
+0.04028963542 0.01742251234
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="targetwalkers"> 256 </parameter>
+     <parameter name="reconfiguration">   yes </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   100 </parameter>
+     <parameter name="blocks">  25 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+
+</simulation>

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -942,6 +942,16 @@ ENDIF(ENABLE_SOA)
                     1 DIAMOND2_DMC_SCALARS # DMC
                     )
 
+  LIST(APPEND DIAMOND2_DMC_SCALARS "totenergy" "-21.844975 0.00779")
+  QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-dmc-reconf_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
+                    qmc_short_vmc_dmc
+                    qmc_short_vmc_dmc_reconf.in.xml
+                    1 16
+                    TRUE
+                    1 DIAMOND2_DMC_SCALARS # DMC
+                    )
+
 
   LIST(APPEND HCP_BE_SCALARS "totenergy" "-1.481656 0.0005")
   LIST(APPEND HCP_BE_SCALARS "samples" "416000 0.0")
@@ -1072,6 +1082,15 @@ ENDIF(ENABLE_SOA)
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
                     qmc_long_vmc_dmc
                     qmc_long_vmc_dmc.in.xml
+                    1 16
+                    TRUE
+                    1 LONG_DIAMOND2_DMC_SCALARS # DMC
+                    )
+
+  QMC_RUN_AND_CHECK(long-diamondC_2x1x1_pp-dmc-reconf_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
+                    qmc_long_vmc_dmc
+                    qmc_long_vmc_dmc_reconf.in.xml
                     1 16
                     TRUE
                     1 LONG_DIAMOND2_DMC_SCALARS # DMC


### PR DESCRIPTION
Minimal fix needed to enable reconfiguration="yes". UnitZeta and DeltaStep (the position of the comb 'teeth') needs to be randomized at each generation to fix the bias error reported in Issue #18.