### PR TITLE
Fix LCAO supertwist (0 0 0) with complex part

### DIFF
--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -861,18 +861,8 @@ void LCAOrbitalBuilder::LoadFullCoefsFromH5(hdf_archive& hin,
   setname = name;
   readRealMatrixFromH5(hin, setname, Creal);
 
-  if (std::abs(SuperTwist[0] - 0.0) < 1e-6 && std::abs(SuperTwist[1] - 0.0) < 1e-6 &&
-      std::abs(SuperTwist[2] - 0.0) < 1e-6)
-  {
-    for (int i = 0; i < Ccmplx.rows(); i++)
-      for (int j = 0; j < Ccmplx.cols(); j++)
-        Ccmplx[i][j] = 0.0;
-  }
-  else
-  {
-    setname = std::string(name) + "_imag";
-    readRealMatrixFromH5(hin, setname, Ccmplx);
-  }
+  setname = std::string(name) + "_imag";
+  readRealMatrixFromH5(hin, setname, Ccmplx);
 
   for (int i = 0; i < Ctemp.rows(); i++)
     for (int j = 0; j < Ctemp.cols(); j++)


### PR DESCRIPTION
Fix case where SuperTwisit 0 0 0 still has Complex component - Was previously forced to put imaginary part to 0. (case of super cells 3x3x3 5x5x5 etc.. ) 