### PR TITLE
Fix FindMKL

### DIFF
--- a/CMake/FindMKL.cmake
+++ b/CMake/FindMKL.cmake
@@ -7,21 +7,21 @@ FILE( WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl.cxx"
     "#include <iostream>\n #include <mkl.h>\n int main() { return 0; }\n" )
 try_compile(HAVE_MKL ${CMAKE_BINARY_DIR}
       ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl.cxx
-      CMAKE_FLAGS "${CMAKE_CXX_FLAGS} -mkl" )
+      COMPILE_DEFINITIONS "-mkl" )
 
 # Check for mkl_vml_functions.h
 FILE( WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl_vml.cxx"
     "#include <iostream>\n #include <mkl_vml_functions.h>\n int main() { return 0; }\n" )
 try_compile(HAVE_MKL_VML ${CMAKE_BINARY_DIR}
       ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl_vml.cxx
-      CMAKE_FLAGS "${CMAKE_CXX_FLAGS} -mkl" )
+      COMPILE_DEFINITIONS "-mkl" )
 
 # Check for fftw3
 FILE( WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl_fftw3.cxx"
     "#include <iostream>\n #include <fftw/fftw3.h>\n int main() { return 0; }\n" )
 try_compile(HAVE_MKL_FFTW3 ${CMAKE_BINARY_DIR}
       ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src_mkl_fftw3.cxx
-      CMAKE_FLAGS "${CMAKE_CXX_FLAGS} -mkl" )
+      COMPILE_DEFINITIONS "-mkl" )
 
 IF ( HAVE_MKL )
     SET( MKL_FOUND 1 )

--- a/config/build_alcf_mira.sh
+++ b/config/build_alcf_mira.sh
@@ -1,20 +1,12 @@
-module unload cray-libsci
-module load cray-hdf5-parallel
+#!/bin/bash
 
-export CC=cc
-export CXX=CC
-export BOOST_ROOT=/soft/libraries/boost/1.64.0/intel
-export CRAYPE_LINK_TYPE=dynamic
-
-#TYPE=RelWithDebInfo
-TYPE=Release
-Compiler=Intel
+Compiler=Clang++11
 
 for name in real_SoA real_SoA_MP cplx_SoA cplx_SoA_MP \
             real real_MP cplx cplx_MP
 do
 
-CMAKE_FLAGS="-D CMAKE_BUILD_TYPE=$TYPE"
+CMAKE_FLAGS="-D CMAKE_TOOLCHAIN_FILE=../config/BGQ_${Compiler}_ToolChain.cmake"
 
 if [[ $name == *"cplx"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -D QMC_COMPLEX=1"
@@ -28,7 +20,7 @@ if [[ $name == *"_MP"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -D QMC_MIXED_PRECISION=1"
 fi
 
-folder=build_KNL_${Compiler}_${name}
+folder=build_${Compiler}_${name}
 echo "**********************************"
 echo "$folder"
 echo "$CMAKE_FLAGS"
@@ -37,8 +29,9 @@ mkdir $folder
 cd $folder
 if [ ! -f CMakeCache.txt ] ; then
 cmake $CMAKE_FLAGS ..
+cmake $CMAKE_FLAGS ..
 fi
-make -j32
+make -j24
 cd ..
 
 echo

--- a/config/build_alcf_theta.sh
+++ b/config/build_alcf_theta.sh
@@ -1,0 +1,47 @@
+module unload cray-libsci
+module load cray-hdf5-parallel
+
+export CC=cc
+export CXX=CC
+export BOOST_ROOT=/soft/libraries/boost/1.64.0/intel
+export CRAYPE_LINK_TYPE=dynamic
+
+#TYPE=RelWithDebInfo
+TYPE=Release
+Compiler=Intel
+
+for name in KNL_${Compiler}_real_SoA KNL_${Compiler}_real_SoA_MP \
+            KNL_${Compiler}_cplx_SoA KNL_${Compiler}_cplx_SoA_MP \
+            KNL_${Compiler}_real KNL_${Compiler}_real_MP \
+            KNL_${Compiler}_cplx KNL_${Compiler}_cplx_MP
+do
+
+CMAKE_FLAGS="-D CMAKE_BUILD_TYPE=$TYPE"
+
+if [[ $name == *"_MP"* ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -D QMC_MIXED_PRECISION=1"
+fi
+
+if [[ $name == *"_cplx"* ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -D QMC_COMPLEX=1"
+fi
+
+if [[ $name == *"_SoA"* ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_SOA=1"
+fi
+
+folder=build_${name}
+echo "**********************************"
+echo "$folder"
+echo "$CMAKE_FLAGS"
+echo "**********************************"
+mkdir $folder
+cd $folder
+if [ ! -f CMakeCache.txt ] ; then
+cmake $CMAKE_FLAGS ..
+fi
+make -j32
+cd ..
+
+echo
+done


### PR DESCRIPTION
FindMKL was not behaving properly on my desktop.
The reason is the following
CMAKE_FLAGS only accept -DVAR:TYPE=VALUE form.
COMPILE_DEFINITIONS is the right one to use. It will invoke add_definitions and allows any flag.
https://cmake.org/cmake/help/v3.2/command/try_compile.html

I actually investigated the problem a year ago #11 but now I have a solution instead of a workaround.

The change has been checked on a linux workstation as well as Cray X40.
Hope this also resolves the LLNL pain.
  
  
  