### PR TITLE
Adjustments and fixes for user meeting

### DIFF
--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -1734,10 +1734,15 @@ def graph_sims(sims=None,savefile=None,useid=False,exit=True,quants=True):
         else:
             nlabel = sim.identifier+' '+str(sim.simid)
         #end if
+        nopts = obj()
+        if 'block' in sim and sim.block:
+            nopts.color     = 'black'
+            nopts.fontcolor = 'white'
+        #end if
         node = obj(
             id    = sim.simid,
             sim   = sim,
-            node  = Node(nlabel,style='filled',shape='Mrecord'),
+            node  = Node(nlabel,style='filled',shape='Mrecord',**nopts),
             edges = obj(),
             )
         nodes[node.id] = node

--- a/nexus/library/simulation.py
+++ b/nexus/library/simulation.py
@@ -1033,15 +1033,17 @@ class Simulation(NexusCore):
 
     def submit(self):
         if not self.submitted:
-            if self.skip_submit:
+            if self.skip_submit and not self.bundled:
                 self.block_dependents(block_self=True)
                 return
             #end if
             self.log('submitting job'+self.idstr(),n=3)
-            if not self.job.local:
-                self.job.submit()
-            else:
-                self.execute() # execute local job immediately
+            if not self.skip_submit:
+                if not self.job.local:
+                    self.job.submit()
+                else:
+                    self.execute() # execute local job immediately
+                #end if
             #end if
             self.submitted = True
             if (self.job.batch_mode or not nexus_core.monitor) and not nexus_core.generate_only:


### PR DESCRIPTION
The PR contains two small commits needed to support the demos given in the Nexus user and developer meeting today.

Fix a recently introduced bug in job bundling (interaction with skip_submit) and color blocked simulations in black when graphing simulation workflows.