### PR TITLE
Update timer names in performance script

### DIFF
--- a/tests/performance/NiO/process_perf.py
+++ b/tests/performance/NiO/process_perf.py
@@ -32,8 +32,8 @@ def get_performance_info(info_fname):
   # Alternative with XPath syntax to find a particular timer
   # vmc_timers = timing.findall(".//timer[name='VMCSingleOMP']")
 
-  vmc_time = get_incl_time(timers, ['VMCSingleOMP', 'VMCcuda'])
-  dmc_time = get_incl_time(timers, ['DMCOMP', 'DMCcuda'])
+  vmc_time = get_incl_time(timers, ['VMC', 'VMCSingleOMP', 'VMCcuda'])
+  dmc_time = get_incl_time(timers, ['DMC', 'DMCOMP', 'DMCcuda'])
 
   return {'VMC Time': vmc_time, 'DMC Time': dmc_time}
 


### PR DESCRIPTION
Dropping 'OMP' in the file and class names in #1178 also drops it from the timer names.
Add the new timer names to the script that processes the nightly performance results.
Fixes #1183