### PR TITLE
Fix error handling of XML include.

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -172,7 +172,7 @@ void Communicate::cleanupMessage(void*)
 
 void Communicate::abort()
 {
-  OOMPI_COMM_WORLD.Abort();
+  myComm.Abort();
 }
 
 void Communicate::barrier()
@@ -183,7 +183,7 @@ void Communicate::barrier()
 void Communicate::abort(const char* msg)
 {
   std::cerr << msg << std::endl;
-  OOMPI_COMM_WORLD.Abort();
+  myComm.Abort();
 }
 
 

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -482,12 +482,20 @@ bool QMCMain::validateXML()
       xmlChar* a=xmlGetProp(cur,(const xmlChar*)"href");
       if(a)
       {
-        if(pushDocument((const char*)a))
+        bool success = pushDocument((const char*)a);
+        xmlFree(a);
+        if(success)
         {
           inputnode = processPWH(XmlDocStack.top()->getRoot());
           popDocument();
         }
-        xmlFree(a);
+        else
+          myComm->abort();
+      }
+      else
+      {
+        app_error() << "tag \"include\" must include an \"href\" attribute." << std::endl;
+        myComm->abort();
       }
     }
     else if(cname == "qmcsystem")

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -479,12 +479,15 @@ bool QMCMain::validateXML()
     else if(cname == "include")
     {
       //file is provided
-      const xmlChar* a=xmlGetProp(cur,(const xmlChar*)"href");
+      xmlChar* a=xmlGetProp(cur,(const xmlChar*)"href");
       if(a)
       {
-        pushDocument((const char*)a);
-        inputnode = processPWH(XmlDocStack.top()->getRoot());
-        popDocument();
+        if(pushDocument((const char*)a))
+        {
+          inputnode = processPWH(XmlDocStack.top()->getRoot());
+          popDocument();
+        }
+        xmlFree(a);
       }
     }
     else if(cname == "qmcsystem")


### PR DESCRIPTION
Close #1423 
Now the code stops correctly reporting the following without a crash.
```
I/O warning : failed to load external entity "PTCL_XML"
ERROR File PTCL_XML is invalid
I/O warning : failed to load external entity "WFS_XML"
ERROR File WFS_XML is invalid
ERROR ERROR: No target particle e exists.
ERROR Illegal input. Missing particleset 
ERROR Input document does not contain valid objects
```