### PR TITLE
Add PYSCF_BIN variable to guard afqmc workflow tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,17 @@ IF ( DEFINED QE_BIN )
 ENDIF()
 
 ######################################################################
+# Verify PYSCF package is present
+######################################################################
+IF ( DEFINED PYSCF_BIN )
+  INCLUDE(CMake/python.cmake)
+  TEST_PYTHON_MODULE(pyscf HAVE_PYSCF)
+  IF (NOT HAVE_PYSCF)
+    MESSAGE( FATAL_ERROR "PYSCF_BIN was specified but could not import pyscf." )
+  ENDIF()
+ENDIF()
+
+######################################################################
 # CTest
 ######################################################################
 INCLUDE( "${qmcpack_SOURCE_DIR}/CMake/macros.cmake" )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,12 @@ ELSE()
 ENDIF()
 
 IF(BUILD_AFQMC)
-  SUBDIRS("afqmc/workflow")
+  IF(PYSCF_BIN)
+    MESSAGE("PYSCF path specified as: ${PYSCF_BIN}.")
+    SUBDIRS("afqmc/workflow")
+  ELSE()
+    MESSAGE("PYSCF_BIN is not set. AFQMC workflow tests will not be performed.")
+  ENDIF()
 ENDIF()
 
 #


### PR DESCRIPTION
Should fix test breakages for nightlies due to a lack of pyscf.