### PR TITLE
Add VTune API support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,6 +760,28 @@ IF(BUILD_LMYENGINE_INTERFACE)
   SET(QMC_UTIL_LIBS formic_utils ${QMC_UTIL_LIBS})
 ENDIF(BUILD_LMYENGINE_INTERFACE)
 
+IF (USE_VTUNE_TASKS)
+  IF (NOT ENABLE_TIMERS)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_TASKS is set, but timers are not enabled.  Set ENABLE_TIMERS=1.")
+  ENDIF()
+  SET(USE_VTUNE_API 1)
+ENDIF()
+
+IF (USE_VTUNE_API)
+  include(CheckIncludeFileCXX)
+  CHECK_INCLUDE_FILE_CXX(ittnotify.h HAVE_ITTNOTIFY_H)
+  IF (NOT HAVE_ITTNOTIFY_H)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_API is defined, but the ittnotify.h include file is not found.  Check that the correct include directory is present in CMAKE_CXX_FLAGS.")
+  ENDIF()
+
+  FIND_LIBRARY(VTUNE_ITTNOTIFY_LIBRARY ittnotify)
+  IF (NOT VTUNE_ITTNOTIFY_LIBRARY)
+    MESSAGE(FATAL_ERROR "USE_VTUNE_API is defined, but the ittnotify library is not found.  Check that correct library path is present in CMAKE_LIBRARY_PATH.")
+  ENDIF()
+  LINK_LIBRARIES("${VTUNE_ITTNOTIFY_LIBRARY}")
+ENDIF()
+
+
 #include(ExternalProject)
 #  set(einspline_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/einspline")
 #  set(einspline_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/einspline")

--- a/manual/external_tools.tex
+++ b/manual/external_tools.tex
@@ -31,5 +31,5 @@ For the command line, set the \texttt{enable-user-tasks} knob to \texttt{true}. 
 amplxe-cl -collect hotspots -knob enable-user-tasks=true ...
 \end{shade}
 
-Collection with the timers set at "fine" is can generate too much task data in the profile.
+Collection with the timers set at "fine" can generate too much task data in the profile.
 Collection with the timers at "medium" collects a more reasonable amount of task data.

--- a/manual/external_tools.tex
+++ b/manual/external_tools.tex
@@ -1,0 +1,35 @@
+\chapter{External Tools}
+\label{chap:external_tools}
+This chapter provides some information on using QMCPACK with external tools.
+
+\section{VTune}
+
+Intel's VTune profiler has an API that allows program control over collection (pause/resume) and can add information to the profile data (e.g. delineating tasks).
+
+\subsection{VTune API}
+
+If the variable \texttt{USE\_VTUNE\_API} is set, QMCPACK will check that the
+include file (\texttt{ittnotify.h}) and the library (\texttt{libittnotify.a}) can
+be found.
+To provide CMake with the VTune paths, add the include path to \texttt{CMAKE\_CXX\_FLAGS} and the the library path to \texttt{CMAKE\_LIBRARY\_PATH}.
+
+An example of options to be passed to CMake
+\begin{shade}
+ -DCMAKE_CXX_FLAGS=-I/opt/intel/vtune_amplifier_xe/include \
+ -DCMAKE_LIBRARY_PATH=/opt/intel/vtune_amplifier_xe/lib64
+\end{shade}
+
+
+\subsection{Timers as Tasks}
+To aid in connecting the timers in the code to the profile data, the start/stop of
+timers will be recorded as a task if \texttt{USE\_VTUNE\_TASKS} is set.
+
+In addition to compiling with \texttt{USE\_VTUNE\_TASKS}, an option needs to be set at runtime to collect the task API data.
+In the GUI, select the checkbox labeled "Analyze user tasks" when setting up the analysis type.
+For the command line, set the \texttt{enable-user-tasks} knob to \texttt{true}. For example,
+\begin{shade}
+amplxe-cl -collect hotspots -knob enable-user-tasks=true ...
+\end{shade}
+
+Collection with the timers set at "fine" is can generate too much task data in the profile.
+Collection with the timers at "medium" collects a more reasonable amount of task data.

--- a/manual/qmcpack_manual.tex
+++ b/manual/qmcpack_manual.tex
@@ -198,6 +198,7 @@
 
 
 \input{additional_tools}
+\input{external_tools}
 \input{contributing}
 \input{unit_testing}
 

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -27,6 +27,9 @@
 #include <algorithm>
 #include <map>
 #include <iostream>
+#ifdef USE_VTUNE_TASKS
+#include <ittnotify.h>
+#endif
 
 #define USE_STACK_TIMERS
 
@@ -137,8 +140,16 @@ protected:
   std::map<timer_id_t, std::string> timer_id_name;
   std::map<std::string, timer_id_t> timer_name_to_id;
 public:
+#ifdef USE_VTUNE_TASKS
+  __itt_domain *task_domain;
+#endif
+
   TimerManagerClass():timer_threshold(timer_level_coarse),max_timer_id(1),
-    max_timers_exceeded(false) {}
+    max_timers_exceeded(false) {
+#ifdef USE_VTUNE_TASKS
+      task_domain = __itt_domain_create("QMCPACK");
+#endif
+    }
   void addTimer (NewTimer* t);
   NewTimer *createTimer(const std::string& myname, timer_levels mytimer = timer_level_fine);
 
@@ -229,6 +240,10 @@ protected:
   std::map<StackKey, double> per_stack_total_time;
   std::map<StackKey, long> per_stack_num_calls;
 #endif
+
+#ifdef USE_VTUNE_TASKS
+  __itt_string_handle *task_name;
+#endif
 public:
 #if not(ENABLE_TIMERS)
   inline void start() {}
@@ -239,6 +254,12 @@ public:
     if (active)
     {
 #ifdef USE_STACK_TIMERS
+
+#ifdef USE_VTUNE_TASKS
+      __itt_id parent_task = __itt_null;
+      __itt_task_begin(manager->task_domain, __itt_null, parent_task, task_name);
+#endif
+
       #pragma omp master
       {
         if (manager)
@@ -276,6 +297,11 @@ public:
     if (active)
     {
 #ifdef USE_STACK_TIMERS
+
+#ifdef USE_VTUNE_TASKS
+      __itt_task_end(manager->task_domain);
+#endif
+
       #pragma omp master
 #endif
       {
@@ -363,7 +389,11 @@ public:
 #ifdef USE_STACK_TIMERS
   ,manager(NULL), parent(NULL)
 #endif
-  { }
+  {
+#ifdef USE_VTUNE_TASKS
+    task_name = __itt_string_handle_create(myname.c_str());
+#endif
+  }
 
 
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -236,6 +236,9 @@
 /* Internal timers */
 #cmakedefine ENABLE_TIMERS @ENABLE_TIMERS@
 
+/* Use VTune API */
+#cmakedefine USE_VTUNE_API @USE_VTUNE_API@
+
 /* Use VTune Task API with timers */
 #cmakedefine USE_VTUNE_TASKS @USE_VTUNE_TASKS@
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -236,5 +236,8 @@
 /* Internal timers */
 #cmakedefine ENABLE_TIMERS @ENABLE_TIMERS@
 
+/* Use VTune Task API with timers */
+#cmakedefine USE_VTUNE_TASKS @USE_VTUNE_TASKS@
+
 #endif // QMCPLUSPLUS_CONFIGURATION_H
 


### PR DESCRIPTION
Incorporates the suggested changes from #629 
- USE_VTUNE_API generically checks that the include and library files can be found
- USE_VTUNE_TASKS adds the timers-as-tasks code
- adds a manual chapter on 'External Tools'