### PR TITLE
Add Local Kinetic Energy "Pulay Term" Contribution

### DIFF
--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -20,7 +20,6 @@
 #include "Particle/WalkerSetRef.h"
 #include "QMCHamiltonians/QMCHamiltonianBase.h"
 #include "ParticleBase/ParticleAttribOps.h"
-#include "QMCWaveFunctions/TrialWaveFunction.h"
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -45,11 +45,22 @@ inline T laplacian(const TinyVector<std::complex<T>,D>& g, const std::complex<T>
   return  l.real()+OTCDot<T,T,D>::apply(g,g);
 }
 
+/** Convenience function to compute  \Re( \nabla^2_i \partial \Psi_T/\Psi_T)
+ * @param g OHMMS_DIM dimensional vector for \nabla_i \ln \Psi_T .  
+ * @param l A number, representing \nabla^2_i \ln \Psi_T .
+ * @param gg OHMMS_DIM dimensional vector containing \nabla_i \partial \ln \Psi_T . 
+ * @param gl A number, representing \nabla^2_i \partial \ln \Psi_T
+ * @param ideriv A number, representing \partial \ln \Psi_T
+ *
+ * @return A number corresponding to \Re( \nabla^2_i \partial \Psi_T/\Psi_T)
+ */
+
 template<typename T, unsigned D>
 inline T dlaplacian(const TinyVector<T,D>& g, const T l, const TinyVector<T,D>& gg, const T gl, const T ideriv)
 {
   return gl + l*ideriv + 2.0*dot(g,gg) + dot(g,g)*ideriv;
 }
+
 template<typename T, unsigned D>
 inline T dlaplacian(const TinyVector<std::complex<T>,D>& g, const std::complex<T> l, 
                     const TinyVector<std::complex<T>,D>& gg, const std::complex<T> gl, const std::complex<T> ideriv)
@@ -222,6 +233,23 @@ struct BareKineticEnergy: public QMCHamiltonianBase
     return Value;
   }
 
+  /**@brief Function to compute the value, direct ionic gradient terms, and pulay terms for the local kinetic energy.
+ *  
+ *  This general function represents the QMCHamiltonianBase interface for computing.  For an operator \hat{O}, this
+ *  function will return \frac{\hat{O}\Psi_T}{\Psi_T},  \frac{\partial(\hat{O})\Psi_T}{\Psi_T}, and 
+ *  \frac{\hat{O}\partial\Psi_T}{\Psi_T} - \frac{\hat{O}\Psi_T}{\Psi_T}\frac{\partial \Psi_T}{\Psi_T}.  These are 
+ *  referred to as Value, HF term, and pulay term respectively.
+ *
+ * @param P electron particle set.
+ * @param ions ion particle set
+ * @param psi Trial wave function object.
+ * @param hf_terms 3Nion dimensional object. All direct force terms, or ionic gradient of operator itself.
+ *                 Contribution of this operator is ADDED onto hf_terms.
+ * @param pulay_terms The terms coming from ionic gradients of trial wavefunction.  Contribution of this operator is
+ *                 ADDED onto pulay_terms.
+ * @return Value of kinetic energy operator at electron/ion positions given by P and ions.  The force contributions from
+ *          this operator are added into hf_terms and pulay_terms.
+ */
   inline Return_t evaluateWithIonDerivs(ParticleSet& P, ParticleSet& ions, TrialWaveFunction& psi, 
                                         ParticleSet::ParticlePos_t& hf_terms, ParticleSet::ParticlePos_t & pulay_terms)
   {

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -20,6 +20,7 @@
 #include "Particle/WalkerSetRef.h"
 #include "QMCHamiltonians/QMCHamiltonianBase.h"
 #include "ParticleBase/ParticleAttribOps.h"
+#include "QMCWaveFunctions/TrialWaveFunction.h"
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -23,6 +23,11 @@
 #include "QMCApp/ParticleSetPool.h"
 #include "QMCHamiltonians/BareKineticEnergy.h"
 
+#include "QMCWaveFunctions/TrialWaveFunction.h"
+#include "QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h"
+#include "QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h"
+#include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
+
 
 #include <stdio.h>
 #include <string>
@@ -107,6 +112,171 @@ TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
   elec.G[1][2] = 0.0;
   v = bare_ke.evaluate(elec);
   REQUIRE(v == -0.5);
+}
+
+TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
+{
+  typedef QMCTraits::RealType RealType;
+  typedef QMCTraits::ValueType ValueType;
+  typedef QMCTraits::PosType PosType;
+  
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate *c = OHMMS::Controller;
+ 
+  //Cell definition:
+
+  Uniform3DGridLayout grid;
+  grid.BoxBConds = true; // periodic
+  grid.R.diagonal(20);
+  grid.LR_dim_cutoff=15;
+  grid.reset();
+
+
+  ParticleSet ions;
+  ParticleSet elec;
+
+  ions.setName("ion0");
+  ions.create(2);
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+  ions.R[1][0] = 6.0;
+  ions.R[1][1] = 0.0;
+  ions.R[1][2] = 0.0;
+
+
+  SpeciesSet &ion_species =  ions.getSpeciesSet();
+  int pIdx = ion_species.addSpecies("Na");
+  int pChargeIdx = ion_species.addAttribute("charge");
+  int iatnumber= ion_species.addAttribute("atomic_number");
+  ion_species(pChargeIdx, pIdx) = 1;
+  ion_species(iatnumber,pIdx) = 11;
+  ions.Lattice.copy(grid);
+  ions.createSK();
+
+
+  elec.Lattice.copy(grid);
+  elec.setName("e");
+  elec.create(2);
+  elec.R[0][0] = 2.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+  elec.R[1][0] = 3.0;
+  elec.R[1][1] = 0.0;
+  elec.R[1][2] = 0.0;
+
+
+  SpeciesSet &tspecies =  elec.getSpeciesSet();
+  int upIdx = tspecies.addSpecies("u");
+  int downIdx = tspecies.addSpecies("d");
+  int chargeIdx = tspecies.addAttribute("charge");
+  int massIdx = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(chargeIdx, downIdx) = -1;
+  tspecies(massIdx, upIdx) = 1.0;
+  tspecies(massIdx, downIdx) = 1.0;
+
+  elec.createSK();
+
+  ParticleSetPool ptcl = ParticleSetPool(c);
+
+  ions.resetGroups();
+
+  // The call to resetGroups is needed transfer the SpeciesSet
+  // settings to the ParticleSet
+  elec.resetGroups();
+  
+  int myTableIndex = -1;
+#ifdef ENABLE_SOA
+  myTableIndex = elec.addTable(ions,DT_SOA);
+  ions.addTable(ions,DT_SOA);
+#else
+  myTableIndex = elec.addTable(ions,DT_AOS);
+  ions.addTable(ions,DT_AOS);
+#endif
+
+  ions.update();
+  elec.update();
+
+
+  //Cool.  Now to construct a wavefunction with 1 and 2 body jastrow (no determinant)
+  TrialWaveFunction psi = TrialWaveFunction(c);
+
+  //Add the two body jastrow
+  const char *particles = \
+  "<tmp> \
+  <jastrow name=\"J2\" type=\"Two-Body\" function=\"Bspline\" print=\"yes\">  \
+      <correlation speciesA=\"u\" speciesB=\"d\" rcut=\"10\" size=\"8\"> \
+          <coefficients id=\"ud\" type=\"Array\"> 2.015599059 1.548994099 1.17959447 0.8769687661 0.6245736507 0.4133517767 0.2333851935 0.1035636904</coefficients> \
+        </correlation> \
+  </jastrow> \
+  </tmp> \
+  "; 
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(particles);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  xmlNodePtr jas2 = xmlFirstElementChild(root);
+
+  RadialJastrowBuilder jastrow(elec, psi);
+  bool build_okay = jastrow.put(jas2);
+  REQUIRE(build_okay);
+  // Done with two body jastrow.
+  
+  //Add the one body jastrow.
+  const char *particles2 = \
+  "<tmp> \
+  <jastrow name=\"J1\" type=\"One-Body\" function=\"Bspline\" source=\"ion0\" print=\"yes\"> \
+        <correlation elementType=\"Na\" rcut=\"10\" size=\"10\" cusp=\"0\"> \
+          <coefficients id=\"eNa\" type=\"Array\"> 1.244201343 -1.188935609 -1.840397253 -1.803849126 -1.612058635 -1.35993202 -1.083353212 -0.8066295188 -0.5319252448 -0.3158819772</coefficients> \
+        </correlation> \
+      </jastrow> \
+  </tmp> \
+  ";
+  bool okay3 = doc.parseFromString(particles2);
+  REQUIRE(okay3);
+
+  root = doc.getRoot();
+
+  xmlNodePtr jas1 = xmlFirstElementChild(root);
+
+  RadialJastrowBuilder jastrow1bdy(elec, psi, ions);
+  bool build_okay2 = jastrow1bdy.put(jas1);
+  REQUIRE(build_okay2);
+
+  const char *kexml = \
+"<tmp> \
+</tmp> \
+";
+
+  root = doc.getRoot();
+
+  xmlNodePtr h1 = xmlFirstElementChild(root);
+
+  BareKineticEnergy<double> bare_ke(elec);
+  bare_ke.put(h1);
+  
+  RealType logpsi = psi.evaluateLog(elec);
+
+  RealType keval = bare_ke.evaluate(elec);
+ 
+  //This is validated against an alternate code path (waveefunction tester for local energy). 
+  REQUIRE( keval == Approx( -0.147507745 ) ); 
+
+  #ifdef ENABLE_SOA
+  ParticleSet::ParticlePos_t PulayTerm;
+  PulayTerm.resize(ions.getTotalNum());
+  //These are validated against finite differences (delta=1e-6).
+  REQUIRE( PulayTerm[0][0] == Approx(-0.13166 ) );
+  REQUIRE( PulayTerm[0][1] == Approx( 0.0) );
+  REQUIRE( PulayTerm[0][2] == Approx( 0.0) );
+  REQUIRE( PulayTerm[1][0] == Approx(-0.12145) );
+  REQUIRE( PulayTerm[1][1] == Approx( 0.0) );
+  REQUIRE( PulayTerm[1][2] == Approx( 0.0) );
+
+  #endif
 }
 }
 

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -266,8 +266,13 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   REQUIRE( keval == Approx( -0.147507745 ) ); 
 
   #ifdef ENABLE_SOA
-  ParticleSet::ParticlePos_t PulayTerm;
+  ParticleSet::ParticlePos_t HFTerm, PulayTerm;
+  HFTerm.resize(ions.getTotalNum());
   PulayTerm.resize(ions.getTotalNum());
+ 
+  RealType keval2 = bare_ke.evaluateWithIonDerivs(elec,ions,psi,HFTerm,PulayTerm);
+  
+  REQUIRE( keval2 == Approx( -0.147507745 ) ); 
   //These are validated against finite differences (delta=1e-6).
   REQUIRE( PulayTerm[0][0] == Approx(-0.13166 ) );
   REQUIRE( PulayTerm[0][1] == Approx( 0.0) );


### PR DESCRIPTION
This adds a function for computing the ionic gradient of the local potential energy (BareKineticEnergy).  A unit test is added which tests the value, HF term (there's none), and "Pulay" term.  These reference values are constructed by explicit finite differences of the local kinetic energy in the wave function tester.