### PR TITLE
Improve support for multiple J1

### DIFF
--- a/nexus/lib/physical_system.py
+++ b/nexus/lib/physical_system.py
@@ -397,7 +397,8 @@ class PhysicalSystem(Matter):
                 ionp = self.particles[ion]
                 if isinstance(ionp,Ion):
                     self.particles[ion] = ionp.pseudize(valence_charge)
-                    self.pseudized = True
+                    if self.particles[ion].protons > valence_charge:
+                      self.pseudized = True
                 else:
                     self.error(ion+' cannot be pseudized',exit=False)
                 #end if

--- a/nexus/lib/physical_system.py
+++ b/nexus/lib/physical_system.py
@@ -397,8 +397,7 @@ class PhysicalSystem(Matter):
                 ionp = self.particles[ion]
                 if isinstance(ionp,Ion):
                     self.particles[ion] = ionp.pseudize(valence_charge)
-                    if self.particles[ion].protons > valence_charge:
-                      self.pseudized = True
+                    self.pseudized = True
                 else:
                     self.error(ion+' cannot be pseudized',exit=False)
                 #end if

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -284,7 +284,12 @@ class Qmcpack(Simulation):
                     jd = dict()
                     for j in js:
                         jtype = j.type.lower().replace('-','_').replace(' ','_')
-                        jd[jtype] = j
+                        key = jtype + j.name
+                        if key in jd.keys():
+                            msg = 'duplicate jastrow in '+self.__class__.__name__
+                            self.error(msg)
+                        #end if
+                        jd[key] = j
                     #end for
                     return jd
                 #end def process_jastrow

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -284,10 +284,14 @@ class Qmcpack(Simulation):
                     jd = dict()
                     for j in js:
                         jtype = j.type.lower().replace('-','_').replace(' ','_')
-                        key = jtype + j.name
-                        if key in jd.keys():
-                            msg = 'duplicate jastrow in '+self.__class__.__name__
-                            self.error(msg)
+                        key = jtype
+                        # take care of multiple jastrows of the same type
+                        if key in jd:  # use name to distinguish
+                            key += j.name
+                            if key in jd:  # if still duplicate then error out
+                                msg = 'duplicate jastrow in '+self.__class__.__name__
+                                self.error(msg)
+                            #end if
                         #end if
                         jd[key] = j
                     #end for

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -272,7 +272,7 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ2(xmlNodePtr cur)
       if (is_manager())
       {
         char fname[32];
-        sprintf(fname, "J2.%s.g%03d.dat", pairType.c_str(), getGroupID());
+        sprintf(fname, "J2.%s.%s.g%03d.dat", NameOpt.c_str(), pairType.c_str(), getGroupID());
         std::ofstream os(fname);
         print(*functor, os);
       }
@@ -303,7 +303,7 @@ void RadialJastrowBuilder::computeJ2uk(const std::vector<RadFuncType*>& functors
   if (is_manager())
   {
     char fname[16];
-    sprintf(fname, "uk.g%03d.dat", getGroupID());
+    sprintf(fname, "uk.%s.g%03d.dat", NameOpt.c_str(), getGroupID());
     fout = fopen(fname, "w");
   }
   for (int iG = 0; iG < targetPtcl.SK->KLists.ksq.size(); iG++)
@@ -414,9 +414,9 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ1(xmlNodePtr cur)
       {
         char fname[128];
         if (speciesB.size())
-          sprintf(fname, "%s.%s%s.g%03d.dat", jname.c_str(), speciesA.c_str(), speciesB.c_str(), getGroupID());
+          sprintf(fname, "%s.%s.%s%s.g%03d.dat", jname.c_str(), NameOpt.c_str(), speciesA.c_str(), speciesB.c_str(), getGroupID());
         else
-          sprintf(fname, "%s.%s.g%03d.dat", jname.c_str(), speciesA.c_str(), getGroupID());
+          sprintf(fname, "%s.%s.%s.g%03d.dat", jname.c_str(), NameOpt.c_str(), speciesA.c_str(), getGroupID());
         std::ofstream os(fname);
         print(*functor, os);
       }


### PR DESCRIPTION
Add Jastrow name as a label so that multiple one-body Jastrows can be used.

There is also a 1-line change to `physical_system.py` to run all-electron simulation of hydrogen.

After these changes, the input attached in #2037 can be generated using nexus.