### PR TITLE
Modify relative path to derivative check scripts

### DIFF
--- a/tests/solids/bccH_2x2x2_ae/CMakeLists.txt
+++ b/tests/solids/bccH_2x2x2_ae/CMakeLists.txt
@@ -4,21 +4,21 @@ IF (NOT MIXED_PRECISION)
     "${CMAKE_SOURCE_DIR}/tests/solids/bccH_2x2x2_ae"
     grad_lap.xml
     1 1
-    ../short-bccH_3x3x3_ae-deriv-1-1/check_grad_lap.py
+    ../../bccH_3x3x3_ae/short-bccH_3x3x3_ae-deriv-1-1/check_grad_lap.py
   )
 
   SIMPLE_RUN_AND_CHECK(short-bccH_2x2x2_ae-deriv
     "${CMAKE_SOURCE_DIR}/tests/solids/bccH_2x2x2_ae"
     deriv.xml
     1 1
-    ../short-bccH_3x3x3_ae-deriv-1-1/check_deriv.py
+    ../../bccH_3x3x3_ae/short-bccH_3x3x3_ae-deriv-1-1/check_deriv.py
   )
 
   SIMPLE_RUN_AND_CHECK(short-bccH_2x2x2_ae-gamma-deriv
     "${CMAKE_SOURCE_DIR}/tests/solids/bccH_2x2x2_ae"
     gamma_deriv.xml
     1 1
-    ../short-bccH_3x3x3_ae-deriv-1-1/check_deriv.py
+    ../../bccH_3x3x3_ae/short-bccH_3x3x3_ae-deriv-1-1/check_deriv.py
   )
 ELSE()
  MESSAGE("Skipping bccH_2x2x2_ae derivative tests in mixed precision (QMC_MIXED_PRECISION=1)")

--- a/tests/solids/bccH_3x3x3_ae/CMakeLists.txt
+++ b/tests/solids/bccH_3x3x3_ae/CMakeLists.txt
@@ -28,5 +28,5 @@ IF (NOT MIXED_PRECISION)
     check_deriv.py
   )
 ELSE()
- MESSAGE("Skipping bccH_2x2x2_ae derivative tests in mixed precision (QMC_MIXED_PRECISION=1)")
+ MESSAGE("Skipping bccH_3x3x3_ae derivative tests in mixed precision (QMC_MIXED_PRECISION=1)")
 ENDIF (NOT MIXED_PRECISION)


### PR DESCRIPTION
For the bccH_2x2x2_ae test, the check scripts are given relative to bccH_3x3x3_ae.
Separating the test files changed the relative layout of these directories. Change
it to match the new layout.

Also fix the test skipping message in bccH_3x3x3_ae to match the test.