### PR TITLE
Nexus: fix convert4qmc workflow in the case -nojastrow is not provided

### DIFF
--- a/nexus/library/qmcpack_converters.py
+++ b/nexus/library/qmcpack_converters.py
@@ -855,7 +855,11 @@ class Convert4qmc(Simulation):
         wfn_file  = prefix+'.Gaussian-G2.xml'
         ptcl_file = prefix+'.Gaussian-G2.ptcl.xml'
         if not os.path.exists(os.path.join(self.locdir,ptcl_file)):
-            wfn_file  = prefix+'.wfnoj.xml'
+            if self.input.no_jastrow:
+                wfn_file  = prefix+'.wfnoj.xml'
+            else:
+                wfn_file  = prefix+'.wfj.xml'
+            #end if
             ptcl_file = prefix+'.structure.xml'
         #end if
         return wfn_file,ptcl_file


### PR DESCRIPTION
Nexus originally expected convert4qmc to produce a wfnoj.xml file.  This file is only produced if the -nojastrow flag is provided and so workflows not involving this flag will not complete successfully, since convert4qmc is erroneously assumed to have failed (no wfnoj.xml file present).  

This PR fixes the issue by judging convert4qmc completion as successful if either wfj.xml or wfnoj.xml are produced.  Either file is now accepted as wavefunction input to QMCPACK.

Issue reported by Chandler Bennett.