### PR TITLE
Fix infinite loop when reading CI coeffs

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -1212,7 +1212,10 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur, std::vector<ci_configuration>
         
        //Will always loop through the whole determinant set as no assumption on the order of the determinant is made 
         if(std::abs(ci) < cutoff)
+        {
+          cur = cur->next;
           continue;
+        }
 
         for(size_t i=0; i<nstates; i++){
           if(alpha[i] != '0' && alpha[i] != '1')


### PR DESCRIPTION
The loop for reading CI coefficients in a detlist element skips processing if the coefficient is less than the cutoff value.  Need to advance to the next element in this case.