### PR TITLE
nexus: fix default trace plot range in qmca

### DIFF
--- a/nexus/executables/qmca
+++ b/nexus/executables/qmca
@@ -2116,7 +2116,6 @@ class DatAnalyzer(QBase):
         plot(xlims,[smean,smean],'r-')
         plot(xlims,[smean+sstd,smean+sstd],'r-.')
         plot(xlims,[smean-sstd,smean-sstd],'r-.')
-        ylims = qmin,qmax
         return xlims,ylims,s,q
     #end def plot_trace
 
@@ -2701,7 +2700,7 @@ QMCA examples:
                                 dx = max(.1*abs(xminp-xmaxp),1)
                                 xminp -= dx
                                 xmaxp += dx
-                                dy = max(.1*abs(yminp-ymaxp),1)
+                                dy = .1*abs(yminp-ymaxp)
                                 yminp -= dy
                                 ymaxp += dy
                                 xlim([xminp,xmaxp])

--- a/nexus/executables/qmca
+++ b/nexus/executables/qmca
@@ -2591,6 +2591,7 @@ QMCA examples:
             self.file_list = file_list
             self.file_map  = file_map
             self.data = obj(avg=adata)
+            self.prefix_list = ['avg']
         #end if
     #end def load_data
 


### PR DESCRIPTION
Trace plots were often too zoomed out by default in qmca.  A visual range of +/- 2 sigma is restored as the default.