### PR TITLE
Modified configuration files for titan, eos, and oic5

### DIFF
--- a/config/build_olcf_eos.sh
+++ b/config/build_olcf_eos.sh
@@ -11,7 +11,7 @@
 ## Settings should be consistent with test scripts e.g.       ##
 ##  ./tests/test_automation/nightly_ornl_olcf_eos.job         ##
 ##                                                            ##
-## Last modified: Sep 25, 2017                                ##
+## Last modified: Dec 7, 2017                                 ##
 ################################################################
 
 
@@ -58,47 +58,47 @@ CMAKE_FLAGS="-DCMAKE_C_COMPILER=cc \
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS real for eos"
-mkdir -p build_cpu_AoS_real_eos
-cd build_cpu_AoS_real_eos
+mkdir -p build_eos_cpu_real
+cd build_eos_cpu_real
 cmake $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -sf ./build_cpu_AoS_real_eos/bin/qmcpack ./qmcpack_cpu_AoS_real_eos
+ln -sf ./build_eos_cpu_real/bin/qmcpack ./qmcpack_eos_cpu_real
 
 
 # Configure and build cpu complex AoS
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS complex for eos"
-mkdir -p build_cpu_AoS_comp_eos
-cd build_cpu_AoS_comp_eos
+mkdir -p build_eos_cpu_comp
+cd build_eos_cpu_comp
 cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -sf ./build_cpu_AoS_comp_eos/bin/qmcpack ./qmcpack_cpu_AoS_comp_eos
+ln -sf ./build_eos_cpu_comp/bin/qmcpack ./qmcpack_eos_cpu_comp
 
 
 # Configure and build cpu real SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA real for eos"
-mkdir -p build_cpu_SoA_real_eos
-cd build_cpu_SoA_real_eos
+mkdir -p build_eos_cpu_real_SoA
+cd build_eos_cpu_real_SoA
 cmake -DENABLE_SOA=1 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -sf ./build_cpu_SoA_real_eos/bin/qmcpack ./qmcpack_cpu_SoA_real_eos
+ln -sf ./build_eos_cpu_real_SoA/bin/qmcpack ./qmcpack_eos_cpu_real_SoA
 
 # Configure and build cpu complex SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA complex for eos"
-mkdir -p build_cpu_SoA_comp_eos
-cd build_cpu_SoA_comp_eos
+mkdir -p build_eos_cpu_comp_SoA
+cd build_eos_cpu_comp_SoA
 cmake -DQMC_COMPLEX=1 -DENABLE_SOA=1 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -sf ./build_cpu_SoA_comp_eos/bin/qmcpack ./qmcpack_cpu_SoA_comp_eos
+ln -sf ./build_eos_cpu_comp_SoA/bin/qmcpack ./qmcpack_eos_cpu_comp_SoA
 
 
 

--- a/config/build_olcf_eos.sh
+++ b/config/build_olcf_eos.sh
@@ -53,28 +53,54 @@ CMAKE_FLAGS="-DCMAKE_C_COMPILER=cc \
              -DCMAKE_CXX_COMPILER=CC"
 
 
-# Configure and build cpu real
+# Configure and build cpu real AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu real"
-mkdir build_eos_cpu_real
-cd build_eos_cpu_real
+echo "building qmcpack for cpu AoS real for eos"
+mkdir -p build_cpu_AoS_real_eos
+cd build_cpu_AoS_real_eos
 cmake $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -s ./build_eos_cpu_real/bin/qmcpack ./qmcpack_eos_cpu_real
+ln -sf ./build_cpu_AoS_real_eos/bin/qmcpack ./qmcpack_cpu_AoS_real_eos
 
 
-# Configure and build cpu complex
+# Configure and build cpu complex AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu complex"
-mkdir build_eos_cpu_comp
-cd build_eos_cpu_comp
+echo "building qmcpack for cpu AoS complex for eos"
+mkdir -p build_cpu_AoS_comp_eos
+cd build_cpu_AoS_comp_eos
 cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
-ln -s ./build_eos_cpu_comp/bin/qmcpack ./qmcpack_eos_cpu_comp
+ln -sf ./build_cpu_AoS_comp_eos/bin/qmcpack ./qmcpack_cpu_AoS_comp_eos
+
+
+# Configure and build cpu real SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA real for eos"
+mkdir -p build_cpu_SoA_real_eos
+cd build_cpu_SoA_real_eos
+cmake -DENABLE_SOA=1 $CMAKE_FLAGS .. 
+make -j 32
+cd ..
+ln -sf ./build_cpu_SoA_real_eos/bin/qmcpack ./qmcpack_cpu_SoA_real_eos
+
+# Configure and build cpu complex SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA complex for eos"
+mkdir -p build_cpu_SoA_comp_eos
+cd build_cpu_SoA_comp_eos
+cmake -DQMC_COMPLEX=1 -DENABLE_SOA=1 $CMAKE_FLAGS .. 
+make -j 32
+cd ..
+ln -sf ./build_cpu_SoA_comp_eos/bin/qmcpack ./qmcpack_cpu_SoA_comp_eos
+
+
+
 
 
 

--- a/config/build_olcf_eos.sh
+++ b/config/build_olcf_eos.sh
@@ -34,6 +34,7 @@ then
 module unload cray-libsci
 fi
 module load PrgEnv-intel
+module unload gcc
 module load gcc
 module load cray-hdf5-parallel
 module load fftw

--- a/config/build_olcf_titan.sh
+++ b/config/build_olcf_titan.sh
@@ -47,56 +47,88 @@ XT_FLAGS="-DHAVE_AMDLIBM=1"
 CMAKE_FLAGS="-D QMC_INCLUDE=/sw/xk7/amdlibm/include \
              -D QMC_EXTRA_LIBS=/sw/xk7/amdlibm/lib/static/libamdlibm.a"
 
-# Configure and build cpu real
+
+
+# Configure and build cpu real AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu real"
-mkdir build_cpu_real
-cd build_cpu_real
+echo "building qmcpack for cpu AoS real for titan"
+mkdir -p build_cpu_AoS_real_titan
+cd build_cpu_AoS_real_titan
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -s ./build_cpu_real/bin/qmcpack ./qmcpack_cpu_real
+ln -sf ./build_cpu_AoS_real_titan/bin/qmcpack ./qmcpack_cpu_AoS_real_titan
 
 
-# Configure and build cpu complex
+# Configure and build cpu complex AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu complex"
-mkdir build_cpu_comp
-cd build_cpu_comp
+echo "building qmcpack for cpu AoS complex for titan"
+mkdir -p build_cpu_AoS_comp_titan
+cd build_cpu_AoS_comp_titan
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       -D QMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -s ./build_cpu_comp/bin/qmcpack ./qmcpack_cpu_comp
+ln -sf ./build_cpu_AoS_comp_titan/bin/qmcpack ./qmcpack_cpu_AoS_comp_titan
+
+# Configure and build cpu real SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA real for titan"
+mkdir -p build_cpu_SoA_real_titan
+cd build_cpu_SoA_real_titan
+cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
+      -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
+      -D ENABLE_SOA=1 \
+      $CMAKE_FLAGS ..
+make -j 32
+cd ..
+ln -sf ./build_cpu_SoA_real_titan/bin/qmcpack ./qmcpack_cpu_SoA_real_titan
+
+
+# Configure and build cpu complex SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA complex for titan"
+mkdir -p build_cpu_SoA_comp_titan
+cd build_cpu_SoA_comp_titan
+cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
+      -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
+      -D ENABLE_SOA=1 \
+      -D QMC_COMPLEX=1 $CMAKE_FLAGS ..
+make -j 32
+cd ..
+ln -sf ./build_cpu_SoA_comp_titan/bin/qmcpack ./qmcpack_cpu_SoA_comp_titan
+
 
 # load cuda toolkit for gpu build
 module load cudatoolkit
 
-# Configure and build gpu real
+# Configure and build gpu real for titan
 echo ""
 echo ""
-echo "building qmcpack for gpu real"
-mkdir build_gpu_real
-cd build_gpu_real
+echo "building qmcpack for gpu real for titan"
+mkdir -p build_gpu_real_titan
+cd build_gpu_real_titan
 cmake -D QMC_CUDA=1 ..
 cmake -D QMC_CUDA=1 ..
 make -j 32
 cd ..
-ln -s ./build_gpu_real/bin/qmcpack ./qmcpack_gpu_real
+ln -sf ./build_gpu_real_titan/bin/qmcpack ./qmcpack_gpu_real_titan
 
 # Configure and build gpu complex
 echo ""
 echo ""
-echo "building qmcpack for gpu complex"
-mkdir build_gpu_comp
-cd build_gpu_comp
+echo "building qmcpack for gpu complex for titan"
+mkdir -p build_gpu_comp_titan
+cd build_gpu_comp_titan
 cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 make -j 32
 cd ..
-ln -s ./build_gpu_comp/bin/qmcpack ./qmcpack_gpu_comp
+ln -sf ./build_gpu_comp_titan/bin/qmcpack ./qmcpack_gpu_comp_titan

--- a/config/build_olcf_titan.sh
+++ b/config/build_olcf_titan.sh
@@ -5,10 +5,10 @@
 ##   on Titan, Oak Ridge National Lab.                        ##
 ##                                                            ##
 ## * Execute this script in trunk/                            ##
-##   ./config/build_titan.sh                                  ##
+##   ./config/build_olcf_titan.sh                             ##
 ##                                                            ##
 ## (c) Scientific Computing Group, NCCS, ORNL.                ##
-## Last modified: Sep 25, 2017                                ##
+## Last modified: Dec 7, 2017                                 ##
 ################################################################
 
 
@@ -53,57 +53,57 @@ CMAKE_FLAGS="-D QMC_INCLUDE=/sw/xk7/amdlibm/include \
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS real for titan"
-mkdir -p build_cpu_AoS_real_titan
-cd build_cpu_AoS_real_titan
+mkdir -p build_titan_cpu_real
+cd build_titan_cpu_real
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -sf ./build_cpu_AoS_real_titan/bin/qmcpack ./qmcpack_cpu_AoS_real_titan
+ln -sf ./build_titan_cpu_real/bin/qmcpack ./qmcpack_titan_cpu_real
 
 
 # Configure and build cpu complex AoS
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS complex for titan"
-mkdir -p build_cpu_AoS_comp_titan
-cd build_cpu_AoS_comp_titan
+mkdir -p build_titan_cpu_comp
+cd build_titan_cpu_comp
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       -D QMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -sf ./build_cpu_AoS_comp_titan/bin/qmcpack ./qmcpack_cpu_AoS_comp_titan
+ln -sf ./build_titan_cpu_comp/bin/qmcpack ./qmcpack_titan_cpu_comp
 
 # Configure and build cpu real SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA real for titan"
-mkdir -p build_cpu_SoA_real_titan
-cd build_cpu_SoA_real_titan
+mkdir -p build_titan_cpu_real_SoA
+cd build_titan_cpu_real_SoA
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       -D ENABLE_SOA=1 \
       $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -sf ./build_cpu_SoA_real_titan/bin/qmcpack ./qmcpack_cpu_SoA_real_titan
+ln -sf ./build_titan_cpu_real_SoA/bin/qmcpack ./qmcpack_titan_cpu_real_SoA
 
 
 # Configure and build cpu complex SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA complex for titan"
-mkdir -p build_cpu_SoA_comp_titan
-cd build_cpu_SoA_comp_titan
+mkdir -p build_titan_cpu_comp_SoA
+cd build_titan_cpu_comp_SoA
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
       -D ENABLE_SOA=1 \
       -D QMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32
 cd ..
-ln -sf ./build_cpu_SoA_comp_titan/bin/qmcpack ./qmcpack_cpu_SoA_comp_titan
+ln -sf ./build_titan_cpu_comp_SoA/bin/qmcpack ./qmcpack_titan_cpu_comp_SoA
 
 
 # load cuda toolkit for gpu build
@@ -113,22 +113,22 @@ module load cudatoolkit
 echo ""
 echo ""
 echo "building qmcpack for gpu real for titan"
-mkdir -p build_gpu_real_titan
-cd build_gpu_real_titan
+mkdir -p build_titan_gpu_real
+cd build_titan_gpu_real
 cmake -D QMC_CUDA=1 ..
 cmake -D QMC_CUDA=1 ..
 make -j 32
 cd ..
-ln -sf ./build_gpu_real_titan/bin/qmcpack ./qmcpack_gpu_real_titan
+ln -sf ./build_titan_gpu_real/bin/qmcpack ./qmcpack_titan_gpu_real
 
 # Configure and build gpu complex
 echo ""
 echo ""
 echo "building qmcpack for gpu complex for titan"
-mkdir -p build_gpu_comp_titan
-cd build_gpu_comp_titan
+mkdir -p build_titan_gpu_comp
+cd build_titan_gpu_comp
 cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 make -j 32
 cd ..
-ln -sf ./build_gpu_comp_titan/bin/qmcpack ./qmcpack_gpu_comp_titan
+ln -sf ./build_titan_gpu_comp/bin/qmcpack ./qmcpack_titan_gpu_comp

--- a/config/build_ornl_oic.sh
+++ b/config/build_ornl_oic.sh
@@ -7,7 +7,7 @@
 ## * Execute this script in trunk/                            ##
 ##   ./config/build_ornl_oic.sh                               ##
 ##                                                            ##
-## Last modified: Oct 6, 2017                                 ##
+## Last modified: Dec 7, 2017                                 ##
 ################################################################
 
 
@@ -29,46 +29,46 @@ CMAKE_FLAGS="-DCMAKE_C_COMPILER=mpicc \
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS real for oic5"
-mkdir -p build_cpu_AoS_real_oic
-cd build_cpu_AoS_real_oic
+mkdir -p build_oic_cpu_real
+cd build_oic_cpu_real
 cmake $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -sf ./build_cpu_AoS_real_oic/bin/qmcpack ./qmcpack_cpu_AoS_real_oic
+ln -sf ./build_oic_cpu_real/bin/qmcpack ./qmcpack_oic_cpu_real
 
 # Configure and build cpu complex AoS
 echo ""
 echo ""
 echo "building qmcpack for cpu AoS complex for oic5"
-mkdir -p build_cpu_AoS_comp_oic
-cd build_cpu_AoS_comp_oic
+mkdir -p build_oic_cpu_comp
+cd build_oic_cpu_comp
 cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -sf ./build_cpu_AoS_comp_oic/bin/qmcpack ./qmcpack_cpu_AoS_comp_oic
+ln -sf ./build_oic_cpu_comp/bin/qmcpack ./qmcpack_oic_cpu_comp
 
 
 # Configure and build cpu real SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA real for oic5"
-mkdir -p build_cpu_SoA_real_oic
-cd build_cpu_SoA_real_oic
+mkdir -p build_oic_cpu_real_SoA
+cd build_oic_cpu_real_SoA
 cmake -DENABLE_SOA=1 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -sf ./build_cpu_SoA_real_oic/bin/qmcpack ./qmcpack_cpu_SoA_real_oic
+ln -sf ./build_oic_cpu_real_SoA/bin/qmcpack ./qmcpack_oic_cpu_real_SoA
 
 # Configure and build cpu complex SoA
 echo ""
 echo ""
 echo "building qmcpack for cpu SoA complex for oic5"
-mkdir -p build_cpu_SoA_comp_oic
-cd build_cpu_SoA_comp_oic
+mkdir -p build_oic_cpu_comp_SoA
+cd build_oic_cpu_comp_SoA
 cmake -DQMC_COMPLEX=1 -DENABLE_SOA=1 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -sf ./build_cpu_SoA_comp_oic/bin/qmcpack ./qmcpack_cpu_SoA_comp_oic
+ln -sf ./build_oic_cpu_comp_SoA/bin/qmcpack ./qmcpack_oic_cpu_comp_SoA
 
 
 

--- a/config/build_ornl_oic.sh
+++ b/config/build_ornl_oic.sh
@@ -25,26 +25,51 @@ export LIBXML2_HOME=/home/j1k/share/oic5_gcc4/libxml2-2.7.6/build
 CMAKE_FLAGS="-DCMAKE_C_COMPILER=mpicc \ 
              -DCMAKE_CXX_COMPILER=mpicxx"
 
-# Configure and build cpu real
+# Configure and build cpu real AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu real"
-mkdir build_cpu_real
-cd build_cpu_real
+echo "building qmcpack for cpu AoS real for oic5"
+mkdir -p build_cpu_AoS_real_oic
+cd build_cpu_AoS_real_oic
 cmake $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -s ./build_cpu_real/bin/qmcpack ./qmcpack_cpu_real
+ln -sf ./build_cpu_AoS_real_oic/bin/qmcpack ./qmcpack_cpu_AoS_real_oic
 
-# Configure and build cpu complex
+# Configure and build cpu complex AoS
 echo ""
 echo ""
-echo "building qmcpack for cpu complex"
-mkdir build_cpu_comp
-cd build_cpu_comp
+echo "building qmcpack for cpu AoS complex for oic5"
+mkdir -p build_cpu_AoS_comp_oic
+cd build_cpu_AoS_comp_oic
 cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
-ln -s ./build_cpu_comp/bin/qmcpack ./qmcpack_cpu_comp
+ln -sf ./build_cpu_AoS_comp_oic/bin/qmcpack ./qmcpack_cpu_AoS_comp_oic
+
+
+# Configure and build cpu real SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA real for oic5"
+mkdir -p build_cpu_SoA_real_oic
+cd build_cpu_SoA_real_oic
+cmake -DENABLE_SOA=1 $CMAKE_FLAGS ..
+make -j 32 
+cd ..
+ln -sf ./build_cpu_SoA_real_oic/bin/qmcpack ./qmcpack_cpu_SoA_real_oic
+
+# Configure and build cpu complex SoA
+echo ""
+echo ""
+echo "building qmcpack for cpu SoA complex for oic5"
+mkdir -p build_cpu_SoA_comp_oic
+cd build_cpu_SoA_comp_oic
+cmake -DQMC_COMPLEX=1 -DENABLE_SOA=1 $CMAKE_FLAGS ..
+make -j 32 
+cd ..
+ln -sf ./build_cpu_SoA_comp_oic/bin/qmcpack ./qmcpack_cpu_SoA_comp_oic
+
+
 
 


### PR DESCRIPTION
The build scripts for titan, eos, and oic5 have been updated in the config folder. On titan the script compiles real and complex codes for AoS, SoA and GPU. On eos and oic5 the scripts compile real and complex codes for AoS and SoA.