### PR TITLE
[Hold] Nexus: clean executables

### DIFF
--- a/nexus/bin/qdens
+++ b/nexus/bin/qdens
@@ -1,50 +1,126 @@
 #! /usr/bin/env python
 
 import gc
-from numpy import ceil,sqrt,dot,ndarray,arange,savetxt
-from numpy.linalg import norm
-from generic import obj
-from developer import DevBase,error,ci,unavailable
-import memory
-from hdfreader import HDFreader
-from fileio import XsfFile,ChgcarFile
-from structure import read_structure,Structure
-from numerics import simplestats,simstats
-from qmcpack_input import QmcpackInput
-from qmcpack_input import spindensity as spindensity_xml
-from plotting import *
-
 import os
+from optparse import OptionParser
 
+
+def find_nexus_modules():
+    import sys
+    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','lib'))
+    assert(os.path.exists(nexus_lib))
+    sys.path.append(nexus_lib)
+#end def find_nexus_modules
+
+
+def import_nexus_module(module_name):
+    import importlib
+    return importlib.import_module(module_name)
+#end def import_nexus_module
+
+
+# Load Nexus modules
 try:
-    from optparse import OptionParser
+    # Attempt specialized path-based imports.
+    #  (The executable should still work even if Nexus is not installed)
+    find_nexus_modules()
+
+    generic = import_nexus_module('generic')
+    obj = generic.obj
+    del generic
+
+    developer = import_nexus_module('developer')
+    DevBase     = developer.DevBase
+    error       = developer.error
+    ci          = developer.ci
+    unavailable = developer.unavailable
+    del developer
+
+    memory = import_nexus_module('memory')
+
+    hdfreader = import_nexus_module('hdfreader')
+    HDFreader = hdfreader.HDFreader
+    del hdfreader
+
+    fileio = import_nexus_module('fileio')
+    XsfFile    = fileio.XsfFile
+    ChgcarFile = fileio.ChgcarFile
+    del fileio
+
+    structure = import_nexus_module('structure')
+    read_structure = structure.read_structure
+    Structure      = structure.Structure
+    del structure
+
+    numerics = import_nexus_module('numerics')
+    simplestats = numerics.simplestats
+    simstats    = numerics.simstats
+    del numerics
+
+    qmcpack_input = import_nexus_module('qmcpack_input')
+    QmcpackInput    = qmcpack_input.QmcpackInput
+    spindensity_xml = qmcpack_input.spindensity
+    del qmcpack_input
 except:
-    OptionParser = unavailable('optparse','OptionParser')
+    from generic import obj
+    from developer import DevBase,error,ci,unavailable
+    import memory
+    from hdfreader import HDFreader
+    from fileio import XsfFile,ChgcarFile
+    from structure import read_structure,Structure
+    from numerics import simplestats,simstats
+    from qmcpack_input import QmcpackInput
+    from qmcpack_input import spindensity as spindensity_xml
 #end try
+
+
 try:
     import h5py
 except:
     h5py = unavailable('h5py')
 #end try
 try:
-    from numpy import array,ones
+    import numpy as np
 except:
-    array,ones = unavailable('numpy','array','ones')
+    np = unavailable('numpy')
+#end try
+
+
+try:
+    import matplotlib
+    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
+    for gui in gui_envs:
+        try:
+            matplotlib.use(gui,warn=False, force=True)
+            from matplotlib import pyplot
+            success = True
+            break
+        except:
+            continue
+        #end try
+    #end for
+    import matplotlib.pyplot as plt
+    params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
+          'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
+    plt.rcParams.update(params)
+except:
+    plt = unavailable('matplotlib.pyplot')
 #end try
 
 
 
 
+
 def h5_int(val):
-    return int(array(val))
+    return int(np.array(val))
 #end def h5_int
 
 def h5_float(val):
-    return float(array(val))
+    return float(np.array(val))
 #end def h5_float
 
 def h5_array(val):
-    return array(val)
+    return np.array(val)
 #end def h5_array
 
 
@@ -102,7 +178,7 @@ def get_grid(s,dr):
     grid = []
     n = 0
     for a in s.axes:
-        grid.append(int(ceil(sqrt(dot(a,a))/dr[n])))
+        grid.append(int(np.ceil(np.sqrt(np.dot(a,a))/dr[n])))
         n+=1
     #end for
     return tuple(grid)
@@ -204,23 +280,23 @@ class SingleDensity(QDBase):
             self.read(filepath,format)
         #end if
         # check that inputted types meet expectations
-        self.check_type('mean'     ,mean     ,'list/ndarray'      ,(list,ndarray))
-        self.check_type('error'    ,error    ,'list/ndarray'      ,(list,ndarray))
-        self.check_type('grid'     ,grid     ,'tuple/list/ndarray',(tuple,list,ndarray))
+        self.check_type('mean'     ,mean     ,'list/ndarray'      ,(list,np.ndarray))
+        self.check_type('error'    ,error    ,'list/ndarray'      ,(list,np.ndarray))
+        self.check_type('grid'     ,grid     ,'tuple/list/ndarray',(tuple,list,np.ndarray))
         self.check_type('structure',structure,'Structure'         ,Structure)
         self.check_type('extension',extension,'string'            ,str)
         # process other inputs
         if mean is not None:
-            self.mean = array(mean,dtype=float)
+            self.mean = np.array(mean,dtype=float)
         #end if
         if error is not None:
-            self.error = array(error,dtype=float)
+            self.error = np.array(error,dtype=float)
         #end if
         if grid is not None:
             if len(grid)!=3:
                 self._error('inputted grid must have length 3, received {0}'.format(grid))
             #end if
-            self.grid = array(grid,dtype=int)
+            self.grid = np.array(grid,dtype=int)
         #end if
         if structure is not None:
             self.structure = structure.copy()
@@ -257,7 +333,7 @@ class SingleDensity(QDBase):
 
 
     def analyze(self,data):
-        self.check_type('data',data,'list/ndarray',(list,ndarray),False)
+        self.check_type('data',data,'list/ndarray',(list,np.ndarray),False)
         self.mean,self.error = simplestats(data,dim=0)
     #end def analyze
 
@@ -571,7 +647,7 @@ class StatFile(QDBase):
         if opt.structure is not None:
             s = opt.structure.copy()
             s.change_units('A')
-            rmax = norm(s.axes[dim])
+            rmax = np.linalg.norm(s.axes[dim])
         else:
             rmax = None
         #end if
@@ -592,26 +668,26 @@ class StatFile(QDBase):
             data = data.sum(2)
             lmean,lvar,lerror,lkappa = simstats(data,dim=0)
             if rmax is None:
-                r = arange(len(lmean))
+                r = np.arange(len(lmean))
                 xlab = 'bin number'
                 ylab = '$N_e$/bin'
             else:
                 dr = rmax/len(lmean)
-                r = dr/2+dr*arange(len(lmean),dtype=float)
+                r = dr/2+dr*np.arange(len(lmean),dtype=float)
                 lmean/=dr
                 lerror/=dr
                 xlab = sdim+' ($\AA$)'.format(dim)
                 ylab = '$N_e/\AA$'
             #end if
-            figure(tight_layout=True)
-            errorbar(r,lmean,lerror,fmt='b.-')
-            xlabel(xlab)
-            ylabel(ylab)
-            title('{0}  (axis {1})  {2}'.format(name,dim,os.path.split(self.file_prefix)[1]))
+            plt.figure(tight_layout=True)
+            plt.errorbar(r,lmean,lerror,fmt='b.-')
+            plt.xlabel(xlab)
+            plt.ylabel(ylab)
+            plt.title('{0}  (axis {1})  {2}'.format(name,dim,os.path.split(self.file_prefix)[1]))
             self.vlog('        creating file {0}.pdf'.format(prefix))
-            savefig(prefix+'.pdf')
+            plt.savefig(prefix+'.pdf')
             self.vlog('        creating file {0}.dat'.format(prefix))
-            savetxt(prefix+'.dat',array(zip(r,lmean,lerror)))
+            np.savetxt(prefix+'.dat',np.array(zip(r,lmean,lerror)))
         #end for
     #end def line_plot
 #end class StatFile
@@ -738,7 +814,7 @@ class QMCDensityProcessor(QDBase):
                 if isinstance(ei,int):
                     e = ei
                 elif isinstance(ei,(list,tuple)):
-                    ei = array(ei,dtype=int)
+                    ei = np.array(ei,dtype=int)
                     for s in range(len(ei)):
                         e[s] = ei[s]
                     #end for
@@ -769,7 +845,7 @@ class QMCDensityProcessor(QDBase):
                     if isinstance(ei,int):
                         e = ei
                     elif isinstance(ei,(list,tuple)):
-                        ei = array(ei,dtype=int)
+                        ei = np.array(ei,dtype=int)
                         for s in range(len(ei)):
                             e[s] = ei[s]
                         #end for
@@ -794,7 +870,7 @@ class QMCDensityProcessor(QDBase):
                 weight_failed = False
                 try:
                     w = comma_list(ws)
-                    w = array(eval(w),dtype=float)
+                    w = np.array(eval(w),dtype=float)
                     opt.weights = w
                     weight_failed = len(w.shape)!=1
                 except:
@@ -862,7 +938,7 @@ class QMCDensityProcessor(QDBase):
         if opt.cell is not None:
             cell = input_list(opt.cell)
             try:
-                cell = array(cell,dtype=float)
+                cell = np.array(cell,dtype=float)
             except:
                 self.error('--cell input misformatted\nexpected a list of real values\nreceived: {0}'.format(cell))
             #end try
@@ -879,7 +955,7 @@ class QMCDensityProcessor(QDBase):
         if opt.grid is not None:
             grid = input_list(opt.grid)
             try:
-                grid = array(grid,dtype=int)
+                grid = np.array(grid,dtype=int)
             except:
                 self.error('--grid input misformatted\nexpected a list of integers\nreceived: {0}'.format(grid))
             #end try
@@ -978,7 +1054,7 @@ class QMCDensityProcessor(QDBase):
                     sfiles = stat_files[series]
                     if len(sfiles)>1:
                         if opt.weights is None:
-                            weights = ones((len(sfiles),),dtype=float)
+                            weights = np.ones((len(sfiles),),dtype=float)
                         else:
                             if len(sfiles)!=len(opt.weights):
                                 self.error('weights provided do not match number of files in series {0}\nnumber of weights provided: {1}\nnumber of files in series {0}: {2}\nfiles in series {0}:\n{3}'.format(series,len(opt.weights),len(sfiles),sfiles))
@@ -1040,7 +1116,7 @@ class QMCDensityProcessor(QDBase):
             #end if
         #end for
         if not opt.noplot and opt.lineplot is not None:
-            show()
+            plt.show()
         #end if
     #end def process
 #end class QMCDensityProcessor

--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -46,22 +46,10 @@ def find_nexus_modules():
 #end def find_nexus_modules
 
 
-def import_nexus_module(module_name,full=False,mod_only=False):
+def import_nexus_module(module_name):
     import inspect
     import importlib
-    members = dict()
-    module = importlib.import_module(module_name)
-    for name,member in inspect.getmembers(module):
-        members[name] = member
-    #end for
-    assert(len(members)>0)
-    if mod_only:
-        return module
-    elif full:
-        return module,members
-    else:
-        return members
-    #end if
+    return importlib.import_module(module_name)
 #end def import_nexus_module
 
 
@@ -72,23 +60,23 @@ try:
     find_nexus_modules()
 
     generic = import_nexus_module('generic')
-    obj   = generic['obj']
-    log   = generic['log']
-    warn  = generic['warn']
-    error = generic['error']
+    obj   = generic.obj
+    log   = generic.log
+    warn  = generic.warn
+    error = generic.error
     del generic
 
     developer = import_nexus_module('developer')
-    DevBase = developer['DevBase']
+    DevBase = developer.DevBase
     del developer
 
     numerics = import_nexus_module('numerics')
-    jackknife            = numerics['jackknife']
-    jackknife_aux        = numerics['jackknife_aux']
-    simstats             = numerics['simstats']
-    equilibration_length = numerics['equilibration_length']
-    curve_fit            = numerics['curve_fit']
-    least_squares        = numerics['least_squares']
+    jackknife            = numerics.jackknife
+    jackknife_aux        = numerics.jackknife_aux
+    simstats             = numerics.simstats
+    equilibration_length = numerics.equilibration_length
+    curve_fit            = numerics.curve_fit
+    least_squares        = numerics.least_squares
     del numerics
 except:
     # Failing path-based imports, import installed Nexus modules.

--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -1,16 +1,21 @@
 #! /usr/bin/env python
 
 import os
-from numpy import array,loadtxt,polyfit,polyval,ndarray,sqrt,floor,sign,linspace
-from numpy import log as nlog
-import numpy.random as random
+import sys
 from optparse import OptionParser
-import inspect
+
+try:
+    import numpy as np
+except:
+    print('qmc-fit error: numpy is not present on your machine.\n  Please install scipy and retry.')
+#end try
+
 try:
     from scipy.optimize import fmin
 except ImportError:
-    print 'qmc-fit error: scipy is not present on your machine\n  please install scipy and retry'
+    print('qmc-fit error: scipy is not present on your machine.\n  Please install scipy and retry.')
 #end try
+
 try:
     import matplotlib
     gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
@@ -23,1023 +28,76 @@ try:
             continue
         #end try
     #end for
-    from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
-
+    import matplotlib.pyplot as plt
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
-    rcParams.update(params)
+    plt.rcParams.update(params)
     plots_available = True
 except (ImportError,RuntimeError):
     plots_available = False
 #end try
 
 
-import sys
-import traceback
-from copy import deepcopy
-import cPickle
-from random import randint
-
-exit_call = sys.exit
-devlog    = sys.stdout
-
-def nocopy(value):
-    return value
-#end def nocopy
-
-
-def log(*items,**kwargs):
-    indent=None
-    logfile=devlog
-    if len(kwargs)>0:
-        n=0
-        if 'indent' in kwargs:
-            indent = kwargs['indent']
-            n+=1
-        #end if
-        if 'logfile' in kwargs:
-            logfile = kwargs['logfile']
-            n+=1
-        #end if
-        if n!=len(kwargs):
-            valid = 'indent logfile'.split()
-            invalid = set(kwargs.keys())-set(valid)
-            error('invalid keyword arguments provided\ninvalid keywords: {0}\nvalid options are: {1}'.format(sorted(invalid),valid))
-        #end if
-    #end if
-    if len(items)==1 and isinstance(items[0],str):
-        s = items[0]
-    else:
-        s=''
-        for item in items:
-            s+=str(item)+' '
-        #end for
-    #end if
-    if len(s)>0:
-        if isinstance(indent,str):
-            s=indent+s.replace('\n','\n'+indent)
-        #end if
-        s += '\n'
-    #end if
-    logfile.write(s)
-#end def log
-
-
-def message(msg,header=None,post_header=' message:',indent='    ',logfile=devlog):
-    if header is None:
-        header = post_header.lstrip()
-    else:
-        header += post_header
-    #end if
-    log('\n  '+header)
-    log(msg.rstrip(),indent=indent,logfile=logfile)
-#end def message
-
-
-def warn(msg,header='qmc-fit',indent='    ',logfile=devlog):
-    post_header=' warning:'
-    message(msg,header,post_header,indent,logfile)
-#end def warn
-
-
-def error(msg,header='qmc-fit',exit=True,trace=False,indent='    ',logfile=devlog):
-    post_header=' error:'
-    message(msg,header,post_header,indent,logfile)
-    if exit:
-        log('  exiting.\n')
-        if trace:
-            traceback.print_stack()
-        #end if
-        exit_call()
-    #end if
-#end def error
-
-
-
-class object_interface(object):
-    _logfile = sys.stdout
-
-    def __len__(self):
-        return len(self.__dict__)
-    #end def __len__
-
-    def __contains__(self,name):
-        return name in self.__dict__
-    #end def
-
-    def __getitem__(self,name):
-        return self.__dict__[name]
-    #end def __getitem__
-
-    def __setitem__(self,name,value):
-        self.__dict__[name]=value
-    #end def __setitem__
-
-    def __delitem__(self,name):
-        del self.__dict__[name]
-    #end def __delitem__
-
-    def __iter__(self):
-        for item in self.__dict__:
-            yield self.__dict__[item]
-        #end for
-    #end def __iter__
-
-    def __repr__(self):
-        s=''
-        for k in sorted(self._keys()):
-            if not isinstance(k,str) or k[0]!='_':
-                v=self.__dict__[k]
-                if hasattr(v,'__class__'):
-                    s+='  {0:<20}  {1:<20}\n'.format(k,v.__class__.__name__)
-                else:
-                    s+='  {0:<20}  {1:<20}\n'.format(k,type(v))
-                #end if
-            #end if
-        #end for
-        return s
-    #end def __repr__
-
-    def __str__(self,nindent=1):
-        pad = '  '
-        npad = nindent*pad
-        s=''
-        normal = []
-        qable  = []
-        for k,v in self._iteritems():
-            if not isinstance(k,str) or k[0]!='_':
-                if isinstance(v,object_interface):
-                    qable.append(k)
-                else:
-                    normal.append(k)
-                #end if
-            #end if
-        #end for
-        normal.sort()
-        qable.sort()
-        indent = npad+18*' '
-        for k in normal:
-            v = self[k]
-            vstr = str(v).replace('\n','\n'+indent)
-            s+=npad+'{0:<15} = '.format(k)+vstr+'\n'
-        #end for
-        for k in qable:
-            v = self[k]
-            s+=npad+str(k)+'\n'
-            s+=v.__str__(nindent+1)
-            if isinstance(k,str):
-                s+=npad+'end '+k+'\n'
-            #end if
-        #end for
-        return s
-    #end def __str__
-
-    def __eq__(self,other): 
-        if not hasattr(other,'__dict__'):
-            return False
-        #end if
-        eq = True
-        for sname in self.__dict__:
-            if sname not in other.__dict__:
-                return False
-            #end if
-            svar  =  self.__dict__[sname]
-            ovar  = other.__dict__[sname]
-            stype = type(svar)
-            otype = type(ovar)
-            if stype!=otype:
-                return False
-            #end if
-            eqval = svar==ovar
-            if isinstance(eqval,bool):
-                eq &= eqval
-            else:
-                try: # accommodate numpy arrays implicitly
-                    eq &= eqval.all()
-                except:
-                    return False
-                #end try
-            #end if
-        #end for
-        return eq
-    #end def __eq__
-
-
-    # dict interface
-    def keys(self):
-        return self.__dict__.keys()
-    #end def keys
-
-    def values(self):
-        return self.__dict__.values()
-    #end def values
-
-    def items(self):
-        return self.__dict__.items()
-    #end def items
-
-    def iterkeys(self):
-        return self.__dict__.iterkeys()
-    #end def iterkeys
-
-    def itervalues(self):
-        return self.__dict__.itervalues()
-    #end def itervalues
-
-    def iteritems(self):
-        return self.__dict__.iteritems()
-    #end def iteritems
-
-    def copy(self):
-        return deepcopy(self)
-    #end def copy
-
-    def clear(self):
-        self.__dict__.clear()
-    #end def clear
-
-
-    # save/load
-    def save(self,fpath=None):
-        if fpath==None:
-            fpath='./'+self.__class__.__name__+'.p'
-        #end if
-        fobj = open(fpath,'w')
-        binary = cPickle.HIGHEST_PROTOCOL
-        cPickle.dump(self,fobj,binary)
-        fobj.close()
-        del fobj
-        del binary
-        return
-    #end def save
-
-    def load(self,fpath=None):
-        if fpath==None:
-            fpath='./'+self.__class__.__name__+'.p'
-        #end if
-        fobj = open(fpath,'r')
-        tmp = cPickle.load(fobj)
-        fobj.close()
-        d = self.__dict__
-        d.clear()
-        for k,v in tmp.__dict__.iteritems():
-            d[k] = v
-        #end for
-        del fobj
-        del tmp
-        return
-    #end def load
-
-
-
-    # log, warning, and error messages
-    def open_log(self,filepath):
-        self._logfile = open(filepath,'w')
-    #end def open_log
-
-    def close_log(self):
-        self._logfile.close()
-    #end def close_log
-
-    def write(self,s):
-        self._logfile.write(s)
-    #end def write
-
-    def log(self,*items,**kwargs):
-        if 'logfile' not in kwargs:
-            kwargs['logfile'] = self._logfile
-        #end if
-        log(*items,**kwargs)
-    #end def log
-
-    def warn(self,message,header=None):
-        if header is None:
-            header=self.__class__.__name__
-        #end if
-        warn(message,header,logfile=self._logfile)
-    #end def warn
-
-    def error(self,message,header=None,exit=True,trace=True):
-        if header==None:
-            header = self.__class__.__name__
-        #end if
-        error(message,header,exit,trace,logfile=self._logfile)
-    #end def error
-
-    @classmethod
-    def class_log(cls,message):
-        log(message,logfile=cls._logfile)
-    #end def class_log
-
-    @classmethod
-    def class_warn(cls,message,header=None,post_header=' Warning:'):
-        if header==None:
-            header=cls.__name__
-        #end if
-        warn(message,header,logfile=cls._logfile)
-    #end def class_warn
-
-    @classmethod
-    def class_error(cls,message,header=None,exit=True,trace=True,post_header=' Error:'):
-        if header==None:
-            header = cls.__name__
-        #end if
-        error(message,header,exit,trace,logfile=cls._logfile)
-    #end def class_error
-
-    @classmethod
-    def class_has(cls,k):
-        return hasattr(cls,k)
-    #end def classmethod
-
-    @classmethod
-    def class_keys(cls):
-        return cls.__dict__.keys()
-    #end def class_keys
-
-    @classmethod
-    def class_iteritems(cls):
-        return cls.__dict__.iteritems()
-    #end def class_iteritems
-
-    @classmethod
-    def class_get(cls,k):
-        return getattr(cls,k)
-    #end def class_set
-
-    @classmethod
-    def class_set(cls,**kwargs):
-        for k,v in kwargs.iteritems():
-            setattr(cls,k,v)
-        #end for
-    #end def class_set
-
-    @classmethod
-    def class_set_single(cls,k,v):
-        setattr(cls,k,v)
-    #end def class_set_single
-
-    @classmethod
-    def class_set_optional(cls,**kwargs):
-        for k,v in kwargs.iteritems():
-            if not hasattr(cls,k):
-                setattr(cls,k,v)
-            #end if
-        #end for
-    #end def class_set_optional
-
-
-    # access preserving functions
-    #  dict interface
-    def _keys(self,*args,**kwargs):
-        return object_interface.keys(self,*args,**kwargs)
-    def _values(self,*args,**kwargs):
-        object_interface.values(self,*args,**kwargs)
-    def _items(self,*args,**kwargs):         
-        return object_interface.items(self,*args,**kwargs)         
-    def _iterkeys(self,*args,**kwargs):
-        return object_interface.iterkeys(self,*args,**kwargs)
-    def _itervalues(self,*args,**kwargs):
-        object_interface.itervalues(self,*args,**kwargs)
-    def _iteritems(self,*args,**kwargs):         
-        return object_interface.iteritems(self,*args,**kwargs)         
-    def _copy(self,*args,**kwargs):              
-        return object_interface.copy(self,*args,**kwargs)
-    def _clear(self,*args,**kwargs):
-        object_interface.clear(self,*args,**kwargs)
-    #  save/load
-    def _save(self,*args,**kwargs):
-        object_interface.save(self,*args,**kwargs)
-    def _load(self,*args,**kwargs):
-        object_interface.load(self,*args,**kwargs)
-    #  log, warning, and error messages
-    def _open_log(self,*args,**kwargs):
-        object_interface.open_log(self,*args,**kwargs)
-    def _close_log(self,*args,**kwargs):
-        object_interface.close_log(self,*args,**kwargs)
-    def _write(self,*args,**kwargs):
-        object_interface.write(self,*args,**kwargs)
-    def _log(self,*args,**kwargs):
-        object_interface.log(self,*args,**kwargs)
-    def _error(self,*args,**kwargs):
-        object_interface.error(self,*args,**kwargs)
-    def _warn(self,*args,**kwargs):
-        object_interface.warn(self,*args,**kwargs)
-
-#end class object_interface
-
-
-
-class obj(object_interface):
-
-    def __init__(self,*vars,**kwargs):
-        for var in vars:
-            if isinstance(var,(dict,object_interface)):
-                for k,v in var.iteritems():
-                    self[k] = v
-                #end for
-            else:
-                self[var] = None
-            #end if
-        #end for
-        for k,v in kwargs.iteritems():
-            self[k] = v
-        #end for
-    #end def __init__
-
-
-    # list interface
-    def append(self,value):
-        self[len(self)] = value
-    #end def append
-
-
-    # return representations
-    def list(self,*keys):
-        nkeys = len(keys)
-        if nkeys==0:
-            keys = sorted(self._keys())
-        elif nkeys==1 and isinstance(keys[0],(list,tuple)):
-            keys = keys[0]
-        #end if
-        values = []
-        for key in keys:
-            values.append(self[key])
-        #end if
-        return values
-    #end def list
-
-    def list_optional(self,*keys):
-        nkeys = len(keys)
-        if nkeys==0:
-            keys = sorted(self._keys())
-        elif nkeys==1 and isinstance(keys[0],(list,tuple)):
-            keys = keys[0]
-        #end if
-        values = []
-        for key in keys:
-            if key in self:
-                values.append(self[key])
-            else:
-                values.append(None)
-            #end if
-        #end if
-        return values
-    #end def list_optional
-
-    def tuple(self,*keys):
-        return tuple(obj.list(self,*keys))
-    #end def tuple
-
-    def dict(self,*keys):
-        nkeys = len(keys)
-        if nkeys==0:
-            keys = sorted(self._keys())
-        elif nkeys==1 and isinstance(keys[0],(list,tuple)):
-            keys = keys[0]
-        #end if
-        d = dict()
-        for k in keys:
-            d[k] = self[k]
-        #end for
-        return d
-    #end def dict
-
-    def to_dict(self):
-        d = dict()
-        for k,v in self:
-            if isinstance(v,obj):
-                d[k] = v.to_dict()
-            else:
-                d[k] = v
-            #end if
-        #end for
-        return d
-    #end def to_dict
-
-    def obj(self,*keys):
-        nkeys = len(keys)
-        if nkeys==0:
-            keys = sorted(self._keys())
-        elif nkeys==1 and isinstance(keys[0],(list,tuple)):
-            keys = keys[0]
-        #end if
-        o = obj()
-        for k in keys:
-            o[k] = self[k]
-        #end for
-        return o
-    #end def obj
-
-
-    # list extensions
-    def first(self):
-        return self[min(self._keys())]
-    #end def first
-
-    def last(self):
-        return self[max(self._keys())]
-    #end def last
-
-    def select_random(self): 
-        return self[randint(0,len(self)-1)]
-    #end def select_random
-
-
-    # dict extensions
-    def set(self,*objs,**kwargs):
-        for key,value in kwargs.iteritems():
-            self[key]=value
-        #end for
-        if len(objs)>0:
-            for o in objs:
-                for k,v in o.iteritems():
-                    self[k] = v
-                #end for
-            #end for
-        #end if
-        return self
-    #end def set
-
-    def set_optional(self,*objs,**kwargs):
-        for key,value in kwargs.iteritems():
-            if key not in self:
-                self[key]=value
-            #end if
-        #end for
-        if len(objs)>0:
-            for o in objs:
-                for k,v in o.iteritems():
-                    if k not in self:
-                        self[k] = v
-                    #end if
-                #end for
-            #end for
-        #end if
-        return self
-    #end def set_optional
-
-    def set_path(self,path,value=None):
-        o = self
-        cls = self.__class__
-        if isinstance(path,str):
-            path = path.split('/')
-        #end if
-        for p in path[0:-1]:
-            if not p in o:
-                o[p] = cls()
-            #end if
-            o = o[p]
-        #end for
-        o[path[-1]] = value
-    #end def set_path
-
-    def get(self,key,value=None): # follow dict interface, no plural
-        if key in self:
-            value = self[key]
-        #end if
-        return value
-    #end def get
-
-    def get_optional(self,key,value=None):
-        if key in self:
-            value = self[key]
-        #end if
-        return value
-    #end def get_optional
-
-    def get_required(self,key):
-        if key in self:
-            value = self[key]
-        else:
-            obj.error(self,'a required key is not present\nkey required: {0}\nkey present: {1}'.format(key,sorted(self._keys())))
-        #end if
-        return value
-    #end def get_required
-
-    def delete(self,*keys):
-        nkeys = len(keys)
-        if nkeys==0:
-            keys = sorted(self._keys())
-        elif nkeys==1 and isinstance(keys[0],(list,tuple)):
-            keys = keys[0]
-        #end if
-        values = []
-        for key in keys:
-            values.append(self[key])
-            del self[key]
-        #end for
-        return values
-    #end def delete
-
-    def delete_optional(self,key,value=None):
-        if key in self:
-            value = self[key]
-            del self[key]
-        #end if
-        return value
-    #end def delete_optional
-
-    def delete_required(self,key):
-        if key in self:
-            value = self[key]
-            del self[key]
-        else:
-            obj.error(self,'a required key is not present\nkey required: {0}\nkeys present: {1}'.format(key,sorted(self._keys())))
-        #end if
-        return value
-    #end def delete_required
-
-    def transfer_from(self,other,keys=None,copy=False,overwrite=True):
-        if keys==None:
-            if isinstance(other,object_interface):
-                keys = other._keys()
-            else:
-                keys = other.keys()
-            #end if
-        #end if
-        if copy:
-            copier = deepcopy
-        else:
-            copier = nocopy
-        #end if
-        if overwrite:
-            for k in keys:
-                self[k]=copier(other[k])
-            #end for
-        else:
-            for k in keys:
-                if k not in self:
-                    self[k]=copier(other[k])
-                #end if
-            #end for            
-        #end if
-    #end def transfer_from
-
-    def transfer_to(self,other,keys=None,copy=False,overwrite=True):
-        if keys==None:
-            keys = self._keys()
-        #end if
-        if copy:
-            copier = deepcopy
-        else:
-            copier = nocopy
-        #end if
-        if overwrite:
-            for k in keys:
-                other[k]=copier(self[k])
-            #end for
-        else:
-            for k in keys:
-                if k not in self:
-                    other[k]=copier(self[k])
-                #end if
-            #end for            
-        #end if
-    #end def transfer_to
-
-    def move_from(self,other,keys=None):
-        if keys==None:
-            if isinstance(other,object_interface):
-                keys = other._keys()
-            else:
-                keys = other.keys()
-            #end if
-        #end if
-        for k in keys:
-            self[k]=other[k]
-            del other[k]
-        #end for
-    #end def move_from
-
-    def move_to(self,other,keys=None):
-        if keys==None:
-            keys = self._keys()
-        #end if
-        for k in keys:
-            other[k]=self[k]
-            del self[k]
-        #end for
-    #end def move_to
-
-    def copy_from(self,other,keys=None,deep=True):
-        obj.transfer_from(self,other,keys,copy=deep)
-    #end def copy_from
-
-    def copy_to(self,other,keys=None,deep=True):
-        obj.transfer_to(self,other,keys,copy=deep)
-    #end def copy_to
-
-    def shallow_copy(self):
-        new = self.__class__()
-        for k,v in self._iteritems():
-            self[k] = v
-        #end for
-        return new
-    #end def shallow_copy
-
-    def inverse(self):
-        new = self.__class__()
-        for k,v in self._iteritems():
-            new[v] = k
-        #end for
-        return new
-    #end def inverse
-
-
-
-    # access preserving functions
-    #  list interface
-    def _append(self,*args,**kwargs):
-        obj.append(self,*args,**kwargs)
-    #  return representations
-    def _list(self,*args,**kwargs):
-        return obj.list(self,*args,**kwargs)
-    def _list_optional(self,*args,**kwargs):
-        return obj.list_optional(self,*args,**kwargs)
-    def _tuple(self,*args,**kwargs):
-        return obj.tuple(self,*args,**kwargs)
-    def _dict(self,*args,**kwargs):
-        return obj.dict(self,*args,**kwargs)
-    def _to_dict(self,*args,**kwargs):
-        return obj.to_dict(self,*args,**kwargs)
-    def _obj(self,*args,**kwargs):
-        return obj.obj(self,*args,**kwargs)
-    #  list extensions
-    def _first(self,*args,**kwargs):
-        return obj.first(self,*args,**kwargs)
-    def _last(self,*args,**kwargs):
-        return obj.last(self,*args,**kwargs)
-    def _select_random(self,*args,**kwargs):
-        return obj.select_random(self,*args,**kwargs)
-    #  dict extensions
-    def _set(self,*args,**kwargs):
-        obj.set(self,*args,**kwargs)
-    def _set_optional(self,*args,**kwargs):
-        obj.set_optional(self,*args,**kwargs)
-    def _set_path(self,*args,**kwargs):
-        obj.set_path(self,*args,**kwargs)
-    def _get(self,*args,**kwargs):
-        obj.get(self,*args,**kwargs)
-    def _get_optional(self,*args,**kwargs):
-        obj.get_optional(self,*args,**kwargs)
-    def _get_required(self,*args,**kwargs):
-        obj.get_required(self,*args,**kwargs)
-    def _delete(self,*args,**kwargs):
-        obj.delete(self,*args,**kwargs)
-    def _delete_optional(self,*args,**kwargs):
-        obj.delete_optional(self,*args,**kwargs)
-    def _delete_required(self,*args,**kwargs):
-        obj.delete_required(self,*args,**kwargs)
-    def _transfer_from(self,*args,**kwargs):
-        obj.transfer_from(self,*args,**kwargs)
-    def _transfer_to(self,*args,**kwargs):
-        obj.transfer_to(self,*args,**kwargs)
-    def _move_from(self,*args,**kwargs):
-        obj.move_from(self,*args,**kwargs)
-    def _move_to(self,*args,**kwargs):
-        obj.move_to(self,*args,**kwargs)
-    def _copy_from(self,*args,**kwargs):
-        obj.copy_from(self,*args,**kwargs)
-    def _copy_to(self,*args,**kwargs):
-        obj.copy_to(self,*args,**kwargs)
-    def _shallow_copy(self,*args,**kwargs):
-        obj.shallow_copy(self,*args,**kwargs)
-    def _inverse(self,*args,**kwargs):
-        return obj.inverse(self,*args,**kwargs)
-
-#end class obj
-
-
-
-class DevBase(obj):
-    None
-#end class DevBase
-
-
-
-
-
-
-
-# minimizers
-least_squares = lambda p,x,y,f: ((f(p,x)-y)**2).sum()
-absmin        = lambda p,x,y,f: abs(f(p,x)-y).sum()
-madmin        = lambda p,x,y,f: abs(f(p,x)-y).max()
-
-
-# curve fit based on fmin from scipy
-def curve_fit(x,y,f,p0,minimizer=least_squares,optimizer='fmin'):
-    if optimizer=='fmin':
-        p = fmin(minimizer,p0,args=(x,y,f),maxiter=10000,maxfun=10000,disp=0)
-    else:
-        error('optimizers other than fmin are not supported yet')
-    return p
-#end def curve_fit
-
-
-
-
-# jackknife
-#   data: a multi-dimensional array with blocks as the first dimension
-#         nblocks = data.shape[0]
-#   function: a function that takes an array for one block (e.g. data[0])
-#             and returns an array or a tuple/list of scalars and arrays
-#             ret = function(*args,**kwargs)
-#   args: a list-like object of positional input arguments
-#   kwargs: a dict-like object of keyword input arguments
-#   position: location to place input_array in input arguments
-#             if integer, will be placed in args:   args[position] = input_array
-#             if string , will be placed in kwargs: kwargs[position] = input_array
-#   capture: an object that will contain most jackknife info upon exit
-def jackknife(data,function,args=None,kwargs=None,position=None,capture=None):
-    capture_results = capture!=None
-    if capture_results:
-        capture.data         = data
-        capture.function     = function
-        capture.args         = args
-        capture.kwargs       = kwargs
-        capture.position     = position
-        capture.jdata        = []
-        capture.jsamples     = []
-    #end if
-    # check the requested argument position
-    argpos,kwargpos,args,kwargs,position = check_jackknife_inputs(args,kwargs,position)
-
-    # obtain sums of the jackknife samples
-    nblocks = data.shape[0]
-    nb = float(nblocks)
-    jnorm   = 1./(nb-1.)
-    data_sum = data.sum(axis=0)
-    array_return = False
-    for b in xrange(nblocks):
-        jdata = jnorm*(data_sum-data[b])
-        if argpos:
-            args[position] = jdata
-        elif kwargpos:
-            kwargs[position] = jdata
-        #end if
-        jsample = function(*args,**kwargs)
-        if b==0:
-            # determine the return type from the first sample
-            # and initialize the jackknife sums
-            array_return = isinstance(jsample,ndarray)
-            if array_return:
-                jsum  = jsample.copy()
-                jsum2 = jsum**2
-            else:
-                jsum  = []
-                jsum2 = []
-                for jval in jsample:
-                    jsum.append(jval)
-                    jsum2.append(jval**2)
-                #end for
-            #end if
-        else:
-            # accumulate the jackknife sums
-            if array_return:
-                jsum  += jsample
-                jsum2 += jsample**2
-            else:
-                for c in xrange(len(jsample)):
-                    jsum[c]  += jsample[c]
-                    jsum2[c] += jsample[c]**2
-                #end for
-            #end if
-        #end if
-        if capture_results:
-            capture.jdata.append(jdata)
-            capture.jsamples.append(jsample)
-        #end if
+def find_nexus_modules():
+    import sys
+    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','lib'))
+    assert(os.path.exists(nexus_lib))
+    sys.path.append(nexus_lib)
+#end def find_nexus_modules
+
+
+def import_nexus_module(module_name,full=False,mod_only=False):
+    import inspect
+    import importlib
+    members = dict()
+    module = importlib.import_module(module_name)
+    for name,member in inspect.getmembers(module):
+        members[name] = member
     #end for
-    # get the jackknife mean and error
-    if array_return:
-        jmean = jsum/nb
-        jerror = sqrt( (nb-1.)/nb*(jsum2-jsum**2/nb) )
+    assert(len(members)>0)
+    if mod_only:
+        return module
+    elif full:
+        return module,members
     else:
-        jmean  = []
-        jerror = []
-        for c in xrange(len(jsum)):
-            jval  = jsum[c]
-            jval2 = jsum2[c]
-            jm = jval/nb
-            je = sqrt( (nb-1.)/nb*(jval2-jval**2/nb) )
-            jmean.append(jm)
-            jerror.append(je)
-        #end for
+        return members
     #end if
-    if capture_results:
-        capture.data_sum     = data_sum
-        capture.nblocks      = nblocks
-        capture.array_return = array_return
-        capture.jsum         = jsum
-        capture.jsum2        = jsum2
-        capture.jmean        = jmean
-        capture.jerror       = jerror
-    #end if
-    return jmean,jerror
-#end def jackknife
+#end def import_nexus_module
 
 
-# get jackknife estimate of auxiliary quantities
-#   jsamples is a subset of jsamples data computed by jackknife above
-#   auxfunc is an additional function to get a jackknife sample of a derived quantity
-def jackknife_aux(jsamples,auxfunc,args=None,kwargs=None,position=None,capture=None):
-    # unpack the argument list if compressed
-    if not inspect.isfunction(auxfunc):
-        if len(auxfunc)==1:
-            auxfunc = auxfunc[0]
-        elif len(auxfunc)==2:
-            auxfunc,args = auxfunc
-        elif len(auxfunc)==3:
-            auxfunc,args,kwargs = auxfunc
-        elif len(auxfunc)==4:
-            auxfunc,args,kwargs,position = auxfunc
-        else:
-            numerics_error('between 1 and 4 fields (auxfunc,args,kwargs,position) can be packed into original auxfunc input, received {0}'.format(len(auxfunc)))
-        #end if
-    #end if
+# Load Nexus modules
+try:
+    # Attempt specialized path-based imports.
+    #  (The executable should still work even if Nexus is not installed)
+    find_nexus_modules()
 
-    # check the requested argument position
-    argpos,kwargpos,args,kwargs,position = check_jackknife_inputs(args,kwargs,position)
+    generic = import_nexus_module('generic')
+    obj   = generic['obj']
+    log   = generic['log']
+    warn  = generic['warn']
+    error = generic['error']
+    del generic
 
-    capture_results = capture!=None
-    if capture_results:
-        capture.auxfunc  = auxfunc 
-        capture.args     = args    
-        capture.kwargs   = kwargs  
-        capture.position = position
-        capture.jdata    = []
-        capture.jsamples = []
-    #end if
+    developer = import_nexus_module('developer')
+    DevBase = developer['DevBase']
+    del developer
 
-    nblocks = len(jsamples)
-    nb      = float(nblocks)
-    for b in xrange(nblocks):
-        jdata = jsamples[b]
-        if argpos:
-            args[position] = jdata
-        elif kwargpos:
-            kwargs[position] = jdata
-        #end if
-        jsample = auxfunc(*args,**kwargs)
-        if b==0:
-            jsum  = jsample.copy()
-            jsum2 = jsum**2
-        else:
-            jsum  += jsample
-            jsum2 += jsample**2
-        #end if
-        if capture_results:
-            capture.jdata.append(jdata)
-            capture.jsamples.append(jsample)
-        #end if
-    #end for
-    jmean = jsum/nb
-    jerror = sqrt( (nb-1.)/nb*(jsum2-jsum**2/nb) )
-
-    if capture_results:
-        capture.nblocks = nblocks
-        capture.jsum    = jsum
-        capture.jsum2   = jsum2
-        capture.jmean   = jmean
-        capture.jerror  = jerror
-    #end if
-
-    return jmean,jerror
-#end def jackknife_aux
-
-
-def check_jackknife_inputs(args,kwargs,position):
-    argpos   = False
-    kwargpos = False
-    if position!=None:
-        if isinstance(position,int):
-            argpos = True
-        elif isinstance(position,str):
-            kwargpos = True
-        else:
-            numerics_error('position must be an integer or keyword, received: {0}'.format(position),'jackknife')
-        #end if
-    elif args is None and kwargs is None:
-        args     = [None]
-        argpos   = True
-        position = 0
-    elif kwargs is None and position is None:
-        argpos   = True
-        position = 0
-    else:
-        numerics_error('function argument position for input data must be provided','jackknife')
-    #end if
-    if args is None:
-        args = []
-    #end if
-    if kwargs is None:
-        kwargs = dict()
-    #end if
-    return argpos,kwargpos,args,kwargs,position
-#end def check_jackknife_inputs
-
+    numerics = import_nexus_module('numerics')
+    jackknife            = numerics['jackknife']
+    jackknife_aux        = numerics['jackknife_aux']
+    simstats             = numerics['simstats']
+    equilibration_length = numerics['equilibration_length']
+    curve_fit            = numerics['curve_fit']
+    least_squares        = numerics['least_squares']
+    del numerics
+except:
+    # Failing path-based imports, import installed Nexus modules.
+    from generic import obj,log,warn,error
+    from developer import DevBase
+    from numerics import jackknife,jackknife_aux
+    from numerics import simstats,equilibration_length
+    from numerics import curve_fit,least_squares
+#end try
 
 
 
@@ -1059,7 +117,7 @@ all_fit_functions = obj(
             ),
         sqrt = obj(
             nparam   = 3,
-            function = lambda p,t: p[0]+p[1]*sqrt(t)+p[2]*t,
+            function = lambda p,t: p[0]+p[1]*np.sqrt(t)+p[2]*t,
             format   = '{0} + {1}*sqrt(t) + {2}*t',
             params   = [('intercept',lambda p: p[0])],
             ),
@@ -1073,7 +131,7 @@ fit_functions = obj()
 def qmcfit(q,E,fname='linear',minimizer=least_squares):
     # ensure data is in proper array format
     if isinstance(E,(list,tuple)):
-        E = array(E,dtype=float)
+        E = np.array(E,dtype=float)
     #end if
     Edata = None
     if len(E)!=E.size and len(E.shape)==2:
@@ -1093,9 +151,9 @@ def qmcfit(q,E,fname='linear',minimizer=least_squares):
 
     # setup initial guess parameters
     if fname=='quadratic':
-        pp = polyfit(q,E,2)
+        pp = np.polyfit(q,E,2)
     else:
-        pp = polyfit(q,E,1)
+        pp = np.polyfit(q,E,1)
     #end if
     p0 = tuple(list(reversed(pp))+(finfo.nparam-len(pp))*[0])
 
@@ -1172,7 +230,7 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         fobj = open(scalar_file,'r')
         quantities = fobj.readline().split()[2:]
         fobj.close()
-        rawdata = loadtxt(scalar_file)[:,1:].transpose()
+        rawdata = np.loadtxt(scalar_file)[:,1:].transpose()
         qdata = obj()
         for i in range(len(quantities)):
             q = quantities[i]
@@ -1200,9 +258,9 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         Edata.append(E)
         n+=1
     #end for
-    Emean = array(Emean)
-    Eerr  = array(Eerr)
-    Ekap  = array(Ekap)
+    Emean = np.array(Emean)
+    Eerr  = np.array(Eerr)
+    Ekap  = np.array(Ekap)
 
     # reblock data into target length
     block_targets = []
@@ -1217,7 +275,7 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         #end if        
     #end if
 
-    bt = array(block_targets,dtype=int).min()
+    bt = np.array(block_targets,dtype=int).min()
     for n in range(len(Edata)):
         E = Edata[n]
         nbe = len(E)%bt
@@ -1230,171 +288,15 @@ def process_scalar_files(scalar_files,equils=None,reblock_factors=None,series_st
         E.shape = (bt,)
         Edata[n] = E
     #end for
-    Edata = array(Edata,dtype=float)
+    Edata = np.array(Edata,dtype=float)
 
     return Edata,Emean,Eerr,scalar_files
 #end def process_scalar_files
 
 
 
-def simstats(x,dim=None):
-    shape = x.shape
-    ndim  = len(shape)
-    if dim==None:
-        dim=ndim-1
-    #end if
-    permute = dim!=ndim-1
-    reshape = ndim>2
-    nblocks = shape[dim]
-    if permute:
-        r = range(ndim)
-        r.pop(dim)
-        r.append(dim)
-        permutation = tuple(r)
-        r = range(ndim)
-        r.pop(ndim-1)
-        r.insert(dim,ndim-1)
-        invperm     = tuple(r)
-        x=x.transpose(permutation)
-        shape = tuple(array(shape)[array(permutation)])
-        dim = ndim-1
-    #end if
-    if reshape:        
-        nvars = prod(shape[0:dim])
-        x=x.reshape(nvars,nblocks)
-        rdim=dim
-        dim=1
-    else:
-        nvars = shape[0]
-    #end if
-
-    mean  = x.mean(dim)
-    var   = x.var(dim)
-
-    N=nblocks
-
-    if ndim==1:
-        i=0          
-        tempC=0.5
-        kappa=0.0
-        mtmp=mean
-        if abs(var)<1e-15:
-            kappa = 1.0
-        else:
-            ovar=1.0/var
-            while (tempC>0 and i<(N-1)):
-                kappa=kappa+2.0*tempC
-                i=i+1
-                tempC = ovar/(N-i)*sum((x[0:N-i]-mtmp)*(x[i:N]-mtmp))
-            #end while
-            if kappa == 0.0:
-                kappa = 1.0
-            #end if
-        #end if
-        Neff=(N+0.0)/(kappa+0.0)
-        if (Neff == 0.0):
-            Neff = 1.0
-        #end if
-        error=sqrt(var/Neff)
-    else:
-        error = zeros(mean.shape)
-        kappa = zeros(mean.shape)
-        for v in xrange(nvars):
-            i=0          
-            tempC=0.5
-            kap=0.0
-            vtmp = var[v]
-            mtmp = mean[v]
-            if abs(vtmp)<1e-15:
-                kap = 1.0
-            else:
-                ovar   = 1.0/vtmp
-                while (tempC>0 and i<(N-1)):
-                    i += 1
-                    kap += 2.0*tempC
-                    tempC = ovar/(N-i)*sum((x[v,0:N-i]-mtmp)*(x[v,i:N]-mtmp))
-                #end while
-                if kap == 0.0:
-                    kap = 1.0
-                #end if
-            #end if
-            Neff=(N+0.0)/(kap+0.0)
-            if (Neff == 0.0):
-                Neff = 1.0
-            #end if
-            kappa[v]=kap
-            error[v]=sqrt(vtmp/Neff)
-        #end for    
-    #end if
-
-    if reshape:
-        x     =     x.reshape(shape)
-        mean  =  mean.reshape(shape[0:rdim])
-        var   =   var.reshape(shape[0:rdim])
-        error = error.reshape(shape[0:rdim])
-        kappa = kappa.reshape(shape[0:rdim])
-    #end if
-    if permute:
-        x=x.transpose(invperm)
-    #end if
-
-    return (mean,var,error,kappa)
-#end def simstats
-
-
-
-def simplestats(x,dim=None):
-    if dim==None:
-        dim=len(x.shape)-1
-    #end if
-    osqrtN = 1.0/sqrt(1.0*x.shape[dim])
-    mean   = x.mean(dim)
-    var    = x.var(dim)
-    error  = var*osqrtN
-    return (mean,var,error,1.0)
-#end def simplestats
-
-
-
-def equilibration_length(x,tail=.5,plot=False,xlim=None,bounces=2):
-    bounces = max(1,bounces)
-    eqlen = 0
-    nx = len(x)
-    xt = x[int((1.-tail)*nx+.5):]
-    nxt = len(xt)
-    if nxt<10:
-        return eqlen
-    #end if
-    xs = array(xt)
-    xs.sort()
-    mean  = xs[int(.5*(nxt-1)+.5)]
-    sigma = (abs(xs[int((.5-.341)*nxt+.5)]-mean)+abs(xs[int((.5+.341)*nxt+.5)]-mean))/2
-    crossings = bounces*[0,0]
-    if abs(x[0]-mean)>sigma:
-        s = -sign(x[0]-mean)
-        ncrossings = 0
-        for i in range(nx):
-            dist = s*(x[i]-mean) 
-            if dist>sigma and dist<5*sigma:
-                crossings[ncrossings]=i
-                s*=-1
-                ncrossings+=1
-                if ncrossings==2*bounces:
-                    break
-                #end if
-            #end if
-        #end for
-        bounce = crossings[-2:]
-        bounce[1] = max(bounce[1],bounce[0])
-        eqlen = bounce[0]+random.randint(bounce[1]-bounce[0]+1)
-    #end if
-    return eqlen
-#end def equilibration_length
-
-
-
 def stat_strings(mean,error):
-    d = int(max(2,1-floor(nlog(error)/nlog(10.))))
+    d = int(max(2,1-np.floor(np.log(error)/np.log(10.))))
     fmt = '{0:16.'+str(d)+'f}'
     mstr = fmt.format(mean).strip()
     estr = fmt.format(error).strip()
@@ -1405,7 +307,7 @@ def stat_strings(mean,error):
 def parse_list(opt,name,dtype,len1=False):
     try:
         if opt[name]!=None:
-            opt[name] = array(opt[name].split(),dtype=dtype)
+            opt[name] = np.array(opt[name].split(),dtype=dtype)
             if len1 and len(opt[name])==1:
                 opt[name] = opt[name][0]
             #end if
@@ -1503,16 +405,16 @@ def timestep_fit():
         ts = opt.timesteps
         tsmax = ts.max()
         E0,E0err = auxres.intercept
-        tsfit = linspace(0,1.1*tsmax,400)
+        tsfit = np.linspace(0,1.1*tsmax,400)
         Efit  = func_info.function(pmean,tsfit)
-        figure()
-        plot(tsfit,Efit,'k-',lw=lw)
-        errorbar(ts,Emean,Eerror,fmt='b.',ms=ms)
-        errorbar([0],[E0],[E0err],fmt='r.',ms=ms)
-        xlim([-0.1*tsmax,1.1*tsmax])
-        xlabel('DMC Timestep (1/Ha)')
-        ylabel('DMC Energy (Ha)')
-        show()
+        plt.figure()
+        plt.plot(tsfit,Efit,'k-',lw=lw)
+        plt.errorbar(ts,Emean,Eerror,fmt='b.',ms=ms)
+        plt.errorbar([0],[E0],[E0err],fmt='r.',ms=ms)
+        plt.xlim([-0.1*tsmax,1.1*tsmax])
+        plt.xlabel('DMC Timestep (1/Ha)')
+        plt.ylabel('DMC Energy (Ha)')
+        plt.show()
     #end if
 #end def timestep_fit
 

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -13,22 +13,10 @@ def find_nexus_modules():
 #end def find_nexus_modules
 
 
-def import_nexus_module(module_name,full=False,mod_only=False):
+def import_nexus_module(module_name):
     import inspect
     import importlib
-    members = dict()
-    module = importlib.import_module(module_name)
-    for name,member in inspect.getmembers(module):
-        members[name] = member
-    #end for
-    assert(len(members)>0)
-    if mod_only:
-        return module
-    elif full:
-        return module,members
-    else:
-        return members
-    #end if
+    return importlib.import_module(module_name)
 #end def import_nexus_module
 
 
@@ -39,22 +27,22 @@ try:
     find_nexus_modules()
 
     generic = import_nexus_module('generic')
-    obj = generic['obj']
+    obj = generic.obj
     del generic
 
     developer = import_nexus_module('developer')
-    DevBase     = developer['DevBase']
-    unavailable = developer['unavailable']
+    DevBase     = developer.DevBase
+    unavailable = developer.unavailable
     del developer
 
     unit_converter = import_nexus_module('unit_converter')
-    convert = unit_converter['convert']
+    convert = unit_converter.convert
     del unit_converter
 
     numerics = import_nexus_module('numerics')
-    simstats             = numerics['simstats']
-    simplestats          = numerics['simplestats']
-    equilibration_length = numerics['equilibration_length']
+    simstats             = numerics.simstats
+    simplestats          = numerics.simplestats
+    equilibration_length = numerics.equilibration_length
     del numerics
 except:
     # Failing path-based imports, import installed Nexus modules.

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -1,1069 +1,21 @@
 #! /usr/bin/env python
 
-import code
 import os
+import sys
 from optparse import OptionParser
-import sys
-import traceback
-from copy import deepcopy
 
 
-class Callable:                        #helper class to create 'static' methods
-    def __init__(self, anycallable):
-        self.__call__ = anycallable
-    #end def init
-#end class Callable
+from generic import obj
+from developer import DevBase,unavailable
+from unit_converter import convert
+from numerics import simstats,simplestats,equilibration_length
 
-import copy
-class Copyable:
-    def _copy(self):
-        return copy.deepcopy(self)
-        #return copy.copy(self)
-    #end def copy
 
-    def _copies(self,count):
-        copies = []
-        for i in range(count):
-            copies.append(self._copy())
-        #end for
-        return copies
-    #end def copies
-#end class Copyable
-
-
-class Comparable:
-    None
-#end class Comparable
-
-
-class Iterable:
-    def __iter__(self):
-        for item in self.__dict__:
-            yield self.__dict__[item]
-        #end for
-    #end def __iter__
-
-    def _iteritems(self):
-        return self.__dict__.iteritems()
-    #end def iteritems
-
-    def _keys(self):
-        return self.__dict__.keys()
-    #end def _keys
-
-    def _values(self):
-        return self.__dict__.values()
-    #end def _keys
-
-    def _inverse(self):
-        new = self.__class__()
-        new.__dict__ = dict((v,k) for k, v in self._iteritems())
-        return new
-    #end def _inverse
-#end class Iterable
-
-
-import inspect
-class Queryable(Iterable):
-    def __str__(self,nindent=1):
-        pad = '  '
-        npad = nindent*pad
-        s=''
-        stype = type(s)
-        normal = []
-        qable  = []
-        for k,v in self._iteritems():
-            if type(k)!=stype or k[0]!='_':
-                if isinstance(v,Queryable):
-                    qable.append(k)
-                else:
-                    normal.append(k)
-                #end if
-            #end if
-        #end for
-        normal.sort()
-        qable.sort()
-        for k in normal:
-            v = self[k]
-            indent = npad+18*' '
-            vstr = str(v).replace('\n','\n'+indent)
-            s+=npad+'{0:<15} = '.format(k)+vstr+'\n'
-        #end for
-        for k in qable:
-            v = self[k]
-            s+=npad+str(k)+'\n'
-            s+=v.__str__(nindent+1)
-            if isinstance(k,str):
-                s+=npad+'end '+k+'\n'
-            #end if
-        #end for
-        return s
-    #end def __str__
-
-    def __repr__(self):
-        s=''
-        stype = type(s)
-        mem = list(self.__dict__.keys())
-        mem.sort()
-        for m in mem:
-            if type(m)!=stype or m[0]!='_':
-#                s+='  '+m+'   '+str(type(self.__dict__[m]))+'\n'
-#                s+='  '+m+'   '+self.__dict__[m].__class__.__name__+'\n'
-                v=self.__dict__[m]
-                if hasattr(v,'__class__'):
-                    s+='  {0:<20}  {1:<20}\n'.format(m,v.__class__.__name__)
-                else:
-                    s+='  {0:<20}  {1:<20}\n'.format(m,type(v))
-                #end if
-            #end if
-        #end for
-        return s
-    #end def __repr__
-
-    def __len__(self):
-        return len(self.__dict__)
-    #end def __len__
-
-    def __contains__(self,name):
-        return name in self.__dict__
-    #end def
-
-    def __getitem__(self,name):
-        return self.__dict__[name]
-    #end def __getitem__
-
-    def __setitem__(self,name,value):
-        self.__dict__[name]=value
-    #end def __setitem__
-
-    def __delitem__(self,name):
-        del self.__dict__[name]
-    #end def __setitem__
-
-    def _set(self,**variables):
-        for name,value in variables.iteritems():
-            self[name]=value
-        #end for
-        return self
-    #end def _set
-
-    def _clear(self):
-        self.__dict__.clear()
-    #end def _clear
-
-    def _add_attribute(self,name,value=None):
-        self[name] = value
-    #end def _add_attribute
-
-    def _add_attributes(self,*names,**attributes):
-        for name in names:
-            self[name] = None
-        #end for
-        for name,value in attributes.iteritems():
-            self[name]=value
-        #end for
-    #end def _add_attributes
-
-    def _transfer_from(self,other,copy=False):
-        if not copy:
-            for k,v in other._iteritems():
-                self[k]=v
-            #end for
-        else:
-            for k,v in other._iteritems():
-                self[k]=deepcopy(v)
-            #end for
-        #end if
-    #end def _transfer_from
-
-    def _transfer_to(self,other,copy=False):
-        other._transfer_from(self,copy)
-    #end def _transfer_to
-
-    def _append(self,value):
-        self[len(self)] = value
-    #end def _append
-#end class Queryable
-
-
-import sys
-class Logable:
-    def _open_log(self,filepath,increment=0,prefix=''):
-        self._log_file=open(filepath,'w')
-        self._log_pad_prefix=prefix
-        self._log_pad_increment=increment
-        self._log_pad_shift=0
-        self._log_pad_update()
-    #end def _open_log
-
-    def _close_log(self):
-        if self._log_file!=sys.stdout:
-            self._log_file.close()
-        #end if
-    #end def _close_log
-
-    def _set_log(self,logfile=sys.stdout,increment=0,prefix=''):
-        self._log_file=logfile
-        self._log_pad_prefix=prefix
-        self._log_pad_increment=increment
-        self._log_pad_shift=0
-        self._log_pad_update()
-    #end def _set_log
-
-    def _get_log(self):
-        L = Logable()
-        L._log_file          = self._log_file               
-        L._log_pad_prefix    = str(self._log_pad_prefix)
-        L._log_pad_increment = int(self._log_pad_increment)
-        L._log_pad_shift     = int(self._log_pad_shift)
-        return L
-    #end def _get_log
-
-    def _transfer_log(self,L):
-        self._log_file          = L._log_file               
-        self._log_pad_prefix    = L._log_pad_prefix   
-        self._log_pad_increment = L._log_pad_increment
-        self._log_pad_shift     = L._log_pad_shift    
-        self._log_pad_update()
-    #end def _transfer_log
-
-    def _increment_pad(self):
-        self._log_pad_shift+=self._log_pad_increment
-        self._log_pad_update()
-    #end def _increment_pad
-
-    def _decrement_pad(self):
-        self._log_pad_shift-=self._log_pad_increment
-        self._log_pad_update()
-    #end def _decrement_pad
-
-    def _set_pad(self,increment=0,prefix=''):
-        self._log_pad_prefix=prefix
-        self._log_pad_increment=increment
-        self._log_pad_update()
-    #end def _set_pad
-
-    def _log(self,s=''):
-        self._log_file.write(self._log_pad+str(s)+'\n')
-    #end def _log
-
-    def _exit(self,s=''):
-        self._log(self.__class__.__name__+' exiting')
-        self._log(s)
-        sys.exit()
-    #end def _exit
-
-    def _error(self,s='',exit_now=False):
-        self._log(self.__class__.__name__+' Error:  '+s)
-        if exit_now:
-            self._exit()
-        #end if
-    #end def _error
-
-    def _warn(self,s):
-        self._log(self.__class__.__name__+' Warning:  '+s)
-        return
-    #end def _warn
-
-
-    #user should not need to use these functions
-    def _log_pad_update(self):
-        self._log_pad = self._log_pad_prefix+self._log_pad_shift*' '
-    #end def _log_pad_update
-#end class Logable
-
-
-import cPickle
-class Savable:
-    def _save(self,fpath=None):
-        #self._unlink_dynamic_methods(self)
-        if fpath==None:
-            fpath='./'+self.__class__.__name__+'.p'
-        #end if
-        #self._savepath=fpath
-        fobj = open(fpath,'w')
-        binary = cPickle.HIGHEST_PROTOCOL
-        cPickle.dump(self,fobj,binary)
-        # fobj.close()
-        del fobj
-        del binary
-        return
-    #end def _save
-
-    def _load(self,fpath=None):
-        if fpath==None:
-            fpath='./'+self.__class__.__name__+'.p'
-        #end if
-        fobj = open(fpath,'r')
-        tmp = cPickle.load(fobj)
-        # fobj.close()
-        self.__dict__.clear()
-        #self.__dict__=tmp.__dict__
-        for k,v in tmp.__dict__.iteritems():
-            self.__dict__[k] = v
-        #end for
-        del fobj
-        del tmp
-        #self._relink_dynamic_methods()
-        return
-    #end def _load
-
-    #def _unlink_dynamic_methods(self,obj):
-    #    if hasattr(obj,'__dict__'):
-    #        for k,v in obj.__dict__.iteritems():
-    #            if type(v)==type(self._unlink_dynamic_methods):
-    #                obj.__dict__[k]=None
-    #            else:
-    #                self._unlink_dynamic_methods(v)
-    #            #end if
-    #        #end for
-    #    elif hasattr(obj,'__iter__'):
-    #        for a in obj:
-    #            self._unlink_dynamic_methods(a)
-    #        #end for
-    #    #end if
-    #    return
-    ##end def _unlink_dynamic_methods
-    #
-    #def _relink_dynamic_methods(self,obj):
-    #    if hasattr(obj,'_set_dynamic_methods'):
-    #        obj._set_dynamic_methods()
-    #    #end if
-    #    if hasattr(obj,'__dict__'):
-    #        for a in obj.__dict__:
-    #            self._relink_dynamic_methods(a)
-    #        #end for
-    #    elif hasattr(obj,'__iter__'):
-    #        for a in obj:
-    #            self._relink_dynamic_methods(a)
-    #        #end for
-    #    #end if
-    #    return
-    ##end def _relink_dynamic_methods
-    #
-    #def _set_dynamic_methods(self):
-    #    return
-    ##end def _set_dynamic_methods
-#end class Savable
-
-
-class Validatable:
-    def _has_type_bindings(self):
-        return '_type_bindings' in self.__class__.__dict__
-    #end def _has_type_bindings
-
-    def _has_rules(self):
-        return '_rules' in self.__class__.__dict__
-    #end def _has_rules
-
-    def _bind_type(self,vname,vtype):
-        if not self._has_type_bindings():
-            self.__class__.__dict__['_type_bindings']=dict()
-        #end if
-        self.__class__.__dict__['_type_bindings'][vname]=vtype
-        return
-    #end def _bind_type
-
-    #rules must have an executable form, eg. vrule='self.var > 1.0'
-    def _add_rule(self,vrule):
-        if not self._has_rules():
-            self.__class__.__dict__['_rules']=list()
-        #end if
-        self.__class__.__dict__['_rules'].append(vrule)
-        return
-    #end def
-
-    def _is_complete(self):
-        complete = True
-        for k,v in self.__dict__.iteritems():
-            if k[0]!='_':
-                complete = complete and v!=None
-            #end if
-        #end for
-        return complete
-    #end def _is_complete
-
-    def _is_type_valid(self,return_exceptions=False):
-        type_valid=True
-        exceptions = dict()
-        if self._has_type_bindings():
-            for k,v in self.__class__.__dict__['_type_bindings'].iteritems():
-                var = self.__dict__[k]
-                if hasattr(v,'__class__'):
-                    vtype = var.__class__.__name__
-                else:
-                    vtype = type(var)
-                #end if
-                var_valid = vtype==v
-                type_valid = type_valid and var_valid
-                if not var_valid:
-                    exceptions[k]=v,vtype
-                #end if
-            #end for
-        #end if
-        if not return_exceptions:
-            return type_valid
-        else:
-            return type_valid,exceptions
-        #end if
-    #end def _is_type_valid
-
-    def _is_legal(self):
-        legal=True
-        if self._has_rules():
-            for rule in self.__class__.__dict__['_rules']:
-                exec 'obeys_rule='+rule
-                legal = legal and obeys_rule
-            #end for
-        #end if
-        return legal
-    #end def _is_legal
-
-    def _is_valid(self,exit_on_fail=False,return_exceptions=False):
-        complete   = self._is_complete()
-        type_valid,type_exceptions = self._is_type_valid(return_exceptions=True)
-        legal      = self._is_legal()
-        valid = complete and type_valid and legal
-        if not valid and exit_on_fail:
-            name = self.__class__.__name__
-            if not complete:
-                print '       '+name+' has None attributes'
-            #end if
-            if not type_valid:
-                print '       '+name+' has invalid attribute types'
-                self._write_type_exceptions(type_exceptions)
-            #end if
-            if not legal:
-                print '       '+name+' violates user-defined rules'
-            #end if
-            sys.exit('Error: '+name+' failed _is_valid, exiting')
-        #end if
-        return valid
-    #end def _is_valid
-
-    def _write_type_exceptions(self,type_exceptions,pad='         '):
-        for k,v in type_exceptions.iteritems():
-            print pad+'variable '+k+' should be '+v[0]+' type, is '+v[1]+' type'
-        #end for
-    #end def _write_type_exceptions        
-#end class Validatable
-
-
-class AllAbilities(Copyable,Comparable,Queryable,Savable,Validatable):
-    def __init__(self,*vals,**attributes):
-        names = []
-        for val in vals:
-            if isinstance(val,str):
-                names.append(val)
-            elif isinstance(val,Iterable):
-                for name,value in val._iteritems():
-                    self[name]=value
-                #end for
-            elif isinstance(val,dict):
-                for name,value in val.iteritems():
-                    self[name]=value
-                #end for
-            #end for
-        #end for
-        self._add_attributes(*names,**attributes)
-    #end def __init__
-#end class AllAbilities
-
-
-
-exit_call = exit
-
-class obj(AllAbilities):
-    logfile = sys.stdout
-
-    def copy(self):
-        return self._copy()
-    def copies(self,count):
-        return self._copies(count)
-    def iteritems(self):
-        return self._iteritems()
-    def keys(self):
-        return self._keys()
-    def values(self):
-        return self._values()
-    def inverse(self):
-        return self._inverse()
-    def set(self,**variables):
-        return self._set(**variables)
-    def clear(self):
-        self._clear()
-    def add_attribute(self,name,value=None):
-        self._add_attribute(name,value)
-    def add_attributes(self,*names,**attributes):
-        self._add_attributes(*names,**attributes)
-    #def transfer_from(self,other,copy=False):
-    #    self._transfer_from(other,copy)
-    #def transfer_to(self,other,copy=False):
-    #    self._transfer_to(other,copy)
-    def append(self,value):
-        self._append(value)
-    def save(self,fpath=None):
-        self._save(fpath)
-    def load(self,fpath):
-        self._load(fpath)
-
-
-    def list(self,*names):
-        if len(names)==0:
-            names = list(self.keys())
-            names.sort()
-        #end if
-        values = []
-        for name in names:
-            values.append(self[name])
-        #end if
-        return values
-    #end def list
-
-    def tuple(self,*names):
-        return tuple(self.list(*names))
-    #end def tuple
-
-    def obj(self,*names):
-        o = obj()
-        o.transfer_from(self,keys=names,copy=False)
-        return o
-    #end def obj
-
-    def first(self):
-        return self[min(self.keys())]
-    #end def first
-
-    def last(self):
-        return self[max(self.keys())]
-    #end def last
-    
-    def open_log(self,filepath):
-        self.logfile = open(filepath,'w')
-    #end def open_log
-
-    def close_log(self):
-        self.logfile.close()
-    #end def close_log
-
-    def _write(self,s):
-        self.logfile.write(s)
-    #end def _write
-
-    def write(self,s):
-        self._write(s)
-    #end def write
-
-    def logna(self,*items):
-        s=''
-        for item in items:
-            s+=str(item)+' '
-        #end for
-        self.logfile.write(s)
-    #end def logna
-
-    def log(self,*items):
-        s=''
-        for item in items:
-            s+=str(item)+' '
-        #end for
-        s+='\n'
-        self.logfile.write(s)
-    #end def log
-
-    def error(self,message,header=None,exit=True,trace=False,post_header=' Error:'):
-        pad = 4*' '
-        if header==None:
-            header = self.__class__.__name__
-        #end if
-        self.log(header+post_header)
-        self.log(pad+message.replace('\n','\n'+pad))
-        if exit:
-            self.log('  exiting.\n')
-            if trace:
-                traceback.print_stack()
-            #end if
-            exit_call()
-        #end if
-    #end def error
-
-    def warn(self,message,header=None,post_header=' Warning:'):
-        pad = 4*' '
-        if header==None:
-            header=self.__class__.__name__
-        #end if
-        self.log(header+post_header)
-        self.log(pad+message.replace('\n','\n'+pad))
-    #end def error
-
-    @classmethod
-    def class_error(cls,message,header=None,exit=True,trace=True,post_header=' Error:'):
-        pad = 4*' '
-        if header==None:
-            header = cls.__name__
-        #end if
-        cls.logfile.write(header+post_header)
-        cls.logfile.write(pad+message.replace('\n','\n'+pad)+'\n')
-        if exit:
-            cls.logfile.write('  exiting.\n\n')
-            if trace:
-                traceback.print_stack()
-            #end if
-            exit_call()
-        #end if
-    #end def class_error
-
-    def transfer_from(self,other,keys=None,copy=False):
-        if keys==None:
-            keys = other.keys()
-        #end if
-        if not copy:
-            for k in keys:
-                self[k]=other[k]
-            #end for
-        else:
-            for k in keys:
-                self[k]=deepcopy(other[k])
-            #end for
-        #end if
-    #end def transfer_from
-
-    def transfer_to(self,other,keys=None,copy=False):
-        if keys==None:
-            keys = self.keys()
-        #end if
-        if not copy:
-            for k in keys:
-                other[k]=self[k]
-            #end for
-        else:
-            for k in keys:
-                other[k]=deepcopy(self[k])
-            #end for
-        #end if
-    #end def transfer_to
-
-    def move_from(self,other,keys=None):
-        if keys==None:
-            keys = other.keys()
-        #end if
-        for k in keys:
-            self[k]=other[k]
-            del other[k]
-        #end for
-    #end def move_from
-
-    def move_to(self,other,keys=None):
-        other.move_from(self,keys)
-    #end def move_to
-
-    def copy_from(self,other,keys=None,deep=False):
-        self.transfer_from(other,keys,copy=deep)
-    #end def copy_from
-
-    def copy_to(self,other,keys=None,deep=False):
-        self.transfer_to(other,keys,copy=deep)
-    #end def copy_to
-
-#end class obj
-
-
-
-
-class DevBase(obj):
-    user_interface_data = obj()
-    dev_instructions_data = obj()
-
-    def not_implemented(self):
-        #self.error('a base class function has not been implemented','Developer')
-        self.error('a base class function has not been implemented',trace=True)
-    #end def not_implemented
-
-    @classmethod
-    def set_user_interface(cls,class_variables=None,class_functions=None,member_variables=None,member_functions=None):
-        if class_variables is None:
-            class_variables = []
-        if class_functions is None:
-            class_functions = []
-        if member_variables is None:
-            member_variables = []
-        if member_functions is None:
-            member_functions = []
-        ui = cls.user_interface_data
-        ui.class_variables = class_variables
-        ui.class_functions = class_functions
-        ui.member_variables= member_variables
-        ui.member_functions= member_functions
-    #end def set_user_interface
-
-    @classmethod
-    def set_dev_instruction(cls,situation='writing a derived class',class_variables=None,class_functions=None,member_variables=None,member_functions=None):
-        if class_variables is None:
-            class_variables = []
-        if class_functions is None:
-            class_functions = []
-        if member_variables is None:
-            member_variables = []
-        if member_functions is None:
-            member_functions = []
-        ins = obj()
-        cls.dev_instructions_data[situation] = ins
-        ins.class_variables = class_variables
-        ins.class_functions = class_functions
-        ins.member_variables= member_variables
-        ins.member_functions= member_functions
-    #end def set_dev_instruction
-        
-    @classmethod
-    def write_dev_data(cls,s,dev_data,indent=''):
-        p1 = '  '
-        p2 = 2*p1
-        p3 = 3*p1
-        dpad = indent+p3
-        for name,value in dev_data.iteritems():
-            s+=indent+p1+name+'\n'
-            if isinstance(value,list):
-                for v in value:
-                    s+=indent+p2+v+'\n'
-                #end for
-            else:
-                for v,description in value.iteritems():
-                    s+=indent+p2+v+'\n'
-                    s+=dpad+description.replace('\n','\n'+dpad)
-                #end for
-            #end for
-        #end for
-        return s
-    #end def write_dev_data
-
-    @classmethod
-    def user_interface(cls):
-        s='User Interface for '+cls.__name__+' Class\n'
-        s+= (len(s)-1)*'='+'\n'
-        s+=cls.write_dev_data(cls.user_interface_data)
-        return s
-    #end def user_interface
-
-    @classmethod
-    def developer_instructions(cls):
-        s='Developer Instructions for '+cls.__name__+' Class\n'
-        s+= (len(s)-1)*'='+'\n'
-        i1='  '
-        i2=2*i1
-        i3=3*i1
-        for situation,instruction in cls.developer_instructions.iteritems():
-            s+=i1+'situation: '+situation+'\n'
-            s+=i2+'define the following variables and functions:'
-            s+=cls.write_dev_data(instructions,i3)
-        #end for
-        return s
-    #end def developer_instructions
-#end class DevBase
-
-
-
-
-
-
-
-
-class Void:
-    void_items = dict()
-
-    @classmethod
-    def _unavailable(cls,self):
-        sid = id(self)
-        if sid in Void.void_items:
-            module,item = Void.void_items[id(self)]
-        else:
-            module,item = None,None
-        #end if
-        if module is None and item is None:
-            msg = 'encountered a void item from an unavailable module'
-        elif module is None:
-            msg = 'item '+str(item)+' is from an unavailable module'
-        elif item is None:
-            msg = 'encountered a void item from unavailable module '+str(module)+'  \nthis python module must be installed on your system to use this feature'
-        else:
-            msg = 'item '+str(item)+' is from unavailable module '+str(module)+'  \nthis python module must be installed on your system to use this feature'
-        #end if
-        DevBase.class_error(msg,'QMCA',trace=False)
-    #end def _unavailable
-
-        
-    @classmethod
-    def _class_unavailable(cls):
-        msg = 'encountered a void item from an unavailable module'
-        DevBase.class_error(msg,'QMCA',trace=False)
-    #end def _class_unavailable
-        
-
-
-    def __init__(self,module=None,item=None):
-        Void.void_items[id(self)] = module,item
-    #end def __init__
-
-
-    #list of magic functions taken from the following sources
-    #  http://web.archive.org/web/20110131211638/http://diveintopython3.org/special-method-names.html
-    #  http://www.ironpythoninaction.com/magic-methods.html
-
-
-    #class methods
-    @classmethod
-    def __instancecheck__(cls,*args,**kwargs):
-        Void._class_unavailable()
-    def __subclasscheck__(cls,*args,**kwargs):
-        Void._class_unavailable()
-    def __subclasshook__(cls,*args,**kwargs):
-        Void._class_unavailable()
-    
-
-    #member methods
-    def __new__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __eq__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ne__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __lt__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __le__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __gt__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ge__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __nonzero__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __subclasses__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __call__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __hash__(self,*args,**kwargs):
-        Void._unavailable(self)
-    #def __del__(self,*args,**kwargs):
-    #    Void._unavailable(self)
-    def __dir__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __getitem__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __setitem__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __delitem__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __len__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __contains__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __iter__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __reversed__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __missing__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __length_hint__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __repr__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __str__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __unicode__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __getattr__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __setattr__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __delattr__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __getattribute__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __add__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __sub__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __mul__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __floordiv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __div__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __truediv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __mod__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __divmod__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __pow__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __lshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __and__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __xor__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __or__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __neg__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __pos__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __abs__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __invert__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __complex__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __int__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __long__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __float__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __oct__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __hex__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __index__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __enter__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __exit__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __get__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __set__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __delete__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __doc__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __dict__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __slots__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __class__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __bases__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __name__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __all__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __file__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __module__(self,*args,**kwargs):
-        Void._unavailable(self)
-    #def __metaclass__(self,*args,**kwargs):
-    #    Void._unavailable(self)
-    def __import__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __radd__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rsub__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rmul__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rtruediv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rfloordiv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rmod__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rdivmod__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rpow__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rlshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rrshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rand__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __rxor__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ror__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __iadd__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __isub__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __imul__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __itruediv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ifloordiv__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __imod__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ipow__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ilshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __irshift__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __iand__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ixor__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ior__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __round__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __ceil__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __floor__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __trunc__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __bool__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __copy__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __deepcopy__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __getstate__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __reduce__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __reduce_ex__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __getnewargs__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __setstate__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __hash__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __bytes__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __format__(self,*args,**kwargs):
-        Void._unavailable(self)
-    def __next__(self,*args,**kwargs):
-        Void._unavailable(self)
-#end class Void
-
-
-def unavailable(module,*items):
-    voids = []
-    if len(items)==0:
-        voids.append(Void(module))
-    #end if
-    for item in items:
-        voids.append(Void(module,item))
-    #end for
-    if len(voids)==1:
-        return voids[0]
-    else:
-        return voids
-    #end if
-#end def unavailable
 
 try:
-    from numpy import array,zeros,dot,loadtxt,floor,empty,sqrt,trace,savetxt,concatenate,real,imag,diag,arange,ones,identity,exp,log,log10,sign,concatenate
+    import numpy as np
 except (ImportError,RuntimeError):
-    array,zeros,dot,loadtxt,floor,empty,sqrt,trace,savetxt,concatenate,real,imag,diag,arange,ones,identity,exp,log,log10,sign,concatenate = unavailable('numpy','array','zeros','dot','loadtxt','floor','empty','sqrt','trace','savetxt','concatenate','real','imag','diag','arange','ones','identity','exp','log','log10','sign','concatenate')
+    np = unavailable('numpy')
 #end try
 try:
     import numpy.random as random
@@ -1071,303 +23,6 @@ except:
     random = unavailable('numpy.random','random')
 #end try
 
-
-class Unit:
-    def __init__(self,name,symbol,type,value,shift=0):
-        self.name = name
-        self.symbol = symbol
-        self.type = type
-        self.value = value
-        self.shift = shift
-    #end def __init__
-#end class Unit
-
-
-class UnitConverter:
-
-    unassigned = None
-
-
-    kb = 1.3806503e-23 #J/K
-
-    count_set = set(['mol'])
-    mol = 6.0221415e23
-
-    distance_set = set(['m','A','B','nm','pm','fm','a','b','c'])
-    m  = 1.e0
-    A  = 1.e-10*m
-    B  = .52917720859e-10*m
-    nm = 1.e-9*m
-    pm = 1.e-12*m
-    fm = 1.e-15*m
-
-    time_set = set(['s','ms','ns','ps','fs'])
-    s = 1.e0
-    ms = 1.e-3*s
-    ns = 1.e-9*s
-    ps = 1.e-12*s
-    fs = 1.e-15*s
-
-    mass_set = set(['kg','me','mp','amu','Da'])
-    kg  = 1.e0
-    me  = 9.10938291e-31*kg
-    mp  = 1.672621777e-27*kg
-    amu = 1.660538921e-27*kg
-    Da  = amu
-
-    energy_set = set(['J','eV','Ry','Ha','kJ_mol','K','degC','degF'])
-    J      = 1.e0
-    eV     = 1.60217646e-19*J
-    Ry     = 13.6056923*eV
-    Ha     = 2*Ry
-    kJ_mol = 1000.*J/mol
-    K      = J/kb
-    degC   = K
-    degF   = 9./5.*K
-
-    degC_shift = -273.15
-    degF_shift = -459.67 
-
-    charge_set = set(['C','e'])
-    C = 1.e0
-    e = 1.60217646e-19*C
-
-    pressure_set = set(['Pa','bar','Mbar','GPa','atm'])
-    Pa   = 1.e0
-    bar  = 1.e5*Pa
-    Mbar = 1.e6*bar
-    GPa  = 1.e9*Pa
-    atm  = 1.01325e5*Pa
-
-    force_set = set(['N','pN'])
-    N  = 1.e0
-    pN = 1e-12*N
-
-    therm_cond_set = set(['W_mK'])
-    W_mK = 1.0
-
-    alatt = unassigned
-    blatt = unassigned
-    clatt = unassigned
-
-    meter      = Unit('meter'     ,'m' ,'distance',m)
-    angstrom   = Unit('Angstrom'  ,'A' ,'distance',A)
-    bohr       = Unit('Bohr'      ,'B' ,'distance',B)
-    nanometer  = Unit('nanometer' ,'nm','distance',nm)
-    picometer  = Unit('picometer' ,'pm','distance',pm)
-    femtometer = Unit('femtometer','pm','distance',fm)
-    a          = Unit('a'         ,'a' ,'distance',alatt)
-    b          = Unit('b'         ,'b' ,'distance',blatt)
-    c          = Unit('c'         ,'c' ,'distance',clatt)
-
-    second      = Unit('second'     ,'s' ,'time',s )
-    millisecond = Unit('millisecond','ms','time',ms)
-    nanosecond  = Unit('nanosecond' ,'ns','time',ns)
-    picosecond  = Unit('picosecond' ,'ps','time',ps)
-    femtosecond = Unit('femtosecond','fs','time',fs)
-
-    kilogram         = Unit('kilogram'        ,'kg' ,'mass',kg)
-    electron_mass    = Unit('electron mass'   ,'me' ,'mass',me)
-    proton_mass      = Unit('proton mass'     ,'mp' ,'mass',mp)
-    atomic_mass_unit = Unit('atomic mass unit','amu','mass',amu)
-    dalton           = Unit('Dalton'          ,'Da' ,'mass',Da)
-        
-    joule         = Unit('Joule'        ,'J'     ,'energy',J)
-    electron_volt = Unit('electron Volt','eV'    ,'energy',eV)
-    rydberg       = Unit('Rydberg'      ,'Ry'    ,'energy',Ry)
-    hartree       = Unit('Hartree'      ,'Ha'    ,'energy',Ha)
-    kJ_mole       = Unit('kJ_mole'      ,'kJ_mol','energy',kJ_mol)
-    kelvin        = Unit('Kelvin'       ,'K'     ,'energy',K)
-    celsius       = Unit('Celsius'      ,'degC'  ,'energy',degC,degC_shift)
-    fahrenheit    = Unit('Fahrenheit'   ,'degF'  ,'energy',degF,degF_shift)
-
-    coulomb         = Unit('Coulomb'        ,'C','charge',C)
-    electron_charge = Unit('electron charge','e','charge',e)
-
-    pascal     = Unit('Pascal'    ,'Pa'  ,'pressure',Pa)
-    bar        = Unit('bar'       ,'bar' ,'pressure',bar)
-    megabar    = Unit('megabar'   ,'Mbar','pressure',Mbar)
-    gigapascal = Unit('gigaPascal','Gpa' ,'pressure',GPa)
-    atmosphere = Unit('atmosphere','atm' ,'pressure',atm)
-
-    newton     = Unit('Newton'    ,'N' ,'force',N)
-    piconewton = Unit('picoNewton','pN','force',pN)
-
-    W_per_mK = Unit('W/(m*K)','W_mK','thermal_cond',W_mK)
-
-
-    distance_dict = dict([('A',angstrom),\
-                          ('B',bohr),\
-                          ('a',a),\
-                          ('b',b),\
-                          ('c',c),\
-                          ('m',meter),\
-                          ('nm',nanometer),\
-                          ('pm',picometer),\
-                          ('fm',femtometer),\
-                          ])
-
-    mass_dict = dict([    ('kg',kilogram),\
-                          ('me',electron_mass),\
-                          ('mp',proton_mass),\
-                          ('amu',atomic_mass_unit),\
-                          ('Da',dalton),\
-                          ])
-    energy_dict = dict([\
-                          ('J',joule),\
-                          ('eV',electron_volt),\
-                          ('Ry',rydberg),\
-                          ('Ha',hartree),\
-                          ('kJ_mol',kJ_mole),\
-                          ('K',kelvin),\
-                          ('degC',celsius),\
-                          ('degF',fahrenheit),\
-                          ])
-
-    charge_dict = dict([\
-                          ('C',coulomb),\
-                          ('e',electron_charge),\
-                          ])
-
-    pressure_dict = dict([\
-                          ('Pa',pascal),\
-                          ('bar',bar),\
-                          ('Mbar',megabar),\
-                          ('GPa',gigapascal),\
-                          ('atm',atmosphere),\
-                              ])
-
-    force_dict = dict([\
-                          ('N',newton),\
-                          ('pN',piconewton),\
-                              ])
-
-    therm_cond_dict = dict([\
-                          ('W_mK',W_per_mK),\
-                          ])
-
-
-    unit_dict = dict([    ('A',angstrom),\
-                          ('B',bohr),\
-                          ('a',a),\
-                          ('b',b),\
-                          ('c',c),\
-                          ('m',meter),\
-                          ('nm',nanometer),\
-                          ('pm',picometer),\
-                          ('fm',femtometer),\
-                          ('kg',kilogram),\
-                          ('me',electron_mass),\
-                          ('mp',proton_mass),\
-                          ('amu',atomic_mass_unit),\
-                          ('J',joule),\
-                          ('eV',electron_volt),\
-                          ('Ry',rydberg),\
-                          ('Ha',hartree),\
-                          ('kJ_mol',kJ_mole),\
-                          ('K',kelvin),\
-                          ('degC',celsius),\
-                          ('degF',fahrenheit),\
-                          ('C',coulomb),\
-                          ('e',electron_charge),\
-                          ('Pa',pascal),\
-                          ('bar',bar),\
-                          ('Mbar',megabar),\
-                          ('GPa',gigapascal),\
-                          ('atm',atmosphere),\
-                          ('N',newton),\
-                          ('pN',piconewton),\
-                          ('W_mK',W_per_mK),\
-                          ])
-
-
-    def __init(self):
-        None
-    #def __init__
-
-    def convert(value,source_unit,target_unit):
-        ui  = UnitConverter.unit_dict[source_unit]
-        uo = UnitConverter.unit_dict[target_unit]
-
-        if(ui.type != uo.type):
-            print 'ERROR: in UnitConverter.convert()'
-            print '   type conversion attempted between'
-            print '   '+ui.type+' and '+uo.type
-        else:
-            value_out = (value*ui.value+ui.shift-uo.shift)/uo.value
-        #end if
-
-        return (value_out,target_unit)
-
-    #end def convert
-    convert = Callable(convert)
-
-
-    def convert_scalar_to_all(units,value_orig):
-        unit_type = UnitConverter.unit_dict[units].type
-
-        value = dict()
-        value['orig'] = value_orig
-
-        for k,u in UnitConverter.unit_dict.iteritems():
-            if(u.type == unit_type and u.value!=UnitConverter.unassigned):
-                (value[k],utmp) = UnitConverter.convert(value['orig'],units,k)
-            #end if
-        #end for
-
-        return value
-    #end def convert_scalar_to_all
-    convert_scalar_to_all = Callable(convert_scalar_to_all)
-
-    
-    def convert_array_to_all(units,arr,vectors=None):
-
-        A = dict()
-        A['orig'] = arr.copy()
-
-        (n,m) = arr.shape
-
-        if(units=='lattice'):
-            if(vectors!=None):
-                A['lattice'] = arr
-            #end if
-            def_unit = 'A'
-            arr_use = dot(arr,vectors.A[def_unit])
-            ui = UnitConverter.unit_dict[def_unit]
-        else:
-            arr_use = arr
-            ui = UnitConverter.unit_dict[units]
-            if(vectors!=None):
-                A['lattice'] = dot(arr,linalg.inv(vectors.A[units]))
-            #end if
-        #end if
-            
-        At = zeros((n,m));
-        for k,u in UnitConverter.unit_dict.iteritems():
-            if(u.type == ui.type and u.value!=UnitConverter.unassigned):
-                for i in range(n):
-                    for j in range(m):
-                        At[i,j] = (arr_use[i,j]*ui.value+ui.shift-u.shift)/u.value
-                    #end for
-                #end for
-                A[k] = At.copy()
-            #end if
-        #end for
-
-        return A
-    #end def convert_array_to_all
-    convert_array_to_all = Callable(convert_array_to_all)
-
-    def submit_unit(uo):
-        UnitConverter.unit_dict[uo.symbol] = uo
-    #end def submit_unit
-    submit_unit = Callable(submit_unit)
-#end class UnitConverter
-
-
-def convert(value,source_unit,target_unit):
-    return UnitConverter.convert(value,source_unit,target_unit)[0]
-#end def convert
 
 
 
@@ -1386,214 +41,28 @@ try:
             continue
         #end try
     #end for
-    from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text
+    import matplotlib.pyplot as plt
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
-    rcParams.update(params)
+    plt.rcParams.update(params)
 except (ImportError,RuntimeError):
     success = False
 #end try
 if not success:
-    figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+    plt = unavailable('matplotlib.pyplot')
 #end if
 
 
 def sigfig_round(some_float, nsigfig):
     if nsigfig >= 1 and nsigfig == int(nsigfig):
-        return round(some_float, nsigfig - int(floor(log10(abs(some_float))))-1) 
+        return round(some_float, nsigfig - int(np.floor(np.log10(abs(some_float))))-1) 
     else:
         QMCA.class_error("Number of significant figures must be a whole number\nreceived {0}".format(nsigfig))
     #end if
 #end sigfig_round
 
 
-def simstats(x,dim=None):
-    shape = x.shape
-    ndim  = len(shape)
-    if dim==None:
-        dim=ndim-1
-    #end if
-    permute = dim!=ndim-1
-    reshape = ndim>2
-    nblocks = shape[dim]
-    if permute:
-        r = range(ndim)
-        r.pop(dim)
-        r.append(dim)
-        permutation = tuple(r)
-        r = range(ndim)
-        r.pop(ndim-1)
-        r.insert(dim,ndim-1)
-        invperm     = tuple(r)
-        x=x.transpose(permutation)
-        shape = tuple(array(shape)[array(permutation)])
-        dim = ndim-1
-    #end if
-    if reshape:        
-        nvars = prod(shape[0:dim])
-        x=x.reshape(nvars,nblocks)
-        rdim=dim
-        dim=1
-    else:
-        nvars = shape[0]
-    #end if
-
-    mean  = x.mean(dim)
-    var   = x.var(dim)
-
-    N=nblocks
-
-    if ndim==1:
-        i=0          
-        tempC=0.5
-        kappa=0.0
-        mtmp=mean
-        if abs(var)<1e-15:
-            kappa = 1.0
-        else:
-            ovar=1.0/var
-            while (tempC>0 and i<(N-1)):
-                kappa=kappa+2.0*tempC
-                i=i+1
-                #tempC=corr(i,x,mean,var)
-                tempC = ovar/(N-i)*sum((x[0:N-i]-mtmp)*(x[i:N]-mtmp))
-            #end while
-            if kappa == 0.0:
-                kappa = 1.0
-            #end if
-        #end if
-        Neff=(N+0.0)/(kappa+0.0)
-        if (Neff == 0.0):
-            Neff = 1.0
-        #end if
-        error=sqrt(var/Neff)
-    else:
-        error = zeros(mean.shape)
-        kappa = zeros(mean.shape)
-        for v in xrange(nvars):
-            i=0          
-            tempC=0.5
-            kap=0.0
-            vtmp = var[v]
-            mtmp = mean[v]
-            if abs(vtmp)<1e-15:
-                kap = 1.0
-            else:
-                ovar   = 1.0/vtmp
-                while (tempC>0 and i<(N-1)):
-                    i += 1
-                    kap += 2.0*tempC
-                    tempC = ovar/(N-i)*sum((x[v,0:N-i]-mtmp)*(x[v,i:N]-mtmp))
-                #end while
-                if kap == 0.0:
-                    kap = 1.0
-                #end if
-            #end if
-            Neff=(N+0.0)/(kap+0.0)
-            if (Neff == 0.0):
-                Neff = 1.0
-            #end if
-            kappa[v]=kap
-            error[v]=sqrt(vtmp/Neff)
-        #end for    
-    #end if
-
-    if reshape:
-        x     =     x.reshape(shape)
-        mean  =  mean.reshape(shape[0:rdim])
-        var   =   var.reshape(shape[0:rdim])
-        error = error.reshape(shape[0:rdim])
-        kappa = kappa.reshape(shape[0:rdim])
-    #end if
-    if permute:
-        x=x.transpose(invperm)
-    #end if
-
-    return (mean,var,error,kappa)
-#end def simstats
-
-
-
-def simplestats(x,dim=None):
-    if dim==None:
-        dim=len(x.shape)-1
-    #end if
-    osqrtN = 1.0/sqrt(1.0*x.shape[dim])
-    mean   = x.mean(dim)
-    var    = x.var(dim)
-    error  = var*osqrtN
-    return (mean,var,error,1.0)
-#end def simplestats
-
-
-def equilibration_length(x,tail=.5,plot=False,xlim=None,bounces=2):
-    bounces = max(1,bounces)
-    eqlen = 0
-    nx = len(x)
-    xt = x[int((1.-tail)*nx+.5):]
-    nxt = len(xt)
-    if nxt<10:
-        return eqlen
-    #end if
-    #mean  = xh.mean()
-    #sigma = sqrt(xh.var())
-    xs = array(xt)
-    xs.sort()
-    mean  = xs[int(.5*(nxt-1)+.5)]
-    sigma = (abs(xs[int((.5-.341)*nxt+.5)]-mean)+abs(xs[int((.5+.341)*nxt+.5)]-mean))/2
-    crossings = bounces*[0,0]
-    if abs(x[0]-mean)>sigma:
-        s = -sign(x[0]-mean)
-        ncrossings = 0
-        for i in range(nx):
-            dist = s*(x[i]-mean) 
-            if dist>sigma and dist<5*sigma:
-                crossings[ncrossings]=i
-                s*=-1
-                ncrossings+=1
-                if ncrossings==2*bounces:
-                    break
-                #end if
-            #end if
-        #end for
-        bounce = crossings[-2:]
-        bounce[1] = max(bounce[1],bounce[0])
-        #print len(x),crossings,crossings[1]-crossings[0]+1
-        eqlen = bounce[0]+random.randint(bounce[1]-bounce[0]+1)
-    #end if
-    if plot:
-        xlims = xlim
-        del plot,xlim
-        from matplotlib.pyplot import plot,figure,show,xlim
-        figure()
-        ix = arange(nx)
-        plot(ix,x,'b.-')
-        plot([0,nx],[mean,mean],'k-')
-        plot([0,nx],[mean+sigma,mean+sigma],'r-')
-        plot([0,nx],[mean-sigma,mean-sigma],'r-')
-        plot(ix[crossings],x[crossings],'r.')
-        plot(ix[bounce],x[bounce],'ro')
-        plot([ix[eqlen],ix[eqlen]],[x.min(),x.max()],'g-')
-        plot(ix[eqlen],x[eqlen],'go')
-        if xlims!=None:
-            xlim(xlims)
-        #end if
-        show()
-    #end if
-    return eqlen
-#end def equilibration_length
-
-
-
-
-def ci(locs,globs):
-    code.interact(local=dict(globs,**locs))
-#end def ci
-
-ls = locals
-gs = globals
-interact = ci
 
 
 class ColorWheel(DevBase):
@@ -1704,7 +173,7 @@ class QBase(DevBase):
             text+=str(t)+' '
         #end for
         pad = n*'  '
-        self.logfile.write(pad+text.replace('\n','\n'+pad)+'\n')
+        self._logfile.write(pad+text.replace('\n','\n'+pad)+'\n')
     #end def log
 #end class QBase
 
@@ -1790,7 +259,7 @@ class DatAnalyzer(QBase):
     def load_data(self,filepath):
         self.data.clear()
         self.extract_info(filepath)
-        lt = loadtxt(filepath)
+        lt = np.loadtxt(filepath)
         if len(lt.shape)==1:
             lt.shape = (1,len(lt))
         #end if
@@ -1818,7 +287,7 @@ class DatAnalyzer(QBase):
         if self.autocorr:
             (mean,var,error,kappa)=simstats(v)
         else:
-            (mean,var,error,kappa)=simplestats(v)
+            (mean,var,error,kappa)=simplestats(v,full=True)
         #end if
         sv = obj(
             mean  = mean,
@@ -1989,7 +458,7 @@ class DatAnalyzer(QBase):
                 #end if
                 qlist.append(other.data[q][nbe:])
             #end for
-            self.data[q] = concatenate(qlist)
+            self.data[q] = np.concatenate(qlist)
         #end for
     #end def join
             
@@ -2119,7 +588,7 @@ class DatAnalyzer(QBase):
             line = '{0:<22}=  {1: '+prec+'} +/- {2: '+prec+'}'
         elif prec=='auto':
             if (q.mean !=0.0 and abs(q.error/q.mean) > 1e-8):
-                d = int(max(2,1-floor(log(q.error)/log(10.))))
+                d = int(max(2,1-np.floor(np.log(q.error)/np.log(10.))))
             else:
                 d = 2
             #end if
@@ -2186,14 +655,14 @@ class DatAnalyzer(QBase):
         qmin = q[middle:].min()
         ylims = (qmean-2*(qmean-qmin),qmean+2*(qmax-qmean))
         smean,svar = self.stats[quantity].tuple('mean','var')
-        sstd = sqrt(svar)
-        s = arange(len(q))+shift
+        sstd = np.sqrt(svar)
+        s = np.arange(len(q))+shift
         xlims = min(s),max(s)
         #plot(s,q,style,label=prefix)
-        plot([nbe+shift,nbe+shift],ylims,'k-.',lw=2)
-        plot(xlims,[smean,smean],'r-')
-        plot(xlims,[smean+sstd,smean+sstd],'r-.')
-        plot(xlims,[smean-sstd,smean-sstd],'r-.')
+        plt.plot([nbe+shift,nbe+shift],ylims,'k-.',lw=2)
+        plt.plot(xlims,[smean,smean],'r-')
+        plt.plot(xlims,[smean+sstd,smean+sstd],'r-.')
+        plt.plot(xlims,[smean-sstd,smean-sstd],'r-.')
         return xlims,ylims,s,q
     #end def plot_trace
 
@@ -2211,8 +680,8 @@ class DatAnalyzer(QBase):
         #qmin = q[middle:].min()
         #ylims = (qmean-2*(qmean-qmin),qmean+2*(qmax-qmean))
         #smean,svar = self.stats[quantity].tuple('mean','var')
-        #sstd = sqrt(svar)
-        #s = arange(len(q))+shift
+        #sstd = np.sqrt(svar)
+        #s = np.arange(len(q))+shift
         #xlims = min(s),max(s)
         ##plot(s,q,style,label=prefix)
         #plot([nbe+shift,nbe+shift],ylims,'k-.',lw=2)
@@ -2476,7 +945,7 @@ QMCA examples:
         if opt.equilibration!='auto':
             try:
                 eq = comma_list(opt.equilibration)
-                eq = array(eq,dtype=int)
+                eq = np.array(eq,dtype=int)
                 if len(eq)==1:
                     e = eq[0]
                 else:
@@ -2497,7 +966,7 @@ QMCA examples:
             else:
                 try:
                     w = comma_list(ws)
-                    w = array(w,dtype=float)
+                    w = np.array(w,dtype=float)
                     opt.weights = w
                     weight_failed = len(w.shape)!=1
                 except:
@@ -2511,7 +980,7 @@ QMCA examples:
             join_failed = False
             try:
                 j = comma_list(opt.join)
-                j = array(j,dtype=int)
+                j = np.array(j,dtype=int)
             except:
                 join_failed = True
             #end try
@@ -2744,7 +1213,7 @@ QMCA examples:
         if opt.average and opt.save_average:
             for fmap in self.file_map:
                 ndata = len(fmap.data.first())
-                data = [arange(ndata)]
+                data = [np.arange(ndata)]
                 keys = 'index'
                 fmt = ['%i']
                 for key in fmap.data.keys():
@@ -2752,8 +1221,8 @@ QMCA examples:
                     keys+='     {}'.format(key)
                     fmt.append('%.10e')
                 #end for
-                data = array(data).transpose()
-                savetxt(fmap.info.filepath,data,header=keys,fmt=fmt)
+                data = np.array(data).transpose()
+                np.savetxt(fmap.info.filepath,data,header=keys,fmt=fmt)
             #end for
         #end if
         show_text  = True
@@ -2807,7 +1276,7 @@ QMCA examples:
                             last_prefix  = np==len(self.data)-1
                             np+=1
                             if first_prefix or not opt.overlay:
-                                fig = figure()
+                                fig = plt.figure()
                                 ax = fig.add_subplot(111)
                                 xminp =  1e99
                                 xmaxp = -1e99
@@ -2851,9 +1320,9 @@ QMCA examples:
                                 series_list.append(series)
                             #end for
                             if mode==iplot:
-                                errorbar(xvals,yvals,yerrs,color=mlcolor,fmt=mlstyle,label=prefix)
+                                plt.errorbar(xvals,yvals,yerrs,color=mlcolor,fmt=mlstyle,label=prefix)
                             elif mode==itrace:
-                                plot(xvals,yvals,lstyle,color=lcolor,label=prefix)
+                                plt.plot(xvals,yvals,lstyle,color=lcolor,label=prefix)
                             #end if
                             if last_prefix or not opt.overlay:
                                 dx = max(.1*abs(xminp-xmaxp),1)
@@ -2862,12 +1331,12 @@ QMCA examples:
                                 dy = .1*abs(yminp-ymaxp)
                                 yminp -= dy
                                 ymaxp += dy
-                                xlim([xminp,xmaxp])
-                                ylim([yminp,ymaxp])
+                                plt.xlim([xminp,xmaxp])
+                                plt.ylim([yminp,ymaxp])
                                 if mode==iplot:
-                                    xlabel('series')
-                                    ylabel(quantity)
-                                    title(quantity+' vs. series')
+                                    plt.xlabel('series')
+                                    plt.ylabel(quantity)
+                                    plt.title(quantity+' vs. series')
                                 elif mode==itrace:
                                     for ishift in range(0,len(shifts)-1):
                                         s1 = shifts[ishift]
@@ -2878,18 +1347,18 @@ QMCA examples:
                                         else:
                                             st = smid
                                         #end if
-                                        text(st,ymaxp-.5*dy,'s'+str(series_list[ishift]).zfill(3))
+                                        plt.text(st,ymaxp-.5*dy,'s'+str(series_list[ishift]).zfill(3))
                                         if ishift!=0:
-                                            plot([s1,s1],[yminp,ymaxp],'k-')
+                                            plt.plot([s1,s1],[yminp,ymaxp],'k-')
                                         #end if
                                     #end for
-                                    xlabel('samples')
-                                    ylabel(quantity)
-                                    title('Trace of '+quantity)
+                                    plt.xlabel('samples')
+                                    plt.ylabel(quantity)
+                                    plt.title('Trace of '+quantity)
                                 elif mode==ihist:
-                                    xlabel(quantity)
-                                    ylabel('counts')
-                                    title('Histogram of '+quantity)
+                                    plt.xlabel(quantity)
+                                    plt.ylabel('counts')
+                                    plt.title('Histogram of '+quantity)
                                 #end if
                                 if opt.legend.lower()!='none':
                                     if opt.legend=='upper right':
@@ -2903,7 +1372,7 @@ QMCA examples:
                     #end if
                 #end for
             #end for
-            show()
+            plt.show()
         #end if
     #end def analyze_data
 

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -8,7 +8,6 @@ from optparse import OptionParser
 def find_nexus_modules():
     import sys
     nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','lib'))
-    print nexus_lib
     assert(os.path.exists(nexus_lib))
     sys.path.append(nexus_lib)
 #end def find_nexus_modules
@@ -33,9 +32,9 @@ def import_nexus_module(module_name,full=False,mod_only=False):
 #end def import_nexus_module
 
 
-# Load nexus modules
+# Load Nexus modules
 try:
-    # Attempt specialized path-based load.
+    # Attempt specialized path-based imports.
     #  (The executable should still work even if Nexus is not installed)
     find_nexus_modules()
 
@@ -58,7 +57,7 @@ try:
     equilibration_length = numerics['equilibration_length']
     del numerics
 except:
-    # Failing path-based load, attempt load based on installed Nexus modules.
+    # Failing path-based imports, import installed Nexus modules.
     from generic import obj
     from developer import DevBase,unavailable
     from unit_converter import convert
@@ -71,11 +70,6 @@ try:
     import numpy as np
 except (ImportError,RuntimeError):
     np = unavailable('numpy')
-#end try
-try:
-    import numpy.random as random
-except:
-    random = unavailable('numpy.random','random')
 #end try
 
 

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -5,13 +5,68 @@ import sys
 from optparse import OptionParser
 
 
-from generic import obj
-from developer import DevBase,unavailable
-from unit_converter import convert
-from numerics import simstats,simplestats,equilibration_length
+def find_nexus_modules():
+    import sys
+    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','lib'))
+    print nexus_lib
+    assert(os.path.exists(nexus_lib))
+    sys.path.append(nexus_lib)
+#end def find_nexus_modules
 
 
+def import_nexus_module(module_name,full=False,mod_only=False):
+    import inspect
+    import importlib
+    members = dict()
+    module = importlib.import_module(module_name)
+    for name,member in inspect.getmembers(module):
+        members[name] = member
+    #end for
+    assert(len(members)>0)
+    if mod_only:
+        return module
+    elif full:
+        return module,members
+    else:
+        return members
+    #end if
+#end def import_nexus_module
 
+
+# Load nexus modules
+try:
+    # Attempt specialized path-based load.
+    #  (The executable should still work even if Nexus is not installed)
+    find_nexus_modules()
+
+    generic = import_nexus_module('generic')
+    obj = generic['obj']
+    del generic
+
+    developer = import_nexus_module('developer')
+    DevBase     = developer['DevBase']
+    unavailable = developer['unavailable']
+    del developer
+
+    unit_converter = import_nexus_module('unit_converter')
+    convert = unit_converter['convert']
+    del unit_converter
+
+    numerics = import_nexus_module('numerics')
+    simstats             = numerics['simstats']
+    simplestats          = numerics['simplestats']
+    equilibration_length = numerics['equilibration_length']
+    del numerics
+except:
+    # Failing path-based load, attempt load based on installed Nexus modules.
+    from generic import obj
+    from developer import DevBase,unavailable
+    from unit_converter import convert
+    from numerics import simstats,simplestats,equilibration_length
+#end try
+
+
+# numpy imports
 try:
     import numpy as np
 except (ImportError,RuntimeError):
@@ -24,9 +79,7 @@ except:
 #end try
 
 
-
-
-
+# matplotlib imports
 success = False
 try:
     import matplotlib
@@ -54,6 +107,7 @@ if not success:
 #end if
 
 
+
 def sigfig_round(some_float, nsigfig):
     if nsigfig >= 1 and nsigfig == int(nsigfig):
         return round(some_float, nsigfig - int(np.floor(np.log10(abs(some_float))))-1) 
@@ -61,7 +115,6 @@ def sigfig_round(some_float, nsigfig):
         QMCA.class_error("Number of significant figures must be a whole number\nreceived {0}".format(nsigfig))
     #end if
 #end sigfig_round
-
 
 
 

--- a/nexus/lib/numerics.py
+++ b/nexus/lib/numerics.py
@@ -894,14 +894,19 @@ def simstats(x,dim=None):
 
 
 
-def simplestats(x,dim=None):
+def simplestats(x,dim=None,full=False):
     if dim is None:
         dim=len(x.shape)-1
     #end if
     osqrtN = 1.0/sqrt(1.0*x.shape[dim])
     mean   = x.mean(dim)
-    error  = x.std(dim)*osqrtN
-    return (mean,error)
+    var    = x.var(dim)
+    error  = sqrt(var)*osqrtN
+    if not full:
+        return (mean,error)
+    else:
+        return (mean,var,error,1.0)
+    #end if
 #end def simplestats
 
 

--- a/nexus/tests/unit/test_bundle.py
+++ b/nexus/tests/unit/test_bundle.py
@@ -17,7 +17,7 @@ def test_bundle():
     from bundle import bundle
     from bundle import SimulationBundle
 
-    from test_simulation import get_test_workflow
+    from test_simulation_module import get_test_workflow
 
     # empty init
     try:

--- a/nexus/tests/unit/test_nxs_sim.py
+++ b/nexus/tests/unit/test_nxs_sim.py
@@ -9,7 +9,7 @@ def test_sim():
     import os
     from execute import execute
     from nexus_base import nexus_core
-    from test_simulation import get_sim
+    from test_simulation_module import get_sim
 
     tpath = testing.setup_unit_test_output_directory('nxs_sim','test_sim',divert=True)
 

--- a/nexus/tests/unit/test_project_manager.py
+++ b/nexus/tests/unit/test_project_manager.py
@@ -32,7 +32,7 @@ def test_add_simulations():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow
+    from test_simulation_module import get_test_workflow
     sims = get_test_workflow(1)
 
     pm = ProjectManager()
@@ -72,7 +72,7 @@ def test_traverse_cascades():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow,n_test_workflows
+    from test_simulation_module import get_test_workflow,n_test_workflows
 
     sims = []
     for n in range(n_test_workflows):
@@ -113,7 +113,7 @@ def test_screen_fake_sims():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow,n_test_workflows
+    from test_simulation_module import get_test_workflow,n_test_workflows
 
     sims = []
     for n in range(n_test_workflows):
@@ -149,7 +149,7 @@ def test_resolve_file_collisions():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow,n_test_workflows
+    from test_simulation_module import get_test_workflow,n_test_workflows
 
     divert_nexus_log()
 
@@ -192,7 +192,7 @@ def test_propagate_blockages():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow,n_test_workflows
+    from test_simulation_module import get_test_workflow,n_test_workflows
 
     sims = []
     for n in range(n_test_workflows):
@@ -237,7 +237,7 @@ def test_load_cascades():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow
+    from test_simulation_module import get_test_workflow
 
     sims = get_test_workflow(1)
 
@@ -266,7 +266,7 @@ def test_check_dependencies():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow
+    from test_simulation_module import get_test_workflow
 
     divert_nexus_log()
 
@@ -293,7 +293,7 @@ def test_write_simulation_status():
     from simulation import Simulation
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow
+    from test_simulation_module import get_test_workflow
 
     divert_nexus()
 
@@ -368,7 +368,7 @@ def test_run_project():
     from simulation import Simulation,input_template
     from project_manager import ProjectManager
 
-    from test_simulation import get_test_workflow,n_test_workflows
+    from test_simulation_module import get_test_workflow,n_test_workflows
 
     tpath = testing.setup_unit_test_output_directory('project_manager','test_run_project',divert=True)
 


### PR DESCRIPTION
Merge only after the 3.9.0 release.

This PR removes code from the `qmca`, `qmc-fit` and `qdens` executables that was copied over from Nexus libraries.

The original intent of the copying was to make the executables stand-alone (no Nexus install needed), and thus increase the chances of successful use.

In moving toward the Python 3 transition, duplicate code is a liability and has been removed.  Instead, the required components are imported from Nexus.  In an attempt to restore the "stand-alone" nature of the executables, relative imports are attempted first.  These also do not require Nexus to be installed to succeed.