### PR TITLE
Add IonIon force observable to CoulombPotential in OBC

### DIFF
--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -19,6 +19,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/WalkerSetRef.h"
 #include "Particle/DistanceTableData.h"
+#include "QMCHamiltonians/ForceBase.h"
 #include "QMCHamiltonians/QMCHamiltonianBase.h"
 #include <numeric>
 
@@ -30,7 +31,7 @@ namespace qmcplusplus
  * Hamiltonian operator for the Coulomb interaction for both AA and AB type for open systems.
  */
 template<typename T>
-struct CoulombPotential : public QMCHamiltonianBase
+struct CoulombPotential : public QMCHamiltonianBase, public ForceBase
 {
   ///true, if CoulombAA for quantum particleset
   bool is_active;
@@ -48,22 +49,29 @@ struct CoulombPotential : public QMCHamiltonianBase
   Array<TraceReal, 1>* Vb_sample;
 #endif
 
+  /// Flag for whether to compute forces or not
+  bool ComputeForces;
+
   /** constructor for AA
    * @param s source particleset
    * @param active if true, new Value is computed whenver evaluate is used.
+   * @param computeForces if true, computes forces between inactive species
    */
-  inline CoulombPotential(ParticleSet& s, bool active, bool copy = false)
-      : Pa(s), myTableIndex(s.addTable(s, DT_SOA_PREFERRED)), is_AA(true), is_active(active)
+  inline CoulombPotential(ParticleSet& s, bool active, bool computeForces, bool copy = false)
+      : Pa(s), myTableIndex(s.addTable(s, DT_SOA_PREFERRED)), is_AA(true), is_active(active), ComputeForces(computeForces), ForceBase(s, s)
   {
     set_energy_domain(potential);
     two_body_quantum_domain(s, s);
     nCenters = s.getTotalNum();
+    prefix = "F_AA";
 
     if (!is_active) //precompute the value
     {
       if (!copy)
         s.update();
       Value = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
+      if ( ComputeForces )
+        evaluateAAForces(s.getDistTable(myTableIndex), s.Z.first_address());
     }
   }
 
@@ -71,9 +79,10 @@ struct CoulombPotential : public QMCHamiltonianBase
    * @param s source particleset
    * @param t target particleset
    * @param active if true, new Value is computed whenver evaluate is used.
+   * @param computeForces does nothing, because forces between AB species not implemented 
    */
-  inline CoulombPotential(ParticleSet& s, ParticleSet& t, bool active, bool copy = false)
-      : Pa(s), myTableIndex(t.addTable(s, DT_SOA_PREFERRED)), is_AA(false), is_active(active)
+  inline CoulombPotential(ParticleSet& s, ParticleSet& t, bool active, bool computeForces, bool copy = false)
+      : Pa(s), myTableIndex(t.addTable(s, DT_SOA_PREFERRED)), is_AA(false), is_active(active), ComputeForces(computeForces), ForceBase(s, t)
   {
     set_energy_domain(potential);
     two_body_quantum_domain(s, t);
@@ -111,6 +120,12 @@ struct CoulombPotential : public QMCHamiltonianBase
   }
 #endif
 
+  inline void addObservables(PropertySetType& plist, BufferType& collectables)
+  {
+    if (ComputeForces)
+      addObservablesF(plist);
+  }
+
   /** evaluate AA-type interactions */
   inline T evaluateAA(const DistanceTableData& d, const ParticleScalar_t* restrict Z)
   {
@@ -144,6 +159,43 @@ struct CoulombPotential : public QMCHamiltonianBase
       }
     }
     return res;
+  }
+
+
+  /** evaluate AA-type forces */
+  inline void evaluateAAForces(const DistanceTableData& d, const ParticleScalar_t* restrict Z)
+  {
+    forces = 0.0;
+    GradType forcetmp = 0.0;
+    if (d.DTType == DT_SOA)
+    {
+      for (size_t iat = 1; iat < nCenters; ++iat)
+      {
+        const RealType* restrict dist = d.Distances[iat];
+        T q                           = Z[iat];
+        for (size_t j = 0; j < iat; ++j)
+        {
+          forcetmp     = -q * Z[j] * d.Displacements[iat][j] / dist[j] / dist[j] / dist[j];
+	  forces[iat] += forcetmp;
+	  forces[j]   -= forcetmp;
+        }
+      }
+    }
+    else
+    {
+      const int* restrict M = d.M.data();
+      const int* restrict J = d.J.data();
+      for (int iat = 0; iat < nCenters; ++iat)
+      {
+        T q = Z[iat];
+        for (int nn = M[iat]; nn < M[iat + 1]; ++nn)
+        {
+          forcetmp     = q * Z[J[nn]] * d.dr(nn) * d.rinv(nn) * d.rinv(nn) * d.rinv(nn);
+	  forces[iat] += forcetmp;
+	  forces[nn]  -= forcetmp;
+        }
+      }
+    }
   }
 
 
@@ -348,6 +400,17 @@ struct CoulombPotential : public QMCHamiltonianBase
     return Value;
   }
 
+  inline Return_t evaluateWithIonDerivs(ParticleSet& P,
+                                 ParticleSet& ions,
+                                 TrialWaveFunction& psi,
+                                 ParticleSet::ParticlePos_t& hf_terms,
+                                 ParticleSet::ParticlePos_t& pulay_terms)
+  {
+    hf_terms -= forces;
+    // No pulay term.
+    return Value;
+  }
+
   bool put(xmlNodePtr cur) { return true; }
 
   bool get(std::ostream& os) const
@@ -359,19 +422,33 @@ struct CoulombPotential : public QMCHamiltonianBase
     return true;
   }
 
+  void setObservables(PropertySetType& plist)
+  {
+    QMCHamiltonianBase::setObservables(plist);
+    if (ComputeForces)
+      setObservablesF(plist);
+  }
+
+  void setParticlePropertyList(PropertySetType& plist, int offset)
+  {
+    QMCHamiltonianBase::setParticlePropertyList(plist, offset);
+    if (ComputeForces)
+      setParticleSetF(plist, offset);
+  }
+
   QMCHamiltonianBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi)
   {
     if (is_AA)
     {
       if (is_active)
-        return new CoulombPotential(qp, true);
+        return new CoulombPotential(qp, true, ComputeForces);
       else
         // Ye Luo April 16th, 2015
         // avoid recomputing ion-ion DistanceTable when reusing ParticleSet
-        return new CoulombPotential(Pa, false, true);
+        return new CoulombPotential(Pa, false, ComputeForces, true);
     }
     else
-      return new CoulombPotential(Pa, qp, true);
+      return new CoulombPotential(Pa, qp, ComputeForces, true);
   }
 };
 

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -125,14 +125,14 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
       if (quantum)
         targetH->addOperator(new CoulombPotentialAA_CUDA(*ptclA, true), title, physical);
       else
-        targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum), title, physical);
+        targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum, doForces), title, physical);
     }
 #else
     if (applyPBC)
       targetH->addOperator(new CoulombPBCAA(*ptclA, quantum, doForces), title, physical);
     else
     {
-      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum), title, physical);
+      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum, doForces), title, physical);
     }
 #endif
   }
@@ -147,7 +147,7 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
     if (applyPBC)
       targetH->addOperator(new CoulombPBCAB(*ptclA, *targetPtcl), title);
     else
-      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, *targetPtcl, true), title);
+      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, *targetPtcl, true, doForces), title);
 #endif
   }
 }


### PR DESCRIPTION
In response to issue #1769 from @rcclay, I've added code to compute IonIon forces due to coulomb potential in OBC, when "forces=yes" attribute is present.  The value is accumulated with that of ACForce estimator.  I've tested that the code works for more than two ions, and checked the validity by hand.