### PR TITLE
Initialize array correctly in test_e2iphi.

### DIFF
--- a/src/Numerics/tests/test_e2iphi.cpp
+++ b/src/Numerics/tests/test_e2iphi.cpp
@@ -30,7 +30,7 @@ void test_e2iphi()
   T vcos[N];
   T vsin[N];
   for (int i = 0; i < N; i++) {
-    phi[0] = 0.2*i;
+    phi[i] = 0.2*i;
   }
 
   eval_e2iphi(N, phi, vcos, vsin);


### PR DESCRIPTION
Some elements of the array were uninitialized, and some machines the values would be NaN.