### PR TITLE
Cache distance table description for later output

### DIFF
--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -50,10 +50,10 @@ DistanceTableData* add(const ParticleSet& s, ParticleSet& t, int dt_type);
 } // namespace DistanceTable
 
 ///free function to create a distable table of s-s
-DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type);
+DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type, std::ostream& description);
 
 ///free function create a distable table of s-t
-DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int dt_type);
+DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int dt_type, std::ostream& description);
 
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/DistanceTableAA.cpp
+++ b/src/Particle/DistanceTableAA.cpp
@@ -167,12 +167,7 @@ DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type)
   p << s.getName() << "_" << s.getName();
   dt->Name = p.str(); //assign the table name
 
-  if (omp_get_thread_num() == 0)
-  {
-    app_log() << std::endl;
-    app_log() << o.str() << std::endl;
-    app_log().flush();
-  }
+  dt->description << o.str() << std::endl;
 
   return dt;
 }

--- a/src/Particle/DistanceTableAA.cpp
+++ b/src/Particle/DistanceTableAA.cpp
@@ -26,7 +26,7 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type)
+DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type, std::ostream& description)
 {
   typedef OHMMS_PRECISION RealType;
   enum
@@ -167,7 +167,7 @@ DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type)
   p << s.getName() << "_" << s.getName();
   dt->Name = p.str(); //assign the table name
 
-  dt->description << o.str() << std::endl;
+  description << o.str() << std::endl;
 
   return dt;
 }

--- a/src/Particle/DistanceTableAB.cpp
+++ b/src/Particle/DistanceTableAB.cpp
@@ -168,12 +168,8 @@ DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int
   p << s.getName() << "_" << t.getName();
   dt->Name = p.str(); //assign the table name
 
-  if (omp_get_thread_num() == 0)
-  {
-    app_log() << std::endl;
-    app_log() << o.str() << std::endl;
-    app_log().flush();
-  }
+  dt->description << o.str() << std::endl;
+
   return dt;
 }
 

--- a/src/Particle/DistanceTableAB.cpp
+++ b/src/Particle/DistanceTableAB.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int dt_type)
+DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int dt_type, std::ostream& description)
 {
   typedef OHMMS_PRECISION RealType;
   enum
@@ -168,7 +168,7 @@ DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int
   p << s.getName() << "_" << t.getName();
   dt->Name = p.str(); //assign the table name
 
-  dt->description << o.str() << std::endl;
+  description << o.str() << std::endl;
 
   return dt;
 }

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -398,6 +398,15 @@ struct DistanceTableData
       Temp.resize(N[SourceIndex]);
     }
   }
+
+  /// Description generated during creation, to be printed later
+  std::ostringstream description;
+
+  void output_description(std::ostream& os)
+  {
+    os << std::endl;
+    os << description.str();
+  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -399,14 +399,6 @@ struct DistanceTableData
     }
   }
 
-  /// Description generated during creation, to be printed later
-  std::ostringstream description;
-
-  void output_description(std::ostream& os)
-  {
-    os << std::endl;
-    os << description.str();
-  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -309,10 +309,10 @@ bool ParticleSet::get(std::ostream& os) const
     os << "    (... and " << (TotalNum - numToPrint) << " more particle positions ...)" << std::endl;
   }
 
-  for (DistanceTableData* dt : DistTables)
+  for (const std::string& description : distTableDescriptions)
   {
     os << std::endl;
-    os << dt->description.str();
+    os << description;
   }
 
   return true;
@@ -369,12 +369,14 @@ int ParticleSet::addTable(const ParticleSet& psrc, int dt_type)
   if (DistTables.empty())
   {
     DistTables.reserve(4);
+    std::ostringstream description;
 #if defined(ENABLE_SOA)
-    DistTables.push_back(createDistanceTable(*this, DT_SOA));
+    DistTables.push_back(createDistanceTable(*this, DT_SOA, description));
 #else
     //if(dt_type==DT_SOA_PREFERRED) dt_type=DT_AOS; //safety
-    DistTables.push_back(createDistanceTable(*this, dt_type));
+    DistTables.push_back(createDistanceTable(*this, dt_type, description));
 #endif
+    distTableDescriptions.push_back(description.str());
     //add  this-this pair
     myDistTableMap.clear();
     myDistTableMap[myName] = 0;
@@ -396,8 +398,10 @@ int ParticleSet::addTable(const ParticleSet& psrc, int dt_type)
   std::map<std::string, int>::iterator tit(myDistTableMap.find(psrc.getName()));
   if (tit == myDistTableMap.end())
   {
+    std::ostringstream description;
     tid = DistTables.size();
-    DistTables.push_back(createDistanceTable(psrc, *this, dt_type));
+    DistTables.push_back(createDistanceTable(psrc, *this, dt_type, description));
+    distTableDescriptions.push_back(description.str());
     myDistTableMap[psrc.getName()] = tid;
     DistTables[tid]->ID            = tid;
     app_debug() << "  ... ParticleSet::addTable Create Table #" << tid << " " << DistTables[tid]->Name << std::endl;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -309,6 +309,12 @@ bool ParticleSet::get(std::ostream& os) const
     os << "    (... and " << (TotalNum - numToPrint) << " more particle positions ...)" << std::endl;
   }
 
+  for (DistanceTableData* dt : DistTables)
+  {
+    os << std::endl;
+    os << dt->description.str();
+  }
+
   return true;
 }
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -160,6 +160,9 @@ public:
   ///distance tables that need to be updated by moving this ParticleSet
   std::vector<DistanceTableData*> DistTables;
 
+  /// Descriptions from distance table creation.  Same order as DistTables.
+  std::vector<std::string> distTableDescriptions;
+
   ///Particle density in G-space for MPC interaction
   std::vector<TinyVector<int, OHMMS_DIM>> DensityReducedGvecs;
   std::vector<ComplexType> Density_G;

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -36,10 +36,14 @@ VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl) : refPS(
   if (refPS.DistTables.size())
   {
     DistTables.resize(refPS.DistTables.size());
+    distTableDescriptions.resize(refPS.DistTables.size());
     for (int i = 0; i < DistTables.size(); ++i)
     {
-      DistTables[i]     = createDistanceTable(refPS.DistTables[i]->origin(), *this, refPS.DistTables[0]->DTType);
-      DistTables[i]->ID = i;
+      std::ostringstream description;
+      DistTables[i] =
+          createDistanceTable(refPS.DistTables[i]->origin(), *this, refPS.DistTables[0]->DTType, description);
+      distTableDescriptions[i] = description.str();
+      DistTables[i]->ID        = i;
     }
   }
 }


### PR DESCRIPTION
Currently the distance table output occurs during the middle of wavefunction output.
Store the description and output it later during the ParticleSetPool output.