### PR TITLE
Set minimum boost version to 1.61.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,14 +642,13 @@ ENDIF(HDF5_FOUND)
 
 #make sure we can find boost if it's not in /usr
 set(Boost_NO_BOOST_CMAKE on)
-find_package(Boost REQUIRED)
+find_package(Boost 1.61.0 REQUIRED)
 IF(Boost_FOUND)
   SET(HAVE_LIBBOOST 1)
   INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
   MESSAGE(STATUS "Setting Boost_INCLUDE_DIRS=${Boost_INCLUDE_DIRS}")
 ELSE()
-  MESSAGE(STATUS "Using MT engine in Utilities/MersenneTwister.h")
-  #MESSAGE(FATAL_ERROR "Require boost 1.33.x or higher. Set BOOST_ROOT")
+  MESSAGE(FATAL_ERROR "Need boost 1.61.0 or higher.  Set BOOST_ROOT")
 ENDIF()
 
 SET(HAVE_CUDA 0)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  * BLAS/LAPACK, numerical library, use platform-optimized libraries
  * Libxml2, XML parser, http://xmlsoft.org/
  * HDF5, portable I/O library, http://www.hdfgroup.org/HDF5/
- * BOOST, peer-reviewed portable C++ source libraries, http://www.boost.org
+ * BOOST, peer-reviewed portable C++ source libraries, http://www.boost.org , version 1.61.0 or higher.
  * FFTW, FFT library, http://www.fftw.org/
 
 See the manual for more detailed version requirements.

--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -100,7 +100,7 @@ Section \ref{sec:buildperformance} for performance suggestions.
 \item CMake, build utility, \url{http://www.cmake.org}
 \item Libxml2, XML parser, \url{http://xmlsoft.org}
 \item HDF5, portable I/O library, \url{http://www.hdfgroup.org/HDF5/}. Good performance at large scale requires parallel version $>=$ 1.10.
-\item BOOST, peer-reviewed portable C++ source libraries, \url{http://www.boost.org}
+\item BOOST, peer-reviewed portable C++ source libraries, \url{http://www.boost.org}.   Minimum version is 1.61.0.
 \item FFTW, FFT library, \url{http://www.fftw.org/}
 \end{itemize}
 


### PR DESCRIPTION
Addresses #1254

This is for AFQMC.  The real-space version may have more relaxed version requirements,
but this version seems available most everywhere and for simplicity a single
version requirement is added.