### PR TITLE
Fix noMPI build with test_message.

### DIFF
--- a/src/Message/catch_mpi_main.hpp
+++ b/src/Message/catch_mpi_main.hpp
@@ -23,7 +23,9 @@
 
 int main(int argc, char* argv[])
 {
+#ifdef HAVE_MPI
   OHMMS::Controller = new Communicate(argc, argv);
+#endif
   int result = Catch::Session().run(argc, argv);
   OHMMS::Controller->finalize();
   return result;


### PR DESCRIPTION
Fixes #1232.
Adding the initialization of Communicate in the no-MPI case calls a different constructor than the default serial constructor.

An alternate approach would be to fix that constructor, but the serial version of Communicate will be removed eventually so there's no need to fix it.