### PR TITLE
Fix to set epsilon values in complex_approx

### DIFF
--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -75,6 +75,7 @@ public:
 
     ComplexApprox &epsilon(double new_epsilon)
     {
+      m_epsilon = new_epsilon;
       return *this;
     }
 


### PR DESCRIPTION
It works better if the method that sets the epsilon values actually sets the epsilon value.