### PR TITLE
Use correct test input path for short/long afqmc tests.

### DIFF
--- a/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
+++ b/tests/solids/diamondC_afqmc_1x1x1_complex/CMakeLists.txt
@@ -1,6 +1,6 @@
 # RHF CHOLESKY
-SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/choldump.h5)
-SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/wfn.dat)
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_1x1x1_dzvp/ham_chol_sc.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_1x1x1_dzvp/wfn_rhf.dat)
 
 #symlink h5 file
 MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump.h5)
@@ -30,8 +30,8 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_cholesky"
                   )
 
 # RHF ISDF/THC
-SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/thc.h5)
-SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/thc_minimal/wfn_thc.dat)
+SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_1x1x1_szv/ham_thc_sc.h5)
+SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_1x1x1_szv/wfn_rhf.dat)
 
 #symlink h5 file
 MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/thc.h5)
@@ -61,35 +61,36 @@ QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_thc"
                   )
 
 # UHF CHOLESKY
-SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/choldump.h5)
-SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/wfn.dat)
+# Need to remake benchmark following change in hamiltonian/wavefunction.
+#SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/choldump.h5)
+#SET(TEST_WFN_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_uhf/wfn.dat)
 
-#symlink h5 file
-MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump_uhf.h5)
-#symlink wfn file
-MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn_uhf.dat)
+##symlink h5 file
+#MAYBE_SYMLINK(${TEST_HDF_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/choldump_uhf.h5)
+##symlink wfn file
+#MAYBE_SYMLINK(${TEST_WFN_INPUT} ${CMAKE_CURRENT_BINARY_DIR}/wfn_uhf.dat)
 
-LIST(APPEND DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00312")
+#LIST(APPEND DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00312")
 
-QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_uhf"
-                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
-                  qmc_short_uhf
-                  qmc_short_uhf.in.xml
-                  16 1
-                  TRUE
-                  0 DIAMOND_AFQMC_SCALARS_UHF
-                  )
+#QMC_RUN_AND_CHECK("short-diamondC_afqmc_1x1x1_complex_uhf"
+                  #"${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  #qmc_short_uhf
+                  #qmc_short_uhf.in.xml
+                  #16 1
+                  #TRUE
+                  #0 DIAMOND_AFQMC_SCALARS_UHF
+                  #)
 
-LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00103")
+#LIST(APPEND LONG_DIAMOND_AFQMC_SCALARS_UHF "EnergyEstim__nume_real" "-10.55151 0.00103")
 
-QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_uhf"
-                  "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
-                  qmc_long_uhf
-                  qmc_long_uhf.in.xml
-                  16 1
-                  TRUE
-                  0 LONG_DIAMOND_AFQMC_SCALARS_UHF
-                  )
+#QMC_RUN_AND_CHECK("long-diamondC_afqmc_1x1x1_complex_uhf"
+                  #"${CMAKE_SOURCE_DIR}/tests/solids/diamondC_afqmc_1x1x1_complex"
+                  #qmc_long_uhf
+                  #qmc_long_uhf.in.xml
+                  #16 1
+                  #TRUE
+                  #0 LONG_DIAMOND_AFQMC_SCALARS_UHF
+                  #)
 
 # PHMSD CHOLESKY
 #SET(TEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/afqmc/C_rhf/choldump_phmsd.h5)


### PR DESCRIPTION
UHF test benchmark will be updated in future due to change in wavefunction.