### PR TITLE
Abort the code if PP charge doesn't match.

### DIFF
--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -30,7 +30,7 @@ namespace qmcplusplus
 
 ECPComponentBuilder::ECPComponentBuilder(const std::string& aname, Communicate* c):
   MPIObjectBase(c),
-  RcutMax(-1), NumNonLocal(0), Lmax(0), Zeff(0), Species(aname), Nrule(4),
+  RcutMax(-1), NumNonLocal(0), Lmax(0), AtomicNumber(0), Zeff(0), Species(aname), Nrule(4),
   grid_global(0),pp_loc(0), pp_nonloc(0)
 {
   angMon["s"]=0;
@@ -163,6 +163,7 @@ bool ECPComponentBuilder::put(xmlNodePtr cur)
     if(cname == "header")
     {
       Zeff = atoi((const char*)xmlGetProp(cur,(const xmlChar*)"zval"));
+      AtomicNumber = atoi((const char*)xmlGetProp(cur,(const xmlChar*)"atomic-number"));
     }
     else if(cname == "grid")
     {

--- a/src/QMCHamiltonians/ECPComponentBuilder.h
+++ b/src/QMCHamiltonians/ECPComponentBuilder.h
@@ -34,6 +34,7 @@ struct ECPComponentBuilder: public MPIObjectBase, public QMCTraits
 
   int NumNonLocal;
   int Lmax, Llocal, Nrule;
+  int AtomicNumber;
   RealType Zeff;
   RealType RcutMax;
   std::string Species;

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -195,6 +195,8 @@ void ECPotentialBuilder::useXmlFormat(xmlNodePtr cur)
       SpeciesSet& ion_species(IonConfig.getSpeciesSet());
       int speciesIndex=ion_species.findSpecies(ionName);
       int chargeIndex=ion_species.findAttribute("charge");
+      int AtomicNumberIndex=ion_species.findAttribute("atomicnumber");
+      if(AtomicNumberIndex==-1) AtomicNumberIndex=ion_species.findAttribute("atomic_number");
       bool success=false;
       if(speciesIndex < ion_species.getTotalNum())
       {
@@ -247,6 +249,21 @@ void ECPotentialBuilder::useXmlFormat(xmlNodePtr cur)
             {
               app_error() << "  Ion species " << ionName << " charge " << ion_charge
                           << " pseudopotential charge " << ecp.Zeff << " mismatch!" << std::endl;
+              success=false;
+            }
+          }
+          if(AtomicNumberIndex == -1)
+          {
+            app_error() << "  Ion species " << ionName << " needs parameter \'atomicnumber\'" << std::endl;
+            success=false;
+          }
+          else
+          {
+            int atomic_number = ion_species(AtomicNumberIndex,speciesIndex);
+            if(atomic_number != ecp.AtomicNumber)
+            {
+              app_error() << "  Ion species " << ionName << " atomicnumber " << atomic_number
+                          << " pseudopotential atomic-number " << ecp.AtomicNumber << " mismatch!" << std::endl;
               success=false;
             }
           }


### PR DESCRIPTION
Check "charge" in pseudopotential file against the particle description in the QMCPACK xml input.
Also abort when PP elementType mismatches particle description. Previously this case only prints an error without a stop.
closes #399