### PR TITLE
Remove cubic spline state

### DIFF
--- a/src/Numerics/OneDimCubicSpline.h
+++ b/src/Numerics/OneDimCubicSpline.h
@@ -259,7 +259,7 @@ public:
 
     value_type dist;
     int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
-    value_type dL = m_grid->getGridSpacing(Loc);
+    value_type dL = m_grid->dr(Loc);
     CubicSplineEvaluator<value_type> eval(dist, dL);
     return eval.cubicInterpolate(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1]);
   }
@@ -289,7 +289,7 @@ public:
       }
     value_type dist;
     int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
-    value_type dL = m_grid->getGridSpacing(Loc);
+    value_type dL = m_grid->dr(Loc);
     CubicSplineEvaluator<value_type> eval(dist, dL);
     return eval.cubicInterpolateSecondDeriv(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
   }
@@ -323,7 +323,7 @@ public:
 
     value_type dist;
     int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
-    value_type dL = m_grid->getGridSpacing(Loc);
+    value_type dL = m_grid->dr(Loc);
     CubicSplineEvaluator<value_type> eval(dist, dL);
     return eval.cubicInterpolateSecondDeriv(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
   }

--- a/src/Numerics/OneDimCubicSpline.h
+++ b/src/Numerics/OneDimCubicSpline.h
@@ -110,6 +110,49 @@ namespace qmcplusplus
  *
 */
 
+template <class T>
+class CubicSplineEvaluator
+{
+private:
+  T dist;
+  T dL;
+  T dLinv;
+  T cL;
+  T cR;
+  T h6;
+  T q1;
+  T q2;
+  T dq1;
+  T dq2;
+
+public:
+  CubicSplineEvaluator(T dist, T dL)
+  {
+    dLinv = 1.0/dL;
+    cL = dist*dLinv;
+    cR = (dL - dist)*dLinv;
+    h6 = dL/6.0;
+    q1 = cR*(cR*cR-1.0)*h6*dL;
+    q2 = cL*(cL*cL-1.0)*h6*dL;
+    dq1 = h6*(1.0-3.0*cR*cR);
+    dq2 = h6*(3.0*cL*cL-1.0);
+  }
+
+  template <typename T1>
+  inline T1 cubicInterpolate(T1 y1, T1 y2, T1 d2y1, T1 d2y2)
+  {
+    return cR*y1+cL*y2+q1*d2y1+q2*d2y2;
+  }
+
+  template <typename T1>
+  inline T1 cubicInterpolateSecondDeriv(T1 y1, T1 y2, T1 d2y1, T1 d2y2, T1& du, T1& d2u) const
+  {
+    du = dLinv*(y2-y1)+dq1*d2y1+dq2*d2y2;
+    d2u = cR*d2y1+cL*d2y2;
+    return cR*y1+cL*y2+q1*d2y1+q2*d2y2;
+  }
+};
+
 template <class Td,
          class Tg = Td,
          class CTd= Vector<Td>,
@@ -202,7 +245,7 @@ public:
   //  m_grid->locate(r);
   //}
 
-  inline value_type splint(point_type r)
+  inline value_type splint(point_type r) const
   {
     if(r<r_min)
     {
@@ -213,12 +256,12 @@ public:
       {
         return ConstValue;
       }
-    if(GridManager)
-    {
-      m_grid->updateSecondOrder(r,false);
-    }
-    int Loc = m_grid->locate(r);
-    return m_grid->cubicInterpolateSecond(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1]);
+
+    value_type dist;
+    int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
+    value_type dL = m_grid->getGridSpacing(Loc);
+    CubicSplineEvaluator<value_type> eval(dist, dL);
+    return eval.cubicInterpolate(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1]);
   }
 
   /** Interpolation to evaluate the function and itsderivatives.
@@ -228,7 +271,7 @@ public:
    *@return the value of the function
   */
   inline value_type
-  splint(point_type r, value_type& du, value_type& d2u)
+  splint(point_type r, value_type& du, value_type& d2u) const
   {
     if(r<r_min)
       //linear-extrapolation returns y[0]+y'*(r-r[0])
@@ -244,13 +287,11 @@ public:
         d2u = 0.0;
         return ConstValue;
       }
-    if(GridManager)
-    {
-      m_grid->updateSecondOrder(r,true);
-    }
-    int Loc = m_grid->locate(r);
-    return
-      m_grid->cubicInterpolateSecond(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
+    value_type dist;
+    int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
+    value_type dL = m_grid->getGridSpacing(Loc);
+    CubicSplineEvaluator<value_type> eval(dist, dL);
+    return eval.cubicInterpolateSecondDeriv(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
   }
 
   /** Interpolation to evaluate the function and itsderivatives.
@@ -261,7 +302,7 @@ public:
    *@return the value of the function
   */
   inline value_type
-  splint(point_type r, value_type& du, value_type& d2u, value_type& d3u)
+  splint(point_type r, value_type& du, value_type& d2u, value_type& d3u) const
   {
     if(r<r_min)
       //linear-extrapolation returns y[0]+y'*(r-r[0])
@@ -277,15 +318,14 @@ public:
         d2u = 0.0;
         return ConstValue;
       }
-    if(GridManager)
-    {
-      m_grid->updateSecondOrder(r,true);
-    }
-    int Loc = m_grid->locate(r);
     // no third derivatives yet, only for templating purposes
     d3u = 0.0;
-    return
-      m_grid->cubicInterpolateSecond(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
+
+    value_type dist;
+    int Loc = m_grid->getIndexAndDistanceFromGridPoint(r, dist);
+    value_type dL = m_grid->getGridSpacing(Loc);
+    CubicSplineEvaluator<value_type> eval(dist, dL);
+    return eval.cubicInterpolateSecondDeriv(m_Y[Loc],m_Y[Loc+1],m_Y2[Loc],m_Y2[Loc+1],du,d2u);
   }
   /** Evaluate the 2nd derivative on the grid points
    *\param imin the index of the first valid data point

--- a/src/Numerics/OneDimCubicSpline.h
+++ b/src/Numerics/OneDimCubicSpline.h
@@ -139,7 +139,7 @@ public:
   }
 
   template <typename T1>
-  inline T1 cubicInterpolate(T1 y1, T1 y2, T1 d2y1, T1 d2y2)
+  inline T1 cubicInterpolate(T1 y1, T1 y2, T1 d2y1, T1 d2y2) const
   {
     return cR*y1+cL*y2+q1*d2y1+q2*d2y2;
   }

--- a/src/Numerics/OneDimGridBase.h
+++ b/src/Numerics/OneDimGridBase.h
@@ -153,11 +153,6 @@ struct OneDimGridBase
     return Loc;
   }
 
-  inline T getGridSpacing(int Loc) const
-  {
-    return X[Loc+1] - X[Loc];
-  }
-
   /** evaluate the index of r
    * @param r current position
    *

--- a/src/Numerics/OneDimQuinticSpline.h
+++ b/src/Numerics/OneDimQuinticSpline.h
@@ -148,12 +148,29 @@ public:
     F           = a.F;
   }
 
-  inline Td quinticInterpolate(Td cL, Td a, Td b, Td c, Td d, Td e, Td f)
+private:
+  inline Td quinticInterpolate(Td cL, Td a, Td b, Td c, Td d, Td e, Td f) const
   {
     return a+cL*(b+cL*(c+cL*(d+cL*(e+cL*f))));
   }
 
-  inline value_type splint(point_type r)
+  inline Td quinticInterpolateSecondDeriv(Td cL, Td a, Td b, Td c, Td d, Td e, Td f, Td &du, Td &d2u) const
+  {
+    du = b+cL*(2.0*c+cL*(3.0*d+cL*(4.0*e+cL*f*5.0)));
+    d2u = 2.0*c+cL*(6.0*d+cL*(12.0*e+cL*f*20.0));
+    return a+cL*(b+cL*(c+cL*(d+cL*(e+cL*f))));
+  }
+
+  inline Td quinticInterpolateThirdDeriv(Td cL, Td a, Td b, Td c, Td d, Td e, Td f, Td &du, Td &d2u, Td &d3u) const
+  {
+    du = b+cL*(2.0*c+cL*(3.0*d+cL*(4.0*e+cL*f*5.0)));
+    d2u = 2.0*c+cL*(6.0*d+cL*(12.0*e+cL*f*20.0));
+    d3u = 6.0*d+cL*(24.0*e+cL*f*60.0);
+    return a+cL*(b+cL*(c+cL*(d+cL*(e+cL*f))));
+  }
+
+public:
+  inline value_type splint(point_type r) const
   {
     if(r<r_min)
     {
@@ -169,16 +186,9 @@ public:
     return quinticInterpolate(cL, m_Y[Loc],B[Loc],m_Y2[Loc],D[Loc],E[Loc],F[Loc]);
   }
 
-  inline Td quinticInterpolateSecondDeriv(Td cL, Td a, Td b, Td c, Td d, Td e, Td f, Td &du, Td &d2u)
-  {
-    du = b+cL*(2.0*c+cL*(3.0*d+cL*(4.0*e+cL*f*5.0)));
-    d2u = 2.0*c+cL*(6.0*d+cL*(12.0*e+cL*f*20.0));
-    return a+cL*(b+cL*(c+cL*(d+cL*(e+cL*f))));
-  }
-
 
   inline value_type
-  splint(point_type r, value_type& du, value_type& d2u)
+  splint(point_type r, value_type& du, value_type& d2u) const
   {
     if(r<r_min)
     {
@@ -194,17 +204,8 @@ public:
     return quinticInterpolateSecondDeriv(cL, m_Y[Loc],B[Loc],m_Y2[Loc],D[Loc],E[Loc],F[Loc],du,d2u);
   }
 
-  inline Td quinticInterpolateThirdDeriv(Td cL, Td a, Td b, Td c, Td d, Td e, Td f, Td &du, Td &d2u, Td &d3u)
-  {
-    du = b+cL*(2.0*c+cL*(3.0*d+cL*(4.0*e+cL*f*5.0)));
-    d2u = 2.0*c+cL*(6.0*d+cL*(12.0*e+cL*f*20.0));
-    d3u = 6.0*d+cL*(24.0*e+cL*f*60.0);
-    return a+cL*(b+cL*(c+cL*(d+cL*(e+cL*f))));
-  }
-
-
   inline value_type
-  splint(point_type r, value_type& du, value_type& d2u, value_type& d3u)
+  splint(point_type r, value_type& du, value_type& d2u, value_type& d3u) const
   {
     if(r<r_min)
     {


### PR DESCRIPTION

The cubic spline state was extracted to a new class, CubicSplineEvaluator.
Ye said the grid manager optimization was not used, so removing it should not cause a performance problem.

All the evaluation routines were made `const` (including those from the quintic splines).
The internal quintic spline routines were made private.

