### PR TITLE
Fix clang warnings in GreenFunctionModifiers

### DIFF
--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBase.h
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBase.h
@@ -37,7 +37,9 @@ public:
                               const GradType& qf,
                               PosType& drift) const = 0;
 
-  virtual bool parseXML(xmlNodePtr cur){}
+  virtual bool parseXML(xmlNodePtr cur) { return true; }
+
+  virtual ~DriftModifierBase() {}
 
 protected:
   // modifer name

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -23,7 +23,7 @@ void DriftModifierUNR::getDrift(RealType tau,
   convert(qf, drift);
   RealType vsq = dot(drift, drift);
   RealType sc =
-      (vsq < std::numeric_limits<RealType>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * tau * vsq)) / vsq);
+      (vsq < std::numeric_limits<RealType>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * a * tau * vsq)) / ( a * vsq ) );
   //Apply the umrigar scaled drift.
   drift *= sc;
 }

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -34,6 +34,7 @@ bool DriftModifierUNR::parseXML(xmlNodePtr cur)
   m_param.add(a, "drift_UNR_a", "double");
   m_param.put(cur);
   app_log() << "  Set drift_modifier UNR parameter a = " << a << std::endl;
+  return true;
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
In addition to issuing a warning at compile time, clang causes the code to abort if the function takes a return value but no return statement is present.

Also add a virtual destructor to the base class to address another clang warning.