### PR TITLE
Add (real space) derivative of long-range component to LR Handlers.  

### DIFF
--- a/src/LongRange/EwaldHandler.h
+++ b/src/LongRange/EwaldHandler.h
@@ -61,6 +61,7 @@ public:
   EwaldHandler(ParticleSet& ref, mRealType kc_in=-1.0)
     : LRHandlerBase(kc_in)
   {
+    LRHandlerBase::ClassName="EwaldHandler";
     Sigma=LR_kc=ref.Lattice.LR_kc;
   }
 
@@ -116,15 +117,6 @@ public:
    */
   inline mRealType srDf(mRealType r, mRealType rinv)
   {
-    return 0.0;
-  }
-  /**  evaluate the first derivative of the long-range part in real space at r
-   *
-   * @param r  radius
-   */
-  inline mRealType lrDf(mRealType r)
-  {
-    APP_ABORT("Error.  lrDf(r) in EwaldHandler not implemented\n");
     return 0.0;
   }
 

--- a/src/LongRange/EwaldHandler3D.h
+++ b/src/LongRange/EwaldHandler3D.h
@@ -47,6 +47,7 @@ public:
   EwaldHandler3D(ParticleSet& ref, mRealType kc_in=-1.0)
     : LRHandlerBase(kc_in)
   {
+    LRHandlerBase::ClassName="EwaldHandler3D";
     Sigma=LR_kc=ref.Lattice.LR_kc;
   }
 

--- a/src/LongRange/LRHandlerBase.h
+++ b/src/LongRange/LRHandlerBase.h
@@ -62,7 +62,7 @@ struct LRHandlerBase
 
   
   //constructor
-  explicit LRHandlerBase(mRealType kc):LR_kc(kc) {}
+  explicit LRHandlerBase(mRealType kc):LR_kc(kc),ClassName("LRHandlerBase") {}
 
   // virtual destructor
   virtual ~LRHandlerBase() {}
@@ -255,10 +255,18 @@ struct LRHandlerBase
   virtual mRealType evaluate(mRealType r, mRealType rinv)=0;
   virtual mRealType evaluateLR(mRealType r)=0;
   virtual mRealType srDf(mRealType r, mRealType rinv)=0;
-  virtual mRealType lrDf(mRealType r)=0;
+
+  virtual mRealType lrDf(mRealType r)
+  {
+    APP_ABORT("Error: lrDf(r) is not implemented in "+ClassName+"\n");
+    return 0.0;
+  };
 
   /** make clone */
   virtual LRHandlerBase* makeClone(ParticleSet& ref)=0;
+  
+  protected:
+    std::string ClassName;
 
 };
 

--- a/src/LongRange/LRHandlerSRCoulomb.h
+++ b/src/LongRange/LRHandlerSRCoulomb.h
@@ -76,6 +76,7 @@ public:
     rV_force(0), rV_energy(0), drV_force(0), rV_stress(0), drV_stress(0)
 
   {
+    LRHandlerBase::ClassName="LRHandlerSRCoulomb";
     myFunc.reset(ref);
   }
    
@@ -276,12 +277,6 @@ public:
 //    wee<<"srDf() #"<<omp_get_thread_num()<<" dspl= "<<rinv*rinv*du-df<<" ref= "<<df<<" r= "<<r<< std::endl;
 //   app_log()<<wee.str();  
     return drV_force->splint(r)/mRealType(r*r) ; 
-  }
-
-  inline mRealType lrDf(mRealType r)
-  {
-    APP_ABORT("Error. lrDf(r) in LRHandlerSRCoulomb not implemented\n");  
-    return 0.0 ; 
   }
 
   inline mRealType srDf_strain(mRealType r, mRealType rinv)

--- a/src/LongRange/LRHandlerTemp.h
+++ b/src/LongRange/LRHandlerTemp.h
@@ -54,10 +54,12 @@ public:
   BreakupBasisType Basis; //This needs a Lattice for the constructor...
   Func myFunc;
 
+
   //Constructor
   LRHandlerTemp(ParticleSet& ref, mRealType kc_in=-1.0):
     LRHandlerBase(kc_in),FirstTime(true), Basis(ref.LRBox)
   {
+    LRHandlerBase::ClassName="LRHandlerTemp";
     myFunc.reset(ref);
   }
 
@@ -276,6 +278,7 @@ private:
     //  Fk[ki] = evalFk(k); //Call derived fn.
     //}
   }
+
 };
 }
 #endif

--- a/src/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/LongRange/LRRPABFeeHandlerTemp.h
@@ -56,6 +56,7 @@ struct LRRPABFeeHandlerTemp: public LRHandlerBase
   LRRPABFeeHandlerTemp(ParticleSet& ref, mRealType kc_in=-1.0):
     LRHandlerBase(kc_in),FirstTime(true), Basis(ref.Lattice)
   {
+    LRHandlerBase::ClassName="LRRPAFeeHandlerTemp";
     myFunc.reset(ref);
   }
 
@@ -131,16 +132,6 @@ struct LRRPABFeeHandlerTemp: public LRHandlerBase
       df += coefs[n]*Basis.df(n,r);
     return df;
   }
-  /**  evaluate the first derivative of the long range part (in real space) at r
-   *
-   * @param r  radius
-   */
-  inline mRealType lrDf(mRealType r)
-  {
-    APP_ABORT("Error.  lrDf(r) in LRRPABFeeHandlerTemp not implemented\n");
-    return 0.0;
-  }
-
 
 
   /** evaluate the contribution from the long-range part for for spline

--- a/src/LongRange/LRRPAHandlerTemp.h
+++ b/src/LongRange/LRRPAHandlerTemp.h
@@ -56,6 +56,7 @@ struct LRRPAHandlerTemp: public LRHandlerBase
   LRRPAHandlerTemp(ParticleSet& ref, mRealType kc_in=-1.0):
     LRHandlerBase(kc_in),FirstTime(true), Basis(ref.Lattice)
   {
+    LRHandlerBase::ClassName="LRRPAHandlerTemp";
     myFunc.reset(ref);
   }
 
@@ -133,12 +134,6 @@ struct LRRPAHandlerTemp: public LRHandlerBase
     for(int n=0; n<coefs.size(); n++)
       df += coefs[n]*Basis.df(n,r);
     return df;
-  }
-
-  inline mRealType lrDf(mRealType r)
-  {
-    APP_ABORT("Error.  lrDf(r) in LRRPAHandlerTemp not imlemented\n");
-    return 0.0;
   }
 
   /** evaluate the contribution from the long-range part for for spline


### PR DESCRIPTION
When constructing and computing forces associated with local ECP channels, derivatives of the following expression are required:  d/dr(vlocal(r) - r*LR(r)).  This PR adds convenience functions lrDf(r) (like srDf, which is the derivative of the short-range part) to help in computing this.  APP_ABORT is called if the function is not implemented.  
