### PR TITLE
Don't attempt to dump HDF5 if nCheckpoint = 0.

### DIFF
--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -107,7 +107,9 @@ bool AFQMCDriver::run(WalkerSet& wset)
 
   }
 
-  checkpoint(wset,iBlock,step_tot);
+  if(nCheckpoint > 0) {
+    checkpoint(wset,iBlock,step_tot);
+  }
 
   app_log()<<"----------------------------------------------------------------\n";
   app_log()<<" Timer: \n";


### PR DESCRIPTION
Small fix to ensure the user is requesting a checkpoint file. Currently the AFQMC code will crash because dumpToHDF5 is not fully implemented yet.