### PR TITLE
Fix Box.com URL

### DIFF
--- a/manual/installation.tex
+++ b/manual/installation.tex
@@ -353,8 +353,8 @@ configured. See tests/performance/NiO/README,
 tests/solids/NiO\_afqmc/README, tests/performance/C-graphite/README, and tests/performance/C-molecule/README
 for details of the current tests and input files and to download them.
 
-Currently the files must be downloaded via
-\url{ttps://anl.box.com/s/yxz1ic4kxtdtgpva5hcmlom9ixfl3v3c}.
+Currently the files must be downloaded via \\
+\url{https://anl.box.com/s/yxz1ic4kxtdtgpva5hcmlom9ixfl3v3c}.
 
 The layout of current complete set of files is given below. If a file is missing, the appropriate performance test is skipped.
 %


### PR DESCRIPTION
Missing h; put on newline for easier cut and paste.
