### PR TITLE
Add unit test for VMCSingleOMP

### DIFF
--- a/src/QMCDrivers/CloneManager.cpp
+++ b/src/QMCDrivers/CloneManager.cpp
@@ -51,10 +51,12 @@ std::vector<std::vector<TrialWaveFunction*> > CloneManager::PsiPoolClones;
 std::vector<std::vector<QMCHamiltonian*> > CloneManager::HPoolClones;
 
 
-// Clear the static clones.  For now only clear wClones so makeClones will work.
-// Used in unit tests.
+// Clear the static clones so makeClones will work as expected.
+// For now only clearing wClones is strictly necessary.  The storage is not freed,
+// and this will leak memory.
+// Only for use in unit tests.
 void
-CloneManager::clear()
+CloneManager::clear_for_unit_tests()
 {
   wClones.clear();
 }

--- a/src/QMCDrivers/CloneManager.cpp
+++ b/src/QMCDrivers/CloneManager.cpp
@@ -50,6 +50,15 @@ std::vector<std::vector<MCWalkerConfiguration*> > CloneManager::WPoolClones;
 std::vector<std::vector<TrialWaveFunction*> > CloneManager::PsiPoolClones;
 std::vector<std::vector<QMCHamiltonian*> > CloneManager::HPoolClones;
 
+
+// Clear the static clones.  For now only clear wClones so makeClones will work.
+// Used in unit tests.
+void
+CloneManager::clear()
+{
+  wClones.clear();
+}
+
 /// Constructor.
 CloneManager::CloneManager(HamiltonianPool& hpool): cloneEngine(hpool)
 {

--- a/src/QMCDrivers/CloneManager.cpp
+++ b/src/QMCDrivers/CloneManager.cpp
@@ -57,6 +57,14 @@ CloneManager::CloneManager(HamiltonianPool& hpool): cloneEngine(hpool)
   wPerNode.resize(NumThreads+1,0);
 }
 
+void
+CloneManager::setup(int numThreads)
+{
+  NumThreads = numThreads;
+  wPerNode.resize(NumThreads+1, 0);
+}
+
+
 ///cleanup non-static data members
 CloneManager::~CloneManager()
 {

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -42,8 +42,11 @@ public:
   ///virtual destructor
   virtual ~CloneManager();
 
+  // Set up for a specific number of threads.  Used in unit testing.
   void setup(int numThreads);
-  static void clear();
+  // Clear static array so makeClones will populate properly
+  // Only for using in unit testing.
+  static void clear_for_unit_tests();
 
   void makeClones(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& ham);
   void makeClones(MCWalkerConfiguration& w, std::vector<TrialWaveFunction*>& psi, std::vector<QMCHamiltonian*>& ham);

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -42,6 +42,8 @@ public:
   ///virtual destructor
   virtual ~CloneManager();
 
+  void setup(int numThreads);
+
   void makeClones(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& ham);
   void makeClones(MCWalkerConfiguration& w, std::vector<TrialWaveFunction*>& psi, std::vector<QMCHamiltonian*>& ham);
   void makeClones(std::vector<MCWalkerConfiguration*>& w, std::vector<TrialWaveFunction*>& psi, std::vector<QMCHamiltonian*>& ham);

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -43,6 +43,7 @@ public:
   virtual ~CloneManager();
 
   void setup(int numThreads);
+  static void clear();
 
   void makeClones(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& ham);
   void makeClones(MCWalkerConfiguration& w, std::vector<TrialWaveFunction*>& psi, std::vector<QMCHamiltonian*>& ham);

--- a/src/QMCDrivers/DMC/DMCOMP.cpp
+++ b/src/QMCDrivers/DMC/DMCOMP.cpp
@@ -165,8 +165,12 @@ void DMCOMP::resetUpdateEngines()
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif
+#ifdef USE_FAKE_RNG
+      Rng[ip] = new FakeRandom();
+#else
       Rng[ip]=new RandomGenerator_t(*RandomNumberControl::Children[ip]);
       hClones[ip]->setRandomGenerator(Rng[ip]);
+#endif
       branchClones[ip] = new BranchEngineType(*branchEngine);
       if(QMCDriverMode[QMC_UPDATE_MODE])
       {
@@ -328,8 +332,10 @@ bool DMCOMP::run()
     block++;
     if(DumpConfig &&block%Period4CheckPoint == 0)
     {
+#ifndef USE_FAKE_RNG
       for(int ip=0; ip<NumThreads; ip++)
         *(RandomNumberControl::Children[ip])=*(Rng[ip]);
+#endif
     }
     recordBlock(block);
     dmc_loop.stop();
@@ -346,8 +352,10 @@ bool DMCOMP::run()
   prof.pop(); //close loop
 
   //for(int ip=0; ip<NumThreads; ip++) Movers[ip]->stopRun();
+#ifndef USE_FAKE_RNG
   for(int ip=0; ip<NumThreads; ip++)
     *(RandomNumberControl::Children[ip])=*(Rng[ip]);
+#endif
   Estimators->stop();
   for (int ip=0; ip<NumThreads; ++ip)
     Movers[ip]->stopRun2();

--- a/src/QMCDrivers/VMC/VMCSingleOMP.cpp
+++ b/src/QMCDrivers/VMC/VMCSingleOMP.cpp
@@ -127,8 +127,10 @@ bool VMCSingleOMP::run()
   Traces->stopRun();
 #endif
   //copy back the random states
+#ifndef USE_FAKE_RNG
   for (int ip=0; ip<NumThreads; ++ip)
     *(RandomNumberControl::Children[ip])=*(Rng[ip]);
+#endif
   ///write samples to a file
   bool wrotesamples=DumpConfig;
   if(DumpConfig)
@@ -171,8 +173,12 @@ void VMCSingleOMP::resetRun()
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif
+#ifdef USE_FAKE_RNG
+      Rng[ip] = new FakeRandom();
+#else
       Rng[ip]=new RandomGenerator_t(*(RandomNumberControl::Children[ip]));
       hClones[ip]->setRandomGenerator(Rng[ip]);
+#endif
       branchClones[ip] = new BranchEngineType(*branchEngine);
       if (QMCDriverMode[QMC_UPDATE_MODE])
       {

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(UTEST_NAME unit_test_${SRC_DIR})
 SET(DRIVER_TEST_SRC test_vmc.cpp test_dmc.cpp test_drift.cpp test_clone_manager.cpp test_fixed_node_branch.cpp)
 
 IF (NOT QMC_CUDA)
-  SET(DRIVER_TEST_SRC ${DRIVER_TEST_SRC} test_vmc_omp.cpp)
+  SET(DRIVER_TEST_SRC ${DRIVER_TEST_SRC} test_vmc_omp.cpp test_dmc_omp.cpp)
 ENDIF()
 
 IF(HAVE_MPI)

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME unit_test_${SRC_DIR})
 
 
-SET(DRIVER_TEST_SRC test_vmc.cpp test_dmc.cpp test_drift.cpp)
+SET(DRIVER_TEST_SRC test_vmc.cpp test_dmc.cpp test_drift.cpp test_clone_manager.cpp test_fixed_node_branch.cpp
+                    test_vmc_omp.cpp)
 IF(HAVE_MPI)
   SET(DRIVER_TEST_SRC ${DRIVER_TEST_SRC} test_walker_control.cpp)
 ENDIF()

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -17,8 +17,12 @@ SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME unit_test_${SRC_DIR})
 
 
-SET(DRIVER_TEST_SRC test_vmc.cpp test_dmc.cpp test_drift.cpp test_clone_manager.cpp test_fixed_node_branch.cpp
-                    test_vmc_omp.cpp)
+SET(DRIVER_TEST_SRC test_vmc.cpp test_dmc.cpp test_drift.cpp test_clone_manager.cpp test_fixed_node_branch.cpp)
+
+IF (NOT QMC_CUDA)
+  SET(DRIVER_TEST_SRC ${DRIVER_TEST_SRC} test_vmc_omp.cpp)
+ENDIF()
+
 IF(HAVE_MPI)
   SET(DRIVER_TEST_SRC ${DRIVER_TEST_SRC} test_walker_control.cpp)
 ENDIF()

--- a/src/QMCDrivers/tests/diffuse.py
+++ b/src/QMCDrivers/tests/diffuse.py
@@ -1,0 +1,56 @@
+
+# Compute diffusion using fake RNG
+# See qmc_algorithms/Diffusion/DMC_Propagator.ipynb
+
+#  Generate values for test_vmc.cpp and test_vmc_omp.cpp
+#
+import numpy as np
+import math
+import sys
+
+# Box-Muller, copies Utilties/RandomGenerator.h
+def gaussian_rng_list(n):
+    input_rng = [0.5]*(n+1) # Fake RNG currently outputs 0.5 every time
+    slightly_less_than_one = 1.0 - sys.float_info.epsilon
+    vals = []
+    for i in range(0,n,2):
+        temp1 = math.sqrt(-2.0 * math.log(1.0- slightly_less_than_one*input_rng[i]))
+        temp2 = 2*math.pi*input_rng[i+1]
+        vals.append(temp1*math.cos(temp2))
+        vals.append(temp2*math.sin(temp2))
+    if n%2 == 1:
+        temp1 = math.sqrt(-2.0 * math.log(1.0- slightly_less_than_one*input_rng[n-1]))
+        temp2 = 2*math.pi*input_rng[n]
+        vals.append(temp1*math.cos(temp2))
+    return vals
+
+
+#  These functions taken from DMC_Propagator Jupyter notebook
+def scaled_drift_func(tau, Fmag2, F_i):
+  return (F_i*((tau) if (Fmag2 < 2.22044604925031e-16) else ((((math.sqrt(2*Fmag2*tau + 1) - 1)/Fmag2) if (True) else None))))
+
+def drift_diffuse_func(r,F_i,chi,dt):
+  return chi + r + F_i*dt
+
+tau = 0.1
+
+chi_vals = np.array(gaussian_rng_list(6)).reshape((2,3))
+
+R = np.array([[1.0, 0.0, 0.0],
+              [0.0, 0.0, 1.0]])
+
+scaled_chi_vals = chi_vals * math.sqrt(tau)
+
+print 'One step'
+for r_val, chi_val in zip(R, scaled_chi_vals):
+  rp_val = drift_diffuse_func(r_val, np.zeros(3), chi_val, tau)
+  print ['%.15g'%v for v in rp_val]
+
+# In test_vmc_omp, there are two steps taken - one for the initial 'randomize' step,
+#  and one for for the actual VMC step.
+print 'Two steps'
+for r_val, chi_val in zip(R, scaled_chi_vals):
+  rp_val = drift_diffuse_func(r_val, np.zeros(3), chi_val, tau)
+  rp2_val = drift_diffuse_func(rp_val, np.zeros(3), chi_val, tau)
+  print ['%.15g'%v for v in rp2_val]
+

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -1,0 +1,89 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+
+#include "Configuration.h"
+#include "Message/Communicate.h"
+#include "Utilities/RandomGenerator.h"
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Lattice/ParticleBConds.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
+#include "Particle/SymmetricDistanceTableData.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "QMCDrivers/CloneManager.h"
+#include "QMCDrivers/QMCUpdateBase.h"
+#include "QMCApp/HamiltonianPool.h"
+
+
+#include <stdio.h>
+#include <string>
+#include <random>
+
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+class FakeUpdate : public QMCUpdateBase
+{
+public:
+
+  FakeUpdate(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h,
+             RandomGenerator_t& rg) : QMCUpdateBase(w, psi, h, rg) {}
+
+  void advanceWalker(Walker_t& thisWalker, bool recompute) override {
+  }
+
+};
+
+TEST_CASE("QMCUpdate", "[drivers]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate *c = OHMMS::Controller;
+
+  MCWalkerConfiguration elec;
+  elec.setName("e");
+  elec.setBoundBox(false);
+  elec.create(1);
+  elec.createWalkers(1);
+
+  FakeRandom rg;
+
+  QMCHamiltonian h;
+  TrialWaveFunction psi(c);
+  FakeUpdate update(elec, psi, h, rg);
+
+  update.put(NULL);
+
+  //update.resetRun(brancher, estimator_manager);
+}
+
+
+TEST_CASE("CloneManager", "[drivers]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate *c = OHMMS::Controller;
+
+  HamiltonianPool hpool(c);
+  CloneManager cm(hpool);
+
+  //double acc_ratio = cm.acceptRatio();
+  //std::cout << "acc ratio = " << acc_ratio << std::endl;
+}
+
+}

--- a/src/QMCDrivers/tests/test_dmc_omp.cpp
+++ b/src/QMCDrivers/tests/test_dmc_omp.cpp
@@ -85,6 +85,7 @@ TEST_CASE("DMCOMP", "[drivers][dmc]")
   elec.addTable(ions,DT_AOS);
   elec.update();
 
+  CloneManager::clear();
 
   TrialWaveFunction psi = TrialWaveFunction(c);
   ConstantOrbital *orb = new ConstantOrbital;

--- a/src/QMCDrivers/tests/test_dmc_omp.cpp
+++ b/src/QMCDrivers/tests/test_dmc_omp.cpp
@@ -1,0 +1,145 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+
+#include "Utilities/RandomGenerator.h"
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Lattice/ParticleBConds.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
+#include "Particle/SymmetricDistanceTableData.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "QMCApp/ParticleSetPool.h"
+#include "QMCApp/HamiltonianPool.h"
+#include "QMCApp/WaveFunctionPool.h"
+#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/TrialWaveFunction.h"
+#include "QMCWaveFunctions/ConstantOrbital.h"
+#include "QMCHamiltonians/BareKineticEnergy.h"
+#include "Estimators/EstimatorManagerBase.h"
+#include "Estimators/TraceManager.h"
+#include "QMCDrivers/DMC/DMCOMP.h"
+
+
+#include <stdio.h>
+#include <string>
+
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+TEST_CASE("DMCOMP", "[drivers][dmc]")
+{
+
+  Communicate *c;
+  OHMMS::Controller->initialize(0, NULL);
+  c = OHMMS::Controller;
+
+  ParticleSet ions;
+  MCWalkerConfiguration elec;
+
+  ions.setName("ion");
+  ions.create(1);
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  elec.setName("elec");
+  elec.setBoundBox(false);
+  std::vector<int> agroup(1);
+  agroup[0] = 2;
+  elec.create(agroup);
+  elec.R[0][0] = 1.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+  elec.R[1][0] = 0.0;
+  elec.R[1][1] = 0.0;
+  elec.R[1][2] = 1.0;
+  elec.createWalkers(1);
+
+  SpeciesSet &tspecies =  elec.getSpeciesSet();
+  int upIdx = tspecies.addSpecies("u");
+  int downIdx = tspecies.addSpecies("d");
+  int chargeIdx = tspecies.addAttribute("charge");
+  int massIdx = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(chargeIdx, downIdx) = -1;
+  tspecies(massIdx, upIdx) = 1.0;
+  tspecies(massIdx, downIdx) = 1.0;
+
+  elec.addTable(ions,DT_AOS);
+  elec.update();
+
+
+  TrialWaveFunction psi = TrialWaveFunction(c);
+  ConstantOrbital *orb = new ConstantOrbital;
+  psi.addOrbital(orb, "Constant");
+  psi.registerData(elec, elec.WalkerList[0]->DataSet);
+  elec.WalkerList[0]->DataSet.allocate();
+
+  FakeRandom rg;
+
+  QMCHamiltonian h;
+  h.addOperator(new BareKineticEnergy<double>(elec),"Kinetic");
+  h.addObservables(elec); // get double free error on 'h.Observables' w/o this
+
+  elec.resetWalkerProperty(); // get memory corruption w/o this
+
+  HamiltonianPool hpool(c);
+
+  WaveFunctionPool wpool(c);
+
+  //EstimatorManagerBase emb(c);
+
+
+  DMCOMP dmc_omp(elec, psi, h, hpool, wpool);
+
+  const char *dmc_input= \
+  "<qmc method=\"dmc\"> \
+   <parameter name=\"steps\">1</parameter> \
+   <parameter name=\"blocks\">1</parameter> \
+   <parameter name=\"timestep\">0.1</parameter> \
+  </qmc> \
+  ";
+  Libxml2Document *doc = new Libxml2Document;
+  bool okay = doc->parseFromString(dmc_input);
+  REQUIRE(okay);
+  xmlNodePtr root = doc->getRoot();
+
+  dmc_omp.process(root); // need to call 'process' for QMCDriver, which in turn calls 'put'
+
+  dmc_omp.run();
+
+  // With the constant wavefunction, no moves should be rejected
+  double ar = dmc_omp.acceptRatio();
+  REQUIRE(ar == Approx(1.0));
+
+  // Each electron moved sqrt(tau)*gaussian_rng()
+  //  See Particle>Base/tests/test_random_seq.cpp for the gaussian random numbers
+  //  Values from diffuse.py for moving two steps
+
+  REQUIRE(elec[0]->R[0][0] == Approx(0.255340517788193));
+  REQUIRE(elec.R[0][1] == Approx(0.0));
+  REQUIRE(elec.R[0][2] == Approx(-0.744659482211807));
+
+  REQUIRE(elec.R[1][0] == Approx(0.0));
+  REQUIRE(elec.R[1][1] == Approx(-0.744659482211807));
+  REQUIRE(elec.R[1][2] == Approx(1.0));
+}
+}
+

--- a/src/QMCDrivers/tests/test_dmc_omp.cpp
+++ b/src/QMCDrivers/tests/test_dmc_omp.cpp
@@ -82,10 +82,14 @@ TEST_CASE("DMCOMP", "[drivers][dmc]")
   tspecies(massIdx, upIdx) = 1.0;
   tspecies(massIdx, downIdx) = 1.0;
 
+#ifdef ENABLE_SOA
+  elec.addTable(ions,DT_SOA);
+#else
   elec.addTable(ions,DT_AOS);
+#endif
   elec.update();
 
-  CloneManager::clear();
+  CloneManager::clear_for_unit_tests();
 
   TrialWaveFunction psi = TrialWaveFunction(c);
   ConstantOrbital *orb = new ConstantOrbital;

--- a/src/QMCDrivers/tests/test_fixed_node_branch.cpp
+++ b/src/QMCDrivers/tests/test_fixed_node_branch.cpp
@@ -1,0 +1,72 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+
+#include "Utilities/RandomGenerator.h"
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Lattice/ParticleBConds.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
+#include "Particle/SymmetricDistanceTableData.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "Estimators/EstimatorManagerBase.h"
+#include "QMCDrivers/SimpleFixedNodeBranch.h"
+
+
+#include <stdio.h>
+#include <string>
+#include <random>
+
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+
+TEST_CASE("Fixed node branch", "[drivers][walker_control]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate *c = OHMMS::Controller;
+
+  EstimatorManagerBase emb(c);
+
+  double tau = 0.5;
+  int nideal = 1;
+  SimpleFixedNodeBranch fnb(tau, nideal);
+
+  fnb.setEstimatorManager(&emb);
+  REQUIRE(fnb.getEstimatorManager() == &emb);
+
+  REQUIRE(fnb.getTau() == Approx(tau));
+
+
+  fnb.advanceQMCCounter();
+  REQUIRE(fnb.iParam[SimpleFixedNodeBranch::B_COUNTER] == 0);
+
+
+  fnb.setTrialEnergy(-4.0);
+
+  REQUIRE(fnb.getEtrial() == Approx(-4.0));
+  REQUIRE(fnb.getEref() == Approx(-4.0));
+
+
+
+  // default is classic cutoff scheme
+  //fnb.setBranchCutoff();
+}
+
+}

--- a/src/QMCDrivers/tests/test_vmc_omp.cpp
+++ b/src/QMCDrivers/tests/test_vmc_omp.cpp
@@ -85,6 +85,7 @@ TEST_CASE("VMCSingleOMP", "[drivers][vmc]")
   elec.addTable(ions,DT_AOS);
   elec.update();
 
+  CloneManager::clear();
 
   TrialWaveFunction psi = TrialWaveFunction(c);
   ConstantOrbital *orb = new ConstantOrbital;

--- a/src/QMCDrivers/tests/test_vmc_omp.cpp
+++ b/src/QMCDrivers/tests/test_vmc_omp.cpp
@@ -82,10 +82,14 @@ TEST_CASE("VMCSingleOMP", "[drivers][vmc]")
   tspecies(massIdx, upIdx) = 1.0;
   tspecies(massIdx, downIdx) = 1.0;
 
+#ifdef ENABLE_SOA
+  elec.addTable(ions,DT_SOA);
+#else
   elec.addTable(ions,DT_AOS);
+#endif
   elec.update();
 
-  CloneManager::clear();
+  CloneManager::clear_for_unit_tests();
 
   TrialWaveFunction psi = TrialWaveFunction(c);
   ConstantOrbital *orb = new ConstantOrbital;

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -22,11 +22,11 @@ namespace qmcplusplus
 class ConstantOrbital: public OrbitalBase
 {
 public:
-  virtual void checkInVariables(opt_variables_type &active) {}
-  virtual void checkOutVariables(const opt_variables_type &active) {}
-  virtual void resetParameters(const opt_variables_type &active) {}
-  virtual void reportStatus(std::ostream& os) {}
-  virtual void resetTargetParticleSet(ParticleSet& P) {}
+  virtual void checkInVariables(opt_variables_type &active) override {}
+  virtual void checkOutVariables(const opt_variables_type &active) override {}
+  virtual void resetParameters(const opt_variables_type &active) override {}
+  virtual void reportStatus(std::ostream& os) override {}
+  virtual void resetTargetParticleSet(ParticleSet& P) override {}
 
   ValueType FakeGradRatio;
 
@@ -35,7 +35,7 @@ public:
   virtual ValueType
   evaluate(ParticleSet& P,
            ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L)
+           ParticleSet::ParticleLaplacian_t& L) override
   {
     G = 0.0;
     L = 0.0;
@@ -44,46 +44,41 @@ public:
 
   virtual RealType
   evaluateLog(ParticleSet& P,
-              ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+              ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) override
   {
     G = 0.0;
     L = 0.0;
     return 0.0;
   }
 
-  virtual ValueType ratio(ParticleSet& P, int iat,
-                          ParticleSet::ParticleGradient_t& dG,
-                          ParticleSet::ParticleLaplacian_t& dL)
-  {
-    dG = 0.0;
-    dL = 0.0;
-    return 1.0;
-  }
+  virtual void acceptMove(ParticleSet& P, int iat) override {}
 
-  virtual void acceptMove(ParticleSet& P, int iat) {}
+  virtual void restore(int iat) override {}
 
-  virtual void restore(int iat) {}
-
-  virtual ValueType ratio(ParticleSet& P, int iat)
+  virtual ValueType ratio(ParticleSet& P, int iat) override
   {
     return 1.0;
   }
 
-  virtual GradType evalGrad(ParticleSet &P, int iat)
+  virtual GradType evalGrad(ParticleSet &P, int iat) override
   {
     return GradType(0.0);
   }
 
-  virtual ValueType ratioGrad(ParticleSet &P, int iat, GradType& grad_iat)
+  virtual ValueType ratioGrad(ParticleSet &P, int iat, GradType& grad_iat) override
   {
     return FakeGradRatio;
   }
 
-  virtual void registerData(ParticleSet& P, WFBufferType& buf) {}
+  virtual void registerData(ParticleSet& P, WFBufferType& buf) override {}
 
-  virtual RealType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch=false) {return 0.0;}
+  virtual RealType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch=false) override {return 0.0;}
 
-  virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) {}
+  virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override {}
+
+  virtual OrbitalBasePtr makeClone(ParticleSet& tpq) const override {
+    return new ConstantOrbital();
+  }
 
 };
 


### PR DESCRIPTION
For ConstantOrbital.h - added one 'override', but then clang complained about all the
 other methods without it.  Using 'override' pointed out a virtual method that was no
 longer overriding anything - remove it.

Add diffuse.py for computing unit test values (the values were slightly different than
 the existing ones in test_vmc.cpp - update those to match.)
(This follows a general trend of putting the generic derivation/explanantion in
qmc_algorithms, and putting the particular python script for computing the unit test
values along side the unit tests.)

Starting point for tests for SimpleFixedNodeBranch, QMCUpdateBase, CloneManager.  The classes are
set up, but there are no tests there yet.

Added a constructor for initializing CloneManager to a number of threads specified by the test,
not just the number of OpenMP threads.