### PR TITLE
[WIP] Convert timer pointers to shared pointers

### DIFF
--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -128,10 +128,12 @@ public:
 // N = 2 gives 16 nesting levels
 typedef StackKeyParam<2> StackKey;
 
+using NewTimerPtr = NewTimer *;
+
 class TimerManagerClass
 {
 protected:
-  std::vector<NewTimer*> TimerList;
+  std::vector<NewTimerPtr> TimerList;
   std::vector<NewTimer*> CurrentTimerStack;
   timer_levels timer_threshold;
   timer_id_t max_timer_id;


### PR DESCRIPTION
The timer objects are one of the leaky resources identified by valgrind.    The TimerManager class contains a list of timer objects and they all need to still be alive when the timers are analyzed and output.    This makes timers a good candidate for shared pointers.

Steps:

1. Create a type alias for NewTimer *, which will later be set to to a shared pointer.    For the purpose of design feedback, only one pointer was changed to NewTimerPtr.  If this design is okay, the rest of the "NewTimer *" locations will be changed to NewTimerPtr to complete this PR
2. In another PR, change NewTimerPtr to std::shared_ptr<NewTimer>. 