### PR TITLE
Fix precision issue in 3D natural spline unit test

### DIFF
--- a/src/einspline/tests/test_3d.cpp
+++ b/src/einspline/tests/test_3d.cpp
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <limits>
 
 using std::string;
 
@@ -52,7 +53,8 @@ TEST_CASE("double_3d_natural","[einspline]")
   eval_UBspline_3d_d(s, 1.0, 1.0, 1.0, &val);
   REQUIRE(val == Approx(2.0));
 
-  eval_UBspline_3d_d(s, 10.0, 10.0, 10.0, &val);
+  double pos=10.0-5*std::numeric_limits<double>::epsilon();
+  eval_UBspline_3d_d(s, pos, pos, pos, &val);
   REQUIRE(val == Approx(9.0));
 
   destroy_Bspline(s);


### PR DESCRIPTION
Fixes failing PGI unit test https://cdash.qmcpack.org/CDash/testDetails.php?test=3571223&build=32626

The unit test of the natural (non-periodic) 3D spline gives a NaN with PGI for a grid point exactly on the outermost spline grid limits. By moving the test point inside the limits by 5\*epsilon we avoid a presumed bounds error inside einspline and the NaN return value. 5\*epsilon is required to pass; 4*epsilon still results in NaN.
