### PR TITLE
Put back the Gamess reference for LiH_dimer_ae_*.

### DIFF
--- a/tests/molecules/LiH_dimer_ae_gms/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_gms/CMakeLists.txt
@@ -4,12 +4,13 @@ IF (NOT QMC_CUDA)
 #
 # LiH molecular dimer gaussian tests, all electron
 # Also check results for different number of mpi tasks and threads keeping total constant
-# Energy from Gamess: E=-7.9873236457     
+# Energy from Gamess: E=-7.9873236457
 #
-  LIST(APPEND LIH_SCALARS "kinetic" "7.964 0.0035") # kinetic energy
-  LIST(APPEND LIH_SCALARS "totenergy" "-7.9846 0.0035") # total energy
-  LIST(APPEND LIH_SCALARS "eeenergy" "3.4892 0.0026") # e-e energy
+  LIST(APPEND LIH_SCALARS "kinetic" "7.9914014383 0.03") # kinetic energy
+  LIST(APPEND LIH_SCALARS "totenergy" "-7.9873236457 0.003") # total energy
+  LIST(APPEND LIH_SCALARS "eeenergy" "3.4888166386 0.0024") # e-e energy
   LIST(APPEND LIH_SCALARS "samples" "1600000 0.0") # samples
+
 #  LIST(APPEND LIH_SCALARS "flux" "0.0 0.1") # sampling check, should be zero
 
   QMC_RUN_AND_CHECK(short-LiH_dimer_ae-vmc_hf_noj

--- a/tests/molecules/LiH_dimer_ae_pyscf/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_pyscf/CMakeLists.txt
@@ -6,9 +6,9 @@ IF (NOT QMC_CUDA)
 # Also check results for different number of mpi tasks and threads keeping total constant
 # Energy from Gamess: E=-7.9873236457148  
 #
-  LIST(APPEND LIH_SCALARS "kinetic" "8.027 0.043") # kinetic energy
-  LIST(APPEND LIH_SCALARS "totenergy" "-7.9886 0.0035") # total energy
-  LIST(APPEND LIH_SCALARS "eeenergy" "3.4947 0.0043") # e-e energy
+  LIST(APPEND LIH_SCALARS "kinetic" "7.9914014383 0.03") # kinetic energy
+  LIST(APPEND LIH_SCALARS "totenergy" "-7.9873236457 0.003") # total energy
+  LIST(APPEND LIH_SCALARS "eeenergy" "3.4888166386 0.0024") # e-e energy
   LIST(APPEND LIH_SCALARS "samples" "1600000 0.0") # samples
 #  LIST(APPEND LIH_SCALARS "flux" "0.0 0.1") # sampling check, should be zero
 

--- a/tests/molecules/LiH_dimer_ae_qp/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_qp/CMakeLists.txt
@@ -6,9 +6,9 @@ IF (NOT QMC_CUDA)
 # Also check results for different number of mpi tasks and threads keeping total constant
 # Energy from Quantum Package: E=-7.987323645629950
 #
-  LIST(APPEND LIH_SCALARS "kinetic" "8.051 0.033") # kinetic energy
-  LIST(APPEND LIH_SCALARS "totenergy" "-7.9833 0.0026") # total energy
-  LIST(APPEND LIH_SCALARS "eeenergy" "3.4899 0.0022") # e-e energy
+  LIST(APPEND LIH_SCALARS "kinetic" "7.9914014383 0.03") # kinetic energy
+  LIST(APPEND LIH_SCALARS "totenergy" "-7.9873236457 0.003") # total energy
+  LIST(APPEND LIH_SCALARS "eeenergy" "3.4888166386 0.0024") # e-e energy
   LIST(APPEND LIH_SCALARS "samples" "1600000 0.0") # samples
 #  LIST(APPEND LIH_SCALARS "flux" "0.0 0.1") # sampling check, should be zero
 


### PR DESCRIPTION
The reference numbers changed by #656 are causing tests failing.
Put back the Gamess reference for gms, qp, pyscf since it is the same calculation and the values of total energy match.