### PR TITLE
Remove unused references to cubic splines.

### DIFF
--- a/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.cpp
+++ b/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.cpp
@@ -17,7 +17,6 @@
 #include "Numerics/GaussianBasisSet.h"
 #include "Numerics/SlaterBasisSet.h"
 #include "Numerics/Transform2GridFunctor.h"
-#include "Numerics/OneDimCubicSpline.h"
 #include "QMCFactory/OneDimGridFactory.h"
 #include "QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h"
 #include "io/hdf_archive.h"
@@ -226,7 +225,7 @@ bool NGOBuilder::addGrid(xmlNodePtr cur)
  * \return true is succeeds
  *
  This function puts the STO on a logarithmic grid and calculates the boundary
- conditions for the 1D Cubic Spline.  The derivates at the endpoint
+ conditions for the 1D quintic spline.  The derivatives at the endpoint
  are assumed to be all zero.  Note: for the radial orbital we use
  \f[ f(r) = \frac{R(r)}{r^l}, \f] where \f$ R(r) \f$ is the usual
  radial orbital and \f$ l \f$ is the angular momentum.

--- a/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h
@@ -17,7 +17,6 @@
 #define QMCPLUSPLUS_NUMERICALGRIDORBITALBUILDER_H
 
 #include "Configuration.h"
-#include "Numerics/OneDimCubicSpline.h"
 #include "Numerics/OneDimQuinticSpline.h"
 #include "Numerics/OptimizableFunctorBase.h"
 #include "QMCWaveFunctions/MolecularOrbitals/SphericalBasisSet.h"
@@ -31,11 +30,7 @@ struct NGOrbital: public OptimizableFunctorBase
   typedef real_type                    value_type;
   typedef real_type                    point_type;
   typedef OneDimGridBase<real_type>    grid_type;
-#if QMC_BUILD_LEVEL>2
   typedef OneDimQuinticSpline<real_type> functor_type;
-#else
-  typedef OneDimCubicSpline<real_type> functor_type;
-#endif
   functor_type myFunc;
   real_type Y, dY, d2Y, d3Y;
 

--- a/src/QMCWaveFunctions/lcao/RadialOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/lcao/RadialOrbitalSetBuilder.h
@@ -25,7 +25,6 @@
 #include "Numerics/GaussianBasisSet.h"
 #include "Numerics/SlaterBasisSet.h"
 #include "Numerics/Transform2GridFunctor.h"
-#include "Numerics/OneDimCubicSpline.h"
 #include "Numerics/OneDimQuinticSpline.h"
 #include "Numerics/OptimizableFunctorBase.h"
 #include "QMCFactory/OneDimGridFactory.h"
@@ -430,7 +429,7 @@ private:
 /* Finalize this set using the common grid
  *
  * This function puts the STO on a logarithmic grid and calculates the boundary
- * conditions for the 1D Cubic Spline.  The derivates at the endpoint
+ * conditions for the 1D quintic spline.  The derivatives at the endpoint
  * are assumed to be all zero.  Note: for the radial orbital we use
  * \f[ f(r) = \frac{R(r)}{r^l}, \f] where \f$ R(r) \f$ is the usual
  * radial orbital and \f$ l \f$ is the angular momentum.


### PR DESCRIPTION
This commit affects the molecular code - both SoA and AoS versions.
The SoA code always uses quintic splines.  Remove the use of cubic splines in the AoS code.

Partially addresses #1051 