### PR TITLE
Nexus: fix CHGCAR conversion

### DIFF
--- a/nexus/lib/fileio.py
+++ b/nexus/lib/fileio.py
@@ -1251,10 +1251,10 @@ class ChgcarFile(StandardFile):
     def incorporate_xsf(self,xsf):
         poscar = PoscarFile()
         poscar.incorporate_xsf(xsf)
-        density = xsf.remove_ghost()
+        density = xsf.remove_ghost().copy()
         self.poscar         = poscar
         self.grid           = array(density.shape,dtype=int)
-        self.charge_density = density.ravel()
+        self.charge_density = density.ravel(order='F')
         self.check_valid()
     #end def incorporate_xsf
 #end class ChgcarFile


### PR DESCRIPTION
Small fix for XSF to CHGCAR conversion.  Bug introduced with changes to internal representation of XSF data a while back (C vs. Fortran array order).