### PR TITLE
type_trait guards for accumulator_set/iszero()

### DIFF
--- a/src/Estimators/accumulators.h
+++ b/src/Estimators/accumulators.h
@@ -32,7 +32,8 @@
  *
  * To simplify i/o, the values are storged in contens
  */
-template<typename T, typename = std::enable_if<std::is_floating_point<T>::value>>
+template<typename T,
+  typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
 struct accumulator_set
 {
   typedef T value_type;

--- a/src/Estimators/accumulators.h
+++ b/src/Estimators/accumulators.h
@@ -10,8 +10,8 @@
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 
 
 
@@ -26,12 +26,13 @@
 
 #include <config/stdlib/limits.h>
 #include <iostream>
+#include <type_traits>
 
 /** generic accumulator of a scalar type
  *
  * To simplify i/o, the values are storged in contens
  */
-template<typename T>
+template<typename T, typename = std::enable_if<std::is_floating_point<T>::value>>
 struct accumulator_set
 {
   typedef T value_type;

--- a/src/Estimators/tests/test_accumulator.cpp
+++ b/src/Estimators/tests/test_accumulator.cpp
@@ -23,38 +23,6 @@
 namespace qmcplusplus
 {
 
-TEST_CASE("accumulator basic int", "[estimators]")
-{
-  //std::cout << "int eps = " << std::numeric_limits<int>::epsilon() << std::endl;
-  //std::cout << "int max = " << std::numeric_limits<int>::max() << std::endl;
-  accumulator_set<int> a1;
-  REQUIRE(a1.count() == 0);
-  REQUIRE(a1.good() == false);
-  REQUIRE(a1.mean() == 0);
-  REQUIRE(a1.mean2() == 0);
-  REQUIRE(a1.variance() == 0);
-  // doesn't work becase epsilon for int is zero
-  //CHECK(a1.bad() == true);
-
-  a1(2);
-  REQUIRE(a1.count() == 1);
-  REQUIRE(a1.good() == true);
-  REQUIRE(a1.result() == 2);
-  REQUIRE(a1.result2() == 4);
-  REQUIRE(a1.mean() == 2);
-  REQUIRE(a1.mean2() == 4);
-  REQUIRE(a1.variance() == 0);
-
-  std::pair<int, int> mv = a1.mean_and_variance();
-  REQUIRE(mv.first == a1.mean());
-  REQUIRE(mv.second == a1.variance());
-
-  a1.clear();
-  REQUIRE(a1.count() == 0);
-  REQUIRE(a1.result() == 0);
-  REQUIRE(a1.result2() == 0);
-}
-
 template<typename T>
 void test_real_accumulator_basic()
 {

--- a/src/config/stdlib/limits.h
+++ b/src/config/stdlib/limits.h
@@ -4,18 +4,19 @@
 //
 // Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
 //
-// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign   
+// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //
-// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign 
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
 
 #ifndef QMCPLUSPLUS_LIMITS_H
 #define QMCPLUSPLUS_LIMITS_H
 #include <limits>
+#include <type_traits>
 
 #ifndef HAVE_ISZERO
-template<typename T>
+template<typename T, typename = std::enable_if<std::is_floating_point<T>::value>>
 inline bool iszero(T a)
 {
   return (std::abs(a)<std::numeric_limits<T>::epsilon());

--- a/src/config/stdlib/limits.h
+++ b/src/config/stdlib/limits.h
@@ -16,7 +16,8 @@
 #include <type_traits>
 
 #ifndef HAVE_ISZERO
-template<typename T, typename = std::enable_if<std::is_floating_point<T>::value>>
+template<typename T,
+  typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
 inline bool iszero(T a)
 {
   return (std::abs(a)<std::numeric_limits<T>::epsilon());


### PR DESCRIPTION
This is an incomplete PR to address issue #540 that I need another pair of eyes on. The type_trait guards here should cause a build error when src/Estimators/tests/test_accumulator.cpp:30 is encountered, but everything still seems to build fine for me (except that this integer test still fails). 

Once I see the `accumulator_set<int> a1;` cause a failure, then I'll follow up with another commit to completely remove that test.

The following minimum example properly doesn't compile, so I can't tell what I'm doing wrong in this patch. Probably something silly.

```
#include <type_traits>  
                                                                                  
template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
struct A {       
  void afoo(T t)  {   std::cout << "in afoo()" << '\n';  }
};

int main() {         
   int i; 
   double d;     
   A<int> a;   
   a.afoo(i);  
}  
```