### PR TITLE
Attempt fix for test_MO with Intel SoA build

### DIFF
--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -61,6 +61,7 @@ void test_He(bool transform)
     ions.R[0] = 0.0;
     SpeciesSet &ispecies = ions.getSpeciesSet();
     int heIdx = ispecies.addSpecies("He");
+    ions.update();
 
 
   #ifdef ENABLE_SOA


### PR DESCRIPTION
Add a call to ions.update to ensure that RSoA.copyIn get called.

It appears that ions must be updated before elec (because the call to elec.update uses
data from ions).

With this change, the run has no uninitialized value errors from valgrind (w/o the change, there are some uninit values errors)

The test failure is here.  I could not reproduce it.  Fix is a guess.
https://cdash.qmcpack.org/CDash/testDetails.php?test=2544595&build=24654