### PR TITLE
Nexus: enable QM Package restart for selected CI

### DIFF
--- a/nexus/library/quantum_package.py
+++ b/nexus/library/quantum_package.py
@@ -116,6 +116,7 @@ class QuantumPackage(Simulation):
                             f = open(sync_record,'w')
                             f.write(command+'\n')
                             f.close()
+                            execute('qp_edit -c {0}'.format(d_ezfio))
                         #end if
                     #end if
                 #end if

--- a/nexus/library/quantum_package_input.py
+++ b/nexus/library/quantum_package_input.py
@@ -657,6 +657,7 @@ run_inputs = set('''
     run_type
     frozen_core
     cis_loop
+    converge_dets
     sleep
     slave
     postprocess
@@ -677,6 +678,7 @@ added_types = obj(
     run_type              = str,
     frozen_core           = bool,
     cis_loop              = (bool,int),
+    converge_dets         = bool,
     sleep                 = (int,float),
     slave                 = str,
     postprocess           = (tuple,list),
@@ -692,6 +694,7 @@ added_types = obj(
 added_required = set('''
     system
     prefix
+    run_type
     sleep
     '''.split())
 qp_defaults_version = 'v1'

--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -909,8 +909,13 @@ class Simulation(NexusCore):
     #end def load_analyzer_image
 
 
+    def attempt_files(self):
+        return (self.infile,self.outfile,self.errfile)
+    #end def attempt_files
+
+
     def save_attempt(self):
-        local = [self.infile,self.outfile,self.errfile]
+        local = self.attempt_files()
         filepaths = []
         for file in local:
             filepath = os.path.join(self.locdir,file)
@@ -938,7 +943,6 @@ class Simulation(NexusCore):
             #os.system('ls '+attempt_dir)
             #exit()
         #end if
-        #self.error('save_attempt')
     #end def save_attempt
 
 


### PR DESCRIPTION
Add input variable "converge_dets" to enable auto restart of selected CI runs that have not reached the target number of determinants.

This PR follows (depends on) #1112.