### PR TITLE
Use MPI3 wrapper

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -1,7 +1,7 @@
 # Check compiler version
-IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3 )
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4 )
   MESSAGE(STATUS "Compiler Version ${CMAKE_CXX_COMPILER_VERSION}")
-  MESSAGE(FATAL_ERROR "Requires clang 3.3 or higher ")
+  MESSAGE(FATAL_ERROR "Requires clang 3.4 or higher ")
 ENDIF()
 
 # Set the std

--- a/CMake/GNUCompilers.cmake
+++ b/CMake/GNUCompilers.cmake
@@ -1,6 +1,6 @@
 # Check compiler version
-IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8 )
-MESSAGE(FATAL_ERROR "Requires gcc 4.8 or higher ")
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0 )
+MESSAGE(FATAL_ERROR "Requires gcc 5.0 or higher ")
 ENDIF()
 
 # Set the std

--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -1,7 +1,7 @@
 # Check compiler version
 SET(INTEL_COMPILER 1)
-IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0 )
-MESSAGE(FATAL_ERROR "Requires Intel 15.0 or higher ")
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0 )
+MESSAGE(FATAL_ERROR "Requires Intel 18.0 or higher ")
 ENDIF()
 
 # Set the std

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,13 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   # Check that a C++ 14 standard library is configured
   include(CMake/TestCxx14Library.cmake)
 
+  #------------------------------
+  #  check Intel compiler version
+  #------------------------------
+  if ((${COMPILER} MATCHES "Intel") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0))
+    message(FATAL_ERROR "Intel compiler must be version 18 or higher (currently using ${CMAKE_CXX_COMPILER_VERSION})")
+  endif()
+
   #-------------------------------------------------------------------
   #  check MPI installation
   #-------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,13 +392,6 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   # Check that a C++ 14 standard library is configured
   include(CMake/TestCxx14Library.cmake)
 
-  #------------------------------
-  #  check Intel compiler version
-  #------------------------------
-  if ((${COMPILER} MATCHES "Intel") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0))
-    message(FATAL_ERROR "Intel compiler must be version 18 or higher (currently using ${CMAKE_CXX_COMPILER_VERSION})")
-  endif()
-
   #-------------------------------------------------------------------
   #  check MPI installation
   #-------------------------------------------------------------------

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -132,6 +132,16 @@ library during configuration, and will halt with an error if one is not found.
 At sites that use modules, running \texttt{module load gcc} is often sufficient to
 load a newer GCC and that will resolve the issue.
 
+\subsection{Intel compiler}
+The Intel compiler version must be 18 or newer.
+The version 17 compiler cannot compile some of the C++ 14 constructs in the code.
+
+If a newer gcc is needed, the \texttt{-cxxlib} option can be used to point to a different gcc installation.
+(Alternately, the \texttt{-gcc-name} or \texttt{-gxx-name} options can be used.)
+Be sure to pass this flag to the C compiler in addition to the C++ compiler.
+The reason is CMake extracts some library paths from the C compiler and those paths usually also contain to the C++ library.
+The symptom of this problem is C++ 14 standard library functions not found at link time.
+
 \section{Building with CMake}
 \label{sec:cmake}
 The build system for QMCPACK is based on CMake.  It will autoconfigure
@@ -680,7 +690,7 @@ Mira/Cetus is a Blue Gene/Q supercomputer at Argonne National Laboratory's Argon
 Mira has 49152 compute nodes and each node has a 16-core PowerPC A2 processor with 16 GB DDR3 memory.
 Due to the fact that the login nodes and the compute nodes have different processors with distinct instruction sets,
 cross-compiling is required on this platform. See details about using Blue Gene/Q at \url{http://www.alcf.anl.gov/user-guides/compiling-linking}.
-On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang and +cmake-3.8.1 in \$HOME/.soft.
+On Mira, compilers are loaded via softenv and users need to add +mpiwrapper-bgclang-mpi3 and +cmake-3.8.1 in \$HOME/.soft.
 In order to build QMCPACK, a toolchain file is provided for setting up CMake.
 \textbf{BGClang is required for C++ 14 support. IBM XL C/C++ compiler should not be used.}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,9 @@ IF (IS_GIT_PROJECT)
   MESSAGE("Git commit hash: ${GIT_CONFIG_COMMIT_HASH}")
 ENDIF()
 
+if (HAVE_MPI)
+  INCLUDE_DIRECTORIES("${qmcpack_SOURCE_DIR}/external_codes/mpi_wrapper")
+endif()
 
 ####################################
 # create liboompi

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -124,43 +124,6 @@ Communicate::Communicate(const Communicate& comm, int nparts)
   MPI_Group_free(&leader_group);
 }
 
-Communicate::Communicate(const Communicate& comm, const std::vector<int>& jobs)
-{
-  //this is a workaround due to the OOMPI bug with split
-  if(jobs.size()>1)
-  {
-    MPI_Comm row;
-    std::vector<int> nplist(jobs.size()+1);
-    int p=-1;
-    nplist[0]=0;
-    for(int i=0; i<jobs.size(); ++i)
-    {
-      nplist[i+1]=nplist[i]+jobs[i];
-      if(comm.rank()>=nplist[i] && comm.rank()<nplist[i+1])
-        p=i;
-    }
-    if(nplist[comm.size()] != comm.size())
-    {
-      APP_ABORT("Communicate::Communicate(comm,jobs) Cannot group MPI tasks. Mismatch of the tasks");
-    }
-    int q=comm.rank()-nplist[p];//rank within a group
-    MPI_Comm_split(comm.getMPI(),p,q,&row);
-    myComm=OOMPI_Intra_comm(row);
-    d_groupid=p;
-  }
-  else
-  {
-    myComm=OOMPI_Intra_comm(comm.getComm());
-    d_groupid=0;
-  }
-  myMPI = myComm.Get_mpi();
-  d_mycontext=myComm.Rank();
-  d_ncontexts=myComm.Size();
-  d_ngroups=jobs.size();
-  GroupLeaderComm=nullptr;
-}
-
-
 
 //================================================================
 // Implements Communicate with OOMPI library

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -49,11 +49,13 @@ Communicate::Communicate():
 {
 }
 
+#ifdef HAVE_MPI
 Communicate::Communicate(const mpi3::environment &env):
   GroupLeaderComm(nullptr)
 {
   initialize(env);
 }
+#endif
 
 Communicate::~Communicate()
 {
@@ -222,9 +224,5 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
   GroupLeaderComm = new Communicate();
 }
 
-Communicate::Communicate(const Communicate& comm, const std::vector<int>& jobs)
-  : myMPI(0), d_mycontext(0), d_ncontexts(1), d_groupid(0), GroupLeaderComm(nullptr)
-{
-}
 
 #endif // !HAVE_OOMPI

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -90,12 +90,6 @@ public:
   //Communicate(const intra_comm_type& c);
   Communicate(const Communicate& comm, int nparts);
 
-  /** constructor
-   * @param comm a communicator which will be split into groups
-   * @param jobs number of tasks per group
-   */
-  Communicate(const Communicate& comm, const std::vector<int>& jobs);
-
   /**destructor
    * Call proper finalization of Communication library
    */

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -23,6 +23,11 @@
 #include "config.h"
 #endif
 
+#ifdef HAVE_MPI
+#include "mpi3/environment.hpp"
+namespace mpi3 = boost::mpi3;
+#endif
+
 #ifdef HAVE_OOMPI
 #include "oompi.h"
 struct CommunicatorTraits
@@ -80,22 +85,28 @@ public:
   ///constructor
   Communicate();
 
-  ///constructor with arguments
-  Communicate(int argc, char **argv);
+  ///constructor from mpi3 environment
+#ifdef HAVE_MPI
+  Communicate(const mpi3::environment &env);
+#endif
 
   ///constructor with communicator
   Communicate(const mpi_comm_type comm_input);
 
   ///constructor with communicator
   //Communicate(const intra_comm_type& c);
-  Communicate(const Communicate& comm, int nparts);
+  Communicate(const Communicate& in_comm, int nparts);
 
   /**destructor
    * Call proper finalization of Communication library
    */
   virtual ~Communicate();
-
+  // Only for unit tests
   void initialize(int argc, char **argv);
+
+#ifdef HAVE_MPI
+  void initialize(const mpi3::environment &env);
+#endif
   void finalize();
   void abort();
   void abort(const char* msg);
@@ -277,6 +288,11 @@ protected:
 public:
   /// Group Lead Communicator
   Communicate *GroupLeaderComm;
+
+  /// mpi3 communicator wrapper
+#ifdef HAVE_MPI
+  mpi3::communicator comm;
+#endif
 };
 
 

--- a/src/Message/catch_mpi_main.hpp
+++ b/src/Message/catch_mpi_main.hpp
@@ -24,7 +24,8 @@
 int main(int argc, char* argv[])
 {
 #ifdef HAVE_MPI
-  OHMMS::Controller = new Communicate(argc, argv);
+  mpi3::environment env(argc, argv);
+  OHMMS::Controller->initialize(env);
 #endif
   int result = Catch::Session().run(argc, argv);
   OHMMS::Controller->finalize();

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -50,7 +50,10 @@ int main(int argc, char **argv)
   //TAU_INIT(&argc, &argv);
   using namespace qmcplusplus;
   //qmc_common  and MPI is initialized
-  OHMMS::Controller->initialize(argc,argv);
+#ifdef HAVE_MPI
+  mpi3::environment env(argc, argv);
+  OHMMS::Controller->initialize(env);
+#endif
   qmcplusplus::qmc_common.initialize(argc,argv);
   int clones=1;
   bool useGPU=(qmc_common.compute_device == 1);

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -47,7 +47,10 @@ int main(int argc, char **argv)
     std::cout << " *.Fchk -> gaussian; *.out -> gamess; *.data -> casino; *.xml -> gamesxml" << std::endl;
     return 1;
   }
-  OHMMS::Controller->initialize(argc,argv);
+#ifdef HAVE_MPI
+  mpi3::environment env(argc, argv);
+  OHMMS::Controller->initialize(env);
+#endif
   if (OHMMS::Controller->rank() != 0) {
     outputManager.shutOff();
   }

--- a/tests/test_automation/jenkins_rhea_cpu.sh
+++ b/tests/test_automation/jenkins_rhea_cpu.sh
@@ -22,6 +22,7 @@ export FFTW_HOME=\$FFTW3_DIR
 module load hdf5
 module load git
 module load cmake/3.6.1
+module load boost
 
 env
 module list

--- a/tests/test_automation/jenkins_rhea_gpu.sh
+++ b/tests/test_automation/jenkins_rhea_gpu.sh
@@ -23,6 +23,7 @@ module load hdf5
 module load git
 module load cudatoolkit/8.0.44
 module load cmake/3.6.1
+module load boost
 
 env
 module list


### PR DESCRIPTION
Includes some updates from the mpi3 wrapper repo that are needed to compile, especially with gcc 5.3 on Rhea.   Also need load the boost module on Rhea to get a newer boost (1.58)

This PR puts the new mpi3 wrapper in charge of initializing MPI, and the old OOMPI wrappers are initialized from that by passing an MPI communicator.

A check is on the Intel compiler version is added and the manual updated.
