### PR TITLE
nexus: fix k-point add for tiling corner case

### DIFF
--- a/nexus/library/structure.py
+++ b/nexus/library/structure.py
@@ -5426,15 +5426,15 @@ def generate_crystal_structure(lattice=None,cell=None,centering=None,
             operations     = operations,
             posu           = posu)
     elif isinstance(structure,Structure):
+        if tiling!=None:
+            structure = structure.tile(tiling)
+        #end if
         if kpoints!=None:
             structure.add_kpoints(kpoints,kweights)
         #end if
         if kgrid!=None:
             structure.add_kmesh(kgrid,kshift)
         #end if        
-        if tiling!=None:
-            structure = structure.tile(tiling)
-        #end if
         return structure
     #end if
 


### PR DESCRIPTION
When a structure object was provided directly to generate_structure via generate_physical_system, the k-point grid was erroneously added prior to tiling.  This PR enforces the expected behavior: the k-point grid is first added to the supercell and and then the k-point grid is tiled for the primitive cell. 