### PR TITLE
Sync shared_window.hpp from gitlab

### DIFF
--- a/external_codes/mpi_wrapper/mpi3/shared_window.hpp
+++ b/external_codes/mpi_wrapper/mpi3/shared_window.hpp
@@ -1,5 +1,5 @@
-#if COMPILATION_INSTRUCTIONS
-(echo "#include\""$0"\"" > $0x.cpp) && mpic++ -O3 -std=c++14 -Wall -Wfatal-errors -D_TEST_MPI3_SHARED_WINDOW $0x.cpp -o $0x.x && time mpirun -n 3 $0x.x $@ && rm -f $0x.x $0x.cpp; exit
+# if COMPILATION_INSTRUCTIONS
+(echo "#include\""$0"\"" > $0x.cpp) && mpic++ -O3 -std=c++14 -Wall -Wextra -Wpedantic -Wfatal-errors -D_TEST_MPI3_SHARED_WINDOW $0x.cpp -o $0x.x && time mpirun -n 3 $0x.x $@ && rm -f $0x.x $0x.cpp; exit
 #endif
 //  (C) Copyright Alfredo A. Correa 2018.
 #ifndef MPI3_SHARED_WINDOW_HPP
@@ -18,44 +18,50 @@
 namespace boost{
 namespace mpi3{
 
-template<class T /*= void*/>
+template<class T>
 struct shared_window : window<T>{
-	shared_communicator* comm_;
+//	shared_communicator& comm_;
 	shared_window(shared_communicator& comm, mpi3::size_t n, int disp_unit = alignof(T)) : //sizeof(T)) : // here we assume that disp_unit is used for align
-		window<T>(), comm_{std::addressof(comm)}
+		window<T>{}//, comm_{comm}
 	{
 		void* base_ptr = nullptr;
-		int s = MPI_Win_allocate_shared(n*sizeof(T), disp_unit, MPI_INFO_NULL, &comm, &base_ptr, &this->impl_);
-		if(s != MPI_SUCCESS) throw std::runtime_error{"cannot create shared window"};
+		auto e = static_cast<enum error>(
+			MPI_Win_allocate_shared(
+				n*sizeof(T), disp_unit, 
+				MPI_INFO_NULL, comm.get(), &base_ptr, &this->impl_
+			)
+		);
+		if(e != mpi3::error::success) throw std::system_error{e, "cannot win_alloc"};
 	}
 	shared_window(shared_communicator& comm, int disp_unit = alignof(T)) : 
 		shared_window(comm, 0, disp_unit)
 	{}
 	shared_window(shared_window const&) = default;
-	shared_window(shared_window&& other) : window<T>{std::move(other)}, comm_{other.comm_}{}
-		group get_group() const{
+	shared_window(shared_window&& other) noexcept : window<T>{std::move(other)}//, comm_{other.comm_}
+	{}
+	group get_group() const{
 		group r; MPI3_CALL(MPI_Win_get_group)(this->impl_, &(&r)); return r;
 	}
-	shared_communicator& get_communicator() const{return *comm_;}
-	using query_t = std::tuple<mpi3::size_t, int, void*>;
-	query_t query(int rank = MPI_PROC_NULL) const{
-		query_t ret;
-		MPI_Win_shared_query(this->impl_, rank, &std::get<0>(ret), &std::get<1>(ret), &std::get<2>(ret));
-		return ret;
+//	shared_communicator& get_communicator() const{return comm_;}
+	struct query_t{
+		mpi3::size_t size;
+		int disp_unit;
+		void* base;
+	};
+	struct query_t query(int rank = MPI_PROC_NULL) const{
+		query_t r;
+		MPI3_CALL(MPI_Win_shared_query)(this->impl_, rank, &r.size, &r.disp_unit, &r.base);
+		return r;
 	}
 	template<class TT = T>
-	mpi3::size_t size(int rank = 0) const{
-		return std::get<0>(query(rank))/sizeof(TT);
-	}
-	int disp_unit(int rank = 0) const{return std::get<1>(query(rank));}
+	mpi3::size_t size(int rank = 0) const{return query(rank).size/sizeof(TT);}
+	int disp_unit(int rank = 0) const{return query(rank).disp_unit;}
 	template<class TT = T>
-	TT* base(int rank = 0) const{return static_cast<TT*>(std::get<2>(query(rank)));}
+	TT* base(int rank = 0) const{return static_cast<TT*>(query(rank).base);}
 };
 
 template<class T /*= char*/> 
-shared_window<T> shared_communicator::make_shared_window(
-	mpi3::size_t size
-){
+shared_window<T> shared_communicator::make_shared_window(mpi3::size_t size){
 	return shared_window<T>(*this, size);
 }
 

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -168,7 +168,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_fill_n(shm_ptr_with_raw_ptr_dispa
         if(first.wSP_->get_group().root()) std::uninitialized_fill_n(to_address(first), n, val); // change to to_pointer
         first.wSP_->fence();
         first.wSP_->fence();
-        (*first.wSP_).comm_->barrier();
+        mpi3::communicator(first.wSP_->get_group()).barrier();
         return first + n;
 }
 
@@ -178,7 +178,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_fill_n(Alloc &a, shm_ptr_with_raw
         if(first.wSP_->get_group().root()) std::uninitialized_fill_n(to_address(first), n, val); // change to to_pointer
         first.wSP_->fence();
         first.wSP_->fence();
-        (*first.wSP_).comm_->barrier();
+        mpi3::communicator(first.wSP_->get_group()).barrier();
         return first + n;
 }
 
@@ -191,7 +191,7 @@ shm_ptr_with_raw_ptr_dispatch<T> destroy_n(shm_ptr_with_raw_ptr_dispatch<T> firs
         }
         first.wSP_->fence();
         first.wSP_->fence();
-        (*first.wSP_).comm_->barrier();
+        mpi3::communicator(first.wSP_->get_group()).barrier();
         return first + n;
 }
 
@@ -204,7 +204,7 @@ shm_ptr_with_raw_ptr_dispatch<T> destroy_n(Alloc &a, shm_ptr_with_raw_ptr_dispat
         }
         first.wSP_->fence();
         first.wSP_->fence();
-        (*first.wSP_).comm_->barrier();
+        mpi3::communicator(first.wSP_->get_group()).barrier();
         return first + n;
 }
 
@@ -214,7 +214,7 @@ shm_ptr_with_raw_ptr_dispatch<T> copy_n(It1 first, Size n, shm_ptr_with_raw_ptr_
         using std::copy_n;
         if(d_first.wSP_->get_group().root()) copy_n(first, n, to_address(d_first));
         d_first.wSP_->fence();
-        (*d_first.wSP_).comm_->barrier();
+        mpi3::communicator(d_first.wSP_->get_group()).barrier();
         return d_first + n;
 }
 
@@ -224,7 +224,7 @@ shm_ptr_with_raw_ptr_dispatch<T> copy(It1 first, It1 last, shm_ptr_with_raw_ptr_
         using std::copy;
         if(d_first.wSP_->get_group().root()) copy(first, last, to_address(d_first));
         first.wSP_->fence();
-        (*d_first.wSP_).comm_->barrier();
+        mpi3::communicator(d_first.wSP_->get_group()).barrier();
         using std::distance;
         return d_first + distance(first, last);
 }
@@ -235,7 +235,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(It1 f, Size n, shm_ptr_wit
         using std::uninitialized_copy_n;
         if(d.wSP_->get_group().root()) uninitialized_copy_n(f, n, to_address(d));
         f.wSP_->fence();
-        (*d.wSP_).comm_->barrier();
+        mpi3::communicator(d.wSP_->get_group()).barrier();
         return d + n;
 }
 
@@ -245,7 +245,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(Alloc &a, It1 f, Size n, s
         using std::uninitialized_copy_n;
         if(d.wSP_->get_group().root()) uninitialized_copy_n(f, n, to_address(d));
         f.wSP_->fence();
-        (*d.wSP_).comm_->barrier();
+        mpi3::communicator(d.wSP_->get_group()).barrier();
         return d + n;
 }
 
@@ -256,7 +256,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy(It1 f, It1 l, shm_ptr_with_r
         using std::uninitialized_copy;
         if(d.wSP_->get_group().root()) uninitialized_copy(f, l, to_address(d));
         d.wSP_->fence();
-        (*d.wSP_).comm_->barrier();
+        mpi3::communicator(d.wSP_->get_group()).barrier();
         using std::distance;
         return d + distance(f, l);
 }
@@ -271,7 +271,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_default_construct_n(shm_ptr_with_
             }catch(...) {throw;} // leak!
         }
         f.wSP_->fence();
-        (*f.wSP_).comm_->barrier();
+        mpi3::communicator(f.wSP_->get_group()).barrier();
         return f + n;
 }
 
@@ -285,7 +285,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_value_construct_n(shm_ptr_with_ra
             }catch(...){throw;} // leak !!
         }
         f.wSP_->fence();
-        (*f.wSP_).comm_->barrier();
+        mpi3::communicator(f.wSP_->get_group()).barrier();
         return f + n;
 }
 
@@ -300,7 +300,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_default_construct_n(Alloc &a, shm
             }catch(...) {throw;} // leak!
         }
         f.wSP_->fence();
-        (*f.wSP_).comm_->barrier();
+        mpi3::communicator(f.wSP_->get_group()).barrier();
         return f + n;
 }
 
@@ -315,7 +315,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_value_construct_n(Alloc &a, shm_p
             }catch(...){throw;} // leak !!
         }
         f.wSP_->fence();
-        (*f.wSP_).comm_->barrier();
+        mpi3::communicator(f.wSP_->get_group()).barrier();
         return f + n;
 }
 
@@ -340,7 +340,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
   }
   base(first).wSP_->fence();
   base(first).wSP_->fence();
-  (*base(first).wSP_).comm_->barrier();
+  mpi3::communicator(base(first).wSP_->get_group()).barrier();
   return first + n;
 }
 
@@ -371,7 +371,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
   }
   base(dest).wSP_->fence();
   base(dest).wSP_->fence();
-  (*base(dest).wSP_).comm_->barrier();
+  mpi3::communicator(base(dest).wSP_->get_group()).barrier();
   return dest + n;
 }
 
@@ -390,7 +390,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
   }
   base(dest).wSP_->fence();
   base(dest).wSP_->fence();
-  (*base(dest).wSP_).comm_->barrier();
+  mpi3::communicator(base(dest).wSP_->get_group()).barrier();
   return dest + n;
 }
 
@@ -463,7 +463,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
   }
   base(dest).wSP_->fence();
   base(dest).wSP_->fence();
-  (*base(dest).wSP_).comm_->barrier();
+  mpi3::communicator(base(dest).wSP_->get_group()).barrier();
   return dest + n;
 }
 
@@ -495,7 +495,7 @@ multi::array_iterator<T, 1, T*> uninitialized_copy(
         a.construct(addressof(*d), *first);
     }catch(...){throw;}
   }
-  (*base(first).wSP_).comm_->barrier();
+  mpi3::communicator(base(first).wSP_->get_group()).barrier();
   return dest + std::distance(first,last);
 }
 


### PR DESCRIPTION
The comm member of the shared_window object goes away, so there needs to be another way to get the communicator object for the barrier call.   Alfredo suggested the replacement code pattern.

The intranode code has been deleted from the gitlab repo, but is kept here until it can be replaced.

This completes the sync from the main mpi3 directory (and implementation subdirectories). The test and fake directories may not be in sync.