### PR TITLE
Restore manual section on adding a wavefunction

### DIFF
--- a/manual/developing.tex
+++ b/manual/developing.tex
@@ -8,3 +8,4 @@ The section gives guidance on how to extend the functionality of QMCPACK. Future
 \input{estimator_implementation}
 \input{estimator_manager}
 \input{backflow_implementation}
+\input{adding_wavefunction}


### PR DESCRIPTION
It was accidentally removed while integrating the edits