### PR TITLE
Describe random number initialization in manual

### DIFF
--- a/manual/input_overview.tex
+++ b/manual/input_overview.tex
@@ -90,3 +90,31 @@ The overall structure of the input file reflects different aspects of the QMC si
 \end{shade}
 The omitted portions (\texttt{...}) are more fine-grained inputs such as the axes of the simulation cell, the number of up and down electrons, positions of atomic species, external orbital files, starting Jastrow parameters, and external pseudopotential files.  
 
+
+\section{Project}
+The \texttt{<project>} tag uses the \texttt{id} and \texttt{series} attributes.
+The value of \texttt{id} is the first part of the prefix for output file names.
+
+Output file names also contain the series number, starting at the value given by the
+\texttt{series} tag.  After every \texttt{<qmc>} section the series value will increment, giving each section a unique prefix.
+
+For the input file shown previously, the output files will start with \texttt{vmc.s000}, for example \texttt{vmc.s000.scalar.dat}.
+If there were another \texttt{<qmc>} section in the input file, the corresponding output files would use the prefix \texttt{vmc.s001}.
+
+
+
+\section{Random number initialization}
+
+The random number generator state is initialized from the \texttt{random} element using the \texttt{seed} attribute.
+\begin{shade}
+<random seed="1000"/>
+\end{shade}
+
+If the random element is not present, or the seed value is negative, the seed will be generated from the current time.
+
+In order to initialize the many independent random number generators (one per thread and MPI process), the seed value is used (modulo 1024) as a starting index into a list of prime numbers.
+Entries in this offset list of prime numbers are then used as the seed for the random generator on each thread and process.
+
+If checkpointing is enabled, the random number state is written to an HDF file at the end of each block (suffix: \texttt{.random.h5}).
+This file will be read if the \texttt{mcwalkerset} tag is present to perform a restart.
+For more information, see the \texttt{checkpoint} element in the QMC methods chapter (\ref{chap:qmcmethods}) and the section on checkpoint and restart files in \ref{sec:checkpoint_files}.

--- a/manual/output_overview.tex
+++ b/manual/output_overview.tex
@@ -62,12 +62,14 @@ be helpful in constructing trial wavefunctions.
 
 
 \section{Checkpoint and restart files}
+\label{sec:checkpoint_files}
 \subsection{The .cont.xml file}
 This file enables continuation of the run.  It is mostly a copy of the input XML file with the series number incremented, and the \texttt{mcwalkerset} element added to read the walkers from a config file.   The \texttt{.cont.xml} file is always created, but other files it depends on are only present if checkpointing is enabled.
 
 \subsection{The .config.h5 file}
 This file contains stored walker configurations.
 
-\subsection{The .random.xml file}
+\subsection{The .random.h5 file}
 This file contains the state of the random number generator to allow restarts.
+(Older versions used an XML file with a suffix of \texttt{.random.xml}).
 


### PR DESCRIPTION
Describe id and series attributes on the project tag.
Describe RNG intialization and the random tag.
This descriptions were put in the Input Overview chapter.  They don't quite seem to belong there, but they don't seem large enough to warrant a separate chapter.

Update description of checkpoint files from XML to HDF.