### PR TITLE
Fix wavefunction unit tests

### DIFF
--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -574,6 +574,8 @@ TEST_CASE("Ethanol MO with cusp", "[wavefunction]")
   REQUIRE(all_grad[0][11][1] == Approx(0.9883840215));
   REQUIRE(all_grad[0][11][2] == Approx(1.7863218842));
   REQUIRE(all_lap[0][11] == Approx(-33.5202249813));
+
+  SPOSetBuilderFactory::clear();
 }
 
 


### PR DESCRIPTION
The "Ethanol MO with cusp" did not clean up at the end, leading to failures in other unit tests (ReadMolecularOrbital*) on some machines.

This should fix the wavefunction unit test failures seen in #1467