### PR TITLE
Nexus: fix skip submit monitoring hang

### DIFF
--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -1023,13 +1023,15 @@ class Simulation(NexusCore):
 
     def submit(self):
         if not self.submitted:
+            if self.skip_submit:
+                self.block_dependents(block_self=True)
+                return
+            #end if
             self.log('submitting job'+self.idstr(),n=3)
-            if not self.skip_submit:
-                if not self.job.local:
-                    self.job.submit()
-                else:
-                    self.execute() # execute local job immediately
-                #end if
+            if not self.job.local:
+                self.job.submit()
+            else:
+                self.execute() # execute local job immediately
             #end if
             self.submitted = True
             if (self.job.batch_mode or not nexus_core.monitor) and not nexus_core.generate_only:


### PR DESCRIPTION
Problem reported by Allison Dzubak.

The skip_submit flag allows the user to write files (including the flow of dependency information) but avert automatic queue submission.  This allows the user to inspect the files before submission and also to opt to submit by hand, if desired.

The manifesting problem was that if skip_submit is used, a Nexus script is closed, and then skip_submit is turned off prior to rerunning the script, occasionally Nexus will not submit the job contrary to expectations.

This PR attempts to fix the bug by never saving state if skip_submit is used.  Additionally, the changes made here allow Nexus to shutdown cleanly (by marking the skipped simulation and its dependents as blocked) when skip_submit is used since this used to lead to monitoring a job that never was going to submit.