### PR TITLE
Clean up the use of donePbyP in drivers

### DIFF
--- a/src/Particle/AsymmetricDistanceTableData.h
+++ b/src/Particle/AsymmetricDistanceTableData.h
@@ -172,7 +172,7 @@ struct AsymmetricDTD
   }
 
   ///not so useful inline but who knows
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P, bool update_neighbor_list)
   {
     const int ns=N[SourceIndex];
     const int nt=N[VisitorIndex];
@@ -186,7 +186,7 @@ struct AsymmetricDTD
   {
     APP_ABORT("  No need to call AsymmetricDTD::evaluate(ParticleSet& P, int jat)");
     //based on full evaluation. Only compute it if jat==0
-    if(jat==0) evaluate(P);
+    if(jat==0) evaluate(P,true);
   }
 
   ///evaluate the temporary pair relations

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -347,16 +347,13 @@ struct DistanceTableData
     return -1;
   }
 
-  ///prepare particle-by-particle moves
-  virtual void setPbyP() { }
-
   ///update internal data after completing particle-by-particle moves
   virtual void donePbyP() { }
 
-  ///evaluate the Distance Table using only with position array
-  virtual void evaluate(ParticleSet& P) = 0;
+  ///evaluate the full Distance Table and neighbor_list if requested
+  virtual void evaluate(ParticleSet& P, bool update_neighbor_list=true) = 0;
 
-  /// evaluate the Distance Table
+  /// evaluate the Distance Table for a given electron
   virtual void evaluate(ParticleSet& P, int jat)=0;
 
   ///evaluate the temporary pair relations

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -578,10 +578,7 @@ bool ParticleSet::makeMove(const Walker_t& awalker
   RSoA.copyIn(R); 
 #endif
   for (int i=0; i<DistTables.size(); i++)
-  {
     DistTables[i]->evaluate(*this);
-    DistTables[i]->donePbyP();
-  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -614,10 +611,7 @@ bool ParticleSet::makeMove(const Walker_t& awalker
   RSoA.copyIn(R); 
 #endif
   for (int i=0; i<DistTables.size(); i++)
-  {
     DistTables[i]->evaluate(*this);
-    DistTables[i]->donePbyP();
-  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -658,10 +652,7 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
   RSoA.copyIn(R); 
 #endif
   for (int i=0; i<DistTables.size(); i++)
-  {
     DistTables[i]->evaluate(*this);
-    DistTables[i]->donePbyP();
-  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -697,10 +688,7 @@ bool ParticleSet::makeMoveWithDrift(const Walker_t& awalker
 #endif
 
   for (int i=0; i<DistTables.size(); i++)
-  {
     DistTables[i]->evaluate(*this);
-    DistTables[i]->donePbyP();
-  }
   if (SK)
     SK->UpdateAllPart(*this);
   //every move is valid
@@ -761,12 +749,12 @@ void ParticleSet::rejectMove(Index_t iat)
   activePtcl=-1;
 }
 
-void ParticleSet::donePbyP(bool skipSK)
+void ParticleSet::donePbyP()
 {
   myTimers[2]->start();
   for (size_t i=0; i<DistTables.size(); i++)
     DistTables[i]->donePbyP();
-  if (!skipSK && SK && !SK->DoUpdate)
+  if (SK && !SK->DoUpdate)
     SK->UpdateAllPart(*this);
   activePtcl=-1;
   myTimers[2]->stop();
@@ -795,7 +783,7 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
     // in certain cases, full tables must be ready
     for (int i=0; i< DistTables.size(); i++)
       if(DistTables[i]->DTType==DT_AOS||DistTables[i]->Need_full_table_loadWalker)
-        DistTables[i]->evaluate(*this);
+        DistTables[i]->evaluate(*this,false);
     //computed so that other objects can use them, e.g., kSpaceJastrow
     if(SK && SK->DoUpdate)
       SK->UpdateAllPart(*this);

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -133,23 +133,24 @@ public:
   bool SameMass;
   ///threa id
   Index_t ThreadID;
-  ///the index of the active particle for particle-by-particle moves
+  /** the index of the active particle during particle-by-particle moves
+   *
+   * when a single particle move is proposed, the particle id is assigned to activePtcl
+   * No matter the move is accepted or rejected, activePtcl is marked back to -1.
+   * This state flag is used for picking coordinates and distances for SPO evaluation.
+   */
   Index_t activePtcl;
-  ///the group of the active particle for particle-by-particle moves
+  ///the group of the active particle during particle-by-particle moves
   Index_t activeGroup;
   ///the index of the active bead for particle-by-particle moves
   Index_t activeBead;
   ///the direction reptile traveling
   Index_t direction;
 
-  /** the position of the active particle for particle-by-particle moves
-   *
-   * Saves the position before making a move to handle rejectMove
-   */
+  ///the proposed position of activePtcl during particle-by-particle moves
   SingleParticlePos_t activePos;
 
-  /** the proposed position in the Lattice unit
-   */
+  ///the proposed position in the Lattice unit
   SingleParticlePos_t newRedPos;
 
   ///SpeciesSet of particles
@@ -452,7 +453,15 @@ public:
    */
   void saveWalker(Walker_t& awalker);
 
-  /** update neighbor list and unmark activePtcl
+  /** update neighbor list, structure factor and unmark activePtcl
+   *
+   * Currently the trial wave function depends only on distances and
+   * doesn't use any neightbor lists from ParticleSet. However, the
+   * evaluation of non-local pseudopotential relies on the neighbor
+   * list of electron-ion and the Coulomb interaction needs the
+   * structure factor. For these reason, donePbyP after the loop of
+   * single electron moves before evaluating the Hamiltonian.
+   * unmark activePtcl is more of a safety measure probably not needed.
    */
   void donePbyP();
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -452,18 +452,17 @@ public:
    */
   void saveWalker(Walker_t& awalker);
 
-  /** update the buffer
-   *@param skip SK update if skipSK is true
+  /** update neighbor list and unmark activePtcl
    */
-  void donePbyP(bool skipSK=false);
+  void donePbyP();
 
-  //return the address of the values of Hamiltonian terms
+  ///return the address of the values of Hamiltonian terms
   inline EstimatorRealType* restrict getPropertyBase()
   {
     return Properties.data();
   }
 
-  //return the address of the values of Hamiltonian terms
+  ///return the address of the values of Hamiltonian terms
   inline const EstimatorRealType* restrict getPropertyBase() const
   {
     return Properties.data();

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -61,7 +61,7 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     Temp_dr.resize(Ntargets);
   }
 
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P, bool update_neighbor_list)
   {
     CONSTEXPR T BigR= std::numeric_limits<T>::max();
     //P.RSoA.copyIn(P.R); 

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -73,7 +73,7 @@ struct SoaDistanceTableAB: public DTD_BConds<T,D,SC>, public DistanceTableData
   SoaDistanceTableAB(const SoaDistanceTableAB&)=delete;
   ~SoaDistanceTableAB() {}
 
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P, bool update_neighbor_list)
   {
     for(int iat=0; iat<Nsources; ++iat)
       DTD_BConds<T,D,SC>::computeDistances(Origin->R[iat], P.RSoA, Distances[iat], Displacements[iat], 0, Ntargets);

--- a/src/Particle/SoaDistanceTableBA.h
+++ b/src/Particle/SoaDistanceTableBA.h
@@ -65,11 +65,12 @@ struct SoaDistanceTableBA: public DTD_BConds<T,D,SC>, public DistanceTableData
   ~SoaDistanceTableBA() {}
 
   /** evaluate the full table */
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P, bool update_neighbor_list)
   {
     //be aware of the sign of Displacement
     for(int iat=0; iat<Ntargets; ++iat)
       DTD_BConds<T,D,SC>::computeDistances(P.R[iat],Origin->RSoA, Distances[iat], Displacements[iat], 0, Nsources);
+    if(update_neighbor_list) donePbyP();
   }
 
   /** evaluate the iat-row with the current position

--- a/src/Particle/SymmetricDistanceTableData.h
+++ b/src/Particle/SymmetricDistanceTableData.h
@@ -124,7 +124,7 @@ struct SymmetricDTD
   //   }
   // }
 
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P, bool update_neighbor_list)
   {
     const int n = N[SourceIndex];
     for(int i=0,ij=0; i<n; i++)
@@ -139,7 +139,7 @@ struct SymmetricDTD
   {
     APP_ABORT("  No need to call SymmetricDTD::evaluate(ParticleSet& P, int jat)");
     //based on full evaluation. Only compute it if jat==0
-    if(jat==0) evaluate(P);
+    if(jat==0) evaluate(P,true);
   }
 
   ///evaluate the temporary pair relations

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -37,7 +37,6 @@ TEST_CASE("symmetric_distance_table", "[particle]")
 
   OHMMS::Controller->initialize(0, NULL);
 
-  typedef SymmetricDTD<ParticleSet::RealType, 3, SUPERCELL_OPEN> sym_dtd_t;
   ParticleSet source;
 
   source.setName("electrons");
@@ -50,10 +49,7 @@ TEST_CASE("symmetric_distance_table", "[particle]")
   source.R[1][1] = 1.0;
   source.R[1][2] = 3.2;
 
-  sym_dtd_t dist(source, source);
-
-  dist.evaluate(source);
-  source.addTable(source,DT_AOS);
+  source.addTable(source,DT_SOA_PREFERRED);
   source.update();
 
   DistanceTableData *dist2 = createDistanceTable(source,DT_AOS);

--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -88,7 +88,6 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
     if(!accepted)
     {
       W.update(thisWalker.R);
-      W.donePbyP(true);
       logpsi = Psi.evaluateLog(W);
     }
 

--- a/src/QMCDrivers/QMCCostFunctionOMP.cpp
+++ b/src/QMCDrivers/QMCCostFunctionOMP.cpp
@@ -283,8 +283,7 @@ void QMCCostFunctionOMP::checkConfigurations()
     for (int iw=0, iwg=wPerNode[ip]; iw<wRef.numSamples(); ++iw,++iwg)
     {
       wRef.loadSample(wRef.R, iw);
-      wRef.update(true);
-      wRef.donePbyP();
+      wRef.update();
       Return_t* restrict saved=(*RecordsOnNode[ip])[iw];
       psiClones[ip]->evaluateDeltaLog(wRef, saved[LOGPSI_FIXED], saved[LOGPSI_FREE], *dLogPsi[iwg], *d2LogPsi[iwg]);
       saved[REWEIGHT]=1.0;
@@ -387,8 +386,7 @@ void QMCCostFunctionOMP::engine_checkConfigurations(cqmc::engine::LMYEngine * En
     for (int iw=0, iwg=wPerNode[ip]; iw<wRef.numSamples(); ++iw,++iwg)
     {
       wRef.loadSample(wRef.R, iw);
-      wRef.update(true);
-      wRef.donePbyP();
+      wRef.update();
       Return_t* restrict saved=(*RecordsOnNode[ip])[iw];
       psiClones[ip]->evaluateDeltaLog(wRef, saved[LOGPSI_FIXED], saved[LOGPSI_FREE], *dLogPsi[iwg], *d2LogPsi[iwg]);
       saved[REWEIGHT]=1.0;
@@ -520,7 +518,6 @@ QMCCostFunctionOMP::Return_t QMCCostFunctionOMP::correlatedSampling(bool needGra
     {
       wRef.loadSample(wRef.R, iw);
       wRef.update(true);
-      if(nlpp) wRef.donePbyP(true);
       Return_t* restrict saved = (*RecordsOnNode[ip])[iw];
       Return_t logpsi;
       logpsi=psiClones[ip]->evaluateDeltaLog(wRef,compute_all_from_scratch);

--- a/src/QMCDrivers/VMC/VMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.cpp
@@ -96,7 +96,6 @@ void VMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
   if(!updated)
   { // W.G and W.L have to be computed because the last move was rejected
     W.update(thisWalker.R); // move W back to last accepted configuration; W.DistTables, SK are updated
-    W.donePbyP(true); // update neighbour list for NLPP
     logpsi_old=Psi.evaluateLog(W); // update W.G,L
   } // W and logpsi_old are up-to-date at this point
 


### PR DESCRIPTION
In the SoA code, electron-ion table not only carries the distances but also a neighbour list for NLPP evaluation. In many cases, when all the distance tables are evaluated from scratch, the neighbour lists need to be updated but only possible through calling donePbyP which is supposed to be used by PbyP drivers only.

This PR changes the default behaviour that the neighbour list is updated automatically when the full table is recomputed. So in most places, the calls to donePbyP can be removed and drivers not tested for SoA may work out of the box.

The only performance penalty I can think of is in optimization when not using NLPP in the correlated sampling. The penalty should be very very small.