### PR TITLE
Set LCAO pyscf tests based on SOA_SUCCESS

### DIFF
--- a/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
@@ -113,7 +113,7 @@ bool AtomicBasisBuilder<RFB>::put(xmlNodePtr cur)
     expandlm = MOD_NATURAL_EXPAND;
     addsignforM=tmp_addsignforM;
     if(sph != "spherical") {
-      APP_ABORT(" Error: expandYlm='pwscf' only compatible with angular='spherical'. Aborting.\n");
+      APP_ABORT(" Error: expandYlm='pyscf' only compatible with angular='spherical'. Aborting.\n");
     }
   }
   if(sph == "cartesian" || Morder == "Gamess")
@@ -165,7 +165,7 @@ bool AtomicBasisBuilder<RFB>::putH5(hdf_archive &hin)
     expandlm = MOD_NATURAL_EXPAND;
     addsignforM=tmp_addsignforM;
     if(sph != "spherical") {
-      APP_ABORT(" Error: expandYlm='pwscf' only compatible with angular='spherical'. Aborting.\n");
+      APP_ABORT(" Error: expandYlm='pyscf' only compatible with angular='spherical'. Aborting.\n");
     }
   }
   if(sph == "cartesian" || Morder == "Gamess")
@@ -603,7 +603,7 @@ int AtomicBasisBuilder<RFB>::expandYlmH5(const std::string& rnl, const QuantumNu
        // }
        // //increment number of basis functions
        // num++;
-      APP_ABORT(" Error: expandYlm='pwscf'  with angular='spherical' And HDF5 not implemented in AOS version of the code. Aborting.\n");
+      APP_ABORT(" Error: expandYlm='pyscf'  with angular='spherical' And HDF5 not implemented in AOS version of the code. Aborting.\n");
        
 
   }

--- a/tests/molecules/FeCO6_b3lyp_pyscf/CMakeLists.txt
+++ b/tests/molecules/FeCO6_b3lyp_pyscf/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 IF (NOT QMC_CUDA)
- IF (NOT QMC_COMPLEX)
-  IF (ENABLE_SOA)
+  IF (NOT QMC_COMPLEX)
 #
 # [Fe(CO)6]2+ molecule gaussian tests, with BFD ECP using pyscf
 
@@ -20,7 +19,7 @@ IF (NOT QMC_CUDA)
                     vmc_short_noj
                     vmc_short_noj.in.xml
                     1 16
-                    TRUE
+                    ${SOA_SUCCESS}
                     0 FeCO6_PYSCF_SHORT # VMC
                     )
 
@@ -33,16 +32,13 @@ IF (NOT QMC_CUDA)
                     vmc_long_noj
                     vmc_long_noj.in.xml
                     1 16
-                    TRUE
+                    ${SOA_SUCCESS}
                     0 FeCO6_PYSCF_LONG # VMC
                     )
 
   ELSE()
-    MESSAGE("Skipping  FeCO6_b3lyp_pyscf tests because Spherical representaion not supported by AoS (ENABLE_SOA=0)")
-  ENDIF()
- ELSE()
     MESSAGE("Skipping  FeCO6_b3lyp_gms tests because gaussian basis sets are not supported by complex build (QMC_COMPLEX=1)")
- ENDIF()
+  ENDIF()
 ELSE()
     MESSAGE("Skipping FeCO6_b3lyp_gms tests because gaussian basis sets are not supported by CUDA build (QMC_CUDA=1)")
 ENDIF()

--- a/tests/molecules/LiH_dimer_ae_gms/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_gms/CMakeLists.txt
@@ -16,7 +16,7 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_SHORT "samples" "9600000 0.0") # samples
   QMC_RUN_AND_CHECK(short-LiH_dimer_ae_gms-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_gms"
-                    vmc_short_noj 
+                    vmc_short_noj
                     vmc_short_noj.in.xml
                     1 16
                     TRUE
@@ -29,8 +29,8 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_LONG "samples" "96000000 0.0") # samples
   QMC_RUN_AND_CHECK(long-LiH_dimer_ae_qp-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_gms"
-                    vmc_long_noj 
-                    vmc_long_noj.in.xml 
+                    vmc_long_noj
+                    vmc_long_noj.in.xml
                     1 16
                     TRUE
                     0 LIH_LONG # VMC

--- a/tests/molecules/LiH_dimer_ae_pyscf/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_pyscf/CMakeLists.txt
@@ -4,7 +4,7 @@ IF (NOT QMC_CUDA)
 #
 # LiH molecular dimer gaussian tests, all electron using pyscf
 # Also check results for different number of mpi tasks and threads keeping total constant
-# Energy from Pyscf: E=-7.9873236457148  
+# Energy from Pyscf: E=-7.9873236457148
 #
 #   "kinetic" "7.991344  0.000065") # kinetic energy
 #   "totenergy" "-7.9873125  0.0000086 ") # total energy
@@ -17,10 +17,10 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_SHORT "samples" "9600000 0.0") # samples
   QMC_RUN_AND_CHECK(short-LiH_dimer_ae_pyscf-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_pyscf"
-                    vmc_short_noj 
+                    vmc_short_noj
                     vmc_short_noj.in.xml
                     1 16
-                    TRUE
+                    ${SOA_SUCCESS}
                     0 LIH_SHORT # VMC
                     )
 
@@ -30,10 +30,10 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_LONG "samples" "96000000 0.0") # samples
   QMC_RUN_AND_CHECK(long-LiH_dimer_ae_pyscf-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_pyscf"
-                    vmc_long_noj 
-                    vmc_long_noj.in.xml 
+                    vmc_long_noj
+                    vmc_long_noj.in.xml
                     1 16
-                    TRUE
+                    ${SOA_SUCCESS}
                     0 LIH_LONG # VMC
                     )
 

--- a/tests/molecules/LiH_dimer_ae_qp/CMakeLists.txt
+++ b/tests/molecules/LiH_dimer_ae_qp/CMakeLists.txt
@@ -18,7 +18,7 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_SHORT "samples" "9600000 0.0") # samples
   QMC_RUN_AND_CHECK(short-LiH_dimer_ae_qp-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_qp"
-                    vmc_short_noj 
+                    vmc_short_noj
                     vmc_short_noj.in.xml
                     1 16
                     TRUE
@@ -31,8 +31,8 @@ IF (NOT QMC_CUDA)
   LIST(APPEND LIH_LONG "samples" "96000000 0.0") # samples
   QMC_RUN_AND_CHECK(long-LiH_dimer_ae_qp-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/molecules/LiH_dimer_ae_qp"
-                    vmc_long_noj 
-                    vmc_long_noj.in.xml 
+                    vmc_long_noj
+                    vmc_long_noj.in.xml
                     1 16
                     TRUE
                     0 LIH_LONG # VMC


### PR DESCRIPTION
pyscf uses spherical tensor and only SoA can run.