### PR TITLE
Re-enable AFQMC estimator HDF5 estimator output

### DIFF
--- a/src/AFQMC/CMakeLists.txt
+++ b/src/AFQMC/CMakeLists.txt
@@ -69,5 +69,6 @@ IF (BUILD_UNIT_TESTS)
   SUBDIRS(HamiltonianOperations/tests)
   SUBDIRS(Wavefunctions/tests)
   SUBDIRS(Propagators/tests)
+  SUBDIRS(Estimators/tests)
 ENDIF()
 

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.h
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.h
@@ -125,7 +125,7 @@ class BackPropagatedEstimator: public EstimatorBase
     }
   }
 
-  void print(std::ofstream& out, WalkerSet& wset)
+  void print(std::ofstream& out, hdf_archive& dump, WalkerSet& wset)
   {
     if(writer) {
       if(importanceSampling) {

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.h
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.h
@@ -34,7 +34,7 @@ class BackPropagatedEstimator: public EstimatorBase
         std::string title, xmlNodePtr cur, WALKER_TYPES wlk, Wavefunction& wfn, bool impsamp_=true) :
                                             EstimatorBase(info),TG(tg_), wfn0(wfn),
                                             greens_function(false),
-                                            nStabalize(1), path_restoration(false),
+                                            nStabalize(1), path_restoration(false), block_size(1),
                                             writer(false), importanceSampling(impsamp_)
   {
 
@@ -43,6 +43,7 @@ class BackPropagatedEstimator: public EstimatorBase
       std::string restore_paths;
       m_param.add(nStabalize, "ortho", "int");
       m_param.add(restore_paths, "path_restoration", "std::string");
+      m_param.add(block_size, "block_size", "int");
       m_param.put(cur);
       if(restore_paths == "true") {
         path_restoration = true;
@@ -67,8 +68,13 @@ class BackPropagatedEstimator: public EstimatorBase
     if(DMBuffer.size() < dm_size) {
       DMBuffer.reextent(extensions<1u>{dm_size});
     }
+    if(DMAverage.size() < dm_size) {
+      DMAverage.reextent(extensions<1u>{dm_size});
+    }
     std::fill(DMBuffer.begin(), DMBuffer.end(), ComplexType(0.0,0.0));
+    std::fill(DMAverage.begin(), DMAverage.end(), ComplexType(0.0,0.0));
     denom.reextent({1});
+    denom_average.reextent({1});
   }
 
   ~BackPropagatedEstimator() {}
@@ -84,6 +90,7 @@ class BackPropagatedEstimator: public EstimatorBase
       CMatrix_ref BackPropDM(DMBuffer.data(), {dm_dims.first,dm_dims.second});
       // Computes GBP(i,j)
       denom[0] = ComplexType(0.0,0.0);
+      std::fill(DMBuffer.begin(), DMBuffer.end(), ComplexType(0.0,0.0));
       wfn0.BackPropagatedDensityMatrix(wset, BackPropDM, denom, path_restoration, !importanceSampling);
       for(int iw = 0; iw < wset.size(); iw++) {
         // Resets B matrix buffer to identity, copies current wavefunction and resets weight
@@ -91,78 +98,36 @@ class BackPropagatedEstimator: public EstimatorBase
         if( iw%TG.TG_local().size() != TG.TG_local().rank() ) continue;
         wset[iw].resetForBackPropagation();
       }
+      write_back_prop = true;
+      iblock++;
     }
   }
 
-  //template <typename T>
-  //ComplexType back_propagate_wavefunction(const boost::multi::array<ComplexType,2>& trialSM, SMType& psiBP, T& walker, int nback_prop)
-  //{
-    //ComplexType detR = one;
-    //walker.decrementBMatrix();
-    //SMType B = walker.BMatrix();
-    //ma::product(ma::H(B), trialSM, T1);
-    //for (int i = 0; i < nback_prop-1; i++) {
-      //walker.decrementBMatrix();
-      //SMType B = walker.BMatrix();
-      //ma::product(ma::H(B), T1, std::forward<SMType>(psiBP));
-      //T1 = psiBP;
-      //if ((i != 0) && (i%nStabalize == 0)) {
-        ////detR *= DenseMatrixOperators::GeneralizedGramSchmidt(T1.data(),NAEA,NMO,NAEA);
-      //}
-    //}
-    //return detR;
-  //}
-
-  void tags(std::ofstream& out)
-  {
-    if(TG.getGlobalRank() == 0) {
-      for(int i = 0; i < dm_dims.first; i++) {
-        for(int j = 0; j < dm_dims.second; j++) {
-          out << "ReG_" << i << "_"  << j << " " << "ImG_" << i << "_" << j << " ";
-        }
-      }
-      if(!importanceSampling) out << "ReG_denom ImG_denom ";
-    }
-  }
+  void tags(std::ofstream& out) {}
 
   void print(std::ofstream& out, hdf_archive& dump, WalkerSet& wset)
   {
     if(writer) {
-      if(importanceSampling) {
-        for(int i = 0; i < DMBuffer.size(); i++) {
-          out << std::setprecision(16) << " " << DMBuffer[i].real() << " ";
+      if(write_back_prop) {
+        for(int i = 0; i < DMBuffer.size(); i++)
+          DMAverage[i] += DMBuffer[i];
+        denom_average[0] += denom[0];
+        if(iblock%block_size == 0) {
+          for(int i = 0; i < DMAverage.size(); i++)
+            DMAverage[i] /= block_size;
+          denom_average[0] /= block_size;
+          dump.push("BackPropagated");
+          dump.write(DMAverage, "one_rdm_"+std::to_string(iblock));
+          dump.write(denom, "one_rdm_denom_"+std::to_string(iblock));
+          dump.pop();
+          std::fill(DMAverage.begin(), DMAverage.end(), ComplexType(0.0,0.0));
         }
-      } else {
-        for(int i = 0; i < DMBuffer.size(); i++) {
-          //RealType re_num = DMBuffer[i].real()*denom[0].real() + DMBuffer[i].imag()*denom[0].imag();
-          out << std::setprecision(16) << " " << DMBuffer[i].real() << " " << DMBuffer[i].imag() << " ";
-        }
-        out << denom[0].real() << " " << denom[0].imag() << " ";
+        write_back_prop = false;
       }
     }
-    // Zero our estimator array.
-    std::fill(DMBuffer.begin(), DMBuffer.end(), ComplexType(0.0,0.0));
-    denom[0] = ComplexType(0.0,0.0);
   }
 
   private:
-
-  //template <typename T>
-  //ComplexType reweighting_factor(T walker, int nback_prop)
-  //{
-    //ComplexType factor = one;
-    //// Get final entry in back propagation buffers = first entry for back propagation.
-    //for (int i = 0; i < nback_prop; i++) {
-      //// undo cosine projection.
-      //walker.decrementBMatrix();
-      //factor *= walker.weightFactor();
-      //if (fully_restore_weights) {
-        //// restore imaginary part of local energy.
-        //factor /= walker.cosineFactor();
-      //}
-    //}
-    //return factor;
-  //}
 
   TaskGroup_& TG;
 
@@ -173,12 +138,13 @@ class BackPropagatedEstimator: public EstimatorBase
   // The first element of data stores the denominator of the estimator (i.e., the total
   // walker weight including rescaling factors etc.). The rest of the elements store the
   // averages of the various elements of the green's function.
-  CVector DMBuffer;
+  CVector DMBuffer, DMAverage;
 
   RealType weight, weight_sub;
   RealType targetW = 1;
   int core_rank;
   int ncores_per_TG;
+  int iblock = 0;
   ComplexType zero = ComplexType(0.0, 0.0);
   ComplexType one = ComplexType(1.0, 0.0);
 
@@ -186,13 +152,16 @@ class BackPropagatedEstimator: public EstimatorBase
   bool greens_function;
   // Frequency of reorthogonalisation.
   int nStabalize;
+  // Block size over which RDM will be averaged.
+  int block_size;
   // Whether to restore cosine projection and real local energy apprximation for weights
   // along back propagation path.
   bool path_restoration, importanceSampling;
   std::vector<ComplexType> weights;
   int dm_size;
+  bool write_back_prop = false;
   std::pair<int,int> dm_dims;
-  CVector denom;
+  CVector denom, denom_average;
 
 };
 }

--- a/src/AFQMC/Estimators/BasicEstimator.h
+++ b/src/AFQMC/Estimators/BasicEstimator.h
@@ -146,7 +146,7 @@ class BasicEstimator: public EstimatorBase
       if(timers) out<<"PseudoEnergy_t vHS_t vbias_t G_t Propagate_t Energy_comm_t vHS_comm_t Block_t ";
   }
 
-  void print(std::ofstream& out,WalkerSet& wset)
+  void print(std::ofstream& out, hdf_archive& dump, WalkerSet& wset)
   {
     data[0] = enume.real()/ncalls;
     data[1] = edeno.real()/ncalls;

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -80,7 +80,7 @@ class EnergyEstimator: public EstimatorBase
     }
   }
 
-  void print(std::ofstream& out,WalkerSet& wset)
+  void print(std::ofstream& out, hdf_archive& dump, WalkerSet& wset)
   {
     if(TG.Global().root()) {
      int n = wset.get_global_target_population();

--- a/src/AFQMC/Estimators/EstimatorBase.h
+++ b/src/AFQMC/Estimators/EstimatorBase.h
@@ -30,7 +30,7 @@ class EstimatorBase: public AFQMCInfo
 
   virtual void accumulate_step(WalkerSet& wlks, std::vector<ComplexType>& curData)=0;
 
-  virtual void print(std::ofstream& out,WalkerSet& wlks)=0;
+  virtual void print(std::ofstream& out, hdf_archive& dump, WalkerSet& wlks)=0;
 
   virtual void print_timers(std::ofstream& out) {}
 

--- a/src/AFQMC/Estimators/EstimatorHandler.h
+++ b/src/AFQMC/Estimators/EstimatorHandler.h
@@ -143,6 +143,11 @@ class EstimatorHandler: public AFQMCInfo
     if(TGgen.getTG(1).getGlobalRank() == 0) {
       //out.open(filename.c_str(),std::ios_base::app | std::ios_base::out);
       std::string filename = project_title+".scalar.dat";
+      hdf_file = project_title+".scalar.h5";
+      if(!dump.create(hdf_file)) {
+        app_log()<<"Problems opening estimator hdf5 output file: " << hdf_file <<std::endl;
+        APP_ABORT("Problems opening estimator hdf5 output file.\n");
+      }
       out.open(filename.c_str());
       if(out.fail()) {
         app_log()<<"Problems opening estimator output file: " <<filename <<std::endl;
@@ -174,11 +179,13 @@ class EstimatorHandler: public AFQMCInfo
   void print(int block, double time, double Es, WalkerSet& wlks)
   {
     out<<block <<" " <<time <<" ";
+    dump.open(hdf_file);
     for(std::vector<EstimPtr>::iterator it=estimators.begin(); it!=estimators.end(); it++)
-      (*it)->print(out,wlks);
+      (*it)->print(out,dump,wlks);
     out<<std::setprecision(12) <<Es <<"  " <<freemem() <<" ";
     estimators[0]->print_timers(out);
     out<<std::endl;
+    dump.close();
     if( (block+1)%10==0 ) out.flush();
   }
 
@@ -204,6 +211,8 @@ class EstimatorHandler: public AFQMCInfo
   std::vector<std::string> tags;
 
   std::ofstream out;
+  hdf_archive dump;
+  std::string hdf_file;
 
 };
 }

--- a/src/AFQMC/Estimators/tests/CMakeLists.txt
+++ b/src/AFQMC/Estimators/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Miguel A. Morales, LLNL
+#//
+#// File created by: Fionn Malone, malone14@llnl.gov, LLNL
+#//////////////////////////////////////////////////////////////////////////////////////
+
+INCLUDE("${qmcpack_SOURCE_DIR}/CMake/macros.cmake")
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
+
+SET(SRC_DIR afqmc_estimators)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
+
+SET(UTEST_DIR ${qmcpack_BINARY_DIR}/tests/afqmc/Estimators)
+SET(UTEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/choldump.h5)
+SET(UTEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/wfn.dat)
+
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")
+MAYBE_SYMLINK(${UTEST_HDF_INPUT} ${UTEST_DIR}/afqmc.h5)
+MAYBE_SYMLINK(${UTEST_WFN_INPUT} ${UTEST_DIR}/wfn.dat)
+
+ADD_EXECUTABLE(${UTEST_EXE} test_estimators.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} afqmc qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
+
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS "unit;afqmc" WORKING_DIRECTORY ${UTEST_DIR})

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -1,0 +1,173 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
+//
+// File created by: Fionn Malone, malone14@llnl.gov, Lawrence Livermore National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "Message/catch_mpi_main.hpp"
+
+#include "Configuration.h"
+
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsApp/ProjectData.h"
+#include "io/hdf_archive.h"
+
+#undef APP_ABORT
+#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+
+#include <stdio.h>
+#include <string>
+
+#include "AFQMC/config.h"
+#include "AFQMC/Matrix/tests/matrix_helpers.h"
+#include "AFQMC/Hamiltonians/HamiltonianFactory.h"
+#include "AFQMC/Hamiltonians/Hamiltonian.hpp"
+#include "AFQMC/Wavefunctions/WavefunctionFactory.h"
+#include "AFQMC/Wavefunctions/Wavefunction.hpp"
+#include "AFQMC/Walkers/WalkerSet.hpp"
+#include "AFQMC/Estimators/EstimatorBase.h"
+#include "AFQMC/Estimators/BackPropagatedEstimator.h"
+#include "AFQMC/Utilities/test_utils.hpp"
+
+using std::string;
+using std::complex;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::ifstream;
+using std::setprecision;
+
+namespace qmcplusplus
+{
+
+using namespace afqmc;
+
+TEST_CASE("back_propagated_rdm", "[estimators]")
+{
+  OHMMS::Controller->initialize(0, NULL);
+  auto world = boost::mpi3::environment::get_world_instance();
+
+  if(not file_exists("./wfn.dat") ) {
+    app_log()<<" Skipping back_propagated_rdm. ./wfn.dat files not found. \n";
+  } else {
+
+    // Global Task Group
+    afqmc::GlobalTaskGroup gTG(world);
+
+    auto file_data = read_test_results_from_hdf<ValueType>("./afqmc.h5");
+    int NMO = file_data.NMO;
+    int NAEA = file_data.NAEA;
+    int NAEB = file_data.NAEB;
+
+    std::map<std::string,AFQMCInfo> InfoMap;
+    InfoMap.insert ( std::pair<std::string,AFQMCInfo>("info0",AFQMCInfo{"info0",NMO,NAEA,NAEB}) );
+    HamiltonianFactory HamFac(InfoMap);
+    const char *ham_xml_block =
+"<Hamiltonian name=\"ham0\" info=\"info0\"> \
+    <parameter name=\"filetype\">hdf5</parameter> \
+    <parameter name=\"filename\">./afqmc.h5</parameter> \
+    <parameter name=\"cutoff_decomposition\">1e-5</parameter> \
+  </Hamiltonian> \
+";
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(ham_xml_block);
+    REQUIRE(okay);
+    std::string ham_name("ham0");
+    HamFac.push(ham_name,doc.getRoot());
+    Hamiltonian& ham = HamFac.getHamiltonian(gTG,ham_name);
+
+
+    auto TG = TaskGroup_(gTG,std::string("WfnTG"),1,gTG.getTotalCores());
+    int nwalk = 11; // choose prime number to force non-trivial splits in shared routines
+    RandomGenerator_t rng;
+
+const char *wfn_xml_block =
+"<Wavefunction name=\"wfn0\" type=\"NOMSD\" info=\"info0\"> \
+  <parameter name=\"filetype\">ascii</parameter> \
+  <parameter name=\"filename\">./wfn.dat</parameter> \
+  <parameter name=\"cutoff\">1e-6</parameter> \
+</Wavefunction> \
+";
+    WALKER_TYPES walker_type = COLLINEAR;
+    Libxml2Document doc2;
+    okay = doc2.parseFromString(wfn_xml_block);
+    REQUIRE(okay);
+    std::string wfn_name("wfn0");
+    WavefunctionFactory WfnFac(InfoMap);
+    WfnFac.push(wfn_name,doc2.getRoot());
+    Wavefunction& wfn = WfnFac.getWavefunction(TG,TG,wfn_name,walker_type,&ham,1e-6,nwalk);
+
+const char *wlk_xml_block =
+"<WalkerSet name=\"wset0\">  \
+  <parameter name=\"walker_type\">collinear</parameter>  \
+  <parameter name=\"back_propagation_steps\">10</parameter>  \
+</WalkerSet> \
+";
+    Libxml2Document doc3;
+    okay = doc3.parseFromString(wlk_xml_block);
+    REQUIRE(okay);
+
+
+    WalkerSet wset(TG,doc3.getRoot(),InfoMap["info0"],&rng);
+    auto initial_guess = WfnFac.getInitialGuess(wfn_name);
+    REQUIRE(initial_guess.shape()[0]==2);
+    REQUIRE(initial_guess.shape()[1]==NMO);
+    REQUIRE(initial_guess.shape()[2]==NAEA);
+    wset.resize(nwalk,initial_guess[0],initial_guess[0]);
+    using EstimPtr = std::shared_ptr<EstimatorBase>;
+    std::vector<EstimPtr> estimators;
+    const char *est_xml_block =
+"<Estimator name=\"back_propagation\"> \
+      <parameter name=\"block_size\">2</parameter> \
+  </Estimator> \
+";
+    Libxml2Document doc4;
+    okay = doc4.parseFromString(est_xml_block);
+    REQUIRE(okay);
+    bool impsamp = true;
+    Wavefunction* wfn0 = &wfn;
+    estimators.emplace_back(static_cast<EstimPtr>(std::make_shared<BackPropagatedEstimator>(TG,InfoMap["info0"],"none",doc4.getRoot(),
+                                                                                            walker_type,*wfn0,impsamp)));
+    hdf_archive dump;
+    std::ofstream out;
+    dump.create("estimates.h5");
+    dump.open("estimates.h5");
+    for (int iblock = 0; iblock < 10; iblock++) {
+      estimators[0]->accumulate_block(wset);
+      estimators[0]->print(out,dump,wset);
+    }
+    dump.close();
+    std::vector<ComplexType> read_data(2*NMO*NMO);
+    hdf_archive reader;
+    // Read from a particular block.
+    if(!reader.open("estimates.h5",H5F_ACC_RDONLY)) {
+      app_error()<<" Error opening estimates.h5. \n";
+      APP_ABORT("");
+    }
+    reader.read(read_data, "BackPropagated/one_rdm_4");
+    reader.close();
+    boost::multi::array_ref<ComplexType,3> BPRDM(read_data.data(), {2,NMO,NMO});
+    ComplexType trace = ComplexType(0.0);
+    for(int i = 0; i < NMO; i++) trace += BPRDM[0][i][i] + BPRDM[1][i][i];
+    REQUIRE(trace.real()==(NAEA+NAEB));
+    // Test the RDM. Since no back propagation has been performed the RDM should be
+    // identical to the mixed estimate.
+    boost::multi::array<ComplexType,3> OrbMat;
+    readWfn(std::string("./wfn.dat"),OrbMat,NMO,NAEA,NAEB);
+    SlaterDetOperations<ComplexType> SDet(NMO,NAEA);
+    boost::multi::array<ComplexType,2> G;
+    G.reextent({NMO,NMO});
+    auto Ovlp = SDet.MixedDensityMatrix_noHerm(OrbMat[0],OrbMat[0],G);
+    verify_approx(G, BPRDM[0]);
+    Ovlp = SDet.MixedDensityMatrix_noHerm(OrbMat[1],OrbMat[1],G);
+    verify_approx(G, BPRDM[1]);
+
+  }
+}
+
+}

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -885,13 +885,21 @@ std::cout<<" E nomsd: " <<nd <<" "
     const int ndet = ci.size();
     bool compact = false;
     auto Gsize = size_t(dm_size(not compact));
-    if(localGbuff.size() < Gsize)
+    if(localGbuff.size() < Gsize) {
+      // Factor of two is for accumulation.
       localGbuff.reextent(extensions<1u>{2*Gsize});
+    }
     auto wlk_dims = wset.walker_dims();
-    if((T2ForBP.shape()[0] != wlk_dims.first || T2ForBP.shape()[1] != wlk_dims.second)) {
-      T2ForBP.reextent({wlk_dims.second,wlk_dims.first});
-      T1ForBP.reextent({NAEA,wlk_dims.first});
-      T3ForBP.reextent({wlk_dims.first,wlk_dims.second});
+    // Transposed temporaries for back propagation.
+    int max_nel = std::max(NAEA,NAEB);
+    if((T1ForBP.shape()[0] != max_nel || T1ForBP.shape()[1] != wlk_dims.first)) {
+      T1ForBP.reextent({max_nel,wlk_dims.first});
+    }
+    if((T2ForBP.shape()[0] != wlk_dims.first || T2ForBP.shape()[1] != max_nel)) {
+      T2ForBP.reextent({wlk_dims.first,max_nel});
+    }
+    if((T3ForBP.shape()[0] != max_nel || T3ForBP.shape()[1] != wlk_dims.first)) {
+      T3ForBP.reextent({max_nel,wlk_dims.first});
     }
     if(walker_type != COLLINEAR) {
       auto Gdims = dm_dims(not compact,Alpha);
@@ -920,10 +928,9 @@ std::cout<<" E nomsd: " <<nd <<" "
           factor = ComplexType(1.0,0.0);
         }
         ComplexType wfac = wset[iw].weight() * factor;
-        ComplexType trace = ComplexType(0.0,0.0);
         for(int id=0; id<ndet; id++) {
           // We construct PsiBP^{\dagger}
-          CMatrix_ref PsiBP = CMatrix_ref(T2ForBP.data(), {NAEA,NMO});
+          CMatrix_ref PsiBP = CMatrix_ref(T3ForBP.data(), {NAEA,NMO});
           ComplexType detR = BackPropagateOrbMat(OrbMats[id], wset[iw], PsiBP);
           // Construct RDM with Slater Matrix from beginning of path.
           ComplexType ov = SDetOp.MixedDensityMatrix(PsiBP,
@@ -933,7 +940,6 @@ std::cout<<" E nomsd: " <<nd <<" "
             ov *= ov;
             detR *= detR;
           }
-          for(int i = 0; i < G2D_.shape()[0]; i++) trace += G2D_[i][i];
           // By construction detR is real (so no complex conjugation needed).
           ov *= detR * std::conj(ci[id]);
           overlap += ov;
@@ -970,6 +976,8 @@ std::cout<<" E nomsd: " <<nd <<" "
       for(int iw=0; iw<nwalk; iw++) {
         if( iw%TG.TG_local().size() != TG.TG_local().rank() ) continue;
         if( std::abs(wset[iw].weight()) < 1e-10 ) continue;
+        std::fill(GA21D_.begin(), GA21D_.end(), ComplexType(0.0));
+        std::fill(GB21D_.begin(), GB21D_.end(), ComplexType(0.0));
         ComplexType factor;
         if(path_restoration) {
           factor = wset[iw].BPWeightFactor();
@@ -981,15 +989,16 @@ std::cout<<" E nomsd: " <<nd <<" "
         ComplexType wfac = wset[iw].weight() * factor;
         ComplexType overlap = ComplexType(0.0,0.0);
         for(int id=0; id<ndet; id++) {
-          CMatrix_ref PsiBPAlpha = CMatrix_ref(T2ForBP.data(), {NAEA,NMO});
+          CMatrix_ref PsiBPAlpha = CMatrix_ref(T3ForBP.data(), {NAEA,NMO});
           ComplexType detR = BackPropagateOrbMat(OrbMats[2*id], wset[iw], PsiBPAlpha);
           ComplexType ov_ = SDetOp.MixedDensityMatrix(PsiBPAlpha,wset[iw].SlaterMatrixN(Alpha),
                                                       GA2D_,compact);
-          CMatrix_ref PsiBPBeta = CMatrix_ref(T2ForBP.data()+NMO*NAEA, {NAEB,NMO});
+          CMatrix_ref PsiBPBeta = CMatrix_ref(T3ForBP.data(), {NAEB,NMO});
           detR *= BackPropagateOrbMat(OrbMats[2*id+1], wset[iw], PsiBPBeta);
           ov_ *= SDetOp.MixedDensityMatrix(PsiBPBeta,wset[iw].SlaterMatrix(Beta),
                                            GB2D_,compact);
           ov_ *= std::conj(ci[id]);
+          overlap += ov_;
           ma::axpy(ov_,GA1D_,GA21D_);
           ma::axpy(ov_,GB1D_,GB21D_);
         }
@@ -997,7 +1006,7 @@ std::cout<<" E nomsd: " <<nd <<" "
         if(free_projection) {
           ov_denom = wfac;
           denom[0] += wfac*overlap;
-        } else { 
+        } else {
           ov_denom = wfac/overlap;
           denom[0] += wfac;
         }
@@ -1005,10 +1014,10 @@ std::cout<<" E nomsd: " <<nd <<" "
         ma::axpy(ov_denom, GB21D_, GB1D);
       }
     }
-    // Average over walker's
+    // Average over walkers
     TG.Global().all_reduce_in_place_n(denom.origin(),1,std::plus<>());
     TG.Global().all_reduce_in_place_n(G.origin(),Gsize,std::plus<>());
-    auto denominator= ComplexType(1.0,0.0)/denom[0];
+    auto denominator = ComplexType(1.0,0.0)/denom[0];
     boost::multi::array_ref<ComplexType,1> GFull(G.origin(), extensions<1u>{Gsize});
     if(!free_projection) {
       ma::scal(denominator,GFull);
@@ -1229,17 +1238,19 @@ std::cout<<" E nomsd: " <<nd <<" "
     const int nbp = walker.NumBackProp();
     int ip = nbp - 1;
     boost::multi::array_ref<const ComplexType, 2> B = walker.BMatrix(ip);
-    ma::product(OrbMat, B, T1ForBP);
+    CMatrix_ref T1 = CMatrix_ref(T1ForBP.data(), {PsiBP.shape()[0],PsiBP.shape()[1]});
+    CMatrix_ref T2 = CMatrix_ref(T2ForBP.data(), {PsiBP.shape()[1],PsiBP.shape()[0]});
+    ma::product(OrbMat, B, T1);
     for (int i = 0; i < nbp-1; i++) {
       ip -= 1;
       boost::multi::array_ref<const ComplexType, 2> B = walker.BMatrix(ip);
-      ma::product(T1ForBP, B, PsiBP);
+      ma::product(T1, B, PsiBP);
       if ((i != 0) && (i%10 == 0)) {
-        ma::transpose(PsiBP, T3ForBP);
-        detR *= SDetOp.Orthogonalize(T3ForBP);
-        ma::transpose(T3ForBP, PsiBP);
+        ma::transpose(PsiBP, T2);
+        detR *= SDetOp.Orthogonalize(T2);
+        ma::transpose(T2, PsiBP);
       }
-      T1ForBP = PsiBP;
+      T1 = PsiBP;
     }
     return detR/1e6;
   }

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -936,21 +936,18 @@ std::cout<<" E nomsd: " <<nd <<" "
           for(int i = 0; i < G2D_.shape()[0]; i++) trace += G2D_[i][i];
           // By construction detR is real (so no complex conjugation needed).
           ov *= detR * std::conj(ci[id]);
-          //std::cout << G2D_[0][0] << " " << ov << " " << wfac << std::endl;
           overlap += ov;
           ma::axpy(ov,G1D_,G21D_);
         }
-        //std::cout << "TRACE: " << trace << " " << std::endl;
         ComplexType ov_denom;
         if(free_projection) {
           ov_denom = wfac;
           denom[0] += wfac*overlap;
-        } else { 
+        } else {
           ov_denom = wfac/overlap;
           denom[0] += wfac;
         }
         ma::axpy(ov_denom, G21D_, G1D);
-        //std::cout << G1D[0] << " " << denom[0] << std::endl;
       }
     } else {
       auto GAdims = dm_dims(not compact,Alpha);


### PR DESCRIPTION
Prints back propagated RDMs to file with a controllable blocking parameter to reduce output. I also added a unit test. In the process of writing the test I discovered a bug for UHF trial wavefunctions, which is also now fixed.