### PR TITLE
add unit tests for derivatives of LRHandlers

### DIFF
--- a/src/LongRange/LRHandlerSRCoulomb.h
+++ b/src/LongRange/LRHandlerSRCoulomb.h
@@ -282,6 +282,7 @@ private:
     LRBreakup<BreakupBasis> breakuphandler(Basis);
     //Find size of basis from cutoffs
     mRealType kc = (LR_kc < 0) ? ref.LR_kc : LR_kc;
+    LR_kc = kc; // set internal kc
     //mRealType kc(ref.LR_kc); //User cutoff parameter...
     //kcut is the cutoff for switching to approximate k-point degeneracies for
     //better performance in making the breakup. A good bet is 30*K-spacing so that

--- a/src/LongRange/tests/CMakeLists.txt
+++ b/src/LongRange/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 
-ADD_EXECUTABLE(${UTEST_EXE} test_lrhandler.cpp test_ewald3d.cpp test_temp.cpp)
+ADD_EXECUTABLE(${UTEST_EXE} test_lrhandler.cpp test_ewald3d.cpp test_temp.cpp
+  test_srcoul.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcbase qmcutil ${QMC_UTIL_LIBS})
 
 #ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")

--- a/src/LongRange/tests/test_ewald3d.cpp
+++ b/src/LongRange/tests/test_ewald3d.cpp
@@ -69,4 +69,61 @@ TEST_CASE("ewald3d", "[lrhandler]")
   }
 }
 
+/** evalaute bare Coulomb derivative using EwaldHandler3D
+ */
+TEST_CASE("ewald3d df", "[lrhandler]")
+{
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice.BoxBConds = true;
+  Lattice.LR_dim_cutoff = 30.;
+  Lattice.R.diagonal(5.0);
+  Lattice.reset();
+  REQUIRE(Lattice.Volume == Approx(125));
+  Lattice.SetLRCutoffs(Lattice.Rv);
+  //Lattice.printCutoffs(app_log());
+  REQUIRE(Lattice.LR_rc == Approx(2.5));
+  REQUIRE(Lattice.LR_kc == Approx(12));
+
+  ParticleSet ref; // handler needs ref.SK.KLists
+  ref.Lattice = Lattice;  // !!!! crucial for access to Volume
+  ref.LRBox = Lattice;  // !!!! crucial for S(k) update
+  StructFact *SK = new StructFact(ref, Lattice.LR_kc);
+  ref.SK = SK;
+  EwaldHandler3D handler(ref, Lattice.LR_kc);
+
+  // make sure initBreakup changes the default sigma
+  REQUIRE(handler.Sigma == Approx(Lattice.LR_kc));
+  handler.initBreakup(ref);
+  REQUIRE(handler.Sigma == Approx(std::sqrt(Lattice.LR_kc/(2.0*Lattice.LR_rc))));
+
+  REQUIRE(handler.MaxKshell == 78);
+  REQUIRE(handler.LR_rc == Approx(2.5));
+  REQUIRE(handler.LR_kc == Approx(12));
+
+  mRealType r, dr, rinv;
+  mRealType rm, rp; // minus (m), plus (p)
+  mRealType vsrm, vsrp, dvsr, vlrm, vlrp, dvlr;
+  dr = 0.00001; // finite difference step
+  std::vector<mRealType> rlist={0.1, 0.5, 1.0, 2.0, 2.5};
+  for (auto it=rlist.begin(); it!=rlist.end(); ++it)
+  {
+    r = *it;
+    // test short-range piece
+    rm = r-dr;
+    rinv = 1./rm;
+    vsrm = handler.evaluate(rm, rinv);
+    vlrm = handler.evaluateLR(rm);
+    rp = r+dr;
+    rinv = 1./rp;
+    vsrp = handler.evaluate(rp, rinv);
+    vlrp = handler.evaluateLR(rp);
+    dvsr = (vsrp-vsrm)/(2*dr);
+    rinv = 1./r;
+    REQUIRE(handler.srDf(r, rinv) == Approx(dvsr));
+    // test long-range piece
+    dvlr = (vlrp-vlrm)/(2*dr);
+    REQUIRE(handler.lrDf(r) == Approx(dvlr));
+  }
+}
+
 } // namespace qmcplusplus

--- a/src/LongRange/tests/test_srcoul.cpp
+++ b/src/LongRange/tests/test_srcoul.cpp
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2019 and QMCPACK developers.
+//
+// File developed by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
+//
+// File created by: Yubo "Paul" Yang, yubo.paul.yang@gmail.com, University of Illinois Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "Configuration.h"
+#include "Lattice/CrystalLattice.h"
+#include "Particle/ParticleSet.h"
+#include "LongRange/LRHandlerSRCoulomb.h"
+
+namespace qmcplusplus
+{
+
+using mRealType = LRHandlerBase::mRealType;
+
+struct EslerCoulomb3D
+{ // stripped down version of LRCoulombSingleton::CoulombFunctor for 3D
+  double norm;
+  inline double operator()(double r, double rinv) {return rinv;}
+  inline double Vk(double k) {return 1./(k*k);}
+  inline double dVk_dk(double k) {return -2*norm/(k*k*k);}
+  void reset(ParticleSet& ref) {norm=4.0*M_PI/ref.LRBox.Volume;}
+  void reset(ParticleSet& ref, double rs) {reset(ref);} // ignore rs
+  inline double df(double r) {return -1./(r*r);}
+};
+
+/** evalaute bare Coulomb in 3D
+ */
+TEST_CASE("srcoul", "[lrhandler]")
+{
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice.BoxBConds = true;
+  Lattice.LR_dim_cutoff = 30.;
+  Lattice.R.diagonal(5.0);
+  Lattice.reset();
+  REQUIRE(Lattice.Volume == Approx(125));
+  Lattice.SetLRCutoffs(Lattice.Rv);
+  //Lattice.printCutoffs(app_log());
+  REQUIRE(Lattice.LR_rc == Approx(2.5));
+  REQUIRE(Lattice.LR_kc == Approx(12));
+
+  ParticleSet ref; // handler needs ref.SK.KLists
+  ref.Lattice = Lattice;  // !!!! crucial for access to Volume
+  ref.LRBox = Lattice;  // !!!! crucial for S(k) update
+  StructFact *SK = new StructFact(ref, Lattice.LR_kc);
+  ref.SK = SK;
+  LRHandlerSRCoulomb<EslerCoulomb3D, LPQHISRCoulombBasis> handler(ref);
+
+  handler.initBreakup(ref);
+  REQUIRE(handler.MaxKshell == 78);
+  REQUIRE(handler.LR_rc == Approx(2.5));
+  REQUIRE(handler.LR_kc == 12);
+
+  mRealType r, dr, rinv;
+  mRealType vsr;
+  int nr = 101;
+  dr = 5.0/nr;  // L/[# of grid points]
+  for (int ir=1;ir<nr;ir++)
+  {
+    r = ir*dr;
+    rinv = 1./r;
+    vsr = handler.evaluate(r, rinv);
+    // short-range part must vanish after rcut
+    if (r>2.5) REQUIRE(vsr == Approx(0.0));
+    //// !!!! SR values not validated, see "srcoul df" test
+    //REQUIRE(vsr == Approx(rinv));
+  }
+}
+
+/** evalaute bare Coulomb derivative in 3D
+ */
+TEST_CASE("srcoul df", "[lrhandler]")
+{
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice.BoxBConds = true;
+  Lattice.LR_dim_cutoff = 30.;
+  Lattice.R.diagonal(5.0);
+  Lattice.reset();
+  REQUIRE(Lattice.Volume == Approx(125));
+  Lattice.SetLRCutoffs(Lattice.Rv);
+  //Lattice.printCutoffs(app_log());
+  REQUIRE(Lattice.LR_rc == Approx(2.5));
+  REQUIRE(Lattice.LR_kc == Approx(12));
+
+  ParticleSet ref; // handler needs ref.SK.KLists
+  ref.Lattice = Lattice;  // !!!! crucial for access to Volume
+  ref.LRBox = Lattice;  // !!!! crucial for S(k) update
+  StructFact *SK = new StructFact(ref, Lattice.LR_kc);
+  ref.SK = SK;
+  LRHandlerSRCoulomb<EslerCoulomb3D, LPQHISRCoulombBasis> handler(ref);
+
+  handler.initBreakup(ref);
+  REQUIRE(handler.MaxKshell == 78);
+  REQUIRE(handler.LR_rc == Approx(2.5));
+  REQUIRE(handler.LR_kc == 12);
+
+  EslerCoulomb3D fref;
+  fref.reset(ref);
+  mRealType r, dr, rinv;
+  mRealType rm, rp; // minus (m), plus (p)
+  mRealType vsrm, vsrp, dvsr, vlrm, vlrp, dvlr;
+  dr = 0.00001; // finite difference step
+  std::vector<mRealType> rlist={0.1, 0.5, 1.0, 2.0, 2.5};
+  for (auto it=rlist.begin(); it!=rlist.end(); ++it)
+  {
+    r = *it;
+    // test short-range piece
+    rm = r-dr;
+    rinv = 1./rm;
+    vsrm = handler.evaluate(rm, rinv);
+    vlrm = handler.evaluateLR(rm);
+    rp = r+dr;
+    rinv = 1./rp;
+    vsrp = handler.evaluate(rp, rinv);
+    vlrp = handler.evaluateLR(rp);
+    dvsr = (vsrp-vsrm)/(2*dr);
+    rinv = 1./r;
+    REQUIRE(handler.srDf(r, rinv) == Approx(dvsr));
+    // test long-range piece
+    dvlr = (vlrp-vlrm)/(2*dr);
+    REQUIRE(handler.lrDf(r) == Approx(dvlr));
+    // test total derivative
+    REQUIRE(dvsr+dvlr == Approx(fref.df(r)));
+  }
+}
+
+} // namespace qmcplusplus


### PR DESCRIPTION
As promised in #2041. This PR adds finite difference tests for `LRHandler`s.