### PR TITLE
Add orbital norm check in SplineAdoptor Readers

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -30,6 +30,8 @@
 #include "Numerics/HDFNumericAttrib.h"
 #include <map>
 
+#define PW_COEFF_NORM_TOLERANCE 1e-6
+
 class Communicate;
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -356,6 +356,13 @@ struct SplineAdoptorReader: public BsplineReaderBase
       std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
       foundit &= h5f.read(cG,s);
       get_psi_g(ti,spin,cur_bands[iorb].BandIndex,cG);//bcast cG
+      double total_norm = compute_norm(cG);
+      if(std::abs(total_norm-1.0)>1e-6)
+      {
+        app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
+                    << ", computed from plane wave coefficients!" << std::endl;
+        APP_ABORT("SplineAdoptorReader Wrong orbital norm!");
+      }
       fft_spline(cG,ti,0);
       bspline->set_spline(spline_r[0],spline_i[0],cur_bands[iorb].TwistIndex,iorb,0);
     }
@@ -411,6 +418,13 @@ struct SplineAdoptorReader: public BsplineReaderBase
         int ti=cur_bands[iorb].TwistIndex;
         std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
         foundit &= h5f.read(cG,s);
+        double total_norm = compute_norm(cG);
+        if(std::abs(total_norm-1.0)>1e-6)
+        {
+          app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
+                      << ", computed from plane wave coefficients!" << std::endl;
+          APP_ABORT("SplineAdoptorReader Wrong orbital norm!");
+        }
         fft_spline(cG,ti,ib);
       }
       if(root)

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -357,7 +357,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
       foundit &= h5f.read(cG,s);
       get_psi_g(ti,spin,cur_bands[iorb].BandIndex,cG);//bcast cG
       double total_norm = compute_norm(cG);
-      if(std::abs(total_norm-1.0)>1e-6)
+      if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
       {
         app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
                     << ", computed from plane wave coefficients!" << std::endl;
@@ -419,7 +419,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
         std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
         foundit &= h5f.read(cG,s);
         double total_norm = compute_norm(cG);
-        if(std::abs(total_norm-1.0)>1e-6)
+        if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
         {
           app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
                       << ", computed from plane wave coefficients!" << std::endl;

--- a/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
@@ -784,6 +784,13 @@ struct SplineHybridAdoptorReader: public BsplineReaderBase
         int ti=cur_bands[iorb].TwistIndex;
         std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
         if(!h5f.read(cG,s)) APP_ABORT("SplineHybridAdoptorReader Failed to read band(s) from h5!\n");
+        double total_norm = compute_norm(cG);
+        if(std::abs(total_norm-1.0)>1e-6)
+        {
+          app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
+                      << ", computed from plane wave coefficients!" << std::endl;
+          APP_ABORT("SplineHybridAdoptorReader Wrong orbital norm!");
+        }
         fft_spline(cG,ti);
         bspline->set_spline(spline_r,spline_i,cur_bands[iorb].TwistIndex,iorb,0);
       }

--- a/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
@@ -785,7 +785,7 @@ struct SplineHybridAdoptorReader: public BsplineReaderBase
         std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
         if(!h5f.read(cG,s)) APP_ABORT("SplineHybridAdoptorReader Failed to read band(s) from h5!\n");
         double total_norm = compute_norm(cG);
-        if(std::abs(total_norm-1.0)>1e-6)
+        if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
         {
           app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
                       << ", computed from plane wave coefficients!" << std::endl;

--- a/src/QMCWaveFunctions/einspline_helper.hpp
+++ b/src/QMCWaveFunctions/einspline_helper.hpp
@@ -240,10 +240,25 @@ namespace qmcplusplus
       }
   }
 
-  /** rotate the state after 3dfft
-   *
-   * Compute the phase factor for rotation. The algorithm aims at balacned real and imaginary parts.
-   *
+  /** Compute the norm of an orbital.
+   * @param cG the plane wave coefficients
+   * @return norm of the orbital
+   */
+  template<typename T>
+    inline T compute_norm(const Vector<std::complex<T> >& cG)
+  {
+    T total_norm2(0);
+    #pragma omp parallel for reduction(+:total_norm2)
+    for (size_t ig=0; ig<cG.size(); ++ig)
+      total_norm2 += cG[ig].real()*cG[ig].real()+cG[ig].imag()*cG[ig].imag();
+    return std::sqrt(total_norm2);
+  }
+
+  /** Compute the phase factor for rotation. The algorithm aims at balanced real and imaginary parts.
+   * @param in the real space orbital value on a 3D grid
+   * @param twist k-point in reduced coordinates
+   * @param phase_r output real part of the phase
+   * @param phase_i output imaginary part of the phase
    */
   template<typename T, typename T2>
     inline void compute_phase(const Array<std::complex<T>,3>& in, const TinyVector<T2,3>& twist, T& phase_r, T& phase_i)


### PR DESCRIPTION
Add the orbital norm check requested by #761.
It many be able to catch #675. 
I ran all the short tests and they are fine.