### PR TITLE
fix for BSD's sed

### DIFF
--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -614,7 +614,7 @@ module load cudatoolkit           # CUDA for GPU build
 module load cray-hdf5
 module load cmake
 module load fftw
-export FFTW_HOME=$(echo $FFTW_DIR | sed -e 's/\/lib//')
+export FFTW_HOME=$FFTW_DIR/..
 module load boost
 mkdir build_titan_gpu
 cd build_titan_gpu

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -614,7 +614,7 @@ module load cudatoolkit           # CUDA for GPU build
 module load cray-hdf5
 module load cmake
 module load fftw
-export FFTW_HOME=$FFTW_DIR/..
+export FFTW_HOME=$(echo $FFTW_DIR | sed -e 's/\/lib//')
 module load boost
 mkdir build_titan_gpu
 cd build_titan_gpu

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,14 +46,24 @@ IF (IS_GIT_PROJECT)
   # If this in the main CMakeLists.txt it does not work.
 
   # Sed flags were once an issue and some HPC have old sed's
-  set(Big_E_Systems Darwin FreeBSD NetBSD OpenBSD)
-  list (FIND Big_E_Systems "${CMAKE_SYSTEM_NAME}" index)
-  if (${index} GREATER -1)
-    set(SED_FLAG "-E")
-  else ()
+  set(SED_FLAG "-E")
+  EXECUTE_PROCESS(COMMAND "sed" ${SED_FLAG} "s/\"/\\\\\"/g" "<${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+    OUTPUT_QUIET
+    ERROR_VARIABLE SED_ERROR)
+  if ( SED_ERROR MATCHES ".*invalid.*" )
     set(SED_FLAG "-r")
-  endif ()
-
+    EXECUTE_PROCESS(COMMAND "sed" ${SED_FLAG} "s/\"/\\\\\"/g" "<${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+      OUTPUT_QUIET ERROR_QUIET
+      ERROR_VARIABLE SED_ERROR)
+    if ( SED_ERROR MATCHES ".*invalid.*" )
+      MESSAGE(WARNING "Your system supports neither the sed -E or -r flag, git revision information will not be included in output")
+    else ( SED_ERROR MATCHES ".*invalid.*" )
+      MESSAGE("sed supports -r")
+    endif ( SED_ERROR MATCHES ".*invalid.*" )
+  else ( SED_ERROR MATCHES ".*invalid.*" )
+    MESSAGE("sed supports -E")
+  endif ( SED_ERROR MATCHES ".*invalid.*" )
+    
   ADD_CUSTOM_COMMAND(
     OUTPUT ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GIT_BRANCH_RAW " > ${GITREV_TMP}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,16 @@ IF (IS_GIT_PROJECT)
   #
   # Apparently custom commands need to be defined where the output is used.
   # If this in the main CMakeLists.txt it does not work.
+
+  # Sed flags were once an issue and some HPC have old sed's
+  set(Big_E_Systems Darwin FreeBSD NetBSD OpenBSD)
+  list (FIND Big_E_Systems "${CMAKE_SYSTEM_NAME}" index)
+  if (${index} GREATER -1)
+    set(SED_FLAG "-E")
+  else ()
+    set(SED_FLAG "-r")
+  endif ()
+
   ADD_CUSTOM_COMMAND(
     OUTPUT ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GIT_BRANCH_RAW " > ${GITREV_TMP}
@@ -56,7 +66,7 @@ IF (IS_GIT_PROJECT)
     COMMAND ${GIT_EXECUTABLE} log -1 --format=%ad >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GIT_COMMIT_SUBJECT_RAW \"" >> ${GITREV_TMP}
-    COMMAND ${GIT_EXECUTABLE} log -1 --format=%s | sed -E "s/\"/\\\\\"/g" | tr -d '\\n' >> ${GITREV_TMP}
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%s | sed ${SED_FLAG} "s/\"/\\\\\"/g" | tr -d '\\n' >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "\"" >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GITREV_TMP} ${GITREV_FILE}


### PR DESCRIPTION
While fixing #695 This leaves OSX able to get git rev and I assume other BSD's as well. It works with  cmake 2.8.10.2 on titan.