### PR TITLE
Fix crashing due to mishandling of DriftModifier pointers

### DIFF
--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBuilder.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBuilder.cpp
@@ -27,7 +27,6 @@ DriftModifierBase* createDriftModifier(xmlNodePtr cur, const Communicate* myComm
     DriftModifier = new DriftModifierUNR;
   else
     myComm->barrier_and_abort("createDriftModifier unknown drift_modifier " + ModifierName);
-  DriftModifier->parseXML(cur);
   return DriftModifier;
 }
 

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -216,8 +216,9 @@ void QMCDriver::process(xmlNodePtr cur)
     branchEngine->setEstimatorManager(Estimators);
     branchEngine->read(h5FileRoot);
   }
-  if (DriftModifier != 0) delete DriftModifier;
-  DriftModifier = createDriftModifier(cur, myComm);
+  if (DriftModifier == 0)
+    DriftModifier = createDriftModifier(cur, myComm);
+  DriftModifier->parseXML(cur);
 #if !defined(REMOVE_TRACEMANAGER)
   //create and initialize traces
   if (Traces == 0)


### PR DESCRIPTION
Close #1584.

Function QMCDriver::process is supposed to handle consecutive driver input blocks without destroying and creating the same driver. I introduced a bug by recreating DriftModifier without updating its pointer used in QMCUpdateBase. With this PR, DriftModifier can be created only once unless a driver is destroyed. The side effect of this fix is that DriftModifier is not allowed to switch between multiple consecutive DMC blocks. This is only a minor issue.

I thinking in the future, we should get rid of reusing drivers. Every driver input section should be a fresh one. The destroying and creating cost is really negligible. This also get rid of the unintended setting left from a previous driver input section.