### PR TITLE
Fix unit test linking issue

### DIFF
--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ SET(SRCS test_accumulator.cpp test_local_energy_est.cpp test_manager.cpp test_tr
 
 
 ADD_EXECUTABLE(${UTEST_EXE} ${SRCS})
-TARGET_LINK_LIBRARIES(${UTEST_EXE} qmc qmcwfs qmcham qmcbase qmcutil qmcdriver ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
+TARGET_LINK_LIBRARIES(${UTEST_EXE} qmc qmcham qmcwfs qmcbase qmcutil qmcdriver ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 
 #ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
 ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")


### PR DESCRIPTION
Happens in certain scenario.
Adjust the linking order to qmcham before qmcwfs because qmcham depends on qmcwfs.