### PR TITLE
Fix orbital rotation failure due to PooledMemory.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
@@ -518,17 +518,9 @@ void SlaterDetOpt::restore(int iat)
 /// \return  the log of the determinant value
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-OrbitalBase::RealType SlaterDetOpt::registerData(ParticleSet& P, BufferType& buf) {
+void SlaterDetOpt::registerData(ParticleSet& P, WFBufferType& buf) {
 
-  // first time
-  if(NP == 0) {
-    NP=P.getTotalNum();
-  }
-
-  //app_log() << " EWN ENTERING SlaterDetOpt::registerData(ParticleSet& P, BufferType& buf)" << std::endl;
-
-  // evaluate the orbital matrix, its inverse, and the log of the determinant value
-  LogValue = evaluateLog(P,P.G,P.L);
+  //app_log() << " EWN ENTERING SlaterDetOpt::registerData(ParticleSet& P, WFBufferType& buf)" << std::endl;
 
   // add the log of the wave function to the buffer
   buf.add(LogValue);
@@ -548,9 +540,6 @@ OrbitalBase::RealType SlaterDetOpt::registerData(ParticleSet& P, BufferType& buf
   // add inverse matrix to the buffer
   buf.add(m_orb_inv_mat.first_address(),m_orb_inv_mat.last_address());
 
-  // return log of determinant value
-  return LogValue;
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -564,10 +553,10 @@ OrbitalBase::RealType SlaterDetOpt::registerData(ParticleSet& P, BufferType& buf
 /// \return  the log of the determinant value
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-OrbitalBase::RealType SlaterDetOpt::updateBuffer(ParticleSet& P, BufferType& buf, bool fromscratch) {
+OrbitalBase::RealType SlaterDetOpt::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch) {
 
   // BEGIN EWN DEBUG 
-  //app_log() << " EWN ENTERING SlaterDetOpt::updateBuffer(ParticleSet& P, BufferType& buf, bool fromscratch)" << std::endl;
+  //app_log() << " EWN ENTERING SlaterDetOpt::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch)" << std::endl;
   //app_log() << "printing P.R" << std::endl;
   //for (int i = 0; i < P.R.size(); i++)
   //  app_log() << P.R[i] << std::endl;
@@ -608,7 +597,7 @@ OrbitalBase::RealType SlaterDetOpt::updateBuffer(ParticleSet& P, BufferType& buf
 /// \param[in]      buf            the buffer to read from
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-void SlaterDetOpt::copyFromBuffer(ParticleSet& P, BufferType& buf) {
+void SlaterDetOpt::copyFromBuffer(ParticleSet& P, WFBufferType& buf) {
 
   // read in the log of the wave function
   buf.get(LogValue);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
@@ -515,8 +515,6 @@ void SlaterDetOpt::restore(int iat)
 /// \param[in]      P              the particle set
 /// \param[in]      buf            the buffer to add essential data to
 ///
-/// \return  the log of the determinant value
-///
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void SlaterDetOpt::registerData(ParticleSet& P, WFBufferType& buf) {
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetOpt.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetOpt.h
@@ -181,11 +181,11 @@ class SlaterDetOpt : public DiracDeterminantBase {
 
     void restore(int iat);
 
-    RealType registerData(ParticleSet& P, BufferType& buf);
+    void registerData(ParticleSet& P, WFBufferType& buf);
 
-    RealType updateBuffer(ParticleSet& P, BufferType& buf, bool fromscratch=false);
+    RealType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch=false);
 
-    void copyFromBuffer(ParticleSet& P, BufferType& buf);
+    void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
     OrbitalBasePtr makeClone(ParticleSet& tqp) const;
 


### PR DESCRIPTION
These files probably got merged after I did PooledMemory on my local branch.
Due to the existence of base class functions. Compilers didn't compilain.
So orbital optimization is broken by #521 

This PR basically corrects the call API and then the orbital rotation is correct
```
    Start 166: short-H2-orb-opt-16-1
1/8 Test #166: short-H2-orb-opt-16-1 .................   Passed   29.71 sec
    Start 167: short-H2-orb-opt-16-1-totenergy
2/8 Test #167: short-H2-orb-opt-16-1-totenergy .......   Passed    0.03 sec
    Start 176: short-H4-orb-opt-16-1
3/8 Test #176: short-H4-orb-opt-16-1 .................   Passed   44.46 sec
    Start 177: short-H4-orb-opt-16-1-totenergy
4/8 Test #177: short-H4-orb-opt-16-1-totenergy .......***Failed    0.02 sec
    Start 178: short-H4-orb-opt-dmc-16-1
5/8 Test #178: short-H4-orb-opt-dmc-16-1 .............   Passed   12.75 sec
    Start 179: short-H4-orb-opt-dmc-16-1-totenergy
6/8 Test #179: short-H4-orb-opt-dmc-16-1-totenergy ...   Passed    0.02 sec
    Start 180: short-H4-orb-opt-dmc-1-16
```
I looked at the failing test short-H4-orb-opt-16-1 and found I can always get lower energy and smaller variance than the reference.
The VMC energy values from the blocks of old runs are much rougher than the runs with this PR.
So I suspect the old code has bugs and my change in #521 resolved it. In #521, the number of walkers are no more changed for optimization.

old code,
```
                            LocalEnergy               Variance           ratio 
H4  series 0  -1.878953 +/- 0.011142   1.901250 +/- 0.097690   1.0119 
H4  series 1  -1.911932 +/- 0.007357   1.993707 +/- 0.144689   1.0428 
H4  series 2  -1.920844 +/- 0.007394   1.988797 +/- 0.160920   1.0354 
H4  series 3  -1.914845 +/- 0.008156   1.679913 +/- 0.080448   0.8773 
H4  series 4  -1.935523 +/- 0.008059   2.123378 +/- 0.285926   1.0971 
H4  series 5  -1.933602 +/- 0.007787   1.735335 +/- 0.087577   0.8975 
H4  series 6  -1.920723 +/- 0.007195   1.844092 +/- 0.117417   0.9601 
H4  series 7  -1.921232 +/- 0.006974   1.687022 +/- 0.083873   0.8781 
H4  series 8  -1.932006 +/- 0.009514   3.673455 +/- 1.896421   1.9014 
H4  series 9  -1.931684 +/- 0.009279   1.887416 +/- 0.125114   0.9771 
H4  series 10  -1.920565 +/- 0.006674   1.913709 +/- 0.143558   0.9964 
H4  series 11  -1.937992 +/- 0.008596   2.191071 +/- 0.248094   1.1306 
H4  series 12  -1.915492 +/- 0.007344   1.836780 +/- 0.102961   0.9589 
H4  series 13  -1.916859 +/- 0.007029   2.115110 +/- 0.355523   1.1034 
H4  series 14  -1.930457 +/- 0.008379   1.671653 +/- 0.074121   0.8659 
```
With this PR
```
                            LocalEnergy               Variance           ratio 
H4  series 0  -1.877549 +/- 0.010447   1.926161 +/- 0.103480   1.0259 
H4  series 1  -1.916666 +/- 0.007186   1.925708 +/- 0.118560   1.0047 
H4  series 2  -1.982625 +/- 0.006460   1.763802 +/- 0.123496   0.8896 
H4  series 3  -1.965280 +/- 0.006907   1.618226 +/- 0.107375   0.8234 
H4  series 4  -1.979522 +/- 0.006156   1.786859 +/- 0.239391   0.9027 
H4  series 5  -1.992730 +/- 0.005928   1.734273 +/- 0.129458   0.8703 
H4  series 6  -1.975706 +/- 0.005280   1.567572 +/- 0.126214   0.7934 
H4  series 7  -1.955307 +/- 0.006252   2.069681 +/- 0.233157   1.0585 
H4  series 8  -2.002935 +/- 0.006780   1.799338 +/- 0.115482   0.8984 
H4  series 9  -1.992542 +/- 0.006531   1.553901 +/- 0.098577   0.7799 
H4  series 10  -1.999157 +/- 0.006687   1.608220 +/- 0.085278   0.8044 
H4  series 11  -1.973196 +/- 0.006228   1.643452 +/- 0.117170   0.8329 
H4  series 12  -1.975057 +/- 0.005177   1.472569 +/- 0.092137   0.7456 
H4  series 13  -1.993094 +/- 0.006185   1.651431 +/- 0.131508   0.8286 
H4  series 14  -1.978983 +/- 0.006184   1.598784 +/- 0.115646   0.8079 
```

The FDLR WF part
```
    Start 168: short-H2-FDLR-16-1
1/4 Test #168: short-H2-FDLR-16-1 ...............   Passed   23.38 sec
    Start 169: short-H2-FDLR-16-1-totenergy
2/4 Test #169: short-H2-FDLR-16-1-totenergy .....   Passed    0.02 sec
    Start 182: short-H4-FDLR-16-1
3/4 Test #182: short-H4-FDLR-16-1 ...............   Passed   50.59 sec
    Start 183: short-H4-FDLR-16-1-totenergy
4/4 Test #183: short-H4-FDLR-16-1-totenergy .....***Failed    0.02 sec
```
There may be still bugs but I no more get crazy numbers.

This PR is related to #602 but only intended to fix the bug in orbital rotation.
Please do not wait #602 but merge this PR.