### PR TITLE
Allow unlisted testbeds

### DIFF
--- a/CMake/ctest_script.cmake
+++ b/CMake/ctest_script.cmake
@@ -83,7 +83,8 @@ ELSEIF( ${HOSTNAME} MATCHES "ryzen-box" )
     SET( QMC_OPTIONS "${QMC_OPTIONS};-DCMAKE_PREFIX_PATH=/opt/OpenBLAS" )
     SET( N_PROCS 16)
 ELSE()
-    MESSAGE( FATAL_ERROR "Unknown host: ${HOSTNAME}" )
+    MESSAGE( MESSAGE "Unknown host: ${HOSTNAME}. Using generic setting." )
+    SET( CTEST_CMAKE_GENERATOR "Unix Makefiles")
 ENDIF()
 
 # Get the source directory based on the current directory

--- a/tests/test_automation/nightly_anl_bora.sh
+++ b/tests/test_automation/nightly_anl_bora.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# Setup for bora.alcf.anl.gov
+#
+# Run the "short" nightlies
+# 
+
+export N_PROCS=32
+export CC=mpicc
+export CXX=mpicxx
+export BOOST_ROOT=/sandbox/opt/qmcdev/trunk/external_codes/boost_1_55_0
+
+QE_BIN=/sandbox/opt/qe-6.2.1/bin
+QMC_DATA=/sandbox/yeluo/benchmark
+site_name=bora.alcf.anl.gov
+
+#Must be an absolute path
+place=/sandbox/QMCPACK_CI_BUILDS_DO_NOT_REMOVE
+
+#define and load compiler
+compiler=Intel2018
+
+if [ ! -e $place ]; then
+mkdir $place
+fi
+
+if [ -e $place ]; then
+cd $place
+
+echo --- Hostname --- $HOSTNAME
+echo --- Checkout for $sys `date`
+
+branch=develop
+entry=qmcpack-${branch}
+
+if [ ! -e $entry ]; then
+echo --- Cloning QMCPACK git `date`
+git clone --depth 1 https://github.com/QMCPACK/qmcpack.git $entry
+else
+echo --- Updating local QMCPACK git `date`
+cd $entry
+git pull
+cd ..
+fi
+
+if [ -e $entry/CMakeLists.txt ]; then
+cd $entry
+
+git checkout $branch
+
+for sys in Real-SoA Real-Mixed-SoA Complex-SoA Complex-Mixed-SoA Real Real-Mixed Complex Complex-Mixed
+do
+
+folder=build_$compiler_$sys
+
+if [ -e $folder ]; then
+rm -r $folder
+fi
+mkdir $folder
+cd $folder
+
+echo --- Building for $sys `date`
+
+# create log file folder if not exist
+mydate=`date +%y_%m_%d`
+if [ ! -e $place/log/$entry/$mydate ];
+then
+  mkdir -p $place/log/$entry/$mydate
+fi
+
+CTEST_FLAGS="-D QE_BIN=$QE_BIN -D QMC_DATA=$QMC_DATA -D CTEST_SITE=$site_name"
+
+if [[ $sys == *"Complex"* ]]; then
+  CTEST_FLAGS="$CTEST_FLAGS -D QMC_COMPLEX=1"
+fi
+
+if [[ $sys == *"-SoA"* ]]; then
+  CTEST_FLAGS="$CTEST_FLAGS -D ENABLE_SOA=1"
+fi
+
+if [[ $sys == *"-Mixed"* ]]; then
+  CTEST_FLAGS="$CTEST_FLAGS -D QMC_MIXED_PRECISION=1"
+fi
+
+export QMCPACK_TEST_SUBMIT_NAME=${compiler}-${sys}-Release
+
+ctest $CTEST_FLAGS -S $PWD/../CMake/ctest_script.cmake,release -VV -E 'long' --timeout 600 &> $place/log/$entry/$mydate/${QMCPACK_TEST_SUBMIT_NAME}.log
+
+cd ..
+echo --- Finished $sys `date`
+done
+
+else
+echo  "ERROR: No CMakeLists. Bad git clone."
+exit 1
+fi
+
+else
+echo "ERROR: No directory $place"
+exit 1
+fi


### PR DESCRIPTION
Currently if a hostname is not recognized, the nightly tests script will abort.
Every time we add a machine, the script needs to be updated. This is not good.
This PR allows using a generic setting and pass extra parameters via environment variables or arguments.

The script for bora.alcf.anl.gov is an example.