### PR TITLE
Clarify license for contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,11 @@ ctest -R name-of-test-to-run
 # Documentation and support
 
 For more informaton, consult QMCPACK pages at http://www.qmcpack.org,
-the linked documentation, https://docs.qmcpack.org/qmcpack_manual.pdf .
+the manual PDF at https://docs.qmcpack.org/qmcpack_manual.pdf, 
+or its sources in the manual directory.
 
 If you have trouble using or building QMCPACK, or have questions about
-its use, please post to the Google QMCPACK group or contact a developer.
+its use, please post to the [Google QMCPACK group](https://groups.google.com/forum/#!forum/qmcpack) or contact a developer.
 
 # Contributing
 
@@ -287,7 +288,7 @@ https://docs.qmcpack.org/qmcpack_manual.pdf . We use a git flow model
 including pull request reviews. A continuous integration system runs
 on pull requests. See https://github.com/QMCPACK/qmcpack/wiki for
 details. For an extensive contribution, it can be helpful to discuss
-on the Google QMCPACK group, to create a GitHub issue, or to talk
+on the [Google QMCPACK group](https://groups.google.com/forum/#!forum/qmcpack), to create a GitHub issue, or to talk
 directly with a developer.
 
 Contributions are made under the same UIUC/NCSA open source license

--- a/README.md
+++ b/README.md
@@ -274,8 +274,21 @@ ctest -R name-of-test-to-run
 # Documentation and support
 
 For more informaton, consult QMCPACK pages at http://www.qmcpack.org,
-the linked documentation, and the local copy of the manual in
-manual/qmcpack_manual.pdf
+the linked documentation, https://docs.qmcpack.org/qmcpack_manual.pdf .
 
 If you have trouble using or building QMCPACK, or have questions about
 its use, please post to the Google QMCPACK group or contact a developer.
+
+# Contributing
+
+Contributions of any size are very welcome. Guidance for contributing
+to QMCPACK is included in Chapter 1 of the manual
+https://docs.qmcpack.org/qmcpack_manual.pdf . We use a git flow model
+including pull request reviews. A continuous integration system runs
+on pull requests. See https://github.com/QMCPACK/qmcpack/wiki for
+details. For an extensive contribution, it can be helpful to discuss
+on the Google QMCPACK group, to create a GitHub issue, or to talk
+directly with a developer.
+
+Contributions are made under the same UIUC/NCSA open source license
+that covers QMCPACK. Please contact us if this is problematic.

--- a/manual/introduction.tex
+++ b/manual/introduction.tex
@@ -256,6 +256,10 @@ work with GitHub and make pull requests (contributions) to the main
 source are listed on the QMCPACK GitHub wiki
 \url{https://github.com/QMCPACK/qmcpack/wiki}.
 
+Contributions are made under the same license as QMCPACK, the
+UIUC/NCSA open source license. If this is problematic, please discuss
+with a developer.
+
 Please note the following guidelines for contributions:
 \begin{itemize}
 \item Additions should be fully synchronized with the latest release


### PR DESCRIPTION
Update README.md and manual to explicitly state that we use the same license for contributions as current QMCPACK.