### PR TITLE
Merge SplineAdoptorReaderP and SplineHybridAdoptorReaderP

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
@@ -88,11 +88,6 @@ struct AtomicOrbitalSoA
     chunked_bcast(comm, MultiSpline);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    chunked_reduce(comm, MultiSpline);
-  }
-
   void gather_tables(Communicate* comm, std::vector<int> &offset_cplx, std::vector<int> &offset_real)
   {
     if(offset_cplx.size()) gatherv(comm, MultiSpline, Npad, offset_cplx);
@@ -446,12 +441,6 @@ struct HybridAdoptorBase
   {
     for(int ic=0; ic<AtomicCenters.size(); ic++)
       AtomicCenters[ic].bcast_tables(comm);
-  }
-
-  void reduce_atomic_tables(Communicate* comm)
-  {
-    for(int ic=0; ic<AtomicCenters.size(); ic++)
-      AtomicCenters[ic].reduce_tables(comm);
   }
 
   void gather_atomic_tables(Communicate* comm, std::vector<int> &offset_cplx, std::vector<int> &offset_real)

--- a/src/QMCWaveFunctions/BsplineFactory/HybridCplxAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridCplxAdoptor.h
@@ -65,12 +65,6 @@ struct HybridCplxSoA: public BaseAdoptor, public HybridAdoptorBase<typename Base
     HybridBase::bcast_tables(comm);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    BaseAdoptor::reduce_tables(comm);
-    HybridBase::reduce_atomic_tables(comm);
-  }
-
   void gather_tables(Communicate* comm)
   {
     BaseAdoptor::gather_tables(comm);

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRealAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRealAdoptor.h
@@ -67,12 +67,6 @@ struct HybridRealSoA: public BaseAdoptor, public HybridAdoptorBase<typename Base
     HybridBase::bcast_tables(comm);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    BaseAdoptor::reduce_tables(comm);
-    HybridBase::reduce_atomic_tables(comm);
-  }
-
   void gather_tables(Communicate* comm)
   {
     BaseAdoptor::gather_tables(comm);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
@@ -129,11 +129,6 @@ struct SplineC2CSoA: public SplineAdoptorBase<ST,3>
     chunked_bcast(comm, MultiSpline);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    chunked_reduce(comm, MultiSpline);
-  }
-
   void gather_tables(Communicate* comm)
   {
     if(comm->size()==1) return;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
@@ -121,11 +121,6 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
     chunked_bcast(comm, MultiSpline);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    chunked_reduce(comm, MultiSpline);
-  }
-
   void gather_tables(Communicate* comm)
   {
     if(comm->size()==1) return;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
@@ -111,11 +111,6 @@ struct SplineR2RSoA: public SplineAdoptorBase<ST,3>
     chunked_bcast(comm, MultiSpline);
   }
 
-  void reduce_tables(Communicate* comm)
-  {
-    chunked_reduce(comm, MultiSpline);
-  }
-
   void gather_tables(Communicate* comm)
   {
     if(comm->size()==1) return;

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -326,7 +326,6 @@ public:
   int LastSpinSet, NumOrbitalsRead;
 
   std::string occ_format;
-  RealType qafm;
   int particle_hole_pairs;
   bool makeRotations;
 #if 0

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -219,7 +219,6 @@ public:
   int NumBands, NumElectrons, NumSpins, NumTwists, NumCoreStates;
   int MaxNumGvecs;
   double MeshFactor;
-  RealType BufferLayer;
   RealType MatchingTol;
   TinyVector<int,3> MeshSize;
   std::vector<std::vector<TinyVector<int,3> > > Gvecs;

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -46,7 +46,6 @@ EinsplineSetBuilder::EinsplineSetBuilder(ParticleSet& p, PtclPoolType& psets, xm
   myTableIndex=1;
 
   MatchingTol=10*std::numeric_limits<float>::epsilon();
-//     for (int i=0; i<3; i++) afm_vector[i]=0;
   for (int i=0; i<3; i++)
     for (int j=0; j<3; j++)
       TileMatrix(i,j) = 0;
@@ -899,30 +898,6 @@ EinsplineSetBuilder::OccupyBands(int spin, int sortBands, int numOrbs)
   app_log() << "We will read " << NumDistinctOrbitals << " distinct orbitals.\n";
   app_log() << "There are " << NumCoreOrbs << " core states and "
             << NumValenceOrbs << " valence states.\n";
-//     if(qafm!=0) //afm_vector[0]=qafm;
-//     {afm_vector
-//       bool found(false);
-//       for (int tj=0; tj<TwistAngles.size(); tj++)
-//       {
-//         PosType ku=TwistAngles[tj];
-//         PosType k2 = OrbitalSet->PrimLattice.k_cart(ku);
-//         double dkx = std::abs(afm_vector[0] - k2[0]);
-//         double dky = std::abs(afm_vector[1] - k2[1]);
-//         double dkz = std::abs(afm_vector[2] - k2[2]);
-//         bool rightK = ((dkx<qafm+0.0001)&&(dkx>qafm-0.0001)&&(dky<0.0001)&&(dkz<0.0001));
-//         if(rightK)
-//         {
-//           afm_vector=k2;
-//           found=true;
-//           break;
-//         }
-//       }
-//       if(!found)
-//       {
-//         app_log()<<"Need twist: ("<<qafm<<",0,0)"<< std::endl;
-//         APP_ABORT("EinsplineSetBuilder::OccupyBands_ESHDF");
-//       }
-//     }
 }
 
 }

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -121,7 +121,6 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
   update_token(__FILE__,__LINE__,"createSPOSetFromXML");
   //use 2 bohr as the default when truncated orbitals are used based on the extend of the ions
-  BufferLayer=2.0;
   SPOSetBase *OrbitalSet;
   int numOrbs = 0;
   int sortBands(1);
@@ -156,7 +155,6 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add (useGPU,     "gpu");
     a.add (spo_prec,   "precision");
     a.add (truncate,   "truncate");
-    a.add (BufferLayer, "buffer");
     a.add (use_einspline_set_extended,"use_old_spline");
     a.add (myName, "tag");
 #if defined(QMC_CUDA)

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -124,7 +124,6 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   BufferLayer=2.0;
   SPOSetBase *OrbitalSet;
   int numOrbs = 0;
-  qafm=0;
   int sortBands(1);
   int spinSet = 0;
   int TwistNum_inp=0;
@@ -148,7 +147,6 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add (H5FileName, "href");
     a.add (TileFactor, "tile");
     a.add (sortBands,  "sort");
-    a.add (qafm,  "afmshift");
     a.add (TileMatrix, "tilematrix");
     a.add (TwistNum_inp,   "twistnum");
     a.add (givenTwist,   "twist");
@@ -251,9 +249,8 @@ EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   H5OrbSet aset(H5FileName, spinSet, numOrbs);
   std::map<H5OrbSet,SPOSetBase*,H5OrbSet>::iterator iter;
   iter = SPOSetMap.find (aset);
-  if ((iter != SPOSetMap.end() ) && (!NewOcc) && (qafm==0))
+  if ((iter != SPOSetMap.end() ) && (!NewOcc))
   {
-    qafm=0;
     app_log() << "SPOSet parameters match in EinsplineSetBuilder:  "
               << "cloning EinsplineSet object.\n";
     return iter->second->makeClone();

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -23,8 +23,8 @@
  * Each band is initialized with UBspline_3d_d and both real and imaginary parts are passed to the adoptor object
  * which will convert the data type to their internal precision. 
  */
-#ifndef QMCPLUSPLUS_EINSPLINE_BASE_ADOPTOR_READERP_H
-#define QMCPLUSPLUS_EINSPLINE_BASE_ADOPTOR_READERP_H
+#ifndef QMCPLUSPLUS_EINSPLINE_ADOPTOR_READERP_H
+#define QMCPLUSPLUS_EINSPLINE_ADOPTOR_READERP_H
 #include <mpi/collectives.h>
 #include <mpi/point2point.h>
 
@@ -222,8 +222,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
           spline_i=einspline::create(spline_i,start,end,MeshSize,bspline->HalfG);
 
         now.restart();
-        //initialize_spline_pio(spin,bandgroup);
-        initialize_spline_pio_reduce(spin,bandgroup);
+        initialize_spline_pio_gather(spin,bandgroup);
         app_log() << "  SplineAdoptorReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
 
         fftw_destroy_plan(FFTplan);
@@ -276,7 +275,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
 
   /** initialize the splines
    */
-  void initialize_spline_pio_reduce(int spin, const BandInfoGroup& bandgroup)
+  void initialize_spline_pio_gather(int spin, const BandInfoGroup& bandgroup)
   {
     //distribute bands over processor groups
     int Nbands=bandgroup.getNumDistinctOrbitals();

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -194,7 +194,6 @@ struct SplineAdoptorReader: public BsplineReaderBase
     {
       app_log() << "Use existing bspline tables in " << splinefile << std::endl;
       now.restart();
-      //chunked_bcast(myComm, bspline->MultiSpline);
       bspline->bcast_tables(myComm);
       app_log() << "  SplineAdoptorReader bcast the full table " << now.elapsed() << " sec" << std::endl;
       app_log().flush();

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -66,6 +66,11 @@ struct SplineAdoptorReader: public BsplineReaderBase
     FFTplan=NULL;
   }
 
+  // set info for Hybrid
+  virtual void initialize_hybridrep_atomic_centers() {}
+  // transform cG to radial functions
+  virtual void create_atomic_centers_Gspace(Vector<std::complex<double> >& cG, Communicate& band_group_comm, int iorb) {}
+
   void export_MultiSpline(multi_UBspline_3d_z** target)
   {
     *target = new multi_UBspline_3d_z;
@@ -136,6 +141,9 @@ struct SplineAdoptorReader: public BsplineReaderBase
       app_log() << "  Using real einspline table" << std::endl;
     if(bspline->is_soa_ready)
       app_log() << "  Can use SoA implementation for mGL" << std::endl;
+
+    // set info for Hybrid
+    this->initialize_hybridrep_atomic_centers();
 
     //baseclass handles twists
     check_twists(bspline,bandgroup);
@@ -306,9 +314,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
         fft_spline(cG,ti);
         bspline->set_spline(spline_r,spline_i,cur_bands[iorb].TwistIndex,iorb,0);
       }
-      band_group_comm.bcast(rotate_phase_r);
-      band_group_comm.bcast(rotate_phase_i);
-      band_group_comm.bcast(cG);
+      this->create_atomic_centers_Gspace(cG, band_group_comm, iorb);
     }
 
     myComm->barrier();

--- a/src/QMCWaveFunctions/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineAdoptorReaderP.h
@@ -287,7 +287,7 @@ struct SplineAdoptorReader: public BsplineReaderBase
     int iorb_first=band_groups[band_group_comm.getGroupID()];
     int iorb_last =band_groups[band_group_comm.getGroupID()+1];
 
-    app_log() << "Start transforming 3D B-Splines and atomic orbitals for hybrid representation." << std::endl;
+    app_log() << "Start transforming plane waves to 3D B-Splines." << std::endl;
     hdf_archive h5f(&band_group_comm,false);
     Vector<std::complex<double> > cG(mybuilder->Gvecs[0].size());
     const std::vector<BandInfo>& cur_bands=bandgroup.myBands;

--- a/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/SplineHybridAdoptorReaderP.h
@@ -16,17 +16,12 @@
     
 /** @file SplineHybridAdoptorReader.h
  *
- * The most general reader class for SplineAdoptor using the full single grid for the supercell
- * - SplineR2RAdoptor
- * - SplineC2CAdoptor
- * - SplineC2RAdoptor
- * Each band is initialized with UBspline_3d_d and both real and imaginary parts are passed to the adoptor object
- * which will convert the data type to their internal precision. 
+ * derived from SplineAdoptorReader
  */
+
 #ifndef QMCPLUSPLUS_EINSPLINE_HYBRID_ADOPTOR_READERP_H
 #define QMCPLUSPLUS_EINSPLINE_HYBRID_ADOPTOR_READERP_H
-#include <mpi/collectives.h>
-#include <mpi/point2point.h>
+
 #include <Numerics/Quadrature.h>
 #include <Numerics/Bessel.h>
 #include <QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h>
@@ -146,245 +141,25 @@ struct Gvectors
 /** General SplineHybridAdoptorReader to handle any unitcell
  */
 template<typename SA>
-struct SplineHybridAdoptorReader: public BsplineReaderBase
+struct SplineHybridAdoptorReader: public SplineAdoptorReader<SA>
 {
-  typedef SA adoptor_type;
-  typedef typename adoptor_type::DataType    DataType;
-  typedef typename adoptor_type::SplineType SplineType;
+  typedef SplineAdoptorReader<SA> BaseReader;
 
-  Array<std::complex<double>,3> FFTbox;
-  Array<double,3> splineData_r, splineData_i;
-  double rotate_phase_r, rotate_phase_i;
-  UBspline_3d_d* spline_r;
-  UBspline_3d_d* spline_i;
-  BsplineSet<adoptor_type>* bspline;
-  fftw_plan FFTplan;
+  using typename BaseReader::DataType;
+  using BaseReader::bspline;
+  using BaseReader::mybuilder;
+  using BaseReader::rotate_phase_r;
+  using BaseReader::rotate_phase_i;
 
   SplineHybridAdoptorReader(EinsplineSetBuilder* e)
-    : BsplineReaderBase(e), spline_r(NULL), spline_i(NULL),
-      bspline(0), FFTplan(NULL)
+    : BaseReader(e)
   {}
 
-  ~SplineHybridAdoptorReader()
-  {
-    clear();
-  }
-
-  void clear()
-  {
-    einspline::destroy(spline_r);
-    einspline::destroy(spline_i);
-    if(FFTplan!=NULL) fftw_destroy_plan(FFTplan);
-    FFTplan=NULL;
-  }
-
-  void export_MultiSpline(multi_UBspline_3d_z** target)
-  {
-    *target = new multi_UBspline_3d_z;
-    multi_UBspline_3d_d* source_MultiSpline = (multi_UBspline_3d_d*) bspline->MultiSpline;
-
-    (*target)->spcode = MULTI_U3D;
-    (*target)->tcode  = DOUBLE_COMPLEX;
-    (*target)->coefs = (complex_double*) source_MultiSpline->coefs;
-    (*target)->x_stride = source_MultiSpline->x_stride/2;
-    (*target)->y_stride = source_MultiSpline->y_stride/2;
-    (*target)->z_stride = source_MultiSpline->z_stride/2;
-
-    (*target)->x_grid.start     = source_MultiSpline->x_grid.start;
-    (*target)->x_grid.end       = source_MultiSpline->x_grid.end;
-    (*target)->x_grid.num       = source_MultiSpline->x_grid.num;
-    (*target)->x_grid.delta     = source_MultiSpline->x_grid.delta;
-    (*target)->x_grid.delta_inv = source_MultiSpline->x_grid.delta_inv;
-    (*target)->y_grid.start     = source_MultiSpline->y_grid.start;
-    (*target)->y_grid.end       = source_MultiSpline->y_grid.end;
-    (*target)->y_grid.num       = source_MultiSpline->y_grid.num;
-    (*target)->y_grid.delta     = source_MultiSpline->y_grid.delta;
-    (*target)->y_grid.delta_inv = source_MultiSpline->y_grid.delta_inv;
-    (*target)->z_grid.start     = source_MultiSpline->z_grid.start;
-    (*target)->z_grid.end       = source_MultiSpline->z_grid.end;
-    (*target)->z_grid.num       = source_MultiSpline->z_grid.num;
-    (*target)->z_grid.delta     = source_MultiSpline->z_grid.delta;
-    (*target)->z_grid.delta_inv = source_MultiSpline->z_grid.delta_inv;
-
-    (*target)->xBC.lCode  = source_MultiSpline->xBC.lCode;
-    (*target)->xBC.rCode  = source_MultiSpline->xBC.rCode;
-    (*target)->xBC.lVal_r = source_MultiSpline->xBC.lVal;
-    (*target)->xBC.lVal_i = source_MultiSpline->xBC.lVal;
-    (*target)->xBC.rVal_r = source_MultiSpline->xBC.rVal;
-    (*target)->xBC.rVal_i = source_MultiSpline->xBC.rVal;
-    (*target)->yBC.lCode  = source_MultiSpline->yBC.lCode;
-    (*target)->yBC.rCode  = source_MultiSpline->yBC.rCode;
-    (*target)->yBC.lVal_r = source_MultiSpline->yBC.lVal;
-    (*target)->yBC.lVal_i = source_MultiSpline->yBC.lVal;
-    (*target)->yBC.rVal_r = source_MultiSpline->yBC.rVal;
-    (*target)->yBC.rVal_i = source_MultiSpline->yBC.rVal;
-    (*target)->zBC.lCode  = source_MultiSpline->zBC.lCode;
-    (*target)->zBC.rCode  = source_MultiSpline->zBC.rCode;
-    (*target)->zBC.lVal_r = source_MultiSpline->zBC.lVal;
-    (*target)->zBC.lVal_i = source_MultiSpline->zBC.lVal;
-    (*target)->zBC.rVal_r = source_MultiSpline->zBC.rVal;
-    (*target)->zBC.rVal_i = source_MultiSpline->zBC.rVal;
-
-    (*target)->num_splines =  source_MultiSpline->num_splines/2;
-    (*target)->coefs_size = source_MultiSpline->coefs_size/2;
-    // (*target)->lapl3 = (complex_double*) malloc (6*sizeof(double)*(*target)->z_stride);
-  }
-
-  void export_MultiSpline(multi_UBspline_3d_d** target)
-  {
-    *target = (multi_UBspline_3d_d*) bspline->MultiSpline;
-  }
-
-  SPOSetBase* create_spline_set(int spin, const BandInfoGroup& bandgroup)
-  {
-    ReportEngine PRE("SplineC2XAdoptorReader","create_spline_set(spin,SPE*)");
-    //Timer c_prep, c_unpack,c_fft, c_phase, c_spline, c_newphase, c_h5, c_init;
-    //double t_prep=0.0, t_unpack=0.0, t_fft=0.0, t_phase=0.0, t_spline=0.0, t_newphase=0.0, t_h5=0.0, t_init=0.0;
-    bspline=new BsplineSet<adoptor_type>;
-    app_log() << "  AdoptorName = " << bspline->AdoptorName << std::endl;
-    if(bspline->is_complex)
-      app_log() << "  Using complex einspline table" << std::endl;
-    else
-      app_log() << "  Using real einspline table" << std::endl;
-    if(bspline->is_soa_ready)
-      app_log() << "  Can use SoA implementation for mGL" << std::endl;
-
-    // set info for Hybrid
-    bspline->set_info(*(mybuilder->SourcePtcl), mybuilder->TargetPtcl, mybuilder->Super2Prim);
-    initialize_atomic_centers(bspline->AtomicCenters);
-
-    //baseclass handles twists
-    check_twists(bspline,bandgroup);
-
-    Ugrid xyz_grid[3];
-
-    typename adoptor_type::BCType xyz_bc[3];
-    bool havePsig=set_grid(bspline->HalfG,xyz_grid, xyz_bc);
-    if(!havePsig)
-    {
-      APP_ABORT("EinsplineAdoptorReader needs psi_g. Set precision=\"double\".");
-    }
-    bspline->create_spline(xyz_grid,xyz_bc);
-    int TwistNum = mybuilder->TwistNum;
-    std::ostringstream oo;
-    oo<<bandgroup.myName << ".g"<<MeshSize[0]<<"x"<<MeshSize[1]<<"x"<<MeshSize[2]<<".h5";
-    std::string splinefile= oo.str(); //bandgroup.myName+".h5";
-    //=make_spline_filename(mybuilder->H5FileName,mybuilder->TileMatrix,spin,TwistNum,bandgroup.GroupID,MeshSize);
-    bool root=(myComm->rank() == 0);
-    int foundspline=0;
-    Timer now;
-    if(root)
-    {
-      now.restart();
-      hdf_archive h5f(myComm);
-      foundspline=h5f.open(splinefile,H5F_ACC_RDONLY);
-      if(foundspline)
-      {
-        std::string aname("none");
-        foundspline = h5f.read(aname,"adoptor_name");
-        foundspline = (aname.find(bspline->KeyWord) != std::string::npos);
-      }
-      if(foundspline)
-      {
-        int sizeD=0;
-        foundspline=h5f.read(sizeD,"sizeof");
-        foundspline = (sizeD == sizeof(typename adoptor_type::DataType));
-      }
-      if(foundspline)
-      {
-        foundspline=bspline->read_splines(h5f);
-        if(foundspline) app_log() << "  Time to read the table in " << splinefile << " = " << now.elapsed() << std::endl;
-      }
-      h5f.close();
-    }
-    myComm->bcast(foundspline);
-    if(foundspline)
-    {
-      app_log() << "Use existing bspline tables in " << splinefile << std::endl;
-      now.restart();
-      //chunked_bcast(myComm, bspline->MultiSpline);
-      bspline->bcast_tables(myComm);
-      app_log() << "  SplineHybridAdoptorReader bcast the full table " << now.elapsed() << " sec" << std::endl;
-      app_log().flush();
-    }
-    else
-    {
-      bspline->flush_zero();
-
-      int nx=MeshSize[0];
-      int ny=MeshSize[1];
-      int nz=MeshSize[2];
-      if(havePsig)//perform FFT using FFTW
-      {
-        FFTbox.resize(nx, ny, nz);
-        FFTplan = fftw_plan_dft_3d(nx, ny, nz,
-                                   reinterpret_cast<fftw_complex*>(FFTbox.data()),
-                                   reinterpret_cast<fftw_complex*>(FFTbox.data()),
-                                   +1, FFTW_ESTIMATE);
-        splineData_r.resize(nx,ny,nz);
-        if(bspline->is_complex) splineData_i.resize(nx,ny,nz);
-
-        TinyVector<double,3> start(0.0);
-        TinyVector<double,3> end(1.0);
-        spline_r=einspline::create(spline_r,start,end,MeshSize,bspline->HalfG);
-        if(bspline->is_complex)
-          spline_i=einspline::create(spline_i,start,end,MeshSize,bspline->HalfG);
-
-        now.restart();
-        //initialize_spline_pio(spin,bandgroup);
-        initialize_spline_pio_reduce(spin,bandgroup);
-        app_log() << "  SplineHybridAdoptorReader initialize_spline_pio " << now.elapsed() << " sec" << std::endl;
-
-        fftw_destroy_plan(FFTplan);
-        FFTplan=NULL;
-      }
-      else//why, don't know
-        initialize_spline_psi_r(spin,bandgroup);
-      if(qmc_common.save_wfs && root)
-      {
-        now.restart();
-        hdf_archive h5f;
-        h5f.create(splinefile);
-        h5f.write(bspline->AdoptorName,"adoptor_name");
-        int sizeD=sizeof(typename adoptor_type::DataType);
-        h5f.write(sizeD,"sizeof");
-        bspline->write_splines(h5f);
-        h5f.close();
-        app_log() << "  SplineHybridAdoptorReader dump " << now.elapsed() << " sec" << std::endl;
-      }
-    }
-
-    clear();
-    return bspline;
-  }
-
-  /** fft and spline cG
-   * @param cG psi_g to be processed
-   * @param ti twist index
-   * @param iorb orbital index
-   *
-   * Perform FFT and spline to spline_r and spline_i
-   */
-  inline void fft_spline(Vector<std::complex<double> >& cG, int ti)
-  {
-    unpack4fftw(cG,mybuilder->Gvecs[0],MeshSize,FFTbox);
-    fftw_execute (FFTplan);
-    if(bspline->is_complex)
-    {
-      fix_phase_rotate_c2c(FFTbox,splineData_r, splineData_i,mybuilder->TwistAngles[ti], rotate_phase_r, rotate_phase_i);
-      einspline::set(spline_r,splineData_r.data());
-      einspline::set(spline_i,splineData_i.data());
-    }
-    else
-    {
-      fix_phase_rotate_c2r(FFTbox,splineData_r, mybuilder->TwistAngles[ti], rotate_phase_r, rotate_phase_i);
-      einspline::set(spline_r,splineData_r.data());
-    }
-  }
-
   /** initialize basic parameters of atomic orbitals */
-  void initialize_atomic_centers(std::vector<AtomicOrbitalSoA<DataType> >& centers)
+  void initialize_hybridrep_atomic_centers() override
   {
+    bspline->set_info(*(mybuilder->SourcePtcl), mybuilder->TargetPtcl, mybuilder->Super2Prim);
+    auto& centers=bspline->AtomicCenters;
     auto& ACInfo=mybuilder->AtomicCentersInfo;
     // load atomic center info only when it is not initialized
     if(centers.size()==0)
@@ -486,8 +261,11 @@ struct SplineHybridAdoptorReader: public BsplineReaderBase
   }
 
   /** initialize construct atomic orbital radial functions from plane waves */
-  inline void create_atomic_centers_Gspace(Vector<std::complex<double> >& cG, Communicate& band_group_comm, int iorb)
+  inline void create_atomic_centers_Gspace(Vector<std::complex<double> >& cG, Communicate& band_group_comm, int iorb) override
   {
+    band_group_comm.bcast(rotate_phase_r);
+    band_group_comm.bcast(rotate_phase_i);
+    band_group_comm.bcast(cG);
     //distribute G-vectors over processor groups
     const int Ngvecs=mybuilder->Gvecs[0].size();
     const int Nprocs=band_group_comm.size();
@@ -786,92 +564,6 @@ struct SplineHybridAdoptorReader: public BsplineReaderBase
     }
   }
 
-
-  /** initialize the splines
-   */
-  void initialize_spline_pio_reduce(int spin, const BandInfoGroup& bandgroup)
-  {
-    //distribute bands over processor groups
-    int Nbands=bandgroup.getNumDistinctOrbitals();
-    const int Nprocs=myComm->size();
-    const int Nbandgroups=std::min(Nbands,Nprocs);
-    Communicate band_group_comm(*myComm, Nbandgroups);
-    std::vector<int> band_groups(Nbandgroups+1,0);
-    FairDivideLow(Nbands,Nbandgroups,band_groups);
-    int iorb_first=band_groups[band_group_comm.getGroupID()];
-    int iorb_last =band_groups[band_group_comm.getGroupID()+1];
-
-    app_log() << "Start transforming 3D B-Splines and atomic orbitals for hybrid representation." << std::endl;
-    hdf_archive h5f(&band_group_comm,false);
-    Vector<std::complex<double> > cG(mybuilder->Gvecs[0].size());
-    const std::vector<BandInfo>& cur_bands=bandgroup.myBands;
-    if(band_group_comm.isGroupLeader())
-      h5f.open(mybuilder->H5FileName,H5F_ACC_RDONLY);
-    for(int iorb=iorb_first; iorb<iorb_last; iorb++)
-    {
-      if(band_group_comm.isGroupLeader())
-      {
-        int ti=cur_bands[iorb].TwistIndex;
-        std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
-        if(!h5f.read(cG,s)) APP_ABORT("SplineHybridAdoptorReader Failed to read band(s) from h5!\n");
-        double total_norm = compute_norm(cG);
-        if((checkNorm)&&(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE))
-        {
-          std::cerr << "The orbital " << iorb << " has a wrong norm " << total_norm
-                    << ", computed from plane wave coefficients!" << std::endl
-                    << "This may indicate a problem with the HDF5 library versions used "
-                    << "during wavefunction conversion or read." << std::endl;
-          APP_ABORT("SplineHybridAdoptorReader Wrong orbital norm!");
-        }
-        fft_spline(cG,ti);
-        bspline->set_spline(spline_r,spline_i,cur_bands[iorb].TwistIndex,iorb,0);
-      }
-      band_group_comm.bcast(rotate_phase_r);
-      band_group_comm.bcast(rotate_phase_i);
-      band_group_comm.bcast(cG);
-      create_atomic_centers_Gspace(cG, band_group_comm, iorb);
-    }
-
-    myComm->barrier();
-    Timer now;
-    if(band_group_comm.isGroupLeader())
-    {
-      now.restart();
-      bspline->gather_tables(band_group_comm.GroupLeaderComm);
-      app_log() << "  Time to gather the table = " << now.elapsed() << std::endl;
-    }
-    now.restart();
-    bspline->bcast_tables(myComm);
-    app_log() << "  Time to bcast the table = " << now.elapsed() << std::endl;
-  }
-
-  void initialize_spline_psi_r(int spin, const BandInfoGroup& bandgroup)
-  {
-    //not used by may be enabled later
-    int nx=MeshSize[0];
-    int ny=MeshSize[1];
-    int nz=MeshSize[2];
-    Array<DataType,3> splineData_r(nx,ny,nz),splineData_i(ny,ny,nz);
-    Array<std::complex<double>,3> rawData(nx,ny,nz);
-    const std::vector<BandInfo>& cur_bands=bandgroup.myBands;
-    //this will be parallelized with OpenMP
-    int N=bandgroup.getNumDistinctOrbitals();
-    for(int iorb=0; iorb<N; ++iorb)
-    {
-      //check dimension
-      if(myComm->rank() ==0)
-      {
-        std::string path=psi_r_path(cur_bands[iorb].TwistIndex,spin,cur_bands[iorb].BandIndex);
-        HDFAttribIO<Array<std::complex<double>,3> >  h_splineData(rawData);
-        h_splineData.read(mybuilder->H5FileID, path.c_str());
-        simd::copy(splineData_r.data(),splineData_i.data(),rawData.data(),rawData.size());
-      }
-      mpi::bcast(*myComm,splineData_r);
-      if(bspline->is_complex)
-        mpi::bcast(*myComm,splineData_i);
-      bspline->set_spline(splineData_r.data(),splineData_i.data(),cur_bands[iorb].TwistIndex,iorb,0);
-    }
-  }
 };
 }
 #endif

--- a/src/spline/einspline_impl.hpp
+++ b/src/spline/einspline_impl.hpp
@@ -452,7 +452,7 @@ namespace qmcplusplus
 
     /** spline destroy */
     template<typename SplineType>
-    inline void destroy(SplineType *restrict spline)
+    inline void destroy(SplineType *restrict &spline)
     {
       if(spline!=NULL)
       {

--- a/src/spline/einspline_util.hpp
+++ b/src/spline/einspline_util.hpp
@@ -55,33 +55,6 @@ namespace qmcplusplus
     chunked_bcast(comm,buffer->coefs, buffer->coefs_size);
   }
 
-  ///handles reduce
-  template<typename T>
-  inline void chunked_reduce(Communicate* comm, T* buffer, size_t ntot)
-  {
-    if(comm->size()==1) return;
-
-    size_t chunk_size=(1<<30)/sizeof(T); //256 MB
-    int n=static_cast<int>(ntot/chunk_size);
-
-    size_t offset=0;
-    for(int i=0; i<n; ++i, offset+=chunk_size)
-    {
-      comm->reduce_in_place(buffer+offset,static_cast<int>(chunk_size));
-    }
-
-    if(offset<ntot)
-    {
-      comm->reduce_in_place(buffer+offset,static_cast<int>(ntot-offset));
-    }
-  }
-
-  template<typename ENGT>
-  inline void chunked_reduce(Communicate* comm, ENGT* buffer)
-  {
-    chunked_reduce(comm,buffer->coefs, buffer->coefs_size);
-  }
-
   template<typename ENGT>
   inline void gatherv(Communicate* comm, ENGT* buffer, const int ncol, std::vector<int> &offset)
   {


### PR DESCRIPTION
When I first developed the reader for constructing orbitals in the hybrid orbital representation, I copied the whole reader for regular splines and add extra stuff. Overtime, I figured out what are the necessary pieces for the extra work for hybrid. So the largely duplicated lines can be removed.

This PR defines the extra work as virtual functions implemented in the reader for hybrid.
The old reader also has diverged code paths for serial and parallel. The serial is added to avoid memory issue but only works for using 1 MPI tasks. Now I do in-place construction using a single implementation and there is no scratch memory issue.