### PR TITLE
Modified the k-grid for the momentum estimator and removed compQ

### DIFF
--- a/src/Lattice/CrystalLattice.cpp
+++ b/src/Lattice/CrystalLattice.cpp
@@ -138,6 +138,7 @@ void CrystalLattice<T,D,ORTHO>::reset()
   DiagonalOnly=ldesc.isDiagonalOnly(R);
   ABC=ldesc.calcSolidAngles(Rv,OneOverLength);
   WignerSeitzRadius = ldesc.calcWignerSeitzRadius(Rv);
+  WignerSeitzRadius_G = ldesc.calcWignerSeitzRadius(Gv);
   SimulationCellRadius = ldesc.calcSimulationCellRadius(Rv);
   // set equal WignerSeitzRadius and SimulationCellRadius when they are very close.
   if ( WignerSeitzRadius > SimulationCellRadius &&

--- a/src/Lattice/CrystalLattice.h
+++ b/src/Lattice/CrystalLattice.h
@@ -105,6 +105,8 @@ struct CrystalLattice
   Scalar_t SimulationCellRadius;
   /// SimulationCellRadius*SimulationCellRadius
   Scalar_t CellRadiusSq;
+  /// Wigner-Seitz cell radius in reciprocal space
+  Scalar_t WignerSeitzRadius_G;
   ///Real-space unit vectors. R(i,j) i=vector and j=x,y,z
   Tensor_t R;
   ///Reciprocal unit vectors. G(j,i) i=vector and j=x,y,z

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -60,8 +60,6 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
   }
 
   std::fill_n(nofK.begin(),nk,RealType(0));
-  std::fill_n(nofk_grad.begin(),nk,PosType(0));
-  std::fill_n(nofk_hess.begin(),nk,Tensor<RealType,OHMMS_DIM>(0));
   for (int i=0; i<np; ++i)
   {
     for (int ik=0; ik<nk; ++ik)
@@ -408,8 +406,6 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   }
   nofK.resize(kPoints.size());
   kdotp.resize(kPoints.size());
-  nofk_grad.resize(kPoints.size());
-  nofk_hess.resize(kPoints.size());
   vPos.resize(M);
   phases.resize(kPoints.size());
   phases_vPos.resize(M);
@@ -441,8 +437,6 @@ void MomentumEstimator::resize(const std::vector<PosType>& kin, const int Min)
   //copy kpoints
   kPoints=kin;
   nofK.resize(kin.size());
-  nofk_grad.resize(kin.size());
-  nofk_hess.resize(kin.size());
   kdotp.resize(kPoints.size());
   phases.resize(kPoints.size());
   //M

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -242,7 +242,8 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
         //convert to Cartesian: note that 2Pi is multiplied
         kpt=Lattice.k_cart(kpt);
         bool not_recorded=true;
-        if (i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && k*k<=kgrid_squared[2] && !sphere_only)
+        // This collects the k-points within the parallelepiped (if not in sphere_only mode)
+        if (!sphere_only && i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && k*k<=kgrid_squared[2])
         {
           kPoints.push_back(kpt);
           kcount0[kgrid+i]=1;
@@ -250,7 +251,8 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
           kcount2[kgrid+k]=1;
           not_recorded=false;
         }
-        if (kpt[0]*kpt[0]+kpt[1]*kpt[1]+kpt[2]*kpt[2]<=kmax_squared && !directional_only && not_recorded) //if (std::sqrt(kx*kx+ky*ky+kz*kz)<=sphere_kmax)
+        // This collects the k-points within a sphere (if not in directional_only mode, and the k-point has not been recorded yet)
+        if (!directional_only && not_recorded && kpt[0]*kpt[0]+kpt[1]*kpt[1]+kpt[2]*kpt[2]<=kmax_squared) //if (std::sqrt(kx*kx+ky*ky+kz*kz)<=sphere_kmax)
         {
           kPoints.push_back(kpt);
         }
@@ -259,8 +261,8 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   }
   if (sphere_only)
   {
-    app_log()<<"   Using all k-space points with (kx^2+ky^2+kz^2)^0.5 < "<< sphere_kmax <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
+    app_log()<<"    Using all k-space points with (kx^2+ky^2+kz^2)^0.5 < "<< sphere_kmax <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
   }
   else if (directional_only)
   {
@@ -274,11 +276,11 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       sums[1]+=kcount1[i];
       sums[2]+=kcount2[i];
     }
-    app_log()<<"   Using all k-space points within cut-offs "<< kmax0 << ", " << kmax1 << ", " << kmax2 <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution: "<< kPoints.size() << std::endl;
-    app_log()<<"    Number of grid points in kmax0 direction: " << sums[0] << std::endl;
-    app_log()<<"    Number of grid points in kmax1 direction: " << sums[1] << std::endl;
-    app_log()<<"    Number of grid points in kmax2 direction: " << sums[2] << std::endl;
+    app_log()<<"    Using all k-space points within cut-offs "<< kmax0 << ", " << kmax1 << ", " << kmax2 <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution: "<< kPoints.size() << std::endl;
+    app_log()<<"      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
+    app_log()<<"      Number of grid points in kmax1 direction: " << sums[1] << std::endl;
+    app_log()<<"      Number of grid points in kmax2 direction: " << sums[2] << std::endl;
   }
   else
   {
@@ -292,15 +294,15 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       sums[1]+=kcount1[i];
       sums[2]+=kcount2[i];
     }
-    app_log()<<"   Using all k-space points with (kx^2+ky^2+kz^2)^0.5 < "<< sphere_kmax <<", and"<< std::endl;
-    app_log()<<"   within the cut-offs "<< kmax0 << ", " << kmax1 << ", " << kmax2 <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
-    app_log()<<"   The number of k-points within the cut-off region: "<< sums[0]*sums[1]*sums[2] << std::endl;
-    app_log()<<"    Number of grid points in kmax0 direction: " << sums[0] << std::endl;
-    app_log()<<"    Number of grid points in kmax1 direction: " << sums[1] << std::endl;
-    app_log()<<"    Number of grid points in kmax2 direction: " << sums[2] << std::endl;
+    app_log()<<"    Using all k-space points with (kx^2+ky^2+kz^2)^0.5 < "<< sphere_kmax <<", and"<< std::endl;
+    app_log()<<"    within the cut-offs "<< kmax0 << ", " << kmax1 << ", " << kmax2 <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
+    app_log()<<"    The number of k-points within the cut-off region: "<< sums[0]*sums[1]*sums[2] << std::endl;
+    app_log()<<"      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
+    app_log()<<"      Number of grid points in kmax1 direction: " << sums[1] << std::endl;
+    app_log()<<"      Number of grid points in kmax2 direction: " << sums[2] << std::endl;
   }
-  app_log()<<"  My twist is: "<<twist[0]<<"  "<<twist[1]<<"  "<<twist[2]<< std::endl;
+  app_log()<<"    My twist is: "<<twist[0]<<"  "<<twist[1]<<"  "<<twist[2]<< std::endl;
 #endif
 #if OHMMS_DIM==2
   PosType kmaxs(0);
@@ -359,14 +361,14 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       //convert to Cartesian: note that 2Pi is multiplied
       kpt=Lattice.k_cart(kpt);
       bool not_recorded=true;
-      if (i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && !disk_only)
+      if (!disk_only && i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1])
       {
         kPoints.push_back(kpt);
         kcount0[kgrid+i]=1;
         kcount1[kgrid+j]=1;
         not_recorded=false;
       }
-      if (kpt[0]*kpt[0]+kpt[1]*kpt[1]<=kmax_squared && !directional_only && not_recorded) //if (std::sqrt(kx*kx+ky*ky)<=disk_kmax)
+      if (!directional_only && not_recorded && kpt[0]*kpt[0]+kpt[1]*kpt[1]<=kmax_squared) //if (std::sqrt(kx*kx+ky*ky)<=disk_kmax)
       {
         kPoints.push_back(kpt);
       }
@@ -374,8 +376,8 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   }
   if (disk_only)
   {
-    app_log()<<"   Using all k-space points with (kx^2+ky^2)^0.5 < "<< disk_kmax <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
+    app_log()<<"    Using all k-space points with (kx^2+ky^2)^0.5 < "<< disk_kmax <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
   }
   else if (directional_only)
   {
@@ -387,10 +389,10 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       sums[0]+=kcount0[i];
       sums[1]+=kcount1[i];
     }
-    app_log()<<"   Using all k-space points within cut-offs "<< kmax0 << ", " << kmax1 <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution: "<< kPoints.size() << std::endl;
-    app_log()<<"    Number of grid points in kmax0 direction: " << sums[0] << std::endl;
-    app_log()<<"    Number of grid points in kmax1 direction: " << sums[1] << std::endl;
+    app_log()<<"    Using all k-space points within cut-offs "<< kmax0 << ", " << kmax1 <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution: "<< kPoints.size() << std::endl;
+    app_log()<<"      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
+    app_log()<<"      Number of grid points in kmax1 direction: " << sums[1] << std::endl;
   }
   else
   {
@@ -402,14 +404,14 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       sums[0]+=kcount0[i];
       sums[1]+=kcount1[i];
     }
-    app_log()<<"   Using all k-space points with (kx^2+ky^2)^0.5 < "<< disk_kmax <<", and"<< std::endl;
-    app_log()<<"   within the cut-offs "<< kmax0 << ", " << kmax1 <<" for Momentum Distribution."<< std::endl;
-    app_log()<<"   Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
-    app_log()<<"   The number of k-points within the cut-off region: "<< sums[0]*sums[1] << std::endl;
-    app_log()<<"    Number of grid points in kmax0 direction: " << sums[0] << std::endl;
-    app_log()<<"    Number of grid points in kmax1 direction: " << sums[1] << std::endl;
+    app_log()<<"    Using all k-space points with (kx^2+ky^2)^0.5 < "<< disk_kmax <<", and"<< std::endl;
+    app_log()<<"    within the cut-offs "<< kmax0 << ", " << kmax1 <<" for Momentum Distribution."<< std::endl;
+    app_log()<<"    Total number of k-points for Momentum Distribution is "<< kPoints.size() << std::endl;
+    app_log()<<"    The number of k-points within the cut-off region: "<< sums[0]*sums[1] << std::endl;
+    app_log()<<"      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
+    app_log()<<"      Number of grid points in kmax1 direction: " << sums[1] << std::endl;
   }
-  app_log()<<"  My twist is: "<<twist[0]<<"  "<<twist[1]<<"  "<<twist[2]<< std::endl;
+  app_log()<<"    My twist is: "<<twist[0]<<"  "<<twist[1]<<"  "<<twist[2]<< std::endl;
 #endif
   if (rootNode)
   {

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -167,18 +167,12 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   pAttrib.add(M,"samples"); // default value is 40 (in the constructor)
   pAttrib.put(cur);
   hdf5_out = (hdf5_flag=="yes");
-  RealType min_Length=1.0e10;
-  PosType vec_length(0);
+  // minimal length as 2 x WS radius.
+  RealType min_Length = elns.Lattice.WignerSeitzRadius_G*4.0*M_PI;
+  PosType vec_length;
+  //length of reciprocal lattice vector
   for (int i=0; i<OHMMS_DIM; i++)
-  {
-    PosType a(0);
-    for (int j=0; j<OHMMS_DIM; j++)
-      a[j]=elns.Lattice.G(j,i);
-    //length of reciprocal lattice vector
-    vec_length[i]=2.0*M_PI*std::sqrt(dot(a,a));
-    if (min_Length>vec_length[i])
-      min_Length=vec_length[i];
-  }
+    vec_length[i]=2.0*M_PI*std::sqrt(dot(elns.Lattice.Gv[i],elns.Lattice.Gv[i]));
 #if OHMMS_DIM==3
   PosType kmaxs(0);
   kmaxs[0]=kmax0;

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -11,8 +11,8 @@
 //
 // File created by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
 #include <QMCHamiltonians/MomentumEstimator.h>
 #include <QMCWaveFunctions/TrialWaveFunction.h>
 #include <Numerics/e2iphi.h>
@@ -166,11 +166,11 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   pAttrib.add(kmax2,"kmax2");
   pAttrib.add(M,"samples"); // default value is 40 (in the constructor)
   pAttrib.put(cur);
-  hdf5_out = (hdf5_flag=="yes");  
+  hdf5_out = (hdf5_flag=="yes");
   RealType min_Length=1.0e10;
   PosType vec_length(0);
   for (int i=0; i<OHMMS_DIM; i++)
-  {    
+  {
     PosType a(0);
     for (int j=0; j<OHMMS_DIM; j++)
       a[j]=elns.Lattice.G(j,i);
@@ -191,7 +191,7 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
   if (kmax<1.0e-10 && sum_kmaxs<1.0e-10)
   {
     // default: kmax = 2 x k_F of polarized non-interacting electron system
-    kmax = 2.0*std::pow(6.0*M_PI*M_PI*elns.getTotalNum()/elns.Lattice.Volume,1.0/3);    
+    kmax = 2.0*std::pow(6.0*M_PI*M_PI*elns.getTotalNum()/elns.Lattice.Volume,1.0/3);
     kgrid = int(kmax/min_Length)+1;
     sphere_kmax=kmax;
     sphere_only=true;
@@ -208,18 +208,18 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
     else
     {
       if (kmax<1.0e-10)
-	sphere_only=false;
+        sphere_only=false;
       if (sum_kmaxs<1.0e-10)
-	directional_only=false;
+        directional_only=false;
     }
     for (int i=0; i<OHMMS_DIM; i++)
     {
       if (kmaxs[i]>kmax)
-	kmax=kmaxs[i];
+        kmax=kmaxs[i];
     }
     kgrid = int(kmax/min_Length)+1;
   }
-  int kgrid_squared[OHMMS_DIM];  
+  int kgrid_squared[OHMMS_DIM];
   for (int i=0; i<OHMMS_DIM; i++)
     kgrid_squared[i]=int(std::round(kmaxs[i]*kmaxs[i]/vec_length[i]/vec_length[i]));
   RealType kmax_squared=sphere_kmax*sphere_kmax;
@@ -235,25 +235,25 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
     {
       for (int k=-kgrid; k<(kgrid+1); k++)
       {
-	PosType kpt;
-	kpt[0]=i-twist[0];
-	kpt[1]=j-twist[1];
-	kpt[2]=k-twist[2];
-	//convert to Cartesian: note that 2Pi is multiplied
-	kpt=Lattice.k_cart(kpt);
-	bool not_recorded=true;
-	if (i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && k*k<=kgrid_squared[2] && !sphere_only)
-	{
-	  kPoints.push_back(kpt);
-	  kcount0[kgrid+i]=1;
-	  kcount1[kgrid+j]=1;
-	  kcount2[kgrid+k]=1;
-	  not_recorded=false;
-	}	
-	if (kpt[0]*kpt[0]+kpt[1]*kpt[1]+kpt[2]*kpt[2]<=kmax_squared && !directional_only && not_recorded) //if (std::sqrt(kx*kx+ky*ky+kz*kz)<=sphere_kmax)
-	{
-	  kPoints.push_back(kpt);
-	}
+        PosType kpt;
+        kpt[0]=i-twist[0];
+        kpt[1]=j-twist[1];
+        kpt[2]=k-twist[2];
+        //convert to Cartesian: note that 2Pi is multiplied
+        kpt=Lattice.k_cart(kpt);
+        bool not_recorded=true;
+        if (i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && k*k<=kgrid_squared[2] && !sphere_only)
+        {
+          kPoints.push_back(kpt);
+          kcount0[kgrid+i]=1;
+          kcount1[kgrid+j]=1;
+          kcount2[kgrid+k]=1;
+          not_recorded=false;
+        }
+        if (kpt[0]*kpt[0]+kpt[1]*kpt[1]+kpt[2]*kpt[2]<=kmax_squared && !directional_only && not_recorded) //if (std::sqrt(kx*kx+ky*ky+kz*kz)<=sphere_kmax)
+        {
+          kPoints.push_back(kpt);
+        }
       }
     }
   }
@@ -330,18 +330,18 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
     else
     {
       if (kmax<1.0e-10)
-	disk_only=false;
+        disk_only=false;
       if (sum_kmaxs<1.0e-10)
-	directional_only=false;
+        directional_only=false;
     }
     for (int i=0; i<OHMMS_DIM; i++)
     {
       if (kmaxs[i]>kmax)
-	kmax=kmaxs[i];
+        kmax=kmaxs[i];
     }
     kgrid = int(kmax/min_Length)+1;
   }
-  int kgrid_squared[OHMMS_DIM];  
+  int kgrid_squared[OHMMS_DIM];
   for (int i=0; i<OHMMS_DIM; i++)
     kgrid_squared[i]=int(std::round(kmaxs[i]*kmaxs[i]/vec_length[i]/vec_length[i]));
   RealType kmax_squared=disk_kmax*disk_kmax;
@@ -361,14 +361,14 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
       bool not_recorded=true;
       if (i*i<=kgrid_squared[0] && j*j<=kgrid_squared[1] && !disk_only)
       {
-	kPoints.push_back(kpt);
-	kcount0[kgrid+i]=1;
-	kcount1[kgrid+j]=1;
-	not_recorded=false;
-      }	
+        kPoints.push_back(kpt);
+        kcount0[kgrid+i]=1;
+        kcount1[kgrid+j]=1;
+        not_recorded=false;
+      }
       if (kpt[0]*kpt[0]+kpt[1]*kpt[1]<=kmax_squared && !directional_only && not_recorded) //if (std::sqrt(kx*kx+ky*ky)<=disk_kmax)
       {
-	kPoints.push_back(kpt);
+        kPoints.push_back(kpt);
       }
     }
   }

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -75,10 +75,6 @@ public:
   std::vector<int> kWeights;
   ///nofK
   aligned_vector<RealType> nofK;
-  ///Gradient of nofK
-  std::vector<PosType> nofk_grad;
-  ///Hessian of nofK
-  std::vector<Tensor<RealType,OHMMS_DIM>> nofk_hess;
   /// print to hdf5 or scalar.dat
   bool hdf5_out;
   PosType twist;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -46,13 +46,11 @@ public:
   QMCHamiltonianBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
   void setRandomGenerator(RandomGenerator_t* rng);
   //resize the internal data by input k-point list
-  void resize(const std::vector<PosType>& kin,const std::vector<RealType>& qin, const int Min);
+  void resize(const std::vector<PosType>& kin, const int Min);
   ///number of samples
   int M;
   ///normalization factor for n(k)
   RealType norm_nofK;
-  ///normalization factor for the Compton profile
-  RealType norm_compQ;
   ///reference to the trial wavefunction for ratio evaluations
   TrialWaveFunction& refPsi;
   ///lattice vector
@@ -77,21 +75,16 @@ public:
   std::vector<int> kWeights;
   ///dims of a grid for k points
   int kgrid;
-  ///maximum k-value in the k-grid
+  ///maximum k-value in the k-grid in cartesian coordinates
   RealType kmax;
+  ///maximum k-values in the k-grid along the reciprocal cell axis
+  RealType kmax0;
+  RealType kmax1;
+  RealType kmax2;
   ///nofK
   aligned_vector<RealType> nofK;
-  ///list of Q for the Compton profile
-  std::vector<RealType> Q;
-  ///compton profile at q
-  Vector<RealType> compQ;
   /// print to hdf5 or scalar.dat
   bool hdf5_out;
-
-  std::vector<std::vector<int> > mappedQtonofK;
-//     std::vector<std::vector<int> > mappednofKtoK;
-  std::vector<RealType> mappedQnorms;
-  std::vector<RealType> mappedKnorms;
   PosType twist;
 };
 

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -77,6 +77,8 @@ public:
   std::vector<int> kWeights;
   ///dims of a grid for k points
   int kgrid;
+  ///maximum k-value in the k-grid
+  RealType kmax;
   ///nofK
   aligned_vector<RealType> nofK;
   ///list of Q for the Compton profile

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -69,14 +69,16 @@ public:
   VectorSoaContainer<RealType,2> phases;
   ///phases of vPos
   std::vector<VectorSoaContainer<RealType,2> > phases_vPos;
-  ///dims of a grid for k points
-  int kgrid;
   ///list of k-points in Cartesian Coordinates
   std::vector<PosType> kPoints;
   ///weight of k-points (make use of symmetry)
   std::vector<int> kWeights;
   ///nofK
   aligned_vector<RealType> nofK;
+  ///Gradient of nofK
+  std::vector<PosType> nofk_grad;
+  ///Hessian of nofK
+  std::vector<Tensor<RealType,OHMMS_DIM>> nofk_hess;
   /// print to hdf5 or scalar.dat
   bool hdf5_out;
   PosType twist;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -69,18 +69,12 @@ public:
   VectorSoaContainer<RealType,2> phases;
   ///phases of vPos
   std::vector<VectorSoaContainer<RealType,2> > phases_vPos;
+  ///dims of a grid for k points
+  int kgrid;
   ///list of k-points in Cartesian Coordinates
   std::vector<PosType> kPoints;
   ///weight of k-points (make use of symmetry)
   std::vector<int> kWeights;
-  ///dims of a grid for k points
-  int kgrid;
-  ///maximum k-value in the k-grid in cartesian coordinates
-  RealType kmax;
-  ///maximum k-values in the k-grid along the reciprocal cell axis
-  RealType kmax0;
-  RealType kmax1;
-  RealType kmax2;
   ///nofK
   aligned_vector<RealType> nofK;
   /// print to hdf5 or scalar.dat


### PR DESCRIPTION
1. The compQ was removed: it can be post-processed rather straightforwardly from n(k).
2. Modified the input options for n(k):
  (a) kmax: desired k-points reside within the sphere of radius kmax
  (b) kmax0, kmax1, kmax2: maximum k-values for a parallelepiped in which the k-points are located
  (c) both (a) and (b): includes k-points within the sphere and those of the parallelepiped outside the sphere
  (d) default behaviour (i.e., not defining any kmax values): uses (a) with kmax=2.0 x k_F, where k_F is the Fermi momentum of polarized non-interacting electron gas at corresponding electron density
