### PR TITLE
Cleaning orbital base

### DIFF
--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -97,7 +97,7 @@ void AGPDeterminant::resetTargetParticleSet(ParticleSet& P)
   GeminalBasis->resetTargetParticleSet(P);
 }
 
-/** Calculate the value of the Dirac determinant for particles
+/** Calculate the log value of the Dirac determinant for particles
  *@param P input configuration containing N particles
  *@param G a vector containing N gradients
  *@param L a vector containing N laplacians
@@ -107,73 +107,6 @@ void AGPDeterminant::resetTargetParticleSet(ParticleSet& P)
  *contribution of the determinant to G(radient) and L(aplacian)
  *for local energy calculations.
  */
-AGPDeterminant::ValueType
-AGPDeterminant::evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
-{
-  APP_ABORT("WHO's calling AGPDeterminant::evaluate!!");
-  return std::exp(LogValue);
-  ////GeminalBasis->evaluate(P);
-  //GeminalBasis->evaluateForWalkerMove(P);//@@
-  ///* evaluate psi_up(iat)= \sum_{j} C_{ij} \phi_j^{u}(r_{iat})
-  // * psi_down(iat-Nup) =  \sum_{j} C_{ij} \phi_j^{d}(r_{iat})
-  // */
-  //MatrixOperators::product(GeminalBasis->Y, Lambda, phiT);
-  //for(int u=0; u<Nup; u++)
-  //{
-  //  for(int d=0, jat=Nup; d<Ndown; d++,jat++) //paired block
-  //  {
-  //    //psiM(d,u) = BLAS::dot(BasisSize,phiT[u],GeminalBasis->y(jat));
-  //    psiM(d,u) = BLAS::dot(BasisSize,phiT[u],GeminalBasis->Y[jat]);//@@
-  //  }
-  //  for(int d=Ndown,unpaired=0; d<Nup; d++,unpaired++)//unpaired block Ndown x unpaired
-  //  {
-  //    //psiM(d,u) = BLAS::dot(BasisSize,LambdaUP[unpaired],GeminalBasis->y(u));
-  //    psiM(d,u) = BLAS::dot(BasisSize,LambdaUP[unpaired],GeminalBasis->Y[u]);//@@
-  //  }
-  //}
-  //CurrentDet = Invert(psiM.data(),Nup,Nup,WorkSpace.data(),Pivot.data());
-  //for(int iat=0; iat<Nup; iat++)
-  //{
-  //  GradType rv;
-  //  ValueType lap=0;
-  //  int jat=Nup;
-  //  for(int d=0; d<Ndown; d++,jat++)
-  //  {
-  //    ValueType dfac=psiM(iat,d);
-  //    //rv += dfac*dot(phiT[jat],GeminalBasis->dy(iat),BasisSize);
-  //    //lap += dfac*dot(phiT[jat],GeminalBasis->d2y(iat),BasisSize);
-  //    rv += dfac*dot(phiT[jat],GeminalBasis->dY[iat],BasisSize);//@@
-  //    lap += dfac*dot(phiT[jat],GeminalBasis->d2Y[iat],BasisSize);//@@
-  //  }
-  //  for(int d=Ndown,unpaired=0; d<Nup; d++,unpaired++)
-  //  {
-  //    ValueType dfac=psiM(iat,d);
-  //    //rv += dfac*dot(LambdaUP[unpaired],GeminalBasis->dy(iat),BasisSize);
-  //    //lap += dfac*dot(LambdaUP[unpaired],GeminalBasis->d2y(iat),BasisSize);
-  //    rv += dfac*dot(LambdaUP[unpaired],GeminalBasis->dY[iat],BasisSize);//@@
-  //    lap += dfac*dot(LambdaUP[unpaired],GeminalBasis->d2Y[iat],BasisSize);//@@
-  //  }
-  //  G(iat) += rv;
-  //  L(iat) += lap-dot(rv,rv);
-  //}
-  //for(int jat=Nup,d=0; jat<NumPtcls; jat++,d++)
-  //{
-  //  GradType rv;
-  //  ValueType lap=0;
-  //  for(int u=0; u<Nup; u++)
-  //  {
-  //    ValueType dfac=psiM(u,d);
-  //    //rv += dfac*dot(phiT[u],GeminalBasis->dy(jat),BasisSize);
-  //    //lap += dfac*dot(phiT[u],GeminalBasis->d2y(jat),BasisSize);
-  //    rv += dfac*dot(phiT[u],GeminalBasis->dY[jat],BasisSize);//@@
-  //    lap += dfac*dot(phiT[u],GeminalBasis->d2Y[jat],BasisSize);//@@
-  //  }
-  //  G(jat) += rv;
-  //  L(jat) += lap-dot(rv,rv);
-  //}
-  //return CurrentDet;
-}
-
 AGPDeterminant::ValueType
 AGPDeterminant::evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/AGPDeterminant.h
+++ b/src/QMCWaveFunctions/AGPDeterminant.h
@@ -85,17 +85,7 @@ public:
 
   void resizeByWalkers(int nwalkers);
 
-  ///evaluate log of determinant for a particle set: should not be called
-  ValueType
-  evaluateLog(ParticleSet& P,
-              ParticleSet::ParticleGradient_t& G,
-              ParticleSet::ParticleLaplacian_t& L);
-  //{
-  //  ValueType psi=evaluate(P,G,L);
-  //  return LogValue = evaluateLogAndPhase(psi,PhaseValue);
-  //}
-
-  /** Calculate the value of the Dirac determinant for particles
+  /** Calculate the log value of the Dirac determinant for particles
    *@param P input configuration containing N particles
    *@param G a vector containing N gradients
    *@param L a vector containing N laplacians
@@ -106,9 +96,9 @@ public:
    *for local energy calculations.
    */
   ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L);
+  evaluateLog(ParticleSet& P,
+              ParticleSet::ParticleGradient_t& G,
+              ParticleSet::ParticleLaplacian_t& L);
 
   OrbitalBasePtr makeClone(ParticleSet& tqp) const;
 

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -32,16 +32,6 @@ public:
 
   ConstantOrbital() : FakeGradRatio(1.0) {}
 
-  virtual ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L) override
-  {
-    G = 0.0;
-    L = 0.0;
-    return 1.0;
-  }
-
   virtual RealType
   evaluateLog(ParticleSet& P,
               ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) override

--- a/src/QMCWaveFunctions/FDLRWfn.cpp
+++ b/src/QMCWaveFunctions/FDLRWfn.cpp
@@ -317,11 +317,6 @@ namespace qmcplusplus {
     throw std::runtime_error("FDLRWfn::resetTargetParticleSet not yet implemented");
   }
 
-  FDLRWfn::ValueType FDLRWfn::evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) {
-    throw std::runtime_error("FDLRWfn::evaluate not yet implemented");
-    return 0.0;
-  }
-
   ///////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief  Evaluates the log of the FDLR wave function, and adds the gradient and laplacian
   ///         of the log of the FDLR wave function to the running total gradient and laplacian.

--- a/src/QMCWaveFunctions/FDLRWfn.h
+++ b/src/QMCWaveFunctions/FDLRWfn.h
@@ -170,8 +170,6 @@ namespace qmcplusplus {
 
     void resetTargetParticleSet(ParticleSet& P);
 
-    ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
-
     RealType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
     RealType evaluateLogFDLR(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.cpp
@@ -553,7 +553,7 @@ DiracDeterminantBase::evalGradSource
 }
 
 
-/** Calculate the value of the Dirac determinant for particles
+/** Calculate the log value of the Dirac determinant for particles
  *@param P input configuration containing N particles
  *@param G a vector containing N gradients
  *@param L a vector containing N laplacians
@@ -563,21 +563,6 @@ DiracDeterminantBase::evalGradSource
  *contribution of the determinant to G(radient) and L(aplacian)
  *for local energy calculations.
  */
-DiracDeterminantBase::ValueType
-DiracDeterminantBase::evaluate(ParticleSet& P,
-                               ParticleSet::ParticleGradient_t& G,
-                               ParticleSet::ParticleLaplacian_t& L)
-{
-  RealType logval = evaluateLog(P, G, L);
-#if defined(QMC_COMPLEX)
-  RealType ratioMag = std::exp(logval);
-  return std::complex<OHMMS_PRECISION>(std::cos(PhaseValue)*ratioMag,std::sin(PhaseValue)*ratioMag);
-#else
-  return std::cos(PhaseValue)*std::exp(logval);
-#endif
-}
-
-
 DiracDeterminantBase::RealType
 DiracDeterminantBase::evaluateLog(ParticleSet& P,
                                   ParticleSet::ParticleGradient_t& G,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -228,11 +228,6 @@ public:
 
   virtual void recompute(ParticleSet& P);
 
-  virtual ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L);
-           
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi);
 
   virtual OrbitalBasePtr makeClone(ParticleSet& tqp) const;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -495,6 +495,16 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
   APP_ABORT("Finished testL: Aborting \n");
 }
 
+/** Calculate the log value of the Dirac determinant for particles
+ *@param P input configuration containing N particles
+ *@param G a vector containing N gradients
+ *@param L a vector containing N laplacians
+ *@return the value of the determinant
+ *
+ *\f$ (first,first+nel). \f$  Add the gradient and laplacian
+ *contribution of the determinant to G(radient) and L(aplacian)
+ *for local energy calculations.
+ */
 DiracDeterminantWithBackflow::RealType
 DiracDeterminantWithBackflow::evaluateLog(ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
@@ -612,31 +622,6 @@ void DiracDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat)
 void DiracDeterminantWithBackflow::restore(int iat)
 {
   curRatio=1.0;
-}
-
-
-/** Calculate the value of the Dirac determinant for particles
- *@param P input configuration containing N particles
- *@param G a vector containing N gradients
- *@param L a vector containing N laplacians
- *@return the value of the determinant
- *
- *\f$ (first,first+nel). \f$  Add the gradient and laplacian
- *contribution of the determinant to G(radient) and L(aplacian)
- *for local energy calculations.
- */
-DiracDeterminantWithBackflow::ValueType
-DiracDeterminantWithBackflow::evaluate(ParticleSet& P,
-                                       ParticleSet::ParticleGradient_t& G,
-                                       ParticleSet::ParticleLaplacian_t& L)
-{
-  RealType logval = evaluateLog(P, G, L);
-#if defined(QMC_COMPLEX)
-  RealType ratioMag = std::exp(logval);
-  return std::complex<OHMMS_PRECISION>(std::cos(PhaseValue)*ratioMag,std::sin(PhaseValue)*ratioMag);
-#else
-  return std::cos(PhaseValue)*std::exp(logval);
-#endif
 }
 
 void

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -148,11 +148,6 @@ public:
               ParticleSet::ParticleGradient_t& G,
               ParticleSet::ParticleLaplacian_t& L) ;
 
-  ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L);
-
   OrbitalBasePtr makeClone(ParticleSet& tqp) const;
 
   /** cloning function

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -164,7 +164,8 @@ OrbitalBase::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P
     spo_up->prepareFor(i);
     grads_up[i]=0.0;
     lapls_up[i]=0.0;
-    detValues_up[i]=dets_up[i]->evaluate(P,grads_up[i],lapls_up[i]);
+    dets_up[i]->evaluateLog(P,grads_up[i],lapls_up[i]);
+    detValues_up[i]=dets_up[i]->getValue();
     // need \nabla^2 Det / Det
     for(int k=FirstIndex_up; k<LastIndex_up; k++)
       lapls_up[i][k] += dot(grads_up[i][k],grads_up[i][k]);
@@ -174,7 +175,8 @@ OrbitalBase::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P
     spo_dn->prepareFor(i);
     grads_dn[i]=0.0;
     lapls_dn[i]=0.0;
-    detValues_dn[i]=dets_dn[i]->evaluate(P,grads_dn[i],lapls_dn[i]);
+    dets_dn[i]->evaluateLog(P,grads_dn[i],lapls_dn[i]);
+    detValues_dn[i]=dets_dn[i]->getValue();
     // need \nabla^2 Det / Det
     for(int k=FirstIndex_dn; k<LastIndex_dn; k++)
       lapls_dn[i][k] += dot(grads_dn[i][k],grads_dn[i][k]);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -125,7 +125,8 @@ OrbitalBase::ValueType MultiSlaterDeterminantWithBackflow::evaluate(ParticleSet&
     spo_up->prepareFor(i);
     grads_up[i]=0.0;
     lapls_up[i]=0.0;
-    detValues_up[i]=dets_up[i]->evaluate(BFTrans->QP,grads_up[i],lapls_up[i]);
+    dets_up[i]->evaluateLog(BFTrans->QP,grads_up[i],lapls_up[i]);
+    detValues_up[i]=dets_up[i]->getValue();
     // need \nabla^2 Det / Det
     for(int k=0; k<numP; k++)
       lapls_up[i][k] += dot(grads_up[i][k],grads_up[i][k]);
@@ -135,7 +136,8 @@ OrbitalBase::ValueType MultiSlaterDeterminantWithBackflow::evaluate(ParticleSet&
     spo_dn->prepareFor(i);
     grads_dn[i]=0.0;
     lapls_dn[i]=0.0;
-    detValues_dn[i]=dets_dn[i]->evaluate(BFTrans->QP,grads_dn[i],lapls_dn[i]);
+    dets_dn[i]->evaluateLog(BFTrans->QP,grads_dn[i],lapls_dn[i]);
+    detValues_dn[i]=dets_dn[i]->getValue();
     // need \nabla^2 Det / Det
     for(int k=0; k<numP; k++)
       lapls_dn[i][k] += dot(grads_dn[i][k],grads_dn[i][k]);

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -123,15 +123,6 @@ void SlaterDet::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& r
     Dets[i]->evaluateRatiosAlltoOne(P, ratios);
 }
 
-SlaterDet::ValueType SlaterDet::evaluate(ParticleSet& P,
-    ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
-{
-  ValueType psi = 1.0;
-  for (int i = 0; i < Dets.size(); i++)
-    psi *= Dets[i]->evaluate(P, G, L);
-  return psi;
-}
-
 SlaterDet::RealType SlaterDet::evaluateLog(ParticleSet& P,
     ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -85,11 +85,6 @@ public:
   virtual void resetTargetParticleSet(ParticleSet& P);
 
   virtual
-  ValueType evaluate(ParticleSet& P
-                     ,ParticleSet::ParticleGradient_t& G
-                     ,ParticleSet::ParticleLaplacian_t& L);
-
-  virtual
   RealType evaluateLog(ParticleSet& P
                        ,ParticleSet::ParticleGradient_t& G
                        ,ParticleSet::ParticleLaplacian_t& L);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetOpt.cpp
@@ -249,29 +249,6 @@ void SlaterDetOpt::resetTargetParticleSet(ParticleSet& P) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-/// \brief  Evaluates the determinant value and adds the gradient and laplacian of the
-///         log of the determinant to the total gradient and laplacian
-///
-/// \param[in]      P              the particle set
-/// \param[in,out]  G              gradient to add to
-/// \param[in,out]  L              laplacian to add to
-///
-/// \return  the determinant value
-///
-///////////////////////////////////////////////////////////////////////////////////////////////////
-OrbitalBase::ValueType SlaterDetOpt::evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) {
-  RealType logval = evaluateLog(P, G, L);
-  // Note that this class probably isn't implemented with complex wave
-  // functions yet, but I'll leave this here anyway...
-#if defined(QMC_COMPLEX)
-  RealType magnitude = std::exp(logval);
-  return std::complex<OHMMS_PRECISION>(std::cos(PhaseValue)*magnitude, std::sin(PhaseValue)*magnitude);
-#else
-  return std::cos(PhaseValue)*std::exp(logval);
-#endif
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  Evaluates the Slater determinant's matrix, its inverse, its first derivatives w.r.t.
 ///         particle positions, and its summed second derivatives w.r.t. particle positions.
 ///         Returns the log of the determinant value.

--- a/src/QMCWaveFunctions/Fermion/SlaterDetOpt.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetOpt.h
@@ -167,8 +167,6 @@ class SlaterDetOpt : public DiracDeterminantBase {
 
     void resetTargetParticleSet(ParticleSet& P);
 
-    ValueType evaluate(ParticleSet& P ,ParticleSet::ParticleGradient_t& G ,ParticleSet::ParticleLaplacian_t& L);
-
     RealType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
     GradType evalGrad(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -52,18 +52,6 @@ void SlaterDetWithBackflow::resetTargetParticleSet(ParticleSet& P)
   }
 }
 
-SlaterDetWithBackflow::ValueType
-SlaterDetWithBackflow::evaluate(ParticleSet& P,
-                                ParticleSet::ParticleGradient_t& G,
-                                ParticleSet::ParticleLaplacian_t& L)
-{
-  BFTrans->evaluate(P);
-  ValueType psi = 1.0;
-  for(int i=0; i<Dets.size(); i++)
-    psi *= Dets[i]->evaluate(P,G,L);
-  return psi;
-}
-
 SlaterDetWithBackflow::RealType
 SlaterDetWithBackflow::evaluateLog(ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -80,10 +80,6 @@ public:
     }
   }
 
-  ValueType evaluate(ParticleSet& P
-                     ,ParticleSet::ParticleGradient_t& G
-                     ,ParticleSet::ParticleLaplacian_t& L);
-
   RealType evaluateLog(ParticleSet& P
                        ,ParticleSet::ParticleGradient_t& G
                        ,ParticleSet::ParticleLaplacian_t& L);

--- a/src/QMCWaveFunctions/IonOrbital.cpp
+++ b/src/QMCWaveFunctions/IonOrbital.cpp
@@ -88,14 +88,6 @@ IonOrbital::evaluateLog(ParticleSet& P,
   return LogValue;
 }
 
-ValueType
-IonOrbital::evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-{
-  return std::exp(evaluateLog(P,G,L));
-}
-
 /** evaluate the ratio \f$exp(U(iat)-U_0(iat))\f$
  * @param P active particle set
  * @param iat particle that has been moved.

--- a/src/QMCWaveFunctions/IonOrbital.h
+++ b/src/QMCWaveFunctions/IonOrbital.h
@@ -65,11 +65,6 @@ public:
 
   void resetTargetParticleSet(ParticleSet& P);
 
-  ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L);
-
   RealType evaluateLog(ParticleSet& P,
                        ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -124,13 +124,6 @@ struct  J1OrbitalSoA : public OrbitalBase
     return LogValue;
   }
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-  
   ValueType ratio(ParticleSet& P, int iat)
   {
     UpdateMode=ORB_PBYP_RATIO;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -178,14 +178,6 @@ struct  J2OrbitalSoA : public OrbitalBase
   /** recompute internal data assuming distance table is fully ready */
   void recompute(ParticleSet& P);
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    evaluateLog(P,G,L);
-    return std::exp(LogValue);
-  }
-
   ValueType ratio(ParticleSet& P, int iat);
   void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
   {

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -410,13 +410,6 @@ public:
     return LogValue;
   }
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   ValueType ratio(ParticleSet& P, int iat)
   {
     UpdateMode=ORB_PBYP_RATIO;

--- a/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/LRTwoBodyJastrow.h
@@ -160,14 +160,6 @@ public:
     Fk_0=Fk;
   }
 
-  inline ValueType evaluate(ParticleSet& P,
-                            ParticleSet::ParticleGradient_t& G,
-                            ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
-
   ValueType ratio(ParticleSet& P, int iat);
 
   ValueType ratioGrad(ParticleSet& P, int iat, GradType & g);

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
@@ -224,13 +224,6 @@ public:
     return LogValue;
   }
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-  
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   {
     LogValue=0.0;

--- a/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
@@ -239,12 +239,6 @@ public:
     return LogValue;
   }
 
-  ValueType evaluate(ParticleSet& P
-                     , ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   /** evaluate the ratio \f$exp(U(iat)-U_0(iat))\f$
    * @param P active particle set
    * @param iat particle that has been moved.

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -73,13 +73,6 @@ struct RPAJastrow: public OrbitalBase
 
   void resetTargetParticleSet(ParticleSet& P);
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   RealType evaluateLog(ParticleSet& P,
                        ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 

--- a/src/QMCWaveFunctions/Jastrow/ThreeBodyBlockSparse.h
+++ b/src/QMCWaveFunctions/Jastrow/ThreeBodyBlockSparse.h
@@ -50,13 +50,6 @@ public:
                        ParticleSet::ParticleGradient_t& G,
                        ParticleSet::ParticleLaplacian_t& L);
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   ValueType ratio(ParticleSet& P, int iat);
 
   void restore(int iat);

--- a/src/QMCWaveFunctions/Jastrow/ThreeBodyGeminal.h
+++ b/src/QMCWaveFunctions/Jastrow/ThreeBodyGeminal.h
@@ -48,12 +48,6 @@ public:
   RealType evaluateLog(ParticleSet& P,
                        ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   ValueType ratio(ParticleSet& P, int iat);
 
   void restore(int iat);

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -292,13 +292,6 @@ public:
     return LogValue;
   }
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-  
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   {
     LogValue=0.0;

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
@@ -493,13 +493,6 @@ public:
     // }
   }
 
-  ValueType evaluate(ParticleSet& P,
-                     ParticleSet::ParticleGradient_t& G,
-                     ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
   inline GradType evalGradSourceFD(ParticleSet& P,
                                    ParticleSet& source, int isrc)
   {

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -165,14 +165,6 @@ public:
                        ParticleSet::ParticleGradient_t& G,
                        ParticleSet::ParticleLaplacian_t& L);
 
-  inline ValueType evaluate(ParticleSet& P,
-                            ParticleSet::ParticleGradient_t& G,
-                            ParticleSet::ParticleLaplacian_t& L)
-  {
-    return std::exp(evaluateLog(P,G,L));
-  }
-
-
   ValueType ratio(ParticleSet& P, int iat);
 
   GradType evalGrad(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -35,12 +35,11 @@ public:
 
   LinearOrbital() {coeff[0]=1.0; coeff[1]= 2.0; coeff[2]=3.0;}
 
-  virtual ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L)
+  virtual RealType
+  evaluateLog(ParticleSet& P,
+              ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    APP_ABORT("LinearOrbital. evaluate");
+    APP_ABORT("LinearOrbital. evaluateLog");
     ValueType v = 0.0;
     for (int i = 0; i < P.R.size(); i++) {
       for (int d = 0; d < OHMMS_DIM; d++) {
@@ -49,17 +48,8 @@ public:
       G[i] = coeff;
     }
     L = 0.0;
-    return v;
-  }
-
-  virtual RealType
-  evaluateLog(ParticleSet& P,
-              ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
-  {
-    APP_ABORT("LinearOrbital. evaluateLog");
-    G = 0.0;
-    L = 0.0;
-    return 0.0;
+    LogValue = evaluateLogAndPhase(v,PhaseValue);
+    return LogValue;
   }
 
   virtual void acceptMove(ParticleSet& P, int iat) {}

--- a/src/QMCWaveFunctions/OrbitalBase.h
+++ b/src/QMCWaveFunctions/OrbitalBase.h
@@ -180,6 +180,17 @@ struct OrbitalBase: public QMCTraits
   ///assign a differential orbital
   virtual void setDiffOrbital(DiffOrbitalBasePtr d);
 
+  ///assembles the full value from LogValue and PhaseValue
+  ValueType getValue() const
+  {
+#if defined(QMC_COMPLEX)
+    RealType ratioMag = std::exp(LogValue);
+    return ValueType(std::cos(PhaseValue)*ratioMag,std::sin(PhaseValue)*ratioMag);
+#else
+    return std::exp(LogValue);
+#endif
+  }
+
   /** check in optimizable parameters
    * @param active a super set of optimizable variables
    *
@@ -206,24 +217,13 @@ struct OrbitalBase: public QMCTraits
   virtual void resetTargetParticleSet(ParticleSet& P)=0;
 
   /** evaluate the value of the orbital for a configuration P.R
-   *@param P  active ParticleSet
-   *@param G  Gradients
-   *@param L  Laplacians
-   *@return the value
+   * @param P  active ParticleSet
+   * @param G Gradients, \f$\nabla\ln\Psi\f$
+   * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
+   * @return the log value
    *
    *Mainly for walker-by-walker move. The initial stage of particle-by-particle
    *move also uses this.
-   */
-  virtual ValueType
-  evaluate(ParticleSet& P,
-           ParticleSet::ParticleGradient_t& G,
-           ParticleSet::ParticleLaplacian_t& L) = 0;
-
-  /** evaluate the value of the orbital
-   * @param P active ParticleSet
-   * @param G Gradients, \f$\nabla\ln\Psi\f$
-   * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
-   *
    */
   virtual RealType
   evaluateLog(ParticleSet& P,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -311,29 +311,6 @@ void TrialWaveFunction::evaluateHessian(ParticleSet & P, HessVector_t& grad_grad
  // app_log()<<" TrialWavefunction::Hessian = "<<grad_grad_psi<< std::endl;
 }
 
-
-/** evaluate the value of a many-body wave function
-*@param P input configuration containing N particles
-*@return the value of many-body wave function
-*
-*Upon return, the gradient and laplacian operators are added by the components.
-*/
-TrialWaveFunction::ValueType TrialWaveFunction::evaluate(ParticleSet& P)
-{
-  //TAU_PROFILE("TrialWaveFunction::evaluate","ParticleSet& P", TAU_USER);
-  P.G = 0.0;
-  P.L = 0.0;
-  ValueType psi(1.0);
-  for(size_t i=0,n=Z.size(); i<n; ++i)
-  {
-    psi *= Z[i]->evaluate(P, P.G, P.L);
-  }
-  //for(int iat=0; iat<P.getTotalNum(); iat++)
-  // std::cout << P.G[iat] << " " << P.L[iat] << std::endl;
-  LogValue = evaluateLogAndPhase(psi,PhaseValue);
-  return psi;
-}
-
 TrialWaveFunction::RealType TrialWaveFunction::ratio(ParticleSet& P,int iat)
 {
   //TAU_PROFILE("TrialWaveFunction::ratio","(ParticleSet& P,int iat)", TAU_USER);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -293,8 +293,6 @@ public:
   void evaluateGradDerivatives(const ParticleSet::ParticleGradient_t& G_in,
                                std::vector<RealType>& dgradlogpsi);
 
-  /** evalaute the values of the wavefunction, gradient and laplacian  for all the walkers */
-  //void evaluate(WalkerSetRef& W, OrbitalBase::ValueVectorType& psi);
   /** evaluate the hessian w.r.t. electronic coordinates of particle iat **/
  // void evaluateHessian(ParticleSet & P, int iat, HessType& grad_grad_psi);
   /** evaluate the hessian hessian w.r.t. electronic coordinates of particle iat **/

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -217,16 +217,6 @@ public:
   /** recursively change the ParticleSet whose G and L are evaluated */
   void resetTargetParticleSet(ParticleSet& P);
 
-  /////Check if aname-ed Single-Particle-Orbital set exists
-  //bool hasSPOSet(const std::string& aname);
-  /////add a Single-Particle-Orbital set
-  //void addSPOSet(OhmmsElementBase* spo);
-  /////return the aname-ed Single-Particle-Orbital set.
-  //OhmmsElementBase* getSPOSet(const std::string& aname);
-
-  /** evalaute the values of the wavefunction, gradient and laplacian  for a walkers */
-  ValueType evaluate(ParticleSet& P);
-
   /** evalaute the values of the wavefunction, gradient and laplacian  for a walkers */
   RealType evaluateLogOnly(ParticleSet& P);
 


### PR DESCRIPTION
Remove evaluate() from TrialWaveFunction and OrbitalBase.
Drivers only needs the log value and evaluateLog is the relevant one.
evaluateLog is more appropriate to use in most cases.
There are still evaluate function left in the MSD part but that operates on a different abstraction layer.
getValue is added in OrbitalBase to assemble LogValue and PhaseValue to a complex number if needed.
So fart it is only needed by the slow MSD implementation.

`virtual void foo() final {};` is a very useful trick for deleting things.