### PR TITLE
Remove the redeclaration of ratio.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -301,7 +301,6 @@ public:
   using WaveFunctionComponent::ratio;
   using WaveFunctionComponent::addRatio;
   using WaveFunctionComponent::calcRatio;
-  using WaveFunctionComponent::ratio;
   using WaveFunctionComponent::addGradient;
   using WaveFunctionComponent::calcGradient;
   using WaveFunctionComponent::update;


### PR DESCRIPTION
"using WaveFunctionComponent::ratio;" was added twice and caught by clang.