### PR TITLE
Store cusp correction parameters in structure.

### DIFF
--- a/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.cpp
+++ b/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.cpp
@@ -14,21 +14,20 @@
     
 #include<iostream>
 
-void fillRadFunWithPhiBar(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, RealType* data)
+void fillRadFunWithPhiBar(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, CuspCorrectionParameters& data)
 {
   Psi1=Phi;
   Psi2=Eta;
   int norb=Psi1->OrbitalSetSize;
   curOrb=curOrb_;
   curCenter=curCenter_;
-  C=data[1];
-  sg=data[2];
-  Rc=data[3];
-  alpha[0]=data[4];
-  alpha[1]=data[5];
-  alpha[2]=data[6];
-  alpha[3]=data[7];
-  alpha[4]=data[8];
+
+  C = data.C;
+  sg = data.sg;
+  Rc = data.Rc;
+  for (int i = 0; i < 5; i++) {
+    alpha[i] = data.alpha[i];
+  }
   Z=Zion;
   val1.resize(norb);
   grad1.resize(norb);
@@ -56,7 +55,7 @@ void fillRadFunWithPhi(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<
   }
 }
 
-void executeWithRCLoop(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, std::string file, RealType cutoff, RealType* data)
+void executeWithRCLoop(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, std::string file, RealType cutoff, CuspCorrectionParameters& data)
 {
   RealType bestRc = cutoff, smallX2;
   RealType xa, xb, xc, xd;
@@ -141,7 +140,7 @@ void executeWithRCLoop(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<
   }
 }
 
-RealType execute(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, std::string thisFile, RealType cutoff, RealType* data)
+RealType execute(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,false>* Phi, LCOrbitalSet<BS,false>* Eta, Vector<RealType>& xgrid, Vector<RealType>& rad_orb, std::string thisFile, RealType cutoff, CuspCorrectionParameters& data)
 {
   bool writeout=(thisFile!="NULL");
   Psi1=Phi;
@@ -299,6 +298,7 @@ RealType execute(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,fal
   if(writeout && printOrbs)
   {
     std::ofstream out(thisFile.c_str());
+    out << "# r  EL_ideal(r) EL_orig(r)  EL_curr(r)  phi(r)  phiBar(r) pr(r)" << std::endl;
     for(int i=0; i<nElms; i++)
     {
       out<<pos[i] <<"  "
@@ -314,6 +314,7 @@ RealType execute(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,fal
     std::string full;
     full = thisFile + ".full.dat";
     out.open(full.c_str());
+    out << "# r   phi(r)" << std::endl;
     int nx = 500;
     for(int i=0; i<nx; i++)
     {
@@ -323,14 +324,12 @@ RealType execute(int curOrb_, int curCenter_, RealType Zion, LCOrbitalSet<BS,fal
     }
     out.close();
   }
-  data[1]=C;
-  data[2]=sg;
-  data[3]=Rc;
-  data[4]=alpha[0];
-  data[5]=alpha[1];
-  data[6]=alpha[2];
-  data[7]=alpha[3];
-  data[8]=alpha[4];
+  data.C = C;
+  data.sg = sg;
+  data.Rc = Rc;
+  for (int i = 0; i < 5; i++) {
+    data.alpha[i] = alpha[i];
+  }
   return chi2;
 }
 

--- a/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
@@ -10,8 +10,11 @@
 //
 // File created by: Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
-    
-    
+
+
+/** @file CuspCorr.h
+  * @brief Corrections to electron-nucleus cusp for all-electron molecular calculations.
+  */
 
 #ifndef _CUSPCORR_
 #define _CUSPCORR_
@@ -34,13 +37,35 @@
 namespace qmcplusplus
 {
 
+/**
+  * @brief Cusp correction parameters
+  *
+  * From "Scheme for adding electron-nuclear cusps to Gaussian orbitals"  Ma, Towler, Drummond, and Needs
+  *  JCP 122, 224322 (2005)
+  *
+  * Equations 7 and 8 in the paper define the correction.  These are the parameters in those equations.
+  */
+
 struct CuspCorrectionParameters
 {
   typedef QMCTraits::ValueType ValueType;
   typedef QMCTraits::RealType RealType;
-  RealType Rc, C, sg;
+
+  /// The cutoff radius
+  RealType Rc;
+
+  /// A shift to keep correction to a single sign
+  RealType C;
+
+  /// The sign of the wavefunction at the nucleus
+  RealType sg;
+
+  /// The coefficients of the polynomial \f$p(r)\f$ in Eq 8
   TinyVector<ValueType, 5> alpha;
+
+  /// Flag to indicate the correction should be recalculated
   int redo;
+
   CuspCorrectionParameters(): Rc(0.0), C(0.0), sg(0.0), redo(0), alpha(0.0) {
   }
 };

--- a/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/CuspCorr.h
@@ -34,6 +34,18 @@
 namespace qmcplusplus
 {
 
+struct CuspCorrectionParameters
+{
+  typedef QMCTraits::ValueType ValueType;
+  typedef QMCTraits::RealType RealType;
+  RealType Rc, C, sg;
+  TinyVector<ValueType, 5> alpha;
+  int redo;
+  CuspCorrectionParameters(): Rc(0.0), C(0.0), sg(0.0), redo(0), alpha(0.0) {
+  }
+};
+
+
 template<class BS>
 class CuspCorr : public QMCTraits
 {

--- a/src/QMCWaveFunctions/MolecularOrbitals/LCOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/MolecularOrbitals/LCOrbitalSetWithCorrection.cpp
@@ -196,7 +196,7 @@ LCOrbitalSet<BS,false>* LCOrbitalSetWithCorrection<BS,false>::clone2LCOrbitalSet
 }
 
 template<class BS>
-bool LCOrbitalSetWithCorrection<BS,false>::readCuspInfo(Matrix<TinyVector<RealType,9> > &info)
+bool LCOrbitalSetWithCorrection<BS,false>::readCuspInfo(Matrix<CuspCorrectionParameters > &info)
 {
   bool success=true;
   std::string cname;
@@ -262,7 +262,7 @@ bool LCOrbitalSetWithCorrection<BS,false>::readCuspInfo(Matrix<TinyVector<RealTy
         {
           int orb=-1;
           OhmmsAttributeSet orbAttrib;
-          RealType a1,a2,a3,a4,a5,a6,a7,a8,a9;
+          RealType a1(0.0),a2,a3,a4,a5,a6,a7,a8,a9;
           orbAttrib.add (orb,"num");
           orbAttrib.add (a1, "redo");
           orbAttrib.add (a2, "C");
@@ -276,15 +276,15 @@ bool LCOrbitalSetWithCorrection<BS,false>::readCuspInfo(Matrix<TinyVector<RealTy
           orbAttrib.put(ctr);
           if(orb < OrbitalSetSize)
           {
-            info(num,orb)[0] = a1;
-            info(num,orb)[1] = a2;
-            info(num,orb)[2] = a3;
-            info(num,orb)[3] = a4;
-            info(num,orb)[4] = a5;
-            info(num,orb)[5] = a6;
-            info(num,orb)[6] = a7;
-            info(num,orb)[7] = a8;
-            info(num,orb)[8] = a9;
+            info(num,orb).redo = a1;
+            info(num,orb).C = a2;
+            info(num,orb).sg = a3;
+            info(num,orb).Rc = a4;
+            info(num,orb).alpha[0] = a5;
+            info(num,orb).alpha[1] = a6;
+            info(num,orb).alpha[2] = a7;
+            info(num,orb).alpha[3] = a8;
+            info(num,orb).alpha[4] = a9;
           }
           /*
           std::cout <<" Found: num,orb:" <<num <<"  " <<orb << std::endl
@@ -367,9 +367,8 @@ bool LCOrbitalSetWithCorrection<BS,false>::transformSPOSet()
   (*dummyLO2->C) = *C;
   dummyLO2->Occ.resize(Occ.size());
   dummyLO2->Occ = Occ;
-  Matrix<TinyVector<RealType,9> > info;
+  Matrix<CuspCorrectionParameters > info;
   info.resize(numCentr,OrbitalSetSize);
-  info=0;
   bool readCuspCoeff=false;
   if(cuspInfoFile != "")
     readCuspCoeff = readCuspInfo(info);
@@ -428,7 +427,7 @@ bool LCOrbitalSetWithCorrection<BS,false>::transformSPOSet()
       {
         if(readCuspCoeff)
         {
-          RealType redo = info(i,k)[0];
+          RealType redo = info(i,k).redo;
           if(redo < -1)
             // no correction to this orbital
           {
@@ -438,25 +437,25 @@ bool LCOrbitalSetWithCorrection<BS,false>::transformSPOSet()
             if(redo > 10)
               // recompute with rc loop
             {
-              myCorr.executeWithRCLoop(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,Rcut,info(i,k).data());
+              myCorr.executeWithRCLoop(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,Rcut,info(i,k));
             }
             else
               if(redo > 1)
                 // no rc loop, read rc from file
               {
-                RealType rc = info(i,k)[3];
-                myCorr.execute(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,rc,info(i,k).data());
+                RealType rc = info(i,k).Rc;
+                myCorr.execute(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,rc,info(i,k));
               }
               else
                 // read from file
               {
-                myCorr.fillRadFunWithPhiBar(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,info(i,k).data());
+                myCorr.fillRadFunWithPhiBar(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,info(i,k));
               }
         }
         else
         {
-          myCorr.executeWithRCLoop(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,Rcut,info(i,k).data());
-          info(i,k)[0]=0;
+          myCorr.executeWithRCLoop(k,i,Z[i],dummyLO1,dummyLO2,xgrid,rad_orb,fileprefix,Rcut,info(i,k));
+          info(i,k).redo=0;
         }
       }
       else
@@ -466,28 +465,28 @@ bool LCOrbitalSetWithCorrection<BS,false>::transformSPOSet()
       }
       C.setf(std::ios::scientific, std::ios::floatfield);
       C.precision(14);
-      C<<info(i,k)[1];
+      C<<info(i,k).C;
       sg.setf(std::ios::scientific, std::ios::floatfield);
       sg.precision(14);
-      sg<<info(i,k)[2];
+      sg<<info(i,k).sg;
       rc.setf(std::ios::scientific, std::ios::floatfield);
       rc.precision(14);
-      rc<<info(i,k)[3];
+      rc<<info(i,k).Rc;
       a1.setf(std::ios::scientific, std::ios::floatfield);
       a1.precision(14);
-      a1<<info(i,k)[4];
+      a1<<info(i,k).alpha[0];
       a2.setf(std::ios::scientific, std::ios::floatfield);
       a2.precision(14);
-      a2<<info(i,k)[5];
+      a2<<info(i,k).alpha[1];
       a3.setf(std::ios::scientific, std::ios::floatfield);
       a3.precision(14);
-      a3<<info(i,k)[6];
+      a3<<info(i,k).alpha[2];
       a4.setf(std::ios::scientific, std::ios::floatfield);
       a4.precision(14);
-      a4<<info(i,k)[7];
+      a4<<info(i,k).alpha[3];
       a5.setf(std::ios::scientific, std::ios::floatfield);
       a5.precision(14);
-      a5<<info(i,k)[8];
+      a5<<info(i,k).alpha[4];
       xmlNewProp(orb,(const xmlChar*)"C",(const xmlChar*)C.str().c_str());
       xmlNewProp(orb,(const xmlChar*)"sg",(const xmlChar*)sg.str().c_str());
       xmlNewProp(orb,(const xmlChar*)"rc",(const xmlChar*)rc.str().c_str());

--- a/src/QMCWaveFunctions/MolecularOrbitals/LCOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/LCOrbitalSetWithCorrection.h
@@ -687,9 +687,9 @@ public:
 
   bool transformSPOSet();
 
-  std::string cuspInfoFile;
-  bool readCuspInfo(Matrix<TinyVector<RealType,9> > &);
+  bool readCuspInfo(Matrix<CuspCorrectionParameters > &);
 
+  std::string cuspInfoFile;
 private:
 
   BS* extractHighYLM(std::vector<bool> &rmv);

--- a/src/QMCWaveFunctions/tests/test_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_cusp_corr.cpp
@@ -220,7 +220,7 @@ TEST_CASE("CuspCorrection He", "[wavefunction]")
   REQUIRE(chi2 == Approx(25854.2846426019));
 
 
-  double data[9];
+  CuspCorrectionParameters data;
   Vector<double> xgrid;
   Vector<double> rad_orb;
   xgrid.resize(1);
@@ -243,7 +243,7 @@ TEST_CASE("readCuspInfo", "[wavefunction]")
 
   OrbType orb;
 
-  Matrix<TinyVector<double, 9>> info;
+  Matrix<CuspCorrectionParameters> info;
   int num_center = 3;
   int orbital_set_size = 7;
   info.resize(num_center, orbital_set_size);
@@ -254,23 +254,24 @@ TEST_CASE("readCuspInfo", "[wavefunction]")
   REQUIRE(okay);
 
   // N
-  REQUIRE(info(0,0)[0] == Approx(0.0)); // redo
-  REQUIRE(info(0,0)[1] == Approx(0.0)); // C
-  REQUIRE(info(0,0)[2] == Approx(1.0)); // sg
-  REQUIRE(info(0,0)[3] == Approx(0.0769130700800000)); // rc
-  REQUIRE(info(0,0)[4] == Approx(2.29508580995773)); // a1
-  REQUIRE(info(0,0)[5] == Approx(-7.00028778782666)); // a2
-  REQUIRE(info(0,0)[6] == Approx(0.834942828252775)); // a3
-  REQUIRE(info(0,0)[7] == Approx(-4.61597420905980)); // a4
-  REQUIRE(info(0,0)[8] == Approx(31.6558091872316)); // a5
+  REQUIRE(info(0,0).redo == Approx(0.0));
+  REQUIRE(info(0,0).C == Approx(0.0));
+  REQUIRE(info(0,0).sg == Approx(1.0));
+  REQUIRE(info(0,0).Rc == Approx(0.0769130700800000));
+  REQUIRE(info(0,0).alpha[0] == Approx(2.29508580995773));
+  REQUIRE(info(0,0).alpha[1] == Approx(-7.00028778782666));
+  REQUIRE(info(0,0).alpha[2] == Approx(0.834942828252775));
+  REQUIRE(info(0,0).alpha[3] == Approx(-4.61597420905980));
+  REQUIRE(info(0,0).alpha[4] == Approx(31.6558091872316));
+
 
   // Spot check a few values from these centers
   // C
-  REQUIRE(info(0,6)[1] == Approx(0.0)); // C
-  REQUIRE(info(0,6)[5] == Approx(0.0)); // a5
+  REQUIRE(info(0,6).C == Approx(0.0));
+  REQUIRE(info(0,6).alpha[4] == Approx(0.0));
 
   // H
-  REQUIRE(info(2,4)[8] == Approx(-404.733151049101)); // a5
+  REQUIRE(info(2,4).alpha[4] == Approx(-404.733151049101));
 
 }
 


### PR DESCRIPTION
Using a structure rather than an array should make the code a little easier to understand.

Also add some headers to describe the columns in the newOrbs* output files.