### PR TITLE
Fix the no-MPI CUDA compilation.

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetCuda.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetCuda.cpp
@@ -700,6 +700,7 @@ EinsplineSetExtended<T>::get_split_spline_pointers()
 {
   split_splines=(gpu::device_group_size>1);
   int size = OHMMS::Controller->size(); // how many MPI ranks
+#ifdef HAVE_MPI
   if ((size>1) && split_splines)
   {
     app_log() << "Gathering einspline GPU memory pointers from all ranks.\n";
@@ -753,6 +754,7 @@ EinsplineSetExtended<T>::get_split_spline_pointers()
     std::cerr << "\n";
 #endif
   }
+#endif
 }
 
 template<typename T> void


### PR DESCRIPTION
The code region using MPI appears to be dynamically executed only if there is more than one rank.  Using HAVE_MPI to ifdef it out should be safe.