### PR TITLE
Allow Pseudopotential Forces in Real Build

### DIFF
--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -22,6 +22,7 @@
 #include "Numerics/OneDimGridFunctor.h"
 #include "Numerics/OneDimLinearSpline.h"
 #include "Numerics/OneDimCubicSpline.h"
+#include "Particle/DistanceTableData.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -36,6 +36,9 @@ struct LocalECPotential: public QMCHamiltonianBase
   typedef OneDimGridBase<RealType> GridType;
   typedef OneDimCubicSpline<RealType> RadialPotentialType;
 
+ 
+  typedef DistanceTableData::RowContainer RowContainerType;
+  
   ///reference to the ionic configuration
   const ParticleSet& IonConfig;
   ///the number of ioncs
@@ -76,6 +79,11 @@ struct LocalECPotential: public QMCHamiltonianBase
 #endif
 
   Return_t evaluate(ParticleSet& P);
+
+  Return_t evaluateWithIonDerivs(ParticleSet& P, ParticleSet& ions, TrialWaveFunction& psi,
+                                 ParticleSet::ParticlePos_t& hf_terms,
+                                 ParticleSet::ParticlePos_t& pulay_terms);
+
 
   Return_t evaluate_orig(ParticleSet& P);
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -283,7 +283,7 @@ NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W, int iat, TrialWaveFu
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
       
-      APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented for real wavefunctions yet.");
+//      APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented for real wavefunctions yet.");
 
       gradtmp_=0;
       ratio=psi.ratioGrad(W,iel,gradtmp_);
@@ -486,11 +486,10 @@ NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W, ParticleSet& ions, i
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
       
-      APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented for real wavefunctions yet.");
-
       gradtmp_=0;
       ratio=psi.ratioGrad(W,iel,gradtmp_);
       
+      psiratiofull_[j]=ratio;
       gradtmp_*=ratio;
       psiratio_[j]=ratio*sgridweight_m[j]; 
      
@@ -530,8 +529,10 @@ NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W, ParticleSet& ions, i
       W.acceptMove(iel);
       iongradtmp_ = psi.evalGradSource(W,ions,jat);
       iongradtmp_*=psiratiofull_[j]*sgridweight_m[j];
+      #ifdef QMC_COMPLEX
       convert(iongradtmp_,pulay_quad[j][jat]);
-      
+      #endif
+      pulay_quad[j][jat] = iongradtmp_;
       //And move the particle back.
       deltaV[j]=dr-r*rrotsgrid_m[j];
       W.makeMoveOnSphere(iel,deltaV[j]);

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -299,11 +299,8 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
       {
           Value1 += nlpp->evaluateOne(elec,iat,psi,jel,dist[iat],RealType(-1)*displ[iat],0,Txy);
           
-          //I know the real version doesn't work yet.  Only test if complex.
-          #ifdef QMC_COMPLEX
           Value2 += nlpp->evaluateOneWithForces(elec,iat,psi,jel,dist[iat],RealType(-1)*displ[iat],HFTerm[iat],0,Txy);
           Value3 += nlpp->evaluateOneWithForces(elec,ions,iat,psi,jel,dist[iat],RealType(-1)*displ[iat],HFTerm2[iat],PulayTerm,0,Txy);
-          #endif
       }
     }
   //These numbers are validated against an alternate code path via wavefunction tester.  
@@ -314,7 +311,6 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
   //  These numbers assume the Hellman Feynmann implementation is correct, and dump the values
   //  when a one body term is added in.  
   
-#ifdef QMC_COMPLEX 
   REQUIRE( Value2 == Approx(6.9015710211e-02) );
   REQUIRE( Value3 == Approx(6.9015710211e-02) );
  
@@ -356,7 +352,6 @@ TEST_CASE("Evaluate_ecp","[hamiltonian]")
   //HFTerm[1][1]+PulayTerm[1][1] =  0.0
   //HFTerm[1][2]+PulayTerm[1][2] =  0.0
   
-  #endif
 
  #else
 


### PR DESCRIPTION
This PR does the following to allow force computation in the real build (targeting openBC's):
1.)  Fixes a known bug in the nonlocalPP evaluation with real build.  I've removed the QMC_COMPLEX=1 guard in the test_ecp unit test, and everything should pass.
2.)  Implements Hellman-Feynman force evaluation for LocalECPotential (SoA only).  Basically a copy-paste job from CoulombPBCAB.cpp.  