### PR TITLE
Skip orbital rotation tests on AoS build

### DIFF
--- a/tests/molecules/H2_ae/CMakeLists.txt
+++ b/tests/molecules/H2_ae/CMakeLists.txt
@@ -1,21 +1,21 @@
 
 IF (NOT QMC_CUDA)
- IF (NOT QMC_COMPLEX)
+ IF (NOT QMC_COMPLEX AND ENABLE_SOA)
+  IF(BUILD_LMYENGINE_INTERFACE)
 
   #
   # H2 test in a DZV basis set, using optimizable determinants, and the adaptive linear method
   #
   LIST(APPEND H2_OPT_SCALARS "totenergy" "-1.124563 0.00084") # total energy
 
-  IF(BUILD_LMYENGINE_INTERFACE)
-    QMC_RUN_AND_CHECK(short-H2-orb-opt
-                      "${CMAKE_SOURCE_DIR}/tests/molecules/H2_ae"
-                      H2
-                      h2_orb_opt.xml
-                      16 1
-                      ${MP_SUCCESS}
-                      10 H2_OPT_SCALARS # Final VMC step
-                      TRUE)
+  QMC_RUN_AND_CHECK(short-H2-orb-opt
+                    "${CMAKE_SOURCE_DIR}/tests/molecules/H2_ae"
+                    H2
+                    h2_orb_opt.xml
+                    16 1
+                    ${MP_SUCCESS}
+                    10 H2_OPT_SCALARS # Final VMC step
+                    TRUE)
 
   #
   # H2 starting from unoptimized CIS coefficients and orbital
@@ -33,12 +33,12 @@ IF (NOT QMC_CUDA)
                     6 H2_FDLR_SCALARS # Final VMC step
                     TRUE)
   ELSE()
-    MESSAGE_VERBOSE("Skipping H4_FDLR test because lmyengine interface was not built (BUILD_LMYENGINE_INTERFACE=0)")
+    MESSAGE_VERBOSE("Skipping H2 test because lmyengine interface was not built (BUILD_LMYENGINE_INTERFACE=0)")
   ENDIF(BUILD_LMYENGINE_INTERFACE)
  ELSE()
-    MESSAGE_VERBOSE("Skipping H4_FDLR tests because gaussian basis sets are not supported by complex build (QMC_COMPLEX=1)")
+    MESSAGE_VERBOSE("Skipping H2 tests because orbital rotation is not supported by complex build (QMC_COMPLEX=1) and SoA build (ENABLE_SOA=1) is required")
  ENDIF()
 ELSE()
-    MESSAGE_VERBOSE("Skipping H4_FDLR tests because gaussian basis sets are not supported by CUDA build (QMC_CUDA=1)")
+    MESSAGE_VERBOSE("Skipping H2 tests because gaussian basis sets are not supported by CUDA build (QMC_CUDA=1)")
 ENDIF()
 

--- a/tests/molecules/H4_ae/CMakeLists.txt
+++ b/tests/molecules/H4_ae/CMakeLists.txt
@@ -79,6 +79,8 @@ IF (NOT QMC_CUDA)
                       ${MP_SUCCESS}
                       5 H4_OPT_SCALARS # OPT step 5
                       )
+
+   IF(ENABLE_SOA)
     #
     # H4 starting from perturbed orbitals, using optimizable determinants, and the adaptive linear method
     #
@@ -147,6 +149,9 @@ IF (NOT QMC_CUDA)
                       ${MP_SUCCESS}
                       8 H4_FDLR_SCALARS # Final VMC step
                       TRUE)
+   ELSE()
+    MESSAGE("Skipping H4_ae orbital rotation tests because they are no more supported with AoS builds.")
+   ENDIF(ENABLE_SOA)
 
     LIST(APPEND H4_CJS_SCALARS "totenergy" "-2.0438 0.0045") # total energy
 


### PR DESCRIPTION
To reduce the red tests on Cdash due to #1893