### PR TITLE
Skip git-rev files for non-git builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,9 +257,8 @@ SET(QMCPACK_UNIT_TEST_DIR ${qmcpack_BINARY_DIR}/tests/bin)
 ######################################################
 FIND_PACKAGE(Git)
 
-SET(IS_GIT_PROJECT false)
-IF (EXISTS "${PROJECT_SOURCE_DIR}/.git")
-  SET(IS_GIT_PROJECT true)
+IF (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  SET(IS_GIT_PROJECT 1)
 ENDIF()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ EXECUTE_PROCESS(
   COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_TMP}
 )
 
-IF (GIT_FOUND AND IS_GIT_PROJECT)
+IF (IS_GIT_PROJECT)
   # The following custom command picks up changes to the git revision information
   # every time the project is rebuilt. Even if the repositiory is updated (git pull)
   # without re-running cmake. It also appends '-dirty' to the commit hash if there are
@@ -93,14 +93,6 @@ IF (GIT_FOUND AND IS_GIT_PROJECT)
   )
   MESSAGE("Git branch: ${GIT_CONFIG_BRANCH}")
   MESSAGE("Git commit hash: ${GIT_CONFIG_COMMIT_HASH}")
-ELSE()
-  # Output a blank git version file
-  EXECUTE_PROCESS(
-    COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_FILE}
-    COMMAND ${CMAKE_COMMAND} -E touch ${GITREV_FILE}
-    COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_TMP}
-    COMMAND ${CMAKE_COMMAND} -E touch ${GITREV_TMP}
-  )
 ENDIF()
 
 
@@ -148,8 +140,10 @@ ENDIF(HAVE_OOMPI)
     spline2/einspline_allocator.c
     spline2/bspline_allocator.cpp
     spline2/MultiBspline.cpp
-    ${GITREV_TMP}
     )
+IF (IS_GIT_PROJECT)
+  SET(UTILITIES "${UTILITIES};${GITREV_TMP}")
+ENDIF()
 
   IF(QMC_ADIOS)
     SET(UTILITIES ${UTILITIES}

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -23,6 +23,9 @@
 /* define the git last commit date */
 // #cmakedefine QMCPLUSPLUS_LAST_CHANGED_DATE  "@QMCPLUSPLUS_LAST_CHANGED_DATE@"
 
+/* building from Git repository or not */
+#cmakedefine IS_GIT_PROJECT  @IS_GIT_PROJECT@
+
 /* define QMC_BUILD_LEVEL */
 #cmakedefine QMC_BUILD_LEVEL @QMC_BUILD_LEVEL@
 

--- a/src/qmcpack_version.h
+++ b/src/qmcpack_version.h
@@ -8,7 +8,9 @@
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
 
+#ifdef IS_GIT_PROJECT
 #include "git-rev.h"
+#endif
 
 #ifdef GIT_BRANCH_RAW
 #define QMCPACK_GIT_BRANCH STR(GIT_BRANCH_RAW)


### PR DESCRIPTION
For builds that do not come from a git repository, the git-rev.h file is empty.  Change the code so git-rev.h and git-rev-tmp.h are not referenced, and are not even created.

Hopefully this can address a Spack issue where sometimes either file is not found.