### PR TITLE
Enable LCAO in complex build

### DIFF
--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -141,7 +141,7 @@ struct BasisSetBase: public OrbitalSetTraits<T>
  * Used by lcao
  */
 template<typename T>
-struct RealBasisSetBase
+struct SoaBasisSetBase
 {
   typedef T value_type;
   typedef VectorSoaContainer<T,OHMMS_DIM+2> vgl_type;
@@ -153,7 +153,7 @@ struct RealBasisSetBase
     return BasisSetSize;
   }
 
-  virtual RealBasisSetBase<T>* makeClone() const = 0;
+  virtual SoaBasisSetBase<T>* makeClone() const = 0;
   virtual void setBasisSetSize(int nbs)=0;
   virtual void evaluateVGL(const ParticleSet& P, int iat, vgl_type& vgl)=0;
   virtual void evaluateV(const ParticleSet& P, int iat, value_type* restrict vals)=0;

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -80,18 +80,25 @@ IF(OHMMS_DIM MATCHES 3)
     Jastrow/CountingJastrowBuilder.cpp
     )
 
-  IF(NOT QMC_COMPLEX AND NOT ENABLE_SOA)
-    SET(FERMION_SRCS ${FERMION_SRCS}
-      MolecularOrbitals/STOBuilder.cpp
-      MolecularOrbitals/GTOBuilder.cpp
-      MolecularOrbitals/NGOBuilder.cpp
-      )
-  ENDIF(NOT QMC_COMPLEX AND NOT ENABLE_SOA)
-
-  IF(NOT QMC_COMPLEX AND ENABLE_SOA)
-    #lcao is deigned for localized orbitals in bulk and complex
-    SET(FERMION_SRCS ${FERMION_SRCS}  lcao/LCAOrbitalSet.cpp lcao/LCAOrbitalBuilder.cpp lcao/CuspCorrection.cpp lcao/LCAOrbitalSetWithCorrection.cpp)
-  ENDIF(NOT QMC_COMPLEX AND ENABLE_SOA)
+  IF(ENABLE_SOA)
+    SET(FERMION_SRCS ${FERMION_SRCS} lcao/LCAOrbitalSet.cpp lcao/LCAOrbitalBuilder.cpp)
+    IF(NOT QMC_COMPLEX)
+      #lcao cusp correction is not ready for complex
+      SET(FERMION_SRCS ${FERMION_SRCS}
+        lcao/CuspCorrection.cpp
+        lcao/LCAOrbitalSetWithCorrection.cpp
+        lcao/CuspCorrectionConstruction.cpp
+        )
+    ENDIF(NOT QMC_COMPLEX)
+  ELSE(ENABLE_SOA)
+    IF(NOT QMC_COMPLEX)
+      SET(FERMION_SRCS ${FERMION_SRCS}
+        MolecularOrbitals/STOBuilder.cpp
+        MolecularOrbitals/GTOBuilder.cpp
+        MolecularOrbitals/NGOBuilder.cpp
+        )
+    ENDIF(NOT QMC_COMPLEX)
+  ENDIF(ENABLE_SOA)
 
   IF(QMC_CUDA)
     SET(FERMION_SRCS ${FERMION_SRCS}

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -20,10 +20,10 @@
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
 #if OHMMS_DIM == 3
-#if !defined(QMC_COMPLEX)
 #if defined(ENABLE_SOA)
 #include "QMCWaveFunctions/lcao/LCAOrbitalBuilder.h"
 #else
+#if !defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/MolecularOrbitals/NGOBuilder.h"
 #include "QMCWaveFunctions/MolecularOrbitals/GTOBuilder.h"
 #include "QMCWaveFunctions/MolecularOrbitals/STOBuilder.h"
@@ -205,7 +205,6 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
     PRE.error("Einspline is missing for B-spline orbitals",true);
 #endif
   }
-#if !defined(QMC_COMPLEX)
   else if(type == "molecularorbital" || type == "mo")
   {
     ParticleSet* ions=0;
@@ -221,6 +220,9 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
 #if defined(ENABLE_SOA)
     bb=new LCAOrbitalBuilder(targetPtcl, *ions, myComm, rootNode);
 #else
+#if defined(QMC_COMPLEX)
+    PRE.error("Complex molecular orbitals not supported by AoS builds!",true);
+#else
     if(transformOpt == "yes")
     {
       app_log() << "Using MolecularSPOBuilder<NGOBuilder>" << std::endl;
@@ -235,9 +237,9 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
       else if(keyOpt == "STO")
         bb = new MolecularSPOBuilder<STOBuilder>(targetPtcl,*ions,myComm);
     }
+#endif //QMC_COMPLEX
 #endif
   }
-#endif //!QMC_COMPLEX
 #endif  //OHMMS_DIM==3
   PRE.flush();
 

--- a/src/QMCWaveFunctions/lcao/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/lcao/CuspCorrectionConstruction.cpp
@@ -1,0 +1,256 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "QMCWaveFunctions/lcao/CuspCorrectionConstruction.h"
+
+namespace qmcplusplus
+{
+
+  // Modifies orbital set lcwc
+  void applyCuspCorrection(const Matrix<CuspCorrectionParameters> &info, int num_centers,
+                            int orbital_set_size, ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
+                            LCAOrbitalSetWithCorrection& lcwc, const std::string &id)
+  {
+    typedef QMCTraits::RealType RealType;
+
+    LCAOrbitalSet phi = LCAOrbitalSet(lcwc.myBasisSet);
+    phi.setOrbitalSetSize(lcwc.OrbitalSetSize);
+    phi.BasisSetSize = lcwc.BasisSetSize;
+    phi.setIdentity(false);
+
+    LCAOrbitalSet eta = LCAOrbitalSet(lcwc.myBasisSet);
+    eta.setOrbitalSetSize(lcwc.OrbitalSetSize);
+    eta.BasisSetSize = lcwc.BasisSetSize;
+    eta.setIdentity(false);
+
+
+    std::vector<bool> corrCenter(num_centers, "true");
+
+    //What's this grid's lifespan?  Why on the heap?
+    LogGrid<RealType>* radial_grid = new LogGrid<RealType>;
+    radial_grid->set(0.000001, 100.0, 1001);
+
+    
+    
+    Vector<RealType> xgrid;
+    Vector<RealType> rad_orb;
+    xgrid.resize(radial_grid->size());
+    rad_orb.resize(radial_grid->size());
+    for (int ig=0; ig < radial_grid->size(); ig++) {
+      xgrid[ig] = radial_grid->r(ig);
+    }
+
+    for (int ic = 0; ic < num_centers; ic++)
+    {
+      *(eta.C) = *(lcwc.C);
+      *(phi.C) = *(lcwc.C);
+
+      splitPhiEta(ic, corrCenter, phi, eta);
+
+      // loop over MO index - cot must be an array (of len MO size)
+      //   the loop is inside cot - in the multiqunitic
+      SoaCuspCorrection::COT *cot = new CuspCorrectionAtomicBasis<RealType>();
+      cot->initializeRadialSet(*radial_grid, orbital_set_size);
+      //How is this useful? 
+      // cot->ID.resize(orbital_set_size);
+      // for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
+      //   cot->ID[mo_idx] = mo_idx;
+      // }
+
+      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
+        computeRadialPhiBar(&targetPtcl, &sourcePtcl, mo_idx, ic, &phi, xgrid, rad_orb, info(ic, mo_idx));
+        OneDimQuinticSpline<RealType> radial_spline(radial_grid, rad_orb);
+        RealType yprime_i = (rad_orb[1] - rad_orb[0])/(radial_grid->r(1) - radial_grid->r(0));
+        radial_spline.spline(0, yprime_i, rad_orb.size()-1, 0.0);
+        cot->addSpline(mo_idx, radial_spline);
+
+        if (outputManager.isDebugActive()) {
+          // For testing against AoS output
+          // Output phiBar to soaOrbs.downdet.C0.MO0
+          int nElms = 500;
+          RealType dx = info(ic,mo_idx).Rc * 1.2/nElms;
+          Vector<RealType> pos;
+          Vector<RealType> output_orb;
+          pos.resize(nElms);
+          output_orb.resize(nElms);
+          for (int i = 0; i < nElms; i++) {
+            pos[i] = (i+1.0)*dx;
+          }
+          computeRadialPhiBar(&targetPtcl, &sourcePtcl, mo_idx, ic, &phi, pos, output_orb, info(ic, mo_idx));
+          std::string filename = "soaOrbs." + id + ".C" + std::to_string(ic) + ".MO" + std::to_string(mo_idx);
+          std::cout << "Writing to " << filename << std::endl;
+          std::ofstream out(filename.c_str());
+          out << "# r phiBar(r)" << std::endl;
+          for (int i = 0; i < nElms; i++) {
+            out << pos[i] << "  "
+                << output_orb[i]
+                << std::endl;
+          }
+        out.close();
+        }
+      }
+      lcwc.cusp.add(ic, cot);
+    }
+    removeSTypeOrbitals(corrCenter, lcwc);
+  }
+
+  void saveCusp(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info, std::string id)
+  {
+
+
+
+    xmlDocPtr doc = xmlNewDoc((const xmlChar*)"1.0");
+    xmlNodePtr cuspRoot = xmlNewNode(NULL, BAD_CAST "qmcsystem");
+    xmlNodePtr spo = xmlNewNode(NULL,(const xmlChar*)"sposet");
+    xmlNewProp(spo,(const xmlChar*)"name",(const xmlChar*)id.c_str());
+    xmlAddChild(cuspRoot,spo);
+    xmlDocSetRootElement(doc, cuspRoot);
+
+    for (int center_idx = 0; center_idx < num_centers; center_idx++) {
+  
+      xmlNodePtr ctr = xmlNewNode(NULL,(const xmlChar*)"center");
+      std::ostringstream num;
+      num <<center_idx;
+      xmlNewProp(ctr,(const xmlChar*)"num",(const xmlChar*)num.str().c_str());
+
+      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
+          std::ostringstream num0, C, sg, rc, a1,a2,a3,a4,a5;
+          xmlNodePtr orb = xmlNewNode(NULL,(const xmlChar*)"orbital"); 
+          num0<<mo_idx;
+          xmlNewProp(orb,(const xmlChar*)"num",(const xmlChar*)num0.str().c_str());
+
+
+      
+          C.setf(std::ios::scientific, std::ios::floatfield);
+          C.precision(14);
+          C<<info(center_idx, mo_idx).C;
+          sg.setf(std::ios::scientific, std::ios::floatfield);
+          sg.precision(14);
+          sg<<info(center_idx, mo_idx).sg;
+          rc.setf(std::ios::scientific, std::ios::floatfield);
+          rc.precision(14);
+          rc<<info(center_idx, mo_idx).Rc;
+          a1.setf(std::ios::scientific, std::ios::floatfield);
+          a1.precision(14);
+          a1<<info(center_idx, mo_idx).alpha[0];
+          a2.setf(std::ios::scientific, std::ios::floatfield);
+          a2.precision(14);
+          a2<<info(center_idx, mo_idx).alpha[1];
+          a3.setf(std::ios::scientific, std::ios::floatfield);
+          a3.precision(14);
+          a3<<info(center_idx, mo_idx).alpha[2];
+          a4.setf(std::ios::scientific, std::ios::floatfield);
+          a4.precision(14);
+          a4<<info(center_idx, mo_idx).alpha[3];
+          a5.setf(std::ios::scientific, std::ios::floatfield);
+          a5.precision(14);
+          a5<<info(center_idx, mo_idx).alpha[4];
+          xmlNewProp(orb,(const xmlChar*)"C",(const xmlChar*)C.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"sg",(const xmlChar*)sg.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"rc",(const xmlChar*)rc.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"a1",(const xmlChar*)a1.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"a2",(const xmlChar*)a2.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"a3",(const xmlChar*)a3.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"a4",(const xmlChar*)a4.str().c_str());
+          xmlNewProp(orb,(const xmlChar*)"a5",(const xmlChar*)a5.str().c_str());
+          xmlAddChild(ctr,orb);
+       }
+       xmlAddChild(spo,ctr);
+    }
+
+    std::string fname = id+".cuspInfo.xml";
+    app_log() <<"Saving resulting cusp Info xml block to: " <<fname << std::endl;
+    xmlSaveFormatFile(fname.c_str(),doc,1);
+    xmlFreeDoc(doc);
+
+
+  }
+
+  void generateCuspInfo(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info,
+                            ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
+                            LCAOrbitalSetWithCorrection& lcwc,std::string id )
+  {
+    typedef QMCTraits::RealType RealType;
+
+    LCAOrbitalSet phi = LCAOrbitalSet(lcwc.myBasisSet);
+    phi.setOrbitalSetSize(lcwc.OrbitalSetSize);
+    phi.BasisSetSize = lcwc.BasisSetSize;
+    phi.setIdentity(false);
+
+    LCAOrbitalSet eta = LCAOrbitalSet(lcwc.myBasisSet);
+    eta.setOrbitalSetSize(lcwc.OrbitalSetSize);
+    eta.BasisSetSize = lcwc.BasisSetSize;
+    eta.setIdentity(false);
+
+
+    std::vector<bool> corrCenter(num_centers, "true");
+
+    typedef OneDimGridBase<RealType> GridType;
+    int npts = 500;
+
+
+    
+    for (int center_idx = 0; center_idx < num_centers; center_idx++)
+    {
+      std::cout<<"Working on Center "<<center_idx<<std::endl;
+      *(eta.C) = *(lcwc.C);
+      *(phi.C) = *(lcwc.C);
+      
+      splitPhiEta(center_idx, corrCenter, phi, eta);
+      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
+        bool corrO = false;
+        auto& cref(*(phi.C));
+        for(int ip=0; ip<cref.cols(); ip++)
+        {
+          if(std::abs(cref(mo_idx,ip)) > 0)
+          {
+            corrO = true;
+            break;
+          }
+        }
+
+        if (corrO) {
+          std::cout<<"Working on Mo "<<mo_idx<<std::endl;
+          OneMolecularOrbital etaMO(&targetPtcl, &sourcePtcl, &eta);
+          etaMO.changeOrbital(center_idx, mo_idx);
+
+          OneMolecularOrbital phiMO(&targetPtcl, &sourcePtcl, &phi);
+          phiMO.changeOrbital(center_idx, mo_idx);
+  
+          SpeciesSet& tspecies(sourcePtcl.getSpeciesSet());
+          int iz = tspecies.addAttribute("charge");
+          RealType Z = tspecies(iz, sourcePtcl.GroupID[center_idx]);
+
+          RealType Rc_max = 0.2;
+          RealType rc = 0.1;
+
+          RealType dx = rc*1.2/npts;
+          ValueVector_t pos(npts);
+          ValueVector_t ELideal(npts);
+          ValueVector_t ELcurr(npts);
+          for (int i = 0; i < npts; i++) {
+            pos[i] = (i+1.0)*dx;
+          }
+
+          RealType eta0 = etaMO.phi(0.0);
+          ValueVector_t ELorig(npts);
+          CuspCorrection cusp(info(center_idx, mo_idx));
+          minimizeForRc(cusp, phiMO, Z, rc, Rc_max, eta0, pos, ELcurr, ELideal);
+          info(center_idx, mo_idx) = cusp.cparam;
+        }
+      }
+    }
+    saveCusp(orbital_set_size,num_centers,info, id);
+  }
+
+}

--- a/src/QMCWaveFunctions/lcao/CuspCorrectionConstruction.h
+++ b/src/QMCWaveFunctions/lcao/CuspCorrectionConstruction.h
@@ -1,0 +1,37 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_CUSP_CORRECTION_CONSTRUCTOR_H
+#define QMCPLUSPLUS_CUSP_CORRECTION_CONSTRUCTOR_H
+
+#include "QMCWaveFunctions/lcao/LCAOrbitalSet.h"
+#include "QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h"
+#include "QMCWaveFunctions/lcao/SoaCuspCorrectionBasisSet.h"
+#include "QMCWaveFunctions/lcao/CuspCorrection.h"
+
+namespace qmcplusplus
+{
+
+  // Modifies orbital set lcwc
+  void applyCuspCorrection(const Matrix<CuspCorrectionParameters> &info, int num_centers,
+                            int orbital_set_size, ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
+                            LCAOrbitalSetWithCorrection& lcwc, const std::string &id);
+
+  void saveCusp(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info, std::string id);
+  
+  void generateCuspInfo(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info,
+                            ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
+                            LCAOrbitalSetWithCorrection& lcwc,std::string id );
+}
+
+#endif

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -24,12 +24,12 @@
 #include "QMCWaveFunctions/lcao/SoaAtomicBasisSet.h"
 #include "QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h"
 #include "QMCWaveFunctions/lcao/LCAOrbitalSet.h"
-#include "QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h"
 //#include "QMCWaveFunctions/lcao/RadialOrbitalSetBuilder.h"
 #include "QMCWaveFunctions/lcao/AOBasisBuilder.h"
 #include "QMCWaveFunctions/lcao/LCAOrbitalBuilder.h"
 #include "QMCWaveFunctions/lcao/MultiFunctorAdapter.h"
 #if !defined(QMC_COMPLEX)
+#include "QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h"
 #include "QMCWaveFunctions/lcao/CuspCorrectionConstruction.h"
 #endif
 #include "io/hdf_archive.h"

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -40,61 +40,63 @@ namespace qmcplusplus
 {
   /** traits for a localized basis set; used by createBasisSet
    *
+   * T radial function value type
+   * ORBT orbital value type, can be complex
    * ROT {0=numuerica;, 1=gto; 2=sto}
    * SH {0=cartesian, 1=spherical}
    * If too confusing, inroduce enumeration.
    */
-  template<typename T, int ROT, int SH> struct ao_traits{};
+  template<typename T, typename ORBT, int ROT, int SH> struct ao_traits{};
 
   /** specialization for numerical-cartesian AO */
-  template<typename T>
-    struct ao_traits<T,0,0>
+  template<typename T, typename ORBT>
+    struct ao_traits<T,ORBT,0,0>
     {
-      typedef MultiQuinticSpline1D<T>                     radial_type;
-      typedef SoaCartesianTensor<T>                       angular_type;
-      typedef SoaAtomicBasisSet<radial_type,angular_type> ao_type;
-      typedef SoaLocalizedBasisSet<ao_type>               basis_type;
+      using radial_type = MultiQuinticSpline1D<T>;
+      using angular_type = SoaCartesianTensor<T>;
+      using ao_type = SoaAtomicBasisSet<radial_type, angular_type>;
+      using basis_type = SoaLocalizedBasisSet<ao_type, ORBT>;
 
     };
 
   /** specialization for numerical-spherical AO */
-  template<typename T>
-    struct ao_traits<T,0,1>
+  template<typename T, typename ORBT>
+    struct ao_traits<T,ORBT,0,1>
     {
-      typedef MultiQuinticSpline1D<T>                     radial_type;
-      typedef SoaSphericalTensor<T>                       angular_type;
-      typedef SoaAtomicBasisSet<radial_type,angular_type> ao_type;
-      typedef SoaLocalizedBasisSet<ao_type>               basis_type;
+      using radial_type = MultiQuinticSpline1D<T>;
+      using angular_type = SoaSphericalTensor<T>;
+      using ao_type = SoaAtomicBasisSet<radial_type, angular_type>;
+      using basis_type = SoaLocalizedBasisSet<ao_type, ORBT>;
     };
 
   /** specialization for GTO-cartesian AO */
-  template<typename T>
-    struct ao_traits<T,1,0>
+  template<typename T, typename ORBT>
+    struct ao_traits<T,ORBT,1,0>
     {
-      typedef MultiFunctorAdapter<GaussianCombo<T> >           radial_type;
-      typedef SoaCartesianTensor<T>                       angular_type;
-      typedef SoaAtomicBasisSet<radial_type,angular_type> ao_type;
-      typedef SoaLocalizedBasisSet<ao_type>               basis_type;
+      using radial_type = MultiFunctorAdapter<GaussianCombo<T> >;
+      using angular_type = SoaCartesianTensor<T>;
+      using ao_type = SoaAtomicBasisSet<radial_type, angular_type>;
+      using basis_type = SoaLocalizedBasisSet<ao_type, ORBT>;
     };
 
   /** specialization for GTO-cartesian AO */
-  template<typename T>
-    struct ao_traits<T,1,1>
+  template<typename T, typename ORBT>
+    struct ao_traits<T,ORBT,1,1>
     {
-      typedef MultiFunctorAdapter<GaussianCombo<T> >           radial_type;
-      typedef SoaSphericalTensor<T>                       angular_type;
-      typedef SoaAtomicBasisSet<radial_type,angular_type> ao_type;
-      typedef SoaLocalizedBasisSet<ao_type>               basis_type;
+      using radial_type = MultiFunctorAdapter<GaussianCombo<T> >;
+      using angular_type = SoaSphericalTensor<T>;
+      using ao_type = SoaAtomicBasisSet<radial_type, angular_type>;
+      using basis_type = SoaLocalizedBasisSet<ao_type, ORBT>;
     };
 
   /** specialization for STO-spherical AO */
-  template<typename T>
-    struct ao_traits<T,2,1>
+  template<typename T, typename ORBT>
+    struct ao_traits<T,ORBT,2,1>
     {
-      typedef MultiFunctorAdapter<SlaterCombo<T> >             radial_type;
-      typedef SoaSphericalTensor<T>                       angular_type;
-      typedef SoaAtomicBasisSet<radial_type,angular_type> ao_type;
-      typedef SoaLocalizedBasisSet<ao_type>               basis_type;
+      using radial_type = MultiFunctorAdapter<SlaterCombo<T> >;
+      using angular_type = SoaSphericalTensor<T>;
+      using ao_type = SoaAtomicBasisSet<radial_type, angular_type>;
+      using basis_type = SoaLocalizedBasisSet<ao_type, ORBT>;
     };
 
 
@@ -282,8 +284,8 @@ namespace qmcplusplus
 
     ReportEngine PRE(ClassName,"createBasisSet(xmlNodePtr)");
 
-    typedef typename ao_traits<RealType,I,J>::ao_type    ao_type;
-    typedef typename ao_traits<RealType,I,J>::basis_type basis_type;
+    using ao_type = typename ao_traits<RealType,ValueType,I,J>::ao_type;
+    using basis_type = typename ao_traits<RealType,ValueType,I,J>::basis_type;
 
     basis_type* mBasisSet=new basis_type(sourcePtcl,targetPtcl);
 
@@ -338,8 +340,8 @@ namespace qmcplusplus
 
     ReportEngine PRE(ClassName,"createBasisSetH5(xmlNodePtr)");
 
-    typedef typename ao_traits<RealType,I,J>::ao_type    ao_type;
-    typedef typename ao_traits<RealType,I,J>::basis_type basis_type;
+    using ao_type = typename ao_traits<RealType,ValueType,I,J>::ao_type;
+    using basis_type = typename ao_traits<RealType,ValueType,I,J>::basis_type;
 
     basis_type* mBasisSet=new basis_type(sourcePtcl,targetPtcl);
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -23,14 +23,15 @@
 #include "QMCWaveFunctions/lcao/SoaSphericalTensor.h"
 #include "QMCWaveFunctions/lcao/SoaAtomicBasisSet.h"
 #include "QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h"
-#include "QMCWaveFunctions/lcao/SoaCuspCorrectionBasisSet.h"
 #include "QMCWaveFunctions/lcao/LCAOrbitalSet.h"
 #include "QMCWaveFunctions/lcao/LCAOrbitalSetWithCorrection.h"
 //#include "QMCWaveFunctions/lcao/RadialOrbitalSetBuilder.h"
 #include "QMCWaveFunctions/lcao/AOBasisBuilder.h"
 #include "QMCWaveFunctions/lcao/LCAOrbitalBuilder.h"
 #include "QMCWaveFunctions/lcao/MultiFunctorAdapter.h"
-#include "QMCWaveFunctions/lcao/CuspCorrection.h"
+#if !defined(QMC_COMPLEX)
+#include "QMCWaveFunctions/lcao/CuspCorrectionConstruction.h"
+#endif
 #include "io/hdf_archive.h"
 #include "Message/CommOperators.h"
 #include "Utilities/ProgressReportEngine.h"
@@ -415,242 +416,7 @@ namespace qmcplusplus
     return mBasisSet;
   }
 
-  // Modifies orbital set lcwc
-  void applyCuspCorrection(const Matrix<CuspCorrectionParameters> &info, int num_centers,
-                            int orbital_set_size, ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
-                            LCAOrbitalSetWithCorrection& lcwc, const std::string &id)
-  {
-    typedef QMCTraits::RealType RealType;
 
-    LCAOrbitalSet phi = LCAOrbitalSet(lcwc.myBasisSet);
-    phi.setOrbitalSetSize(lcwc.OrbitalSetSize);
-    phi.BasisSetSize = lcwc.BasisSetSize;
-    phi.setIdentity(false);
-
-    LCAOrbitalSet eta = LCAOrbitalSet(lcwc.myBasisSet);
-    eta.setOrbitalSetSize(lcwc.OrbitalSetSize);
-    eta.BasisSetSize = lcwc.BasisSetSize;
-    eta.setIdentity(false);
-
-
-    std::vector<bool> corrCenter(num_centers, "true");
-
-    //What's this grid's lifespan?  Why on the heap?
-    LogGrid<RealType>* radial_grid = new LogGrid<RealType>;
-    radial_grid->set(0.000001, 100.0, 1001);
-
-    
-    
-    Vector<RealType> xgrid;
-    Vector<RealType> rad_orb;
-    xgrid.resize(radial_grid->size());
-    rad_orb.resize(radial_grid->size());
-    for (int ig=0; ig < radial_grid->size(); ig++) {
-      xgrid[ig] = radial_grid->r(ig);
-    }
-
-    for (int ic = 0; ic < num_centers; ic++)
-    {
-      *(eta.C) = *(lcwc.C);
-      *(phi.C) = *(lcwc.C);
-
-      splitPhiEta(ic, corrCenter, phi, eta);
-
-      // loop over MO index - cot must be an array (of len MO size)
-      //   the loop is inside cot - in the multiqunitic
-      SoaCuspCorrection::COT *cot = new CuspCorrectionAtomicBasis<RealType>();
-      cot->initializeRadialSet(*radial_grid, orbital_set_size);
-      //How is this useful? 
-      // cot->ID.resize(orbital_set_size);
-      // for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
-      //   cot->ID[mo_idx] = mo_idx;
-      // }
-
-      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
-        computeRadialPhiBar(&targetPtcl, &sourcePtcl, mo_idx, ic, &phi, xgrid, rad_orb, info(ic, mo_idx));
-        OneDimQuinticSpline<RealType> radial_spline(radial_grid, rad_orb);
-        RealType yprime_i = (rad_orb[1] - rad_orb[0])/(radial_grid->r(1) - radial_grid->r(0));
-        radial_spline.spline(0, yprime_i, rad_orb.size()-1, 0.0);
-        cot->addSpline(mo_idx, radial_spline);
-
-        if (outputManager.isDebugActive()) {
-          // For testing against AoS output
-          // Output phiBar to soaOrbs.downdet.C0.MO0
-          int nElms = 500;
-          RealType dx = info(ic,mo_idx).Rc * 1.2/nElms;
-          Vector<RealType> pos;
-          Vector<RealType> output_orb;
-          pos.resize(nElms);
-          output_orb.resize(nElms);
-          for (int i = 0; i < nElms; i++) {
-            pos[i] = (i+1.0)*dx;
-          }
-          computeRadialPhiBar(&targetPtcl, &sourcePtcl, mo_idx, ic, &phi, pos, output_orb, info(ic, mo_idx));
-          std::string filename = "soaOrbs." + id + ".C" + std::to_string(ic) + ".MO" + std::to_string(mo_idx);
-          std::cout << "Writing to " << filename << std::endl;
-          std::ofstream out(filename.c_str());
-          out << "# r phiBar(r)" << std::endl;
-          for (int i = 0; i < nElms; i++) {
-            out << pos[i] << "  "
-                << output_orb[i]
-                << std::endl;
-          }
-        out.close();
-        }
-      }
-      lcwc.cusp.add(ic, cot);
-    }
-    removeSTypeOrbitals(corrCenter, lcwc);
-  }
-  void saveCusp(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info, std::string id)
-  {
-
-
-
-    xmlDocPtr doc = xmlNewDoc((const xmlChar*)"1.0");
-    xmlNodePtr cuspRoot = xmlNewNode(NULL, BAD_CAST "qmcsystem");
-    xmlNodePtr spo = xmlNewNode(NULL,(const xmlChar*)"sposet");
-    xmlNewProp(spo,(const xmlChar*)"name",(const xmlChar*)id.c_str());
-    xmlAddChild(cuspRoot,spo);
-    xmlDocSetRootElement(doc, cuspRoot);
-
-    for (int center_idx = 0; center_idx < num_centers; center_idx++) {
-  
-      xmlNodePtr ctr = xmlNewNode(NULL,(const xmlChar*)"center");
-      std::ostringstream num;
-      num <<center_idx;
-      xmlNewProp(ctr,(const xmlChar*)"num",(const xmlChar*)num.str().c_str());
-
-      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
-          std::ostringstream num0, C, sg, rc, a1,a2,a3,a4,a5;
-          xmlNodePtr orb = xmlNewNode(NULL,(const xmlChar*)"orbital"); 
-          num0<<mo_idx;
-          xmlNewProp(orb,(const xmlChar*)"num",(const xmlChar*)num0.str().c_str());
-
-
-      
-          C.setf(std::ios::scientific, std::ios::floatfield);
-          C.precision(14);
-          C<<info(center_idx, mo_idx).C;
-          sg.setf(std::ios::scientific, std::ios::floatfield);
-          sg.precision(14);
-          sg<<info(center_idx, mo_idx).sg;
-          rc.setf(std::ios::scientific, std::ios::floatfield);
-          rc.precision(14);
-          rc<<info(center_idx, mo_idx).Rc;
-          a1.setf(std::ios::scientific, std::ios::floatfield);
-          a1.precision(14);
-          a1<<info(center_idx, mo_idx).alpha[0];
-          a2.setf(std::ios::scientific, std::ios::floatfield);
-          a2.precision(14);
-          a2<<info(center_idx, mo_idx).alpha[1];
-          a3.setf(std::ios::scientific, std::ios::floatfield);
-          a3.precision(14);
-          a3<<info(center_idx, mo_idx).alpha[2];
-          a4.setf(std::ios::scientific, std::ios::floatfield);
-          a4.precision(14);
-          a4<<info(center_idx, mo_idx).alpha[3];
-          a5.setf(std::ios::scientific, std::ios::floatfield);
-          a5.precision(14);
-          a5<<info(center_idx, mo_idx).alpha[4];
-          xmlNewProp(orb,(const xmlChar*)"C",(const xmlChar*)C.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"sg",(const xmlChar*)sg.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"rc",(const xmlChar*)rc.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"a1",(const xmlChar*)a1.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"a2",(const xmlChar*)a2.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"a3",(const xmlChar*)a3.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"a4",(const xmlChar*)a4.str().c_str());
-          xmlNewProp(orb,(const xmlChar*)"a5",(const xmlChar*)a5.str().c_str());
-          xmlAddChild(ctr,orb);
-       }
-       xmlAddChild(spo,ctr);
-    }
-
-    std::string fname = id+".cuspInfo.xml";
-    app_log() <<"Saving resulting cusp Info xml block to: " <<fname << std::endl;
-    xmlSaveFormatFile(fname.c_str(),doc,1);
-    xmlFreeDoc(doc);
-
-
-  }
-  void generateCuspInfo(int orbital_set_size, int num_centers, Matrix<CuspCorrectionParameters>& info,
-                            ParticleSet& targetPtcl, ParticleSet& sourcePtcl,
-                            LCAOrbitalSetWithCorrection& lcwc,std::string id )
-  {
-    typedef QMCTraits::RealType RealType;
-
-    LCAOrbitalSet phi = LCAOrbitalSet(lcwc.myBasisSet);
-    phi.setOrbitalSetSize(lcwc.OrbitalSetSize);
-    phi.BasisSetSize = lcwc.BasisSetSize;
-    phi.setIdentity(false);
-
-    LCAOrbitalSet eta = LCAOrbitalSet(lcwc.myBasisSet);
-    eta.setOrbitalSetSize(lcwc.OrbitalSetSize);
-    eta.BasisSetSize = lcwc.BasisSetSize;
-    eta.setIdentity(false);
-
-
-    std::vector<bool> corrCenter(num_centers, "true");
-
-    typedef OneDimGridBase<RealType> GridType;
-    int npts = 500;
-
-
-    
-    for (int center_idx = 0; center_idx < num_centers; center_idx++)
-    {
-      std::cout<<"Working on Center "<<center_idx<<std::endl;
-      *(eta.C) = *(lcwc.C);
-      *(phi.C) = *(lcwc.C);
-      
-      splitPhiEta(center_idx, corrCenter, phi, eta);
-      for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++) {
-        bool corrO = false;
-        auto& cref(*(phi.C));
-        for(int ip=0; ip<cref.cols(); ip++)
-        {
-          if(std::abs(cref(mo_idx,ip)) > 0)
-          {
-            corrO = true;
-            break;
-          }
-        }
-
-        if (corrO) {
-          std::cout<<"Working on Mo "<<mo_idx<<std::endl;
-          OneMolecularOrbital etaMO(&targetPtcl, &sourcePtcl, &eta);
-          etaMO.changeOrbital(center_idx, mo_idx);
-
-          OneMolecularOrbital phiMO(&targetPtcl, &sourcePtcl, &phi);
-          phiMO.changeOrbital(center_idx, mo_idx);
-  
-          SpeciesSet& tspecies(sourcePtcl.getSpeciesSet());
-          int iz = tspecies.addAttribute("charge");
-          RealType Z = tspecies(iz, sourcePtcl.GroupID[center_idx]);
-
-          RealType Rc_max = 0.2;
-          RealType rc = 0.1;
-
-          RealType dx = rc*1.2/npts;
-          ValueVector_t pos(npts);
-          ValueVector_t ELideal(npts);
-          ValueVector_t ELcurr(npts);
-          for (int i = 0; i < npts; i++) {
-            pos[i] = (i+1.0)*dx;
-          }
-
-          RealType eta0 = etaMO.phi(0.0);
-          ValueVector_t ELorig(npts);
-          CuspCorrection cusp(info(center_idx, mo_idx));
-          minimizeForRc(cusp, phiMO, Z, rc, Rc_max, eta0, pos, ELcurr, ELideal);
-          info(center_idx, mo_idx) = cusp.cparam;
-        }
-      }
-    }
-    saveCusp(orbital_set_size,num_centers,info, id);
-  }
-
-  
   SPOSet* LCAOrbitalBuilder::createSPOSetFromXML(xmlNodePtr cur)
   {
     ReportEngine PRE(ClassName,"createSPO(xmlNodePtr)");
@@ -664,15 +430,16 @@ namespace qmcplusplus
 
     if(myBasisSet==nullptr) PRE.error("Missing basisset.",true);
     LCAOrbitalSet *lcos = nullptr;
+#if !defined(QMC_COMPLEX)
     LCAOrbitalSetWithCorrection *lcwc = nullptr;
-    if (doCuspCorrection) {
-      lcwc =new LCAOrbitalSetWithCorrection(sourcePtcl, targetPtcl, myBasisSet);
-      lcos = lcwc;
-    } else {
-      lcos=new LCAOrbitalSet(myBasisSet);
-    }
+    if (doCuspCorrection)
+      lcos = lcwc = new LCAOrbitalSetWithCorrection(sourcePtcl, targetPtcl, myBasisSet);
+    else
+      lcos = new LCAOrbitalSet(myBasisSet);
+#endif
     loadMO(*lcos, cur);
 
+#if !defined(QMC_COMPLEX)
     if (doCuspCorrection) {
       int num_centers = sourcePtcl.getTotalNum();
 
@@ -689,6 +456,7 @@ namespace qmcplusplus
 
       applyCuspCorrection(info, num_centers, orbital_set_size, targetPtcl, sourcePtcl, *lcwc, id);
     }
+#endif
 
     if(optimize=="yes")
     {

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -33,7 +33,7 @@ namespace qmcplusplus
   class LCAOrbitalBuilder: public SPOSetBuilder
   {
     public:
-    typedef RealBasisSetBase<ValueType> BasisSet_t;
+    typedef typename LCAOrbitalSet::basis_type BasisSet_t;
     /** constructor
      * \param els reference to the electrons
      * \param ions reference to the ions

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -33,7 +33,7 @@ namespace qmcplusplus
   class LCAOrbitalBuilder: public SPOSetBuilder
   {
     public:
-    typedef RealBasisSetBase<RealType> BasisSet_t;
+    typedef RealBasisSetBase<ValueType> BasisSet_t;
     /** constructor
      * \param els reference to the electrons
      * \param ions reference to the ions

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -72,7 +72,7 @@ namespace qmcplusplus
     }
     else
     {
-      Vector<basis_type::value_type> vTemp(Temp.data(0),BasisSetSize);
+      Vector<ValueType> vTemp(Temp.data(0),BasisSetSize);
       myBasisSet->evaluateV(P,iat,vTemp.data());
       simd::gemv(*C,Temp.data(0),psi.data());
     }
@@ -91,14 +91,13 @@ namespace qmcplusplus
           zero, C.data(), C.capacity());
     }
 
-  template<typename VGL>
-  inline void LCAOrbitalSet::evaluate_vgl_impl(const VGL& temp,
+  inline void LCAOrbitalSet::evaluate_vgl_impl(const vgl_type& temp,
       ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) const
   {
     std::copy_n(temp.data(0),OrbitalSetSize,psi.data());
-    const auto* restrict gx=temp.data(1);
-    const auto* restrict gy=temp.data(2);
-    const auto* restrict gz=temp.data(3);
+    const ValueType* restrict gx=temp.data(1);
+    const ValueType* restrict gy=temp.data(2);
+    const ValueType* restrict gz=temp.data(3);
     for(size_t j=0; j<OrbitalSetSize; j++)
     {
       dpsi[j][0]=gx[j];
@@ -124,8 +123,8 @@ namespace qmcplusplus
 
   void LCAOrbitalSet::evaluateDetRatios(const VirtualParticleSet& VP, ValueVector_t& psi, const ValueVector_t& psiinv, std::vector<ValueType>& ratios)
   {
-    Vector<basis_type::value_type> vTemp(Temp.data(0),BasisSetSize);
-    Vector<ValueType> invTemp(Tempv.data(0),BasisSetSize);
+    Vector<ValueType> vTemp(Temp.data(0),BasisSetSize);
+    Vector<ValueType> invTemp(Temp.data(1),BasisSetSize);
 
     MatrixOperators::product_Atx(*C, psiinv, invTemp.data());
 
@@ -149,14 +148,13 @@ namespace qmcplusplus
       }
 
   /* implement using gemm algorithm */
-  template<typename VGL>
-  inline void LCAOrbitalSet::evaluate_vgl_impl(const VGL& temp, int i,
+  inline void LCAOrbitalSet::evaluate_vgl_impl(const vgl_type& temp, int i,
       ValueMatrix_t& logdet, GradMatrix_t& dlogdet, ValueMatrix_t& d2logdet) const
   {
     std::copy_n(temp.data(0),OrbitalSetSize,logdet[i]);
-    const auto* restrict gx=temp.data(1);
-    const auto* restrict gy=temp.data(2);
-    const auto* restrict gz=temp.data(3);
+    const ValueType* restrict gx=temp.data(1);
+    const ValueType* restrict gy=temp.data(2);
+    const ValueType* restrict gz=temp.data(3);
     for(size_t j=0; j<OrbitalSetSize; j++)
     {
       dlogdet[i][j][0]=gx[j];

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -68,18 +68,13 @@ namespace qmcplusplus
   {
     if(Identity)
     { //PAY ATTENTION TO COMPLEX
-#if !defined(QMC_COMPLEX)
       myBasisSet->evaluateV(P,iat,psi.data());
-#endif
     }
     else
     {
       Vector<basis_type::value_type> vTemp(Temp.data(0),BasisSetSize);
       myBasisSet->evaluateV(P,iat,vTemp.data());
-#if !defined(QMC_COMPLEX)
-      // Y2A: implement gemv with a complex matrix and a real vector
       simd::gemv(*C,Temp.data(0),psi.data());
-#endif
     }
   }
 
@@ -122,10 +117,7 @@ namespace qmcplusplus
         evaluate_vgl_impl(Temp,psi,dpsi,d2psi);
       else
       {
-#if !defined(QMC_COMPLEX)
-        // Y2A: implement gemm with a real matrix times complex matrix and save to a complex matrix
         Product_ABt(Temp,*C,Tempv);
-#endif
         evaluate_vgl_impl(Tempv,psi,dpsi,d2psi);
       }
     }
@@ -190,10 +182,7 @@ namespace qmcplusplus
       for(size_t i=0, iat=first; iat<last; i++,iat++)
       {
         myBasisSet->evaluateVGL(P,iat,Temp);
-#if !defined(QMC_COMPLEX)
-        // Y2A: implement gemm with a real matrix times complex matrix and save to a complex matrix
         Product_ABt(Temp,*C,Tempv);
-#endif
         evaluate_vgl_impl(Tempv,i,logdet,dlogdet,d2logdet);
       }
     }

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -190,12 +190,10 @@ namespace qmcplusplus
 
   private:
     //helper functions to handl Identity
-    template<typename VGL>
-    void evaluate_vgl_impl(const VGL& temp,
+    void evaluate_vgl_impl(const vgl_type& temp,
         ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) const;
 
-    template<typename VGL>
-    void evaluate_vgl_impl(const VGL& temp, int i,
+    void evaluate_vgl_impl(const vgl_type& temp, int i,
         ValueMatrix_t& logdet, GradMatrix_t& dlogdet, ValueMatrix_t& d2logdet) const;
 
 #if !defined(QMC_COMPLEX)

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -29,7 +29,7 @@ namespace qmcplusplus
   struct LCAOrbitalSet: public SPOSet
   {
   public:
-    typedef RealBasisSetBase<ValueType> basis_type;
+    typedef SoaBasisSetBase<ValueType> basis_type;
     typedef basis_type::vgl_type vgl_type;
 
     ///pointer to the basis set

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -29,7 +29,7 @@ namespace qmcplusplus
   struct LCAOrbitalSet: public SPOSet
   {
   public:
-    typedef RealBasisSetBase<RealType> basis_type;
+    typedef RealBasisSetBase<ValueType> basis_type;
     typedef basis_type::vgl_type vgl_type;
 
     ///pointer to the basis set
@@ -55,7 +55,7 @@ namespace qmcplusplus
     ///Temp(BasisSetSize) : Row index=V,Gx,Gy,Gz,L
     vgl_type Temp; 
     ///Tempv(OrbitalSetSize) Tempv=C*Temp
-    VectorSoaContainer<ValueType,OHMMS_DIM+2> Tempv;
+    vgl_type Tempv;
     //vector that contains active orbital rotation parameter indices 
     std::vector<std::pair<int,int> > m_act_rot_inds;
     /** constructor

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -55,7 +55,7 @@ namespace qmcplusplus
     ///Temp(BasisSetSize) : Row index=V,Gx,Gy,Gz,L
     vgl_type Temp; 
     ///Tempv(OrbitalSetSize) Tempv=C*Temp
-    vgl_type Tempv; 
+    VectorSoaContainer<ValueType,OHMMS_DIM+2> Tempv;
     //vector that contains active orbital rotation parameter indices 
     std::vector<std::pair<int,int> > m_act_rot_inds;
     /** constructor
@@ -121,6 +121,7 @@ namespace qmcplusplus
     ///reset
     void resetParameters(const opt_variables_type& active)
     {
+#if !defined(QMC_COMPLEX)
       if (Optimizable)
       {
         std::vector<RealType> param( m_act_rot_inds.size() );
@@ -132,7 +133,7 @@ namespace qmcplusplus
         apply_rotation(param);
 
       }
-
+#endif
     }
 
     ///reset the target particleset
@@ -187,13 +188,17 @@ namespace qmcplusplus
 
     void evaluateThirdDeriv(const ParticleSet& P, int first, int last , GGGMatrix_t& grad_grad_grad_logdet);
 
+  private:
     //helper functions to handl Identity
-    void evaluate_vgl_impl(const vgl_type& temp,
+    template<typename VGL>
+    void evaluate_vgl_impl(const VGL& temp,
         ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) const;
-    void evaluate_vgl_impl(const vgl_type& temp, int i,
+
+    template<typename VGL>
+    void evaluate_vgl_impl(const VGL& temp, int i,
         ValueMatrix_t& logdet, GradMatrix_t& dlogdet, ValueMatrix_t& d2logdet) const;
 
-  private:
+#if !defined(QMC_COMPLEX)
     //function to perform orbital rotations
     void apply_rotation(const std::vector<RealType>& param);
 
@@ -230,6 +235,7 @@ namespace qmcplusplus
                            const size_t NP1,
                            const size_t NP2,
                            const std::vector< std::vector<int> > & lookup_tbl);
+#endif
 
   };
 }

--- a/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
@@ -152,11 +152,11 @@ namespace qmcplusplus
           RealType* restrict d2phi=tempS.data(2);
 
           //V,Gx,Gy,Gz,L
-          T* restrict psi   =vgl.data(0)+offset; const T* restrict ylm_v=Ylm[0]; //value
-          T* restrict dpsi_x=vgl.data(1)+offset; const T* restrict ylm_x=Ylm[1]; //gradX
-          T* restrict dpsi_y=vgl.data(2)+offset; const T* restrict ylm_y=Ylm[2]; //gradY
-          T* restrict dpsi_z=vgl.data(3)+offset; const T* restrict ylm_z=Ylm[3]; //gradZ
-          T* restrict d2psi =vgl.data(4)+offset; const T* restrict ylm_l=Ylm[4]; //lap
+          auto* restrict psi   =vgl.data(0)+offset; const T* restrict ylm_v=Ylm[0]; //value
+          auto* restrict dpsi_x=vgl.data(1)+offset; const T* restrict ylm_x=Ylm[1]; //gradX
+          auto* restrict dpsi_y=vgl.data(2)+offset; const T* restrict ylm_y=Ylm[2]; //gradY
+          auto* restrict dpsi_z=vgl.data(3)+offset; const T* restrict ylm_z=Ylm[3]; //gradZ
+          auto* restrict d2psi =vgl.data(4)+offset; const T* restrict ylm_l=Ylm[4]; //lap
 
           for(size_t ib=0; ib<BasisSetSize; ++ib)
           {
@@ -220,16 +220,16 @@ namespace qmcplusplus
           } 
         }
 
-      template<typename LAT, typename T, typename PosType>
+      template<typename LAT, typename T, typename PosType, typename VT>
       inline void
-        evaluateV(const LAT& lattice, const T r, const PosType& dr, T* restrict psi) 
+        evaluateV(const LAT& lattice, const T r, const PosType& dr, VT* restrict psi) 
         {
          
           int TransX,TransY,TransZ;
 
           PosType dr_new;
           T r_new;
-          T psi_new;
+          //T psi_new;
           RealType* restrict ylm_v=tempS.data(0);
           RealType* restrict phi_r=tempS.data(1);
           for(size_t ib=0; ib<BasisSetSize; ++ib)

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -33,13 +33,14 @@ namespace qmcplusplus
  * The template parameter COT denotes Centered-Orbital-Type which provides
  * a set of localized orbitals associated with a center.
  */
-template<class COT>
-struct SoaLocalizedBasisSet: public RealBasisSetBase<typename COT::RealType>
+template<class COT, typename ORBT>
+struct SoaLocalizedBasisSet: public RealBasisSetBase<ORBT>
 {
   typedef typename COT::RealType RealType;
-  typedef typename RealBasisSetBase<RealType>::vgl_type vgl_type;
+  typedef RealBasisSetBase<ORBT> BaseType;
+  typedef typename BaseType::vgl_type vgl_type;
 
-  using RealBasisSetBase<RealType>::BasisSetSize;
+  using BaseType::BasisSetSize;
 
   ///number of centers, e.g., ions
   size_t NumCenters;
@@ -81,9 +82,9 @@ struct SoaLocalizedBasisSet: public RealBasisSetBase<typename COT::RealType>
 
   /** makeClone */
   //SoaLocalizedBasisSet<COT>* makeClone() const
-  RealBasisSetBase<RealType>* makeClone() const
+  BaseType* makeClone() const
   {
-    SoaLocalizedBasisSet<COT>* myclone=new SoaLocalizedBasisSet<COT>(*this);
+    SoaLocalizedBasisSet<COT,ORBT>* myclone=new SoaLocalizedBasisSet<COT,ORBT>(*this);
     for(int i=0; i<LOBasisSet.size(); ++i)
       myclone->LOBasisSet[i]=LOBasisSet[i]->makeClone();
     return myclone;
@@ -170,7 +171,7 @@ struct SoaLocalizedBasisSet: public RealBasisSetBase<typename COT::RealType>
    *
    * Always uses Temp_r and Temp_dr
    */
-  inline void evaluateV(const ParticleSet& P, int iat, RealType* restrict vals)
+  inline void evaluateV(const ParticleSet& P, int iat, ORBT* restrict vals)
   {
     const DistanceTableData* d_table=P.DistTables[myTableIndex];
     const RealType* restrict  dist = (P.activePtcl==iat)? d_table->Temp_r.data(): d_table->Distances[iat];

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -26,18 +26,19 @@
 namespace qmcplusplus
 {
 
-/** A localized basis set derived from RealBasisSetBase<typename COT::value_type>
+/** A localized basis set derived from SoaBasisSetBase<ORBT>
  *
  * This class performs the evaluation of the basis functions and their
  * derivatives for each of the N-particles in a configuration.
  * The template parameter COT denotes Centered-Orbital-Type which provides
  * a set of localized orbitals associated with a center.
+ * The template parameter ORBT denotes the orbital value return type
  */
 template<class COT, typename ORBT>
-struct SoaLocalizedBasisSet: public RealBasisSetBase<ORBT>
+struct SoaLocalizedBasisSet: public SoaBasisSetBase<ORBT>
 {
   typedef typename COT::RealType RealType;
-  typedef RealBasisSetBase<ORBT> BaseType;
+  typedef SoaBasisSetBase<ORBT> BaseType;
   typedef typename BaseType::vgl_type vgl_type;
 
   using BaseType::BasisSetSize;


### PR DESCRIPTION
This PR enables complex LCAO infrastructure.
The design is to support complex MO using complex basis set (complex AO with real radial functions).
The actually functionality will be completed by @anbenali 

Significant changes are
1. Separate functions for cusp correction from LCAOrbitalBuilder to its own header and cpp files.
2. Rename RealBasisSetBase to SoaBasisSetBase which now serves both real and complex.
3. Orbital optimization and cusp currections are not enabled in the complex build.