### PR TITLE
Fix PGI compiler build with GCC 7

### DIFF
--- a/CMake/PGICompilers.cmake
+++ b/CMake/PGICompilers.cmake
@@ -24,6 +24,12 @@ SET( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fast" )
 SET( CMAKE_C_FLAGS_RELWITHDEBINFO     "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fast" )
 SET( CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fast" )
 
+
+# Setting this to 'OFF' adds the -A flag, which enforces strict standard compliance
+#  and causes the compilation to fail with some GNU header files
+SET(CMAKE_CXX_EXTENSIONS ON)
+
+
 # Add static flags if necessary
 IF(QMC_BUILD_STATIC)
     SET(CMAKE_CXX_LINK_FLAGS " -Bstatic")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,13 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
     ENDIF(QMC_CUDA)
   ENDIF($ENV{CRAYPE_VERSION} MATCHES ".")
 
+  #--------------------------------
+  #  C++ 14 is the minimum standard
+  #--------------------------------
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
   #------------------------------------
   # Identify the compiler -- This serves only to deal with case where only C or CXX is set, refactor? 
   #------------------------------------
@@ -385,11 +392,10 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
     MESSAGE(WARNING "No default file for compiler (${COMPILER})")
   ENDIF()
 
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
 
+  #---------------------------------------------------
   # Check that a C++ 14 standard library is configured
+  #---------------------------------------------------
   include(CMake/TestCxx14Library.cmake)
 
   #-------------------------------------------------------------------


### PR DESCRIPTION
Move the CMake C++ standard settings before the compiler-specific configuration files.
The compiler configuration files can then override these settings if necessary.