### PR TITLE
Add unit test for Communicate class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,6 +349,7 @@ ENDIF()
     SUBDIRS(Estimators/tests)
     SUBDIRS(QMCDrivers/tests)
     SUBDIRS(QMCApp/tests)
+    SUBDIRS(Message/tests)
   endif() #}
 
 endif() #}}}

--- a/src/Message/catch_mpi_main.hpp
+++ b/src/Message/catch_mpi_main.hpp
@@ -21,8 +21,9 @@
 // Replacement unit test main function to ensure that MPI is finalized once 
 // (and only once) at the end of the unit test.
 
-int main(int argc, const char* argv[])
+int main(int argc, char* argv[])
 {
+  OHMMS::Controller = new Communicate(argc, argv);
   int result = Catch::Session().run(argc, argv);
   OHMMS::Controller->finalize();
   return result;

--- a/src/Message/tests/CMakeLists.txt
+++ b/src/Message/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+#//
+#// File created by: Mark Dewing, mdewing@ganl.gov Argonne National Laboratory
+#//////////////////////////////////////////////////////////////////////////////////////
+
+
+SET( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR} )
+
+SET(SRC_DIR message)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
+
+ADD_EXECUTABLE(${UTEST_EXE} test_communciate.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
+
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")

--- a/src/Message/tests/test_communciate.cpp
+++ b/src/Message/tests/test_communciate.cpp
@@ -1,0 +1,100 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "Message/catch_mpi_main.hpp"
+
+namespace qmcplusplus {
+
+TEST_CASE("test_communicate_split_one", "[message]")
+{
+  Communicate *c = OHMMS::Controller;
+
+  Communicate *c2 = new Communicate(*c, 1);
+
+  REQUIRE(c2->size() == c->size());
+  REQUIRE(c2->rank() == c->rank());
+
+  if (c->rank() == 0) {
+    REQUIRE(c2->isGroupLeader() == true);
+    REQUIRE(c2->GroupLeaderComm != nullptr);
+    REQUIRE(c2->GroupLeaderComm->size() == 1);
+    REQUIRE(c2->GroupLeaderComm->rank() == 0);
+  } else {
+    REQUIRE(c2->isGroupLeader() == false);
+    REQUIRE(c2->GroupLeaderComm == nullptr);
+  }
+}
+
+TEST_CASE("test_communicate_split_two", "[message]")
+{
+  Communicate *c = OHMMS::Controller;
+  if (c->size() >= 2) {
+    Communicate *c2 = new Communicate(*c, 2);
+
+    std::vector<int> new_size(2);
+    new_size[0] = c->size()/2;
+    new_size[1] = c->size()/2;
+
+    int midpoint = c->size()/2;
+    int new_group_id = c->rank() < midpoint ? 0 : 1;
+    int new_rank = c->rank();
+    if (c->rank() >= midpoint) {
+      new_rank -= midpoint;
+    }
+    // Adjust for odd size - the last group has the extra process
+    if (c->size()%2 == 1) {
+      new_size[1] = new_size[1] + 1;
+    }
+    REQUIRE(c2->size() == new_size[new_group_id]);
+    REQUIRE(c2->rank() == new_rank);
+
+    if (c->rank() == 0 || c->rank() == midpoint) {
+      REQUIRE(c2->isGroupLeader() == true);
+      REQUIRE(c2->GroupLeaderComm != nullptr);
+      REQUIRE(c2->GroupLeaderComm->size() == 2);
+      if (c->rank() == 0) {
+        REQUIRE(c2->GroupLeaderComm->rank() == 0);
+      } else {
+        REQUIRE(c2->GroupLeaderComm->rank() == 1);
+      }
+    } else {
+      REQUIRE(c2->isGroupLeader() == false);
+      REQUIRE(c2->GroupLeaderComm == nullptr);
+    }
+  }
+}
+
+TEST_CASE("test_communicate_split_four", "[message]")
+{
+  Communicate *c = OHMMS::Controller;
+  // For simplicity, only test the case where the number of processes is divisible by 4.
+  if (c->size()%4 == 0) {
+    Communicate *c2 = new Communicate(*c, 4);
+
+    REQUIRE(c2->size() == c->size()/4);
+    int group_size = c->size()/4;
+    int new_rank = c->rank() % group_size;
+    REQUIRE(c2->rank() == new_rank);
+
+    if (new_rank == 0) {
+      REQUIRE(c2->isGroupLeader() == true);
+      REQUIRE(c2->GroupLeaderComm != nullptr);
+      REQUIRE(c2->GroupLeaderComm->size() == 4);
+      REQUIRE(c2->GroupLeaderComm->rank() == c->rank()/group_size);
+    } else {
+      REQUIRE(c2->isGroupLeader() == false);
+      REQUIRE(c2->GroupLeaderComm == nullptr);
+    }
+  }
+}
+
+}


### PR DESCRIPTION
In particular, test the splitting constructor used for ensemble runs.
Test that it splits the processes as expected and creates the group leader communicator.
Purpose is to ensure this functionality doesn't regress when moving to the new MPI wrapper.

Add MPI initialization to the Catch MPI header.   The OHMMS::Controller initialization can
be removed from some of the unit tests that have it.

The test is designed to run under multiple MPI processes, but test system doesn't
handle this yet.  This test can be run manually to check that it works for different
numbers of MPI processes.