### PR TITLE
Require the same data type between container and allocator

### DIFF
--- a/src/OhmmsPETE/OhmmsMatrix.h
+++ b/src/OhmmsPETE/OhmmsMatrix.h
@@ -14,10 +14,11 @@
 #ifndef OHMMS_PETE_MATRIX_H
 #define OHMMS_PETE_MATRIX_H
 
-#include "PETE/PETE.h"
 #include <cstdlib>
-#include "OhmmsPETE/OhmmsVector.h"
+#include <type_traits>
 #include <iostream>
+#include "PETE/PETE.h"
+#include "OhmmsPETE/OhmmsVector.h"
 
 namespace qmcplusplus
 {
@@ -85,6 +86,7 @@ public:
 
   inline void resize(size_type n, size_type m)
   {
+    static_assert(std::is_same<value_type, typename Alloc::value_type>::value, "Matrix and Alloc data types must agree!");
     D1      = n;
     D2      = m;
     TotSize = n * m;

--- a/src/OhmmsPETE/OhmmsVector.h
+++ b/src/OhmmsPETE/OhmmsVector.h
@@ -19,13 +19,13 @@
 
 #ifndef OHMMS_NEW_VECTOR_H
 #define OHMMS_NEW_VECTOR_H
-#include "PETE/PETE.h"
 #include <algorithm>
 #include <vector>
 #include <iostream>
 #include <type_traits>
 #include <stdexcept>
-#include <simd/MemorySpace.hpp>
+#include "PETE/PETE.h"
+#include "simd/MemorySpace.hpp"
 
 namespace qmcplusplus
 {
@@ -34,6 +34,7 @@ class Vector
 {
 public:
   typedef T Type_t;
+  typedef T value_type;
   typedef T* iterator;
   typedef const T* const_iterator;
   typedef typename Alloc::size_type size_type;
@@ -124,6 +125,7 @@ public:
   ///resize
   inline void resize(size_t n, Type_t val = Type_t())
   {
+    static_assert(std::is_same<value_type, typename Alloc::value_type>::value, "Vector and Alloc data types must agree!");
     if (nLocal > nAllocated)
       throw std::runtime_error("Resize not allowed on Vector constructed by initialized memory.");
     if (n > nAllocated)

--- a/src/OhmmsSoA/VectorSoaContainer.h
+++ b/src/OhmmsSoA/VectorSoaContainer.h
@@ -16,9 +16,11 @@
  */
 #ifndef QMCPLUSPLUS_VECTOR_SOA_H
 #define QMCPLUSPLUS_VECTOR_SOA_H
-#include <simd/allocator.hpp>
-#include <simd/algorithm.hpp>
-#include <ParticleBase/ParticleAttrib.h>
+
+#include <type_traits>
+#include "simd/allocator.hpp"
+#include "simd/algorithm.hpp"
+#include "ParticleBase/ParticleAttrib.h"
 
 namespace qmcplusplus
 {
@@ -132,6 +134,7 @@ struct VectorSoaContainer
        */
   __forceinline void resize(size_t n)
   {
+    static_assert(std::is_same<Element_t, typename Alloc::value_type>::value, "VectorSoaContainer and Alloc data types must agree!");
     if (nAllocated)
       myAlloc.deallocate(myData, nAllocated);
     nLocal     = n;

--- a/src/OpenMP/OMPallocator.hpp
+++ b/src/OpenMP/OMPallocator.hpp
@@ -15,6 +15,7 @@
 #define QMCPLUSPLUS_OPENMP_ALLOCATOR_H
 
 #include <memory>
+#include <type_traits>
 #include "config.h"
 
 namespace qmcplusplus
@@ -39,6 +40,7 @@ struct OMPallocator : public HostAllocator
 
   value_type* allocate(std::size_t n)
   {
+    static_assert(std::is_same<T, value_type>::value, "OMPallocator and HostAllocator data types must agree!");
     value_type* pt = HostAllocator::allocate(n);
     PRAGMA_OFFLOAD("omp target enter data map(alloc:pt[0:n])")
     return pt;

--- a/src/spline2/MultiBspline.hpp
+++ b/src/spline2/MultiBspline.hpp
@@ -18,10 +18,11 @@
  */
 #ifndef QMCPLUSPLUS_MULTIEINSPLINE_COMMON_HPP
 #define QMCPLUSPLUS_MULTIEINSPLINE_COMMON_HPP
-#include "config.h"
 #include <iostream>
-#include <spline2/BsplineAllocator.hpp>
-#include <stdlib.h>
+#include <cstdlib>
+#include <type_traits>
+#include "config.h"
+#include "spline2/BsplineAllocator.hpp"
 
 namespace qmcplusplus
 {
@@ -57,6 +58,7 @@ struct MultiBspline
   template<typename GT, typename BCT>
   void create(GT& grid, BCT& bc, int num_splines)
   {
+    static_assert(std::is_same<T, typename ALLOC::value_type>::value, "MultiBspline and ALLOC data types must agree!");
     if (getAlignedSize<T, ALIGN>(num_splines) != num_splines)
       throw std::runtime_error("When creating the data space of MultiBspline, num_splines must be padded!\n");
     if (spline_m == nullptr)


### PR DESCRIPTION
This PR enforces a container and its allocator using the same data type.
This is a restriction stronger than std::vector.
std::vector documentation says "The behaviour is undefined if Allocator::value_type is not the same as T".