### PR TITLE
[WIP] General Numerical orbitals 

### DIFF
--- a/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
@@ -111,10 +111,10 @@ bool AtomicBasisBuilder<RFB>::put(xmlNodePtr cur)
   else if(Morder == "pyscf")
   {
     expandlm = MOD_NATURAL_EXPAND;
-    addsignforM=tmp_addsignforM;
-    if(sph != "spherical") {
-      APP_ABORT(" Error: expandYlm='pyscf' only compatible with angular='spherical'. Aborting.\n");
-    }
+    addsignforM=1;
+    //if(sph != "spherical") 
+    //  APP_ABORT(" Error: expandYlm='pyscf' only compatible with angular='spherical'. Aborting.\n");
+    
   }
   if(sph == "cartesian" || Morder == "Gamess")
   {
@@ -156,11 +156,11 @@ bool AtomicBasisBuilder<RFB>::putH5(hdf_archive &hin)
   {
     expandlm = NATURAL_EXPAND;
   }
-  else if(Morder == "no" || Morder == "Numerical")
+  else if(Morder == "no")
   {
     expandlm = DONOT_EXPAND;
   }
-  else if(Morder == "pyscf")
+  else if(Morder == "pyscf" || Morder == "Numerical")
   {
     expandlm = MOD_NATURAL_EXPAND;
     addsignforM=tmp_addsignforM;
@@ -582,28 +582,29 @@ int AtomicBasisBuilder<RFB>::expandYlmH5(const std::string& rnl, const QuantumNu
   }
   else
   {
+       
        //assign the index for real Spherical Harmonic with (l,m)
-       // aos->LM[num] = aos->Ylm.index(nlms[q_l],nlms[q_m]);
-        //radial orbitals: add only distinct orbitals
-       // std::map<std::string,int>::iterator rnl_it = RnlID.find(rnl);
-       // if(rnl_it == RnlID.end())
-       // {
-       //   int nl = aos->Rnl.size();
-       //   if(radFuncBuilder.addRadialOrbitalH5(hin,nlms))
-       //     //assign the index for radial orbital with (n,l)
-       //   {
-       //     aos->NL[num] = nl;
-       //     RnlID[rnl] = nl;
-       //   }
-       // }
-       // else
-       // {
-       //   //assign the index for radial orbital with (n,l) if repeated
-       //   aos->NL[num] = (*rnl_it).second;
-       // }
-       // //increment number of basis functions
-       // num++;
-      APP_ABORT(" Error: expandYlm='pyscf'  with angular='spherical' And HDF5 not implemented in AOS version of the code. Aborting.\n");
+        aos->LM[num] = aos->Ylm.index(nlms[q_l],nlms[q_m]);
+       // //radial orbitals: add only distinct orbitals
+        std::map<std::string,int>::iterator rnl_it = RnlID.find(rnl);
+        if(rnl_it == RnlID.end())
+        {
+          int nl = aos->Rnl.size();
+          if(radFuncBuilder.addRadialOrbitalH5(hin,nlms))
+            //assign the index for radial orbital with (n,l)
+          {
+            aos->NL[num] = nl;
+            RnlID[rnl] = nl;
+          }
+        }
+        else
+        {
+          //assign the index for radial orbital with (n,l) if repeated
+          aos->NL[num] = (*rnl_it).second;
+        }
+        //increment number of basis functions
+        num++;
+      //APP_ABORT(" Error: expandYlm='pyscf'  with angular='spherical' And HDF5 not implemented in AOS version of the code. Aborting.\n");
        
 
   }

--- a/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/AtomicBasisBuilder.h
@@ -156,7 +156,7 @@ bool AtomicBasisBuilder<RFB>::putH5(hdf_archive &hin)
   {
     expandlm = NATURAL_EXPAND;
   }
-  else if(Morder == "no")
+  else if(Morder == "no" || Morder == "Numerical")
   {
     expandlm = DONOT_EXPAND;
   }

--- a/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
@@ -179,7 +179,6 @@ public:
 
              if(!hin.read(elementType,"elementType"))
                  PRE.error("Could not read elementType in H5; Probably Corrupt H5 file",true);
-             std::cout<<"elementType="<<elementType<<" basiset_name="<<basiset_name<<std::endl;
           }
           myComm->bcast(basiset_name);
           myComm->bcast(elementType);

--- a/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
@@ -179,6 +179,7 @@ public:
 
              if(!hin.read(elementType,"elementType"))
                  PRE.error("Could not read elementType in H5; Probably Corrupt H5 file",true);
+             std::cout<<"elementType="<<elementType<<" basiset_name="<<basiset_name<<std::endl;
           }
           myComm->bcast(basiset_name);
           myComm->bcast(elementType);

--- a/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h
@@ -162,6 +162,7 @@ public:
 private:
   void addGaussian(xmlNodePtr cur);
   void addGaussianH5(hdf_archive &hin);
+  void addNumericalH5(hdf_archive &hin);
   void addSlater(xmlNodePtr cur);
   void addNumerical(xmlNodePtr cur, const std::string& dsname);
   void addPade(xmlNodePtr cur);


### PR DESCRIPTION
Converter: 
in the HDF5 format, converter requires No change at all. Input files can be genereated using the tag: 
convert4qmc -orbitals MyFile.h5

ParserFromCodeX:
Parser is still being refined. However, It should produce an identical H5 file as every other code (pyscf, QP or gamess). 
Main difference is located in : 
/basiset/atomicBasisSet{id}/basisGroup{id}/grid_name = "numerical"
which will then trigger reading 
/basiset/atomicBasisSet{id}/basisGroup{id}/basis_grid_xy = Matrix(npts_grid,2)

Compared to Gaussian Code, this corresponds to: 
/basiset/atomicBasisSet{id}/basisGroup{id}/grid_name = "Gaussian"
/basiset/atomicBasisSet{id}/basisGroup{id}/RadFunctions = (rad, exponent, contraction)

For accuracy testing and code correctness, initial implementation done with FHI-Aims for the trial wavefunction. Since the code is all electrons, I started with the AoS code. PR will have AoS and SoA implementation. 

AoS route: 

- Fixing the Spherical representation (sign issue) in AtomicBasisBuilder.h
- Function addRadialOrbitalH5(hin,nlms) in NGOBuilder.cpp  called from AtomicBasisBuilder.h will read the grid name. if numerical will call a new function: addNumericalH5 instead of addGaussianH5. 

-Creating addNumericalH5.() in NGOBuilder.cpp.  Function will read the grid, the number of points in the grid and will assign the grid (Matrix(npts,2)) directly to  radorb.  In Gaussian route, this was done through the class : 
Transform2GridFunctor<GaussianCombo<RealType>,RadialOrbitalType> transform(gset, *radorb);
Where:
for (int i=0;i<npts;i++)
    (*radorb)(i)=(guassian_fetchgrid(i)*pow(grid,inversepower);  // some function to put radial function into a loose grid ( see line 85 in Numerics/Transform2GridFunctor.h) 

Note that derivatives at the end of the grid where computed to force the grid to 0 at both ends. This is not necessary for numerical orbitals as the orbitals (and their derivatives cancel per construction at the edges. 
deriv = (deriv*pow(r,np)+static_cast<result_t>(np)*out_(0)*pow(r,np-1));


In the Numerical route, this is simply: 
for (int i=0;i<npts;i++)
    (*radorb)(i)=numGrid[i][1];

We then use 10D cubic splines for interpolation directly by calling 
radorb->spline(0,0,npts-1,0.0);

note that in this scheme, we never call  Transform2GridFunctor.h. 

===============
To do:
- Clean Aims Parser
- Generate AOS tests for correctness
- Port the code to SOA (will still not be usable due to the lack of Cusp Correction) 


