### PR TITLE
Improve per node walker count handling in multi-rank runs after branching

### DIFF
--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -62,11 +62,13 @@ WalkerControlMPI::WalkerControlMPI(Communicate* c): WalkerControlBase(c)
 
 /** Perform branch and swap walkers as required
  *
- *  It takes 4 steps:
+ *  It takes 5 steps:
  *    1. sortWalkers marks good and bad walkers.
- *    2. allreduce and make the decision of load balancing.
- *    3. send/recv walkers. Receiving side recycles bad walkers' memory first.
- *    4. copyWalkers generates copies of good walkers.
+ *    2. allreduce collects the number of good walkers + copies on every rank.
+ *    3. applyNmaxNmin avoids too large or too small global population.
+ *    4. swapWalkersSimple makes a decision of load balancing and send/recv walkers.
+ *       Receiving side recycles bad walkers' memory first.
+ *    5. copyWalkers generates copies of good walkers.
  *  In order to minimize the memory footprint fluctuation
  *  the walker copying is placed as the last step.
  *  In order to reduce the time for allocating walker memory,

--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -164,7 +164,7 @@ void WalkerControlMPI::swapWalkersSimple(MCWalkerConfiguration& W)
   std::vector<int> minus, plus;
   determineNewWalkerPopulation(Cur_pop, NumContexts, MyContext, NumPerNode, FairOffSet, minus, plus);
 
-  Walker_t& wRef(*good_w[0]);
+  Walker_t& wRef(*(good_w.empty()?bad_w[0]:good_w[0]));
   std::vector<Walker_t*> newW;
   std::vector<int> ncopy_newW;
 #ifdef MCWALKERSET_MPI_DEBUG

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -385,11 +385,23 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
   //W.EnsembleProperty.Variance=(e2sum*wsum-esum*esum)/(wsum*wsum-w2sum);
   if (!WriteRN)
   {
-    if(good_w.empty())
+    // single rank run, need at least one good walker
+    if( NumContexts==1 && good_w.empty() )
     {
-      app_error() << "All the walkers have died. Abort. " << std::endl;
+      app_error() << "It should never happen that all the walkers died. "
+                  << "Please report to developers. " << std::endl;
       APP_ABORT("WalkerControlBase::sortWalkers");
     }
+
+    // more than one rank, allow no good walkers left
+    if( NumContexts>1 && good_w.empty() && bad_w.empty() )
+    {
+      app_error() << "It should never happen that no walkers, "
+                  << "neither good nor bad, exist on a node. "
+                  << "Please report to developers. " << std::endl;
+      APP_ABORT("WalkerControlBase::sortWalkers");
+    }
+
     int sizeofgood = good_w.size();
     //check if the projected number of walkers is too small or too large
     if(NumWalkers>Nmax)

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -19,6 +19,7 @@
 #include "QMCDrivers/WalkerControlBase.h"
 #include "Particle/HDFWalkerIO.h"
 #include "OhmmsData/ParameterSet.h"
+#include <numeric>
 
 namespace qmcplusplus
 {
@@ -236,7 +237,7 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
 
 int WalkerControlBase::branch(int iter, MCWalkerConfiguration& W, RealType trigger)
 {
-  int prefill_numwalkers = sortWalkers(W);
+  NumPerNode[0] = sortWalkers(W);
   measureProperties(iter);
   W.EnsembleProperty=EnsembleProperty;
   //un-biased variance but we use the saimple one
@@ -246,6 +247,7 @@ int WalkerControlBase::branch(int iter, MCWalkerConfiguration& W, RealType trigg
   //accumData[ENERGY_SQ_INDEX]  += curData[ENERGY_SQ_INDEX]*wgtInv;
   //accumData[WALKERSIZE_INDEX] += curData[WALKERSIZE_INDEX];
   //accumData[WEIGHT_INDEX]     += curData[WEIGHT_INDEX];
+  applyNmaxNmin();
   int nw_tot = copyWalkers(W);
   //set Weight and Multiplicity to default values
   MCWalkerConfiguration::iterator it(W.begin()),it_end(W.end());
@@ -385,23 +387,8 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
   //W.EnsembleProperty.Variance=(e2sum*wsum-esum*esum)/(wsum*wsum-w2sum);
   if (!WriteRN)
   {
-    // single rank run, need at least one good walker
-    if( NumContexts==1 && good_w.empty() )
-    {
-      app_error() << "It should never happen that all the walkers died. "
-                  << "Please report to developers. " << std::endl;
-      APP_ABORT("WalkerControlBase::sortWalkers");
-    }
-
-    // more than one rank, allow no good walkers left
-    if( NumContexts>1 && good_w.empty() && bad_w.empty() )
-    {
-      app_error() << "It should never happen that no walkers, "
-                  << "neither good nor bad, exist on a node. "
-                  << "Please report to developers. " << std::endl;
-      APP_ABORT("WalkerControlBase::sortWalkers");
-    }
-
+#if 0
+    /// Ye: Since I have no idea about release node code, the old code is only commented out.
     int sizeofgood = good_w.size();
     //check if the projected number of walkers is too small or too large
     if(NumWalkers>Nmax)
@@ -420,25 +407,25 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       }
       NumWalkers -= nsub;
     }
-    else
-      if(NumWalkers < Nmin)
+    else if(NumWalkers < Nmin)
+    {
+      int nadd=0;
+      int nadd_target = static_cast<int>(Nmin*1.1)-(NumWalkers-nrn);
+      if(nadd_target> sizeofgood)
       {
-        int nadd=0;
-        int nadd_target = static_cast<int>(Nmin*1.1)-(NumWalkers-nrn);
-        if(nadd_target> sizeofgood)
-        {
-          app_warning() << "The number of walkers is running low. Requested walkers "
-                        << nadd_target << " good walkers = " << sizeofgood << std::endl;
-        }
-        int i=0;
-        while(i< sizeofgood && nadd<nadd_target)
-        {
-          ncopy_w[i]++;
-          ++nadd;
-          ++i;
-        }
-        NumWalkers +=  nadd;
+        app_warning() << "The number of walkers is running low. Requested walkers "
+                      << nadd_target << " good walkers = " << sizeofgood << std::endl;
       }
+      int i=0;
+      while(i< sizeofgood && nadd<nadd_target)
+      {
+        ncopy_w[i]++;
+        ++nadd;
+        ++i;
+      }
+      NumWalkers +=  nadd;
+    }
+#endif
   }
   else
   {
@@ -453,6 +440,105 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
     }
   }
   return NumWalkers;
+}
+
+int WalkerControlBase::applyNmaxNmin()
+{
+  int current_population = std::accumulate(NumPerNode.begin(), NumPerNode.end(), 0);
+
+  // limit Nmax
+  int current_max = (current_population + NumContexts - 1) / NumContexts;
+  if(current_max>Nmax)
+  {
+    app_warning() << "Exceeding Max Walkers per MPI rank : "
+                  << Nmax << ". Ceiling is applied" << std::endl;
+    int nsub = current_population - Nmax * NumContexts;
+    for(int inode=0; inode<NumContexts; inode++)
+      if(NumPerNode[inode]>Nmax)
+      {
+        int n_remove = std::min(nsub, NumPerNode[inode]-Nmax);
+        NumPerNode[inode] -= n_remove;
+        nsub -= n_remove;
+
+        if(inode==MyContext)
+        {
+          for(int iw=0; iw<ncopy_w.size(); iw++)
+          {
+            int n_remove_walker = std::min(ncopy_w[iw], n_remove);
+            ncopy_w[iw] -= n_remove_walker;
+            n_remove -= n_remove_walker;
+            if(n_remove==0) break;
+          }
+
+          if(n_remove>0)
+          {
+            app_warning() << "Removing copies of good walkers is not enough. "
+                          << "Removing good walkers." << std::endl;
+            do
+            {
+              bad_w.push_back(good_w.back());
+              good_w.pop_back();
+              ncopy_w.pop_back();
+              --n_remove;
+            } while(n_remove>0 && !good_w.empty());
+          }
+
+          if(n_remove)
+            APP_ABORT("WalkerControlBase::applyNmax not able to remove sufficient walkers on a node!");
+          if(std::accumulate(ncopy_w.begin(), ncopy_w.end(), ncopy_w.size())!=NumPerNode[inode])
+            APP_ABORT("WalkerControlBase::applyNmax walker removal mismatch!");
+        }
+
+        if(nsub==0) break;
+      }
+
+    if(nsub) APP_ABORT("WalkerControlBase::applyNmax not able to remove sufficient walkers overall!");
+  }
+
+  // at least one walker after load-balancing
+  int current_min = current_population / NumContexts;
+  if(current_min==0)
+  {
+    app_error() << "Some MPI ranks have no walkers after load balancing. This should not happen."
+                << "Improve the trial wavefunction or adjust the simulation parameters." << std::endl;
+    APP_ABORT("WalkerControlBase::sortWalkers");
+  }
+
+  // limit Nmin
+  if(current_min<Nmin)
+  {
+    app_warning() << "The number of walkers is running lower than Min Walkers per MPI rank : "
+                  << Nmin << ". Floor is applied" << std::endl;
+    int nadd = Nmin * NumContexts - current_population;
+    for(int inode=0; inode<NumContexts; inode++)
+      if(NumPerNode[inode]<Nmin)
+      {
+        int n_insert = std::min(nadd, Nmin-NumPerNode[inode]);
+        NumPerNode[inode] += n_insert;
+        nadd -= n_insert;
+
+        if(inode==MyContext)
+        {
+          int n_avg_insert_per_walker = ( n_insert + ncopy_w.size() - 1 ) / ncopy_w.size();
+          for(int iw=0; iw<ncopy_w.size(); iw++)
+          {
+            int n_insert_walker = std::min(n_avg_insert_per_walker, n_insert);
+            ncopy_w[iw] += n_insert_walker;
+            n_insert -= n_insert_walker;
+            if(n_insert==0) break;
+          }
+
+          if(std::accumulate(ncopy_w.begin(), ncopy_w.end(), ncopy_w.size())!=NumPerNode[inode])
+            APP_ABORT("WalkerControlBase::applyNmax walker insertion mismatch!");
+        }
+
+        if(nadd==0) break;
+      }
+
+    if(nadd) APP_ABORT("WalkerControlBase::applyNmax not able to add sufficient walkers overall!");
+  }
+
+  return std::accumulate(NumPerNode.begin(), NumPerNode.end(), 0);
 }
 
 /** copy good walkers to W
@@ -545,8 +631,8 @@ bool WalkerControlBase::put(xmlNodePtr cur)
   //app_log() << "    energyBound = " << targetEnergyBound << std::endl;
   //app_log() << "    sigmaBound = " << targetSigma << std::endl;
   app_log() << "    maxCopy = " << MaxCopy << std::endl;
-  app_log() << "    Max Walkers per node " << Nmax << std::endl;
-  app_log() << "    Min Walkers per node " << Nmin << std::endl;
+  app_log() << "    Max Walkers per MPI rank " << Nmax << std::endl;
+  app_log() << "    Min Walkers per MPI rank " << Nmin << std::endl;
   app_log() << "    Using " << (use_nonblocking?"non-":"") << "blocking send/recv" << std::endl;
   return true;
 }

--- a/src/QMCDrivers/WalkerControlBase.h
+++ b/src/QMCDrivers/WalkerControlBase.h
@@ -194,6 +194,11 @@ public:
   /** sort Walkers between good and bad and prepare branching
    */
   int sortWalkers(MCWalkerConfiguration& W);
+
+  /** apply per node limit Nmax and Nmin
+   */
+  int applyNmaxNmin();
+
   /** copy good walkers to W
    */
   int copyWalkers(MCWalkerConfiguration& W);


### PR DESCRIPTION
Currently the code aborts if there are no good walkers left on a node after branching within a node.
In a multi-rank run, the situation of no good walkers should be allowed to proceed since new walkers will be received from other ranks. This happens rarely in production stage but happens more frequently during equilibration.

In this PR, the algorithm changes into
1. sortWalkers marks good and bad walkers.
2. allreduce collects the number of good walkers + copies on every rank.
3. applyNmaxNmin avoids too large or too small global population.
4. swapWalkersSimple makes a decision of load balancing and send/recv walkers.
5. copyWalkers generates copies of good walkers.

The step 3 is new. It checks at least one good walker per node based on the global population.
In the old code, max and min is applied inside sortwalker based on the walkers within a node.
This introduces more bias than being applied globally. Now everytime min and max kicks in, a warning messing is printed.