### PR TITLE
Move cmake_policy before project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-PROJECT(qmcpack)
-
-
-#####################################################
+######################################################################
+# CMake version and policies
+######################################################################
 CMAKE_MINIMUM_REQUIRED(VERSION 3.6.0)
+
 IF(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   IF (COMPILING_ON_BGQ)
@@ -33,8 +33,10 @@ ENDIF(COMMAND cmake_policy)
 
 
 ######################################################################
-# Version
+# QMCPACK
 ######################################################################
+PROJECT(qmcpack)
+
 SET(QMCPACK_VERSION_MAJOR 3)
 SET(QMCPACK_VERSION_MINOR 8)
 SET(QMCPACK_VERSION_PATCH 9)

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -207,7 +207,7 @@ bool WaveFunctionFactory::addFermionTerm(xmlNodePtr cur)
   }
   else
     detbuilder = new SlaterDetBuilder(myComm, *targetPtcl, *targetPsi, ptclPool);
-  targetPsi->addComponent(detbuilder->buildComponent(cur), "electron-gas/PW");
+  targetPsi->addComponent(detbuilder->buildComponent(cur), "SlaterDet");
   addNode(detbuilder, cur);
   return true;
 }


### PR DESCRIPTION
cmake_policy affects project() invocation which uses try_compile underneath.
I noticed this when trying CMAKE_EXE_LINKER_FLAGS.