### PR TITLE
Remove QMC_BUILD_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ MESSAGE(STATUS "QMC_SYMLINK_TEST_FILES = ${QMC_SYMLINK_TEST_FILES}.  ${SYMLINK_M
 ######################################################################
 # Build level
 ######################################################################
-SET(QMC_BUILD_LEVEL 3 CACHE INTEGER
-  "QMC Build Level: 1=bare, 2=developer, 3=experimental, 4=minimal")
+
+SET(QMC_BUILD_SANDBOX_ONLY OFF CACHE BOOLEAN "Build only applications in Sandbox directory")
 IF ( NOT CMAKE_BUILD_TYPE AND NOT CMAKE_TOOLCHAIN_FILE)
   SET( CMAKE_BUILD_TYPE Release )
 ENDIF()
@@ -180,12 +180,10 @@ CHECK_INCLUDE_FILE(unistd.h HAVE_UNISTD_H)
 # Build options
 # QMC_BUILD_STATIC build static/dynamic  libraries
 # BUILD_QMCTOOLS   build utility programs
-# BUILD_SANDBOX    build test programs and miniapps
 # MPIP_PROFILE     profile mpi performance
 ######################################################################
 SET(QMC_ADIOS 0 CACHE BOOL "Build with ADIOS")
 SET(BUILD_UNIT_TESTS 1 CACHE BOOL "Build unit tests")
-SET(BUILD_SANDBOX 1 CACHE BOOL "Build sandbox tests and miniapps")
 SET(BUILD_LMYENGINE_INTERFACE 1 CACHE BOOL "Build LMY engine")
 IF (QMC_CUDA AND BUILD_LMYENGINE_INTERFACE)
   MESSAGE(STATUS "LMY engine is not compatible with CUDA build! Disabling LMY engine")
@@ -876,7 +874,7 @@ ENDIF(QMC_ADIOS)
 
 SUBDIRS(src)
 
-IF(NOT(QMC_BUILD_LEVEL GREATER 4))
+IF(NOT QMC_BUILD_SANDBOX_ONLY)
   SUBDIRS(tests)
   SUBDIRS(examples)
   IF(IS_DIRECTORY "${PROJECT_SOURCE_DIR}/nexus")

--- a/doxygen/config.h
+++ b/doxygen/config.h
@@ -29,9 +29,6 @@
 /* define the subversion last changed date */
 #define QMCPLUSPLUS_LAST_CHANGED_DATE  "2012-04-22 10:24:14 -0400 (Sun, 22 Apr 2012)"
 
-/* define QMC_BUILD_LEVEL */
-#define QMC_BUILD_LEVEL 3
-
 /* define PRINT_DEBUG */
 /* #undef PRINT_DEBUG */
 

--- a/manual/hamiltonianobservable.tex
+++ b/manual/hamiltonianobservable.tex
@@ -127,9 +127,9 @@ Additional information:
   \item{\textbf{source/target:}  These specify the particles involved in a pair interaction.  If an interaction is between classical (e.g. ions) and quantum (e.g. electrons), \texttt{source}/\texttt{target} should be the name of the classical/quantum particleset.}
   \item{Only \texttt{coulomb, pseudo, mpc} are described in detail below.  The older or less used types (\texttt{cpp, skpot}) are not covered.}
   \dev{
-  \item{Available only if \texttt{QMC\_BUILD\_LEVEL>2} and \texttt{QMC\_CUDA} is not defined: \texttt{skpot}.}
+  \item{Available only if \texttt{QMC\_CUDA} is not defined: \texttt{skpot}.}
   \item{Available only if \texttt{OHMMS\_DIM==3}: \texttt{mpc, vhxc, pseudo}.}
-  \item{Available only if \texttt{OHMMS\_DIM==3} and \texttt{QMC\_BUILD\_LEVEL>2} and \texttt{QMC\_CUDA} is not defined: \texttt{cpp}.}
+  \item{Available only if \texttt{OHMMS\_DIM==3} and \texttt{QMC\_CUDA} is not defined: \texttt{cpp}.}
   }
 \end{itemize}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,11 +248,6 @@ ENDIF()
     SET(PARTICLE ${PARTICLE} LongRange/TwoDEwaldHandler.cpp)
   ENDIF(OHMMS_DIM MATCHES 2)
 
-  # IF(QMC_BUILD_LEVEL GREATER 2)
-  #   IF(NOT QMC_COMPLEX)
-  #     SET(PARTICLE ${PARTICLE} Particle/Bead_ParticleSet.cpp )
-  #   ENDIF(NOT QMC_COMPLEX)
-  # ENDIF(QMC_BUILD_LEVEL GREATER 2)
 
   SET(PARTICLEIO
     ParticleTags.cpp 
@@ -280,7 +275,7 @@ ENDIF()
   ENDIF(HAVE_LIBHDF5 OR HAVE_ADIOS)
 
   #Need to add this if nothing else but miniapps is compiled
-  if(QMC_BUILD_LEVEL GREATER 4)
+  if(QMC_BUILD_SANDBOX_ONLY)
     set(PARTICLE  ${PARTICLE} QMCWaveFunctions/WaveFunctionComponent.cpp)
   endif()
 
@@ -293,7 +288,7 @@ ENDIF()
   #ENDIF(QMC_BUILD_STATIC)
   #SUBDIRS(einspline)
 
-  if(QMC_BUILD_LEVEL GREATER 4)
+  if(QMC_BUILD_SANDBOX_ONLY)
 
     MESSAGE(STATUS "Minimal build: only Sandbox")
     SUBDIRS(Sandbox)

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -84,11 +84,9 @@ IF(BUILD_LMYENGINE_INTERFACE)
      )
 ENDIF(BUILD_LMYENGINE_INTERFACE)
 
-IF(QMC_BUILD_LEVEL GREATER 1)
-  SET(QMCDRIVERS ${QMCDRIVERS}
-    ../Estimators/CSEnergyEstimator.cpp
-  )
-ENDIF(QMC_BUILD_LEVEL GREATER 1)
+SET(QMCDRIVERS ${QMCDRIVERS}
+  ../Estimators/CSEnergyEstimator.cpp
+)
 
 
 ####################################

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -48,7 +48,7 @@
 #include "QMCHamiltonians/SkAllEstimator.h"
 #endif
 // #include "QMCHamiltonians/ZeroVarObs.h"
-#if !defined(QMC_CUDA) && QMC_BUILD_LEVEL>2
+#if !defined(QMC_CUDA)
 #include "QMCHamiltonians/SkPot.h"
 #endif
 #include "OhmmsData/AttributeSet.h"
@@ -155,7 +155,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       {
         addCoulombPotential(cur);
       }
-#if !defined(QMC_CUDA) && QMC_BUILD_LEVEL>2
+#if !defined(QMC_CUDA)
       else if (potType == "skpot")
       {
         SkPot* hs = new SkPot(*targetPtcl);
@@ -168,7 +168,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         addMPCPotential(cur);
       else if(potType == "pseudo")
         addPseudoPotential(cur);
-#if !defined(QMC_CUDA) && QMC_BUILD_LEVEL>2
+#if !defined(QMC_CUDA)
       else if(potType == "cpp")
       {
         addCorePolPotential(cur);

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -168,14 +168,11 @@ IF(OHMMS_DIM MATCHES 3)
     )
   ENDIF(QMC_COMPLEX)
 
-  #only experimental version
-  IF(QMC_BUILD_LEVEL GREATER 2)
-    IF(NOT QMC_COMPLEX)
-    SET(FERMION_SRCS ${FERMION_SRCS}
-      AGPDeterminant.cpp AGPDeterminantBuilder.cpp
-      )
-    ENDIF(NOT QMC_COMPLEX)
-  ENDIF(QMC_BUILD_LEVEL GREATER 2)
+  IF(NOT QMC_COMPLEX)
+  SET(FERMION_SRCS ${FERMION_SRCS}
+    AGPDeterminant.cpp AGPDeterminantBuilder.cpp
+    )
+  ENDIF(NOT QMC_COMPLEX)
 
 ENDIF(OHMMS_DIM MATCHES 3)
 

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
@@ -17,9 +17,7 @@
 #include "QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
-#if QMC_BUILD_LEVEL>2
 #include "QMCWaveFunctions/Fermion/BackflowTransformation.h"
-#endif
 #include "OhmmsData/AttributeSet.h"
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -18,13 +18,11 @@
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "OhmmsData/AttributeSet.h"
-#if QMC_BUILD_LEVEL>2
 #include "QMCWaveFunctions/Fermion/BackflowBuilder.h"
 #include "QMCWaveFunctions/Fermion/BackflowTransformation.h"
 #include "QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h"
-#endif
 
 namespace qmcplusplus
 {
@@ -42,11 +40,7 @@ RealEGOSet::RealEGOSet(const std::vector<PosType>& k, const std::vector<RealType
 }
 
 ElectronGasOrbitalBuilder::ElectronGasOrbitalBuilder(ParticleSet& els, TrialWaveFunction& psi):
-#if QMC_BUILD_LEVEL>2
   WaveFunctionComponentBuilder(els,psi),UseBackflow(false),BFTrans(0)
-#else
-  WaveFunctionComponentBuilder(els,psi),UseBackflow(false)
-#endif
 {
 }
 
@@ -65,7 +59,6 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
   aAttrib.put(cur);
   if (nc2==-2)
     nc2=nc;
-#if QMC_BUILD_LEVEL>2
   xmlNodePtr curRoot=cur;
   xmlNodePtr BFNode(NULL);
   std::string cname;
@@ -82,7 +75,6 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
     }
     cur = cur->next;
   }
-#endif
   typedef DiracDeterminant Det_t;
   typedef SlaterDet SlaterDeterminant_t;
   HEGGrid<RealType,OHMMS_DIM> egGrid(targetPtcl.Lattice);
@@ -136,11 +128,9 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
     }
   //create a Slater determinant
   SlaterDeterminant_t *sdet;
-#if QMC_BUILD_LEVEL>2
   if(UseBackflow)
     sdet = new SlaterDetWithBackflow(targetPtcl,BFTrans);
   else
-#endif
     sdet  = new SlaterDeterminant_t(targetPtcl);
   //add SPOSets
   sdet->add(psiu,"u");
@@ -148,7 +138,6 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
     sdet->add(psid,"d");
   {
     Det_t *updet, *downdet;
-#if QMC_BUILD_LEVEL>2
     if(UseBackflow)
     {
       app_log() <<"Creating Backflow transformation in ElectronGasOrbitalBuilder::put(xmlNodePtr cur).\n";
@@ -174,7 +163,6 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
       sdet->resetTargetParticleSet(targetPtcl);
     }
     else
-#endif
     {
       //create up determinant
       updet = new Det_t(psiu);
@@ -190,12 +178,6 @@ bool ElectronGasOrbitalBuilder::put(xmlNodePtr cur)
         sdet->add(downdet,1);
     }
   }
-//#if QMC_BUILD_LEVEL>2
-//    // change DistanceTables if using backflow
-//    if(UseBackflow)   {
-//       sdet->resetTargetParticleSet(targetPtcl);
-//    }
-//#endif
   //add Slater determinant to targetPsi
   targetPsi.addOrbital(sdet,"SlaterDet",true);
   return true;

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -546,7 +546,7 @@ struct BsplineFunctor: public OptimizableFunctorBase
     app_log() << "New parameters are:\n";
     for (int i=0; i < Parameters.size(); i++)
       app_log() << "   " << Parameters[i] << std::endl;
-#if !QMC_BUILD_SANDBOX_ONLY
+#if !defined(QMC_BUILD_SANDBOX_ONLY)
     if(optimize == "yes")
     {
       // Setup parameter names

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -546,7 +546,7 @@ struct BsplineFunctor: public OptimizableFunctorBase
     app_log() << "New parameters are:\n";
     for (int i=0; i < Parameters.size(); i++)
       app_log() << "   " << Parameters[i] << std::endl;
-#if QMC_BUILD_LEVEL < 5
+#if !QMC_BUILD_SANDBOX_ONLY
     if(optimize == "yes")
     {
       // Setup parameter names

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -14,7 +14,7 @@
 #ifndef QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#if QMC_BUILD_LEVEL<5
+#if !QMC_BUILD_SANDBOX_ONLY
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h"
 #include <qmc_common.h>

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -14,7 +14,7 @@
 #ifndef QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#if !QMC_BUILD_SANDBOX_ONLY
+#if !defined(QMC_BUILD_SANDBOX_ONLY)
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h"
 #include <qmc_common.h>

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -13,7 +13,7 @@
 #ifndef QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#if QMC_BUILD_LEVEL<5
+#if !QMC_BUILD_SANDBOX_ONLY
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #endif
 #include "Particle/DistanceTableData.h"

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -13,7 +13,7 @@
 #ifndef QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#if !QMC_BUILD_SANDBOX_ONLY
+#if !defined(QMC_BUILD_SANDBOX_ONLY)
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #endif
 #include "Particle/DistanceTableData.h"

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -546,7 +546,7 @@ public:
 
   RealType ChiesaKEcorrection()
   {
-#if QMC_BUILD_LEVEL<5
+#if !QMC_BUILD_SANDBOX_ONLY
     if ((!PtclRef->Lattice.SuperCellEnum))
       return 0.0;
     const int numPoints = 1000;

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -546,7 +546,7 @@ public:
 
   RealType ChiesaKEcorrection()
   {
-#if !QMC_BUILD_SANDBOX_ONLY
+#if !defined(QMC_BUILD_SANDBOX_ONLY)
     if ((!PtclRef->Lattice.SuperCellEnum))
       return 0.0;
     const int numPoints = 1000;

--- a/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
+++ b/src/QMCWaveFunctions/MolecularOrbitals/MolecularSPOBuilder.h
@@ -28,9 +28,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "io/hdf_archive.h"
 #include "Message/CommOperators.h"
-#if QMC_BUILD_LEVEL>2
 #include "QMCWaveFunctions/MolecularOrbitals/LCOrbitalSetWithCorrection.h"
-#endif
 namespace qmcplusplus
 {
 
@@ -238,7 +236,6 @@ public:
         OhmmsAttributeSet coeffAttrib;
         coeffAttrib.add (algorithm, "algorithm");
         coeffAttrib.put(cur);
-#if QMC_BUILD_LEVEL>2
         if(cuspCorr)
         {
           app_log() << "Creating LCOrbitalSetWithCorrection with the input coefficients" << std::endl;
@@ -255,7 +252,6 @@ public:
             lcos->objectName=id;
         }
         else
-#endif
         {
           if ( use_new_opt_class == "yes" ) {
 #ifndef ENABLE_SOA

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -224,18 +224,12 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
     if(transformOpt == "yes")
     {
       app_log() << "Using MolecularSPOBuilder<NGOBuilder>" << std::endl;
-#if QMC_BUILD_LEVEL>2
       bb = new MolecularSPOBuilder<NGOBuilder>(targetPtcl,*ions,myComm,cuspC=="yes",cuspInfo,MOH5Ref);
-#else
-      bb = new MolecularSPOBuilder<NGOBuilder>(targetPtcl,*ions,myComm,false);
-#endif
     }
     else
     {
-#if QMC_BUILD_LEVEL>2
       if(cuspC == "yes")
         app_log() <<" ****** Cusp Correction algorithm is only implemented in combination with numerical radial orbitals. Use transform=yes to enable this option. \n";
-#endif
       if(keyOpt == "GTO")
         bb = new MolecularSPOBuilder<GTOBuilder>(targetPtcl,*ions,myComm);
       else if(keyOpt == "STO")

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -35,7 +35,7 @@
 #endif
 
 #include "QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h"
-#if OHMMS_DIM==3 && QMC_BUILD_LEVEL>1 && !defined(QMC_COMPLEX)
+#if OHMMS_DIM==3 && !defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/AGPDeterminantBuilder.h"
 #endif
 
@@ -147,7 +147,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
     {
       APP_ABORT("  Removed Helium Molecular terms from qmcpack ");
     }
-#if QMC_BUILD_LEVEL>2 && !defined(QMC_COMPLEX) && OHMMS_DIM==3
+#if !defined(QMC_COMPLEX) && OHMMS_DIM==3
     else if(cname == "agp")
     {
       AGPDeterminantBuilder* agpbuilder = new AGPDeterminantBuilder(*targetPtcl,*targetPsi,ptclPool);
@@ -191,12 +191,10 @@ bool WaveFunctionFactory::addFermionTerm(xmlNodePtr cur)
     detbuilder = new ElectronGasOrbitalBuilder(*targetPtcl,*targetPsi);
 #endif
   }
-//#if OHMMS_DIM == 3 && QMC_BUILD_LEVEL>1
     else if(orbtype == "PWBasis" || orbtype == "PW" || orbtype == "pw")
     {
       detbuilder = new PWOrbitalBuilder(*targetPtcl,*targetPsi,ptclPool);
     }
-//#endif /* QMC_BUILD_LEVEL>1 */
   else
     detbuilder = new SlaterDetBuilder(*targetPtcl,*targetPsi,ptclPool);
   detbuilder->put(cur);

--- a/src/Sandbox/CMakeLists.txt
+++ b/src/Sandbox/CMakeLists.txt
@@ -1,6 +1,6 @@
 PROJECT(Sandbox)
 
-if(QMC_BUILD_LEVEL GREATER 4)
+if(QMC_BUILD_SANDBOX_ONLY)
 # add apps XYZ.cpp, e.g., qmc_particles.cpp
 SET(ESTEST einspline_smp einspline_spo qmc_particles moveonsphere twobody ptclset)
 SET(ESTEST diff_distancetables diff_jeeI diff_j2 diff_j1 einspline_spo einspline_spo_nested determinant restart determinant_delayed_update)

--- a/src/Sandbox/README.md
+++ b/src/Sandbox/README.md
@@ -1,7 +1,7 @@
 QMCPACK miniapps
 ================
 
-Add `-DQMC_BUILD_LEVEL=5` in CMake to build the miniapps in this folder.
+Add `-DQMC_BUILD_SANDBOX_ONLY=1` in CMake to build the miniapps in this folder.
 Optionally using `-DQMC_MIXED_PRECISION=1` to access mixed precision (most of the element values are single).
 Assume that the mixed precision is sufficient to evaluate the algorithms, implementations and performance.
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -26,8 +26,8 @@
 /* building from Git repository or not */
 #cmakedefine IS_GIT_PROJECT  @IS_GIT_PROJECT@
 
-/* define QMC_BUILD_LEVEL */
-#cmakedefine QMC_BUILD_LEVEL @QMC_BUILD_LEVEL@
+/* define QMC_BUILD_SANDBOX_ONLY */
+#cmakedefine QMC_BUILD_SANDBOX_ONLY @QMC_BUILD_SANDBOX_ONLY@
 
 /* define PRINT_DEBUG */
 #cmakedefine PRINT_DEBUG @PRINT_DEBUG@


### PR DESCRIPTION
The default had been set to 3, and was only changed to build the sandbox apps.
Remove the ifdefs in most places, and replace with QMC_BUILD_SANDBOX_ONLY where appropriate.
Fixes #1051.