### PR TITLE
Fix infinite loop related to SO ECP handling

### DIFF
--- a/src/OhmmsData/libxmldefs.h
+++ b/src/OhmmsData/libxmldefs.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <typeinfo>
 
 template<typename _CharT>
 inline void getNodeName(std::basic_string<_CharT>& cname, xmlNodePtr cur)

--- a/src/OhmmsData/libxmldefs.h
+++ b/src/OhmmsData/libxmldefs.h
@@ -126,6 +126,12 @@ inline bool putContent(std::vector<T>& a, xmlNodePtr cur)
   {
     if (stream >> t)
       b.push_back(t);
+    else if (!stream.eof() && stream.fail())
+    {
+      std::cerr << "failbit detected when reading type (type_info::name) "
+                << typeid(T).name() << ", value " << t << std::endl;
+      stream.clear();
+    }
   }
   a = b;
   return true;

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -47,12 +47,12 @@ private:
   std::vector<RadialPotentialType*> sopp_m;
 
 public:
-  SOECPComponent(){};
 
-  ///destructor
-  ~SOECPComponent(){};
-
-  SOECPComponent* makeClone(const ParticleSet& qp){};
+  SOECPComponent* makeClone(const ParticleSet& qp)
+  {
+    APP_ABORT("SOECPComponent::makeClone not yet implemented");
+    return nullptr;
+  };
 
   ///add a new Spin-Orbit component
   void add(int l, RadialPotentialType* pp);


### PR DESCRIPTION
Closes #1779 
libc++ treat subnormal number conversion as badbit when operating istream. The badbit but not eof status caused infinite loop and timeout in the nightlies (bgclang and oxygen clang). With this fix, the infinite loop is avoided and the code prints
```
failbit detected when reading type (type_info::name) d, value 2.21025771677336e-308
```
file Zn.ccECP-SO.xml needs a fix to put subnormal number as zero. I also don't like tabs in that file.

Also removed a compiler warning for not providing a return.