### PR TITLE
Switch some constructors to the new mpi wrapper

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -35,6 +35,10 @@
 #include "ADIOS/ADIOS_config.h"
 #endif
 
+#ifdef HAVE_MPI
+#include "mpi3/shared_communicator.hpp"
+#endif
+
 
 //static data of TagMaker::CurrentTag is initialized.
 int TagMaker::CurrentTag = 1000;
@@ -68,15 +72,17 @@ Communicate::~Communicate()
 //exclusive:  OOMPI, MPI or Serial
 #ifdef HAVE_OOMPI
 
-Communicate::Communicate(const mpi_comm_type comm_input):
+#ifdef HAVE_MPI
+Communicate::Communicate(const mpi3::communicator &in_comm):
   d_groupid(0), d_ngroups(1), GroupLeaderComm(nullptr)
 {
-  MPI_Comm_dup(comm_input, &myMPI);
+  comm = mpi3::communicator(in_comm);
+  myMPI = &comm;
   myComm = OOMPI_Intra_comm(myMPI);
-  // TODO: mpi3 needs to define comm
   d_mycontext = myComm.Rank();
   d_ncontexts = myComm.Size();
 }
+#endif
 
 
 Communicate::Communicate(const Communicate& in_comm, int nparts)
@@ -84,26 +90,24 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
   std::vector<int> nplist(nparts+1);
   int p=FairDivideLow(in_comm.rank(), in_comm.size(), nparts, nplist); //group
   int q=in_comm.rank()-nplist[p]; //rank within a group
-  MPI_Comm_split(in_comm.getMPI(),p,q,&myMPI);
-  myComm=OOMPI_Intra_comm(myMPI);
-  // TODO: mpi3 needs to define comm
+
+  comm = in_comm.comm.split(p, q);
+  myMPI = &comm;
+  myComm = OOMPI_Intra_comm(myMPI);
+
+
   d_mycontext=myComm.Rank();
   d_ncontexts=myComm.Size();
   d_groupid=p;
   d_ngroups=nparts;
+
   // create a communicator among group leaders.
-  MPI_Group parent_group, leader_group;
-  MPI_Comm_group(in_comm.getMPI(), &parent_group);
-  MPI_Group_incl(parent_group, nparts, nplist.data(), &leader_group);
-  MPI_Comm leader_comm;
-  MPI_Comm_create(in_comm.getMPI(), leader_group, &leader_comm);
+  nplist.pop_back();
+  mpi3::communicator leader_comm = in_comm.comm.subcomm(nplist);
   if(isGroupLeader())
     GroupLeaderComm = new Communicate(leader_comm);
   else
     GroupLeaderComm = nullptr;
-  MPI_Comm_free(&leader_comm);
-  MPI_Group_free(&leader_group);
-  MPI_Group_free(&parent_group);
 }
 
 
@@ -143,9 +147,9 @@ void Communicate::initialize(int argc, char **argv)
 
 void Communicate::initializeAsNodeComm(const Communicate& parent)
 {
-  MPI_Comm_split_type(parent.getMPI(), MPI_COMM_TYPE_SHARED, parent.rank(), MPI_INFO_NULL, &myMPI);
+  comm = parent.comm.split_shared();
+  myMPI = &comm;
   myComm = OOMPI_Intra_comm(myMPI);
-  // TODO: mpi3 needs to define comm
   d_mycontext = myComm.Rank();
   d_ncontexts = myComm.Size();
 }

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -255,13 +255,16 @@ public:
   template<typename T> void allgather(T* sb, T* rb, int count);
   template<typename T> void gsum(T&);
 
-protected:
-
-  /** Raw communicator
-   *
-   *  Currently it is only owned by Communicate which manages its creation and destruction
-   *  After switching to mpi3::communicator, myMPI is only a reference to the raw communicator owned by mpi3::communicator
+public:
+#ifdef HAVE_MPI
+  /** mpi3 communicator wrapper
+   * must be declared before myComm to ensure its destruction after myComm
    */
+  mpi3::communicator comm;
+#endif
+
+protected:
+  /// a reference to the raw communicator owned by comm
   mpi_comm_type myMPI;
   /// OOMPI communicator
   intra_comm_type myComm;
@@ -279,11 +282,6 @@ protected:
 public:
   /// Group Lead Communicator
   Communicate *GroupLeaderComm;
-
-  /// mpi3 communicator wrapper
-#ifdef HAVE_MPI
-  mpi3::communicator comm;
-#endif
 };
 
 

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -91,8 +91,10 @@ public:
   Communicate(const mpi3::environment &env);
 #endif
 
+#ifdef HAVE_MPI
   ///constructor with communicator
-  Communicate(const mpi_comm_type comm_input);
+  Communicate(const mpi3::communicator &in_comm);
+#endif
 
   ///constructor with communicator
   //Communicate(const intra_comm_type& c);


### PR DESCRIPTION
The constructor accepting a bare MPI communicator was changed to accept an mpi3::communicator instead.

The splitting constructor for ensemble runs and the shared node initialization functionnnow use the mpi wrapper for implementation.

The goal is to make the new wrapper responsible for management of the MPI communicators.
This might mean that #1447 is not necessary.