### PR TITLE
Two year rule and software versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ performance and easiest configuration.
 Nightly testing currently includes the following software versions on x86:
 
 * Compilers
-  * GCC 8.3.0, 7.4.0, 5.50
+  * GCC 8.3.0, 7.4.0, 5.5.0
   * Clang/LLVM 7.0.1, 6.0.1, 4.0.1
   * Intel 2018.3
   * PGI 19.4

--- a/README.md
+++ b/README.md
@@ -1,29 +1,51 @@
 # Getting and building QMCPACK
 
- Obtain the latest release or development copy from http://www.qmcpack.org
+ Obtain the latest release from https://github.com/QMCPACK/qmcpack/releases or clone the development source from
+ https://github.com/QMCPACK/qmcpack. 
 
 # Prerequisites
 
- * C++ 14 and C99 capable compilers. e.g. gcc 5.0, Intel 2018, clang 3.5 or newer. 
+ * C++ 14 and C99 capable compilers. 
  * CMake, build utility, http://www.cmake.org
- * BLAS/LAPACK, numerical library, use platform-optimized libraries
- * Libxml2, XML parser, http://xmlsoft.org/
+ * BLAS/LAPACK, numerical library. Use platform-optimized libraries.
+ * LibXml2, XML parser, http://xmlsoft.org/
  * HDF5, portable I/O library, http://www.hdfgroup.org/HDF5/
- * BOOST, peer-reviewed portable C++ source libraries, http://www.boost.org , version 1.61.0 or higher.
+ * BOOST, peer-reviewed portable C++ source libraries, http://www.boost.org
  * FFTW, FFT library, http://www.fftw.org/
+ * MPI, parallel library. Optional, but a near requirement for production calculations.
 
-See the manual for more detailed version requirements.
+We aim to support open source compilers and libraries released within two years of each QMCPACK release. Use of software versions over
+two years old may work but is discouraged and untested. Proprietary compilers (Intel, PGI) are generally supported over the same
+period but may require use of an exact version. We also aim to support the standard software environments on Summit at OLCF, Theta
+at ALCF, and Cori at NERSC. Use of the most recently released compilers and library versions is particularly encouraged for highest
+performance and easiest configuration.
+
+Nightly testing currently includes the following software versions on x86:
+
+* Compilers
+  * GCC 8.3.0, 7.4.0, 5.50
+  * Clang/LLVM 7.0.1, 6.0.1, 4.0.1
+  * Intel 2018.3
+  * PGI 19.4
+* Boost 1.70.0, 1.61.0 
+* HDF5 1.10.5, 1.8.19
+* FFTW 3.3.8, 3.3.4
+* CMake 3.14.4, 3.8.2
+* MPI
+  * OpenMPI 4.0.1, 2.1.1
+  * Intel MPI 2018.3
+* CUDA 10.0
 
 # Building with CMake
 
- The build system for QMCPACK is based on CMake.  It will autoconfigure
+ The build system for QMCPACK is based on CMake.  It will auto-configure
  based on the detected compilers and libraries. Previously QMCPACK made
  extensive use of toolchains, but the system has since been updated to
  eliminate the use of toolchain files for most cases.  The build
  system works with GNU, Intel, and IBM XLC compilers.  Specific compile options
  can be specified either through specific environment or CMake
  variables.  When the libraries are installed in standard locations,
- e.g., /usr, /usr/local, there is no need to set environment or cmake
+ e.g., /usr, /usr/local, there is no need to set environment or CMake
  variables for the packages.
 
  See the manuals linked at https://www.qmcpack.org/documentation or buildable via
@@ -36,7 +58,7 @@ See the manual for more detailed version requirements.
 
  * Safest quick build option is to specify the C and C++ compilers
    through their MPI wrappers. Here we use Intel MPI and Intel
-   compilers. Move to the build directory, run cmake and make
+   compilers. Move to the build directory, run CMake and make
 ```
 cd build
 cmake -DCMAKE_C_COMPILER=mpiicc -DCMAKE_CXX_COMPILER=mpiicpc ..
@@ -60,7 +82,7 @@ make -j 8
 ```
 
  The complexities of modern computer hardware and software systems are
- such that you should check that the autoconfiguration system has made
+ such that you should check that the auto-configuration system has made
  good choices and picked optimized libraries and compiler settings
  before doing significant production. i.e. Check the details below.
 
@@ -84,8 +106,8 @@ make -j 8
  In addition to reading the environment variables, CMake provides a
  number of optional variables that can be set to control the build and
  configure steps.  When passed to CMake, these variables will take
- precident over the environment and default variables.  To set them
- add -D FLAG=VALUE to the configure line between the cmake command and
+ precedent over the environment and default variables.  To set them
+ add -D FLAG=VALUE to the configure line between the CMake command and
  the path to the source directory.
 
  * General build options
@@ -193,8 +215,8 @@ rm -rf CMake*
 
 cmake                                               \
   -D CMAKE_BUILD_TYPE=Debug                         \
-  -D Libxml2_INCLUDE_DIRS=/usr/include/libxml2      \
-  -D Libxml2_LIBRARY_DIRS=/usr/lib/x86_64-linux-gnu \
+  -D LIBXML2_INCLUDE_DIR=/usr/include/libxml2      \
+  -D LIBXML2_LIBRARY=/usr/lib/x86_64-linux-gnu/libxml2.so \
   -D FFTW_INCLUDE_DIRS=/usr/include                 \
   -D FFTW_LIBRARY_DIRS=/usr/lib/x86_64-linux-gnu    \
   -D QMC_EXTRA_LIBS="-ldl ${ACML_HOME}/lib/libacml.a -lgfortran" \
@@ -262,8 +284,6 @@ ctest -R unit
 All of these tests should pass.
 
 ## Run the deterministic tests
-
-**Under development - some tests will fail**
 
 From the build directory, invoke ctest specifying only tests
 that are deterministic and known to be reliable.


### PR DESCRIPTION
Write down the "two year rule" and fix typos and leftovers in the README.

The list of tested software versions corresponds exactly to what is tested on oxygen. This is now done in an easily updatable manner. 

