### PR TITLE
Exclude -ffast-math when building ppconvert

### DIFF
--- a/src/QMCTools/ppconvert/CMakeLists.txt
+++ b/src/QMCTools/ppconvert/CMakeLists.txt
@@ -1,5 +1,7 @@
 # in this directory and below remove the -DNDEBUG flag from build configs that add it
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+string(REPLACE "-ffast-math" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+string(REPLACE "-ffast-math" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 add_subdirectory(src)
 add_subdirectory(test)

--- a/src/QMCTools/ppconvert/src/common/RadialWF.cc
+++ b/src/QMCTools/ppconvert/src/common/RadialWF.cc
@@ -309,6 +309,16 @@ RadialWF::Solve(double tolerance)
       Energy = Eold;
       done = true;
     }
+    else
+    {
+      if(std::isnan(Etrial))
+      {
+        std::cerr << "NaN detected!" << std::endl;
+        std::cerr << "NumNodes = " << NumNodes << " TotalNodes = " << TotalNodes << std::endl;
+        std::cerr << "Etrial = " << Etrial << " Eold = " << Eold << std::endl;
+        exit(1);
+      }
+    }
     Eold = Etrial;       
   }
   IntegrateInOut(tindex);


### PR DESCRIPTION
When -ffast-math is used with GNU and Clang, some values become NaN and cause infinite loops in ppconvert. This PR only workaround the problem. It **does not** fix the cause of the NaN.