### PR TITLE
Fix J3 AoS when Nthread<Nwalker.

### DIFF
--- a/src/Particle/AsymmetricDistanceTableData.h
+++ b/src/Particle/AsymmetricDistanceTableData.h
@@ -184,6 +184,7 @@ struct AsymmetricDTD
 
   inline void evaluate(ParticleSet& P, int jat)
   {
+    APP_ABORT("  No need to call AsymmetricDTD::evaluate(ParticleSet& P, int jat)");
     //based on full evaluation. Only compute it if jat==0
     if(jat==0) evaluate(P);
   }

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -504,8 +504,9 @@ ParticleSet::makeMove(Index_t iat, const SingleParticlePos_t& displ)
 void ParticleSet::setActive(int iat)
 {
   myTimers[3]->start();
-  for (size_t i=0,n=DistTables.size(); i< n; i++)
-    DistTables[i]->evaluate(*this,iat);
+  for (size_t i=0; i<DistTables.size(); i++)
+    if(DistTables[i]->DTType==DT_SOA)
+      DistTables[i]->evaluate(*this,iat);
   myTimers[3]->stop();
 }
 
@@ -809,7 +810,8 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
   {
     // in certain cases, full tables must be ready
     for (int i=0; i< DistTables.size(); i++)
-      if(DistTables[i]->Need_full_table_loadWalker) DistTables[i]->evaluate(*this);
+      if(DistTables[i]->DTType==DT_AOS||DistTables[i]->Need_full_table_loadWalker)
+        DistTables[i]->evaluate(*this);
     //computed so that other objects can use them, e.g., kSpaceJastrow
     if(SK && SK->DoUpdate)
       SK->UpdateAllPart(*this);

--- a/src/Particle/SymmetricDistanceTableData.h
+++ b/src/Particle/SymmetricDistanceTableData.h
@@ -137,6 +137,7 @@ struct SymmetricDTD
 
   inline void evaluate(ParticleSet& P, int jat)
   {
+    APP_ABORT("  No need to call SymmetricDTD::evaluate(ParticleSet& P, int jat)");
     //based on full evaluation. Only compute it if jat==0
     if(jat==0) evaluate(P);
   }


### PR DESCRIPTION
AoS distance tables must be computed when a walker is loaded (pre-v3.2 behaviour).
With this change, setActive does nothing for AoS.
This change also saves some computing when nsubsteps>1 with AoS.

