### PR TITLE
Fix incorrect sign in LR Breakup

### DIFF
--- a/src/LongRange/LRHandlerTemp.h
+++ b/src/LongRange/LRHandlerTemp.h
@@ -141,7 +141,7 @@ public:
   {
     mRealType v=0.0;
     for(int n=0; n<coefs.size(); n++)
-      v -= coefs[n]*Basis.h(n,r);
+      v += coefs[n]*Basis.h(n,r);
     return v;
   }
 

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -594,7 +594,7 @@ void CoulombPBCAB::add(int groupID, RadFunctorType* ppot)
     {
       RealType r=(*myGrid)[ig];
       //need to multiply r for the LR
-      v[ig]=r*AB->evaluateLR(r)+ppot->splint(r);
+      v[ig]= -r*AB->evaluateLR(r)+ppot->splint(r);
     }
     v[0] = 2.0*v[1] - v[2];
     //by construction, v has to go to zero at the boundary


### PR DESCRIPTION
The Esler style long-range breakup has the wrong sign for LRHandlerTemp::evaluateLR(r), but the error is compensated by an incorrect sign when computing the LocalECP in CoulombPBCAB.cpp.  LocalECP energy now correct when using Ewald or Esler breakups.