### PR TITLE
Generalize time limit code

### DIFF
--- a/src/Utilities/Clock.h
+++ b/src/Utilities/Clock.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
 #if defined(USE_FAKE_CLOCK)
 extern double fake_cpu_clock_value;
 extern double fake_cpu_clock_increment;
-double fake_cpu_clock()
+inline double fake_cpu_clock()
 {
     fake_cpu_clock_value += fake_cpu_clock_increment;
     return fake_cpu_clock_value;

--- a/src/Utilities/RunTimeManager.cpp
+++ b/src/Utilities/RunTimeManager.cpp
@@ -15,6 +15,7 @@
 
  */
 #include <Utilities/RunTimeManager.h>
+#include <sstream>
 
 
 namespace qmcplusplus
@@ -29,6 +30,29 @@ LoopTimer::get_time_per_iteration() {
     return total_time/nloop;
   }
   return 0.0;
+}
+
+bool
+RunTimeControl::enough_time_for_next_iteration(LoopTimer &loop_timer)
+{
+    m_loop_time = loop_timer.get_time_per_iteration();
+    m_elapsed = runtimeManager.elapsed();
+    m_remaining = MaxCPUSecs - m_elapsed;
+    bool enough_time = true;
+    if ((m_loop_margin*m_loop_time + m_runtime_safety_padding) > m_remaining) enough_time = false;
+
+    return enough_time;
+}
+
+std::string
+RunTimeControl::time_limit_message(const std::string &driverName, int block)
+{
+  std::stringstream log;
+  log << "Time limit reached for " << driverName << ", stopping after block " << block-1 << std::endl;
+  log << "  Iteration time per " << driverName <<  " block (seconds) = " << m_loop_time << std::endl;
+  log << "  Elapsed time (seconds)       = " << m_elapsed << std::endl;
+  log << "  Remaining time (seconds)      = " << m_remaining << std::endl;
+  return log.str();
 }
 
 }

--- a/src/Utilities/RunTimeManager.h
+++ b/src/Utilities/RunTimeManager.h
@@ -17,6 +17,7 @@
 #define QMCPLUSPLUS_RUNTIME_MANAGER_H
 
 #include <Utilities/Clock.h>
+#include <string>
 
 
 namespace qmcplusplus
@@ -48,6 +49,31 @@ private:
   double start_time;
   double total_time;
 };
+
+class RunTimeControl
+{
+  int MaxCPUSecs;
+  double m_runtime_safety_padding;
+  double m_loop_margin;
+  double m_loop_time;
+  double m_elapsed;
+  double m_remaining;
+  RunTimeManagerClass &runtimeManager;
+public:
+
+  RunTimeControl(RunTimeManagerClass &rm, int maxCPUSecs) : runtimeManager(rm), MaxCPUSecs(maxCPUSecs) {
+     m_runtime_safety_padding = 10.0; // 10 seconds - enough to shut down?
+     m_loop_margin = 1.1; // 10% margin on average loop time?
+  }
+
+  void runtime_padding(int runtime_padding) { m_runtime_safety_padding = runtime_padding; }
+  void loop_margin(int loopMargin) { m_loop_margin = loopMargin; }
+
+  bool enough_time_for_next_iteration(LoopTimer &loop_timer);
+  std::string time_limit_message(const std::string &driverName, int block);
+
+};
+
 
 }
 #endif

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ SET(SRC_DIR utilities)
 SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME unit_test_${SRC_DIR})
 
-ADD_EXECUTABLE(${UTEST_EXE} test_rng.cpp test_parser.cpp test_timer.cpp test_prime_set.cpp)
+ADD_EXECUTABLE(${UTEST_EXE} test_rng.cpp test_parser.cpp test_timer.cpp test_prime_set.cpp
+                            test_runtime_manager.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 
 #ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")


### PR DESCRIPTION
Extract the cpu time limit code from DMCOMP.cpp to a new class, RunTimeControl.
The remaining code in DMCOMP.cpp is a pattern for the code to be added to the other drivers.

The one change beyond refactoring is to add the MPI broadcast of the loop decision.  This prevents the case where different processors make different decisions about continuing the loop, which would cause QMCPACK to hang.


