### PR TITLE
Allow multi det with mixed precision.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -261,9 +261,6 @@ bool SlaterDetBuilder::put(xmlNodePtr cur)
       {
         APP_ABORT("multideterminant is already instantiated.");
       }
-#ifdef MIXED_PRECISION
-      APP_ABORT("multideterminant is not safe with mixed precision. Please use full precision build instead.");
-#endif
       std::string spo_alpha;
       std::string spo_beta;
       std::string fastAlg("yes");


### PR DESCRIPTION
i ran the 10 times by hand both the short and long tests.
The table method code-path pass stably while the traditional code path still sometimes fails.
Remove the safe guard to get tests running properly during the night.