### PR TITLE
abort if trying to use LRHandlerTemp derivatives

### DIFF
--- a/src/LongRange/LRHandlerTemp.h
+++ b/src/LongRange/LRHandlerTemp.h
@@ -116,6 +116,7 @@ public:
    */
   inline mRealType srDf(mRealType r, mRealType rinv)
   {
+    APP_ABORT("LRHandlerTemp::srDF not implemented (missing gcoefs)");
     mRealType df = 0.0;
     if (r>=LR_rc) return df;
     df = myFunc.df(r);
@@ -140,6 +141,7 @@ public:
    */
   inline mRealType lrDf(mRealType r)
   {
+    APP_ABORT("LRHandlerTemp::lrDF not implemented (missing gcoefs)");
     mRealType dv = 0.0;
     if (r < LR_rc)
     {


### PR DESCRIPTION
small amendment to #2047, abort is using `LRHandlerTemp` derivatives per @prckent suggestion.