### PR TITLE
Fix writing of 4-fold symmetric FCIDUMPs

### DIFF
--- a/utils/afqmctools/afqmctools/hamiltonian/converter.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/converter.py
@@ -73,8 +73,6 @@ def read_fcidump(filename, symmetry=8, verbose=True):
             # <ij|kl> = <ji|lk> = <kl|ij> = <lk|ji> =
             # <kj|il> = <li|jk> = <il|kj> = <jk|li>
             # (ik|jl)
-            if i == 1 and k == 1 and j == 49 and l == 50:
-                print(integral)
             h2e[i-1,k-1,j-1,l-1] = integral
             if symmetry == 1:
                 continue
@@ -232,11 +230,17 @@ def check_sym(ikjl, nmo, sym):
         return True
     else:
         i, k, j, l = ikjl
-        ik = i + k*nmo
-        jl = j + l*nmo
         if sym == 4:
-            return (i >= k or j >= l) and ik >= jl
+            kilj = (k,i,l,j)
+            jlik = (j,l,i,k)
+            ljki = (l,j,k,i)
+            if (ikjl > jlik) or (ikjl > kilj) or (ikjl > ljki):
+                return False
+            else:
+                return True
         else:
+            ik = i + k*nmo
+            jl = j + l*nmo
             return (i >= k and j >= l) and ik >= jl
 
 def fmt_integral(intg, i, k, j, l, cplx, paren=False):

--- a/utils/afqmctools/afqmctools/hamiltonian/tests/test_converter.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/tests/test_converter.py
@@ -18,7 +18,7 @@ class TestConverter(unittest.TestCase):
     def test_convert_real(self):
         nmo = 17
         nelec = (3,3)
-        h1e, chol, enuc = generate_hamiltonian(nmo, nelec, cplx=False, sym=8)
+        h1e, chol, enuc, eri = generate_hamiltonian(nmo, nelec, cplx=False, sym=8)
         chols = scipy.sparse.csr_matrix(chol.reshape((-1,nmo*nmo)).T.copy())
         write_qmcpack_cholesky(h1e, chols,  nelec, nmo, e0=enuc, real_chol=True)
         hamil = read_qmcpack_hamiltonian('hamiltonian.h5')
@@ -32,11 +32,28 @@ class TestConverter(unittest.TestCase):
         chol_r = chol_r.reshape((-1,nmo,nmo))
         self.assertAlmostEqual(numpy.einsum('ij,ij->', dm, h1e-h1e_r).real, 0.0)
         self.assertAlmostEqual(numpy.einsum('ij,nij->', dm, chol-chol_r).real, 0.0)
+        # Test integral only appears once in file.
+        h1e_r, eri_r, enuc_r, nelec_r = read_fcidump('FCIDUMP', symmetry=1,
+                                                     verbose=False)
+        i,j,k,l = (0,1,2,3)
+        combs = [
+            (i,j,k,l),
+            (k,l,i,j),
+            (j,i,l,k),
+            (l,k,j,i),
+            (j,i,k,l),
+            (l,k,i,j),
+            (i,j,l,k),
+            (k,l,i,j),
+            ]
+        for c in combs:
+            if abs(eri_r[c]) > 0:
+                self.assertEqual(c,(l,k,j,i))
 
     def test_convert_cplx(self):
         nmo = 17
         nelec = (3,3)
-        h1e, chol, enuc = generate_hamiltonian(nmo, nelec, cplx=True, sym=4)
+        h1e, chol, enuc, eri = generate_hamiltonian(nmo, nelec, cplx=True, sym=4)
         chols = scipy.sparse.csr_matrix(chol.reshape((-1,nmo*nmo)).T.copy())
         write_qmcpack_cholesky(h1e, chols,  nelec, nmo, e0=enuc, real_chol=False)
         hamil = read_qmcpack_hamiltonian('hamiltonian.h5')
@@ -51,6 +68,20 @@ class TestConverter(unittest.TestCase):
         chol_r = chol_r.reshape((-1,nmo,nmo))
         self.assertAlmostEqual(numpy.einsum('ij,ij->', dm, h1e-h1e_r).real, 0.0)
         self.assertAlmostEqual(numpy.einsum('ij,nij->', dm, chol-chol_r).real, 0.0)
+        # Test integral only appears once in file.
+        h1e_r, eri_r, enuc_r, nelec_r = read_fcidump('FCIDUMP', symmetry=1,
+                                                     verbose=False)
+        i,k,j,l = (1,0,0,0)
+        ikjl = (i,k,j,l)
+        jlik = (j,l,i,k)
+        kilj = (k,i,l,j)
+        ljki = (l,j,k,i)
+        d1 = eri_r[ikjl] - eri_r[kilj].conj()
+        d2 = eri_r[ikjl] - eri_r[jlik]
+        d3 = eri_r[ikjl] - eri_r[ljki].conj()
+        self.assertAlmostEqual(d1,0.0)
+        self.assertAlmostEqual(d2,0.0)
+        self.assertAlmostEqual(d3,-0.00254428836-0.00238852605j)
 
     def tearDown(self):
         cwd = os.getcwd()

--- a/utils/afqmctools/afqmctools/utils/testing.py
+++ b/utils/afqmctools/afqmctools/utils/testing.py
@@ -16,10 +16,12 @@ def generate_hamiltonian(nmo, nelec, cplx=False, sym=8):
         eri = eri + eri.transpose(3,2,1,0).conj()
     if sym == 8:
         eri = eri + eri.transpose(1,0,2,3)
+    # Construct hermitian matrix M_{ik,lj}.
+    eri = eri.transpose((0,1,3,2))
     eri = eri.reshape((nmo*nmo,nmo*nmo))
     # Make positive semi-definite.
     eri = numpy.dot(eri,eri.conj().T)
     chol = modified_cholesky_direct(eri, tol=1e-4, verbose=False)
     chol = chol.reshape((-1,nmo,nmo))
     enuc = numpy.random.rand()
-    return h1e, chol, enuc
+    return h1e, chol, enuc, eri


### PR DESCRIPTION
Incorrect logic lead to symmetry equivalent integrals being printed. I added to the unit test to check for this.