### PR TITLE
Consistent name SingleParticleXXX

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -135,11 +135,11 @@ struct PtclOnLatticeTraits
 #if defined(QMC_COMPLEX)
   typedef ParticleAttrib<TinyVector<Complex_t,OHMMS_DIM> > ParticleGradient_t;
   typedef ParticleAttrib<Complex_t>                      ParticleLaplacian_t;
-  typedef Complex_t                                      ParticleValue_t;
+  typedef Complex_t                                      SingleParticleValue_t;
 #else
   typedef ParticleAttrib<TinyVector<Scalar_t,OHMMS_DIM> > ParticleGradient_t;
   typedef ParticleAttrib<Scalar_t>                       ParticleLaplacian_t;
-  typedef Scalar_t                                       ParticleValue_t;
+  typedef Scalar_t                                       SingleParticleValue_t;
 #endif
 };
 

--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -95,7 +95,7 @@ struct Walker
   /** array of laplacians */
   typedef typename p_traits::ParticleLaplacian_t ParticleLaplacian_t;
   /** typedef for value data type. */
-  typedef typename p_traits::ParticleValue_t ParticleValue_t;
+  typedef typename p_traits::SingleParticleValue_t SingleParticleValue_t;
 
   ///typedef for the property container, fixed size
   typedef Matrix<EstimatorRealType>           PropertyContainer_t;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
@@ -168,7 +168,7 @@ void CSVMCUpdateAllWithDrift::advanceWalker(Walker_t& thisWalker, bool recompute
   for(int ipsi=0; ipsi<nPsi; ipsi++)
   {
     invsumratio[ipsi]=1.0/sumratio[ipsi];
-    cumGrad+=Psi1[ipsi]->G*static_cast<Walker_t::ParticleValue_t>(invsumratio[ipsi]);
+    cumGrad+=Psi1[ipsi]->G*static_cast<Walker_t::SingleParticleValue_t>(invsumratio[ipsi]);
   }
 
     for(int ipsi=0; ipsi<nPsi; ipsi++) cumNorm[ipsi]+=invsumratio[ipsi];

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -1296,7 +1296,7 @@ void WaveFunctionTester::runRatioTest2()
       RealType ratio_accum(1.0);
       for (int iat=0; iat<nat; iat++)
       {
-        TinyVector<ParticleSet::ParticleValue_t,OHMMS_DIM> grad_now=Psi.evalGrad(W,iat);
+        TinyVector<ParticleSet::SingleParticleValue_t,OHMMS_DIM> grad_now=Psi.evalGrad(W,iat);
         GradType grad_new;
         for(int sds=0; sds<3; sds++)
           fout<< realGrad[iat][sds]-grad_now[sds]<<" ";

--- a/src/QMCHamiltonians/PulayForce.cpp
+++ b/src/QMCHamiltonians/PulayForce.cpp
@@ -134,7 +134,7 @@ PulayForce::evaluate(ParticleSet& P)
   {
     GradLogPsi[ion] = EGradLogPsi[ion] = PosType();
     for(int nn=d_ab.M[ion], elec=0; nn<d_ab.M[ion+1]; ++nn,++elec)
-      GradLogPsi[ion] -= P.G[elec] * static_cast<ParticleSet::ParticleValue_t>(WarpNorm[elec] * WarpFunction(d_ab.r(nn)));
+      GradLogPsi[ion] -= P.G[elec] * static_cast<ParticleSet::SingleParticleValue_t>(WarpNorm[elec] * WarpFunction(d_ab.r(nn)));
       //GradLogPsi[ion] -= P.G[elec] * (ParticleSet::Scalar_t)(WarpNorm[elec] * WarpFunction(d_ab.r(nn)));
     RealType E = tWalker->Properties(0,LOCALENERGY);
     // EGradLogPsi[ion] = P.getPropertyBase()[LOCALENERGY] * GradLogPsi[ion];

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -416,7 +416,7 @@ SymTensor<StressPBC::RealType,OHMMS_DIM> StressPBC::evaluateKineticSymTensor(Par
   for (int iat=0; iat<P.getTotalNum(); iat++)
   {
     const RealType minv(1.0/P.Mass[iat]);
-    complex_ktensor+=outerProduct(P.G[iat],P.G[iat])*static_cast<ParticleSet::ParticleValue_t>(minv);
+    complex_ktensor+=outerProduct(P.G[iat],P.G[iat])*static_cast<ParticleSet::SingleParticleValue_t>(minv);
     complex_ktensor+=grad_grad_psi[iat]*minv;
     //complex_ktensor+=(grad_grad_psi[iat] + outerProduct(P.G[iat],P.G[iat]))*(1.0/(P.Mass[iat]));
   }

--- a/src/QMCWaveFunctions/AGPDeterminant.h
+++ b/src/QMCWaveFunctions/AGPDeterminant.h
@@ -171,9 +171,9 @@ public:
   ///address of FirstAddressOfdVD+OHMMS_DIM*Ndown*Nup
   BasisSetType::ValueType *LastAddressOfdVD;
   ///address of myG[0][0]
-  ParticleSet::ParticleValue_t *FirstAddressOfG;
+  ParticleSet::SingleParticleValue_t *FirstAddressOfG;
   ///address of FirstAddressOfG+OHMMS_DIM*NumPtcls
-  ParticleSet::ParticleValue_t *LastAddressOfG;
+  ParticleSet::SingleParticleValue_t *LastAddressOfG;
   ///address of dY[0][0]
   BasisSetType::ValueType *FirstAddressOfdY;
   ///address of FirstAddressOfdY+NumPtcls*BasisSize

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -52,7 +52,7 @@ public:
   typedef SPOSetBase::HessType      HessType;
 
 #ifdef MIXED_PRECISION
-  typedef ParticleSet::ParticleValue_t mValueType;
+  typedef ParticleSet::SingleParticleValue_t mValueType;
   typedef OrbitalSetTraits<mValueType>::ValueMatrix_t ValueMatrix_hp_t;
 #else
   typedef ValueType mValueType;
@@ -293,7 +293,7 @@ public:
 #ifdef MIXED_PRECISION
   /// temporal matrix and workspace in higher precision for the accurate inversion.
   ValueMatrix_hp_t psiM_hp;
-  Vector<ParticleSet::ParticleValue_t> WorkSpace_hp;
+  Vector<ParticleSet::SingleParticleValue_t> WorkSpace_hp;
   DiracMatrix<mValueType> detEng_hp;
 #endif
   DiracMatrix<ValueType> detEng;
@@ -302,8 +302,8 @@ public:
   Vector<IndexType> Pivot;
 
   ValueType curRatio,cumRatio;
-  ParticleSet::ParticleValue_t *FirstAddressOfG;
-  ParticleSet::ParticleValue_t *LastAddressOfG;
+  ParticleSet::SingleParticleValue_t *FirstAddressOfG;
+  ParticleSet::SingleParticleValue_t *LastAddressOfG;
   ValueType *FirstAddressOfdV;
   ValueType *LastAddressOfdV;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -757,10 +757,10 @@ DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     int kk = BFTrans->optIndexMap[pa];
 #if defined(QMC_COMPLEX)
     dlogpsi[kk]+=real(dpsia);
-    dhpsioverpsi[kk] -= real(0.5*static_cast<ParticleSet::ParticleValue_t>(dLa)+Dot(P.G,Gtemp));
+    dhpsioverpsi[kk] -= real(0.5*static_cast<ParticleSet::SingleParticleValue_t>(dLa)+Dot(P.G,Gtemp));
 #else
     dlogpsi[kk]+=dpsia;
-    dhpsioverpsi[kk] -= (0.5*static_cast<ParticleSet::ParticleValue_t>(dLa)+Dot(P.G,Gtemp));
+    dhpsioverpsi[kk] -= (0.5*static_cast<ParticleSet::SingleParticleValue_t>(dLa)+Dot(P.G,Gtemp));
 #endif
   }
 }
@@ -899,7 +899,7 @@ DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
 #endif
     // \sum_i (\nabla_pa  \nabla2_i D) / D
     for(int k=0; k<num; k++)
-      dG(offset,pa,k) = Gtemp[k] + myG[k]*static_cast<ParticleSet::ParticleValue_t>(dpsia);  // (\nabla_pa \nabla_i D) / D
+      dG(offset,pa,k) = Gtemp[k] + myG[k]*static_cast<ParticleSet::SingleParticleValue_t>(dpsia);  // (\nabla_pa \nabla_i D) / D
   }
 }
 
@@ -1013,10 +1013,10 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     int kk = pa; //BFTrans->optIndexMap[pa];
 #if defined(QMC_COMPLEX)
     dlogpsi[kk]+=real(dpsia);
-    dhpsioverpsi[kk] -= real(0.5*static_cast<ParticleSet::ParticleValue_t>(La1+La2+La3)+Dot(P.G,Gtemp));
+    dhpsioverpsi[kk] -= real(0.5*static_cast<ParticleSet::SingleParticleValue_t>(La1+La2+La3)+Dot(P.G,Gtemp));
 #else
     dlogpsi[kk]+=dpsia;
-    dhpsioverpsi[kk] -= (0.5*static_cast<ParticleSet::ParticleValue_t>(La1+La2+La3)+Dot(P.G,Gtemp));
+    dhpsioverpsi[kk] -= (0.5*static_cast<ParticleSet::SingleParticleValue_t>(La1+La2+La3)+Dot(P.G,Gtemp));
 #endif
     *G0 += Gtemp;
     (*L0)[0] += La1+La2+La3;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -188,7 +188,7 @@ OrbitalBase::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P
   {
     int upC = C2node_up[i];
     int dnC = C2node_dn[i];
-    ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+    ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
     psi += tmp;
     //for(int n=FirstIndex_up; n<LastIndex_up; n++) {
     myG += grads_up[upC]*tmp; // other spin sector should be zero
@@ -602,7 +602,7 @@ OrbitalBase::RealType MultiSlaterDeterminant::updateBuffer(ParticleSet& P, WFBuf
   {
     int upC = C2node_up[i];
     int dnC = C2node_dn[i];
-    ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+    ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
     psi += tmp;
     //for(int n=FirstIndex_up; n<LastIndex_up; n++) {
     myG += grads_up[upC]*tmp; // other spin sector should be zero
@@ -754,7 +754,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
         int dnC = C2node_dn[i];
         ValueType tmp = C[i]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
         lapl_sum += tmp*(tempstorage_up[upC]+tempstorage_dn[dnC]);
-        ParticleSet::ParticleValue_t tmp_DP(tmp);
+        ParticleSet::SingleParticleValue_t tmp_DP(tmp);
         g += grads_up[upC]*tmp_DP;
         g += grads_dn[dnC]*tmp_DP;
       }
@@ -783,7 +783,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
           ValueType tmp=CSFexpansion[cnt]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
           cdet+=tmp;
           q0 += tmp*(tempstorage_up[upC]+tempstorage_dn[dnC]);
-          ParticleSet::ParticleValue_t tmp_DP(tmp);
+          ParticleSet::SingleParticleValue_t tmp_DP(tmp);
           v1 += tmp_DP*(Dot(gmP,grads_up[upC])+Dot(gmP,grads_dn[dnC]));
 //           v1 += tmp*(Dot(P.G,grads_up[upC])-Dot(g,grads_up[upC]));
 //           v2 += tmp*(Dot(P.G,grads_dn[dnC])-Dot(g,grads_dn[dnC]));
@@ -824,7 +824,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
         int dnC = C2node_dn[i];
         ValueType tmp = C[i]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
         lapl_sum += tmp*(tempstorage_up[upC]+tempstorage_dn[dnC]);
-        ParticleSet::ParticleValue_t tmp_DP(tmp);
+        ParticleSet::SingleParticleValue_t tmp_DP(tmp);
         g += grads_up[upC]*tmp_DP;
         g += grads_dn[dnC]*tmp_DP;
       }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -149,14 +149,14 @@ OrbitalBase::ValueType MultiSlaterDeterminantWithBackflow::evaluate(ParticleSet&
   {
     int upC = C2node_up[i];
     int dnC = C2node_dn[i];
-    ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+    ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
     psi += tmp;
     myG += grads_up[upC]*tmp;
     myG += grads_dn[dnC]*tmp;
     myL += lapls_up[upC]*tmp;
     myL += lapls_dn[dnC]*tmp;
     for(int k=0; k<numP; k++)
-      myL[k] += 2.0*static_cast<ParticleSet::ParticleValue_t>(tmp)*dot(grads_up[upC][k],grads_dn[dnC][k]);
+      myL[k] += 2.0*static_cast<ParticleSet::SingleParticleValue_t>(tmp)*dot(grads_up[upC][k],grads_dn[dnC][k]);
   }
   ValueType psiinv = (RealType)1.0/psi;
   myG *= psiinv;
@@ -191,7 +191,7 @@ OrbitalBase::GradType MultiSlaterDeterminantWithBackflow::evalGrad(ParticleSet& 
     {
       int upC = C2node_up[i];
       int dnC = C2node_dn[i];
-      ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+      ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
       psi += tmp;
       grad_iat += grads_up[upC][iat]*tmp;
     }
@@ -210,7 +210,7 @@ OrbitalBase::GradType MultiSlaterDeterminantWithBackflow::evalGrad(ParticleSet& 
     {
       int upC = C2node_up[i];
       int dnC = C2node_dn[i];
-      ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+      ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
       psi += tmp;
       grad_iat += grads_dn[dnC][iat]*tmp;
     }
@@ -577,7 +577,7 @@ OrbitalBase::RealType MultiSlaterDeterminantWithBackflow::updateBuffer(ParticleS
   {
     int upC = C2node_up[i];
     int dnC = C2node_dn[i];
-    ParticleSet::ParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
+    ParticleSet::SingleParticleValue_t tmp = C[i]*detValues_up[upC]*detValues_dn[dnC];
     psi += tmp;
     myG += grads_up[upC]*tmp; // other spin sector should be zero
     myG += grads_dn[dnC]*tmp; // other spin sector should be zero
@@ -735,8 +735,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
         ValueType tmp = C[i]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
         lapl_sum += tmp*(tempstorage_up[upC]+tempstorage_dn[dnC]
                          +static_cast<ValueType>(2.0*Dot(grads_up[upC],grads_dn[dnC])));
-        g += grads_up[upC]*static_cast<ParticleSet::ParticleValue_t>(tmp);
-        g += grads_dn[dnC]*static_cast<ParticleSet::ParticleValue_t>(tmp);
+        g += grads_up[upC]*static_cast<ParticleSet::SingleParticleValue_t>(tmp);
+        g += grads_dn[dnC]*static_cast<ParticleSet::SingleParticleValue_t>(tmp);
       }
       gmP=g-P.G;
       gg=Dot(gmP,g);
@@ -799,8 +799,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
         int dnC = C2node_dn[i];
         ValueType tmp = C[i]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
         lapl_sum += tmp*(tempstorage_up[upC]+tempstorage_dn[dnC]+static_cast<ValueType>(2.0*Dot(grads_up[upC],grads_dn[dnC])));
-        g += grads_up[upC]*static_cast<ParticleSet::ParticleValue_t>(tmp);
-        g += grads_dn[dnC]*static_cast<ParticleSet::ParticleValue_t>(tmp);
+        g += grads_up[upC]*static_cast<ParticleSet::SingleParticleValue_t>(tmp);
+        g += grads_dn[dnC]*static_cast<ParticleSet::SingleParticleValue_t>(tmp);
       }
       gmP=g-P.G;
       ggP=Dot(gmP,g);
@@ -867,7 +867,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             int upC = C2node_up[i];
             int dnC = C2node_dn[i];
             ValueType cdet=C[i]*detValues_up[upC]*detValues_dn[dnC]*psiinv;
-            ParticleSet::ParticleValue_t dot1=0.0;
+            ParticleSet::SingleParticleValue_t dot1=0.0;
             ValueType dpsi1=dpsia_up(upC,pa);
             ValueType dpsi2=dpsia_dn(dnC,pa);
             ParticleSet::ParticleGradient_t& g1 = grads_up[upC];
@@ -875,8 +875,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             for(int k=0; k<n; k++)
               dot1 += dot((g2[k]-gmP[k]),dGa_up(upC,pa,k))
                       + dot((g1[k]-gmP[k]),dGa_dn(dnC,pa,k))
-                      - static_cast<ParticleSet::ParticleValue_t>(dpsi1)*(dot(gmP[k],g2[k]))
-                      - static_cast<ParticleSet::ParticleValue_t>(dpsi2)*(dot(gmP[k],g1[k]));
+                      - static_cast<ParticleSet::SingleParticleValue_t>(dpsi1)*(dot(gmP[k],g2[k]))
+                      - static_cast<ParticleSet::SingleParticleValue_t>(dpsi2)*(dot(gmP[k],g1[k]));
             dlog += cdet*(dpsi1+dpsi2);
             dhpsi += cdet*( dLa_up(upC,pa) + dLa_dn(dnC,pa)
                             + dpsi2*tempstorage_up[upC] + dpsi1*tempstorage_dn[dnC]

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -220,7 +220,7 @@ void SlaterDetWithBackflow::testDerivGL(ParticleSet& P)
     BFTrans->evaluate(P);
     for(int k=0; k<Dets.size(); k++)
       psi2 += Dets[k]->evaluateLog(P,G2,L2);
-    ParticleSet::ParticleValue_t tmp=0.0;
+    ParticleSet::SingleParticleValue_t tmp=0.0;
     for(int q=0; q<P.getTotalNum(); q++)
       tmp+=(L1[q]-L2[q])/(2.0*dh);
     app_log() <<i <<"\n"

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -399,7 +399,7 @@ void PWOrbitalBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, 
   RealType dy=1.0/static_cast<RealType>(nG[1]-1);
   RealType dz=1.0/static_cast<RealType>(nG[2]-1);
 #if defined(VERYTINYMEMORY)
-  typedef Array<ParticleSet::ParticleValue_t,3> StorageType;
+  typedef Array<ParticleSet::SingleParticleValue_t,3> StorageType;
   StorageType inData(nG[0],nG[1],nG[2]);
   int ib=0;
   while(ib<myParam->numBands)
@@ -451,7 +451,7 @@ void PWOrbitalBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, 
     ++ib;
   }
 #else
-  typedef Array<ParticleSet::ParticleValue_t,3> StorageType;
+  typedef Array<ParticleSet::SingleParticleValue_t,3> StorageType;
   std::vector<StorageType*> inData;
   int nb=myParam->numBands;
   for(int ib=0; ib<nb; ib++)


### PR DESCRIPTION
When I first added the type, the name was not chosen consistently.
ParticleXXX_t refers all the particles.
SingleParticleValueXXX_t refers one particle.