### PR TITLE
Nexus: update tests for recent changes

### DIFF
--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -2298,11 +2298,11 @@ def machines():
         ('summit'         , 'n2_t2_e'       ) : 'jsrun -a 10 -r 2 -b rs -c 20 -d packed -n 4 -g 0 test.x',
         ('summit'         , 'n2_t2_e_g6'    ) : 'jsrun -a 3 -r 6 -b rs -c 6 -d packed -n 12 -g 1 test.x',
         ('summit'         , 'n2_t2_g6'      ) : 'jsrun -a 3 -r 6 -b rs -c 6 -d packed -n 12 -g 1 test.x',
-        ('supermuc'       , 'n1'            ) : 'mpiexec -n 40 test.x',
+        ('supermuc'       , 'n1'            ) : 'mpiexec -n 28 test.x',
         ('supermuc'       , 'n1_p1'         ) : 'mpiexec -n 1 test.x',
-        ('supermuc'       , 'n2'            ) : 'mpiexec -n 80 test.x',
-        ('supermuc'       , 'n2_t2'         ) : 'mpiexec -n 40 test.x',
-        ('supermuc'       , 'n2_t2_e'       ) : 'mpiexec -n 40 test.x',
+        ('supermuc'       , 'n2'            ) : 'mpiexec -n 56 test.x',
+        ('supermuc'       , 'n2_t2'         ) : 'mpiexec -n 28 test.x',
+        ('supermuc'       , 'n2_t2_e'       ) : 'mpiexec -n 28 test.x',
         ('supermuc'       , 'n2_t2_p2'      ) : 'mpiexec -n 4 test.x',
         ('supermucng'     , 'n1'            ) : 'mpiexec -n 48 test.x',
         ('supermucng'     , 'n1_p1'         ) : 'mpiexec -n 1 test.x',
@@ -2905,6 +2905,10 @@ def pwscf_input():
         pseudos          = ['V.opt.upf','O.opt.upf'],
         kgrid            = (6,6,6),
         kshift           = (0,0,0),
+        # added for reverse compatibility
+        celldm           = {1:1.0},
+        cell_option      = 'alat',
+        positions_option = 'alat',
         )
 
     generations[infile] = pw

--- a/nexus/lib/pwscf_input.py
+++ b/nexus/lib/pwscf_input.py
@@ -204,6 +204,7 @@ class PwscfInputBase(DevBase):
         'esm_efield','fcp_mu','london_c6','london_rvdw','xdm_a1','xdm_a2',
         # 6.3 additions
         'block_1','block_2','block_height','zgate','ts_vdw_econv_thr',
+        'starting_charge'
         ]
     strs=[
         # pre 5.4
@@ -245,7 +246,7 @@ class PwscfInputBase(DevBase):
     species_arrays = [
         'starting_magnetization', 'hubbard_alpha', 'hubbard_u', 'hubbard_j0', 
         'hubbard_beta', 'hubbard_j', 'angle1', 'angle2', 
-        'london_c6', 'london_rvdw',
+        'london_c6', 'london_rvdw','starting_charge',
         ]
 
     species_array_indices = obj(hubbard_j=1)
@@ -510,7 +511,11 @@ class Card(Element):
 
     def change_specifier(self,new_specifier):
         self.not_implemented()
-    #end def change_specifier    
+    #end def change_specifier
+
+    def change_option(self,*args,**kwargs):
+        self.change_specifier(*args,**kwargs)
+    #end def change_option
 #end class Card
 
 
@@ -1050,7 +1055,7 @@ class atomic_positions(Card):
 
 
     def change_specifier(self,new_specifier,pwi):
-        scale,axes = pwi.get_common_vars('scale','axes')
+        scale = pwi.get_common_vars('scale')
 
         pos = self.positions
 
@@ -1062,6 +1067,7 @@ class atomic_positions(Card):
         elif spec=='angstrom':
             pos *= convert(1.,'A','B')
         elif spec=='crystal':
+            axes = pwi.get_common_vars('axes')
             pos = dot(pos,axes)
         else:
             self.error('old specifier for atomic_positions is invalid\n  old specifier: '+spec+'\n  valid options: alat, bohr, angstrom, crystal')
@@ -1075,6 +1081,7 @@ class atomic_positions(Card):
         elif spec=='angstrom':
             pos /= convert(1.,'A','B')
         elif spec=='crystal':
+            axes = pwi.get_common_vars('axes')
             pos = dot(pos,inv(axes))
         else:
             self.error('new specifier for atomic_positions is invalid\n  new specifier: '+spec+'\n  valid options: alat, bohr, angstrom, crystal')
@@ -1219,6 +1226,37 @@ class cell_parameters(Card):
     def write_text(self):
         return array_to_string(self.vectors)
     #end def write_text
+
+    def change_specifier(self,new_specifier,pwi):
+        scale = pwi.get_common_vars('scale')
+
+        vec = self.vectors
+
+        spec = self.specifier
+        if spec=='alat' or spec=='':
+            vec *= scale
+        elif spec=='bohr':
+            None
+        elif spec=='angstrom':
+            vec *= convert(1.,'A','B')
+        else:
+            self.error('old specifier for cell_parameters is invalid\nold specifier: '+spec+'\nvalid options: alat, bohr, angstrom')
+        #end if
+
+        spec = new_specifier
+        if spec=='alat' or spec=='':
+            vec /= scale
+        elif spec=='bohr':
+            None
+        elif spec=='angstrom':
+            vec /= convert(1.,'A','B')
+        else:
+            self.error('new specifier for cell_parameters is invalid\nnew specifier: '+spec+'\nvalid options: alat, bohr, angstrom')
+        #end if
+            
+        self.vectors   = vec
+        self.specifier = new_specifier
+    #end def change_specifier
 #end class cell_parameters
 
 
@@ -1465,20 +1503,16 @@ class PwscfInput(SimulationInput):
 
 
     def get_common_vars(self,*vars):
-        scale = None
+        scale = 1.0
         axes  = None
         kaxes = None
 
         if 'celldm(1)' in self.system:
             scale = self.system['celldm(1)']
-        elif 'ibrav' in self.system and self.system.ibrav==0:
-            scale = 1.0
         #end if
-        if scale!=None:
-            if 'cell_parameters' in self:
-                axes = scale*array(self.cell_parameters.vectors)
-                kaxes = 2*pi*inv(axes).T
-            #end if
+        if 'cell_parameters' in self:
+            axes = scale*array(self.cell_parameters.vectors)
+            kaxes = 2*pi*inv(axes).T
         #end if
 
         vals = []
@@ -1579,7 +1613,7 @@ class PwscfInput(SimulationInput):
             #end if
         #end for
 
-        self.atomic_positions.specifier = 'alat'
+        self.atomic_positions.specifier = 'bohr'
         self.atomic_positions.positions = s.pos.copy()
         self.atomic_positions.atoms     = list(s.elem)
         if s.frozen!=None:
@@ -1670,7 +1704,7 @@ class PwscfInput(SimulationInput):
             #end if
         #end for
 
-        self.atomic_positions.specifier = 'alat'
+        self.atomic_positions.specifier = 'bohr'
         self.atomic_positions.positions = s.pos.copy()
         self.atomic_positions.atoms     = list(s.elem)
         if s.frozen!=None:
@@ -1957,20 +1991,34 @@ def generate_any_pwscf_input(**kwargs):
     #end for
 
     #process other keywords
-    use_folded    = kwargs.delete_required('use_folded')
-    kgrid         = kwargs.delete_required('kgrid')
-    kshift        = kwargs.delete_required('kshift')
-    system        = kwargs.delete_optional('system',None)
-    pseudos       = kwargs.delete_optional('pseudos',[])
-    elem_order    = kwargs.delete_optional('elem_order',None)
-    mass          = kwargs.delete_optional('mass',None)
-    elem          = kwargs.delete_optional('elem',None)
-    pos           = kwargs.delete_optional('pos',None)
-    pos_specifier = kwargs.delete_optional('pos_specifier',None)
-    totmag_sys    = kwargs.delete_optional('totmag_sys',False)
-    start_mag     = kwargs.delete_optional('start_mag',None)
-    bandfac       = kwargs.delete_optional('bandfac',None)
-    nogamma       = kwargs.delete_optional('nogamma',False)
+    use_folded       = kwargs.delete_required('use_folded')
+    kgrid            = kwargs.delete_required('kgrid')
+    kshift           = kwargs.delete_required('kshift')
+    system           = kwargs.delete_optional('system',None)
+    pseudos          = kwargs.delete_optional('pseudos',[])
+    elem_order       = kwargs.delete_optional('elem_order',None)
+    mass             = kwargs.delete_optional('mass',None)
+    elem             = kwargs.delete_optional('elem',None)
+    pos              = kwargs.delete_optional('pos',None)
+    totmag_sys       = kwargs.delete_optional('totmag_sys',False)
+    start_mag        = kwargs.delete_optional('start_mag',None)
+    bandfac          = kwargs.delete_optional('bandfac',None)
+    nogamma          = kwargs.delete_optional('nogamma',False)
+    positions_option = kwargs.delete_optional('pos_specifier',None)
+    if positions_option is None:
+        positions_option = kwargs.delete_optional('positions_option',None)
+    #end if
+    if positions_option is None:
+        positions_option = kwargs.delete_optional('atomic_positions_option',None)
+    #end if
+    kpoints_option   = kwargs.delete_optional('kpoints_option',None)
+    if kpoints_option is None:
+        kpoints_option   = kwargs.delete_optional('k_points_option',None)
+    #end if
+    cell_option      = kwargs.delete_optional('cell_option',None)
+    if cell_option is None:
+        cell_option      = kwargs.delete_optional('cell_parameters_option',None)
+    #end if
 
     #  pseudopotentials
     pseudopotentials = obj()
@@ -1997,8 +2045,8 @@ def generate_any_pwscf_input(**kwargs):
             if pos is None:
                 PwscfInput.class_error('"pos" must be provided when "elem" is given','generate_pwscf_input')
             #end if
-            if pos_specifier is None:
-                PwscfInput.class_error('"pos_specifier" must be provided when "elem" is given','generate_pwscf_input')
+            if positions_option is None:
+                PwscfInput.class_error('"atomic_positions_option" must be provided when "elem" is given','generate_pwscf_input')
             #end if
 
             # fill in atomic_species
@@ -2025,7 +2073,7 @@ def generate_any_pwscf_input(**kwargs):
             #end for
 
             # fill in atomic_positions
-            pw.atomic_positions.specifier = pos_specifier
+            pw.atomic_positions.specifier = positions_option
             pw.atomic_positions.positions = array(pos,dtype=float)
             pw.atomic_positions.atoms     = list(elem)
         #end if
@@ -2135,6 +2183,21 @@ def generate_any_pwscf_input(**kwargs):
     #        shift     = kshift
     #        )
     #end if
+
+    # adjust card options, if requested
+    options = obj(
+        atomic_positions = positions_option,
+        k_points         = kpoints_option,
+        cell_parameters  = cell_option,
+        )
+    for card_name,option in options.items():
+        if option is not None:
+            if card_name not in pw:
+                PwscfInput.class_error('Card option provided for card "{}" but card is not present\noption provided: {}'.format(card_name,option))
+            #end if
+            pw[card_name].change_option(option,pw)
+        #end if
+    #end for
 
     # check for misformatted kpoints
     if len(pw.k_points)==0:

--- a/nexus/tests/reference/user_examples/qmcpack/H2O/runs/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/H2O/runs/scf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.001
    ecutrho         = 400
    ecutwfc         = 50
@@ -38,7 +38,7 @@ ATOMIC_SPECIES
    H  1.00794 H.BFD.upf
    O  15.999 O.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    O        4.05580089       4.05580089       3.00901473 
    H        4.05580089       1.35193363       5.10258705 
    H        4.05580089       6.75966815       5.10258705 
@@ -46,7 +46,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    1 1 1  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          8.11160178       0.00000000       0.00000000 
          0.00000000       8.11160178       0.00000000 
          0.00000000       0.00000000       8.11160178 

--- a/nexus/tests/reference/user_examples/qmcpack/LiH/runs/nscf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/LiH/runs/nscf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 1800
    ecutwfc         = 450
@@ -38,14 +38,14 @@ ATOMIC_SPECIES
    H  1.00794 H.TN-DF.upf
    Li 6.941 Li.TN-DF.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Li       0.00000000       0.00000000       0.00000000 
    H        3.55000000       3.55000000       3.55000000 
 
 K_POINTS automatic
    1 1 1  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          3.55000000       3.55000000       0.00000000 
         -0.00000000       3.55000000       3.55000000 
          3.55000000       0.00000000       3.55000000 

--- a/nexus/tests/reference/user_examples/qmcpack/LiH/runs/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/LiH/runs/scf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 1800
    ecutwfc         = 450
@@ -38,14 +38,14 @@ ATOMIC_SPECIES
    H  1.00794 H.TN-DF.upf
    Li 6.941 Li.TN-DF.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Li       0.00000000       0.00000000       0.00000000 
    H        3.55000000       3.55000000       3.55000000 
 
 K_POINTS automatic
    7 7 7  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          3.55000000       3.55000000       0.00000000 
         -0.00000000       3.55000000       3.55000000 
          3.55000000       0.00000000       3.55000000 

--- a/nexus/tests/reference/user_examples/qmcpack/c20/runs/c20/scf/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/c20/runs/c20/scf/scf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 600
    ecutwfc         = 150
@@ -38,7 +38,7 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        5.67201488       2.07077135       6.12363826 
    C        6.75261319      10.35385673       6.12363826 
    C        7.08201324       3.22522394       3.94377340 
@@ -63,7 +63,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    1 1 1  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         12.42462807       0.00000000       0.00000000 
          0.00000000      12.42462807       0.00000000 
          0.00000000       0.00000000      12.42462807 

--- a/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond/scf/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond/scf/scf.in
@@ -7,7 +7,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    ecutwfc         = 200
    ibrav           = 0
    input_dft       = 'lda'
@@ -26,7 +26,7 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        1.68658058       1.68658058       1.68658058 
 
@@ -41,7 +41,7 @@ K_POINTS crystal
          0.00000000       0.50000000       0.50000000       0.12500000 
          0.50000000       0.50000000       0.50000000       0.12500000 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          3.37316115       3.37316115       0.00000000 
          0.00000000       3.37316115       3.37316115 
          3.37316115       0.00000000       3.37316115 

--- a/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond_vacancy/relax/relax.in
+++ b/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond_vacancy/relax/relax.in
@@ -6,7 +6,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    ecutwfc         = 35
    ibrav           = 0
    input_dft       = 'lda'
@@ -28,7 +28,7 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        3.37316115       3.37316115       0.00000000 
    C        5.05974172       5.05974172       1.68658057 
@@ -48,7 +48,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    2 2 2  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          6.74632229       6.74632229       0.00000000 
         -0.00000000       6.74632229       6.74632229 
          6.74632229       0.00000000       6.74632229 

--- a/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond_vacancy/scf/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/diamond/runs/diamond_vacancy/scf/scf.in
@@ -6,7 +6,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    ecutwfc         = 75
    ibrav           = 0
    input_dft       = 'lda'
@@ -24,7 +24,7 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        3.37316115       3.37316115       0.00000000 
    C        5.05974172       5.05974172       1.68658057 
@@ -44,7 +44,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    2 2 2  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          6.74632229       6.74632229       0.00000000 
          0.00000000       6.74632229       6.74632229 
          6.74632229       0.00000000       6.74632229 

--- a/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/nscf/nscf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/nscf/nscf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 600
    ecutwfc         = 150
@@ -38,7 +38,7 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        2.32625287       1.34306272       0.00000000 
 
@@ -49,7 +49,7 @@ K_POINTS crystal
          0.25000000       0.75000000       0.50000000       0.25000000 
          0.75000000       0.75000000       0.50000000       0.25000000 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          4.65250574       0.00000000       0.00000000 
         -2.32625287       4.02918816       0.00000000 
         -0.00000000       0.00000000      18.89726133 

--- a/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/nscf_opt/nscf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/nscf_opt/nscf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 600
    ecutwfc         = 150
@@ -38,14 +38,14 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        2.32625287       1.34306272       0.00000000 
 
 K_POINTS automatic
    1 1 1  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          4.65250574       0.00000000       0.00000000 
         -2.32625287       4.02918816       0.00000000 
          0.00000000      -0.00000000      18.89726133 

--- a/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/scf/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/graphene/runs/graphene/scf/scf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 600
    ecutwfc         = 150
@@ -38,14 +38,14 @@
 ATOMIC_SPECIES 
    C  12.011 C.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    C        0.00000000       0.00000000       0.00000000 
    C        2.32625287       1.34306272       0.00000000 
 
 K_POINTS automatic
    8 8 8  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
          4.65250574       0.00000000       0.00000000 
         -2.32625287       4.02918816       0.00000000 
          0.00000000       0.00000000      18.89726133 

--- a/nexus/tests/reference/user_examples/qmcpack/oxygen_dimer/scale_1.0/scf.in
+++ b/nexus/tests/reference/user_examples/qmcpack/oxygen_dimer/scale_1.0/scf.in
@@ -12,7 +12,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !!celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 800
    ecutwfc         = 200
@@ -40,14 +40,14 @@
 ATOMIC_SPECIES 
    O  15.999 O.BFD.upf
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    O       13.03211833      14.17294600      14.17294600 
    O       15.31377366      14.17294600      14.17294600 
 
 K_POINTS automatic
    1 1 1  0 0 0 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         28.34589199       0.00000000       0.00000000 
          0.00000000      28.34589199       0.00000000 
          0.00000000       0.00000000      28.34589199 

--- a/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_111/relax.in
+++ b/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_111/relax.in
@@ -10,7 +10,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 200
    ecutwfc         = 50
@@ -43,7 +43,7 @@
 ATOMIC_SPECIES 
    Ge 72.61 Ge.pbe-kjpaw.UPF
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Ge       5.34792496       5.34792496       5.34792496 
    Ge       0.00000000       0.00000000       0.00000000 
    Ge       2.67396248       2.67396248       2.67396248 
@@ -65,7 +65,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    1 1 1  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         10.69584991      10.69584991       0.00000000 
          0.00000000      10.69584991      10.69584991 
         10.69584991       0.00000000      10.69584991 

--- a/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_222/relax.in
+++ b/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_222/relax.in
@@ -10,7 +10,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 200
    ecutwfc         = 50
@@ -43,7 +43,7 @@
 ATOMIC_SPECIES 
    Ge 72.61 Ge.pbe-kjpaw.UPF
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Ge       5.34792496       5.34792496       5.34792496 
    Ge       0.00000000       0.00000000       0.00000000 
    Ge       2.67396248       2.67396248       2.67396248 
@@ -65,7 +65,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    2 2 2  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         10.69584991      10.69584991       0.00000000 
          0.00000000      10.69584991      10.69584991 
         10.69584991       0.00000000      10.69584991 

--- a/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_444/relax.in
+++ b/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_444/relax.in
@@ -10,7 +10,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 200
    ecutwfc         = 50
@@ -43,7 +43,7 @@
 ATOMIC_SPECIES 
    Ge 72.61 Ge.pbe-kjpaw.UPF
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Ge       5.34792496       5.34792496       5.34792496 
    Ge       0.00000000       0.00000000       0.00000000 
    Ge       2.67396248       2.67396248       2.67396248 
@@ -65,7 +65,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    4 4 4  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         10.69584991      10.69584991       0.00000000 
          0.00000000      10.69584991      10.69584991 
         10.69584991       0.00000000      10.69584991 

--- a/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_666/relax.in
+++ b/nexus/tests/reference/user_examples/quantum_espresso/relax_Ge_T_vs_kpoints/runs/relax/kgrid_666/relax.in
@@ -10,7 +10,7 @@
 /
 
 &SYSTEM
-   celldm(1)       = 1.0
+   !celldm(1)       = 1.0
    degauss         = 0.0001
    ecutrho         = 200
    ecutwfc         = 50
@@ -43,7 +43,7 @@
 ATOMIC_SPECIES 
    Ge 72.61 Ge.pbe-kjpaw.UPF
 
-ATOMIC_POSITIONS alat
+ATOMIC_POSITIONS bohr
    Ge       5.34792496       5.34792496       5.34792496 
    Ge       0.00000000       0.00000000       0.00000000 
    Ge       2.67396248       2.67396248       2.67396248 
@@ -65,7 +65,7 @@ ATOMIC_POSITIONS alat
 K_POINTS automatic
    6 6 6  1 1 1 
 
-CELL_PARAMETERS alat
+CELL_PARAMETERS bohr
         10.69584991      10.69584991       0.00000000 
          0.00000000      10.69584991      10.69584991 
         10.69584991       0.00000000      10.69584991 


### PR DESCRIPTION
Update test reference data to reflect changes made by PR #1665.  PR #1665 updated the definition for the SuperMUC machine (corrected number of cores) which is now accomodated in the tests.  That PR additionally changed the default option for PWSCF card inputs from "alat" to "bohr".  This has also been updated in the test data.

Additional options were also added for input generation to specify any kind of card option, which was used to regain backwards compatibility with older inputs.