### PR TITLE
Nexus: error trap reads of misformatted estimators

### DIFF
--- a/nexus/library/qmcpack_input.py
+++ b/nexus/library/qmcpack_input.py
@@ -1481,6 +1481,8 @@ class QIxmlFactory(Names):
                 type = kw[self.typekey2]
             elif self.default!=None:
                 type = self.default
+            elif self.typeindex==-1:
+                self.error('QMCPACK input file is misformatted\ncannot identify type for <{0}/> element\nwith contents:\n{1}\nplease find the XML element matching this description in the input file to identify the problem\nmost likely, it is missing attributes "{2}" or "{3}"'.format(self.name,str(v).rstrip(),self.typekey,self.typekey2))
             else:
                 type = a[self.typeindex]
             #end if


### PR DESCRIPTION
This is a quick fix for reads of misformatted estimators.  The code now aborts with an error message instead of crashing if a user has written (and tries to read) an input file with unnamed/untyped estimators.