### PR TITLE
Align pade2 input tag as pade

### DIFF
--- a/manual/jastrow_one_body_pade.tex
+++ b/manual/jastrow_one_body_pade.tex
@@ -65,14 +65,14 @@ The name of the particleset holding the ionic positions is "i".
 \begin{lstlisting}[language=xml]
 <jastrow name="J1" function="pade2" type="One-Body" print="yes" source="i">
   <correlation elementType="Li">
-    <var id="LiA" name="A">  0.34 </parameter>
-    <var id="LiB" name="B"> 12.78 </parameter>
-    <var id="LiC" name="C">  1.62 </parameter>
+    <var id="LiA" name="A">  0.34 </var>
+    <var id="LiB" name="B"> 12.78 </var>
+    <var id="LiC" name="C">  1.62 </var>
   </correlation>
   <correlation elementType="H"">
-    <parameter id="HA" name="A">  0.14 </parameter>
-    <parameter id="HB" name="B"> 6.88 </parameter>
-    <parameter id="HC" name="C"> 0.237 </parameter>
+    <var id="HA" name="A">  0.14 </var>
+    <var id="HB" name="B"> 6.88 </var>
+    <var id="HC" name="C"> 0.237 </var>
   </correlation>
 </jastrow>
 \end{lstlisting}

--- a/manual/jastrow_one_body_pade.tex
+++ b/manual/jastrow_one_body_pade.tex
@@ -65,9 +65,9 @@ The name of the particleset holding the ionic positions is "i".
 \begin{lstlisting}[language=xml]
 <jastrow name="J1" function="pade2" type="One-Body" print="yes" source="i">
   <correlation elementType="Li">
-    <parameter id="LiA" name="A">  0.34 </parameter>
-    <parameter id="LiB" name="B"> 12.78 </parameter>
-    <parameter id="LiC" name="C">  1.62 </parameter>
+    <var id="LiA" name="A">  0.34 </parameter>
+    <var id="LiB" name="B"> 12.78 </parameter>
+    <var id="LiC" name="C">  1.62 </parameter>
   </correlation>
   <correlation elementType="H"">
     <parameter id="HA" name="A">  0.14 </parameter>

--- a/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
+++ b/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
@@ -427,7 +427,11 @@ struct Pade2ndOrderFunctor:public OptimizableFunctorBase
     while(tcur != NULL)
     {
       std::string cname((const char*)(tcur->name));
-      if(cname == "parameter" || cname == "Var")
+      if(cname == "parameter")
+      {
+        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var'");
+      }
+      else if(cname == "var" || cname == "Var")
       {
         std::string doopt("yes");
         std::string id_in("0");
@@ -704,7 +708,11 @@ struct PadeTwo2ndOrderFunctor:public OptimizableFunctorBase
     while(tcur != NULL)
     {
       std::string cname((const char*)(tcur->name));
-      if(cname == "parameter" || cname == "Var")
+      if(cname == "parameter")
+      {
+        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var'");
+      }
+      else if(cname == "var" || cname == "Var")
       {
         std::string id_in("0");
         std::string p_name("B");

--- a/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
+++ b/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
@@ -429,7 +429,7 @@ struct Pade2ndOrderFunctor:public OptimizableFunctorBase
       std::string cname((const char*)(tcur->name));
       if(cname == "parameter")
       {
-        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var'");
+        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var' in the 'correlation' of pade2 Jastrow!");
       }
       else if(cname == "var" || cname == "Var")
       {
@@ -710,7 +710,7 @@ struct PadeTwo2ndOrderFunctor:public OptimizableFunctorBase
       std::string cname((const char*)(tcur->name));
       if(cname == "parameter")
       {
-        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var'");
+        throw std::runtime_error("Keyword 'parameter' has been replaced by 'var' in the 'correlation' of pade2 Jastrow!");
       }
       else if(cname == "var" || cname == "Var")
       {


### PR DESCRIPTION
Now pade2 no more accept parameter but var/Var.
As @jtkrogel pointed out that 'parameter' should only accept a name/value pair and will be parsed by designated parser(validation will be added in the future).
close #413