### PR TITLE
Add test for transform to grid.

### DIFF
--- a/src/Numerics/tests/CMakeLists.txt
+++ b/src/Numerics/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ SET(UTEST_NAME unit_test_${SRC_DIR})
 
 SET(UTEST_SRCS test_grid_functor.cpp test_nr_spline.cpp test_stdlib.cpp test_bessel.cpp
                test_ylm.cpp test_e2iphi.cpp test_aligned_allocator.cpp
-               test_gaussian_basis.cpp test_cartesian_tensor.cpp test_soa_cartesian_tensor.cpp)
+               test_gaussian_basis.cpp test_cartesian_tensor.cpp test_soa_cartesian_tensor.cpp
+               test_transform.cpp)
 
 # Run gen_gto.py to create these files.  They may take a long time to compile.
 #SET(UTEST_SRCS ${UTEST_SRCS} test_full_cartesian_tensor.cpp test_full_soa_cartesian_tensor.cpp)

--- a/src/Numerics/tests/test_transform.cpp
+++ b/src/Numerics/tests/test_transform.cpp
@@ -1,0 +1,62 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include <stdio.h>
+#include <string>
+#include <iostream>
+
+#include "Numerics/Transform2GridFunctor.h"
+#include "Numerics/OneDimQuinticSpline.h"
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+class Input
+{
+public:
+  typedef double value_type;
+
+  double f(double r) {
+    return r*r;
+  }
+
+  double df(double r) {
+    return 2*r;
+  }
+};
+
+TEST_CASE("transform2gridfunctor", "[numerics]")
+{
+
+  typedef OneDimGridBase<double> GridType;
+  typedef OneDimQuinticSpline<double> OutputType;
+
+  GridType *agrid = new LogGrid<double>;
+  agrid->set(0.1, 10, 10);
+  OutputType output(agrid);
+  Input input;
+  Transform2GridFunctor<Input, OutputType> transform(input, output);
+  double rmin = 0.1;
+  double rmax = 10;
+  int npts = 10;
+  transform.generate(rmin, rmax, npts);
+  REQUIRE(output.splint(0.1) == Approx(0.01));
+  REQUIRE(output.splint(0.15) == Approx(0.0225));
+  REQUIRE(output.splint(7.0) == Approx(49.0));
+  REQUIRE(output.splint(10) == Approx(100.0));
+
+}
+}


### PR DESCRIPTION
A simple test for converting a functor to a grid, which is used in representing atomic orbitals.