### PR TITLE
Adjust one body Jastrow SoA algorithm

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -456,7 +456,6 @@ void ParticleSet::update(bool skipSK)
   if (!skipSK && SK)
     SK->UpdateAllPart(*this);
 
-  Ready4Measure=true;
   activePtcl=-1;
 }
 
@@ -471,7 +470,6 @@ void ParticleSet::update(const ParticlePos_t& pos)
   if (SK && !SK->DoUpdate)
     SK->UpdateAllPart(*this);
 
-  Ready4Measure=true;
   activePtcl=-1;
 }
 
@@ -590,7 +588,6 @@ bool ParticleSet::makeMove(const Walker_t& awalker
 bool ParticleSet::makeMove(const Walker_t& awalker
                            , const ParticlePos_t& deltaR, const std::vector<RealType>& dt)
 {
-  Ready4Measure=false;
   activePtcl=-1;
   if (UseBoundBox)
   {
@@ -632,7 +629,6 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
                                     , const ParticlePos_t& drift , const ParticlePos_t& deltaR
                                     , RealType dt)
 {
-  Ready4Measure=false;
   activePtcl=-1;
   if (UseBoundBox)
   {
@@ -669,7 +665,6 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
                                     , const ParticlePos_t& drift , const ParticlePos_t& deltaR
                                     , const std::vector<RealType>& dt)
 {
-  Ready4Measure=false;
   activePtcl=-1;
   if (UseBoundBox)
   {
@@ -765,7 +760,6 @@ void ParticleSet::donePbyP(bool skipSK)
     DistTables[i]->donePbyP();
   if (!skipSK && SK && !SK->DoUpdate)
     SK->UpdateAllPart(*this);
-  Ready4Measure=true;
   activePtcl=-1;
   myTimers[2]->stop();
 }
@@ -799,7 +793,6 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
       SK->UpdateAllPart(*this);
   }
 
-  Ready4Measure=false;
   activePtcl=-1;
 }
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -131,8 +131,6 @@ public:
   bool IsGrouped;
   ///true if the particles have the same mass
   bool SameMass;
-  /// true if all the internal state is ready for estimators
-  bool Ready4Measure;
   ///threa id
   Index_t ThreadID;
   ///the index of the active particle for particle-by-particle moves

--- a/src/Sandbox/diff_j1.cpp
+++ b/src/Sandbox/diff_j1.cpp
@@ -195,8 +195,6 @@ int main(int argc, char** argv)
       double r_ratio=0.0;
       double g_ratio=0.0;
 
-      els.Ready4Measure=false;
-
       int naccepted=0;
       for(int iel=0; iel<nels; ++iel)
       {

--- a/src/Sandbox/diff_wfs.cpp
+++ b/src/Sandbox/diff_wfs.cpp
@@ -90,6 +90,8 @@ int main(int argc, char** argv)
 
   {
     ParticleSet ions, els;
+    ions.setName("ion");
+    els.setName("e");
     OHMMS_PRECISION scale=1.0;
 
     int np=omp_get_num_threads();

--- a/src/Sandbox/diff_wfs.cpp
+++ b/src/Sandbox/diff_wfs.cpp
@@ -177,8 +177,6 @@ int main(int argc, char** argv)
       double r_ratio=0.0;
       double g_ratio=0.0;
 
-      els.Ready4Measure=false;
-
       int naccepted=0;
       for(int iel=0; iel<nels; ++iel)
       {

--- a/src/Sandbox/miniqmc.cpp
+++ b/src/Sandbox/miniqmc.cpp
@@ -165,6 +165,8 @@ int main(int argc, char** argv)
     clock.restart();
 
     ParticleSet ions, els;
+    ions.setName("ion");
+    els.setName("e");
     const OHMMS_PRECISION scale=1.0;
 
     const int np=omp_get_num_threads();

--- a/src/simd/algorithm.hpp
+++ b/src/simd/algorithm.hpp
@@ -44,13 +44,13 @@ namespace qmcplusplus {
         return res;
       }
 
-  ///inner product
-  template<typename T1, typename T2, typename T3>
-    inline T3 inner_product_n(const T1* restrict a, const T2* restrict b, int n, T3 res)
-    {
-      for(int i=0; i<n; ++i) res += a[i]*b[i];
-      return res;
-    }
+    ///inner product
+    template<typename T1, typename T2, typename T3>
+      inline T3 inner_product_n(const T1* restrict a, const T2* restrict b, int n, T3 res)
+      {
+        for(int i=0; i<n; ++i) res += a[i]*b[i];
+        return res;
+      }
 
   } //simd namepsace
 }


### PR DESCRIPTION
The SoA J1 was written not using the memory pool while J2 and JeeI do.
When a walker with its memory pool loaded, Det and J2 JeeI have the up-to-date value but J1 doesn't.
This is not a problem after all the electrons are proposed to move once but not from the beginning.
This potential risk is secured by checking the ParticleSet.Ready4Measure flag.
However, the flag is delicate and needs a careful maintaining.

This PR changes the algorithm to be aligned as J2 and JeeI. No more need to recompute since it is loaded from the memory pool and the needed size is small, order Nelec.
The state flag ParticleSet.Ready4Measure is also removed.

This PR also fixed the missing names of ParticleSet objects in Sandbox apps.