### PR TITLE
Nexus: enable POSCAR and CHGCAR file I/O

### DIFF
--- a/nexus/library/periodic_table.py
+++ b/nexus/library/periodic_table.py
@@ -17,7 +17,7 @@
 #                                                                    #
 #    Element                                                         #
 #      Class representing a single element.                          #
-#                                                                    #                                        
+#                                                                    #
 #====================================================================#
 
 
@@ -51,10 +51,6 @@ class SimpleElement(DevBase):
         self.ionic_radius      = None 
         self.melting_point     = None 
         self.boiling_point     = None 
-        #self. = None
-        #self. = None
-        #self. = None
-        #self. = None
 
         self.string_rep = None
         self.var_dict = None
@@ -536,7 +532,7 @@ class PeriodicTable(DevBase):
 	e[84].group = 16
 	e[85].group = 17
 	e[86].group = 18
-	e[87].group =1
+	e[87].group = 1
 	e[88].group = 2
 	e[89].group = 3
 	e[90].group = 0

--- a/nexus/library/vasp_input.py
+++ b/nexus/library/vasp_input.py
@@ -901,40 +901,41 @@ class Poscar(VFormattedFile):
         VFile.__init__(self,filepath)
     #end def __init__
 
+
     def change_specifier(self,specifier,vasp_input_class):
         axes=vasp_input_class.poscar.axes
         scale=vasp_input_class.poscar.scale
         unitcellvec=axes*scale
 
-      #units are in angstroms.  
+        #units are in angstroms.  
         pos=self.pos
         spec=self.coord  #the current specifier
         
         if spec==specifier:
-            #do nothing
+            return
+        #end if
+        if spec=="cartesian":
             pass
+        elif spec=="direct":
+            pos=dot(pos,unitcellvec)
         else:
-        
-            if spec=="cartesian":
-                pass
-            elif spec=="direct":
-                pos=dot(pos,unitcellvec)
-            else:
-                raise Exception("Poscar.change_specifier():  %s is not a valid coordinate specifier"%(spec))
-                 
-            spec=specifier  #the new specifier
+            self.error("Poscar.change_specifier():  %s is not a valid coordinate specifier"%(spec))
+        #end if
+        spec=specifier  #the new specifier
 
-            if spec=="cartesian":
-                pass # already in cartesian coordinates.   
-            elif spec=="direct":
-                pos=dot(pos,inv(axes))
-            else:
-                raise Exception("Poscar.change_specifier():  %s is not a valid coordinate specifier"%(spec))
+        if spec=="cartesian":
+            pass # already in cartesian coordinates.
+        elif spec=="direct":
+            pos=dot(pos,inv(axes))
+        else:
+            self.error("Poscar.change_specifier():  %s is not a valid coordinate specifier"%(spec))
+        #end if
 
-            self.coord=spec
-            self.pos=pos
-      
-        
+        self.coord=spec
+        self.pos=pos
+    #end def change_specifier
+
+
     def read_text(self,text,filepath=''):
         lines = self.read_lines(text,remove_empty=False)
         nlines = len(lines)


### PR DESCRIPTION
This PR draws POSCAR file I/O from deeper in the Nexus tree up to the more independent fileio.py module level.  CHGCAR I/O added to enable, e.g. conversion from XCrysDen xsf files to CHGCAR.  

Currently the POSCAR I/O functionality is duplicative w.r.t. portions within structure.py and vasp_input.py.  When tests for these code sections are in place later on, the duplicated code portions in these files will be replaced with usage of the PoscarFile class in fileio.py 