### PR TITLE
Nexus: fix miscategorized starting_charge

### DIFF
--- a/nexus/lib/pwscf_input.py
+++ b/nexus/lib/pwscf_input.py
@@ -204,7 +204,6 @@ class PwscfInputBase(DevBase):
         'esm_efield','fcp_mu','london_c6','london_rvdw','xdm_a1','xdm_a2',
         # 6.3 additions
         'block_1','block_2','block_height','zgate','ts_vdw_econv_thr',
-        'starting_charge',
         ]
     strs=[
         # pre 5.4
@@ -240,6 +239,7 @@ class PwscfInputBase(DevBase):
         'hubbard_j0', 'hubbard_beta', 'hubbard_j',
         'starting_ns_eigenvalue', 'angle1', 'angle2', 'fixed_magnetization',
         'fe_step', 'efield_cart', 'london_c6', 'london_rvdw',
+        'starting_charge',
         ]
 
     species_arrays = [


### PR DESCRIPTION
The PWSCF input parameter "starting_charge" was miscategorized as a simple float, whereas it is really an array of floats.  This prevented appropriate input generation when using this parameter.

Other arrays that are dimensioned by ntyp were explicitly checked for correct categorization.