### PR TITLE
Fix targetwalkers entry in dmc.tex

### DIFF
--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -9,7 +9,7 @@
 \hline
 \multicolumn{2}{l}{parameters}  & \multicolumn{4}{l}{}\\
    &   \bfseries name     & \bfseries datatype & \bfseries values & \bfseries default   & \bfseries description \\
-   &   \texttt{targetwalkers             } &  integer  & $> 0$ & dep.   & number of walkers per node  \\
+   &   \texttt{targetwalkers             } &  integer  & $> 0$ & dep.   & overall total number of walkers \\
    &   \texttt{blocks              } &  integer  & $\ge 0$ & 1   & number of blocks            \\
    &   \texttt{steps               } &  integer  & $\ge 0$ & 1   & number of steps per block   \\
    &   \texttt{warmupsteps         } &  integer  & $\ge 0$ & 0   & number of steps for warming up\\


### PR DESCRIPTION
Bugfix 

targetwalkers is total walker count, not a per node or thread count.
