### PR TITLE
Fix check_stats script

### DIFF
--- a/tests/scripts/check_stats.py
+++ b/tests/scripts/check_stats.py
@@ -1052,17 +1052,7 @@ from numpy import array,ndarray,minimum,abs,ix_,resize
 import sys
 import keyword
 from inspect import getmembers
-
-from superstring import valid_variable_name
-from generic import obj
-from developer import DevBase,unavailable
-try:
-    import h5py
-except ImportError:
-    h5py = unavailable('h5py')
-#end try
-from debug import *
-
+import h5py
 
 
 class HDFglobals(DevBase):


### PR DESCRIPTION
Fix the check_stats.py script by removing dangling Nexus imports.  Previously the script would fail to run due to these imports being missing in the host environment.  With these imports removed, tests of stat.h5 quantities are correctly performed even if the PYTHONPATH is blank, consistent with check_stats.py being independent of the Nexus installation.

Addresses #1027. 