### PR TITLE
Fixing error in Basiset. Indexing of unique Atomic Basisets was messedup

### DIFF
--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -264,7 +264,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[]):
   #atomicBasisSets Group
   for x in range(NbSpecies):
 
-    MyIdx=idxAtomstoSpecies[x]
+    MyIdx=idxSpeciestoAtoms[x][0]
     atomicBasisSetGroup=GroupBasisSet.create_group("atomicBasisSet"+str(x))
     mylen="S"+str(len(uniq_atoms[x][0]))
 


### PR DESCRIPTION
Bug in the creation of pyscf HDF5.
When removing duplicated basisset (in the case of multiple similar atoms) names of the atoms were entangled.  

Fixed now. 