### PR TITLE
Use VTune task API with timers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,8 +767,25 @@ IF(BUILD_LMYENGINE_INTERFACE)
 ENDIF(BUILD_LMYENGINE_INTERFACE)
 
 IF (USE_VTUNE_TASKS)
-  LINK_LIBRARIES(ittnotify)
+  IF (NOT ENABLE_TIMERS)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_TASKS is set, but timers are not enabled.  Set ENABLE_TIMERS=1.")
+  ENDIF()
+  SET(USE_VTUNE_API 1)
 ENDIF()
+
+IF (USE_VTUNE_API)
+  CHECK_INCLUDE_FILE_CXX(ittnotify.h HAVE_ITTNOTIFY_H)
+  IF (NOT HAVE_ITTNOTIFY_H)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_API defined, but the ittnotify.h include file is not found.  Check that the correct include directory is present in CMAKE_CXX_FLAGS.")
+  ENDIF()
+
+  FIND_LIBRARY(VTUNE_ITTNOTIFY_LIBRARY ittnotify)
+  IF (NOT VTUNE_ITTNOTIFY_LIBRARY)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_API defined, but ittnotify library is not found.  Check that correct lib path is present in CMAKE_LIBRARY_PATH.")
+  ENDIF()
+  LINK_LIBRARIES("${VTUNE_ITTNOTIFY_LIBRARY}")
+ENDIF()
+
 
 #include(ExternalProject)
 #  set(einspline_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/einspline")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,10 @@ IF(BUILD_LMYENGINE_INTERFACE)
   SET(QMC_UTIL_LIBS formic_utils ${QMC_UTIL_LIBS})
 ENDIF(BUILD_LMYENGINE_INTERFACE)
 
+IF (USE_VTUNE_TASKS)
+  LINK_LIBRARIES(ittnotify)
+ENDIF()
+
 #include(ExternalProject)
 #  set(einspline_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/einspline")
 #  set(einspline_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/einspline")

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -27,6 +27,9 @@
 #include <algorithm>
 #include <map>
 #include <iostream>
+#ifdef USE_VTUNE_TASKS
+#include <ittnotify.h>
+#endif
 
 #define USE_STACK_TIMERS
 
@@ -137,8 +140,16 @@ protected:
   std::map<timer_id_t, std::string> timer_id_name;
   std::map<std::string, timer_id_t> timer_name_to_id;
 public:
+#ifdef USE_VTUNE_TASKS
+  __itt_domain *task_domain;
+#endif
+
   TimerManagerClass():timer_threshold(timer_level_coarse),max_timer_id(1),
-    max_timers_exceeded(false) {}
+    max_timers_exceeded(false) {
+#ifdef USE_VTUNE_TASKS
+      task_domain = __itt_domain_create("QMCPACK");
+#endif
+    }
   void addTimer (NewTimer* t);
   NewTimer *createTimer(const std::string& myname, timer_levels mytimer = timer_level_fine);
 
@@ -229,6 +240,10 @@ protected:
   std::map<StackKey, double> per_stack_total_time;
   std::map<StackKey, long> per_stack_num_calls;
 #endif
+
+#ifdef USE_VTUNE_TASKS
+  __itt_string_handle *task_name;
+#endif
 public:
 #if not(ENABLE_TIMERS)
   inline void start() {}
@@ -239,6 +254,12 @@ public:
     if (active)
     {
 #ifdef USE_STACK_TIMERS
+
+#ifdef USE_VTUNE_TASKS
+      __itt_id parent_task = __itt_null;
+      __itt_task_begin(manager->task_domain, __itt_null, parent_task, task_name);
+#endif
+
       #pragma omp master
       {
         if (manager)
@@ -276,6 +297,11 @@ public:
     if (active)
     {
 #ifdef USE_STACK_TIMERS
+
+#ifdef USE_VTUNE_TASKS
+      __itt_task_end(manager->task_domain);
+#endif
+
       #pragma omp master
 #endif
       {
@@ -363,7 +389,11 @@ public:
 #ifdef USE_STACK_TIMERS
   ,manager(NULL), parent(NULL)
 #endif
-  { }
+  {
+#ifdef USE_VTUNE_TASKS
+    task_name = __itt_string_handle_create(myname.c_str());
+#endif
+  }
 
 
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -209,5 +209,8 @@
 /* Internal timers */
 #cmakedefine ENABLE_TIMERS @ENABLE_TIMERS@
 
+/* Use VTune Task API with timers */
+#cmakedefine USE_VTUNE_TASKS @USE_VTUNE_TASKS@
+
 #endif // QMCPLUSPLUS_CONFIGURATION_H
 


### PR DESCRIPTION
Enable with -DUSE_VTUNE_TASKS=1.

Will need to add the VTune include directory to QMC_INCLUDE
and add the VTune lib directory (-L<vtune lib dir>) to CMAKE_CXX_FLAGS.

Also requires a knob or option to be enabled at collection time as the task API information is not collected by default.

This could also serve as a guide for adding annotations for other profiling tools.
