### PR TITLE
Nexus: output corrected energy via qmca with MPC alone

### DIFF
--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -1847,6 +1847,10 @@ class DatAnalyzer(QBase):
             v = data.LocalEnergy - data.ElecElec + data.MPC + data.KEcorr
             data.CorrectedEnergy  = v
             stats.CorrectedEnergy = self.stat_value(v[nbe:])
+        elif 'LocalEnergy' in data and 'ElecElec' in data and 'MPC' in data:
+            v = data.LocalEnergy - data.ElecElec + data.MPC
+            data.CorrectedEnergy  = v
+            stats.CorrectedEnergy = self.stat_value(v[nbe:])
         #end if
         if len(data)>0:
             example = data.first()


### PR DESCRIPTION
Enable calculation of a finite size corrected energy value when only MPC is present.

@zenandrea, please can you confirm that this works for you as expected?  Usage: `qmca -q ce *scalar*`.