### PR TITLE
Update check_affinity: Ordered by MPI_rank

### DIFF
--- a/src/QMCTools/check-affinity.cpp
+++ b/src/QMCTools/check-affinity.cpp
@@ -53,53 +53,63 @@ int get_hwthread()
 
 int main()
 {
-  int rank = 0;
+  int rank = 0, world_size = 1;
 #ifdef HAVE_MPI
   int provided;
   MPI_Init_thread(NULL, NULL, MPI_THREAD_FUNNELED, &provided);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 #endif
 
   bool hwthread_id_supported = (get_hwthread()!=-1);
 
-  #pragma omp parallel
+  for ( int l_rank = 0; l_rank < world_size; l_rank++)
   {
-    int L1_thread_id  = omp_get_thread_num();
-    int L1_num_thread = omp_get_num_threads();
-    #pragma omp parallel
+    if (l_rank == rank)
     {
-      #pragma omp master
-      if(L1_thread_id==0)
-        std::cout << "OpenMP enables " << L1_num_thread << " 1st level threads, "
-                  << "and " << omp_get_num_threads() << " 2nd level threads." << std::endl << std::endl;
-    }
-    #pragma omp barrier
-
-    for(int i=0; i<L1_num_thread; i++)
-    {
-      if(L1_thread_id==i)
+      #pragma omp parallel
       {
+        int L1_thread_id  = omp_get_thread_num();
+        int L1_num_thread = omp_get_num_threads();
         #pragma omp parallel
         {
-          int L2_thread_id  = omp_get_thread_num();
-          int L2_num_thread = omp_get_num_threads();
-          for(int j=0; j<L2_num_thread; j++)
+          #pragma omp master
+          if(L1_thread_id==0 and l_rank == 0)
+            std::cout << "OpenMP enables " << L1_num_thread << " 1st level threads, "
+                      << "and " << omp_get_num_threads() << " 2nd level threads." << std::endl << std::endl;
+        }
+        #pragma omp barrier
+    
+        for(int i=0; i<L1_num_thread; i++)
+        {
+          if(L1_thread_id==i)
           {
-            if(L2_thread_id==j)
+            #pragma omp parallel
             {
-              std::ostringstream o;
-              o << "MPI rank " << rank << " L1 tid " << L1_thread_id << " L2 tid " << L2_thread_id
-                << " is placed on Core ID " << get_core();
-              if(hwthread_id_supported) o << " HW thread ID " << get_hwthread();
-              o << std::endl;
-              std::cout << o.str();
+              int L2_thread_id  = omp_get_thread_num();
+              int L2_num_thread = omp_get_num_threads();
+              for(int j=0; j<L2_num_thread; j++)
+              {
+                if(L2_thread_id==j)
+                {
+                  std::ostringstream o;
+                  o << "MPI rank " << rank << " L1 tid " << L1_thread_id << " L2 tid " << L2_thread_id
+                    << " is placed on Core ID " << get_core();
+                  if(hwthread_id_supported) o << " HW thread ID " << get_hwthread();
+                  o << std::endl;
+                  std::cout << o.str();
+                }
+                #pragma omp barrier
+              }
             }
-            #pragma omp barrier
           }
+          #pragma omp barrier
         }
       }
-      #pragma omp barrier
     }
+    #ifdef HAVE_MPI
+    MPI_Barrier(MPI_COMM_WORLD);
+    #endif
   }
 #ifdef HAVE_MPI
   MPI_Finalize();


### PR DESCRIPTION
A race condition existed between mpi process.  This pull request fixes the issue.

Modification:
1.  "OpenMP enables..." is printed only once. 
2. For loop over MPI_rank + MPI_barrier.