### PR TITLE
remove ENABLE_SMARTPOINTER

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -476,11 +476,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
     {
       //SPOSet[detname]=psi;
       app_log() << "  Create a new SPO set " << sposet << std::endl;
-#if defined(ENABLE_SMARTPOINTER)
-      psi.reset(mySPOSetBuilderFactory->createSPOSet(cur));
-#else
       psi = mySPOSetBuilderFactory->createSPOSet(cur);
-#endif
     }
     //psi->put(cur);
     psi->checkObject();

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -33,11 +33,8 @@ PWOrbitalBuilder::PWOrbitalBuilder(ParticleSet& els, TrialWaveFunction& psi, Ptc
     : WaveFunctionComponentBuilder(els, psi),
       ptclPool(psets),
       hfileID(-1),
-      rootNode(NULL)
-#if !defined(ENABLE_SMARTPOINTER)
-      ,
-      myBasisSet(0)
-#endif
+      rootNode(NULL),
+      myBasisSet(nullptr)
 {
   myParam = new PWParameterSet(myComm);
 }
@@ -205,17 +202,10 @@ bool PWOrbitalBuilder::createPWBasis(xmlNodePtr cur)
   HDFAttribIO<TinyVector<double, OHMMS_DIM>> hdfobj_twist(TwistAngle_DP);
   hdfobj_twist.read(hfileID, "/electrons/kpoint_0/reduced_k");
   TwistAngle = TwistAngle_DP;
-#if defined(ENABLE_SMARTPOINTER)
-  if (myBasisSet.get() == 0)
-  {
-    myBasisSet.reset(new PWBasis(TwistAngle));
-  }
-#else
-  if (myBasisSet == 0)
+  if (myBasisSet == nullptr)
   {
     myBasisSet = new PWBasis(TwistAngle);
   }
-#endif
   //Read the planewave basisset.
   //Note that the same data is opened here for each twist angle-avoids duplication in the
   //h5 file (which may become very large).

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -21,12 +21,10 @@ namespace qmcplusplus
 {
 PWOrbitalSet::~PWOrbitalSet()
 {
-#if !defined(ENABLE_SMARTPOINTER)
   if (OwnBasisSet && myBasisSet)
     delete myBasisSet;
   if (!IsCloned && C != nullptr)
     delete C;
-#endif
 }
 
 SPOSet* PWOrbitalSet::makeClone() const

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -28,11 +28,7 @@ class PWOrbitalSet : public SPOSet
 {
 public:
   typedef PWBasis BasisSet_t;
-#if defined(ENABLE_SMARTPOINTER)
-  typedef boost::shared_ptr<PWBasis> PWBasisPtr;
-#else
   typedef PWBasis* PWBasisPtr;
-#endif
 
   /** inherit the enum of BasisSet_t */
   enum

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -26,10 +26,8 @@ namespace qmcplusplus
 {
 PWRealOrbitalSet::~PWRealOrbitalSet()
 {
-#if !defined(ENABLE_SMARTPOINTER)
   if (OwnBasisSet && myBasisSet)
     delete myBasisSet;
-#endif
 }
 
 SPOSet* PWRealOrbitalSet::makeClone() const

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -32,11 +32,7 @@ class PWRealOrbitalSet : public SPOSet
 {
 public:
   typedef PWBasis BasisSet_t;
-#if defined(ENABLE_SMARTPOINTER)
-  typedef boost::shared_ptr<PWBasis> PWBasisPtr;
-#else
   typedef PWBasis* PWBasisPtr;
-#endif
 
   /** inherit the enum of BasisSet_t */
   enum

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -32,10 +32,6 @@
 #include "type_traits/CUDATypes.h"
 #endif
 
-#if defined(ENABLE_SMARTPOINTER)
-#include <boost/shared_ptr.hpp>
-#endif
-
 namespace qmcplusplus
 {
 /** base class for Single-particle orbital sets
@@ -479,11 +475,7 @@ protected:
   std::string className;
 };
 
-#if defined(ENABLE_SMARTPOINTER)
-typedef boost::shared_ptr<SPOSet> SPOSetPtr;
-#else
 typedef SPOSet* SPOSetPtr;
-#endif
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -28,11 +28,8 @@ WaveFunctionComponent::WaveFunctionComponent()
       LogValue(1.0),
       PhaseValue(0.0),
       ClassName("WaveFunctionComponent"),
-      Bytes_in_WFBuffer(0)
-#if !defined(ENABLE_SMARTPOINTER)
-      ,
+      Bytes_in_WFBuffer(0),
       dPsi(0)
-#endif
 {
 }
 
@@ -50,11 +47,7 @@ WaveFunctionComponent::WaveFunctionComponent()
 
 void WaveFunctionComponent::setDiffOrbital(DiffWaveFunctionComponentPtr d)
 {
-#if defined(ENABLE_SMARTPOINTER)
-  dPsi = DiffWaveFunctionComponentPtr(d);
-#else
   dPsi = d;
-#endif
 }
 
 void WaveFunctionComponent::evaluateDerivatives(ParticleSet& P,
@@ -62,11 +55,7 @@ void WaveFunctionComponent::evaluateDerivatives(ParticleSet& P,
                                       std::vector<ValueType>& dlogpsi, 
                                       std::vector<ValueType>& dhpsioverpsi)
 {
-#if defined(ENABLE_SMARTPOINTER)
-  if (dPsi.get())
-#else
   if (dPsi)
-#endif
     dPsi->evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi);
 }
 
@@ -74,11 +63,7 @@ void WaveFunctionComponent::evaluateDerivativesWF(ParticleSet& P,
                                       const opt_variables_type& active,
                                       std::vector<ValueType>& dlogpsi)
 {
-#if defined(ENABLE_SMARTPOINTER)
-  if (dPsi.get())
-#else
   if (dPsi)
-#endif
     dPsi->evaluateDerivativesWF(P, active, dlogpsi);
 }
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -29,9 +29,6 @@
 #ifdef QMC_CUDA
 #include "type_traits/CUDATypes.h"
 #endif
-#if defined(ENABLE_SMARTPOINTER)
-#include <boost/shared_ptr.hpp>
-#endif
 
 /**@file WaveFunctionComponent.h
  *@brief Declaration of WaveFunctionComponent
@@ -53,13 +50,8 @@ class WaveFunctionComponent;
 ///forward declaration of DiffWaveFunctionComponent
 class DiffWaveFunctionComponent;
 
-#if defined(ENABLE_SMARTPOINTER)
-typedef boost::shared_ptr<WaveFunctionComponent> WaveFunctionComponentPtr;
-typedef boost::shared_ptr<DiffWaveFunctionComponent> DiffWaveFunctionComponentPtr;
-#else
 typedef WaveFunctionComponent* WaveFunctionComponentPtr;
 typedef DiffWaveFunctionComponent* DiffWaveFunctionComponentPtr;
-#endif
 
 /**@defgroup WaveFunctionComponent group
  * @brief Classes which constitute a many-body trial wave function


### PR DESCRIPTION
Closes #1844
Typedef like the following are kept for indicating c++ smartpointers usage in the future refactoring.
`typedef PWBasis* PWBasisPtr`

`PWBasisPtr, SPOSetPtr, WaveFunctionComponentPtr, DiffWaveFunctionComponentPtr` are introduced in the initial attempt of using smart pointers.