### PR TITLE
Improve Bspline Jastrow test.

### DIFF
--- a/src/QMCWaveFunctions/tests/gen_bspline_jastrow.py
+++ b/src/QMCWaveFunctions/tests/gen_bspline_jastrow.py
@@ -1,0 +1,151 @@
+
+# Generate Bspline Jastrow values to test against
+
+# Cut and paste the relevant part of the output into test_bspline_jastrow.cpp
+
+from sympy import *
+from collections import defaultdict
+import numpy as np
+
+def to_interval(ival):
+    """Convert relational expression to an Interval"""
+    min_val = None
+    lower_open = False
+    max_val = None
+    upper_open = True
+    if isinstance(ival, And):
+        for rel in ival.args:
+            if isinstance(rel, StrictGreaterThan):
+                min_val = rel.args[1]
+                #lower_open = True
+            elif isinstance(rel, GreaterThan):
+                min_val = rel.args[1]
+                #lower_open = False
+            elif isinstance(rel, StrictLessThan):
+                max_val = rel.args[1]
+                #upper_open = True
+            elif isinstance(rel, LessThan):
+                max_val = rel.args[1]
+                #upper_open = False
+            else:
+                print('unhandled ',rel)
+
+    if min_val == None or max_val == None:
+        print('error',ival)
+    return Interval(min_val, max_val, lower_open, upper_open)
+
+# Transpose the interval and coefficients
+#  Note that interval [0,1) has the polynomial coefficients found in the einspline code
+#  The other intervals could be shifted, and they would also have the same polynomials
+def transpose_interval_and_coefficients(sym_basis):
+    cond_map = defaultdict(list)
+
+    i1 = Interval(0,5, False, False) # interval for evaluation
+    for idx, s0 in enumerate(sym_basis):
+        for expr, cond in s0.args:
+            if cond != True:
+                i2 = to_interval(cond)
+                if not i1.is_disjoint(i2):
+                    cond_map[i2].append( (idx, expr) )
+    return cond_map
+
+# Create piecewise expression from the transposed intervals
+# basis_map - map of interval to list of spline expressions for that interval
+#         c - coefficient symbol (needs to allow indexing)
+#        xs - symbol for the position variable ('x')
+def recreate_piecewise(basis_map, c, xs):
+    args = []
+    for cond, exprs in basis_map.items():
+        e = 0
+        for idx, b in exprs:
+            e += c[idx] * b
+        args.append( (e, cond.as_relational(xs)))
+    args.append((0, True))
+    return Piecewise(*args)
+
+
+
+# Generate output for these parameters
+
+#<jastrow name=\"J2\" type=\"Two-Body\" function=\"Bspline\" print=\"yes\"> \
+#   <correlation rcut=\"10\" size=\"10\" speciesA=\"u\" speciesB=\"d\"> \
+#      <coefficients id=\"ud\" type=\"Array\"> 0.02904699284 -0.1004179 -0.1752703883 -0.2232576505 -0.2728029201 -0.3253286875 -0.3624525145 -0.3958223107 -0.4268582166 -0.4394531176</coefficients> \
+#    </correlation> \
+#</jastrow> \
+
+def gen_case_one():
+
+  rcut_val = 10
+  param = np.array([0.02904699284, -0.1004179, -0.1752703883, -0.2232576505, -0.2728029201, -0.3253286875, -0.3624525145, -0.3958223107, -0.4268582166, -0.4394531176])
+
+
+  xs = Symbol('x')
+
+  Delta = Symbol('Delta',positive=True)
+  nknots = 10
+  knots = [i*Delta for i in range(nknots)]
+  print 'knots = ',knots
+  all_knots = [i*Delta for i in range(-3,nknots+3)]
+  rcut = (nknots-1)*Delta
+
+  # Third-order bspline
+  jastrow_sym_basis = bspline_basis_set(3, all_knots, xs)
+  print("Number of basis functions = ",len(jastrow_sym_basis))
+  #jastrow_sym_basis
+
+  # Rearrange the basis and conditionals into a more useful form
+  jastrow_cond_map = transpose_interval_and_coefficients(jastrow_sym_basis)
+  c = IndexedBase('c',shape=(nknots+3))
+  #c = MatrixSymbol('c',nknots+2,1)  # better for code-gen
+  jastrow_spline = recreate_piecewise(jastrow_cond_map, c, xs)
+
+
+  cusp_val = -0.5
+  Delta_val = rcut_val*1.0/(nknots+1)
+  #print 'Delta = ',Delta_val
+  #print 'coeff size = ',nknots+4
+
+  coeffs = np.zeros(nknots+4)
+  coeffs[0] = -2*cusp_val*Delta_val + param[1]
+  coeffs[1] = param[0]
+  coeffs[2] = param[1]
+  coeffs[3:-3] = param[2:]
+  #print 'coeffs',coeffs
+
+  deriv_jastrow_spline = diff(jastrow_spline, xs)
+  deriv2_jastrow_spline = diff(jastrow_spline, xs, 2)
+
+  vals = []
+  for i in range(20):
+    x = 0.6*i
+    jv = jastrow_spline.subs({xs:x,Delta:Delta_val})
+    jd = deriv_jastrow_spline.subs({xs:x,Delta:Delta_val})
+    jdd = deriv2_jastrow_spline.subs({xs:x,Delta:Delta_val})
+    #print jj
+    subslist = dict()
+    for i in range(12):
+      subslist[c[i]] = coeffs[i]
+    #print x,jv.subs(subslist),jd.subs(subslist),jdd.subs(subslist)
+    vals.append((x,jv.subs(subslist),jd.subs(subslist),jdd.subs(subslist)))
+
+ # Assumes
+ # struct JValues
+ # {
+ #  double r;
+ #  double u;
+ #  double du;
+ #  double ddu;
+ # };
+  tmpl = """
+ const int N = {N};
+ JValues Vals[N] = {{
+   {values}
+ }};
+"""
+  fmt_values = ',\n  '.join("{%.2f, %15.10g, %15.10g, %15.10g}"%(r,u,du,ddu) for r,u,du,ddu in vals)
+  s = tmpl.format(N=len(vals), values=fmt_values)
+  print s
+
+
+if __name__ == '__main__':
+  gen_case_one()

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -142,10 +142,56 @@ const char *particles = \
 
   double KE = -0.5*(Dot(elec_.G,elec_.G)+Sum(elec_.L));
   REQUIRE(KE == Approx(-0.1616624771)); // note: number not validated
-  
+
+
+  struct JValues
+  {
+   double r;
+   double u;
+   double du;
+   double ddu;
+  };
+
+  // Cut and paste from output of gen_bspline_jastrow.py
+   const int N = 20;
+   JValues Vals[N] = {
+    {0.00,    0.1374071801,            -0.5,    0.7866949593},
+    {0.60,  -0.04952403966,   -0.1706645865,    0.3110897524},
+    {1.20,    -0.121361995,  -0.09471371432,     0.055337302},
+    {1.80,   -0.1695590431,  -0.06815900213,    0.0331784053},
+    {2.40,   -0.2058414025,  -0.05505192964,   0.01049597156},
+    {3.00,   -0.2382237097,  -0.05422744821, -0.002401552969},
+    {3.60,   -0.2712606182,  -0.05600918024, -0.003537553803},
+    {4.20,   -0.3047843679,  -0.05428535477,    0.0101841028},
+    {4.80,   -0.3347515004,  -0.04506573714,   0.01469003611},
+    {5.40,   -0.3597048574,  -0.03904232165,  0.005388015505},
+    {6.00,   -0.3823503292,  -0.03657502025,  0.003511355265},
+    {6.60,   -0.4036800017,  -0.03415678101,  0.007891305516},
+    {7.20,   -0.4219818468,  -0.02556305518,   0.02075444724},
+    {7.80,   -0.4192355508,   0.06799438701,    0.3266190181},
+    {8.40,   -0.3019238309,      0.32586994,    0.2880861726},
+    {9.00,  -0.09726352421,    0.2851358014,   -0.4238666348},
+    {9.60, -0.006239062395,   0.04679296796,   -0.2339648398},
+    {10.20,               0,               0,               0},
+    {10.80,               0,               0,               0},
+    {11.40,               0,               0,               0}
+   };
+
+
+  BsplineFunctor<OrbitalBase::RealType> *bf = j2->F[0];
+
+  for (int i = 0; i < N; i++) {
+    OrbitalBase::RealType dv = 0.0;
+    OrbitalBase::RealType ddv = 0.0;
+    OrbitalBase::RealType val = bf->evaluate(Vals[i].r,dv,ddv);
+    REQUIRE(Vals[i].u == Approx(val));
+    REQUIRE(Vals[i].du == Approx(dv));
+    REQUIRE(Vals[i].ddu == Approx(ddv));
+  }
+
 #if 0
   // write out values of the Bspline functor
-  BsplineFunctor<double> *bf = j2->F[0];
+  //BsplineFunctor<double> *bf = j2->F[0];
   printf("NumParams = %d\n",bf->NumParams);
   printf("CuspValue = %g\n",bf->CuspValue);
   printf("DeltaR = %g\n",bf->DeltaR);
@@ -156,13 +202,16 @@ const char *particles = \
   }
   printf("\n");
 
-  for (int i = 0; i < 50; i++) {
-    double r = 0.2*i;
+  for (int i = 0; i < 20; i++) {
+    double r = 0.6*i;
     elec_.R[0][0] = r;
     elec_.update();
     double logpsi = psi.evaluateLog(elec_);
-    double alt_val = bf->evaluate(r);
-    printf("%g %g %g\n",r,logpsi,alt_val);
+    //double alt_val = bf->evaluate(r);
+    double dv = 0.0;
+    double ddv = 0.0;
+    double alt_val = bf->evaluate(r,dv,ddv);
+    printf("%g %g %g %g %g\n",r,logpsi,alt_val,dv,ddv);
   }
 #endif
 


### PR DESCRIPTION
Compare with a series of values obtained from a python script (gen_bspline_jastrow.py)
The script generates the comparsion using the B-splines built into Sympy.
The first and second derivatives are also tested now.

The testing is not as extensive as code generating the expression to compare against, but is better than what was there.