### PR TITLE
Rename EstimatorRealType to FullPrecRealType.

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -62,9 +62,10 @@ struct QMCTraits
   typedef QTBase::TensorType TensorType;
   ///define other types
   typedef OHMMS_INDEXTYPE IndexType;
-  typedef QTFull::RealType EstimatorRealType;
+  typedef QTFull::RealType FullPrecRealType;
+  typedef QTFull::ValueType FullPrecValueType;
   ///define PropertyList_t
-  typedef RecordNamedProperty<EstimatorRealType> PropertySetType;
+  typedef RecordNamedProperty<FullPrecRealType> PropertySetType;
 };
 
 /** Particle traits to use UniformGridLayout for the ParticleLayout.

--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -40,7 +40,7 @@ class CollectablesEstimator;
 class EstimatorManagerBase
 {
 public:
-  typedef QMCTraits::EstimatorRealType RealType;
+  typedef QMCTraits::FullPrecRealType RealType;
   typedef ScalarEstimatorBase EstimatorType;
   typedef std::vector<RealType> BufferType;
   //enum { WEIGHT_INDEX=0, BLOCK_CPU_INDEX, ACCEPT_RATIO_INDEX, TOTAL_INDEX};

--- a/src/Estimators/ScalarEstimatorBase.h
+++ b/src/Estimators/ScalarEstimatorBase.h
@@ -37,7 +37,7 @@ class observable_helper;
  */
 struct ScalarEstimatorBase
 {
-  typedef QMCTraits::EstimatorRealType RealType;
+  typedef QMCTraits::FullPrecRealType RealType;
   typedef accumulator_set<RealType> accumulator_type;
   typedef MCWalkerConfiguration::Walker_t Walker_t;
   typedef MCWalkerConfiguration::const_iterator WalkerIterator;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -669,7 +669,7 @@ void ParticleSet::clearDistanceTables()
 int ParticleSet::addPropertyHistory(int leng)
 {
   int newL                                     = PropertyHistory.size();
-  std::vector<EstimatorRealType> newVecHistory = std::vector<EstimatorRealType>(leng, 0.0);
+  std::vector<FullPrecRealType> newVecHistory = std::vector<FullPrecRealType>(leng, 0.0);
   PropertyHistory.push_back(newVecHistory);
   PHindex.push_back(0);
   return newL;

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -88,7 +88,7 @@ public:
 
   //@{ public data members
   ///property of an ensemble represented by this ParticleSet
-  MCDataType<EstimatorRealType> EnsembleProperty;
+  MCDataType<FullPrecRealType> EnsembleProperty;
 
   ///ParticleLayout
   ParticleLayout_t Lattice, PrimitiveLattice;
@@ -191,7 +191,7 @@ public:
   std::vector<ParticleSet*> myClones;
 
   ///Property history vector
-  std::vector<std::vector<EstimatorRealType>> PropertyHistory;
+  std::vector<std::vector<FullPrecRealType>> PropertyHistory;
   std::vector<int> PHindex;
   ///@}
 
@@ -414,16 +414,16 @@ public:
   void donePbyP();
 
   ///return the address of the values of Hamiltonian terms
-  inline EstimatorRealType* restrict getPropertyBase() { return Properties.data(); }
+  inline FullPrecRealType* restrict getPropertyBase() { return Properties.data(); }
 
   ///return the address of the values of Hamiltonian terms
-  inline const EstimatorRealType* restrict getPropertyBase() const { return Properties.data(); }
+  inline const FullPrecRealType* restrict getPropertyBase() const { return Properties.data(); }
 
   ///return the address of the i-th properties
-  inline EstimatorRealType* restrict getPropertyBase(int i) { return Properties[i]; }
+  inline FullPrecRealType* restrict getPropertyBase(int i) { return Properties[i]; }
 
   ///return the address of the i-th properties
-  inline const EstimatorRealType* restrict getPropertyBase(int i) const { return Properties[i]; }
+  inline const FullPrecRealType* restrict getPropertyBase(int i) const { return Properties[i]; }
 
   inline void setTwist(SingleParticlePos_t& t) { myTwist = t; }
   inline SingleParticlePos_t getTwist() const { return myTwist; }

--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -75,7 +75,7 @@ struct Walker
   /** typedef for real data type */
   typedef typename t_traits::RealType RealType;
   /** typedef for estimator real data type */
-  typedef typename t_traits::EstimatorRealType EstimatorRealType;
+  typedef typename t_traits::FullPrecRealType FullPrecRealType;
   /** typedef for value data type. */
   typedef typename t_traits::ValueType ValueType;
 #ifdef QMC_CUDA
@@ -93,7 +93,7 @@ struct Walker
   typedef typename p_traits::SingleParticleValue_t SingleParticleValue_t;
 
   ///typedef for the property container, fixed size
-  typedef Matrix<EstimatorRealType> PropertyContainer_t;
+  typedef Matrix<FullPrecRealType> PropertyContainer_t;
   typedef PooledMemory<OHMMS_PRECISION_FULL> WFBuffer_t;
   typedef PooledData<RealType> Buffer_t;
 
@@ -108,7 +108,7 @@ struct Walker
   ///Age of this walker age is incremented when a walker is not moved after a sweep
   int ReleasedNodeAge;
   ///Weight of the walker
-  EstimatorRealType Weight;
+  FullPrecRealType Weight;
   ///Weight of the walker
   RealType ReleasedNodeWeight;
   /** Number of copies for branching
@@ -132,7 +132,7 @@ struct Walker
   PropertyContainer_t Properties;
 
   ///Property history vector
-  std::vector<std::vector<EstimatorRealType>> PropertyHistory;
+  std::vector<std::vector<FullPrecRealType>> PropertyHistory;
   std::vector<int> PHindex;
 
   ///buffer for the data for particle-by-particle update
@@ -216,7 +216,7 @@ struct Walker
     }
   }
 
-  inline void addPropertyHistoryPoint(int index, EstimatorRealType data)
+  inline void addPropertyHistoryPoint(int index, FullPrecRealType data)
   {
     PropertyHistory[index][PHindex[index]] = (data);
     PHindex[index]++;
@@ -225,10 +225,10 @@ struct Walker
     //       PropertyHistory[index].pop_back();
   }
 
-  inline EstimatorRealType getPropertyHistorySum(int index, int endN)
+  inline FullPrecRealType getPropertyHistorySum(int index, int endN)
   {
-    EstimatorRealType mean = 0.0;
-    typename std::vector<EstimatorRealType>::const_iterator phStart;
+    FullPrecRealType mean = 0.0;
+    typename std::vector<FullPrecRealType>::const_iterator phStart;
     phStart = PropertyHistory[index].begin() + PHindex[index];
     for (int i = 0; i < endN; phStart++, i++)
     {
@@ -301,16 +301,16 @@ struct Walker
   }
 
   //return the address of the values of Hamiltonian terms
-  inline EstimatorRealType* restrict getPropertyBase() { return Properties.data(); }
+  inline FullPrecRealType* restrict getPropertyBase() { return Properties.data(); }
 
   //return the address of the values of Hamiltonian terms
-  inline const EstimatorRealType* restrict getPropertyBase() const { return Properties.data(); }
+  inline const FullPrecRealType* restrict getPropertyBase() const { return Properties.data(); }
 
   ///return the address of the i-th properties
-  inline EstimatorRealType* restrict getPropertyBase(int i) { return Properties[i]; }
+  inline FullPrecRealType* restrict getPropertyBase(int i) { return Properties[i]; }
 
   ///return the address of the i-th properties
-  inline const EstimatorRealType* restrict getPropertyBase(int i) const { return Properties[i]; }
+  inline const FullPrecRealType* restrict getPropertyBase(int i) const { return Properties[i]; }
 
 
   /** reset the property of a walker
@@ -321,7 +321,7 @@ struct Walker
    *Assign the values and reset the age
    * but leave the weight and multiplicity
    */
-  inline void resetProperty(EstimatorRealType logpsi, EstimatorRealType sigN, EstimatorRealType ene)
+  inline void resetProperty(FullPrecRealType logpsi, FullPrecRealType sigN, FullPrecRealType ene)
   {
     Age = 0;
     //Weight=1.0;
@@ -330,15 +330,15 @@ struct Walker
     Properties(LOCALENERGY) = ene;
   }
 
-  inline void resetReleasedNodeProperty(EstimatorRealType localenergy,
-                                        EstimatorRealType alternateEnergy,
-                                        EstimatorRealType altR)
+  inline void resetReleasedNodeProperty(FullPrecRealType localenergy,
+                                        FullPrecRealType alternateEnergy,
+                                        FullPrecRealType altR)
   {
     Properties(ALTERNATEENERGY) = alternateEnergy;
     Properties(LOCALENERGY)     = localenergy;
     Properties(SIGN)            = altR;
   }
-  inline void resetReleasedNodeProperty(EstimatorRealType localenergy, EstimatorRealType alternateEnergy)
+  inline void resetReleasedNodeProperty(FullPrecRealType localenergy, FullPrecRealType alternateEnergy)
   {
     Properties(ALTERNATEENERGY) = alternateEnergy;
     Properties(LOCALENERGY)     = localenergy;
@@ -354,12 +354,12 @@ struct Walker
    *Assign the values and reset the age
    * but leave the weight and multiplicity
    */
-  inline void resetProperty(EstimatorRealType logpsi,
-                            EstimatorRealType sigN,
-                            EstimatorRealType ene,
-                            EstimatorRealType r2a,
-                            EstimatorRealType r2p,
-                            EstimatorRealType vq)
+  inline void resetProperty(FullPrecRealType logpsi,
+                            FullPrecRealType sigN,
+                            FullPrecRealType ene,
+                            FullPrecRealType r2a,
+                            FullPrecRealType r2p,
+                            FullPrecRealType vq)
   {
     Age                     = 0;
     Properties(LOGPSI)      = logpsi;

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -61,8 +61,8 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
   int nAcceptTemp(0);
   int nRejectTemp(0);
   //copy the old energy and scale factor of drift
-  EstimatorRealType eold(thisWalker.Properties(LOCALENERGY));
-  EstimatorRealType enew(eold);
+  FullPrecRealType eold(thisWalker.Properties(LOCALENERGY));
+  FullPrecRealType enew(eold);
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
   RealType gf_acc      = 1.0;
@@ -100,11 +100,11 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
       }
       else
       {
-        EstimatorRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
+        FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
         //Use the force of the particle iat
         DriftModifier->getDrift(tauovermass, grad_iat, dr);
         dr                      = W.R[iat] - W.activePos - dr;
-        EstimatorRealType logGb = -oneover2tau * dot(dr, dr);
+        FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
         RealType prob           = ratio * ratio * std::exp(logGb - logGf);
         if (RandomGen() < prob)
         {

--- a/src/QMCDrivers/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/QMCLinearOptimize.cpp
@@ -215,7 +215,7 @@ void QMCLinearOptimize::generateSamples()
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
   app_log() << "</vmc>" << std::endl;
   //write parameter history and energies to the parameter file in the trial wave function through opttarget
-  EstimatorRealType e, w, var;
+  FullPrecRealType e, w, var;
   vmcEngine->Estimators->getEnergyAndWeight(e, w, var);
   //     NumOfVMCWalkers=W.getActiveWalkers();
   //branchEngine->Eref=vmcEngine->getBranchEngine()->Eref;

--- a/src/QMCDrivers/QMCOptimize.cpp
+++ b/src/QMCDrivers/QMCOptimize.cpp
@@ -153,7 +153,7 @@ void QMCOptimize::generateSamples()
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
   app_log() << "</vmc>" << std::endl;
   //write parameter history and energies to the parameter file in the trial wave function through opttarget
-  EstimatorRealType e, w, var;
+  FullPrecRealType e, w, var;
   vmcEngine->Estimators->getEnergyAndWeight(e, w, var);
 
   h5FileRoot = RootName;

--- a/src/QMCDrivers/RMC/RMCUpdateAll.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.cpp
@@ -143,7 +143,7 @@ void RMCUpdateAllWithDrift::advanceWalkersVMC()
   else
     assignDrift(m_tauovermass, W.G, drift);
   fromdeltaR = curhead.R - W.R - drift;
-  EstimatorRealType* restrict new_headProp(W.getPropertyBase());
+  FullPrecRealType* restrict new_headProp(W.getPropertyBase());
 
   RealType logGb = -m_oneover2tau * Dot(fromdeltaR, fromdeltaR);
 
@@ -370,7 +370,7 @@ void RMCUpdateAllWithDrift::advanceWalkersRMC()
   else
     assignDrift(m_tauovermass, W.G, drift);
   fromdeltaR = curhead.R - W.R - drift;
-  EstimatorRealType* restrict new_headProp(W.getPropertyBase());
+  FullPrecRealType* restrict new_headProp(W.getPropertyBase());
   W.Properties(W.reptile->TransProb[backward]) = -m_oneover2tau * Dot(fromdeltaR, fromdeltaR);
   W.Properties(W.reptile->Action[backward])    = 0.5 * m_oneover2tau * Dot(fromdeltaR, fromdeltaR);
 

--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -132,7 +132,7 @@ int SimpleFixedNodeBranch::initWalkerController(MCWalkerConfiguration& walkers, 
   //check if tau is different and set the initial values
   //vParam[B_TAU]=tau;
   bool fromscratch      = false;
-  EstimatorRealType tau = vParam[B_TAU];
+  FullPrecRealType tau = vParam[B_TAU];
 
   int nwtot_now = walkers.getGlobalNumWalkers();
 
@@ -221,7 +221,7 @@ void SimpleFixedNodeBranch::initReptile(MCWalkerConfiguration& W)
   //check if tau is different and set the initial values
   //vParam[B_TAU]=tau;
   bool fromscratch      = false;
-  EstimatorRealType tau = vParam[B_TAU];
+  FullPrecRealType tau = vParam[B_TAU];
   //this is the first time DMC is used
   if (WalkerController == 0)
   {
@@ -281,7 +281,7 @@ void SimpleFixedNodeBranch::branch(int iter, MCWalkerConfiguration& walkers)
 {
   //collect the total weights and redistribute the walkers accordingly, using a fixed tolerance
   //RealType pop_now= WalkerController->branch(iter,walkers,0.1);
-  EstimatorRealType pop_now;
+  FullPrecRealType pop_now;
   if (BranchMode[B_DMCSTAGE] || iter)
     pop_now = WalkerController->branch(iter, walkers, 0.1);
   else
@@ -371,7 +371,7 @@ void SimpleFixedNodeBranch::branch(int iter, MCWalkerConfiguration& walkers)
   }
   WalkerController->setTrialEnergy(vParam[B_ETRIAL]);
   //accumulate collectables and energies for scalar.dat
-  EstimatorRealType wgt_inv = WalkerController->NumContexts / WalkerController->EnsembleProperty.Weight;
+  FullPrecRealType wgt_inv = WalkerController->NumContexts / WalkerController->EnsembleProperty.Weight;
   walkers.Collectables *= wgt_inv;
   MyEstimator->accumulate(walkers);
 }
@@ -488,7 +488,7 @@ void SimpleFixedNodeBranch::reset()
     if (BranchMode[B_POPCONTROL])
     {
       //logN = Feedback*std::log(static_cast<RealType>(iParam[B_TARGETWALKERS]));
-      logN = std::log(static_cast<EstimatorRealType>(iParam[B_TARGETWALKERS]));
+      logN = std::log(static_cast<FullPrecRealType>(iParam[B_TARGETWALKERS]));
       if (vParam[B_FEEDBACK] == 0.0)
         vParam[B_FEEDBACK] = 1.0;
     }
@@ -641,7 +641,7 @@ void SimpleFixedNodeBranch::checkParameters(MCWalkerConfiguration& w)
   std::ostringstream o;
   if (!BranchMode[B_DMCSTAGE])
   {
-    EstimatorRealType e, sigma2;
+    FullPrecRealType e, sigma2;
     MyEstimator->getCurrentStatistics(w, e, sigma2);
     vParam[B_ETRIAL] = vParam[B_EREF] = e;
     vParam[B_SIGMA2]                  = sigma2;
@@ -696,7 +696,7 @@ void SimpleFixedNodeBranch::finalize(MCWalkerConfiguration& w)
   else
   {
     //running VMC
-    EstimatorRealType e, sigma2;
+    FullPrecRealType e, sigma2;
     //MyEstimator->getEnergyAndWeight(e,w,sigma2);
     MyEstimator->getCurrentStatistics(w, e, sigma2);
     vParam[B_ETRIAL] = vParam[B_EREF] = e;
@@ -827,9 +827,9 @@ void SimpleFixedNodeBranch::read(const std::string& fname)
 //     }
 //   }
 
-void SimpleFixedNodeBranch::setBranchCutoff(EstimatorRealType variance,
-                                            EstimatorRealType targetSigma,
-                                            EstimatorRealType maxSigma,
+void SimpleFixedNodeBranch::setBranchCutoff(FullPrecRealType variance,
+                                            FullPrecRealType targetSigma,
+                                            FullPrecRealType maxSigma,
                                             int Nelec)
 {
   if (branching_cutoff_scheme == "DRV")

--- a/src/QMCDrivers/SimpleFixedNodeBranch.h
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.h
@@ -138,7 +138,7 @@ struct SimpleFixedNodeBranch : public QMCTraits
    *
    * Mostly internal
    */
-  typedef TinyVector<EstimatorRealType, B_VPARAM_MAX> VParamType;
+  typedef TinyVector<FullPrecRealType, B_VPARAM_MAX> VParamType;
   VParamType vParam;
 
   /** number of remaning steps for a specific tasks
@@ -147,7 +147,7 @@ struct SimpleFixedNodeBranch : public QMCTraits
    */
   int ToDoSteps;
   ///Feed*log(N)
-  EstimatorRealType logN;
+  FullPrecRealType logN;
   ///save xml element
   xmlNodePtr myNode;
   ///WalkerController
@@ -157,9 +157,9 @@ struct SimpleFixedNodeBranch : public QMCTraits
   ///EstimatorManager
   EstimatorManagerBase* MyEstimator;
   ///a simple accumulator for energy
-  accumulator_set<EstimatorRealType> EnergyHist;
+  accumulator_set<FullPrecRealType> EnergyHist;
   ///a simple accumulator for variance
-  accumulator_set<EstimatorRealType> VarianceHist;
+  accumulator_set<FullPrecRealType> VarianceHist;
   ///a simple accumulator for energy
   accumulator_set<RealType> R2Accepted;
   ///a simple accumulator for energy
@@ -180,7 +180,7 @@ struct SimpleFixedNodeBranch : public QMCTraits
   std::vector<std::string> sParam;
 
   /// Used for the average scaling
-  EstimatorRealType ScaleSum;
+  FullPrecRealType ScaleSum;
   unsigned long ScaleNum;
   //@TODO move these to private
   ///LogJacob
@@ -263,10 +263,10 @@ struct SimpleFixedNodeBranch : public QMCTraits
    *
    * Cutoff values are set by the variance
    */
-  inline RealType branchWeight(EstimatorRealType enew, EstimatorRealType eold) const
+  inline RealType branchWeight(FullPrecRealType enew, FullPrecRealType eold) const
   {
-    EstimatorRealType taueff_ = vParam[B_TAUEFF] * 0.5;
-    EstimatorRealType x       = std::max(vParam[B_EREF] - enew, vParam[B_EREF] - eold);
+    FullPrecRealType taueff_ = vParam[B_TAUEFF] * 0.5;
+    FullPrecRealType x       = std::max(vParam[B_EREF] - enew, vParam[B_EREF] - eold);
     if (x > vParam[B_BRANCHMAX])
       taueff_ = 0.0;
     else if (x > vParam[B_BRANCHCUTOFF])
@@ -315,8 +315,8 @@ struct SimpleFixedNodeBranch : public QMCTraits
    */
   inline RealType branchWeight(RealType enew, RealType eold, RealType scnew, RealType scold) const
   {
-    EstimatorRealType s1 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew;
-    EstimatorRealType s0 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold;
+    FullPrecRealType s1 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew;
+    FullPrecRealType s0 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold;
     return std::exp(vParam[B_TAUEFF] * 0.5 * (s1 + s0));
   }
 
@@ -329,8 +329,8 @@ struct SimpleFixedNodeBranch : public QMCTraits
    */
   inline RealType branchWeight(RealType enew, RealType eold, RealType scnew, RealType scold, RealType p) const
   {
-    EstimatorRealType s1 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew;
-    EstimatorRealType s0 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold;
+    FullPrecRealType s1 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew;
+    FullPrecRealType s0 = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold;
     return std::exp(vParam[B_TAUEFF] * (p * 0.5 * (s1 - s0) + s0));
     //return std::exp(TauEff*(p*0.5*(sp-sq)+sq));
   }
@@ -345,9 +345,9 @@ struct SimpleFixedNodeBranch : public QMCTraits
   {
     ScaleSum += scnew + scold;
     ScaleNum += 2;
-    EstimatorRealType scavg = (ScaleNum > 10000) ? ScaleSum / (RealType)ScaleNum : 1.0;
-    EstimatorRealType s1    = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew / scavg;
-    EstimatorRealType s0    = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold / scavg;
+    FullPrecRealType scavg = (ScaleNum > 10000) ? ScaleSum / (RealType)ScaleNum : 1.0;
+    FullPrecRealType s1    = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - enew) * scnew / scavg;
+    FullPrecRealType s0    = (vParam[B_ETRIAL] - vParam[B_EREF]) + (vParam[B_EREF] - eold) * scold / scavg;
     return std::exp(taueff * 0.5 * (s1 + s0));
   }
 
@@ -424,9 +424,9 @@ private:
   //void read(hid_t grp);
 
   ///set branch cutoff, max, filter
-  void setBranchCutoff(EstimatorRealType variance,
-                       EstimatorRealType targetSigma,
-                       EstimatorRealType maxSigma,
+  void setBranchCutoff(FullPrecRealType variance,
+                       FullPrecRealType targetSigma,
+                       FullPrecRealType maxSigma,
                        int Nelec = 0);
 };
 

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -121,7 +121,7 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
   myTimers[0]->stop();
   // end PbyP moves
   myTimers[2]->start();
-  EstimatorRealType eloc = H.evaluate(W);
+  FullPrecRealType eloc = H.evaluate(W);
   thisWalker.resetProperty(logpsi, Psi.getPhase(), eloc);
   myTimers[2]->stop();
   myTimers[3]->start();

--- a/src/QMCDrivers/WalkerControlBase.h
+++ b/src/QMCDrivers/WalkerControlBase.h
@@ -47,7 +47,7 @@ public:
   ///typedef of Walker_t
   typedef MCWalkerConfiguration::Walker_t Walker_t;
   ///typedef of RealType
-  typedef QMCTraits::EstimatorRealType RealType;
+  typedef QMCTraits::FullPrecRealType RealType;
   ///typedef of IndexType
   typedef QMCTraits::IndexType IndexType;
 

--- a/src/QMCHamiltonians/ForceCeperley.h
+++ b/src/QMCHamiltonians/ForceCeperley.h
@@ -33,9 +33,9 @@ public:
   double Rcut;                    // parameter: radial distance within which estimator is used
   int m_exp;                      // parameter: exponent in polynomial fit
   int N_basis;                    // parameter: size of polynomial basis set
-  Matrix<EstimatorRealType> Sinv; // terms in fitting polynomial
-  Vector<EstimatorRealType> h;    // terms in fitting polynomial
-  Vector<EstimatorRealType> c;    // polynomial coefficients
+  Matrix<FullPrecRealType> Sinv; // terms in fitting polynomial
+  Vector<FullPrecRealType> h;    // terms in fitting polynomial
+  Vector<FullPrecRealType> c;    // polynomial coefficients
   // container for short-range force estimator
 
   ParticleSet::ParticlePos_t forces_ShortRange;

--- a/src/QMCHamiltonians/QMCHamiltonianBase.h
+++ b/src/QMCHamiltonians/QMCHamiltonianBase.h
@@ -63,7 +63,7 @@ struct QMCHamiltonianBase : public QMCTraits
 {
   /** type of return value of evaluate
    */
-  typedef EstimatorRealType Return_t;
+  typedef FullPrecRealType Return_t;
   /** typedef for the serialized buffer
    *
    * PooledData<RealType> is used to serialized an anonymous buffer

--- a/src/QMCHamiltonians/observable_helper.h
+++ b/src/QMCHamiltonians/observable_helper.h
@@ -35,7 +35,7 @@ const hsize_t h5_observable_type = H5T_NATIVE_DOUBLE;
  */
 struct observable_helper
 {
-  typedef QMCTraits::EstimatorRealType value_type;
+  typedef QMCTraits::FullPrecRealType value_type;
   ///this can be handled by template argument
   //enum {type_id=H5T_NATIVE_DOUBLE};
   ///starting index


### PR DESCRIPTION
EstimatorRealType was initially introduced when I worked on the mixed precision in CPU code.
FullPrecRealType is the right name to reflect its actual use.