### PR TITLE
Fix backflow

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -61,6 +61,17 @@ public:
   DiracDeterminantWithBackflow(const DiracDeterminantWithBackflow& s) = delete;
   DiracDeterminantWithBackflow& operator=(const DiracDeterminantWithBackflow& s) = delete;
 
+  /** set the index of the first particle in the determinant and reset the size of the determinant
+   *@param first index of first particle
+   *@param nel number of particles in the determinant
+   *@param delay dummy argument
+   */
+  void set(int first, int nel, int delay=1) final
+  {
+    FirstIndex = first;
+    resize(nel,nel);
+  }
+
   ///set BF pointers
   void setBF(BackflowTransformation* bf)
   {


### PR DESCRIPTION
#1428 introduced a bug and caused segmentation fault due to missing resizing of vectors.
This PR should fix problems like https://cdash.qmcpack.org/CDash/testDetails.php?test=4493186&build=47567