### PR TITLE
Fix ECP behavior with Gamess

### DIFF
--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -291,7 +291,6 @@ int main(int argc, char **argv)
     parser->Title=prefix;
     parser->debug=debug;
     parser->DoCusp=addCusp;
-    parser->ECP=!addCusp;
     parser->UseHDF5=usehdf5;
     if (usehdf5)
       parser->h5file=parser->Title+".orbs.h5";


### PR DESCRIPTION
This  PR fixes the default behavior of the converter for Gamess when All electrons are used. 

closes #1318 