### PR TITLE
Fix build issues

### DIFF
--- a/src/Numerics/Ylm.h
+++ b/src/Numerics/Ylm.h
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <complex>
 #include "OhmmsPETE/TinyVector.h"
+#include "config/stdlib/Constants.h"
 
 namespace qmcplusplus
 {

--- a/src/ParticleBase/RandomSeqGenerator.h
+++ b/src/ParticleBase/RandomSeqGenerator.h
@@ -21,6 +21,7 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "ParticleBase/ParticleAttrib.h"
 #include "Utilities/RandomGenerator.h"
+#include "config/stdlib/Constants.h"
 
 /*!\fn template<class T> void assignGaussRand(T* restrict a, unsigned n)
   *\param a the starting pointer

--- a/src/QMCTools/BMakeFunc.cpp
+++ b/src/QMCTools/BMakeFunc.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include "OhmmsData/libxmldefs.h"
 #include "QMCTools/BMakeFunc.h"
+#include "config/stdlib/Constants.h"
 
 std::vector<double> BMakeFuncBase::YlmNorm;
 void BMakeFuncBase::init()

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2CAdoptor.h
@@ -17,6 +17,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_C2C_SOA_ADOPTOR_H
 #define QMCPLUSPLUS_EINSPLINE_C2C_SOA_ADOPTOR_H
 
+#include <memory>
 #include <OhmmsSoA/Container.h>
 #include <spline2/MultiBspline.hpp>
 #include <spline2/MultiBsplineEval.hpp>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2RAdoptor.h
@@ -21,6 +21,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_C2R_ADOPTOR_H
 #define QMCPLUSPLUS_EINSPLINE_C2R_ADOPTOR_H
 
+#include <memory>
 #include <OhmmsSoA/Container.h>
 #include <spline2/MultiBspline.hpp>
 #include <spline2/MultiBsplineEval.hpp>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
@@ -17,6 +17,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_C2R_OMP_H
 #define QMCPLUSPLUS_EINSPLINE_C2R_OMP_H
 
+#include <memory>
 #include <OhmmsSoA/Container.h>
 #include <spline2/MultiBspline.hpp>
 #include <spline2/MultiBsplineEval.hpp>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2RAdoptor.h
@@ -15,6 +15,7 @@
 #ifndef QMCPLUSPLUS_EINSPLINE_R2RSOA_ADOPTOR_H
 #define QMCPLUSPLUS_EINSPLINE_R2RSOA_ADOPTOR_H
 
+#include <memory>
 #include <OhmmsSoA/Container.h>
 #include <spline2/MultiBspline.hpp>
 #include <spline2/MultiBsplineEval.hpp>

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -888,7 +888,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             ValueType dpsi2                         = dpsia_dn(dnC, pa);
             ParticleSet::ParticleGradient_t& g1     = grads_up[upC];
             ParticleSet::ParticleGradient_t& g2     = grads_dn[dnC];
-#if ((__INTEL_COMPILER == 1900) && (__INTEL_COMPILER_UPDATE == 0) && !defined(QMC_COMPLEX))
+#if (__INTEL_COMPILER == 1900 && !defined(QMC_COMPLEX))
 #pragma omp simd reduction(+ : dot1)
 #endif
             for (int k = 0; k < n; k++)

--- a/src/config/stdlib/Constants.h
+++ b/src/config/stdlib/Constants.h
@@ -1,0 +1,22 @@
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License. See LICENSE file in top directory for details.
+//
+// Copyright (c) 2019 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef TWOPI
+#define TWOPI (2 * M_PI)
+#endif /* TWOPI */
+
+#endif

--- a/src/config/stdlib/math.h
+++ b/src/config/stdlib/math.h
@@ -14,15 +14,7 @@
 #define QMCPLUSPLUS_STDLIB_PORT_H
 #include <config.h>
 #include <cmath>
-
-#ifndef TWOPI
-#ifndef M_PI
-#define TWOPI 6.2831853071795862
-#else
-#define TWOPI (2*M_PI)
-#endif /* M_PI */
-#endif /* TWOPI */
-
+#include "config/stdlib/Constants.h"
 
 #if __APPLE__
 

--- a/src/einspline/tests/test_3d.cpp
+++ b/src/einspline/tests/test_3d.cpp
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <limits>
+#include "config/stdlib/Constants.h"
 
 TEST_CASE("double_3d_natural","[einspline]")
 {

--- a/src/einspline/tests/test_one.cpp
+++ b/src/einspline/tests/test_one.cpp
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <vector>
+#include "config/stdlib/Constants.h"
 
 TEST_CASE("double_1d_natural", "[einspline]")
 {

--- a/src/spline2/tests/test_multi_spline.cpp
+++ b/src/spline2/tests/test_multi_spline.cpp
@@ -17,6 +17,7 @@
 #include "spline2/MultiBspline.hpp"
 #include "spline2/MultiBsplineEval.hpp"
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
+#include "config/stdlib/Constants.h"
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
1. Most of time M_PI is defined in math.h but this is not part of the language standard.
So define M_PI, if M_PI was not previously defined in included files.
2. `<memory>` is needed by smart pointers.
3. Intel workaround needs to cover all 19 updates.

Closes #1696