### PR TITLE
Pair corr estimator norm factor fix

### DIFF
--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -110,83 +110,85 @@ PairCorrEstimator::PairCorrEstimator(ParticleSet& elns, std::string& sources)
 
 void PairCorrEstimator::resetTargetParticleSet(ParticleSet& P) {}
 
-PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
-{
-  BufferType& collectables(P.Collectables);
-  const DistanceTableData& dii(P.getDistTable(d_aa_ID_));
-  if (dii.DTType == DT_SOA)
+  PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
   {
-    for (int iat = 1; iat < dii.centers(); ++iat)
-    {
-      const RealType* restrict dist = dii.Distances[iat];
-      const int ig                  = P.GroupID[iat];
-      for (int j = 0; j < iat; ++j)
+    BufferType& collectables(P.Collectables);
+    const DistanceTableData& dii(P.getDistTable(d_aa_ID_));
+    if (dii.DTType == DT_SOA)
       {
-        const RealType r = dist[j];
-        if (r >= Dmax)
-          continue;
-        const int loc     = static_cast<int>(DeltaInv * r);
-        const int jg      = P.GroupID[j];
-        const int pair_id = ig * (ig + 1) / 2 + jg;
-        collectables[pair_id * NumBins + loc + myIndex] += norm_factor(pair_id + 1, loc);
+	// std::cerr << "PairCorrEstimator::evaluate() is in SOA mode\n";
+	for (int iat = 1; iat < dii.centers(); ++iat)
+	  {
+	    const RealType* restrict dist = dii.Distances[iat];
+	    const int ig                  = P.GroupID[iat];
+	    for (int j = 0; j < iat; ++j)
+	      {
+		const RealType r = dist[j];
+		if (r >= Dmax)
+		  continue;
+		const int loc     = static_cast<int>(DeltaInv * r);
+		const int jg      = P.GroupID[j];
+		const int pair_id = ig * (ig + 1) / 2 + jg;
+		collectables[pair_id * NumBins + loc + myIndex] += norm_factor(pair_id + 1, loc);
+	      }
+	  }
+	for (int k = 0; k < other_ids.size(); ++k)
+	  {
+	    const DistanceTableData& d1(P.getDistTable(other_ids[k]));
+	    const ParticleSet::ParticleIndex_t& gid(d1.origin().GroupID);
+	    int koff        = other_offsets[k];
+	    RealType overNI = 1.0 / d1.centers();
+	    for (int iat = 0; iat < d1.targets(); ++iat)
+	      {
+		const RealType* restrict dist = d1.Distances[iat];
+		for (int j = 0; j < d1.centers(); ++j)
+		  {
+		    const RealType r = dist[j];
+		    if (r >= Dmax)
+		      continue;
+		    int toff = (gid[j] + koff) * NumBins;
+		    int loc  = static_cast<int>(DeltaInv * r);
+		    collectables[toff + loc + myIndex] += norm_factor(0, loc) * overNI;
+		  }
+	      }
+	  }
       }
-    }
-    for (int k = 0; k < other_ids.size(); ++k)
-    {
-      const DistanceTableData& d1(P.getDistTable(other_ids[k]));
-      const ParticleSet::ParticleIndex_t& gid(d1.origin().GroupID);
-      int koff        = other_offsets[k];
-      RealType overNI = 1.0 / d1.centers();
-      for (int iat = 0; iat < d1.targets(); ++iat)
+    else
       {
-        const RealType* restrict dist = d1.Distances[iat];
-        for (int j = 0; j < d1.centers(); ++j)
-        {
-          const RealType r = dist[j];
-          if (r >= Dmax)
-            continue;
-          int toff = (gid[j] + koff) * NumBins;
-          int loc  = static_cast<int>(DeltaInv * r);
-          collectables[toff + loc + myIndex] += norm_factor(0, loc) * overNI;
-        }
+	// std::cerr << "PairCorrEstimator::evaluate() is in AOS mode\n";
+	for (int iat = 0; iat < dii.centers(); ++iat)
+	  {
+	    for (int nn = dii.M[iat]; nn < dii.M[iat + 1]; ++nn)
+	      {
+		RealType r = dii.r(nn);
+		if (r >= Dmax)
+		  continue;
+		int loc = static_cast<int>(DeltaInv * r);
+		collectables[pair_ids[nn] * NumBins + loc + myIndex] += norm_factor(pair_ids[nn] + 1, loc);
+	      }
+	  }
+	for (int k = 0; k < other_ids.size(); ++k)
+	  {
+	    const DistanceTableData& d1(P.getDistTable(other_ids[k]));
+	    const ParticleSet::ParticleIndex_t& gid(d1.origin().GroupID);
+	    int koff = other_offsets[k];
+	    for (int iat = 0; iat < d1.centers(); ++iat)
+	      {
+		RealType overNI = 1.0 / d1.centers();
+		int toff        = (gid[iat] + koff) * NumBins;
+		for (int nn = d1.M[iat]; nn < d1.M[iat + 1]; ++nn)
+		  {
+		    RealType r = dii.r(nn);
+		    if (r >= Dmax)
+		      continue;
+		    int loc = static_cast<int>(DeltaInv * r);
+		    collectables[toff + loc + myIndex] += norm_factor(0, loc) * overNI;
+		  }
+	      }
+	  }
       }
-    }
+    return 0.0;
   }
-  else
-  {
-    for (int iat = 0; iat < dii.centers(); ++iat)
-    {
-      for (int nn = dii.M[iat]; nn < dii.M[iat + 1]; ++nn)
-      {
-        RealType r = dii.r(nn);
-        if (r >= Dmax)
-          continue;
-        int loc = static_cast<int>(DeltaInv * r);
-        collectables[pair_ids[nn] * NumBins + loc + myIndex] += norm_factor(pair_ids[nn] + 1, loc);
-      }
-    }
-    for (int k = 0; k < other_ids.size(); ++k)
-    {
-      const DistanceTableData& d1(P.getDistTable(other_ids[k]));
-      const ParticleSet::ParticleIndex_t& gid(d1.origin().GroupID);
-      int koff = other_offsets[k];
-      for (int iat = 0; iat < d1.centers(); ++iat)
-      {
-        RealType overNI = 1.0 / d1.centers();
-        int toff        = (gid[iat] + koff) * NumBins;
-        for (int nn = d1.M[iat]; nn < d1.M[iat + 1]; ++nn)
-        {
-          RealType r = dii.r(nn);
-          if (r >= Dmax)
-            continue;
-          int loc = static_cast<int>(DeltaInv * r);
-          collectables[toff + loc + myIndex] += norm_factor(0, loc) * overNI;
-        }
-      }
-    }
-  }
-  return 0.0;
-}
 
 void PairCorrEstimator::registerCollectables(std::vector<observable_helper*>& h5list, hid_t gid) const
 {

--- a/src/QMCHamiltonians/PairCorrEstimator.h
+++ b/src/QMCHamiltonians/PairCorrEstimator.h
@@ -49,9 +49,10 @@ public:
   bool get(std::ostream& os) const;
   QMCHamiltonianBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
 
+  void set_norm_factor();
   void report();
 
-private:
+ private:
   ///number of bins
   int NumBins;
   /// maximum distance
@@ -68,11 +69,15 @@ private:
   std::vector<int> other_ids;
   /// offset of the gofr's associated with others_id
   std::vector<int> other_offsets;
-  /////save source indices
-  //vector<int> source_ids;
-  ///normalization factor
+
+  ///normalization factors
   Matrix<RealType> norm_factor;
-  int num_species, N_e;
+  
+  // Number of species
+  int num_species;
+  // Total number of electrons
+  int N_e; 
+  // Number of electrons per species
   std::vector<RealType> n_vec;
   // AA table ID
   const int d_aa_ID_;

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 SET(UTEST_DIR ${qmcpack_BINARY_DIR}/tests/hamiltonians)
 
 SET(SRCS test_bare_kinetic.cpp test_coulomb_pbcAB.cpp test_coulomb_pbcAB_ewald.cpp test_coulomb_pbcAA.cpp
-         test_coulomb_pbcAA_ewald.cpp test_force.cpp test_force_ewald.cpp test_ecp.cpp test_hamiltonian_factory.cpp)
+         test_coulomb_pbcAA_ewald.cpp test_force.cpp test_force_ewald.cpp test_ecp.cpp test_hamiltonian_factory.cpp test_paircorr.cpp)
 IF(QMC_CUDA)
   SET(SRCS ${SRCS}
       test_coulomb_CUDA.cpp 

--- a/src/QMCHamiltonians/tests/test_paircorr.cpp
+++ b/src/QMCHamiltonians/tests/test_paircorr.cpp
@@ -15,7 +15,6 @@
 #include "Lattice/ParticleBConds.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/DistanceTableData.h"
-#include "Particle/SymmetricDistanceTableData.h"
 #include "QMCHamiltonians/PairCorrEstimator.h"
 #include "QMCApp/ParticleSetPool.h"
 
@@ -134,8 +133,13 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
 
   elec->get(std::cout); // print particleset info to stdout
 
-  // Set up the distance table
+  // Set up the distance table, match expected layout
+#ifdef ENABLE_SOA
+  const int ee_table_id = elec->addTable(*elec, DT_SOA, false);
+#else
   const int ee_table_id = elec->addTable(*elec, DT_AOS, false);
+#endif
+  
   const DistanceTableData& dii(elec->getDistTable(ee_table_id));
   elec->update(); // distance table evaluation here
 
@@ -174,6 +178,11 @@ TEST_CASE("Pair Correlation", "[hamiltonian]")
     } 
 
   // Verify against analytic result.
+  // NB: At the moment the tolerance is fairly loose because there
+  //     is about 0.08-0.01 disagreement between QMCPACK and analytic
+  //     result, depending on the bin. I'm not sure about the source
+  //     of the disagreement because norm_factor is now exact. 
+  //     The only thing left is the distance table (I think)...
   const RealType eps = 1E-01;  // tolerance
 
   // Nearest neighbor peak (ud) | Distance = 1

--- a/src/QMCHamiltonians/tests/test_paircorr.cpp
+++ b/src/QMCHamiltonians/tests/test_paircorr.cpp
@@ -12,6 +12,7 @@
 
 #include "catch.hpp"
 #include "OhmmsData/Libxml2Doc.h"
+#include "Lattice/CrystalLattice.h"
 #include "Lattice/ParticleBConds.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/DistanceTableData.h"

--- a/src/QMCHamiltonians/tests/test_paircorr.cpp
+++ b/src/QMCHamiltonians/tests/test_paircorr.cpp
@@ -1,0 +1,197 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+#include "OhmmsData/Libxml2Doc.h"
+#include "Lattice/ParticleBConds.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/DistanceTableData.h"
+#include "Particle/SymmetricDistanceTableData.h"
+#include "QMCHamiltonians/PairCorrEstimator.h"
+#include "QMCApp/ParticleSetPool.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+
+/*
+  Minimal input block (based off HEG problem).
+  This is a dumb way to construct a test, but I can't figure out
+  the right way to initialize a ParticleSet, so instead hijack 
+  the ParticleSetPool class to make a ParticleSet for me.
+
+  NB: Hardcoded 8 particles (4 each of u/d) on a B1 (NaCl) lattice.
+ */
+
+// Lattice block
+const char *lat_xml = "<simulationcell> \
+                         <parameter name=\"bconds\"> \
+                           p p p \
+                        </parameter> \
+                        <parameter name=\"LR_dim_cutoff\" >     6  </parameter> \
+                        <parameter name=\"rs\"            >   1.0  </parameter> \
+                        <parameter name=\"nparticles\"    >     8  </parameter> \
+                        </simulationcell>";
+
+// Particleset block
+const char *pset_xml = "<particleset name=\"e\" random=\"yes\"> \
+                          <group name=\"u\" size=\"4\" mass=\"1.0\"> \
+                            <parameter name=\"charge\" >   -1  </parameter> \
+                            <parameter name=\"mass\"   >  1.0  </parameter> \
+                          </group> \
+                          <group name=\"d\" size=\"4\" mass=\"1.0\"> \
+                            <parameter name=\"charge\" >   -1  </parameter> \
+                            <parameter name=\"mass\"   >  1.0  </parameter> \
+                          </group> \
+                        </particleset>";
+
+// PairCorrEstimator block
+const char* gofr_xml = "<estimator type=\"gofr\" name=\"gofr\" rmax=\"2.0\" num_bin=\"20\" />";
+
+
+namespace qmcplusplus
+{
+TEST_CASE("Pair Correlation", "[hamiltonian]")
+{
+  std::cout << std::fixed;
+  std::cout << std::setprecision(8);
+  typedef QMCTraits::RealType RealType;
+
+  Communicate* c;
+  OHMMS::Controller->initialize(0, NULL);
+  c = OHMMS::Controller;
+
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
+  Lattice.BoxBConds = true; // periodic
+  Lattice.R.diagonal(2.0);
+  Lattice.reset();
+
+  // XML parser
+  Libxml2Document doc;
+
+  std::cout << "\n\n\ntest_paircorr:: START\n";
+
+  // TEST new idea: ParticlesetPool to make a ParticleSet
+  bool lat_okay = doc.parseFromString(lat_xml);
+  REQUIRE(lat_okay);
+  xmlNodePtr lat_xml_root = doc.getRoot();
+
+  ParticleSetPool pset_builder(c, "pset_builder");
+  pset_builder.putLattice(lat_xml_root); // Builds lattice
+
+  bool pset_okay = doc.parseFromString(pset_xml);
+  REQUIRE(pset_okay);
+  xmlNodePtr pset_xml_root = doc.getRoot();
+  pset_builder.put(pset_xml_root);  // Builds ParticleSet
+
+  // Get the (now assembled) ParticleSet, do simple sanity checks, then print info 
+  ParticleSet* elec = pset_builder.getParticleSet("e");
+  elec->Lattice.copy(Lattice); // copy in the new Lattice
+
+  REQUIRE(elec->SameMass);
+  REQUIRE(elec->getName() == "e");
+
+  // Move the particles manually onto B1 lattice
+  // NB: Spins are grouped contiguously
+  // Up spins
+  elec->R[0][0] = 0.0;
+  elec->R[0][1] = 0.0;
+  elec->R[0][2] = 0.0;
+  elec->R[1][0] = 1.0;
+  elec->R[1][1] = 1.0;
+  elec->R[1][2] = 0.0;
+  elec->R[2][0] = 1.0;
+  elec->R[2][1] = 0.0;
+  elec->R[2][2] = 1.0;
+  elec->R[3][0] = 0.0;
+  elec->R[3][1] = 1.0;
+  elec->R[3][2] = 1.0;
+
+  // Down spins
+  elec->R[4][0] = 1.0;
+  elec->R[4][1] = 0.0;
+  elec->R[4][2] = 0.0;
+  elec->R[5][0] = 0.0;
+  elec->R[5][1] = 1.0;
+  elec->R[5][2] = 0.0;
+  elec->R[6][0] = 0.0;
+  elec->R[6][1] = 0.0;
+  elec->R[6][2] = 1.0;
+  elec->R[7][0] = 1.0;
+  elec->R[7][1] = 1.0;
+  elec->R[7][2] = 1.0;
+
+  elec->get(std::cout); // print particleset info to stdout
+
+  // Set up the distance table
+  const int ee_table_id = elec->addTable(*elec, DT_AOS, false);
+  const DistanceTableData& dii(elec->getDistTable(ee_table_id));
+  elec->update(); // distance table evaluation here
+
+  // Make a PairCorrEstimator, call put() to set up internals
+  std::string name = elec->getName();
+  PairCorrEstimator* paircorr = new PairCorrEstimator(*elec, name);
+  bool gofr_okay = doc.parseFromString(gofr_xml);
+  REQUIRE(gofr_okay);
+  xmlNodePtr gofr_xml_root = doc.getRoot();
+  paircorr->put(gofr_xml_root);
+  paircorr->addObservables( elec->PropertyList, elec->Collectables );
+
+  // Compute g(r) then print it to stdout
+  // NB: Hardcoded to match hardcoded xml above. ***Fragile!!!***
+  paircorr->evaluate(*elec);
+
+  auto gofr = elec->Collectables;
+  std::cout << "\n";
+  std::cout << "gofr:\n";
+  std::cout << std::fixed;
+  std::cout << std::setprecision(6);
+  std::cout <<  std::setw(4) << "i" 
+	    << "  " << std::setw(12) << "r" 
+	    << "  " << std::setw(12) << "uu" 
+	    << "  " << std::setw(12) << "ud" 
+	    << "  " << std::setw(12) << "dd" << "\n";
+  std::cout << "============================================================\n";
+  for ( int i(0); i<20; i++ )
+    {
+      std::cout << std::setw(4) << i
+		<< "  " << std::setw(12) << i*0.10
+  		<< "  " << std::setw(12) << gofr[i]
+  		<< "  " << std::setw(12) << gofr[i+20]
+  		<< "  " << std::setw(12) << gofr[i+40] 
+  		<< "\n";
+    } 
+
+  // Verify against analytic result.
+  const RealType eps = 1E-01;  // tolerance
+
+  // Nearest neighbor peak (ud) | Distance = 1
+  REQUIRE( std::fabs( gofr[10] - 0.00000 ) < eps );
+  REQUIRE( std::fabs( gofr[30] - 4.32744 ) < eps );
+  REQUIRE( std::fabs( gofr[50] - 0.00000 ) < eps );
+
+  // 2nd-nearest neighbor peak (uu/dd) | Distance = sqrt(2)
+  REQUIRE( std::fabs( gofr[14] - 2.96827 ) < eps );
+  REQUIRE( std::fabs( gofr[34] - 0.00000 ) < eps );
+  REQUIRE( std::fabs( gofr[54] - 2.96827 ) < eps );
+
+  // 3rd-nearest neighbor peak (ud) | Distance = sqrt(3)
+  REQUIRE( std::fabs( gofr[17] - 0.00000 ) < eps );
+  REQUIRE( std::fabs( gofr[37] - 0.50103 ) < eps );
+  REQUIRE( std::fabs( gofr[57] - 0.00000 ) < eps );
+
+  delete paircorr;
+  std::cout << "test_paircorr:: STOP\n";
+}
+} // namespace qmcplusplus


### PR DESCRIPTION
Fixed PairCorrEstimator so that it will pass unit test.

The reason it failed was that norm_factor was built using two approximations:
1.) Small delta approximation: (r+delta)^3 - r^3 = 3*delta*r^2 + 3*r*delta^2 ~ 3*delta*r^2
2.) Large N approximation: N(N-1) = N^2 - N ~ N^2

Both approximations are badly violated for a small cell with a large delta and small number of particles, which is exactly the case for the unit test.

Because computing the normalization is not the computational bottleneck in a typical QMC calculation, I changed norm_factor to use the exact expressions.