### PR TITLE
Fix ctest script

### DIFF
--- a/CMake/ctest_script.cmake
+++ b/CMake/ctest_script.cmake
@@ -2,7 +2,11 @@
 # Usage:  ctest -s script,build
 #   build = debug / optimized / valgrind / coverage
 # Note: this test will use use the number of processors defined in the variable N_PROCS,
-#   the enviornmental variable N_PROCS, or the number of processors availible (if not specified)
+#   the enviornmental variables
+#   N_PROCS, or the number of processors availible (if not specified)
+#   N_PROCS_BUILD, or N_PROCS (if not specified)
+#   N_CONCURRENT_TESTS, or N_PROCS (if not specified)
+#   TEST_SITE_NAME, or HOSTNAME (if not specified)
 
 # Set platform specific variables
 SITE_NAME( HOSTNAME )
@@ -54,12 +58,6 @@ ELSEIF( ${HOSTNAME} MATCHES "titan" )
     SET( CTEST_CMAKE_GENERATOR "Unix Makefiles")
     SET( CTEST_SITE "titan.ccs.ornl.gov" )
     SET( N_PROCS_BUILD 8 )
-ELSEIF( ${HOSTNAME} MATCHES "cetus" )
-# Setup for cetus.alcf.anl.gov BlueGene/Q
-    SET( CTEST_CMAKE_GENERATOR "Unix Makefiles")
-    SET( CTEST_SITE "cetus.alcf.anl.gov" )
-    SET( N_PROCS 24)
-    SET( TEST_PARALLEL_LEVEL 1 ) 
 ELSEIF( ${HOSTNAME} MATCHES "billmp1" )
 # Setup for billmp1.ornl.gov Mac
     SET( CC /opt/mpich/install/mpich-3.2/bin/mpicc )
@@ -76,12 +74,6 @@ ELSEIF( ${HOSTNAME} MATCHES "billmp1" )
     ELSE()
         SET( CTEST_BUILD_NAME Clang-Release-Mac )
     ENDIF()
-ELSEIF( ${HOSTNAME} MATCHES "ryzen-box" )
-    SET( CC mpicc )
-    SET( CXX mpicxx )
-    SET( CTEST_CMAKE_GENERATOR "Unix Makefiles")
-    SET( QMC_OPTIONS "${QMC_OPTIONS};-DCMAKE_PREFIX_PATH=/opt/OpenBLAS" )
-    SET( N_PROCS 16)
 ELSE()
     MESSAGE( MESSAGE "Unknown host: ${HOSTNAME}. Using generic setting." )
     SET( CTEST_CMAKE_GENERATOR "Unix Makefiles")
@@ -159,11 +151,11 @@ IF( NOT DEFINED N_PROCS )
     ENDIF()
 ENDIF()
 
+MESSAGE("Testing with ${N_PROCS} processors")
+
 # Set the number of processors
 IF( NOT DEFINED N_PROCS_BUILD )
-     IF ( DEFINED $ENV{N_PROCS_BUILD} )
-        SET( N_PROCS_BUILD $ENV{N_PROCS_BUILD} )
-     ENDIF()
+    SET( N_PROCS_BUILD $ENV{N_PROCS_BUILD} )
 ENDIF()	
 
 # Set basic variables
@@ -183,12 +175,11 @@ IF ( BUILD_SERIAL )
     SET( CTEST_BUILD_COMMAND "${MAKE_CMD} -i" )
 ELSEIF ( DEFINED N_PROCS_BUILD )
     SET( CTEST_BUILD_COMMAND "${MAKE_CMD} -i -j ${N_PROCS_BUILD}" )
+    MESSAGE("Building with ${N_PROCS_BUILD} processors")
 ELSE()
     SET( CTEST_BUILD_COMMAND "${MAKE_CMD} -i -j ${N_PROCS}" )
+    MESSAGE("Building with ${N_PROCS} processors")
 ENDIF()
-
-MESSAGE("Building with ${N_PROCS_BUILD} processors")
-MESSAGE("Testing with ${N_PROCS} processors")
 
 # Set valgrind options
 SET( VALGRIND_COMMAND_OPTIONS  "--tool=memcheck --leak-check=yes --track-fds=yes --num-callers=50 --show-reachable=yes --suppressions=${QMC_SOURCE_DIR}/src/ValgrindSuppresionFile" )
@@ -272,11 +263,14 @@ ENDIF()
 MESSAGE("Configure options:")
 MESSAGE("   ${CTEST_OPTIONS}")
 
+IF ( NOT DEFINED CTEST_SITE )
+    SET( CTEST_SITE $ENV{TEST_SITE_NAME} )
+ENDIF()
+IF ( NOT DEFINED CTEST_SITE )
+    SET( CTEST_SITE ${HOSTNAME} )
+ENDIF()
 
 # Configure and run the tests
-IF ( NOT DEFINED CTEST_SITE )
-     SET( CTEST_SITE ${HOSTNAME} )
-ENDIF()
 CTEST_START("${CTEST_DASHBOARD}")
 CTEST_UPDATE()
 CTEST_CONFIGURE(
@@ -294,7 +288,7 @@ ELSEIF (CTEST_COVERAGE_COMMAND)
   # Skip the normal tests when doing coverage
 ELSE()
 #    CTEST_TEST( INCLUDE short PARALLEL_LEVEL ${N_PROCS} )
-    IF( DEFINED TEST_PARALLEL_LEVEL )
+    IF( DEFINED ENV{N_CONCURRENT_TESTS} )
          CTEST_TEST( PARALLEL_LEVEL ${TEST_PARALLEL_LEVEL} )
     ELSE()
          CTEST_TEST( PARALLEL_LEVEL ${N_PROCS} )

--- a/tests/test_automation/nightly_anl_bora.sh
+++ b/tests/test_automation/nightly_anl_bora.sh
@@ -5,14 +5,15 @@
 # Run the "short" nightlies
 # 
 
+export TEST_SITE_NAME=bora.alcf.anl.gov
+export N_PROCS_BUILD=24
 export N_PROCS=32
 export CC=mpicc
 export CXX=mpicxx
 export BOOST_ROOT=/sandbox/opt/qmcdev/trunk/external_codes/boost_1_55_0
 
-QE_BIN=/sandbox/opt/qe-6.2.1/bin
+QE_BIN=/sandbox/opt/qe-stable/qe-6.2.1/bin
 QMC_DATA=/sandbox/yeluo/benchmark
-site_name=bora.alcf.anl.gov
 
 #Must be an absolute path
 place=/sandbox/QMCPACK_CI_BUILDS_DO_NOT_REMOVE
@@ -68,7 +69,7 @@ then
   mkdir -p $place/log/$entry/$mydate
 fi
 
-CTEST_FLAGS="-D QE_BIN=$QE_BIN -D QMC_DATA=$QMC_DATA -D CTEST_SITE=$site_name"
+CTEST_FLAGS="-D QE_BIN=$QE_BIN -D QMC_DATA=$QMC_DATA"
 
 if [[ $sys == *"Complex"* ]]; then
   CTEST_FLAGS="$CTEST_FLAGS -D QMC_COMPLEX=1"

--- a/tests/test_automation/nightly_anl_cetus.sub
+++ b/tests/test_automation/nightly_anl_cetus.sub
@@ -11,6 +11,10 @@
 # Run the "short" nightlies, requeue if an executable is built
 # 
 
+export TEST_SITE_NAME=cetus.alcf.anl.gov
+export N_PROCS_BUILD=24
+export N_CONCURRENT_TESTS=1
+
 #Must be an absolute path
 place=/projects/PSFMat/QMCPACK_CI_BUILDS_DO_NOT_REMOVE
 


### PR DESCRIPTION
expose more environment variables
N_PROCS_BUILD to restrict the number of processors during compilation
N_CONCURRENT_TESTS to restrict the number of tests running simultaneously.
TEST_SITE_NAME, name to be shown on the site column on cdash.

In principle, all the per machine configurations are no more needed.
Using the following in the job script.
CC, CXX, N_PROCS, N_PROCS_BUILD, N_CONCURRENT_TESTS, TEST_SITE_NAME

There was a bug in the script
`IF ( DEFINED $ENV{N_PROCS_BUILD} )`
If N_PROCS_BUILD is defined a value 18, it is checking if 18 is defined.
should be
 `IF ( DEFINED ENV{N_PROCS_BUILD} )`