### PR TITLE
Add more constructors to ComplexApprox

### DIFF
--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -9,7 +9,23 @@ namespace Catch {
 class ComplexApprox
 {
 public:
-    ComplexApprox(std::complex<double> value) : m_value(value), m_compare_real_only(false) {
+    ComplexApprox(const std::complex<double> &value) : m_value(value), m_compare_real_only(false) {
+      init_epsilon();
+    }
+
+    ComplexApprox(const std::complex<float> &value) : m_value(value), m_compare_real_only(false) {
+      init_epsilon();
+    }
+
+    ComplexApprox(const double &value) : m_value(value), m_compare_real_only(false) {
+      init_epsilon();
+    }
+
+    ComplexApprox(const float &value) : m_value(value), m_compare_real_only(false) {
+      init_epsilon();
+    }
+
+   void init_epsilon() {
       // Copied from catch.hpp - would be better to copy it from Approx object
       m_epsilon = std::numeric_limits<float>::epsilon()*100;
     }


### PR DESCRIPTION
Addresses an issue with the Intel compiler where a complex float constant would not be passed properly to a function accepting a complex double.

Also add constructors for non-complex double and float to avoid ambiguity errors with non-complex constants.

solves part of #1871