### PR TITLE
Optimize ratio evaluation in 1RDM estimator

### DIFF
--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -360,16 +360,13 @@ void DensityMatrices1B::initialize()
     normalize();
   }
 
-  // jtk timer
-  // add timers
-  eval_timer = TimerManager.createTimer("DensityMatrices1B::evaluate", timer_level_medium);
-  gen_samples_timer = TimerManager.createTimer("DensityMatrices1B::generate_samples", timer_level_fine);
-  gen_sample_basis_timer = TimerManager.createTimer("DensityMatrices1B::generate_sample_basis", timer_level_fine);
-  gen_sample_ratios_timer = TimerManager.createTimer("DensityMatrices1B::generate_sample_ratios", timer_level_fine);
+  eval_timer               = TimerManager.createTimer("DensityMatrices1B::evaluate", timer_level_medium);
+  gen_samples_timer        = TimerManager.createTimer("DensityMatrices1B::generate_samples", timer_level_fine);
+  gen_sample_basis_timer   = TimerManager.createTimer("DensityMatrices1B::generate_sample_basis", timer_level_fine);
+  gen_sample_ratios_timer  = TimerManager.createTimer("DensityMatrices1B::generate_sample_ratios", timer_level_fine);
   gen_particle_basis_timer = TimerManager.createTimer("DensityMatrices1B::generate_particle_basis", timer_level_fine);
-  matrix_products_timer = TimerManager.createTimer("DensityMatrices1B::evaluate_matrix_products", timer_level_fine);
-  accumulate_timer = TimerManager.createTimer("DensityMatrices1B::evaluate_matrix_accum", timer_level_fine);
-   // end jtk timer
+  matrix_products_timer    = TimerManager.createTimer("DensityMatrices1B::evaluate_matrix_products", timer_level_fine);
+  accumulate_timer         = TimerManager.createTimer("DensityMatrices1B::evaluate_matrix_accum", timer_level_fine);
 
   initialized = true;
 }
@@ -588,10 +585,7 @@ void DensityMatrices1B::warmup_sampling()
 
 DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
 {
-  // jtk timer
   eval_timer->start();
-  // end jtk timer
-
   if (have_required_traces || !energy_mat)
   {
     if (check_derivatives)
@@ -603,11 +597,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
     else
       APP_ABORT("DensityMatrices1B::evaluate  invalid evaluator");
   }
-
-  // jtk timer
   eval_timer->stop();
-  // end jtk timer
-
   return 0.0;
 }
 
@@ -633,9 +623,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
   generate_sample_ratios(Psi_NM);     // conj(Psi ratio) : particles x samples
   generate_particle_basis(P, Phi_NB); // conj(basis)     : particles x basis_size
   // perform integration via matrix products
-  // jtk timer
   matrix_products_timer->start();
-  // end jtk timer
   for (int s = 0; s < nspecies; ++s)
   {
     Matrix_t& Psi_nm     = *Psi_NM[s];
@@ -651,13 +639,9 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
       product_AtB(Phi_nb, Phi_Psi_nb, *E_BB[s]); // (energies*conj(basis))^T*ratio*basis
     }
   }
-  // jtk timer
   matrix_products_timer->stop();
-  // end jtk timer
   // accumulate data into collectables
-  // jtk timer
   accumulate_timer->start();
-  // end jtk timer
   const int basis_size2 = basis_size * basis_size;
   int ij                = nindex;
   for (int s = 0; s < nspecies; ++s)
@@ -694,9 +678,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
       }
     }
   }
-  // jtk timer
   accumulate_timer->stop();
-  // end jtk timer
 
 
   // jtk come back to this
@@ -907,9 +889,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
 
 inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
 {
-  // jtk timer
   gen_samples_timer->start();
-  // end jtk timer
   RandomGenerator_t& rng = *uniform_random;
   bool save              = false;
   if (steps == 0)
@@ -963,9 +943,7 @@ inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
     app_log() << "  rmean = " << rmean << std::endl;
     app_log() << "  rstd  = " << rstd << std::endl;
   }
-  // jtk timer
   gen_samples_timer->stop();
-  // end jtk timer
 }
 
 
@@ -1167,9 +1145,7 @@ void DensityMatrices1B::get_energies(std::vector<Vector_t*>& E_n)
 
 void DensityMatrices1B::generate_sample_basis(Matrix_t& Phi_mb)
 {
-  // jtk timer
   gen_sample_basis_timer->start();
-  // end jtk timer
   int mb = 0;
   for (int m = 0; m < samples; ++m)
   {
@@ -1177,17 +1153,13 @@ void DensityMatrices1B::generate_sample_basis(Matrix_t& Phi_mb)
     for (int b = 0; b < basis_size; ++b, ++mb)
       Phi_mb(mb) = basis_values[b];
   }
-  // jtk timer
   gen_sample_basis_timer->stop();
-  // end jtk timer
 }
 
 
 void DensityMatrices1B::generate_sample_ratios(std::vector<Matrix_t*> Psi_nm)
 {
-  // jtk timer
   gen_sample_ratios_timer->start();
-  // end jtk timer
   for (int m = 0; m < samples; ++m)
   {
     // get N ratios for the current sample point
@@ -1205,17 +1177,13 @@ void DensityMatrices1B::generate_sample_ratios(std::vector<Matrix_t*> Psi_nm)
       }
     }
   }
-  // jtk timer
   gen_sample_ratios_timer->stop();
-  // end jtk timer
 }
 
 
 void DensityMatrices1B::generate_particle_basis(ParticleSet& P, std::vector<Matrix_t*>& Phi_nb)
 {
-  // jtk timer
   gen_particle_basis_timer->start();
-  // end jtk timer
   int p = 0;
   for (int s = 0; s < nspecies; ++s)
   {
@@ -1228,9 +1196,7 @@ void DensityMatrices1B::generate_particle_basis(ParticleSet& P, std::vector<Matr
         P_nb(nb) = qmcplusplus::conj(basis_values[b]);
     }
   }
-  // jtk timer
   gen_particle_basis_timer->stop();
-  // end jtk timer
 }
 
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -587,7 +587,7 @@ void DensityMatrices1B::warmup_sampling()
 
 DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
 {
-  timers[DM_eval]->start();
+  ScopedTimer t(timers[DM_eval]);
   if (have_required_traces || !energy_mat)
   {
     if (check_derivatives)
@@ -599,7 +599,6 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
     else
       APP_ABORT("DensityMatrices1B::evaluate  invalid evaluator");
   }
-  timers[DM_eval]->stop();
   return 0.0;
 }
 
@@ -891,7 +890,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
 
 inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
 {
-  timers[DM_gen_samples]->start();
+  ScopedTimer t(timers[DM_gen_samples]);
   RandomGenerator_t& rng = *uniform_random;
   bool save              = false;
   if (steps == 0)
@@ -945,7 +944,6 @@ inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
     app_log() << "  rmean = " << rmean << std::endl;
     app_log() << "  rstd  = " << rstd << std::endl;
   }
-  timers[DM_gen_samples]->stop();
 }
 
 
@@ -1147,7 +1145,7 @@ void DensityMatrices1B::get_energies(std::vector<Vector_t*>& E_n)
 
 void DensityMatrices1B::generate_sample_basis(Matrix_t& Phi_mb)
 {
-  timers[DM_gen_sample_basis]->start();
+  ScopedTimer t(timers[DM_gen_sample_basis]);
   int mb = 0;
   for (int m = 0; m < samples; ++m)
   {
@@ -1155,13 +1153,12 @@ void DensityMatrices1B::generate_sample_basis(Matrix_t& Phi_mb)
     for (int b = 0; b < basis_size; ++b, ++mb)
       Phi_mb(mb) = basis_values[b];
   }
-  timers[DM_gen_sample_basis]->stop();
 }
 
 
 void DensityMatrices1B::generate_sample_ratios(std::vector<Matrix_t*> Psi_nm)
 {
-  timers[DM_gen_sample_ratios]->start();
+  ScopedTimer t(timers[DM_gen_sample_ratios]);
   for (int m = 0; m < samples; ++m)
   {
     // get N ratios for the current sample point
@@ -1179,13 +1176,12 @@ void DensityMatrices1B::generate_sample_ratios(std::vector<Matrix_t*> Psi_nm)
       }
     }
   }
-  timers[DM_gen_sample_ratios]->stop();
 }
 
 
 void DensityMatrices1B::generate_particle_basis(ParticleSet& P, std::vector<Matrix_t*>& Phi_nb)
 {
-  timers[DM_gen_particle_basis]->start();
+  ScopedTimer t(timers[DM_gen_particle_basis]);
   int p = 0;
   for (int s = 0; s < nspecies; ++s)
   {
@@ -1198,7 +1194,6 @@ void DensityMatrices1B::generate_particle_basis(ParticleSet& P, std::vector<Matr
         P_nb(nb) = qmcplusplus::conj(basis_values[b]);
     }
   }
-  timers[DM_gen_particle_basis]->stop();
 }
 
 

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -139,7 +139,6 @@ public:
 
   RandomGenerator_t* uniform_random;
 
-  // jtk timer
   NewTimer* eval_timer;
   NewTimer* gen_samples_timer;
   NewTimer* gen_sample_basis_timer;
@@ -147,7 +146,6 @@ public:
   NewTimer* gen_particle_basis_timer;
   NewTimer* matrix_products_timer;
   NewTimer* accumulate_timer;
-  // end jtk timer
 
 
   //constructor/destructor

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -22,6 +22,20 @@ namespace qmcplusplus
 {
 class DensityMatrices1B : public QMCHamiltonianBase
 {
+protected:
+  enum DMTimers
+  {
+    DM_eval,
+    DM_gen_samples,
+    DM_gen_sample_basis,
+    DM_gen_sample_ratios,
+    DM_gen_particle_basis,
+    DM_matrix_products,
+    DM_accumulate,
+  };
+
+  TimerList_t timers;
+
 public:
   enum
   {

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -71,6 +71,7 @@ public:
   bool warmed_up;
   std::vector<PosType> rsamples;
   Vector<RealType> sample_weights;
+  std::vector<ValueType> psi_ratios;
   RealType dens;
   PosType drift;
   int nindex;

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -153,14 +153,6 @@ public:
 
   RandomGenerator_t* uniform_random;
 
-  NewTimer* eval_timer;
-  NewTimer* gen_samples_timer;
-  NewTimer* gen_sample_basis_timer;
-  NewTimer* gen_sample_ratios_timer;
-  NewTimer* gen_particle_basis_timer;
-  NewTimer* matrix_products_timer;
-  NewTimer* accumulate_timer;
-
 
   //constructor/destructor
   DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl);


### PR DESCRIPTION
This PR addresses #975.

I did a series of performance profiling runs by rejigging the NiO performance tests to include the 1RDM.  These tests showed that a ~4x performance penalty is found for production system sizes when using 1 non-local sample per atom.  Higher sampling densities would result in proportional cost increases (2x more samples leads to 2x slowdown).  Below is a plot showing the BlockCPU time in DMC vs. number of atoms/samples relative to a run of the same size containing no estimator.

![baseline_reltime_vs_atoms_samples](https://user-images.githubusercontent.com/24547905/60299624-2535b200-98fb-11e9-8f60-b69ccb970045.png)

By inserting timers into the 1RDM eval, I was able to see the fraction of time spent on each sub-component.  Components include ratio eval, spo eval (labeled "basis" below), and matrix products.  As a function of system size, the ratio eval clearly dominates (approaches 100% of the overall time):

![baseline_1rdm_fractions](https://user-images.githubusercontent.com/24547905/60299741-7180f200-98fb-11e9-80e1-0d883f76d378.png)

With the performance improvements in this PR (solely due to Ye's evaluateRatiosAlltoOne function), the added cost over and estimator-free run drops to about 30% regardless of system size:

![optimized_reltime_vs_atoms_samples](https://user-images.githubusercontent.com/24547905/60299909-d2102f00-98fb-11e9-9617-b4c632b3932b.png)

The balance between different evaluation components is now much closer with matrix products and spo evals becoming competitive with ratio evals as the leading source of efficiency loss:

![optimized_1rdm_fractions](https://user-images.githubusercontent.com/24547905/60299980-fff57380-98fb-11e9-8459-210961d629f4.png)

In production runs, the spo eval and matrix products are likely to become even more significant since the performance tests are limited to an artificially small basis that comprises just the occupied states.  In a production setting, spo evals are likely to grow by 2-3x and matrix products possibly by 4-10x.  The performance analysis will be redone in a more production setting once support has been added for independent spin up/down bases (which will further strain the spo eval).  In any event, the ratio contribution seems to now be handled.