### PR TITLE
Branching memory

### DIFF
--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -61,8 +61,15 @@ WalkerControlMPI::WalkerControlMPI(Communicate* c): WalkerControlBase(c)
   setup_timers(myTimers, DMCMPITimerNames, timer_level_medium);
 }
 
-int
-WalkerControlMPI::branch(int iter, MCWalkerConfiguration& W, RealType trigger)
+/** perform branch and swap walkers as required
+ *
+ *  it takes 4 steps:
+ *    1. shortWalkers marks good and bad walkers.
+ *    2. allreduce and make the decision of load balancing.
+ *    3. send/recv walkers. Receiving side recycle bad walkers' memory first.
+ *    4. copyWalkers generate walker copies of good walkers.
+ */
+int WalkerControlMPI::branch(int iter, MCWalkerConfiguration& W, RealType trigger)
 {
   myTimers[DMC_MPI_branch]->start();
   myTimers[DMC_MPI_prebalance]->start();

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -288,7 +288,7 @@ void WalkerControlBase::Write2XYZ(MCWalkerConfiguration& W)
 int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
 {
   MCWalkerConfiguration::iterator it(W.begin());
-  std::vector<Walker_t*> bad,good_rn;
+  std::vector<Walker_t*> good_rn;
   std::vector<int> ncopy_rn;
   NumWalkers=0;
   MCWalkerConfiguration::iterator it_end(W.end());
@@ -353,7 +353,7 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
     }
     else
     {
-      bad.push_back(*it);
+      bad_w.push_back(*it);
     }
     ++it;
   }
@@ -378,9 +378,6 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
   //W.EnsembleProperty.Energy=(esum/=wsum);
   //W.EnsembleProperty.Variance=(e2sum/wsum-esum*esum);
   //W.EnsembleProperty.Variance=(e2sum*wsum-esum*esum)/(wsum*wsum-w2sum);
-  //remove bad walkers empty the container
-  for(int i=0; i<bad.size(); i++)
-    delete bad[i];
   if (!WriteRN)
   {
     if(good_w.empty())
@@ -443,23 +440,40 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
 
 int WalkerControlBase::copyWalkers(MCWalkerConfiguration& W)
 {
+  // save current good walker size.
+  const int size_good_w = good_w.size();
+  for(int i=0; i<size_good_w; i++)
+  {
+    for(int j=0; j<ncopy_w[i]; j++)
+    {
+      Walker_t* awalker;
+      if(bad_w.empty())
+      {
+        awalker=new Walker_t(*(good_w[i]));
+      }
+      else
+      {
+        awalker=bad_w.back();
+        *awalker=*(good_w[i]);
+        bad_w.pop_back();
+      }
+      awalker->ID=(++NumWalkersCreated)*NumContexts+MyContext;
+      awalker->ParentID=good_w[i]->ParentID;
+      good_w.push_back(awalker);
+    }
+  }
+
   //clear the WalkerList to populate them with the good walkers
   W.clear();
   W.insert(W.begin(), good_w.begin(), good_w.end());
-  int cur_walker = good_w.size();
-  for(int i=0; i<good_w.size(); i++)
-    //,ie+=ncols) {
-  {
-    for(int j=0; j<ncopy_w[i]; j++, cur_walker++)
-    {
-      Walker_t* awalker=new Walker_t(*(good_w[i]));
-      awalker->ID=(++NumWalkersCreated)*NumContexts+MyContext;
-      awalker->ParentID=good_w[i]->ParentID;
-      W.push_back(awalker);
-    }
-  }
+
+  //remove bad walkers if there is any left
+  for(int i=0; i<bad_w.size(); i++)
+    delete bad_w[i];
+
   //clear good_w and ncopy_w for the next branch
   good_w.clear();
+  bad_w.clear();
   ncopy_w.clear();
   return W.getActiveWalkers();
 }

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -283,7 +283,11 @@ void WalkerControlBase::Write2XYZ(MCWalkerConfiguration& W)
 }
 
 
-/** evaluate curData and mark the bad/good walkers
+/** evaluate curData and mark the bad/good walkers.
+ *
+ *  Each good walker has a counter registering the
+ *  number of copies needed to be generated from this walker.
+ *  Bad walkers will be either recycled or removed later.
  */
 int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
 {
@@ -438,6 +442,11 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
   return NumWalkers;
 }
 
+/** copy good walkers to W
+ *
+ *  Good walkers are copied based on the registered number of copies
+ *  Bad walkers are recycled to avoid memory allocation and deallocation.
+ */
 int WalkerControlBase::copyWalkers(MCWalkerConfiguration& W)
 {
   // save current good walker size.

--- a/src/QMCDrivers/WalkerControlBase.h
+++ b/src/QMCDrivers/WalkerControlBase.h
@@ -125,8 +125,8 @@ public:
   std::vector<RealType> accumData;
   ///any temporary data
   std::vector<RealType> curData;
-  ///temporary storage for good walkers
-  std::vector<Walker_t*> good_w;
+  ///temporary storage for good and bad walkers
+  std::vector<Walker_t*> good_w, bad_w;
   ///temporary storage for copy counters
   std::vector<int> ncopy_w;
   ///Add released-node fields to .dmc.dat file


### PR DESCRIPTION
This PR changes the memory handling of walker creating and annihilation.
This is the second PR for #609 
In the old algorithm,
1. sortWalkers makes decision of walker creating and annihilation. good_w and bad_w are assigned and good walkers have counters (ncopy_w) recording how many copies it should have. bad_w are freed.
2. copyWalkers first copy good walkers based on ncopy_w.
3. With MPI loadbalancing, walkers are sent from nodes with more walkers to nodes with less walkers. When walkers are transferred, their memory is freed.

In the new algorithm,
1. largely unchanged but the bad walkers are not freed.
2. First do the old step 3, send walkers from good_w, and decrease copy counter if a copy is sent. On the receiving side, bad_w are used to accept walkers from other nodes until bad_w is depleted. Received walkers are removed from bad_w registered in good_w.
3. copyWalkers based on the copy counter, first recycle bad_w and then allocating new walkers. If there is any bad_w left, free them. The copy procedure is also threaded.

With this new algorithm, actual walker memory allocation and deallocation is around zero each iteration and there is no sudden high memory needs in the intermediate steps.