### PR TITLE
Abort with error message for AoS distance tables.

### DIFF
--- a/src/Particle/createDistanceTableAA.cpp
+++ b/src/Particle/createDistanceTableAA.cpp
@@ -47,7 +47,12 @@ DistanceTableData* createDistanceTable(ParticleSet& s, int dt_type, std::ostream
   }
   else
   {
+#ifdef ENABLE_SOA
+    APP_ABORT("createDistanceTable (AA). Using array-of-structure (AoS) data layout is no longer supported in builds with ENABLE_SOA=1.");
+#else
     o << "    Using array-of-structure (AoS) data layout (less efficient than SoA)" << std::endl;
+#endif
+
   }
 
   if (sc == SUPERCELL_BULK)

--- a/src/Particle/createDistanceTableAB.cpp
+++ b/src/Particle/createDistanceTableAB.cpp
@@ -49,7 +49,11 @@ DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, int
   }
   else
   {
+#ifdef ENABLE_SOA
+    APP_ABORT("createDistanceTable (AB). Using array-of-structure (AoS) data layout is no longer supported in builds with ENABLE_SOA=1.");
+#else
     o << "    Using array-of-structure (AoS) data layout (less efficient than SoA)" << std::endl;
+#endif
   }
 
   if (sc == SUPERCELL_BULK)


### PR DESCRIPTION
If an AoS distance table is requested in a build with ENABLE_SOA=1, abort with an error message.

This continues the work in #1846 to isolate the AoS code and addresses the request in #1897 to make the error more obvious.