### PR TITLE
Calling cublas inversion with pivot.

### DIFF
--- a/src/Numerics/CUDA/cuda_inverse.h
+++ b/src/Numerics/CUDA/cuda_inverse.h
@@ -25,6 +25,7 @@ void
 cublas_inverse (cublasHandle_t handle,
                 float *Alist_d[], float *Ainvlist_d[],
                 float *AWorkList_d[], float *AinvWorkList_d[],
+                int *PivotArray, int *infoArray,
                 int N, int rowStride, int numMats,
                 bool useHigherPrecision = true);
 
@@ -35,6 +36,7 @@ void
 cublas_inverse (cublasHandle_t handle,
                 double *Alist_d[], double *Ainvlist_d[],
                 double *AWorklist_d[], double *AinvWorklist_d[],
+                int *PivotArray, int *infoArray,
                 int N, int rowStride, int numMats, 
                 bool useHigherPrecision = true);
 
@@ -46,6 +48,7 @@ void
 cublas_inverse (cublasHandle_t handle,
                 std::complex<float> *Alist_d[], std::complex<float> *Ainvlist_d[],
                 std::complex<float> *AWorkList_d[], std::complex<float> *AinvWorkList_d[],
+                int *PivotArray, int *infoArray,
                 int N, int rowStride, int numMats,
                 bool useHigherPrecision = true);
 
@@ -56,6 +59,7 @@ void
 cublas_inverse (cublasHandle_t handle,
                 std::complex<double> *Alist_d[], std::complex<double> *Ainvlist_d[],
                 std::complex<double> *AWorklist_d[], std::complex<double> *AinvWorklist_d[],
+                int *PivotArray, int *infoArray,
                 int N, int rowStride, int numMats, 
                 bool useHigherPrecision = true);
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -40,7 +40,7 @@ public:
   typedef ParticleSet::Walker_t     Walker_t;
 
   DiracDeterminantCUDA(SPOSetBasePtr const &spos, int first=0);
-  DiracDeterminantCUDA(const DiracDeterminantCUDA& s);
+  DiracDeterminantCUDA(const DiracDeterminantCUDA& s) = delete;
 
 protected:
   /////////////////////////////////////////////////////
@@ -60,6 +60,9 @@ protected:
   gpu::device_vector<CudaValueType*> srcList_d, destList_d, AList_d, AinvList_d, newRowList_d, 
                                     AinvDeltaList_d, AinvColkList_d, gradLaplList_d, 
                                     newGradLaplList_d, AWorkList_d, AinvWorkList_d, GLList_d;
+  gpu::device_vector<int> PivotArray_d;
+  gpu::device_vector<int> infoArray_d;
+  gpu::host_vector<int> infoArray_host;
   gpu::device_vector<CudaValueType> ratio_d;
   gpu::host_vector<CudaValueType> ratio_host;
   gpu::device_vector<CudaValueType> gradLapl_d;
@@ -118,6 +121,9 @@ protected:
     // HACK HACK HACK
     // gradLapl_d.resize   (numWalkers*NumOrbitals*4);
     // gradLapl_host.resize(numWalkers*NumOrbitals*4);
+    infoArray_d.resize(numWalkers*2);
+    infoArray_host.resize(numWalkers*2);
+    PivotArray_d.resize(numWalkers*NumOrbitals);
     gradLapl_d.resize   (numWalkers*RowStride*4);
     gradLapl_host.resize(numWalkers*RowStride*4);
     NLrowBuffer_d.resize(NLrowBufferRows*RowStride);


### PR DESCRIPTION
I hit this issue when doing large scale runs on Titan.
Without pivoting, the inversion fails at certain matrices (not singular) and gives inf (not NaN). The failure occurs more frequently when system gets large and orbital value varies more.
With pivoting, the same matrix can be inverted successfully.
A check has been added after the inversion call and the status of every matrix is checked.

Once the review pass, I can rebase this PR to have the history clean.
  
  
  