### PR TITLE
Improve description of verbosity in manual

### DIFF
--- a/manual/running.tex
+++ b/manual/running.tex
@@ -27,12 +27,10 @@ option is disabled.
   coefficients of the single particle wave functions. See the manual
   \ref{sec:spo_spline} for more information.}
 \item[\texttt{-{}-vacuum X}]{Removed, use `vacuum' input tag described in \ref{chap:simulationcell}. }
-\item[\texttt{-{}-verbosity=low|high|debug}]{ Control the output verbosity. }
+\item[\texttt{-{}-verbosity=low|high|debug}]{ Control the output verbosity. The default low verbosity is concise and, e.g., does not include all electron or atomic positions for large systems to reduce output size. Use 'high' to see this information and more details of initialization, allocations, QMC method settings etc.. }
 \item[\texttt{-{}-version}]{ Print version information and optional arguments.
   Same as \texttt{-{}-help}. }
 \end{description}
-
-
 
 
 \section{Input files}


### PR DESCRIPTION
Additional description. Closes #957 , which was not essential because the description was already there.