### PR TITLE
Nexus: make import exceptions less restrictive

### DIFF
--- a/nexus/library/graph.py
+++ b/nexus/library/graph.py
@@ -18,7 +18,7 @@ from generic import obj
 from developer import DevBase,unavailable
 try:
     from pydot import Dot,Node,Edge,Cluster as pdCluster
-except ImportError:
+except:
     Dot,Node,Edge,pdCluster = unavailable('Dot','Node','Edge','pdCluster')
 #end try
 

--- a/nexus/library/hdfreader.py
+++ b/nexus/library/hdfreader.py
@@ -29,7 +29,7 @@ from generic import obj
 from developer import DevBase,unavailable
 try:
     import h5py
-except ImportError:
+except:
     h5py = unavailable('h5py')
 #end try
 from debug import *

--- a/nexus/library/numerics.py
+++ b/nexus/library/numerics.py
@@ -96,7 +96,7 @@ try:
     from scipy.optimize import fmin
     from scipy.spatial import KDTree,Delaunay,Voronoi
     scipy_unavailable = False
-except ImportError:
+except:
     betainc = unavailable('scipy.special' ,'betainc')
     fmin    = unavailable('scipy.optimize','fmin')
     KDTree,Delaunay,Voronoi  = unavailable('scipy.spatial' ,'KDTree','Delaunay','Voronoi')

--- a/nexus/library/plotting.py
+++ b/nexus/library/plotting.py
@@ -31,7 +31,7 @@ try:
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
     rcParams.update(params)
-except (ImportError,RuntimeError):
+except:
     success = False
 #end try
 if not success:

--- a/nexus/library/qmcpack.py
+++ b/nexus/library/qmcpack.py
@@ -44,7 +44,7 @@ from developer import unavailable
 from nexus_base import nexus_core
 try:
     import h5py
-except ImportError:
+except:
     h5py = unavailable('h5py')
 #end try
 

--- a/nexus/library/qmcpack_analyzer.py
+++ b/nexus/library/qmcpack_analyzer.py
@@ -54,7 +54,7 @@ from debug import *
 try:
     import h5py
     h5py_unavailable = False
-except ImportError:
+except:
     h5py = unavailable('h5py')
     h5py_unavailable = True
 #end try

--- a/nexus/library/qmcpack_property_analyzers.py
+++ b/nexus/library/qmcpack_property_analyzers.py
@@ -43,7 +43,7 @@ from developer import unavailable
 from debug import *
 try:
     from matplotlib.pyplot import plot,show,figure,xlabel,ylabel,title,legend
-except (ImportError,RuntimeError):
+except:
     plot,show,figure,xlabel,ylabel,title,legend = unavailable('matplotlib.pyplot','plot','show','figure','xlabel','ylabel','title','legend')
 #end try
 

--- a/nexus/library/structure.py
+++ b/nexus/library/structure.py
@@ -43,13 +43,13 @@ from debug import ci,ls,gs
 
 try:
     from scipy.special import erfc
-except ImportError:
+except:
     erfc = unavailable('scipy.special','erfc')
 #end try
 try:
     import matplotlib.pyplot as plt
     from matplotlib.pyplot import plot,subplot,title,xlabel,ylabel
-except (ImportError,RuntimeError):
+except:
     plot,subplot,title,xlabel,ylabel,plt = unavailable('matplotlib.pyplot','plot','subplot','title','xlabel','ylabel','plt')
 #end try
 


### PR DESCRIPTION
One reason the Nexus example tests are currently failing on oxygen is due to an uncaught import exception for matplotlib in structure.py.  The matplotlib import is protected by try-except, but only for RuntimeError and ImportError.  

Remove these restrictions so that exceptions are caught regardless of kind and the protections afforded by the unavailable function are in place (i.e. missing imports only cause execution to cease with a raised error if an unavailable imported name is actually accessed somewhere at runtime).  

The intended design is that Nexus should always run in a basic way, provided Python and NumPy are available.  