### PR TITLE
[WIP] Change RNG seed generation scheme.

### DIFF
--- a/src/OhmmsApp/RandomNumberControl.h
+++ b/src/OhmmsApp/RandomNumberControl.h
@@ -18,6 +18,8 @@
 #include "Utilities/RandomGenerator.h"
 #include "Utilities/PrimeNumberSet.h"
 #include <io/hdf_archive.h>
+#include <chrono>
+#include <random>
 
 class Communicate;
 
@@ -50,8 +52,8 @@ public:
   void reset();
   static void test();
 
-  static void make_seeds();
-  static void make_children();
+  static void make_seeds(bool init_from_time = true, uint_type time_seed = 0);
+  static void make_children(std::vector<uint_type> &mySeeds);
 
   xmlNodePtr initialize(xmlXPathContextPtr);
 

--- a/src/Utilities/BoostRandom.h
+++ b/src/Utilities/BoostRandom.h
@@ -92,6 +92,14 @@ public:
     uni.engine().seed(baseSeed);
   }
 
+  /** initialize the generator with a seed
+   * @param iseed_in input seed
+   */
+  void init(uint_type iseed_in)
+  {
+    uni.engine().seed(iseed_in);
+  }
+
   ///get baseOffset
   inline int offset() const
   {


### PR DESCRIPTION
step 1, get initial seed by time std::chrono
step 2, generate seeds for RNGs used by MC. Each rank needs omp_get_max_threads()+1 seeds. jump ahead rank()*(omp_get_max_threads()+1) with discard(). Very fast 0.14 sec for 10^8.
step 3, seed the per-rank RNG.
step 4, seed the per-thread RNG.

After dive in the code a bit, I feel a lot of cleaning is needed.
Mostly RandomGenerator_t needs to be simplified. All the information about MPI and threads should be removed.