### PR TITLE
nexus: fix array initialization in GAMESS input class

### DIFF
--- a/nexus/library/gamess_input.py
+++ b/nexus/library/gamess_input.py
@@ -159,8 +159,7 @@ class KeywordGroup(Group):
                 var,index = var.replace('(',' ').replace(')','').split()
                 index = int(index)
                 if not var in self:
-                    arr = GIarray()
-                    arr[index] = val
+                    arr = GIarray({index:val})
                     self[var] = arr
                 else:
                     self[var][index]=val


### PR DESCRIPTION
This is a very simple bugfix for a problem reported by Cody Melton.  Originally the GIarray constructor was called improperly.