### PR TITLE
Opt momentum estimator

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -80,7 +80,6 @@ struct TempDisplacement
   T rinv1;
   ///new displacement
   TinyVector<T,N> dr1;
-  TinyVector<T,N> dr1_nobox;
   inline TempDisplacement():r1(0.0),rinv1(0.0) {}
   inline void reset()
   {

--- a/src/Particle/SymmetricDistanceTableData.h
+++ b/src/Particle/SymmetricDistanceTableData.h
@@ -147,7 +147,6 @@ struct SymmetricDTD
     for(int iat=0; iat<N[SourceIndex]; ++iat)
     {
       PosType drij(rnew - P.R[iat]);
-      Temp[iat].dr1_nobox=drij;
       RealType sep=std::sqrt(DTD_BConds<T,D,SC>::apply_bc(drij));
       Temp[iat].r1=sep;
       Temp[iat].rinv1=1.0/sep;

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -77,10 +77,8 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
       RealType *restrict nofK_here=nofK.data();
       #pragma omp simd aligned(nofK_here,phases_c,phases_s,phases_vPos_c,phases_vPos_s)
       for (int ik=0; ik<nk; ++ik)
-        nofK[ik] += phases_c[ik]*phases_vPos_c[ik]*ratio_c
-                  - phases_s[ik]*phases_vPos_c[ik]*ratio_s
-                  - phases_c[ik]*phases_vPos_s[ik]*ratio_s
-                  - phases_s[ik]*phases_vPos_s[ik]*ratio_c;
+        nofK_here[ik] += ( phases_c[ik]*phases_vPos_c[ik] - phases_s[ik]*phases_vPos_s[ik] ) * ratio_c
+                       - ( phases_s[ik]*phases_vPos_c[ik] + phases_c[ik]*phases_vPos_s[ik] ) * ratio_s ;
     }
   }
 

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -53,6 +53,10 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
     refPsi.evaluateRatiosAlltoOne(P,psi_ratios);
     for (int i=0; i<np; ++i)
       psi_ratios_all[s][i] = psi_ratios[i];
+
+    for (int ik=0; ik<nk; ++ik)
+       kdotp[ik] = -dot(kPoints[ik], vPos[s]);
+    eval_e2iphi(nk, kdotp.data(), phases_vPos[s]);
   }
 
   nofK=0.0;
@@ -62,14 +66,8 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
       kdotp[ik] = dot(kPoints[ik], P.R[i]);
     eval_e2iphi(nk, kdotp.data(), phases.data());
     for (int s=0; s<M; ++s)
-    {
       for (int ik=0; ik<nk; ++ik)
-         kdotp[ik] = -dot(kPoints[ik], vPos[s]);
-      eval_e2iphi(nk, kdotp.data(), phases_activePos.data());
-
-      for (int ik=0; ik<nk; ++ik)
-        nofK[ik]+=std::real(phases[ik]*phases_activePos[ik]*psi_ratios_all[s][i]);
-    }
+        nofK[ik]+=std::real(phases[ik]*phases_vPos[s][ik]*psi_ratios_all[s][i]);
   }
 
   compQ=0.0;
@@ -312,7 +310,7 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   kdotp.resize(kPoints.size());
   vPos.resize(M);
   phases.resize(kPoints.size());
-  phases_activePos.resize(kPoints.size());
+  phases_vPos.resize(M,kPoints.size());
   psi_ratios_all.resize(M,psi_ratios.size());
   norm_nofK=1.0/RealType(M);
   return true;
@@ -346,7 +344,6 @@ void MomentumEstimator::resize(const std::vector<PosType>& kin, const std::vecto
   nofK.resize(kin.size());
   kdotp.resize(kPoints.size());
   phases.resize(kPoints.size());
-  phases_activePos.resize(kPoints.size());
   //copy q
   Q=qin;
   compQ.resize(qin.size());
@@ -354,6 +351,7 @@ void MomentumEstimator::resize(const std::vector<PosType>& kin, const std::vecto
   M=Min;
   vPos.resize(M);
   psi_ratios_all.resize(M,psi_ratios.size());
+  phases_vPos.resize(M,kPoints.size());
 }
 
 void MomentumEstimator::setRandomGenerator(RandomGenerator_t* rng)

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -313,7 +313,7 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   vPos.resize(M);
   phases.resize(kPoints.size());
   phases_activePos.resize(kPoints.size());
-  psi_ratios_all.resize(M,elns.getTotalNum());
+  psi_ratios_all.resize(M,psi_ratios.size());
   norm_nofK=1.0/RealType(M);
   return true;
 }
@@ -327,7 +327,7 @@ QMCHamiltonianBase* MomentumEstimator::makeClone(ParticleSet& qp
     , TrialWaveFunction& psi)
 {
   MomentumEstimator* myclone=new MomentumEstimator(qp,psi);
-  myclone->resize(kPoints,Q);
+  myclone->resize(kPoints,Q,M);
   myclone->myIndex=myIndex;
   myclone->kgrid=kgrid;
   myclone->norm_nofK=norm_nofK;
@@ -336,18 +336,24 @@ QMCHamiltonianBase* MomentumEstimator::makeClone(ParticleSet& qp
     myclone->mappedQtonofK[i]=mappedQtonofK[i];
   myclone->hdf5_out=hdf5_out;
   myclone->mappedQnorms=mappedQnorms;
-  myclone->M=M;
   return myclone;
 }
 
-void MomentumEstimator::resize(const std::vector<PosType>& kin, const std::vector<RealType>& qin)
+void MomentumEstimator::resize(const std::vector<PosType>& kin, const std::vector<RealType>& qin, const int Min)
 {
   //copy kpoints
   kPoints=kin;
   nofK.resize(kin.size());
+  kdotp.resize(kPoints.size());
+  phases.resize(kPoints.size());
+  phases_activePos.resize(kPoints.size());
   //copy q
   Q=qin;
   compQ.resize(qin.size());
+  //M
+  M=Min;
+  vPos.resize(M);
+  psi_ratios_all.resize(M,psi_ratios.size());
 }
 
 void MomentumEstimator::setRandomGenerator(RandomGenerator_t* rng)

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -59,12 +59,16 @@ public:
   ParticleSet::ParticleLayout_t Lattice;
   ///random generator
   RandomGenerator_t myRNG;
+  ///sample positions
+  std::vector<PosType> vPos;
   ///wavefunction ratios
   std::vector<ValueType> psi_ratios;
+  ///wavefunction ratios all samples
+  Matrix<ValueType> psi_ratios_all;
   ///nofK internal
   Vector<RealType> kdotp;
   ///phases
-  Vector<ComplexType> phases;
+  Vector<ComplexType> phases, phases_activePos;
   ///list of k-points in Cartesian Coordinates
   std::vector<PosType> kPoints;
   ///weight of k-points (make use of symmetry)

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -68,9 +68,9 @@ public:
   ///nofK internal
   Vector<RealType> kdotp;
   ///phases
-  Vector<ComplexType> phases;
+  VectorSoaContainer<RealType,2> phases;
   ///phases of vPos
-  Matrix<ComplexType> phases_vPos;
+  std::vector<VectorSoaContainer<RealType,2> > phases_vPos;
   ///list of k-points in Cartesian Coordinates
   std::vector<PosType> kPoints;
   ///weight of k-points (make use of symmetry)
@@ -78,7 +78,7 @@ public:
   ///dims of a grid for k points
   int kgrid;
   ///nofK
-  Vector<RealType> nofK;
+  aligned_vector<RealType> nofK;
   ///list of Q for the Compton profile
   std::vector<RealType> Q;
   ///compton profile at q

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -68,7 +68,9 @@ public:
   ///nofK internal
   Vector<RealType> kdotp;
   ///phases
-  Vector<ComplexType> phases, phases_activePos;
+  Vector<ComplexType> phases;
+  ///phases of vPos
+  Matrix<ComplexType> phases_vPos;
   ///list of k-points in Cartesian Coordinates
   std::vector<PosType> kPoints;
   ///weight of k-points (make use of symmetry)

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -46,7 +46,7 @@ public:
   QMCHamiltonianBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
   void setRandomGenerator(RandomGenerator_t* rng);
   //resize the internal data by input k-point list
-  void resize(const std::vector<PosType>& kin,const std::vector<RealType>& qin);
+  void resize(const std::vector<PosType>& kin,const std::vector<RealType>& qin, const int Min);
   ///number of samples
   int M;
   ///normalization factor for n(k)

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -141,7 +141,7 @@ struct  J1OrbitalSoA : public OrbitalBase
     {
       for(int jg=0; jg<NumGroups; ++jg)
       {
-        if(F[jg]!=nullptr) 
+        if(F[jg]!=nullptr)
           curAt += F[jg]->evaluateV(-1, Ions.first(jg), Ions.last(jg), dist, DistCompressed.data());
       }
     }
@@ -162,6 +162,31 @@ struct  J1OrbitalSoA : public OrbitalBase
     }
 
     return std::exp(Vat[iat]-curAt);
+  }
+
+  void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
+  {
+    const valT* restrict dist=P.DistTables[myTableID]->Temp_r.data();
+    curAt = valT(0);
+    if(NumGroups>0)
+    {
+      for(int jg=0; jg<NumGroups; ++jg)
+      {
+        if(F[jg]!=nullptr)
+          curAt += F[jg]->evaluateV(-1, Ions.first(jg), Ions.last(jg), dist, DistCompressed.data());
+      }
+    }
+    else
+    {
+      for(int c=0; c<Nions; ++c)
+      {
+        int gid=Ions.GroupID[c];
+        if(F[gid]!=nullptr) curAt += F[gid]->evaluate(dist[c]);
+      }
+    }
+
+    for(int i=0; i<Nelec; ++i)
+      ratios[i]=std::exp(Vat[i]-curAt);
   }
 
   inline void evaluateGL(ParticleSet& P,

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
@@ -256,8 +256,6 @@ public:
     }
   } 
   
-//  ValueType evaluate(ParticleSet& P, ParticleSet::
-
   /** evaluate the ratio \f$exp(U(iat)-U_0(iat))\f$
    * @param P active particle set
    * @param iat particle that has been moved.

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -810,11 +810,13 @@ void TrialWaveFunction::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value
 {
   std::fill(ratios.begin(),ratios.end(),1.0);
   std::vector<ValueType> t(ratios.size());
-  for (int i=0; i<Z.size(); ++i)
+  for (int i=0, ii=V_TIMER; i<Z.size(); ++i,ii+=TIMER_SKIP)
   {
+    myTimers[ii]->start();
     Z[i]->evaluateRatiosAlltoOne(P,t);
     for (int j=0; j<t.size(); ++j)
       ratios[j]*=t[j];
+    myTimers[ii]->stop();
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -330,6 +330,8 @@ const char *particles = \
   J1Type *j1 = dynamic_cast<J1Type *>(orb);
   REQUIRE(j1 != NULL);
 
+  double logpsi = psi.evaluateLog(elec_);
+  REQUIRE(logpsi == Approx(0.3160552244)); // note: number not validated
 
   struct JValues
   {
@@ -406,6 +408,29 @@ const char *particles = \
   }
 #endif
 
+  typedef QMCTraits::ValueType ValueType;
+  typedef QMCTraits::PosType PosType;
+
+  // set virtutal particle position
+  PosType newpos(0.3,0.2,0.5);
+
+  elec_.makeVirtualMoves(newpos);
+  std::vector<ValueType> ratios(elec_.getTotalNum());
+  j1->evaluateRatiosAlltoOne(elec_,ratios);
+
+  REQUIRE(ratios[0] == ComplexApprox(0.9819208747).compare_real_only());
+  REQUIRE(ratios[1] == ComplexApprox(1.0040884258).compare_real_only());
+
+  elec_.makeMove(0, newpos-elec_.R[0]);
+  ValueType ratio_0 = j1->ratio(elec_,0);
+  elec_.rejectMove(0);
+
+  elec_.makeMove(1, newpos-elec_.R[1]);
+  ValueType ratio_1 = j1->ratio(elec_,1);
+  elec_.rejectMove(1);
+
+  REQUIRE(ratio_0 == ComplexApprox(0.9819208747).compare_real_only());
+  REQUIRE(ratio_1 == ComplexApprox(1.0040884258).compare_real_only());
 
 }
 }


### PR DESCRIPTION
The computation inside momentum estimator has been optimized by rearranging the calculation and reusing data. This is effective for both AoS and SoA.
The evaluateRatiosAlltoOne of J1,J2,J3 with SoA has also been optimized by using specialized implementation.

The test case I used is VO2 48 atom cell. 400 electron. On titan, 2 MPI per node and 8 thread per MPI.
When using 128 samples, I saw huge speed up.
No estimator, 1.564921 sec
With 128 samples, 28.948585 sec
Optimized code with 128 samples, 4.872676 sec.

@kylanpaa Please verify that
- [x] real is good.
- [x] complex is good.