### PR TITLE
Handle the negative count coverage case.

### DIFF
--- a/tests/coverage/read_gcov.py
+++ b/tests/coverage/read_gcov.py
@@ -203,6 +203,18 @@ def read_gcov(fname):
                 else:
                     parts = line.split(':',2)
                     current_src_line = line_no
+                    line_count = 0
+                    try:
+                      line_count = int(exe_count)
+                      if line_count < 0:
+                          print 'Warning, negative exe count found'
+                          print '  ',line
+                          print '  ',fname
+                          print '   Replacing with uncovered'
+                          Uncov_norm = '#####'
+                          exe_count = Uncov_norm
+                    except:
+                      pass
                     line_info[line_no] = LineInfo(exe_count, line_no, parts[2])
             else:
                 print 'Unhandled line: ',parts


### PR DESCRIPTION
Occasionally GCC produces negative coverage counts (should be impossible!), and this
causes problems wih the coverage scripts.  The processing stops at the point the
file with the negative count is found.  Which may be why files seem to be missing from
the coverage reports.

Fix is to detect negative counts when reading the file and mark them as uncovered (all the
cases I found with negative counts should have been uncovered).