### PR TITLE
Nonblocking send/recv

### DIFF
--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -46,6 +46,7 @@
  %  &   \texttt{wlen                } &  integer  & $\ge 0$ & 0   & number of samples per  thread  \\
    &   \texttt{maxDisplSq      } &  real  & all values & -1   & maximum particle move  \\
    &   \texttt{storeconfigs        } &  integer  & all values & 0   & store configurations  \\
+   &   \texttt{use\_nonblocking    } &  string  & yes/other & yes   & using non-blocking send/recv \\
    &   \texttt{blocks\_between\_recompute} &  integer  & $\ge 0$ & dep.  & wavefunction recompute frequency  \\
   \hline
 \end{tabularx}

--- a/manual/running.tex
+++ b/manual/running.tex
@@ -12,9 +12,6 @@ are performed. If the flag is absent, then the corresponding
 option is disabled.
 
 \begin{description}
-\item[\texttt{-{}-async\_swap}]{ When enabled, this option will launch a new thread
-  to handle the communication between walkers. If it is not enabled,
-  then the communication happens on the current thread. }
 \item[\texttt{-{}-dryrun}]{ Validate the input file without performing the simulation.
   This is a good way to ensure that QMCPACK will do what you think it will. }
 \item[\texttt{-{}-help}]{ Print version information as well as a list of optional

--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -121,6 +121,8 @@ struct Walker
    * When Multiplicity = 0, this walker will be destroyed.
    */
   RealType Multiplicity;
+  ////Number of copies sent only for MPI
+  int NumSentCopies;
 
   /** The configuration vector (3N-dimensional vector to store
      the positions of all the particles for a single walker)*/
@@ -437,6 +439,7 @@ struct Walker
     DataSet.add(Age);
     DataSet.add(ReleasedNodeAge);
     DataSet.add(ReleasedNodeWeight);
+    DataSet.add(NumSentCopies);
     // vectors
     DataSet.add(R.first_address(), R.last_address());
 #if !defined(SOA_MEMORY_OPTIMIZED)
@@ -466,7 +469,7 @@ struct Walker
   void copyFromBuffer()
   {
     DataSet.rewind();
-    DataSet >> ID >> ParentID >> Generation >> Age >> ReleasedNodeAge >> ReleasedNodeWeight;
+    DataSet >> ID >> ParentID >> Generation >> Age >> ReleasedNodeAge >> ReleasedNodeWeight >> NumSentCopies;
     // vectors
     DataSet.get(R.first_address(), R.last_address());
 #if !defined(SOA_MEMORY_OPTIMIZED)
@@ -513,7 +516,7 @@ struct Walker
   void updateBuffer()
   {
     DataSet.rewind();
-    DataSet << ID << ParentID << Generation << Age << ReleasedNodeAge << ReleasedNodeWeight;
+    DataSet << ID << ParentID << Generation << Age << ReleasedNodeAge << ReleasedNodeWeight << NumSentCopies;
     // vectors
     DataSet.put(R.first_address(), R.last_address());
 #if !defined(SOA_MEMORY_OPTIMIZED)

--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -193,7 +193,10 @@ void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
 #endif
   if(plus.size()!=minus.size())
   {
-    app_error() << "Walker send/recv pattern doesn't match." << std::endl;
+    app_error() << "Walker send/recv pattern doesn't match. "
+                << "The send size " << plus.size()
+                << " is not equal to the receive size " << minus.size()
+                << " ." << std::endl;
     APP_ABORT("WalkerControlMPI::swapWalkersSimple");
   }
   int nswap=plus.size();

--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -65,18 +65,18 @@ WalkerControlMPI::WalkerControlMPI(Communicate* c): WalkerControlBase(c)
   setup_timers(myTimers, DMCMPITimerNames, timer_level_medium);
 }
 
-/** perform branch and swap walkers as required
+/** Perform branch and swap walkers as required
  *
- *  it takes 4 steps:
- *    1. shortWalkers marks good and bad walkers.
+ *  It takes 4 steps:
+ *    1. sortWalkers marks good and bad walkers.
  *    2. allreduce and make the decision of load balancing.
- *    3. send/recv walkers. Receiving side recycle bad walkers' memory first.
- *    4. copyWalkers generate walker copies of good walkers.
+ *    3. send/recv walkers. Receiving side recycles bad walkers' memory first.
+ *    4. copyWalkers generates copies of good walkers.
  *  In order to minimize the memory footprint fluctuation
  *  the walker copying is placed as the last step.
  *  In order to reduce the time for allocating walker memory,
  *  this algorithm does not destroy the bad walkers in step 1.
- *  All the bad walkers are recyled as much as possible in step 3/4.
+ *  All the bad walkers are recycled as much as possible in step 3/4.
  */
 int WalkerControlMPI::branch(int iter, MCWalkerConfiguration& W, RealType trigger)
 {
@@ -156,12 +156,12 @@ void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, c
 /** swap Walkers with Recv/Send or Irecv/Isend
  *
  * The algorithm ensures that the load per node can differ only by one walker.
- * Each MPI rank can only be sending or receiving or silient.
+ * Each MPI rank can only send or receive or be silent.
  * The communication is one-dimensional and very local.
- * If mutiple copies of a walker need to be sent to the target rank,
+ * If multiple copies of a walker need to be sent to the target rank,
  * only one walker is sent and the number of copies is encoded in the message.
  * The blocking send/recv may become serialized and worsen load imbalance.
- * Non blocking send/recv algorithm avoids completely serialziation.
+ * Non blocking send/recv algorithm avoids serialization completely.
  */
 void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
 {

--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -98,7 +98,7 @@ int WalkerControlMPI::branch(int iter, MCWalkerConfiguration& W, RealType trigge
   }
   myTimers[DMC_MPI_prebalance]->stop();
   myTimers[DMC_MPI_loadbalance]->start();
-  swapWalkersSimple(W,true);
+  swapWalkersSimple(W);
   myTimers[DMC_MPI_loadbalance]->stop();
   myTimers[DMC_MPI_copyWalkers]->start();
   copyWalkers(W);
@@ -158,7 +158,7 @@ void determineNewWalkerPopulation(int Cur_pop, int NumContexts, int MyContext, c
  * The algorithm ensures that the load per node can differ only by one walker.
  * The communication is one-dimensional.
  */
-void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W, bool use_nonblocking)
+void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
 {
   std::vector<int> minus, plus;
   determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, FairOffSet, minus, plus);

--- a/src/QMCDrivers/DMC/WalkerControlMPI.h
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.h
@@ -45,7 +45,7 @@ struct WalkerControlMPI: public WalkerControlBase
   int branch(int iter, MCWalkerConfiguration& W, RealType trigger);
 
   //current implementations
-  void swapWalkersSimple(MCWalkerConfiguration& W, bool use_isend);
+  void swapWalkersSimple(MCWalkerConfiguration& W, bool use_nonblocking);
 
   //old implementations
   void swapWalkersAsync(MCWalkerConfiguration& W);

--- a/src/QMCDrivers/DMC/WalkerControlMPI.h
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.h
@@ -45,7 +45,7 @@ struct WalkerControlMPI: public WalkerControlBase
   int branch(int iter, MCWalkerConfiguration& W, RealType trigger);
 
   //current implementations
-  void swapWalkersSimple(MCWalkerConfiguration& W, bool use_nonblocking);
+  void swapWalkersSimple(MCWalkerConfiguration& W);
 
 };
 }

--- a/src/QMCDrivers/DMC/WalkerControlMPI.h
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.h
@@ -47,10 +47,6 @@ struct WalkerControlMPI: public WalkerControlBase
   //current implementations
   void swapWalkersSimple(MCWalkerConfiguration& W, bool use_nonblocking);
 
-  //old implementations
-  void swapWalkersAsync(MCWalkerConfiguration& W);
-  // Removed swapWalkersBlocked and swapWalkersMap (minimize size and number of messages)
-
 };
 }
 #endif

--- a/src/QMCDrivers/DMC/WalkerControlMPI.h
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.h
@@ -44,7 +44,8 @@ struct WalkerControlMPI: public WalkerControlBase
   /** perform branch and swap walkers as required */
   int branch(int iter, MCWalkerConfiguration& W, RealType trigger);
 
-  void swapWalkersSimple(MCWalkerConfiguration& W);
+  //current implementations
+  void swapWalkersSimple(MCWalkerConfiguration& W, bool use_isend);
 
   //old implementations
   void swapWalkersAsync(MCWalkerConfiguration& W);

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -502,22 +502,26 @@ int WalkerControlBase::copyWalkers(MCWalkerConfiguration& W)
 bool WalkerControlBase::put(xmlNodePtr cur)
 {
   int nw_target=0, nw_max=0;
+  std::string nonblocking="yes";
   ParameterSet params;
   params.add(targetEnergyBound,"energyBound","double");
   params.add(targetSigma,"sigmaBound","double");
   params.add(MaxCopy,"maxCopy","int");
   params.add(nw_target,"targetwalkers","int");
   params.add(nw_max,"max_walkers","int");
+  params.add(nonblocking,"use_nonblocking","string");
 
   bool success=params.put(cur);
 
   setMinMax(nw_target,nw_max);
+  use_nonblocking = nonblocking=="yes";
   app_log() << "  WalkerControlBase parameters " << std::endl;
   //app_log() << "    energyBound = " << targetEnergyBound << std::endl;
   //app_log() << "    sigmaBound = " << targetSigma << std::endl;
   app_log() << "    maxCopy = " << MaxCopy << std::endl;
   app_log() << "    Max Walkers per node " << Nmax << std::endl;
   app_log() << "    Min Walkers per node " << Nmin << std::endl;
+  app_log() << "    Using " << (use_nonblocking?"non-":"") << "blocking send/recv" << std::endl;
   return true;
 }
 

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -225,6 +225,7 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
   curData[RNSIZE_INDEX]=nrn;
   curData[B_ENERGY_INDEX]=besum;
   curData[B_WGT_INDEX]=bwgtsum;
+  curData[SENTWALKERS_INDEX]=NumWalkersSent=0;
   myComm->allreduce(curData);
   measureProperties(iter);
   trialEnergy=EnsembleProperty.Energy;
@@ -438,19 +439,6 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       ncopy_w.push_back(ncopy_rn[indy]);
       it++,indy++;
     }
-  }
-
-  // sort good walkers by the number of copies
-  assert(good_w.size()==ncopy_w.size());
-  std::vector<Walker_t*> good_w_temp(good_w);
-  std::vector<std::pair<int,int> > ncopy_pairs;
-  for(int iw=0; iw<ncopy_w.size(); iw++)
-    ncopy_pairs.push_back(std::make_pair(ncopy_w[iw],iw));
-  std::sort(ncopy_pairs.begin(), ncopy_pairs.end());
-  for(int iw=0; iw<ncopy_w.size(); iw++)
-  {
-    good_w[iw]=good_w_temp[ncopy_pairs[iw].second];
-    ncopy_w[iw]=ncopy_pairs[iw].first;
   }
   return NumWalkers;
 }

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -439,6 +439,19 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       it++,indy++;
     }
   }
+
+  // sort good walkers by the number of copies
+  assert(good_w.size()==ncopy_w.size());
+  std::vector<Walker_t*> good_w_temp(good_w);
+  std::vector<std::pair<int,int> > ncopy_pairs;
+  for(int iw=0; iw<ncopy_w.size(); iw++)
+    ncopy_pairs.push_back(std::make_pair(ncopy_w[iw],iw));
+  std::sort(ncopy_pairs.begin(), ncopy_pairs.end());
+  for(int iw=0; iw<ncopy_w.size(); iw++)
+  {
+    good_w[iw]=good_w_temp[ncopy_pairs[iw].second];
+    ncopy_w[iw]=ncopy_pairs[iw].first;
+  }
   return NumWalkers;
 }
 

--- a/src/QMCDrivers/WalkerControlBase.h
+++ b/src/QMCDrivers/WalkerControlBase.h
@@ -131,6 +131,8 @@ public:
   std::vector<int> ncopy_w;
   ///Add released-node fields to .dmc.dat file
   bool WriteRN;
+  ///Use non-blocking isend/irecv
+  bool use_nonblocking;
 
   /** default constructor
    *

--- a/src/qmc_common.cpp
+++ b/src/qmc_common.cpp
@@ -29,7 +29,6 @@ QMCState::QMCState()
   use_density=false;
   dryrun=false;
   save_wfs=false;
-  async_swap=false;
   io_node=true;
   mpi_groups=1;
   use_ewald=false;
@@ -59,10 +58,6 @@ void QMCState::initialize(int argc, char **argv)
     else if(c.find("--save_wfs") < c.size())
     {
       save_wfs=(c.find("no")>=c.size());
-    }
-    else if(c.find("--async_swap") < c.size())
-    {
-      async_swap=(c.find("no")>=c.size());
     }
     else if(c.find("--help")< c.size())
     {
@@ -99,7 +94,7 @@ void QMCState::initialize(int argc, char **argv)
     std::cerr << "  git last commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED << std::endl;
     std::cerr << "  git last commit subject: " << QMCPACK_GIT_COMMIT_SUBJECT << std::endl;
 #endif
-    std::cerr << std::endl << "Usage: qmcpack input [--dryrun --save_wfs[=no] --async_swap[=no] --gpu]" << std::endl << std::endl;
+    std::cerr << std::endl << "Usage: qmcpack input [--dryrun --save_wfs[=no] --gpu]" << std::endl << std::endl;
   }
   if(stopit)
   {
@@ -115,10 +110,6 @@ void QMCState::print_options(std::ostream& os)
     os << "  dryrun : qmc sections will be ignored." << std::endl;
   if(save_wfs)
     os << "  save_wfs=1 : save wavefunctions in hdf5. " << std::endl;
-  if(async_swap)
-    os << "  async_swap=1 : using async isend/irecv for walker swaps " << std::endl;
-  else
-    os << "  async_swap=0 : using blocking send/recv for walker swaps " << std::endl;
 }
 
 void QMCState::print_memory_change(const std::string& who, size_t before)

--- a/src/qmc_common.h
+++ b/src/qmc_common.h
@@ -37,8 +37,6 @@ struct QMCState
   bool dryrun;
   ///true, if wave functions are stored for next runs
   bool save_wfs;
-  ///true, if walker swap is done by async
-  bool async_swap;
   ///true, print out file
   bool io_node;
   ///true, use Ewald instead of optimal breakup for the Coulomb


### PR DESCRIPTION
This PR introduce two optimization in the walker send/recv. This is the third PR for #609.
1, multiple copy of one walker is sent in one shot. This reduces the amount of data transferred.
2, Using non-blocking send/recv to avoid blocking send/recv serialization. Turned on by default.
Both algorithms will be transferred to reconfiguration in the near future.

Command line option async_swap has been removed as well as the old implementation.
input parameter use_nonblocking is introduced to toggle on/off non-blocking send/recv.
manual has been updated.
  
  
  
  