### PR TITLE
Small bug fixes to NonLocalECPotential and DiracDeterminant

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -160,7 +160,7 @@ NonLocalECPotential::evaluateWithIonDerivs(ParticleSet& P, ParticleSet& ions, Tr
   }
   hf_terms-=forces;
   pulay_terms-=PulayTerm;
-  
+  return Value;
 }
 
 NonLocalECPotential::Return_t

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -146,6 +146,7 @@ DiracDeterminant::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   }
   curRatio = simd::dot(invRow.data(), psiV.data(), invRow.size());
   grad_iat += ((RealType)1.0/curRatio) * simd::dot(invRow.data(), dpsiV.data(), invRow.size());
+  RatioTimer.stop();
   return curRatio;
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -23,6 +23,7 @@
 #include "Numerics/BlasThreadingEnv.h"
 #include "Numerics/MatrixOperators.h"
 #include "simd/simd.hpp"
+#include <typeinfo>
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
1) clang 6 surfaced a missing header inclusion for comparing types.
2) clang 6 warning also spotted a bug from #1405 
3) I made a mistake in #1404. A timer stop is missing.