### PR TITLE
Fix timer crash in optimizer

### DIFF
--- a/src/QMCDrivers/QMCCorrelatedSamplingLinearOptimize.cpp
+++ b/src/QMCDrivers/QMCCorrelatedSamplingLinearOptimize.cpp
@@ -130,9 +130,9 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
   RealType startCost(0);
   //    if ((GEVtype!="H2")||(MinMethod!="rescale"))
   //    {
-  myTimers[4]->start();
+  cost_function_timer_.start();
   startCost = lastCost = optTarget->Cost(false);
-  myTimers[4]->stop();
+  cost_function_timer_.stop();
   //    }
   bool apply_inverse(true);
   if (apply_inverse)
@@ -172,7 +172,7 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
     }
     RealType lowestEV(0);
     RealType bigVec(0);
-    myTimers[2]->start();
+    eigenvalue_timer_.start();
     //                     lowestEV =getLowestEigenvector(LeftT,RightT,currentParameterDirections);
     if (GEVtype != "sd")
     {
@@ -190,7 +190,7 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
         currentParameterDirections[i + 1] = LeftT(i + 1, 0) * rscale;
       Lambda = 1.0;
     }
-    myTimers[2]->stop();
+    eigenvalue_timer_.stop();
     for (int i = 0; i < numParams; i++)
       bigVec = std::max(bigVec, std::abs(currentParameterDirections[i + 1]));
     if (std::abs(Lambda * bigVec) > bigChange)
@@ -234,7 +234,7 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
       quadstep         = stepsize / bigVec;
       //                  initial guess for line min bracketing
       LambdaMax = quadstep;
-      myTimers[3]->start();
+      line_min_timer_.start();
       if (MinMethod == "quartic")
       {
         int npts(7);
@@ -244,7 +244,7 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
       }
       else
         lineoptimization2();
-      myTimers[3]->stop();
+      line_min_timer_.stop();
       RealType biggestParameterChange = bigOptVec * std::abs(Lambda);
       if (biggestParameterChange > bigChange)
       {

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -321,9 +321,6 @@ protected:
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;
 
-  ///a list of timers
-  std::vector<NewTimer*> myTimers;
-
   ///temporary storage for drift
   ParticleSet::ParticlePos_t drift;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -250,9 +250,6 @@ protected:
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;
 
-  ///a list of timers
-  std::vector<NewTimer*> myTimers;
-
   ///temporary storage for drift
   ParticleSet::ParticlePos_t drift;
 

--- a/src/QMCDrivers/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/QMCFixedSampleLinearOptimize.cpp
@@ -236,9 +236,9 @@ bool QMCFixedSampleLinearOptimize::run()
     //     reset params if necessary
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters[i];
-    myTimers[4]->start();
+    cost_function_timer_.start();
     RealType lastCost(optTarget->Cost(true));
-    myTimers[4]->stop();
+    cost_function_timer_.stop();
     //     if cost function is currently invalid continue
     Valid = optTarget->IsValid;
     if (!ValidCostFunction(Valid))
@@ -292,10 +292,10 @@ bool QMCFixedSampleLinearOptimize::run()
         Right(i, i) += std::exp(XS);
       app_log() << "  Using XS:" << XS << " " << failedTries << " " << stability << std::endl;
       RealType lowestEV(0);
-      myTimers[2]->start();
+      eigenvalue_timer_.start();
       lowestEV = getLowestEigenvector(Right, currentParameterDirections);
       Lambda   = getNonLinearRescale(currentParameterDirections, S);
-      myTimers[2]->stop();
+      eigenvalue_timer_.stop();
       //       biggest gradient in the parameter direction vector
       RealType bigVec(0);
       for (int i = 0; i < numParams; i++)
@@ -331,7 +331,7 @@ bool QMCFixedSampleLinearOptimize::run()
         AbsFuncTol       = true;
         largeQuarticStep = bigChange / bigVec;
         LambdaMax        = 0.5 * Lambda;
-        myTimers[3]->start();
+        line_min_timer_.start();
         if (MinMethod == "quartic")
         {
           int npts(7);
@@ -341,7 +341,7 @@ bool QMCFixedSampleLinearOptimize::run()
         }
         else
           Valid = lineoptimization2();
-        myTimers[3]->stop();
+        line_min_timer_.stop();
         RealType biggestParameterChange = bigVec * std::abs(Lambda);
         if (biggestParameterChange > bigChange)
         {

--- a/src/QMCDrivers/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/QMCLinearOptimize.cpp
@@ -59,7 +59,9 @@ QMCLinearOptimize::QMCLinearOptimize(MCWalkerConfiguration& w,
       param_tol(1e-4),
       generate_samples_timer_(*TimerManager.createTimer("QMCLinearOptimize::GenerateSamples", timer_level_medium)),
       initialize_timer_(*TimerManager.createTimer("QMCLinearOptimize::Initialize", timer_level_medium)),
-      eigenvalue_timer_(*TimerManager.createTimer("QMCLinearOptimize::Eigenvalue", timer_level_medium))
+      eigenvalue_timer_(*TimerManager.createTimer("QMCLinearOptimize::Eigenvalue", timer_level_medium)),
+      line_min_timer_(*TimerManager.createTimer("QMCLinearOptimize::Line_Minimization", timer_level_medium)),
+      cost_function_timer_(*TimerManager.createTimer("QMCLinearOptimize::CostFunction", timer_level_medium))
 {
   IsQMCDriver = false;
   //     //set the optimization flag

--- a/src/QMCDrivers/QMCLinearOptimize.h
+++ b/src/QMCDrivers/QMCLinearOptimize.h
@@ -195,6 +195,8 @@ public:
   NewTimer& generate_samples_timer_;
   NewTimer& initialize_timer_;
   NewTimer& eigenvalue_timer_;
+  NewTimer& line_min_timer_;
+  NewTimer& cost_function_timer_;
   Timer t1;
 };
 } // namespace qmcplusplus


### PR DESCRIPTION
Addresses #1854

The timers in QMCLinearOptimize are used in derived classes QMCFixedSampleLinearOptimize and QMCCorrelatedSamplingLinearOptimize.  The pointers to myTimers elements caused seg faults as the array is no longer initialized.  Update the timers in those classes.

Also remove the myTimers array from the QMCDriver base to catch these problems at compile time.