### PR TITLE
Titan requires cmake3 doesn't need 2 cmakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   #------------------------
   IF($ENV{CRAYPE_VERSION} MATCHES ".")
     MESSAGE(STATUS "Running on a Cray machine.")
+    CMAKE_MINIMUM_REQUIRED(VERSION 3.6.1)
     SET(CMAKE_SKIP_RPATH TRUE)
 
     # Flags for ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,6 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   #------------------------
   IF($ENV{CRAYPE_VERSION} MATCHES ".")
     MESSAGE(STATUS "Running on a Cray machine.")
-    CMAKE_MINIMUM_REQUIRED(VERSION 3.6.1)
     SET(CMAKE_SKIP_RPATH TRUE)
 
     # Flags for ctest

--- a/config/build_olcf_titan.sh
+++ b/config/build_olcf_titan.sh
@@ -116,7 +116,6 @@ echo "building qmcpack for gpu real for titan"
 mkdir -p build_titan_gpu_real
 cd build_titan_gpu_real
 cmake -D QMC_CUDA=1 ..
-cmake -D QMC_CUDA=1 ..
 make -j 32
 cd ..
 ln -sf ./build_titan_gpu_real/bin/qmcpack ./qmcpack_titan_gpu_real
@@ -127,7 +126,6 @@ echo ""
 echo "building qmcpack for gpu complex for titan"
 mkdir -p build_titan_gpu_comp
 cd build_titan_gpu_comp
-cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
 make -j 32
 cd ..

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -645,15 +645,18 @@ used. The build system checks for these and does not (should not) use
 the compilers directly.
 
 \begin{verbatim}
+export CRAYPE_LINK_TYPE=dynamic
 module swap PrgEnv-pgi PrgEnv-gnu # Use gnu compilers
 module load cudatoolkit           # CUDA for GPU build
-module load cray-hdf5
-module load cmake
+module load cray-hdf5-parallel
+module load cmake3
 module load fftw
 export FFTW_HOME=$FFTW_DIR/..
 module load boost
 mkdir build_titan_gpu
 cd build_titan_gpu
+export CC=cc
+export CXX=CC
 cmake -DQMC_CUDA=1 ..             # Must enable CUDA capabilities
 make -j 8
 ls -l bin/qmcpack
@@ -667,13 +670,15 @@ Crays requires only loading the appropriate library modules.
 export CRAYPE_LINK_TYPE=dynamic
 module swap PrgEnv-pgi PrgEnv-gnu # Use gnu compilers
 module unload cudatoolkit         # No CUDA for CPU build
-module load cray-hdf5
-module load cmake
+module load cray-hdf5-parallel
+module load cmake3
 module load fftw
 export FFTW_HOME=$FFTW_DIR/..
 module load boost
 mkdir build_titan_cpu
 cd build_titan_cpu
+export CC=cc
+export CXX=CC
 cmake ..
 make -j 8
 ls -l bin/qmcpack


### PR DESCRIPTION
Installation guide updated to work, build_olcf_titan.sh fixed

cmake no longer needs to be run twice on titan