### PR TITLE
Nexus: pyscf expects kpoints in bohr regardless of input units

### DIFF
--- a/nexus/lib/pyscf_input.py
+++ b/nexus/lib/pyscf_input.py
@@ -202,7 +202,9 @@ class PyscfInput(SimulationInputTemplateDev):
                 sys_inputs.dimension = len(s.axes)
                 sys_inputs.a         = s.write_axes()
                 if len(s.kpoints)>0:
-                    sys_kpoints = s.kpoints.copy()
+                    skp = s.copy()
+                    skp.change_units('B')
+                    sys_kpoints = skp.kpoints.copy()
                 #end if
             #end if
         #end if


### PR DESCRIPTION
Fix for Pyscf workflows involving k-points.  Regardless of whether input structure is in Angstrom or Bohr units, Pyscf expects k-points in Bohr units.

This update is needed for the workshop, please expedite.