### PR TITLE
Check clang version for undefined-var-template.

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -23,7 +23,10 @@ SET( HAVE_POSIX_MEMALIGN 0 )    # Clang doesn't support -malign-double
 
 # Suppress compile warnings
 SET(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -Wno-deprecated -Wno-unused-value")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-unused-value -Wno-undefined-var-template")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-unused-value")
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8 )
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
+ENDIF()
 
 # Set extra optimization specific flags
 SET( CMAKE_C_FLAGS_RELEASE     "${CMAKE_C_FLAGS_RELEASE} -ffast-math" )


### PR DESCRIPTION
The -Wno-undefined-var-template option was added in clang 3.9.
Add a version check so this flag is not added for older versions of clang.

Clang 3.8 and earlier issue a warning about the flag which then causes the C++ 11 check to fail.