### PR TITLE
Expand minimum bracket search for cusp correction

### DIFF
--- a/src/Numerics/MinimizeOneDim.h
+++ b/src/Numerics/MinimizeOneDim.h
@@ -93,8 +93,12 @@ Bracket_min_t<T> bracket_minimum(const F& f, T initial_value, T bound_max = -1.0
     {
       delx *= 5;
     }
-    cnt++;
     if (cnt == 1000)
+    {
+      delx *= 5;
+    }
+    cnt++;
+    if (cnt == 10000)
     {
       throw std::runtime_error("Failed to bracket minimum");
     }


### PR DESCRIPTION
This addresses a case with the cusp correction where the starting function value is around 1e18, and is very sharply peaked near the starting value. The step size is not large enough to reach the minimum in 1000 iterations.
The algorithm succeeds if another step size increment is added at 1000 iterations and the max iteration count raised to 10000.