### PR TITLE
[WIP - Cosmetic level. functionality implemented] Evaluation of Complex Wavefunctiuon in LCAO.

### DIFF
--- a/src/QMCTools/LCAOH5Parser.cpp
+++ b/src/QMCTools/LCAOH5Parser.cpp
@@ -63,7 +63,7 @@ void LCAOParser::parse(const std::string& fname)
   hin.read(PBC, "PBC");
   hin.pop();
 
-  std::cout << "Periodic Boundary Comditions: " << (PBC ? ("yes") : ("no")) << std::endl;
+  std::cout << "Periodic Boundary Conditions: " << (PBC ? ("yes") : ("no")) << std::endl;
   std::cout.flush();
 
 
@@ -150,7 +150,7 @@ void LCAOParser::parse(const std::string& fname)
   if (PBC)
   {
     getCell(fname);
-    getKpts(fname);
+    getSTwist(fname);
     if (debug)
     {
       getGaussianCenters(fname);
@@ -337,7 +337,7 @@ void LCAOParser::getGeometry(const std::string& fname)
   hin.close();
 }
 
-void LCAOParser::getKpts(const std::string& fname)
+void LCAOParser::getSTwist(const std::string& fname)
 {
   Matrix<double> MyVec(1, 3);
   hdf_archive hin;
@@ -348,28 +348,20 @@ void LCAOParser::getKpts(const std::string& fname)
     abort();
   }
 
-  hin.push("Nb_KPTS");
-  hin.read(NbKpts, "Nbkpts");
-  hin.pop();
-  Kpoints_Coord.resize(NbKpts);
-
-  for (int i = 0; i < NbKpts; i++)
+  if(!hin.push("Super_Twist"))
   {
-    Kpoints_Coord[i].resize(3);
-    std::stringstream ss;
-    ss << "KPTS_" << i;
-    if (!hin.push(ss.str()))
-    {
-      std::cerr << "Could not find coordinates for Kpoint Nb" << i << std::endl;
-      abort();
-    }
-    hin.read(MyVec, "Coord");
-    hin.pop();
-    std::cout << "MyCoord=" << MyVec[0][0] << "  " << MyVec[0][1] << "  " << MyVec[0][2] << std::endl;
-    Kpoints_Coord[i][0] = MyVec[0][0];
-    Kpoints_Coord[i][1] = MyVec[0][1];
-    Kpoints_Coord[i][2] = MyVec[0][2];
+    std::cerr << "Could not find Super Twist" << std::endl;
+    abort();
   }
+  STwist_Coord.resize(3);
+
+  hin.read(MyVec,"Coord");
+
+  hin.pop();
+  STwist_Coord[0]=MyVec[0][0];
+  STwist_Coord[1]=MyVec[0][1];
+  STwist_Coord[2]=MyVec[0][2];
+  
   hin.close();
 }
 

--- a/src/QMCTools/LCAOH5Parser.h
+++ b/src/QMCTools/LCAOH5Parser.h
@@ -38,7 +38,7 @@ public:
 
   void getGeometry(const std::string& fname);
   void getCell(const std::string& fname);
-  void getKpts(const std::string& fname);
+  void getSTwist(const std::string& fname);
   void getMO(const std::string& fname);
   void getGaussianCenters(const std::string fname);
 };

--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -12,7 +12,7 @@
 
 
 
-def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],cas_idx=None):
+def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.0,cas_idx=None):
   import h5py, re, sys
   from collections import defaultdict
   from pyscf.pbc import gto, scf, df, dft
@@ -491,23 +491,20 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],cas_idx=N
           return ll_new
   
   mo_coeff = mf.mo_coeff
-#  if len(kpts)==0:
-#     Complex=False
-#  else:
-#     Complex=True
+  if len(kpts)==0:
+     Complex=False
+  else:
+     Complex=True
   GroupParameter.create_dataset("IsComplex",(1,),dtype="b1",data=Complex)
 
  
   GroupParameter.create_dataset("SpinRestricted",(1,),dtype="b1",data=Restricted)
-  #GroupNbkpts=H5_qmcpack.create_group("Nb_KPTS")
+  GroupDet=H5_qmcpack.create_group("Super_Twist")
   if not PBC:
-    Nbkpts=1
-    GroupNbkpts.create_dataset("Nbkpts",(1,),dtype="i4",data=Nbkpts)
-    
-    GroupDet=H5_qmcpack.create_group("KPTS_0")
     if Restricted==True:
-      NbMO=len(mo_coeff)
-      NbAO=len(mo_coeff[0])
+      NbAO, NbMO =mo_coeff.shape 
+      #NbMO=len(mo_coeff)
+      #NbAO=len(mo_coeff[0])
       if loc_cell.cart==True:
         eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=order_mo_coef(mo_coeff))
       else:
@@ -526,9 +523,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],cas_idx=N
     def get_mo(mo_coeff, cart):
         return order_mo_coef(mo_coeff) if cart else zip(*mo_coeff)
 
-
-
-    GroupDet=H5_qmcpack.create_group("Super_Twist")
+    #Supertwist Coordinate
     GroupDet.create_dataset("Coord",(1,3),dtype="f8",data=sp_twist)
 
     if Gamma:  

--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -503,8 +503,6 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
   if not PBC:
     if Restricted==True:
       NbAO, NbMO =mo_coeff.shape 
-      #NbMO=len(mo_coeff)
-      #NbAO=len(mo_coeff[0])
       if loc_cell.cart==True:
         eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=order_mo_coef(mo_coeff))
       else:

--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -12,7 +12,7 @@
 
 
 
-def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
+def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],cas_idx=None):
   import h5py, re, sys
   from collections import defaultdict
   from pyscf.pbc import gto, scf, df, dft
@@ -29,8 +29,10 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
   Python3=False
   Python2=False
   #Twists generation not yet implemented
-  Nbkpts=1
-
+#  Nbkpts=1
+  
+  if len(sp_twist)== 0:
+       sp_twist=[0.0,0.0,0.0]
   if sys.version_info >= (3, 0):
      sys.stdout.write("Using Python 3.x\n") 
      Python3=True
@@ -52,9 +54,9 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
            PBC=True
 
   if PBC and len(kpts) == 0:
-        #sys.exit("You need to specify explicit the list of K-point (including gamma)")
+  #      #sys.exit("You need to specify explicit the list of K-point (including gamma)")
         Gamma=True
-
+  
   def get_supercell(cell,kmesh=[]):
     latt_vec = cell.lattice_vectors()
     if len(kmesh)==0:
@@ -92,6 +94,8 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
         R_rel_a = numpy.arange(kmesh[0])
         R_rel_b = numpy.arange(kmesh[1])
         R_rel_c = numpy.arange(kmesh[2])
+
+
         R_vec_rel = lib.cartesian_prod((R_rel_a, R_rel_b, R_rel_c))
         R_vec_abs = numpy.einsum('nu, uv -> nv', R_vec_rel, latt_vec)
  
@@ -127,6 +131,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
         # Transform MO indices
         E_k_degen = abs(E_g[1:] - E_g[:-1]).max() < 1e-5
         if numpy.any(E_k_degen):
+            print "Entered Strange If statement"
             degen_mask = numpy.append(False, E_k_degen) | numpy.append(E_k_degen, False)
             shift = min(E_g[degen_mask]) - .1
             f = numpy.dot(C_gamma[:,degen_mask] * (E_g[degen_mask] - shift),
@@ -137,7 +142,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
             C_gamma[:,degen_mask] = na_orb[:, e>0]
  
         #assert(abs(C_gamma.imag).max() < 1e-2)
-        C_gamma = C_gamma.real
+        #C_gamma = C_gamma.real
         #assert(abs(reduce(numpy.dot, (C_gamma.conj().T, s, C_gamma))
         #           - numpy.eye(Nmo*Nk)).max() < 1e-2)
  
@@ -148,7 +153,8 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
         mo_phase = lib.einsum('kum,kuv,vi->kmi', C_k.conj(), s_k_g, C_gamma)
         C_gamma_unsorted=C_gamma[:,E_desort_idx]
         E_g_unsorted=E_g[E_desort_idx]
-        return E_g_unsorted, C_gamma_unsorted, 
+        #return E_g_unsorted, C_gamma_unsorted, 
+        return E_g, C_gamma, E_g_unsorted,C_gamma_unsorted
 
 
   IonName=dict([('H',1),  ('He',2),  ('Li',3),('Be',4),  ('B', 5),  ('C', 6),  ('N', 7),('O', 8),  ('F', 9),   ('Ne',10),   ('Na',11),('Mg',12),   ('Al',13),   ('Si',14),   ('P', 15),   ('S', 16),('Cl',17),   ('Ar',18),   ('K', 19),   ('Ca',20),   ('Sc',21),   ('Ti',22),   ('V', 23),   ('Cr',24),   ('Mn',25),   ('Fe',26),   ('Co',27),   ('Ni',28),   ('Cu',29),   ('Zn',30),   ('Ga',31),   ('Ge',32),   ('As',33),   ('Se',34),   ('Br',35),   ('Kr',36),   ('Rb',37),   ('Sr',38),   ('Y', 39),  ('Zr',40),   ('Nb',41),   ('Mo',42),   ('Tc',43),   ('Ru',44),   ('Rh',45),   ('Pd',46),   ('Ag',47),   ('Cd',48),   ('In',49),   ('Sn',50),   ('Sb',51),   ('Te',52),   ('I', 53),   ('Xe',54),   ('Cs',55),   ('Ba',56),   ('La',57),   ('Ce',58), ('Pr',59),   ('Nd',60),   ('Pm',61),   ('Sm',62),   ('Eu',63),   ('Gd',64),   ('Tb',65),   ('Dy',66),   ('Ho',67),  ('Er',68),   ('Tm',69),   ('Yb',70),   ('Lu',71),   ('Hf',72),   ('Ta',73),   ('W', 74),   ('Re',75),   ('Os',76),   ('Ir',77),   ('Pt',78),   ('Au',79),   ('Hg',80), ('Tl',81),   ('Pb',82),  ('Bi',83),   ('Po',84),   ('At',85),   ('Rn',86),   ('Fr',87),   ('Ra',88),   ('Ac',89),   ('Th',90),   ('Pa',91),   ('U', 92),   ('Np',93)]) 
@@ -493,7 +499,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
 
  
   GroupParameter.create_dataset("SpinRestricted",(1,),dtype="b1",data=Restricted)
-  GroupNbkpts=H5_qmcpack.create_group("Nb_KPTS")
+  #GroupNbkpts=H5_qmcpack.create_group("Nb_KPTS")
   if not PBC:
     Nbkpts=1
     GroupNbkpts.create_dataset("Nbkpts",(1,),dtype="i4",data=Nbkpts)
@@ -519,31 +525,45 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],cas_idx=None):
 
 
     if Gamma:  
-       NbMO=len(mo_coeff[0])
-       NbAO=len(mo_coeff[0][0])
        E_g=mf.mo_energy
+       E_g_unsorted=E_g
     else: 
-
-       mo_k = numpy.array([c[:,cas_idx] for c in mf.mo_coeff] if cas_idx is not None else mf.mo_coeff)
-       e_k =  numpy.array([e[cas_idx] for e in mf.mo_energy] if cas_idx is not None else mf.mo_energy)
-       E_g, C_gamma = mo_k2gamma(cell, e_k, mo_k, kpts,kmesh)
-       #E_g, C_gamma = mo_k2gamma(cell, mf.mo_energy, mf.mo_coeff, kpts,kmesh)
-       mo_coeff=C_gamma
-       NbAO, NbMO =mo_coeff.shape 
+      mo_k = numpy.array([c[:,cas_idx] for c in mf.mo_coeff] if cas_idx is not None else mf.mo_coeff)
+      e_k =  numpy.array([e[cas_idx] for e in mf.mo_energy] if cas_idx is not None else mf.mo_energy)
+      E_g, C_gamma,E_g_unsorted,C_unsorted = mo_k2gamma(cell, e_k, mo_k, kpts,kmesh)
+      mo_coeff=C_gamma
+    
+    NbAO, NbMO =mo_coeff.shape 
 
 
     def get_mo(mo_coeff, cart):
         return order_mo_coef(mo_coeff) if cart else zip(*mo_coeff)
 
 
-    GroupNbkpts.create_dataset("Nbkpts",(1,),dtype="i4",data=Nbkpts)
+#    GroupNbkpts.create_dataset("Nbkpts",(1,),dtype="i4",data=Nbkpts)
+    if Gamma:
+      mo_coeff_ = get_mo(mo_coeff, loc_cell.cart) 
+      mo_coeff_imag = get_mo(mo_coeff, loc_cell.cart) 
+      mo_coeff_unsorted = mo_coeff_ 
+      mo_coeff_unsorted_imag = mo_coeff_imag
+    else:    
+      mo_coeff_ = get_mo(mo_coeff.real, loc_cell.cart) 
+      mo_coeff_imag = get_mo(mo_coeff.imag, loc_cell.cart) 
+      mo_coeff_unsorted = get_mo(C_unsorted.real, loc_cell.cart) 
+      mo_coeff_unsorted_imag = get_mo(C_unsorted.imag, loc_cell.cart) 
 
-    GroupDet=H5_qmcpack.create_group("KPTS_0")
-    GroupDet.create_dataset("Coord",(1,3),dtype="f8",data=[0.0,0.0,0.0])
-    mo_coeff_ = get_mo(mo_coeff, loc_cell.cart) 
+    GroupDet=H5_qmcpack.create_group("Super_Twist")
+    GroupDet.create_dataset("Coord",(1,3),dtype="f8",data=sp_twist)
     eigenset=GroupDet.create_dataset("eigenset_0",(NbMO,NbAO),dtype="f8",data=mo_coeff_) 
+    eigenset_imag=GroupDet.create_dataset("eigenset_0_imag",(NbMO,NbAO),dtype="f8",data=mo_coeff_imag) 
     eigenvalue=GroupDet.create_dataset("eigenval_0",(1,NbMO),dtype="f8",data=E_g)
  
+    #Unsorted Mo_coeffs for Multideterminants order matching QP
+    eigenset_unsorted=GroupDet.create_dataset("eigenset_unsorted_0",(NbMO,NbAO),dtype="f8",data=mo_coeff_unsorted) 
+    eigenset_unsorted_imag=GroupDet.create_dataset("eigenset_unsorted_0_imag",(NbMO,NbAO),dtype="f8",data=mo_coeff_unsorted_imag) 
+    eigenvalue_unsorted=GroupDet.create_dataset("eigenval_unsorted_0",(1,NbMO),dtype="f8",data=E_g_unsorted)
+ 
+    
 
   GroupParameter.create_dataset("numMO",(1,),dtype="i4",data=NbMO)
   GroupParameter.create_dataset("numAO",(1,),dtype="i4",data=NbAO)

--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -1747,7 +1747,7 @@ void QMCGaussianParserBase::dump(const std::string& psi_tag, const std::string& 
       std::cout << "Consider using HDF5 via -hdf5 for higher performance and smaller wavefunction files" << std::endl;
 }
 
-void QMCGaussianParserBase::dumpPBC(const std::string& psi_tag, const std::string& ion_tag, const int KptsNum)
+void QMCGaussianParserBase::dumpPBC(const std::string& psi_tag, const std::string& ion_tag)
 {
   std::cout << " QMCGaussianParserBase::dumpPBC " << std::endl;
   if (!Structure)
@@ -1779,7 +1779,7 @@ void QMCGaussianParserBase::dumpPBC(const std::string& psi_tag, const std::strin
       xmlNewProp(detPtr, (const xmlChar*)"transform", (const xmlChar*)"yes");
 
       std::stringstream ss;
-      ss << Kpoints_Coord[KptsNum][0] << "  " << Kpoints_Coord[KptsNum][1] << "  " << Kpoints_Coord[KptsNum][2];
+      ss << STwist_Coord[0] << "  " <<  STwist_Coord[1] << "  " <<  STwist_Coord[2];
       xmlNewProp(detPtr, (const xmlChar*)"twist", (const xmlChar*)(ss.str()).c_str());
 
       if (DoCusp == true)

--- a/src/QMCTools/QMCGaussianParserBase.h
+++ b/src/QMCTools/QMCGaussianParserBase.h
@@ -78,7 +78,7 @@ struct QMCGaussianParserBase
   int FMOIndexI, FMOIndexJ, FMOIndexK;
   bool FMO, FMO1, FMO2, FMO3, DoCusp, FixValence, QP;
 
-  std::vector<std::vector<double>> Kpoints_Coord; //Kpoints Coordinates
+  std::vector<double> STwist_Coord; //Super Twist Coordinates
   int NbKpts;
 
   std::string Title;
@@ -160,7 +160,7 @@ struct QMCGaussianParserBase
 
   virtual void parse(const std::string& fname) = 0;
 
-  virtual void dumpPBC(const std::string& psi_tag, const std::string& ion_tag, const int KptsNum);
+  virtual void dumpPBC(const std::string& psi_tag, const std::string& ion_tag);
 
   virtual void dump(const std::string& psi_tag, const std::string& ion_tag);
 

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -334,58 +334,44 @@ int main(int argc, char** argv)
     if (prod)
     {
       parser->addJastrow = addJastrow;
+      parser->WFS_name = jastrow;
       if (parser->PBC)
       {
         std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0]
                   << "  " << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-        std::stringstream ss;
-        ss << jastrow << "-Twist";
-        parser->WFS_name = ss.str();
         parser->dumpPBC(psi_tag, ion_tag);
-        parser->dumpStdInputProd(psi_tag, ion_tag);
       }
       else
-      {
-        parser->WFS_name = jastrow;
         parser->dump(psi_tag, ion_tag);
-        parser->dumpStdInputProd(psi_tag, ion_tag);
-      }
+      parser->dumpStdInputProd(psi_tag, ion_tag);
     }
     else
     {
       parser->addJastrow = false;
+      jastrow = "noj";
+      parser->WFS_name = jastrow;
       if (parser->PBC)
       {
         std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0]
                   << "  " << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-        jastrow = "noj";
-        std::stringstream ss;
-        ss << jastrow << "-Twist";
-        parser->WFS_name = ss.str();
         parser->dumpPBC(psi_tag, ion_tag);
-        parser->dumpStdInput(psi_tag, ion_tag);
-
-        std::stringstream sss;
-        parser->addJastrow = true;
-        jastrow            = "j";
-        sss << jastrow << "-Twist" ;
-        parser->WFS_name = sss.str();
-        parser->dumpPBC(psi_tag, ion_tag);
-        parser->dumpStdInput(psi_tag, ion_tag);
       }
       else
-      {
-        jastrow          = "noj";
-        parser->WFS_name = jastrow;
         parser->dump(psi_tag, ion_tag);
-        parser->dumpStdInput(psi_tag, ion_tag);
+      parser->dumpStdInput(psi_tag, ion_tag);
 
-        parser->addJastrow = true;
-        jastrow            = "j";
-        parser->WFS_name   = jastrow;
-        parser->dump(psi_tag, ion_tag);
-        parser->dumpStdInput(psi_tag, ion_tag);
+      parser->addJastrow = true;
+      jastrow            = "j";
+      parser->WFS_name = jastrow;
+      if (parser->PBC)
+      {
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0]
+                  << "  " << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        parser->dumpPBC(psi_tag, ion_tag);
       }
+      else
+        parser->dump(psi_tag, ion_tag);
+      parser->dumpStdInput(psi_tag, ion_tag);
     }
 
 

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -336,16 +336,13 @@ int main(int argc, char** argv)
       parser->addJastrow = addJastrow;
       if (parser->PBC)
       {
-        for (int i = 0; i < parser->NbKpts; i++)
-        {
-          std::cout << "Generating Inputs for twist Nb:" << i << " with coordinate:" << parser->Kpoints_Coord[i][0]
-                    << "  " << parser->Kpoints_Coord[i][1] << "  " << parser->Kpoints_Coord[i][2] << std::endl;
-          std::stringstream ss;
-          ss << jastrow << "-Twist" << i;
-          parser->WFS_name = ss.str();
-          parser->dumpPBC(psi_tag, ion_tag, i);
-          parser->dumpStdInputProd(psi_tag, ion_tag);
-        }
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0]
+                  << "  " << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        std::stringstream ss;
+        ss << jastrow << "-Twist";
+        parser->WFS_name = ss.str();
+        parser->dumpPBC(psi_tag, ion_tag);
+        parser->dumpStdInputProd(psi_tag, ion_tag);
       }
       else
       {
@@ -359,25 +356,22 @@ int main(int argc, char** argv)
       parser->addJastrow = false;
       if (parser->PBC)
       {
-        for (int i = 0; i < parser->NbKpts; i++)
-        {
-          std::cout << "Generating Inputs for twist Nb:" << i << " with coordinate:" << parser->Kpoints_Coord[i][0]
-                    << "  " << parser->Kpoints_Coord[i][1] << "  " << parser->Kpoints_Coord[i][2] << std::endl;
-          jastrow = "noj";
-          std::stringstream ss;
-          ss << jastrow << "-Twist" << i;
-          parser->WFS_name = ss.str();
-          parser->dumpPBC(psi_tag, ion_tag, i);
-          parser->dumpStdInput(psi_tag, ion_tag);
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0]
+                  << "  " << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        jastrow = "noj";
+        std::stringstream ss;
+        ss << jastrow << "-Twist";
+        parser->WFS_name = ss.str();
+        parser->dumpPBC(psi_tag, ion_tag);
+        parser->dumpStdInput(psi_tag, ion_tag);
 
-          std::stringstream sss;
-          parser->addJastrow = true;
-          jastrow            = "j";
-          sss << jastrow << "-Twist" << i;
-          parser->WFS_name = sss.str();
-          parser->dumpPBC(psi_tag, ion_tag, i);
-          parser->dumpStdInput(psi_tag, ion_tag);
-        }
+        std::stringstream sss;
+        parser->addJastrow = true;
+        jastrow            = "j";
+        sss << jastrow << "-Twist" ;
+        parser->WFS_name = sss.str();
+        parser->dumpPBC(psi_tag, ion_tag);
+        parser->dumpStdInput(psi_tag, ion_tag);
       }
       else
       {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -150,12 +150,14 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
   aAttrib.add(cuspInfo,"cuspInfo");
   aAttrib.add(MOH5Ref,"href");
 
+  
+  
   if(rootNode != NULL)
     aAttrib.put(rootNode);
 
   std::string type_in=type;
   tolower(type);
-
+  app_log()<<"name=" <<name<<"   type="<<type<<std::endl;
   //when name is missing, type becomes the input
   if(name.empty()) name=type_in;
 

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -121,6 +121,7 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
   aAttrib.add(cuspC, "cuspCorrection");
   aAttrib.add(cuspInfo, "cuspInfo");
   aAttrib.add(h5_path, "href");
+  aAttrib.add(Stwist, "twist");
   aAttrib.add(PBCImages, "PBCimages");
   aAttrib.put(cur);
 
@@ -331,6 +332,7 @@ LCAOrbitalBuilder::BasisSet_t* LCAOrbitalBuilder::createBasisSet(xmlNodePtr cur)
 
   mBasisSet->setBasisSetSize(-1);
   mBasisSet->setPBCImages(PBCImages);
+  mBasisSet->setStwist(Stwist);
   return mBasisSet;
 }
 
@@ -730,7 +732,9 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
 
     hin.close();
   }
+#ifdef HAVE_MPI
   myComm->comm.broadcast_n(spo.C->data(), spo.C->size());
+#endif
 #else
   APP_ABORT("LCAOrbitalBuilder::putFromH5 HDF5 is disabled.")
 #endif

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -715,7 +715,7 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
       setname="/Super_Twist/Coord";
       //setname = name;
       hin.read(twistH5, setname);
-/*      if (std::abs(twistH5[0] - twist[0]) > 1e-6 || std::abs(twistH5[1] - twist[1]) > 1e-6 ||
+      if (std::abs(twistH5[0] - twist[0]) > 1e-6 || std::abs(twistH5[1] - twist[1]) > 1e-6 ||
           std::abs(twistH5[2] - twist[2]) > 1e-6)
       {
          app_log()<<"Super Twist in XML : "<<twist[0]<<"    In H5:"<<twistH5[0]<<std::endl;
@@ -725,7 +725,7 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
          app_log()<<"                  y :"<<std::abs(twistH5[1] - twist[1])<<std::endl;
          app_log()<<"                  z :"<<std::abs(twistH5[2] - twist[2])<<std::endl;
          APP_ABORT("Requested Super Twist in XML and Super Twist in HDF5 do not Match!!! Aborting."); 
-      }*/
+      }
 #if not defined(QMC_COMPLEX)
       LoadCMatrix(spo,hin,neigs,setVal,norbs);
 #else
@@ -882,16 +882,25 @@ void LCAOrbitalBuilder::EvalPhaseFactor(PosType twist)
 #else
     ///Exp(ik.g) where i is imaginary, k is the supertwist and g is the translation vector PBCImage.
     int phase_idx=0;
+    int TransX, TransY, TransZ;
     for (int i = 0; i <= PBCImages[0]; i++) //loop Translation over X
+    {
+      TransX = ((i % 2) * 2 - 1) * ((i + 1) / 2);
       for (int j = 0; j <= PBCImages[1]; j++) //loop Translation over Y
+      {
+        TransY = ((j % 2) * 2 - 1) * ((j + 1) / 2);
         for (int k = 0; k <= PBCImages[2]; k++) //loop Translation over Z
         {
+          TransZ    = ((k % 2) * 2 - 1) * ((k + 1) / 2);
            RealType s,c;
            RealType vec_scalar;
-           vec_scalar=i*twist[0]+j*twist[1]+k*twist[2];
-           sincos(vec_scalar, &s,&c);
+           vec_scalar=(TransX*twist[0]+TransY*twist[1]+TransZ*twist[2]);
+           sincos(-2*M_PI*vec_scalar, &s,&c);
            PhaseFactor.emplace_back(c,s);
         }
+      }
+     }
 #endif
+        
 }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -439,6 +439,8 @@ SPOSet* LCAOrbitalBuilder::createSPOSetFromXML(xmlNodePtr cur)
     lcos = lcwc = new LCAOrbitalSetWithCorrection(sourcePtcl, targetPtcl, myBasisSet);
   else
     lcos = new LCAOrbitalSet(myBasisSet);
+#else
+  lcos = new LCAOrbitalSet(myBasisSet);
 #endif
   loadMO(*lcos, cur);
 
@@ -631,12 +633,19 @@ bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
 
     Matrix<RealType> Ctemp(neigs, spo.getBasisSetSize());
     char name[72];
-    sprintf(name, "%s%d", "/KPTS_0/eigenset_", setVal);
+
+    //This is to make sure of Backward compatibility with previous tags. 
+    sprintf(name, "%s%d", "/Super_Twist/eigenset_", setVal);
     setname = name;
     if (!hin.readEntry(Ctemp, setname))
     {
-      setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
-      APP_ABORT(setname.c_str());
+        sprintf(name, "%s%d", "/KPTS_0/eigenset_", setVal);
+        setname = name;
+        if (!hin.readEntry(Ctemp, setname))
+        {
+           setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
+           APP_ABORT(setname.c_str());
+        }
     }
     hin.close();
 
@@ -670,8 +679,6 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
   int norbs  = spo.getOrbitalSetSize();
   int neigs  = spo.getBasisSetSize();
   int setVal = -1;
-  int NbKpts;
-  int KptIdx     = 0;
   bool IsComplex = false;
   PosType twist(0.0);
   PosType twistH5(0.0);
@@ -695,56 +702,35 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
     hin.push("parameters");
     hin.read(IsComplex, "IsComplex");
     hin.pop();
-    hin.push("Nb_KPTS");
-    hin.read(NbKpts, "Nbkpts");
-    hin.pop();
-    for (int i = 0; i < NbKpts; i++)
-    {
+
+#if not defined(QMC_COMPLEX)
+    //  if(IsComplex)
+       //  APP_ABORT("HDF5 contains a complex Wavefunction. You are not running QMCPACK with Complex capabilities. Please run QMCPACK compiled with QMC_COMPLEX=1");
+#endif
+
       char name[72];
-      sprintf(name, "%s%d%s", "/KPTS_", i, "/Coord");
-      setname = name;
+      setname="/Super_Twist/Coord";
+      //setname = name;
       hin.read(twistH5, setname);
-      if (std::abs(twistH5[0] - twist[0]) < 1e-6 && std::abs(twistH5[1] - twist[1]) < 1e-6 &&
-          std::abs(twistH5[2] - twist[2]) < 1e-6)
+      if (std::abs(twistH5[0] - twist[0]) > 1e-6 || std::abs(twistH5[1] - twist[1]) > 1e-6 ||
+          std::abs(twistH5[2] - twist[2]) > 1e-6)
       {
-        KptIdx = i;
-        break;
+         app_log()<<"Super Twist in XML : "<<twist[0]<<"    In H5:"<<twistH5[0]<<std::endl;
+         app_log()<<"                     "<<twist[1]<<"          "<<twistH5[1]<<std::endl;
+         app_log()<<"                     "<<twist[2]<<"          "<<twistH5[2]<<std::endl;
+         app_log()<<"Diff in Coord     x :"<<std::abs(twistH5[0] - twist[0])<<std::endl;
+         app_log()<<"                  y :"<<std::abs(twistH5[1] - twist[1])<<std::endl;
+         app_log()<<"                  z :"<<std::abs(twistH5[2] - twist[2])<<std::endl;
+         APP_ABORT("Requested Super Twist in XML and Super Twist in HDF5 do not Match!!! Aborting."); 
       }
-    }
+   if(IsComplex)
+       LoadCMatrix_cplx(spo,hin,neigs,setVal,norbs);
+   else
+       LoadCMatrix(spo,hin,neigs,setVal,norbs);
 
-    Matrix<RealType> Ctemp(neigs, spo.getBasisSetSize());
-
-    char name[72];
-    if (IsComplex)
-      sprintf(name, "%s%d%s%d%s", "/KPTS_", KptIdx, "/eigenset_", setVal, "_real");
-    else
-      sprintf(name, "%s%d%s%d", "/KPTS_", KptIdx, "/eigenset_", setVal);
-
-
-    setname = name;
-    if (!hin.readEntry(Ctemp, setname))
-    {
-      setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
-      APP_ABORT(setname.c_str());
-    }
-
-#if defined(QMC_COMPLEX)
-    APP_ABORT("Complex Wavefunction not implemented yet. Please contact Developers");
-#endif //COMPLEX
     hin.close();
-
-    int n = 0, i = 0;
-    while (i < norbs)
-    {
-      if (Occ[n] > 0.0)
-      {
-        std::copy(Ctemp[n], Ctemp[n + 1], (*spo.C)[i]);
-        i++;
-      }
-      n++;
-    }
   }
-  myComm->bcast(spo.C->data(), spo.C->size());
+  myComm->comm.broadcast_n(spo.C->data(), spo.C->size());
 #else
   APP_ABORT("LCAOrbitalBuilder::putFromH5 HDF5 is disabled.")
 #endif
@@ -793,5 +779,85 @@ bool LCAOrbitalBuilder::putOccupation(LCAOrbitalSet& spo, xmlNodePtr occ_ptr)
     putContent(Occ, occ_ptr);
   }
   return true;
+}
+///////SHOULD BE TEMPLATED I GUESS//// 
+bool LCAOrbitalBuilder::LoadCMatrix_cplx(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs)
+{
+    bool success=false;
+    char name[72];
+    std::string setname;
+    Matrix<ValueType> Ctemp(neigs, spo.getBasisSetSize());
+    Matrix<RealType> Creal(neigs, spo.getBasisSetSize());
+    Matrix<RealType> Ccmplx(neigs, spo.getBasisSetSize());
+    
+    sprintf(name, "%s%d", "/Super_Twist/eigenset_", setVal);
+    setname = name;
+    if (!hin.readEntry(Creal, setname))
+    {
+       setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
+       APP_ABORT(setname.c_str());
+        
+    }
+     
+    
+    sprintf(name, "%s%d%s", "/Super_Twist/eigenset_", setVal,"_imag");
+    setname = name;
+    if (!hin.readEntry(Ccmplx, setname))
+    {
+        setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
+        APP_ABORT(setname.c_str());
+    }
+
+    for (int i=0; i<neigs; i++)
+       for (int j=0; j<spo.getBasisSetSize(); j++){
+          ValueType temp(Creal[i][j],Ccmplx[i][j]);
+          Ctemp[i][j]=temp;
+       }
+
+    int n = 0, i = 0;
+    while (i < norbs)
+    {
+      if (Occ[n] > 0.0)
+      {
+        std::copy(Ctemp[n], Ctemp[n + 1], (*spo.C)[i]);
+        i++;
+      }
+      n++;
+    }
+    return success;
+}
+
+
+bool LCAOrbitalBuilder::LoadCMatrix(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs)
+{
+    bool success=false;
+    char name[72];
+    std::string setname;
+    Matrix<ValueType> Ctemp(neigs, spo.getBasisSetSize());
+    
+    sprintf(name, "%s%d", "/Super_Twist/eigenset_", setVal);
+    setname = name;
+    if (!hin.readEntry(Ctemp, setname))
+    {
+        sprintf(name, "%s%d", "/KPTS_0/eigenset_", setVal);
+        setname = name;
+        if (!hin.readEntry(Ctemp, setname))
+        {
+           setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
+           APP_ABORT(setname.c_str());
+        }
+    }
+     
+    int n = 0, i = 0;
+    while (i < norbs)
+    {
+      if (Occ[n] > 0.0)
+      {
+        std::copy(Ctemp[n], Ctemp[n + 1], (*spo.C)[i]);
+        i++;
+      }
+      n++;
+    }
+    return success;
 }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -42,6 +42,7 @@ public:
   void loadBasisSetFromXML(xmlNodePtr cur);
   SPOSet* createSPOSetFromXML(xmlNodePtr cur);
 
+
 private:
   ///target ParticleSet
   ParticleSet& targetPtcl;
@@ -57,6 +58,8 @@ private:
   std::string h5_path;
   ///Number of periodic Images for Orbital evaluation
   TinyVector<int, 3> PBCImages;
+  ///Coordinates of Supertwist (for phase Factor purpose
+  TinyVector<double, 3> Stwist;
 
   /// Enable cusp correction
   bool doCuspCorrection;
@@ -80,6 +83,8 @@ private:
   bool putFromXML(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr);
   bool putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr);
   bool putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr);
+  bool LoadCMatrix_cplx(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs);
+  bool LoadCMatrix(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.h
@@ -58,8 +58,9 @@ private:
   std::string h5_path;
   ///Number of periodic Images for Orbital evaluation
   TinyVector<int, 3> PBCImages;
-  ///Coordinates of Supertwist (for phase Factor purpose
-  TinyVector<double, 3> Stwist;
+  ///Phase Factor. Computed only once.
+  std::vector<ValueType> PhaseFactor;
+  
 
   /// Enable cusp correction
   bool doCuspCorrection;
@@ -85,6 +86,7 @@ private:
   bool putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr);
   bool LoadCMatrix_cplx(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs);
   bool LoadCMatrix(LCAOrbitalSet& spo,hdf_archive hin, int neigs,int setVal,int norbs);
+  void EvalPhaseFactor(PosType twist);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
@@ -237,7 +237,6 @@ struct SoaAtomicBasisSet
 
     PosType dr_new;
     T r_new;
-    //T psi_new;
     RealType* restrict ylm_v = tempS.data(0);
     RealType* restrict phi_r = tempS.data(1);
     //Phase_idx needs to be initialized at -1 as it has to be incremented first to comply with the if statement (r_new >=Rmax) 
@@ -267,7 +266,6 @@ struct SoaAtomicBasisSet
 
           Ylm.evaluateV(-dr_new[0], -dr_new[1], -dr_new[2], ylm_v);
           MultiRnl->evaluate(r_new, phi_r);
-
           for (size_t ib = 0; ib < BasisSetSize; ++ib)
             psi[ib] += ylm_v[LM[ib]] * phi_r[NL[ib]]*phase_factor[phase_idx];
          

--- a/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
@@ -34,6 +34,8 @@ struct SoaAtomicBasisSet
   int BasisSetSize;
   ///Number of Cell images for the evaluation of the orbital with PBC. If No PBC, should be 0;
   TinyVector<int, 3> PBCImages;
+  ///Coordinates of Super twist to compute phase factor. If No PBC, should be 0;
+  TinyVector<double, 3> Stwist;
   ///maximum radius of this center
   RealType Rmax;
   ///spherical harmonics
@@ -91,8 +93,12 @@ struct SoaAtomicBasisSet
     return BasisSetSize;
   }
 
-  // Set the number of periodic image for the evaluation of the orbitals.
+  /// Set the number of periodic image for the evaluation of the orbitals.
   void setPBCImages(const TinyVector<int, 3>& pbc_images) { PBCImages = pbc_images; }
+
+
+  /// Set the number of periodic image for the evaluation of the orbitals.
+  void setStwist(const TinyVector<double, 3>& stwist) { Stwist = stwist; }
 
   /** implement a BasisSetBase virtual function
        *

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -91,22 +91,13 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
   }
   /** set Number of periodic Images to evaluate the orbitals. 
       Set to 0 for non-PBC, and set manually in the input.
+      Passes the pre-computed phase factor for evaluation of complex wavefunction. If WF is real Phase_factor is real and equals 1.  
   */
-  void setPBCImages(const TinyVector<int, 3>& PBCImages)
+  void setPBCParams(const TinyVector<int, 3>& PBCImages,const std::vector<QMCTraits::ValueType>& phase_factor)
   {
     for (int i = 0; i < LOBasisSet.size(); ++i)
-      LOBasisSet[i]->setPBCImages(PBCImages);
+      LOBasisSet[i]->setPBCParams(PBCImages,phase_factor);
   }
-
-  /** Set Supertwist in PBC to value in Input. 
-      Set to 0 for non-PBC.
-  */
-  void setStwist(const TinyVector<double, 3>& Stwist)
-  {
-    for (int i = 0; i < LOBasisSet.size(); ++i)
-      LOBasisSet[i]->setStwist(Stwist);
-  }
-
 
 
   /** set BasisSetSize and allocate mVGL container

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -97,6 +97,18 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     for (int i = 0; i < LOBasisSet.size(); ++i)
       LOBasisSet[i]->setPBCImages(PBCImages);
   }
+
+  /** Set Supertwist in PBC to value in Input. 
+      Set to 0 for non-PBC.
+  */
+  void setStwist(const TinyVector<double, 3>& Stwist)
+  {
+    for (int i = 0; i < LOBasisSet.size(); ++i)
+      LOBasisSet[i]->setStwist(Stwist);
+  }
+
+
+
   /** set BasisSetSize and allocate mVGL container
    */
   void setBasisSetSize(int nbs)

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -173,6 +173,20 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     {
       LOBasisSet[IonID[c]]->evaluateVGL(P.Lattice, dist[c], displ[c], BasisOffset[c], vgl);
     }
+    std::vector<double> K {0.333,0.333,0.333};
+    RealType s,c;
+    RealType vec_scalar;
+    vec_scalar=(((P.activePtcl == iat) ? P.activePos : P.R[iat])[0]*K[0]+((P.activePtcl == iat) ? P.activePos : P.R[iat])[1]*K[1]+((P.activePtcl == iat) ? P.activePos : P.R[iat])[2]*K[2]);  
+    sincos(-2*M_PI*vec_scalar, &s,&c);
+    QMCTraits::ValueType PhaseFactor(c,s);
+    for (int i =0; i<BasisSetSize;i++)
+    {
+      vgl.data(0)[i]*=PhaseFactor;
+      vgl.data(1)[i]*=PhaseFactor;
+      vgl.data(2)[i]*=PhaseFactor;
+      vgl.data(3)[i]*=PhaseFactor;
+      vgl.data(4)[i]*=PhaseFactor;
+    }
   }
 
   /** compute values for the iat-paricle move
@@ -188,6 +202,16 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     {
       LOBasisSet[IonID[c]]->evaluateV(P.Lattice, dist[c], displ[c], vals + BasisOffset[c]);
     }
+    std::vector<double> K {0.333,0.333,0.333};
+    RealType s,c;
+    RealType vec_scalar;
+    vec_scalar=(((P.activePtcl == iat) ? P.activePos : P.R[iat])[0]*K[0]+((P.activePtcl == iat) ? P.activePos : P.R[iat])[1]*K[1]+((P.activePtcl == iat) ? P.activePos : P.R[iat])[2]*K[2]);  
+    sincos(-2*M_PI*vec_scalar, &s,&c);
+    QMCTraits::ValueType PhaseFactor(c,s);
+    for (int i =0; i<BasisSetSize;i++)
+      vals[i]*=PhaseFactor;
+
+    
   }
 
   /** add a new set of Centered Atomic Orbitals


### PR DESCRIPTION
Evaluation of Complex wavefunction for solids. (case of Kpoints)

- All input are read in complex.
- All data is complex and bcasted correctly properly accross the code
- The Tiling of the cell is done outside QMCPACK in the Pyscf converter. 
- Pyscf converter now stores one real matrix and one complex matrix stored in: 
 eigenstate_0 
 eigenstate_0_imag

-Modification of the hierarchy in the HDF5 where /KPOINT_0/ becomes /Super_Twist/
 Backwards compatibility is preserved for real wavefunction. 

- Create a function to compute all phases in one shot and store them. Evaluated in builder (LCAOrbitalBuilder::EvalPhaseFactor). 

- Phase Factor applied in SoaAtomicBasisSet.h 

TO DO (these are cosmetic and verification oriented) :

- Clean Converter generator. 
- Create tests
- Verify that the phase factor applies to first derivatives AND second Derivatives. @lshulen / @jtkrogel ? can you confirm? 


- Modify functions: LoadCMatrix and LoadCMatrix_cplx to become only one templated function with some specialization for cplx.  @markdewing ?
- Modify function: LCAOrbitalBuilder::EvalPhaseFactor to have specialization for Complex.  @markdewing  ? 


