### PR TITLE
Nexus: fix jastrow dependency for unreweightedvariance

### DIFF
--- a/nexus/lib/qmcpack_result_analyzers.py
+++ b/nexus/lib/qmcpack_result_analyzers.py
@@ -67,7 +67,8 @@ class OptimizationAnalyzer(ResultAnalyzer):
                 vw = 0
                 if crv is not None:
                     vw += crv
-                elif curv is not None:
+                #end if
+                if curv is not None:
                     vw += curv
                 #end if
             #end if


### PR DESCRIPTION
Quick fix for processing of jastrow dependencies following optimization when using only unreweighted variance.