### PR TITLE
Fix WalkerOffset bug due to code extraction change.

### DIFF
--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -148,16 +148,16 @@ WalkerControlMPI::branch(int iter, MCWalkerConfiguration& W, RealType trigger)
 }
 
 // determine new walker population on each node
-void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, std::vector<int> NumPerNode, std::vector<int> &minus, std::vector<int> &plus)
+void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, const std::vector<int> &NumPerNode, std::vector<int> &FairOffSet, std::vector<int> &minus, std::vector<int> &plus)
 {
   // Cur_pop - in - current population
   // NumContexts -in - number of MPI processes
   // MyContext - in - my MPI rank
   // NumPerNode - in - current walkers per node
+  // FairOffSet - out - new walker offset
   // minus - out - number of walkers to be removed from each node
   // plus -  out - number of walkers to be added to each node
 
-  std::vector<int> FairOffSet;
   FairDivideLow(Cur_pop,NumContexts,FairOffSet);
   int deltaN;
   for(int ip=0; ip<NumContexts; ip++)
@@ -184,7 +184,7 @@ void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, s
 void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
 {
   std::vector<int> minus, plus;
-  determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, minus, plus);
+  determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, FairOffSet, minus, plus);
 
   Walker_t& wRef(*W[0]);
   std::vector<Walker_t*> newW;
@@ -255,7 +255,7 @@ void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
 void WalkerControlMPI::swapWalkersAsync(MCWalkerConfiguration& W)
 {
   std::vector<int> minus, plus;
-  determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, minus, plus);
+  determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, FairOffSet, minus, plus);
   Walker_t& wRef(*W[0]);
   std::vector<Walker_t*> newW;
   std::vector<Walker_t*> oldW;

--- a/src/QMCDrivers/tests/test_walker_control.cpp
+++ b/src/QMCDrivers/tests/test_walker_control.cpp
@@ -37,7 +37,7 @@ namespace qmcplusplus
 {
 
 // add declaration here so it's accessible for testing
-void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, std::vector<int> NumPerNode, std::vector<int> &minus, std::vector<int> &plus);
+void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, const std::vector<int> &NumPerNode, std::vector<int> &FairOffset, std::vector<int> &minus, std::vector<int> &plus);
 
 void output_vector(const std::string &name, std::vector<int> &vec)
 {
@@ -55,6 +55,7 @@ TEST_CASE("Walker control assign walkers", "[drivers][walker_control]")
   int NumContexts = 4;
   int MyContext = 0;
   std::vector<int> NumPerNode = {4,4,0,0};
+  std::vector<int> FairOffset(NumContexts+1);
 
   std::vector<int> NewNum = NumPerNode;
   for (int me = 0; me < NumContexts; me++)
@@ -63,7 +64,7 @@ TEST_CASE("Walker control assign walkers", "[drivers][walker_control]")
     std::vector<int> plus;
 
     //std::cout << "For processor number " << me << std::endl;
-    determineNewWalkerPopulation(Cur_pop, NumContexts, me, NumPerNode, minus, plus);
+    determineNewWalkerPopulation(Cur_pop, NumContexts, me, NumPerNode, FairOffset, minus, plus);
 
     REQUIRE(minus.size() == plus.size());
     //output_vector("  Minus: ", minus);
@@ -79,8 +80,6 @@ TEST_CASE("Walker control assign walkers", "[drivers][walker_control]")
   }
   //output_vector("New num per node: ", NewNum);
 
-  std::vector<int> FairOffset;
-  FairDivideLow(Cur_pop,NumContexts,FairOffset);
   for (int i = 0; i < NewNum.size(); i++) {
     int num = FairOffset[i+1] - FairOffset[i];
     REQUIRE(NewNum[i] == num);


### PR DESCRIPTION
Fix bug introduced in PR #488.
FairOffset  is used by the caller of determineNewWalkerPopulation.
So FairOffset needs to be returned from determineNewWalkerPopulation