### PR TITLE
Add a completion message to pyscf_to_afqmc.py

### DIFF
--- a/utils/afqmctools/bin/pyscf_to_afqmc.py
+++ b/utils/afqmctools/bin/pyscf_to_afqmc.py
@@ -133,6 +133,9 @@ def main(args):
     if comm.rank == 0:
         write_metadata(options, sha1, cwd, date_time)
 
+    if comm.rank == 0:
+        print("\n # Finished.")
+
 if __name__ == '__main__':
 
     main(sys.argv[1:])


### PR DESCRIPTION
The converter now prints `# Finished.` when it has completed.  This will make it easier for users and Nexus alike to catch unsuccessful execution.