### PR TITLE
Fix broadcast of bool from CPU time limit.

### DIFF
--- a/src/QMCDrivers/DMC/DMCOMP.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.cpp
@@ -25,6 +25,7 @@
 #include "QMCDrivers/DMC/DMCUpdateAll.h"
 #include "QMCApp/HamiltonianPool.h"
 #include "Message/Communicate.h"
+#include "Message/CommOperators.h"
 #include "Message/OpenMP.h"
 #include "Utilities/Timer.h"
 #include "Utilities/RunTimeManager.h"


### PR DESCRIPTION
Some compilers (Intel) require the actual definition of bcast with a bool argument.  Presumably others convert the bool to an int.
Add the CommOperators.h include so the code compiles with the Intel compiler.