### PR TITLE
Update pw2qmcpack + manual

### DIFF
--- a/external_codes/quantum_espresso/README
+++ b/external_codes/quantum_espresso/README
@@ -18,10 +18,8 @@ from within the top level quantum espresso directory.
 Notes for maintainers:
 
 1. Update the new version of QE. Hopefully the old patch
-works. Typically there are small makefile updates and minor updates to
-Module interfaces in read_file_lite. If install/configure.ac is
-updated, be sure to run autoconf to generate a new
-install/configure.
+works. Typically there are small makefile updates. If install/configure.ac is
+updated, be sure to run autoconf to generate a new install/configure.
 
 2. Create a new patch.
 

--- a/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.2.1.diff
+++ b/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.2.1.diff
@@ -1,6 +1,6 @@
 diff -W 205 -urN qe-6.2.1_original/clib/esh5_interfaces.c qe-6.2.1_updated/clib/esh5_interfaces.c
 --- qe-6.2.1_original/clib/esh5_interfaces.c	1969-12-31 18:00:00.000000000 -0600
-+++ qe-6.2.1_updated/clib/esh5_interfaces.c	2018-02-07 23:57:43.000000000 -0600
++++ qe-6.2.1_updated/clib/esh5_interfaces.c	2018-04-25 13:54:45.809746856 -0500
 @@ -0,0 +1,962 @@
 +/*
 + * Copyright (C) 2004 PWSCF group 
@@ -965,16 +965,16 @@ diff -W 205 -urN qe-6.2.1_original/clib/esh5_interfaces.c qe-6.2.1_updated/clib/
 +
 +#endif
 diff -W 205 -urN qe-6.2.1_original/clib/make.depend qe-6.2.1_updated/clib/make.depend
---- qe-6.2.1_original/clib/make.depend	2017-12-11 04:41:41.000000000 -0600
-+++ qe-6.2.1_updated/clib/make.depend	2018-02-07 23:57:43.000000000 -0600
+--- qe-6.2.1_original/clib/make.depend	2017-12-11 10:51:48.000000000 -0600
++++ qe-6.2.1_updated/clib/make.depend	2018-04-25 13:54:45.809746856 -0500
 @@ -1,3 +1,4 @@
  md5.o : 
  md5_from_file.o : 
  memstat.o : ../include/c_defs.h
 +esh5_interfaces.o : ../include/c_defs.h
 diff -W 205 -urN qe-6.2.1_original/clib/Makefile qe-6.2.1_updated/clib/Makefile
---- qe-6.2.1_original/clib/Makefile	2017-12-11 04:41:41.000000000 -0600
-+++ qe-6.2.1_updated/clib/Makefile	2018-02-07 23:57:43.000000000 -0600
+--- qe-6.2.1_original/clib/Makefile	2017-12-11 10:51:48.000000000 -0600
++++ qe-6.2.1_updated/clib/Makefile	2018-04-25 13:54:45.809746856 -0500
 @@ -16,14 +16,18 @@
  ptrace.o \
  sockets.o \
@@ -997,8 +997,8 @@ diff -W 205 -urN qe-6.2.1_original/clib/Makefile qe-6.2.1_updated/clib/Makefile
  	co -l $(OBJS:.o=.c)
  
 diff -W 205 -urN qe-6.2.1_original/install/configure qe-6.2.1_updated/install/configure
---- qe-6.2.1_original/install/configure	2017-12-11 04:41:41.000000000 -0600
-+++ qe-6.2.1_updated/install/configure	2018-02-07 23:57:43.000000000 -0600
+--- qe-6.2.1_original/install/configure	2017-12-11 10:52:53.000000000 -0600
++++ qe-6.2.1_updated/install/configure	2018-04-25 13:54:45.813746859 -0500
 @@ -8809,10 +8809,10 @@
           elif test -e $with_hdf5_path/bin/h5fc; then
               hdf5_libs=`$with_hdf5_path/bin/h5fc -show | awk -F'-L' '{$1="";$2="-L"$2; print $0}'`
@@ -1013,8 +1013,8 @@ diff -W 205 -urN qe-6.2.1_original/install/configure qe-6.2.1_updated/install/co
  
        hdf5_line="HDF5_LIBS=$hdf5_libs"
 diff -W 205 -urN qe-6.2.1_original/Modules/qeh5_module.f90 qe-6.2.1_updated/Modules/qeh5_module.f90
---- qe-6.2.1_original/Modules/qeh5_module.f90	2017-12-11 04:41:41.000000000 -0600
-+++ qe-6.2.1_updated/Modules/qeh5_module.f90	2018-02-07 23:57:43.000000000 -0600
+--- qe-6.2.1_original/Modules/qeh5_module.f90	2017-12-11 10:53:17.000000000 -0600
++++ qe-6.2.1_updated/Modules/qeh5_module.f90	2018-04-25 13:54:45.813746859 -0500
 @@ -163,13 +163,12 @@
         CASE default 
           ierr =1 
@@ -1036,8 +1036,8 @@ diff -W 205 -urN qe-6.2.1_original/Modules/qeh5_module.f90 qe-6.2.1_updated/Modu
      ! //' with action '// trim(action), 1 )  
    END SUBROUTINE  qeh5_openfile  
 diff -W 205 -urN qe-6.2.1_original/PP/src/Makefile qe-6.2.1_updated/PP/src/Makefile
---- qe-6.2.1_original/PP/src/Makefile	2017-12-11 04:41:41.000000000 -0600
-+++ qe-6.2.1_updated/PP/src/Makefile	2018-02-07 23:57:43.000000000 -0600
+--- qe-6.2.1_original/PP/src/Makefile	2017-12-11 10:51:58.000000000 -0600
++++ qe-6.2.1_updated/PP/src/Makefile	2018-04-25 13:54:45.813746859 -0500
 @@ -61,7 +61,7 @@
        pawplot.x sumpdos.x pw2wannier90.x pw_export.x pw2gw.x \
        wannier_ham.x wannier_plot.x molecularpdos.x \
@@ -1061,8 +1061,8 @@ diff -W 205 -urN qe-6.2.1_original/PP/src/Makefile qe-6.2.1_updated/PP/src/Makef
  	( cd ../.. ; $(MAKE) $(TLDEPS) || exit 1 ) ; fi
 diff -W 205 -urN qe-6.2.1_original/PP/src/pw2qmcpack.f90 qe-6.2.1_updated/PP/src/pw2qmcpack.f90
 --- qe-6.2.1_original/PP/src/pw2qmcpack.f90	1969-12-31 18:00:00.000000000 -0600
-+++ qe-6.2.1_updated/PP/src/pw2qmcpack.f90	2018-02-07 23:57:43.000000000 -0600
-@@ -0,0 +1,1289 @@
++++ qe-6.2.1_updated/PP/src/pw2qmcpack.f90	2018-04-25 13:55:23.133771005 -0500
+@@ -0,0 +1,1338 @@
 +!
 +! Copyright (C) 2004 PWSCF group 
 +! This file is distributed under the terms of the
@@ -1181,6 +1181,47 @@ diff -W 205 -urN qe-6.2.1_original/PP/src/pw2qmcpack.f90 qe-6.2.1_updated/PP/src
 +
 +END PROGRAM pw2qmcpack
 +
++SUBROUTINE check_norm(ng, eigvec, collect_intra_pool, jks, ibnd, tag)
++  USE mp_pools, ONLY: me_pool, intra_pool_comm
++  USE mp,       ONLY: mp_sum
++  USE KINDS,    ONLY: DP
++  !
++  IMPLICIT NONE
++  !
++  COMPLEX(DP), INTENT(IN) :: eigvec(ng)
++  INTEGER, INTENT(IN) :: ng, jks, ibnd
++  LOGICAL, INTENT(IN) :: collect_intra_pool
++  CHARACTER(len=*), INTENT(IN) :: tag
++  !
++  INTEGER :: ig
++  REAL(DP) :: total_norm
++  !
++  ! check normalization before writing h5
++  total_norm = 0.d0
++  !$omp parallel do reduction(+:total_norm)
++  DO ig=1, ng
++    total_norm = total_norm + eigvec(ig)*CONJG(eigvec(ig))
++  ENDDO
++  ! collect within a pool
++  IF(collect_intra_pool) CALL mp_sum ( total_norm , intra_pool_comm )
++  ! compute the norm
++  total_norm = SQRT(total_norm)
++  ! check abort if necessary
++  IF (me_pool==0 .AND. ABS(total_norm-1.d0)>1.d-6) THEN
++    WRITE(*,"(A,I3,A,I3,3A,F20.15)") "The wrong norm of k-point ", jks, " band ", ibnd, " , ", &
++                                      tag, ", is ", total_norm
++    IF (.NOT. collect_intra_pool) THEN
++      WRITE(*,"(3A)") "The orbitals went wrong before being written to h5 file. ", &
++                      "Please first add debug=.true. in the pw2qmcpack input file to check ", &
++                      "if the orbitals can be read from QE files correctly."
++    ELSE
++      WRITE(*,"(2A)") "The orbitals read from QE files are incorrect. ", &
++                      "Perhaps your QE orbital files are corrupted."
++    ENDIF
++    STOP
++  ENDIF
++  !
++END SUBROUTINE
 +
 +SUBROUTINE compute_qmcpack(write_psir, expand_kp, debug)
 +
@@ -1256,7 +1297,7 @@ diff -W 205 -urN qe-6.2.1_original/PP/src/pw2qmcpack.f90 qe-6.2.1_updated/PP/src
 +  CHARACTER(iotk_attlenx) :: attr
 +  
 +  INTEGER :: rest, nbase, basekindex, nktot
-+  real (dp) :: xk_cryst(3)
++  REAL(DP) :: xk_cryst(3)
 +
 +  INTEGER :: npwx_tot, igk_g;
 +  
@@ -1939,10 +1980,14 @@ diff -W 205 -urN qe-6.2.1_original/PP/src/pw2qmcpack.f90 qe-6.2.1_updated/PP/src
 +    DO ibnd = 1, nbnd
 +      eigpacked(:)=(0.d0,0.d0)
 +      eigpacked(igtomin(ig_l2g(igk_k(1:npw,ik))))=evc(1:npw,ibnd)
-+      if(debug) write(6,"(A,1I5)") "     collecting band ", ibnd
++      IF (debug) CALL check_norm(npw, evc(1,ibnd), .true., jks, ibnd, "before collection")
++      if (debug) write(6,"(A,1I5)") "     collecting band ", ibnd
 +      CALL mp_sum ( eigpacked , intra_pool_comm )
-+      if(debug) write(6,"(A,1I5)") "        writing band ", ibnd
-+      if(pool_ionode) CALL esh5_write_psi_g(ibnd,eigpacked,ngtot)
++      if (debug) write(6,"(A,1I5)") "        writing band ", ibnd
++      if (pool_ionode) THEN
++        CALL check_norm(ngtot, eigpacked, .false., jks, ibnd, "after collection before writing")
++        CALL esh5_write_psi_g(ibnd,eigpacked,ngtot)
++      ENDIF
 +    enddo
 +    if(pool_ionode) CALL esh5_close_spin()
 +    if(pool_ionode) CALL esh5_close_kpoint() 
@@ -2066,11 +2111,15 @@ diff -W 205 -urN qe-6.2.1_original/PP/src/pw2qmcpack.f90 qe-6.2.1_updated/PP/src
 +             !tmp_evc(:) = evc(:,ibnd)
 +             eigpacked(:)=(0.d0,0.d0)
 +             eigpacked(igtomin(ig_l2g(igk_k(1:npw,ik))))=evc(1:npw,ibnd)
++             IF (debug) CALL check_norm(npw, evc(1,ibnd), .true., jks, ibnd, "before collection")
 +             !
 +           ENDIF ! expandkp
 +
 +           CALL mp_sum ( eigpacked , intra_pool_comm )
-+           if(pool_ionode) CALL esh5_write_psi_g(ibnd,eigpacked,ngtot)
++           if (pool_ionode) THEN
++             CALL check_norm(ngtot, eigpacked, .false., jks, ibnd, "after collection before writing")
++             CALL esh5_write_psi_g(ibnd,eigpacked,ngtot)
++           ENDIF
 +
 +           IF (write_psir) THEN
 +              psic(:)=(0.d0,0.d0)

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -1355,7 +1355,8 @@ cd espresso-6.2.1
 ./configure --with-hdf5=/opt/local   # Specify HDF5 base directory
 \end{verbatim}
    {\bf check} the end of configure output if HDF5 libraries are found properly.
-   If not, either install a complete library or use the other scheme.
+   If not, either install a complete library or use the other scheme. If using a parallel HDF5 library, be sure to use
+   the same MPI with QE as used to build the parallel HDF5 library.
 
    Currently HDF5 support in QE itself is preliminary. To enable use of pw2qmcpack
    but use the old non-HDF5 I/O within QE, replace \texttt{-D\_\_HDF5} with \texttt{-D\_\_HDF5\_C} in make.inc.

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -1354,6 +1354,9 @@ the HDF5 capability enabled in either way:
 cd espresso-6.2.1
 ./configure --with-hdf5=/opt/local   # Specify HDF5 base directory
 \end{verbatim}
+   {\bf check} the end of configure output if HDF5 libraries are found properly.
+   If not, either install a complete library or use the other scheme.
+
    Currently HDF5 support in QE itself is preliminary. To enable use of pw2qmcpack
    but use the old non-HDF5 I/O within QE, replace \texttt{-D\_\_HDF5} with \texttt{-D\_\_HDF5\_C} in make.inc.
 \item if your system has HDF5 with C only, manually edit make.inc by adding \texttt{-D\_\_HDF5\_C} and \texttt{-DH5\_USE\_16\_API}

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -1341,17 +1341,24 @@ Quantum ESPRESSO distribution.
 To simplify the process of patching Quantum ESPRESSO we have developed
 a script that will automatically download and patch the source
 code. The patches are specific to each version. e.g. To download and
-patch QE v5.3.0:
+patch QE v6.2.1:
 \begin{verbatim}
 cd external_codes/quantum_espresso
-./download_and_patch_qe5.3.0.sh
+./download_and_patch_qe6.2.1.sh
 \end{verbatim}
 After running the patch, you must configure Quantum ESPRESSO with
-the HDF5 capability enabled, i.e.
+the HDF5 capability enabled in either way:
+\begin{itemize}
+\item if your system already has HDF5 installed with Fortran, use the -{}-with-hdf5 configuration option.
 \begin{verbatim}
-cd espresso-5.3.0
-./configure --with-hdf5 HDF5_DIR=/opt/local   # Specify HDF5 base directory
+cd espresso-6.2.1
+./configure --with-hdf5=/opt/local   # Specify HDF5 base directory
 \end{verbatim}
+   Currently HDF5 support in QE itself is preliminary. To enable use of pw2qmcpack
+   but use the old non-HDF5 I/O within QE, replace \texttt{-D\_\_HDF5} with \texttt{-D\_\_HDF5\_C} in make.inc.
+\item if your system has HDF5 with C only, manually edit make.inc by adding \texttt{-D\_\_HDF5\_C} and \texttt{-DH5\_USE\_16\_API}
+   in \texttt{DFLAGS} and provide include and library path in \texttt{IFLAGS} and \texttt{HDF5\_LIB}
+\end{itemize}
 
 The complete process is described in external\_codes/quantum\_espresso/README.
 

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -359,8 +359,10 @@ struct SplineAdoptorReader: public BsplineReaderBase
       double total_norm = compute_norm(cG);
       if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
       {
-        app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
-                    << ", computed from plane wave coefficients!" << std::endl;
+        std::cerr << "The orbital " << iorb << " has a wrong norm " << total_norm
+                  << ", computed from plane wave coefficients!" << std::endl
+                  << "This may indicate a problem with the HDF5 library versions used "
+                  << "during wavefunction conversion or read." << std::endl;
         APP_ABORT("SplineAdoptorReader Wrong orbital norm!");
       }
       fft_spline(cG,ti,0);
@@ -421,8 +423,10 @@ struct SplineAdoptorReader: public BsplineReaderBase
         double total_norm = compute_norm(cG);
         if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
         {
-          app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
-                      << ", computed from plane wave coefficients!" << std::endl;
+          std::cerr << "The orbital " << iorb << " has a wrong norm " << total_norm
+                    << ", computed from plane wave coefficients!" << std::endl
+                    << "This may indicate a problem with the HDF5 library versions used "
+                    << "during wavefunction conversion or read." << std::endl;
           APP_ABORT("SplineAdoptorReader Wrong orbital norm!");
         }
         fft_spline(cG,ti,ib);

--- a/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
@@ -817,8 +817,10 @@ struct SplineHybridAdoptorReader: public BsplineReaderBase
         double total_norm = compute_norm(cG);
         if(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE)
         {
-          app_error() << "The orbital " << iorb << " has a wrong norm " << total_norm
-                      << ", computed from plane wave coefficients!" << std::endl;
+          std::cerr << "The orbital " << iorb << " has a wrong norm " << total_norm
+                    << ", computed from plane wave coefficients!" << std::endl
+                    << "This may indicate a problem with the HDF5 library versions used "
+                    << "during wavefunction conversion or read." << std::endl;
           APP_ABORT("SplineHybridAdoptorReader Wrong orbital norm!");
         }
         fft_spline(cG,ti);


### PR DESCRIPTION
Add orbital norm check in pw2qmcpack of the qe 6.2.1 patch.
Update orbital norm check error message in QMCPACK.
Closes #763

Update manual section about the installation of pw2qmcpack.
Closes #681