### PR TITLE
Pass Communicate pointer in hdf_archive.

### DIFF
--- a/src/io/hdf_archive.cpp
+++ b/src/io/hdf_archive.cpp
@@ -51,6 +51,7 @@ void hdf_archive::set_access_plist()
 void hdf_archive::set_access_plist(bool request_pio, Communicate* comm)
 {
   access_id=H5P_DEFAULT;
+  myComm = comm;
   if(comm && comm->size()>1) //for parallel communicator
   {
     bool use_phdf5=false;


### PR DESCRIPTION
Fixes segfaults in gaussian orbital test cases.
Gaussian orbital HDF readers use this pointer.  The code should be changed to pass the Communicate pointer to these functions directly rather than use the pointer in hdf_archive.