### PR TITLE
Add Calculation of Pulay Terms to NonLocalECPComponent

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -375,6 +375,192 @@ NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W, int iat, TrialWaveFu
   return pairpot;
 }
 
+NonLocalECPComponent::RealType
+NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W, ParticleSet& ions, int iat, TrialWaveFunction& psi, 
+    int iel, RealType r, const PosType& dr, 
+    PosType & force_iat, ParticleSet::ParticlePos_t & pulay_terms, bool Tmove, std::vector<NonLocalData>& Txy) const
+{
+  constexpr RealType czero(0);
+  constexpr RealType cone(1);
+
+  //Array for P_l[cos(theta)].
+  RealType lpol_[lmax+1];
+  //Array for P'_l[cos(theta)]
+  RealType dlpol_[lmax+1];
+
+  //Array for v_l(r).
+  RealType vrad_[nchannel];
+  //Array for (2l+1)*v'_l(r)/r.
+  RealType dvrad_[nchannel];
+
+  //$\Psi(...q...)/\Psi(...r...)$ for all quadrature points q.
+  std::vector<RealType> psiratio_(nknot);
+  //$\nabla \Psi(...q...)/\Psi(...r...)$ for all quadrature points q.
+  //  $\nabla$ is w.r.t. the electron coordinates involved in the quadrature.
+  std::vector<PosType> gradpsiratio_(nknot);
+
+  //This stores gradient of v(r):
+  std::vector<PosType> vgrad_(nchannel);  
+  //This stores the gradient of the cos(theta) term in force expression.
+  std::vector<PosType> cosgrad_(nknot);
+  //This stores grad psi/psi - dot(u,grad psi)
+  std::vector<PosType> wfngrad_(nknot);
+
+  //^^^ "Why not GradType?" you ask.  Because GradType can be complex.
+  PosType deltaV[nknot];
+
+  GradType gradtmp_(0);
+  PosType realgradtmp_(0);
+
+  //Pseudopotential derivative w.r.t. ions can be split up into 3 contributions:
+  // term coming from the gradient of the radial potential
+  PosType gradpotterm_(0);
+  // term coming from gradient of legendre polynomial
+  PosType gradlpolyterm_(0);
+  // term coming from dependence of quadrature grid on ion position.
+  PosType gradwfnterm_(0);
+
+  if(VP)
+  {
+    APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
+    // Compute ratios with VP
+    ParticleSet::ParticlePos_t VPos(nknot);
+    for (int j=0; j<nknot; j++)
+    {
+      deltaV[j]=r*rrotsgrid_m[j]-dr;
+      VPos[j]=deltaV[j]+W.R[iel];
+    }
+    VP->makeMoves(iel,VPos,true,iat);
+    psi.evaluateRatios(*VP,psiratio_);
+    for (int j=0; j<nknot; j++)
+      psiratio_[j]*=sgridweight_m[j];
+  }
+  else
+  { 
+    ValueType ratio(0);
+    // Compute ratio of wave functions
+    for (int j=0; j<nknot; j++)
+    {
+      deltaV[j]=r*rrotsgrid_m[j]-dr;
+      W.makeMoveOnSphere(iel,deltaV[j]);
+#if defined(QMC_COMPLEX)
+      gradtmp_=0;
+
+      RealType ratio_mag=psi.ratioGrad(W,iel,gradtmp_);
+      RealType ratio_r=ratio_mag*std::cos(psi.getPhaseDiff());
+      RealType ratio_i=ratio_mag*std::sin(psi.getPhaseDiff());
+
+      ratio=ValueType(ratio_r,ratio_i);
+     
+      //Only need the real part.
+      psiratio_[j]=ratio_r*sgridweight_m[j]; 
+     
+      //QMCPACK spits out $\nabla\Psi(q)/\Psi(q)$.
+      //Multiply times $\Psi(q)/\Psi(r)$ to get 
+      // $\nabla\Psi(q)/\Psi(r)
+      gradtmp_*=ratio;
+
+      //And now we take the real part and save it.  
+      convert(gradtmp_,gradpsiratio_[j]);
+     
+    
+#else
+      //Real nonlocalpp forces seem to differ from those in the complex build.  Since
+      //complex build has been validated against QE, that indicates there's a bug for the real build.
+      
+      APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented for real wavefunctions yet.");
+
+      gradtmp_=0;
+      ratio=psi.ratioGrad(W,iel,gradtmp_);
+      
+      gradtmp_*=ratio;
+      psiratio_[j]=ratio*sgridweight_m[j]; 
+     
+      gradpsiratio_[j]=gradtmp_;
+#endif
+      W.rejectMove(iel);
+      psi.resetPhaseDiff();
+      //psi.rejectMove(iel);
+    }
+  }
+
+  // This is just a temporary variable to dump d2/dr2 into for spline evaluation.
+  RealType secondderiv(0);
+
+  const RealType rinv=cone/r;
+
+  // Compute radial potential and its derivative times (2l+1)
+  for(int ip=0; ip< nchannel; ip++)
+  {
+    //fun fact.  NLPComponent stores v(r) as v(r), and not as r*v(r) like in other places.  
+    vrad_[ip]=nlpp_m[ip]->splint(r,dvrad_[ip],secondderiv)*wgt_angpp_m[ip];
+    vgrad_[ip]=dvrad_[ip]*dr*wgt_angpp_m[ip]*rinv;
+  }
+
+  RealType pairpot=0; 
+  // Compute spherical harmonics on grid
+  for (int j=0;  j<nknot ; j++)
+  {
+    RealType zz=dot(dr,rrotsgrid_m[j])*rinv;
+    PosType uminusrvec=rrotsgrid_m[j]-zz*dr*rinv;
+    
+    cosgrad_[j]=rinv*uminusrvec;
+
+    RealType udotgradpsi=dot(gradpsiratio_[j],rrotsgrid_m[j]);
+    wfngrad_[j]=gradpsiratio_[j] - dr*(udotgradpsi*rinv);
+    wfngrad_[j]*=sgridweight_m[j];
+
+    // Forming the Legendre polynomials
+    //P_0(x)=1; P'_0(x)=0.
+    lpol_[0]=cone;
+    dlpol_[0]=czero;
+
+    RealType lpolprev=czero;
+    RealType dlpolprev=czero;
+
+    for (int l=0 ; l< lmax ; l++)
+    {
+      //Legendre polynomial recursion formula.
+      lpol_[l+1]=Lfactor1[l]*zz*lpol_[l]-l*lpolprev;
+      lpol_[l+1]*=Lfactor2[l];
+       
+      //and for the derivative...
+      dlpol_[l+1]=Lfactor1[l]*(zz*dlpol_[l]+lpol_[l])-l*dlpolprev;
+      dlpol_[l+1]*=Lfactor2[l];
+
+      lpolprev=lpol_[l];
+      dlpolprev=dlpol_[l];
+    }
+
+    RealType lsum=czero;
+   // Now to compute the forces:
+    gradpotterm_  =0;
+    gradlpolyterm_=0;
+    gradwfnterm_  =0;
+    
+    for(int l=0; l<nchannel; l++)
+    {
+      lsum          += vrad_[l] * lpol_[ angpp_m[l] ] * psiratio_[j];
+      gradpotterm_  += vgrad_[l] * lpol_[ angpp_m[l] ] * psiratio_[j];
+      gradlpolyterm_ += vrad_[l] * dlpol_[ angpp_m[l] ] * cosgrad_[j] * psiratio_[j];
+      gradwfnterm_  += vrad_[l] * lpol_[ angpp_m[l] ] * wfngrad_[j]; 
+    }
+    
+    if(Tmove) Txy.push_back(NonLocalData(iel,lsum,deltaV[j]));
+    pairpot+=lsum;
+    force_iat+=  gradpotterm_ + gradlpolyterm_ - gradwfnterm_;
+    
+  }
+
+#if !defined(REMOVE_TRACEMANAGER)
+  if( streaming_particles)
+  {
+    (*Vi_sample)(iat) += .5*pairpot;
+    (*Ve_sample)(iel) += .5*pairpot;
+  }
+#endif
+  return pairpot;
+}
 ///Randomly rotate sgrid_m
 void NonLocalECPComponent::randomize_grid(RandomGenerator_t& myRNG)
 {

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -111,16 +111,58 @@ struct NonLocalECPComponent: public QMCTraits
   void randomize_grid(RandomGenerator_t& myRNG);
   template<typename T> void randomize_grid(std::vector<T> &sphere, RandomGenerator_t& myRNG);
 
+/** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid 
+ *           to total energy from ion "iat" and electron "iel".  
+ *
+ *    @param W electron particle set.
+ *    @param iat index of ion.
+ *    @param Psi trial wave function object
+ *    @param iel index of electron
+ *    @param r the distance between ion iat and electron iel.
+ *    @param dr displacement from ion iat to electron iel.
+ *    @param Tmove flag to compute tmove contributions.
+ *    @param Txy nonlocal move data.
+ *
+ *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+ */     
   RealType evaluateOne(ParticleSet& W, int iat, TrialWaveFunction& Psi, 
       int iel, RealType r, const PosType& dr, bool Tmove, std::vector<NonLocalData>& Txy) const;
 
-  ///Computes the nonlocal PP energy and Hellman-Feynman force contribution coming from
-  /// ion "iat" and electron "iel".  
+/** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid 
+ *           to total energy from ion "iat" and electron "iel". 
+ *
+ *    @param W electron particle set.
+ *    @param iat index of ion.
+ *    @param Psi trial wave function object
+ *    @param iel index of electron
+ *    @param r the distance between ion iat and electron iel.
+ *    @param dr displacement from ion iat to electron iel.
+ *    @param Tmove flag to compute tmove contributions.
+ *    @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
+ *    @param Txy nonlocal move data.
+ *
+ *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+ */     
   RealType evaluateOneWithForces(ParticleSet& W, int iat, TrialWaveFunction& Psi, 
       int iel, RealType r, const PosType& dr, PosType &force_iat, bool Tmove, std::vector<NonLocalData>& Txy) const;
 
-  ///Computes the nonlocal PP energy and Hellman-Feynman and Pulay force contribution coming from
-  /// ion "iat" and electron "iel".  
+/** @brief Evaluate the nonlocal pp energy, Hellman-Feynman force, and "Pulay" force contribution 
+ *          via randomized quadrature grid from ion "iat" and electron "iel". 
+ *
+ *    @param W electron particle set.
+ *    @param ions ion particle set.
+ *    @param iat index of ion.
+ *    @param Psi trial wave function object
+ *    @param iel index of electron
+ *    @param r the distance between ion iat and electron iel.
+ *    @param dr displacement from ion iat to electron iel.
+ *    @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
+ *    @param pulay_terms Nion x 3 object, holding a contribution for each ionic gradient from \Psi_T. 
+ *    @param Tmove flag to compute tmove contributions.
+ *    @param Txy nonlocal move data.
+ *
+ *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+ */     
   RealType evaluateOneWithForces(ParticleSet& W, ParticleSet& ions, int iat, TrialWaveFunction& Psi, 
       int iel, RealType r, const PosType& dr, PosType &force_iat, ParticleSet::ParticlePos_t& pulay_terms, 
       bool Tmove, std::vector<NonLocalData>& Txy) const;

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -119,6 +119,12 @@ struct NonLocalECPComponent: public QMCTraits
   RealType evaluateOneWithForces(ParticleSet& W, int iat, TrialWaveFunction& Psi, 
       int iel, RealType r, const PosType& dr, PosType &force_iat, bool Tmove, std::vector<NonLocalData>& Txy) const;
 
+  ///Computes the nonlocal PP energy and Hellman-Feynman and Pulay force contribution coming from
+  /// ion "iat" and electron "iel".  
+  RealType evaluateOneWithForces(ParticleSet& W, ParticleSet& ions, int iat, TrialWaveFunction& Psi, 
+      int iel, RealType r, const PosType& dr, PosType &force_iat, ParticleSet::ParticlePos_t& pulay_terms, 
+      bool Tmove, std::vector<NonLocalData>& Txy) const;
+
   RealType
   evaluateValueAndDerivatives(ParticleSet& P,
       int iat, TrialWaveFunction& psi,

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -279,10 +279,12 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
   //Forces are only implemented in SOA version, hence the guard.
   double Value2(0.0);
   double Value3(0.0);
-  ParticleSet::ParticlePos_t PulayTerm,HFTerm;
+  ParticleSet::ParticlePos_t PulayTerm,HFTerm,HFTerm2;
   HFTerm.resize(ions.getTotalNum());
+  HFTerm2.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
   HFTerm=0;
+  HFTerm2=0;
   PulayTerm=0;
 
   //Need to set up temporary data for this configuration in trial wavefunction.  Needed for ratios.
@@ -299,6 +301,7 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
           //I know the real version doesn't work yet.  Only test if complex.
           #ifdef QMC_COMPLEX
           Value2 += nlpp->evaluateOneWithForces(elec,iat,psi,jel,dist[iat],RealType(-1)*displ[iat],HFTerm[iat],0,Txy);
+          Value3 += nlpp->evaluateOneWithForces(elec,ions,iat,psi,jel,dist[iat],RealType(-1)*displ[iat],HFTerm2[iat],PulayTerm,0,Txy);
           #endif
       }
     }
@@ -329,6 +332,13 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
   REQUIRE( HFTerm[1][0] == Approx(  0.001068673105 ) );
   REQUIRE( HFTerm[1][1] == Approx(  0.0 ) );
   REQUIRE( HFTerm[1][2] == Approx(  0.0 ) );
+  
+  REQUIRE( HFTerm2[0][0] == Approx( -0.3557369031 ) );
+  REQUIRE( HFTerm2[0][1] == Approx(  0.0 ) );
+  REQUIRE( HFTerm2[0][2] == Approx(  0.0 ) );
+  REQUIRE( HFTerm2[1][0] == Approx(  0.001068673105 ) );
+  REQUIRE( HFTerm2[1][1] == Approx(  0.0 ) );
+  REQUIRE( HFTerm2[1][2] == Approx(  0.0 ) );
   
   REQUIRE( PulayTerm[0][0] == Approx(  0.008300993315 ) );
   REQUIRE( PulayTerm[0][1] == Approx(  0.0 ) );

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -274,6 +274,9 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
 
   const auto myTable = elec.DistTables[myTableIndex];
   
+  //Need to set up temporary data for this configuration in trial wavefunction.  Needed for ratios.
+  double logpsi = psi.evaluateLog(elec);
+  
   double Value1(0.0);
  #ifdef ENABLE_SOA
   //Forces are only implemented in SOA version, hence the guard.
@@ -287,8 +290,6 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
   HFTerm2=0;
   PulayTerm=0;
 
-  //Need to set up temporary data for this configuration in trial wavefunction.  Needed for ratios.
-  double logpsi = psi.evaluateLog(elec);
   for(int jel=0; jel<elec.getTotalNum(); jel++)
   {
     const auto& dist  = myTable->Distances[jel];
@@ -369,7 +370,7 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
       Value1 += nlpp->evaluateOne(elec,iat,psi,iel,r,myTable->dr(nn),0,Txy);
     }
   }
-  REQUIRE( Value1 == Approx(0.9498625845) );
+  REQUIRE( Value1 == Approx(6.9015710211e-02) );
 
 #endif   
 }


### PR DESCRIPTION
This PR adds a function to NonLocalECPComponent to spit out the contributions to the Nonlocal pseudopotential force coming from ionic derivatives of $Psi_T$.  This also adds a unit test of this feature.