### PR TITLE
Enforce the destruction of myMPI after myComm

### DIFF
--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -261,6 +261,21 @@ protected:
    *  After switching to mpi3::communicator, myMPI is only a reference to the raw communicator owned by mpi3::communicator
    */
   mpi_comm_type myMPI;
+#ifdef HAVE_MPI
+  /* helper class to destroy myMPI after the destruction of myComm
+   * it must be declared before myComm and the destruction automatically happens after myComm
+   */
+  class MPI_Comm_destructor
+  {
+    MPI_Comm& comm;
+  public:
+    MPI_Comm_destructor(MPI_Comm& myMPI) : comm(myMPI) {}
+    ~MPI_Comm_destructor()
+    {
+      if(comm!=MPI_COMM_NULL) MPI_Comm_free(&comm);
+    }
+  } myMPI_destroy_helper;
+#endif
   /// OOMPI communicator
   intra_comm_type myComm;
   /// Communicator name
@@ -278,8 +293,8 @@ public:
   /// Group Lead Communicator
   Communicate *GroupLeaderComm;
 
-  /// mpi3 communicator wrapper
 #ifdef HAVE_MPI
+  /// mpi3 communicator wrapper
   mpi3::communicator comm;
 #endif
 };


### PR DESCRIPTION
A bug was introduced in #1437.
OOMPI object must be destructed before the MPI raw communicator gets freed.
I was doing that by calling the destructor by hand before freeing the raw communicator.
This is wrong because the destructor will be called again by the auto generated code in the Communicate class and try to access the communicator which has been freed already.
The solution is using a helper class which has a destructor freeing the raw communicator.
As long as it is declared before the OOMPI object, the destruction order is correct.