### PR TITLE
Sent output of ReportEngine to debug stream

### DIFF
--- a/src/Utilities/ProgressReportEngine.cpp
+++ b/src/Utilities/ProgressReportEngine.cpp
@@ -24,16 +24,16 @@ void ReportEngine::echo(xmlNodePtr cur, bool recursive)
 {
   if(cur==NULL)
     return;
-  app_log()<< "<input node=\""<<(const char*)(cur->name) << "\"";
+  app_debug()<< "<input node=\""<<(const char*)(cur->name) << "\"";
   xmlAttrPtr att = cur->properties;
   char atext[1024];
   while(att != NULL)
   {
     sprintf(atext,"  %s=\"%s\"",(const char*)(att->name),(const char*)(att->children->content));
-    app_log() << atext;
+    app_debug() << atext;
     att = att->next;
   }
-  app_log() << "/>\n";
+  app_debug() << "/>\n";
 }
 
 bool ReportEngine::DoOutput = false;

--- a/src/Utilities/ProgressReportEngine.h
+++ b/src/Utilities/ProgressReportEngine.h
@@ -37,7 +37,7 @@ class ReportEngine
 public:
 
   inline ReportEngine(const std::string& cname, const std::string& fname, int atype=1):
-    ReportType(atype),ClassName(cname), LogBuffer(infoLog), FuncName(fname)
+    ReportType(atype),ClassName(cname), LogBuffer(infoDebug), FuncName(fname)
   {
     if (DoOutput) {
       LogBuffer << "  " << ClassName << "::" << FuncName << "\n";
@@ -75,7 +75,7 @@ public:
 
   inline void error(const std::string& msg, bool fatal=false)
   {
-    LogBuffer << ("ERROR: "+msg+"\n");
+    app_error() << ("ERROR: "+msg+"\n");
     if(fatal)
       APP_ABORT(ClassName+"::"+FuncName);
   }
@@ -103,7 +103,7 @@ private:
    */
   InfoStream& LogBuffer;
   //disable copy constructor
-  ReportEngine(const ReportEngine& a):LogBuffer(infoLog) {}
+  ReportEngine(const ReportEngine& a):LogBuffer(infoDebug) {}
 
   static bool DoOutput;
 
@@ -114,7 +114,7 @@ template<class T>
 inline
 ReportEngine& operator<<(ReportEngine& o, const T& val)
 {
-  app_log()<< val;
+  app_debug() << val;
   return o;
 }
 }


### PR DESCRIPTION
Except for any error output, the default output stream for the ReportEngine is now the debug stream.

Partially addresses #35