### PR TITLE
Adjust AFQMC cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,10 +193,16 @@ IF(MIXED_PRECISION AND BUILD_LMYENGINE_INTERFACE)
   MESSAGE(STATUS "LMY engine is not compatible with CPU mixed precision build! Disabling LMY engine")
   SET(BUILD_LMYENGINE_INTERFACE 0)
 ENDIF()
-IF(QMC_MPI AND QMC_COMPLEX AND NOT MIXED_PRECISION AND NOT QMC_CUDA)
-  SET(BUILD_AFQMC 1 CACHE BOOL "Build with AFQMC")
-ELSE()
-  SET(BUILD_AFQMC 0 CACHE BOOL "Build with AFQMC")
+SET(BUILD_AFQMC 0 CACHE BOOL "Build with AFQMC")
+# AFQMC requires MPI. Works with neither real nor mixed precision builds.
+If (BUILD_AFQMC AND NOT QMC_MPI)
+  MESSAGE(FATAL_ERROR "AFQMC requires building with MPI (QMC_MPI=1). Set BUILD_AFQMC=0 or configure MPI.")
+ENDIF()
+If (BUILD_AFQMC AND NOT QMC_COMPLEX)
+  MESSAGE(FATAL_ERROR "AFQMC requires building with QMC_COMPLEX=1 for now.")
+ENDIF()
+If (BUILD_AFQMC AND MIXED_PRECISION)
+  MESSAGE(FATAL_ERROR "AFQMC requires building with QMC_MIXED_PRECISION=0 for now.")
 ENDIF()
 SET(BUILD_FCIQMC 0 CACHE BOOL "Build with FCIQMC")
 #SET(BUILD_QMCTOOLS 1 CACHE BOOL "Build tools for QMCPACK")
@@ -513,21 +519,6 @@ ENDIF(ENABLE_GCOV)
 # AFQMC requires MKL sparse for good performance (roughly a factor of 2x)
 IF (BUILD_AFQMC AND NOT MKL_FOUND)
   MESSAGE(WARNING "AFQMC - MKL not found, using simple sparse matrix routines.  Link with MKL sparse libraries for better performance.")
-ENDIF()
-
-# AFQMC requires MPI
-If (BUILD_AFQMC AND NOT QMC_MPI)
-  MESSAGE(FATAL_ERROR "AFQMC requires building with MPI (QMC_MPI=1). Set BUILD_AFQMC=0 or configure MPI.")
-ENDIF()
-
-# AFQMC does not work with real builds for now
-If (BUILD_AFQMC AND NOT QMC_COMPLEX)
-  MESSAGE(FATAL_ERROR "AFQMC requires building with QMC_COMPLEX=1 for now.")
-ENDIF()
-
-# AFQMC does not work with mixed precision builds for now
-If (BUILD_AFQMC AND MIXED_PRECISION)
-  MESSAGE(FATAL_ERROR "AFQMC requires building with QMC_MIXED_PRECISION=0 for now.")
 ENDIF()
 
 IF (BUILD_AFQMC AND NOT APPLE)

--- a/tests/test_automation/jenkins_rhea_cpu.sh
+++ b/tests/test_automation/jenkins_rhea_cpu.sh
@@ -89,7 +89,7 @@ rm -rf ./${BUILD_TAG}-build
 mkdir -p ${BUILD_TAG}-build
 cd ${BUILD_TAG}-build
 
-cmake -DQMC_COMPLEX=1 -DQMC_MIXED_PRECISION=0 -DCMAKE_C_COMPILER="mpicc" -DCMAKE_CXX_COMPILER="mpicxx" -DBLAS_blas_LIBRARY="/usr/lib64/libblas.so.3" -DLAPACK_lapack_LIBRARY="/usr/lib64/atlas/liblapack.so.3" -DHDF5_INCLUDE_DIR="/sw/rhea/hdf5/1.8.11/rhel6.6_gnu4.8.2/include" /tmp/${BUILD_TAG}-src 2>&1 | tee cmake.out
+cmake -DQMC_COMPLEX=1 -DQMC_MIXED_PRECISION=0 -DBUILD_AFQMC=1 -DCMAKE_C_COMPILER="mpicc" -DCMAKE_CXX_COMPILER="mpicxx" -DBLAS_blas_LIBRARY="/usr/lib64/libblas.so.3" -DLAPACK_lapack_LIBRARY="/usr/lib64/atlas/liblapack.so.3" -DHDF5_INCLUDE_DIR="/sw/rhea/hdf5/1.8.11/rhel6.6_gnu4.8.2/include" /tmp/${BUILD_TAG}-src 2>&1 | tee cmake.out
 
 make -j 24
 ctest -L unit --output-on-failure

--- a/tests/test_automation/nightly_anl_bora.sh
+++ b/tests/test_automation/nightly_anl_bora.sh
@@ -10,7 +10,7 @@ export N_PROCS_BUILD=24
 export N_PROCS=32
 export CC=mpicc
 export CXX=mpicxx
-export BOOST_ROOT=/sandbox/opt/qmcdev/trunk/external_codes/boost_1_55_0
+export BOOST_ROOT=/sandbox/opt/boost_1_61_0
 
 QE_BIN=/sandbox/opt/qe-stable/qe-6.3/bin
 QMC_DATA=/sandbox/opt/h5data
@@ -19,7 +19,7 @@ QMC_DATA=/sandbox/opt/h5data
 place=/sandbox/QMCPACK_CI_BUILDS_DO_NOT_REMOVE
 
 #define and load compiler
-compiler=Intel2018
+compiler=Intel2019
 
 if [ ! -e $place ]; then
 mkdir $place


### PR DESCRIPTION
Turn off AFQMC by default. 
Turn on AFQMC in the CI script when appropriate.