### PR TITLE
Fix hdf reading boolean

### DIFF
--- a/src/io/hdf_dataproxy.h
+++ b/src/io/hdf_dataproxy.h
@@ -62,7 +62,7 @@ struct h5data_proxy<bool> : public h5_space_type<int, 0>
 
   inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    int copy;
+    int copy = static_cast<int>(ref_);
     bool okay = h5d_read(grp, aname, get_address(&copy), xfer_plist);
     ref_ = static_cast<bool>(copy);
     return okay;

--- a/src/io/hdf_hyperslab.h
+++ b/src/io/hdf_hyperslab.h
@@ -13,6 +13,7 @@
 #ifndef QMCPLUSPLUS_HDF_HYPERSLAB_IO_H
 #define QMCPLUSPLUS_HDF_HYPERSLAB_IO_H
 
+#include <array>
 #include <type_traits/container_traits.h>
 #include <io/hdf_datatype.h>
 #include <io/hdf_dataspace.h>


### PR DESCRIPTION
Reading bool in hdf must save initial value to prevent uninitialized values in case of missing intended dataset.
It should fix converter_test_LiH_pyscf failure on multiple platforms.
https://cdash.qmcpack.org/CDash/testDetails.php?test=6111561&build=78400

In addition, I add one more header inclusion. Hopefully it fixes the Clang 4.0 compilation error. I don't have clang 4.0 at hand for testing.