### PR TITLE
Nexus: Fix orbital file path handling for pyscf to qmcpack

### DIFF
--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -284,6 +284,12 @@ class Qmcpack(Simulation):
                 #end if
                 if 'orbfile' in result:
                     orb_h5file = result.orbfile
+                    if not os.path.exists(orb_h5file) and 'href' in dset:
+                        orb_h5file = os.path.join(sim.locdir,dset.href)
+                    #end if
+                    if not os.path.exists(orb_h5file):
+                        self.error('orbital h5 file from convert4qmc does not exist\nlocation checked: {}'.format(orb_h5file))
+                    #end if
                     orb_path = os.path.relpath(orb_h5file,self.locdir)
                     dset.href = orb_path
                     detlist = dset.get('detlist')


### PR DESCRIPTION
Fix the handling of the H5 orbital file path when using convert4qmc to "convert" the orbitals from PySCF to QMCPACK.

Unlike other cases, convert4qmc does not actually create an h5 file in this case.   Instead a pre-existing h5 file made at the save_to_qmcpack step from PySCF needs to be used.  This fix passes the correct path info along, which comes from the xml input files created by convert4qmc.

This fix is needed for the workshop, please expedite.