### PR TITLE
Change walker offset IO handling.

### DIFF
--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -298,7 +298,7 @@ bool HDFWalkerInput_0_4::read_phdf5( std::string h5name)
   bool success;
 
   { // handle small dataset with master rank
-    hdf_archive hin(myComm,false); //everone reads this
+    hdf_archive hin(myComm,false);
     if(!myComm->rank())
     {
       success=hin.open(h5name,H5F_ACC_RDONLY);
@@ -326,6 +326,8 @@ bool HDFWalkerInput_0_4::read_phdf5( std::string h5name)
     mpi::bcast(*myComm,success);
     if(!success) return false;
 
+    // load woffsets by master
+    // can not read collectively since the size may differ from Nranks+1.
     if(!myComm->rank())
     {
       hin.read(woffsets,"walker_partition");

--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -203,7 +203,8 @@ void HDFWalkerOutput::write_configuration(MCWalkerConfiguration& W, hdf_archive&
 
   if(hout.is_parallel())
   {
-    { // write walker offset
+    { // write walker offset.
+      // Though it is a small array, it needs to be written collectively in large scale runs.
       TinyVector<int,1> gcounts(myComm->size()+1);
       TinyVector<int,1> counts;
       TinyVector<int,1> offsets(myComm->rank());

--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -196,22 +196,42 @@ void HDFWalkerOutput::write_configuration(MCWalkerConfiguration& W, hdf_archive&
     block = nblock;
   }
 
-  hout.write(W.WalkerOffsets,"walker_partition");
-
   number_of_walkers=W.WalkerOffsets[myComm->size()];
   hout.write(number_of_walkers,hdf::num_walkers);
 
   TinyVector<int,3> gcounts(number_of_walkers,number_of_particles,OHMMS_DIM);
 
   if(hout.is_parallel())
-  { 
-    TinyVector<int,3> counts(W.getActiveWalkers(),            number_of_particles,OHMMS_DIM);
-    TinyVector<int,3> offsets(W.WalkerOffsets[myComm->rank()],0,0);
-    hyperslab_proxy<BufferType,3> slab(*RemoteData[0],gcounts,counts,offsets);
-    hout.write(slab,hdf::walkers);
+  {
+    { // write walker offset
+      TinyVector<int,1> gcounts(myComm->size()+1);
+      TinyVector<int,1> counts;
+      TinyVector<int,1> offsets(myComm->rank());
+      std::vector<int> myWalkerOffset;
+      if(myComm->size()-1==myComm->rank())
+      {
+        counts[0]=2;
+        myWalkerOffset.push_back(W.WalkerOffsets[myComm->rank()]);
+        myWalkerOffset.push_back(W.WalkerOffsets[myComm->size()]);
+      }
+      else
+      {
+        counts[0]=1;
+        myWalkerOffset.push_back(W.WalkerOffsets[myComm->rank()]);
+      }
+      hyperslab_proxy<std::vector<int>,1> slab(myWalkerOffset,gcounts,counts,offsets);
+      hout.write(slab,"walker_partition");
+    }
+    { // write walker configuration
+      TinyVector<int,3> counts(W.getActiveWalkers(),number_of_particles,OHMMS_DIM);
+      TinyVector<int,3> offsets(W.WalkerOffsets[myComm->rank()],0,0);
+      hyperslab_proxy<BufferType,3> slab(*RemoteData[0],gcounts,counts,offsets);
+      hout.write(slab,hdf::walkers);
+    }
   }
   else
   { //gaterv to the master and master writes it, could use isend/irecv
+    hout.write(W.WalkerOffsets,"walker_partition");
     if(myComm->size()>1)
     {
       std::vector<int> displ(myComm->size()), counts(myComm->size());


### PR DESCRIPTION
Hit some issue on Mira when using >= 32768 ranks.

walker offsets (an array) of all the nodes are recorded in the config.h5 for restart.
It was written by every node to the file even though the file is open in collective IO mode.
It is not a problem when the node count was small (<=16384). With a large node count, hdf5 library crashed inside.
Changes to the offset IO:
write: collectively by every node, each contribute its own offset. The last node contributes 2 (for the end)
read: since the next run can be with a different node count, offset now is loaded by the master node and broadcast to all the nodes.
performance:
Both IO operations are measured faster.

Restart miniapp has passed all the checks with 65536 ranks.
restart tests also pass.

Wait for a big run (in a few days) on Mira before merge.