### PR TITLE
Cache ENABLE_SOA in CMakeLists and print in header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ SET(QMC_OMP 1 CACHE BOOL "Enable/disable OpenMP")
 SET(QMC_COMPLEX 0 CACHE INTEGER "Build for complex binary")
 SET(PRINT_DEBUG 0 CACHE BOOL "Enable/disable debug printing")
 SET(QMC_CUDA 0 CACHE BOOL "Build with GPU support through CUDA")
+SET(ENABLE_SOA 0 CACHE BOOL "Enable/disable SoA optimization")
 
 ######################################################################
 # set debug printout

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -111,6 +111,9 @@ QMCMain::QMCMain(Communicate* c)
       << "\n  CUDA base precision = " << GET_MACRO_VAL(CUDA_PRECISION) 
       << "\n  CUDA full precision = " << GET_MACRO_VAL(CUDA_PRECISION_FULL)
 #endif
+#ifdef ENABLE_SOA
+      << "\n\n  Structure-of-arrays (SoA) optimization enabled"
+#endif
       << std::endl;
   app_summary() << std::endl;
   app_summary().flush();


### PR DESCRIPTION
ENABLE_SOA was not cached in the past but needed to be captured by the testing system for parsing flags.
Now it also print a message in the header indicating SoA optimization is enabled.