### PR TITLE
Add CoulombAA SoA Force path.  CoulombAB bug fix.

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -36,11 +36,12 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active,
   DistanceTableData *d_aa = DistanceTable::add(ref,DT_SOA_PREFERRED);
   PtclRefName=d_aa->Name;
   initBreakup(ref);
-//  if(!is_active)
-//  {
+  ref.turnOnPerParticleSK(); 
+  if(!is_active)
+  {
     //d_aa->evaluate(ref);
     update_source(ref);
-//  }
+  }
   prefix="F_AA";
   app_log() << "  Maximum K shell " << AA->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << AA->Fk.size() << std::endl;

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -36,12 +36,14 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active,
   DistanceTableData *d_aa = DistanceTable::add(ref,DT_SOA_PREFERRED);
   PtclRefName=d_aa->Name;
   initBreakup(ref);
-  ref.turnOnPerParticleSK(); 
-  if(!is_active)
+
+  if(ComputeForces)
   {
-    //d_aa->evaluate(ref);
+    ref.turnOnPerParticleSK(); 
     update_source(ref);
   }
+  if(!is_active)
+    update_source(ref);
   prefix="F_AA";
   app_log() << "  Maximum K shell " << AA->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << AA->Fk.size() << std::endl;

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -327,19 +327,19 @@ CoulombPBCAA::evalLRwithForces(ParticleSet& P)
 CoulombPBCAA::Return_t
 CoulombPBCAA::evalSRwithForces(ParticleSet& P)
 {
-  const DistanceTableData *d_aa = P.DistTables[0];
+  const DistanceTableData &d_aa(*P.DistTables[0]);
   mRealType SR=0.0;
   for(int ipart=0; ipart<NumCenters; ipart++)
   {
     mRealType esum = 0.0;
-    for(int nn=d_aa->M[ipart],jpart=ipart+1; nn<d_aa->M[ipart+1]; nn++,jpart++)
+    for(int nn=d_aa.M[ipart],jpart=ipart+1; nn<d_aa.M[ipart+1]; nn++,jpart++)
     {
       RealType rV, d_rV_dr, d2_rV_dr2;
-      rV = rVs->splint(d_aa->r(nn), d_rV_dr, d2_rV_dr2);
-      RealType V = rV *d_aa->rinv(nn);
-      esum += Zat[jpart]*d_aa->rinv(nn)*rV;
+      rV = rVs->splint(d_aa.r(nn), d_rV_dr, d2_rV_dr2);
+      RealType V = rV *d_aa.rinv(nn);
+      esum += Zat[jpart]*d_aa.rinv(nn)*rV;
       PosType grad = Zat[jpart]*Zat[ipart]*
-                     (d_rV_dr - V)*d_aa->rinv(nn)*d_aa->rinv(nn)*d_aa->dr(nn);
+                     (d_rV_dr - V)*d_aa.rinv(nn)*d_aa.rinv(nn)*d_aa.dr(nn);
       forces[ipart] += grad;
       forces[jpart] -= grad;
     }

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -19,6 +19,7 @@
 #include "QMCHamiltonians/QMCHamiltonianBase.h"
 #include "QMCHamiltonians/ForceBase.h"
 #include "LongRange/LRCoulombSingleton.h"
+#include "Particle/DistanceTableData.h"
 
 namespace qmcplusplus
 {
@@ -36,6 +37,9 @@ struct CoulombPBCAA: public QMCHamiltonianBase, public ForceBase
   typedef LRCoulombSingleton::GridType       GridType;
   typedef LRCoulombSingleton::RadFunctorType RadFunctorType;
   typedef LRHandlerType::mRealType           mRealType;
+
+  typedef DistanceTableData::RowContainer RowContainerType;
+ 
   LRHandlerType* AA;
   GridType* myGrid;
   RadFunctorType* rVs;

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -180,7 +180,8 @@ CoulombPBCAB::evaluateWithIonDerivs(ParticleSet&P, ParticleSet& ions, TrialWaveF
   forces=0.0;
   Value = evalLRwithForces(P)+evalSRwithForces(P)+myConst;
   hf_terms -= forces;
-  //And no Pulay contribution.  
+  //And no Pulay contribution.
+  return Value; 
 }
 
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -791,7 +791,7 @@ CoulombPBCAB::evalSRwithForces(ParticleSet& P)
         rV=Vat[a]->splint(dist[a]);
         frV=fVat[a]->splint(dist[a]);
         fdrV=fdVat[a]->splint(dist[a]);
-        dvdr=Qat[b]*Zat[a]*(fdrV-frV)*rinv;
+        dvdr=Qat[b]*Zat[a]*(fdrV-frV*rinv)*rinv;
         forces[a][0]-=dvdr*dr[a][0]*rinv;
         forces[a][1]-=dvdr*dr[a][1]*rinv;
         forces[a][2]-=dvdr*dr[a][2]*rinv;


### PR DESCRIPTION
As the title says:  this adds a code path so that AA particle sets (read ions) can have forces computed correctly within the SoA build.  Moreover, there was a forgotten term in the expression for the CoulombPBCAB force, which has been added.   Ion-Ion force validated against quantum espresso, and electron-ion force separately validated.