### PR TITLE
Add space in front of -x check for Intel compilers

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -56,13 +56,15 @@ ENDIF( INTEL_FTZ)
 #------------------------
 IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
 
+SET(X_OPTION "^-x| -x")
+SET(A_XOPTION "^-ax| -ax")
 #check if the user has already specified -x option for cross-compiling.
-if(CMAKE_CXX_FLAGS MATCHES " -x" OR CMAKE_C_FLAGS MATCHES " -x" OR
-    CMAKE_CXX_FLAGS MATCHES " -ax" OR CMAKE_C_FLAGS MATCHES " -ax")
+if(CMAKE_CXX_FLAGS MATCHES ${X_OPTION} OR CMAKE_C_FLAGS MATCHES ${X_OPTION} OR
+    CMAKE_CXX_FLAGS MATCHES ${AX_OPTION} OR CMAKE_C_FLAGS MATCHES ${AX_OPTION})
   # make sure that the user specifies -x for both CMAKE_CXX_FLAGS and CMAKE_C_FLAGS.
-  if(CMAKE_CXX_FLAGS MATCHES " -x" AND CMAKE_C_FLAGS MATCHES " -x")
+  if(CMAKE_CXX_FLAGS MATCHES ${X_OPTION} AND CMAKE_C_FLAGS MATCHES ${X_OPTION})
   else() #(CMAKE_CXX_FLAGS MATCHES "-x" AND CMAKE_C_FLAGS MATCHES "-x")
-    if(CMAKE_CXX_FLAGS MATCHES " -ax" AND CMAKE_C_FLAGS MATCHES " -ax")
+    if(CMAKE_CXX_FLAGS MATCHES ${AX_OPTION} AND CMAKE_C_FLAGS MATCHES ${AX_OPTION})
     else()
       MESSAGE(FATAL_ERROR "if -xcode or -axcode is specified by the user, it should be added in both CMAKE_CXX_FLAGS and CMAKE_C_FLAGS!")
     endif()

--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -57,7 +57,7 @@ ENDIF( INTEL_FTZ)
 IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
 
 SET(X_OPTION "^-x| -x")
-SET(A_XOPTION "^-ax| -ax")
+SET(AX_OPTION "^-ax| -ax")
 #check if the user has already specified -x option for cross-compiling.
 if(CMAKE_CXX_FLAGS MATCHES ${X_OPTION} OR CMAKE_C_FLAGS MATCHES ${X_OPTION} OR
     CMAKE_CXX_FLAGS MATCHES ${AX_OPTION} OR CMAKE_C_FLAGS MATCHES ${AX_OPTION})

--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -57,12 +57,12 @@ ENDIF( INTEL_FTZ)
 IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
 
 #check if the user has already specified -x option for cross-compiling.
-if(CMAKE_CXX_FLAGS MATCHES "-x" OR CMAKE_C_FLAGS MATCHES "-x" OR
-    CMAKE_CXX_FLAGS MATCHES "-ax" OR CMAKE_C_FLAGS MATCHES "-ax")
+if(CMAKE_CXX_FLAGS MATCHES " -x" OR CMAKE_C_FLAGS MATCHES " -x" OR
+    CMAKE_CXX_FLAGS MATCHES " -ax" OR CMAKE_C_FLAGS MATCHES " -ax")
   # make sure that the user specifies -x for both CMAKE_CXX_FLAGS and CMAKE_C_FLAGS.
-  if(CMAKE_CXX_FLAGS MATCHES "-x" AND CMAKE_C_FLAGS MATCHES "-x")
+  if(CMAKE_CXX_FLAGS MATCHES " -x" AND CMAKE_C_FLAGS MATCHES " -x")
   else() #(CMAKE_CXX_FLAGS MATCHES "-x" AND CMAKE_C_FLAGS MATCHES "-x")
-    if(CMAKE_CXX_FLAGS MATCHES "-ax" AND CMAKE_C_FLAGS MATCHES "-ax")
+    if(CMAKE_CXX_FLAGS MATCHES " -ax" AND CMAKE_C_FLAGS MATCHES " -ax")
     else()
       MESSAGE(FATAL_ERROR "if -xcode or -axcode is specified by the user, it should be added in both CMAKE_CXX_FLAGS and CMAKE_C_FLAGS!")
     endif()


### PR DESCRIPTION
Add the space to ensure this only matches options where -x is at the beginning.

Issue showed up passing the option "-cxxlib=/path/linux-rhel7-x86_64".
The '-x' in the middle of the expression would satisfy the match condition.