### PR TITLE
Fix band read for hybrids

### DIFF
--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -236,14 +236,17 @@ class PwscfAnalyzer(SimulationAnalyzer):
             read_rel      = False
             for i in xrange(len(lines)):
                 l = lines[i]
-                if '- SPIN UP -' in l:
-                    up_spin   = True
+                if 'End of self-consistent calculation' in l:
                     # Initialize each time in case a hybrid functional was used
                     nfound = 0
                     index = -1
                     bands = obj()
                     bands.up = obj()
                     bands.down = obj()
+                #end if
+
+                if '- SPIN UP -' in l:
+                    up_spin   = True
                 elif '- SPIN DOWN -' in l:
                     up_spin   = False
                     index = -1
@@ -254,7 +257,6 @@ class PwscfAnalyzer(SimulationAnalyzer):
                         num_kpoints      = int(l.strip().split()[4])
                     except:
                         print "Number of k-points {0} is not an integer".format(num_kpoints)
-
                     kpoints_2pi_alat = lines[i+2:i+2+num_kpoints]
                     kpoints_rel      = lines[i+4+num_kpoints:i+4+2*num_kpoints]
                     kpoints_2pi_alat = array([k.strip().split()[4:6] + [k.strip().split()[6][0:-2]] for k in kpoints_2pi_alat], dtype=float)

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -227,6 +227,11 @@ class PwscfAnalyzer(SimulationAnalyzer):
         #end try
         try:
             # get bands and occupations
+            nfound = 0
+            index = -1
+            bands = obj()
+            bands.up = obj()
+            bands.down = obj()
             polarized = False
             if self.input.system.nspin > 1:
                 polarized = True
@@ -238,11 +243,13 @@ class PwscfAnalyzer(SimulationAnalyzer):
                 l = lines[i]
                 if 'End of self-consistent calculation' in l:
                     # Initialize each time in case a hybrid functional was used
-                    nfound = 0
-                    index = -1
-                    bands = obj()
-                    bands.up = obj()
-                    bands.down = obj()
+                    if nfound > 0:
+                        nfound = 0
+                        index = -1
+                        bands = obj()
+                        bands.up = obj()
+                        bands.down = obj()
+                    #end if
                 #end if
 
                 if '- SPIN UP -' in l:

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -257,6 +257,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
                         num_kpoints      = int(l.strip().split()[4])
                     except:
                         print "Number of k-points {0} is not an integer".format(num_kpoints)
+
                     kpoints_2pi_alat = lines[i+2:i+2+num_kpoints]
                     kpoints_rel      = lines[i+4+num_kpoints:i+4+2*num_kpoints]
                     kpoints_2pi_alat = array([k.strip().split()[4:6] + [k.strip().split()[6][0:-2]] for k in kpoints_2pi_alat], dtype=float)

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -227,11 +227,6 @@ class PwscfAnalyzer(SimulationAnalyzer):
         #end try
         try:
             # get bands and occupations
-            nfound = 0
-            index = -1
-            bands = obj()
-            bands.up = obj()
-            bands.down = obj()
             polarized = False
             if self.input.system.nspin > 1:
                 polarized = True
@@ -243,6 +238,12 @@ class PwscfAnalyzer(SimulationAnalyzer):
                 l = lines[i]
                 if '- SPIN UP -' in l:
                     up_spin   = True
+                    # Initialize each time in case a hybrid functional was used
+                    nfound = 0
+                    index = -1
+                    bands = obj()
+                    bands.up = obj()
+                    bands.down = obj()
                 elif '- SPIN DOWN -' in l:
                     up_spin   = False
                     index = -1


### PR DESCRIPTION
In this PR, a fix is made that avoids band read failure when a hybrid
functional is used in the calculation. During a hybrid calculation,
band data is printed multiple times in the output (once for each scf
convergence). The changes here make sure that nfound, index, and the
band objects are re-initialized each time '- SPIN UP -' is seen in
the output.