### PR TITLE
Nexus: improve user example tests

### DIFF
--- a/nexus/executables/ntest
+++ b/nexus/executables/ntest
@@ -191,7 +191,7 @@ class NexusTestBase(object):
     nexus_test_dir = '.nexus_test' # ntest directory
 
     launch_path    = None # path from which ntest exe was launched
-    current_test   = ''   # current NexusTest.name
+    current_test   = None # current NexusTest
     current_label  = ''   # current nlabel()
     test_count     =  0   # current test count
     label_count    =  0   # current label count in NexusTest.operation()
@@ -219,7 +219,11 @@ class NexusTestBase(object):
         label  = label.replace(' ','_').replace('-','_')
         tcount = str(NexusTestBase.test_count).zfill(2)
         lcount = str(NexusTestBase.label_count).zfill(2)
-        test_dir  = '{0}_{1}'.format(tcount,test)
+        if test.test_dir is None:
+            test_dir  = '{0}_{1}'.format(tcount,test.name)
+        else:
+            test_dir = test.test_dir
+        #end if
         label_dir = '{0}_{1}'.format(lcount,label)
         ntdir  = NexusTestBase.nexus_test_dir
         nlpath = NexusTestBase.launch_path
@@ -407,7 +411,7 @@ class NexusTest(NexusTestBase):
 
 
     # register the current test object in the global test list
-    def __init__(self,operation,name=None):
+    def __init__(self,operation,name=None,op_inputs=None,test_dir=None):
         if not callable(operation):
             raise NexusTestMisconstructed
         #end if
@@ -416,8 +420,16 @@ class NexusTest(NexusTestBase):
         elif not isinstance(name,str):
             raise NexusTestMisconstructed
         #end if
+        if op_inputs is not None and not isinstance(op_inputs,(tuple,dict)):
+            raise NexusTestMisconstructed
+        #end if
+        if test_dir is not None and not isinstance(test_dir,str):
+            raise NexusTestMisconstructed
+        #end if
         self.name         = name
         self.operation    = operation
+        self.op_inputs    = op_inputs
+        self.test_dir     = test_dir
         self.exception    = None
         self.status  = NexusTest.status_options['unused']
         NexusTest.test_list.append(self)
@@ -444,12 +456,20 @@ class NexusTest(NexusTestBase):
     # run the current test
     def run(self):
         nleave()
-        NexusTestBase.current_test  = self.name
+        NexusTestBase.current_test  = self
         NexusTestBase.current_label = ''
         NexusTestBase.test_count   += 1
         NexusTestBase.label_count   = 0
         try:
-            self.operation()
+            if self.op_inputs is None:
+                self.operation()
+            elif isinstance(self.op_inputs,tuple):
+                self.operation(*self.op_inputs)
+            elif isinstance(self.op_inputs,dict):
+                self.operation(**self.op_inputs)
+            else:
+                raise NexusTestMisconstructed
+            #end if
             self.status=NexusTest.status_options['passed']
         except Exception,e:
             self.exception = e
@@ -1662,91 +1682,129 @@ def settings_operation():
 
 
 
-
-example_scripts = [
-    'quantum_espresso/relax_Ge_T_vs_kpoints/relax_vs_kpoints_example.py',
-    'qmcpack/H2O/H2O.py',
-    'qmcpack/LiH/LiH.py',
-    'qmcpack/c20/c20.py',
-    'qmcpack/diamond/diamond.py',
-    'qmcpack/diamond/diamond_vacancy.py',
-    'qmcpack/graphene/graphene.py',
-    'qmcpack/oxygen_dimer/oxygen_dimer.py',
-    ]
-
-example_files = dict(
-    pwscf_relax_Ge_T = [
-        ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_111/relax.in'),
-        ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_222/relax.in'),
-        ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_444/relax.in'),
-        ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_666/relax.in'),
-        ],
-    qmcpack_H2O = [
-        ('pwscf'     ,'input','qmcpack/H2O/runs/scf.in'),
-        ('pw2qmcpack','input','qmcpack/H2O/runs/p2q.in'),
-        ('qmcpack'   ,'input','qmcpack/H2O/runs/opt.in.xml'),
-        ('qmcpack'   ,'input','qmcpack/H2O/runs/dmc.in.xml'),
-        ],
-    qmcpack_LiH = [
-        ('pwscf'     ,'input','qmcpack/LiH/runs/scf.in'),
-        ('pwscf'     ,'input','qmcpack/LiH/runs/nscf.in'),
-        ('pw2qmcpack','input','qmcpack/LiH/runs/p2q.in'),
-        ('qmcpack'   ,'input','qmcpack/LiH/runs/opt.in.xml'),
-        ('qmcpack'   ,'input','qmcpack/LiH/runs/dmc.in.xml'),
-        ],
-    qmcpack_c20 = [
-        ('pwscf'     ,'input','qmcpack/c20/runs/c20/scf/scf.in'),
-        ('pw2qmcpack','input','qmcpack/c20/runs/c20/nscf/p2q.in'),
-        ('qmcpack'   ,'input','qmcpack/c20/runs/c20/opt/opt.in.xml'),
-        ('qmcpack'   ,'input','qmcpack/c20/runs/c20/qmc/qmc.in.xml'),
-        ],
-    qmcpack_diamond = [
-        ('pwscf'     ,'input','qmcpack/diamond/runs/diamond/scf/scf.in'),
-        ('pw2qmcpack','input','qmcpack/diamond/runs/diamond/scf/conv.in'),
-        ('qmcpack'   ,'input','qmcpack/diamond/runs/diamond/vmc/vmc.in.xml'),
-        ('pwscf'     ,'input','qmcpack/diamond/runs/diamond_vacancy/relax/relax.in'),
-        ('pwscf'     ,'input','qmcpack/diamond/runs/diamond_vacancy/scf/scf.in'),
-        ],
-    qmcpack_graphene = [
-        ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/scf/scf.in'),
-        ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/nscf/nscf.in'),
-        ('pw2qmcpack','input','qmcpack/graphene/runs/graphene/nscf/p2q.in'),
-        ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/nscf_opt/nscf.in'),
-        ('pw2qmcpack','input','qmcpack/graphene/runs/graphene/nscf_opt/p2q.in'),
-        ('qmcpack'   ,'input','qmcpack/graphene/runs/graphene/opt/opt.in.xml'),
-        ('qmcpack'   ,'input','qmcpack/graphene/runs/graphene/qmc/qmc.in.xml'),
-        ],
-    qmcpack_oxygen_dimer = [
-        ('pwscf'     ,'input','qmcpack/oxygen_dimer/scale_1.0/scf.in'),
-        ('pw2qmcpack','input','qmcpack/oxygen_dimer/scale_1.0/p2q.in'),
-        ('qmcpack'   ,'input','qmcpack/oxygen_dimer/scale_1.0/opt.in.xml'),
-        ('qmcpack'   ,'input','qmcpack/oxygen_dimer/scale_1.0/qmc.in.xml'),
-        ],
+example_information = dict(
+    pwscf_relax_Ge_T = dict(
+        scripts = [
+            'quantum_espresso/relax_Ge_T_vs_kpoints/relax_vs_kpoints_example.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_111/relax.in'),
+            ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_222/relax.in'),
+            ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_444/relax.in'),
+            ('pwscf'     ,'input','quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_666/relax.in'),
+            ],
+        ),
+    qmcpack_H2O = dict(
+        scripts = [
+            'qmcpack/H2O/H2O.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/H2O/runs/scf.in'),
+            ('pw2qmcpack','input','qmcpack/H2O/runs/p2q.in'),
+            ('qmcpack'   ,'input','qmcpack/H2O/runs/opt.in.xml'),
+            ('qmcpack'   ,'input','qmcpack/H2O/runs/dmc.in.xml'),
+            ],
+        ),
+    qmcpack_LiH = dict(
+        scripts = [
+            'qmcpack/LiH/LiH.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/LiH/runs/scf.in'),
+            ('pwscf'     ,'input','qmcpack/LiH/runs/nscf.in'),
+            ('pw2qmcpack','input','qmcpack/LiH/runs/p2q.in'),
+            ('qmcpack'   ,'input','qmcpack/LiH/runs/opt.in.xml'),
+            ('qmcpack'   ,'input','qmcpack/LiH/runs/dmc.in.xml'),
+            ],
+        ),
+    qmcpack_c20 = dict(
+        scripts = [
+            'qmcpack/c20/c20.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/c20/runs/c20/scf/scf.in'),
+            ('pw2qmcpack','input','qmcpack/c20/runs/c20/nscf/p2q.in'),
+            ('qmcpack'   ,'input','qmcpack/c20/runs/c20/opt/opt.in.xml'),
+            ('qmcpack'   ,'input','qmcpack/c20/runs/c20/qmc/qmc.in.xml'),
+            ],
+        ),
+    qmcpack_diamond = dict(
+        scripts = [
+            'qmcpack/diamond/diamond.py',
+            'qmcpack/diamond/diamond_vacancy.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/diamond/runs/diamond/scf/scf.in'),
+            ('pw2qmcpack','input','qmcpack/diamond/runs/diamond/scf/conv.in'),
+            ('qmcpack'   ,'input','qmcpack/diamond/runs/diamond/vmc/vmc.in.xml'),
+            ('pwscf'     ,'input','qmcpack/diamond/runs/diamond_vacancy/relax/relax.in'),
+            ('pwscf'     ,'input','qmcpack/diamond/runs/diamond_vacancy/scf/scf.in'),
+            ],
+        ),
+    qmcpack_graphene = dict(
+        scripts = [
+            'qmcpack/graphene/graphene.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/scf/scf.in'),
+            ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/nscf/nscf.in'),
+            ('pw2qmcpack','input','qmcpack/graphene/runs/graphene/nscf/p2q.in'),
+            ('pwscf'     ,'input','qmcpack/graphene/runs/graphene/nscf_opt/nscf.in'),
+            ('pw2qmcpack','input','qmcpack/graphene/runs/graphene/nscf_opt/p2q.in'),
+            ('qmcpack'   ,'input','qmcpack/graphene/runs/graphene/opt/opt.in.xml'),
+            ('qmcpack'   ,'input','qmcpack/graphene/runs/graphene/qmc/qmc.in.xml'),
+            ],
+        ),
+    qmcpack_oxygen_dimer = dict(
+        scripts = [
+            'qmcpack/oxygen_dimer/oxygen_dimer.py',
+            ],
+        files = [
+            ('pwscf'     ,'input','qmcpack/oxygen_dimer/scale_1.0/scf.in'),
+            ('pw2qmcpack','input','qmcpack/oxygen_dimer/scale_1.0/p2q.in'),
+            ('qmcpack'   ,'input','qmcpack/oxygen_dimer/scale_1.0/opt.in.xml'),
+            ('qmcpack'   ,'input','qmcpack/oxygen_dimer/scale_1.0/qmc.in.xml'),
+            ],
+        ),
     )
 
-def user_examples():
+def user_examples(label):
 
     from pwscf_input import PwscfInput
     from qmcpack_converters import Pw2qmcpackInput
+    from gamess_input import GamessInput
     from qmcpack_input import QmcpackInput
+
+    # load information for a single user example
+    if label not in example_information:
+        raise NexusTestMisconstructed
+    #end if
+    einfo = example_information[label]
 
     # create local directory for these tests
     test_dir = nenter()
 
     # copy over nexus user examples into reference generation directory
-    command = 'rsync -av {0}/* {1}/'.format(example_dir,test_dir)
-    out,err,rc = execute(command)
-    if rc>0:
-        nfail('copying example directory failed\nattempted command:\n'+command)
+    #   only do this the first time as all user example tests share a test directory
+    if not os.path.exists(os.path.join(test_dir,'qmcpack')):
+        command = 'rsync -av {0}/* {1}/'.format(example_dir,test_dir)
+        out,err,rc = execute(command)
+        if rc>0:
+            nfail('copying example directory failed\nattempted command:\n'+command)
+        #end if
     #end if
 
     # execute all example scripts in generate_only mode
-    for script_path in example_scripts:
+    for script_path in einfo['scripts']:
         path,script = os.path.split(script_path)
         path = os.path.join(test_dir,path)
         cwd = os.getcwd()
         os.chdir(path)
-        execute('./'+script+' --generate_only --sleep=0.01')
+        command = './'+script+' --generate_only --sleep=0.01'
+        out,err,rc = execute(command)
+        if rc>0:
+            nfail('example script failed to run\nattempted command: {0}\nlocation: {1}'.format(command,path))
+        #end if
         os.chdir(cwd)
     #end for
 
@@ -1755,47 +1813,69 @@ def user_examples():
     input_classes = dict(
         pwscf      = PwscfInput,
         pw2qmcpack = Pw2qmcpackInput,
+        gamess     = GamessInput,
         qmcpack    = QmcpackInput,
         )
-    for label,filelist in example_files.iteritems():
-        # label the subtest afer the example directory
-        nlabel(label)
-        # check all generated files against the reference files
-        for code,filetype,filepath in filelist:
-            ref_filepath = os.path.join(ref_example_dir,filepath)
-            gen_filepath = os.path.join(test_dir,filepath)
-            # check that the reference file exists
-            if not os.path.exists(ref_filepath):
-                nfail('reference file is missing\nfile should be located at: {0}'.format(ref_filepath))
+    for code,filetype,filepath in einfo['files']:
+        ref_filepath = os.path.join(ref_example_dir,filepath)
+        gen_filepath = os.path.join(test_dir,filepath)
+        # check that the reference file exists
+        if not os.path.exists(ref_filepath):
+            nfail('reference file is missing\nfile should be located at: {0}'.format(ref_filepath))
+        #end if
+        # check that the generated file exists
+        if not os.path.exists(gen_filepath):
+            nfail('input file was not generated: {0}'.format(gen_filepath))
+        #end if
+        # check that the generated file matches the reference file
+        #   read the files into Nexus' object representation
+        #   use object_diff to compare object represenations
+        #   this is needed to compare floats within a tolerance
+        if filetype=='input':
+            input_class = input_classes[code]
+            ref_input = input_class(ref_filepath)
+            gen_input = input_class(gen_filepath)
+            diff,dgen,dref = object_diff(gen_input,ref_input,full=True)
+            if diff:
+                # assume failure
+                failed = True
+                # if difference due to periodically equivalent points
+                # then it is not a failure
+                check_pbc = code=='qmcpack' and len(dgen)==1 and len(dref)==1 and dgen.keys()[0].endswith('/position') and dref.keys()[0].endswith('/position')
+                check_pbc |= code=='pwscf' and len(dgen)==1 and len(dref)==1 and dgen.keys()[0].endswith('/positions') and dref.keys()[0].endswith('/positions')
+                if check_pbc:
+                    try:
+                        # extract Structure objects from SimulationInput objects
+                        rs = ref_input.return_structure()
+                        gs = gen_input.return_structure()
+                        # compare minimum image distances of all atomic coordinates
+                        d = rs.min_image_distances(gs.pos,pairs=False)
+                        # allow for small deviation due to precision of ascii floats in the text input files 
+                        if d.min()<1e-6:
+                            failed = False
+                        #end if
+                    except:
+                        None
+                    #end try
+                #end if
+                if failed:
+                    from generic import obj
+                    dgen = obj(dgen)
+                    dref = obj(dref)
+                    msg = 'reference and generated input files differ\n'
+                    msg += 'reference file: '+filepath+'\n'
+                    msg += 'reference file difference\n'
+                    msg += 40*'='+'\n'
+                    msg += str(dref)
+                    msg += 'generated file difference\n'
+                    msg += 40*'='+'\n'
+                    msg += str(dgen)
+                    nfail(msg)
+                #end if
             #end if
-            # check that the generated file exists
-            if not os.path.exists(gen_filepath):
-                nfail('input file was not generated: {0}'.format(gen_filepath))
-            #end if
-            # check that the generated file matches the reference file
-            #   read the files into Nexus' object representation
-            #   use object_diff to compare object represenations
-            #   this is needed to compare floats within a tolerance
-            if filetype=='input':
-                input_class = input_classes[code]
-                ref_input = input_class(ref_filepath)
-                gen_input = input_class(gen_filepath)
-                diff,dgen,dref = object_diff(gen_input,ref_input,full=True)
-                #if diff:
-                #    from generic import obj
-                #    dgen = obj(dgen)
-                #    dref = obj(dref)
-                #    print filepath
-                #    print 20*'='
-                #    print dref
-                #    print 20*'='
-                #    print dgen
-                ##end if
-                nassert(not diff)
-            else:
-                raise NexusTestMisconstructed
-            #end if
-        #end for
+        else:
+            raise NexusTestMisconstructed
+        #end if
     #end for
 #end def user_examples
 
@@ -1808,7 +1888,15 @@ NexusTest( generic_intrinsics )
 NexusTest( generic_extensions )
 NexusTest( nexus_imports      )
 NexusTest( settings_operation , 'settings' )
-NexusTest( user_examples      )
+
+for label in example_information.keys():
+    NexusTest(
+        name      = 'example_'+label,  # individually label tests
+        operation = user_examples,     # all tests call the same test function
+        op_inputs = dict(label=label), #   but with different inputs
+        test_dir  = 'user_examples',   # all tests are run in the same base directory 
+        )
+#end for
 
 
 
@@ -1878,14 +1966,21 @@ def regenerate_reference(update=False,overwrite=True):
     #end if
 
     # execute all example scripts in generate_only mode
-    for script_path in example_scripts:
-        print '  generating reference data for '+script_path
-        path,script = os.path.split(script_path)
-        path = os.path.join(refgen_example_dir,path)
-        cwd = os.getcwd()
-        os.chdir(path)
-        execute('./'+script+' --generate_only --sleep=0.1')
-        os.chdir(cwd)
+    for label,einfo in example_information.iteritems():
+        for script_path in einfo.scripts:
+            print '  generating reference data for '+script_path
+            path,script = os.path.split(script_path)
+            path = os.path.join(refgen_example_dir,path)
+            cwd = os.getcwd()
+            os.chdir(path)
+            command = './'+script+' --generate_only --sleep=0.1'
+            out,err,rc = execute(command)
+            if rc>0:
+                print('example script failed to run\nattempted command: {0}\nlocation: {1}'.format(command,script_path))
+                exit(1)
+            #end if
+            os.chdir(cwd)
+        #end for
     #end for
 
     # update the reference set of example files
@@ -1933,6 +2028,10 @@ if __name__=='__main__':
     parser.add_option('-R','--regex',dest='regex',
                       default='none',
                       help='Tests with names matching the regular expression (regex) will be run.  The default behavior is to run all tests (default=%default).'
+                      )
+    parser.add_option('--list',dest='list',
+                      action='store_true',default=False,
+                      help='List tests in human readable format. (default=%default).'
                       )
     parser.add_option('--ctestlist',dest='ctestlist',
                       action='store_true',default=False,
@@ -1998,6 +2097,13 @@ if __name__=='__main__':
             tests.append(test)
         #end if
     #end for
+    if options.list:
+        print 'Test list:'
+        for test in tests:
+            print ' ',test.name
+        #end for
+        exit()
+    #end if
     if len(tests)!=1 and ctest:
         exit_fail('Exactly one test should be selected when using ctest\n  tests requested: {0}'.format([test.name for test in tests]))
     #end if
@@ -2025,8 +2131,8 @@ if __name__=='__main__':
         test.run()
 
         # print the pass/fail line
-        if len(test.name)<35:
-            title = test.name+(35-len(test.name))*'.'
+        if len(test.name)<40:
+            title = test.name+(40-len(test.name))*'.'
         else:
             title = test.name
         #end if
@@ -2041,7 +2147,12 @@ if __name__=='__main__':
         #end if
         t2 = time()
         if not ctest:
-            print ' {0}/{1} {2}   {3}  {4:3.2f} sec'.format(n,len(tests),title,status,t2-t1)
+            slt = str(len(tests))
+            sn  = str(n)
+            if len(sn)<len(slt):
+                sn = (len(slt)-len(sn))*' '+sn
+            #end if
+            print ' {0}/{1} {2}   {3}  {4:3.2f} sec'.format(sn,slt,title,status,t2-t1)
         #end if
         
         # print more information if failed

--- a/nexus/library/pwscf_input.py
+++ b/nexus/library/pwscf_input.py
@@ -1495,7 +1495,7 @@ class PwscfInput(SimulationInput):
     #end def incorporate_system_old
 
         
-    def return_system(self,**valency):
+    def return_system(self,structure_only=False,**valency):
         ibrav = self.system.ibrav
         if ibrav!=0:
             self.error('ability to handle non-zero ibrav not yet implemented')
@@ -1525,6 +1525,10 @@ class PwscfInput(SimulationInput):
             )
         structure.zero_corner()
         structure.recenter()
+
+        if structure_only:
+            return structure
+        #end if
   
         ion_charge = 0
         atoms   = list(self.atomic_positions.atoms)

--- a/nexus/library/qmcpack_input.py
+++ b/nexus/library/qmcpack_input.py
@@ -3605,7 +3605,7 @@ class QmcpackInput(SimulationInput,Names):
     #end def incorporate_system
         
 
-    def return_system(self):
+    def return_system(self,structure_only=False):
         input = self.copy()
         input.pluralize()
         axes,ps,H = input.get('lattice','particlesets','hamiltonian')
@@ -3751,7 +3751,11 @@ class QmcpackInput(SimulationInput,Names):
 
         system = PhysicalSystem(structure,net_charge,net_spin,**valency) 
         
-        return system
+        if structure_only:
+            return structure
+        else:
+            return system
+        #end if
     #end def return_system
 
 

--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -120,6 +120,10 @@ class SimulationInput(NexusCore):
         return text
     #end def write
 
+    def return_structure(self):
+        return self.return_system(structure_only=True)
+    #end def return_structure
+
     def read_text(self,text,filepath=None):
         self.not_implemented()
     #end def read_text
@@ -133,7 +137,7 @@ class SimulationInput(NexusCore):
         self.not_implemented()
     #end def incorporate_system
 
-    def return_system(self):
+    def return_system(self,structure_only=False):
         #create a physical system object from input file information
         self.not_implemented()
     #end def return_system

--- a/nexus/library/sqd_input.py
+++ b/nexus/library/sqd_input.py
@@ -1682,14 +1682,18 @@ class SqdInput(SimulationInput,Names):
     #end def incorporate_system
         
 
-    def return_system(self):
+    def return_system(self,structure_only=False):
         system = PhysicalSystem(
             structure = Structure(
                 elem = [self.simulation.atom.name],
                 pos  = [[0,0,0]]
                 )
             )
-        return system
+        if structure_only:
+            return system.structure
+        else:
+            return system
+        #end if
     #end def return_system
 #end class SqdInput
 

--- a/nexus/library/structure.py
+++ b/nexus/library/structure.py
@@ -746,10 +746,10 @@ class Structure(Sobj):
                       magnetic_prim  = magnetic_prim
                       )
         #end if
-        if kpoints!=None:
+        if kpoints is not None:
             self.add_kpoints(kpoints,kweights)
         #end if
-        if kgrid!=None:
+        if kgrid is not None:
             self.add_kmesh(kgrid,kshift)
         #end if        
         if rescale:

--- a/nexus/library/vasp_input.py
+++ b/nexus/library/vasp_input.py
@@ -1369,7 +1369,9 @@ class VaspInput(SimulationInput,Vobj):
 
         return species
     #end def incorporate_system
-    def return_system(self,**valency):
+
+
+    def return_system(self,structure_only=False,**valency):
         axes=self.poscar.axes
         scale=self.poscar.scale
         axes=scale*axes
@@ -1419,6 +1421,10 @@ class VaspInput(SimulationInput,Vobj):
          
         structure.zero_corner()
         structure.recenter()
+
+        if structure_only:
+            return structure
+        #end if
 
         ion_charge = 0
         atoms   = list(elem)


### PR DESCRIPTION
Improve user example tests in two ways: 

1) Split the user example tests into many, i.e. one for each user example test directory rather than a single monolithic test encompassing all of them. 

2) Improve input file fidelity checks in the case of periodic boundary conditions.  Due to rounding errors, an atom at position 0 may be assigned a position at either 0 or L, which are equivalent in PBC but not w.r.t. plain float comparison.  Check whether a comparison of reference and generated input files is failing on the basis of different atomic positions alone and whether the positions differ w.r.t. PBC or not.