### PR TITLE
SOA versions of `latdev` and `ionwf`

### DIFF
--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -106,12 +106,11 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   const auto& d_table = P.getDistTable(myTableID_);
 
   // temp variables
-  RealType r2;
+  RealType r, r2;
   PosType dr;
 
   int nsite(0);    // site index
   int cur_jat(-1); // target particle index
-#ifndef ENABLE_SOA
   for (int iat = 0; iat < spset.getTotalNum(); iat++)
   { // for each desired source particle
     if (sspecies.speciesName[spset.GroupID[iat]] == sgroup)
@@ -121,8 +120,14 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
         if (tspecies.speciesName[tpset.GroupID[jat]] == tgroup)
         {
           // distance between particle iat in source pset, and jat in target pset
+#ifdef ENABLE_SOA
+          r = d_table.Distances[jat][iat];
+#else
           int nn = d_table.loc(iat, jat); // location where distance is stored
-          r2     = std::pow(d_table.r(nn), 2);
+          r = d_table.r(nn);
+#endif
+
+          r2 = r*r;
           Value += r2;
 
           if (hdf5_out & !per_xyz)
@@ -132,7 +137,11 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
 
           if (per_xyz)
           {
+#ifdef ENABLE_SOA
+            dr = d_table.Displacements[jat][iat];
+#else
             dr = d_table.dr(nn);
+#endif
             for (int idir = 0; idir < OHMMS_DIM; idir++)
             {
               RealType dir2 = dr[idir] * dr[idir];
@@ -151,7 +160,6 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
       nsite += 1; // count the number of sites, for checking only
     }             // found desired species (source particle)
   }
-#endif
 
   if (nsite != num_sites)
   {

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -54,8 +54,8 @@ SET(JASTROW_SRCS
   Jastrow/RadialJastrowBuilder.cpp
   Jastrow/CountingJastrowBuilder.cpp
   Jastrow/RPAJastrow.cpp
-  IonOrbital.cpp
-  IonOrbitalBuilder.cpp
+  LatticeGaussianProduct.cpp
+  LatticeGaussianProductBuilder.cpp
   OptimizableSPOBuilder.cpp
   Fermion/SPOSetProxy.cpp
   Fermion/SPOSetProxyForMSD.cpp

--- a/src/QMCWaveFunctions/IonOrbital.cpp
+++ b/src/QMCWaveFunctions/IonOrbital.cpp
@@ -80,7 +80,7 @@ IonOrbital::RealType IonOrbital::evaluateLog(ParticleSet& P,
     {
 #ifdef ENABLE_SOA
       dist = d_table.Distances[iat][icent];
-      disp = d_table.Displacements[iat][icent];
+      disp = -1.0*d_table.Displacements[iat][icent];
 #else
       int index     = d_table.M[icent] + iat;
       dist = d_table.r(index);
@@ -124,7 +124,7 @@ GradType IonOrbital::evalGrad(ParticleSet& P, int iat)
     return GradType();
   RealType a      = ParticleAlpha[iat];
 #ifdef ENABLE_SOA
-  PosType newdisp = d_table.Temp_dr[icent];
+  PosType newdisp = -1.0*d_table.Temp_dr[icent];
 #else
   PosType newdisp = d_table.Temp[icent].dr1;
 #endif
@@ -150,7 +150,7 @@ ValueType IonOrbital::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   RealType a       = ParticleAlpha[iat];
 #ifdef ENABLE_SOA
   RealType newdist = d_table.Temp_r[icent];
-  PosType newdisp = d_table.Temp_dr[icent];
+  PosType newdisp = -1.0*d_table.Temp_dr[icent];
 #else
   RealType newdist = d_table.Temp[icent].r1;
   PosType newdisp  = d_table.Temp[icent].dr1;
@@ -189,7 +189,7 @@ void IonOrbital::evaluateLogAndStore(ParticleSet& P,
     {
 #ifdef ENABLE_SOA
       dist = d_table.Distances[iat][icent];
-      disp = d_table.Displacements[iat][icent];
+      disp = -1.0*d_table.Displacements[iat][icent];
 #else
       int index     = d_table.M[icent] + iat;
       dist = d_table.r(index);

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -13,17 +13,17 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "QMCWaveFunctions/IonOrbital.h"
+#include "QMCWaveFunctions/LatticeGaussianProduct.h"
 
 namespace qmcplusplus
 {
-typedef IonOrbital::ValueType ValueType;
-typedef IonOrbital::GradType GradType;
+typedef LatticeGaussianProduct::ValueType ValueType;
+typedef LatticeGaussianProduct::GradType GradType;
 
-IonOrbital::IonOrbital(ParticleSet& centers, ParticleSet& ptcls) : CenterRef(centers)
+LatticeGaussianProduct::LatticeGaussianProduct(ParticleSet& centers, ParticleSet& ptcls) : CenterRef(centers)
 {
   Optimizable    = false;
-  ClassName      = "IonOrbital";
+  ClassName      = "LatticeGaussianProduct";
   NumTargetPtcls = ptcls.getTotalNum();
   NumCenters     = centers.getTotalNum();
 #ifdef ENABLE_SOA
@@ -38,14 +38,14 @@ IonOrbital::IonOrbital(ParticleSet& centers, ParticleSet& ptcls) : CenterRef(cen
   LastAddressOfdU  = FirstAddressOfdU + dU.size() * OHMMS_DIM;
 }
 
-IonOrbital::~IonOrbital() {}
+LatticeGaussianProduct::~LatticeGaussianProduct() {}
 
 //evaluate the distance table with P
-void IonOrbital::resetTargetParticleSet(ParticleSet& P) {}
-void IonOrbital::checkInVariables(opt_variables_type& active) {}
-void IonOrbital::checkOutVariables(const opt_variables_type& active) {}
-void IonOrbital::resetParameters(const opt_variables_type& active) {}
-void IonOrbital::reportStatus(std::ostream& os) {}
+void LatticeGaussianProduct::resetTargetParticleSet(ParticleSet& P) {}
+void LatticeGaussianProduct::checkInVariables(opt_variables_type& active) {}
+void LatticeGaussianProduct::checkOutVariables(const opt_variables_type& active) {}
+void LatticeGaussianProduct::resetParameters(const opt_variables_type& active) {}
+void LatticeGaussianProduct::reportStatus(std::ostream& os) {}
 
 /**
      *@param P input configuration containing N particles
@@ -61,7 +61,7 @@ void IonOrbital::reportStatus(std::ostream& os) {}
      *such that \f[ G[i]+={\bf \nabla}_i J({\bf R}) \f]
      *and \f[ L[i]+=\nabla^2_i J({\bf R}). \f]
      */
-IonOrbital::RealType IonOrbital::evaluateLog(ParticleSet& P,
+LatticeGaussianProduct::RealType LatticeGaussianProduct::evaluateLog(ParticleSet& P,
                                              ParticleSet::ParticleGradient_t& G,
                                              ParticleSet::ParticleLaplacian_t& L)
 {
@@ -100,7 +100,7 @@ IonOrbital::RealType IonOrbital::evaluateLog(ParticleSet& P,
  * @param P active particle set
  * @param iat particle that has been moved.
  */
-ValueType IonOrbital::ratio(ParticleSet& P, int iat)
+ValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = ParticleCenter[iat];
@@ -116,7 +116,7 @@ ValueType IonOrbital::ratio(ParticleSet& P, int iat)
 }
 
 
-GradType IonOrbital::evalGrad(ParticleSet& P, int iat)
+GradType LatticeGaussianProduct::evalGrad(ParticleSet& P, int iat)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = ParticleCenter[iat];
@@ -134,14 +134,14 @@ GradType IonOrbital::evalGrad(ParticleSet& P, int iat)
 
 
 //   GradType
-//   IonOrbital::evalGradSource
+//   LatticeGaussianProduct::evalGradSource
 //   (ParticleSet& P, ParticleSet& source, int isrc,
 //    TinyVector<ParticleSet::ParticleGradient_t, OHMMS_DIM> &grad_grad,
 //    TinyVector<ParticleSet::ParticleLaplacian_t,OHMMS_DIM> &lapl_grad)
 //   {
 //   }
 
-ValueType IonOrbital::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+ValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = ParticleCenter[iat];
@@ -161,16 +161,16 @@ ValueType IonOrbital::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   return std::exp(U[iat] - curVal);
 }
 
-void IonOrbital::restore(int iat) {}
+void LatticeGaussianProduct::restore(int iat) {}
 
-void IonOrbital::acceptMove(ParticleSet& P, int iat)
+void LatticeGaussianProduct::acceptMove(ParticleSet& P, int iat)
 {
   U[iat]   = curVal;
   dU[iat]  = curGrad;
   d2U[iat] = curLap;
 }
 
-void IonOrbital::evaluateLogAndStore(ParticleSet& P,
+void LatticeGaussianProduct::evaluateLogAndStore(ParticleSet& P,
                                      ParticleSet::ParticleGradient_t& dG,
                                      ParticleSet::ParticleLaplacian_t& dL)
 {
@@ -207,7 +207,7 @@ void IonOrbital::evaluateLogAndStore(ParticleSet& P,
 }
 
 /** equivalent to evalaute with additional data management */
-void IonOrbital::registerData(ParticleSet& P, WFBufferType& buf)
+void LatticeGaussianProduct::registerData(ParticleSet& P, WFBufferType& buf)
 {
   evaluateLogAndStore(P, P.G, P.L);
   // Add U, d2U and dU. Keep the order!!!
@@ -216,7 +216,7 @@ void IonOrbital::registerData(ParticleSet& P, WFBufferType& buf)
   buf.add(FirstAddressOfdU, LastAddressOfdU);
 }
 
-IonOrbital::RealType IonOrbital::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
+LatticeGaussianProduct::RealType LatticeGaussianProduct::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
 {
   evaluateLogAndStore(P, P.G, P.L);
   buf.put(U.first_address(), U.last_address());
@@ -231,16 +231,16 @@ IonOrbital::RealType IonOrbital::updateBuffer(ParticleSet& P, WFBufferType& buf,
  *
  *copyFromBuffer uses the data stored by registerData
  */
-void IonOrbital::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
+void LatticeGaussianProduct::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 {
   buf.get(U.first_address(), U.last_address());
   buf.get(d2U.first_address(), d2U.last_address());
   buf.get(FirstAddressOfdU, LastAddressOfdU);
 }
 
-WaveFunctionComponentPtr IonOrbital::makeClone(ParticleSet& tqp) const
+WaveFunctionComponentPtr LatticeGaussianProduct::makeClone(ParticleSet& tqp) const
 {
-  IonOrbital* j1copy     = new IonOrbital(CenterRef, tqp);
+  LatticeGaussianProduct* j1copy     = new LatticeGaussianProduct(CenterRef, tqp);
   j1copy->ParticleAlpha  = ParticleAlpha;
   j1copy->ParticleCenter = ParticleCenter;
   return j1copy;

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.h
@@ -12,11 +12,11 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-/** @file IonOrbital.h
+/** @file LatticeGaussianProduct.h
  * @brief Simple gaussian functions used for orbitals for ions
  */
-#ifndef QMCPLUSPLUS_ION_ORBITAL
-#define QMCPLUSPLUS_ION_ORBITAL
+#ifndef QMCPLUSPLUS_LATTICE_GAUSSIAN_PRODUCT
+#define QMCPLUSPLUS_LATTICE_GAUSSIAN_PRODUCT
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "Particle/DistanceTableData.h"
 
@@ -24,7 +24,7 @@ namespace qmcplusplus
 {
 /** A composite Orbital
  */
-struct IonOrbital : public WaveFunctionComponent
+struct LatticeGaussianProduct : public WaveFunctionComponent
 {
 private:
   ParticleAttrib<RealType> U, d2U;
@@ -42,9 +42,9 @@ public:
   std::vector<RealType> ParticleAlpha;
   std::vector<int> ParticleCenter;
 
-  IonOrbital(ParticleSet& centers, ParticleSet& ptcls);
+  LatticeGaussianProduct(ParticleSet& centers, ParticleSet& ptcls);
 
-  ~IonOrbital();
+  ~LatticeGaussianProduct();
 
   /** check out optimizable variables
    */

--- a/src/QMCWaveFunctions/LatticeGaussianProductBuilder.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProductBuilder.cpp
@@ -12,17 +12,17 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "QMCWaveFunctions/IonOrbitalBuilder.h"
-#include "QMCWaveFunctions/IonOrbital.h"
+#include "QMCWaveFunctions/LatticeGaussianProductBuilder.h"
+#include "QMCWaveFunctions/LatticeGaussianProduct.h"
 #include "OhmmsData/AttributeSet.h"
 
 namespace qmcplusplus
 {
-IonOrbitalBuilder::IonOrbitalBuilder(ParticleSet& p, TrialWaveFunction& psi, PtclPoolType& psets)
+LatticeGaussianProductBuilder::LatticeGaussianProductBuilder(ParticleSet& p, TrialWaveFunction& psi, PtclPoolType& psets)
     : WaveFunctionComponentBuilder(p, psi), ptclPool(psets)
 {}
 
-bool IonOrbitalBuilder::put(xmlNodePtr cur)
+bool LatticeGaussianProductBuilder::put(xmlNodePtr cur)
 {
   ParticleSet& p = targetPtcl;
   // initialize widths to zero; if no user input, then abort
@@ -34,7 +34,7 @@ bool IonOrbitalBuilder::put(xmlNodePtr cur)
   oAttrib.put(cur);
   if (nameOpt == "")
   {
-    app_warning() << "  IonOrbitalBuilder::put does not have name " << std::endl;
+    app_warning() << "  LatticeGaussianProductBuilder::put does not have name " << std::endl;
   }
   std::map<std::string, ParticleSet*>::iterator pa_it(ptclPool.find(sourceOpt));
   if (pa_it == ptclPool.end())
@@ -42,7 +42,7 @@ bool IonOrbitalBuilder::put(xmlNodePtr cur)
     app_error() << "Could not file source ParticleSet " << sourceOpt << " for ion wave function.\n";
   }
   ParticleSet* sourcePtcl = (*pa_it).second;
-  IonOrbital* orb         = new IonOrbital(*sourcePtcl, targetPtcl);
+  LatticeGaussianProduct* orb         = new LatticeGaussianProduct(*sourcePtcl, targetPtcl);
   orb->ParticleAlpha.resize(targetPtcl.getTotalNum());
   orb->ParticleCenter.resize(targetPtcl.getTotalNum());
   int num_nonzero = 0;

--- a/src/QMCWaveFunctions/LatticeGaussianProductBuilder.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProductBuilder.h
@@ -12,20 +12,20 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef QMCPLUSPLUS_ION_ORBITAL_BUILDER_H
-#define QMCPLUSPLUS_ION_ORBITAL_BUILDER_H
+#ifndef QMCPLUSPLUS_LATTICE_GAUSSIAN_BUILDER_H
+#define QMCPLUSPLUS_LATTICE_GAUSSIAN_BUILDER_H
 #include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
 
 namespace qmcplusplus
 {
 class OrbitalConstraintsBase;
 
-/** IonOrbital IonOrbital Builder with constraints
+/** LatticeGaussianProduct LatticeGaussianProduct Builder with constraints
  */
-class IonOrbitalBuilder : public WaveFunctionComponentBuilder
+class LatticeGaussianProductBuilder : public WaveFunctionComponentBuilder
 {
 public:
-  IonOrbitalBuilder(ParticleSet& p, TrialWaveFunction& psi, PtclPoolType& psets);
+  LatticeGaussianProductBuilder(ParticleSet& p, TrialWaveFunction& psi, PtclPoolType& psets);
 
   bool put(xmlNodePtr cur);
 
@@ -33,7 +33,7 @@ private:
   ///particleset pool to get ParticleSet other than the target
   PtclPoolType& ptclPool;
   ///index for the jastrow type: 1, 2, 3
-  int IonOrbitalType;
+  int LatticeGaussianProductType;
   ///name
   std::string nameOpt;
   ///type

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -22,7 +22,7 @@
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCWaveFunctions/Jastrow/JastrowBuilder.h"
 #include "QMCWaveFunctions/Fermion/SlaterDetBuilder.h"
-#include "QMCWaveFunctions/IonOrbitalBuilder.h"
+#include "QMCWaveFunctions/LatticeGaussianProductBuilder.h"
 #include "QMCWaveFunctions/ExampleHeBuilder.h"
 
 #if !defined(QMC_COMPLEX)
@@ -137,7 +137,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
     }
     else if (cname == WaveFunctionComponentBuilder::ionorb_tag)
     {
-      IonOrbitalBuilder* builder = new IonOrbitalBuilder(*targetPtcl, *targetPsi, ptclPool);
+      LatticeGaussianProductBuilder* builder = new LatticeGaussianProductBuilder(*targetPtcl, *targetPsi, ptclPool);
       success                    = builder->put(cur);
       addNode(builder, cur);
     }

--- a/tests/estimator/CMakeLists.txt
+++ b/tests/estimator/CMakeLists.txt
@@ -45,6 +45,18 @@ if (add_test)
   )
 endif()
 
+set(latdev_free_python_reqs numpy;h5py)
+CHECK_PYTHON_REQS(latdev_python_reqs estimator-latdev-free add_test)
+
+if (add_test)
+  SIMPLE_RUN_AND_CHECK(estimator-latdev-free
+    "${CMAKE_SOURCE_DIR}/tests/estimator/latdev/free"
+    two.xml
+    1 16
+    flatdev.py
+  )
+endif()
+
 set(sofk_python_reqs numpy;pandas;h5py)
 CHECK_PYTHON_REQS(sofk_python_reqs estimator-sofk add_test)
 

--- a/tests/estimator/latdev/free/flatdev.py
+++ b/tests/estimator/latdev/free/flatdev.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import h5py
+import numpy as np
+
+def corr(trace):
+  """ calculate the autocorrelation of a trace of scalar data
+
+  correlation time is defined as the integral of the auto-correlation
+   function from t=0 to when the function first reaches 0.
+
+  Args:
+    trace (list): should be a 1D iterable array of floating point numbers
+  Return:
+    float: correlation_time, the autocorrelation time of this trace of scalars
+  """
+  mu     = np.mean(trace)
+  stddev = np.std(trace, ddof=1)
+  if np.isclose(stddev, 0):  # easy case
+    return np.inf  # infinite correlation for constant trace
+  correlation_time = 0.
+  for k in range(1, len(trace)):
+    # calculate auto_correlation
+    auto_correlation = 0.0
+    num = len(trace)-k
+    auto_correlation = np.dot(trace[:num]-mu, trace[k:]-mu)
+    auto_correlation *= 1.0/(num*stddev**2)
+    if auto_correlation > 0:
+      correlation_time += auto_correlation
+    else:
+      break
+  correlation_time = 1.0 + 2.0*correlation_time
+  return correlation_time
+
+def get_latdev_me(fh5, nequil):
+  # get raw data
+  fp = h5py.File(fh5, 'r')
+  data = fp['latdev/value'][()]
+  fp.close()
+
+  nb, ncol = data.shape
+  npt = nb-nequil
+  # calculate mean
+  ym = data[nequil:, :].mean(axis=0)
+  # calculate standard error
+  yc = np.array([corr(data[nequil:, icol]) for icol in range(ncol)])
+  neff = npt/yc
+  ye = data[nequil:, :].std(ddof=1, axis=0)/neff**0.5
+  return ym, ye
+
+def check_latdev(w1, w2, ym, ye, ndim=3):
+  expect = np.array([w1**2/2.]*ndim + [w2**2/2.]*ndim)
+  zscore = abs(ym-expect)/ye
+  fail = np.any(zscore > 3.)
+  success = ~fail
+  return success, zscore
+
+if __name__ == '__main__':
+  # calculate <x^2> <y^2> <z^2>
+  nequil = 6
+  fh5 = 'mt.s000.stat.h5'
+  ym, ye = get_latdev_me(fh5, nequil)
+
+  # check answers
+  w1 = 0.3
+  w2 = 0.5
+  success, zscore = check_latdev(w1, w2, ym, ye)
+  if not success:
+    print(zscore)
+
+  if success:
+    exit(0)
+  else:
+    exit(1)
+# end __main__

--- a/tests/estimator/latdev/free/two.xml
+++ b/tests/estimator/latdev/free/two.xml
@@ -1,0 +1,61 @@
+<simulation>
+  <project id="mt" series="0"/>
+
+  <qmcsystem>
+    <simulationcell>
+      <parameter name="lattice" units="bohr">
+        10 0 0
+        0 10 0
+        0 0 10
+      </parameter>
+      <parameter name="bconds">
+        p p p
+      </parameter>
+    </simulationcell>
+
+    <particleset name="e">
+      <group name="m5" size="2">
+        <parameter name="mass">   5.0   </parameter>
+        <attrib name="position" datatype="posArray" condition="0">
+          1.0001 1.0001 1.0002
+          6.0001 6.0001 6.0002
+        </attrib>
+      </group>
+    </particleset>
+    <particleset name="trap_center">
+      <group name="center" size="2">
+        <attrib name="position" datatype="posArray" condition="0">
+          1 1 1
+          6 6 6
+        </attrib>
+      </group>
+    </particleset>
+    <particleset name="measure_center">
+      <group name="origin" size="2">
+        <attrib name="position" datatype="posArray" condition="0">
+          1 1 1
+          6 6 6
+        </attrib>
+      </group>
+    </particleset>
+
+    <wavefunction target="e" id="psi0">
+      <ionwf name="ionwf" source="trap_center" width="0.3 0.5"/>
+    </wavefunction>
+
+    <hamiltonian name="h0" type="generic" target="e">
+      <estimator name="skinetic" type="specieskinetic"/>
+      <estimator type="latticedeviation" name="latdev" hdf5="yes" per_xyz="yes" target="e" tgroup="m5" source="measure_center" sgroup="origin"/>
+      <!--
+      <estimator name="dens" type="density" delta="0.04 0.04 0.04" x_min="0" x_max="10" y_min="0" ymax="10" z_min="0" z_max="10"/>
+      -->
+    </hamiltonian>
+  </qmcsystem>
+
+  <qmc method="vmc" move="whatever">
+    <parameter name="blocks">    16  </parameter>
+    <parameter name="steps">   1024  </parameter>
+    <parameter name="substeps">   8  </parameter>
+    <parameter name="timestep"> 0.3  </parameter>
+  </qmc>
+</simulation>

--- a/tests/models/sho/vmc_sho.xml
+++ b/tests/models/sho/vmc_sho.xml
@@ -21,8 +21,8 @@
         </attrib>
       </group>
     </particleset>
-    <particleset name="trap_center" size="1">
-      <group name="center">
+    <particleset name="trap_center">
+      <group name="center" size="1">
         <attrib name="position" datatype="posArray" condition="0">
           0 0 0
         </attrib>


### PR DESCRIPTION
Responding to #861 and #1897.

I added a better test for `LatticeDeviationEstimator`, then added SOA implementation for `LatticeDeviationEstimator` and `IonOrbital`.