### PR TITLE
Use a scoped timer for the spo_timer

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -127,9 +127,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   std::string useGPU = "no";
 #endif
   std::string GPUsharing = "no";
-  NewTimer* spo_timer    = new NewTimer("einspline::CreateSPOSetFromXML", timer_level_medium);
-  TimerManager.addTimer(spo_timer);
-  spo_timer->start();
+  ScopedTimer spo_timer_scope(TimerManager.createTimer("einspline::CreateSPOSetFromXML", timer_level_medium));
 
   {
     OhmmsAttributeSet a;
@@ -465,7 +463,6 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 #endif
   OrbitalSet->finalizeConstruction();
   SPOSetMap[aset] = OrbitalSet;
-  spo_timer->stop();
   return OrbitalSet;
 }
 


### PR DESCRIPTION
If spin up and spin down are the same when constructing SPO's, there is an early return that skips the stop timer call.  This leads to incorrect nesting and some negative times in the results.  Use a scoped timer wrapper to let the compiler handle all the return paths.

The C-graphite performance tests show the problem - incorrect nesting of DMC under Startup and the negative exclusive time for Startup.
```
Stack timer profile
Timer                                       Inclusive_time  Exclusive_time  Calls       Time_per_call
Total                                         40.2266    39.3282              1      40.226648092
  Startup                                      0.8984   -38.9094              1       0.898411989
    DMC                                       30.5521     6.0097              1      30.552102804
      DMCUpdatePbyP::Buffer                    0.0519     0.0057            800       0.000064869
```