### PR TITLE
Implement Ionic Derivatives of LCAO-type SPO's for SoA

### DIFF
--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -157,10 +157,17 @@ struct SoaBasisSetBase
 
   virtual SoaBasisSetBase<T>* makeClone() const = 0;
   virtual void setBasisSetSize(int nbs)=0;
+ 
+  //Evaluates value, gradient, and laplacian for electron "iat".  Parks them into a temporary data structure "vgl".
   virtual void evaluateVGL(const ParticleSet& P, int iat, vgl_type& vgl)=0;
+  //Evaluates value, gradient, and Hessian for electron "iat".  Parks them into a temporary data structure "vgh".
   virtual void evaluateVGH(const ParticleSet& P, int iat, vgh_type& vgh)=0;
+  //Evaluates value, gradient, and Hessian, and Gradient Hessian for electron "iat".  Parks them into a temporary data structure "vghgh".
   virtual void evaluateVGHGH(const ParticleSet& P, int iat, vghgh_type& vghgh)=0;
+  //Evaluates the x,y, and z components of ionic gradient associated with "jion" of value.  Parks the raw data into "vgl" container.
   virtual void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vgl_type& vgl)=0;
+  //Evaluates the x,y, and z components of ionic gradient associated with "jion" value, gradient, and laplacian.  
+  //    Parks the raw data into "vghgh" container.
   virtual void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)=0;
   virtual void evaluateV(const ParticleSet& P, int iat, value_type* restrict vals)=0;
   virtual bool is_S_orbital(int mo_idx, int ao_idx) { return false;}

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -160,6 +160,8 @@ struct SoaBasisSetBase
   virtual void evaluateVGL(const ParticleSet& P, int iat, vgl_type& vgl)=0;
   virtual void evaluateVGH(const ParticleSet& P, int iat, vgh_type& vgh)=0;
   virtual void evaluateVGHGH(const ParticleSet& P, int iat, vghgh_type& vghgh)=0;
+  virtual void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)=0;
+  virtual void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)=0;
   virtual void evaluateV(const ParticleSet& P, int iat, value_type* restrict vals)=0;
   virtual bool is_S_orbital(int mo_idx, int ao_idx) { return false;}
 

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -160,7 +160,7 @@ struct SoaBasisSetBase
   virtual void evaluateVGL(const ParticleSet& P, int iat, vgl_type& vgl)=0;
   virtual void evaluateVGH(const ParticleSet& P, int iat, vgh_type& vgh)=0;
   virtual void evaluateVGHGH(const ParticleSet& P, int iat, vghgh_type& vghgh)=0;
-  virtual void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)=0;
+  virtual void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vgl_type& vgl)=0;
   virtual void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)=0;
   virtual void evaluateV(const ParticleSet& P, int iat, value_type* restrict vals)=0;
   virtual bool is_S_orbital(int mo_idx, int ao_idx) { return false;}

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -490,6 +490,21 @@ void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
+void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last, 
+                                       const ParticleSet& source, int iat_src, 
+                                       GradMatrix_t& gradphi)
+{
+
+}
+
+void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last,
+                                       const ParticleSet& source, int iat_src,
+                                       GradMatrix_t& grad_phi, HessMatrix_t& grad_grad_phi, 
+                                       GradMatrix_t& grad_lapl_phi)
+{
+
+}
+
 void LCAOrbitalSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix_t& grad_grad_grad_logdet)
 {
   APP_ABORT("LCAOrbitalSet::evaluateThirdDeriv(P,istart,istop,ggg_logdet) not implemented\n");

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -494,7 +494,23 @@ void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last
                                        const ParticleSet& source, int iat_src, 
                                        GradMatrix_t& gradphi)
 {
-
+  if (Identity)
+  {
+    for (size_t i = 0, iat = first; iat < last; i++, iat++)
+    {
+      myBasisSet->evaluateVGHGH(P, iat, Tempgh);
+  //    evaluate_vghgh_impl(Tempgh, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
+    }
+  }
+  else
+  {
+    for (size_t i = 0, iat = first; iat < last; i++, iat++)
+    {
+    //  myBasisSet->evaluateVGHGH(P, iat, Tempgh);
+      Product_ABt(Tempgh, *C, Tempghv);
+    //  evaluate_vghgh_impl(Tempghv, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
+    }
+  }
 }
 
 void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last,
@@ -502,7 +518,23 @@ void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last
                                        GradMatrix_t& grad_phi, HessMatrix_t& grad_grad_phi, 
                                        GradMatrix_t& grad_lapl_phi)
 {
-
+  if (Identity)
+  {
+    for (size_t i = 0, iat = first; iat < last; i++, iat++)
+    {
+    //  myBasisSet->evaluateVGHGH(P, iat, Tempgh);
+    //  evaluate_vghgh_impl(Tempgh, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
+    }
+  }
+  else
+  {
+    for (size_t i = 0, iat = first; iat < last; i++, iat++)
+    {
+    //  myBasisSet->evaluateVGHGH(P, iat, Tempgh);
+      Product_ABt(Tempgh, *C, Tempghv);
+    //  evaluate_vghgh_impl(Tempghv, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
+    }
+  }
 }
 
 void LCAOrbitalSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix_t& grad_grad_grad_logdet)

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.cpp
@@ -411,6 +411,56 @@ inline void LCAOrbitalSet::evaluate_vgh_impl(const vgh_type& temp,
   }
 }
 
+inline void LCAOrbitalSet::evaluate_ionderiv_vgl_impl(const vghgh_type& temp,
+                                             int i,
+                                             GradMatrix_t& dpsi,
+                                             HessMatrix_t& dgpsi,
+                                             GradMatrix_t& dlpsi) const
+{
+ // std::copy_n(temp.data(0), OrbitalSetSize, psi.data());
+  const ValueType* restrict gx = temp.data(1);
+  const ValueType* restrict gy = temp.data(2);
+  const ValueType* restrict gz = temp.data(3);
+  const ValueType* restrict hxx = temp.data(4);
+  const ValueType* restrict hxy = temp.data(5);
+  const ValueType* restrict hxz = temp.data(6);
+  const ValueType* restrict hyy = temp.data(7);
+  const ValueType* restrict hyz = temp.data(8);
+  const ValueType* restrict hzz = temp.data(9);
+  const ValueType* restrict gh_xxx = temp.data(10);
+  const ValueType* restrict gh_xxy = temp.data(11);
+  const ValueType* restrict gh_xxz = temp.data(12);
+  const ValueType* restrict gh_xyy = temp.data(13);
+  const ValueType* restrict gh_xyz = temp.data(14);
+  const ValueType* restrict gh_xzz = temp.data(15);
+  const ValueType* restrict gh_yyy = temp.data(16);
+  const ValueType* restrict gh_yyz = temp.data(17);
+  const ValueType* restrict gh_yzz = temp.data(18);
+  const ValueType* restrict gh_zzz = temp.data(19);
+
+  for (size_t j = 0; j < OrbitalSetSize; j++)
+  {
+    //As mentioned in SoaLocalizedBasisSet, LCAO's have a nice property that
+    // for an atomic center, the ion gradient is the negative of the elecron gradient.
+    // Hence minus signs for each of these.
+    dpsi[i][j][0] = -gx[j];
+    dpsi[i][j][1] = -gy[j];
+    dpsi[i][j][2] = -gz[j];
+    
+    dgpsi[i][j](0,0)                 = -hxx[j]; 
+    dgpsi[i][j](0,1) = dgpsi[i][j](1,0) = -hxy[j]; 
+    dgpsi[i][j](0,2) = dgpsi[i][j](2,0) = -hxz[j]; 
+    dgpsi[i][j](1,1)                 = -hyy[j]; 
+    dgpsi[i][j](2,1) = dgpsi[i][j](1,2) = -hyz[j]; 
+    dgpsi[i][j](2,2)                 = -hzz[j]; 
+   
+    //Since this returns the ion gradient of the laplacian, we have to trace the grad hessian vector.
+    dlpsi[i][j][0] = -(gh_xxx[j]+gh_xyy[j]+gh_xzz[j]);
+    dlpsi[i][j][1] = -(gh_xxy[j]+gh_yyy[j]+gh_yzz[j]);
+    dlpsi[i][j][2] = -(gh_xxz[j]+gh_yyz[j]+gh_zzz[j]);
+  }
+}
+
 void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P,
                                          int first,
                                          int last,
@@ -518,20 +568,22 @@ void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P, int first, int last
                                        GradMatrix_t& grad_phi, HessMatrix_t& grad_grad_phi, 
                                        GradMatrix_t& grad_lapl_phi)
 {
+
   if (Identity)
   {
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
-    //  myBasisSet->evaluateVGHGH(P, iat, Tempgh);
-    //  evaluate_vghgh_impl(Tempgh, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
+      myBasisSet->evaluateGradSourceVGL(P, iat, source, iat_src, Tempgh);
+      evaluate_ionderiv_vgl_impl(Tempgh, i, grad_phi, grad_grad_phi, grad_lapl_phi);
     }
   }
   else
   {
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
-    //  myBasisSet->evaluateVGHGH(P, iat, Tempgh);
+      myBasisSet->evaluateGradSourceVGL(P, iat, source, iat_src, Tempgh);
       Product_ABt(Tempgh, *C, Tempghv);
+      evaluate_ionderiv_vgl_impl(Tempghv, i, grad_phi, grad_grad_phi, grad_lapl_phi);
     //  evaluate_vghgh_impl(Tempghv, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
     }
   }

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -223,6 +223,22 @@ public:
                             HessMatrix_t& grad_grad_logdet,
                             GGGMatrix_t& grad_grad_grad_logdet);
 
+  void evaluateGradSource(const ParticleSet& P,
+                          int first,
+                          int last,
+                          const ParticleSet& source,
+                          int iat_src,
+                          GradMatrix_t& gradphi);
+
+  void evaluateGradSource(const ParticleSet& P,
+                          int first,
+                          int last,
+                          const ParticleSet& source,
+                          int iat_src,
+                          GradMatrix_t& grad_phi,
+                          HessMatrix_t& grad_grad_phi,
+                          GradMatrix_t& grad_lapl_phi);
+
   void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix_t& grad_grad_grad_logdet);
 
 private:

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -275,6 +275,12 @@ private:
                          HessMatrix_t& dhlogdet,
                          GGGMatrix_t& dghlogdet) const;
   
+  void evaluate_ionderiv_vgl_impl(const vghgh_type& temp,
+                         int i,
+                         GradMatrix_t& dlogdet,
+                         HessMatrix_t& dglogdet,
+                         GradMatrix_t& dllogdet) const;
+  
 
 #if !defined(QMC_COMPLEX)
   //function to perform orbital rotations

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -223,13 +223,62 @@ public:
                             HessMatrix_t& grad_grad_logdet,
                             GGGMatrix_t& grad_grad_grad_logdet);
 
+ //NOTE:  The data types get complicated here, so here's an overview of the 
+ //       data types associated with ionic derivatives, and how to get their data.
+ //
+ //NOTE:  These data structures hold the data for one particular ion, and so the ID is implicit.
+ //       It's up to the user to keep track of which ion these derivatives refer to.   
+ //
+ // 1.) GradMatrix_t grad_phi:  Holds the ionic derivatives of each SPO for each electron.  
+ //            Example:  grad_phi[iel][iorb][idim].  iel  -- electron index.
+ //                                                iorb -- orbital index.
+ //                                                idim  -- cartesian index of ionic derivative.  
+ //                                                        X=0, Y=1, Z=2.
+ //                                                        
+ // 2.) HessMatrix_t grad_grad_phi:  Holds the ionic derivatives of the electron gradient components 
+ //                                   for each SPO and each electron.  
+ //            Example:  grad_grad_phi[iel][iorb](idim,edim)  iel  -- electron index.
+ //                                                           iorb -- orbital index. 
+ //                                                           idim -- ionic derivative's cartesian index.
+ //                                                              X=0, Y=1, Z=2
+ //                                                           edim -- electron derivative's cartesian index.
+ //                                                              x=0, y=1, z=2.
+ //
+ // 3.) GradMatrix_t grad_lapl_phi:  Holds the ionic derivatives of the electron laplacian for each SPO and each electron.                                                
+ //            Example:  grad_lapl_phi[iel][iorb][idim].  iel  -- electron index.
+ //                                                       iorb -- orbital index.
+ //                                                       idim -- cartesian index of ionic derivative.  
+ //                                                           X=0, Y=1, Z=2.
+
+ /**
+ * \brief Calculate ion derivatives of SPO's.
+ *  
+ *  @param P Electron particle set.
+ *  @param first index of first electron 
+ *  @@param last index of last electron
+ *  @param source Ion particle set.
+ *  @param iat_src  Index of ion.
+ *  @param gradphi Container storing ion gradients for all particles and all orbitals.
+ */
   void evaluateGradSource(const ParticleSet& P,
                           int first,
                           int last,
                           const ParticleSet& source,
                           int iat_src,
-                          GradMatrix_t& gradphi);
+                          GradMatrix_t& grad_phi);
 
+ /**
+ * \brief Calculate ion derivatives of SPO's, their gradients, and their laplacians.
+ *  
+ *  @param P Electron particle set.
+ *  @param first index of first electron.
+ *  @@param last index of last electron
+ *  @param source Ion particle set.
+ *  @param iat_src  Index of ion.
+ *  @param grad_phi Container storing ion gradients for all particles and all orbitals.
+ *  @param grad_grad_phi Container storing ion gradients of electron gradients for all particles and all orbitals.
+ *  @param grad_lapl_phi Container storing ion gradients of SPO laplacians for all particles and all orbitals.
+ */
   void evaluateGradSource(const ParticleSet& P,
                           int first,
                           int last,
@@ -274,11 +323,15 @@ private:
                          GradMatrix_t& dlogdet,
                          HessMatrix_t& dhlogdet,
                          GGGMatrix_t& dghlogdet) const;
-  
+
+
+  //Unpacks data in vgl object and calculates/places ionic gradient result into dlogdet.   
   void evaluate_ionderiv_v_impl(const vgl_type& temp,
                          int i,
                          GradMatrix_t& dlogdet) const;
   
+  //Unpacks data in vgl object and calculates/places ionic gradient of value, 
+  //  electron gradient, and electron laplacian result into dlogdet, dglogdet, and dllogdet respectively.   
   void evaluate_ionderiv_vgl_impl(const vghgh_type& temp,
                          int i,
                          GradMatrix_t& dlogdet,

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalSet.h
@@ -275,6 +275,10 @@ private:
                          HessMatrix_t& dhlogdet,
                          GGGMatrix_t& dghlogdet) const;
   
+  void evaluate_ionderiv_v_impl(const vgl_type& temp,
+                         int i,
+                         GradMatrix_t& dlogdet) const;
+  
   void evaluate_ionderiv_vgl_impl(const vghgh_type& temp,
                          int i,
                          GradMatrix_t& dlogdet,

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -229,15 +229,73 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     }
   }
   
-  
+  //These are going to use the vghgh containers as temporary arrays.  The main difference between
+  //replacing an ion derivative with an electron derivative is the -1 factor incurred.  This will be taken care of
+  //in LCAO orbital set.   
   inline void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
   {
-
+    const DistanceTableData* d_table = P.DistTables[myTableIndex];
+    const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
+    const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
+    
+    LOBasisSet[IonID[jion]]->evaluateVGH(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vghgh);
   }
 
   inline void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
   {
+    auto* restrict gx  = vghgh.data(1);
+    auto* restrict gy  = vghgh.data(2);
+    auto* restrict gz  = vghgh.data(3);
 
+    auto* restrict hxx = vghgh.data(4);
+    auto* restrict hxy = vghgh.data(5);
+    auto* restrict hxz = vghgh.data(6);
+    auto* restrict hyy = vghgh.data(7);
+    auto* restrict hyz = vghgh.data(8);
+    auto* restrict hzz = vghgh.data(9);
+    
+    auto* restrict gxxx = vghgh.data(10);
+    auto* restrict gxxy = vghgh.data(11);
+    auto* restrict gxxz = vghgh.data(12);
+    auto* restrict gxyy = vghgh.data(13);
+    auto* restrict gxyz = vghgh.data(14);
+    auto* restrict gxzz = vghgh.data(15);
+    auto* restrict gyyy = vghgh.data(16);
+    auto* restrict gyyz = vghgh.data(17);
+    auto* restrict gyzz = vghgh.data(18);
+    auto* restrict gzzz = vghgh.data(19);
+
+
+    for(int ib=0; ib<BasisSetSize; ib++)
+    {
+      gx[ib]=0;
+      gy[ib]=0;
+      gz[ib]=0;
+
+      hxx[ib]=0;
+      hxy[ib]=0;
+      hxz[ib]=0;
+      hyy[ib]=0;
+      hyz[ib]=0;
+      hzz[ib]=0;
+
+      gxxx[ib]=0;
+      gxxy[ib]=0;
+      gxxz[ib]=0;
+      gxyy[ib]=0;
+      gxyz[ib]=0;
+      gxzz[ib]=0;
+      gyyy[ib]=0;
+      gyyz[ib]=0;
+      gyzz[ib]=0;
+      gzzz[ib]=0;
+    }
+    const DistanceTableData* d_table = P.DistTables[myTableIndex];
+    const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
+    const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
+    
+    LOBasisSet[IonID[jion]]->evaluateVGHGH(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vghgh);
+    
   }
   /** add a new set of Centered Atomic Orbitals
    * @param icenter the index of the center

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -182,8 +182,6 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
    */
   inline void evaluateVGH(const ParticleSet& P, int iat, vgh_type& vgh)
   {
-   // APP_ABORT("SoaLocalizedBasisSet::evaluateVGH() not implemented\n");
-    
     const DistanceTableData* d_table = P.DistTables[myTableIndex];
     const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
     const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
@@ -229,12 +227,9 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     }
   }
   
-  //These are going to use the vghgh containers as temporary arrays.  The main difference between
-  //replacing an ion derivative with an electron derivative is the -1 factor incurred.  This will be taken care of
-  //in LCAO orbital set.   
   inline void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vgl_type& vgl)
   {
-
+    //We need to zero out the temporary array vgl.  
     auto* restrict gx  = vgl.data(1);
     auto* restrict gy  = vgl.data(2);
     auto* restrict gz  = vgl.data(3);
@@ -249,13 +244,17 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     const DistanceTableData* d_table = P.DistTables[myTableIndex];
     const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
     const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
-    
+  
+    //Since LCAO's are written only in terms of (r-R), ionic derivatives only exist for the atomic center
+    //that we wish to take derivatives of.  Moreover, we can obtain an ion derivative by multiplying an electron
+    //derivative by -1.0.  Handling this sign is left to LCAOrbitalSet.  For now, just note this is the electron VGL function.
     LOBasisSet[IonID[jion]]->evaluateVGL(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vgl);
 
   }
 
   inline void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
   {
+    //We need to zero out the temporary array vghgh.
     auto* restrict gx  = vghgh.data(1);
     auto* restrict gy  = vghgh.data(2);
     auto* restrict gz  = vghgh.data(3);
@@ -303,10 +302,14 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
       gyzz[ib]=0;
       gzzz[ib]=0;
     }
+
     const DistanceTableData* d_table = P.DistTables[myTableIndex];
     const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
     const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
     
+    //Since LCAO's are written only in terms of (r-R), ionic derivatives only exist for the atomic center
+    //that we wish to take derivatives of.  Moreover, we can obtain an ion derivative by multiplying an electron
+    //derivative by -1.0.  Handling this sign is left to LCAOrbitalSet.  For now, just note this is the electron VGL function.
     LOBasisSet[IonID[jion]]->evaluateVGHGH(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vghgh);
     
   }

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -228,7 +228,17 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
       LOBasisSet[IonID[c]]->evaluateV(P.Lattice, dist[c], displ[c], vals + BasisOffset[c]);
     }
   }
+  
+  
+  inline void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
+  {
 
+  }
+
+  inline void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
+  {
+
+  }
   /** add a new set of Centered Atomic Orbitals
    * @param icenter the index of the center
    * @param aos a set of Centered Atomic Orbitals

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -232,13 +232,26 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
   //These are going to use the vghgh containers as temporary arrays.  The main difference between
   //replacing an ion derivative with an electron derivative is the -1 factor incurred.  This will be taken care of
   //in LCAO orbital set.   
-  inline void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)
+  inline void evaluateGradSourceV(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vgl_type& vgl)
   {
+
+    auto* restrict gx  = vgl.data(1);
+    auto* restrict gy  = vgl.data(2);
+    auto* restrict gz  = vgl.data(3);
+
+    for(int ib=0; ib<BasisSetSize; ib++)
+    {
+      gx[ib]=0;
+      gy[ib]=0;
+      gz[ib]=0;
+    }
+
     const DistanceTableData* d_table = P.DistTables[myTableIndex];
     const RealType* restrict dist    = (P.activePtcl == iat) ? d_table->Temp_r.data() : d_table->Distances[iat];
     const auto& displ                = (P.activePtcl == iat) ? d_table->Temp_dr : d_table->Displacements[iat];
     
-    LOBasisSet[IonID[jion]]->evaluateVGH(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vghgh);
+    LOBasisSet[IonID[jion]]->evaluateVGL(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vgl);
+
   }
 
   inline void evaluateGradSourceVGL(const ParticleSet& P, int iat, const ParticleSet& ions, int jion, vghgh_type& vghgh)

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -209,9 +209,9 @@ def gen_HCN_force():
       mo_g_m = np.dot(MO_matrix, g_m)
       mo_l_m = np.dot(MO_matrix, l_m)
 
-      dmo_v = 2.0*deltainv*(mo_v_p-mo_v_m)
-      dmo_g = 2.0*deltainv*(mo_g_p-mo_g_m)
-      dmo_l = 2.0*deltainv*(mo_l_p-mo_l_m)
+      dmo_v = 0.5*deltainv*(mo_v_p-mo_v_m)
+      dmo_g = 0.5*deltainv*(mo_g_p-mo_g_m)
+      dmo_l = 0.5*deltainv*(mo_l_p-mo_l_m)
       print "//============== Ion ",iat," Component ",idim,"==================="
       for iorb in xrange(0,norb):
         print '  REQUIRE( dionpsi[0][%d][%d]       == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -179,6 +179,9 @@ def gen_HCN_force():
 
   Natom=ionpos.shape[0];
   norb=7
+
+  print '  // Generated from gen_mo.py for position %s'%str(pos)
+
   for iat in xrange(0,Natom):
     for idim in xrange(0,3):
       ionpos_p=np.array(ionpos)

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -214,11 +214,11 @@ def gen_HCN_force():
       dmo_l = 2.0*deltainv*(mo_l_p-mo_l_m)
       print "//============== Ion ",iat," Component ",idim,"==================="
       for iorb in xrange(0,norb):
-        print '  REQUIRE( dv[%d][%d]    == Approx(%15.10g) );  '%(idim,iorb,dmo_v[iorb])
-        print '  REQUIRE( dg[%d][%d][0] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
-        print '  REQUIRE( dg[%d][%d][1] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
-        print '  REQUIRE( dg[%d][%d][2] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
-        print '  REQUIRE( dl[%d][%d]    == Approx(%15.10g) );  '%(idim,iorb,dmo_v[iorb])
+        print '  REQUIRE( dionpsi[0][%d][%d]       == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])
+        print '  REQUIRE( diongradpsi[0][%d](%d,0) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
+        print '  REQUIRE( diongradpsi[0][%d](%d,1) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
+        print '  REQUIRE( diongradpsi[0][%d](%d,2) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
+        print '  REQUIRE( dionlaplpsi[0][%d][%d]  == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])
     
   print '  // Generated from gen_mo.py for position %s'%str(pos)
  # for i in range(7):

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -216,9 +216,9 @@ def gen_HCN_force():
       for iorb in xrange(0,norb):
         print '  REQUIRE( dionpsi[0][%d][%d]       == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])
         print '  REQUIRE( diongradpsi[0][%d](%d,0) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
-        print '  REQUIRE( diongradpsi[0][%d](%d,1) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
-        print '  REQUIRE( diongradpsi[0][%d](%d,2) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
-        print '  REQUIRE( dionlaplpsi[0][%d][%d]  == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])
+        print '  REQUIRE( diongradpsi[0][%d](%d,1) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][1])
+        print '  REQUIRE( diongradpsi[0][%d](%d,2) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][2])
+        print '  REQUIRE( dionlaplpsi[0][%d][%d]  == Approx(%15.10g) );  '%(iorb,idim,dmo_l[iorb])
     
   print '  // Generated from gen_mo.py for position %s'%str(pos)
  # for i in range(7):

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -211,11 +211,11 @@ def gen_HCN_force():
       dmo_l = 2.0*deltainv*(mo_l_p-mo_l_m)
       print "//============== Ion ",iat," Component ",idim,"==================="
       for iorb in xrange(0,norb):
-        print ' d %d v = %15.10g  '%(iorb,dmo_v[iorb])
-        print ' d %d gx = %15.10g '%(iorb,dmo_g[iorb][0])
-        print ' d %d gy = %15.10g '%(iorb,dmo_g[iorb][1])
-        print ' d %d gz = %15.10g '%(iorb,dmo_g[iorb][2])
-        print ' d %d l  = %15.10g '%(iorb,dmo_l[iorb])
+        print '  REQUIRE( dv[%d][%d]    == Approx(%15.10g) );  '%(idim,iorb,dmo_v[iorb])
+        print '  REQUIRE( dg[%d][%d][0] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
+        print '  REQUIRE( dg[%d][%d][1] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
+        print '  REQUIRE( dg[%d][%d][2] == Approx(%15.10g) );  '%(idim,iorb,dmo_g[iorb][0])
+        print '  REQUIRE( dl[%d][%d]    == Approx(%15.10g) );  '%(idim,iorb,dmo_v[iorb])
     
   print '  // Generated from gen_mo.py for position %s'%str(pos)
  # for i in range(7):

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -166,8 +166,81 @@ def gen_HCN():
     print '  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(i,mo_gh[i][8])
     print '  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(i,mo_gh[i][9])
     print ''
-   
+  
+
+def gen_HCN_force():
+  basis_sets, MO_matrix = read_qmcpack.parse_qmc_wf("hcn.wfnoj.xml",['N','C','H'])
+  ionpos, elements = read_qmcpack.read_structure_file("hcn.structure.xml")
+
+  pos = [0.02, -0.1, 0.05]
+
+  delta=1.0e-6
+  deltainv=1.0/delta
+
+  Natom=ionpos.shape[0];
+  norb=7
+  for iat in xrange(0,Natom):
+    for idim in xrange(0,3):
+      ionpos_p=np.array(ionpos)
+      ionpos_m=np.array(ionpos)
+      
+      ionpos_p[iat][idim]+=delta
+      ionpos_m[iat][idim]-=delta
+
+      gtos_p = gaussian_orbitals.GTO_centers(ionpos_p, elements, basis_sets)
+      gtos_m = gaussian_orbitals.GTO_centers(ionpos_m, elements, basis_sets)
+      
+      atomic_orbs_p = gtos_p.eval_v(*pos)
+      atomic_orbs_m = gtos_m.eval_v(*pos)
+      
+      mol_orbs_p =  np.dot(MO_matrix, atomic_orbs_p)
+      mol_orbs_m =  np.dot(MO_matrix, atomic_orbs_m)
+
+      v_p,g_p,l_p = gtos_p.eval_vgl(*pos)
+      mo_v_p = np.dot(MO_matrix, v_p)
+      mo_g_p = np.dot(MO_matrix, g_p)
+      mo_l_p = np.dot(MO_matrix, l_p)
+
+      v_m,g_m,l_m = gtos_m.eval_vgl(*pos)
+      mo_v_m = np.dot(MO_matrix, v_m)
+      mo_g_m = np.dot(MO_matrix, g_m)
+      mo_l_m = np.dot(MO_matrix, l_m)
+
+      dmo_v = 2.0*deltainv*(mo_v_p-mo_v_m)
+      dmo_g = 2.0*deltainv*(mo_g_p-mo_g_m)
+      dmo_l = 2.0*deltainv*(mo_l_p-mo_l_m)
+      print "//============== Ion ",iat," Component ",idim,"==================="
+      for iorb in xrange(0,norb):
+        print ' d %d v = %15.10g  '%(iorb,dmo_v[iorb])
+        print ' d %d gx = %15.10g '%(iorb,dmo_g[iorb][0])
+        print ' d %d gy = %15.10g '%(iorb,dmo_g[iorb][1])
+        print ' d %d gz = %15.10g '%(iorb,dmo_g[iorb][2])
+        print ' d %d l  = %15.10g '%(iorb,dmo_l[iorb])
+    
+  print '  // Generated from gen_mo.py for position %s'%str(pos)
+ # for i in range(7):
+ #   print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mol_orbs[i])
+
+#  v,g,l = gtos.eval_vgl(*pos)
+#  mo_v = np.dot(MO_matrix, v)
+#  mo_g = np.dot(MO_matrix, g)
+#  mo_l = np.dot(MO_matrix, l)
+#  print '  // Generated from gen_mo.py for position %s'%str(pos)
+#  for i in range(7):
+#    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mo_v[i])
+#    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(i,mo_g[i][0])
+#    print '  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(i,mo_l[i])
+#    print ''
+
+#  v,g,h = gtos.eval_vgh(*pos)
+#  gh    = gtos.eval_gradhess(*pos)
+#  mo_v = np.dot(MO_matrix,v)
+#  mo_g = np.dot(MO_matrix,g)
+#  mo_h = np.dot(MO_matrix,h)
+#  mo_gh = np.dot(MO_matrix,gh)
+ 
 if __name__ == '__main__':
   #gen_He()
   #gen_Ne()
-  gen_HCN()
+  #gen_HCN()
+  gen_HCN_force()

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -667,6 +667,38 @@ void test_HCN(bool transform)
     REQUIRE( diongradpsi[0][6](2,1) == Approx(-2.048666792e-06) );  
     REQUIRE( diongradpsi[0][6](2,2) == Approx(2.967709412e-06) );  
     REQUIRE( dionlaplpsi[0][6][2]  == Approx(-0.0002018111858) );  
+
+   //Same tests as before, but for the gradient only.
+
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,0, dionpsi);
+  //============== Ion  0  Component  0 ===================
+    REQUIRE( dionpsi[0][0][0]       == Approx(   0.0453112082) );  
+    REQUIRE( dionpsi[0][1][0]       == Approx(-0.0006473819623) );  
+    REQUIRE( dionpsi[0][2][0]       == Approx(    0.265578336) );  
+    REQUIRE( dionpsi[0][3][0]       == Approx( -0.06444305979) );  
+    REQUIRE( dionpsi[0][4][0]       == Approx(   0.1454357726) );  
+    REQUIRE( dionpsi[0][5][0]       == Approx( -0.04329985085) );  
+    REQUIRE( dionpsi[0][6][0]       == Approx(  0.01207541177) );  
+   
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,1, dionpsi);
+  //============== Ion  1  Component  1 ===================
+    REQUIRE( dionpsi[0][0][1]       == Approx(0.0001412373768) );  
+    REQUIRE( dionpsi[0][1][1]       == Approx( -0.01029290716) );  
+    REQUIRE( dionpsi[0][2][1]       == Approx(  -0.0230872583) );  
+    REQUIRE( dionpsi[0][3][1]       == Approx(  0.01850231814) );  
+    REQUIRE( dionpsi[0][4][1]       == Approx( -0.02136209962) );  
+    REQUIRE( dionpsi[0][5][1]       == Approx(  -0.1942343714) );  
+    REQUIRE( dionpsi[0][6][1]       == Approx( -0.03930992259) );  
+  
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,2, dionpsi);
+  //============== Ion  2  Component  2 ===================
+    REQUIRE( dionpsi[0][0][2]       == Approx(1.302648961e-06) );  
+    REQUIRE( dionpsi[0][1][2]       == Approx(3.248738084e-07) );  
+    REQUIRE( dionpsi[0][2][2]       == Approx(3.264249981e-06) );  
+    REQUIRE( dionpsi[0][3][2]       == Approx(0.0001288974413) );  
+    REQUIRE( dionpsi[0][4][2]       == Approx(-7.300043903e-05) );  
+    REQUIRE( dionpsi[0][5][2]       == Approx(2.910525987e-06) );  
+    REQUIRE( dionpsi[0][6][2]       == Approx(-1.56074936e-05) );  
 #endif
  
     SPOSetBuilderFactory::clear();

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -545,7 +545,7 @@ void test_HCN(bool transform)
     elec.makeMove(0, disp);
 
 
- 
+#if defined(ENABLE_SOA) 
     SPOSet::GradMatrix_t dionpsi(elec.R.size(), sposet->getOrbitalSetSize());
     SPOSet::HessMatrix_t diongradpsi(elec.R.size(), sposet->getOrbitalSetSize());
     SPOSet::GradMatrix_t dionlaplpsi(elec.R.size(), sposet->getOrbitalSetSize());
@@ -667,6 +667,7 @@ void test_HCN(bool transform)
     REQUIRE( diongradpsi[0][6](2,1) == Approx(-2.048666792e-06) );  
     REQUIRE( diongradpsi[0][6](2,2) == Approx(2.967709412e-06) );  
     REQUIRE( dionlaplpsi[0][6][2]  == Approx(-0.0002018111858) );  
+#endif
  
     SPOSetBuilderFactory::clear();
   }

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -539,7 +539,48 @@ void test_HCN(bool transform)
     REQUIRE(d3psiV[0][2][1](2,2) == Approx(              0));
     REQUIRE(d3psiV[0][2][2](2,2) == Approx(              0));
  
+    SPOSet::GradMatrix_t dionpsi(elec.R.size(), sposet->getOrbitalSetSize());
+    SPOSet::HessMatrix_t diongradpsi(elec.R.size(), sposet->getOrbitalSetSize());
+    SPOSet::GradMatrix_t dionlaplpsi(elec.R.size(), sposet->getOrbitalSetSize());
+
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,0, dionpsi,diongradpsi,dionlaplpsi);
     
+    //============== Ion  0  Component  0 ===================
+    REQUIRE( dionpsi[0][0][0]       == Approx(   0.1812448328) );
+    REQUIRE( diongradpsi[0][0](0,0) == Approx(   -1.177405598) );
+    REQUIRE( diongradpsi[0][0](0,1) == Approx(   -1.177405598) );
+    REQUIRE( diongradpsi[0][0](0,2) == Approx(   -1.177405598) );
+    REQUIRE( dionlaplpsi[0][0][0]  == Approx(   0.1812448328) );
+    REQUIRE( dionpsi[0][1][0]       == Approx(-0.002589527849) );
+    REQUIRE( diongradpsi[0][1](0,0) == Approx( 0.001885363005) );
+    REQUIRE( diongradpsi[0][1](0,1) == Approx( 0.001885363005) );
+    REQUIRE( diongradpsi[0][1](0,2) == Approx( 0.001885363005) );
+    REQUIRE( dionlaplpsi[0][1][0]  == Approx(-0.002589527849) );
+    REQUIRE( dionpsi[0][2][0]       == Approx(    1.062313344) );
+    REQUIRE( diongradpsi[0][2](0,0) == Approx(  -0.3474321646) );
+    REQUIRE( diongradpsi[0][2](0,1) == Approx(  -0.3474321646) );
+    REQUIRE( diongradpsi[0][2](0,2) == Approx(  -0.3474321646) );
+    REQUIRE( dionlaplpsi[0][2][0]  == Approx(    1.062313344) );
+    REQUIRE( dionpsi[0][3][0]       == Approx(  -0.2577722392) );
+    REQUIRE( diongradpsi[0][3](0,0) == Approx(-0.008052607692) );
+    REQUIRE( diongradpsi[0][3](0,1) == Approx(-0.008052607692) );
+    REQUIRE( diongradpsi[0][3](0,2) == Approx(-0.008052607692) );
+    REQUIRE( dionlaplpsi[0][3][0]  == Approx(  -0.2577722392) );
+    REQUIRE( dionpsi[0][4][0]       == Approx(   0.5817430905) );
+    REQUIRE( diongradpsi[0][4](0,0) == Approx(  -0.9321997722) );
+    REQUIRE( diongradpsi[0][4](0,1) == Approx(  -0.9321997722) );
+    REQUIRE( diongradpsi[0][4](0,2) == Approx(  -0.9321997722) );
+    REQUIRE( dionlaplpsi[0][4][0]  == Approx(   0.5817430905) );
+    REQUIRE( dionpsi[0][5][0]       == Approx(  -0.1731994034) );
+    REQUIRE( diongradpsi[0][5](0,0) == Approx(   0.3620797322) );
+    REQUIRE( diongradpsi[0][5](0,1) == Approx(   0.3620797322) );
+    REQUIRE( diongradpsi[0][5](0,2) == Approx(   0.3620797322) );
+    REQUIRE( dionlaplpsi[0][5][0]  == Approx(  -0.1731994034) );
+    REQUIRE( dionpsi[0][6][0]       == Approx(   0.0483016471) );
+    REQUIRE( diongradpsi[0][6](0,0) == Approx(  -0.1009762174) );
+    REQUIRE( diongradpsi[0][6](0,1) == Approx(  -0.1009762174) );
+    REQUIRE( diongradpsi[0][6](0,2) == Approx(  -0.1009762174) );
+    REQUIRE( dionlaplpsi[0][6][0]  == Approx(   0.0483016471) );
 
     SPOSetBuilderFactory::clear();
   }

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -538,6 +538,13 @@ void test_HCN(bool transform)
     REQUIRE(d3psiV[0][2][1](1,2) == Approx(              0));
     REQUIRE(d3psiV[0][2][1](2,2) == Approx(              0));
     REQUIRE(d3psiV[0][2][2](2,2) == Approx(              0));
+
+
+    //Move electron 0 to some nontrivial position:
+    ParticleSet::SingleParticlePos_t disp(0.02, -0.1, 0.05);
+    elec.makeMove(0, disp);
+
+
  
     SPOSet::GradMatrix_t dionpsi(elec.R.size(), sposet->getOrbitalSetSize());
     SPOSet::HessMatrix_t diongradpsi(elec.R.size(), sposet->getOrbitalSetSize());
@@ -545,43 +552,122 @@ void test_HCN(bool transform)
 
     sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,0, dionpsi,diongradpsi,dionlaplpsi);
     
-    //============== Ion  0  Component  0 ===================
-    REQUIRE( dionpsi[0][0][0]       == Approx(   0.1812448328) );
-    REQUIRE( diongradpsi[0][0](0,0) == Approx(   -1.177405598) );
-    REQUIRE( diongradpsi[0][0](0,1) == Approx(   -1.177405598) );
-    REQUIRE( diongradpsi[0][0](0,2) == Approx(   -1.177405598) );
-    REQUIRE( dionlaplpsi[0][0][0]  == Approx(   0.1812448328) );
-    REQUIRE( dionpsi[0][1][0]       == Approx(-0.002589527849) );
-    REQUIRE( diongradpsi[0][1](0,0) == Approx( 0.001885363005) );
-    REQUIRE( diongradpsi[0][1](0,1) == Approx( 0.001885363005) );
-    REQUIRE( diongradpsi[0][1](0,2) == Approx( 0.001885363005) );
-    REQUIRE( dionlaplpsi[0][1][0]  == Approx(-0.002589527849) );
-    REQUIRE( dionpsi[0][2][0]       == Approx(    1.062313344) );
-    REQUIRE( diongradpsi[0][2](0,0) == Approx(  -0.3474321646) );
-    REQUIRE( diongradpsi[0][2](0,1) == Approx(  -0.3474321646) );
-    REQUIRE( diongradpsi[0][2](0,2) == Approx(  -0.3474321646) );
-    REQUIRE( dionlaplpsi[0][2][0]  == Approx(    1.062313344) );
-    REQUIRE( dionpsi[0][3][0]       == Approx(  -0.2577722392) );
-    REQUIRE( diongradpsi[0][3](0,0) == Approx(-0.008052607692) );
-    REQUIRE( diongradpsi[0][3](0,1) == Approx(-0.008052607692) );
-    REQUIRE( diongradpsi[0][3](0,2) == Approx(-0.008052607692) );
-    REQUIRE( dionlaplpsi[0][3][0]  == Approx(  -0.2577722392) );
-    REQUIRE( dionpsi[0][4][0]       == Approx(   0.5817430905) );
-    REQUIRE( diongradpsi[0][4](0,0) == Approx(  -0.9321997722) );
-    REQUIRE( diongradpsi[0][4](0,1) == Approx(  -0.9321997722) );
-    REQUIRE( diongradpsi[0][4](0,2) == Approx(  -0.9321997722) );
-    REQUIRE( dionlaplpsi[0][4][0]  == Approx(   0.5817430905) );
-    REQUIRE( dionpsi[0][5][0]       == Approx(  -0.1731994034) );
-    REQUIRE( diongradpsi[0][5](0,0) == Approx(   0.3620797322) );
-    REQUIRE( diongradpsi[0][5](0,1) == Approx(   0.3620797322) );
-    REQUIRE( diongradpsi[0][5](0,2) == Approx(   0.3620797322) );
-    REQUIRE( dionlaplpsi[0][5][0]  == Approx(  -0.1731994034) );
-    REQUIRE( dionpsi[0][6][0]       == Approx(   0.0483016471) );
-    REQUIRE( diongradpsi[0][6](0,0) == Approx(  -0.1009762174) );
-    REQUIRE( diongradpsi[0][6](0,1) == Approx(  -0.1009762174) );
-    REQUIRE( diongradpsi[0][6](0,2) == Approx(  -0.1009762174) );
-    REQUIRE( dionlaplpsi[0][6][0]  == Approx(   0.0483016471) );
+  //============== Ion  0  Component  0 ===================
+    REQUIRE( dionpsi[0][0][0]       == Approx(   0.0453112082) );  
+    REQUIRE( diongradpsi[0][0](0,0) == Approx(  -0.2943513994) );  
+    REQUIRE( diongradpsi[0][0](0,1) == Approx(    0.030468047) );  
+    REQUIRE( diongradpsi[0][0](0,2) == Approx(  -0.0152340235) );  
+    REQUIRE( dionlaplpsi[0][0][0]  == Approx(    1.333755581) );  
+    REQUIRE( dionpsi[0][1][0]       == Approx(-0.0006473819623) );  
+    REQUIRE( diongradpsi[0][1](0,0) == Approx(0.0004713407512) );  
+    REQUIRE( diongradpsi[0][1](0,1) == Approx(-0.0001254975603) );  
+    REQUIRE( diongradpsi[0][1](0,2) == Approx(6.274878013e-05) );  
+    REQUIRE( dionlaplpsi[0][1][0]  == Approx( 0.001057940846) );  
+    REQUIRE( dionpsi[0][2][0]       == Approx(    0.265578336) );  
+    REQUIRE( diongradpsi[0][2](0,0) == Approx( -0.08685804115) );  
+    REQUIRE( diongradpsi[0][2](0,1) == Approx(  0.05438178417) );  
+    REQUIRE( diongradpsi[0][2](0,2) == Approx( -0.02719089209) );  
+    REQUIRE( dionlaplpsi[0][2][0]  == Approx(   -1.882489819) );  
+    REQUIRE( dionpsi[0][3][0]       == Approx( -0.06444305979) );  
+    REQUIRE( diongradpsi[0][3](0,0) == Approx(-0.002013151923) );  
+    REQUIRE( diongradpsi[0][3](0,1) == Approx(-0.002535923431) );  
+    REQUIRE( diongradpsi[0][3](0,2) == Approx( 0.001267961716) );  
+    REQUIRE( dionlaplpsi[0][3][0]  == Approx(   0.4547401581) );  
+    REQUIRE( dionpsi[0][4][0]       == Approx(   0.1454357726) );  
+    REQUIRE( diongradpsi[0][4](0,0) == Approx(  -0.2330499431) );  
+    REQUIRE( diongradpsi[0][4](0,1) == Approx(  0.09667641762) );  
+    REQUIRE( diongradpsi[0][4](0,2) == Approx( -0.04833820881) );  
+    REQUIRE( dionlaplpsi[0][4][0]  == Approx(  -0.9197558839) );  
+    REQUIRE( dionpsi[0][5][0]       == Approx( -0.04329985085) );  
+    REQUIRE( diongradpsi[0][5](0,0) == Approx(  0.09051993304) );  
+    REQUIRE( diongradpsi[0][5](0,1) == Approx(    0.382375474) );  
+    REQUIRE( diongradpsi[0][5](0,2) == Approx( -0.07043361927) );  
+    REQUIRE( dionlaplpsi[0][5][0]  == Approx(   0.2201672051) );  
+    REQUIRE( dionpsi[0][6][0]       == Approx(  0.01207541177) );  
+    REQUIRE( diongradpsi[0][6](0,0) == Approx( -0.02524405435) );  
+    REQUIRE( diongradpsi[0][6](0,1) == Approx(   0.0800332842) );  
+    REQUIRE( diongradpsi[0][6](0,2) == Approx(   0.3929818664) );  
+    REQUIRE( dionlaplpsi[0][6][0]  == Approx(  -0.0614000824) );  
 
+
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,1, dionpsi,diongradpsi,dionlaplpsi);
+
+  //============== Ion  1  Component  1 ===================
+    REQUIRE( dionpsi[0][0][1]       == Approx(0.0001412373768) );  
+    REQUIRE( diongradpsi[0][0](1,0) == Approx(0.0001124265646) );  
+    REQUIRE( diongradpsi[0][0](1,1) == Approx(-0.001383378615) );  
+    REQUIRE( diongradpsi[0][0](1,2) == Approx(-1.449757545e-05) );  
+    REQUIRE( dionlaplpsi[0][0][1]  == Approx(-0.001252043663) );  
+    REQUIRE( dionpsi[0][1][1]       == Approx( -0.01029290716) );  
+    REQUIRE( diongradpsi[0][1](1,0) == Approx( -0.06178485148) );  
+    REQUIRE( diongradpsi[0][1](1,1) == Approx(   0.0971577216) );  
+    REQUIRE( diongradpsi[0][1](1,2) == Approx( 0.002885675005) );  
+    REQUIRE( dionlaplpsi[0][1][1]  == Approx(  -0.1403103458) );  
+    REQUIRE( dionpsi[0][2][1]       == Approx(  -0.0230872583) );  
+    REQUIRE( diongradpsi[0][2](1,0) == Approx( -0.02537847709) );  
+    REQUIRE( diongradpsi[0][2](1,1) == Approx(   0.2268946564) );  
+    REQUIRE( diongradpsi[0][2](1,2) == Approx( 0.001988963201) );  
+    REQUIRE( dionlaplpsi[0][2][1]  == Approx(   0.2028851421) );  
+    REQUIRE( dionpsi[0][3][1]       == Approx(  0.01850231814) );  
+    REQUIRE( diongradpsi[0][3](1,0) == Approx(  0.05709948475) );  
+    REQUIRE( diongradpsi[0][3](1,1) == Approx(  -0.1776515965) );  
+    REQUIRE( diongradpsi[0][3](1,2) == Approx(-0.003685792479) );  
+    REQUIRE( dionlaplpsi[0][3][1]  == Approx(  -0.1280699725) );  
+    REQUIRE( dionpsi[0][4][1]       == Approx( -0.02136209962) );  
+    REQUIRE( diongradpsi[0][4](1,0) == Approx( -0.03836586276) );  
+    REQUIRE( diongradpsi[0][4](1,1) == Approx(   0.2084578148) );  
+    REQUIRE( diongradpsi[0][4](1,2) == Approx( 0.002581590766) );  
+    REQUIRE( dionlaplpsi[0][4][1]  == Approx(   0.1792683544) );  
+    REQUIRE( dionpsi[0][5][1]       == Approx(  -0.1942343714) );  
+    REQUIRE( diongradpsi[0][5](1,0) == Approx(  -0.3037357197) );  
+    REQUIRE( diongradpsi[0][5](1,1) == Approx( -0.09561978734) );  
+    REQUIRE( diongradpsi[0][5](1,2) == Approx(  0.02118492506) );  
+    REQUIRE( dionlaplpsi[0][5][1]  == Approx(   0.6410434658) );  
+    REQUIRE( dionpsi[0][6][1]       == Approx( -0.03930992259) );  
+    REQUIRE( diongradpsi[0][6](1,0) == Approx( -0.06331544695) );  
+    REQUIRE( diongradpsi[0][6](1,1) == Approx(-0.002807368817) );  
+    REQUIRE( diongradpsi[0][6](1,2) == Approx( -0.02801340823) );  
+    REQUIRE( dionlaplpsi[0][6][1]  == Approx(   0.1369061053) ); 
+
+    sposet->evaluateGradSource(elec, 0, elec.R.size(),ions,2, dionpsi,diongradpsi,dionlaplpsi);
+
+  //============== Ion  2  Component  2 ===================
+    REQUIRE( dionpsi[0][0][2]       == Approx(1.302648961e-06) );  
+    REQUIRE( diongradpsi[0][0](2,0) == Approx(1.865129579e-06) );  
+    REQUIRE( diongradpsi[0][0](2,1) == Approx(6.142092043e-08) );  
+    REQUIRE( diongradpsi[0][0](2,2) == Approx(2.602225618e-05) );  
+    REQUIRE( dionlaplpsi[0][0][2]  == Approx(1.234692903e-06) );  
+    REQUIRE( dionpsi[0][1][2]       == Approx(3.248738084e-07) );  
+    REQUIRE( diongradpsi[0][1](2,0) == Approx(-2.044420189e-06) );  
+    REQUIRE( diongradpsi[0][1](2,1) == Approx(-7.011145137e-08) );  
+    REQUIRE( diongradpsi[0][1](2,2) == Approx(6.532522353e-06) );  
+    REQUIRE( dionlaplpsi[0][1][2]  == Approx(-6.10958506e-06) );  
+    REQUIRE( dionpsi[0][2][2]       == Approx(3.264249981e-06) );  
+    REQUIRE( diongradpsi[0][2](2,0) == Approx(2.820971234e-05) );  
+    REQUIRE( diongradpsi[0][2](2,1) == Approx(9.405184964e-07) );  
+    REQUIRE( diongradpsi[0][2](2,2) == Approx(6.481420782e-05) );  
+    REQUIRE( dionlaplpsi[0][2][2]  == Approx( 5.73961989e-05) );  
+    REQUIRE( dionpsi[0][3][2]       == Approx(0.0001288974413) );  
+    REQUIRE( diongradpsi[0][3](2,0) == Approx(0.0002840756879) );  
+    REQUIRE( diongradpsi[0][3](2,1) == Approx(9.281700408e-06) );  
+    REQUIRE( diongradpsi[0][3](2,2) == Approx( 0.002573308008) );  
+    REQUIRE( dionlaplpsi[0][3][2]  == Approx(0.0003025314443) );  
+    REQUIRE( dionpsi[0][4][2]       == Approx(-7.300043903e-05) );  
+    REQUIRE( diongradpsi[0][4](2,0) == Approx(-0.0001000016834) );  
+    REQUIRE( diongradpsi[0][4](2,1) == Approx(-3.233243534e-06) );  
+    REQUIRE( diongradpsi[0][4](2,2) == Approx(-0.001458391774) );  
+    REQUIRE( dionlaplpsi[0][4][2]  == Approx(-3.546690719e-05) );  
+    REQUIRE( dionpsi[0][5][2]       == Approx(2.910525987e-06) );  
+    REQUIRE( diongradpsi[0][5](2,0) == Approx(1.307065133e-05) );  
+    REQUIRE( diongradpsi[0][5](2,1) == Approx(1.560390706e-06) );  
+    REQUIRE( diongradpsi[0][5](2,2) == Approx(-2.92731811e-06) );  
+    REQUIRE( dionlaplpsi[0][5][2]  == Approx(3.797816228e-05) );  
+    REQUIRE( dionpsi[0][6][2]       == Approx(-1.56074936e-05) );  
+    REQUIRE( diongradpsi[0][6](2,0) == Approx(-7.009049656e-05) );  
+    REQUIRE( diongradpsi[0][6](2,1) == Approx(-2.048666792e-06) );  
+    REQUIRE( diongradpsi[0][6](2,2) == Approx(2.967709412e-06) );  
+    REQUIRE( dionlaplpsi[0][6][2]  == Approx(-0.0002018111858) );  
+ 
     SPOSetBuilderFactory::clear();
   }
 }


### PR DESCRIPTION
This implements all analytic ion derivatives of the LCAO-type single-particle orbitals required for ZVZB force estimation--in particular, ionic derivatives of the SPO, SPO electron gradients, and SPO electron laplacians.  I've also added unit tests of these new API's, with reference values generated from finite differences.  This code is included in src/QMCWaveFunction/tests/gen_mo.py.