### PR TITLE
Fix Unitialized XMLNodePtr in test_DescentEngine

### DIFF
--- a/src/QMCDrivers/tests/test_DescentEngine.cpp
+++ b/src/QMCDrivers/tests/test_DescentEngine.cpp
@@ -30,7 +30,7 @@ TEST_CASE("DescentEngine RMSprop update","[drivers][descent]")
 
 Communicate* myComm;
 
-xmlNodePtr fakeXML;
+xmlNodePtr fakeXML = nullptr;
 
 std::unique_ptr<DescentEngine> descentEngineObj = std::make_unique<DescentEngine>(myComm, fakeXML);
 

--- a/src/QMCDrivers/tests/test_DescentEngine.cpp
+++ b/src/QMCDrivers/tests/test_DescentEngine.cpp
@@ -12,7 +12,7 @@
 
 #include "catch.hpp"
 
-#include <libxml/tree.h>
+#include "OhmmsData/Libxml2Doc.h"
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "Optimize/VariableSet.h"
 #include "Configuration.h"
@@ -28,11 +28,17 @@ typedef qmcplusplus::QMCTraits::ValueType ValueType;
 TEST_CASE("DescentEngine RMSprop update","[drivers][descent]")
 {
 
-Communicate* myComm;
+  Communicate myComm;
 
-xmlNodePtr fakeXML = nullptr;
+  const std::string engine_input("<tmp> </tmp>");
 
-std::unique_ptr<DescentEngine> descentEngineObj = std::make_unique<DescentEngine>(myComm, fakeXML);
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(engine_input);
+  REQUIRE(okay);
+
+  xmlNodePtr fakeXML = doc.getRoot();
+
+std::unique_ptr<DescentEngine> descentEngineObj = std::make_unique<DescentEngine>(&myComm, fakeXML);
 
 optimize::VariableSet myVars;
 


### PR DESCRIPTION
This unsurprisingly causes crashes (sometimes) in release builds. This clears one of the remaining CI issues with #1998 

Also I think this hidden "default" constructor is a bad smell.
