### PR TITLE
Remove ReportLevel in LCAOrbitalSet

### DIFF
--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -662,10 +662,10 @@ namespace qmcplusplus
     LCAOrbitalSet *lcos = nullptr;
     LCAOrbitalSetWithCorrection *lcwc = nullptr;
     if (doCuspCorrection) {
-      lcwc =new LCAOrbitalSetWithCorrection(sourcePtcl, targetPtcl, myBasisSet, rank()==0);
+      lcwc =new LCAOrbitalSetWithCorrection(sourcePtcl, targetPtcl, myBasisSet);
       lcos = lcwc;
     } else {
-      lcos=new LCAOrbitalSet(myBasisSet,rank()==0);
+      lcos=new LCAOrbitalSet(myBasisSet);
     }
     loadMO(*lcos, cur);
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -16,8 +16,8 @@
 
 namespace qmcplusplus
 {
-  LCAOrbitalSet::LCAOrbitalSet(basis_type* bs,int rl):
-    myBasisSet(nullptr), C(nullptr), ReportLevel(rl), params_supplied(false),
+  LCAOrbitalSet::LCAOrbitalSet(basis_type* bs):
+    myBasisSet(nullptr), C(nullptr), params_supplied(false),
     BasisSetSize(0), Identity(true), IsCloned(false)
   {
     if(bs != nullptr) setBasisSet(bs);

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -32,8 +32,6 @@ namespace qmcplusplus
     typedef RealBasisSetBase<RealType> basis_type;
     typedef basis_type::vgl_type vgl_type;
 
-    ///level of printing
-    int ReportLevel;
     ///pointer to the basis set
     basis_type* myBasisSet;
     ///number of Single-particle orbitals
@@ -62,9 +60,8 @@ namespace qmcplusplus
     std::vector<std::pair<int,int> > m_act_rot_inds;
     /** constructor
      * @param bs pointer to the BasisSet
-     * @param rl report level
      */
-    LCAOrbitalSet(basis_type* bs=nullptr,int rl=0);
+    LCAOrbitalSet(basis_type* bs=nullptr);
 
     LCAOrbitalSet(const LCAOrbitalSet& in)=default;
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.cpp
@@ -15,8 +15,8 @@
 
 namespace qmcplusplus
 {
-LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(ParticleSet& ions, ParticleSet& els, basis_type* bs, int rl)
-    : LCAOrbitalSet(bs, rl), cusp(ions, els)
+LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(ParticleSet& ions, ParticleSet& els, basis_type* bs)
+    : LCAOrbitalSet(bs), cusp(ions, els)
 {
 }
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h
@@ -34,7 +34,7 @@ struct LCAOrbitalSetWithCorrection : public LCAOrbitalSet
      * @param bs pointer to the BasisSet
      * @param rl report level
      */
-  LCAOrbitalSetWithCorrection(ParticleSet& ions, ParticleSet& els, basis_type* bs = nullptr, int rl = 0);
+  LCAOrbitalSetWithCorrection(ParticleSet& ions, ParticleSet& els, basis_type* bs = nullptr);
 
   LCAOrbitalSetWithCorrection(const LCAOrbitalSetWithCorrection& in) = default;
 


### PR DESCRIPTION
The builder is responsible to deal with ReportLevel.