### PR TITLE
Remove workaround in SplineC2ROMP

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
@@ -736,10 +736,10 @@ struct SplineC2ROMP : public SplineAdoptorBase<ST, 3>
 
     const auto padded_size = myV.size();
     if (offload_scratch.size() < padded_size * 10)
-      offload_scratch.resize(padded_size * 50); // temporal solution putting 5x
+      offload_scratch.resize(padded_size * 10);
     const auto orb_size = psi.size();
     if (results_scratch.size() < orb_size * 5)
-      results_scratch.resize(orb_size * 50); // temporal solution putting 10x
+      results_scratch.resize(orb_size * 5);
 
     // Ye: need to extract sizes and pointers before entering target region
     const auto* spline_ptr    = SplineInst->spline_m;


### PR DESCRIPTION
The allocator bug has been fixed when fixing the unit test before the v3.7 release.