### PR TITLE
Pass the entire what to do bitset to VMCFactory

### DIFF
--- a/src/QMCApp/QMCDriverFactory.cpp
+++ b/src/QMCApp/QMCDriverFactory.cpp
@@ -252,7 +252,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   if (das.new_run_type == QMCRunType::VMC || das.new_run_type == QMCRunType::CSVMC)
   {
     //VMCFactory fac(curQmcModeBits[UPDATE_MODE],cur);
-    VMCFactory fac(das.what_to_do[UPDATE_MODE], cur);
+    VMCFactory fac(das.what_to_do.to_ulong(), cur);
     new_driver.reset(
         fac.create(qmc_system, *primaryPsi, *primaryH, particle_pool, hamiltonian_pool, wavefunction_pool, comm));
     //TESTING CLONE

--- a/src/QMCDrivers/VMC/VMCFactory.h
+++ b/src/QMCDrivers/VMC/VMCFactory.h
@@ -23,11 +23,11 @@ class HamiltonianPool;
 class VMCFactory
 {
 private:
-  int VMCMode;
+  unsigned long VMCMode;
   xmlNodePtr myNode;
 
 public:
-  VMCFactory(int vmode, xmlNodePtr cur) : VMCMode(vmode), myNode(cur) {}
+  VMCFactory(unsigned long vmode, xmlNodePtr cur) : VMCMode(vmode), myNode(cur) {}
 
   QMCDriverInterface* create(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,


### PR DESCRIPTION
fixes #1848 caused by only passing the part of the bitset. @markdewing pointed this out in the #1810 review.