### PR TITLE
Add private/public in NonLocalECPComponent

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -162,7 +162,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
   {
     RealType zz = dot(dr, rrotsgrid_m[j]) * rinv;
     // Forming the Legendre polynomials
-    lpol[0]          = cone;
+    lpol[0]           = cone;
     RealType lpolprev = czero;
     for (int l = 0; l < lmax; l++)
     {
@@ -304,7 +304,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
     cosgrad[j] = rinv * uminusrvec;
 
     RealType udotgradpsi = dot(gradpsiratio[j], rrotsgrid_m[j]);
-    wfngrad[j]          = gradpsiratio[j] - dr * (udotgradpsi * rinv);
+    wfngrad[j]           = gradpsiratio[j] - dr * (udotgradpsi * rinv);
     wfngrad[j] *= sgridweight_m[j];
 
     // Forming the Legendre polynomials
@@ -337,15 +337,15 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
 
     for (int l = 0; l < nchannel; l++)
     {
-      lsum           += vrad[l] * lpol[angpp_m[l]] * psiratio[j];
-      gradpotterm_   += vgrad[l] * lpol[angpp_m[l]] * psiratio[j];
+      lsum += vrad[l] * lpol[angpp_m[l]] * psiratio[j];
+      gradpotterm_ += vgrad[l] * lpol[angpp_m[l]] * psiratio[j];
       gradlpolyterm_ += vrad[l] * dlpol[angpp_m[l]] * cosgrad[j] * psiratio[j];
-      gradwfnterm_   += vrad[l] * lpol[angpp_m[l]] * wfngrad[j];
+      gradwfnterm_ += vrad[l] * lpol[angpp_m[l]] * wfngrad[j];
     }
 
     if (Tmove)
       Txy.push_back(NonLocalData(iel, lsum, deltaV[j]));
-    pairpot   += lsum;
+    pairpot += lsum;
     force_iat += gradpotterm_ + gradlpolyterm_ - gradwfnterm_;
   }
 
@@ -514,7 +514,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
     cosgrad[j] = rinv * uminusrvec;
 
     RealType udotgradpsi = dot(gradpsiratio[j], rrotsgrid_m[j]);
-    wfngrad[j]          = gradpsiratio[j] - dr * (udotgradpsi * rinv);
+    wfngrad[j]           = gradpsiratio[j] - dr * (udotgradpsi * rinv);
     wfngrad[j] *= sgridweight_m[j];
 
     // Forming the Legendre polynomials
@@ -550,17 +550,17 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
     {
       //Note.  Because we are computing "forces", there's a -1 difference between this and
       //direct finite difference calculations.
-      lsum           += vrad[l] * lpol[angpp_m[l]] * psiratio[j];
-      gradpotterm_   += vgrad[l] * lpol[angpp_m[l]] * psiratio[j];
+      lsum += vrad[l] * lpol[angpp_m[l]] * psiratio[j];
+      gradpotterm_ += vgrad[l] * lpol[angpp_m[l]] * psiratio[j];
       gradlpolyterm_ += vrad[l] * dlpol[angpp_m[l]] * cosgrad[j] * psiratio[j];
-      gradwfnterm_   += vrad[l] * lpol[angpp_m[l]] * wfngrad[j];
+      gradwfnterm_ += vrad[l] * lpol[angpp_m[l]] * wfngrad[j];
       pulaytmp_ -= vrad[l] * lpol[angpp_m[l]] * pulay_quad[j];
     }
     pulaytmp_ += lsum * pulay_ref;
     if (Tmove)
       Txy.push_back(NonLocalData(iel, lsum, deltaV[j]));
-    pairpot     += lsum;
-    force_iat   += gradpotterm_ + gradlpolyterm_ - gradwfnterm_;
+    pairpot += lsum;
+    force_iat += gradpotterm_ + gradlpolyterm_ - gradwfnterm_;
     pulay_terms += pulaytmp_;
   }
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -225,7 +225,7 @@ public:
   inline int getLmax() const { return lmax; }
 
   // copy sgridxyz_m to rrotsgrid_m without rotation. For testing only.
-  inline void copyGridUnrotated() { rrotsgrid_m = sgridxyz_m; }
+  friend void copyGridUnrotatedForTest(NonLocalECPComponent& nlpp);
 
   friend class ECPComponentBuilder;
   // a lazy temporal solution

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -28,14 +28,13 @@ namespace qmcplusplus
 {
 /** Contains a set of radial grid potentials around a center.
 */
-struct NonLocalECPComponent : public QMCTraits
+class NonLocalECPComponent : public QMCTraits
 {
+private:
   typedef std::vector<PosType> SpherGridType;
   typedef OneDimGridBase<RealType> GridType;
   typedef OneDimCubicSpline<RealType> RadialPotentialType;
 
-  ///index of the distance table
-  int myTableIndex;
   ///Non Local part: angular momentum, potential and grid
   int lmax;
   ///the number of non-local channels
@@ -63,7 +62,7 @@ struct NonLocalECPComponent : public QMCTraits
   ///Working arrays
   std::vector<RealType> wvec, Amat, dAmat;
 
-  //^^^ "Why not GradType?" you ask.  Because GradType can be complex.
+  //Position delta for virtual moves.
   std::vector<PosType> deltaV;
   //Array for P_l[cos(theta)].
   std::vector<RealType> lpol;
@@ -98,15 +97,13 @@ struct NonLocalECPComponent : public QMCTraits
   ///virtual particle set: delay initialization
   VirtualParticleSet* VP;
 
-  //DistanceTableData* myTable;
-
+public:
 #if !defined(REMOVE_TRACEMANAGER)
   ///pointers to trace data of containing NonLocalECPotential object
   Array<TraceReal, 1>* Ve_sample;
   Array<TraceReal, 1>* Vi_sample;
   bool streaming_particles;
 #endif
-
 
   NonLocalECPComponent();
 
@@ -131,20 +128,20 @@ struct NonLocalECPComponent : public QMCTraits
   template<typename T>
   void randomize_grid(std::vector<T>& sphere, RandomGenerator_t& myRNG);
 
-  /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid 
- *           to total energy from ion "iat" and electron "iel".  
- *
- *    @param W electron particle set.
- *    @param iat index of ion.
- *    @param Psi trial wave function object
- *    @param iel index of electron
- *    @param r the distance between ion iat and electron iel.
- *    @param dr displacement from ion iat to electron iel.
- *    @param Tmove flag to compute tmove contributions.
- *    @param Txy nonlocal move data.
- *
- *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
- */
+  /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid
+   * to total energy from ion "iat" and electron "iel".
+   *
+   * @param W electron particle set.
+   * @param iat index of ion.
+   * @param Psi trial wave function object
+   * @param iel index of electron
+   * @param r the distance between ion iat and electron iel.
+   * @param dr displacement from ion iat to electron iel.
+   * @param Tmove flag to compute tmove contributions.
+   * @param Txy nonlocal move data.
+   *
+   * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+   */
   RealType evaluateOne(ParticleSet& W,
                        int iat,
                        TrialWaveFunction& Psi,
@@ -154,21 +151,21 @@ struct NonLocalECPComponent : public QMCTraits
                        bool Tmove,
                        std::vector<NonLocalData>& Txy);
 
-  /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid 
- *           to total energy from ion "iat" and electron "iel". 
- *
- *    @param W electron particle set.
- *    @param iat index of ion.
- *    @param Psi trial wave function object
- *    @param iel index of electron
- *    @param r the distance between ion iat and electron iel.
- *    @param dr displacement from ion iat to electron iel.
- *    @param Tmove flag to compute tmove contributions.
- *    @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
- *    @param Txy nonlocal move data.
- *
- *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
- */
+  /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid
+   * to total energy from ion "iat" and electron "iel".
+   *
+   * @param W electron particle set.
+   * @param iat index of ion.
+   * @param Psi trial wave function object
+   * @param iel index of electron
+   * @param r the distance between ion iat and electron iel.
+   * @param dr displacement from ion iat to electron iel.
+   * @param Tmove flag to compute tmove contributions.
+   * @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
+   * @param Txy nonlocal move data.
+   *
+   * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+   */
   RealType evaluateOneWithForces(ParticleSet& W,
                                  int iat,
                                  TrialWaveFunction& Psi,
@@ -179,23 +176,23 @@ struct NonLocalECPComponent : public QMCTraits
                                  bool Tmove,
                                  std::vector<NonLocalData>& Txy);
 
-  /** @brief Evaluate the nonlocal pp energy, Hellman-Feynman force, and "Pulay" force contribution 
- *          via randomized quadrature grid from ion "iat" and electron "iel". 
- *
- *    @param W electron particle set.
- *    @param ions ion particle set.
- *    @param iat index of ion.
- *    @param Psi trial wave function object
- *    @param iel index of electron
- *    @param r the distance between ion iat and electron iel.
- *    @param dr displacement from ion iat to electron iel.
- *    @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
- *    @param pulay_terms Nion x 3 object, holding a contribution for each ionic gradient from \Psi_T. 
- *    @param Tmove flag to compute tmove contributions.
- *    @param Txy nonlocal move data.
- *
- *    @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
- */
+  /** @brief Evaluate the nonlocal pp energy, Hellman-Feynman force, and "Pulay" force contribution
+   * via randomized quadrature grid from ion "iat" and electron "iel".
+   *
+   * @param W electron particle set.
+   * @param ions ion particle set.
+   * @param iat index of ion.
+   * @param Psi trial wave function object
+   * @param iel index of electron
+   * @param r the distance between ion iat and electron iel.
+   * @param dr displacement from ion iat to electron iel.
+   * @param force_iat 3d vector for Hellman-Feynman contribution.  This gets modified.
+   * @param pulay_terms Nion x 3 object, holding a contribution for each ionic gradient from \Psi_T.
+   * @param Tmove flag to compute tmove contributions.
+   * @param Txy nonlocal move data.
+   *
+   * @return RealType Contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
+   */
   RealType evaluateOneWithForces(ParticleSet& W,
                                  ParticleSet& ions,
                                  int iat,
@@ -208,18 +205,31 @@ struct NonLocalECPComponent : public QMCTraits
                                  bool Tmove,
                                  std::vector<NonLocalData>& Txy);
 
+  // This function needs to be updated to SoA. myTableIndex is introduced temporarily.
   RealType evaluateValueAndDerivatives(ParticleSet& P,
                                        int iat,
                                        TrialWaveFunction& psi,
                                        const opt_variables_type& optvars,
                                        const std::vector<RealType>& dlogpsi,
-                                       std::vector<RealType>& dhpsioverpsi);
+                                       std::vector<RealType>& dhpsioverpsi,
+                                       const int myTableIndex);
 
   void print(std::ostream& os);
 
   void initVirtualParticle(const ParticleSet& qp);
 
+  inline void setRmax(int rmax) { Rmax = rmax; }
+  inline RealType getRmax() const { return Rmax; }
+  inline int getNknot() const { return nknot; }
+  inline void setLmax(int Lmax) { lmax = Lmax; }
+  inline int getLmax() const { return lmax; }
 
+  // copy sgridxyz_m to rrotsgrid_m without rotation. For testing only.
+  inline void copyGridUnrotated() { rrotsgrid_m = sgridxyz_m; }
+
+  friend class ECPComponentBuilder;
+  // a lazy temporal solution
+  friend class NonLocalECPotential_CUDA;
 }; //end of RadialPotentialSet
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -30,7 +30,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
       PPset[ipp]->randomize_grid(*myRNG);
   for (int iat = 0; iat < NumIons; iat++)
     if (PP[iat])
-      Value += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, optvars, dlogpsi, dhpsioverpsi);
+      Value += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, optvars, dlogpsi, dhpsioverpsi, myTableIndex);
   return Value;
 
   //int Nvars=optvars.size();
@@ -104,7 +104,8 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
                                                                                  TrialWaveFunction& psi,
                                                                                  const opt_variables_type& optvars,
                                                                                  const std::vector<RealType>& dlogpsi,
-                                                                                 std::vector<RealType>& dhpsioverpsi)
+                                                                                 std::vector<RealType>& dhpsioverpsi,
+                                                                                 const int myTableIndex)
 {
 #if defined(ENABLE_SOA)
   APP_ABORT("NonLocalECPComponent::evaluateValueAndDerivatives(W,iat,psi.opt.dlogpsi,dhpsioverpsi) not implemented for SoA.\n");

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -82,7 +82,7 @@ public:
 
   QMCHamiltonianBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
 
-  void add(int groupID, NonLocalECPComponent* pp);
+  void addComponent(int groupID, NonLocalECPComponent* pp);
 
   /** set the internal RNG pointer as the given pointer
    * @param rng input RNG pointer
@@ -128,8 +128,6 @@ private:
   NonLocalTOperator nonLocalOps;
   ///true if we should compute forces
   bool ComputeForces;
-  ///true if we should use new algorithm
-  bool UseVP;
   ///Pulay force vector
   ParticleSet::ParticlePos_t PulayTerm;
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
@@ -50,7 +50,7 @@ QMCHamiltonianBase* NonLocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWa
   for (int ig = 0; ig < PPset.size(); ++ig)
   {
     if (PPset[ig])
-      myclone->add(ig, PPset[ig]->makeClone(qp));
+      myclone->addComponent(ig, PPset[ig]->makeClone(qp));
   }
   return myclone;
 }

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -353,7 +353,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
     for (int nn = myTable.M[iat], iel = 0; nn < myTable.M[iat + 1]; nn++, iel++)
     {
       const RealType r(myTable.r(nn));
-      if (r > nlpp->Rmax)
+      if (r > nlpp->getRmax())
         continue;
       Value1 += nlpp->evaluateOne(elec, iat, psi, iel, r, myTable.dr(nn), 0, Txy);
     }

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -121,6 +121,11 @@ TEST_CASE("ReadFileBuffer_reopen", "[hamiltonian]")
   REQUIRE(buf.length > 14);
 }
 
+void copyGridUnrotatedForTest(NonLocalECPComponent& nlpp)
+{
+  nlpp.rrotsgrid_m = nlpp.sgridxyz_m;
+}
+
 TEST_CASE("Evaluate_ecp", "[hamiltonian]")
 {
   typedef QMCTraits::RealType RealType;
@@ -248,7 +253,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   //This line is required because the randomized quadrature Lattice is set by
   //random number generator in NonLocalECPotential.  We take the unrotated
   //quadrature Lattice instead...
-  nlpp->copyGridUnrotated();
+  copyGridUnrotatedForTest(*nlpp);
 
 
   //Not testing nonlocal moves here, but the PP functions take this as an argument

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -248,7 +248,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   //This line is required because the randomized quadrature Lattice is set by
   //random number generator in NonLocalECPotential.  We take the unrotated
   //quadrature Lattice instead...
-  nlpp->rrotsgrid_m = nlpp->sgridxyz_m;
+  nlpp->copyGridUnrotated();
 
 
   //Not testing nonlocal moves here, but the PP functions take this as an argument
@@ -284,7 +284,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
     const auto& dist  = myTable.Distances[jel];
     const auto& displ = myTable.Displacements[jel];
     for (int iat = 0; iat < ions.getTotalNum(); iat++)
-      if (nlpp != nullptr && dist[iat] < nlpp->Rmax)
+      if (nlpp != nullptr && dist[iat] < nlpp->getRmax())
       {
         Value1 += nlpp->evaluateOne(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat], 0, Txy);
 


### PR DESCRIPTION
More concise access control.
`friend class NonLocalECPotential_CUDA;` is introduced only as a temporal workaround.