### PR TITLE
Workaround for 1RDM zero problem

### DIFF
--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -453,12 +453,14 @@ namespace qmcplusplus
       for(int s=0;s<nspecies;++s)
       {
         out<<pad<<"  matrices/vectors for species "<<s<< std::endl;
-        out<<pad<<"    E_N        : "<< E_N[s]->size()<< std::endl;
+        if(energy_mat)
+          out<<pad<<"    E_N        : "<< E_N[s]->size()<< std::endl;
         out<<pad<<"    Phi_NB     : "<< Phi_NB[s]->rows()<<" "<<Phi_NB[s]->cols()<< std::endl;
         out<<pad<<"    Psi_NM     : "<< Psi_NM[s]->rows()<<" "<<Psi_NM[s]->cols()<< std::endl;
         out<<pad<<"    Phi_Psi_NB : "<< Phi_Psi_NB[s]->rows()<<" "<<Phi_Psi_NB[s]->cols()<< std::endl;
         out<<pad<<"    N_BB       : "<< N_BB[s]->rows()<<" "<<N_BB[s]->cols()<< std::endl;
-        out<<pad<<"    E_BB       : "<< E_BB[s]->rows()<<" "<<E_BB[s]->cols()<< std::endl;
+        if(energy_mat)
+          out<<pad<<"    E_BB       : "<< E_BB[s]->rows()<<" "<<E_BB[s]->cols()<< std::endl;
       }
     }
     out<<pad<<"  basis_norms"<< std::endl;
@@ -590,7 +592,7 @@ namespace qmcplusplus
 
   DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
   {
-    if(have_required_traces)
+    if(have_required_traces || !energy_mat)
     {
       if(check_derivatives)
         test_derivatives();
@@ -611,7 +613,11 @@ namespace qmcplusplus
     if(!warmed_up)
       warmup_sampling();
     // get weight and single particle energy trace data
-    RealType weight=w_trace->sample[0]*metric;
+    RealType weight;
+    if(energy_mat)
+      weight=w_trace->sample[0]*metric;
+    else
+      weight=tWalker->Weight*metric;
     if(energy_mat)
       get_energies(E_N);               // energies        : particles x 1
     // compute sample positions (monte carlo or deterministic)
@@ -825,7 +831,11 @@ namespace qmcplusplus
     const int basis_size2 = basis_size*basis_size;
     if(!warmed_up)
       warmup_sampling();
-    RealType weight=w_trace->sample[0]*metric;
+    RealType weight;
+    if(energy_mat)
+      weight=w_trace->sample[0]*metric;
+    else
+      weight=tWalker->Weight*metric;
     int nparticles = P.getTotalNum();
     generate_samples(weight);
     int n=0;


### PR DESCRIPTION
This PR fixes the manifesting problem with the 1RDM, namely that zeros are populated in the stat.h5 file output.

The overarching issue is a currently unresolved bug in the flow of Traces logic, as it applies to the special case of Traces being used to stream e.g. energetic information to estimators.  Even when the streaming of data is requested, this currently does not happen.

Since this data is only strictly necessary for the energy density matrix (1REDM), a workaround is put in place to allow computation of the 1RDM when the 1REDM is turned off via the input file.

Following this PR, the 1RDM works as originally implemented and is appropriately diagonal for a system w/o a Jastrow (tested explicitly for a small diamond cell).  Further correctness tests and efficiency improvements remain to be made.

A full fix for the data streaming issue will follow the pending implementation of tests for the energy density, 1REDM, and traces.

Input for a working variant of the diamond test case (tests/solids/diamondC_1x1x1_pp) is attached (see [qmc.zip](https://github.com/QMCPACK/qmcpack/files/2275699/qmc.zip)).

