### PR TITLE
Store r values in vector for 1D quintic splines

### DIFF
--- a/src/QMCWaveFunctions/lcao/MultiQuinticSpline1D.h
+++ b/src/QMCWaveFunctions/lcao/MultiQuinticSpline1D.h
@@ -33,6 +33,7 @@ namespace qmcplusplus
       T upper_bound;
       T OneOverLogDelta;
       double LogDelta;
+      aligned_vector<T> r_values;
 
       inline void set(T ri, T rf, int n)
       {
@@ -44,6 +45,11 @@ namespace qmcplusplus
         double dlog_ratio = log_ratio/static_cast<double>(n-1);
         LogDelta = dlog_ratio;
         OneOverLogDelta = 1.0/dlog_ratio;
+        r_values.resize(n);
+        for (int i=0; i<n; i++)
+        {
+          r_values[i] = ri*std::exp(i*dlog_ratio);
+        }
       }
 
       inline int locate(T r) const
@@ -53,7 +59,8 @@ namespace qmcplusplus
 
       inline T operator()(int i)
       {
-        return static_cast<T>(lower_bound*std::exp(i*LogDelta));
+        //return static_cast<T>(lower_bound*std::exp(i*LogDelta));
+        return r_values[i];
       }
 
       //CHECK MIXED PRECISION SENSITIVITY
@@ -61,7 +68,8 @@ namespace qmcplusplus
       {
         loc=static_cast<int>(std::log(r/lower_bound)*OneOverLogDelta);
         //return r-static_cast<T>(lower_bound*std::exp(loc*LogDelta));
-        return r-lower_bound*std::exp(loc*LogDelta);
+        //return r-lower_bound*std::exp(loc*LogDelta);
+        return r-r_values[loc];
       }
     };
 


### PR DESCRIPTION
store values to avoid repeated calls to exp