### PR TITLE
Using pointers instead of RefVector when calling WFC

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -386,7 +386,7 @@ void TrialWaveFunction::flex_calcRatio(const RefVector<TrialWaveFunction>& wf_li
       {
         ScopedTimer local_timer(wf_list[0].get().get_timers()[ii]);
         const auto wfc_list(extract_WFC_list(wf_list, i));
-        wavefunction_components[i]->mw_calcRatio(wfc_list, p_list, iat, ratios_z);
+        wavefunction_components[i]->mw_calcRatio(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list), iat, ratios_z);
         for (int iw = 0; iw < wf_list.size(); iw++)
           ratios[iw] *= ratios_z[iw];
       }
@@ -511,8 +511,7 @@ void TrialWaveFunction::flex_ratioGrad(const RefVector<TrialWaveFunction>& wf_li
       ScopedTimer localtimer(wf_list[0].get().get_timers()[ii]);
       //ScopedTimer local_timer(myTimers[ii]);
       const auto wfc_list(extract_WFC_list(wf_list, i));
-      
-      wavefunction_components[i]->mw_ratioGrad(wfc_list, p_list, iat, ratios_z, grad_new);
+      wavefunction_components[i]->mw_ratioGrad(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list), iat, ratios_z, grad_new);
       for (int iw = 0; iw < wf_list.size(); iw++)
         ratios[iw] *= ratios_z[iw];
     }

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -344,6 +344,17 @@ private:
   // helper function for extracting a list of WaveFunctionComponent from a list of TrialWaveFunction
   std::vector<WaveFunctionComponent*> extract_WFC_list(const std::vector<TrialWaveFunction*>& WF_list, int id) const;
 
+  // temporal helper function
+  template<class T>
+  static std::vector<T*> convert_ref_to_ptr_list(const std::vector<std::reference_wrapper<T>>& ref_list)
+  {
+    std::vector<T*> ptr_list;
+    ptr_list.reserve(ref_list.size());
+    for (auto& ref : ref_list)
+    ptr_list.push_back(&ref.get());
+    return ptr_list;
+  }
+
   static std::vector<std::reference_wrapper<WaveFunctionComponent>> extract_WFC_list(
       const std::vector<std::reference_wrapper<TrialWaveFunction>>& WF_list,
       int id);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -21,9 +21,14 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 
-
 namespace qmcplusplus
 {
+
+#ifdef ENABLE_CUDA
+using DiracDet = DiracDeterminant<DelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
+#else
+using DiracDet = DiracDeterminant<DelayedUpdate<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;
+#endif
 
 using LogValueType = TrialWaveFunction::LogValueType;
 using PsiValueType = TrialWaveFunction::PsiValueType;
@@ -105,9 +110,9 @@ TEST_CASE("TrialWaveFunction", "[wavefunction]")
   SPOSet* spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo != nullptr);
 
-  auto* det_up = new DiracDeterminant<>(spo);
+  auto* det_up = new DiracDet(spo);
   det_up->set(0, 2);
-  auto* det_dn = new DiracDeterminant<>(spo);
+  auto* det_dn = new DiracDet(spo);
   det_dn->set(2, 2);
 
   auto* slater_det = new SlaterDet(elec_);


### PR DESCRIPTION
Using RefVector in TrialWaveFunction basically requires changing all the lower levels using the same pattern. Instead of doing all the places, let us do it layer by layer. This PR restores using pointers when calling WFC such that the existing virtual function specializations in derived class can work as needed.

PS: there is a small fix for the tests on GPU as well.