### PR TITLE
batch driver cleaning and fixes

### DIFF
--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -11,14 +11,6 @@
 
 namespace qmcplusplus
 {
-void Crowd::clearResults()
-{
-  // These were cleared to 1.0 each loop by VMCUpdatePbyP advance walker
-  // refactored code may depend on this initial value.
-  std::fill(log_gf_.begin(), log_gf_.end(), 1.0);
-  std::fill(log_gb_.begin(), log_gb_.end(), 1.0);
-}
-
 void Crowd::clearWalkers()
 {
   mcp_walkers_.clear();
@@ -40,18 +32,6 @@ void Crowd::reserve(int crowd_size)
   reserveCS(walker_elecs_);
   reserveCS(walker_twfs_);
   reserveCS(walker_hamiltonians_);
-
-  resizeResults(crowd_size);
-}
-
-void Crowd::resizeResults(int crowd_size) {
-  auto resizeCS = [crowd_size](auto& avector) { avector.resize(crowd_size); };
-  resizeCS(grads_now_);
-  resizeCS(grads_new_);
-  resizeCS(ratios_);
-  resizeCS(log_gf_);
-  resizeCS(log_gb_);
-  resizeCS(prob_);
 }
 
 void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& twf, QMCHamiltonian& hamiltonian)
@@ -61,8 +41,6 @@ void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& 
   walker_elecs_.push_back(elecs);
   walker_twfs_.push_back(twf);
   walker_hamiltonians_.push_back(hamiltonian);
-  if(mcp_walkers_.size() != grads_now_.size())
-    resizeResults(mcp_walkers_.size());
 };
 
 void Crowd::loadWalkers()

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -54,14 +54,6 @@ public:
 
   void loadWalkers();
 
-  /** clears log_gf and log_gb
-   *
-   *  This is a legacy "call"
-   *  TODO: likely remove log_gf and log_gb from crowd
-   *        seems unlikely these should be persistent state.
-   */
-  void clearResults();
-  
   /** Clears all walker vectors
    *
    *  Unless you are _redistributing_ walkers to crowds don't
@@ -94,12 +86,6 @@ public:
   std::vector<std::reference_wrapper<TrialWaveFunction>>& get_walker_twfs() { return walker_twfs_; }
   std::vector<std::reference_wrapper<QMCHamiltonian>>& get_walker_hamiltonians() { return walker_hamiltonians_; }
 
-  std::vector<GradType>& get_grads_now() { return grads_now_; }
-  std::vector<GradType>& get_grads_new() { return grads_new_; }
-  std::vector<TrialWaveFunction::PsiValueType>& get_ratios() { return ratios_; }
-  std::vector<RealType>& get_log_gf() { return log_gf_; }
-  std::vector<RealType>& get_log_gb() { return log_gb_; }
-  std::vector<RealType>& get_prob() { return prob_; }
   RefVector<WFBuffer>& get_mcp_wfbuffers() { return mcp_wfbuffers_; }
   const EstimatorManagerCrowd& get_estimator_manager_crowd() const { return estimator_manager_crowd_; }
   int size() const { return mcp_walkers_.size(); }
@@ -115,7 +101,6 @@ public:
   }
   unsigned long get_nonlocal_accept() { return n_nonlocal_accept_; }
 private:
-  void resizeResults(int crowd_size);
   /** @name Walker Vectors
    *
    *  A single index into these ordered lists constitue a complete 
@@ -130,19 +115,6 @@ private:
   /** }@ */
   
   EstimatorManagerCrowd estimator_manager_crowd_;
-  /** @name Work Buffers
-   *  @{
-   *  There are many "local" variables in execution of the driver that are convenient to 
-   *  place in a stl containers to use <alogorithm> style calls with.
-   *  Eventually this will also us to allow some sort of appropriate parallel policy for these calls.
-   */
-  std::vector<GradType> grads_now_;
-  std::vector<GradType> grads_new_;
-  std::vector<TrialWaveFunction::PsiValueType> ratios_;
-  std::vector<RealType> log_gf_;
-  std::vector<RealType> log_gb_;
-  std::vector<RealType> prob_;
-  /** }@ */
 
   /** @name Step State
    * 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -362,6 +362,13 @@ void QMCDriverNew::createRngsStepContexts()
 
   Rng.resize(num_crowds_);
 
+  if (RandomNumberControl::Children.size() == 0)
+  {
+    app_warning() << "  Initializing global RandomNumberControl! "
+                  << "This message should not be seen in production code but only in unit tests." << std::endl;
+    RandomNumberControl::make_seeds();
+  }
+
   for(int i = 0; i < num_crowds_; ++i)
   {
     Rng[i].reset(RandomNumberControl::Children[i]);

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -89,7 +89,11 @@ int QMCDriverNew::addObservable(const std::string& aname)
 QMCDriverNew::RealType QMCDriverNew::getObservable(int i) { return estimator_manager_->getObservable(i); }
 
 
-QMCDriverNew::~QMCDriverNew() {}
+QMCDriverNew::~QMCDriverNew()
+{
+  for(int i = 0; i < Rng.size(); ++i)
+    RandomNumberControl::Children[i] = Rng[i].release();
+}
 
 void QMCDriverNew::add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi)
 {
@@ -114,16 +118,6 @@ void QMCDriverNew::add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi)
  */
 void QMCDriverNew::process(xmlNodePtr cur)
 {
-  // if (qmcdriver_input_.get_reset_random() || RandomNumberControl)
-  // {
-
-  // if seeds are not made then neither are the children. So when MoveContexts are created a segfault occurs.
-  // For now it is unclear whether get_reset_random should always be true on the first run or what.
-  app_log() << "  Regenerate random seeds." << std::endl;
-  RandomNumberControl::make_seeds();
-  // }
-
-  
   setupWalkers();
 
   // If you really want to persist the MCPopulation it is not the business of QMCDriver to reset it.
@@ -370,9 +364,11 @@ void QMCDriverNew::createRngsStepContexts()
 
   for(int i = 0; i < num_crowds_; ++i)
   {
-    Rng[i].reset(new RandomGenerator_t(*(RandomNumberControl::Children[i])));
-    step_contexts_[i].reset(new ContextForSteps(crowds_[i]->size(), population_.get_num_particles(),
-                                            population_.get_particle_group_indexes(), *(Rng[i])));
+    Rng[i].reset(RandomNumberControl::Children[i]);
+    // Ye: RandomNumberControl::Children needs to be replaced with unique_ptr and use Rng[i].swap()
+    RandomNumberControl::Children[i] = nullptr;
+    step_contexts_[i] = std::make_unique<ContextForSteps>(crowds_[i]->size(), population_.get_num_particles(),
+                                            population_.get_particle_group_indexes(), *(Rng[i]));
   }
 }
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -26,8 +26,7 @@ VMCBatched::VMCBatched(QMCDriverInput&& qmcdriver_input,
                        QMCHamiltonian& h,
                        WaveFunctionPool& ppool,
                        Communicate* comm)
-    : QMCDriverNew(std::move(qmcdriver_input), pop, psi, h, ppool, "VMCBatched::", comm),
-      vmcdriver_input_(input)
+    : QMCDriverNew(std::move(qmcdriver_input), pop, psi, h, ppool, "VMCBatched::", comm), vmcdriver_input_(input)
 {
   QMCType = "VMCBatched";
   // qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
@@ -43,7 +42,8 @@ VMCBatched::IndexType VMCBatched::calc_default_local_walkers(IndexType walkers_p
 
   if (walkers_per_rank < num_crowds_)
     walkers_per_rank = num_crowds_;
-  walkers_per_crowd_      = (walkers_per_rank % num_crowds_) ? walkers_per_rank / num_crowds_ + 1 : walkers_per_rank / num_crowds_;
+  walkers_per_crowd_ =
+      (walkers_per_rank % num_crowds_) ? walkers_per_rank / num_crowds_ + 1 : walkers_per_rank / num_crowds_;
   IndexType local_walkers = walkers_per_crowd_ * num_crowds_;
   population_.set_num_local_walkers(local_walkers);
   population_.set_num_global_walkers(local_walkers * population_.get_num_ranks());
@@ -55,8 +55,8 @@ VMCBatched::IndexType VMCBatched::calc_default_local_walkers(IndexType walkers_p
     app_warning() << "VMCBatched currently ignores samples and samplesperthread\n";
 
   if (local_walkers != walkers_per_rank)
-    app_warning() << "VMCBatched changed the number of walkers to " << local_walkers << ". User input was " << walkers_per_rank
-                  << std::endl;
+    app_warning() << "VMCBatched changed the number of walkers to " << local_walkers << ". User input was "
+                  << walkers_per_rank << std::endl;
 
   app_log() << "VMCBatched walkers per crowd " << walkers_per_crowd_ << std::endl;
   // TODO: Simplify samples, samples per thread etc in the unified driver
@@ -91,10 +91,6 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   std::vector<bool> moved(num_walkers, false);
   constexpr RealType mhalf(-0.5);
   const bool use_drift = sft.vmcdrv_input.get_use_drift();
-  //This generates an entire steps worth of deltas.
-  step_context.nextDeltaRs();
-  auto it_delta_r = step_context.deltaRsBegin();
-
   std::vector<TrialWaveFunction::GradType> grads_now(num_walkers);
   std::vector<TrialWaveFunction::GradType> grads_new(num_walkers);
   std::vector<TrialWaveFunction::PsiValueType> ratios(num_walkers);
@@ -112,91 +108,99 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   twf_accept_list.reserve(num_walkers);
   twf_reject_list.reserve(num_walkers);
 
-  // up and down electrons are "species" within qmpack
-  for (int ig = 0; ig < step_context.get_num_groups(); ++ig) //loop over species
+  for (int sub_step = 0; sub_step < sft.qmcdrv_input.get_sub_steps(); sub_step++)
   {
-    RealType tauovermass = sft.qmcdrv_input.get_tau() * sft.population.get_ptclgrp_inv_mass()[ig];
-    RealType oneover2tau = 0.5 / (tauovermass);
-    RealType sqrttau     = std::sqrt(tauovermass);
-    int start_index      = step_context.getPtclGroupStart(ig);
-    int end_index        = step_context.getPtclGroupEnd(ig);
-    for (int iat = start_index; iat < end_index; ++iat)
+    //This generates an entire steps worth of deltas.
+    step_context.nextDeltaRs();
+
+    // up and down electrons are "species" within qmpack
+    for (int ig = 0; ig < step_context.get_num_groups(); ++ig) //loop over species
     {
-      ParticleSet::flex_setActive(crowd.get_walker_elecs(), iat);
-      // step_context.deltaRsBegin returns an iterator to a flat series of PosTypes
-      // fastest in walkers then particles
-      auto delta_r_start = it_delta_r + iat * num_walkers;
-      auto delta_r_end = delta_r_start + num_walkers;
-
-      if (use_drift)
+      RealType tauovermass = sft.qmcdrv_input.get_tau() * sft.population.get_ptclgrp_inv_mass()[ig];
+      RealType oneover2tau = 0.5 / (tauovermass);
+      RealType sqrttau     = std::sqrt(tauovermass);
+      int start_index      = step_context.getPtclGroupStart(ig);
+      int end_index        = step_context.getPtclGroupEnd(ig);
+      for (int iat = start_index; iat < end_index; ++iat)
       {
-        TrialWaveFunction::flex_evalGrad(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, grads_now);
-        sft.drift_modifier.getDrifts(tauovermass, grads_now, drifts);
+        ParticleSet::flex_setActive(crowd.get_walker_elecs(), iat);
+        // step_context.deltaRsBegin returns an iterator to a flat series of PosTypes
+        // fastest in walkers then particles
+        auto delta_r_start = step_context.deltaRsBegin() + iat * num_walkers;
+        auto delta_r_end   = delta_r_start + num_walkers;
 
-        std::transform(drifts.begin(), drifts.end(), delta_r_start, drifts.begin(),
-                       [sqrttau](const PosType& drift, const PosType& delta_r) { return drift + (sqrttau * delta_r); });
-      }
-      else
-      {
-        std::transform(delta_r_start, delta_r_end, drifts.begin(),
-                       [sqrttau](const PosType& delta_r) { return sqrttau * delta_r; });
-      }
-
-      ParticleSet::flex_makeMove(crowd.get_walker_elecs(), iat, drifts);
-
-      // This is inelegant
-      if (use_drift)
-      {
-        TrialWaveFunction::flex_ratioGrad(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, ratios,
-                                          grads_new);
-        std::transform(delta_r_start, delta_r_end, log_gf.begin(),
-                       [mhalf](const PosType& delta_r) { return mhalf * dot(delta_r, delta_r); });
-
-        sft.drift_modifier.getDrifts(tauovermass, grads_new, drifts);
-
-        std::transform(crowd.beginElectrons(), crowd.endElectrons(), drifts.begin(), drifts.begin(),
-                       [iat](const ParticleSet& elecs, const PosType& drift) { return elecs.R[iat] - elecs.activePos - drift; });
-
-        std::transform(drifts.begin(), drifts.end(), log_gb.begin(),
-                       [oneover2tau](const PosType& drift) { return -oneover2tau * dot(drift, drift); });
-      }
-      else
-      {
-        TrialWaveFunction::flex_calcRatio(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, ratios);
-      }
-
-      std::transform(ratios.begin(), ratios.end(), prob.begin(),
-                     [](auto ratio) { return std::norm(ratio); });
-
-      twf_accept_list.clear();
-      twf_reject_list.clear();
-      elec_accept_list.clear();
-      elec_reject_list.clear();
-
-      for (int i_accept = 0; i_accept < num_walkers; ++i_accept)
-        if (prob[i_accept] >= std::numeric_limits<RealType>::epsilon() &&
-            step_context.get_random_gen()() < prob[i_accept] * std::exp(log_gb[i_accept] - log_gf[i_accept]))
+        if (use_drift)
         {
-          crowd.incAccept();
-          twf_accept_list.push_back(crowd.get_walker_twfs()[i_accept]);
-          elec_accept_list.push_back(crowd.get_walker_elecs()[i_accept]);
+          TrialWaveFunction::flex_evalGrad(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, grads_now);
+          sft.drift_modifier.getDrifts(tauovermass, grads_now, drifts);
+
+          std::transform(drifts.begin(), drifts.end(), delta_r_start, drifts.begin(),
+                         [sqrttau](const PosType& drift, const PosType& delta_r) {
+                           return drift + (sqrttau * delta_r);
+                         });
         }
         else
         {
-          crowd.incReject();
-          twf_reject_list.push_back(crowd.get_walker_twfs()[i_accept]);
-          elec_reject_list.push_back(crowd.get_walker_elecs()[i_accept]);
+          std::transform(delta_r_start, delta_r_end, drifts.begin(),
+                         [sqrttau](const PosType& delta_r) { return sqrttau * delta_r; });
         }
 
-      TrialWaveFunction::flex_acceptMove(twf_accept_list, elec_accept_list, iat);
-      TrialWaveFunction::flex_rejectMove(twf_reject_list, iat);
+        ParticleSet::flex_makeMove(crowd.get_walker_elecs(), iat, drifts);
 
-      ParticleSet::flex_acceptMove(elec_accept_list, iat);
-      ParticleSet::flex_rejectMove(elec_reject_list, iat);
+        // This is inelegant
+        if (use_drift)
+        {
+          TrialWaveFunction::flex_ratioGrad(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, ratios, grads_new);
+          std::transform(delta_r_start, delta_r_end, log_gf.begin(),
+                         [mhalf](const PosType& delta_r) { return mhalf * dot(delta_r, delta_r); });
+
+          sft.drift_modifier.getDrifts(tauovermass, grads_new, drifts);
+
+          std::transform(crowd.beginElectrons(), crowd.endElectrons(), drifts.begin(), drifts.begin(),
+                         [iat](const ParticleSet& elecs, const PosType& drift) {
+                           return elecs.R[iat] - elecs.activePos - drift;
+                         });
+
+          std::transform(drifts.begin(), drifts.end(), log_gb.begin(),
+                         [oneover2tau](const PosType& drift) { return -oneover2tau * dot(drift, drift); });
+        }
+        else
+        {
+          TrialWaveFunction::flex_calcRatio(crowd.get_walker_twfs(), crowd.get_walker_elecs(), iat, ratios);
+        }
+
+        std::transform(ratios.begin(), ratios.end(), prob.begin(), [](auto ratio) { return std::norm(ratio); });
+
+        twf_accept_list.clear();
+        twf_reject_list.clear();
+        elec_accept_list.clear();
+        elec_reject_list.clear();
+
+        for (int i_accept = 0; i_accept < num_walkers; ++i_accept)
+          if (prob[i_accept] >= std::numeric_limits<RealType>::epsilon() &&
+              step_context.get_random_gen()() < prob[i_accept] * std::exp(log_gb[i_accept] - log_gf[i_accept]))
+          {
+            crowd.incAccept();
+            twf_accept_list.push_back(crowd.get_walker_twfs()[i_accept]);
+            elec_accept_list.push_back(crowd.get_walker_elecs()[i_accept]);
+          }
+          else
+          {
+            crowd.incReject();
+            twf_reject_list.push_back(crowd.get_walker_twfs()[i_accept]);
+            elec_reject_list.push_back(crowd.get_walker_elecs()[i_accept]);
+          }
+
+        TrialWaveFunction::flex_acceptMove(twf_accept_list, elec_accept_list, iat);
+        TrialWaveFunction::flex_rejectMove(twf_reject_list, iat);
+
+        ParticleSet::flex_acceptMove(elec_accept_list, iat);
+        ParticleSet::flex_rejectMove(elec_reject_list, iat);
+      }
     }
+    std::for_each(crowd.get_walker_twfs().begin(), crowd.get_walker_twfs().end(),
+                  [](TrialWaveFunction& twf) { twf.completeUpdates(); });
   }
-  std::for_each(crowd.get_walker_twfs().begin(), crowd.get_walker_twfs().end(),
-                [](TrialWaveFunction& twf) { twf.completeUpdates(); });
 
   ParticleSet::flex_donePbyP(crowd.get_walker_elecs());
   timers.movepbyp_timer.stop();
@@ -251,7 +255,7 @@ void VMCBatched::runVMCStep(int crowd_id,
 {
   Crowd& crowd = *(crowds[crowd_id]);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
-  
+
   int max_steps = sft.qmcdrv_input.get_max_steps();
   bool is_recompute_block =
       sft.recomputing_blocks ? (1 + sft.block) % sft.qmcdrv_input.get_blocks_between_recompute() == 0 : false;
@@ -349,9 +353,9 @@ bool VMCBatched::run()
   // bool wrotesamples = qmcdriver_input_.get_dump_config();
   // if (qmcdriver_input_.get_dump_config())
   // {
-    //wrotesamples = W.dumpEnsemble(wClones, wOut, myComm->size(), nBlocks);
-    //if (wrotesamples)
-    //  app_log() << "  samples are written to the config.h5" << std::endl;
+  //wrotesamples = W.dumpEnsemble(wClones, wOut, myComm->size(), nBlocks);
+  //if (wrotesamples)
+  //  app_log() << "  samples are written to the config.h5" << std::endl;
   // }
 
   // second argument was !wrotesample so if W.dumpEnsemble returns false or

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -147,7 +147,6 @@ TEST_CASE("Crowd redistribute walkers")
     crowd.addWalker(*crowd_with_walkers.walkers[iw], *crowd_with_walkers.psets[iw], *crowd_with_walkers.twfs[iw],
                     *crowd_with_walkers.hams[iw]);
   REQUIRE(crowd.size() == 3);
-  REQUIRE(crowd.get_grads_new().size() == 3);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -397,6 +397,8 @@ void TrialWaveFunction::flex_calcRatio(const RefVector<TrialWaveFunction>& wf_li
           ratios[iw] *= ratios_z[iw];
       }
     }
+    for (int iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].get().PhaseDiff = std::imag(std::arg(ratios[iw]));
   }
   else if (wf_list.size() == 1)
     ratios[0] = wf_list[0].get().calcRatio(p_list[0], iat);


### PR DESCRIPTION
1. Keep crowd class fit. many temporal result arrays moved inside driver functions since they are used locally.
2. driver Rng array directly take RandomNumberControl::Children pointers. Pointer ownership transfers if Rng is activated and deactivated. Remove a make_seeds() to recover reproducibility compared to the non-batched driver. Part of the deterministic tests can be used by the batched driver directly now.
3. Fix VMC without drift.

Q: how to update the failing deterministic test for the new batched driver.
Because in PBC calculation, the non-batched driver use makeMoveAndCheck which reject moves with displacement larger than half of the box while the batched driver doesn't use check since it complicates the driver a lot and doesn't seem helpful overall. This check doesn't impact large system with big boxes but affect small system. Our existing 1 walker deterministic VMC tests have small cell and large time step and thus get affected. A safe route to me is updating current tests with small er time step still based on non-batched driver and make sure they are not affected by the check.