### PR TITLE
Extend CPU limit to new drivers and add tests

### DIFF
--- a/src/QMCDrivers/VMC/VMCSingleOMP.cpp
+++ b/src/QMCDrivers/VMC/VMCSingleOMP.cpp
@@ -24,6 +24,7 @@
 #include "OhmmsApp/RandomNumberControl.h"
 #include "Message/OpenMP.h"
 #include "Message/CommOperators.h"
+#include "Utilities/RunTimeManager.h"
 #include "tau/profiler.h"
 #include <qmc_common.h>
 //#define ENABLE_VMC_OMP_MASTER
@@ -65,9 +66,15 @@ bool VMCSingleOMP::run()
 #if !defined(REMOVE_TRACEMANAGER)
   Traces->startRun(nBlocks,traceClones);
 #endif
+
+  LoopTimer vmc_loop;
+  RunTimeControl runtimeControl(RunTimeManager, MaxCPUSecs);
+  bool enough_time_for_next_iteration = true;
+
   const bool has_collectables=W.Collectables.size();
   for (int block=0; block<nBlocks; ++block)
   {
+    vmc_loop.start();
     #pragma omp parallel
     {
       int ip=omp_get_thread_num();
@@ -105,6 +112,13 @@ bool VMCSingleOMP::run()
 #endif
     if(storeConfigs)
       recordBlock(block);
+    vmc_loop.stop();
+    enough_time_for_next_iteration = runtimeControl.enough_time_for_next_iteration(vmc_loop);
+    myComm->bcast(enough_time_for_next_iteration);
+    if (!enough_time_for_next_iteration) {
+      app_log() << runtimeControl.time_limit_message("VMC", block);
+      break;
+    }
   }//block
   Estimators->stop(estimatorClones);
   for (int ip=0; ip<NumThreads; ++ip)

--- a/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
+++ b/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
@@ -139,6 +139,21 @@ IF (NOT QMC_CUDA)
                     TRUE
                     1 BCC_H_RMC_SCALARS #series#
                     )
+
+  # Check CPU time limit
+  SET(FULL_NAME "cpu_limit-bccH_1x1x1_ae-rmc-1-1")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae"
+              1 1
+              TEST_ADDED
+              qmc_cpu_limit_rmc.xml)
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY TIMEOUT 120)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
+  ENDIF()
+
 ELSE()
   MESSAGE("Skipping bccH_1x1x1_ae tests for VMC all-particle moves, CSVMC, and RMC because they are not supported by CUDA build (QMC_CUDA=1)")
 ENDIF()

--- a/tests/solids/bccH_1x1x1_ae/qmc_cpu_limit_rmc.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_cpu_limit_rmc.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_cpu_limit_rmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.77945227        0.00000000        0.00000000
+                 -0.00000000        3.77945227        0.00000000
+                 -0.00000000       -0.00000000        3.77945227
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="H" size="2" mass="1837.36221934">
+            <parameter name="charge"              >    1                     </parameter>
+            <parameter name="valence"             >    1                     </parameter>
+            <parameter name="atomicnumber"        >    1                     </parameter>
+            <parameter name="mass"                >    1837.36221934            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.88972614        1.88972614        1.88972614
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="1">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="H" size="8" cusp="1.0">
+               <coefficients id="eH" type="Array">                  
+0.00206602038 -0.002841926986 0.0036266191 -0.001913930279 8.457152991e-06 
+0.0007380321824 3.635172529e-05 0.0001299635851
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.5954603818 0.5062051797 0.3746940461 0.2521010502 0.1440163317 0.07796688253 
+0.03804420551 0.01449320872
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+
+    <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  0.3 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="rmc" move="pbyp" checkpoint="-1">
+     <estimator name="RMC" hdf5="no"/>
+     <parameter name="warmupSteps">  2000 </parameter>
+     <parameter name="timestep">  0.008 </parameter>
+     <parameter name="beads"> 400 </parameter>
+     <parameter name="steps">   400 </parameter>
+     <parameter name="blocks">  20000 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+     <parameter name="maxcpusecs"> 60 </parameter>
+   </qmc>
+   
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -81,7 +81,33 @@ ENDIF(ENABLE_SOA)
   ENDIF()
 
 # Test time limit
-  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-dmc")
+  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-vmc-1-1")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+              1 1
+              TEST_ADDED
+              qmc_cpu_limit_vmc.xml)
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY TIMEOUT 120)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
+  ENDIF()
+
+  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-vmc-4-4")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+              4 4
+              TEST_ADDED
+              qmc_cpu_limit_vmc.xml)
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY TIMEOUT 120)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
+  ENDIF()
+
+  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-dmc-1-1")
   SET(TEST_ADDED FALSE)
   RUN_QMC_APP(${FULL_NAME}
               "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
@@ -94,6 +120,18 @@ ENDIF(ENABLE_SOA)
     SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
   ENDIF()
 
+  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-dmc-4-4")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+              4 4
+              TEST_ADDED
+              qmc_cpu_limit_dmc.xml)
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY TIMEOUT 120)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
+  ENDIF()
 
 
 #

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -80,6 +80,21 @@ ENDIF(ENABLE_SOA)
     SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY LABELS "coverage")
   ENDIF()
 
+# Test time limit
+  SET(FULL_NAME "cpu_limit-diamondC_1x1x1_pp-dmc")
+  SET(TEST_ADDED FALSE)
+  RUN_QMC_APP(${FULL_NAME}
+              "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+              1 1
+              TEST_ADDED
+              qmc_cpu_limit_dmc.xml)
+
+  IF (TEST_ADDED)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY TIMEOUT 120)
+    SET_PROPERTY(TEST ${FULL_NAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
+  ENDIF()
+
+
 
 #
 # Long tests

--- a/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_dmc.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_dmc.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_cpu_limit_dmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  1 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="targetwalkers"> 256 </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   100 </parameter>
+
+     <!-- make large to ensure time limit is hit -->
+     <parameter name="blocks">  10000 </parameter>
+
+     <parameter name="nonlocalmoves">  no </parameter>
+     <parameter name="maxcpusecs"> 60 </parameter>
+
+
+   </qmc>
+
+</simulation>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_vmc.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_vmc.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_cpu_limit_dmc" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+            <slaterdeterminant>
+               <determinant id="updet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers">    256 </parameter>
+     <parameter name="substeps">  1 </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="steps">  1 </parameter>
+     <parameter name="blocks">  100000 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+     <parameter name="maxcpusecs"> 60 </parameter>
+   </qmc>
+
+</simulation>


### PR DESCRIPTION
Add CPU time limit code to VMC CPU and CUDA, DMC CUDA, RMC.
Also add tests.  The time limit is set to 60 seconds, and the corresponding test configuration has a time-out set for 120 seconds.
The test names start with 'cpu_limit'.  They don't seem important enough to include with the 'short' tests.

Partially addresses #379 