### PR TITLE
Update manual testing description consistent with new labeling scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,6 @@ cmake                                               \
 
 ##  Additional examples:
 
-QMCPACK includes validation tests to ensure the correctness of the
-code, compilers, tools, and runtime. The tests should ideally be run
-each compilation, and certainly before any research use. The tests
-check the output against known mean-field, quantum chemistry, and
-other QMC results.
-
 Set compile flags manually:
 ```
    cmake                                                \
@@ -234,40 +228,57 @@ Add extra include directories:
 
 # Testing and validation of QMCPACK
 
-For more informaton, consult QMCPACK pages at http://www.qmcpack.org and the manual.
+Before using QMCPACK we highly encourage tests to be run.
+QMCPACK includes extensive validation tests to ensure the correctness of the
+code, compilers, tools, and runtime. The tests should ideally be run
+each compilation, and certainly before any research use. The tests include
+checks of the output against known mean-field, quantum chemistry, and
+other QMC results.
+
+While some tests are fully deterministic, due to QMCPACK's stochastic
+nature some tests are statistical and can occasionally fail. We employ
+a range of test names and labeling to differentiate between these, as
+well as developmental tests that are known to fail. In particular,
+"deterministic" tests include this in their ctest test name, while
+tests known to be unstable (stochastically or otherwise) are labeled
+unstable using ctest labels.
+
+For more informaton, consult http://www.qmcpack.org and the manual.
 The tests currently use up to 16 cores in various combinations of MPI
-tasks and OpenMP threads.
+tasks and OpenMP threads. Current status for many systems can be
+checked at https://cdash.qmcpack.org
 
 Note that due to the small electron and walker counts used in the
 tests, they should not be used for any performance measurements. These
 should be made on problem sizes that are representative of actual
-research calculations.
+research calculations. As described in the manual, performance tests
+are provided to aid in monitoring performance.
 
+## Run the deterministic tests
+
+From the build directory, invoke ctest specifying only tests
+that are deterministic and known to be reliable.
+```
+ctest -R deterministic -LE unstable
+```
+
+These tests currently take a few seconds to run, and include all the
+ unit tests. All tests should pass. Failing tests likely indicate a
+ significant problem that should be solved before using QMCPACK
+ further. This ctest invocation can be used as part of an automated
+ installation verification process.
+ 
 ## Run the short (quick) tests
 
  From the build directory, invoke ctest specifying only tests
- including "short" should be run
+ including "short" to run that are known to be stable.
 ```
-ctest -R short
-```
-
- These tests currently take several minutes to run. All tests should pass.
-
-## Run the long verification tests
-
-For greater surety, the long verification tests use a far greater
-number of statistical samples than the "short" tests. These take
-several hours each to run.
-
-From the build directory, invoke ctest with an increased test timeout
-```
-ctest --timeout 36000
+ctest -R short -LE unstable
 ```
 
-This will run all the defined tests, "short" and "long" as well as the
-unit and other tests. If you are running on a system such as a large
-shared supercomputer you will likely have to run these tests from
-inside a submitted job to avoid run length limits.
+ These tests currently take up to around one hour. On average, all
+ tests should pass at a three sigma level of reliability. Any
+ initially failing test should pass when rerun.
 
 ## Run individual tests
 

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -661,7 +661,7 @@ make -j 12
   X will request approval of the network connection for each executable.
 \verbatimfont{\footnotesize}%
 \begin{verbatim}
-ctest -R short
+ctest -R short -LE unstable
 \end{verbatim}
 \end{enumerate}
 
@@ -1197,26 +1197,57 @@ against this fork \url{https://github.com/naromero77/spack}
 \section{Testing and validation of QMCPACK}
 \label{sec:testing}
 We \textbf{strongly encourage} running the included tests each time
-QMCPACK is built. These compare the results from the executable with
-known-good mean-field, quantum chemical, and other QMC results.
+QMCPACK is built. A range of unit and integration tests ensure that
+the code behaves as expected and that results are consistent with
+known-good mean-field, quantum chemical, and historical QMC results.
 
-The tests included with QMCPACK currently mainly test the VMC code with
-single determinant wavefunction and simple spline Jastrow
-wavefunctions, and for gaussian and periodic spline basis
-sets. We check that the known mean
-field results are obtained with no Jastrow. When Jastrow functions are
-included we test against previous QMC data. The tests are statistical
-with a generous 3 $\sigma$ tolerance, however the system sizes are
-small, typically $<10$ electrons, so the error bars are typically
-small. Limited DMC and optimizer tests included and are scheduled for expansion.
+The tests include:
+\begin{itemize}
+\item Unit tests : to check fundamental behavior. These should always pass.
+\item Stochastic integration tests : to check computed results from
+  the Monte Carlo methods. These may fail statistically, but rarely,
+  due to the use of three sigma level statistics. These tests are
+  further split into ``short'' tests, which have just sufficient
+  length to have valid statistics, and ``long'' tests, to check
+  behavior to higher statistical accuracy.
+\item Converter tests : to check conversion of trial wavefunctions
+  from codes such as Quantum Espresso and GAMESS to QMCPACK's
+  formats. These should always pass.
+\item Workflow tests : in the case of Quantum Espresso, we test the
+  entire cycle of DFT calculation, trial wavefunction conversion, and
+  a subsequent VMC run.  
+\item Performance : to help performance monitoring. Only the timing of
+  these runs is relevant.  
+\end{itemize}
 
- The ``short'' tests only take a few minutes on a 16
-core machine. You can run these tests using the command below in the
+
+The test types are differentiated by prefixes in their names,
+e.g. ``short-LiH\_dimer\_ae\_vmc\_hf\_noj\_16-1'' indicates a short VMC test
+for the LiH dime. 
+
+QMCPACK also includes tests for developmental features and feature
+that are unsupported on certain platforms. To indicate these, tests
+that are unstable are labeled with the ctest label
+``unstable''. e.g. They are unreliable, unsupported, or known to fail
+due to partial implementation or bugs.
+
+When installing QMCPACK you should run at least the deterministic
+tests
+\begin{verbatim}
+ctest -R deterministic -LE unstable
+\end{verbatim}
+These currently take only a few seconds to run. All should pass. A
+failure here may indicate a major problem with the installation.
+
+If time allows, the ``short'' stochastic tests should also be run.
+The ``short'' tests each take a few minutes each on a 16
+core machine, totally around 1 hour depending on the platform. You can run these tests using the command below in the
 build directory:
 
 \verbatimfont{\footnotesize}
 \begin{verbatim}
-ctest -R short   # Run the tests with "short" in their name
+ctest -R short -LE unstable  # Run the tests with "short" in their name.
+                             # Exclude any known unstable tests.
 \end{verbatim}
 The output should be similar to the following:
 \verbatimfont{\footnotesize}
@@ -1237,8 +1268,9 @@ Test project build_gcc
 
 Total Test time (real) = 167.14 sec
 \end{verbatim}
+
 Note that the number of tests that are run varies between the
-standard, complex, and GPU compilations.
+standard, complex, and GPU compilations. These tests should pass with three sigma reliability. i.e. They should nearly always pass, and when rerunning a failed test it should usually pass. Overly frequent failures suggest a problem that should be addressed before any scientific production.
 
 The  full set of tests consist of significantly longer versions of the short
 tests, as well as tests of the conversion utilities. The runs require
@@ -1248,7 +1280,7 @@ directory:
 
 \verbatimfont{\footnotesize}
 \begin{verbatim}
-ctest            # Run all the tests. This will take several hours.
+ctest -LE unstable           # Run all the stable tests. This will take several hours.
 \end{verbatim}
 
 You can also run verbose tests which direct the QMCPACK
@@ -1267,7 +1299,7 @@ Under each physical system directory there may be tests for multiple QMC methods
 The numerical comparisons and test definitions are in the \texttt{CMakeLists.txt} file in each physical system directory.
 
 If \textit{all} the QMC tests fail it is likely
-that the appropriate mpiexec (or aprun, srun) is not being
+that the appropriate mpiexec (or mpirun, aprun, srun, jsrun) is not being
 called or found. If the QMC runs appear to work but all the other
 tests fail it is possible that python is not working on your system -
 we suggest checking some of the test console output in \texttt{build/Testing/Temporary/LastTest.log}
@@ -1275,24 +1307,26 @@ or the output files under \texttt{build/tests/}.
 %The runs occur in \texttt{build/tests/test\_dir/test\_name}.
 
 
-Note that because most of these tests are very small, consisting of only a few
+Note that because most of the tests are very small, consisting of only a few
 electrons, the performance is not representative of larger
 calculations. For example, while the calculations might fit in cache,
 there will be essentially no vectorization due to the small electron
 counts. \textbf{These tests should therefore not be used for any benchmarking or
-performance analysis}.
-
-Example runs that can be used for testing performance are described in
+performance analysis}. Example runs that can be used for testing performance are described in
 Sec. \ref{sec:perftests}
 
-\subsection{Unit tests}
+\subsection{Determinstic and unit tests}
 
-QMCPACK has a set of unit tests.
-All of the unit tests can be run with the following command (in the build directory):
+QMCPACK has a set of deterministic tests, predominantly unit tests.
+All of these tests can be run with the following command (in the build directory):
 \verbatimfont{\footnotesize}
 \begin{verbatim}
-ctest -L unit
+ctest -R deterministic -LE unstable
 \end{verbatim}
+
+These tests should always pass. Failure could indicate a major problem
+with the compiler, compiler settings, or a linked library that would
+give incorrect results.
 
 The output should look similar to the following:
 \verbatimfont{\footnotesize}
@@ -1417,25 +1451,21 @@ We currently test
 the following combinations nightly (workstations) and weekly (supercomputers):
 
 \begin{itemize}
-\item On a Linux Intel Xeon workstation:
+\item On a Linux Intel Xeon workstation, combinations of:
   \begin{itemize}
-  \item GCC 4.8.5 with OpenMPI and CUDA 8.0 (GPU build, run on NVIDIA K40s)
-  \item GCC 4.8.5 with OpenMPI with Netlib BLAS
-  \item GCC 4.8.5 with OpenMPI with Intel MKL
-  \item Intel 2017 with Intel MPI and MKL
-  \item Intel 2015 with Intel MPI and MKL and CUDA 8.0 (GPU build, run on NVIDIA K40s)
-  \item Intel 2015 with Intel MPI  and MKL
+  \item GCC 8.2.0, Intel2019, Clang6, Clang7, PGI2018
+  \item No MPI, Intel MPI, and OpenMPI
+  \item CPU and GPU builds using CUDA 10.0
   \end{itemize}
 \item On a Linux Intel Knight's Landing workstation:
   \begin{itemize}
   \item Intel 2017 with Intel MPI and MKL
- \item GCC 4.8.5 with Intel MPI and MKL
+  \item GCC 6.3.1 with Intel MPI and MKL
   \end{itemize}
 \item On Eos, a Cray XC30 Intel machine:
   \begin{itemize}
 \item The default Intel programming environment and compiler with Cray MPI and Intel MKL
   \end{itemize}
-
 \item On Titan, a Cray XK7 CPU+GPU machine:
   \begin{itemize}
   \item The GCC programming environment and compiler with Cray MPI and CUDA
@@ -1443,7 +1473,7 @@ the following combinations nightly (workstations) and weekly (supercomputers):
   \end{itemize}
 \item On Cetus, an IBM Blue Gene Q machine:
 \begin{itemize}
-\item Blue Gene Clang 4.0
+\item Blue Gene Clang
 \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
Covers the unstable label and the different test types now implemented. @jtkrogel may wish to go into more details in a subsequent update, e.g. the different label categories. Also updates the description of the nightlies.

Closes #1147 
