### PR TITLE
Fix the residual from getSplineBound.

### DIFF
--- a/src/spline2/MultiBsplineData.hpp
+++ b/src/spline2/MultiBsplineData.hpp
@@ -31,9 +31,24 @@ namespace spline2
 template<typename T, typename TRESIDUAL>
 inline void getSplineBound(T x, TRESIDUAL& dx, int& ind, int ng)
 {
-  T ipart;
-  dx=std::modf(x,&ipart);
-  ind = std::min(std::max(int(0),static_cast<int>(ipart)),ng);
+  // lower bound
+  if (x < 0)
+  {
+    ind = 0;
+    dx = T(0);
+  }
+  else
+  {
+    T ipart;
+    dx=std::modf(x,&ipart);
+    ind = static_cast<int>(ipart);
+    // upper bound
+    if (ind > ng)
+    {
+      ind = ng;
+      dx = T(1) - std::numeric_limits<T>::epsilon();
+    }
+  }
 }
 
 /** class for cublic spline parameters

--- a/src/spline2/tests/test_multi_spline.cpp
+++ b/src/spline2/tests/test_multi_spline.cpp
@@ -34,13 +34,13 @@ void test_spline_bounds()
   // check clamping to a maximum index value
   x = 11.5;
   spline2::getSplineBound(x, dx, ind, ng);
-  REQUIRE(dx == Approx(0.5));
+  REQUIRE(dx == Approx(1.0));
   REQUIRE(ind == 10);
 
   // check clamping to a zero index value
   x = -1.3;
   spline2::getSplineBound(x, dx, ind, ng);
-  REQUIRE(dx == Approx(-0.3));
+  REQUIRE(dx == Approx(0.0));
   REQUIRE(ind == 0);
 
 }


### PR DESCRIPTION
Related to issue #1369 but in a different place.
spline2 is only intended for PBC or anti-PBC.