### PR TITLE
Add and tidy applications aborts

### DIFF
--- a/src/QMCHamiltonians/QMCHamiltonianBase.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonianBase.cpp
@@ -16,6 +16,7 @@
 /**@file QMCHamiltonianBase.cpp
  *@brief Definition of QMCHamiltonianBase
  */
+#include "Message/Communicate.h"
 #include <QMCHamiltonians/QMCHamiltonianBase.h>
 #include <QMCHamiltonians/QMCHamiltonian.h>
 
@@ -119,8 +120,7 @@ void QMCHamiltonianBase::registerObservables(std::vector<observable_helper*>& h5
 void QMCHamiltonianBase::addEnergy(MCWalkerConfiguration &W,
     std::vector<RealType> &LocalEnergy)
 {
-  app_error() << "Need specialization for " << myName
-    << "::addEnergy(MCWalkerConfiguration &W).\n";
+  APP_ABORT("Need specialization for "+myName+"::addEnergy(MCWalkerConfiguration &W).\n Required functionality not implemented\n");
 }
 
 }

--- a/src/QMCWaveFunctions/OptimizableSPOSet.cpp
+++ b/src/QMCWaveFunctions/OptimizableSPOSet.cpp
@@ -15,7 +15,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
     
     
-
+#include "Message/Communicate.h"
 #include "QMCWaveFunctions/OptimizableSPOSet.h"
 #include "Numerics/OhmmsBlas.h"
 #include "OhmmsData/AttributeSet.h"
@@ -447,8 +447,7 @@ OptimizableSPOSet::evaluate(const ParticleSet& P, int iat,
                             ValueVector_t& psi, GradVector_t& dpsi,
                             HessVector_t& gg_psi)
 {
-  app_error() << "Need specialization for OptimizableSPOSet::evaluate(HessVector_t)  Abort.\n";
-  abort();
+  APP_ABORT("Need specialization for OptimizableSPOSet::evaluate(HessVector_t)  Abort.\n");
 }
 
 void

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -16,6 +16,7 @@
 
 
 #include "QMCWaveFunctions/SPOSet.h"
+#include "Message/Communicate.h"
 #include "Numerics/MatrixOperators.h"
 #include "OhmmsData/AttributeSet.h"
 #include <simd/simd.hpp>
@@ -38,6 +39,11 @@ SPOSet::SPOSet()
   //default is false: LCOrbitalSet.h needs to set this true and recompute needs to check
   myComm=nullptr;
 #endif
+}
+
+void SPOSet::evaluate (const ParticleSet& P, PosType &r, ValueVector_t &psi)
+{
+  APP_ABORT("Need specialization for SPOSet::evaluate(const ParticleSet& P, PosType &r)\n");
 }
 
 void SPOSet::evaluateDetRatios(const VirtualParticleSet& VP, ValueVector_t& psi, const ValueVector_t& psiinv, std::vector<ValueType>& ratios)

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -20,7 +20,6 @@
 #ifndef QMCPLUSPLUS_SINGLEPARTICLEORBITALSETBASE_H
 #define QMCPLUSPLUS_SINGLEPARTICLEORBITALSETBASE_H
 
-#include "Message/Communicate.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/VirtualParticleSet.h"
@@ -216,11 +215,7 @@ public:
   /** Evaluate the SPO value at an explicit position.
    * Ye: This is used only for debugging the CUDA code and should be removed.
    */
-  virtual void
-  evaluate (const ParticleSet& P, PosType &r, ValueVector_t &psi)
-  {
-    APP_ABORT("Need specialization for SPOSet::evaluate(const ParticleSet& P, PosType &r)\n");
-  }
+  virtual void evaluate (const ParticleSet& P, PosType &r, ValueVector_t &psi);
 
   /** evaluate the values of this single-particle orbital set
    * @param P current ParticleSet

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -20,6 +20,7 @@
 #ifndef QMCPLUSPLUS_SINGLEPARTICLEORBITALSETBASE_H
 #define QMCPLUSPLUS_SINGLEPARTICLEORBITALSETBASE_H
 
+#include "Message/Communicate.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/VirtualParticleSet.h"
@@ -218,9 +219,7 @@ public:
   virtual void
   evaluate (const ParticleSet& P, PosType &r, ValueVector_t &psi)
   {
-    app_error() << "Need specialization for SPOSet::evaluate "
-                << "(const ParticleSet& P, PosType &r).\n";
-    abort();
+    APP_ABORT("Need specialization for SPOSet::evaluate(const ParticleSet& P, PosType &r)\n");
   }
 
   /** evaluate the values of this single-particle orbital set

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -17,6 +17,7 @@
     
 #ifndef QMCPLUSPLUS_WAVEFUNCTIONCOMPONENT_H
 #define QMCPLUSPLUS_WAVEFUNCTIONCOMPONENT_H
+#include "Message/Communicate.h"
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/VirtualParticleSet.h"
@@ -259,7 +260,8 @@ struct WaveFunctionComponent: public QMCTraits
                                   ParticleSet& source,
                                   int iat)
   {
-    // APP_ABORT("WaveFunctionComponent::evalGradSource is not implemented");
+    // unit_test_hamiltonian calls this function incorrectly; do not abort for now
+    //    APP_ABORT("WaveFunctionComponent::evalGradSource is not implemented");
     return GradType();
   }
 
@@ -377,8 +379,7 @@ struct WaveFunctionComponent: public QMCTraits
    */
   virtual void evaluateGradDerivatives(const ParticleSet::ParticleGradient_t& G_in,
                                        std::vector<RealType>& dgradlogpsi) {
-    app_error() << "Need specialization of WaveFunctionComponent::evaluateGradDerivatives in "+ClassName+" class.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::evaluateGradDerivatives in "+ClassName+" class.\n");
   }
 
   virtual void finalizeOptimization() { }
@@ -426,10 +427,7 @@ struct WaveFunctionComponent: public QMCTraits
   addLog (MCWalkerConfiguration &W,
           std::vector<RealType> &logPsi)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::addLog for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::addLog for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   /** Evaluate the wave-function ratio w.r.t. moving particle iat
@@ -442,10 +440,7 @@ struct WaveFunctionComponent: public QMCTraits
   ratio (MCWalkerConfiguration &W, int iat,
          std::vector<ValueType> &psi_ratios)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::ratio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::ratio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   // Returns the WF ratio and gradient w.r.t. iat for each walker
@@ -454,10 +449,7 @@ struct WaveFunctionComponent: public QMCTraits
   ratio (MCWalkerConfiguration &W, int iat,
          std::vector<ValueType> &psi_ratios,	std::vector<GradType>  &grad)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::ratio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::ratio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -465,10 +457,7 @@ struct WaveFunctionComponent: public QMCTraits
          std::vector<ValueType> &psi_ratios,	std::vector<GradType>  &grad,
          std::vector<ValueType> &lapl)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::ratio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::ratio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -476,10 +465,7 @@ struct WaveFunctionComponent: public QMCTraits
              std::vector<ValueType> &psi_ratios,	std::vector<GradType>  &grad,
              std::vector<ValueType> &lapl)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::calcRatio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::calcRatio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -487,10 +473,7 @@ struct WaveFunctionComponent: public QMCTraits
             std::vector<ValueType> &psi_ratios,	std::vector<GradType>  &grad,
             std::vector<ValueType> &lapl)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::addRatio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::addRatio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -498,10 +481,7 @@ struct WaveFunctionComponent: public QMCTraits
          std::vector<PosType> &rNew,  std::vector<ValueType> &psi_ratios,
          std::vector<GradType>  &grad,  std::vector<ValueType> &lapl)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::ratio for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::ratio for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
 
@@ -509,30 +489,21 @@ struct WaveFunctionComponent: public QMCTraits
   addGradient(MCWalkerConfiguration &W, int iat,
               std::vector<GradType> &grad)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::addGradient for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::addGradient for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
   calcGradient(MCWalkerConfiguration &W, int iat, int k,
                std::vector<GradType> &grad)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::calcGradient for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::calcGradient for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
   gradLapl (MCWalkerConfiguration &W, GradMatrix_t &grads,
             ValueMatrix_t &lapl)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::gradLapl for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::gradLapl for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -542,29 +513,20 @@ struct WaveFunctionComponent: public QMCTraits
                  std::vector<ValueType> &lapl,
                  int iat, int k, int kd, int nw)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::det_lookahead for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::det_lookahead for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
   update (MCWalkerConfiguration *W, std::vector<Walker_t*> &walkers, int iat, std::vector<bool> *acc, int k)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::update for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::update for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
   update (const std::vector<Walker_t*> &walkers,
           const std::vector<int> &iatList)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::update for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::update for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
 
@@ -572,10 +534,7 @@ struct WaveFunctionComponent: public QMCTraits
   NLratios (MCWalkerConfiguration &W,  std::vector<NLjob> &jobList,
             std::vector<PosType> &quadPoints, std::vector<ValueType> &psi_ratios)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::NLRatios for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::NLRatios for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -585,10 +544,7 @@ struct WaveFunctionComponent: public QMCTraits
             gpu::device_vector<CUDA_PRECISION*> &RatioList,
             int numQuadPoints)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::NLRatios for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::NLRatios for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 
   virtual void
@@ -597,10 +553,7 @@ struct WaveFunctionComponent: public QMCTraits
                        RealMatrix_t &dgrad_logpsi,
                        RealMatrix_t &dhpsi_over_psi)
   {
-    app_error() << "Need specialization of WaveFunctionComponent::evaluateDerivatives for "
-                << ClassName << ".\n";
-    app_error() << "Required CUDA functionality not implemented. Contact developers.\n";
-    abort();
+    APP_ABORT("Need specialization of WaveFunctionComponent::evaluateDerivatives for "+ClassName+".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 #endif
 };


### PR DESCRIPTION
1. QMCHamiltonianBase::addEnergy was missing an abort, causing the CUDA code to crash when certain unimplemented functionality was used (user reported).
2. Tidied many APP_ABORT calls for consistency.
3. I noticed that unit_test_hamiltonian calls WaveFunctionComponent::evalGradSource incorrectly. The function in the base class should never be called. The abort there was commented out, and still is. Simulations run correctly with the abort present, so this is an issue in the test setup.
