### PR TITLE
Isolate boost::multi hdf template specialisations.

### DIFF
--- a/src/AFQMC/Drivers/AFQMCDriver.h
+++ b/src/AFQMC/Drivers/AFQMCDriver.h
@@ -1,6 +1,7 @@
 #ifndef QMCPLUSPLUS_AFQMC_AFQMCDRIVER_H
 #define QMCPLUSPLUS_AFQMC_AFQMCDRIVER_H
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "mpi3/communicator.hpp"
 

--- a/src/AFQMC/Drivers/BenchmarkDriver.h
+++ b/src/AFQMC/Drivers/BenchmarkDriver.h
@@ -2,6 +2,7 @@
 #define QMCPLUSPLUS_AFQMC_BENCHMARKDRIVER_H
 
 #include<Message/MPIObjectBase.h>
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 
 #include "AFQMC/config.h"

--- a/src/AFQMC/Drivers/Driver.h
+++ b/src/AFQMC/Drivers/Driver.h
@@ -2,6 +2,7 @@
 #define QMCPLUSPLUS_AFQMC_DRIVER_H
 
 #include<Message/MPIObjectBase.h>
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 
 #include "AFQMC/config.h"

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.h
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "OhmmsData/libxmldefs.h"
 #include "Utilities/NewTimer.h"

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -9,6 +9,7 @@
 #include<iostream>
 #include<fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "OhmmsData/libxmldefs.h"
 #include "Utilities/NewTimer.h"

--- a/src/AFQMC/Estimators/EstimatorBase.h
+++ b/src/AFQMC/Estimators/EstimatorBase.h
@@ -6,6 +6,7 @@
 #include<iostream>
 #include<fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "OhmmsData/libxmldefs.h"
 

--- a/src/AFQMC/Estimators/OneRdmEstimator.h
+++ b/src/AFQMC/Estimators/OneRdmEstimator.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "OhmmsData/libxmldefs.h"
 #include "Utilities/NewTimer.h"

--- a/src/AFQMC/Estimators/WalkerDMEstimator.h
+++ b/src/AFQMC/Estimators/WalkerDMEstimator.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "OhmmsData/libxmldefs.h"
 #include "Utilities/NewTimer.h"

--- a/src/AFQMC/HamiltonianOperations/HamOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/HamOpsIO.hpp
@@ -18,6 +18,7 @@
 
 #include<fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 
 #include "AFQMC/config.h"

--- a/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
@@ -18,6 +18,7 @@
 
 #include<fstream>
 
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 
 #include "AFQMC/config.h"

--- a/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
@@ -18,6 +18,8 @@
 
 #include<fstream>
 
+#include "type_traits/container_proxy_multi.h"
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 
 #include "AFQMC/config.h"

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -21,6 +21,7 @@
 #include "OhmmsData/ParameterSet.h"
 #include "Utilities/SimpleParser.h"
 #include "Configuration.h"
+#include "io/hdf_multi.h"
 #include "io/hdf_archive.h"
 #include "Message/CommOperators.h"
 

--- a/src/AFQMC/Walkers/WalkerIO.hpp
+++ b/src/AFQMC/Walkers/WalkerIO.hpp
@@ -20,6 +20,7 @@
 #include<cstdlib>
 #include<vector>
 #include<type_traits>
+#include "type_traits/container_proxy_multi.h"
 
 #include "Configuration.h"
 #include "AFQMC/config.h"

--- a/src/io/hdf_archive.h
+++ b/src/io/hdf_archive.h
@@ -22,7 +22,6 @@
 #include <io/hdf_stl.h>
 #include <io/hdf_hyperslab.h>
 #include <io/hdf_double_hyperslab.h>
-#include <io/hdf_multi.h>
 #if defined(HAVE_LIBBOOST)
 #include <io/hdf_ma.h>
 #if !defined(__bgq__)

--- a/src/io/hdf_multi.h
+++ b/src/io/hdf_multi.h
@@ -11,15 +11,13 @@
 
 #ifndef QMCPLUSPLUS_HDF_MULTI_INTERFACE_H
 #define QMCPLUSPLUS_HDF_MULTI_INTERFACE_H
-#include <vector>
-#include <sstream>
-#include <bitset>
-#include <deque>
-#include <type_traits>
+#include <io/hdf_dataproxy.h>
 #include "multi/array.hpp"
 #include "multi/array_ref.hpp"
+
 namespace qmcplusplus
 {
+
 /** specialization for vector<T>
  *
  * Used with any T with a proper h5_space_type, e.g., intrinsic, TinyVector<T,D>, Tensor<T,D>

--- a/src/type_traits/container_proxy.h
+++ b/src/type_traits/container_proxy.h
@@ -24,8 +24,6 @@
 #if defined(HAVE_LIBBOOST)
 #include <boost/multi_array.hpp>
 #endif
-#include "multi/array.hpp"
-#include "multi/array_ref.hpp"
 
 namespace qmcplusplus
 {
@@ -292,65 +290,6 @@ struct container_proxy<boost::multi_array_ref<T,2> >
 };
 #endif
 
-template<typename T, class Alloc>
-struct container_proxy<boost::multi::array<T,2,Alloc> >
-{
-  enum {DIM=scalar_traits<T>::DIM};
-  typedef typename container_proxy<T>::pointer pointer;
-  boost::multi::array<T,2,Alloc>& ref;
-  inline container_proxy(boost::multi::array<T,2,Alloc>& a):ref(a) {}
-  inline size_t size() const
-  {
-    return ref.num_elements()*DIM;
-  }
-  inline pointer data()
-  {
-    //using detail::to_address;
-    //return scalar_traits<T>::get_address(to_address(ref.origin()));
-    return scalar_traits<T>::get_address(std::addressof(*ref.origin()));
-  }
-  inline void resize(size_t n)
-  {
-    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array<T,D,Alloc> >. \n");
-  }
-  template<typename I>
-  inline void resize(I* n, int d)
-  {
-    if(d < 2)
-      APP_ABORT(" Error: Inconsistent dimension in container_proxy<boost::multi::array<T,D,Alloc> >::resize(I*,int). \n");
-    ref.reextent({n[0],n[1]});
-  }
-};
-
-template<typename T>
-struct container_proxy<boost::multi::array_ref<T,2> >
-{
-  enum {DIM=scalar_traits<T>::DIM};
-  typedef typename container_proxy<T>::pointer pointer;
-  boost::multi::array_ref<T,2>& ref;
-  inline container_proxy(boost::multi::array_ref<T,2>& a):ref(a) {}
-  inline size_t size() const
-  {
-    return ref.num_elements()*DIM;
-  }
-  inline pointer data()
-  {
-    //using detail::to_address;
-    //return scalar_traits<T>::get_address(to_address(ref.origin()));
-    return scalar_traits<T>::get_address(std::addressof(*ref.origin()));
-  }
-  inline void resize(size_t n)
-  {
-    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array_ref<T,D> >. \n");
-  }
-
-  template<typename I>
-  inline void resize(I* n, int d)
-  {
-    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array_ref<T,D> >. \n");
-  }
-
-};
 
 }
 #endif

--- a/src/type_traits/container_proxy_multi.h
+++ b/src/type_traits/container_proxy_multi.h
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_CONTAINER_PROXY_MULTI_H
+#define QMCPLUSPLUS_CONTAINER_PROXY_MULTI_H
+
+#include "multi/array.hpp"
+#include "multi/array_ref.hpp"
+
+namespace qmcplusplus
+{
+
+template<typename T, class Alloc>
+struct container_proxy<boost::multi::array<T,2,Alloc> >
+{
+  enum {DIM=scalar_traits<T>::DIM};
+  typedef typename container_proxy<T>::pointer pointer;
+  boost::multi::array<T,2,Alloc>& ref;
+  inline container_proxy(boost::multi::array<T,2,Alloc>& a):ref(a) {}
+  inline size_t size() const
+  {
+    return ref.num_elements()*DIM;
+  }
+  inline pointer data()
+  {
+    //using detail::to_address;
+    //return scalar_traits<T>::get_address(to_address(ref.origin()));
+    return scalar_traits<T>::get_address(std::addressof(*ref.origin()));
+  }
+  inline void resize(size_t n)
+  {
+    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array<T,D,Alloc> >. \n");
+  }
+  template<typename I>
+  inline void resize(I* n, int d)
+  {
+    if(d < 2)
+      APP_ABORT(" Error: Inconsistent dimension in container_proxy<boost::multi::array<T,D,Alloc> >::resize(I*,int). \n");
+    ref.reextent({n[0],n[1]});
+  }
+};
+
+template<typename T>
+struct container_proxy<boost::multi::array_ref<T,2> >
+{
+  enum {DIM=scalar_traits<T>::DIM};
+  typedef typename container_proxy<T>::pointer pointer;
+  boost::multi::array_ref<T,2>& ref;
+  inline container_proxy(boost::multi::array_ref<T,2>& a):ref(a) {}
+  inline size_t size() const
+  {
+    return ref.num_elements()*DIM;
+  }
+  inline pointer data()
+  {
+    //using detail::to_address;
+    //return scalar_traits<T>::get_address(to_address(ref.origin()));
+    return scalar_traits<T>::get_address(std::addressof(*ref.origin()));
+  }
+  inline void resize(size_t n)
+  {
+    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array_ref<T,D> >. \n");
+  }
+
+  template<typename I>
+  inline void resize(I* n, int d)
+  {
+    APP_ABORT(" Error: Can not resize container_proxy<boost::multi::array_ref<T,D> >. \n");
+  }
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
Removes include of boost::multi template specialisations from being included in hdf_archive by default. Prevents boost::multi related warnings when building the real space code with intel.