### PR TITLE
Update minimum CMake version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ PROJECT(qmcpack)
 CMAKE_MINIMUM_REQUIRED(VERSION 3.6.0)
 IF(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
+  IF (COMPILING_ON_BGQ)
+    # On BG/Q, the HDF libraries variable includes some supporting shared libraries
+    # such as libm.so.  With the old behavior of CMP0060, these were converted
+    # to -lm for the linker, which then correctly selects the static version.
+    # With the new behavior of CMP0060, the form of the libraries are left alone
+    # on the link line (eg. /usr/lib64/libm.so), and this causes a linker error
+    # because shared libraries are not allowed with static linking.
+    cmake_policy(SET CMP0060 OLD)
+  ENDIF()
   IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
     cmake_policy(SET CMP0056 NEW)
     # This policy insures that the CMAKE_EXE_LINKER_FLAGS of the calling project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,15 @@ PROJECT(qmcpack)
 
 
 #####################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.10)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.6.0)
 IF(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
-  IF(CMAKE_VERSION VERSION_GREATER 3.1.3 AND NOT $ENV{CRAYPE_VERSION} MATCHES ".")
+  IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
     cmake_policy(SET CMP0056 NEW)
     # This policy insures that the CMAKE_EXE_LINKER_FLAGS of the calling project
     # are used in try_compile test cmake projects.
     # CHECK_CXX_SOURCE_COMPILES and others depend on try_compile
-  endif(CMAKE_VERSION VERSION_GREATER 3.1.3 AND NOT $ENV{CRAYPE_VERSION} MATCHES ".")
+  endif(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
   IF(CMAKE_GENERATOR MATCHES "Ninja")
     cmake_policy(SET CMP0058 NEW)
   ENDIF(CMAKE_GENERATOR MATCHES "Ninja")
@@ -374,33 +374,9 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
     MESSAGE(WARNING "No default file for compiler (${COMPILER})")
   ENDIF()
 
-  # Check for the compiler C++11 flag, if we go to requiring >= cmake 3.1.3 we could drop this
-  # and just write
-  # set(CMAKE_CXX_STANDARD_REQUIRED 11 CACHE INTEGER "C++ stangard must be at least 11")
-  SET(CXX11_FLAG "-std=c++11")
-  #check if the CXX compiler supports -std=c++11 option
-  include(CheckCXXCompilerFlag) # works with clean load paths and non system compilers with CMP0056
-  CHECK_CXX_COMPILER_FLAG(${CXX11_FLAG} CXX_COMPILER_SUPPORT_CXX11)
-
-  # Force the flag on Cray with Intel compiler, because the Cray wrapper
-  #  prints an warning that interferes with the flag detection code
-  #  with older versions of CMake.
-  IF($ENV{CRAYPE_VERSION} MATCHES ".")
-    IF( ${COMPILER} MATCHES "Intel" AND NOT CXX_COMPILER_SUPPORT_CXX11)
-      SET(CXX_COMPILER_SUPPORT_CXX11 TRUE)
-      MESSAGE(STATUS "Forcing C++11 support on Cray with Intel")
-    ENDIF()
-  ENDIF()
-
-  IF (CXX_COMPILER_SUPPORT_CXX11)
-    # avoid repeated -std=c++11 flag
-    STRING(REPLACE "++" "\\+\\+" CXX11_FLAG_MATCH ${CXX11_FLAG})
-    IF(NOT CMAKE_CXX_FLAGS MATCHES ${CXX11_FLAG_MATCH})
-      SET (CMAKE_CXX_FLAGS "${CXX11_FLAG} ${CMAKE_CXX_FLAGS}")
-    ENDIF()
-  ELSE()
-    MESSAGE(FATAL_ERROR "A compiler supporting C++11 is required. Use a newer C++ compiler.")
-  ENDIF()
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 
   #-------------------------------------------------------------------
   #  check MPI installation

--- a/config/BGQ_Clang++11_ToolChain.cmake
+++ b/config/BGQ_Clang++11_ToolChain.cmake
@@ -1,6 +1,8 @@
 set(CMAKE_C_COMPILER mpiclang) 
 set(CMAKE_CXX_COMPILER mpiclang++11)
 
+set(COMPILING_ON_BGQ TRUE)
+
 set(GNU_OPTS "-O3 -g -ffast-math -fopenmp -fstrict-aliasing -Wno-deprecated -Wno-unused-value -Wno-type-safety -Wno-undefined-var-template")
 set(GNU_FLAGS "-Drestrict=__restrict__ -DADD_ -DHAVE_MASS -DHAVE_MASSV -DSPLINEFLOAT -DBGQPX -D__forceinline=inline")
 set(CMAKE_CXX_FLAGS "${GNU_FLAGS} ${GNU_OPTS} -ftemplate-depth-60" CACHE STRING "" FORCE)

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -123,8 +123,16 @@ can result.
 The build system for QMCPACK is based on CMake.  It will autoconfigure
 based on the detected compilers and libraries. The most recent
 version of CMake has the best detection for the greatest variety of
-systems - at the time of writing this means CMake 3.4.3. The much
-older CMake 2.8 is known to work, but might not work optimally on your system.
+systems.  The minimum required version of CMake is 3.6.  That is the
+oldest version to support correct application of C++11 flags for the Intel compiler.
+Most computer installations have a sufficiently recent CMake, though it may not be
+the default.
+
+If no appropriate version CMake is available, building it from source is straightforward.
+Download a version from \url{https://cmake.org/download/} and unpack the files.
+Run \texttt{./boostrap} from the CMake directory, and then run \texttt{make}
+when that finishes.  The resulting CMake executable will be in the \texttt{bin/} directory.
+The executable can be run directly from that location.
 
 Previously QMCPACK made extensive use of toolchains, but the build system
 has since been updated to eliminate the use of toolchain files for
@@ -649,7 +657,7 @@ Mira/Cetus is a Blue Gene/Q supercomputer at Argonne National Laboratory's Argon
 Mira has 49152 compute nodes and each node has a 16-core PowerPC A2 processor with 16 GB DDR3 memory.
 Due to the fact that the login nodes and the compute nodes have different processors with distinct instruction sets,
 cross-compiling is required on this platform. See details about using Blue Gene/Q at \url{http://www.alcf.anl.gov/user-guides/compiling-linking}.
-On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang and +cmake in \$HOME/.soft.
+On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang and +cmake-3.8.1 in \$HOME/.soft.
 In order to build QMCPACK, a toolchain file is provided for setting up CMake.
 \textbf{BGClang is required for C++11 support. IBM XL C/C++ compiler should not be used.}
 
@@ -668,6 +676,7 @@ Each node features a second-generation Intel Xeon Phi 7230 processor and 192 GB 
 \verbatimfont{\footnotesize}%
 \begin{verbatim}
 export CRAYPE_LINK_TYPE=dynamic
+module load cmake/3.9.1
 module unload cray-libsci
 module load cray-hdf5-parallel
 export BOOST_ROOT=/soft/libraries/boost/1.64.0/intel
@@ -743,7 +752,7 @@ usually preferred to GNU.
 export CRAYPE_LINK_TYPE=dynamic
 module unload cray-libsci
 module load cray-hdf5
-module load cmake
+module load cmake3/3.6.1   # Or newer
 module load fftw
 export FFTW_HOME=$FFTW_DIR/..
 module load boost
@@ -796,32 +805,33 @@ installed at NERSC. The build settings are identical to eos.
 export CRAYPE_LINK_TYPE=dynamic
 module unload cray-libsci
 module load boost
-module load cmake
+module load cmake/3.11.4
 module load libxml2
 module load cray-hdf5-parallel
 cmake ..
 make -j 8
 ls -l bin/qmcpack
 \end{verbatim}
-When the above was tested on 15 September 2017, the following module and
+When the above was tested on 24 October 2018, the following module and
 software versions were present:
 \verbatimfont{\footnotesize}
 \begin{verbatim}
-qmcpack@edison04:trunk> module list
-urrently Loaded Modulefiles:
-  1) modules/3.2.10.6                              14) rca/2.2.11-6.0.4.0_13.2__g84de67a.ari
-  2) intel/17.0.2.174                              15) atp/2.1.1
-  3) craype-network-aries                          16) PrgEnv-intel/6.0.4
-  4) craype/2.5.12.3                               17) craype-ivybridge
-  5) udreg/2.3.2-6.0.4.0_12.2__g2f9c3ee.ari        18) cray-shmem/7.6.0
-  6) ugni/6.0.14-6.0.4.0_14.1__ge7db4a2.ari        19) cray-mpich/7.6.0
-  7) pmi/5.0.12                                    20) altd/2.0
-  8) dmapp/7.1.1-6.0.4.0_46.2__gb8abda2.ari        21) darshan/3.1.4
-  9) gni-headers/5.0.11-6.0.4.0_7.2__g7136988.ari  22) boost/1.63
- 10) xpmem/2.2.2-6.0.4.0_3.1__g43b0535.ari         23) cmake/3.8.1
- 11) job/2.2.2-6.0.4.0_8.2__g3c644b5.ari           24) cray-hdf5-parallel/1.10.0.3
- 12) dvs/2.7_2.2.30-6.0.4.1_5.4__gd731684          25) libxml2/2.9.4
- 13) alps/6.4.1-6.0.4.0_7.2__g86d0f3d.ari
+build> module list
+Currently Loaded Modulefiles:
+  1) modules/3.2.10.6                                 14) alps/6.6.43-6.0.7.0_26.4__ga796da3.ari
+  2) nsg/1.2.0                                        15) rca/2.2.18-6.0.7.0_33.3__g2aa4f39.ari
+  3) intel/18.0.1.163                                 16) atp/2.1.1
+  4) craype-network-aries                             17) PrgEnv-intel/6.0.4
+  5) craype/2.5.14                                    18) craype-ivybridge
+  6) udreg/2.3.2-6.0.7.0_33.18__g5196236.ari          19) cray-mpich/7.7.0
+  7) ugni/6.0.14.0-6.0.7.0_23.1__gea11d3d.ari         20) altd/2.0
+  8) pmi/5.0.13                                       21) darshan/3.1.4
+  9) dmapp/7.1.1-6.0.7.0_34.3__g5a674e0.ari           22) boost/1.63
+ 10) gni-headers/5.0.12.0-6.0.7.0_24.1__g3b1768f.ari  23) cmake/3.11.4
+ 11) xpmem/2.2.15-6.0.7.1_5.8__g7549d06.ari           24) libxml2/2.9.4
+ 12) job/2.2.3-6.0.7.0_44.1__g6c4e934.ari             25) cray-hdf5-parallel/1.10.1.1
+ 13) dvs/2.7_2.2.112-6.0.7.1_6.4__ge96a422
+
 \end{verbatim}
 
 \subsection{Installing on NERSC Cori, Haswell Partition, Cray XC40}
@@ -834,7 +844,7 @@ export CRAYPE_LINK_TYPE=dynamic
 module unload cray-libsci
 module load boost
 module load cray-hdf5-parallel
-module load cmake
+module load cmake/3.11.4
 mkdir build_cori_hsw
 cd build_cori_hsw
 cmake ..
@@ -842,26 +852,25 @@ make -j 16
 ls -l bin/qmcpack
 \end{verbatim}
 
-When the above was tested on 29 August 2017, the following module and
+When the above was tested on 24 October 2018, the following module and
 software versions were present:
 
 \verbatimfont{\footnotesize}
 \begin{verbatim}
 build_cori_hsw> module list
 Currently Loaded Modulefiles:
-  1) modules/3.2.10.6                              14) alps/6.4.1-6.0.4.0_7.2__g86d0f3d.ari
-  2) nsg/1.2.0                                     15) rca/2.2.11-6.0.4.0_13.2__g84de67a.ari
-  3) intel/17.0.2.174                              16) atp/2.1.1
-  4) craype-network-aries                          17) PrgEnv-intel/6.0.4
-  5) craype/2.5.12                                 18) craype-haswell
-  6) udreg/2.3.2-6.0.4.0_12.2__g2f9c3ee.ari        19) cray-shmem/7.6.0
-  7) ugni/6.0.14-6.0.4.0_14.1__ge7db4a2.ari        20) cray-mpich/7.6.0
-  8) pmi/5.0.12                                    21) altd/2.0
-  9) dmapp/7.1.1-6.0.4.0_46.2__gb8abda2.ari        22) darshan/3.1.4
- 10) gni-headers/5.0.11-6.0.4.0_7.2__g7136988.ari  23) boost/1.61
- 11) xpmem/2.2.2-6.0.4.0_3.1__g43b0535.ari         24) cmake/3.3.2
- 12) job/2.2.2-6.0.4.0_8.2__g3c644b5.ari           25) cray-hdf5-parallel/1.10.0.3
- 13) dvs/2.7_2.2.31-6.0.4.1_6.1__gb3b87e6
+  1) modules/3.2.10.6                                 13) dvs/2.7_2.2.113-6.0.7.1_7.1__g1bbc03e
+  2) nsg/1.2.0                                        14) alps/6.6.43-6.0.7.0_26.4__ga796da3.ari
+  3) intel/18.0.1.163                                 15) rca/2.2.18-6.0.7.0_33.3__g2aa4f39.ari
+  4) craype-network-aries                             16) atp/2.1.1
+  5) craype/2.5.14                                    17) PrgEnv-intel/6.0.4
+  6) udreg/2.3.2-6.0.7.0_33.18__g5196236.ari          18) craype-haswell
+  7) ugni/6.0.14.0-6.0.7.0_23.1__gea11d3d.ari         19) cray-mpich/7.7.0
+  8) pmi/5.0.13                                       20) altd/2.0
+  9) dmapp/7.1.1-6.0.7.0_34.3__g5a674e0.ari           21) darshan/3.1.4
+ 10) gni-headers/5.0.12.0-6.0.7.0_24.1__g3b1768f.ari  22) boost/1.63
+ 11) xpmem/2.2.15-6.0.7.1_5.8__g7549d06.ari           23) cray-hdf5-parallel/1.10.1.1
+ 12) job/2.2.3-6.0.7.0_44.1__g6c4e934.ari             24) cmake/3.11.4
 \end{verbatim}
 
 \subsection{Installing on NERSC Cori, Xeon Phi KNL partition, Cray XC40}
@@ -876,7 +885,7 @@ module swap craype-haswell craype-mic-knl
 module unload cray-libsci
 module load boost
 module load cray-hdf5-parallel
-module load cmake
+module load cmake/3.11.4
 mkdir build_cori_knl
 cd build_cori_knl
 cmake ..
@@ -884,22 +893,26 @@ make -j 16
 ls -l bin/qmcpack
 \end{verbatim}
 
-When the above was tested on 29 August 2017, the following module and
+When the above was tested on 24 October 2018, the following module and
 software versions were present:
 
 \verbatimfont{\footnotesize}
 \begin{verbatim}
-build_cori_knl> module list
+build_core_knl> module list
 Currently Loaded Modulefiles:
-  1) modules/3.2.10.6                              10) gni-headers/5.0.11-6.0.4.0_7.2__g7136988.ari  19) cray-shmem/7.6.0
-  2) nsg/1.2.0                                     11) xpmem/2.2.2-6.0.4.0_3.1__g43b0535.ari         20) cray-mpich/7.6.0
-  3) intel/17.0.2.174                              12) job/2.2.2-6.0.4.0_8.2__g3c644b5.ari           21) altd/2.0
-  4) craype-network-aries                          13) dvs/2.7_2.2.31-6.0.4.1_6.1__gb3b87e6          22) darshan/3.1.4
-  5) craype/2.5.12                                 14) alps/6.4.1-6.0.4.0_7.2__g86d0f3d.ari          23) boost/1.61
-  6) udreg/2.3.2-6.0.4.0_12.2__g2f9c3ee.ari        15) rca/2.2.11-6.0.4.0_13.2__g84de67a.ari         24) cray-hdf5-parallel/1.10.0.3
-  7) ugni/6.0.14-6.0.4.0_14.1__ge7db4a2.ari        16) atp/2.1.1                                     25) cmake/3.3.2
-  8) pmi/5.0.12                                    17) PrgEnv-intel/6.0.4
-  9) dmapp/7.1.1-6.0.4.0_46.2__gb8abda2.ari        18) craype-mic-knl
+  1) modules/3.2.10.6                                 13) dvs/2.7_2.2.113-6.0.7.1_7.1__g1bbc03e
+  2) nsg/1.2.0                                        14) alps/6.6.43-6.0.7.0_26.4__ga796da3.ari
+  3) intel/18.0.1.163                                 15) rca/2.2.18-6.0.7.0_33.3__g2aa4f39.ari
+  4) craype-network-aries                             16) atp/2.1.1
+  5) craype/2.5.14                                    17) PrgEnv-intel/6.0.4
+  6) udreg/2.3.2-6.0.7.0_33.18__g5196236.ari          18) craype-mic-knl
+  7) ugni/6.0.14.0-6.0.7.0_23.1__gea11d3d.ari         19) cray-mpich/7.7.0
+  8) pmi/5.0.13                                       20) altd/2.0
+  9) dmapp/7.1.1-6.0.7.0_34.3__g5a674e0.ari           21) darshan/3.1.4
+ 10) gni-headers/5.0.12.0-6.0.7.0_24.1__g3b1768f.ari  22) boost/1.63
+ 11) xpmem/2.2.15-6.0.7.1_5.8__g7549d06.ari           23) cray-hdf5-parallel/1.10.1.1
+ 12) job/2.2.3-6.0.7.0_44.1__g6c4e934.ari             24) cmake/3.11.4
+
 \end{verbatim}
 
 \subsection{Installing on Windows}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,11 +327,6 @@ ENDIF()
   #ENDIF(BUILD_QMCTOOLS)
 
   if (BUILD_UNIT_TESTS) #{
-    SET(HAS_TARGET_COMPILE_DEFINITIONS 1)
-    IF (CMAKE_VERSION VERSION_LESS "2.8.11")
-      MESSAGE("CMake version 2.8.10 - some unit tests will not be built")
-      SET(HAS_TARGET_COMPILE_DEFINITIONS 0)
-    ENDIF()
     #Unit test directories
     INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/external_codes/catch)
     INCLUDE(${PROJECT_SOURCE_DIR}/CMake/unit_test.cmake)
@@ -349,12 +344,10 @@ ENDIF()
     SUBDIRS(QMCHamiltonians/tests)
     SUBDIRS(type_traits/tests)
   
-    IF (HAS_TARGET_COMPILE_DEFINITIONS)
-      SUBDIRS(ParticleBase/tests)
-      SUBDIRS(Estimators/tests)
-      SUBDIRS(QMCDrivers/tests)
-      SUBDIRS(QMCApp/tests)
-    ENDIF()
+    SUBDIRS(ParticleBase/tests)
+    SUBDIRS(Estimators/tests)
+    SUBDIRS(QMCDrivers/tests)
+    SUBDIRS(QMCApp/tests)
   endif() #}
 
 endif() #}}}

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -95,10 +95,8 @@ ENDIF(QMC_BUILD_LEVEL GREATER 1)
 # create libqmc 
 ####################################
 ADD_LIBRARY(qmcdriver ${QMCDRIVERS})
-IF (HAS_TARGET_COMPILE_DEFINITIONS)
-  ADD_LIBRARY(qmcdriver_unit ${QMCDRIVERS})
-  USE_FAKE_RNG(qmcdriver_unit)
-ENDIF()
+ADD_LIBRARY(qmcdriver_unit ${QMCDRIVERS})
+USE_FAKE_RNG(qmcdriver_unit)
 #IF(QMC_BUILD_STATIC)
 #  ADD_LIBRARY(qmcdriver STATIC ${QMCDRIVERS})
 #ELSE(QMC_BUILD_STATIC)


### PR DESCRIPTION
Implements #832 

Switches to the CMake method of specifying the C++11 flags.
Version checks for older CMake's are removed.

The manual is also updated.