### PR TITLE
Limit maxCopy due to nonblocking send/recv bug

### DIFF
--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -46,7 +46,7 @@
  %  &   \texttt{wlen                } &  integer  & $\ge 0$ & 0   & number of samples per  thread  \\
    &   \texttt{maxDisplSq      } &  real  & all values & -1   & maximum particle move  \\
    &   \texttt{storeconfigs        } &  integer  & all values & 0   & store configurations  \\
-   &   \texttt{use\_nonblocking    } &  string  & yes/other & yes   & using non-blocking send/recv \\
+   &   \texttt{use\_nonblocking    } &  string  & yes/no & no   & using non-blocking send/recv \\
    &   \texttt{blocks\_between\_recompute} &  integer  & $\ge 0$ & dep.  & wavefunction recompute frequency  \\
   \hline
 \end{tabularx}

--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -46,7 +46,7 @@
  %  &   \texttt{wlen                } &  integer  & $\ge 0$ & 0   & number of samples per  thread  \\
    &   \texttt{maxDisplSq      } &  real  & all values & -1   & maximum particle move  \\
    &   \texttt{storeconfigs        } &  integer  & all values & 0   & store configurations  \\
-   &   \texttt{use\_nonblocking    } &  string  & yes/no & no   & using non-blocking send/recv \\
+   &   \texttt{use\_nonblocking    } &  string  & yes/no & yes   & using non-blocking send/recv \\
    &   \texttt{blocks\_between\_recompute} &  integer  & $\ge 0$ & dep.  & wavefunction recompute frequency  \\
   \hline
 \end{tabularx}

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -502,7 +502,7 @@ int WalkerControlBase::copyWalkers(MCWalkerConfiguration& W)
 bool WalkerControlBase::put(xmlNodePtr cur)
 {
   int nw_target=0, nw_max=0;
-  std::string nonblocking="yes";
+  std::string nonblocking="no";
   ParameterSet params;
   params.add(targetEnergyBound,"energyBound","double");
   params.add(targetSigma,"sigmaBound","double");
@@ -513,8 +513,23 @@ bool WalkerControlBase::put(xmlNodePtr cur)
 
   bool success=params.put(cur);
 
+  // validating input
+  if(nonblocking=="yes")
+  {
+    APP_ABORT("WalkerControlBase::put use_nonblocking==\"yes\" is disabled currently!");
+    use_nonblocking = true;
+  }
+  else if(nonblocking=="no")
+  {
+    use_nonblocking = false;
+  }
+  else
+  {
+    APP_ABORT("WalkerControlBase::put unknown use_nonblocking option " + nonblocking);
+  }
+
   setMinMax(nw_target,nw_max);
-  use_nonblocking = nonblocking=="yes";
+
   app_log() << "  WalkerControlBase parameters " << std::endl;
   //app_log() << "    energyBound = " << targetEnergyBound << std::endl;
   //app_log() << "    sigmaBound = " << targetSigma << std::endl;

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -502,7 +502,7 @@ int WalkerControlBase::copyWalkers(MCWalkerConfiguration& W)
 bool WalkerControlBase::put(xmlNodePtr cur)
 {
   int nw_target=0, nw_max=0;
-  std::string nonblocking="no";
+  std::string nonblocking="yes";
   ParameterSet params;
   params.add(targetEnergyBound,"energyBound","double");
   params.add(targetSigma,"sigmaBound","double");
@@ -516,8 +516,12 @@ bool WalkerControlBase::put(xmlNodePtr cur)
   // validating input
   if(nonblocking=="yes")
   {
-    APP_ABORT("WalkerControlBase::put use_nonblocking==\"yes\" is disabled currently!");
     use_nonblocking = true;
+    if(MaxCopy>2)
+    {
+      app_warning() << "use_nonblocking==\"yes\" doesn't support maxCopy>2. Overwriting it to 2." << std::endl;
+      MaxCopy=2;
+    }
   }
   else if(nonblocking=="no")
   {


### PR DESCRIPTION
For #631 
The default maxCopy=2 doesn't hit the bug. But I think it is better to have code on the safe side.
In this PR, I just disabled the nonblocking.
if disabling only maxCopy>2 + nonblocking is preferred, I can change this PR.