### PR TITLE
Fix pbc scripts

### DIFF
--- a/utils/afqmctools/afqmctools/hamiltonian/kpoint.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/kpoint.py
@@ -118,13 +118,14 @@ def write_basic(comm, cell, kpts, hcore, h5file, X, nmo_pk, qk_to_k2, kminus,
 
     # zero electron energies, including madelung term
     if comm.rank == 0:
-        e0 = cell.energy_nuc()
+        e0 = nkpts * cell.energy_nuc()
         if exxdiv == 'ewald':
             madelung = tools.pbc.madelung(cell, kpts)
             emad = -0.5*nelectron*madelung
             e0 += emad
             if verbose:
-                print(" # Adding ewald correction to the energy: {}".format(emad))
+                print(" # Adding ewald correction to the energy:"
+                      " {}".format(emad))
         sys.stdout.flush()
 
     comm.barrier()
@@ -137,7 +138,7 @@ def write_basic(comm, cell, kpts, hcore, h5file, X, nmo_pk, qk_to_k2, kminus,
     kminus_ = h5file.grp.create_dataset("MinusK", (nkpts,), dtype=numpy.int32)
     if comm.rank == 0:
         dims_[:] = numpy.array([0, 0, nkpts, nmo_tot, nup, ndown, 0, 0])
-        et_[:] = numpy.array([e0*nkpts, 0])
+        et_[:] = numpy.array([e0, 0])
         kp_[:,:] = kpts[:,:]
         nmo_pk_[:] = nmo_pk[:]
         kminus_[:] = kminus[:]

--- a/utils/afqmctools/afqmctools/hamiltonian/supercell.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/supercell.py
@@ -118,24 +118,11 @@ def setup_basis_map(Xocc, nmo_max, nkpts, nmo_pk, ortho_ao):
     ik2n = -1*numpy.ones((nmo_max,nkpts), dtype=numpy.int32)
     # ik2n[:,:]=-1
     cnt = 0
-    if ortho_ao:
-        for ki in range(nkpts):
-            for i in range(nmo_pk[ki]):
-                ik2n[i,ki] = cnt
-                cnt += 1
-    else:
-        # can safely assume isUHF==False
-        # Why are there two loops
-        for ki in range(nkpts):
-            for i in range(nmo_pk[ki]):
-                if Xocc[ki][i] > 0.9:
-                    ik2n[i,ki] = cnt
-                    cnt += 1
-        for ki in range(nkpts):
-            for i in range(nmo_pk[ki]):
-                if Xocc[ki][i] < 0.9:
-                    ik2n[i,ki] = cnt
-                    cnt += 1
+    # if ortho_ao:
+    for ki in range(nkpts):
+        for i in range(nmo_pk[ki]):
+            ik2n[i,ki] = cnt
+            cnt += 1
     nmo_tot = cnt
     return ik2n, nmo_tot
 

--- a/utils/afqmctools/afqmctools/hamiltonian/supercell.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/supercell.py
@@ -245,13 +245,13 @@ def write_info(h5grp, cell, v2cnts, h1size, nmo_tot, numv,
     h5grp.create_dataset("occups", data=occ)
 
     # zero electron energies, including madelung term
-    e0 = cell.energy_nuc()
+    e0 = nkpts * cell.energy_nuc()
     if exxdiv=='ewald':
         madelung = tools.pbc.madelung(cell, kpts)
         e0 += madelung*nelectron * -.5
         print(" # Adding ewald correction to the energy: "
               "{:13.8e}".format(-0.5*madelung*nelectron))
-    h5grp.create_dataset("Energies", data=numpy.array([e0*nkpts, 0]))
+    h5grp.create_dataset("Energies", data=numpy.array([e0, 0]))
 
 
 def generate_grid_shifts(cell):

--- a/utils/afqmctools/afqmctools/inputs/from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/from_pyscf.py
@@ -34,9 +34,6 @@ def write_qmcpack(comm, chkfile, hamil_file, threshold,
             print(" # Generating Hamiltonian and wavefunction from pyscf cell"
                   " object.")
         scf_data = load_from_pyscf_chk(chkfile, orthoAO=ortho_ao)
-        if comm.rank == 0:
-            nelec = write_wfn_pbc(scf_data, ortho_ao, wfn_file, verbose=verbose,
-                                  ndet_max=ndet_max)
         if write_hamil:
             if kpoint:
                 write_hamil_kpoints(comm, scf_data, hamil_file, threshold,
@@ -46,6 +43,9 @@ def write_qmcpack(comm, chkfile, hamil_file, threshold,
                 write_hamil_supercell(comm, scf_data, hamil_file, threshold,
                                       verbose=verbose, cas=cas,
                                       ortho_ao=ortho_ao)
+        if comm.rank == 0:
+            nelec = write_wfn_pbc(scf_data, ortho_ao, wfn_file, verbose=verbose,
+                                  ndet_max=ndet_max)
     else:
         if comm.rank == 0 and verbose:
             print(" # Generating Hamiltonian and wavefunction from pysc mol"

--- a/utils/afqmctools/afqmctools/wavefunction/pbc.py
+++ b/utils/afqmctools/afqmctools/wavefunction/pbc.py
@@ -91,7 +91,7 @@ def generate_orbitals(fock, X, nmo_pk, rediag, ortho_ao,
         if verbose:
             print(" # Generating trial wavefunction for kpoint: "
                   "{:d}".format(k))
-        if rediag and ortho_ao:
+        if ortho_ao:
             start = time.time()
             ea, orb_a = rediag_fock(fock[0,k], X[k][:,:nmo_pk[k]])
             full_mo_a.append(orb_a)
@@ -105,7 +105,7 @@ def generate_orbitals(fock, X, nmo_pk, rediag, ortho_ao,
             if verbose:
                 print(" # Time to rediagonalise fock: "
                       "  {:13.8e} s".format(time.time()-start))
-        elif not rediag and not ortho_ao:
+        else:
             if uhf:
                 print("WARNING: UHF wavefunction with ortho_ao = False not "
                       "allowed.")
@@ -116,9 +116,8 @@ def generate_orbitals(fock, X, nmo_pk, rediag, ortho_ao,
             full_mo_a.append(orb_a)
             ks.append([k]*len(ea))
             bands.append([i for i in range(len(ea))])
-        elif ortho_ao and not rediag:
-            print("WARNING: ortho_ao = True and rediag = False not implemented.")
-            sys.exit()
+            eigs_b = eigs_a
+            foll_mo_b = full_mo_b
     return ((eigs_a,eigs_b), (full_mo_a,full_mo_b), ks, bands)
 
 def create_wavefunction(orbs, occs, nmo_pk, nelec, uhf, verbose):


### PR DESCRIPTION
Some fixes for AFQMC pyscf PBC integral/wavefunction generation scripts following update for non-integer occupancies.
1. Fixes inconsistent multiplication of nkpts since nelectron is now the total number of electrons in the supercell.
2. Fixes bug when generating trial in MO basis
3. Fixes order of writing wavefunction and hamiltonian so that wavefunction and hamiltonian can be written to same file. 