### PR TITLE
Sort QMCPACK publications by date

### DIFF
--- a/manual/qmcpack_papers.bib
+++ b/manual/qmcpack_papers.bib
@@ -1,5 +1,15 @@
+% Encoding: UTF-8
+% Entries in this file should be in date order (old-new). JabRef Magic strings are included to automate this.
 
-% 2006
+% (thesis) das walk on sphere
+@book{das2005thesis,
+  title={Quantum Monte Carlo With a Stochastic Poisson Solver},
+  author={Das, Dyutiman},
+  year={2005},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/80519}
+}
+
 % (method) walk on spheres
 @article{das2006,
   title = {Quantum Monte Carlo method using a stochastic Poisson solver},
@@ -16,10 +26,15 @@
   url = {http://link.aps.org/doi/10.1103/PhysRevE.73.046702}
 }
 
+% (thesis) vincent germanium nanoparticle
+@book{vincent2006thesis,
+  title={Quantum Monte Carlo Calculations of the Electronic Excitations of Germanium Atoms, Molecules and Nanoclusters Using Core-Polarization Potentials},
+  author={Vincent, Jordan Eric},
+  year={2006},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/80541}
+}
 
-
-
-% 2007
 % (app/dev) vincent ge nanoparticle core pol pot
 @article{vincent2007,
   title = {Quantum Monte Carlo calculations of the optical gaps of Ge nanoclusters using core-polarization potentials},
@@ -34,22 +49,6 @@
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevB.75.045302},
   url = {http://link.aps.org/doi/10.1103/PhysRevB.75.045302}
-}
-
-
-
-
-% 2008
-% (qmchpc) endstation project
-@article{esler2008,
-  author={K P Esler and J Kim and D M Ceperley and W Purwanto and E J Walter and H Krakauer and S Zhang and P R C Kent and R G Hennig and C Umrigar and M Bajdich and J Kolorenč and L Mitas and A Srinivasan},
-  title={Quantum Monte Carlo algorithms for electronic structure at the petascale; the Endstation project},
-  journal={Journal of Physics: Conference Series},
-  volume={125},
-  number={1},
-  pages={012057},
-  url={http://stacks.iop.org/1742-6596/125/i=1/a=012057},
-  year={2008},
 }
 
 % (app) beaudet hydrogen on benzene
@@ -69,18 +68,34 @@ eprint = { http://dx.doi.org/10.1063/1.2987716 }
 
 
 
+% (qmchpc) endstation project
+@article{esler2008,
+  author={K P Esler and J Kim and D M Ceperley and W Purwanto and E J Walter and H Krakauer and S Zhang and P R C Kent and R G Hennig and C Umrigar and M Bajdich and J Kolorenč and L Mitas and A Srinivasan},
+  title={Quantum Monte Carlo algorithms for electronic structure at the petascale; the Endstation project},
+  journal={Journal of Physics: Conference Series},
+  volume={125},
+  number={1},
+  pages={012057},
+  url={http://stacks.iop.org/1742-6596/125/i=1/a=012057},
+  year={2008},
+}
 
-% 2010
-% (hpc) enos qmcpack gpu
-@INPROCEEDINGS{enos2010, 
-author={J. Enos and C. Steffen and J. Fullop and M. Showerman and G. Shi and K. Esler and V. Kindratenko and J. E. Stone and J. C. Phillips}, 
-booktitle={International Conference on Green Computing}, 
-title={Quantifying the impact of GPUs on performance and energy efficiency in HPC clusters}, 
-year={2010}, 
-pages={317-324}, 
-keywords={computer graphic equipment;coprocessors;power consumption;workstation clusters;CPU hosts;GPU;HPC clusters;cluster management software tools;hardware-software infrastructure;performance-per-watt;power monitoring hardware;power usage data;power usage monitoring;software stack;Benchmark testing;Graphics processing unit;Monitoring;Power demand;Power measurement;Sensors;GPU;cluster;power efficiency;power monitoring}, 
-doi={10.1109/GREENCOMP.2010.5598297}, 
-month={Aug},
+% (thesis) clark order N
+@phdthesis{clark2009thesis,
+  title={Strongly Correlated Systems Approach Through Quantum Monte Carlo},
+  author={Clark, Bryan},
+  year={2009},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/80605},
+}
+
+% (thesis) gergely water
+@phdthesis{gergely2009thesis,
+  title={Quantum Monte Carlo Methods for First Principles Simulation of Liquid Water},
+  author={Gergely, John Robert},
+  year={2009},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/80610}
 }
 
 % (app) esler all electron cubic boron nitride
@@ -97,6 +112,18 @@ month={Aug},
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevLett.104.185702},
   url = {http://link.aps.org/doi/10.1103/PhysRevLett.104.185702}
+}
+
+% (hpc) enos qmcpack gpu
+@INPROCEEDINGS{enos2010, 
+author={J. Enos and C. Steffen and J. Fullop and M. Showerman and G. Shi and K. Esler and V. Kindratenko and J. E. Stone and J. C. Phillips}, 
+booktitle={International Conference on Green Computing}, 
+title={Quantifying the impact of GPUs on performance and energy efficiency in HPC clusters}, 
+year={2010}, 
+pages={317-324}, 
+keywords={computer graphic equipment;coprocessors;power consumption;workstation clusters;CPU hosts;GPU;HPC clusters;cluster management software tools;hardware-software infrastructure;performance-per-watt;power monitoring hardware;power usage data;power usage monitoring;software stack;Benchmark testing;Graphics processing unit;Monitoring;Power demand;Power measurement;Sensors;GPU;cluster;power efficiency;power monitoring}, 
+doi={10.1109/GREENCOMP.2010.5598297}, 
+month={Aug},
 }
 
 % (method/app) houtari (mcminis) sodium momentum distribution
@@ -131,43 +158,23 @@ eprint = { http://dx.doi.org/10.1021/jz100418p }
 
 
 
-% 2011
-% (dev) ahuja linear scaling qmc
-@article{ahuja2011,
-author = {Kapil Ahuja and Bryan K. Clark and Eric de Sturler and David M. Ceperley and Jeongnim Kim},
-title = {Improved Scaling for Quantum Monte Carlo on Insulators},
-journal = {SIAM Journal on Scientific Computing},
-volume = {33},
-number = {4},
-pages = {1837-1859},
-year = {2011},
-doi = {10.1137/100805467},
-URL = { http://dx.doi.org/10.1137/100805467 },
-eprint = { http://dx.doi.org/10.1137/100805467 }
-}
 
-% (dev) esler qmcpack gpu
-@article{esler2011,
-  title={Fully accelerating quantum Monte Carlo simulations of real materials on GPU clusters},
-  author={Esler, Kenneth P and Kim, Jeongnim and Schulenburger, L and Ceperley, DM},
-  journal={Computing in Science and Eng},
-  volume={13},
-  number={5},
-  year={2011}
-}
 
-% (method/app) clark table method, multidet water molecule
-@article{clark2011,
-author = {Bryan K. Clark and Miguel A. Morales and Jeremy McMinis and Jeongnim Kim and Gustavo E. Scuseria},
-title = {Computing the energy of a water molecule using multideterminants: A simple, efficient algorithm},
-journal = {The Journal of Chemical Physics},
-volume = {135},
-number = {24},
-pages = {244105},
-year = {2011},
-doi = {10.1063/1.3665391},
-URL = { http://dx.doi.org/10.1063/1.3665391 },
-eprint = { http://dx.doi.org/10.1063/1.3665391 }
+
+% (app) spherical jellium qwalk (used orbitals from SQD code, packaged/part of qmcpack)
+@article{bajdich2011,
+  title = {Simple impurity embedded in a spherical jellium: Approximations of density functional theory compared to quantum Monte Carlo benchmarks},
+  author = {Bajdich, Michal and Kent, P. R. C. and Kim, Jeongnim and Reboredo, Fernando A.},
+  journal = {Phys. Rev. B},
+  volume = {84},
+  issue = {7},
+  pages = {075131},
+  numpages = {8},
+  year = {2011},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.84.075131},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.84.075131}
 }
 
 % (app) holzmann (mcminis) heg momentum distribution
@@ -186,11 +193,62 @@ eprint = { http://dx.doi.org/10.1063/1.3665391 }
   url = {http://link.aps.org/doi/10.1103/PhysRevLett.107.110402}
 }
 
+% (thesis) ahuja linear scaling qmc
+@phdthesis{ahuja2011thesis,
+  title={Recycling Krylov subspaces and preconditioners},
+  author={Ahuja, Kapil},
+  year={2011},
+  school={Virginia Polytechnic Institute and State University},
+  url={http://theses.lib.vt.edu/theses/available/etd-11112011-010340/}
+}
 
+% (dev) ahuja linear scaling qmc
+@article{ahuja2011,
+author = {Kapil Ahuja and Bryan K. Clark and Eric de Sturler and David M. Ceperley and Jeongnim Kim},
+title = {Improved Scaling for Quantum Monte Carlo on Insulators},
+journal = {SIAM Journal on Scientific Computing},
+volume = {33},
+number = {4},
+pages = {1837-1859},
+year = {2011},
+doi = {10.1137/100805467},
+URL = { http://dx.doi.org/10.1137/100805467 },
+eprint = { http://dx.doi.org/10.1137/100805467 }
+}
 
+% (thesis) beaudet hydrogen on carbon/transition metal
+@phdthesis{beaudet2011thesis,
+  title={Quantum Monte Carlo Study of Hydrogen Adsorption on Carbon and Transition Metal Systems},
+  author={Beaudet, Todd D},
+  year={2011},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/18600}
+}
 
+% (method/app) clark table method, multidet water molecule
+@article{clark2011,
+author = {Bryan K. Clark and Miguel A. Morales and Jeremy McMinis and Jeongnim Kim and Gustavo E. Scuseria},
+title = {Computing the energy of a water molecule using multideterminants: A simple, efficient algorithm},
+journal = {The Journal of Chemical Physics},
+volume = {135},
+number = {24},
+pages = {244105},
+year = {2011},
+doi = {10.1063/1.3665391},
+URL = { http://dx.doi.org/10.1063/1.3665391 },
+eprint = { http://dx.doi.org/10.1063/1.3665391 }
+}
 
-% 2012
+% (dev) esler qmcpack gpu
+@article{esler2011,
+  title={Fully accelerating quantum Monte Carlo simulations of real materials on GPU clusters},
+  author={Esler, Kenneth P and Kim, Jeongnim and Schulenburger, L and Ceperley, DM},
+  journal={Computing in Science and Eng},
+  volume={13},
+  number={5},
+  year={2011}
+}
+
 % (dev) esler qmcpack gpu
 @ARTICLE{esler2012, 
 author={K. Esler and J. Kim and D. Ceperley and L. Shulenburger}, 
@@ -206,6 +264,14 @@ ISSN={1521-9615},
 month={Jan},
 }
 
+% (hpc) baue cray user group
+@inproceedings{baue2012,
+  title={Analyses and modeling of applications used to demonstrate sustained petascale performance on Blue Waters},
+  author={Bauer, Gregory H and Hoefler, Torsten and Kramer, William T and Fiedler, Robert A},
+  booktitle={Proceedings of the Annual Meeting of the Cray Users Group},
+  year={2012}
+}
+
 % (dev) kim qmcpack gpu
 @article{kim2012,
   author={Jeongnim Kim and Kenneth P Esler and Jeremy McMinis and Miguel A Morales and Bryan K Clark and Luke Shulenburger and David M Ceperley},
@@ -218,29 +284,82 @@ month={Jan},
   year={2012},
 }
 
-% (hpc) baue cray user group
-@inproceedings{baue2012,
-  title={Analyses and modeling of applications used to demonstrate sustained petascale performance on Blue Waters},
-  author={Bauer, Gregory H and Hoefler, Torsten and Kramer, William T and Fiedler, Robert A},
-  booktitle={Proceedings of the Annual Meeting of the Cray Users Group},
-  year={2012}
-}
-
 % (app) watson molecular crystal
-@inbook{watson2012,
-author = {Watson, Mark A. and Hongo, Kenta and Iitaka, Toshiaki and Aspuru-Guzik, Alán},
-title = {A Benchmark Quantum Monte Carlo Study of Molecular Crystal Polymorphism: A Challenging Case for Density-Functional Theory},
-booktitle = {Advances in Quantum Monte Carlo},
-chapter = {9},
-pages = {101-117},
-doi = {10.1021/bk-2012-1094.ch009},
-URL = {http://pubs.acs.org/doi/abs/10.1021/bk-2012-1094.ch009},
-eprint = {http://pubs.acs.org/doi/pdf/10.1021/bk-2012-1094.ch009}
+
+@InBook{watson2012,
+  chapter   = {9},
+  pages     = {101-117},
+  title     = {A Benchmark Quantum Monte Carlo Study of Molecular Crystal Polymorphism: A Challenging Case for Density-Functional Theory},
+  year      = {2012},
+  author    = {Watson, Mark A. and Hongo, Kenta and Iitaka, Toshiaki and Aspuru-Guzik, Alán},
+  booktitle = {Advances in Quantum Monte Carlo},
+  doi       = {10.1021/bk-2012-1094.ch009},
+  eprint    = {http://pubs.acs.org/doi/pdf/10.1021/bk-2012-1094.ch009},
+  url       = {http://pubs.acs.org/doi/abs/10.1021/bk-2012-1094.ch009},
 }
 
+% (dev) coghlan (romero) qmcpack mira
+@ARTICLE{coghlan2013, 
+author={S. Coghlan and K. Kumaran and R. M. Loy and P. Messina and V. Morozov and J. C. Osborn and S. Parker and K. M. Riley and N. A. Romero and T. J. Williams}, 
+journal={IBM Journal of Research and Development}, 
+title={Argonne applications for the IBM Blue Gene/Q, Mira}, 
+year={2013}, 
+volume={57}, 
+number={1/2}, 
+pages={12:1-12:11}, 
+doi={10.1147/JRD.2013.2238371}, 
+ISSN={0018-8646}, 
+month={Jan},
+}
 
+% (method/app) mcminis heg renyi entropy
+@article{mcminis2013,
+  title = {Renyi entropy of the interacting Fermi liquid},
+  author = {McMinis, Jeremy and Tubman, Norm M.},
+  journal = {Phys. Rev. B},
+  volume = {87},
+  issue = {8},
+  pages = {081108},
+  numpages = {4},
+  year = {2013},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.87.081108},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.87.081108}
+}
 
-% 2013
+% (app) swingle fermi gas/liquid entanglement (swap operator in qmcpack?)
+@article{swingle2013,
+  title = {Oscillating terms in the Renyi entropy of Fermi gases and liquids},
+  author = {Swingle, Brian and McMinis, Jeremy and Tubman, Norm M.},
+  journal = {Phys. Rev. B},
+  volume = {87},
+  issue = {23},
+  pages = {235112},
+  numpages = {10},
+  year = {2013},
+  month = {Jun},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.87.235112},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.87.235112}
+}
+
+% (method/dev) krogel energy density
+@article{krogel2013,
+  title = {Quantum energy density: Improved efficiency for quantum Monte Carlo calculations},
+  author = {Krogel, Jaron T. and Yu, Min and Kim, Jeongnim and Ceperley, David M.},
+  journal = {Phys. Rev. B},
+  volume = {88},
+  issue = {3},
+  pages = {035137},
+  numpages = {10},
+  year = {2013},
+  month = {Jul},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.88.035137},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.88.035137}
+}
+
 % (compsci) matheny (krogel) adios I/O
 @INPROCEEDINGS{matheny2013, 
 author={S. Herbein and M. Matheny and M. Wezowicz and J. Krogel and J. Logan and J. Kim and S. Klasky and M. Taufer}, 
@@ -269,58 +388,72 @@ month={Dec},
   url = {http://link.aps.org/doi/10.1103/PhysRevB.88.245117}
 }
 
-% (method/app) mcminis heg renyi entropy
-@article{mcminis2013,
-  title = {Renyi entropy of the interacting Fermi liquid},
-  author = {McMinis, Jeremy and Tubman, Norm M.},
+% (thesis) krogel germanium energy density
+@phdthesis{krogel2013thesis,
+  title={Energetics of neutral interstitials in germanium},
+  author={Krogel, Jaron},
+  year={2013},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/44417},
+}
+
+% (thesis) mcminis pressure entanglement
+@phdthesis{mcminis2013thesis,
+  title={Benchmark studies using quantum Monte Carlo: pressure estimators, energy, and entanglement},
+  author={McMinis, Jeremy},
+  year={2013},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/44344},
+}
+
+% (method/app) clay hydrogen forces
+@article{clay2014,
+  title = {Benchmarking exchange-correlation functionals for hydrogen at high pressures using quantum Monte Carlo},
+  author = {Clay, Raymond C. and Mcminis, Jeremy and McMahon, Jeffrey M. and Pierleoni, Carlo and Ceperley, David M. and Morales, Miguel A.},
   journal = {Phys. Rev. B},
-  volume = {87},
-  issue = {8},
-  pages = {081108},
-  numpages = {4},
-  year = {2013},
-  month = {Feb},
+  volume = {89},
+  issue = {18},
+  pages = {184106},
+  numpages = {11},
+  year = {2014},
+  month = {May},
   publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.87.081108},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.87.081108}
+  doi = {10.1103/PhysRevB.89.184106},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.89.184106}
 }
 
-% (dev) coghlan (romero) qmcpack mira
-@ARTICLE{coghlan2013, 
-author={S. Coghlan and K. Kumaran and R. M. Loy and P. Messina and V. Morozov and J. C. Osborn and S. Parker and K. M. Riley and N. A. Romero and T. J. Williams}, 
-journal={IBM Journal of Research and Development}, 
-title={Argonne applications for the IBM Blue Gene/Q, Mira}, 
-year={2013}, 
-volume={57}, 
-number={1/2}, 
-pages={12:1-12:11}, 
-doi={10.1147/JRD.2013.2238371}, 
-ISSN={0018-8646}, 
-month={Jan},
-}
-
-% (method/dev) krogel energy density
-@article{krogel2013,
-  title = {Quantum energy density: Improved efficiency for quantum Monte Carlo calculations},
-  author = {Krogel, Jaron T. and Yu, Min and Kim, Jeongnim and Ceperley, David M.},
-  journal = {Phys. Rev. B},
-  volume = {88},
+% (app) foyevtsova cuprate
+@article{foyevtsova2014,
+  title = {Ab initio},
+  author = {Foyevtsova, Kateryna and Krogel, Jaron T. and Kim, Jeongnim and Kent, P. R. C. and Dagotto, Elbio and Reboredo, Fernando A.},
+  journal = {Phys. Rev. X},
+  volume = {4},
   issue = {3},
-  pages = {035137},
-  numpages = {10},
-  year = {2013},
+  pages = {031003},
+  numpages = {7},
+  year = {2014},
   month = {Jul},
   publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.88.035137},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.88.035137}
+  doi = {10.1103/PhysRevX.4.031003},
+  url = {http://link.aps.org/doi/10.1103/PhysRevX.4.031003}
 }
 
+% (method/dev) krogel energy density matrix
+@article{krogel2014,
+  title = {Energy density matrix formalism for interacting quantum systems: Quantum Monte Carlo study},
+  author = {Krogel, Jaron T. and Kim, Jeongnim and Reboredo, Fernando A.},
+  journal = {Phys. Rev. B},
+  volume = {90},
+  issue = {3},
+  pages = {035125},
+  numpages = {8},
+  year = {2014},
+  month = {Jul},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.90.035125},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.90.035125}
+}
 
-
-
-
-
-% 2014
 % (compsci) herbein adios I/O
 @INPROCEEDINGS{herbein2014, 
 author={S. Herbein and S. Klasky and M. Taufer}, 
@@ -332,53 +465,6 @@ keywords={Monte Carlo methods;benchmark testing;input-output programs;mesh gener
 doi={10.1109/ICPPW.2014.46}, 
 ISSN={0190-3918}, 
 month={Sept},}
-
-% (compsci) matheny adios I/O
-@INPROCEEDINGS{matheny2014, 
-author={M. Matheny and S. Herbein and N. Podhorszki and S. Klasky and M. Taufer}, 
-booktitle={2014 20th IEEE International Conference on Parallel and Distributed Systems (ICPADS)}, 
-title={Using surrogate-based modeling to predict optimal I/O parameters of applications at the extreme scale}, 
-year={2014}, 
-pages={568-575}, 
-keywords={input-output programs;parallel processing;I/O times;engineering method;exascale computing;optimal I/O parameter values;petascale systems;surrogate-based modeling;Computational modeling;Data models;Kernel;Polynomials;Predictive models;Response surface methodology;Runtime;I/O modeling and tuning;Irregular I/O pattern;Peta- and exascale computing;QMCPack;Scientific applications}, 
-doi={10.1109/PADSW.2014.7097855}, 
-ISSN={1521-9097}, 
-month={Dec},
-}
-
-% (hpc) mendes blue waters sustained petaflop
-@article{mendes2014,
-title = "Deploying a Large Petascale System: The Blue Waters Experience",
-journal = "Procedia Computer Science",
-volume = "29",
-number = "",
-pages = "198 - 209",
-year = "2014",
-note = "",
-issn = "1877-0509",
-doi = "http://dx.doi.org/10.1016/j.procs.2014.05.018",
-url = "http://www.sciencedirect.com/science/article/pii/S1877050914001951",
-author = "Celso L. Mendes and Brett Bode and Gregory H. Bauer and Jeremy Enos and Cristina Beldica and William T. Kramer",
-keywords = "large system deployment",
-keywords = "acceptance testing",
-keywords = "petascale performance"
-}
-
-% (dev/app) tubman born oppenheimer molecules
-@article{tubman2014,
-  title = {Beyond the Born-Oppenheimer approximation with quantum Monte Carlo methods},
-  author = {Tubman, Norm M. and Kyl\"anp\"a\"a, Ilkka and Hammes-Schiffer, Sharon and Ceperley, David M.},
-  journal = {Phys. Rev. A},
-  volume = {90},
-  issue = {4},
-  pages = {042507},
-  numpages = {5},
-  year = {2014},
-  month = {Oct},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.90.042507},
-  url = {http://link.aps.org/doi/10.1103/PhysRevA.90.042507}
-}
 
 % (app) shulenburger xenon melting
 @article{shulenburger2014,
@@ -396,34 +482,20 @@ keywords = "petascale performance"
   url = {http://link.aps.org/doi/10.1103/PhysRevB.90.140104}
 }
 
-% (app) morales hydrogen/water
-@Article{morales2014,
-AUTHOR = {Morales, Miguel A. and Clay, Raymond and Pierleoni, Carlo and Ceperley, David M.},
-TITLE = {First Principles Methods: A Perspective from Quantum Monte Carlo},
-JOURNAL = {Entropy},
-VOLUME = {16},
-YEAR = {2014},
-NUMBER = {1},
-PAGES = {287--321},
-URL = {http://www.mdpi.com/1099-4300/16/1/287},
-ISSN = {1099-4300},
-DOI = {10.3390/e16010287}
-}
-
-% (app) foyevtsova cuprate
-@article{foyevtsova2014,
-  title = {Ab initio},
-  author = {Foyevtsova, Kateryna and Krogel, Jaron T. and Kim, Jeongnim and Kent, P. R. C. and Dagotto, Elbio and Reboredo, Fernando A.},
-  journal = {Phys. Rev. X},
-  volume = {4},
-  issue = {3},
-  pages = {031003},
-  numpages = {7},
+% (dev/app) tubman born oppenheimer molecules
+@article{tubman2014,
+  title = {Beyond the Born-Oppenheimer approximation with quantum Monte Carlo methods},
+  author = {Tubman, Norm M. and Kyl\"anp\"a\"a, Ilkka and Hammes-Schiffer, Sharon and Ceperley, David M.},
+  journal = {Phys. Rev. A},
+  volume = {90},
+  issue = {4},
+  pages = {042507},
+  numpages = {5},
   year = {2014},
-  month = {Jul},
+  month = {Oct},
   publisher = {American Physical Society},
-  doi = {10.1103/PhysRevX.4.031003},
-  url = {http://link.aps.org/doi/10.1103/PhysRevX.4.031003}
+  doi = {10.1103/PhysRevA.90.042507},
+  url = {http://link.aps.org/doi/10.1103/PhysRevA.90.042507}
 }
 
 % (app) lin mgsio3
@@ -458,6 +530,19 @@ DOI = {10.3390/e16010287}
   url = {http://link.aps.org/doi/10.1103/PhysRevB.90.184105}
 }
 
+% (compsci) matheny adios I/O
+@INPROCEEDINGS{matheny2014, 
+author={M. Matheny and S. Herbein and N. Podhorszki and S. Klasky and M. Taufer}, 
+booktitle={2014 20th IEEE International Conference on Parallel and Distributed Systems (ICPADS)}, 
+title={Using surrogate-based modeling to predict optimal I/O parameters of applications at the extreme scale}, 
+year={2014}, 
+pages={568-575}, 
+keywords={input-output programs;parallel processing;I/O times;engineering method;exascale computing;optimal I/O parameter values;petascale systems;surrogate-based modeling;Computational modeling;Data models;Kernel;Polynomials;Predictive models;Response surface methodology;Runtime;I/O modeling and tuning;Irregular I/O pattern;Peta- and exascale computing;QMCPack;Scientific applications}, 
+doi={10.1109/PADSW.2014.7097855}, 
+ISSN={1521-9097}, 
+month={Dec},
+}
+
 % (app) benali ar/kr/xe, dna
 @article{benali2014,
 author = {Benali, Anouar and Shulenburger, Luke and Romero, Nichols A. and Kim, Jeongnim and von Lilienfeld, O. Anatole},
@@ -471,36 +556,6 @@ doi = {10.1021/ct5003225},
 note ={PMID: 26588310},
 URL = { http://dx.doi.org/10.1021/ct5003225 },
 eprint = { http://dx.doi.org/10.1021/ct5003225 }
-}
-
-% (app) shin graphyne
-@article{shin2014,
-author = {Hyeondeok Shin and Sinabro Kang and Jahyun Koo and Hoonkyung Lee and Jeongnim Kim and Yongkyung Kwon},
-title = {Cohesion energetics of carbon allotropes: Quantum Monte Carlo study},
-journal = {The Journal of Chemical Physics},
-volume = {140},
-number = {11},
-pages = {114702},
-year = {2014},
-doi = {10.1063/1.4867544},
-URL = { http://dx.doi.org/10.1063/1.4867544 },
-eprint = { http://dx.doi.org/10.1063/1.4867544 }
-}
-
-% (method/app) clay hydrogen forces
-@article{clay2014,
-  title = {Benchmarking exchange-correlation functionals for hydrogen at high pressures using quantum Monte Carlo},
-  author = {Clay, Raymond C. and Mcminis, Jeremy and McMahon, Jeffrey M. and Pierleoni, Carlo and Ceperley, David M. and Morales, Miguel A.},
-  journal = {Phys. Rev. B},
-  volume = {89},
-  issue = {18},
-  pages = {184106},
-  numpages = {11},
-  year = {2014},
-  month = {May},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.89.184106},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.89.184106}
 }
 
 % (app) ganesh li in graphite
@@ -532,6 +587,38 @@ URL = { http://dx.doi.org/10.1063/1.4880275 },
 eprint = { http://dx.doi.org/10.1063/1.4880275 }
 }
 
+% (hpc) mendes blue waters sustained petaflop
+@article{mendes2014,
+title = "Deploying a Large Petascale System: The Blue Waters Experience",
+journal = "Procedia Computer Science",
+volume = "29",
+number = "",
+pages = "198 - 209",
+year = "2014",
+note = "",
+issn = "1877-0509",
+doi = "http://dx.doi.org/10.1016/j.procs.2014.05.018",
+url = "http://www.sciencedirect.com/science/article/pii/S1877050914001951",
+author = "Celso L. Mendes and Brett Bode and Gregory H. Bauer and Jeremy Enos and Cristina Beldica and William T. Kramer",
+keywords = "large system deployment",
+keywords = "acceptance testing",
+keywords = "petascale performance"
+}
+
+% (app) morales hydrogen/water
+@Article{morales2014,
+AUTHOR = {Morales, Miguel A. and Clay, Raymond and Pierleoni, Carlo and Ceperley, David M.},
+TITLE = {First Principles Methods: A Perspective from Quantum Monte Carlo},
+JOURNAL = {Entropy},
+VOLUME = {16},
+YEAR = {2014},
+NUMBER = {1},
+PAGES = {287--321},
+URL = {http://www.mdpi.com/1099-4300/16/1/287},
+ISSN = {1099-4300},
+DOI = {10.3390/e16010287}
+}
+
 % (app) morales/gergely water
 @article{morales2014b,
 author = {Morales, Miguel A. and Gergely, John R. and McMinis, Jeremy and McMahon, Jeffrey M. and Kim, Jeongnim and Ceperley, David M.},
@@ -545,6 +632,20 @@ doi = {10.1021/ct500129p},
 note ={PMID: 26580755},
 URL = { http://dx.doi.org/10.1021/ct500129p },
 eprint = { http://dx.doi.org/10.1021/ct500129p }
+}
+
+% (app) shin graphyne
+@article{shin2014,
+author = {Hyeondeok Shin and Sinabro Kang and Jahyun Koo and Hoonkyung Lee and Jeongnim Kim and Yongkyung Kwon},
+title = {Cohesion energetics of carbon allotropes: Quantum Monte Carlo study},
+journal = {The Journal of Chemical Physics},
+volume = {140},
+number = {11},
+pages = {114702},
+year = {2014},
+doi = {10.1063/1.4867544},
+URL = { http://dx.doi.org/10.1063/1.4867544 },
+eprint = { http://dx.doi.org/10.1063/1.4867544 }
 }
 
 % (compsci) sreepathi oxbow toolkit profiling
@@ -565,40 +666,20 @@ eprint = { http://dx.doi.org/10.1021/ct500129p }
  address = {Piscataway, NJ, USA},
 } 
 
-% (method/dev) krogel energy density matrix
-@article{krogel2014,
-  title = {Energy density matrix formalism for interacting quantum systems: Quantum Monte Carlo study},
-  author = {Krogel, Jaron T. and Kim, Jeongnim and Reboredo, Fernando A.},
-  journal = {Phys. Rev. B},
-  volume = {90},
-  issue = {3},
-  pages = {035125},
-  numpages = {8},
-  year = {2014},
-  month = {Jul},
+% (app) mcminis atomic molecular hydrogen
+@article{mcminis2015,
+  title = {Molecular to Atomic Phase Transition in Hydrogen under High Pressure},
+  author = {McMinis, Jeremy and Clay, Raymond C. and Lee, Donghwa and Morales, Miguel A.},
+  journal = {Phys. Rev. Lett.},
+  volume = {114},
+  issue = {10},
+  pages = {105305},
+  numpages = {6},
+  year = {2015},
+  month = {Mar},
   publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.90.035125},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.90.035125}
-}
-
-
-% 2015
-% (hpc) mendes blue waters sustained petaflop
-@article{mendes2015,
-title = "Deployment and testing of the sustained petascale Blue Waters system ",
-journal = "Journal of Computational Science ",
-volume = "10",
-number = "",
-pages = "327 - 337",
-year = "2015",
-note = "",
-issn = "1877-7503",
-doi = "http://dx.doi.org/10.1016/j.jocs.2015.03.007",
-url = "http://www.sciencedirect.com/science/article/pii/S1877750315000344",
-author = "Celso L. Mendes and Brett Bode and Gregory H. Bauer and Jeremy Enos and Cristina Beldica and William T. Kramer",
-keywords = "Large system deployment",
-keywords = "Acceptance testing",
-keywords = "Petascale performance "
+  doi = {10.1103/PhysRevLett.114.105305},
+  url = {http://link.aps.org/doi/10.1103/PhysRevLett.114.105305}
 }
 
 % (hpc) hwu qmcpack gpu
@@ -623,6 +704,16 @@ keywords={parallel machines;power aware computing;statistical analysis;Tianhe-2 
 doi={10.1109/HPCC-CSS-ICESS.2015.15}, 
 month={Aug},}
 
+% (thesis) deible multidet molecules
+@misc{deible2015thesis,
+           month = {September},
+           title = {Theory and Applications of Quantum Monte Carlo},
+          author = {Michael Deible},
+            year = {2015},
+        keywords = {Quantum Monte Carlo},
+             url = {http://d-scholarship.pitt.edu/25747/},
+}
+
 % (app) shulenburger mgo
 @article{shulenburger2015,
   title = {Shock Response and Phase Transitions of MgO at Planetary Impact Conditions},
@@ -637,6 +728,20 @@ month={Aug},}
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevLett.115.198501},
   url = {http://link.aps.org/doi/10.1103/PhysRevLett.115.198501}
+}
+
+% (app) deible be dimer
+@article{deible2015,
+author = {Michael J. Deible and Melody Kessler and Kevin E. Gasperich and Kenneth D. Jordan},
+title = {Quantum Monte Carlo calculation of the binding energy of the beryllium dimer},
+journal = {The Journal of Chemical Physics},
+volume = {143},
+number = {8},
+pages = {084116},
+year = {2015},
+doi = {10.1063/1.4929351},
+URL = { http://dx.doi.org/10.1063/1.4929351 },
+eprint = { http://dx.doi.org/10.1063/1.4929351 }
 }
 
 % (hpc) gioiosa system calls
@@ -658,18 +763,36 @@ month={Aug},}
  address = {New York, NY, USA},
 } 
 
-% (app) deible be dimer
-@article{deible2015,
-author = {Michael J. Deible and Melody Kessler and Kevin E. Gasperich and Kenneth D. Jordan},
-title = {Quantum Monte Carlo calculation of the binding energy of the beryllium dimer},
+% (app) mcminis metallic hydrogen
+@article{mcminis2015b,
+author = {Jeremy McMinis and Miguel A. Morales and David M. Ceperley and Jeongnim Kim},
+title = {The transition to the metallic state in low density hydrogen},
 journal = {The Journal of Chemical Physics},
 volume = {143},
-number = {8},
-pages = {084116},
+number = {19},
+pages = {194703},
 year = {2015},
-doi = {10.1063/1.4929351},
-URL = { http://dx.doi.org/10.1063/1.4929351 },
-eprint = { http://dx.doi.org/10.1063/1.4929351 }
+doi = {10.1063/1.4935808},
+URL = { http://dx.doi.org/10.1063/1.4935808 },
+eprint = { http://dx.doi.org/10.1063/1.4935808 }
+}
+
+% (hpc) mendes blue waters sustained petaflop
+@article{mendes2015,
+title = "Deployment and testing of the sustained petascale Blue Waters system ",
+journal = "Journal of Computational Science ",
+volume = "10",
+number = "",
+pages = "327 - 337",
+year = "2015",
+note = "",
+issn = "1877-7503",
+doi = "http://dx.doi.org/10.1016/j.jocs.2015.03.007",
+url = "http://www.sciencedirect.com/science/article/pii/S1877750315000344",
+author = "Celso L. Mendes and Brett Bode and Gregory H. Bauer and Jeremy Enos and Cristina Beldica and William T. Kramer",
+keywords = "Large system deployment",
+keywords = "Acceptance testing",
+keywords = "Petascale performance "
 }
 
 % (app) mitra nio
@@ -686,6 +809,29 @@ URL = { http://dx.doi.org/10.1063/1.4934262 },
 eprint = { http://dx.doi.org/10.1063/1.4934262 }
 }
 
+% (thesis) niu global array bspline orbitals
+@phdthesis{niu2015thesis,
+  title={Characterization and Enhancement of Data Locality and Load Balancing for Irregular Applications},
+  author={Niu, Qingpeng},
+  year={2015},
+  school={The Ohio State University},
+  url={https://etd.ohiolink.edu/!etd.send_file?accession=osu1420811652&disposition=attachment}
+}
+
+% (tech) clay multidet orbitals
+@article{clay2016,
+author = {Raymond C. Clay III and Miguel A. Morales},
+title = {Influence of single particle orbital sets and configuration selection on multideterminant wavefunctions in quantum Monte Carlo},
+journal = {The Journal of Chemical Physics},
+volume = {142},
+number = {23},
+pages = {234103},
+year = {2015},
+doi = {10.1063/1.4921984},
+URL = { http://dx.doi.org/10.1063/1.4921984 },
+eprint = { http://dx.doi.org/10.1063/1.4921984 }
+}
+
 % (app) santana zno
 @article{santana2015,
 author = {Juan A. Santana and Jaron T. Krogel and Jeongnim Kim and Paul R. C. Kent and Fernando A. Reboredo},
@@ -698,20 +844,6 @@ year = {2015},
 doi = {10.1063/1.4919242},
 URL = { http://dx.doi.org/10.1063/1.4919242 },
 eprint = { http://dx.doi.org/10.1063/1.4919242 }
-}
-
-% (method/app) yang non-adiabatic atoms/dimers
-@article{yang2015,
-author = {Yubo Yang and Ilkka Kylänpää and Norm M. Tubman and Jaron T. Krogel and Sharon Hammes-Schiffer and David M. Ceperley},
-title = {How large are nonadiabatic effects in atomic and diatomic systems?},
-journal = {The Journal of Chemical Physics},
-volume = {143},
-number = {12},
-pages = {124308},
-year = {2015},
-doi = {10.1063/1.4931667},
-URL = { http://dx.doi.org/10.1063/1.4931667 },
-eprint = { http://dx.doi.org/10.1063/1.4931667 }
 }
 
 % (app) shulenburger black phosphorous
@@ -729,36 +861,6 @@ URL = { http://dx.doi.org/10.1021/acs.nanolett.5b03615 },
 eprint = { http://dx.doi.org/10.1021/acs.nanolett.5b03615 }
 }
 
-% (app) mcminis atomic molecular hydrogen
-@article{mcminis2015,
-  title = {Molecular to Atomic Phase Transition in Hydrogen under High Pressure},
-  author = {McMinis, Jeremy and Clay, Raymond C. and Lee, Donghwa and Morales, Miguel A.},
-  journal = {Phys. Rev. Lett.},
-  volume = {114},
-  issue = {10},
-  pages = {105305},
-  numpages = {6},
-  year = {2015},
-  month = {Mar},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevLett.114.105305},
-  url = {http://link.aps.org/doi/10.1103/PhysRevLett.114.105305}
-}
-
-% (app) mcminis metallic hydrogen
-@article{mcminis2015b,
-author = {Jeremy McMinis and Miguel A. Morales and David M. Ceperley and Jeongnim Kim},
-title = {The transition to the metallic state in low density hydrogen},
-journal = {The Journal of Chemical Physics},
-volume = {143},
-number = {19},
-pages = {194703},
-year = {2015},
-doi = {10.1063/1.4935808},
-URL = { http://dx.doi.org/10.1063/1.4935808 },
-eprint = { http://dx.doi.org/10.1063/1.4935808 }
-}
-
 % (app) shulenburger be phase transition (arxiv)
 @article{shulenburger2015c,
   title={Beyond chemical accuracy: The pseudopotential approximation in diffusion Monte Carlo calculations of the HCP to BCC phase transition in beryllium},
@@ -768,84 +870,131 @@ eprint = { http://dx.doi.org/10.1063/1.4935808 }
   url={https://arxiv.org/abs/1501.03850}
 }
 
-
-
-
-
-
-
-
-
-% 2016
-% (compsci) mcdaniel delayed update gpu
-@inproceedings{mcdaniel2016,
- author = {McDaniel, Tyler and D'Azevedo, Ed and Li, Ying Wai and Kent, Paul and Wong, Ming and Wong, Kwai},
- title = {Delayed Update Algorithms for Quantum Monte Carlo Simulation on GPU: Extended Abstract},
- booktitle = {Proceedings of the XSEDE16 Conference on Diversity, Big Data, and Science at Scale},
- series = {XSEDE16},
- year = {2016},
- isbn = {978-1-4503-4755-6},
- location = {Miami, USA},
- pages = {13:1--13:4},
- articleno = {13},
- numpages = {4},
- url = {http://doi.acm.org/10.1145/2949550.2949579},
- doi = {10.1145/2949550.2949579},
- acmid = {2949579},
- publisher = {ACM},
- address = {New York, NY, USA},
- keywords = {QMC simulation, emergent platforms, scientific computing},
-} 
-
-% (compsci) lopez qmcpack gpu kernel AMP
-@Inbook{lopez2016,
-author="Lopez, M. Graham
-and Bergstrom, Christopher
-and Li, Ying Wai
-and Elwasif, Wael
-and Hernandez, Oscar",
-editor="Taufer, Michela
-and Mohr, Bernd
-and Kunkel, Julian M.",
-title="Using C++ AMP to Accelerate HPC Applications on Multiple Platforms",
-bookTitle="High Performance Computing: ISC High Performance 2016 International Workshops, ExaComm, E-MuCoCoS, HPC-IODC, IXPUG, IWOPH, P3MA, VHPC, WOPSSS, Frankfurt, Germany, June 19--23, 2016, Revised Selected Papers",
-year="2016",
-publisher="Springer International Publishing",
-address="Cham",
-pages="563--576",
-isbn="978-3-319-46079-6",
-doi="10.1007/978-3-319-46079-6_38",
-url="http://dx.doi.org/10.1007/978-3-319-46079-6_38"
-}
-
-% (app) santana binary oxides
-@article{santana2016,
-author = {Juan A. Santana and Jaron T. Krogel and Paul R. C. Kent and Fernando A. Reboredo},
-title = {Cohesive energy and structural parameters of binary oxides of groups IIA and IIIB from diffusion quantum Monte Carlo},
+% (method/app) yang non-adiabatic atoms/dimers
+@article{yang2015,
+author = {Yubo Yang and Ilkka Kylänpää and Norm M. Tubman and Jaron T. Krogel and Sharon Hammes-Schiffer and David M. Ceperley},
+title = {How large are nonadiabatic effects in atomic and diatomic systems?},
 journal = {The Journal of Chemical Physics},
-volume = {144},
-number = {17},
-pages = {174707},
-year = {2016},
-doi = {10.1063/1.4947569},
-URL = {http://dx.doi.org/10.1063/1.4947569 },
-eprint = { http://dx.doi.org/10.1063/1.4947569 }
+volume = {143},
+number = {12},
+pages = {124308},
+year = {2015},
+doi = {10.1063/1.4931667},
+URL = { http://dx.doi.org/10.1063/1.4931667 },
+eprint = { http://dx.doi.org/10.1063/1.4931667 }
 }
 
-% (dev) niu global array orbitals
-@article {niu2016,
-author = {Niu, Qingpeng and Dinan, James and Tirukkovalur, Sravya and Benali, Anouar and Kim, Jeongnim and Mitas, Lubos and Wagner, Lucas and Sadayappan, P.},
-title = {Global-view coefficients: a data management solution for parallel quantum Monte Carlo applications},
-journal = {Concurrency and Computation: Practice and Experience},
-volume = {28},
-number = {13},
-issn = {1532-0634},
-url = {http://dx.doi.org/10.1002/cpe.3748},
-doi = {10.1002/cpe.3748},
-pages = {3655--3671},
-keywords = {quantum Monte Carlo, global arrays, PGAS},
+% (app/method) clay H-He mix forces
+@article{clay2016b,
+  title = {Benchmarking density functionals for hydrogen-helium mixtures with quantum Monte Carlo: Energetics, pressures, and forces},
+  author = {Clay, Raymond C. and Holzmann, Markus and Ceperley, David M. and Morales, Miguel A.},
+  journal = {Phys. Rev. B},
+  volume = {93},
+  issue = {3},
+  pages = {035121},
+  numpages = {12},
+  year = {2016},
+  month = {Jan},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.93.035121},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.035121}
+}
+
+% (app/tech) krogel pseudopotential dev 
+@article{krogel2016b,
+  title = {Pseudopotentials for quantum Monte Carlo studies of transition metal oxides},
+  author = {Krogel, Jaron T. and Santana, Juan A. and Reboredo, Fernando A.},
+  journal = {Phys. Rev. B},
+  volume = {93},
+  issue = {7},
+  pages = {075143},
+  numpages = {10},
+  year = {2016},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.93.075143},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.075143}
+}
+
+% (app/tech) nazarov locality fixed node error Ag/Sn/others
+@article{nazarov2016,
+  title = {Benchmarking the pseudopotential and fixed-node approximations in diffusion Monte Carlo calculations of molecules and solids},
+  author = {Nazarov, R. and Shulenburger, L. and Morales, M. and Hood, Randolph Q.},
+  journal = {Phys. Rev. B},
+  volume = {93},
+  issue = {9},
+  pages = {094111},
+  numpages = {15},
+  year = {2016},
+  month = {Mar},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.93.094111},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.094111}
+}
+
+% (method) holzmann finite size
+@article{holzmann2016,
+  title = {Theory of finite size effects for electronic quantum Monte Carlo calculations of liquids and solids},
+  author = {Holzmann, Markus and Clay, Raymond C. and Morales, Miguel A. and Tubman, Norm M. and Ceperley, David M. and Pierleoni, Carlo},
+  journal = {Phys. Rev. B},
+  volume = {94},
+  issue = {3},
+  pages = {035126},
+  numpages = {16},
+  year = {2016},
+  month = {Jul},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevB.94.035126},
+  url = {http://link.aps.org/doi/10.1103/PhysRevB.94.035126}
+}
+
+% (app) benali ti4o7
+@Article{benali2016,
+author ="Benali, Anouar and Shulenburger, Luke and Krogel, Jaron T. and Zhong, Xiaoliang and Kent, Paul R. C. and Heinonen, Olle",
+title  ="Quantum Monte Carlo analysis of a charge ordered insulating antiferromagnet: the Ti4O7 Magneli phase",
+journal  ="Phys. Chem. Chem. Phys.",
+year  ="2016",
+volume  ="18",
+issue  ="27",
+pages  ="18323-18335",
+publisher  ="The Royal Society of Chemistry",
+doi  ="10.1039/C6CP02067D",
+url  ="http://dx.doi.org/10.1039/C6CP02067D",
+}
+
+% (app) shulenburger lithium flouride
+@article{davis2016,
+author = {Jean-Paul Davis and Marcus D. Knudson and Luke Shulenburger and Scott D. Crockett},
+title = {Mechanical and optical response of [100] lithium fluoride to multi-megabar dynamic pressures},
+journal = {Journal of Applied Physics},
+volume = {120},
+number = {16},
+pages = {165901},
 year = {2016},
-note = {cpe.3748},
+doi = {10.1063/1.4965869},
+URL = { http://dx.doi.org/10.1063/1.4965869 },
+eprint = { http://dx.doi.org/10.1063/1.4965869 }
+}
+
+% (compsci) herbein adios I/O
+@article{herbein2016,
+title = "Performance characterization of irregular I/O at the extreme scale ",
+journal = "Parallel Computing ",
+volume = "51",
+number = "",
+pages = "17 - 36",
+year = "2016",
+note = "Special Issue on Parallel Programming Models and SystemsSoftware for High-End Computing ",
+issn = "0167-8191",
+doi = "http://dx.doi.org/10.1016/j.parco.2015.10.009",
+url = "http://www.sciencedirect.com/science/article/pii/S0167819115001386",
+author = "S. Herbein and S. McDaniel and N. Podhorszki and J. Logan and S. Klasky and M. Taufer",
+keywords = "Exascale",
+keywords = "Irregular I/O",
+keywords = "QMCPack",
+keywords = "ENZO",
+keywords = "ADIOS",
+keywords = "HDF5 "
 }
 
 % (dev) krogel nexus
@@ -871,6 +1020,27 @@ keywords = "Quantum Espresso",
 keywords = "VASP "
 }
 
+% (compsci) lopez qmcpack gpu kernel AMP
+@Inbook{lopez2016,
+author="Lopez, M. Graham
+and Bergstrom, Christopher
+and Li, Ying Wai
+and Elwasif, Wael
+and Hernandez, Oscar",
+editor="Taufer, Michela
+and Mohr, Bernd
+and Kunkel, Julian M.",
+title="Using C++ AMP to Accelerate HPC Applications on Multiple Platforms",
+bookTitle="High Performance Computing: ISC High Performance 2016 International Workshops, ExaComm, E-MuCoCoS, HPC-IODC, IXPUG, IWOPH, P3MA, VHPC, WOPSSS, Frankfurt, Germany, June 19--23, 2016, Revised Selected Papers",
+year="2016",
+publisher="Springer International Publishing",
+address="Cham",
+pages="563--576",
+isbn="978-3-319-46079-6",
+doi="10.1007/978-3-319-46079-6_38",
+url="http://dx.doi.org/10.1007/978-3-319-46079-6_38"
+}
+
 % (app) luo tio2
 @article{luo2016,
   author={Ye Luo and Anouar Benali and Luke Shulenburger and Jaron T Krogel and Olle Heinonen and Paul R C Kent},
@@ -881,174 +1051,6 @@ keywords = "VASP "
   pages={113049},
   url={http://stacks.iop.org/1367-2630/18/i=11/a=113049},
   year={2016},
-}
-
-% (compsci) herbein adios I/O
-@article{herbein2016,
-title = "Performance characterization of irregular I/O at the extreme scale ",
-journal = "Parallel Computing ",
-volume = "51",
-number = "",
-pages = "17 - 36",
-year = "2016",
-note = "Special Issue on Parallel Programming Models and SystemsSoftware for High-End Computing ",
-issn = "0167-8191",
-doi = "http://dx.doi.org/10.1016/j.parco.2015.10.009",
-url = "http://www.sciencedirect.com/science/article/pii/S0167819115001386",
-author = "S. Herbein and S. McDaniel and N. Podhorszki and J. Logan and S. Klasky and M. Taufer",
-keywords = "Exascale",
-keywords = "Irregular I/O",
-keywords = "QMCPack",
-keywords = "ENZO",
-keywords = "ADIOS",
-keywords = "HDF5 "
-}
-
-% (method) holzmann finite size
-@article{holzmann2016,
-  title = {Theory of finite size effects for electronic quantum Monte Carlo calculations of liquids and solids},
-  author = {Holzmann, Markus and Clay, Raymond C. and Morales, Miguel A. and Tubman, Norm M. and Ceperley, David M. and Pierleoni, Carlo},
-  journal = {Phys. Rev. B},
-  volume = {94},
-  issue = {3},
-  pages = {035126},
-  numpages = {16},
-  year = {2016},
-  month = {Jul},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.94.035126},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.94.035126}
-}
-
-% (app/tech) nazarov locality fixed node error Ag/Sn/others
-@article{nazarov2016,
-  title = {Benchmarking the pseudopotential and fixed-node approximations in diffusion Monte Carlo calculations of molecules and solids},
-  author = {Nazarov, R. and Shulenburger, L. and Morales, M. and Hood, Randolph Q.},
-  journal = {Phys. Rev. B},
-  volume = {93},
-  issue = {9},
-  pages = {094111},
-  numpages = {15},
-  year = {2016},
-  month = {Mar},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.93.094111},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.094111}
-}
-
-% (app) powell co/n2 dimer
-@article{powell2016,
-author = {Andrew D. Powell and Richard Dawes},
-title = {Calculating potential energy curves with fixed-node diffusion Monte Carlo: CO and N2},
-journal = {The Journal of Chemical Physics},
-volume = {145},
-number = {22},
-pages = {224308},
-year = {2016},
-doi = {10.1063/1.4971378},
-URL = { http://aip.scitation.org/doi/abs/10.1063/1.4971378 },
-eprint = { http://aip.scitation.org/doi/pdf/10.1063/1.4971378 }
-}
-
-% (tech) clay multidet orbitals
-@article{clay2016,
-author = {Raymond C. Clay III and Miguel A. Morales},
-title = {Influence of single particle orbital sets and configuration selection on multideterminant wavefunctions in quantum Monte Carlo},
-journal = {The Journal of Chemical Physics},
-volume = {142},
-number = {23},
-pages = {234103},
-year = {2015},
-doi = {10.1063/1.4921984},
-URL = { http://dx.doi.org/10.1063/1.4921984 },
-eprint = { http://dx.doi.org/10.1063/1.4921984 }
-}
-
-% (app) benali ti4o7
-@Article{benali2016,
-author ="Benali, Anouar and Shulenburger, Luke and Krogel, Jaron T. and Zhong, Xiaoliang and Kent, Paul R. C. and Heinonen, Olle",
-title  ="Quantum Monte Carlo analysis of a charge ordered insulating antiferromagnet: the Ti4O7 Magneli phase",
-journal  ="Phys. Chem. Chem. Phys.",
-year  ="2016",
-volume  ="18",
-issue  ="27",
-pages  ="18323-18335",
-publisher  ="The Royal Society of Chemistry",
-doi  ="10.1039/C6CP02067D",
-url  ="http://dx.doi.org/10.1039/C6CP02067D",
-}
-
-% (method) tubman nonadiabatic wavefunctions
-@inbook{tubman2016,
-author = {Tubman, Norm M. and Yang, Yubo and Hammes-Schiffer, Sharon and Ceperley, David M.},
-title = {Interpolated Wave Functions for Nonadiabatic Simulations with the Fixed-Node Quantum Monte Carlo Method},
-booktitle = {Recent Progress in Quantum Monte Carlo},
-chapter = {3},
-pages = {47-61},
-doi = {10.1021/bk-2016-1234.ch003},
-URL = {http://pubs.acs.org/doi/abs/10.1021/bk-2016-1234.ch003},
-eprint = {http://pubs.acs.org/doi/pdf/10.1021/bk-2016-1234.ch003}
-}
-
-% (app) shulenburger lithium flouride
-@article{davis2016,
-author = {Jean-Paul Davis and Marcus D. Knudson and Luke Shulenburger and Scott D. Crockett},
-title = {Mechanical and optical response of [100] lithium fluoride to multi-megabar dynamic pressures},
-journal = {Journal of Applied Physics},
-volume = {120},
-number = {16},
-pages = {165901},
-year = {2016},
-doi = {10.1063/1.4965869},
-URL = { http://dx.doi.org/10.1063/1.4965869 },
-eprint = { http://dx.doi.org/10.1063/1.4965869 }
-}
-
-% (app/tech) krogel pseudopotential dev 
-@article{krogel2016b,
-  title = {Pseudopotentials for quantum Monte Carlo studies of transition metal oxides},
-  author = {Krogel, Jaron T. and Santana, Juan A. and Reboredo, Fernando A.},
-  journal = {Phys. Rev. B},
-  volume = {93},
-  issue = {7},
-  pages = {075143},
-  numpages = {10},
-  year = {2016},
-  month = {Feb},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.93.075143},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.075143}
-}
-
-% (app/method) clay H-He mix forces
-@article{clay2016b,
-  title = {Benchmarking density functionals for hydrogen-helium mixtures with quantum Monte Carlo: Energetics, pressures, and forces},
-  author = {Clay, Raymond C. and Holzmann, Markus and Ceperley, David M. and Morales, Miguel A.},
-  journal = {Phys. Rev. B},
-  volume = {93},
-  issue = {3},
-  pages = {035121},
-  numpages = {12},
-  year = {2016},
-  month = {Jan},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.93.035121},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.93.035121}
-}
-
-% (method) zhao excited state optimization
-@article{zhao2016,
-author = {Zhao, Luning and Neuscamman, Eric},
-title = {An Efficient Variational Principle for the Direct Optimization of Excited States},
-journal = {Journal of Chemical Theory and Computation},
-volume = {12},
-number = {8},
-pages = {3436-3440},
-year = {2016},
-doi = {10.1021/acs.jctc.6b00508},
-note ={PMID: 27379468},
-URL = { http://dx.doi.org/10.1021/acs.jctc.6b00508 },
-eprint = { http://dx.doi.org/10.1021/acs.jctc.6b00508 }
 }
 
 % (dev) mathuriya parallel bspline evaluation (arxiv)
@@ -1069,6 +1071,108 @@ eprint = { http://dx.doi.org/10.1021/acs.jctc.6b00508 }
   bibsource = {dblp computer science bibliography, http://dblp.org}
 }
 
+% (compsci) mcdaniel delayed update gpu
+@inproceedings{mcdaniel2016,
+ author = {McDaniel, Tyler and D'Azevedo, Ed and Li, Ying Wai and Kent, Paul and Wong, Ming and Wong, Kwai},
+ title = {Delayed Update Algorithms for Quantum Monte Carlo Simulation on GPU: Extended Abstract},
+ booktitle = {Proceedings of the XSEDE16 Conference on Diversity, Big Data, and Science at Scale},
+ series = {XSEDE16},
+ year = {2016},
+ isbn = {978-1-4503-4755-6},
+ location = {Miami, USA},
+ pages = {13:1--13:4},
+ articleno = {13},
+ numpages = {4},
+ url = {http://doi.acm.org/10.1145/2949550.2949579},
+ doi = {10.1145/2949550.2949579},
+ acmid = {2949579},
+ publisher = {ACM},
+ address = {New York, NY, USA},
+ keywords = {QMC simulation, emergent platforms, scientific computing},
+} 
+
+% (dev) niu global array orbitals
+@article {niu2016,
+author = {Niu, Qingpeng and Dinan, James and Tirukkovalur, Sravya and Benali, Anouar and Kim, Jeongnim and Mitas, Lubos and Wagner, Lucas and Sadayappan, P.},
+title = {Global-view coefficients: a data management solution for parallel quantum Monte Carlo applications},
+journal = {Concurrency and Computation: Practice and Experience},
+volume = {28},
+number = {13},
+issn = {1532-0634},
+url = {http://dx.doi.org/10.1002/cpe.3748},
+doi = {10.1002/cpe.3748},
+pages = {3655--3671},
+keywords = {quantum Monte Carlo, global arrays, PGAS},
+year = {2016},
+note = {cpe.3748},
+}
+
+% (app) powell co/n2 dimer
+@article{powell2016,
+author = {Andrew D. Powell and Richard Dawes},
+title = {Calculating potential energy curves with fixed-node diffusion Monte Carlo: CO and N2},
+journal = {The Journal of Chemical Physics},
+volume = {145},
+number = {22},
+pages = {224308},
+year = {2016},
+doi = {10.1063/1.4971378},
+URL = { http://aip.scitation.org/doi/abs/10.1063/1.4971378 },
+eprint = { http://aip.scitation.org/doi/pdf/10.1063/1.4971378 }
+}
+
+% (app) santana binary oxides
+@article{santana2016,
+author = {Juan A. Santana and Jaron T. Krogel and Paul R. C. Kent and Fernando A. Reboredo},
+title = {Cohesive energy and structural parameters of binary oxides of groups IIA and IIIB from diffusion quantum Monte Carlo},
+journal = {The Journal of Chemical Physics},
+volume = {144},
+number = {17},
+pages = {174707},
+year = {2016},
+doi = {10.1063/1.4947569},
+URL = {http://dx.doi.org/10.1063/1.4947569 },
+eprint = { http://dx.doi.org/10.1063/1.4947569 }
+}
+
+% (method) tubman nonadiabatic wavefunctions
+
+@InBook{tubman2016,
+  chapter   = {203},
+  pages     = {47-61},
+  title     = {Interpolated Wave Functions for Nonadiabatic Simulations with the Fixed-Node Quantum Monte Carlo Method},
+  year      = {2016},
+  author    = {Tubman, Norm M. and Yang, Yubo and Hammes-Schiffer, Sharon and Ceperley, David M.},
+  booktitle = {Recent Progress in Quantum Monte Carlo},
+  doi       = {10.1021/bk-2016-1234.ch003},
+  eprint    = {http://pubs.acs.org/doi/pdf/10.1021/bk-2016-1234.ch003},
+  url       = {http://pubs.acs.org/doi/abs/10.1021/bk-2016-1234.ch003},
+}
+
+% (thesis) yang molecule entanglement
+@phdthesis{yang2016thesis,
+  title={Pairing and entanglement: quantum Monte Carlo studies},
+  author={Yang, David Chang-Mo},
+  year={2016},
+  school={University of Illinois at Urbana-Champaign},
+  url={http://hdl.handle.net/2142/90737},
+}
+
+% (method) zhao excited state optimization
+@article{zhao2016,
+author = {Zhao, Luning and Neuscamman, Eric},
+title = {An Efficient Variational Principle for the Direct Optimization of Excited States},
+journal = {Journal of Chemical Theory and Computation},
+volume = {12},
+number = {8},
+pages = {3436-3440},
+year = {2016},
+doi = {10.1021/acs.jctc.6b00508},
+note ={PMID: 27379468},
+URL = { http://dx.doi.org/10.1021/acs.jctc.6b00508 },
+eprint = { http://dx.doi.org/10.1021/acs.jctc.6b00508 }
+}
+
 
 
 
@@ -1084,148 +1188,6 @@ eprint = { http://dx.doi.org/10.1021/acs.jctc.6b00508 }
   url={https://arxiv.org/abs/1702.01481},
 }
 
+@Comment{jabref-meta: databaseType:bibtex;}
 
-
-
-
-
-% (app) spherical jellium qwalk (used orbitals from SQD code, packaged/part of qmcpack)
-@article{bajdich2011,
-  title = {Simple impurity embedded in a spherical jellium: Approximations of density functional theory compared to quantum Monte Carlo benchmarks},
-  author = {Bajdich, Michal and Kent, P. R. C. and Kim, Jeongnim and Reboredo, Fernando A.},
-  journal = {Phys. Rev. B},
-  volume = {84},
-  issue = {7},
-  pages = {075131},
-  numpages = {8},
-  year = {2011},
-  month = {Aug},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.84.075131},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.84.075131}
-}
-
-% (app) swingle fermi gas/liquid entanglement (swap operator in qmcpack?)
-@article{swingle2013,
-  title = {Oscillating terms in the Renyi entropy of Fermi gases and liquids},
-  author = {Swingle, Brian and McMinis, Jeremy and Tubman, Norm M.},
-  journal = {Phys. Rev. B},
-  volume = {87},
-  issue = {23},
-  pages = {235112},
-  numpages = {10},
-  year = {2013},
-  month = {Jun},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevB.87.235112},
-  url = {http://link.aps.org/doi/10.1103/PhysRevB.87.235112}
-}
-
-
-
-
-% qmcpack theses
-% (thesis) das walk on sphere
-@book{das2005thesis,
-  title={Quantum Monte Carlo With a Stochastic Poisson Solver},
-  author={Das, Dyutiman},
-  year={2005},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/80519}
-}
-
-% (thesis) vincent germanium nanoparticle
-@book{vincent2006thesis,
-  title={Quantum Monte Carlo Calculations of the Electronic Excitations of Germanium Atoms, Molecules and Nanoclusters Using Core-Polarization Potentials},
-  author={Vincent, Jordan Eric},
-  year={2006},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/80541}
-}
-
-% (thesis) gergely water
-@phdthesis{gergely2009thesis,
-  title={Quantum Monte Carlo Methods for First Principles Simulation of Liquid Water},
-  author={Gergely, John Robert},
-  year={2009},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/80610}
-}
-
-% (thesis) clark order N
-@phdthesis{clark2009thesis,
-  title={Strongly Correlated Systems Approach Through Quantum Monte Carlo},
-  author={Clark, Bryan},
-  year={2009},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/80605},
-}
-
-% (thesis) beaudet hydrogen on carbon/transition metal
-@phdthesis{beaudet2011thesis,
-  title={Quantum Monte Carlo Study of Hydrogen Adsorption on Carbon and Transition Metal Systems},
-  author={Beaudet, Todd D},
-  year={2011},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/18600}
-}
-
-% (thesis) ahuja linear scaling qmc
-@phdthesis{ahuja2011thesis,
-  title={Recycling Krylov subspaces and preconditioners},
-  author={Ahuja, Kapil},
-  year={2011},
-  school={Virginia Polytechnic Institute and State University},
-  url={http://theses.lib.vt.edu/theses/available/etd-11112011-010340/}
-}
-
-% (thesis) krogel germanium energy density
-@phdthesis{krogel2013thesis,
-  title={Energetics of neutral interstitials in germanium},
-  author={Krogel, Jaron},
-  year={2013},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/44417},
-}
-
-% (thesis) mcminis pressure entanglement
-@phdthesis{mcminis2013thesis,
-  title={Benchmark studies using quantum Monte Carlo: pressure estimators, energy, and entanglement},
-  author={McMinis, Jeremy},
-  year={2013},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/44344},
-}
-
-% (thesis) niu global array bspline orbitals
-@phdthesis{niu2015thesis,
-  title={Characterization and Enhancement of Data Locality and Load Balancing for Irregular Applications},
-  author={Niu, Qingpeng},
-  year={2015},
-  school={The Ohio State University},
-  url={https://etd.ohiolink.edu/!etd.send_file?accession=osu1420811652&disposition=attachment}
-}
-
-% (thesis) deible multidet molecules
-@misc{deible2015thesis,
-           month = {September},
-           title = {Theory and Applications of Quantum Monte Carlo},
-          author = {Michael Deible},
-            year = {2015},
-        keywords = {Quantum Monte Carlo},
-             url = {http://d-scholarship.pitt.edu/25747/},
-}
-
-% (thesis) yang molecule entanglement
-@phdthesis{yang2016thesis,
-  title={Pairing and entanglement: quantum Monte Carlo studies},
-  author={Yang, David Chang-Mo},
-  year={2016},
-  school={University of Illinois at Urbana-Champaign},
-  url={http://hdl.handle.net/2142/90737},
-}
-
-
-
-
-
+@Comment{jabref-meta: saveOrderConfig:specified;year;false;month;false;author;false;}


### PR DESCRIPTION
These are printed in the order that they appear in the qmcpack_papers.bib file.
Fixed two missing years.  Use of JabRef recommended for further cleanup of this file.

I verified that the same total number of papers was printed before/after this change.

