### PR TITLE
Update value in test_einset.cpp

### DIFF
--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -166,7 +166,7 @@ const char *particles =
   REQUIRE(ddpsiV[1](0,1) == ComplexApprox(1.8089479397).compare_real_only());
   REQUIRE(ddpsiV[1](0,2) == ComplexApprox(0.5608575749).compare_real_only());
   REQUIRE(ddpsiV[1](1,0) == ComplexApprox(1.8089479397).compare_real_only());
-  REQUIRE(ddpsiV[1](1,1) == ComplexApprox(-0.0799493616).compare_real_only());
+  REQUIRE(ddpsiV[1](1,1) == ComplexApprox(-0.07996207476).compare_real_only());
   REQUIRE(ddpsiV[1](1,2) == ComplexApprox(0.5237969314).compare_real_only());
   REQUIRE(ddpsiV[1](2,0) == ComplexApprox(0.5608575749).compare_real_only());
   REQUIRE(ddpsiV[1](2,1) == ComplexApprox(0.5237969314).compare_real_only());


### PR DESCRIPTION
The value winds up out of tolerance in newer clang compilers.  The new value comes from clang 6 in debug mode.
Debug and release values from gcc 4.8.4 are also closer to this value.