### PR TITLE
All QMCHamiltonians now have their setNonLocalMoveHandler called.

### DIFF
--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -53,7 +53,8 @@ private:
   ParticleSet ions_;
   std::vector<IndexType> walker_offsets_;
   // By making this a linked list and creating the crowds at the same time we could get first touch.
-  std::vector<std::unique_ptr<MCPWalker>> walkers_;
+  UPtrVector<MCPWalker> walkers_;
+  UPtrVector<MCPWalker> dead_walkers_;
   std::vector<std::pair<int, int>> particle_group_indexes_;
   SpeciesSet species_set_;
   std::vector<RealType> ptclgrp_mass_;
@@ -118,6 +119,7 @@ public:
    */
   MCPWalker& spawnWalker();
   void killWalker(MCPWalker&);
+  void killLastWalker();
   void createWalkerInplace(UPtr<MCPWalker>& walker_ptr);
   void allocateWalkerStuffInplace(int walker_index);
   /** }@ */
@@ -172,7 +174,7 @@ public:
    *  is invalid. Ideally MCPopulation not process any calls in this state, next best would be to only
    *  process calls to become valid.
    */
-  IndexType get_active_walkers() const { return walkers_.size(); }
+  //IndexType get_active_walkers() const { return walkers_.size(); }
   int get_num_ranks() const { return num_ranks_; }
   IndexType get_num_global_walkers() const { return num_global_walkers_; }
   IndexType update_num_global_walkers(Communicate* comm);
@@ -198,6 +200,7 @@ public:
   }
 
   UPtrVector<MCPWalker>& get_walkers() { return walkers_; }
+  UPtrVector<QMCHamiltonian>& get_hamiltonians() { return walker_hamiltonians_; }
   const std::vector<std::pair<int, int>>& get_particle_group_indexes() const { return particle_group_indexes_; }
   const std::vector<RealType>& get_ptclgrp_mass() const { return ptclgrp_mass_; }
   const std::vector<RealType>& get_ptclgrp_inv_mass() const { return ptclgrp_inv_mass_; }

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -167,7 +167,7 @@ public:
   std::string getEngineName() { return QMCType; }
   unsigned long getDriverMode() { return qmc_driver_mode_.to_ulong(); }
   IndexType get_walkers_per_crowd() const { return walkers_per_crowd_; }
-  IndexType get_living_walkers() const { return population_.get_active_walkers(); }
+  IndexType get_living_walkers() const { return population_.get_walkers().size(); }
 
   /** @ingroup Legacy interface to be dropped
    *  @{
@@ -183,7 +183,7 @@ public:
 
   static void initialLogEvaluation(int crowd_id, UPtrVector<Crowd>& crowds, UPtrVector<ContextForSteps>& step_context);
 
-  
+
   /** should be set in input don't see a reason to set individually
    * @param pbyp if true, use particle-by-particle update
    */
@@ -349,12 +349,17 @@ public:
 
   bool putQMCInfo(xmlNodePtr cur);
 
-  void addWalkers(int nwalkers, const ParticleAttrib<TinyVector<QMCTraits::RealType, 3>>& positions);
+  /** Adjust populations local walkers to this number
+  * @param nwalkers number of walkers to add
+  *
+  */
+  void makeLocalWalkers(int nwalkers, const ParticleAttrib<TinyVector<QMCTraits::RealType, 3>>& positions);
 
   int get_num_crowds() { return num_crowds_; }
   void set_num_crowds(int num_crowds, const std::string& reason);
   void set_walkers_per_rank(int walkers_per_rank, const std::string& reason);
   DriftModifierBase& get_drift_modifier() const { return *drift_modifier_; }
+
   /** record the state of the block
    * @param block current block
    *

--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -464,7 +464,7 @@ void SimpleFixedNodeBranch::branch(int iter, UPtrVector<Crowd>& crowds,  MCPopul
   RefVector<MCPWalker> walkers(convertUPtrToRefVector(population.get_walkers()));
 
   FullPrecRealType pop_now;
-  if (BranchMode[B_DMCSTAGE] || iter)
+  if (false) //BranchMode[B_DMCSTAGE] || iter)
     pop_now = WalkerController->branch(iter, population, 0.1);
   else
     pop_now = WalkerController->doNotBranch(iter, population); //do not branch for the first step of a warmup

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -633,7 +633,7 @@ WalkerControlBase::PopulationAdjustment WalkerControlBase::calcPopulationAdjustm
   //update curData
   curData[ENERGY_INDEX]     = esum;
   curData[ENERGY_SQ_INDEX]  = e2sum;
-  curData[WALKERSIZE_INDEX] = pop.get_active_walkers();
+  curData[WALKERSIZE_INDEX] = pop.get_walkers().size();
   curData[WEIGHT_INDEX]     = wsum;
   curData[EREF_INDEX]       = ecum;
   curData[R2ACCEPTED_INDEX] = r2_accepted;

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch.in.xml
@@ -101,7 +101,7 @@
      <parameter name="timestep">  0.005 </parameter>
      <parameter name="steps">   100 </parameter>
      <parameter name="blocks">  25 </parameter>
-     <parameter name="nonlocalmoves">  no </parameter>
+     <parameter name="nonlocalmoves">  yes </parameter>
    </qmc>
 
 </simulation>


### PR DESCRIPTION
This occurs after the starting walkers for the section are established. The default handler is a no-op.

I also returned the reuse of MCPWalker optimization.

This follows #2029 