### PR TITLE
Fix TM1/3 when using both batched algorithm and delayed updates

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
@@ -76,13 +76,12 @@ namespace qmcplusplus {
         }
         const T cone(1);
         const T czero(0);
-        const T* AinvRow = Ainv[rowchanged];
         const int norb = Ainv.rows();
         const int lda_Binv = Binv.cols();
-        // save AinvRow to new_AinvRow
-        std::copy_n(AinvRow, norb, invRow.data());
-        // multiply V (NxK) Binv(KxK) U(KxN) AinvRow right to the left
-        BLAS::gemv('T', norb, delay_count, cone, U.data(), norb, AinvRow, 1, czero, p.data(), 1);
+        // save Ainv[rowchanged] to invRow
+        std::copy_n(Ainv[rowchanged], norb, invRow.data());
+        // multiply V (NxK) Binv(KxK) U(KxN) invRow right to the left
+        BLAS::gemv('T', norb, delay_count, cone, U.data(), norb, invRow.data(), 1, czero, p.data(), 1);
         BLAS::gemv('N', delay_count, delay_count, cone, Binv.data(), lda_Binv, p.data(), 1, czero, Binv[delay_count], 1);
         BLAS::gemv('N', norb, delay_count, -cone, V.data(), norb, Binv[delay_count], 1, cone, invRow.data(), 1);
       }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -117,8 +117,8 @@ DiracDeterminant::evalGrad(ParticleSet& P, int iat)
 {
   const int WorkingIndex = iat-FirstIndex;
   RatioTimer.start();
-  updateEng.getInvRow(psiM, WorkingIndex, invRow);
   invRow_id = WorkingIndex;
+  updateEng.getInvRow(psiM, WorkingIndex, invRow);
   GradType g = simd::dot(invRow.data(), dpsiM[WorkingIndex], invRow.size());
   RatioTimer.stop();
   return g;
@@ -139,8 +139,8 @@ DiracDeterminant::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   // This is not a safety check. Some code paths do call ratioGrad without calling evalGrad first.
   if(invRow_id != WorkingIndex)
   {
-    updateEng.getInvRow(psiM, WorkingIndex, invRow);
     invRow_id = WorkingIndex;
+    updateEng.getInvRow(psiM, WorkingIndex, invRow);
   }
   curRatio = simd::dot(invRow.data(), psiV.data(), invRow.size());
   grad_iat += ((RealType)1.0/curRatio) * simd::dot(invRow.data(), dpsiV.data(), invRow.size());
@@ -283,8 +283,8 @@ DiracDeterminant::ValueType DiracDeterminant::ratio(ParticleSet& P, int iat)
   // This is intended to save redundant compuation in TM1 and TM3
   if(invRow_id != WorkingIndex)
   {
-    updateEng.getInvRow(psiM, WorkingIndex, invRow);
     invRow_id = WorkingIndex;
+    updateEng.getInvRow(psiM, WorkingIndex, invRow);
   }
   curRatio = simd::dot(invRow.data(), psiV.data(), invRow.size());
   RatioTimer.stop();
@@ -293,9 +293,11 @@ DiracDeterminant::ValueType DiracDeterminant::ratio(ParticleSet& P, int iat)
 
 void DiracDeterminant::evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
 {
-  ValueVector_t psiM_row(psiM[VP.refPtcl-FirstIndex], psiM.cols());
   SPOVTimer.start();
-  Phi->evaluateDetRatios(VP, psiV, psiM_row, ratios);
+  const int WorkingIndex = VP.refPtcl-FirstIndex;
+  invRow_id = WorkingIndex;
+  updateEng.getInvRow(psiM, WorkingIndex, invRow);
+  Phi->evaluateDetRatios(VP, psiV, invRow, ratios);
   SPOVTimer.stop();
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -135,8 +135,9 @@ DiracDeterminant::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   UpdateMode=ORB_PBYP_PARTIAL;
   GradType rv;
 
-  // check invRow_id against WorkingIndex to ensure getInvRow() called before ratioGrad()
-  // This is not a safety check. Some code paths do call ratioGrad without calling evalGrad first.
+  // This is an optimization.
+  // check invRow_id against WorkingIndex to see if getInvRow() has been called already
+  // Some code paths call evalGrad before calling ratioGrad.
   if(invRow_id != WorkingIndex)
   {
     invRow_id = WorkingIndex;
@@ -264,6 +265,8 @@ void DiracDeterminant::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
   d2psiM.attachReference(buf.lendReference<ValueType>(d2psiM.size()));
   buf.get(LogValue);
   buf.get(PhaseValue);
+  // start with invRow labelled invalid
+  invRow_id = -1;
   BufferTimer.stop();
 }
 
@@ -279,6 +282,7 @@ DiracDeterminant::ValueType DiracDeterminant::ratio(ParticleSet& P, int iat)
   Phi->evaluate(P, iat, psiV);
   SPOVTimer.stop();
   RatioTimer.start();
+  // This is an optimization.
   // check invRow_id against WorkingIndex to see if getInvRow() has been called
   // This is intended to save redundant compuation in TM1 and TM3
   if(invRow_id != WorkingIndex)

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -183,6 +183,16 @@ public:
   DiracMatrix<mValueType> detEng;
   DelayedUpdate<ValueType> updateEng;
 
+  /// the row of up-to-date inverse matrix
+  ValueVector_t invRow;
+
+  /** row id correspond to the up-to-date invRow. [0 norb), invRow is ready; -1, invRow is not valid.
+   *  This id is set after calling getInvRow indicating invRow has been prepared for the invRow_id row
+   *  ratioGrad checks if invRow_id is consistent. If not, invRow needs to be recomputed.
+   *  acceptMove and completeUpdates mark invRow invalid by setting invRow_id to -1
+   */
+  int invRow_id;
+
   ValueType curRatio,cumRatio;
   ParticleSet::SingleParticleValue_t *FirstAddressOfG;
   ParticleSet::SingleParticleValue_t *LastAddressOfG;

--- a/src/QMCWaveFunctions/tests/test_dirac_matrix.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_matrix.cpp
@@ -121,13 +121,13 @@ TEST_CASE("DiracMatrix_update_row", "[wavefunction][fermion]")
   dm.invert(a,false);
 
   // new row
-  Vector<ValueType> v;
-  v.resize(3);
+  Vector<ValueType> v(3), invRow(3);
   v[0] = 1.9;
   v[1] = 2.0;
   v[2] = 3.1;
 
-  ValueType det_ratio1 = updateEng.ratio(a,0,v);
+  updateEng.getInvRow(a,0,invRow);
+  ValueType det_ratio1 = simd::dot(v.data(), invRow.data(), invRow.size());
 
   ValueType det_ratio = 0.178276269185;
   REQUIRE(det_ratio1 == ValueApprox(det_ratio));


### PR DESCRIPTION
1. Fix Tmove v1 and v3 when using both batched algorithm and delayed updates
2. Move the state machine invRow_id to the DiracDeterminat class
3. ratio, ratioGrad, evalGrad inside DelayedUpdate class is not necessary and moved back to DiracDeterminat.