### PR TITLE
Fix CUDA runs due to NLPP RNG = nullptr

### DIFF
--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -53,6 +53,8 @@ DMCcuda::DMCcuda(MCWalkerConfiguration& w,
   //m_param.add(myWarmupSteps,"warmupSteps","int");
   //m_param.add(nTargetSamples,"targetWalkers","int");
   m_param.add(ScaleWeight, "scaleweight", "string");
+
+  H.setRandomGenerator(&Random);
 }
 
 bool DMCcuda::checkBounds(const PosType& newpos)

--- a/src/QMCDrivers/VMC/VMC_CUDA.cpp
+++ b/src/QMCDrivers/VMC/VMC_CUDA.cpp
@@ -53,6 +53,8 @@ VMCcuda::VMCcuda(MCWalkerConfiguration& w,
   m_param.add(w_beta, "beta", "double");
   m_param.add(w_alpha, "alpha", "double");
   m_param.add(GEVtype, "GEVMethod", "string");
+
+  H.setRandomGenerator(&Random);
 }
 
 bool VMCcuda::checkBounds(std::vector<PosType>& newpos, std::vector<bool>& valid)

--- a/tests/test_automation/nightly_olcf_summit.sh
+++ b/tests/test_automation/nightly_olcf_summit.sh
@@ -31,6 +31,7 @@ module load essl
 module load netlib-lapack
 module load hdf5
 module load boost
+module load cuda
 
 export TEST_SITE_NAME=summit.olcf.ornl.gov
 export N_PROCS_BUILD=32


### PR DESCRIPTION
Fix summit CUDA failures in determinsitic tests.
https://cdash.qmcpack.org/CDash/index.php?project=QMCPACK&date=2019-10-17
Bug introduced in #1998 not caught due to missing working CUDA tests in nightlies.