### PR TITLE
Read/write imaginary part of ci coefficient.

### DIFF
--- a/utils/afqmctools/afqmctools/wavefunction/converter.py
+++ b/utils/afqmctools/afqmctools/wavefunction/converter.py
@@ -158,6 +158,8 @@ def read_qmcpack_ci_wavefunction(input_file, nelec, nmo, ndets=None):
         ci_b = fh5['MultiDet/CI_Beta'][:]
         nbs = fh5['MultiDet/Nbits'][()]
         coeffs = fh5['MultiDet/Coeff'][:][:ndets]
+        coeffs_imag = fh5['MultiDet/Coeff_imag'][:][:ndets]
+        coeffs = coeffs + 1j*coeffs_imag
         occa = []
         occb = []
         for i, (ca, cb) in enumerate(zip(ci_a[:ndets], ci_b[:ndets])):


### PR DESCRIPTION
Fix for real space to afqmc wavefunction converter. I didn't realise the real/imaginary parts of the ci coefficients were stored in different data sets.