### PR TITLE
Nexus: enable control over qmca floating point output

### DIFF
--- a/nexus/executables/qmca
+++ b/nexus/executables/qmca
@@ -2045,7 +2045,7 @@ class DatAnalyzer(QBase):
         q = self.stats[qname]
         if opt.precision is not None:
             prec = opt.precision
-            line = '{0:<22}=  {1:'+prec+'} +/- {2:'+prec+'}'
+            line = '{0:<22}=  {1: '+prec+'} +/- {2: '+prec+'}'
         elif prec=='auto':
             if (q.mean !=0.0 and abs(q.error/q.mean) > 1e-8):
                 d = int(max(2,1-floor(log(q.error)/log(10.))))

--- a/nexus/executables/qmca
+++ b/nexus/executables/qmca
@@ -2029,6 +2029,7 @@ class DatAnalyzer(QBase):
                         line = self.stat_line(qname,prec='16.0f')
                     else:
                         line = self.stat_line(qname)
+                    #end if
                     if qname=='CorrectedEnergy':
                         self.log(len(line)*'-',n=1)
                     #end if
@@ -2036,13 +2037,16 @@ class DatAnalyzer(QBase):
                 #end if
             #end for
         #end if
-#AcceptRatio           =          0.492020 +/-         0.000025
     #end def write_stats
 
     
     def stat_line(self,qname,compress=False,prec='auto'):
+        opt = self.options
         q = self.stats[qname]
-        if prec=='auto':
+        if opt.precision is not None:
+            prec = opt.precision
+            line = '{0:<22}=  {1:'+prec+'} +/- {2:'+prec+'}'
+        elif prec=='auto':
             if (q.mean !=0.0 and abs(q.error/q.mean) > 1e-8):
                 d = int(max(2,1-floor(log(q.error)/log(10.))))
             else:
@@ -2357,6 +2361,10 @@ QMCA examples:
                                 'first, current particle number second (default=%default)'
                                )
                          )
+        parser.add_option('--fp',dest='precision',
+                          default=None,
+                          help='Sets the floating point precision of displayed statistical results.  Must be a floating point format string such as 16.8f, 8.6e, or similar (default=%default).'
+                          )
 
         unsupported = set('histogram image reblock report'.split())
 
@@ -2475,6 +2483,13 @@ QMCA examples:
             #end if
         #end for
         opt.quantities = list(set(quants)-set(remove))
+        if opt.precision is not None:
+            try:
+                fp = ('{0: '+opt.precision+'}').format(1.234567)
+            except:
+                self.error('floating point format is not a proper format\nformat provided via --fp: {0}\nplease use a standard floating point format statement like 16.8f, 8.6e, or similar'.format(opt.precision))
+            #end try
+        #end if
         if opt.show_options or self.verbose:
             self.log('options provided:',n=1)
             self.log(str(self.options),n=1)


### PR DESCRIPTION
This PR allows control over the floating point format used by qmca to report statistical results.  A new command line flag (--fp) accepts any Python floating point format string.

Original output:
```
>qmca -e 20 -q 'ekp' *g000*scalar*

vmc.g000  series 0 
  LocalEnergy           =         -629.7563 +/-           0.0052 
  Kinetic               =           256.394 +/-            0.042 
  LocalPotential        =          -886.150 +/-            0.042 
```

Example output with 16.8f:
```
>qmca -e 20 -q 'ekp' --fp 16.8f *g000*scalar*

vmc.g000  series 0 
  LocalEnergy           =     -629.75631828 +/-       0.00516018 
  Kinetic               =      256.39372968 +/-       0.04156487 
  LocalPotential        =     -886.15004796 +/-       0.04212690 
```

Example output with 8.6e:
```
>qmca -e 20 -q 'ekp' --fp 8.6e *g000*scalar*

vmc.g000  series 0 
  LocalEnergy           =  -6.297563e+02 +/-  5.160177e-03 
  Kinetic               =   2.563937e+02 +/-  4.156487e-02 
  LocalPotential        =  -8.861500e+02 +/-  4.212690e-02 
```