### PR TITLE
Clean up SPOSet Builder creation logic and naming

### DIFF
--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -18,7 +18,7 @@
 #include <Numerics/MatrixOperators.h>
 #include <Utilities/IteratorUtility.h>
 #include <Utilities/string_utils.h>
-#include <QMCWaveFunctions/BasisSetFactory.h>
+#include <QMCWaveFunctions/SPOSetBuilderFactory.h>
 
 
 

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -14,7 +14,7 @@
 
 #include <QMCHamiltonians/OrbitalImages.h>
 #include <OhmmsData/AttributeSet.h>
-#include <QMCWaveFunctions/BasisSetFactory.h>
+#include <QMCWaveFunctions/SPOSetBuilderFactory.h>
 #include <Utilities/unit_conversion.h>
 
 

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -153,7 +153,7 @@ class OrbitalImages : public QMCHamiltonianBase
   ///indices of orbitals within each sposet to evaluate
   std::vector<std::vector<int>*> sposet_indices;
 
-  ///sposets obtained by name from BasisSetFactory
+  ///sposets obtained by name from SPOSetBuilderFactory
   std::vector<SPOSetBase*> sposets;
 
   ///evaluate points at grid cell centers instead of edges

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -149,7 +149,8 @@ bool AGPDeterminantBuilder::put(xmlNodePtr cur)
   if(mySPOSetBuilderFactory == 0)
   {
     mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl,targetPsi,ptclPool);
-    mySPOSetBuilderFactory->createSPOSetBuilder(bPtr,curRoot);
+    mySPOSetBuilderFactory->createSPOSetBuilder(curRoot);
+    mySPOSetBuilderFactory->loadBasisSetFromXML(bPtr);
   }
 // mmorales: this needs to be fixed after changes to BasisSetfactory
 //    BasisSetBase<RealType>* myBasisSet=mySPOSetBuilderFactory->getBasisSet();

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -18,7 +18,7 @@
  */
 #include "QMCWaveFunctions/AGPDeterminant.h"
 #include "QMCWaveFunctions/AGPDeterminantBuilder.h"
-#include "QMCWaveFunctions/MolecularOrbitals/MolecularBasisBuilder.h"
+#include "QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h"
 //#include "QMCWaveFunctions/MolecularOrbitals/GridMolecularOrbitals.h"
 //#include "QMCWaveFunctions/MolecularOrbitals/STOMolecularOrbitals.h"
 //#include "QMCWaveFunctions/MolecularOrbitals/GTOMolecularOrbitals.h"

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
 
 AGPDeterminantBuilder::AGPDeterminantBuilder(ParticleSet& els, TrialWaveFunction& wfs,
     PtclPoolType& pset):
-  OrbitalBuilderBase(els,wfs), ptclPool(pset), myBasisSetFactory(0), agpDet(0)
+  OrbitalBuilderBase(els,wfs), ptclPool(pset), mySPOSetBuilderFactory(0), agpDet(0)
 {
 }
 
@@ -146,14 +146,14 @@ bool AGPDeterminantBuilder::put(xmlNodePtr cur)
     app_error() << "    Missing <basisset/> or <coefficients/>" << std::endl;
     return false;
   }
-  if(myBasisSetFactory == 0)
+  if(mySPOSetBuilderFactory == 0)
   {
-    myBasisSetFactory = new BasisSetFactory(targetPtcl,targetPsi,ptclPool);
-    myBasisSetFactory->createBasisSet(bPtr,curRoot);
+    mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl,targetPsi,ptclPool);
+    mySPOSetBuilderFactory->createBasisSet(bPtr,curRoot);
   }
 // mmorales: this needs to be fixed after changes to BasisSetfactory
-//    BasisSetBase<RealType>* myBasisSet=myBasisSetFactory->getBasisSet();
-  BasisSetBase<RealType>* myBasisSet=0; //=myBasisSetFactory->getBasisSet();
+//    BasisSetBase<RealType>* myBasisSet=mySPOSetBuilderFactory->getBasisSet();
+  BasisSetBase<RealType>* myBasisSet=0; //=mySPOSetBuilderFactory->getBasisSet();
   int nup=targetPtcl.first(1), ndown=0;
   if(targetPtcl.groups()>1)
     ndown = targetPtcl.first(2)-nup;

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -149,7 +149,7 @@ bool AGPDeterminantBuilder::put(xmlNodePtr cur)
   if(mySPOSetBuilderFactory == 0)
   {
     mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl,targetPsi,ptclPool);
-    mySPOSetBuilderFactory->createBasisSet(bPtr,curRoot);
+    mySPOSetBuilderFactory->createSPOSetBuilder(bPtr,curRoot);
   }
 // mmorales: this needs to be fixed after changes to BasisSetfactory
 //    BasisSetBase<RealType>* myBasisSet=mySPOSetBuilderFactory->getBasisSet();

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.h
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.h
@@ -18,7 +18,7 @@
 #ifndef QMCPLUSPLUS_AGPDETERMINANT_GEMINALBUILDER_H
 #define QMCPLUSPLUS_AGPDETERMINANT_GEMINALBUILDER_H
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
-#include "QMCWaveFunctions/BasisSetFactory.h"
+#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 namespace qmcplusplus
 {
 
@@ -42,7 +42,7 @@ protected:
   ///reference to a PtclPoolType
   PtclPoolType& ptclPool;
   ///basiset Factory
-  BasisSetFactory* myBasisSetFactory;
+  SPOSetBuilderFactory* mySPOSetBuilderFactory;
   ///AGPDeterminant
   AGPDeterminant* agpDet;
   std::string funcOpt;

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -195,7 +195,8 @@ struct SPOSetBuilder: public QMCTraits, public MPIObjectBase
 
   SPOSetBuilder();
   virtual ~SPOSetBuilder() {}
-  virtual bool put(xmlNodePtr cur)=0;
+  /// load from XML if there is a basisset
+  virtual void loadBasisSetFromXML(xmlNodePtr cur) {}
 
   /// reserve space for states (usually only one set, multiple for e.g. spin dependent einspline)
   void reserve_states(int nsets=1);

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -22,12 +22,7 @@
 #define QMCPLUSPLUS_BASISSETBASE_H
 
 #include "Particle/ParticleSet.h"
-#include "Message/MPIObjectBase.h"
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
-#include "QMCWaveFunctions/SPOSetInfo.h"
-#include <QMCWaveFunctions/SPOSetInputInfo.h>
-#include "QMCWaveFunctions/SPOSetBase.h"
-
 
 namespace qmcplusplus
 {
@@ -162,67 +157,6 @@ struct RealBasisSetBase
   virtual void setBasisSetSize(int nbs)=0;
   virtual void evaluateVGL(const ParticleSet& P, int iat, vgl_type& vgl)=0;
   virtual void evaluateV(const ParticleSet& P, int iat, value_type* restrict vals)=0;
-};
-
-
-/** base class for the real BasisSet builder
- *
- * \warning {
- * We have not quite figured out how to use real/complex efficiently.
- * There are three cases we have to deal with
- * - real basis functions and real coefficients
- * - real basis functions and complex coefficients
- * - complex basis functions and complex coefficients
- * For now, we decide to keep both real and complex basis sets and expect
- * the user classes {\bf KNOW} what they need to use.
- * }
- */
-struct SPOSetBuilder: public QMCTraits, public MPIObjectBase
-{
-  typedef std::map<std::string,SPOSetBase*> SPOPool_t;
-  typedef std::vector<int> indices_t;
-  typedef std::vector<RealType> energies_t;
-
-
-  /// whether implementation conforms only to legacy standard
-  bool legacy;
-
-  /// state info of all possible states available in the basis
-  std::vector<SPOSetInfo*> states;
-
-  /// list of all sposets created by this builder
-  std::vector<SPOSetBase*> sposets;
-
-  SPOSetBuilder();
-  virtual ~SPOSetBuilder() {}
-  /// load from XML if there is a basisset
-  virtual void loadBasisSetFromXML(xmlNodePtr cur) {}
-
-  /// reserve space for states (usually only one set, multiple for e.g. spin dependent einspline)
-  void reserve_states(int nsets=1);
-
-  /// allow modification of state information
-  inline void modify_states(int index=0)
-  {
-    states[index]->modify();
-  }
-
-  /// clear state information
-  inline void clear_states(int index=0)
-  {
-    states[index]->clear();
-  }
-
-  /// create an sposet from xml (legacy)
-  virtual SPOSetBase* createSPOSetFromXML(xmlNodePtr cur)=0;
-
-  /// create an sposet from a general xml request
-  virtual SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input_info);
-
-  /// create an sposet from xml and save the resulting SPOSet
-  SPOSetBase* createSPOSet(xmlNodePtr cur);
-
-
 };
 
 }

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -177,7 +177,7 @@ struct RealBasisSetBase
  * the user classes {\bf KNOW} what they need to use.
  * }
  */
-struct BasisSetBuilder: public QMCTraits, public MPIObjectBase
+struct SPOSetBuilder: public QMCTraits, public MPIObjectBase
 {
   typedef std::map<std::string,SPOSetBase*> SPOPool_t;
   typedef std::vector<int> indices_t;
@@ -193,8 +193,8 @@ struct BasisSetBuilder: public QMCTraits, public MPIObjectBase
   /// list of all sposets created by this builder
   std::vector<SPOSetBase*> sposets;
 
-  BasisSetBuilder();
-  virtual ~BasisSetBuilder() {}
+  SPOSetBuilder();
+  virtual ~SPOSetBuilder() {}
   virtual bool put(xmlNodePtr cur)=0;
 
   /// reserve space for states (usually only one set, multiple for e.g. spin dependent einspline)

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -182,7 +182,7 @@ SET(FERMION_SRCS ${FERMION_SRCS}
   Fermion/DiracDeterminantWithBackflow.cpp
   Fermion/SlaterDetWithBackflow.cpp
   Fermion/MultiSlaterDeterminantWithBackflow.cpp
-  BasisSetFactory.cpp
+  SPOSetBuilderFactory.cpp
   TrialWaveFunction.cpp
   WaveFunctionFactory.cpp
   )

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -22,7 +22,7 @@ SET(WFBASE_SRCS
   OrbitalBase.cpp
   DiffOrbitalBase.cpp
   OrbitalBuilderBase.cpp
-  BasisSetBuilder.cpp
+  SPOSetBuilder.cpp
   SPOInfo.cpp
   SPOSetInfo.cpp
   SPOSetInputInfo.cpp

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -248,8 +248,4 @@ namespace qmcplusplus
     return createSPOSetFromXML(cur);
   }
 
-  bool CompositeSPOSetBuilder::put(xmlNodePtr cur)
-  {
-    return true;
-  }
 }

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -17,7 +17,7 @@
 #include <Utilities/IteratorUtility.h>
 #include <algorithm>
 #include <OhmmsData/AttributeSet.h>
-#include <QMCWaveFunctions/BasisSetFactory.h>
+#include <QMCWaveFunctions/SPOSetBuilderFactory.h>
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -87,10 +87,10 @@ namespace qmcplusplus
 
   };
 
-  struct CompositeSPOSetBuilder : public BasisSetBuilder
+  struct CompositeSPOSetBuilder : public SPOSetBuilder
   {
 
-    //BasisSetBuilder interface
+    //SPOSetBuilder interface
     SPOSetBase* createSPOSetFromXML(xmlNodePtr cur);
 
     SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input);

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -18,6 +18,7 @@
 
 #include <QMCWaveFunctions/SPOSetBase.h>
 #include <QMCWaveFunctions/BasisSetBase.h>
+#include <QMCWaveFunctions/SPOSetBuilderBase.h>
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -18,7 +18,7 @@
 
 #include <QMCWaveFunctions/SPOSetBase.h>
 #include <QMCWaveFunctions/BasisSetBase.h>
-#include <QMCWaveFunctions/SPOSetBuilderBase.h>
+#include <QMCWaveFunctions/SPOSetBuilder.h>
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -95,7 +95,6 @@ namespace qmcplusplus
 
     SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input);
     
-    bool put(xmlNodePtr cur);
   };
 }
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -121,7 +121,7 @@ struct H5OrbSet
 
 /** EinsplineSet builder
  */
-class EinsplineSetBuilder : public BasisSetBuilder
+class EinsplineSetBuilder : public SPOSetBuilder
 {
 public:
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -23,7 +23,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_SET_BUILDER_H
 #define QMCPLUSPLUS_EINSPLINE_SET_BUILDER_H
 
-#include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 #include "QMCWaveFunctions/BandInfo.h"
 #include "QMCWaveFunctions/AtomicOrbital.h"
 #include "QMCWaveFunctions/EinsplineSet.h"

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -162,9 +162,6 @@ public:
   ///destructor
   ~EinsplineSetBuilder();
 
-  /** process xml node to initialize the builder */
-  bool put (xmlNodePtr cur);
-
   /** initialize the Antisymmetric wave function for electrons
    * @param cur the current xml node
    */

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -23,7 +23,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_SET_BUILDER_H
 #define QMCPLUSPLUS_EINSPLINE_SET_BUILDER_H
 
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/BandInfo.h"
 #include "QMCWaveFunctions/AtomicOrbital.h"
 #include "QMCWaveFunctions/EinsplineSet.h"

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -88,15 +88,6 @@ EinsplineSetBuilder::~EinsplineSetBuilder()
 
 
 bool
-EinsplineSetBuilder::put(xmlNodePtr cur)
-{
-  std::string hdfName;
-  OhmmsAttributeSet attribs;
-  attribs.add (hdfName, "href");
-  return attribs.put(XMLRoot);
-}
-
-bool
 EinsplineSetBuilder::CheckLattice()
 {
   update_token(__FILE__,__LINE__,"CheckLattice");

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
@@ -98,12 +98,12 @@ bool ElectronGasComplexOrbitalBuilder::put(xmlNodePtr cur)
   return true;
 }
 
-ElectronGasBasisBuilder::ElectronGasBasisBuilder(ParticleSet& p, xmlNodePtr cur)
+ElectronGasSPOBuilder::ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur)
   :egGrid(p.Lattice),unique_twist(-1.0),has_twist(false)
 {
 }
 
-bool ElectronGasBasisBuilder::put(xmlNodePtr cur)
+bool ElectronGasSPOBuilder::put(xmlNodePtr cur)
 {
   OhmmsAttributeSet aAttrib;
   aAttrib.add(unique_twist,"twist");
@@ -116,9 +116,9 @@ bool ElectronGasBasisBuilder::put(xmlNodePtr cur)
   return true;
 }
 
-SPOSetBase* ElectronGasBasisBuilder::createSPOSetFromXML(xmlNodePtr cur)
+SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
-  app_log() << "ElectronGasBasisBuilder::createSPOSet " << std::endl;
+  app_log() << "ElectronGasSPOBuilder::createSPOSet " << std::endl;
   int nc=0;
   int ns=0;
   PosType twist(0.0);
@@ -136,7 +136,7 @@ SPOSetBase* ElectronGasBasisBuilder::createSPOSetFromXML(xmlNodePtr cur)
   if (nc<0)
   {
     app_error() << "  HEG Invalid Shell." << std::endl;
-    APP_ABORT("ElectronGasBasisBuilder::put");
+    APP_ABORT("ElectronGasSPOBuilder::put");
   }
   egGrid.createGrid(nc,ns,twist);
   EGOSet* spo = new EGOSet(egGrid.kpt,egGrid.mk2,egGrid.deg);
@@ -144,7 +144,7 @@ SPOSetBase* ElectronGasBasisBuilder::createSPOSetFromXML(xmlNodePtr cur)
 }
 
 
-SPOSetBase* ElectronGasBasisBuilder::createSPOSetFromIndices(indices_t& indices)
+SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromIndices(indices_t& indices)
 {
   egGrid.createGrid(indices);
   EGOSet* spo = new EGOSet(egGrid.kpt,egGrid.mk2,egGrid.deg);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
@@ -103,19 +103,6 @@ ElectronGasSPOBuilder::ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur)
 {
 }
 
-bool ElectronGasSPOBuilder::put(xmlNodePtr cur)
-{
-  OhmmsAttributeSet aAttrib;
-  aAttrib.add(unique_twist,"twist");
-  aAttrib.put(cur);
-
-  has_twist = true;
-  for(int d=0;d<OHMMS_DIM;++d)
-    has_twist &= (unique_twist[d]+1.0)>1e-6;
-
-  return true;
-}
-
 SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
   app_log() << "ElectronGasSPOBuilder::createSPOSet " << std::endl;
@@ -131,6 +118,13 @@ SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
   aAttrib.put(cur);
   if(has_twist)
     twist = unique_twist;
+  else
+  {
+    unique_twist = twist;
+    has_twist = true;
+    for(int d=0;d<OHMMS_DIM;++d)
+      has_twist &= (unique_twist[d]+1.0)>1e-6;
+  }
   if(ns>0)
     nc = egGrid.getShellIndex(ns);
   if (nc<0)

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -18,7 +18,7 @@
 
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
 #include "QMCWaveFunctions/SPOSetBase.h"
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 
 

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -120,7 +120,7 @@ public:
 
 /** OrbitalBuilder for Slater determinants of electron-gas
 */
-class ElectronGasBasisBuilder: public BasisSetBuilder
+class ElectronGasBasisBuilder: public SPOSetBuilder
 {
 protected:
   bool has_twist;

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -120,7 +120,7 @@ public:
 
 /** OrbitalBuilder for Slater determinants of electron-gas
 */
-class ElectronGasBasisBuilder: public SPOSetBuilder
+class ElectronGasSPOBuilder: public SPOSetBuilder
 {
 protected:
   bool has_twist;
@@ -129,7 +129,7 @@ protected:
   xmlNodePtr spo_node;
 public:
   ///constructor
-  ElectronGasBasisBuilder(ParticleSet& p, xmlNodePtr cur);
+  ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur);
 
   ///implement virtual function
   bool put(xmlNodePtr cur);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -18,7 +18,7 @@
 
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
 #include "QMCWaveFunctions/SPOSetBase.h"
-#include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 
 

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -131,8 +131,6 @@ public:
   ///constructor
   ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur);
 
-  ///implement virtual function
-  bool put(xmlNodePtr cur);
   /** initialize the Antisymmetric wave function for electrons
   *@param cur the current xml node
   */

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -208,11 +208,6 @@ ElectronGasSPOBuilder::ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur)
 {
 }
 
-bool ElectronGasSPOBuilder::put(xmlNodePtr cur)
-{
-  return true;
-}
-  
 SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
   app_log() << "ElectronGasSPOBuilder::createSPOSet " << std::endl;

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -203,19 +203,19 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
   return true;
 }
 
-ElectronGasBasisBuilder::ElectronGasBasisBuilder(ParticleSet& p, xmlNodePtr cur)
+ElectronGasSPOBuilder::ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur)
   :egGrid(p.Lattice)
 {
 }
 
-bool ElectronGasBasisBuilder::put(xmlNodePtr cur)
+bool ElectronGasSPOBuilder::put(xmlNodePtr cur)
 {
   return true;
 }
   
-SPOSetBase* ElectronGasBasisBuilder::createSPOSetFromXML(xmlNodePtr cur)
+SPOSetBase* ElectronGasSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
-  app_log() << "ElectronGasBasisBuilder::createSPOSet " << std::endl;
+  app_log() << "ElectronGasSPOBuilder::createSPOSet " << std::endl;
   int nc=0;
   int ns=0;
   PosType twist(0.0);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -328,8 +328,6 @@ public:
   ///constructor
   ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur);
 
-  ///implement vritual function
-  bool put(xmlNodePtr cur);
   /** initialize the Antisymmetric wave function for electrons
   *@param cur the current xml node
   */

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -319,14 +319,14 @@ public:
 
 /** OrbitalBuilder for Slater determinants of electron-gas
 */
-class ElectronGasBasisBuilder: public SPOSetBuilder
+class ElectronGasSPOBuilder: public SPOSetBuilder
 {
 protected:
   HEGGrid<RealType,OHMMS_DIM> egGrid;
   xmlNodePtr spo_node;
 public:
   ///constructor
-  ElectronGasBasisBuilder(ParticleSet& p, xmlNodePtr cur);
+  ElectronGasSPOBuilder(ParticleSet& p, xmlNodePtr cur);
 
   ///implement vritual function
   bool put(xmlNodePtr cur);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -21,7 +21,7 @@
 #include <QMCWaveFunctions/SPOSetBase.h>
 #include <config/stdlib/math.h>
 
-#include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 
 #if defined(QMC_COMPLEX)

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -319,7 +319,7 @@ public:
 
 /** OrbitalBuilder for Slater determinants of electron-gas
 */
-class ElectronGasBasisBuilder: public BasisSetBuilder
+class ElectronGasBasisBuilder: public SPOSetBuilder
 {
 protected:
   HEGGrid<RealType,OHMMS_DIM> egGrid;

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -21,7 +21,7 @@
 #include <QMCWaveFunctions/SPOSetBase.h>
 #include <config/stdlib/math.h>
 
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 
 #if defined(QMC_COMPLEX)

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -106,7 +106,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
     getNodeName(cname,cur);
     if (cname == basisset_tag)
     {
-      mySPOSetBuilderFactory->createBasisSet(cur,curRoot);
+      mySPOSetBuilderFactory->createSPOSetBuilder(cur,curRoot);
     }
     else if ( cname == sposet_tag )
     {
@@ -155,7 +155,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
   //{
   //  mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl,targetPsi, ptclPool);
   //  mySPOSetBuilderFactory->setReportLevel(ReportLevel);
-  //  mySPOSetBuilderFactory->createBasisSet(curRoot,curRoot);
+  //  mySPOSetBuilderFactory->createSPOSetBuilder(curRoot,curRoot);
   //}
 
   //sposet_builder is defined outside <determinantset/>
@@ -185,7 +185,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
               spomap[aspo]=aset;
             else
             {
-              mySPOSetBuilderFactory->createBasisSet(cur1,curRoot);
+              mySPOSetBuilderFactory->createSPOSetBuilder(cur1,curRoot);
               aset = mySPOSetBuilderFactory->createSPOSet(cur1);
               if(aset) spomap[aspo]=aset;
             }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -97,6 +97,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
   {//always create one, using singleton and just to access the member functions
     mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl, targetPsi, ptclPool);
     mySPOSetBuilderFactory->setReportLevel(ReportLevel);
+    mySPOSetBuilderFactory->createSPOSetBuilder(curRoot);
   }
 
   //check the basis set
@@ -106,7 +107,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
     getNodeName(cname,cur);
     if (cname == basisset_tag)
     {
-      mySPOSetBuilderFactory->createSPOSetBuilder(cur,curRoot);
+      mySPOSetBuilderFactory->loadBasisSetFromXML(cur);
     }
     else if ( cname == sposet_tag )
     {
@@ -149,15 +150,6 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
     cur = cur->next;
   }
 
-  //missing basiset, e.g. einspline
-  // mmorales: this should not be allowed now, either basisset or sposet must exist
-  //if (mySPOSetBuilderFactory == 0)
-  //{
-  //  mySPOSetBuilderFactory = new SPOSetBuilderFactory(targetPtcl,targetPsi, ptclPool);
-  //  mySPOSetBuilderFactory->setReportLevel(ReportLevel);
-  //  mySPOSetBuilderFactory->createSPOSetBuilder(curRoot,curRoot);
-  //}
-
   //sposet_builder is defined outside <determinantset/>
   if(spomap.empty())
   {
@@ -185,7 +177,7 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
               spomap[aspo]=aset;
             else
             {
-              mySPOSetBuilderFactory->createSPOSetBuilder(cur1,curRoot);
+              mySPOSetBuilderFactory->createSPOSetBuilder(curRoot);
               aset = mySPOSetBuilderFactory->createSPOSet(cur1);
               if(aset) spomap[aspo]=aset;
             }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -18,7 +18,7 @@
 
 #include <vector>
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
-#include "QMCWaveFunctions/BasisSetFactory.h"
+#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h"
 #include "QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h"
@@ -61,7 +61,7 @@ private:
 
   ///reference to a PtclPoolType
   PtclPoolType& ptclPool;
-  BasisSetFactory* myBasisSetFactory;
+  SPOSetBuilderFactory* mySPOSetBuilderFactory;
   SlaterDeterminant_t* slaterdet_0;
   MultiSlaterDeterminant_t* multislaterdet_0;
   MultiSlaterDeterminantFast* multislaterdetfast_0;

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
@@ -22,7 +22,7 @@
 namespace qmcplusplus
 {
 
-  struct SHOSetBuilder : public BasisSetBuilder
+  struct SHOSetBuilder : public SPOSetBuilder
   {
 
     //enum{DIM=OHMMS_DIM}
@@ -48,12 +48,12 @@ namespace qmcplusplus
     //reset parameters
     void reset();
 
-    //BasisSetBuilder interface
+    //SPOSetBuilder interface
     SPOSetBase* createSPOSetFromXML(xmlNodePtr cur);
 
     SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input);
     
-    //unneeded BasisSetBuilder interface functions
+    //unneeded SPOSetBuilder interface functions
     bool put(xmlNodePtr cur)
     { 
       return true; 

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
@@ -16,7 +16,7 @@
 #define QMCPLUSPLUS_SHO_BASIS_BUILDER_H
 
 #include <QMCWaveFunctions/HarmonicOscillator/SHOSet.h>
-#include <QMCWaveFunctions/BasisSetBase.h>
+#include <QMCWaveFunctions/SPOSetBuilderBase.h>
 #include <QMCWaveFunctions/SPOSetInfo.h>
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
@@ -53,12 +53,6 @@ namespace qmcplusplus
 
     SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input);
     
-    //unneeded SPOSetBuilder interface functions
-    bool put(xmlNodePtr cur)
-    { 
-      return true; 
-    }
-
     //local functions
     void update_basis_states(int smax);
     void report(const std::string& pad="");

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h
@@ -16,7 +16,7 @@
 #define QMCPLUSPLUS_SHO_BASIS_BUILDER_H
 
 #include <QMCWaveFunctions/HarmonicOscillator/SHOSet.h>
-#include <QMCWaveFunctions/SPOSetBuilderBase.h>
+#include <QMCWaveFunctions/SPOSetBuilder.h>
 #include <QMCWaveFunctions/SPOSetInfo.h>
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
@@ -26,7 +26,7 @@ namespace qmcplusplus
 {
 
 template<class RFB>
-struct AtomicBasisBuilder: public BasisSetBuilder
+struct AtomicBasisBuilder: public SPOSetBuilder
 {
 
   typedef typename RFB::CenteredOrbitalType COT;

--- a/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
@@ -19,7 +19,7 @@
 #include<cmath>
 #include <iostream>
 #include "Configuration.h"
-//#include "QMCWaveFunctions/BasisSetFactory.h"
+//#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 //#include "Utilities/ProgressReportEngine.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Particle/ParticleSet.h"

--- a/src/QMCWaveFunctions/MolecularOrbitals/MolecularBasisBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/MolecularBasisBuilder.h
@@ -32,13 +32,13 @@
 namespace qmcplusplus
 {
 
-/** derived class from BasisSetBuilder
+/** derived class from SPOSetBuilder
  *
  * Create a basis set of molecular orbital types as defined in MolecularOrbitalBasis
  * with radial wave functions on the radial grids.
  */
 template<class RFB>
-class MolecularBasisBuilder: public BasisSetBuilder
+class MolecularBasisBuilder: public SPOSetBuilder
 {
 
 public:
@@ -99,7 +99,7 @@ public:
           att.put(cur);
           if(elementType.empty())
             PRE.error("Missing elementType attribute of atomicBasisSet.",true);
-          std::map<std::string,BasisSetBuilder*>::iterator it = aoBuilders.find(elementType);
+          std::map<std::string,SPOSetBuilder*>::iterator it = aoBuilders.find(elementType);
           if(it == aoBuilders.end())
           {
             AtomicBasisBuilder<RFB>* any = new AtomicBasisBuilder<RFB>(elementType);
@@ -175,7 +175,7 @@ public:
           myComm->bcast(basiset_name);
           myComm->bcast(elementType);
 
-          std::map<std::string,BasisSetBuilder*>::iterator it = aoBuilders.find(elementType);
+          std::map<std::string,SPOSetBuilder*>::iterator it = aoBuilders.find(elementType);
           if(it == aoBuilders.end())
           {
             AtomicBasisBuilder<RFB>* any = new AtomicBasisBuilder<RFB>(elementType);
@@ -280,7 +280,7 @@ private:
   ///BasisSet
   ThisBasisSetType* thisBasisSet;
   ///save AtomiBasisBuilder<RFB>*
-  std::map<std::string,BasisSetBuilder*> aoBuilders;
+  std::map<std::string,SPOSetBuilder*> aoBuilders;
   ///apply cusp correction to molecular orbitals
   bool cuspCorr;
   std::string cuspInfo;

--- a/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
@@ -38,7 +38,7 @@ namespace qmcplusplus
  * with radial wave functions on the radial grids.
  */
 template<class RFB>
-class MolecularBasisBuilder: public SPOSetBuilder
+class MolecularSPOBuilder: public SPOSetBuilder
 {
 
 public:
@@ -51,10 +51,10 @@ public:
    * \param els reference to the electrons
    * \param ions reference to the ions
    */
-  MolecularBasisBuilder(ParticleSet& els, ParticleSet& ions, bool cusp=false, std::string cusp_info="",std::string MOH5Ref=""):
+  MolecularSPOBuilder(ParticleSet& els, ParticleSet& ions, bool cusp=false, std::string cusp_info="",std::string MOH5Ref=""):
     targetPtcl(els), sourcePtcl(ions), thisBasisSet(0), cuspCorr(cusp), cuspInfo(cusp_info), h5_path(MOH5Ref)
   {
-    ClassName="MolecularBasisBuilder";
+    ClassName="MolecularSPOBuilder";
   }
 
   inline bool is_same(const xmlChar* a, const char* b)

--- a/src/QMCWaveFunctions/OptimizableSPOBuilder.cpp
+++ b/src/QMCWaveFunctions/OptimizableSPOBuilder.cpp
@@ -26,13 +26,6 @@ OptimizableSPOBuilder::OptimizableSPOBuilder
 {
 }
 
-bool
-OptimizableSPOBuilder::put (xmlNodePtr cur)
-{
-  return true;
-}
-
-
 SPOSetBase*
 OptimizableSPOBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {

--- a/src/QMCWaveFunctions/OptimizableSPOBuilder.h
+++ b/src/QMCWaveFunctions/OptimizableSPOBuilder.h
@@ -23,7 +23,7 @@
 
 namespace qmcplusplus
 {
-class OptimizableSPOBuilder : public BasisSetBuilder
+class OptimizableSPOBuilder : public SPOSetBuilder
 {
 protected:
   typedef std::map<std::string,ParticleSet*> PtclPoolType;

--- a/src/QMCWaveFunctions/OptimizableSPOBuilder.h
+++ b/src/QMCWaveFunctions/OptimizableSPOBuilder.h
@@ -33,8 +33,6 @@ public:
   OptimizableSPOBuilder(ParticleSet& p, PtclPoolType& psets,
                         xmlNodePtr cur);
 
-  bool put (xmlNodePtr cur);
-
   /** initialize the Antisymmetric wave function for electrons
    *@param cur the current xml node
    */

--- a/src/QMCWaveFunctions/OptimizableSPOBuilder.h
+++ b/src/QMCWaveFunctions/OptimizableSPOBuilder.h
@@ -17,7 +17,7 @@
 #ifndef OPTIMIZABLE_SPO_BUILDER_H
 #define OPTIMIZABLE_SPO_BUILDER_H
 
-#include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 #include "QMCWaveFunctions/OptimizableSPOSet.h"
 
 

--- a/src/QMCWaveFunctions/OptimizableSPOBuilder.h
+++ b/src/QMCWaveFunctions/OptimizableSPOBuilder.h
@@ -17,7 +17,7 @@
 #ifndef OPTIMIZABLE_SPO_BUILDER_H
 #define OPTIMIZABLE_SPO_BUILDER_H
 
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/OptimizableSPOSet.h"
 
 

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -19,14 +19,14 @@
 namespace qmcplusplus
 {
 
-  BasisSetBuilder::BasisSetBuilder()
+  SPOSetBuilder::SPOSetBuilder()
     : MPIObjectBase(0), legacy(true) 
   {
     reserve_states();
   }
 
 
-  void BasisSetBuilder::reserve_states(int nsets)
+  void SPOSetBuilder::reserve_states(int nsets)
   {
     int sets_needed = nsets - states.size();
     if(sets_needed>0)
@@ -35,14 +35,14 @@ namespace qmcplusplus
   }
 
 
-  SPOSetBase* BasisSetBuilder::createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input_info)
+  SPOSetBase* SPOSetBuilder::createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input_info)
   { 
     APP_ABORT("BasisSetBase::createSPOSet(cur,input_info) has not been implemented");
     return 0;
   }
 
 
-  SPOSetBase* BasisSetBuilder::createSPOSet(xmlNodePtr cur)
+  SPOSetBase* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   {
     // read specialized sposet construction requests
     //   and translate them into a set of orbital indices
@@ -64,7 +64,7 @@ namespace qmcplusplus
       sposets.push_back(sposet);
     }
     else
-      APP_ABORT("BasisSetBuilder::createSPOSet  sposet creation failed");
+      APP_ABORT("SPOSetBuilder::createSPOSet  sposet creation failed");
 
     return sposet;
   }

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -10,11 +10,9 @@
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
 
-#include <QMCWaveFunctions/BasisSetBase.h>
 
+#include <QMCWaveFunctions/SPOSetBuilderBase.h>
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -12,7 +12,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include <QMCWaveFunctions/SPOSetBuilderBase.h>
+#include <QMCWaveFunctions/SPOSetBuilder.h>
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/SPOSetBuilder.h
+++ b/src/QMCWaveFunctions/SPOSetBuilder.h
@@ -15,11 +15,11 @@
 //////////////////////////////////////////////////////////////////////////////////////
     
     
-/** @file SPOSetBuilderBase.h
- * @brief Declaration of a base class of SPOSetBuilder
+/** @file SPOSetBuilder.h
+ * @brief Declaration of a base class of SPOSet Builders
  */
-#ifndef QMCPLUSPLUS_SPOSET_BUILDER_BASE_H
-#define QMCPLUSPLUS_SPOSET_BUILDER_BASE_H
+#ifndef QMCPLUSPLUS_SPOSET_BUILDER_H
+#define QMCPLUSPLUS_SPOSET_BUILDER_H
 
 #include "Message/MPIObjectBase.h"
 #include "QMCWaveFunctions/SPOSetInfo.h"

--- a/src/QMCWaveFunctions/SPOSetBuilderBase.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderBase.h
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+    
+    
+/** @file SPOSetBuilderBase.h
+ * @brief Declaration of a base class of SPOSetBuilder
+ */
+#ifndef QMCPLUSPLUS_SPOSET_BUILDER_BASE_H
+#define QMCPLUSPLUS_SPOSET_BUILDER_BASE_H
+
+#include "Message/MPIObjectBase.h"
+#include "QMCWaveFunctions/SPOSetInfo.h"
+#include <QMCWaveFunctions/SPOSetInputInfo.h>
+#include "QMCWaveFunctions/SPOSetBase.h"
+
+
+namespace qmcplusplus
+{
+
+/** base class for the real SPOSet builder
+ *
+ * \warning {
+ * We have not quite figured out how to use real/complex efficiently.
+ * There are three cases we have to deal with
+ * - real basis functions and real coefficients
+ * - real basis functions and complex coefficients
+ * - complex basis functions and complex coefficients
+ * For now, we decide to keep both real and complex basis sets and expect
+ * the user classes {\bf KNOW} what they need to use.
+ * }
+ */
+struct SPOSetBuilder: public QMCTraits, public MPIObjectBase
+{
+  typedef std::map<std::string,SPOSetBase*> SPOPool_t;
+  typedef std::vector<int> indices_t;
+  typedef std::vector<RealType> energies_t;
+
+
+  /// whether implementation conforms only to legacy standard
+  bool legacy;
+
+  /// state info of all possible states available in the basis
+  std::vector<SPOSetInfo*> states;
+
+  /// list of all sposets created by this builder
+  std::vector<SPOSetBase*> sposets;
+
+  SPOSetBuilder();
+  virtual ~SPOSetBuilder() {}
+  /// load from XML if there is a basisset
+  virtual void loadBasisSetFromXML(xmlNodePtr cur) {}
+
+  /// reserve space for states (usually only one set, multiple for e.g. spin dependent einspline)
+  void reserve_states(int nsets=1);
+
+  /// allow modification of state information
+  inline void modify_states(int index=0)
+  {
+    states[index]->modify();
+  }
+
+  /// clear state information
+  inline void clear_states(int index=0)
+  {
+    states[index]->clear();
+  }
+
+  /// create an sposet from xml (legacy)
+  virtual SPOSetBase* createSPOSetFromXML(xmlNodePtr cur)=0;
+
+  /// create an sposet from a general xml request
+  virtual SPOSetBase* createSPOSet(xmlNodePtr cur,SPOSetInputInfo& input_info);
+
+  /// create an sposet from xml and save the resulting SPOSet
+  SPOSetBase* createSPOSet(xmlNodePtr cur);
+
+
+};
+
+}
+#endif

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -122,7 +122,7 @@ bool SPOSetBuilderFactory::put(xmlNodePtr cur)
   return true;
 }
 
-SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodePtr  rootNode)
+SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
 {
   ReportEngine PRE(ClassName,"createSPOSetBuilder");
   std::string sourceOpt("ion0");
@@ -162,8 +162,6 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
     app_log() << "Reuse SPOSetBuilder \""<<name << "\" type " << type_in << std::endl;
     app_log().flush();
     bb=(*bbit).second;
-    bb->put(rootNode);
-   
     return last_builder=bb;
   }
 
@@ -252,7 +250,6 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
   {
     bb->setReportLevel(ReportLevel);
     bb->initCommunicator(myComm);
-    bb->put(cur);
     app_log()<<"  Created SPOSet builder named '"<< name<< "' of type "<< type << std::endl;
     spo_builders[name]=bb; //use name, if missing type is used
   }
@@ -265,12 +262,10 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
 SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
 {
   std::string bname("");
-  std::string bsname("");
   std::string sname("");
   std::string type("");
   OhmmsAttributeSet aAttrib;
   aAttrib.add(bname,"basisset");
-  aAttrib.add(bsname,"basis_sposet");
   aAttrib.add(sname,"name");
   aAttrib.add(type,"type");
   //aAttrib.put(rcur);
@@ -290,11 +285,14 @@ SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
     std::string cname("");
     xmlNodePtr tcur=cur->children;
     if(tcur!=NULL)
-      getNodeName(cname,cur);
+      getNodeName(cname,tcur);
     if(cname==basisset_tag)
-      bb = createSPOSetBuilder(tcur,cur);
+    {
+      bb = createSPOSetBuilder(cur);
+      bb->loadBasisSetFromXML(tcur);
+    }
     else
-      bb = createSPOSetBuilder(cur,cur);
+      bb = createSPOSetBuilder(cur);
   }
   if(bb)
   {
@@ -319,7 +317,7 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 
   app_log()<<"building sposet collection of type "<<type<< std::endl;
 
-  SPOSetBuilder* bb = createSPOSetBuilder(cur,cur);
+  SPOSetBuilder* bb = createSPOSetBuilder(cur);
   xmlNodePtr element = parent->children;
   int nsposets = 0;
   while(element!=NULL)

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -47,14 +47,14 @@ namespace qmcplusplus
 {
 
   //initialization of the static data of SPOSetBuilderFactory 
-  std::map<std::string,BasisSetBuilder*> SPOSetBuilderFactory::basis_builders;
-  BasisSetBuilder* SPOSetBuilderFactory::last_builder=0;
+  std::map<std::string,SPOSetBuilder*> SPOSetBuilderFactory::basis_builders;
+  SPOSetBuilder* SPOSetBuilderFactory::last_builder=0;
 
   SPOSetBase* get_sposet(const std::string& name)
   {
     int nfound = 0;
     SPOSetBase* spo = 0;
-    std::map<std::string,BasisSetBuilder*>::iterator it;
+    std::map<std::string,SPOSetBuilder*>::iterator it;
     for(it=SPOSetBuilderFactory::basis_builders.begin();
         it!=SPOSetBuilderFactory::basis_builders.end();++it)
     {
@@ -86,12 +86,12 @@ namespace qmcplusplus
   void write_basis_builders(const std::string& pad)
   {
     std::string pad2 = pad+"  ";
-    std::map<std::string,BasisSetBuilder*>::iterator it;
+    std::map<std::string,SPOSetBuilder*>::iterator it;
     for(it=SPOSetBuilderFactory::basis_builders.begin();it!=SPOSetBuilderFactory::basis_builders.end();++it)
     {
       const std::string& type = it->first;
       std::vector<SPOSetBase*>& sposets = it->second->sposets;
-      app_log()<<pad<<"sposets for BasisSetBuilder of type "<<type<< std::endl;
+      app_log()<<pad<<"sposets for SPOSetBuilder of type "<<type<< std::endl;
       for(int i=0;i<sposets.size();++i)
       {
         app_log()<<pad2<<"sposet "<<sposets[i]->objectName<< std::endl;
@@ -122,7 +122,7 @@ bool SPOSetBuilderFactory::put(xmlNodePtr cur)
   return true;
 }
 
-BasisSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodePtr  rootNode)
+SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodePtr  rootNode)
 {
   ReportEngine PRE(ClassName,"createSPOSetBuilder");
   std::string sourceOpt("ion0");
@@ -153,13 +153,13 @@ BasisSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNod
   //when name is missing, type becomes the input
   if(name.empty()) name=type_in;
 
-  BasisSetBuilder* bb=0;
+  SPOSetBuilder* bb=0;
 
   //check if builder can be reused
-  std::map<std::string,BasisSetBuilder*>::iterator bbit=basis_builders.find(name);
+  std::map<std::string,SPOSetBuilder*>::iterator bbit=basis_builders.find(name);
   if(bbit!= basis_builders.end())
   {
-    app_log() << "Reuse BasisSetBuilder \""<<name << "\" type " << type_in << std::endl;
+    app_log() << "Reuse SPOSetBuilder \""<<name << "\" type " << type_in << std::endl;
     app_log().flush();
     bb=(*bbit).second;
     bb->put(rootNode);
@@ -244,10 +244,10 @@ BasisSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNod
   PRE.flush();
 
   if(bb==0)
-    APP_ABORT_TRACE(__FILE__, __LINE__, "SPOSetBuilderFactory::createSPOSetBuilder\n  BasisSetBuilder creation failed.");
+    APP_ABORT_TRACE(__FILE__, __LINE__, "SPOSetBuilderFactory::createSPOSetBuilder\n  SPOSetBuilder creation failed.");
 
   if(bb == last_builder)
-    app_log() << " Missing both \"@name\" and \"@type\". Use the last BasisSetBuilder." << std::endl;
+    app_log() << " Missing both \"@name\" and \"@type\". Use the last SPOSetBuilder." << std::endl;
   else
   {
     bb->setReportLevel(ReportLevel);
@@ -278,7 +278,7 @@ SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
 
   //tolower(type);
 
-  BasisSetBuilder* bb;
+  SPOSetBuilder* bb;
   if(bname=="")
     bname=type;
   if(type=="")
@@ -319,7 +319,7 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 
   app_log()<<"building sposet collection of type "<<type<< std::endl;
 
-  BasisSetBuilder* bb = createSPOSetBuilder(cur,cur);
+  SPOSetBuilder* bb = createSPOSetBuilder(cur,cur);
   xmlNodePtr element = parent->children;
   int nsposets = 0;
   while(element!=NULL)
@@ -332,7 +332,7 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
       attrib.add(name,"name");
       attrib.put(element);
 
-      app_log()<<"  Building SPOSet \""<<name<<"\" with "<<type<<" BasisSetBuilder"<< std::endl;
+      app_log()<<"  Building SPOSet \""<<name<<"\" with "<<type<<" SPOSetBuilder"<< std::endl;
       SPOSetBase* spo = bb->createSPOSet(element);
       spo->objectName = name;
       nsposets++;

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -27,7 +27,7 @@
 #include "QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h"
 #include "QMCWaveFunctions/MolecularOrbitals/GTOBuilder.h"
 #include "QMCWaveFunctions/MolecularOrbitals/STOBuilder.h"
-#include "QMCWaveFunctions/MolecularOrbitals/MolecularBasisBuilder.h"
+#include "QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h"
 #endif
 #endif
 
@@ -219,11 +219,11 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
 #else
     if(transformOpt == "yes")
     {
-      app_log() << "Using MolecularBasisBuilder<NGOBuilder>" << std::endl;
+      app_log() << "Using MolecularSPOBuilder<NGOBuilder>" << std::endl;
 #if QMC_BUILD_LEVEL>2
-      bb = new MolecularBasisBuilder<NGOBuilder>(targetPtcl,*ions,cuspC=="yes",cuspInfo,MOH5Ref);
+      bb = new MolecularSPOBuilder<NGOBuilder>(targetPtcl,*ions,cuspC=="yes",cuspInfo,MOH5Ref);
 #else
-      bb = new MolecularBasisBuilder<NGOBuilder>(targetPtcl,*ions,false);
+      bb = new MolecularSPOBuilder<NGOBuilder>(targetPtcl,*ions,false);
 #endif
     }
     else
@@ -233,9 +233,9 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
         app_log() <<" ****** Cusp Correction algorithm is only implemented in combination with numerical radial orbitals. Use transform=yes to enable this option. \n";
 #endif
       if(keyOpt == "GTO")
-        bb = new MolecularBasisBuilder<GTOBuilder>(targetPtcl,*ions);
+        bb = new MolecularSPOBuilder<GTOBuilder>(targetPtcl,*ions);
       else if(keyOpt == "STO")
-        bb = new MolecularBasisBuilder<STOBuilder>(targetPtcl,*ions);
+        bb = new MolecularSPOBuilder<STOBuilder>(targetPtcl,*ions);
     }
 #endif
   }

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -47,7 +47,7 @@ namespace qmcplusplus
 {
 
   //initialization of the static data of SPOSetBuilderFactory 
-  std::map<std::string,SPOSetBuilder*> SPOSetBuilderFactory::basis_builders;
+  std::map<std::string,SPOSetBuilder*> SPOSetBuilderFactory::spo_builders;
   SPOSetBuilder* SPOSetBuilderFactory::last_builder=0;
 
   SPOSetBase* get_sposet(const std::string& name)
@@ -55,8 +55,8 @@ namespace qmcplusplus
     int nfound = 0;
     SPOSetBase* spo = 0;
     std::map<std::string,SPOSetBuilder*>::iterator it;
-    for(it=SPOSetBuilderFactory::basis_builders.begin();
-        it!=SPOSetBuilderFactory::basis_builders.end();++it)
+    for(it=SPOSetBuilderFactory::spo_builders.begin();
+        it!=SPOSetBuilderFactory::spo_builders.end();++it)
     {
       std::vector<SPOSetBase*>& sposets = it->second->sposets;
       for(int i=0;i<sposets.size();++i)
@@ -71,23 +71,23 @@ namespace qmcplusplus
     }
     if(nfound>1)
     {
-      write_basis_builders();
+      write_spo_builders();
       APP_ABORT_TRACE(__FILE__, __LINE__, "get_sposet: requested sposet "+name+" is not unique");
     }
     //else if(spo==NULL)
     //{
-    //  write_basis_builders();
+    //  write_spo_builders();
     //  APP_ABORT("get_sposet: requested sposet "+name+" does not exist");
     //}
     return spo;
   }
 
 
-  void write_basis_builders(const std::string& pad)
+  void write_spo_builders(const std::string& pad)
   {
     std::string pad2 = pad+"  ";
     std::map<std::string,SPOSetBuilder*>::iterator it;
-    for(it=SPOSetBuilderFactory::basis_builders.begin();it!=SPOSetBuilderFactory::basis_builders.end();++it)
+    for(it=SPOSetBuilderFactory::spo_builders.begin();it!=SPOSetBuilderFactory::spo_builders.end();++it)
     {
       const std::string& type = it->first;
       std::vector<SPOSetBase*>& sposets = it->second->sposets;
@@ -156,8 +156,8 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
   SPOSetBuilder* bb=0;
 
   //check if builder can be reused
-  std::map<std::string,SPOSetBuilder*>::iterator bbit=basis_builders.find(name);
-  if(bbit!= basis_builders.end())
+  std::map<std::string,SPOSetBuilder*>::iterator bbit=spo_builders.find(name);
+  if(bbit!= spo_builders.end())
   {
     app_log() << "Reuse SPOSetBuilder \""<<name << "\" type " << type_in << std::endl;
     app_log().flush();
@@ -253,8 +253,8 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
     bb->setReportLevel(ReportLevel);
     bb->initCommunicator(myComm);
     bb->put(cur);
-    app_log()<<"  Created basis set builder named '"<< name<< "' of type "<< type << std::endl;
-    basis_builders[name]=bb; //use name, if missing type is used
+    app_log()<<"  Created SPOSet builder named '"<< name<< "' of type "<< type << std::endl;
+    spo_builders[name]=bb; //use name, if missing type is used
   }
   last_builder = bb;
 
@@ -283,8 +283,8 @@ SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
     bname=type;
   if(type=="")
     bb = last_builder;
-  else if(basis_builders.find(type)!=basis_builders.end())
-    bb = basis_builders[type];
+  else if(spo_builders.find(type)!=spo_builders.end())
+    bb = spo_builders[type];
   else
   {
     std::string cname("");
@@ -303,7 +303,7 @@ SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
   }
   else
   {
-    APP_ABORT("SPOSetBuilderFactory::createSPOSet Failed to create a SPOSet. basisBuilder is empty.");
+    APP_ABORT("SPOSetBuilderFactory::createSPOSet Failed to create a SPOSet. SPOSetBuilder is empty.");
     return 0;
   }
 }

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -178,7 +178,7 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodeP
   else if (type == "jellium" || type == "heg")
   {
     app_log()<<"Electron gas SPO set"<< std::endl;
-    bb = new ElectronGasBasisBuilder(targetPtcl,rootNode);
+    bb = new ElectronGasSPOBuilder(targetPtcl,rootNode);
   }
   else if (type == "sho")
   {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -122,9 +122,9 @@ bool SPOSetBuilderFactory::put(xmlNodePtr cur)
   return true;
 }
 
-BasisSetBuilder* SPOSetBuilderFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr  rootNode)
+BasisSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr cur,xmlNodePtr  rootNode)
 {
-  ReportEngine PRE(ClassName,"createBasisSet");
+  ReportEngine PRE(ClassName,"createSPOSetBuilder");
   std::string sourceOpt("ion0");
   std::string type("");
   std::string name("");
@@ -244,7 +244,7 @@ BasisSetBuilder* SPOSetBuilderFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr 
   PRE.flush();
 
   if(bb==0)
-    APP_ABORT_TRACE(__FILE__, __LINE__, "SPOSetBuilderFactory::createBasisSet\n  BasisSetBuilder creation failed.");
+    APP_ABORT_TRACE(__FILE__, __LINE__, "SPOSetBuilderFactory::createSPOSetBuilder\n  BasisSetBuilder creation failed.");
 
   if(bb == last_builder)
     app_log() << " Missing both \"@name\" and \"@type\". Use the last BasisSetBuilder." << std::endl;
@@ -292,13 +292,13 @@ SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
     if(tcur!=NULL)
       getNodeName(cname,cur);
     if(cname==basisset_tag)
-      bb = createBasisSet(tcur,cur);
+      bb = createSPOSetBuilder(tcur,cur);
     else
-      bb = createBasisSet(cur,cur);
+      bb = createSPOSetBuilder(cur,cur);
   }
   if(bb)
   {
-    app_log()<<"  Building SPOset '" << sname << "' with '" << bname << "' basis set."<< std::endl;
+    app_log()<<"  Building SPOSet '" << sname << "' with '" << bname << "' basis set."<< std::endl;
     return bb->createSPOSet(cur);
   }
   else
@@ -319,7 +319,7 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 
   app_log()<<"building sposet collection of type "<<type<< std::endl;
 
-  BasisSetBuilder* bb = createBasisSet(cur,cur);
+  BasisSetBuilder* bb = createSPOSetBuilder(cur,cur);
   xmlNodePtr element = parent->children;
   int nsposets = 0;
   while(element!=NULL)

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -16,7 +16,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
     
     
-#include "QMCWaveFunctions/BasisSetFactory.h"
+#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
 #if OHMMS_DIM == 3
@@ -46,17 +46,17 @@
 namespace qmcplusplus
 {
 
-  //initialization of the static data of BasisSetFactory 
-  std::map<std::string,BasisSetBuilder*> BasisSetFactory::basis_builders;
-  BasisSetBuilder* BasisSetFactory::last_builder=0;
+  //initialization of the static data of SPOSetBuilderFactory 
+  std::map<std::string,BasisSetBuilder*> SPOSetBuilderFactory::basis_builders;
+  BasisSetBuilder* SPOSetBuilderFactory::last_builder=0;
 
   SPOSetBase* get_sposet(const std::string& name)
   {
     int nfound = 0;
     SPOSetBase* spo = 0;
     std::map<std::string,BasisSetBuilder*>::iterator it;
-    for(it=BasisSetFactory::basis_builders.begin();
-        it!=BasisSetFactory::basis_builders.end();++it)
+    for(it=SPOSetBuilderFactory::basis_builders.begin();
+        it!=SPOSetBuilderFactory::basis_builders.end();++it)
     {
       std::vector<SPOSetBase*>& sposets = it->second->sposets;
       for(int i=0;i<sposets.size();++i)
@@ -87,7 +87,7 @@ namespace qmcplusplus
   {
     std::string pad2 = pad+"  ";
     std::map<std::string,BasisSetBuilder*>::iterator it;
-    for(it=BasisSetFactory::basis_builders.begin();it!=BasisSetFactory::basis_builders.end();++it)
+    for(it=SPOSetBuilderFactory::basis_builders.begin();it!=SPOSetBuilderFactory::basis_builders.end();++it)
     {
       const std::string& type = it->first;
       std::vector<SPOSetBase*>& sposets = it->second->sposets;
@@ -106,23 +106,23 @@ namespace qmcplusplus
  * \param psi reference to the wavefunction
  * \param ions reference to the ions
  */
-BasisSetFactory::BasisSetFactory(ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets):
+SPOSetBuilderFactory::SPOSetBuilderFactory(ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets):
   OrbitalBuilderBase(els,psi), ptclPool(psets)
 {
-  ClassName="BasisSetFactory";
+  ClassName="SPOSetBuilderFactory";
 }
 
-BasisSetFactory::~BasisSetFactory()
+SPOSetBuilderFactory::~SPOSetBuilderFactory()
 {
-  DEBUG_MEMORY("BasisSetFactory::~BasisSetFactory");
+  DEBUG_MEMORY("SPOSetBuilderFactory::~SPOSetBuilderFactory");
 }
 
-bool BasisSetFactory::put(xmlNodePtr cur)
+bool SPOSetBuilderFactory::put(xmlNodePtr cur)
 {
   return true;
 }
 
-BasisSetBuilder* BasisSetFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr  rootNode)
+BasisSetBuilder* SPOSetBuilderFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr  rootNode)
 {
   ReportEngine PRE(ClassName,"createBasisSet");
   std::string sourceOpt("ion0");
@@ -244,7 +244,7 @@ BasisSetBuilder* BasisSetFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr  root
   PRE.flush();
 
   if(bb==0)
-    APP_ABORT_TRACE(__FILE__, __LINE__, "BasisSetFactory::createBasisSet\n  BasisSetBuilder creation failed.");
+    APP_ABORT_TRACE(__FILE__, __LINE__, "SPOSetBuilderFactory::createBasisSet\n  BasisSetBuilder creation failed.");
 
   if(bb == last_builder)
     app_log() << " Missing both \"@name\" and \"@type\". Use the last BasisSetBuilder." << std::endl;
@@ -262,7 +262,7 @@ BasisSetBuilder* BasisSetFactory::createBasisSet(xmlNodePtr cur,xmlNodePtr  root
 }
 
 
-SPOSetBase* BasisSetFactory::createSPOSet(xmlNodePtr cur)
+SPOSetBase* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
 {
   std::string bname("");
   std::string bsname("");
@@ -303,12 +303,12 @@ SPOSetBase* BasisSetFactory::createSPOSet(xmlNodePtr cur)
   }
   else
   {
-    APP_ABORT("BasisSetFactory::createSPOSet Failed to create a SPOSet. basisBuilder is empty.");
+    APP_ABORT("SPOSetBuilderFactory::createSPOSet Failed to create a SPOSet. basisBuilder is empty.");
     return 0;
   }
 }
 
-void BasisSetFactory::build_sposet_collection(xmlNodePtr cur)
+void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 {
   xmlNodePtr parent = cur;
   std::string type("");
@@ -340,7 +340,7 @@ void BasisSetFactory::build_sposet_collection(xmlNodePtr cur)
     element = element->next;
   }
   if(nsposets==0)
-    APP_ABORT("BasisSetFactory::build_sposet_collection  no <sposet/> elements found");
+    APP_ABORT("SPOSetBuilderFactory::build_sposet_collection  no <sposet/> elements found");
 }
 
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -17,7 +17,7 @@
 #define QMCPLUSPLUS_BASISSETFACTORY_H
 
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
-#include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -17,7 +17,7 @@
 #define QMCPLUSPLUS_BASISSETFACTORY_H
 
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -53,7 +53,12 @@ public:
   ~SPOSetBuilderFactory();
   bool put(xmlNodePtr cur);
 
-  SPOSetBuilder* createSPOSetBuilder(xmlNodePtr cur, xmlNodePtr rootNode=NULL);
+  SPOSetBuilder* createSPOSetBuilder(xmlNodePtr rootNode);
+
+  void loadBasisSetFromXML(xmlNodePtr cur)
+  {
+    last_builder->loadBasisSetFromXML(cur);
+  }
 
   SPOSetBase* createSPOSet(xmlNodePtr cur);
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -41,7 +41,7 @@ class SPOSetBuilderFactory: public OrbitalBuilderBase
 public:
 
   ///set of basis set builders resolved by type
-  static std::map<std::string,BasisSetBuilder*> basis_builders;
+  static std::map<std::string,SPOSetBuilder*> basis_builders;
 
   /** constructor
    * \param els reference to the electrons
@@ -53,7 +53,7 @@ public:
   ~SPOSetBuilderFactory();
   bool put(xmlNodePtr cur);
 
-  BasisSetBuilder* createSPOSetBuilder(xmlNodePtr cur, xmlNodePtr rootNode=NULL);
+  SPOSetBuilder* createSPOSetBuilder(xmlNodePtr cur, xmlNodePtr rootNode=NULL);
 
   SPOSetBase* createSPOSet(xmlNodePtr cur);
 
@@ -62,7 +62,7 @@ public:
 private:
 
   ///store the last builder, use if type not provided
-  static BasisSetBuilder* last_builder;
+  static SPOSetBuilder* last_builder;
 
   ///reference to the particle pool
   PtclPoolType& ptclPool;

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -35,7 +35,7 @@ namespace qmcplusplus
 
 /** derived class from OrbitalBuilderBase
  */
-class BasisSetFactory: public OrbitalBuilderBase
+class SPOSetBuilderFactory: public OrbitalBuilderBase
 {
 
 public:
@@ -48,9 +48,9 @@ public:
    * \param psi reference to the wavefunction
    * \param ions reference to the ions
    */
-  BasisSetFactory(ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets);
+  SPOSetBuilderFactory(ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets);
 
-  ~BasisSetFactory();
+  ~SPOSetBuilderFactory();
   bool put(xmlNodePtr cur);
 
   BasisSetBuilder* createBasisSet(xmlNodePtr cur, xmlNodePtr rootNode=NULL);

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -23,7 +23,7 @@ namespace qmcplusplus
 {
 
   ///writes info about contained sposets to stdout
-  void write_basis_builders(const std::string& pad="");
+  void write_spo_builders(const std::string& pad="");
 
   /**returns a named sposet from the global pool
    *  only use in serial portion of execution
@@ -41,7 +41,7 @@ class SPOSetBuilderFactory: public OrbitalBuilderBase
 public:
 
   ///set of basis set builders resolved by type
-  static std::map<std::string,SPOSetBuilder*> basis_builders;
+  static std::map<std::string,SPOSetBuilder*> spo_builders;
 
   /** constructor
    * \param els reference to the electrons

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -53,7 +53,7 @@ public:
   ~SPOSetBuilderFactory();
   bool put(xmlNodePtr cur);
 
-  BasisSetBuilder* createBasisSet(xmlNodePtr cur, xmlNodePtr rootNode=NULL);
+  BasisSetBuilder* createSPOSetBuilder(xmlNodePtr cur, xmlNodePtr rootNode=NULL);
 
   SPOSetBase* createSPOSet(xmlNodePtr cur);
 

--- a/src/QMCWaveFunctions/SPOSetInfo.h
+++ b/src/QMCWaveFunctions/SPOSetInfo.h
@@ -128,7 +128,7 @@ namespace qmcplusplus
     /// empty collection and render mutable
     void clear();
 
-    friend class BasisSetBuilder;
+    friend class SPOSetBuilder;
   };
 
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -89,7 +89,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
     std::string cname((const char*)(cur->name));
     if(cname =="sposet_builder")
     {
-      BasisSetFactory basisFactory(*targetPtcl,*targetPsi,ptclPool);
+      SPOSetBuilderFactory basisFactory(*targetPtcl,*targetPsi,ptclPool);
       basisFactory.build_sposet_collection(cur);
     }
     else if (cname == OrbitalBuilderBase::detset_tag)

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -21,7 +21,7 @@
 
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/OrbitalBuilderBase.h"
-#include "QMCWaveFunctions/BasisSetFactory.h"
+#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "Message/MPIObjectBase.h"
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/lcao/AOBasisBuilder.h
+++ b/src/QMCWaveFunctions/lcao/AOBasisBuilder.h
@@ -17,6 +17,8 @@
 #ifndef QMCPLUSPLUS_ATOMICORBITALBUILDER_H
 #define QMCPLUSPLUS_ATOMICORBITALBUILDER_H
 
+
+#include "Message/MPIObjectBase.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/lcao/RadialOrbitalSetBuilder.h"
@@ -30,7 +32,7 @@ namespace qmcplusplus
    * Reimplement AtomiSPOSetBuilder.h
    */
 template<typename COT>
-struct AOBasisBuilder: public SPOSetBuilder
+struct AOBasisBuilder: public MPIObjectBase
 {
   enum {DONOT_EXPAND=0, GAUSSIAN_EXPAND=1, NATURAL_EXPAND, CARTESIAN_EXPAND, MOD_NATURAL_EXPAND};
 

--- a/src/QMCWaveFunctions/lcao/AOBasisBuilder.h
+++ b/src/QMCWaveFunctions/lcao/AOBasisBuilder.h
@@ -27,10 +27,10 @@ namespace qmcplusplus
   /** atomic basisset builder
    * @tparam COT, CenteredOrbitalType = SoaAtomicBasisSet<RF,SH>
    *
-   * Reimplement AtomiBasisSetBuilder.h
+   * Reimplement AtomiSPOSetBuilder.h
    */
 template<typename COT>
-struct AOBasisBuilder: public BasisSetBuilder
+struct AOBasisBuilder: public SPOSetBuilder
 {
   enum {DONOT_EXPAND=0, GAUSSIAN_EXPAND=1, NATURAL_EXPAND, CARTESIAN_EXPAND, MOD_NATURAL_EXPAND};
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -279,7 +279,7 @@ namespace qmcplusplus
     basis_type* mBasisSet=new basis_type(sourcePtcl,targetPtcl);
 
     //keep the builder local
-    std::map<std::string,BasisSetBuilder*> aoBuilders;
+    std::map<std::string,SPOSetBuilder*> aoBuilders;
 
     /** process atomicBasisSet per ion species */
     cur = cur->xmlChildrenNode;
@@ -298,7 +298,7 @@ namespace qmcplusplus
         if(elementType.empty())
           PRE.error("Missing elementType attribute of atomicBasisSet.",true);
 
-        std::map<std::string,BasisSetBuilder*>::iterator it = aoBuilders.find(elementType);
+        std::map<std::string,SPOSetBuilder*>::iterator it = aoBuilders.find(elementType);
         if(it == aoBuilders.end())
         {
           AOBasisBuilder<ao_type>* any = new AOBasisBuilder<ao_type>(elementType);
@@ -318,7 +318,7 @@ namespace qmcplusplus
     } // done with basis set
 
     { //cleanup basisset builder
-      std::map<std::string,BasisSetBuilder*>::iterator itX=aoBuilders.begin();
+      std::map<std::string,SPOSetBuilder*>::iterator itX=aoBuilders.begin();
       while(itX!=aoBuilders.end())
       {
         delete (*itX).second;
@@ -345,7 +345,7 @@ namespace qmcplusplus
     basis_type* mBasisSet=new basis_type(sourcePtcl,targetPtcl);
 
     //keep the builder local
-    std::map<std::string,BasisSetBuilder*> aoBuilders;
+    std::map<std::string,SPOSetBuilder*> aoBuilders;
     
     int Nb_Elements(0);
     std::string basiset_name;
@@ -387,7 +387,7 @@ namespace qmcplusplus
       myComm->bcast(basiset_name);
       myComm->bcast(elementType);
 
-      std::map<std::string,BasisSetBuilder*>::iterator it = aoBuilders.find(elementType);
+      std::map<std::string,SPOSetBuilder*>::iterator it = aoBuilders.find(elementType);
       if(it == aoBuilders.end())
       {
         AOBasisBuilder<ao_type>* any = new AOBasisBuilder<ao_type>(elementType);
@@ -414,7 +414,7 @@ namespace qmcplusplus
     }
 
     { //cleanup basisset builder
-      std::map<std::string,BasisSetBuilder*>::iterator itX=aoBuilders.begin();
+      std::map<std::string,SPOSetBuilder*>::iterator itX=aoBuilders.begin();
       while(itX!=aoBuilders.end())
       {
         delete (*itX).second;

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -38,9 +38,7 @@ namespace qmcplusplus
      */
     LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, xmlNodePtr cur);
     ~LCAOrbitalBuilder();
-    bool put(xmlNodePtr cur);
-    bool putXML(xmlNodePtr cur);
-    bool putH5();
+    void loadBasisSetFromXML(xmlNodePtr cur);
     SPOSetBase* createSPOSetFromXML(xmlNodePtr cur);
 
     private:
@@ -60,6 +58,8 @@ namespace qmcplusplus
     ///Number of periodic Images for Orbital evaluation
     TinyVector<int,3> PBCImages;
 
+    ///load basis set from hdf5 file
+    void loadBasisSetFromH5();
     /** create basis set
      *
      * Use ao_traits<T,I,J> to match (ROT)x(SH) combo

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -19,6 +19,7 @@
 #define QMCPLUSPLUS_SOA_LCAO_ORBITAL_BUILDER_H
 
 #include "QMCWaveFunctions/BasisSetBase.h"
+#include "QMCWaveFunctions/SPOSetBuilderBase.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -19,7 +19,7 @@
 #define QMCPLUSPLUS_SOA_LCAO_ORBITAL_BUILDER_H
 
 #include "QMCWaveFunctions/BasisSetBase.h"
-#include "QMCWaveFunctions/SPOSetBuilderBase.h"
+#include "QMCWaveFunctions/SPOSetBuilder.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -23,12 +23,12 @@
 namespace qmcplusplus
 {
 
-  /** BasisSetBuilder using new LCAOrbitalSet and Soa versions
+  /** SPOSetBuilder using new LCAOrbitalSet and Soa versions
    *
-   * Reimplement MolecularBasisSetBuilder
+   * Reimplement MolecularSPOSetBuilder
    * - support both CartesianTensor and SphericalTensor
    */
-  class LCAOrbitalBuilder: public BasisSetBuilder
+  class LCAOrbitalBuilder: public SPOSetBuilder
   {
     public:
     typedef RealBasisSetBase<RealType> BasisSet_t;


### PR DESCRIPTION
Largely renaming files, classes and functions to make them matching the actual role.
In a lot of places, BasisSet actually refers to SPOSet or SPOSetBuilder.
Actual BasisSet creation is now separated from SPOSetBuilder creation and fixes a bug that the code complains about missing basisBuilder(SPOSetBuilder).