### PR TITLE
Fixes for all particle move VMC/DMC drivers

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -577,8 +577,11 @@ bool ParticleSet::makeMove(const Walker_t& awalker
 #if defined(ENABLE_SOA)
   RSoA.copyIn(R); 
 #endif
-  for (int i=0; i< DistTables.size(); i++)
+  for (int i=0; i<DistTables.size(); i++)
+  {
     DistTables[i]->evaluate(*this);
+    DistTables[i]->donePbyP();
+  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -610,8 +613,11 @@ bool ParticleSet::makeMove(const Walker_t& awalker
 #if defined(ENABLE_SOA)
   RSoA.copyIn(R); 
 #endif
-  for (int i=0; i< DistTables.size(); i++)
+  for (int i=0; i<DistTables.size(); i++)
+  {
     DistTables[i]->evaluate(*this);
+    DistTables[i]->donePbyP();
+  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -651,10 +657,11 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
 #if defined(ENABLE_SOA)
   RSoA.copyIn(R); 
 #endif
-  for (int i=0; i< DistTables.size(); i++)
+  for (int i=0; i<DistTables.size(); i++)
+  {
     DistTables[i]->evaluate(*this);
-  for (size_t i=0; i<DistTables.size(); i++)
     DistTables[i]->donePbyP();
+  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -689,10 +696,11 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
   RSoA.copyIn(R); 
 #endif
 
-  for (int i=0; i< DistTables.size(); i++)
+  for (int i=0; i<DistTables.size(); i++)
+  {
     DistTables[i]->evaluate(*this);
-  for (size_t i=0; i<DistTables.size(); i++)
     DistTables[i]->donePbyP();
+  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid

--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -114,7 +114,14 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
     if(NonLocalMoveAcceptedTemp>0)
     {
       W.saveWalker(thisWalker);
-      thisWalker.resetProperty(logpsi,Psi.getPhase(),enew);
+      thisWalker.resetProperty(Psi.getLogPsi(),Psi.getPhase(),enew);
+      // debugging lines
+      //logpsi = Psi.getLogPsi();
+      //W.update(true);
+      //RealType logpsi2 = Psi.evaluateLog(W);
+      //if(logpsi!=logpsi2) std::cout << " logpsi " << logpsi << " logpsi2 " << logpsi2
+      //                              << " diff " << logpsi2-logpsi << std::endl;
+
       NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
     }
 

--- a/src/QMCDrivers/VMC/VMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.cpp
@@ -96,11 +96,12 @@ void VMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
   if(!updated)
   { // W.G and W.L have to be computed because the last move was rejected
     W.update(thisWalker.R); // move W back to last accepted configuration; W.DistTables, SK are updated
+    W.donePbyP(true); // update neighbour list for NLPP
     logpsi_old=Psi.evaluateLog(W); // update W.G,L
   } // W and logpsi_old are up-to-date at this point
 
   RealType eloc = H.evaluate(W); // calculate local energy; W.SK must be up-to-date if Coulomb interaction is used with periodic boundary. W.SK is used to calculate the long-range part of the Coulomb potential.
-  thisWalker.R = W.R;
+  W.saveWalker(thisWalker);
   thisWalker.resetProperty(logpsi_old,Psi.getPhase(),eloc); // update thisWalker::Properties[LOGPSI,SIGN,LOCALENERGY]
   H.auxHevaluate(W,thisWalker); // update auxiliary observables, i.e. fill H::Observables
   H.saveProperty(thisWalker.getPropertyBase()); // copy H::Observables to thisWalker::Properties

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -48,7 +48,6 @@ struct  J1OrbitalSoA : public OrbitalBase
   ///reference to the sources (ions)
   const ParticleSet& Ions;
 
-  valT LogValue;
   valT curAt;
   valT curLap;
   posT curGrad;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -521,6 +521,7 @@ J2OrbitalSoA<FT>::acceptMove(ParticleSet& P, int iat)
     }
     cur_dUat[idim] = cur_g;
   }
+  LogValue  += Uat[iat]-cur_Uat;
   Uat[iat]   = cur_Uat;
   dUat(iat)  = cur_dUat;
   d2Uat[iat] = cur_d2Uat;

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -515,6 +515,7 @@ public:
         save_g[jel]+=new_g[jel]-old_g[jel];
     }
 
+    LogValue  += Uat[iat]-cur_Uat;
     Uat[iat]   = cur_Uat;
     dUat(iat)  = cur_dUat;
     d2Uat[iat] = cur_d2Uat;

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
@@ -394,9 +394,10 @@ public:
 
   void acceptMove(ParticleSet& P, int iat)
   {
-    U[iat] = curVal;
-    dU[iat]=curGrad;
-    d2U[iat]=curLap;
+    LogValue += U[iat]-curVal;
+    U[iat]    = curVal;
+    dU[iat]   = curGrad;
+    d2U[iat]  = curLap;
   }
 
   void evaluateLogAndStore(ParticleSet& P,

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -236,12 +236,7 @@ const char *particles = \
   ValueType ratio_0 = j2->ratio(elec_,0);
   elec_.rejectMove(0);
 
-  elec_.makeMove(1, newpos-elec_.R[1]);
-  ValueType ratio_1 = j2->ratio(elec_,1);
-  elec_.rejectMove(1);
-
   REQUIRE(ratio_0 == ComplexApprox(0.9522052017).compare_real_only());
-  REQUIRE(ratio_1 == ComplexApprox(0.9871985577).compare_real_only());
 
   VirtualParticleSet VP(elec_,2);
   ParticleSet::ParticlePos_t newpos2(2);
@@ -252,6 +247,16 @@ const char *particles = \
 
   REQUIRE(ratios[0] == ComplexApprox(0.9871985577).compare_real_only());
   REQUIRE(ratios[1] == ComplexApprox(0.9989268241).compare_real_only());
+
+  //test acceptMove
+  elec_.makeMove(1, newpos-elec_.R[1]);
+  ValueType ratio_1 = j2->ratio(elec_,1);
+  j2->acceptMove(elec_,1);
+  elec_.acceptMove(1);
+
+  REQUIRE(ratio_1 == ComplexApprox(0.9871985577).compare_real_only());
+  REQUIRE(j2->LogValue == Approx(0.0883791773));
+
 }
 
 TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
@@ -434,12 +439,16 @@ const char *particles = \
   ValueType ratio_0 = j1->ratio(elec_,0);
   elec_.rejectMove(0);
 
+  REQUIRE(ratio_0 == ComplexApprox(0.9819208747).compare_real_only());
+
+  // test acceptMove results
   elec_.makeMove(1, newpos-elec_.R[1]);
   ValueType ratio_1 = j1->ratio(elec_,1);
-  elec_.rejectMove(1);
+  j1->acceptMove(elec_,1);
+  elec_.acceptMove(1);
 
-  REQUIRE(ratio_0 == ComplexApprox(0.9819208747).compare_real_only());
   REQUIRE(ratio_1 == ComplexApprox(1.0040884258).compare_real_only());
+  REQUIRE(j1->LogValue == Approx(0.32013531536));
 
 }
 }

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -106,7 +106,7 @@ ENDIF()
 IF(NOT QMC_CUDA)
   QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-vmc-dmc-allp_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
-                    qmc_short_vmc_dmc_allp
+                    qmc_vmc_dmc_allp
                     qmc_short_vmc_dmc_allp.in.xml
                     1 16
                     TRUE
@@ -210,6 +210,36 @@ ENDIF()
                     TRUE
                     0 LONG_DIAMOND_SCALARS # VMC
                     )
+
+IF(NOT QMC_CUDA)
+  # VMC ref
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "totenergy" "-10.491445 0.0065")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "kinetic" "11.434392 0.006")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "potential" "-21.925822 0.006")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "eeenergy" "-2.700534 0.0015")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "ionion" "-12.77566752 0.0004")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "localecp" "-7.046740 0.0065")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "nonlocalecp" "0.597119 0.0019")
+  LIST(APPEND LONG_DIAMOND_ALLP_SCALARS "samples" "1280000 0.0")
+  #DMC ref
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "totenergy"   "-10.5316 0.0008")
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "kinetic"      "11.4857 0.0077")
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "potential"   "-22.0170 0.0080")
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "localecp"     "-7.1518 0.0108")
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "nonlocalecp"  "0.62688 0.0027")
+  LIST(APPEND LONG_DIAMOND_DMC_ALLP_SCALARS "eeenergy"    "-2.71641 0.0028")
+
+  QMC_RUN_AND_CHECK(long-diamondC_1x1x1_pp-vmc-dmc-allp_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+                    qmc_vmc_dmc_allp
+                    qmc_long_vmc_dmc_allp.in.xml
+                    1 16
+                    TRUE
+                    0 LONG_DIAMOND_ALLP_SCALARS # VMC without drift
+                    1 LONG_DIAMOND_ALLP_SCALARS # VMC with drift
+                    2 LONG_DIAMOND_DMC_ALLP_SCALARS # DMC
+                    )
+ENDIF()
 
   LIST(APPEND LONG_DIAMOND_KSPACE_SCALARS "totenergy" "-10.500719 0.001769")
   LIST(APPEND LONG_DIAMOND_KSPACE_SCALARS "variance"  "0.312264 0.028662")

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -103,6 +103,7 @@ ENDIF()
                     1 DIAMOND_DMC_SCALARS # DMC
                     )
 
+IF(NOT QMC_CUDA)
   QMC_RUN_AND_CHECK(short-diamondC_1x1x1_pp-vmc-dmc-allp_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
                     qmc_short_vmc_dmc_allp
@@ -113,6 +114,9 @@ ENDIF()
                     1 DIAMOND_SCALARS # VMC with drift
                     2 DIAMOND_DMC_SCALARS # DMC
                     )
+ELSE()
+  MESSAGE("Skipping diamondC_1x1x1_pp all particle move VMC/DMC tests because they are not supported by CUDA build (QMC_CUDA=1)")
+ENDIF()
 
 # Coverage test - shorter version of dmc test
   SET(FULL_NAME "coverage-diamondC_1x1x1_pp-vmc_sdj-1-1")

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_allp.in.xml
@@ -85,7 +85,7 @@
      <estimator name="LocalEnergy" hdf5="no"/>
      <parameter name="walkers"     > 256 </parameter>
      <parameter name="blocks"      > 125 </parameter>
-     <parameter name="steps"       > 4   </parameter>
+     <parameter name="steps"       > 40   </parameter>
      <parameter name="subSteps"    > 4   </parameter>
      <parameter name="timestep"    > 0.2 </parameter>
      <parameter name="warmupSteps" > 10  </parameter>
@@ -95,7 +95,7 @@
      <estimator name="LocalEnergy" hdf5="no"/>
      <parameter name="walkers"     > 256 </parameter>
      <parameter name="blocks"      > 125 </parameter>
-     <parameter name="steps"       > 4   </parameter>
+     <parameter name="steps"       > 40   </parameter>
      <parameter name="subSteps"    > 8   </parameter>
      <parameter name="timestep"    > 0.1 </parameter>
      <parameter name="warmupSteps" > 10  </parameter>
@@ -107,7 +107,7 @@
      <parameter name="reconfiguration">   no </parameter>
      <parameter name="warmupSteps">  100 </parameter>
      <parameter name="timestep">  0.005 </parameter>
-     <parameter name="steps">   100 </parameter>
+     <parameter name="steps">   1000 </parameter>
      <parameter name="blocks">  100 </parameter>
      <parameter name="nonlocalmoves">  no </parameter>
    </qmc>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
@@ -87,19 +87,19 @@
      <parameter name="blocks"      > 125 </parameter>
      <parameter name="steps"       > 4   </parameter>
      <parameter name="subSteps"    > 4   </parameter>
-     <parameter name="timestep"    > 1.0 </parameter>
+     <parameter name="timestep"    > 0.2 </parameter>
      <parameter name="warmupSteps" > 10  </parameter>
-     <parameter name="usedrift"    > no  </parameter>
+     <parameter name="usedrift"    > yes </parameter>
    </qmc>
    <qmc method="vmc" move="allp">
      <estimator name="LocalEnergy" hdf5="no"/>
      <parameter name="walkers"     > 256 </parameter>
      <parameter name="blocks"      > 125 </parameter>
      <parameter name="steps"       > 4   </parameter>
-     <parameter name="subSteps"    > 4   </parameter>
-     <parameter name="timestep"    > 1.0 </parameter>
+     <parameter name="subSteps"    > 8   </parameter>
+     <parameter name="timestep"    > 0.1 </parameter>
      <parameter name="warmupSteps" > 10  </parameter>
-     <parameter name="usedrift"    > yes </parameter>
+     <parameter name="usedrift"    > no  </parameter>
    </qmc>
    <qmc method="dmc" move="allp" checkpoint="-1">
      <estimator name="LocalEnergy" hdf5="no"/>


### PR DESCRIPTION
Some left over fix for #754 and #755.
allp DMC Tmove is fixed in the driver with LogValue fix in Jastrow factors.
LogValue needs to be updated by acceptMove such that Psi.getLogPsi() returns the correct value at any time.  Unit tests are updated.
allp VMC failing in SoA is fixed by adding the missing neighbour list construction needed by NLPP. This is not exposed by bccH tests.
The allp VMC tests on diamond had too large time step. This is also fixed and they pass stably now.