### PR TITLE
Update configs for SOA default

### DIFF
--- a/config/blue_waters.sh
+++ b/config/blue_waters.sh
@@ -71,7 +71,7 @@ echo ""
 echo "building qmcpack for cpu real"
 mkdir build$suffix
 cd build$suffix
-cmake $CMAKE_FLAGS ..
+cmake -D ENABLE_SOA=0 $CMAKE_FLAGS ..
 make -j 32
 cd ..
 ln -s ./build$suffix/bin/qmcpack ./qmcpack$suffix
@@ -83,7 +83,7 @@ echo ""
 echo "building qmcpack for cpu complex"
 mkdir build$suffix
 cd build$suffix
-cmake $CMAKE_FLAGS -D QMC_COMPLEX=1 ..
+cmake -D ENABLE_SOA=0 $CMAKE_FLAGS -D QMC_COMPLEX=1 ..
 make -j 32
 cd ..
 ln -s ./build$suffix/bin/qmcpack ./qmcpack$suffix
@@ -124,8 +124,8 @@ echo ""
 echo "building qmcpack for gpu real"
 mkdir build$suffix
 cd build$suffix
-cmake -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
-cmake -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
+cmake -D ENABLE_SOA=0 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
+cmake -D ENABLE_SOA=0 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
 make -j 32
 cd ..
 ln -s ./build$suffix/bin/qmcpack ./qmcpack$suffix
@@ -137,8 +137,8 @@ echo ""
 echo "building qmcpack for gpu real"
 mkdir build$suffix
 cd build$suffix
-cmake -D QMC_COMPLEX=1 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
-cmake -D QMC_COMPLEX=1 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
+cmake -D ENABLE_SOA=0 -D QMC_COMPLEX=1 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
+cmake -D ENABLE_SOA=0 -D QMC_COMPLEX=1 -D QMC_CUDA=1 -DCUDA_HOST_COMPILER=$(which CC) ..
 make -j 32
 cd ..
 ln -s ./build$suffix/bin/qmcpack ./qmcpack$suffix

--- a/config/build_alcf_mira.sh
+++ b/config/build_alcf_mira.sh
@@ -14,6 +14,8 @@ fi
 
 if [[ $name == *"_SoA"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_SOA=1"
+else
+  CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_SOA=0"
 fi
 
 if [[ $name == *"_MP"* ]]; then

--- a/config/build_alcf_theta.sh
+++ b/config/build_alcf_theta.sh
@@ -22,6 +22,8 @@ fi
 
 if [[ $name == *"_SoA"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_SOA=1"
+else
+  CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_SOA=0"
 fi
 
 if [[ $name == *"_MP"* ]]; then

--- a/config/build_olcf_eos.sh
+++ b/config/build_olcf_eos.sh
@@ -60,7 +60,7 @@ echo ""
 echo "building qmcpack for cpu AoS real for eos"
 mkdir -p build_eos_cpu_real
 cd build_eos_cpu_real
-cmake $CMAKE_FLAGS .. 
+cmake -DENABLE_SOA=0 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
 ln -sf ./build_eos_cpu_real/bin/qmcpack ./qmcpack_eos_cpu_real
@@ -72,7 +72,7 @@ echo ""
 echo "building qmcpack for cpu AoS complex for eos"
 mkdir -p build_eos_cpu_comp
 cd build_eos_cpu_comp
-cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS .. 
+cmake -DENABLE_SOA=0 -DQMC_COMPLEX=1 $CMAKE_FLAGS .. 
 make -j 32
 cd ..
 ln -sf ./build_eos_cpu_comp/bin/qmcpack ./qmcpack_eos_cpu_comp

--- a/config/build_olcf_titan.sh
+++ b/config/build_olcf_titan.sh
@@ -56,6 +56,7 @@ mkdir -p build_titan_cpu_real
 cd build_titan_cpu_real
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
+      -D ENABLE_SOA=0 \
       $CMAKE_FLAGS ..
 make -j 32
 cd ..
@@ -70,6 +71,7 @@ mkdir -p build_titan_cpu_comp
 cd build_titan_cpu_comp
 cmake -D CMAKE_C_FLAGS="$XT_FLAGS" \
       -D CMAKE_CXX_FLAGS="$XT_FLAGS" \
+      -D ENABLE_SOA=0 \
       -D QMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32
 cd ..
@@ -114,7 +116,7 @@ echo ""
 echo "building qmcpack for gpu real for titan"
 mkdir -p build_titan_gpu_real
 cd build_titan_gpu_real
-cmake -D QMC_CUDA=1 ..
+cmake -D QMC_CUDA=1 -D ENABLE_SOA=0 ..
 make -j 32
 cd ..
 ln -sf ./build_titan_gpu_real/bin/qmcpack ./qmcpack_titan_gpu_real
@@ -125,7 +127,7 @@ echo ""
 echo "building qmcpack for gpu complex for titan"
 mkdir -p build_titan_gpu_comp
 cd build_titan_gpu_comp
-cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 ..
+cmake -D QMC_CUDA=1 -D QMC_COMPLEX=1 -D ENABLE_SOA=0 ..
 make -j 32
 cd ..
 ln -sf ./build_titan_gpu_comp/bin/qmcpack ./qmcpack_titan_gpu_comp

--- a/config/build_ornl_cades.sh
+++ b/config/build_ornl_cades.sh
@@ -43,7 +43,7 @@ echo ""
 echo "building QMCPACK for cpu AoS real for CADES SHPC Condo"
 mkdir -p build_cades_cpu_real
 cd build_cades_cpu_real
-cmake $CMAKE_FLAGS ..
+cmake -DENABLE_SOA=0 $CMAKE_FLAGS ..
 make -j 16
 cd ..
 ln -sf ./build_cades_cpu_real/bin/qmcpack ./qmcpack_cades_cpu_real
@@ -54,7 +54,7 @@ echo ""
 echo "building QMCPACK for cpu AoS complex for CADES SHPC Condo"
 mkdir -p build_cades_cpu_comp
 cd build_cades_cpu_comp
-cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
+cmake -DENABLE_SOA=0 -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 16
 cd ..
 ln -sf ./build_cades_cpu_comp/bin/qmcpack ./qmcpack_cades_cpu_comp

--- a/config/build_ornl_oic.sh
+++ b/config/build_ornl_oic.sh
@@ -31,7 +31,7 @@ echo ""
 echo "building qmcpack for cpu AoS real for oic5"
 mkdir -p build_oic_cpu_real
 cd build_oic_cpu_real
-cmake $CMAKE_FLAGS ..
+cmake -DENABLE_SOA=0 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
 ln -sf ./build_oic_cpu_real/bin/qmcpack ./qmcpack_oic_cpu_real
@@ -42,7 +42,7 @@ echo ""
 echo "building qmcpack for cpu AoS complex for oic5"
 mkdir -p build_oic_cpu_comp
 cd build_oic_cpu_comp
-cmake -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
+cmake -DENABLE_SOA=0 -DQMC_COMPLEX=1 $CMAKE_FLAGS ..
 make -j 32 
 cd ..
 ln -sf ./build_oic_cpu_comp/bin/qmcpack ./qmcpack_oic_cpu_comp


### PR DESCRIPTION
This naive update to the example/reference build scripts ensures that executables are still named correctly by specifying ENABLE_SOA=0 for non-soa builds.
