### PR TITLE
Change finite difference spacing for user jastrow test

### DIFF
--- a/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_user_jastrow.cpp
@@ -58,7 +58,7 @@ TEST_CASE("UserJastrowFunctor", "[wavefunction]")
 
   // Finite difference to verify the spatial derivatives
 
-  RealType h           = 0.001;
+  RealType h           = 0.01;
   RealType r_plus_h    = r + h;
   RealType r_minus_h   = r - h;
   RealType val_plus_h  = uf.evaluate(r_plus_h);


### PR DESCRIPTION
Fixes the test for mixed precision builds compiled with clang.
Note that the comparison epsilon is set to h as well, but this is not what makes the test pass.  Printing the values shows the finite difference value with the larger h is much closer to the analytic value.

Fixes #1669 