### PR TITLE
fixing CMP0074 policy setting to prevent cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ IF(COMMAND cmake_policy)
   IF(CMAKE_GENERATOR MATCHES "Ninja")
     cmake_policy(SET CMP0058 NEW)
   ENDIF(CMAKE_GENERATOR MATCHES "Ninja")
+  # CMake find_package will use <PackageName>_ROOT CMake variable
+  # and environment variable in search path.
+  # various Find<Package>.cmake modules may not follow this policy
+  cmake_policy(SET CMP0074 NEW)
 ENDIF(COMMAND cmake_policy)
 
 


### PR DESCRIPTION
Fixing #1574 we now set this policy.  Most except for FindCUDA which use CUDA_TOOLKIT_ROOT_DIR most of the Find<PACKAGE_NAME>.cmake modules follow this policay as well. I don't think we should map CUDA_ROOT --> CUDA_TOOLKIT_ROOT_DIR since we will should switch to CUDA as a language support and this eccentricity of the FindCUDA.cmake is well known, i.e. we're all used to CUDA_TOOLKIT_ROOT_DIR.