### PR TITLE
Organize variational parameter output tables.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,6 +356,7 @@ ENDIF()
     SUBDIRS(QMCApp/tests)
     SUBDIRS(Message/tests)
     SUBDIRS(OpenMP/tests)
+    SUBDIRS(Optimize/tests)
   endif() #}
 
 endif() #}}}

--- a/src/Optimize/VariableSet.cpp
+++ b/src/Optimize/VariableSet.cpp
@@ -15,6 +15,11 @@
 #include "Optimize/VariableSet.h"
 #include <map>
 #include <stdexcept>
+#include <iomanip>
+#include <ios>
+#include <algorithm>
+
+using std::setw;
 
 namespace optimize
 {
@@ -228,16 +233,54 @@ void VariableSet::setDefaults(bool optimize_all)
     Index[i] = optimize_all ? i : -1;
 }
 
-void VariableSet::print(std::ostream& os)
+void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader)
 {
+  std::string pad_str = std::string(leftPadSpaces, ' ');
+  int max_name_len    = 0;
+  max_name_len =
+      std::max_element(NameAndValue.begin(), NameAndValue.end(),
+                       [](const pair_type& e1, const pair_type& e2) { return e1.first.length() < e2.first.length(); })
+          ->first.length();
+
+  int max_value_len     = 13; // 6 for the precision and 7 for minus sign, leading value, period, and exponent.
+  int max_type_len      = 1;
+  int max_recompute_len = 1;
+  int max_use_len       = 3;
+  int max_index_len     = 1;
+  if (printHeader)
+  {
+    max_name_len      = std::max(max_name_len, 4); // size of "Name" header
+    max_type_len      = 4;
+    max_recompute_len = 9;
+    max_index_len     = 5;
+    os << pad_str << setw(max_name_len) << "Name"
+       << " " << setw(max_value_len) << "Value"
+       << " " << setw(max_type_len) << "Type"
+       << " " << setw(max_recompute_len) << "Recompute"
+       << " " << setw(max_use_len) << "Use"
+       << " " << setw(max_index_len) << "Index" << std::endl;
+    os << pad_str << std::setfill('-') << setw(max_name_len) << ""
+       << " " << setw(max_value_len) << ""
+       << " " << setw(max_type_len) << ""
+       << " " << setw(max_recompute_len) << ""
+       << " " << setw(max_use_len) << ""
+       << " " << setw(max_index_len) << "" << std::endl;
+    os << std::setfill(' ');
+  }
+
   for (int i = 0; i < NameAndValue.size(); ++i)
   {
-    os << NameAndValue[i].first << " " << NameAndValue[i].second << " " << ParameterType[i].second << " "
-       << Recompute[i].second << " ";
+    os << pad_str << setw(max_name_len) << NameAndValue[i].first << " " << std::setprecision(6) << std::scientific
+       << setw(max_value_len) << NameAndValue[i].second << " " << setw(max_type_len) << ParameterType[i].second << " "
+       << setw(max_recompute_len) << Recompute[i].second << " ";
+
+    os << std::defaultfloat;
+
     if (Index[i] < 0)
-      os << " OFF" << std::endl;
+      os << setw(max_use_len) << "OFF" << std::endl;
     else
-      os << " ON " << Index[i] << std::endl;
+      os << setw(max_use_len) << "ON"
+         << " " << setw(max_index_len) << Index[i] << std::endl;
   }
 }
 

--- a/src/Optimize/VariableSet.h
+++ b/src/Optimize/VariableSet.h
@@ -329,7 +329,7 @@ struct VariableSet
    */
   void setDefaults(bool optimize_all);
 
-  void print(std::ostream& os);
+  void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false);
 };
 } // namespace optimize
 

--- a/src/Optimize/tests/CMakeLists.txt
+++ b/src/Optimize/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+#//////////////////////////////////////////////////////////////////////////////////////
+#// This file is distributed under the University of Illinois/NCSA Open Source License.
+#// See LICENSE file in top directory for details.
+#//
+#// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+#//
+#// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+#//
+#// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+#//////////////////////////////////////////////////////////////////////////////////////
+
+INCLUDE("${qmcpack_SOURCE_DIR}/CMake/macros.cmake")
+
+
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
+
+SET(SRC_DIR optimize)
+SET(UTEST_EXE test_${SRC_DIR})
+SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
+
+ADD_EXECUTABLE(${UTEST_EXE} test_variable_set.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS})
+
+ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")

--- a/src/Optimize/tests/test_variable_set.cpp
+++ b/src/Optimize/tests/test_variable_set.cpp
@@ -1,0 +1,92 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2019 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "Optimize/VariableSet.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+namespace optimize
+{
+TEST_CASE("VariableSet empty", "[optimize]")
+{
+  VariableSet vs;
+
+  REQUIRE(vs.is_optimizable() == false);
+  REQUIRE(vs.size_of_active() == 0);
+  REQUIRE(vs.find("something") == vs.NameAndValue.end());
+  REQUIRE(vs.getIndex("something") == -1);
+}
+
+TEST_CASE("VariableSet one", "[optimize]")
+{
+  VariableSet vs;
+  double first_val = 1.123456789;
+  vs.insert("first", first_val);
+  std::vector<std::string> names{"first"};
+  vs.activate(names.begin(), names.end(), true);
+
+  REQUIRE(vs.is_optimizable() == true);
+  REQUIRE(vs.size_of_active() == 1);
+  REQUIRE(vs.getIndex("first") == 0);
+  REQUIRE(vs.name(0) == "first");
+  REQUIRE(vs[0] == Approx(first_val));
+
+  std::ostringstream o;
+  vs.print(o, 0, false);
+  //std::cout << o.str() << std::endl;
+  REQUIRE(o.str() == "first  1.123457e+00 0 1  ON 0\n");
+
+  std::ostringstream o2;
+  vs.print(o2, 1, true);
+  //std::cout << o2.str() << std::endl;
+
+  char formatted_output[] = "  Name         Value Type Recompute Use Index\n"
+                            " ----- ------------- ---- --------- --- -----\n"
+                            " first  1.123457e+00    0         1  ON     0\n";
+
+
+  REQUIRE(o2.str() == formatted_output);
+}
+
+TEST_CASE("VariableSet output", "[optimize]")
+{
+  VariableSet vs;
+  double first_val  = 11234.56789;
+  double second_val = 0.000256789;
+  double third_val  = -1.2;
+  vs.insert("s", first_val);
+  vs.insert("second", second_val);
+  vs.insert("really_long_name", third_val);
+  std::vector<std::string> names{"s", "second", "really_long_name"};
+  vs.activate(names.begin(), names.end(), true);
+
+  std::ostringstream o;
+  vs.print(o, 0, true);
+  //std::cout << o.str() << std::endl;
+
+  char formatted_output[] = "            Name         Value Type Recompute Use Index\n"
+                            "---------------- ------------- ---- --------- --- -----\n"
+                            "               s  1.123457e+04    0         1  ON     0\n"
+                            "          second  2.567890e-04    0         1  ON     1\n"
+                            "really_long_name -1.200000e+00    0         1  ON     2\n";
+
+
+  REQUIRE(o.str() == formatted_output);
+}
+
+} // namespace optimize


### PR DESCRIPTION
Add an option to put header generation in the print function. 
Add names for all the columns.   Add column widths.
Force the values into scientific notation to have a consistent width.

Add option to left pad by a number of spaces, so the tables can fit into output scheme of indicating sections by indentation.

Add unit tests.

New output looks like
```
Name         Value Type Recompute Use Index
---- ------------- ---- --------- --- -----
uu_0  5.680176e-01    1         1  ON     0
uu_1  3.699138e-01    1         1  ON     1
uu_2  2.108829e-01    1         1  ON     2
uu_3  9.267632e-02    1         1  ON     3

```

The current code prints headers at the point where the code calls 'print', so header generation was made optional to enable gradual conversion of each call point to use the new output.