### PR TITLE
Centralize printing of git repository info

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -46,7 +46,6 @@
 #include "HDFVersion.h"
 #include "OhmmsData/AttributeSet.h"
 #include "qmc_common.h"
-#include "qmcpack_version.h"
 #ifdef HAVE_ADIOS
 #include "ADIOS/ADIOS_config.h"
 #include <adios_read.h>
@@ -77,13 +76,9 @@ QMCMain::QMCMain(Communicate* c)
       << "\n=====================================================\n"
       <<  "                    QMCPACK "
       << QMCPACK_VERSION_MAJOR << "." << QMCPACK_VERSION_MINOR << "." << QMCPACK_VERSION_PATCH << " \n"
-      << "\n  (c) Copyright 2003-  QMCPACK developers            \n"
-#if defined(QMCPACK_GIT_BRANCH)
-      << "\n  Git branch: " << QMCPACK_GIT_BRANCH
-      << "\n  Last git commit: " << QMCPACK_GIT_HASH
-      << "\n  Last commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED
-#endif
-      << "\n=====================================================\n";
+      << "\n  (c) Copyright 2003-  QMCPACK developers            \n\n";
+  qmc_common.print_git_info_if_present(app_summary());
+  app_summary()  << "=====================================================\n";
   qmc_common.print_options(app_log());
   app_summary()
       << "\n  MPI Nodes            = " << OHMMS::Controller->size()

--- a/src/qmc_common.cpp
+++ b/src/qmc_common.cpp
@@ -88,12 +88,7 @@ void QMCState::initialize(int argc, char **argv)
   {
     std::cerr << std::endl << "QMCPACK version "<< QMCPACK_VERSION_MAJOR <<"." << QMCPACK_VERSION_MINOR << "." << QMCPACK_VERSION_PATCH
         << " built on " << __DATE__ << std::endl;
-#ifdef QMCPACK_GIT_BRANCH
-    std::cerr << "  git branch: " << QMCPACK_GIT_BRANCH << std::endl;
-    std::cerr << "  git last commit: " << QMCPACK_GIT_HASH << std::endl;
-    std::cerr << "  git last commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED << std::endl;
-    std::cerr << "  git last commit subject: " << QMCPACK_GIT_COMMIT_SUBJECT << std::endl;
-#endif
+    print_git_info_if_present(std::cerr);
     std::cerr << std::endl << "Usage: qmcpack input [--dryrun --save_wfs[=no] --gpu]" << std::endl << std::endl;
   }
   if(stopit)
@@ -117,6 +112,17 @@ void QMCState::print_memory_change(const std::string& who, size_t before)
   before=memory_allocated-before;
   app_log() << "MEMORY increase " << (before>>20) << " MB " << who << std::endl;
 }
+
+void QMCState::print_git_info_if_present(std::ostream& os)
+{
+#ifdef QMCPACK_GIT_BRANCH
+    os << "  Git branch: " << QMCPACK_GIT_BRANCH << std::endl;
+    os << "  Last git commit: " << QMCPACK_GIT_HASH << std::endl;
+    os << "  Last git commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED << std::endl;
+    os << "  Last git commit subject: " << QMCPACK_GIT_COMMIT_SUBJECT << std::endl;
+#endif
+}
+
 
 QMCState qmc_common;
 

--- a/src/qmc_common.h
+++ b/src/qmc_common.h
@@ -67,6 +67,9 @@ struct QMCState
    * @param before memory_allocated before calling print
    */
   void print_memory_change(const std::string& who, size_t before);
+
+  /// Print git info (commit hash, etc) if project was build from git repository
+  void print_git_info_if_present(std::ostream& os);
 };
 
 ///a unique QMCState during a run


### PR DESCRIPTION
Move the printing of git repository info to qmc_common.
By removing the direct dependency of QMCMain.cpp on qmcpack_verison.h, the git-rev-tmp.h race condition at compile time should be fixed.