### PR TITLE
Nexus: QmcpackAnalyzer Warning

### DIFF
--- a/nexus/lib/qmcpack_method_analyzers.py
+++ b/nexus/lib/qmcpack_method_analyzers.py
@@ -79,7 +79,7 @@ class MethodAnalyzer(QAanalyzer):
             complete &= 'opt' in files
         #end if
         equil = request.equilibration
-        nblocks_exclude = -1
+        nblocks_exclude = 0
         if isinstance(equil,int):
             nblocks_exclude = equil
         elif isinstance(equil,(dict,obj)):


### PR DESCRIPTION
Changing the initial value of "nblocks_exclude" to zero.
This suppresses the warning below when "nblocks_exclude"
is never re-assigned to a non-negative value.

  QmcpackAnalyzer warning:
    runtime exception encountered
    Traceback (most recent call last):
      File "../nexus/lib/qmcpack_analyzer.py", line 482, in analyze
        QAanalyzer.analyze(self,force=force)
      File "../nexus/lib/qmcpack_analyzer_base.py", line 487, in analyze
        v.analyze(force)
      File "../nexus/lib/qmcpack_analyzer_base.py", line 494, in analyze
        self.analyze_local()
      File "../nexus/lib/qmcpack_result_analyzers.py", line 397, in analyze_local
        energies.append(dmc.scalars.LocalEnergy.mean)
    AttributeError: 'DmcAnalyzer' object has no attribute 'scalars'

Comment from Jaron regarding this:

When the user does not provide a value for nblocks_exclude, the analyzer is supposed to set the value by calling equilibration_length. ...