### PR TITLE
Open HDF orbital file in read-only mode in PW code

### DIFF
--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -523,7 +523,7 @@ hid_t PWOrbitalBuilder::getH5(xmlNodePtr cur, const char* aname)
   {
     return -1;
   }
-  hid_t h = H5Fopen((const char*)aptr,H5F_ACC_RDWR,H5P_DEFAULT);
+  hid_t h = H5Fopen((const char*)aptr,H5F_ACC_RDONLY,H5P_DEFAULT);
   if(h<0)
   {
     app_error() << " Cannot open " << (const char*)aptr << " file." << std::endl;


### PR DESCRIPTION
If the wavefunction unit tests are run under MPI, they halt here opening the orbital HDF file.  Change the mode to read-only so multiple nodes could open the file simultaneously.
This code is not performance critical nor used much, so updating it to read the HDF file properly in parallel is not a priority.