### PR TITLE
adding emacs temp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
+# emacs temp files
+*~
+*#
+
+# python bytecode 
 *.pyc
+
+# excluded manual files 
 *.aux
 qmcpack_manual.bbl
 qmcpack_manual.blg
 qmcpack_manual.log
 qmcpack_manual.out
 qmcpack_manual.toc
-qmcpack_manual.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ qmcpack_manual.blg
 qmcpack_manual.log
 qmcpack_manual.out
 qmcpack_manual.toc
+qmcpack_manual.pdf


### PR DESCRIPTION
I'm tired of `git status` scrolling off the top of the screen.
These are common elements in .gitignore of other projects.