### PR TITLE
Update patch version to indicate development code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ ENDIF(COMMAND cmake_policy)
 ######################################################################
 SET(QMCPACK_VERSION_MAJOR 3)
 SET(QMCPACK_VERSION_MINOR 7)
-SET(QMCPACK_VERSION_PATCH 0)
+SET(QMCPACK_VERSION_PATCH 9)
 SET(QMCPACK_VERSION "${QMCPACK_VERSION_MAJOR}.${QMCPACK_VERSION_MINOR}.${QMCPACK_VERSION_PATCH}")
 
 ######################################################################


### PR DESCRIPTION
Following discussions, the development source will be labeled with patch version 9, i.e. the version will report as x.y.9. No patch 9 version will ever be released. This should help distinguish development builds from released versions. The next version will normally be x.y+1.0 or x.y.1 if we need to make a bugfix.