### PR TITLE
Add complex build afqmc tests

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -163,8 +163,8 @@ ENDFUNCTION()
 
 FUNCTION(QMC_RUN_AND_CHECK BASE_NAME BASE_DIR PREFIX INPUT_FILE PROCS THREADS SHOULD_SUCCEED)
     # Map from name of check to appropriate flag for check_scalars.py
-    LIST(APPEND SCALAR_CHECK_TYPE "kinetic" "totenergy" "variance" "eeenergy" "samples" "potential" "ionion" "localecp" "nonlocalecp" "flux" "kinetic_mixed" "kinetic_pure" "eeenergy_mixed" "eeenergy_pure" "potential_pure" "totenergy_A" "totenergy_B" "dtotenergy_AB" "ionion_A" "ionion_B" "dionion_AB" "eeenergy_A" "eeenergy_B" "deeenergy_AB" "Eloc" "ElocEstim" "latdev")
-    LIST(APPEND CHECK_SCALAR_FLAG "--ke"    "--le"    "--va"    "--ee"     "--ts"    "--lp"      "--ii"       "--lpp"    "--nlpp" "--fl" "--ke_m" "--ke_p" "--ee_m" "--ee_p" "--lp_p" "--le_A" "--le_B" "--dle_AB" "--ii_A" "--ii_B" "--dii_AB" "--ee_A" "--ee_B" "--dee_AB" "--eloc" "--elocest" "--latdev")
+    LIST(APPEND SCALAR_CHECK_TYPE "kinetic" "totenergy" "variance" "eeenergy" "samples" "potential" "ionion" "localecp" "nonlocalecp" "flux" "kinetic_mixed" "kinetic_pure" "eeenergy_mixed" "eeenergy_pure" "potential_pure" "totenergy_A" "totenergy_B" "dtotenergy_AB" "ionion_A" "ionion_B" "dionion_AB" "eeenergy_A" "eeenergy_B" "deeenergy_AB" "Eloc" "ElocEstim" "latdev" "EnergyEstim__nume_real")
+    LIST(APPEND CHECK_SCALAR_FLAG "--ke"    "--le"    "--va"    "--ee"     "--ts" "--lp"      "--ii"       "--lpp"    "--nlpp" "--fl" "--ke_m" "--ke_p" "--ee_m" "--ee_p" "--lp_p" "--le_A" "--le_B" "--dle_AB" "--ii_A" "--ii_B" "--dii_AB" "--ee_A" "--ee_B" "--dee_AB" "--eloc" "--elocest" "--latdev" "--enum_real")
 
 
     SET( TEST_ADDED FALSE )

--- a/tests/scripts/check_scalars.py
+++ b/tests/scripts/check_scalars.py
@@ -193,6 +193,7 @@ def read_command_line():
 #AFQMC quantities
             eloc    = 'Eloc',
             elocest = 'ElocEstim',
+            enum_real = 'EnergyEstim__nume_real',
             )
 
         for qshort in sorted(quantities.keys()):

--- a/tests/solids/CMakeLists.txt
+++ b/tests/solids/CMakeLists.txt
@@ -19,5 +19,7 @@ SUBDIRS("NiO_a4_e48_pp")
 IF (BUILD_AFQMC AND NOT QMC_COMPLEX)
    SUBDIRS("diamondC_afqmc")
    SUBDIRS("NiO_afqmc")
+ELSEIF (BUILD_AFQMC AND QMC_COMPLEX)
+   SUBDIRS("diamondC_afqmc_1x1x1_complex")
 ENDIF()
 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -1,0 +1,59 @@
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/choldump.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/wfn.dat)
+
+#symlink h5 file
+MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump.h5)
+#symlink wfn file
+MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn.dat)
+
+LIST(APPEND DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-379.2037 0.0282")
+
+QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_cholesky"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_short_chol
+                  qmc_short_chol.in.xml
+                  16 1
+                  TRUE
+                  0 DIAMOND_AFQMC_SCALARS_CHOL
+                  )
+
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-379.2037 0.0043")
+
+QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_cholesky"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_long_chol
+                  qmc_long_chol.in.xml
+                  16 1
+                  TRUE
+                  0 LONG_DIAMOND_AFQMC_SCALARS_CHOL
+                  )
+
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/thc.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/wfn_thc.dat)
+
+#symlink h5 file
+MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/thc.h5)
+#symlink wfn file
+MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn_thc.dat)
+
+LIST(APPEND DIAMOND_AFQMC_SCALARS_THC "EnergyEstim__nume_real" "-10.33408 0.00432")
+
+QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_thc"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_short_thc
+                  qmc_short_thc.in.xml
+                  16 1
+                  TRUE
+                  0 DIAMOND_AFQMC_SCALARS_THC
+                  )
+
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_THC "EnergyEstim__nume_real" "-10.33408 0.00143")
+
+QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_thc"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_long_thc
+                  qmc_long_thc.in.xml
+                  16 1
+                  TRUE
+                  0 LONG_DIAMOND_AFQMC_SCALARS_THC
+                  )

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -57,3 +57,33 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_thc"
                   TRUE
                   0 LONG_DIAMOND_AFQMC_SCALARS_THC
                   )
+
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/choldump.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/wfn.dat)
+
+#symlink h5 file
+MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump_uhf.h5)
+#symlink wfn file
+MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn_uhf.dat)
+
+LIST(APPEND DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00312")
+
+QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_uhf"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_short_uhf
+                  qmc_short_uhf.in.xml
+                  16 1
+                  TRUE
+                  0 DIAMOND_AFQMC_SCALARS_UHF
+                  )
+
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00103")
+
+QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_uhf"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_long_uhf
+                  qmc_long_uhf.in.xml
+                  16 1
+                  TRUE
+                  0 LONG_DIAMOND_AFQMC_SCALARS_UHF
+                  )

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -6,7 +6,7 @@ MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump.h5)
 #symlink wfn file
 MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn.dat)
 
-LIST(APPEND DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-379.2037 0.0282")
+LIST(APPEND DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-10.55201 0.00332")
 
 QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_cholesky"
                   "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
@@ -17,7 +17,7 @@ QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_cholesky"
                   0 DIAMOND_AFQMC_SCALARS_CHOL
                   )
 
-LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-379.2037 0.0043")
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_CHOL "EnergyEstim__nume_real" "-10.55201 0.00109")
 
 QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_cholesky"
                   "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -110,7 +110,7 @@ QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_phmsd"
                   0 DIAMOND_AFQMC_SCALARS_PHMSD
                   )
 
-LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_PHMSD "EnergyEstim__nume_real" "-10.55085 0.00086")
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_PHMSD "EnergyEstim__nume_real" "-10.55085 0.00119")
 
 QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_phmsd"
                   "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -1,3 +1,4 @@
+# RHF CHOLESKY
 SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/choldump.h5)
 SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/wfn.dat)
 
@@ -28,6 +29,7 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_cholesky"
                   0 LONG_DIAMOND_AFQMC_SCALARS_CHOL
                   )
 
+# RHF ISDF/THC
 SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/thc.h5)
 SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/wfn_thc.dat)
 
@@ -58,6 +60,7 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_thc"
                   0 LONG_DIAMOND_AFQMC_SCALARS_THC
                   )
 
+# UHF CHOLESKY
 SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/choldump.h5)
 SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/wfn.dat)
 
@@ -86,4 +89,34 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_uhf"
                   16 1
                   TRUE
                   0 LONG_DIAMOND_AFQMC_SCALARS_UHF
+                  )
+
+# PHMSD CHOLESKY
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/choldump_phmsd.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/wfn_phmsd.dat)
+#symlink h5 file
+MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump_phmsd.h5)
+#symlink wfn file
+MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn_phmsd.dat)
+
+LIST(APPEND DIAMOND_AFQMC_SCALARS_PHMSD "EnergyEstim__nume_real" "-10.55085 0.00368")
+
+QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_phmsd"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_short_phmsd
+                  qmc_short_phmsd.in.xml
+                  16 1
+                  TRUE
+                  0 DIAMOND_AFQMC_SCALARS_PHMSD
+                  )
+
+LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_PHMSD "EnergyEstim__nume_real" "-10.55085 0.00086")
+
+QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_phmsd"
+                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  qmc_long_phmsd
+                  qmc_long_phmsd.in.xml
+                  16 1
+                  TRUE
+                  0 LONG_DIAMOND_AFQMC_SCALARS_PHMSD
                   )

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/README
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/README
@@ -1,34 +1,42 @@
 These tests include short and long AFQMC runs for a two atom diamond
 primitive cell at the gamma point. Tests exist for both the Cholesky
-and ISDF factorization of the integrals. For the Cholesky factorization
-there are tests for RHF, UHF and particle-hole multi-Slater determinant
-(PHMSD) trial wavefunctions. For the ISDF factorization a RHF trial
-wavefunction is used.
-Reference data from the high block count AFQMC runs is found below:
+and ISDF factorization of the integrals. For the Cholesky
+factorization there are tests for RHF, UHF and particle-hole
+multi-Slater determinant (PHMSD) trial wavefunctions. For the ISDF
+factorization a RHF trial wavefunction is used.  Reference data from
+the high block count AFQMC runs is found below:
 
                       EnergyEstim__num_real
 afqmc cholesky rhf   -10.55201 +/- 0.00033
 afqmc cholesky uhf   -10.55151 +/- 0.00031
-afqmc cholesky phmsd -10.55151 +/- 0.00031
+afqmc cholesky phmsd -10.55085 +/- 0.00026
 afqmc isdf     rhf   -10.33408 +/- 0.00043
 
-These values can also be found in qmc-ref/qmc_ref.qmca
+These values can also be found in qmc-ref/qmc_ref.qmca. The scalar.dat
+files were too large to include with qmcpack. The first 10 blocks were
+discarded from the reference scalar.dat files during analysis with the
+qmca script.
 
 Test input files were created by reducing the number of steps from the
 included reference by a factor of 10 for the "long" tests and by a
 further factor of 10 for the "short" tests.
 
 A reference value for the mean local energy was taken from the high
-block count reference run.  Expected error bars were derived from
-the high block count data by multiplying the reference error bars by
-a factor of sqrt(10+1) and sqrt(100+1) for the long and short tests,
+block count reference run.  Expected error bars for tests using
+single determinant trial wavefunctions were derived from the high
+block count data by multiplying the reference error bars by a factor
+of sqrt(10+1) and sqrt(100+1) for the long and short tests,
 respectively.  The factor of +1 accounts for the error bar intrinsic
-to the high block count runs.
+to the high block count runs. Similarly for multi determinant case,
+the reference error bars were multiplied by a factor of sqrt(20+1) and
+sqrt(201+1) for the long and short tests. The tests were made half as
+long due to the additional overhead associated with running
+multi-determinant calculations.
 
 The target means and error bars for long and short tests are:
 
                       refmean      referr    longerr   shorterr
 afqmc cholesky rhf   -10.55201 +/- 0.00033   0.00109   0.00332
-afqmc cholesky uhf   -10.55151 +/- 0.00031
-afqmc cholesky phmsd -10.55151 +/- 0.00031   0.00103   0.00312
+afqmc cholesky uhf   -10.55151 +/- 0.00031   0.00103   0.00312
+afqmc cholesky phmsd -10.55085 +/- 0.00026   0.00119   0.00369
 afqmc isdf     rhf   -10.33408 +/- 0.00043   0.00143   0.00432

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/README
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/README
@@ -1,0 +1,34 @@
+These tests include short and long AFQMC runs for a two atom diamond
+primitive cell at the gamma point. Tests exist for both the Cholesky
+and ISDF factorization of the integrals. For the Cholesky factorization
+there are tests for RHF, UHF and particle-hole multi-Slater determinant
+(PHMSD) trial wavefunctions. For the ISDF factorization a RHF trial
+wavefunction is used.
+Reference data from the high block count AFQMC runs is found below:
+
+                      EnergyEstim__num_real
+afqmc cholesky rhf   -10.55201 +/- 0.00033
+afqmc cholesky uhf   -10.55151 +/- 0.00031
+afqmc cholesky phmsd -10.55151 +/- 0.00031
+afqmc isdf     rhf   -10.33408 +/- 0.00043
+
+These values can also be found in qmc-ref/qmc_ref.qmca
+
+Test input files were created by reducing the number of steps from the
+included reference by a factor of 10 for the "long" tests and by a
+further factor of 10 for the "short" tests.
+
+A reference value for the mean local energy was taken from the high
+block count reference run.  Expected error bars were derived from
+the high block count data by multiplying the reference error bars by
+a factor of sqrt(10+1) and sqrt(100+1) for the long and short tests,
+respectively.  The factor of +1 accounts for the error bar intrinsic
+to the high block count runs.
+
+The target means and error bars for long and short tests are:
+
+                      refmean      referr    longerr   shorterr
+afqmc cholesky rhf   -10.55201 +/- 0.00033   0.00109   0.00332
+afqmc cholesky uhf   -10.55151 +/- 0.00031
+afqmc cholesky phmsd -10.55151 +/- 0.00031   0.00103   0.00312
+afqmc isdf     rhf   -10.33408 +/- 0.00043   0.00143   0.00432

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/README
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/README
@@ -1,10 +1,13 @@
 These tests include short and long AFQMC runs for a two atom diamond
 primitive cell at the gamma point. Tests exist for both the Cholesky
-and ISDF factorization of the integrals. For the Cholesky
+and ISDF/THC factorization of the integrals. For the Cholesky
 factorization there are tests for RHF, UHF and particle-hole
 multi-Slater determinant (PHMSD) trial wavefunctions. For the ISDF
-factorization a RHF trial wavefunction is used.  Reference data from
-the high block count AFQMC runs is found below:
+factorization a RHF trial wavefunction is used. The integrals and
+trial wavefunctions were generated using pyscf. The relevant scripts
+and files are available in tests/afqmc as these files are re-used for
+afqmc unit tests.
+Reference data from the high block count AFQMC runs is found below:
 
                       EnergyEstim__num_real
 afqmc cholesky rhf   -10.55201 +/- 0.00033

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
@@ -12,3 +12,17 @@ qmc_ref_thc series 0
   nWalkers              =            320.00 +/-             0.00 
   time                  =           5005.50 +/-          1820.99 
   weight                =         319.93007 +/-          0.00017 
+
+qmc_ref_chol  series 0 
+  EnergyEstim__deno_imag=  -0.000000000000000000030 +/- 0.000000000000000000032 
+  EnergyEstim__deno_real=              1.00 +/-             0.00 
+  EnergyEstim__nume_imag=          -0.00002 +/-          0.00014 
+  EnergyEstim__nume_real=         -10.55201 +/-          0.00033 
+  EnergyEstim__timer    =        0.00036789 +/-       0.00000074 
+  Eshift                =           6.28010 +/-          0.00090 
+  Ovlp                  =           0.19732 +/-          0.00013 
+  PseudoEloc            =           6.28046 +/-          0.00028 
+  freeMemory            =         108153.06 +/-          1189.52 
+  nWalkers              =            320.00 +/-             0.00 
+  time                  =           5005.50 +/-          1820.99 
+  weight                =         319.77758 +/-          0.00045 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
@@ -26,3 +26,17 @@ qmc_ref_chol  series 0
   nWalkers              =            320.00 +/-             0.00 
   time                  =           5005.50 +/-          1820.99 
   weight                =         319.77758 +/-          0.00045 
+
+qmc_ref_uhf  series 0 
+  EnergyEstim__deno_imag=  0.000000000000000000038 +/- 0.000000000000000000054 
+  EnergyEstim__deno_real=              1.00 +/-             0.00 
+  EnergyEstim__nume_imag=           0.00014 +/-          0.00014 
+  EnergyEstim__nume_real=         -10.55151 +/-          0.00031 
+  EnergyEstim__timer    =         0.0008867 +/-        0.0000012 
+  Eshift                =           6.27941 +/-          0.00092 
+  Ovlp                  =           0.19761 +/-          0.00012 
+  PseudoEloc            =           6.28059 +/-          0.00028 
+  freeMemory            =         123301.02 +/-             1.07 
+  nWalkers              =            320.00 +/-             0.00 
+  time                  =           5005.50 +/-          1820.99 
+  weight                =         319.77846 +/-          0.00039 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
@@ -1,0 +1,14 @@
+
+qmc_ref_thc series 0 
+  EnergyEstim__deno_imag=  0.000000000000000000024 +/- 0.000000000000000000033 
+  EnergyEstim__deno_real=              1.00 +/-             0.00 
+  EnergyEstim__nume_imag=          0.000208 +/-         0.000096 
+  EnergyEstim__nume_real=         -10.33408 +/-          0.00043 
+  EnergyEstim__timer    =        0.00032045 +/-       0.00000026 
+  Eshift                =           6.56291 +/-          0.00075 
+  Ovlp                  =           0.40740 +/-          0.00017 
+  PseudoEloc            =           6.56204 +/-          0.00037 
+  freeMemory            =         124804.68 +/-             2.35 
+  nWalkers              =            320.00 +/-             0.00 
+  time                  =           5005.50 +/-          1820.99 
+  weight                =         319.93007 +/-          0.00017 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref.qmca
@@ -40,3 +40,17 @@ qmc_ref_uhf  series 0
   nWalkers              =            320.00 +/-             0.00 
   time                  =           5005.50 +/-          1820.99 
   weight                =         319.77846 +/-          0.00039 
+
+qmc_ref_phmsd  series 0 
+  EnergyEstim__deno_imag=  0.000000000000000000002 +/- 0.000000000000000000062 
+  EnergyEstim__deno_real=              1.00 +/-             0.00 
+  EnergyEstim__nume_imag=           0.00008 +/-          0.00012 
+  EnergyEstim__nume_real=         -10.55085 +/-          0.00026 
+  EnergyEstim__timer    =         0.0058799 +/-        0.0000020 
+  Eshift                =           6.26356 +/-          0.00087 
+  Ovlp                  =           0.17948 +/-          0.00012 
+  PseudoEloc            =           6.26336 +/-          0.00023 
+  freeMemory            =         121597.11 +/-             0.90 
+  nWalkers              =            320.00 +/-             0.00 
+  time                  =           5005.50 +/-          1820.99 
+  weight                =         319.78828 +/-          0.00038 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_chol.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_chol.in.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_ref_thc" series="0"/>
+  <project id="qmc_ref_chol" series="0"/>
 
   <AFQMCInfo name="info0">
-    <parameter name="NMO">8</parameter>
+    <parameter name="NMO">26</parameter>
     <parameter name="NAEA">4</parameter>
     <parameter name="NAEB">4</parameter>
   </AFQMCInfo>
 
-  <Hamiltonian name="ham0" type="THC" info="info0">
+  <Hamiltonian name="ham0" type="Factorized" info="info0">
     <parameter name="filetype">hdf5</parameter>
-    <parameter name="filename">thc.h5</parameter>
+    <parameter name="filename">choldump.h5</parameter>
   </Hamiltonian>
 
   <Wavefunction name="wfn0" type="MSD" info="info0">
     <parameter name="filetype">ascii</parameter>
-    <parameter name="filename">wfn_thc.dat</parameter>
+    <parameter name="filename">wfn.dat</parameter>
   </Wavefunction>
 
   <WalkerSet name="wset0">

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_chol.out
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_chol.out
@@ -1,0 +1,167 @@
+  Input file(s): qmc_ref.in.xml 
+
+=====================================================
+                    QMCPACK 3.6.0 
+
+       (c) Copyright 2003-  QMCPACK developers
+
+                    Please cite:
+ J. Kim et al. J. Phys. Cond. Mat. 30 195901 (2018)
+      https://doi.org/10.1088/1361-648X/aab9c3
+
+  Git branch: develop
+  Last git commit: 4d91cf2bf1176c52a59a25721317cb73cd6a6762
+  Last git commit date: Sat Dec 29 13:32:07 2018 +0800
+  Last git commit subject: Merge pull request #1274 from jtkrogel/qtest_dev2
+=====================================================
+  Global options 
+
+  MPI Nodes             = 16
+  MPI Nodes per group   = 16
+  MPI Group ID          = 0
+  OMP 1st level threads = 2
+  OMP nested threading disabled or only 1 thread on the 2nd level
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = qmc_ref.in.xml
+
+/*************************************************
+ ********  This is an AFQMC calculation   ********
+ *************************************************
+ Random Number
+ -------------
+  Offset for the random number seeds based on time: 136
+
+  Range of prime numbers to use as seeds over processors and threads = 787-1013
+
+
+
+****************************************************
+****************************************************
+****************************************************
+          Beginning Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+ Using 1 cores per node in all TaskGroups. 
+
+****************************************************
+           Initializating Shared Walker Set 
+****************************************************
+ Using a closed-shell (closed-shell RHF) walker. 
+ Using asynchronous non-blocking swap load balancing algorithm. 
+ Using population control algorithm based on paired walker branching ( a la QWalk). 
+
+
+****************************************************
+               Initializating Hamiltonian 
+****************************************************
+
+ Initializing Hamiltonian from file: choldump.h5
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 0
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ here 1
+ -- Time to count elements in hdf5 read: 0.0257292
+ -- Time to read into ucsr matrix: 0.0192881
+ -- Time to read move ucsr into csr matrix: 0.00414109
+ Memory used by factorized 2-el integral table (on head node): 0.927311 MB. 
+ -- Time to initialize Hamiltonian from h5 file: 0.223308
+
+****************************************************
+               Initializating Wavefunction 
+****************************************************
+
+Reading a RHF-type trial wave-function. 
+ Wavefunction type: NOMSD
+Reading a RHF-type trial wave-function. 
+
+Partition of cholesky vector over nodes in TG: 229
+Number of terms in Cholesky Matrix per node in TG: 48077
+ Time for calculateHSPotentials: 0.0185549
+ Time for halfRotateCholeskyMatrixForBias: 0.176423
+ Calculating half-rotated Hamiltonian using Dense x Dense matrix multiplication. 
+ Approximate memory usage for half-rotated Hamiltonian construction: 
+   max. number of orbital in a node: 26
+   Qk/Rl matrices size (assuming dense) each = maxnorb * nup * ncholvecs complex numbers = 0.363403 MB 
+   Maximum size of communication buffer: 1024 MB
+   Temporary integral matrix Ta: 0.165039 MB 
+  Number of terms in Vijkl: 
+    Local: (min/max)116 0.00221252 MB  -  219 0.00417709 MB 
+    Node (min/max): 2654 0.050621 MB   -   2654 0.050621 MB 
+    Global: 2654 0.050621 MB
+
+ Time for halfRotateHijkl: 0.0354352
+
+****************************************************
+               Initializating Propagator 
+****************************************************
+
+ Using mean-field substraction in propagator: prop0
+ Largest component of Mean-field substraction potential: 1.20867
+
+
+ --------------- Parsing Propagator input ------------------ 
+
+ Using hybrid method to calculate the weights during the propagation.
+
+ Energy of starting determinant - E1, EJ, EXX: (-10.8097667596,0) (1.46758186973,0) (-0.977572668585,0)
+  BasicEstimator: Number of products in weight history: 0
+
+****************************************************
+****************************************************
+****************************************************
+          Finished Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+Initial weight and number of walkers: 320 320
+Initial Eshift: 0
+----------------------------------------------------------------
+ Timer: 
+ Average time in Generic: 0.0354351997375
+ Average time in Generic1: 0.00414109230042
+----------------------------------------------------------------
+Stack timer profile
+Timer             Inclusive_time  Exclusive_time  Calls       Time_per_call
+Total             2544.1055     0.8256              1    2544.105543225
+  Block           2543.2799   753.1498          10000       0.254327993
+    Energy           3.6800     3.6800          10000       0.000367997
+    G_for_vbias     65.7826    65.7826        1000000       0.000065783
+    Propagate      343.5849   343.5849        1000000       0.000343585
+    PseudoEnergy    14.5363    14.5363        1000000       0.000014536
+    vHS           1180.6494  1180.6494        1000000       0.001180649
+    vbias          181.8969   181.8969        1000000       0.000181897

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_phmsd.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_phmsd.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_short_uhf" series="0"/>
+  <project id="qmc_ref_phmsd" series="0"/>
 
   <AFQMCInfo name="info0">
     <parameter name="NMO">26</parameter>
@@ -10,12 +10,12 @@
 
   <Hamiltonian name="ham0" type="Factorized" info="info0">
     <parameter name="filetype">hdf5</parameter>
-    <parameter name="filename">../choldump_uhf.h5</parameter>
+    <parameter name="filename">../choldump_phmsd.h5</parameter>
   </Hamiltonian>
 
-  <Wavefunction name="wfn0" type="MSD" info="info0">
+  <Wavefunction name="wfn0" type="PHMSD" info="info0">
     <parameter name="filetype">ascii</parameter>
-    <parameter name="filename">../wfn_uhf.dat</parameter>
+    <parameter name="filename">../wfn_phmsd.dat</parameter>
   </Wavefunction>
 
   <WalkerSet name="wset0">
@@ -27,8 +27,8 @@
 
   <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
     <parameter name="timestep">0.01</parameter>
-    <parameter name="blocks">1000</parameter>
-    <parameter name="steps">10</parameter>
+    <parameter name="blocks">10000</parameter>
+    <parameter name="steps">100</parameter>
     <parameter name="nWalkers">20</parameter>
   </execute>
 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_phmsd.out
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_phmsd.out
@@ -1,0 +1,133 @@
+  Input file(s): qmc_ref_phmsd.in.xml 
+
+=====================================================
+                    QMCPACK 3.6.0
+
+       (c) Copyright 2003-  QMCPACK developers
+
+                    Please cite:
+ J. Kim et al. J. Phys. Cond. Mat. 30 195901 (2018)
+      https://doi.org/10.1088/1361-648X/aab9c3
+
+  Git branch: develop
+  Last git commit: 4862d84198c38cac01cd448a768b0e1dce2875fb
+  Last git commit date: Fri Jan 4 13:29:36 2019 -0500
+  Last git commit subject: Merge pull request #1298 from mmorale3/remove_old_shm_classes
+=====================================================
+  Global options 
+
+  MPI Nodes             = 16
+  MPI Nodes per group   = 16
+  MPI Group ID          = 0
+  OMP 1st level threads = 2
+  OMP nested threading disabled or only 1 thread on the 2nd level
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = qmc_ref_phmsd.in.xml
+
+/*************************************************
+ ********  This is an AFQMC calculation   ********
+ *************************************************
+ Random Number
+ -------------
+  Offset for the random number seeds based on time: 933
+
+  Range of prime numbers to use as seeds over processors and threads = 7333-7607
+
+
+
+****************************************************
+****************************************************
+****************************************************
+          Beginning Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+ Using 1 cores per node in all TaskGroups. 
+
+****************************************************
+           Initializating Shared Walker Set 
+****************************************************
+ Using a collinear (UHF/ROHF) walker. 
+ Using asynchronous non-blocking swap load balancing algorithm. 
+ Using population control algorithm based on paired walker branching ( a la QWalk). 
+
+
+****************************************************
+               Initializating Hamiltonian 
+****************************************************
+
+ Initializing Hamiltonian from file: choldump_phmsd.h5
+ -- Time to count elements in hdf5 read: 0.0298851
+ -- Time to read into ucsr matrix: 0.0192251
+ -- Time to read move ucsr into csr matrix: 0.00159979
+ Memory used by factorized 2-el integral table (on head node): 0.927311 MB. 
+ -- Time to initialize Hamiltonian from h5 file: 0.400535
+
+****************************************************
+               Initializating Wavefunction 
+****************************************************
+
+ Wavefunction type: PHMSD
+
+Partition of cholesky vector over nodes in TG: 229
+Number of terms in Cholesky Matrix per node in TG: 48077
+ Time for calculateHSPotentials: 0.0101709
+ Time for halfRotateCholeskyMatrixForBias: 0.126681
+ Calculating half-rotated Hamiltonian using Dense x Dense matrix multiplication. 
+ Approximate memory usage for half-rotated Hamiltonian construction: 
+   max. number of orbital in a node: 26
+   Qk/Rl matrices size (assuming dense) each = maxnorb * nup * ncholvecs complex numbers = 0.635956 MB 
+   Maximum size of communication buffer: 1024 MB
+   Temporary integral matrix Ta: 0.505432 MB 
+  Number of terms in Vijkl: 
+    Local: (min/max)388 0.00740051 MB  -  645 0.0123024 MB 
+    Node (min/max): 8128 0.155029 MB   -   8128 0.155029 MB 
+    Global: 8128 0.155029 MB
+
+ Time for halfRotateHijkl: 0.0304229
+
+****************************************************
+               Initializating Propagator 
+****************************************************
+
+ Using mean-field substraction in propagator: prop0
+ Largest component of Mean-field substraction potential: 1.20205
+
+
+ --------------- Parsing Propagator input ------------------ 
+
+ Using hybrid method to calculate the weights during the propagation.
+
+ Energy of starting determinant - E1, EJ, EXX: (-10.8097667596,0) (1.46758186973,0) (-0.977572668585,0)
+  BasicEstimator: Number of products in weight history: 0
+
+****************************************************
+****************************************************
+****************************************************
+          Finished Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+Initial weight and number of walkers: 320 320
+Initial Eshift: 0
+----------------------------------------------------------------
+ Timer: 
+ Average time in Generic: 0.0304229259491
+ Average time in Generic1: 0.00159978866577
+----------------------------------------------------------------
+Stack timer profile
+Timer             Inclusive_time  Exclusive_time  Calls       Time_per_call
+Total             4230.0921     1.1368              1    4230.092125467
+  Block           4228.9554  1475.3895          10000       0.422895537
+    Energy          58.8000    58.8000          10000       0.005880005
+    G_for_vbias    436.6629   436.6629        1000000       0.000436663
+    Propagate      682.8200   682.8200        1000000       0.000682820
+    PseudoEnergy   131.0006   131.0006        1000000       0.000131001
+    vHS            910.1284   910.1284        1000000       0.000910128
+    vbias          534.1540   534.1540        1000000       0.000534154

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_thc.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_thc.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_ref_thc" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">8</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="THC" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../thc.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn_thc.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">closed</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">10000</parameter>
+    <parameter name="steps">100</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_thc.out
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_thc.out
@@ -1,0 +1,112 @@
+  Input file(s): qmc_ref.in.xml 
+
+=====================================================
+                    QMCPACK 3.6.0 
+
+       (c) Copyright 2003-  QMCPACK developers
+
+                    Please cite:
+ J. Kim et al. J. Phys. Cond. Mat. 30 195901 (2018)
+      https://doi.org/10.1088/1361-648X/aab9c3
+
+  Git branch: develop
+  Last git commit: 4d91cf2bf1176c52a59a25721317cb73cd6a6762
+  Last git commit date: Sat Dec 29 13:32:07 2018 +0800
+  Last git commit subject: Merge pull request #1274 from jtkrogel/qtest_dev2
+=====================================================
+  Global options 
+
+  MPI Nodes             = 16
+  MPI Nodes per group   = 16
+  MPI Group ID          = 0
+  OMP 1st level threads = 2
+  OMP nested threading disabled or only 1 thread on the 2nd level
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = qmc_ref_thc.in.xml
+
+/*************************************************
+ ********  This is an AFQMC calculation   ********
+ *************************************************
+ Random Number
+ -------------
+  Offset for the random number seeds based on time: 288
+
+  Range of prime numbers to use as seeds over processors and threads = 1889-2137
+
+
+
+****************************************************
+****************************************************
+****************************************************
+          Beginning Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+ Using 1 cores per node in all TaskGroups. 
+
+****************************************************
+           Initializating Shared Walker Set 
+****************************************************
+ Using a closed-shell (closed-shell RHF) walker. 
+ Using asynchronous non-blocking swap load balancing algorithm. 
+ Using population control algorithm based on paired walker branching ( a la QWalk). 
+
+
+****************************************************
+               Initializating Hamiltonian 
+****************************************************
+
+ Initializing Hamiltonian from file: thc.h5
+
+****************************************************
+               Initializating Wavefunction 
+****************************************************
+
+Reading a RHF-type trial wave-function. 
+ Wavefunction type: NOMSD
+Reading a RHF-type trial wave-function. 
+
+****************************************************
+               Initializating Propagator 
+****************************************************
+
+ Using mean-field substraction in propagator: prop0
+ Largest component of Mean-field substraction potential: 0.844658
+
+
+ --------------- Parsing Propagator input ------------------ 
+
+ Using hybrid method to calculate the weights during the propagation.
+
+ Energy of starting determinant - E1, EJ, EXX: (-10.7779370917,0) (1.53127649406,0) (-0.911842098707,5.54667823984e-32)
+  BasicEstimator: Number of products in weight history: 0
+
+****************************************************
+****************************************************
+****************************************************
+          Finished Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+Initial weight and number of walkers: 320 320
+Initial Eshift: 0
+----------------------------------------------------------------
+ Timer: 
+ Average time in Generic: 0
+----------------------------------------------------------------
+Stack timer profile
+Timer             Inclusive_time  Exclusive_time  Calls       Time_per_call
+Total              604.3735     0.3198              1     604.373462809
+  Block            604.0537   333.1627          10000       0.060405370
+    Energy           3.2045     3.2045          10000       0.000320454
+    G_for_vbias     38.9518    38.9518        1000000       0.000038952
+    Propagate       94.3164    94.3164        1000000       0.000094316
+    PseudoEnergy    14.1291    14.1291        1000000       0.000014129
+    vHS             63.4925    63.4925        1000000       0.000063492
+    vbias           56.7967    56.7967        1000000       0.000056797

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_uhf.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_uhf.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_ref_uhf" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">26</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="Factorized" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../choldump_uhf.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn_uhf.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">collinear</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">1000</parameter>
+    <parameter name="steps">10</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_uhf.out
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc-ref/qmc_ref_uhf.out
@@ -1,0 +1,135 @@
+  Input file(s): qmc_ref_uhf.in.xml 
+
+=====================================================
+                    QMCPACK 3.6.0
+
+       (c) Copyright 2003-  QMCPACK developers
+
+                    Please cite:
+ J. Kim et al. J. Phys. Cond. Mat. 30 195901 (2018)
+      https://doi.org/10.1088/1361-648X/aab9c3
+
+  Git branch: develop
+  Last git commit: 4862d84198c38cac01cd448a768b0e1dce2875fb
+  Last git commit date: Fri Jan 4 13:29:36 2019 -0500
+  Last git commit subject: Merge pull request #1298 from mmorale3/remove_old_shm_classes
+=====================================================
+  Global options 
+
+  MPI Nodes             = 16
+  MPI Nodes per group   = 16
+  MPI Group ID          = 0
+  OMP 1st level threads = 2
+  OMP nested threading disabled or only 1 thread on the 2nd level
+
+  Precision used in this calculation, see definitions in the manual:
+  Base precision      = double
+  Full precision      = double
+
+  Input XML = qmc_ref_uhf.in.xml
+
+/*************************************************
+ ********  This is an AFQMC calculation   ********
+ *************************************************
+ Random Number
+ -------------
+  Offset for the random number seeds based on time: 485
+
+  Range of prime numbers to use as seeds over processors and threads = 3469-3719
+
+
+
+****************************************************
+****************************************************
+****************************************************
+          Beginning Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+ Using 1 cores per node in all TaskGroups. 
+
+****************************************************
+           Initializating Shared Walker Set 
+****************************************************
+ Using a collinear (UHF/ROHF) walker. 
+ Using asynchronous non-blocking swap load balancing algorithm. 
+ Using population control algorithm based on paired walker branching ( a la QWalk). 
+
+
+****************************************************
+               Initializating Hamiltonian 
+****************************************************
+
+ Initializing Hamiltonian from file: choldump.h5
+ -- Time to count elements in hdf5 read: 0.0253339
+ -- Time to read into ucsr matrix: 0.0208859
+ -- Time to read move ucsr into csr matrix: 0.00160694
+ Memory used by factorized 2-el integral table (on head node): 1.0211 MB. 
+ -- Time to initialize Hamiltonian from h5 file: 0.151146
+
+****************************************************
+               Initializating Wavefunction 
+****************************************************
+
+Reading a UHF-type trial wave-function. 
+ Wavefunction type: NOMSD
+Reading a UHF-type trial wave-function. 
+
+Partition of cholesky vector over nodes in TG: 227
+Number of terms in Cholesky Matrix per node in TG: 52994
+ Time for calculateHSPotentials: 0.0107272
+ Time for halfRotateCholeskyMatrixForBias: 0.111488
+ Calculating half-rotated Hamiltonian using Dense x Dense matrix multiplication. 
+ Approximate memory usage for half-rotated Hamiltonian construction: 
+   max. number of orbital in a node: 26
+   Qk/Rl matrices size (assuming dense) each = maxnorb * nup * ncholvecs complex numbers = 0.360229 MB 
+   Maximum size of communication buffer: 1024 MB
+   Temporary integral matrix Ta: 0.165039 MB 
+  Number of terms in Vijkl: 
+    Local: (min/max)254 0.00484467 MB  -  442 0.00843048 MB 
+    Node (min/max): 5512 0.105133 MB   -   5512 0.105133 MB 
+    Global: 5512 0.105133 MB
+
+ Time for halfRotateHijkl: 0.0285408
+
+****************************************************
+               Initializating Propagator 
+****************************************************
+
+ Using mean-field substraction in propagator: prop0
+ Largest component of Mean-field substraction potential: 1.30132
+
+
+ --------------- Parsing Propagator input ------------------ 
+
+ Using hybrid method to calculate the weights during the propagation.
+
+ Energy of starting determinant - E1, EJ, EXX: (-10.8097667941,0) (1.46757152068,0) (-0.977560027902,2.08356819284e-19)
+  BasicEstimator: Number of products in weight history: 0
+
+****************************************************
+****************************************************
+****************************************************
+          Finished Driver initialization.
+****************************************************
+****************************************************
+****************************************************
+
+Initial weight and number of walkers: 320 320
+Initial Eshift: 0
+----------------------------------------------------------------
+ Timer: 
+ Average time in Generic: 0.0285408496857
+ Average time in Generic1: 0.00160694122314
+----------------------------------------------------------------
+Stack timer profile
+Timer             Inclusive_time  Exclusive_time  Calls       Time_per_call
+Total             3690.7644     0.6623              1    3690.764443142
+  Block           3690.1021  1437.9375          10000       0.369010210
+    Energy           8.8674     8.8674          10000       0.000886741
+    G_for_vbias    129.6681   129.6681        1000000       0.000129668
+    Propagate      665.1451   665.1451        1000000       0.000665145
+    PseudoEnergy    32.5833    32.5833        1000000       0.000032583
+    vHS            989.2381   989.2381        1000000       0.000989238
+    vbias          426.6626   426.6626        1000000       0.000426663

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_chol.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_chol.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_short_chol" series="0"/>
+  <project id="qmc_long_chol" series="0"/>
 
   <AFQMCInfo name="info0">
     <parameter name="NMO">26</parameter>
@@ -28,7 +28,7 @@
   <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
     <parameter name="timestep">0.01</parameter>
     <parameter name="blocks">1000</parameter>
-    <parameter name="steps">10</parameter>
+    <parameter name="steps">100</parameter>
     <parameter name="nWalkers">20</parameter>
   </execute>
 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_phmsd.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_phmsd.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_short_uhf" series="0"/>
+  <project id="qmc_long_phmsd" series="0"/>
 
   <AFQMCInfo name="info0">
     <parameter name="NMO">26</parameter>
@@ -10,12 +10,12 @@
 
   <Hamiltonian name="ham0" type="Factorized" info="info0">
     <parameter name="filetype">hdf5</parameter>
-    <parameter name="filename">../choldump_uhf.h5</parameter>
+    <parameter name="filename">../choldump_phmsd.h5</parameter>
   </Hamiltonian>
 
-  <Wavefunction name="wfn0" type="MSD" info="info0">
+  <Wavefunction name="wfn0" type="PHMSD" info="info0">
     <parameter name="filetype">ascii</parameter>
-    <parameter name="filename">../wfn_uhf.dat</parameter>
+    <parameter name="filename">../wfn_phmsd.dat</parameter>
   </Wavefunction>
 
   <WalkerSet name="wset0">
@@ -27,8 +27,8 @@
 
   <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
     <parameter name="timestep">0.01</parameter>
-    <parameter name="blocks">1000</parameter>
-    <parameter name="steps">10</parameter>
+    <parameter name="blocks">500</parameter>
+    <parameter name="steps">100</parameter>
     <parameter name="nWalkers">20</parameter>
   </execute>
 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_thc.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_thc.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_long_thc" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">8</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="THC" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../thc.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn_thc.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">closed</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">1000</parameter>
+    <parameter name="steps">100</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_uhf.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_long_uhf.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_short_uhf" series="0"/>
+  <project id="qmc_long_uhf" series="0"/>
 
   <AFQMCInfo name="info0">
     <parameter name="NMO">26</parameter>
@@ -28,7 +28,7 @@
   <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
     <parameter name="timestep">0.01</parameter>
     <parameter name="blocks">1000</parameter>
-    <parameter name="steps">10</parameter>
+    <parameter name="steps">100</parameter>
     <parameter name="nWalkers">20</parameter>
   </execute>
 

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_chol.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_chol.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_short" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">26</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="Factorized" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../choldump.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">closed</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">100</parameter>
+    <parameter name="steps">10</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_phmsd.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_phmsd.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation method="afqmc">
-  <project id="qmc_short_uhf" series="0"/>
+  <project id="qmc_short_phmsd" series="0"/>
 
   <AFQMCInfo name="info0">
     <parameter name="NMO">26</parameter>
@@ -10,12 +10,12 @@
 
   <Hamiltonian name="ham0" type="Factorized" info="info0">
     <parameter name="filetype">hdf5</parameter>
-    <parameter name="filename">../choldump_uhf.h5</parameter>
+    <parameter name="filename">../choldump_phmsd.h5</parameter>
   </Hamiltonian>
 
-  <Wavefunction name="wfn0" type="MSD" info="info0">
+  <Wavefunction name="wfn0" type="PHMSD" info="info0">
     <parameter name="filetype">ascii</parameter>
-    <parameter name="filename">../wfn_uhf.dat</parameter>
+    <parameter name="filename">../wfn_phmsd.dat</parameter>
   </Wavefunction>
 
   <WalkerSet name="wset0">
@@ -27,7 +27,7 @@
 
   <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
     <parameter name="timestep">0.01</parameter>
-    <parameter name="blocks">1000</parameter>
+    <parameter name="blocks">500</parameter>
     <parameter name="steps">10</parameter>
     <parameter name="nWalkers">20</parameter>
   </execute>

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_thc.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_thc.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_short_thc" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">8</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="THC" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../thc.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn_thc.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">closed</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">1000</parameter>
+    <parameter name="steps">10</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+

--- a/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_uhf.in.xml
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/qmc_short_uhf.in.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<simulation method="afqmc">
+  <project id="qmc_short_uhf" series="0"/>
+
+  <AFQMCInfo name="info0">
+    <parameter name="NMO">26</parameter>
+    <parameter name="NAEA">4</parameter>
+    <parameter name="NAEB">4</parameter>
+  </AFQMCInfo>
+
+  <Hamiltonian name="ham0" type="Factorized" info="info0">
+    <parameter name="filetype">hdf5</parameter>
+    <parameter name="filename">../choldump_uhf.h5</parameter>
+  </Hamiltonian>
+
+  <Wavefunction name="wfn0" type="MSD" info="info0">
+    <parameter name="filetype">ascii</parameter>
+    <parameter name="filename">../wfn_uhf.dat</parameter>
+  </Wavefunction>
+
+  <WalkerSet name="wset0">
+    <parameter name="walker_type">collinear</parameter>
+  </WalkerSet>
+
+  <Propagator name="prop0" info="info0">
+  </Propagator>
+
+  <execute wset="wset0" ham="ham0" wfn="wfn0" prop="prop0" info="info0">
+    <parameter name="timestep">0.01</parameter>
+    <parameter name="blocks">10000</parameter>
+    <parameter name="steps">100</parameter>
+    <parameter name="nWalkers">20</parameter>
+  </execute>
+
+</simulation>
+


### PR DESCRIPTION
Currently only complex builds of AFQMC are supported, but the tests in tests/solids are set up for real builds.

I've adapted the unit tests to long and short tests for complex builds of AFQMC for use in CI.
The tests currently cover Cholesky factorized integrals with RHF, UHF and particle-hole multi determinant trial wavefunctions, and ISDF/THC factorized integrals with an RHF trial wavefunction.