### PR TITLE
Tidy up math functions

### DIFF
--- a/src/config/stdlib/math.h
+++ b/src/config/stdlib/math.h
@@ -14,7 +14,7 @@
 #define QMCPLUSPLUS_STDLIB_PORT_H
 #include <config.h>
 #include <cmath>
-#include <cstdlib>
+
 #ifndef TWOPI
 #ifndef M_PI
 #define TWOPI 6.2831853071795862
@@ -23,18 +23,28 @@
 #endif /* M_PI */
 #endif /* TWOPI */
 
-#if (__cplusplus < 201103L)
-inline float round(float x)
+
+#if __APPLE__
+
+inline void sincos(double a, double* s, double* c)
 {
-  return roundf(x);
+  __sincos(a,s,c);
 }
-#endif
+
+inline void sincos(float a, float* s, float* c)
+{
+  __sincosf(a,s,c);
+}
+
+#else // not __APPLE__
 
 #if defined(HAVE_SINCOS)
+
 inline void sincos(float a, float* s, float* c)
 {
 #ifdef __bgq__
   // BGQ has no sincosf in libmass
+  // libmass sincos is faster than libm sincosf
   double ds,dc;
   sincos((double)a,&ds,&dc);
   *s=ds; *c=dc;
@@ -42,19 +52,19 @@ inline void sincos(float a, float* s, float* c)
   sincosf(a,s,c);
 #endif
 }
+
 #else
+
 template<typename T>
 inline void sincos(T a, T* restrict s, T*  restrict c)
 {
   *s=std::sin(a);
   *c=std::cos(a);
 }
-inline void sincos(float a, float* restrict s, float*  restrict c)
-{
-  *s=sinf(a);
-  *c=cosf(a);
-}
-#endif
+
+#endif // HAVE_SINCOS
+
+#endif // __APPLE__
 
 namespace qmcplusplus
 {

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -32,24 +32,12 @@
 
 namespace qmcplusplus
 {
-  template<typename T> struct SplineBound {};
-
-  template<> struct SplineBound <double>
+  template<typename T> struct SplineBound
   {
-    static inline void get(double x, double& dx, int& ind, int ng)
+    static inline void get(T x, T& dx, int& ind, int ng)
     {
-      double ipart;
-      dx=modf(x,&ipart);
-      ind = std::min(std::max(int(0),static_cast<int>(ipart)),ng);
-    }
-  };
-
-  template<> struct SplineBound <float>
-  {
-    static inline void get(float x, float& dx, int& ind, int ng)
-    {
-      float ipart;
-      dx=modff(x,&ipart);
+      T ipart;
+      dx=std::modf(x,&ipart);
       ind = std::min(std::max(int(0),static_cast<int>(ipart)),ng);
     }
   };


### PR DESCRIPTION
round is in the C++11 standard.
sincos/sincosf is protected for Mac OS.
std::modf handles both float and double.