### PR TITLE
Use the C MPI API in the formic library.

### DIFF
--- a/src/formic/utils/lmyengine/block_mat.cpp
+++ b/src/formic/utils/lmyengine/block_mat.cpp
@@ -313,7 +313,7 @@ void cqmc::engine::LMBlockerMatData::mpi_finalize(const double total_weight) {
 
   // <wfn|wfn>
   double m_ww_tot = 0.0;
-  formic::mpi::reduce(&m_ww[0], &m_ww_tot, 1, MPI::SUM);
+  formic::mpi::reduce(&m_ww[0], &m_ww_tot, 1, MPI_SUM);
   //MPI_Reduce(&m_ww, &m_ww_tot, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   m_ww[0] = m_ww_tot / total_weight;
 
@@ -333,14 +333,14 @@ void cqmc::engine::LMBlockerMatData::mpi_finalize(const double total_weight) {
 
   // do MPI reduce
   for (int i = 0; i < this->nb(); i++) {
-    formic::mpi::reduce(&m_wv[0].at(i).at(0), &m_wv_tot.at(i).at(0), this->bl(i), MPI::SUM);
-    formic::mpi::reduce(&m_vw[0].at(i).at(0), &m_vw_tot.at(i).at(0), this->bl(i), MPI::SUM);
-    formic::mpi::reduce(&m_vv[0].at(i).at(0,0), &m_vv_tot.at(i).at(0,0), m_vv[0].at(i).size(), MPI::SUM);
-    formic::mpi::reduce(&m_wo[0].at(i).at(0), &m_wo_tot.at(i).at(0), m_nou, MPI::SUM);
-    formic::mpi::reduce(&m_ow[0].at(i).at(0), &m_ow_tot.at(i).at(0), m_nou, MPI::SUM); 
-    formic::mpi::reduce(&m_ov[0].at(i).at(0,0), &m_ov_tot.at(i).at(0,0), m_ov[0].at(i).size(), MPI::SUM);
-    formic::mpi::reduce(&m_vo[0].at(i).at(0,0), &m_vo_tot.at(i).at(0,0), m_vo[0].at(i).size(), MPI::SUM);
-    formic::mpi::reduce(&m_oo[0].at(i).at(0,0), &m_oo_tot.at(i).at(0,0), m_oo[0].at(i).size(), MPI::SUM);
+    formic::mpi::reduce(&m_wv[0].at(i).at(0), &m_wv_tot.at(i).at(0), this->bl(i), MPI_SUM);
+    formic::mpi::reduce(&m_vw[0].at(i).at(0), &m_vw_tot.at(i).at(0), this->bl(i), MPI_SUM);
+    formic::mpi::reduce(&m_vv[0].at(i).at(0,0), &m_vv_tot.at(i).at(0,0), m_vv[0].at(i).size(), MPI_SUM);
+    formic::mpi::reduce(&m_wo[0].at(i).at(0), &m_wo_tot.at(i).at(0), m_nou, MPI_SUM);
+    formic::mpi::reduce(&m_ow[0].at(i).at(0), &m_ow_tot.at(i).at(0), m_nou, MPI_SUM);
+    formic::mpi::reduce(&m_ov[0].at(i).at(0,0), &m_ov_tot.at(i).at(0,0), m_ov[0].at(i).size(), MPI_SUM);
+    formic::mpi::reduce(&m_vo[0].at(i).at(0,0), &m_vo_tot.at(i).at(0,0), m_vo[0].at(i).size(), MPI_SUM);
+    formic::mpi::reduce(&m_oo[0].at(i).at(0,0), &m_oo_tot.at(i).at(0,0), m_oo[0].at(i).size(), MPI_SUM);
   }
 
   // evaluate the average across all processors

--- a/src/formic/utils/lmyengine/davidson_solver.cpp
+++ b/src/formic/utils/lmyengine/davidson_solver.cpp
@@ -494,7 +494,7 @@ void cqmc::engine::DavidsonLMHD::add_krylov_vector(const formic::ColVec<double> 
     this -> SMatVecOp(_wv1, _wv2);
     // reduce the result vector
     formic::ColVec<double> _wv2_avg(_wv2.size());
-    formic::mpi::reduce(&_wv2.at(0), &_wv2_avg.at(0), _wv2.size(), MPI::SUM);
+    formic::mpi::reduce(&_wv2.at(0), &_wv2_avg.at(0), _wv2.size(), MPI_SUM);
     _wv2 = _wv2_avg.clone();
   }
 
@@ -511,7 +511,7 @@ void cqmc::engine::DavidsonLMHD::add_krylov_vector(const formic::ColVec<double> 
     this -> HMatVecOp(_wv1, hs);
     // reduce the result vector 
     formic::ColVec<double> hs_avg(hs.size());
-    formic::mpi::reduce(&hs.at(0), &hs_avg.at(0), hs.size(), MPI::SUM);
+    formic::mpi::reduce(&hs.at(0), &hs_avg.at(0), hs.size(), MPI_SUM);
     hs = hs_avg.clone();
     //if (my_rank == 0) {
     //  for (int i = 0; i < hs_avg.size(); i++) 

--- a/src/formic/utils/lmyengine/energy_target_accu.cpp
+++ b/src/formic/utils/lmyengine/energy_target_accu.cpp
@@ -130,7 +130,7 @@ double cqmc::engine::ETCompute::bvar(const int nblocks) const
   // compute avergae of each block across all processes
   std::vector<double> full_avgs; 
   full_avgs.assign(nblocks, 0.0);
-  formic::mpi::reduce(&avgs.at(0), &full_avgs.at(0), nblocks, MPI::SUM);
+  formic::mpi::reduce(&avgs.at(0), &full_avgs.at(0), nblocks, MPI_SUM);
   for (int i = 0; i < nblocks; i++) {
     full_avgs.at(i) /= double(rank_num);
   }

--- a/src/formic/utils/lmyengine/engine.cpp
+++ b/src/formic/utils/lmyengine/engine.cpp
@@ -582,7 +582,7 @@ void cqmc::engine::LMYEngine::sample_finish() {
   }
 
   double total_weight = 0.0;
-  formic::mpi::allreduce(&_tw, &total_weight, 1, MPI::SUM);
+  formic::mpi::allreduce(&_tw, &total_weight, 1, MPI_SUM);
 
   // for energy evaluation only calculation, do nothing
   if ( !_wfn_update )
@@ -641,7 +641,7 @@ void cqmc::engine::LMYEngine::sample_finish() {
       double all_samp_weight = 0.0;
 
       // mpi all reduce
-      formic::mpi::allreduce(&total_weight, &all_samp_weight, 1, MPI::SUM);
+      formic::mpi::allreduce(&total_weight, &all_samp_weight, 1, MPI_SUM);
 
       // call the finalize function for the block algorithm object
       _lmb.mpi_finalize(all_samp_weight);
@@ -665,7 +665,7 @@ void cqmc::engine::LMYEngine::sample_finish() {
       double all_samp_weight = 0.0;
 
       // mpi all reduce
-      formic::mpi::allreduce(&tot_weight, &all_samp_weight, 1, MPI::SUM);
+      formic::mpi::allreduce(&tot_weight, &all_samp_weight, 1, MPI_SUM);
       
       // sum over threads for block matrices 
       for (int ip = 1; ip < NumThreads; ip++) {
@@ -678,8 +678,8 @@ void cqmc::engine::LMYEngine::sample_finish() {
       formic::Matrix<double> ss_block_tot(ss_block[0].rows(), ss_block[0].cols());
 
       // compute average of matrices
-      formic::mpi::reduce(&hh_block[0].at(0,0), &hh_block_tot.at(0,0), hh_block[0].size(), MPI::SUM);
-      formic::mpi::reduce(&ss_block[0].at(0,0), &ss_block_tot.at(0,0), ss_block[0].size(), MPI::SUM); 
+      formic::mpi::reduce(&hh_block[0].at(0,0), &hh_block_tot.at(0,0), hh_block[0].size(), MPI_SUM);
+      formic::mpi::reduce(&ss_block[0].at(0,0), &ss_block_tot.at(0,0), ss_block[0].size(), MPI_SUM);
 
       // compute average on root process
       if ( my_rank == 0 ) {

--- a/src/formic/utils/lmyengine/engine_numeric.cpp
+++ b/src/formic/utils/lmyengine/engine_numeric.cpp
@@ -114,7 +114,7 @@ void cqmc::mpi_unbiased_ratio_of_means(const int n, const double * const p, cons
       y[4] += x * g[i];
   }
   double z[8];
-  formic::mpi::allreduce(&y[0], &z[0], 8, MPI::SUM);
+  formic::mpi::allreduce(&y[0], &z[0], 8, MPI_SUM);
   const double mf = z[1] / z[0]; // mean of numerator
   const double mg = z[2] / z[0]; // mean of denominator
   const double sf = z[3] / z[0]; // mean of the square of the numerator terms

--- a/src/formic/utils/lmyengine/engine_timing.cpp
+++ b/src/formic/utils/lmyengine/engine_timing.cpp
@@ -46,7 +46,7 @@ void cqmc::Stopwatch::reset(const std::string & name) {
 void cqmc::Stopwatch::start(const std::string & name) {
   if (_running)
     throw formic::Exception("cannot start Stopwatch \"%s\" because it is already running") % name;
-  _start_time = MPI::Wtime();
+  _start_time = MPI_Wtime();
   _running = true;
 }
 
@@ -57,7 +57,7 @@ void cqmc::Stopwatch::start(const std::string & name) {
 void cqmc::Stopwatch::stop(const std::string & name) {
   if (!_running)
     throw formic::Exception("cannot stop Stopwatch \"%s\" because it is not running") % name;
-  _elapsed_time = _elapsed_time + ( MPI::Wtime() - _start_time );
+  _elapsed_time = _elapsed_time + ( MPI_Wtime() - _start_time );
   _running = false;
 }
 
@@ -68,7 +68,7 @@ void cqmc::Stopwatch::stop(const std::string & name) {
 double cqmc::Stopwatch::elapsed_seconds() const {
   double total = _elapsed_time;
   if (_running)
-    total = total + ( MPI::Wtime() - _start_time );
+    total = total + ( MPI_Wtime() - _start_time );
   return total;
 }
 

--- a/src/formic/utils/lmyengine/matrix_builder.cpp
+++ b/src/formic/utils/lmyengine/matrix_builder.cpp
@@ -254,10 +254,10 @@ void cqmc::engine::HamOvlpBuilderHD::finish_sample(const double total_weight)
   //std::cout << "netering matrix build finish_sample3" << std::endl;
 
   // mpi reduce 
-  formic::mpi::reduce(&_hmat_temp[0].at(0,0), &_hmat.at(0,0), _hmat_temp[0].size(), MPI::SUM);
-  formic::mpi::reduce(&_smat_temp[0].at(0,0), &_smat.at(0,0), _smat_temp[0].size(), MPI::SUM);
+  formic::mpi::reduce(&_hmat_temp[0].at(0,0), &_hmat.at(0,0), _hmat_temp[0].size(), MPI_SUM);
+  formic::mpi::reduce(&_smat_temp[0].at(0,0), &_smat.at(0,0), _smat_temp[0].size(), MPI_SUM);
   if ( _ss_build ) 
-    formic::mpi::reduce(&_ssmat_temp[0].at(0,0), &_ssmat.at(0,0), _ssmat_temp[0].size(), MPI::SUM);   
+    formic::mpi::reduce(&_ssmat_temp[0].at(0,0), &_ssmat.at(0,0), _ssmat_temp[0].size(), MPI_SUM);
 
   //std::cout << "netering matrix build finish_sample4" << std::endl;
  
@@ -417,23 +417,23 @@ void cqmc::engine::HamOvlpBuilderHD::MatrixBuild(std::ostream & output)
   x[1] = _vgsa;
 
   // all reduce 
-  formic::mpi::allreduce(x, y, nred, MPI::SUM);
+  formic::mpi::allreduce(x, y, nred, MPI_SUM);
 
   // record results
   _total_weight = y[0];
   _vgsa = y[1] / _total_weight;
 
   // now do mpi reduce 
-  formic::mpi::reduce(&_hmat_temp.at(0,0), &_hmat.at(0,0), _hmat_temp.size(), MPI::SUM);
-  formic::mpi::reduce(&_smat_temp.at(0,0), &_smat.at(0,0), _smat_temp.size(), MPI::SUM);
+  formic::mpi::reduce(&_hmat_temp.at(0,0), &_hmat.at(0,0), _hmat_temp.size(), MPI_SUM);
+  formic::mpi::reduce(&_smat_temp.at(0,0), &_smat.at(0,0), _smat_temp.size(), MPI_SUM);
 
   // if doing variance correct calculation, reduce nomral linear method overlap matrix 
   if ( _variance_correct ) 
-    formic::mpi::reduce(&_lsmat_temp.at(0,0), &_lsmat.at(0,0), _lsmat_temp.size(), MPI::SUM);
+    formic::mpi::reduce(&_lsmat_temp.at(0,0), &_lsmat.at(0,0), _lsmat_temp.size(), MPI_SUM);
 
   // if requested, also reduce S^2 matrix 
   if ( _ss_build ) 
-    formic::mpi::reduce(&_ssmat_temp.at(0,0), &_ssmat.at(0,0), _ssmat_temp.size(), MPI::SUM);
+    formic::mpi::reduce(&_ssmat_temp.at(0,0), &_ssmat.at(0,0), _ssmat_temp.size(), MPI_SUM);
 
   // finally
   _hmat /= (_total_weight * _vgsa);
@@ -507,8 +507,8 @@ double cqmc::engine::HamOvlpBuilderHD::MatrixAbsorb()
   x_appro[1] = _vgsa_appro;
 
   // all reduce 
-  formic::mpi::allreduce(x, y, nred, MPI::SUM);
-  formic::mpi::allreduce(x_appro, y_appro, nred, MPI::SUM);
+  formic::mpi::allreduce(x, y, nred, MPI_SUM);
+  formic::mpi::allreduce(x_appro, y_appro, nred, MPI_SUM);
 
   // record results
   _total_weight = y[0];

--- a/src/formic/utils/lmyengine/spam_solver.cpp
+++ b/src/formic/utils/lmyengine/spam_solver.cpp
@@ -379,13 +379,13 @@ void cqmc::engine::SpamLMHD::add_krylov_vector_inner(const formic::ColVec<double
   formic::ColVec<double> hs(_nfds);
   this -> HMatVecOp(_wv1, hs, false, true);
   formic::ColVec<double> hs_avg(hs.size());
-  formic::mpi::reduce(&hs.at(0), &hs_avg.at(0), hs.size(), MPI::SUM);
+  formic::mpi::reduce(&hs.at(0), &hs_avg.at(0), hs.size(), MPI_SUM);
   hs = hs_avg.clone();
 
   // compute the product of approximate overlap matrix times this new krylov vector
   this -> SMatVecOp(_wv1, _wv2, true);
   formic::ColVec<double> _wv2_avg(_wv2.size());
-  formic::mpi::reduce(&_wv2.at(0), &_wv2_avg.at(0), _wv2.size(), MPI::SUM);
+  formic::mpi::reduce(&_wv2.at(0), &_wv2_avg.at(0), _wv2.size(), MPI_SUM);
   _wv2 = _wv2_avg.clone();
 
 
@@ -528,20 +528,20 @@ void cqmc::engine::SpamLMHD::add_krylov_vectors_outer(const formic::Matrix<doubl
   formic::Matrix<double> hs(_nfds, Nnew);
   this -> HMatMatOp(_wm1, hs, false, false);
   formic::Matrix<double> hs_avg(_nfds, Nnew);
-  formic::mpi::reduce(&hs.at(0,0), &hs_avg.at(0,0), hs.size(), MPI::SUM);
+  formic::mpi::reduce(&hs.at(0,0), &hs_avg.at(0,0), hs.size(), MPI_SUM);
   hs = hs_avg.clone();
 
   // compute the product of Hamiltonian transpose times these new krylov vectors
   formic::Matrix<double> ths(_nfds, Nnew);
   this -> HMatMatOp(_wm1, ths, true, false);
   formic::Matrix<double> ths_avg(ths.rows(), ths.cols());
-  formic::mpi::reduce(&ths.at(0,0), &ths_avg.at(0,0), ths.size(), MPI::SUM);
+  formic::mpi::reduce(&ths.at(0,0), &ths_avg.at(0,0), ths.size(), MPI_SUM);
   ths = ths_avg.clone();
 
   // compute the product of the overlap matrix times these new krylov vectors
   this -> SMatMatOp(_wm1, _wm2, false);
   formic::Matrix<double> _wm2_avg(_wm2.rows(), _wm2.cols());
-  formic::mpi::reduce(&_wm2.at(0,0), &_wm2_avg.at(0,0), _wm2.size(), MPI::SUM);
+  formic::mpi::reduce(&_wm2.at(0,0), &_wm2_avg.at(0,0), _wm2.size(), MPI_SUM);
   _wm2 = _wm2_avg.clone();
 
   // modify hamiltonian product to account for "identity" shift

--- a/src/formic/utils/mpi_interface.cpp.in
+++ b/src/formic/utils/mpi_interface.cpp.in
@@ -12,24 +12,25 @@
 
 //#include <unistd.h> // needed for gethostname
 
-${MPI_COMMENT_O}MPI::Comm MPI::COMM_WORLD;
-${MPI_COMMENT_O}MPI::Op MPI::SUM;
-${MPI_COMMENT_O}MPI::Datatype MPI::CHAR;
-${MPI_COMMENT_O}MPI::Datatype MPI::SHORT;
-${MPI_COMMENT_O}MPI::Datatype MPI::INT;
-${MPI_COMMENT_O}MPI::Datatype MPI::LONG;
-${MPI_COMMENT_O}MPI::Datatype MPI::SIGNED_CHAR;
-${MPI_COMMENT_O}MPI::Datatype MPI::UNSIGNED_CHAR;
-${MPI_COMMENT_O}MPI::Datatype MPI::UNSIGNED_SHORT;
-${MPI_COMMENT_O}MPI::Datatype MPI::UNSIGNED;
-${MPI_COMMENT_O}MPI::Datatype MPI::UNSIGNED_LONG;
-${MPI_COMMENT_O}MPI::Datatype MPI::FLOAT;
-${MPI_COMMENT_O}MPI::Datatype MPI::DOUBLE;
-${MPI_COMMENT_O}MPI::Datatype MPI::LONG_DOUBLE;
-${MPI_COMMENT_O}MPI::Datatype MPI::BOOL;
-${MPI_COMMENT_O}MPI::Datatype MPI::COMPLEX;
-${MPI_COMMENT_O}MPI::Datatype MPI::DOUBLE_COMPLEX;
-${MPI_COMMENT_O}MPI::Datatype MPI::LONG_DOUBLE_COMPLEX;
+${MPI_COMMENT_O}MPI_Comm MPI_COMM_WORLD;
+${MPI_COMMENT_O}MPI_Op MPI_SUM;
+${MPI_COMMENT_O}MPI_Datatype MPI_CHAR;
+${MPI_COMMENT_O}MPI_Datatype MPI_SHORT;
+${MPI_COMMENT_O}MPI_Datatype MPI_INT;
+${MPI_COMMENT_O}MPI_Datatype MPI_LONG;
+${MPI_COMMENT_O}MPI_Datatype MPI_SIGNED_CHAR;
+${MPI_COMMENT_O}MPI_Datatype MPI_UNSIGNED_CHAR;
+${MPI_COMMENT_O}MPI_Datatype MPI_UNSIGNED_SHORT;
+${MPI_COMMENT_O}MPI_Datatype MPI_UNSIGNED;
+${MPI_COMMENT_O}MPI_Datatype MPI_UNSIGNED_LONG;
+${MPI_COMMENT_O}MPI_Datatype MPI_FLOAT;
+${MPI_COMMENT_O}MPI_Datatype MPI_DOUBLE;
+${MPI_COMMENT_O}MPI_Datatype MPI_LONG_DOUBLE;
+${MPI_COMMENT_O}MPI_Datatype MPI_BOOL;
+${MPI_COMMENT_O}MPI_Datatype MPI_COMPLEX;
+${MPI_COMMENT_O}MPI_Datatype MPI_DOUBLE_COMPLEX;
+${MPI_COMMENT_O}MPI_Datatype MPI_LONG_DOUBLE_COMPLEX;
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief   initializes MPI
@@ -37,10 +38,11 @@ ${MPI_COMMENT_O}MPI::Datatype MPI::LONG_DOUBLE_COMPLEX;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void formic::mpi::init(int argc, char **argv) {
 
-//  ${MPI_COMMENT_I}MPI::Init(argc, argv);
+//  ${MPI_COMMENT_I}MPI_Init(argc, argv);
 
   ${MPI_COMMENT_I}const int requested = ${MPI_REQUESTED_THREADING};
-  ${MPI_COMMENT_I}const int provided = MPI::Init_thread(argc, argv, requested);
+  ${MPI_COMMENT_I}int provided = 0;
+  ${MPI_COMMENT_I}MPI_Init_thread(&argc, &argv, requested, &provided);
   ${MPI_COMMENT_I}if ( provided != requested) {
   ${MPI_COMMENT_I}  //std::printf("MPI_THREAD_SINGLE     = %10i\n", MPI_THREAD_SINGLE);
   ${MPI_COMMENT_I}  //std::printf("MPI_THREAD_FUNNELED   = %10i\n", MPI_THREAD_FUNNELED);
@@ -58,7 +60,7 @@ void formic::mpi::init(int argc, char **argv) {
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void formic::mpi::finalize() {
-  ${MPI_COMMENT_I}MPI::Finalize();
+  ${MPI_COMMENT_I}MPI_Finalize();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -88,18 +90,18 @@ void formic::mpi::finalize() {
 /// \param[in,out] data     a pointer to the data to be broadcast
 /// \param[in]     n        the number of data elements
 /// \param[in]     root     which processor to broadcast from
-/// \param[in]     comm     the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm     the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::bcast(T * data, size_t n, int root, const MPI::Comm & comm) {
+template<class T> void formic::mpi::bcast(T * data, size_t n, int root, const MPI_Comm & comm) {
   ${MPI_COMMENT_I}const int block_size = 100000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Bcast((void *)data, block_size, formic::mpi::datatype<T>(), root);
+  ${MPI_COMMENT_I}  MPI_Bcast((void *)data, block_size, formic::mpi::datatype<T>(), root, comm);
   ${MPI_COMMENT_I}  data += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Bcast((void *)data, int(n), formic::mpi::datatype<T>(), root);
+  ${MPI_COMMENT_I}  MPI_Bcast((void *)data, int(n), formic::mpi::datatype<T>(), root, comm);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -110,21 +112,21 @@ template<class T> void formic::mpi::bcast(T * data, size_t n, int root, const MP
 /// \param[in]     n          the number of data elements
 /// \param[in]     op         the reduce operation to use
 /// \param[in]     root       which processor to reduce to
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::reduce(const T * send_buf, T * recv_buf, size_t n,
-                                         const MPI::Op & op, int root, const MPI::Comm & comm) {
+                                         const MPI_Op & op, int root, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 100000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Reduce(send_buf, recv_buf, block_size, formic::mpi::datatype<T>(), op, root);
+  ${MPI_COMMENT_I}  MPI_Reduce(const_cast<T*>(send_buf), recv_buf, block_size, formic::mpi::datatype<T>(), op, root, comm);
   ${MPI_COMMENT_I}  send_buf += block_size;
   ${MPI_COMMENT_I}  recv_buf += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Reduce(send_buf, recv_buf, int(n), formic::mpi::datatype<T>(), op, root);
+  ${MPI_COMMENT_I}  MPI_Reduce(const_cast<T*>(send_buf), recv_buf, int(n), formic::mpi::datatype<T>(), op, root, comm);
 
   ${MPI_COMMENT_O}std::copy(send_buf, send_buf+n, recv_buf);
 
@@ -137,21 +139,21 @@ template<class T> void formic::mpi::reduce(const T * send_buf, T * recv_buf, siz
 /// \param[out]    recv_buf   a pointer to where the reduced result will be stored
 /// \param[in]     n          the number of data elements
 /// \param[in]     op         the reduce operation to use
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::allreduce(const T * send_buf, T * recv_buf, size_t n,
-                                            const MPI::Op & op, const MPI::Comm & comm) {
+                                            const MPI_Op & op, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 100000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Allreduce(send_buf, recv_buf, block_size, formic::mpi::datatype<T>(), op);
+  ${MPI_COMMENT_I}  MPI_Allreduce(const_cast<T*>(send_buf), recv_buf, block_size, formic::mpi::datatype<T>(), op, comm);
   ${MPI_COMMENT_I}  send_buf += block_size;
   ${MPI_COMMENT_I}  recv_buf += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Allreduce(send_buf, recv_buf, int(n), formic::mpi::datatype<T>(), op);
+  ${MPI_COMMENT_I}  MPI_Allreduce(const_cast<T*>(send_buf), recv_buf, int(n), formic::mpi::datatype<T>(), op, comm);
 
   ${MPI_COMMENT_O}std::copy(send_buf, send_buf+n, recv_buf);
 
@@ -164,19 +166,19 @@ template<class T> void formic::mpi::allreduce(const T * send_buf, T * recv_buf, 
 /// \param[in]     n          the number of data elements
 /// \param[in]     dest       rank of the process to send to
 /// \param[in]     tag        a tag to label the transmission
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::send(const T * buf, size_t n, const int dest, const int tag, const MPI::Comm & comm) {
+template<class T> void formic::mpi::send(const T * buf, size_t n, const int dest, const int tag, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 100000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Send(buf, block_size, formic::mpi::datatype<T>(), dest, tag);
+  ${MPI_COMMENT_I}  MPI_Send(const_cast<T*>(buf), block_size, formic::mpi::datatype<T>(), dest, tag, comm);
   ${MPI_COMMENT_I}  buf += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Send(buf, int(n), formic::mpi::datatype<T>(), dest, tag);
+  ${MPI_COMMENT_I}  MPI_Send(const_cast<T*>(buf), int(n), formic::mpi::datatype<T>(), dest, tag, comm);
 
   ${MPI_COMMENT_O}throw formic::Exception("cannot use formic::mpi::send without MPI");
 
@@ -189,19 +191,20 @@ template<class T> void formic::mpi::send(const T * buf, size_t n, const int dest
 /// \param[in]     n          the number of data elements
 /// \param[in]     source     rank of the sending process
 /// \param[in]     tag        a tag to label the transmission
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::recv(T * buf, size_t n, const int source, const int tag, const MPI::Comm & comm) {
+template<class T> void formic::mpi::recv(T * buf, size_t n, const int source, const int tag, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 100000000/sizeof(T);
+  ${MPI_COMMENT_I}MPI_Status status;
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Recv(buf, block_size, formic::mpi::datatype<T>(), source, tag);
+  ${MPI_COMMENT_I}  MPI_Recv(buf, block_size, formic::mpi::datatype<T>(), source, tag, comm, &status);
   ${MPI_COMMENT_I}  buf += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Recv(buf, int(n), formic::mpi::datatype<T>(), source, tag);
+  ${MPI_COMMENT_I}  MPI_Recv(buf, int(n), formic::mpi::datatype<T>(), source, tag, comm, &status);
 
   ${MPI_COMMENT_O}throw formic::Exception("cannot use formic::mpi::recv without MPI");
 
@@ -214,20 +217,22 @@ template<class T> void formic::mpi::recv(T * buf, size_t n, const int source, co
 /// \param[out]    recv_buf   a pointer to where the scattered data will be placed
 /// \param[in]     n          the number of data elements each process should receive
 /// \param[in]     root       which processor to scatter from
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::scatter(const T * send_buf, T * recv_buf, size_t n, int root, const MPI::Comm & comm) {
+template<class T> void formic::mpi::scatter(const T * send_buf, T * recv_buf, size_t n, int root, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 1000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Scatter(send_buf, block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>(), root);
-  ${MPI_COMMENT_I}  send_buf += size_t(comm.Get_size()) * block_size;
+  ${MPI_COMMENT_I}  MPI_Scatter(const_cast<T*>(send_buf), block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>(), root, comm);
+  ${MPI_COMMENT_I}  int size;
+  ${MPI_COMMENT_I}  MPI_Comm_size(comm, &size);
+  ${MPI_COMMENT_I}  send_buf += size_t(size) * block_size;
   ${MPI_COMMENT_I}  recv_buf += block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Scatter(send_buf, int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>(), root);
+  ${MPI_COMMENT_I}  MPI_Scatter(const_cast<T*>(send_buf), int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>(), root, comm);
 
   ${MPI_COMMENT_O}std::copy(send_buf, send_buf+n, recv_buf);
 
@@ -240,20 +245,22 @@ template<class T> void formic::mpi::scatter(const T * send_buf, T * recv_buf, si
 /// \param[out]    recv_buf   a pointer to where the gathered data will be placed
 /// \param[in]     n          the number of data elements each process will send
 /// \param[in]     root       which processor to gather to
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::gather(const T * send_buf, T * recv_buf, size_t n, int root, const MPI::Comm & comm) {
+template<class T> void formic::mpi::gather(const T * send_buf, T * recv_buf, size_t n, int root, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 1000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Gather(send_buf, block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>(), root);
+  ${MPI_COMMENT_I}  MPI_Gather(const_cast<T*>(send_buf), block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>(), root, comm);
   ${MPI_COMMENT_I}  send_buf += block_size;
-  ${MPI_COMMENT_I}  recv_buf += size_t(comm.Get_size()) * block_size;
+  ${MPI_COMMENT_I}  int size;
+  ${MPI_COMMENT_I}  MPI_Comm_size(comm, &size);
+  ${MPI_COMMENT_I}  recv_buf += size_t(size) * block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Gather(send_buf, int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>(), root);
+  ${MPI_COMMENT_I}  MPI_Gather(const_cast<T*>(send_buf), int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>(), root, comm);
 
   ${MPI_COMMENT_O}std::copy(send_buf, send_buf+n, recv_buf);
 
@@ -265,20 +272,22 @@ template<class T> void formic::mpi::gather(const T * send_buf, T * recv_buf, siz
 /// \param[in]     send_buf   a pointer to the data to be gathered
 /// \param[out]    recv_buf   a pointer to where the gathered data will be placed
 /// \param[in]     n          the number of data elements each process will send
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::allgather(const T * send_buf, T * recv_buf, size_t n, const MPI::Comm & comm) {
+template<class T> void formic::mpi::allgather(const T * send_buf, T * recv_buf, size_t n, const MPI_Comm & comm) {
 
   ${MPI_COMMENT_I}const int block_size = 1000000/sizeof(T);
   ${MPI_COMMENT_I}while ( n > size_t(block_size) ) {
-  ${MPI_COMMENT_I}  comm.Allgather(send_buf, block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>());
+  ${MPI_COMMENT_I}  MPI_Allgather(const_cast<T*>(send_buf), block_size, formic::mpi::datatype<T>(), recv_buf, block_size, formic::mpi::datatype<T>(), comm);
   ${MPI_COMMENT_I}  send_buf += block_size;
-  ${MPI_COMMENT_I}  recv_buf += size_t(comm.Get_size()) * block_size;
+  ${MPI_COMMENT_I}  int size;
+  ${MPI_COMMENT_I}  MPI_Comm_size(comm, &size);
+  ${MPI_COMMENT_I}  recv_buf += size_t(size) * block_size;
   ${MPI_COMMENT_I}  n -= size_t(block_size);
   ${MPI_COMMENT_I}}
   ${MPI_COMMENT_I}if (n > 0)
-  ${MPI_COMMENT_I}  comm.Allgather(send_buf, int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>());
+  ${MPI_COMMENT_I}  MPI_Allgather(const_cast<T*>(send_buf), int(n), formic::mpi::datatype<T>(), recv_buf, int(n), formic::mpi::datatype<T>(), comm);
 
   ${MPI_COMMENT_O}std::copy(send_buf, send_buf+n, recv_buf);
 
@@ -289,10 +298,10 @@ template<class T> void formic::mpi::allgather(const T * send_buf, T * recv_buf, 
 ///
 /// \param[in,out] v        the vector to be broadcast
 /// \param[in]     root     which processor to broadcast from
-/// \param[in]     comm     the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm     the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-template<class T> void formic::mpi::bcast(std::vector<T> & v, int root, const MPI::Comm & comm) {
+template<class T> void formic::mpi::bcast(std::vector<T> & v, int root, const MPI_Comm & comm) {
   size_t n = v.size();
   formic::mpi::bcast(&n, 1, root, comm);
   v.resize(n);
@@ -307,11 +316,11 @@ template<class T> void formic::mpi::bcast(std::vector<T> & v, int root, const MP
 /// \param[out]    recv_v     the vector where the result of the reduction will be stored
 /// \param[in]     op         the reduce operation to use
 /// \param[in]     root       which processor to reduce to
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::reduce(const std::vector<T> & send_v, std::vector<T> & recv_v,
-                                         const MPI::Op & op, int root, const MPI::Comm & comm) {
+                                         const MPI_Op & op, int root, const MPI_Comm & comm) {
   const size_t n = send_v.size();
   if (formic::mpi::rank() == root)
     recv_v.resize(n);
@@ -325,11 +334,11 @@ template<class T> void formic::mpi::reduce(const std::vector<T> & send_v, std::v
 /// \param[in]     send_v     the vector to reduce
 /// \param[out]    recv_v     the vector where the result of the reduction will be stored
 /// \param[in]     op         the reduce operation to use
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::allreduce(const std::vector<T> & send_v, std::vector<T> & recv_v,
-                                            const MPI::Op & op, const MPI::Comm & comm) {
+                                            const MPI_Op & op, const MPI_Comm & comm) {
   const size_t n = send_v.size();
   recv_v.resize(n);
   if (n > 0)
@@ -342,11 +351,11 @@ template<class T> void formic::mpi::allreduce(const std::vector<T> & send_v, std
 /// \param[in]     v          the vector to send
 /// \param[in]     dest       rank of the process to send to
 /// \param[in]     tag        a tag to label the transmission
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::send(const std::vector<T> & v, const int dest, const int tag,
-                                       const MPI::Comm & comm) {
+                                       const MPI_Comm & comm) {
   const size_t n = v.size();
   formic::mpi::send(&n, 1, dest, tag, comm);
   if (n > 0)
@@ -359,11 +368,11 @@ template<class T> void formic::mpi::send(const std::vector<T> & v, const int des
 /// \param[out]    v          the vector that the received vector will overwrite
 /// \param[in]     source     rank of the sending process
 /// \param[in]     tag        a tag to label the transmission
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::recv(std::vector<T> & v, const int source, const int tag,
-                                       const MPI::Comm & comm) {
+                                       const MPI_Comm & comm) {
   size_t n;
   formic::mpi::recv(&n, 1, source, tag, comm);
   v.resize(n);
@@ -371,206 +380,206 @@ template<class T> void formic::mpi::recv(std::vector<T> & v, const int source, c
     formic::mpi::recv(&v.at(0), n, source, tag, comm);
 }
 
-template void formic::mpi::bcast(bool                  *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(char                  *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(signed short          *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(signed int            *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(signed long           *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(signed char           *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(unsigned char         *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(unsigned short        *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(unsigned int          *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(unsigned long int     *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(float                 *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(double                *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(long double           *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::complex<float>   *, size_t, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::complex<double>  *, size_t, int, const MPI::Comm &);
+template void formic::mpi::bcast(bool                  *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(char                  *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(signed short          *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(signed int            *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(signed long           *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(signed char           *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(unsigned char         *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(unsigned short        *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(unsigned int          *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(unsigned long int     *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(float                 *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(double                *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(long double           *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::complex<float>   *, size_t, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::complex<double>  *, size_t, int, const MPI_Comm &);
 
-template void formic::mpi::reduce(const char                *, char                *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const signed short        *, signed short        *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const signed int          *, signed int          *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const signed long         *, signed long         *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const signed char         *, signed char         *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const unsigned char       *, unsigned char       *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const unsigned short      *, unsigned short      *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const unsigned int        *, unsigned int        *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const unsigned long int   *, unsigned long int   *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const float               *, float               *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const double              *, double              *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const long double         *, long double         *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::complex<float> *, std::complex<float> *, size_t, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::complex<double>*, std::complex<double>*, size_t, const MPI::Op&, int, const MPI::Comm&);
+template void formic::mpi::reduce(const char                *, char                *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const signed short        *, signed short        *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const signed int          *, signed int          *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const signed long         *, signed long         *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const signed char         *, signed char         *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const unsigned char       *, unsigned char       *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const unsigned short      *, unsigned short      *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const unsigned int        *, unsigned int        *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const unsigned long int   *, unsigned long int   *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const float               *, float               *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const double              *, double              *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const long double         *, long double         *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::complex<float> *, std::complex<float> *, size_t, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::complex<double>*, std::complex<double>*, size_t, const MPI_Op&, int, const MPI_Comm&);
 
-template void formic::mpi::allreduce(const char                *, char                *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const signed short        *, signed short        *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const signed int          *, signed int          *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const signed long         *, signed long         *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const signed char         *, signed char         *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const unsigned char       *, unsigned char       *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const unsigned short      *, unsigned short      *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const unsigned int        *, unsigned int        *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const unsigned long int   *, unsigned long int   *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const float               *, float               *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const double              *, double              *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const long double         *, long double         *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::complex<float> *, std::complex<float> *, size_t, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::complex<double>*, std::complex<double>*, size_t, const MPI::Op&, const MPI::Comm&);
+template void formic::mpi::allreduce(const char                *, char                *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const signed short        *, signed short        *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const signed int          *, signed int          *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const signed long         *, signed long         *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const signed char         *, signed char         *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const unsigned char       *, unsigned char       *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const unsigned short      *, unsigned short      *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const unsigned int        *, unsigned int        *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const unsigned long int   *, unsigned long int   *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const float               *, float               *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const double              *, double              *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const long double         *, long double         *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::complex<float> *, std::complex<float> *, size_t, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::complex<double>*, std::complex<double>*, size_t, const MPI_Op&, const MPI_Comm&);
 
-template void formic::mpi::send(const bool                *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const char                *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const signed short        *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const signed int          *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const signed long         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const signed char         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const unsigned char       *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const unsigned short      *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const unsigned int        *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const unsigned long int   *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const float               *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const double              *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const long double         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const std::complex<float> *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::send(const std::complex<double>*, size_t, const int, const int, const MPI::Comm&);
+template void formic::mpi::send(const bool                *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const char                *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const signed short        *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const signed int          *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const signed long         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const signed char         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const unsigned char       *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const unsigned short      *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const unsigned int        *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const unsigned long int   *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const float               *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const double              *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const long double         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const std::complex<float> *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::send(const std::complex<double>*, size_t, const int, const int, const MPI_Comm&);
 
-template void formic::mpi::recv(bool                *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(char                *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(signed short        *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(signed int          *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(signed long         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(signed char         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(unsigned char       *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(unsigned short      *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(unsigned int        *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(unsigned long int   *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(float               *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(double              *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(long double         *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(std::complex<float> *, size_t, const int, const int, const MPI::Comm&);
-template void formic::mpi::recv(std::complex<double>*, size_t, const int, const int, const MPI::Comm&);
+template void formic::mpi::recv(bool                *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(char                *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(signed short        *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(signed int          *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(signed long         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(signed char         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(unsigned char       *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(unsigned short      *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(unsigned int        *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(unsigned long int   *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(float               *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(double              *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(long double         *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(std::complex<float> *, size_t, const int, const int, const MPI_Comm&);
+template void formic::mpi::recv(std::complex<double>*, size_t, const int, const int, const MPI_Comm&);
 
-template void formic::mpi::scatter(const bool                *, bool                *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const char                *, char                *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const signed short        *, signed short        *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const signed int          *, signed int          *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const signed long         *, signed long         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const signed char         *, signed char         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const unsigned char       *, unsigned char       *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const unsigned short      *, unsigned short      *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const unsigned int        *, unsigned int        *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const unsigned long int   *, unsigned long int   *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const float               *, float               *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const double              *, double              *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const long double         *, long double         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const std::complex<float> *, std::complex<float> *, size_t, int, const MPI::Comm&);
-template void formic::mpi::scatter(const std::complex<double>*, std::complex<double>*, size_t, int, const MPI::Comm&);
+template void formic::mpi::scatter(const bool                *, bool                *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const char                *, char                *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const signed short        *, signed short        *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const signed int          *, signed int          *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const signed long         *, signed long         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const signed char         *, signed char         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const unsigned char       *, unsigned char       *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const unsigned short      *, unsigned short      *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const unsigned int        *, unsigned int        *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const unsigned long int   *, unsigned long int   *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const float               *, float               *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const double              *, double              *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const long double         *, long double         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const std::complex<float> *, std::complex<float> *, size_t, int, const MPI_Comm&);
+template void formic::mpi::scatter(const std::complex<double>*, std::complex<double>*, size_t, int, const MPI_Comm&);
 
-template void formic::mpi::gather(const bool                *, bool                *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const char                *, char                *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const signed short        *, signed short        *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const signed int          *, signed int          *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const signed long         *, signed long         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const signed char         *, signed char         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const unsigned char       *, unsigned char       *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const unsigned short      *, unsigned short      *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const unsigned int        *, unsigned int        *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const unsigned long int   *, unsigned long int   *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const float               *, float               *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const double              *, double              *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const long double         *, long double         *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const std::complex<float> *, std::complex<float> *, size_t, int, const MPI::Comm&);
-template void formic::mpi::gather(const std::complex<double>*, std::complex<double>*, size_t, int, const MPI::Comm&);
+template void formic::mpi::gather(const bool                *, bool                *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const char                *, char                *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const signed short        *, signed short        *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const signed int          *, signed int          *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const signed long         *, signed long         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const signed char         *, signed char         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const unsigned char       *, unsigned char       *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const unsigned short      *, unsigned short      *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const unsigned int        *, unsigned int        *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const unsigned long int   *, unsigned long int   *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const float               *, float               *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const double              *, double              *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const long double         *, long double         *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const std::complex<float> *, std::complex<float> *, size_t, int, const MPI_Comm&);
+template void formic::mpi::gather(const std::complex<double>*, std::complex<double>*, size_t, int, const MPI_Comm&);
 
-template void formic::mpi::allgather(const bool                *, bool                *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const char                *, char                *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const signed short        *, signed short        *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const signed int          *, signed int          *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const signed long         *, signed long         *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const signed char         *, signed char         *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const unsigned char       *, unsigned char       *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const unsigned short      *, unsigned short      *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const unsigned int        *, unsigned int        *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const unsigned long int   *, unsigned long int   *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const float               *, float               *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const double              *, double              *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const long double         *, long double         *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const std::complex<float> *, std::complex<float> *, size_t, const MPI::Comm&);
-template void formic::mpi::allgather(const std::complex<double>*, std::complex<double>*, size_t, const MPI::Comm&);
+template void formic::mpi::allgather(const bool                *, bool                *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const char                *, char                *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const signed short        *, signed short        *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const signed int          *, signed int          *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const signed long         *, signed long         *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const signed char         *, signed char         *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const unsigned char       *, unsigned char       *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const unsigned short      *, unsigned short      *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const unsigned int        *, unsigned int        *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const unsigned long int   *, unsigned long int   *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const float               *, float               *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const double              *, double              *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const long double         *, long double         *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const std::complex<float> *, std::complex<float> *, size_t, const MPI_Comm&);
+template void formic::mpi::allgather(const std::complex<double>*, std::complex<double>*, size_t, const MPI_Comm&);
 
-template void formic::mpi::bcast(std::vector<char                  > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<signed short          > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<signed int            > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<signed long           > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<signed char           > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<unsigned char         > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<unsigned short        > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<unsigned int          > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<unsigned long int     > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<float                 > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<double                > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<long double           > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<std::complex<float>   > &, int, const MPI::Comm &);
-template void formic::mpi::bcast(std::vector<std::complex<double>  > &, int, const MPI::Comm &);
+template void formic::mpi::bcast(std::vector<char                  > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<signed short          > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<signed int            > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<signed long           > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<signed char           > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<unsigned char         > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<unsigned short        > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<unsigned int          > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<unsigned long int     > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<float                 > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<double                > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<long double           > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<std::complex<float>   > &, int, const MPI_Comm &);
+template void formic::mpi::bcast(std::vector<std::complex<double>  > &, int, const MPI_Comm &);
 
-template void formic::mpi::reduce(const std::vector<char                 >&, std::vector<char                 >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<signed short         >&, std::vector<signed short         >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<signed int           >&, std::vector<signed int           >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<signed long          >&, std::vector<signed long          >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<signed char          >&, std::vector<signed char          >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<unsigned char        >&, std::vector<unsigned char        >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<unsigned short       >&, std::vector<unsigned short       >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<unsigned int         >&, std::vector<unsigned int         >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<unsigned long int    >&, std::vector<unsigned long int    >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<float                >&, std::vector<float                >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<double               >&, std::vector<double               >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<long double          >&, std::vector<long double          >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<std::complex<float>  >&, std::vector<std::complex<float>  >&, const MPI::Op&, int, const MPI::Comm&);
-template void formic::mpi::reduce(const std::vector<std::complex<double> >&, std::vector<std::complex<double> >&, const MPI::Op&, int, const MPI::Comm&);
+template void formic::mpi::reduce(const std::vector<char                 >&, std::vector<char                 >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<signed short         >&, std::vector<signed short         >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<signed int           >&, std::vector<signed int           >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<signed long          >&, std::vector<signed long          >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<signed char          >&, std::vector<signed char          >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<unsigned char        >&, std::vector<unsigned char        >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<unsigned short       >&, std::vector<unsigned short       >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<unsigned int         >&, std::vector<unsigned int         >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<unsigned long int    >&, std::vector<unsigned long int    >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<float                >&, std::vector<float                >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<double               >&, std::vector<double               >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<long double          >&, std::vector<long double          >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<std::complex<float>  >&, std::vector<std::complex<float>  >&, const MPI_Op&, int, const MPI_Comm&);
+template void formic::mpi::reduce(const std::vector<std::complex<double> >&, std::vector<std::complex<double> >&, const MPI_Op&, int, const MPI_Comm&);
 
-template void formic::mpi::allreduce(const std::vector<char                 >&, std::vector<char                 >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<signed short         >&, std::vector<signed short         >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<signed int           >&, std::vector<signed int           >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<signed long          >&, std::vector<signed long          >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<signed char          >&, std::vector<signed char          >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<unsigned char        >&, std::vector<unsigned char        >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<unsigned short       >&, std::vector<unsigned short       >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<unsigned int         >&, std::vector<unsigned int         >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<unsigned long int    >&, std::vector<unsigned long int    >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<float                >&, std::vector<float                >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<double               >&, std::vector<double               >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<long double          >&, std::vector<long double          >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<std::complex<float>  >&, std::vector<std::complex<float>  >&, const MPI::Op&, const MPI::Comm&);
-template void formic::mpi::allreduce(const std::vector<std::complex<double> >&, std::vector<std::complex<double> >&, const MPI::Op&, const MPI::Comm&);
+template void formic::mpi::allreduce(const std::vector<char                 >&, std::vector<char                 >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<signed short         >&, std::vector<signed short         >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<signed int           >&, std::vector<signed int           >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<signed long          >&, std::vector<signed long          >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<signed char          >&, std::vector<signed char          >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<unsigned char        >&, std::vector<unsigned char        >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<unsigned short       >&, std::vector<unsigned short       >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<unsigned int         >&, std::vector<unsigned int         >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<unsigned long int    >&, std::vector<unsigned long int    >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<float                >&, std::vector<float                >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<double               >&, std::vector<double               >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<long double          >&, std::vector<long double          >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<std::complex<float>  >&, std::vector<std::complex<float>  >&, const MPI_Op&, const MPI_Comm&);
+template void formic::mpi::allreduce(const std::vector<std::complex<double> >&, std::vector<std::complex<double> >&, const MPI_Op&, const MPI_Comm&);
 
-template void formic::mpi::send(const std::vector<char                  > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<signed short          > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<signed int            > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<signed long           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<signed char           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<unsigned char         > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<unsigned short        > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<unsigned int          > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<unsigned long int     > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<float                 > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<double                > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<long double           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<std::complex<float>   > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::send(const std::vector<std::complex<double>  > &, const int, const int, const MPI::Comm &);
+template void formic::mpi::send(const std::vector<char                  > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<signed short          > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<signed int            > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<signed long           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<signed char           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<unsigned char         > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<unsigned short        > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<unsigned int          > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<unsigned long int     > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<float                 > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<double                > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<long double           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<std::complex<float>   > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::send(const std::vector<std::complex<double>  > &, const int, const int, const MPI_Comm &);
 
-template void formic::mpi::recv(std::vector<char                  > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<signed short          > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<signed int            > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<signed long           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<signed char           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<unsigned char         > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<unsigned short        > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<unsigned int          > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<unsigned long int     > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<float                 > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<double                > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<long double           > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<std::complex<float>   > &, const int, const int, const MPI::Comm &);
-template void formic::mpi::recv(std::vector<std::complex<double>  > &, const int, const int, const MPI::Comm &);
+template void formic::mpi::recv(std::vector<char                  > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<signed short          > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<signed int            > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<signed long           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<signed char           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<unsigned char         > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<unsigned short        > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<unsigned int          > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<unsigned long int     > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<float                 > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<double                > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<long double           > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<std::complex<float>   > &, const int, const int, const MPI_Comm &);
+template void formic::mpi::recv(std::vector<std::complex<double>  > &, const int, const int, const MPI_Comm &);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief   reads an object from an archive an broadcasts it
@@ -579,14 +588,14 @@ template void formic::mpi::recv(std::vector<std::complex<double>  > &, const int
 /// \param[out]    val       the object that is read
 /// \param[in]     error_msg  an error message to display if the read fails
 /// \param[in]     root       which processor to broadcast from
-/// \param[in]     comm       the communicator to use (defaults to MPI::COMM_WORLD)
+/// \param[in]     comm       the communicator to use (defaults to MPI_COMM_WORLD)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T> void formic::mpi::read_and_bcast(formic::Archive & arch,
                                                    T & val,
                                                    const std::string & error_msg,
                                                    int root,
-                                                   const MPI::Comm & comm) {
+                                                   const MPI_Comm & comm) {
 
   // get MPI info
   const int nproc  = formic::mpi::size(comm);
@@ -602,19 +611,19 @@ template<class T> void formic::mpi::read_and_bcast(formic::Archive & arch,
 
 }
 
-template void formic::mpi::read_and_bcast(formic::Archive &, bool &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, int &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, long int &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, double &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::complex<double> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::string &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<int> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<long int> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<double> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<std::complex<double> > &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<std::string> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, formic::Matrix<double> &, const std::string &, int, const MPI::Comm &);
-template void formic::mpi::read_and_bcast(formic::Archive &, formic::Matrix<std::complex<double> > &, const std::string &, int, const MPI::Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, bool &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, int &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, long int &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, double &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::complex<double> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::string &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<int> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<long int> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<double> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<std::complex<double> > &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, std::vector<std::string> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, formic::Matrix<double> &, const std::string &, int, const MPI_Comm &);
+template void formic::mpi::read_and_bcast(formic::Archive &, formic::Matrix<std::complex<double> > &, const std::string &, int, const MPI_Comm &);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief   broadcast a string
@@ -624,7 +633,7 @@ template void formic::mpi::read_and_bcast(formic::Archive &, formic::Matrix<std:
 /// \param[in]     comm       the communicator to use
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-void formic::mpi::bcast(std::string & s, int root, const MPI::Comm & comm) {
+void formic::mpi::bcast(std::string & s, int root, const MPI_Comm & comm) {
   std::vector<char> v(s.begin(), s.end());
   formic::mpi::bcast(v, root, comm);
   s = std::string(v.begin(), v.end());
@@ -638,7 +647,7 @@ void formic::mpi::bcast(std::string & s, int root, const MPI::Comm & comm) {
 /// \param[in]     comm       the communicator to use
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-void formic::mpi::bcast(std::vector<std::string> & v, int root, const MPI::Comm & comm) {
+void formic::mpi::bcast(std::vector<std::string> & v, int root, const MPI_Comm & comm) {
   size_t n = v.size();
   formic::mpi::bcast(n, root, comm);
   v.resize(n);

--- a/src/formic/utils/mpi_interface.h.in
+++ b/src/formic/utils/mpi_interface.h.in
@@ -17,34 +17,32 @@
 
 ${MPI_COMMENT_I}#include <mpi.h>
 
-${MPI_COMMENT_O}namespace MPI {
 ${MPI_COMMENT_O}
 ${MPI_COMMENT_O}  // declare some empty classes as placeholders if we are not using mpi
-${MPI_COMMENT_O}  class Comm {};
-${MPI_COMMENT_O}  class Op {};
-${MPI_COMMENT_O}  class Datatype {};
-${MPI_COMMENT_O}  extern MPI::Comm COMM_WORLD;
-${MPI_COMMENT_O}  extern MPI::Op SUM;
-${MPI_COMMENT_O}  extern MPI::Datatype CHAR;
-${MPI_COMMENT_O}  extern MPI::Datatype SHORT;
-${MPI_COMMENT_O}  extern MPI::Datatype INT;
-${MPI_COMMENT_O}  extern MPI::Datatype LONG;
-${MPI_COMMENT_O}  extern MPI::Datatype SIGNED_CHAR;
-${MPI_COMMENT_O}  extern MPI::Datatype UNSIGNED_CHAR;
-${MPI_COMMENT_O}  extern MPI::Datatype UNSIGNED_SHORT;
-${MPI_COMMENT_O}  extern MPI::Datatype UNSIGNED;
-${MPI_COMMENT_O}  extern MPI::Datatype UNSIGNED_LONG;
-${MPI_COMMENT_O}  extern MPI::Datatype FLOAT;
-${MPI_COMMENT_O}  extern MPI::Datatype DOUBLE;
-${MPI_COMMENT_O}  extern MPI::Datatype LONG_DOUBLE;
-${MPI_COMMENT_O}  extern MPI::Datatype BOOL;
-${MPI_COMMENT_O}  extern MPI::Datatype COMPLEX;
-${MPI_COMMENT_O}  extern MPI::Datatype DOUBLE_COMPLEX;
-${MPI_COMMENT_O}  extern MPI::Datatype LONG_DOUBLE_COMPLEX;
+${MPI_COMMENT_O}  class MPI_Comm {};
+${MPI_COMMENT_O}  class MPI_Op {};
+${MPI_COMMENT_O}  class MPI_Datatype {};
+${MPI_COMMENT_O}  extern MPI_Comm MPI_COMM_WORLD;
+${MPI_COMMENT_O}  extern MPI_Op MPI_SUM;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_CHAR;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_SHORT;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_INT;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_LONG;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_SIGNED_CHAR;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_UNSIGNED_CHAR;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_UNSIGNED_SHORT;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_UNSIGNED;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_UNSIGNED_LONG;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_FLOAT;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_DOUBLE;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_LONG_DOUBLE;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_BOOL;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_COMPLEX;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_DOUBLE_COMPLEX;
+${MPI_COMMENT_O}  extern MPI_Datatype MPI_LONG_DOUBLE_COMPLEX;
 ${MPI_COMMENT_O}
-${MPI_COMMENT_O}  inline double Wtime() { return double(std::clock()) / double(CLOCKS_PER_SEC); }
+${MPI_COMMENT_O}  inline double MPI_Wtime() { return double(std::clock()) / double(CLOCKS_PER_SEC); }
 ${MPI_COMMENT_O}
-${MPI_COMMENT_O}}
 
 namespace formic {
 
@@ -63,33 +61,37 @@ namespace mpi {
   /// \return the global communicator
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  inline const MPI::Comm & world() {
-    return MPI::COMM_WORLD;
+  inline const MPI_Comm world() {
+    return MPI_COMM_WORLD;
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief   returns the number of processes in a communicator
   ///
-  /// \param[in]     comm     the communicator to use (defaults to MPI::COMM_WORLD)
+  /// \param[in]     comm     the communicator to use (defaults to MPI_COMM_WORLD)
   ///
   /// \return the number of processes in comm
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  inline int size(const MPI::Comm & comm = MPI::COMM_WORLD) {
-    ${MPI_COMMENT_I}return comm.Get_size();
+  inline int size(const MPI_Comm & comm = MPI_COMM_WORLD) {
+    ${MPI_COMMENT_I}int size;
+    ${MPI_COMMENT_I}MPI_Comm_size(comm, &size);
+    ${MPI_COMMENT_I}return size;
     ${MPI_COMMENT_O}return 1;
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief   returns rank of the current process in a communicator
   ///
-  /// \param[in]     comm     the communicator to use (defaults to MPI::COMM_WORLD)
+  /// \param[in]     comm     the communicator to use (defaults to MPI_COMM_WORLD)
   ///
   /// \return the rank of the current process in comm
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  inline int rank(const MPI::Comm & comm = MPI::COMM_WORLD) {
-    ${MPI_COMMENT_I}return comm.Get_rank();
+  inline int rank(const MPI_Comm & comm = MPI_COMM_WORLD) {
+    ${MPI_COMMENT_I}int rank;
+    ${MPI_COMMENT_I}MPI_Comm_rank(comm, &rank);
+    ${MPI_COMMENT_I}return rank;
     ${MPI_COMMENT_O}return 0;
   }
 
@@ -100,42 +102,42 @@ namespace mpi {
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief   waits for all processes in the communicator
   ///
-  /// \param[in]     comm     the communicator to use (defaults to MPI::COMM_WORLD)
+  /// \param[in]     comm     the communicator to use (defaults to MPI_COMM_WORLD)
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  inline void barrier(const MPI::Comm & comm = MPI::COMM_WORLD) {
-    ${MPI_COMMENT_I}comm.Barrier();
+  inline void barrier(const MPI_Comm & comm = MPI_COMM_WORLD) {
+    ${MPI_COMMENT_I}MPI_Barrier(comm);
   }
 
   // declare mpi templates, setting the default communicator to the global communicator
   template<class T> void bcast(T * data, size_t n, int root = 0,
-                               const MPI::Comm & comm = MPI::COMM_WORLD);
-  template<class T> void reduce(const T * send_buf, T * recv_buf, size_t n, const MPI::Op & op, int root = 0,
-                                const MPI::Comm & comm = MPI::COMM_WORLD);
-  template<class T> void allreduce(const T * send_buf, T * recv_buf, size_t n, const MPI::Op & op,
-                                   const MPI::Comm & comm = MPI::COMM_WORLD);
+                               const MPI_Comm & comm = MPI_COMM_WORLD);
+  template<class T> void reduce(const T * send_buf, T * recv_buf, size_t n, const MPI_Op & op, int root = 0,
+                                const MPI_Comm & comm = MPI_COMM_WORLD);
+  template<class T> void allreduce(const T * send_buf, T * recv_buf, size_t n, const MPI_Op & op,
+                                   const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void send(const T * buf, size_t n, const int dest, const int tag,
-                              const MPI::Comm & comm = MPI::COMM_WORLD);
+                              const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void recv(T * buf, size_t n, const int source, const int tag,
-                              const MPI::Comm & comm = MPI::COMM_WORLD);
+                              const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void scatter(const T * send_buf, T * recv_buf, size_t n, int root = 0,
-                                 const MPI::Comm & comm = MPI::COMM_WORLD);
+                                 const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void gather(const T * send_buf, T * recv_buf, size_t n, int root = 0,
-                                const MPI::Comm & comm = MPI::COMM_WORLD);
+                                const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void allgather(const T * send_buf, T * recv_buf, size_t n,
-                                   const MPI::Comm & comm = MPI::COMM_WORLD);
-  template<class T> void bcast(std::vector<T> & v, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD);
+                                   const MPI_Comm & comm = MPI_COMM_WORLD);
+  template<class T> void bcast(std::vector<T> & v, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void reduce(const std::vector<T> & send_v, std::vector<T> & recv_v,
-                                const MPI::Op & op, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD);
+                                const MPI_Op & op, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void allreduce(const std::vector<T> & send_v, std::vector<T> & recv_v,
-                                   const MPI::Op & op, const MPI::Comm & comm = MPI::COMM_WORLD);
+                                   const MPI_Op & op, const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void send(const std::vector<T> & v, const int dest, const int tag,
-                              const MPI::Comm & comm = MPI::COMM_WORLD);
+                              const MPI_Comm & comm = MPI_COMM_WORLD);
   template<class T> void recv(std::vector<T> & v, const int source, const int tag,
-                              const MPI::Comm & comm = MPI::COMM_WORLD);
+                              const MPI_Comm & comm = MPI_COMM_WORLD);
 
 //  template<class T> void bcast(T * const data, size_t n, int root = 0,
-//                               const MPI::Comm & comm = MPI::COMM_WORLD) {
+//                               const MPI_Comm & comm = MPI_COMM_WORLD) {
 //    T * data_ptr = data;
 //    formic::mpi::bcast(data_ptr, n, root, comm);
 //  }
@@ -148,13 +150,13 @@ namespace mpi {
   /// \param[in]     comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class T> inline void bcast(T & datum, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD) {
+  template<class T> inline void bcast(T & datum, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD) {
     formic::mpi::bcast(&datum, 1, root, comm);
   }
 
-  void bcast(std::string & s, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD);
+  void bcast(std::string & s, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD);
 
-  void bcast(std::vector<std::string> & v, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD);
+  void bcast(std::vector<std::string> & v, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD);
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief   broadcast a Matrix
@@ -164,7 +166,7 @@ namespace mpi {
   /// \param[in]     comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> inline void bcast(formic::Matrix<S> & mat, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD) {
+  template<class S> inline void bcast(formic::Matrix<S> & mat, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD) {
     unsigned long int n = mat.rows();
     unsigned long int m = mat.cols();
     formic::mpi::bcast(n, root, comm);
@@ -183,7 +185,7 @@ namespace mpi {
   /// \param[in]     comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> inline void bcast(formic::ColVec<S> & vec, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD) {
+  template<class S> inline void bcast(formic::ColVec<S> & vec, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD) {
     unsigned long int n = vec.size();
     formic::mpi::bcast(n, root, comm);
     if ( vec.size() != n )
@@ -200,7 +202,7 @@ namespace mpi {
   /// \param[in]     comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> inline void bcast(formic::RowVec<S> & vec, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD) {
+  template<class S> inline void bcast(formic::RowVec<S> & vec, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD) {
     unsigned long int n = vec.size();
     formic::mpi::bcast(n, root, comm);
     if ( vec.size() != n )
@@ -217,11 +219,11 @@ namespace mpi {
   /// \param[in]      comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> inline void reduce(formic::Matrix<S> & mat, int root = 0, const MPI::Comm & comm = MPI::COMM_WORLD) {
+  template<class S> inline void reduce(formic::Matrix<S> & mat, int root = 0, const MPI_Comm & comm = MPI_COMM_WORLD) {
     if ( formic::mpi::rank() == root )
-      formic::mpi::reduce(mat.clone().begin(), mat.begin(), mat.size(), MPI::SUM, root, comm);
+      formic::mpi::reduce(mat.clone().begin(), mat.begin(), mat.size(), MPI_SUM, root, comm);
     else
-      formic::mpi::reduce(        mat.begin(), mat.begin(), mat.size(), MPI::SUM, root, comm);
+      formic::mpi::reduce(        mat.begin(), mat.begin(), mat.size(), MPI_SUM, root, comm);
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -231,8 +233,8 @@ namespace mpi {
   /// \param[in]      comm       the communicator to use
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> inline void allreduce(formic::Matrix<S> & mat, const MPI::Comm & comm = MPI::COMM_WORLD) {
-    formic::mpi::allreduce(mat.clone().begin(), mat.begin(), mat.size(), MPI::SUM, comm);
+  template<class S> inline void allreduce(formic::Matrix<S> & mat, const MPI_Comm & comm = MPI_COMM_WORLD) {
+    formic::mpi::allreduce(mat.clone().begin(), mat.begin(), mat.size(), MPI_SUM, comm);
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -241,32 +243,32 @@ namespace mpi {
   /// \return the appropriate MPI datatype
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class T> inline const MPI::Datatype & datatype() {
+  template<class T> inline const MPI_Datatype datatype() {
     throw formic::Exception("unknown mpi datatype");
-    return MPI::DOUBLE;
+    return MPI_DOUBLE;
   }
-  template <> inline const MPI::Datatype & datatype< char                      >() { return MPI::CHAR;                }
-  template <> inline const MPI::Datatype & datatype< signed short              >() { return MPI::SHORT;               }
-  template <> inline const MPI::Datatype & datatype< signed int                >() { return MPI::INT;                 }
-  template <> inline const MPI::Datatype & datatype< signed long               >() { return MPI::LONG;                }
-  template <> inline const MPI::Datatype & datatype< signed char               >() { return MPI::SIGNED_CHAR;         }
-  template <> inline const MPI::Datatype & datatype< unsigned char             >() { return MPI::UNSIGNED_CHAR;       }
-  template <> inline const MPI::Datatype & datatype< unsigned short            >() { return MPI::UNSIGNED_SHORT;      }
-  template <> inline const MPI::Datatype & datatype< unsigned int              >() { return MPI::UNSIGNED;            }
-  template <> inline const MPI::Datatype & datatype< unsigned long int         >() { return MPI::UNSIGNED_LONG;       }
-  template <> inline const MPI::Datatype & datatype< float                     >() { return MPI::FLOAT;               }
-  template <> inline const MPI::Datatype & datatype< double                    >() { return MPI::DOUBLE;              }
-  template <> inline const MPI::Datatype & datatype< long double               >() { return MPI::LONG_DOUBLE;         }
-  template <> inline const MPI::Datatype & datatype< bool                      >() { return MPI::BOOL;                }
-  template <> inline const MPI::Datatype & datatype< std::complex<float>       >() { return MPI::COMPLEX;             }
-  template <> inline const MPI::Datatype & datatype< std::complex<double>      >() { return MPI::DOUBLE_COMPLEX;      }
-  template <> inline const MPI::Datatype & datatype< std::complex<long double> >() { return MPI::LONG_DOUBLE_COMPLEX; }
+  template <> inline const MPI_Datatype  datatype< char                      >() { return MPI_CHAR;                }
+  template <> inline const MPI_Datatype  datatype< signed short              >() { return MPI_SHORT;               }
+  template <> inline const MPI_Datatype  datatype< signed int                >() { return MPI_INT;                 }
+  template <> inline const MPI_Datatype  datatype< signed long               >() { return MPI_LONG;                }
+  template <> inline const MPI_Datatype  datatype< signed char               >() { return MPI_SIGNED_CHAR;         }
+  template <> inline const MPI_Datatype  datatype< unsigned char             >() { return MPI_UNSIGNED_CHAR;       }
+  template <> inline const MPI_Datatype  datatype< unsigned short            >() { return MPI_UNSIGNED_SHORT;      }
+  template <> inline const MPI_Datatype  datatype< unsigned int              >() { return MPI_UNSIGNED;            }
+  template <> inline const MPI_Datatype  datatype< unsigned long int         >() { return MPI_UNSIGNED_LONG;       }
+  template <> inline const MPI_Datatype  datatype< float                     >() { return MPI_FLOAT;               }
+  template <> inline const MPI_Datatype  datatype< double                    >() { return MPI_DOUBLE;              }
+  template <> inline const MPI_Datatype  datatype< long double               >() { return MPI_LONG_DOUBLE;         }
+  template <> inline const MPI_Datatype  datatype< bool                      >() { return MPI_INT;                 }
+  template <> inline const MPI_Datatype  datatype< std::complex<float>       >() { return MPI_COMPLEX;             }
+  template <> inline const MPI_Datatype  datatype< std::complex<double>      >() { return MPI_DOUBLE_COMPLEX;      }
+  //template <> inline const MPI_Datatype  datatype< std::complex<long double> >() { return MPI_LONG_DOUBLE_COMPLEX; }
 
   template<class T> void read_and_bcast(formic::Archive & arch,
                                         T & val,
                                         const std::string & error_msg = "failed to read from archive in read_and_bcast",
                                         int root = 0,
-                                        const MPI::Comm & comm = MPI::COMM_WORLD);
+                                        const MPI_Comm & comm = MPI_COMM_WORLD);
 
 } // end namespace mpi
 

--- a/src/formic/utils/numeric.cpp
+++ b/src/formic/utils/numeric.cpp
@@ -254,7 +254,7 @@ void formic::mpi_unbiased_ratio_of_means(const int n, const double * const p, co
     y[4] += x * g[i];
   }
   double z[7];
-  formic::mpi::allreduce(&y[0], &z[0], 7, MPI::SUM);
+  formic::mpi::allreduce(&y[0], &z[0], 7, MPI_SUM);
   const double mf = z[1] / z[0]; // mean of numerator
   const double mg = z[2] / z[0]; // mean of denominator
   const double sf = z[3] / z[0]; // mean of the square of the numerator terms

--- a/src/formic/utils/timing.cpp
+++ b/src/formic/utils/timing.cpp
@@ -45,7 +45,7 @@ void formic::Stopwatch::reset(const std::string & name) {
 void formic::Stopwatch::start(const std::string & name) {
   if (_running)
     throw formic::Exception("cannot start Stopwatch \"%s\" because it is already running") % name;
-  _start_time = MPI::Wtime();
+  _start_time = MPI_Wtime();
   _running = true;
 }
 
@@ -56,7 +56,7 @@ void formic::Stopwatch::start(const std::string & name) {
 void formic::Stopwatch::stop(const std::string & name) {
   if (!_running)
     throw formic::Exception("cannot stop Stopwatch \"%s\" because it is not running") % name;
-  _elapsed_time = _elapsed_time + ( MPI::Wtime() - _start_time );
+  _elapsed_time = _elapsed_time + ( MPI_Wtime() - _start_time );
   _running = false;
 }
 
@@ -67,7 +67,7 @@ void formic::Stopwatch::stop(const std::string & name) {
 double formic::Stopwatch::elapsed_seconds() const {
   double total = _elapsed_time;
   if (_running)
-    total = total + ( MPI::Wtime() - _start_time );
+    total = total + ( MPI_Wtime() - _start_time );
   return total;
 }
 


### PR DESCRIPTION
The C++ bindings to the MPI library were deprecated and are removed in MPI-3.
This change should enable QMCPACK to compile with newer versions of MPI
implementations.

Addresses issue #326

Some issues:

There is no MPI_* type corresponding to MPI::Bool.  Hopefully translating to
MPI_INT should work okay.

MPI-3 added 'const' to a number of parameters in the C interface.
These 'const' qualifiers had already been present in the C++ interface.
When compiling with MPI-2.2 (or older), the formic wrappers use a
'const T*' to call a function with a non-const 'T *'.
Newer GCC versions (7.1) give an error about converting from 'const' to non-'const'.

The fix is to add const_cast's to remove the 'const' qualifier.