### PR TITLE
fix bug in GNU __builtin_assume_alinged() usage

### DIFF
--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -206,11 +206,11 @@
     #if defined(__AVX512F__)
       #define QMC_CLINE 64
       #define QMC_ALIGNAS alignas(64)
-      #define ASSUME_ALIGNED(x) __builtin_assume_aligned(x,64)
+      #define ASSUME_ALIGNED(x) (x) = (__typeof__(x)) __builtin_assume_aligned(x,64)
     #else
       #define QMC_CLINE 32
       #define QMC_ALIGNAS alignas(32)
-      #define ASSUME_ALIGNED(x) __builtin_assume_aligned(x,32)
+      #define ASSUME_ALIGNED(x) (x) = (__typeof__(x)) __builtin_assume_aligned(x,32)
     #endif
   #else
    #define QMC_CLINE 32


### PR DESCRIPTION
I believe that the way GNU's __builtin_assume_aligned() is being called is incorrect, and not having the intended effect (equivalent to the Intel version).

This should be the fix.

C.f. https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html