### PR TITLE
Fix the complex build with intel 19u0

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -872,7 +872,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             ValueType dpsi2=dpsia_dn(dnC,pa);
             ParticleSet::ParticleGradient_t& g1 = grads_up[upC];
             ParticleSet::ParticleGradient_t& g2 = grads_dn[dnC];
-#if ( ( __INTEL_COMPILER == 1900 ) && ( __INTEL_COMPILER_UPDATE == 0 ) )
+#if ( ( __INTEL_COMPILER == 1900 ) && ( __INTEL_COMPILER_UPDATE == 0 ) && !defined(QMC_COMPLEX) )
             #pragma omp simd reduction(+:dot1)
 #endif
             for(int k=0; k<n; k++)


### PR DESCRIPTION
The previous workaround using omp simd breaks the complex build due to missing definition of reduction on complex data type.
Now the workaround is only applied on real builds.

Intel 19 update 1 still carries this bug and its internal macro __INTEL_COMPILER_UPDATE still has the value 0. For this reason, the current workaround covers Intel 19 update 0 and 1.