### PR TITLE
Reorder splines for simpler parallel construction

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
@@ -446,6 +446,7 @@ struct HybridAdoptorBase
 
   void gather_atomic_tables(Communicate* comm, std::vector<int> &offset)
   {
+    if(comm->size()==1) return;
     for(int ic=0; ic<AtomicCenters.size(); ic++)
       AtomicCenters[ic].gather_tables(comm, offset);
   }

--- a/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridAdoptorBase.h
@@ -90,10 +90,9 @@ struct AtomicOrbitalSoA
     chunked_bcast(comm, MultiSpline);
   }
 
-  void gather_tables(Communicate* comm, std::vector<int> &offset_cplx, std::vector<int> &offset_real)
+  void gather_tables(Communicate* comm, std::vector<int> &offset)
   {
-    if(offset_cplx.size()) gatherv(comm, MultiSpline, Npad, offset_cplx);
-    if(offset_real.size()) gatherv(comm, MultiSpline, Npad, offset_real);
+    gatherv(comm, MultiSpline, Npad, offset);
   }
 
   template<typename PT, typename VT>
@@ -445,10 +444,10 @@ struct HybridAdoptorBase
       AtomicCenters[ic].bcast_tables(comm);
   }
 
-  void gather_atomic_tables(Communicate* comm, std::vector<int> &offset_cplx, std::vector<int> &offset_real)
+  void gather_atomic_tables(Communicate* comm, std::vector<int> &offset)
   {
     for(int ic=0; ic<AtomicCenters.size(); ic++)
-      AtomicCenters[ic].gather_tables(comm, offset_cplx, offset_real);
+      AtomicCenters[ic].gather_tables(comm, offset);
   }
 
   inline void flush_zero()

--- a/src/QMCWaveFunctions/BsplineFactory/HybridCplxAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridCplxAdoptor.h
@@ -68,7 +68,7 @@ struct HybridCplxSoA: public BaseAdoptor, public HybridAdoptorBase<typename Base
   void gather_tables(Communicate* comm)
   {
     BaseAdoptor::gather_tables(comm);
-    HybridBase::gather_atomic_tables(comm, this->offset_cplx, this->offset_real);
+    HybridBase::gather_atomic_tables(comm, BaseAdoptor::offset);
   }
 
   bool read_splines(hdf_archive& h5f)

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRealAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRealAdoptor.h
@@ -70,7 +70,7 @@ struct HybridRealSoA: public BaseAdoptor, public HybridAdoptorBase<typename Base
   void gather_tables(Communicate* comm)
   {
     BaseAdoptor::gather_tables(comm);
-    HybridBase::gather_atomic_tables(comm, this->offset_cplx, this->offset_real);
+    HybridBase::gather_atomic_tables(comm, BaseAdoptor::offset);
   }
 
   inline void flush_zero()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineAdoptorBase.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineAdoptorBase.h
@@ -75,10 +75,10 @@ struct SplineAdoptorBase
   std::vector<bool>               MakeTwoCopies;
   ///kpoints for each unique orbitals
   std::vector<TinyVector<ST,D> >  kPoints;
-  ///remap band
+  ///remap splines to orbitals
   aligned_vector<int> BandIndexMap;
-  /// band offsets
-  std::vector<int> offset_real, offset_cplx;
+  /// band offsets used for communication
+  std::vector<int> offset;
   ///name of the adoptor
   std::string AdoptorName;
   ///keyword used to match hdf5
@@ -99,6 +99,9 @@ struct SplineAdoptorBase
     GGt=dot(transpose(PrimLattice.G),PrimLattice.G);
     kPoints.resize(n);
     MakeTwoCopies.resize(n);
+    BandIndexMap.resize(n);
+    for(int i=0; i<n; i++)
+      BandIndexMap[i]=i;
   }
 
   ///remap kpoints to group general kpoints & special kpoints
@@ -106,7 +109,6 @@ struct SplineAdoptorBase
   {
     std::vector<TinyVector<ST,D> >  k_copy(kPoints);
     const int nk=kPoints.size();
-    BandIndexMap.resize(nk);
     int nCB=0;
     //two pass
     for(int i=0; i<nk; ++i)
@@ -114,7 +116,7 @@ struct SplineAdoptorBase
       if(MakeTwoCopies[i]) 
       {
         kPoints[nCB]=k_copy[i];
-        BandIndexMap[i]=nCB++;
+        BandIndexMap[nCB++]=i;
       }
     }
     int nRealBands=nCB;
@@ -123,7 +125,7 @@ struct SplineAdoptorBase
       if(!MakeTwoCopies[i]) 
       {
         kPoints[nRealBands]=k_copy[i];
-        BandIndexMap[i]=nRealBands++;
+        BandIndexMap[nRealBands++]=i;
       }
     }
     return nCB; //return the number of complex bands

--- a/src/QMCWaveFunctions/BsplineFactory/SplineAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineAdoptorReaderP.h
@@ -297,20 +297,21 @@ struct SplineAdoptorReader: public BsplineReaderBase
     {
       if(band_group_comm.isGroupLeader())
       {
-        int ti=cur_bands[iorb].TwistIndex;
-        std::string s=psi_g_path(ti,spin,cur_bands[iorb].BandIndex);
+        int iorb_h5=bspline->BandIndexMap[iorb];
+        int ti=cur_bands[iorb_h5].TwistIndex;
+        std::string s=psi_g_path(ti,spin,cur_bands[iorb_h5].BandIndex);
         if(!h5f.read(cG,s)) APP_ABORT("SplineAdoptorReader Failed to read band(s) from h5!\n");
         double total_norm = compute_norm(cG);
         if((checkNorm)&&(std::abs(total_norm-1.0)>PW_COEFF_NORM_TOLERANCE))
         {
-          std::cerr << "The orbital " << iorb << " has a wrong norm " << total_norm
+          std::cerr << "The orbital " << iorb_h5 << " has a wrong norm " << total_norm
                     << ", computed from plane wave coefficients!" << std::endl
                     << "This may indicate a problem with the HDF5 library versions used "
                     << "during wavefunction conversion or read." << std::endl;
           APP_ABORT("SplineAdoptorReader Wrong orbital norm!");
         }
         fft_spline(cG,ti);
-        bspline->set_spline(spline_r,spline_i,cur_bands[iorb].TwistIndex,iorb,0);
+        bspline->set_spline(spline_r,spline_i,cur_bands[iorb_h5].TwistIndex,iorb,0);
       }
       this->create_atomic_centers_Gspace(cG, band_group_comm, iorb);
     }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
@@ -56,8 +56,7 @@ struct SplineC2CSoA: public SplineAdoptorBase<ST,3>
   using BaseType::PrimLattice;
   using BaseType::kPoints;
   using BaseType::MakeTwoCopies;
-  using BaseType::offset_cplx;
-  using BaseType::offset_real;
+  using BaseType::offset;
 
   ///number of points of the original grid
   int BaseN[3];
@@ -118,11 +117,11 @@ struct SplineC2CSoA: public SplineAdoptorBase<ST,3>
     if(comm->size()==1) return;
     const int Nbands = kPoints.size();
     const int Nbandgroups = comm->size();
-    offset_cplx.resize(Nbandgroups+1,0);
-    FairDivideLow(Nbands,Nbandgroups,offset_cplx);
-    for(size_t ib=0; ib<offset_cplx.size(); ib++)
-      offset_cplx[ib]*=2;
-    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset_cplx);
+    offset.resize(Nbandgroups+1,0);
+    FairDivideLow(Nbands,Nbandgroups,offset);
+    for(size_t ib=0; ib<offset.size(); ib++)
+      offset[ib]*=2;
+    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset);
   }
 
   template<typename GT, typename BCT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
@@ -155,7 +155,7 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
   inline void resize_kpoints()
   {
 #ifndef QMC_CUDA
-    // GPU code needs the old ordering.
+    // GPU CUDA code doesn't allow a change of the ordering
     nComplexBands=this->remap_kpoints();
 #endif
     int nk=kPoints.size();

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
@@ -59,8 +59,7 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
   using BaseType::PrimLattice;
   using BaseType::kPoints;
   using BaseType::MakeTwoCopies;
-  using BaseType::offset_cplx;
-  using BaseType::offset_real;
+  using BaseType::offset;
 
   ///number of complex bands
   int nComplexBands;
@@ -82,7 +81,7 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
   gContainer_type myG;
   hContainer_type myH;
 
-  SplineC2RSoA(): BaseType(), SplineInst(nullptr), MultiSpline(nullptr)
+  SplineC2RSoA(): BaseType(), nComplexBands(0), SplineInst(nullptr), MultiSpline(nullptr)
   {
     this->is_complex=true;
     this->is_soa_ready=true;
@@ -123,41 +122,12 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
     if(comm->size()==1) return;
     const int Nbands = kPoints.size();
     const int Nbandgroups = comm->size();
-    std::vector<int> offset(Nbandgroups+1,0);
+    offset.resize(Nbandgroups+1,0);
     FairDivideLow(Nbands,Nbandgroups,offset);
 
-#ifdef QMC_CUDA
     for(size_t ib=0; ib<offset.size(); ib++)
       offset[ib] = offset[ib]*2;
     gatherv(comm, MultiSpline, MultiSpline->z_stride, offset);
-#else
-    // complex bands
-    int gid=1;
-    offset_cplx.resize(Nbandgroups+1,0);
-    for(int ib=0; ib<Nbands; ++ib)
-    {
-      if(ib==offset[gid]) gid++;
-      if(MakeTwoCopies[ib])
-        offset_cplx[gid]++;
-    }
-    for(int bg=0; bg<Nbandgroups; ++bg)
-      offset_cplx[bg+1] = offset_cplx[bg+1]*2+offset_cplx[bg];
-    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset_cplx);
-
-    // real bands
-    gid=1;
-    offset_real.resize(Nbandgroups+1,0);
-    for(int ib=0; ib<Nbands; ++ib)
-    {
-      if(ib==offset[gid]) gid++;
-      if(!MakeTwoCopies[ib])
-        offset_real[gid]++;
-    }
-    offset_real[0]=nComplexBands*2;
-    for(int bg=0; bg<Nbandgroups; ++bg)
-      offset_real[bg+1] = offset_real[bg+1]*2+offset_real[bg];
-    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset_real);
-#endif
   }
 
   template<typename GT, typename BCT>
@@ -184,7 +154,10 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
   /** remap kPoints to pack the double copy */
   inline void resize_kpoints()
   {
+#ifndef QMC_CUDA
+    // GPU code needs the old ordering.
     nComplexBands=this->remap_kpoints();
+#endif
     int nk=kPoints.size();
     mKK.resize(nk);
     myKcart.resize(nk);
@@ -197,27 +170,15 @@ struct SplineC2RSoA: public SplineAdoptorBase<ST,3>
 
   inline void set_spline(SingleSplineType* spline_r, SingleSplineType* spline_i, int twist, int ispline, int level)
   {
-#ifdef QMC_CUDA
-    // GPU code needs the old ordering.
-    int iband=ispline;
-#else
-    int iband=this->BandIndexMap[ispline];
-#endif
-    SplineInst->copy_spline(spline_r,2*iband  ,BaseOffset, BaseN);
-    SplineInst->copy_spline(spline_i,2*iband+1,BaseOffset, BaseN);
+    SplineInst->copy_spline(spline_r,2*ispline  ,BaseOffset, BaseN);
+    SplineInst->copy_spline(spline_i,2*ispline+1,BaseOffset, BaseN);
   }
 
   void set_spline(ST* restrict psi_r, ST* restrict psi_i, int twist, int ispline, int level)
   {
     Vector<ST> v_r(psi_r,0), v_i(psi_i,0);
-#ifdef QMC_CUDA
-    // GPU code needs the old ordering.
-    int iband=ispline;
-#else
-    int iband=this->BandIndexMap[ispline];
-#endif
-    SplineInst->set(2*iband  ,v_r);
-    SplineInst->set(2*iband+1,v_i);
+    SplineInst->set(2*ispline  ,v_r);
+    SplineInst->set(2*ispline+1,v_i);
   }
 
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineHybridAdoptorReaderP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineHybridAdoptorReaderP.h
@@ -512,9 +512,8 @@ struct SplineHybridAdoptorReader: public SplineAdoptorReader<SA>
             for(size_t ip=0; ip<spline_npoints; ip++)
               splineData_i[ip]=all_vals[idx][ip][lm+lm_tot];
             atomic_spline_i=einspline::create(atomic_spline_i, 0.0, spline_radius, spline_npoints, splineData_i.data(), ((lm==0)||(lm>3)));
-            int iband=bspline->BandIndexMap.size()>0?bspline->BandIndexMap[iorb]:iorb;
-            mycenter.set_spline(atomic_spline_r,lm,iband*2);
-            mycenter.set_spline(atomic_spline_i,lm,iband*2+1);
+            mycenter.set_spline(atomic_spline_r,lm,iorb*2);
+            mycenter.set_spline(atomic_spline_i,lm,iorb*2+1);
             einspline::destroy(atomic_spline_r);
             einspline::destroy(atomic_spline_i);
           }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
@@ -133,25 +133,6 @@ struct SplineR2RSoA: public SplineAdoptorBase<ST,3>
     qmc_common.memory_allocated += SplineInst->sizeInByte();
   }
 
-  void create_spline(TinyVector<int,D>& mesh, int n)
-  {
-    Ugrid xyz_grid[D];
-    BCType xyz_bc[D];
-    for(int i=0; i<D; ++i)
-    {
-      xyz_grid[i].start = 0.0;
-      xyz_grid[i].end = 1.0;
-      xyz_grid[i].num = mesh[i];
-      xyz_bc[i].lCode=xyz_bc[i].rCode=(HalfG[i])? ANTIPERIODIC:PERIODIC;
-      BaseOffset[i]=0;
-      BaseN[i]=xyz_grid[i].num+3;
-    }
-    SplineInst=new MultiBspline<ST>();
-    SplineInst->create(xyz_grid,xyz_bc,n);
-    MultiSpline=SplineInst->spline_m;
-    qmc_common.memory_allocated += MultiSpline->coefs_size*sizeof(ST);
-  }
-
   inline void flush_zero()
   {
     SplineInst->flush_zero();

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
@@ -52,8 +52,7 @@ struct SplineR2RSoA: public SplineAdoptorBase<ST,3>
   using BaseType::GGt;
   using BaseType::PrimLattice;
   using BaseType::kPoints;
-  using BaseType::offset_cplx;
-  using BaseType::offset_real;
+  using BaseType::offset;
 
   ///number of points of the original grid
   int BaseN[3];
@@ -112,9 +111,9 @@ struct SplineR2RSoA: public SplineAdoptorBase<ST,3>
     if(comm->size()==1) return;
     const int Nbands = kPoints.size();
     const int Nbandgroups = comm->size();
-    offset_real.resize(Nbandgroups+1,0);
-    FairDivideLow(Nbands,Nbandgroups,offset_real);
-    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset_real);
+    offset.resize(Nbandgroups+1,0);
+    FairDivideLow(Nbands,Nbandgroups,offset);
+    gatherv(comm, MultiSpline, MultiSpline->z_stride, offset);
   }
 
   template<typename GT, typename BCT>


### PR DESCRIPTION
In the C2R case, the splines are reordered based on whether one or two orbitals are generated.
When the splines are constructed in parallel over MPI, the construction uses the old older reading from h5 and then dump the splines into memory with the new order. This makes the the communication at the end of the parallel construction very complicated.
In this PR enables parallel construction directly in the new order and then all the communication part becomes simple and the lines of code reduce.