### PR TITLE
Rename ENABLE_OUTSIDE_MKL to ENABLE_MKL.

### DIFF
--- a/CMake/FindMKL.cmake
+++ b/CMake/FindMKL.cmake
@@ -12,7 +12,7 @@ if ( NOT CMAKE_CXX_COMPILER_ID MATCHES "Intel" )
     string(REPLACE "/include" "" MKL_ROOT ${MKL_ROOT})
   endif (NOT MKL_ROOT)
   if (NOT MKL_ROOT)
-    message (FATAL_ERROR "ENABLE_OUTSIDE_MKL is TRUE and mkl not found. Set MKL_ROOT." )
+    message (FATAL_ERROR "ENABLE_MKL is TRUE and mkl not found. Set MKL_ROOT." )
   endif (NOT MKL_ROOT)
 
   # Finding and setting the MKL_LINK_DIRECTORIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,11 +439,15 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   #-------------------------------------------------------------------
   # Quick search for MKL (this will need to be improved).
   # This reproduces the old intel -mkl behavior or
-  # if ENABLE_OUTSIDE_MKL is set to 1 supports other compilers
-  SET(ENABLE_OUTSIDE_MKL FALSE CACHE BOOL "ENABLE MKL for non-intel compilers (Experimental)")
-  IF (INTEL_COMPILER OR ENABLE_OUTSIDE_MKL)
+  # if ENABLE_MKL is set to 1 supports other compilers
+  IF (INTEL_COMPILER)
+    SET(ENABLE_MKL TRUE CACHE BOOL "ENABLE MKL for Intel compilers")
+  ELSE (INTEL_COMPILER)
+    SET(ENABLE_MKL FALSE CACHE BOOL "ENABLE MKL for non-intel compilers (Experimental)")
+  ENDIF (INTEL_COMPILER)
+  IF (ENABLE_MKL)
    INCLUDE(CMake/FindMKL.cmake)
-  ENDIF(INTEL_COMPILER OR ENABLE_OUTSIDE_MKL)
+  ENDIF(ENABLE_MKL)
   IF ( HAVE_MKL )
     # We found MKL, add the link library
     SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${MKL_FLAGS}")


### PR DESCRIPTION
ENABLE_MKL is more general now.
It allows disabling MKL when using Intel compilers.