### PR TITLE
Fix all-particle move DMC driver

### DIFF
--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -49,67 +49,73 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
 {
     W.loadWalker(thisWalker,false);
     //create a 3N-Dimensional Gaussian with variance=1
-    RealType nodecorr=setScaledDriftPbyPandNodeCorr(Tau,MassInvP,W.G,drift);
+    RealType nodecorr = setScaledDriftPbyPandNodeCorr(Tau,MassInvP,W.G,drift);
     //RealType nodecorr = setScaledDriftPbyPandNodeCorr(m_tauovermass,W.G,drift);
     makeGaussRandomWithEngine(deltaR,RandomGen);
-    //if(!W.makeMoveWithDrift(thisWalker,drift,deltaR, m_sqrttau))
-    if (!W.makeMoveWithDrift(thisWalker,drift ,deltaR,SqrtTauOverMass))
-    {
-      H.rejectedMove(W,thisWalker);
-      return;
-    }
     //save old local energy
-    RealType eold    = thisWalker.Properties(LOCALENERGY);
-    RealType signold = thisWalker.Properties(SIGN);
-    RealType enew  = eold;
-    //evaluate wave functior
-    RealType logpsi(Psi.evaluateLog(W));
-    if(UseTMove)
-      nonLocalOps.reset();
-    bool accepted=false;
+    RealType eold = thisWalker.Properties(LOCALENERGY);
+    RealType enew = eold;
+    bool accepted = false;
     RealType rr_accepted = 0.0;
-    nodecorr=0.0;
-    if(branchEngine->phaseChanged(Psi.getPhaseDiff()))
+    RealType rr_proposed = 0.0;
+    RealType logpsi;
+
+    if (W.makeMoveWithDrift(thisWalker, drift, deltaR, SqrtTauOverMass))
     {
-      thisWalker.Age++;
-      H.rejectedMove(W,thisWalker);
+      //evaluate the new wave function
+      logpsi = Psi.evaluateLog(W);
+      //fixed node
+      if(!branchEngine->phaseChanged(Psi.getPhaseDiff()))
+      {
+        RealType logGf = -0.5*Dot(deltaR,deltaR);
+        nodecorr = setScaledDriftPbyPandNodeCorr(Tau,MassInvP,W.G,drift);
+        deltaR = thisWalker.R - W.R - drift;
+        RealType logGb=logBackwardGF(deltaR);
+        //RealType logGb = -m_oneover2tau*Dot(deltaR,deltaR);
+        RealType prob = std::min(std::exp(logGb-logGf+2.0*(logpsi-thisWalker.Properties(LOGPSI))),1.0);
+        //calculate rr_proposed here
+        deltaR = W.R-thisWalker.R;
+        rr_proposed = Dot(deltaR,deltaR);
+        if(RandomGen() <= prob)
+        {
+          accepted=true;
+          rr_accepted = rr_proposed;
+        }
+      }
+    }
+
+    // recompute Psi if the move is rejected
+    if(!accepted)
+    {
+      W.update(thisWalker.R);
+      W.donePbyP(true);
+      logpsi = Psi.evaluateLog(W);
+    }
+
+    // evaluate Hamiltonian
+    if(UseTMove)
+    {
+      nonLocalOps.reset();
+      enew = H.evaluate(W,nonLocalOps.Txy);
+    }
+    else
+      enew = H.evaluate(W);
+    H.auxHevaluate(W,thisWalker);
+    H.saveProperty(thisWalker.getPropertyBase());
+
+    // operate on thisWalker.
+    if(accepted)
+    {
+      W.saveWalker(thisWalker);
+      thisWalker.resetProperty(logpsi,Psi.getPhase(),enew,rr_accepted,rr_proposed,nodecorr);
     }
     else
     {
-      if(UseTMove)
-        enew=H.evaluate(W,nonLocalOps.Txy);
-      else
-        enew=H.evaluate(W);
-
-      RealType logGf = -0.5*Dot(deltaR,deltaR);
-      //RealType nodecorr = setScaledDriftPbyPandNodeCorr(m_tauovermass,W.G,drift);
-      RealType nodecorr=setScaledDriftPbyPandNodeCorr(Tau,MassInvP,W.G,drift);
-      deltaR = thisWalker.R - W.R - drift;
-      RealType logGb=logBackwardGF(deltaR);
-      //RealType logGb = -m_oneover2tau*Dot(deltaR,deltaR);
-      RealType prob= std::min(std::exp(logGb-logGf +2.0*(logpsi-thisWalker.Properties(LOGPSI))),1.0);
-      //calculate rr_proposed here
-      deltaR = W.R-thisWalker.R;
-      RealType rr_proposed = Dot(deltaR,deltaR);
-      if(RandomGen() > prob)
-      {
-        thisWalker.Age++;
-        enew=eold;
-        thisWalker.Properties(R2ACCEPTED)=0.0;
-        thisWalker.Properties(R2PROPOSED)=rr_proposed;
-        H.rejectedMove(W,thisWalker);
-      }
-      else
-      {
-        accepted=true;
-        thisWalker.Age=0;
-        W.saveWalker(thisWalker);
-        rr_accepted = rr_proposed;
-        thisWalker.resetProperty(logpsi,Psi.getPhase(),enew,rr_accepted,rr_proposed,nodecorr);
-        H.auxHevaluate(W,thisWalker);
-        H.saveProperty(thisWalker.getPropertyBase());
-      }
+      thisWalker.Age++;
+      thisWalker.Properties(R2ACCEPTED)=0.0;
+      thisWalker.Properties(R2PROPOSED)=rr_proposed;
     }
+
     if(UseTMove)
     {
       int ibar=nonLocalOps.selectMove(RandomGen());
@@ -120,8 +126,8 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
         W.R[iat] += nonLocalOps.delta(ibar);
         W.update();
         logpsi=Psi.evaluateLog(W);
-        thisWalker.resetProperty(logpsi,Psi.getPhase(),eold);
-        thisWalker.R[iat] = W.R[iat];
+        thisWalker.resetProperty(logpsi,Psi.getPhase(),enew);
+        W.saveWalker(thisWalker);
         ++NonLocalMoveAccepted;
       }
     }
@@ -166,7 +172,6 @@ void DMCUpdateAllWithKill::advanceWalker(Walker_t& thisWalker, bool recompute)
     //save old local energy
     RealType eold = thisWalker.Properties(LOCALENERGY);
     RealType enew = eold;
-    RealType signold = thisWalker.Properties(SIGN);
     RealType logpsi(Psi.evaluateLog(W));
     bool accepted=false;
     RealType rr_accepted = 0.0;

--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -106,10 +106,10 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
         W.saveWalker(thisWalker);
         rr_accepted = rr_proposed;
         thisWalker.resetProperty(logpsi,Psi.getPhase(),enew,rr_accepted,rr_proposed,nodecorr);
+        H.auxHevaluate(W,thisWalker);
+        H.saveProperty(thisWalker.getPropertyBase());
       }
     }
-    H.auxHevaluate(W,thisWalker);
-    H.saveProperty(thisWalker.getPropertyBase());
     if(UseTMove)
     {
       int ibar=nonLocalOps.selectMove(RandomGen());

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -109,8 +109,9 @@ ENDIF()
                     qmc_short_vmc_dmc_allp.in.xml
                     1 16
                     TRUE
-                    0 DIAMOND_SCALARS # VMC
-                    1 DIAMOND_DMC_SCALARS # DMC
+                    0 DIAMOND_SCALARS # VMC without drift
+                    1 DIAMOND_SCALARS # VMC with drift
+                    2 DIAMOND_DMC_SCALARS # DMC
                     )
 
 # Coverage test - shorter version of dmc test

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -87,13 +87,29 @@ ENDIF()
                     )
 
 # Reference DMC run in qmc-ref "-10.531583 0.000265"
-  LIST(APPEND DIAMOND_DMC_SCALARS "totenergy" "-10.531583 0.0024")
+  LIST(APPEND DIAMOND_DMC_SCALARS "totenergy"   "-10.5316 0.0024")
+  LIST(APPEND DIAMOND_DMC_SCALARS "kinetic"      "11.4857 0.0231")
+  LIST(APPEND DIAMOND_DMC_SCALARS "potential"   "-22.0170 0.0239")
+  LIST(APPEND DIAMOND_DMC_SCALARS "localecp"     "-7.1518 0.0323")
+  LIST(APPEND DIAMOND_DMC_SCALARS "nonlocalecp"  "0.62688 0.0080")
+  LIST(APPEND DIAMOND_DMC_SCALARS "eeenergy"    "-2.71641 0.0073")
+
   QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-dmc_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
                     qmc_short_vmc_dmc
                     qmc_short_vmc_dmc.in.xml
                     1 16
                     TRUE
+                    1 DIAMOND_DMC_SCALARS # DMC
+                    )
+
+  QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-dmc-allp_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+                    qmc_short_vmc_dmc_allp
+                    qmc_short_vmc_dmc_allp.in.xml
+                    1 16
+                    TRUE
+                    0 DIAMOND_SCALARS # VMC
                     1 DIAMOND_DMC_SCALARS # DMC
                     )
 

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -103,7 +103,7 @@ ENDIF()
                     1 DIAMOND_DMC_SCALARS # DMC
                     )
 
-  QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-dmc-allp_sdj
+  QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-vmc-dmc-allp_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
                     qmc_short_vmc_dmc_allp
                     qmc_short_vmc_dmc_allp.in.xml

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long-meshf.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long-meshf.in.xml
@@ -81,6 +81,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    7680.0          </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long.in.xml
@@ -81,6 +81,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    7680.0          </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_kspace.in.xml
@@ -95,6 +95,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    80              </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short-meshf.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short-meshf.in.xml
@@ -81,6 +81,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    8.0             </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short.in.xml
@@ -81,6 +81,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    8.0             </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_hybridrep_batched.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_hybridrep_batched.in.xml
@@ -85,6 +85,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    8.0             </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace.in.xml
@@ -95,6 +95,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    16              </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    8.0             </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace_4_4.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace_4_4.in.xml
@@ -95,6 +95,7 @@
       </hamiltonian>
    </qmcsystem>
    <qmc method="vmc" move="pbyp">
+      <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="walkers"             >    1               </parameter>
       <parameter name="blocks"              >    1000            </parameter>
       <parameter name="steps"               >    8.0             </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
@@ -91,6 +91,16 @@
      <parameter name="warmupSteps" > 10  </parameter>
      <parameter name="usedrift"    > no  </parameter>
    </qmc>
+   <qmc method="vmc" move="allp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers"     > 256 </parameter>
+     <parameter name="blocks"      > 125 </parameter>
+     <parameter name="steps"       > 4   </parameter>
+     <parameter name="subSteps"    > 4   </parameter>
+     <parameter name="timestep"    > 1.0 </parameter>
+     <parameter name="warmupSteps" > 10  </parameter>
+     <parameter name="usedrift"    > yes </parameter>
+   </qmc>
    <qmc method="dmc" move="allp" checkpoint="-1">
      <estimator name="LocalEnergy" hdf5="no"/>
      <parameter name="targetwalkers"> 256 </parameter>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="qmc_short" series="0">
+   <project id="qmc_short_vmc_dmc_allp" series="0">
       <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
    </project>
    <qmcsystem>
@@ -31,10 +31,6 @@
             <parameter name="valence"             >    4                     </parameter>
             <parameter name="atomicnumber"        >    6                     </parameter>
             <parameter name="mass"                >    21894.7135906            </parameter>
-            <parameter name="cutoff_radius"       >    1.1                   </parameter>
-            <parameter name="spline_radius"       >    1.2                   </parameter>
-            <parameter name="spline_npoints"      >    121                   </parameter>
-            <parameter name="lmax"                >    3                     </parameter>
             <attrib name="position" datatype="posArray" condition="0">
                      0.00000000        0.00000000        0.00000000
                      1.68658058        1.68658058        1.68658058
@@ -42,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float" hybridrep="yes">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>
@@ -81,16 +77,29 @@
          <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
             <pseudo elementType="C" href="C.BFD.xml"/>
          </pairpot>
-         <estimator type="flux" name="Flux"/>
+         <!-- <estimator type="flux" name="Flux"/> -->
       </hamiltonian>
    </qmcsystem>
-   <qmc method="vmc" move="pbyp">
-      <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="walkers"             >    16              </parameter>
-      <parameter name="blocks"              >    1000            </parameter>
-      <parameter name="steps"               >    8.0             </parameter>
-      <parameter name="subSteps"            >    2               </parameter>
-      <parameter name="timestep"            >    0.3             </parameter>
-      <parameter name="warmupSteps"         >    100             </parameter>
+
+   <qmc method="vmc" move="allp">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="walkers"     > 256 </parameter>
+     <parameter name="blocks"      > 125 </parameter>
+     <parameter name="steps"       > 4   </parameter>
+     <parameter name="subSteps"    > 4   </parameter>
+     <parameter name="timestep"    > 1.0 </parameter>
+     <parameter name="warmupSteps" > 10  </parameter>
+     <parameter name="usedrift"    > no  </parameter>
    </qmc>
+   <qmc method="dmc" move="allp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="targetwalkers"> 256 </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  100 </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   100 </parameter>
+     <parameter name="blocks">  100 </parameter>
+     <parameter name="nonlocalmoves">  no </parameter>
+   </qmc>
+
 </simulation>


### PR DESCRIPTION
See more details in #753 for the bug and use that issue to track progress.

This PR adds an integration test for VMC and DMC with all particle moves on diamondC 1x1x1.
Reference values of VMC and DMC are taken from pbyp moves.

This PR largely rewrite the DMC driver routine makes the DMC tests passing but VMC part remains failing. PR #423 also touched the VMC driver but I have no idea if the VMC was broken even before.