### PR TITLE
Protect 0 in the copy constructor of OhmmsVector

### DIFF
--- a/src/CUDA/tests/test_CUDAallocator.cpp
+++ b/src/CUDA/tests/test_CUDAallocator.cpp
@@ -46,6 +46,11 @@ TEST_CASE("CUDA_allocators", "[CUDA]")
     cudaPointerAttributes attr;
     cudaErrorCheck(cudaPointerGetAttributes(&attr, vec.data()) , "cudaPointerGetAttributes failed!");
     REQUIRE(attr.type == cudaMemoryTypeHost);
+    Vector<double, CUDALockedPageAllocator<double>> vecb(vec);
+  }
+  { // CUDALockedPageAllocator zero size and copy constructor
+    Vector<double, CUDALockedPageAllocator<double>> vec;
+    Vector<double, CUDALockedPageAllocator<double>> vecb(vec);
   }
 }
 

--- a/src/OhmmsPETE/OhmmsVector.h
+++ b/src/OhmmsPETE/OhmmsVector.h
@@ -59,9 +59,12 @@ public:
   /** copy constructor */
   Vector(const Vector& rhs) : nLocal(rhs.nLocal), nAllocated(0), X(nullptr)
   {
-    resize_impl(rhs.nLocal);
-    if (allocator_traits<Alloc>::is_host_accessible)
-      std::copy_n(rhs.data(), nLocal, X);
+    if (nLocal)
+    {
+      resize_impl(rhs.nLocal);
+      if (allocator_traits<Alloc>::is_host_accessible)
+        std::copy_n(rhs.data(), nLocal, X);
+    }
   }
 
   // default assignment operator


### PR DESCRIPTION
OhmmsVector::resize_impl(0) caused error in CUDALockedPageAllocator which tries to register a null pointer. Between protect the allocator or the container. I think protect the container is better because we don't know what happens if an arbitrary allocator will be put in. The added unit test reproduces the issue and this PR fixes the issue.