### PR TITLE
Nexus: fix nscf rsync overwrite problem resulting from interrupt

### DIFF
--- a/nexus/library/pwscf.py
+++ b/nexus/library/pwscf.py
@@ -228,11 +228,18 @@ class Pwscf(Simulation):
                 None # don't need to do anything if in same directory
             elif self.sync_from_scf: # rsync output into nscf dir
                 outdir = os.path.join(self.locdir,c.outdir)
-                command = 'rsync -avz {0}/* {1}/'.format(result.outdir,outdir)
+                command = 'rsync -av {0}/* {1}/'.format(result.outdir,outdir)
                 if not os.path.exists(outdir):
                     os.makedirs(outdir)
                 #end if
-                execute(command)
+                sync_record = os.path.join(outdir,'nexus_sync_record')
+                if not os.path.exists(sync_record):
+                    print 'executing',command
+                    execute(command)
+                    f = open(sync_record,'w')
+                    f.write('\n')
+                    f.close()
+                #end if
             else: # attempt to use symbolic links instead
                 link_loc = os.path.join(self.locdir,c.outdir,c.prefix+'.save')
                 cd_loc = result.location

--- a/nexus/library/pwscf.py
+++ b/nexus/library/pwscf.py
@@ -234,7 +234,6 @@ class Pwscf(Simulation):
                 #end if
                 sync_record = os.path.join(outdir,'nexus_sync_record')
                 if not os.path.exists(sync_record):
-                    print 'executing',command
                     execute(command)
                     f = open(sync_record,'w')
                     f.write('\n')


### PR DESCRIPTION
Problem reported by Kayahan Saritas and reproduced by @kylanpaa.

When running QE nscf in a different directory than scf, Nexus uses rsync to copy the scf output directory to the nscf location so that the original scf files remain untouched (useful when performing multiple nscf from a single scf).

In this case, if Nexus is interrupted by the user after submitting the nscf job, upon rewaking it tries to rsync a second time which can overwrite the running or completed nscf output with the old scf files.

This PR fixes the problem by writing a single record file into the nscf output directory upon successful completion of rsync and only performing an rsync if this file is not present.

Additionally, compression (-z) is turned off, which results in significantly faster file transfer.

 