### PR TITLE
Fix for distance table soa heap buffer read overflow

### DIFF
--- a/src/OhmmsSoA/VectorSoaContainer.h
+++ b/src/OhmmsSoA/VectorSoaContainer.h
@@ -64,7 +64,7 @@ namespace qmcplusplus
       {
         setDefaults();
         resize(in.nLocal);
-        simd::copy_n(in.myData,nGhosts*D,myData);
+        std::copy_n(in.myData,nGhosts*D,myData);
       }
 
       ///default copy operator
@@ -73,7 +73,7 @@ namespace qmcplusplus
         if(myData!=in.myData) 
         {
           resize(in.nLocal);
-          simd::copy_n(in.myData,nGhosts*D,myData);
+          std::copy_n(in.myData,nGhosts*D,myData);
         }
         return *this;
       }

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -131,9 +131,9 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     if(iat==0) return;
     //update by a cache line
     const int nupdate=getAlignedSize<T>(iat);
-    simd::copy_n(Temp_r.data(),nupdate,Distances[iat]); // [iat - 1] also passes tests
+    std::copy_n(Temp_r.data(),nupdate,Distances[iat]); // [iat - 1] also passes tests
     for(int idim=0;idim<D; ++idim)
-      simd::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim)); // [iat - 1] also passes tests
+      std::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim)); // [iat - 1] also passes tests
   }
 
 };

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -118,15 +118,22 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     return index;
   }
 
-  ///update the iat-th row for iat=[0,iat-1)
+  /** update the iat-th row for iat=[0,iat-1)
+   * into element iat of Distances and Displacements skiping element iat - 0
+   * doesn't really seem correct
+   * unless Distances[0] is original and Distances[1] is the proposed.
+   * in which case the brief above is just misinformation
+   * copying to Distances, Displacements iat or iat-1 both pass test_particles
+   * test_wavefunctions
+   */
   inline void update(IndexType iat)
   {
     if(iat==0) return;
     //update by a cache line
     const int nupdate=getAlignedSize<T>(iat);
-    simd::copy_n(Temp_r.data(),nupdate,Distances[iat]);
+    simd::copy_n(Temp_r.data(),nupdate,Distances[iat]); // [iat - 1] also passes tests
     for(int idim=0;idim<D; ++idim)
-      simd::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim));
+      simd::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim)); // [iat - 1] also passes tests
   }
 
 };

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -57,7 +57,9 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     for(int i=0; i<Ntargets; ++i)
       Displacements[i].attachReference(i,total_size,memoryPool.data()+compute_size(i));
 
-    Temp_r.resize(Ntargets);
+    // The padding of Temp_r and Temp_dr is necessary
+    // Temp_r is padded explicitly while Temp_dr is padded internally
+    Temp_r.resize(Ntargets_padded);
     Temp_dr.resize(Ntargets);
   }
 
@@ -118,22 +120,19 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     return index;
   }
 
-  /** update the iat-th row for iat=[0,iat-1)
-   * into element iat of Distances and Displacements skiping element iat - 0
-   * doesn't really seem correct
-   * unless Distances[0] is original and Distances[1] is the proposed.
-   * in which case the brief above is just misinformation
-   * copying to Distances, Displacements iat or iat-1 both pass test_particles
-   * test_wavefunctions
+  /** After accepting the iat-th particle, update the iat-th row of Distances and Displacements.
+   * Since the upper triangle is not needed in the later computation,
+   * only the [0,iat-1) columns need to save the new values.
+   * The memory copy goes up to the padded size only for better performance.
    */
   inline void update(IndexType iat)
   {
     if(iat==0) return;
     //update by a cache line
     const int nupdate=getAlignedSize<T>(iat);
-    std::copy_n(Temp_r.data(),nupdate,Distances[iat]); // [iat - 1] also passes tests
+    std::copy_n(Temp_r.data(),nupdate,Distances[iat]);
     for(int idim=0;idim<D; ++idim)
-      std::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim)); // [iat - 1] also passes tests
+      std::copy_n(Temp_dr.data(idim),nupdate,Displacements[iat].data(idim));
   }
 
 };

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -57,7 +57,7 @@ struct SoaDistanceTableAA: public DTD_BConds<T,D,SC>, public DistanceTableData
     for(int i=0; i<Ntargets; ++i)
       Displacements[i].attachReference(i,total_size,memoryPool.data()+compute_size(i));
 
-    // The padding of Temp_r and Temp_dr is necessary
+    // The padding of Temp_r and Temp_dr is necessary for the memory copy in the update function
     // Temp_r is padded explicitly while Temp_dr is padded internally
     Temp_r.resize(Ntargets_padded);
     Temp_dr.resize(Ntargets);

--- a/src/Particle/SoaDistanceTableBA.h
+++ b/src/Particle/SoaDistanceTableBA.h
@@ -48,7 +48,7 @@ struct SoaDistanceTableBA: public DTD_BConds<T,D,SC>, public DistanceTableData
     for(int i=0; i<Ntargets; ++i)
       Displacements[i].attachReference(Nsources,Nsources_padded,memoryPool.data()+i*BlockSize);
 
-    // The padding of Temp_r and Temp_dr is necessary
+    // The padding of Temp_r and Temp_dr is necessary for the memory copy in the update function
     // Temp_r is padded explicitly while Temp_dr is padded internally
     Temp_r.resize(Nsources_padded);
     Temp_dr.resize(Nsources);

--- a/src/Particle/SoaDistanceTableBA.h
+++ b/src/Particle/SoaDistanceTableBA.h
@@ -48,7 +48,9 @@ struct SoaDistanceTableBA: public DTD_BConds<T,D,SC>, public DistanceTableData
     for(int i=0; i<Ntargets; ++i)
       Displacements[i].attachReference(Nsources,Nsources_padded,memoryPool.data()+i*BlockSize);
 
-    Temp_r.resize(Nsources);
+    // The padding of Temp_r and Temp_dr is necessary
+    // Temp_r is padded explicitly while Temp_dr is padded internally
+    Temp_r.resize(Nsources_padded);
     Temp_dr.resize(Nsources);
   }
 

--- a/src/Particle/SoaDistanceTableBA.h
+++ b/src/Particle/SoaDistanceTableBA.h
@@ -98,9 +98,9 @@ struct SoaDistanceTableBA: public DTD_BConds<T,D,SC>, public DistanceTableData
   ///update the stripe for jat-th particle
   inline void update(IndexType iat)
   {
-    simd::copy_n(Temp_r.data(),Nsources,Distances[iat]);
+    std::copy_n(Temp_r.data(),Nsources,Distances[iat]);
     for(int idim=0;idim<D; ++idim)
-      simd::copy_n(Temp_dr.data(idim),Nsources,Displacements[iat].data(idim));
+      std::copy_n(Temp_dr.data(idim),Nsources,Displacements[iat].data(idim));
   }
 
   size_t get_neighbors(int iat, RealType rcut, int* restrict jid, RealType* restrict dist, PosType* restrict displ) const

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
@@ -89,7 +89,7 @@ namespace qmcplusplus {
         const int norb = Ainv.rows();
         const int lda_Binv = Binv.cols();
         // save AinvRow to new_AinvRow
-        simd::copy_n(AinvRow, norb, V[delay_count]);
+        std::copy_n(AinvRow, norb, V[delay_count]);
         // multiply V (NxK) Binv(KxK) U(KxN) AinvRow right to the left
         BLAS::gemv('T', norb, delay_count, cone, U.data(), norb, AinvRow, 1, czero, p.data(), 1);
         BLAS::gemv('N', delay_count, delay_count, cone, Binv.data(), lda_Binv, p.data(), 1, czero, Binv[delay_count], 1);
@@ -159,8 +159,8 @@ namespace qmcplusplus {
         const T czero(0);
         const int norb = Ainv.rows();
         const int lda_Binv = Binv.cols();
-        simd::copy_n(Ainv[rowchanged], norb, V[delay_count]);
-        simd::copy_n(psiV.data(), norb, U[delay_count]);
+        std::copy_n(Ainv[rowchanged], norb, V[delay_count]);
+        std::copy_n(psiV.data(), norb, U[delay_count]);
         delay_list[delay_count] = rowchanged;
         // the new Binv is [[X Y] [Z x]]
         BLAS::gemv('T', norb, delay_count+1, cminusone, V.data(), norb, psiV.data(), 1, czero, p.data(), 1);

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -93,7 +93,7 @@ namespace qmcplusplus
   inline void LCAOrbitalSet::evaluate_vgl_impl(const vgl_type& temp,
       ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) const
   {
-    simd::copy_n(temp.data(0),OrbitalSetSize,psi.data());
+    std::copy_n(temp.data(0),OrbitalSetSize,psi.data());
     const ValueType* restrict gx=temp.data(1);
     const ValueType* restrict gy=temp.data(2);
     const ValueType* restrict gz=temp.data(3);
@@ -103,7 +103,7 @@ namespace qmcplusplus
       dpsi[j][1]=gy[j];
       dpsi[j][2]=gz[j];
     }
-    simd::copy_n(temp.data(4),OrbitalSetSize,d2psi.data());
+    std::copy_n(temp.data(4),OrbitalSetSize,d2psi.data());
   }
 
   void LCAOrbitalSet::evaluate(const ParticleSet& P, int iat,
@@ -150,7 +150,7 @@ namespace qmcplusplus
   inline void LCAOrbitalSet::evaluate_vgl_impl(const vgl_type& temp, int i,
       ValueMatrix_t& logdet, GradMatrix_t& dlogdet, ValueMatrix_t& d2logdet) const
   {
-    simd::copy_n(temp.data(0),OrbitalSetSize,logdet[i]);
+    std::copy_n(temp.data(0),OrbitalSetSize,logdet[i]);
     const ValueType* restrict gx=temp.data(1);
     const ValueType* restrict gy=temp.data(2);
     const ValueType* restrict gz=temp.data(3);
@@ -160,7 +160,7 @@ namespace qmcplusplus
       dlogdet[i][j][1]=gy[j];
       dlogdet[i][j][2]=gz[j];
     }
-    simd::copy_n(temp.data(4),OrbitalSetSize,d2logdet[i]);
+    std::copy_n(temp.data(4),OrbitalSetSize,d2logdet[i]);
   }
 
   void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P, int first, int last,

--- a/src/simd/Mallocator.hpp
+++ b/src/simd/Mallocator.hpp
@@ -37,17 +37,22 @@ namespace qmcplusplus
     T* allocate(std::size_t n)
     {
       void* pt(nullptr);
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 16
       std::size_t asize = n * sizeof(T);
       std::size_t amod = asize % ALIGN;
       if (amod != 0) asize += ALIGN - amod;
-      // as per C++11 standard asize must be an integral multiple of ALIGN
-      // or behavior is undefined.  Some implementation support all positive
+
+#if __STDC_VERSION__ >= 201112L || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 16)
+      // as per C11 standard asize must be an integral multiple of ALIGN
+      // or behavior is undefined.  Some implementations support all positive
       // values of asize but the standard has not been amended
-      // This is also not guaranteed threadsafe until C++17
+      // This is also not guaranteed threadsafe until it appeared in
+      // the C++17 standard.
       pt = aligned_alloc(ALIGN,asize);
 #else
-      posix_memalign(&pt, ALIGN, n*sizeof(T));
+      // While posix memalign can deal with asize violating the C11 standard
+      // assumptions made later by our simd code namely copyn require allocation
+      // of the entire aligned block to avoid heap buffer read overflows later
+      posix_memalign(&pt, ALIGN, asize);
 #endif
       if ( pt == nullptr )
         throw std::runtime_error("Allocation failed in Mallocator, requested size in bytes = " + std::to_string(n*sizeof(T)));

--- a/src/simd/algorithm.hpp
+++ b/src/simd/algorithm.hpp
@@ -25,13 +25,20 @@ namespace qmcplusplus {
      * @param first starting address of the input
      * @param count number of elements to copy
      * @param result starting address of the output
+     * One hopes this optimization is worth it, caller is responsible for safety
+     * first must of been aligned_alloc and this is still
+     * technically a heap buffer read violation if first did not use all of the aligned block.
+     * What is in those bytes is undefined.  So if your result isn't aligned_alloc and 
+     * doesn't get a matching element count from somewhere you are going to have garbage in result.
      */
     template<typename T1, typename T2>
-      inline void copy_n(const T1* restrict first, size_t count, T2* restrict result)
+    __attribute__((no_sanitize_address)) inline void copy_n(const T1* restrict first, size_t count, T2* restrict result) 
       {
-//#pragma omp simd 
-        for(size_t i=0; i<count; ++i)
-          result[i]=static_cast<T2>(first[i]);
+//#pragma omp simd
+
+	//If anything is going to emit SIMD instructions
+	//std::memcpy should
+	std::memcpy(result, first, count * sizeof(T1));
       }
 
     template<typename T1, typename T2>

--- a/src/simd/algorithm.hpp
+++ b/src/simd/algorithm.hpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2019 QMCPACK developers.
 //
 // File developed by:
 //
@@ -20,32 +20,6 @@ namespace qmcplusplus
 {
 namespace simd
 {
-/** simd version of copy_n( InputIt first, Size count, OutputIt result)
-     * @param first starting address of the input
-     * @param count number of elements to copy
-     * @param result starting address of the output
-     * One hopes this optimization is worth it, caller is responsible for safety
-     * first must of been aligned_alloc and this is still
-     * technically a heap buffer read violation if first did not use all of the aligned block.
-     * What is in those bytes is undefined.  So if your result isn't aligned_alloc and 
-     * doesn't get a matching element count from somewhere you are going to have garbage in result.
-     */
-template<typename T1, typename T2, typename std::enable_if<std::is_same<T1, T2>::value>::type* = nullptr>
-void copy_n(const T1* restrict first, size_t count, T2* restrict result)
-{
-  //If anything is going to emit SIMD instructions
-  //std::memcpy should
-  std::memcpy(result, first, count * sizeof(T1));
-}
-
-/** specialization for when simd::copy_n gets called with mixed types
- */
-template<typename T1, typename T2, typename std::enable_if<!std::is_same<T1, T2>::value>::type* = nullptr>
-void copy_n(const T1* restrict first, size_t count, T2* restrict result)
-{
-  std::copy_n(first, count, result);
-}
-
 
 template<typename T1, typename T2>
 inline T2 accumulate_n(const T1* restrict in, size_t n, T2 res)

--- a/src/simd/algorithm.hpp
+++ b/src/simd/algorithm.hpp
@@ -32,7 +32,7 @@ namespace qmcplusplus {
      * doesn't get a matching element count from somewhere you are going to have garbage in result.
      */
     template<typename T1, typename T2>
-    __attribute__((no_sanitize_address)) inline void copy_n(const T1* restrict first, size_t count, T2* restrict result) 
+    inline void copy_n(const T1* restrict first, size_t count, T2* restrict result) 
       {
 //#pragma omp simd
 

--- a/src/simd/allocator.hpp
+++ b/src/simd/allocator.hpp
@@ -32,15 +32,17 @@ namespace qmcplusplus
 
 }
 
-template<typename T> inline size_t getAlignedSize(size_t n)
+/** return size in T's of allocated aligned memory
+ */
+template<typename T, size_t ALIGN = QMC_CLINE> inline size_t getAlignedSize(size_t n)
 {
-  constexpr size_t ND=QMC_CLINE/sizeof(T);
+  constexpr size_t ND=ALIGN/sizeof(T);
   return ((n+ND-1)/ND)*ND;
 }
 
-template<typename T> inline size_t getAlignment()
+template<typename T, size_t ALIGN = QMC_CLINE> inline size_t getAlignment()
 {
-  return QMC_CLINE/sizeof(T);
+  return ALIGN/sizeof(T);
 }
 
 #endif

--- a/src/simd/allocator.hpp
+++ b/src/simd/allocator.hpp
@@ -37,11 +37,13 @@ namespace qmcplusplus
 template<typename T, size_t ALIGN = QMC_CLINE> inline size_t getAlignedSize(size_t n)
 {
   constexpr size_t ND=ALIGN/sizeof(T);
+  static_assert(ALIGN % sizeof(T) == 0, "getAlignedSize ALIGN must be a multiple of sizeof(T)");
   return ((n+ND-1)/ND)*ND;
 }
 
 template<typename T, size_t ALIGN = QMC_CLINE> inline size_t getAlignment()
 {
+  static_assert(ALIGN % sizeof(T) == 0, "getAlignedSize ALIGN must be a multiple of sizeof(T)");
   return ALIGN/sizeof(T);
 }
 


### PR DESCRIPTION
Several issues here,
SoaDistanceTableAA::update is either mis documented or doing someting different. What are the valid values for iat? I'm reasoning this out and will write a unit test, but if you feel responsible for this feel free to chime in.

The underlying simd::copy_n `/src/simd/algorithm.h` function when called as in SoaDistanceTableAA after getAlignedSize and not just as an alias of std::copy_n may not be causing an error its still incorrect code if it is intended to 'copy a cache line' of data allocated with aligned_alloc or posix_memalign. While in release you can copy from an invalid pointer to T1* you shouldn't. This does trip a heap buffer read overflow in LLVM ASAN. However you can legally copy from the allocated memory via void* of one aligned_alloc vector data region to another. This should result in the "optimal" copy instruction as well since std::memcpy should be heavily optimized on all platforms and compilers. 

Note src/simd/allocator.hpp is also involved via getAlignedSize and use of this function with a type of size larger than ALIGN is a div 0 error. I need to think through what would happen is sizeof(T) was not a divisor of ALIGN.

If used as in SoaDistanceTableAA For example (not saying SoaDistanceTableAA ever does this but if you used its code as an example)
I have a aligned vector A of two doubles and vector B of 4 doubles and ALIGN=32 
first = A.data()
result = B.data()
copy_n(first,getAlignedSize<double>(2),result)
Now I have undefined garbage in B[2] and B[3]

### In conclusion
when std::copy_n, the developer is responsible to guarantee sufficient size of A and B.
The Temp_r was not providing sufficient size before the fix. The bug doesn't affect any result because the incorrectly copied data is not used in the later calculation.