### PR TITLE
Nexus: fix density matrix analyzer

### DIFF
--- a/nexus/library/numerics.py
+++ b/nexus/library/numerics.py
@@ -848,8 +848,8 @@ def simstats(x,dim=None):
         #end if
         error=sqrt(var/Neff)
     else:
-        error = zeros(mean.shape)
-        kappa = zeros(mean.shape)
+        error = zeros(mean.shape,dtype=mean.dtype)
+        kappa = zeros(mean.shape,dtype=mean.dtype)
         for v in xrange(nvars):
             i=0          
             tempC=0.5

--- a/nexus/library/qmcpack_quantity_analyzers.py
+++ b/nexus/library/qmcpack_quantity_analyzers.py
@@ -1484,10 +1484,14 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                 loc_data[mname] = mdata
                 for species,d in matrix.iteritems():
                     v = d.value
-                    v2 = d.value_squared
+                    if 'value_squared' in d:
+                        v2 = d.value_squared
+                    #end if
                     if len(v.shape)==4 and v.shape[3]==2:
                         d.value         = v[:,:,:,0]  + i*v[:,:,:,1]
-                        d.value_squared = v2[:,:,:,0] + i*v2[:,:,:,1]
+                        if 'value_squared' in d:
+                            d.value_squared = v2[:,:,:,0] + i*v2[:,:,:,1]
+                        #end if
                         self.info.complex = True
                     #end if
                     mdata[species] = d
@@ -1549,7 +1553,7 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                 tdata = zeros((len(md_all),))
                 b = 0
                 for mat in md_all:
-                    tdata[b] = trace(mat)
+                    tdata[b] = trace(mat).real # trace sums to N-elec (real)
                     b+=1
                 #end for
                 t,tvar,terr,tkap = simstats(tdata[nbe:])
@@ -1577,6 +1581,9 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                         )
                 else:
                     m,mvar,merr,mkap = simstats(mdata.transpose((1,2,0)))
+
+                    mfull  = m
+                    mefull = merr
 
                     if matrix_name=='number_matrix':
                         # remove states that do not have significant occupation
@@ -1619,7 +1626,7 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
                     insig_coup = ones(m.shape,dtype=bool)
                     for i in range(nsig):
                         for j in range(nsig):
-                            mdiag = min(abs(m[i,i]),abs(m[j,j]))
+                            mdiag = min((abs(m[i,i]),abs(m[j,j])))
                             insig_coup[i,j] = abs(m[i,j])/mdiag < coup_tol
                         #end for
                     #end for
@@ -1638,15 +1645,17 @@ class DensityMatricesAnalyzer(HDFAnalyzer):
 
                     # save common results
                     msres.set(
-                        matrix          = m,
-                        matrix_error    = merr,
-                        sig_states      = sig_states,
-                        sig_occ         = sig_occ,
-                        insig_coup      = insig_coup,
-                        insig_stat      = insig_stat,
-                        insig_coup_stat = insig_coup_stat,
-                        eigval          = eigval,
-                        eigvec          = eigvec
+                        matrix            = m,
+                        matrix_error      = merr,
+                        sig_states        = sig_states,
+                        sig_occ           = sig_occ,
+                        insig_coup        = insig_coup,
+                        insig_stat        = insig_stat,
+                        insig_coup_stat   = insig_coup_stat,
+                        eigval            = eigval,
+                        eigvec            = eigvec,
+                        matrix_full       = mfull,
+                        matrix_error_full = mefull,
                         )
 
                     if jackknife:


### PR DESCRIPTION
Density matrix analyzer needed to be updated to account for the removal of value_squared from the stat.h5 output.  Also fixed the issuance of several warnings related to complex to real conversion (computations all kept in complex now, except for the matrix trace which must be real).

Example usage:
```
from qmcpack_analyzer import QmcpackAnalyzer
qm = QmcpackAnalyzer(‘qmc.in.xml’,analyze=True)
nm = qa.qmc[0].DensityMatrices.number_matrix
print nm
```

Data structure of "nm" printed above:
```
B: number of statistical blocks
M: number of orbitals/states in basis
S: number of significant states (determined by occupation number)

occ_tol default : 1e-3
coup_tol default: 1e-4
stat_tol default: 2.0

nm                - number (a.k.a. density) matrix
  u                 - up electron matrix
    data              - B,M,M complex array, raw matrix data
    trace_data        - B     real array,  per block trace of density matrix
    trace             - 1     real number, mean of trace of density matrix
    trace_error       - 1     real number, error bar of trace of density matrix

    matrix_full       - M,M   complex array, raw density matrix mean
    matrix_error_full - M,M   complex array, raw density matrix error bar

    sig_occ           - S     int array, states with sum(occ)>Nu-occ_tol
    sig_states        - M,M   bool array, mask array of sig_occ matrix elements
    insig_coup        - S,S   bool array, |m_ij|/min(|m_ii|,|m_jj|)<coup_tol
    insig_stat        - S,S   bool array, |m_ij|/me_ij<stat_tol
    insig_coup_stat   - S,S   bool array, insig_coup or insig_stat

    matrix            - S,S   complex array, filtered density matrix mean
    matrix_error      - S,S   complex array, filtered density matrix error bar
                        (matrix = matrix_full[sig_states], matrix[insig_coup_stat]=0)

    eigmean           - S     complex array, occupation number means
    eigerr            - S     complex array, occupation number errorbars (via jackknife)
    eigval            - S     same as eigmean
    eigvec            - S,S   complex array, natural orbitals

  d                 - down electron matrix
    (identical structure to u above)
```