### PR TITLE
optimized JeeI

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor3D.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor3D.h
@@ -388,7 +388,7 @@ struct BsplineFunctor3D: public OptimizableFunctorBase
 
   // assume r_1I < L && r_2I < L, compression and screening is handled outside
   inline void evaluateVGL(int Nptcl, const real_type* restrict r_12_array,
-                          const real_type r_1I,
+                          const real_type* restrict r_1I_array,
                           const real_type* restrict r_2I_array,
                           real_type* restrict val_array,
                           real_type* restrict grad0_array,

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor3D.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor3D.h
@@ -270,13 +270,14 @@ struct BsplineFunctor3D: public OptimizableFunctorBase
     return val;
   }
 
-  inline real_type evaluateV(int Nptcl, const real_type* restrict r_12_array,
-                            const real_type r_1I,
-                            const real_type* restrict r_2I_array) const
+  inline real_type evaluateV(int Nptcl,
+                             const real_type* restrict r_12_array,
+                             const real_type* restrict r_1I_array,
+                             const real_type* restrict r_2I_array) const
   {
     real_type val_tot(0);
     for(int ptcl=0; ptcl<Nptcl; ptcl++)
-      val_tot+=evaluate(r_12_array[ptcl],r_1I,r_2I_array[ptcl]);
+      val_tot+=evaluate(r_12_array[ptcl],r_1I_array[ptcl],r_2I_array[ptcl]);
     return val_tot;
   }
 

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -178,12 +178,12 @@ public:
     //initialize buffers
     Nbuffer=Nelec;
     mVGL.resize(Nbuffer);
-    DistkI_Compressed.resize(Nbuffer);
     Distjk_Compressed.resize(Nbuffer);
+    DistjI_Compressed.resize(Nbuffer);
+    DistkI_Compressed.resize(Nbuffer);
     Disp_jk_Compressed.resize(Nbuffer);
     Disp_jI_Compressed.resize(Nbuffer);
     Disp_kI_Compressed.resize(Nbuffer);
-    DistjI_Compressed.resize(Nbuffer);
     DistIndice_k.resize(Nbuffer);
     DistIndice_i.resize(Nbuffer);
   }
@@ -643,6 +643,7 @@ public:
     feeI.evaluateVGL(kel_counter, Distjk_Compressed.data(), DistjI_Compressed.data(), DistkI_Compressed.data(),
                      val, gradF0, gradF1, gradF2, hessF00, hessF11, hessF22, hessF01, hessF02);
 
+    // collect displacements
     for(int idim=0; idim<OHMMS_DIM; ++idim)
     {
       valT *restrict jk = Disp_jk_Compressed.data(idim);

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -670,7 +670,7 @@ public:
         // recycle hessF11
         hessF11[kel_index] += kI[kel_index] * jk[kel_index];
         dUj_x += gradF1[kel_index] * jI[kel_index];
-        // destroy kI
+        // destroy jk, kI
         const valT temp = jk[kel_index] * gradF0[kel_index];
         dUj_x += temp;
         jk[kel_index] *= jI[kel_index];
@@ -861,7 +861,7 @@ public:
 
       build_compact_list(P);
 
-      dLogPsi=czero;
+      dLogPsi = czero;
       gradLogPsi = PosType();
       lapLogPsi = czero;
 
@@ -873,7 +873,7 @@ public:
           {
             const int jel=elecs_inside(jg,iat)[jind];
             const valT r_Ij     = elecs_inside_dist(jg,iat)[jind];
-            const posT disp_Ij  = cminus*eI_table.Displacements[jel][iat];
+            const posT disp_Ij  = cminus*elecs_inside_displ(jg,iat)[jind];
             const valT r_Ij_inv = cone/r_Ij;
 
             for(int kg=0; kg<eGroups; ++kg)
@@ -885,7 +885,7 @@ public:
                   const FT& feeI(*F(ig,jg,kg));
 
                   const valT r_Ik     = elecs_inside_dist(kg,iat)[kind];
-                  const posT disp_Ik  = cminus*eI_table.Displacements[kel][iat];
+                  const posT disp_Ik  = cminus*elecs_inside_displ(kg,iat)[kind];
                   const valT r_Ik_inv = cone/r_Ik;
 
                   const valT r_jk     = ee_table.Distances[jel][kel];

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -633,7 +633,6 @@ public:
 
     constexpr valT czero(0);
     constexpr valT cone(1);
-    constexpr valT cminus(-1);
     constexpr valT ctwo(2);
     constexpr valT lapfac=OHMMS_DIM-cone;
 
@@ -718,7 +717,6 @@ public:
                         Vector<valT>& Uk, gContainer_type& dUk, Vector<valT>& d2Uk, bool triangle=false)
   {
     constexpr valT czero(0);
-    constexpr valT cminus(-1);
 
     Uj = czero;
     dUj = posT();

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -688,17 +688,23 @@ public:
       }
       dUj[idim] += dUj_x;
 
+      valT *restrict jk0 = Disp_jk_Compressed.data(0);
+      if(idim>0)
+      {
+        #pragma omp simd aligned(jk,jk0)
+        for(int kel_index=0; kel_index<kel_counter; kel_index++)
+          jk0[kel_index] += jk[kel_index];
+      }
+
       valT *restrict dUk_x = dUk.data(idim);
       for(int kel_index=0; kel_index<kel_counter; kel_index++)
         dUk_x[DistIndice_k[kel_index]] += kI[kel_index];
     }
     valT sum(0);
-    valT *restrict jk_x = Disp_jk_Compressed.data(0);
-    valT *restrict jk_y = Disp_jk_Compressed.data(1);
-    valT *restrict jk_z = Disp_jk_Compressed.data(2);
-    #pragma omp simd aligned(jk_x,jk_y,jk_z,hessF01) reduction(+:sum)
+    valT *restrict jk0 = Disp_jk_Compressed.data(0);
+    #pragma omp simd aligned(jk0,hessF01) reduction(+:sum)
     for(int kel_index=0; kel_index<kel_counter; kel_index++)
-      sum += hessF01[kel_index] * (jk_x[kel_index]+jk_y[kel_index]+jk_z[kel_index]);
+      sum += hessF01[kel_index] * jk0[kel_index];
     d2Uj -= ctwo * sum;
 
     #pragma omp simd aligned(hessF00,hessF22,gradF0,gradF2,hessF02,hessF11)

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -171,9 +171,9 @@ public:
 
     F.resize(iGroups,eGroups,eGroups);
     F=nullptr;
-    elecs_inside.resize(Nion,eGroups);
-    elecs_inside_dist.resize(Nion,eGroups);
-    elecs_inside_displ.resize(Nion,eGroups);
+    elecs_inside.resize(eGroups,Nion);
+    elecs_inside_dist.resize(eGroups,Nion);
+    elecs_inside_displ.resize(eGroups,Nion);
     ions_nearby.resize(Nion);
     Ion_cutoff.resize(Nion, 0.0);
 
@@ -386,9 +386,9 @@ public:
     for(int iat=0; iat<Nion; ++iat)
       for(int jg=0; jg<eGroups; ++jg)
       {
-        elecs_inside(iat,jg).clear();
-        elecs_inside_dist(iat,jg).clear();
-        elecs_inside_displ(iat,jg).clear();
+        elecs_inside(jg,iat).clear();
+        elecs_inside_dist(jg,iat).clear();
+        elecs_inside_displ(jg,iat).clear();
       }
 
     for(int jg=0; jg<eGroups; ++jg)
@@ -396,9 +396,9 @@ public:
         for(int iat=0; iat<Nion; ++iat)
           if(eI_table.Distances[jel][iat]<Ion_cutoff[iat])
           {
-            elecs_inside(iat,jg).push_back(jel);
-            elecs_inside_dist(iat,jg).push_back(eI_table.Distances[jel][iat]);
-            elecs_inside_displ(iat,jg).push_back(eI_table.Displacements[jel][iat]);
+            elecs_inside(jg,iat).push_back(jel);
+            elecs_inside_dist(jg,iat).push_back(eI_table.Distances[jel][iat]);
+            elecs_inside_displ(jg,iat).push_back(eI_table.Displacements[jel][iat]);
           }
   }
 
@@ -515,16 +515,16 @@ public:
     for (int jat=0; jat < Nion; jat++)
     {
       bool inside = eI_table.Temp_r[jat] < Ion_cutoff[jat];
-      auto iter = find(elecs_inside(jat,ig).begin(), elecs_inside(jat,ig).end(), iat);
-      auto iter_dist = elecs_inside_dist(jat,ig).begin()+std::distance(elecs_inside(jat,ig).begin(),iter);
-      auto iter_displ = elecs_inside_displ(jat,ig).begin()+std::distance(elecs_inside(jat,ig).begin(),iter);
+      auto iter = find(elecs_inside(ig,jat).begin(), elecs_inside(ig,jat).end(), iat);
+      auto iter_dist = elecs_inside_dist(ig,jat).begin()+std::distance(elecs_inside(ig,jat).begin(),iter);
+      auto iter_displ = elecs_inside_displ(ig,jat).begin()+std::distance(elecs_inside(ig,jat).begin(),iter);
       if(inside)
       {
-        if(iter==elecs_inside(jat,ig).end())
+        if(iter==elecs_inside(ig,jat).end())
         {
-          elecs_inside(jat,ig).push_back(iat);
-          elecs_inside_dist(jat,ig).push_back(eI_table.Temp_r[jat]);
-          elecs_inside_displ(jat,ig).push_back(eI_table.Temp_dr[jat]);
+          elecs_inside(ig,jat).push_back(iat);
+          elecs_inside_dist(ig,jat).push_back(eI_table.Temp_r[jat]);
+          elecs_inside_displ(ig,jat).push_back(eI_table.Temp_dr[jat]);
         }
         else
         {
@@ -534,14 +534,14 @@ public:
       }
       else
       {
-        if(iter!=elecs_inside(jat,ig).end())
+        if(iter!=elecs_inside(ig,jat).end())
         {
-          *iter = elecs_inside(jat,ig).back();
-          elecs_inside(jat,ig).pop_back();
-          *iter_dist = elecs_inside_dist(jat,ig).back();
-          elecs_inside_dist(jat,ig).pop_back();
-          *iter_displ = elecs_inside_displ(jat,ig).back();
-          elecs_inside_displ(jat,ig).pop_back();
+          *iter = elecs_inside(ig,jat).back();
+          elecs_inside(ig,jat).pop_back();
+          *iter_dist = elecs_inside_dist(ig,jat).back();
+          elecs_inside_dist(ig,jat).pop_back();
+          *iter_displ = elecs_inside_displ(ig,jat).back();
+          elecs_inside_displ(ig,jat).pop_back();
         }
       }
     }
@@ -596,12 +596,12 @@ public:
         const int iat = ions_nearby[iind];
         const int ig = Ions.GroupID[iat];
         const valT r_jI = distjI[iat];
-        for(int kind=0; kind<elecs_inside(iat,kg).size(); kind++)
+        for(int kind=0; kind<elecs_inside(kg,iat).size(); kind++)
         {
-          const int kel=elecs_inside(iat,kg)[kind];
+          const int kel=elecs_inside(kg,iat)[kind];
           if(kel!=jel)
           {
-            DistkI_Compressed[kel_counter]=elecs_inside_dist(iat,kg)[kind];
+            DistkI_Compressed[kel_counter]=elecs_inside_dist(kg,iat)[kind];
             Distjk_Compressed[kel_counter]=distjk[kel];
             DistjI_Compressed[kel_counter]=r_jI;
             kel_counter++;
@@ -746,15 +746,15 @@ public:
         const int ig = Ions.GroupID[iat];
         const valT r_jI = distjI[iat];
         const posT disp_Ij = displjI[iat];
-        for(int kind=0; kind<elecs_inside(iat,kg).size(); kind++)
+        for(int kind=0; kind<elecs_inside(kg,iat).size(); kind++)
         {
-          const int kel=elecs_inside(iat,kg)[kind];
+          const int kel=elecs_inside(kg,iat)[kind];
           if(kel<kelmax && kel!=jel)
           {
-            DistkI_Compressed[kel_counter]=elecs_inside_dist(iat,kg)[kind];
+            DistkI_Compressed[kel_counter]=elecs_inside_dist(kg,iat)[kind];
             DistjI_Compressed[kel_counter]=r_jI;
             Distjk_Compressed[kel_counter]=distjk[kel];
-            Disp_kI_Compressed(kel_counter)=elecs_inside_displ(iat,kg)[kind];
+            Disp_kI_Compressed(kel_counter)=elecs_inside_displ(kg,iat)[kind];
             Disp_jI_Compressed(kel_counter)=disp_Ij;
             Disp_jk_Compressed(kel_counter)=displjk[kel];
             DistIndice_k[kel_counter]=kel;
@@ -869,22 +869,22 @@ public:
       {
         const int ig=Ions.GroupID[iat];
         for(int jg=0; jg<eGroups; ++jg)
-          for(int jind=0; jind<elecs_inside(iat,jg).size(); jind++)
+          for(int jind=0; jind<elecs_inside(jg,iat).size(); jind++)
           {
-            const int jel=elecs_inside(iat,jg)[jind];
-            const valT r_Ij     = elecs_inside_dist(iat,jg)[jind];
+            const int jel=elecs_inside(jg,iat)[jind];
+            const valT r_Ij     = elecs_inside_dist(jg,iat)[jind];
             const posT disp_Ij  = cminus*eI_table.Displacements[jel][iat];
             const valT r_Ij_inv = cone/r_Ij;
 
             for(int kg=0; kg<eGroups; ++kg)
-              for(int kind=0; kind<elecs_inside(iat,kg).size(); kind++)
+              for(int kind=0; kind<elecs_inside(kg,iat).size(); kind++)
               {
-                const int kel=elecs_inside(iat,kg)[kind];
+                const int kel=elecs_inside(kg,iat)[kind];
                 if(kel<jel)
                 {
                   const FT& feeI(*F(ig,jg,kg));
 
-                  const valT r_Ik     = elecs_inside_dist(iat,kg)[kind];
+                  const valT r_Ik     = elecs_inside_dist(kg,iat)[kind];
                   const posT disp_Ik  = cminus*eI_table.Displacements[kel][iat];
                   const valT r_Ik_inv = cone/r_Ik;
 

--- a/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
+++ b/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
@@ -501,7 +501,7 @@ struct PolynomialFunctor3D: public OptimizableFunctorBase
 
   // assume r_1I < L && r_2I < L, compression and screening is handled outside
   inline void evaluateVGL(int Nptcl, const real_type* restrict r_12_array,
-                          const real_type r_1I,
+                          const real_type* restrict r_1I_array,
                           const real_type* restrict r_2I_array,
                           real_type* restrict val_array,
                           real_type* restrict grad0_array,
@@ -519,12 +519,13 @@ struct PolynomialFunctor3D: public OptimizableFunctorBase
     constexpr real_type ctwo(2);
 
     const real_type L = chalf*cutoff_radius;
-    #pragma omp simd aligned(r_12_array,r_2I_array,val_array, \
+    #pragma omp simd aligned(r_12_array,r_1I_array,r_2I_array,val_array, \
       grad0_array,grad1_array,grad2_array, \
       hess00_array,hess11_array,hess22_array,hess01_array,hess02_array)
     for(int ptcl=0; ptcl<Nptcl; ptcl++)
     {
       const real_type r_12 = r_12_array[ptcl];
+      const real_type r_1I = r_1I_array[ptcl];
       const real_type r_2I = r_2I_array[ptcl];
 
       real_type val(czero);

--- a/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
+++ b/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
@@ -372,9 +372,10 @@ struct PolynomialFunctor3D: public OptimizableFunctorBase
   }
 
   // assume r_1I < L && r_2I < L, compression and screening is handled outside
-  inline real_type evaluateV(int Nptcl, const real_type* restrict r_12_array,
-                            const real_type r_1I,
-                            const real_type* restrict r_2I_array) const
+  inline real_type evaluateV(int Nptcl,
+                             const real_type* restrict r_12_array,
+                             const real_type* restrict r_1I_array,
+                             const real_type* restrict r_2I_array) const
   {
     constexpr real_type czero(0);
     constexpr real_type cone(1);
@@ -383,10 +384,11 @@ struct PolynomialFunctor3D: public OptimizableFunctorBase
     const real_type L = chalf*cutoff_radius;
     real_type val_tot = czero;
 
-    #pragma omp simd aligned(r_12_array,r_2I_array) reduction(+:val_tot)
+    #pragma omp simd aligned(r_12_array,r_1I_array,r_2I_array) reduction(+:val_tot)
     for(int ptcl=0; ptcl<Nptcl; ptcl++)
     {
       const real_type r_12 = r_12_array[ptcl];
+      const real_type r_1I = r_1I_array[ptcl];
       const real_type r_2I = r_2I_array[ptcl];
       real_type val = czero;
       real_type r2l(cone);

--- a/tests/solids/monoO_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/monoO_1x1x1_pp/CMakeLists.txt
@@ -12,6 +12,17 @@
                     0 MONO_O_SCALARS # VMC
                     )
 
+  LIST(APPEND MONO_O_J3_SCALARS "totenergy" "-31.913838 0.0025")
+  LIST(APPEND MONO_O_J3_SCALARS "samples" "204800 0.0")
+  QMC_RUN_AND_CHECK(short-monoO_1x1x1_pp-vmc_sdj3
+                    "${CMAKE_SOURCE_DIR}/tests/solids/monoO_1x1x1_pp"
+                    qmc_j3_short
+                    qmc_j3_short.in.xml
+                    1 16
+                    TRUE
+                    0 MONO_O_J3_SCALARS # VMC
+                    )
+
 #
 # Long test
 #
@@ -28,5 +39,18 @@
                     1 16
                     TRUE
                     0 LONG_MONO_O_SCALARS # VMC
+                    )
+
+  LIST(APPEND LONG_MONO_O_J3_SCALARS "totenergy" "-31.913838 0.0008")
+  LIST(APPEND LONG_MONO_O_J3_SCALARS "samples" "2048000 0.0")
+  LIST(APPEND LONG_MONO_O_J3_SCALARS "flux" "0.0 0.27")
+
+  QMC_RUN_AND_CHECK(long-monoO_1x1x1_pp-vmc_sdj3
+                    "${CMAKE_SOURCE_DIR}/tests/solids/monoO_1x1x1_pp"
+                    qmc_j3_long
+                    qmc_j3_long.in.xml
+                    1 16
+                    TRUE
+                    0 LONG_MONO_O_J3_SCALARS # VMC
                     )
 

--- a/tests/solids/monoO_1x1x1_pp/qmc_j3_long.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_j3_long.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="qmc_short" series="0">
+   <project id="qmc_j3_long" series="0">
       <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
    </project>
    <qmcsystem>
@@ -50,25 +50,24 @@
          </determinantset>
          <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
             <correlation elementType="O" size="8" cusp="0.0">
-               <coefficients id="eO" type="Array">                  
--0.6248667077 -0.546777858 -0.4621312431 -0.345220471 -0.237294967 -0.1481619198 
--0.07866871881 -0.02907267611
-               </coefficients>
+               <coefficients id="eO" type="Array"> -0.8696890534 -0.7933441198 -0.7025438674 -0.5453877801 -0.3403047754 -0.2291021778 -0.1249523107 -0.05787395961</coefficients>
             </correlation>
          </jastrow>
          <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
             <correlation speciesA="u" speciesB="u" size="8">
-               <coefficients id="uu" type="Array">                  
-0.2998686578 0.2642554885 0.1891560257 0.1364877872 0.09129097706 0.05696496974 
-0.03131546855 0.01282034609
-               </coefficients>
+               <coefficients id="uu" type="Array"> 0.3023075362 0.2303430148 0.169494251 0.1210306138 0.08244364039 0.05163617317 0.02775379295 0.01172449577</coefficients>
             </correlation>
             <correlation speciesA="u" speciesB="d" size="8">
-               <coefficients id="ud" type="Array">                  
-0.5203752657 0.3852829583 0.2766401094 0.1955100684 0.1307486555 0.08240956143 
-0.04509612654 0.01948477444
-               </coefficients>
+               <coefficients id="ud" type="Array"> 0.48581383 0.3448735978 0.2390201254 0.1622242167 0.1074572884 0.06748900952 0.0373874482 0.0168097496</coefficients>
             </correlation>
+         </jastrow>
+         <jastrow name="J3" type="eeI" function="polynomial" source="ion0" print="yes">
+           <correlation ispecies="O" especies="u" isize="3" esize="3">
+             <coefficients id="uuO" type="Array" optimize="yes"> -0.003103380779 0.02857628667 0.03590183922 -0.03208413286 0.06303466381 0.02028280939 -0.01637683343 0.01045076917 -0.006159456741 0.02636381262 -0.005324462034 0.0234416233 -0.0272677791 0.0307802581 0.03928462569 0.01545788859 0.01596206888 -0.01690132029 1.855519635e-05 -0.0150372004 0.02502527353 0.01715726243 0.01238460123 0.01318361443 0.01776219906 0.02967045442</coefficients>
+           </correlation>
+           <correlation ispecies="O" especies1="u" especies2="d" isize="3" esize="3">
+             <coefficients id="udO" type="Array" optimize="yes"> -0.03957461434 0.03987834931 -0.004914971037 0.03222743071 0.1130446183 0.007802539618 0.05866717255 0.04406122947 -0.0385877459 -0.02060959354 0.01545782204 0.03181720087 -0.09177584641 0.03522222384 0.04425147857 0.07138256621 0.009504749617 0.004772801499 0.02242981334 -0.02902336727 0.05578580401 0.06586070328 0.01245772376 0.04015709612 0.03998030858 0.03281735495</coefficients>
+           </correlation>
          </jastrow>
       </wavefunction>
       <hamiltonian name="h0" type="generic" target="e">
@@ -82,11 +81,11 @@
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="walkers"     >  16    </parameter>
-      <parameter name="blocks"      >  1000  </parameter>
-      <parameter name="steps"       >  4     </parameter>
-      <parameter name="subSteps"    >  2     </parameter>
-      <parameter name="timestep"    >  0.3   </parameter>
-      <parameter name="warmupSteps" >  100   </parameter>
+      <parameter name="walkers"     >  1    </parameter>
+      <parameter name="blocks"      >  400  </parameter>
+      <parameter name="steps"       >  320   </parameter>
+      <parameter name="subSteps"    >  4    </parameter>
+      <parameter name="timestep"    >  0.5  </parameter>
+      <parameter name="warmupSteps" >  20   </parameter>
    </qmc>
 </simulation>

--- a/tests/solids/monoO_1x1x1_pp/qmc_j3_short.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_j3_short.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="qmc_short" series="0">
+   <project id="qmc_j3_short" series="0">
       <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
    </project>
    <qmcsystem>
@@ -50,25 +50,24 @@
          </determinantset>
          <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
             <correlation elementType="O" size="8" cusp="0.0">
-               <coefficients id="eO" type="Array">                  
--0.6248667077 -0.546777858 -0.4621312431 -0.345220471 -0.237294967 -0.1481619198 
--0.07866871881 -0.02907267611
-               </coefficients>
+               <coefficients id="eO" type="Array"> -0.8696890534 -0.7933441198 -0.7025438674 -0.5453877801 -0.3403047754 -0.2291021778 -0.1249523107 -0.05787395961</coefficients>
             </correlation>
          </jastrow>
          <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
             <correlation speciesA="u" speciesB="u" size="8">
-               <coefficients id="uu" type="Array">                  
-0.2998686578 0.2642554885 0.1891560257 0.1364877872 0.09129097706 0.05696496974 
-0.03131546855 0.01282034609
-               </coefficients>
+               <coefficients id="uu" type="Array"> 0.3023075362 0.2303430148 0.169494251 0.1210306138 0.08244364039 0.05163617317 0.02775379295 0.01172449577</coefficients>
             </correlation>
             <correlation speciesA="u" speciesB="d" size="8">
-               <coefficients id="ud" type="Array">                  
-0.5203752657 0.3852829583 0.2766401094 0.1955100684 0.1307486555 0.08240956143 
-0.04509612654 0.01948477444
-               </coefficients>
+               <coefficients id="ud" type="Array"> 0.48581383 0.3448735978 0.2390201254 0.1622242167 0.1074572884 0.06748900952 0.0373874482 0.0168097496</coefficients>
             </correlation>
+         </jastrow>
+         <jastrow name="J3" type="eeI" function="polynomial" source="ion0" print="yes">
+           <correlation ispecies="O" especies="u" isize="3" esize="3">
+             <coefficients id="uuO" type="Array" optimize="yes"> -0.003103380779 0.02857628667 0.03590183922 -0.03208413286 0.06303466381 0.02028280939 -0.01637683343 0.01045076917 -0.006159456741 0.02636381262 -0.005324462034 0.0234416233 -0.0272677791 0.0307802581 0.03928462569 0.01545788859 0.01596206888 -0.01690132029 1.855519635e-05 -0.0150372004 0.02502527353 0.01715726243 0.01238460123 0.01318361443 0.01776219906 0.02967045442</coefficients>
+           </correlation>
+           <correlation ispecies="O" especies1="u" especies2="d" isize="3" esize="3">
+             <coefficients id="udO" type="Array" optimize="yes"> -0.03957461434 0.03987834931 -0.004914971037 0.03222743071 0.1130446183 0.007802539618 0.05866717255 0.04406122947 -0.0385877459 -0.02060959354 0.01545782204 0.03181720087 -0.09177584641 0.03522222384 0.04425147857 0.07138256621 0.009504749617 0.004772801499 0.02242981334 -0.02902336727 0.05578580401 0.06586070328 0.01245772376 0.04015709612 0.03998030858 0.03281735495</coefficients>
+           </correlation>
          </jastrow>
       </wavefunction>
       <hamiltonian name="h0" type="generic" target="e">
@@ -82,11 +81,11 @@
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="walkers"     >  16    </parameter>
-      <parameter name="blocks"      >  1000  </parameter>
-      <parameter name="steps"       >  4     </parameter>
-      <parameter name="subSteps"    >  2     </parameter>
-      <parameter name="timestep"    >  0.3   </parameter>
-      <parameter name="warmupSteps" >  100   </parameter>
+      <parameter name="walkers"     >  1    </parameter>
+      <parameter name="blocks"      >  400  </parameter>
+      <parameter name="steps"       >  32   </parameter>
+      <parameter name="subSteps"    >  4    </parameter>
+      <parameter name="timestep"    >  0.5  </parameter>
+      <parameter name="warmupSteps" >  20   </parameter>
    </qmc>
 </simulation>


### PR DESCRIPTION
The new algorithm uses batched computation and optimizes the memory access.
Gain significant speed-up when a large cutoff is used and ion particles are grouped.
Short and long integration tests based on monoO are added requested by #573, no new hdf5 needed.