### PR TITLE
Adjust WFC::ratio/ratioGrad precision handling

### DIFF
--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -101,8 +101,8 @@ void AGPDeterminant::resetTargetParticleSet(ParticleSet& P) { GeminalBasis->rese
  *for local energy calculations.
  */
 AGPDeterminant::LogValueType AGPDeterminant::evaluateLog(ParticleSet& P,
-                                                      ParticleSet::ParticleGradient_t& G,
-                                                      ParticleSet::ParticleLaplacian_t& L)
+                                                         ParticleSet::ParticleGradient_t& G,
+                                                         ParticleSet::ParticleLaplacian_t& L)
 {
   evaluateLogAndStore(P);
   G += myG;

--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -244,7 +244,7 @@ void AGPDeterminant::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
  * @param P current configuration
  * @param iat the particle thas is being moved
  */
-AGPDeterminant::ValueType AGPDeterminant::ratio(ParticleSet& P, int iat)
+AGPDeterminant::PsiValueType AGPDeterminant::ratio(ParticleSet& P, int iat)
 {
   UpdateMode = ORB_PBYP_RATIO;
   //GeminalBasis->evaluate(P,iat);

--- a/src/QMCWaveFunctions/AGPDeterminant.h
+++ b/src/QMCWaveFunctions/AGPDeterminant.h
@@ -66,7 +66,7 @@ public:
    * @param P current configuration
    * @param iat the particle thas is being moved
    */
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
 
   void ratioUp(ParticleSet& P, int iat);
 
@@ -153,7 +153,7 @@ public:
   IndexVector_t Pivot;
 
   ///current ratio
-  RealType curRatio;
+  PsiValueType curRatio;
   ///cummulate ratio for particle-by-particle update
   RealType cumRatio;
   ///address of  dpsiU[0][0]

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -31,8 +31,8 @@ public:
   ConstantOrbital() : FakeGradRatio(1.0) {}
 
   virtual LogValueType evaluateLog(ParticleSet& P,
-                               ParticleSet::ParticleGradient_t& G,
-                               ParticleSet::ParticleLaplacian_t& L) override
+                                   ParticleSet::ParticleGradient_t& G,
+                                   ParticleSet::ParticleLaplacian_t& L) override
   {
     G = 0.0;
     L = 0.0;
@@ -51,7 +51,10 @@ public:
 
   virtual void registerData(ParticleSet& P, WFBufferType& buf) override {}
 
-  virtual LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override { return 0.0; }
+  virtual LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override
+  {
+    return 0.0;
+  }
 
   virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override {}
 

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -26,7 +26,7 @@ public:
   virtual void reportStatus(std::ostream& os) override {}
   virtual void resetTargetParticleSet(ParticleSet& P) override {}
 
-  ValueType FakeGradRatio;
+  PsiValueType FakeGradRatio;
 
   ConstantOrbital() : FakeGradRatio(1.0) {}
 
@@ -43,11 +43,11 @@ public:
 
   virtual void restore(int iat) override {}
 
-  virtual ValueType ratio(ParticleSet& P, int iat) override { return 1.0; }
+  virtual PsiValueType ratio(ParticleSet& P, int iat) override { return 1.0; }
 
   virtual GradType evalGrad(ParticleSet& P, int iat) override { return GradType(0.0); }
 
-  virtual ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override { return FakeGradRatio; }
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override { return FakeGradRatio; }
 
   virtual void registerData(ParticleSet& P, WFBufferType& buf) override {}
 

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -62,8 +62,8 @@ bool ExampleHeComponent::put(xmlNodePtr cur)
 }
 
 ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(ParticleSet& P,
-                                                             ParticleSet::ParticleGradient_t& G,
-                                                             ParticleSet::ParticleLaplacian_t& L)
+                                                                 ParticleSet::ParticleGradient_t& G,
+                                                                 ParticleSet::ParticleLaplacian_t& L)
 {
   const auto& ee_table = P.getDistTable(my_table_ee_idx_);
   // Only the lower triangle is up-to-date after particle-by-particle moves

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -105,7 +105,7 @@ ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(ParticleSet& P,
   return -Z * (r1 + r2) + std::log(norm * norm) - u;
 }
 
-ExampleHeComponent::ValueType ExampleHeComponent::ratio(ParticleSet& P, int iat)
+ExampleHeComponent::PsiValueType ExampleHeComponent::ratio(ParticleSet& P, int iat)
 {
   const int jat = (iat == 0 ? 1 : 0);
 
@@ -127,7 +127,7 @@ ExampleHeComponent::ValueType ExampleHeComponent::ratio(ParticleSet& P, int iat)
   double log_v_old = -Z * (r_old)-u_old;
   double log_v_new = -Z * (r_new)-u_new;
 
-  return std::exp((log_v_new - log_v_old));
+  return std::exp(static_cast<PsiValueType>(log_v_new - log_v_old));
 }
 
 ExampleHeComponent::GradType ExampleHeComponent::evalGrad(ParticleSet& P, int iat)
@@ -151,7 +151,7 @@ ExampleHeComponent::GradType ExampleHeComponent::evalGrad(ParticleSet& P, int ia
   return Z * rhat + rhat12 * du;
 }
 
-ExampleHeComponent::ValueType ExampleHeComponent::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+ExampleHeComponent::PsiValueType ExampleHeComponent::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   const auto& ee_table = P.getDistTable(my_table_ee_idx_);
 
@@ -181,7 +181,7 @@ ExampleHeComponent::ValueType ExampleHeComponent::ratioGrad(ParticleSet& P, int 
   double log_v_old = -Z * (r_old)-u_old;
   double log_v_new = -Z * (r_new)-u_new;
 
-  return std::exp((log_v_new - log_v_old));
+  return std::exp(static_cast<PsiValueType>(log_v_new - log_v_old));
 }
 
 

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -53,11 +53,11 @@ public:
 
   void restore(int iat) override {}
 
-  ValueType ratio(ParticleSet& P, int iat) override;
+  PsiValueType ratio(ParticleSet& P, int iat) override;
 
   GradType evalGrad(ParticleSet& P, int iat) override;
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
 
   void evaluateDerivatives(ParticleSet& P,
                            const OptVariablesType& optvars,

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -26,15 +26,14 @@ namespace qmcplusplus
 class ExampleHeComponent : public WaveFunctionComponent
 {
 public:
-
   ExampleHeComponent(const ParticleSet& ions, ParticleSet& els)
-    : ions_(ions), my_table_ee_idx_(els.addTable(els, DT_SOA)), my_table_ei_idx_(els.addTable(ions, DT_SOA))
+      : ions_(ions), my_table_ee_idx_(els.addTable(els, DT_SOA)), my_table_ei_idx_(els.addTable(ions, DT_SOA))
   {
     ClassName = "ExampleHeComponent";
   };
 
   using OptVariablesType = optimize::VariableSet;
-  using PtclGrpIndexes = QMCTraits::PtclGrpIndexes;
+  using PtclGrpIndexes   = QMCTraits::PtclGrpIndexes;
 
   void checkInVariables(OptVariablesType& active) override { active.insertFrom(my_vars_); }
   void checkOutVariables(const OptVariablesType& active) override { my_vars_.getIndex(active); }
@@ -46,8 +45,8 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override {}
 
   LogValueType evaluateLog(ParticleSet& P,
-                       ParticleSet::ParticleGradient_t& G,
-                       ParticleSet::ParticleLaplacian_t& L) override;
+                           ParticleSet::ParticleGradient_t& G,
+                           ParticleSet::ParticleLaplacian_t& L) override;
 
   void acceptMove(ParticleSet& P, int iat) override {}
 

--- a/src/QMCWaveFunctions/FDLRWfn.cpp
+++ b/src/QMCWaveFunctions/FDLRWfn.cpp
@@ -502,7 +502,7 @@ FDLRWfn::GradType FDLRWfn::evalGrad(ParticleSet& P, int iat)
 /// \return  the ratio of new and old FDLR wave function values.
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////
-FDLRWfn::ValueType FDLRWfn::ratioGrad(ParticleSet& P, int iat, FDLRWfn::GradType& grad_iat)
+FDLRWfn::PsiValueType FDLRWfn::ratioGrad(ParticleSet& P, int iat, FDLRWfn::GradType& grad_iat)
 {
   FDLRWfn::RealType logpsi_plus      = m_wfn_xpd->getLogPsi();
   FDLRWfn::RealType logpsi_minus     = m_wfn_xmd->getLogPsi();
@@ -628,7 +628,7 @@ void FDLRWfn::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
   buf.get(LogValue);
 }
 
-FDLRWfn::ValueType FDLRWfn::ratio(ParticleSet& P, int iat)
+FDLRWfn::PsiValueType FDLRWfn::ratio(ParticleSet& P, int iat)
 {
   FDLRWfn::RealType logpsi_plus      = m_wfn_xpd->getLogPsi();
   FDLRWfn::RealType logpsi_minus     = m_wfn_xmd->getLogPsi();

--- a/src/QMCWaveFunctions/FDLRWfn.cpp
+++ b/src/QMCWaveFunctions/FDLRWfn.cpp
@@ -352,8 +352,8 @@ void FDLRWfn::resetTargetParticleSet(ParticleSet& P)
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////
 FDLRWfn::LogValueType FDLRWfn::evaluateLog(ParticleSet& P,
-                                       ParticleSet::ParticleGradient_t& G,
-                                       ParticleSet::ParticleLaplacian_t& L)
+                                           ParticleSet::ParticleGradient_t& G,
+                                           ParticleSet::ParticleLaplacian_t& L)
 {
   // "x+d"
   m_wfn_xpd->evaluateLog(P);
@@ -397,16 +397,16 @@ FDLRWfn::LogValueType FDLRWfn::evaluateLog(ParticleSet& P,
 ///
 ///////////////////////////////////////////////////////////////////////////////////////////////
 FDLRWfn::LogValueType FDLRWfn::evaluateLogFDLR(ParticleSet& P,
-                                           ParticleSet::ParticleGradient_t& G,
-                                           ParticleSet::ParticleLaplacian_t& L,
-                                           const FDLRWfn::RealType& logpsi_plus,
-                                           const FDLRWfn::RealType logpsi_minus,
-                                           const FDLRWfn::RealType& phasevalue_plus,
-                                           const FDLRWfn::RealType phasevalue_minus,
-                                           const ParticleSet::ParticleGradient_t& G_plus,
-                                           const ParticleSet::ParticleGradient_t& G_minus,
-                                           const ParticleSet::ParticleLaplacian_t& L_plus,
-                                           const ParticleSet::ParticleLaplacian_t& L_minus)
+                                               ParticleSet::ParticleGradient_t& G,
+                                               ParticleSet::ParticleLaplacian_t& L,
+                                               const FDLRWfn::RealType& logpsi_plus,
+                                               const FDLRWfn::RealType logpsi_minus,
+                                               const FDLRWfn::RealType& phasevalue_plus,
+                                               const FDLRWfn::RealType phasevalue_minus,
+                                               const ParticleSet::ParticleGradient_t& G_plus,
+                                               const ParticleSet::ParticleGradient_t& G_minus,
+                                               const ParticleSet::ParticleLaplacian_t& L_plus,
+                                               const ParticleSet::ParticleLaplacian_t& L_minus)
 {
   PsiValueType psi(0.0), psi_plus(0.0), psi_minus(0.0);
   FDLRWfn::ValueType scaling_fac_1, scaling_fac_2;

--- a/src/QMCWaveFunctions/FDLRWfn.h
+++ b/src/QMCWaveFunctions/FDLRWfn.h
@@ -177,16 +177,16 @@ public:
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   LogValueType evaluateLogFDLR(ParticleSet& P,
-                           ParticleSet::ParticleGradient_t& G,
-                           ParticleSet::ParticleLaplacian_t& L,
-                           const RealType& logpsi_plus,
-                           const RealType logpsi_minus,
-                           const RealType& phasevalue_plus,
-                           const RealType phasevalue_minus,
-                           const ParticleSet::ParticleGradient_t& G_plus,
-                           const ParticleSet::ParticleGradient_t& G_minus,
-                           const ParticleSet::ParticleLaplacian_t& L_plus,
-                           const ParticleSet::ParticleLaplacian_t& L_minus);
+                               ParticleSet::ParticleGradient_t& G,
+                               ParticleSet::ParticleLaplacian_t& L,
+                               const RealType& logpsi_plus,
+                               const RealType logpsi_minus,
+                               const RealType& phasevalue_plus,
+                               const RealType phasevalue_minus,
+                               const ParticleSet::ParticleGradient_t& G_plus,
+                               const ParticleSet::ParticleGradient_t& G_minus,
+                               const ParticleSet::ParticleLaplacian_t& L_plus,
+                               const ParticleSet::ParticleLaplacian_t& L_minus);
 
   GradType evalGrad(ParticleSet& P, int iat);
 

--- a/src/QMCWaveFunctions/FDLRWfn.h
+++ b/src/QMCWaveFunctions/FDLRWfn.h
@@ -119,7 +119,7 @@ private:
   std::vector<RealType> dlogpsi_fdlr_d;
   std::vector<RealType> dhpsioverpsi_fdlr_d;
 
-  ValueType curRatio;
+  PsiValueType curRatio;
 
   // gradients of FDLR wavefunction
   ParticleSet::ParticleGradient_t G_FDLR;
@@ -190,7 +190,7 @@ public:
 
   GradType evalGrad(ParticleSet& P, int iat);
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
   void registerData(ParticleSet& P, WFBufferType& buf);
 
@@ -198,7 +198,7 @@ public:
 
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
 
   void acceptMove(ParticleSet& P, int iat);
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -98,9 +98,9 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
 }
 
 template<typename DU_TYPE>
-typename DiracDeterminant<DU_TYPE>::ValueType DiracDeterminant<DU_TYPE>::ratioGrad(ParticleSet& P,
-                                                                                   int iat,
-                                                                                   GradType& grad_iat)
+typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratioGrad(ParticleSet& P,
+                                                                                      int iat,
+                                                                                      GradType& grad_iat)
 {
   SPOVGLTimer.start();
   Phi->evaluate(P, iat, psiV, dpsiV, d2psiV);
@@ -109,7 +109,7 @@ typename DiracDeterminant<DU_TYPE>::ValueType DiracDeterminant<DU_TYPE>::ratioGr
 }
 
 template<typename DU_TYPE>
-typename DiracDeterminant<DU_TYPE>::ValueType DiracDeterminant<DU_TYPE>::ratioGrad_compute(int iat,
+typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratioGrad_compute(int iat,
                                                                                            GradType& grad_iat)
 {
   UpdateMode             = ORB_PBYP_PARTIAL;
@@ -126,7 +126,7 @@ typename DiracDeterminant<DU_TYPE>::ValueType DiracDeterminant<DU_TYPE>::ratioGr
     updateEng.getInvRow(psiM, WorkingIndex, invRow);
   }
   curRatio = simd::dot(invRow.data(), psiV.data(), invRow.size());
-  grad_iat += ((RealType)1.0 / curRatio) * simd::dot(invRow.data(), dpsiV.data(), invRow.size());
+  grad_iat += static_cast<ValueType>(static_cast<PsiValueType>(1.0) / curRatio) * simd::dot(invRow.data(), dpsiV.data(), invRow.size());
   RatioTimer.stop();
   return curRatio;
 }
@@ -293,7 +293,7 @@ void DiracDeterminant<DU_TYPE>::copyFromBuffer(ParticleSet& P, WFBufferType& buf
  * @param iat the particle thas is being moved
  */
 template<typename DU_TYPE>
-typename DiracDeterminant<DU_TYPE>::ValueType DiracDeterminant<DU_TYPE>::ratio(ParticleSet& P, int iat)
+typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratio(ParticleSet& P, int iat)
 {
   UpdateMode             = ORB_PBYP_RATIO;
   const int WorkingIndex = iat - FirstIndex;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -47,7 +47,7 @@ void DiracDeterminant<DU_TYPE>::set(int first, int nel, int delay)
 
   resize(nel, nel);
 
-  if(Optimizable)
+  if (Optimizable)
     Phi->buildOptVariables(nel);
 }
 
@@ -82,7 +82,6 @@ void DiracDeterminant<DU_TYPE>::resize(int nel, int morb)
   d2psiV.resize(NumOrbitals);
   FirstAddressOfdV = &(dpsiM(0, 0)[0]); //(*dpsiM.begin())[0]);
   LastAddressOfdV  = FirstAddressOfdV + NumPtcls * NumOrbitals * DIM;
-
 }
 
 template<typename DU_TYPE>
@@ -110,9 +109,9 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
 
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratioGrad_compute(int iat,
-                                                                                           GradType& grad_iat)
+                                                                                              GradType& grad_iat)
 {
-  UpdateMode             = ORB_PBYP_PARTIAL;
+  UpdateMode = ORB_PBYP_PARTIAL;
   RatioTimer.start();
   const int WorkingIndex = iat - FirstIndex;
   GradType rv;
@@ -126,7 +125,8 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
     updateEng.getInvRow(psiM, WorkingIndex, invRow);
   }
   curRatio = simd::dot(invRow.data(), psiV.data(), invRow.size());
-  grad_iat += static_cast<ValueType>(static_cast<PsiValueType>(1.0) / curRatio) * simd::dot(invRow.data(), dpsiV.data(), invRow.size());
+  grad_iat += static_cast<ValueType>(static_cast<PsiValueType>(1.0) / curRatio) *
+      simd::dot(invRow.data(), dpsiV.data(), invRow.size());
   RatioTimer.stop();
   return curRatio;
 }
@@ -134,18 +134,22 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
 
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
-                       const std::vector<ParticleSet*>& P_list,
-                       int iat,
-                       std::vector<PsiValueType>& ratios,
-                       std::vector<GradType>& grad_new)
+                                             const std::vector<ParticleSet*>& P_list,
+                                             int iat,
+                                             std::vector<PsiValueType>& ratios,
+                                             std::vector<GradType>& grad_new)
 {
   SPOVGLTimer.start();
-  std::vector<SPOSet*> phi_list; phi_list.reserve(WFC_list.size());
-  std::vector<ValueVector_t*> psi_v_list; psi_v_list.reserve(WFC_list.size());
-  std::vector<GradVector_t*> dpsi_v_list; dpsi_v_list.reserve(WFC_list.size());
-  std::vector<ValueVector_t*> d2psi_v_list; d2psi_v_list.reserve(WFC_list.size());
+  std::vector<SPOSet*> phi_list;
+  phi_list.reserve(WFC_list.size());
+  std::vector<ValueVector_t*> psi_v_list;
+  psi_v_list.reserve(WFC_list.size());
+  std::vector<GradVector_t*> dpsi_v_list;
+  dpsi_v_list.reserve(WFC_list.size());
+  std::vector<ValueVector_t*> d2psi_v_list;
+  d2psi_v_list.reserve(WFC_list.size());
 
-  for(auto wfc : WFC_list)
+  for (auto wfc : WFC_list)
   {
     auto det = static_cast<DiracDeterminant<DU_TYPE>*>(wfc);
     phi_list.push_back(det->Phi);
@@ -256,8 +260,8 @@ void DiracDeterminant<DU_TYPE>::registerData(ParticleSet& P, WFBufferType& buf)
 
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::updateBuffer(ParticleSet& P,
-                                                                                     WFBufferType& buf,
-                                                                                     bool fromscratch)
+                                                                                         WFBufferType& buf,
+                                                                                         bool fromscratch)
 {
   if (fromscratch)
   {
@@ -353,11 +357,11 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
                                                                                        int iat)
 {
   GradType g(0.0);
-  if(Phi->hasIonDerivs())
+  if (Phi->hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
     Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
-    g=simd::dot(psiM.data(), grad_source_psiM.data(), psiM.size());
+    g = simd::dot(psiM.data(), grad_source_psiM.data(), psiM.size());
   }
 
   return g;
@@ -398,17 +402,11 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
     TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad)
 {
   GradType gradPsi(0.0);
-  if(Phi->hasIonDerivs())
+  if (Phi->hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
-    Phi->evaluateGradSource(P,
-			    FirstIndex,
-			    LastIndex,
-			    source,
-			    iat,
-			    grad_source_psiM,
-			    grad_grad_source_psiM,
-			    grad_lapl_source_psiM);
+    Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
+                            grad_lapl_source_psiM);
     // HACK HACK HACK
     // Phi->evaluate(P, FirstIndex, LastIndex, psiM, dpsiM, d2psiM);
     // psiM_temp = psiM;
@@ -436,58 +434,59 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
     for (int i = 0; i < NumPtcls; i++)
       for (int j = 0; j < NumOrbitals; j++)
       {
-	lapl_phi_Minv(i, j) = 0.0;
-	for (int k = 0; k < NumOrbitals; k++)
-	  lapl_phi_Minv(i, j) += d2psiM(i, k) * psiM(j, k);
+        lapl_phi_Minv(i, j) = 0.0;
+        for (int k = 0; k < NumOrbitals; k++)
+          lapl_phi_Minv(i, j) += d2psiM(i, k) * psiM(j, k);
       }
     for (int dim = 0; dim < OHMMS_DIM; dim++)
     {
       for (int i = 0; i < NumPtcls; i++)
-	for (int j = 0; j < NumOrbitals; j++)
-	{
-	  for (int k = 0; k < NumOrbitals; k++)
-	  {
-	    phi_alpha_Minv(i, j)[dim] += grad_source_psiM(i, k)[dim] * psiM(j, k);
-	    grad_phi_Minv(i, j)[dim] += dpsiM(i, k)[dim] * psiM(j, k);
-	    for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
-	      grad_phi_alpha_Minv(i, j)(dim, dim_el) += grad_grad_source_psiM(i, k)(dim, dim_el) * psiM(j, k);
-	  }
-	}
+        for (int j = 0; j < NumOrbitals; j++)
+        {
+          for (int k = 0; k < NumOrbitals; k++)
+          {
+            phi_alpha_Minv(i, j)[dim] += grad_source_psiM(i, k)[dim] * psiM(j, k);
+            grad_phi_Minv(i, j)[dim] += dpsiM(i, k)[dim] * psiM(j, k);
+            for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
+              grad_phi_alpha_Minv(i, j)(dim, dim_el) += grad_grad_source_psiM(i, k)(dim, dim_el) * psiM(j, k);
+          }
+        }
     }
     for (int i = 0, iel = FirstIndex; i < NumPtcls; i++, iel++)
     {
       HessType dval(0.0);
       GradType d2val(0.0);
       for (int dim = 0; dim < OHMMS_DIM; dim++)
-	for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
-	  dval(dim, dim_el) = grad_phi_alpha_Minv(i, i)(dim, dim_el);
+        for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
+          dval(dim, dim_el) = grad_phi_alpha_Minv(i, i)(dim, dim_el);
       for (int j = 0; j < NumOrbitals; j++)
       {
-	gradPsi += grad_source_psiM(i, j) * psiM(i, j);
-	for (int dim = 0; dim < OHMMS_DIM; dim++)
-	  for (int k = 0; k < OHMMS_DIM; k++)
-	    dval(dim, k) -= phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, j)[k];
+        gradPsi += grad_source_psiM(i, j) * psiM(i, j);
+        for (int dim = 0; dim < OHMMS_DIM; dim++)
+          for (int k = 0; k < OHMMS_DIM; k++)
+            dval(dim, k) -= phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, j)[k];
       }
       for (int dim = 0; dim < OHMMS_DIM; dim++)
       {
-	for (int k = 0; k < OHMMS_DIM; k++)
-	  grad_grad[dim][iel][k] += dval(dim, k);
-	for (int j = 0; j < NumOrbitals; j++)
-	{
-	  // First term, eq 9
-	  lapl_grad[dim][iel] += grad_lapl_source_psiM(i, j)[dim] * psiM(i, j);
-	  // Second term, eq 9
-	  if (j == i)
-	    for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
-	      lapl_grad[dim][iel] -= (RealType)2.0 * grad_phi_alpha_Minv(j, i)(dim, dim_el) * grad_phi_Minv(i, j)[dim_el];
-	  // Third term, eq 9
-	  // First term, eq 10
-	  lapl_grad[dim][iel] -= phi_alpha_Minv(j, i)[dim] * lapl_phi_Minv(i, j);
-	  // Second term, eq 11
-	  for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
-	    lapl_grad[dim][iel] +=
-		(RealType)2.0 * phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, i)[dim_el] * grad_phi_Minv(i, j)[dim_el];
-	}
+        for (int k = 0; k < OHMMS_DIM; k++)
+          grad_grad[dim][iel][k] += dval(dim, k);
+        for (int j = 0; j < NumOrbitals; j++)
+        {
+          // First term, eq 9
+          lapl_grad[dim][iel] += grad_lapl_source_psiM(i, j)[dim] * psiM(i, j);
+          // Second term, eq 9
+          if (j == i)
+            for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
+              lapl_grad[dim][iel] -=
+                  (RealType)2.0 * grad_phi_alpha_Minv(j, i)(dim, dim_el) * grad_phi_Minv(i, j)[dim_el];
+          // Third term, eq 9
+          // First term, eq 10
+          lapl_grad[dim][iel] -= phi_alpha_Minv(j, i)[dim] * lapl_phi_Minv(i, j);
+          // Second term, eq 11
+          for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
+            lapl_grad[dim][iel] +=
+                (RealType)2.0 * phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, i)[dim_el] * grad_phi_Minv(i, j)[dim_el];
+        }
       }
     }
   }
@@ -506,9 +505,10 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
  *for local energy calculations.
  */
 template<typename DU_TYPE>
-typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::evaluateLog(ParticleSet& P,
-                                                                                    ParticleSet::ParticleGradient_t& G,
-                                                                                    ParticleSet::ParticleLaplacian_t& L)
+typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::evaluateLog(
+    ParticleSet& P,
+    ParticleSet::ParticleGradient_t& G,
+    ParticleSet::ParticleLaplacian_t& L)
 {
   recompute(P);
 
@@ -557,7 +557,6 @@ void DiracDeterminant<DU_TYPE>::evaluateDerivatives(ParticleSet& P,
                                                     std::vector<ValueType>& dlogpsi,
                                                     std::vector<ValueType>& dhpsioverpsi)
 {
-
   Phi->evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi, FirstIndex, LastIndex);
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -86,7 +86,7 @@ public:
    * @param P current configuration
    * @param iat the particle thas is being moved
    */
-  ValueType ratio(ParticleSet& P, int iat) override;
+  PsiValueType ratio(ParticleSet& P, int iat) override;
 
   //Ye: TODO, good performance needs batched SPO evaluation.
   //void mw_calcRatio(const std::vector<WaveFunctionComponent*>& WFC_list,
@@ -98,7 +98,7 @@ public:
    */
   void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios) override;
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
 
   void mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
                     const std::vector<ParticleSet*>& P_list,
@@ -207,7 +207,7 @@ public:
    */
   int invRow_id;
 
-  ValueType curRatio;
+  PsiValueType curRatio;
   ValueType* FirstAddressOfdV;
   ValueType* LastAddressOfdV;
 
@@ -219,7 +219,7 @@ private:
   void resizeScratchObjectsForIonDerivs();
 
   /// internal function computing ratio and gradients after computing the SPOs, used by ratioGrad.
-  ValueType ratioGrad_compute(int iat, GradType& grad_iat);
+  PsiValueType ratioGrad_compute(int iat, GradType& grad_iat);
 };
 
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -161,9 +161,9 @@ public:
 
   void restore(int iat) { APP_ABORT("Calling DiracDeterminantCUDA::restore is illegal!"); }
 
-  ValueType ratio(ParticleSet& P, int iat) { APP_ABORT("Calling DiracDeterminantCUDA::ratio is illegal!"); }
+  PsiValueType ratio(ParticleSet& P, int iat) { APP_ABORT("Calling DiracDeterminantCUDA::ratio is illegal!"); }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     APP_ABORT("Calling DiracDeterminantCUDA::ratioGrad is illegal!");
   }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -200,7 +200,7 @@ void DiracDeterminantWithBackflow::copyFromBuffer(ParticleSet& P, WFBufferType& 
  * @param P current configuration
  * @param iat the particle thas is being moved
  */
-DiracDeterminantWithBackflow::ValueType DiracDeterminantWithBackflow::ratio(ParticleSet& P, int iat)
+DiracDeterminantWithBackflow::PsiValueType DiracDeterminantWithBackflow::ratio(ParticleSet& P, int iat)
 {
   // FIX FIX FIX : code Woodbury formula
   psiM_temp = psiM;
@@ -269,9 +269,9 @@ DiracDeterminantWithBackflow::GradType DiracDeterminantWithBackflow::evalGradSou
   return GradType();
 }
 
-DiracDeterminantWithBackflow::ValueType DiracDeterminantWithBackflow::ratioGrad(ParticleSet& P,
-                                                                                int iat,
-                                                                                GradType& grad_iat)
+DiracDeterminantWithBackflow::PsiValueType DiracDeterminantWithBackflow::ratioGrad(ParticleSet& P,
+                                                                                   int iat,
+                                                                                   GradType& grad_iat)
 {
   // FIX FIX FIX : code Woodbury formula
   psiM_temp                         = psiM;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -33,9 +33,9 @@ DiracDeterminantWithBackflow::DiracDeterminantWithBackflow(ParticleSet& ptcl,
                                                            int first)
     : DiracDeterminantBase(spos, first)
 {
-  Optimizable = true;
+  Optimizable  = true;
   is_fermionic = true;
-  ClassName   = "DiracDeterminantWithBackflow";
+  ClassName    = "DiracDeterminantWithBackflow";
   registerTimers();
   BFTrans      = BF;
   NumParticles = ptcl.getTotalNum();
@@ -98,12 +98,7 @@ void DiracDeterminantWithBackflow::evaluate_SPO(ValueMatrix_t& logdet,
                                                 HessMatrix_t& grad_grad_logdet,
                                                 GGGMatrix_t& grad_grad_grad_logdet)
 {
-  Phi->evaluate_notranspose(BFTrans->QP,
-                            FirstIndex,
-                            LastIndex,
-                            psiM_temp,
-                            dlogdet,
-                            grad_grad_logdet,
+  Phi->evaluate_notranspose(BFTrans->QP, FirstIndex, LastIndex, psiM_temp, dlogdet, grad_grad_logdet,
                             grad_grad_grad_logdet);
   simd::transpose(psiM_temp.data(), NumOrbitals, psiM_temp.cols(), logdet.data(), NumOrbitals, logdet.cols());
 }
@@ -152,8 +147,8 @@ void DiracDeterminantWithBackflow::registerData(ParticleSet& P, WFBufferType& bu
 }
 
 DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::updateBuffer(ParticleSet& P,
-                                                                                  WFBufferType& buf,
-                                                                                  bool fromscratch)
+                                                                                      WFBufferType& buf,
+                                                                                      bool fromscratch)
 {
   // for now, always recalculate from scratch
   // enable from_scratch = true later
@@ -490,9 +485,10 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
  *contribution of the determinant to G(radient) and L(aplacian)
  *for local energy calculations.
  */
-DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluateLog(ParticleSet& P,
-                                                                                 ParticleSet::ParticleGradient_t& G,
-                                                                                 ParticleSet::ParticleLaplacian_t& L)
+DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluateLog(
+    ParticleSet& P,
+    ParticleSet::ParticleGradient_t& G,
+    ParticleSet::ParticleLaplacian_t& L)
 {
   //testGG(P);
   //testL(P);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -107,11 +107,11 @@ public:
    * @param P current configuration
    * @param iat the particle thas is being moved
    */
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios);
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
   GradType evalGrad(ParticleSet& P, int iat);
   GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat);
 
@@ -188,7 +188,7 @@ public:
   GradVector_t dpsiV;
   ValueVector_t d2psiV;
 
-  ValueType curRatio;
+  PsiValueType curRatio;
   ParticleSet::SingleParticleValue_t* FirstAddressOfG;
   ParticleSet::SingleParticleValue_t* LastAddressOfG;
   ValueType* FirstAddressOfdV;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -64,10 +64,10 @@ public:
    *@param nel number of particles in the determinant
    *@param delay dummy argument
    */
-  void set(int first, int nel, int delay=1) final
+  void set(int first, int nel, int delay = 1) final
   {
     FirstIndex = first;
-    resize(nel,nel);
+    resize(nel, nel);
   }
 
   ///set BF pointers

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -135,32 +135,9 @@ public:
     const size_t NP1 = NumPtcls;
     const size_t NP2 = pseudo_dn.NumPtcls;
 
-    Phi->evaluateDerivatives(P,
-                             optvars,
-                             dlogpsi,
-                             dhpsioverpsi,
-                             psiCurrent,
-                             Coeff,
-                             C2node_up,
-                             C2node_dn,
-                             detValues_up,
-                             detValues_dn,
-                             grads_up,
-                             grads_dn,
-                             lapls_up,
-                             lapls_dn,
-                             M_up,
-                             M_dn,
-                             Minv_up,
-                             Minv_dn,
-                             B_grad,
-                             B_lapl,
-                             *detData,
-                             N1,
-                             N2,
-                             NP1,
-                             NP2,
-                             lookup_tbl);
+    Phi->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi, psiCurrent, Coeff, C2node_up, C2node_dn, detValues_up,
+                             detValues_dn, grads_up, grads_dn, lapls_up, lapls_dn, M_up, M_dn, Minv_up, Minv_dn, B_grad,
+                             B_lapl, *detData, N1, N2, NP1, NP2, lookup_tbl);
   }
 
 
@@ -241,34 +218,25 @@ public:
       return 1.0;
     case 1:
       return dotProducts(*it, *(it + 1));
-    case 2:
-    {
+    case 2: {
       const int i = *it;
       const int j = *(it + 1);
       const int a = *(it + 2);
       const int b = *(it + 3);
       return dotProducts(i, a) * dotProducts(j, b) - dotProducts(i, b) * dotProducts(j, a);
     }
-    case 3:
-    {
+    case 3: {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
       const int a1 = *(it + 3);
       const int a2 = *(it + 4);
       const int a3 = *(it + 5);
-      return DetCalculator.evaluate(dotProducts(i1, a1),
-                                    dotProducts(i1, a2),
-                                    dotProducts(i1, a3),
-                                    dotProducts(i2, a1),
-                                    dotProducts(i2, a2),
-                                    dotProducts(i2, a3),
-                                    dotProducts(i3, a1),
-                                    dotProducts(i3, a2),
+      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
+                                    dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
                                     dotProducts(i3, a3));
     }
-    case 4:
-    {
+    case 4: {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
@@ -277,25 +245,12 @@ public:
       const int a2 = *(it + 5);
       const int a3 = *(it + 6);
       const int a4 = *(it + 7);
-      return DetCalculator.evaluate(dotProducts(i1, a1),
-                                    dotProducts(i1, a2),
-                                    dotProducts(i1, a3),
-                                    dotProducts(i1, a4),
-                                    dotProducts(i2, a1),
-                                    dotProducts(i2, a2),
-                                    dotProducts(i2, a3),
-                                    dotProducts(i2, a4),
-                                    dotProducts(i3, a1),
-                                    dotProducts(i3, a2),
-                                    dotProducts(i3, a3),
-                                    dotProducts(i3, a4),
-                                    dotProducts(i4, a1),
-                                    dotProducts(i4, a2),
-                                    dotProducts(i4, a3),
-                                    dotProducts(i4, a4));
+      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+                                    dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
+                                    dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
+                                    dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
     }
-    case 5:
-    {
+    case 5: {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
@@ -306,30 +261,12 @@ public:
       const int a3 = *(it + 7);
       const int a4 = *(it + 8);
       const int a5 = *(it + 9);
-      return DetCalculator.evaluate(dotProducts(i1, a1),
-                                    dotProducts(i1, a2),
-                                    dotProducts(i1, a3),
-                                    dotProducts(i1, a4),
-                                    dotProducts(i1, a5),
-                                    dotProducts(i2, a1),
-                                    dotProducts(i2, a2),
-                                    dotProducts(i2, a3),
-                                    dotProducts(i2, a4),
-                                    dotProducts(i2, a5),
-                                    dotProducts(i3, a1),
-                                    dotProducts(i3, a2),
-                                    dotProducts(i3, a3),
-                                    dotProducts(i3, a4),
-                                    dotProducts(i3, a5),
-                                    dotProducts(i4, a1),
-                                    dotProducts(i4, a2),
-                                    dotProducts(i4, a3),
-                                    dotProducts(i4, a4),
-                                    dotProducts(i4, a5),
-                                    dotProducts(i5, a1),
-                                    dotProducts(i5, a2),
-                                    dotProducts(i5, a3),
-                                    dotProducts(i5, a4),
+      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+                                    dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
+                                    dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
+                                    dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),
+                                    dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4), dotProducts(i4, a5),
+                                    dotProducts(i5, a1), dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
                                     dotProducts(i5, a5));
     }
     default:

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -190,10 +190,10 @@ public:
    * These functions should not be called.
    ***************************************************************************/
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return ValueType();
+    return PsiValueType();
   }
 
   GradType evalGrad(ParticleSet& P, int iat)
@@ -202,10 +202,10 @@ public:
     return GradType();
   }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
-    return ValueType();
+    return PsiValueType();
   }
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -265,7 +265,7 @@ WaveFunctionComponent::GradType MultiSlaterDeterminant::evalGrad(ParticleSet& P,
   }
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminant::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminant::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   UpdateMode = ORB_PBYP_PARTIAL;
   if (DetID[iat] == 0)
@@ -334,7 +334,7 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminant::ratioGrad(ParticleSet& 
 
 
 // use ci_node for this routine only
-WaveFunctionComponent::ValueType MultiSlaterDeterminant::ratio(ParticleSet& P, int iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminant::ratio(ParticleSet& P, int iat)
 {
   UpdateMode = ORB_PBYP_RATIO;
   if (DetID[iat] == 0)

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -214,8 +214,8 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P
 }
 
 WaveFunctionComponent::LogValueType MultiSlaterDeterminant::evaluateLog(ParticleSet& P,
-                                                                    ParticleSet::ParticleGradient_t& G,
-                                                                    ParticleSet::ParticleLaplacian_t& L)
+                                                                        ParticleSet::ParticleGradient_t& G,
+                                                                        ParticleSet::ParticleLaplacian_t& L)
 {
   return LogValue = convertValueToLog(evaluate(P, G, L));
 }
@@ -526,8 +526,8 @@ void MultiSlaterDeterminant::registerData(ParticleSet& P, WFBufferType& buf)
 
 // FIX FIX FIX
 WaveFunctionComponent::LogValueType MultiSlaterDeterminant::updateBuffer(ParticleSet& P,
-                                                                     WFBufferType& buf,
-                                                                     bool fromscratch)
+                                                                         WFBufferType& buf,
+                                                                         bool fromscratch)
 {
   UpdateTimer.start();
   if (fromscratch || UpdateMode == ORB_PBYP_RATIO)
@@ -543,10 +543,10 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminant::updateBuffer(Particl
     P.G = 0.0;
     P.L = 0.0;
     spo_up->prepareFor(i);
-    logpsi = dets_up[i]->updateBuffer(P, buf, fromscratch);
+    logpsi          = dets_up[i]->updateBuffer(P, buf, fromscratch);
     detValues_up[i] = dets_up[i]->getValue();
-    grads_up[i] = P.G;
-    lapls_up[i] = P.L;
+    grads_up[i]     = P.G;
+    lapls_up[i]     = P.L;
     for (int k = FirstIndex_up; k < LastIndex_up; k++)
       lapls_up[i][k] += dot(grads_up[i][k], grads_up[i][k]);
   }
@@ -555,10 +555,10 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminant::updateBuffer(Particl
     P.G = 0.0;
     P.L = 0.0;
     spo_dn->prepareFor(i);
-    logpsi = dets_dn[i]->updateBuffer(P, buf, fromscratch);
+    logpsi          = dets_dn[i]->updateBuffer(P, buf, fromscratch);
     detValues_dn[i] = dets_dn[i]->getValue();
-    grads_dn[i] = P.G;
-    lapls_dn[i] = P.L;
+    grads_dn[i]     = P.G;
+    lapls_dn[i]     = P.L;
     for (int k = FirstIndex_dn; k < LastIndex_dn; k++)
       lapls_dn[i][k] += dot(grads_dn[i][k], grads_dn[i][k]);
   }
@@ -716,7 +716,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
   {
     if (usingCSF)
     {
-      int n = P.getTotalNum();
+      int n            = P.getTotalNum();
       ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
 
       ValueType lapl_sum = 0.0;
@@ -780,7 +780,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
     }
     else
     {
-      int n = P.getTotalNum();
+      int n            = P.getTotalNum();
       ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
 
       ValueType lapl_sum = 0.0;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
@@ -88,9 +88,9 @@ public:
   virtual ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   virtual LogValueType evaluateLog(ParticleSet& P //const DistanceTableData* dtable,
-                               ,
-                               ParticleSet::ParticleGradient_t& G,
-                               ParticleSet::ParticleLaplacian_t& L);
+                                   ,
+                                   ParticleSet::ParticleGradient_t& G,
+                                   ParticleSet::ParticleLaplacian_t& L);
 
   virtual GradType evalGrad(ParticleSet& P, int iat);
   virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
@@ -93,8 +93,8 @@ public:
                                ParticleSet::ParticleLaplacian_t& L);
 
   virtual GradType evalGrad(ParticleSet& P, int iat);
-  virtual ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
-  virtual ValueType ratio(ParticleSet& P, int iat);
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  virtual PsiValueType ratio(ParticleSet& P, int iat);
   virtual void acceptMove(ParticleSet& P, int iat);
   virtual void restore(int iat);
 
@@ -156,7 +156,7 @@ public:
   // lap(#uniqueDet,part#)
   std::vector<ParticleSet::ParticleLaplacian_t> templapl;
 
-  ValueType curRatio;
+  PsiValueType curRatio;
   ValueType psiCurrent;
   ValueVector_t detsRatios;
   ValueVector_t tempstorage_up;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -204,9 +204,10 @@ void MultiSlaterDeterminantFast::testMSD(ParticleSet& P, int iat)
  * - evaluateLog(P,G,L,buf,fillbuffer)
  * Miguel's note: can this change over time??? I don't know yet
  */
-WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate_vgl_impl(ParticleSet& P,
-                                                                               ParticleSet::ParticleGradient_t& g_tmp,
-                                                                               ParticleSet::ParticleLaplacian_t& l_tmp)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate_vgl_impl(
+    ParticleSet& P,
+    ParticleSet::ParticleGradient_t& g_tmp,
+    ParticleSet::ParticleLaplacian_t& l_tmp)
 {
   const ValueVector_t& detValues_up = Dets[0]->detValues;
   const ValueVector_t& detValues_dn = Dets[1]->detValues;
@@ -220,16 +221,16 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate_vgl_imp
   const size_t NP2                  = Dets[1]->NumPtcls;
   const ValueType czero(0);
   PsiValueType psi = czero;
-  g_tmp         = czero;
-  l_tmp         = czero;
+  g_tmp            = czero;
+  l_tmp            = czero;
 
   const ValueType* restrict cptr = C->data();
-  const size_t nc               = C->size();
-  const size_t* restrict upC    = C2node_up->data();
-  const size_t* restrict dnC    = C2node_dn->data();
+  const size_t nc                = C->size();
+  const size_t* restrict upC     = C2node_up->data();
+  const size_t* restrict dnC     = C2node_dn->data();
   for (size_t i = 0; i < nc; ++i)
   {
-    const ValueType c  = cptr[i];
+    const ValueType c = cptr[i];
     const size_t up   = upC[i];
     const size_t down = dnC[i];
     psi += c * detValues_up[up] * detValues_dn[down];
@@ -273,16 +274,16 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate(Particl
 }
 
 WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::evaluateLog(ParticleSet& P,
-                                                                        ParticleSet::ParticleGradient_t& G,
-                                                                        ParticleSet::ParticleLaplacian_t& L)
+                                                                            ParticleSet::ParticleGradient_t& G,
+                                                                            ParticleSet::ParticleLaplacian_t& L)
 {
   return LogValue = convertValueToLog(evaluate(P, G, L));
 }
 
 WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evalGrad_impl(ParticleSet& P,
-                                                                           int iat,
-                                                                           bool newpos,
-                                                                           GradType& g_at)
+                                                                              int iat,
+                                                                              bool newpos,
+                                                                              GradType& g_at)
 {
   const bool upspin = (iat < FirstIndex_dn);
   const int spin0   = (upspin) ? 0 : 1;
@@ -298,7 +299,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evalGrad_impl(Pa
   const ValueType* restrict detValues1 = Dets[spin1]->detValues.data();
   const size_t* restrict det0          = (upspin) ? C2node_up->data() : C2node_dn->data();
   const size_t* restrict det1          = (upspin) ? C2node_dn->data() : C2node_up->data();
-  const ValueType* restrict cptr        = C->data();
+  const ValueType* restrict cptr       = C->data();
   const size_t nc                      = C->size();
   const size_t noffset                 = Dets[spin0]->FirstIndex;
   PsiValueType psi(0);
@@ -354,7 +355,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratio_impl(Parti
   const ValueType* restrict detValues1 = Dets[spin1]->detValues.data();
   const size_t* restrict det0          = (upspin) ? C2node_up->data() : C2node_dn->data();
   const size_t* restrict det1          = (upspin) ? C2node_dn->data() : C2node_up->data();
-  const ValueType* restrict cptr        = C->data();
+  const ValueType* restrict cptr       = C->data();
   const size_t nc                      = C->size();
 
   PsiValueType psi = 0;
@@ -370,9 +371,9 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratio(ParticleSe
   {
     APP_ABORT("Fast MSD+BF: ratio not implemented. \n");
   }
-  UpdateMode       = ORB_PBYP_RATIO;
+  UpdateMode          = ORB_PBYP_RATIO;
   PsiValueType psiNew = ratio_impl(P, iat);
-  curRatio         = psiNew / psiCurrent;
+  curRatio            = psiNew / psiCurrent;
   return curRatio;
 }
 
@@ -424,8 +425,8 @@ void MultiSlaterDeterminantFast::registerData(ParticleSet& P, WFBufferType& buf)
 
 // FIX FIX FIX
 WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::updateBuffer(ParticleSet& P,
-                                                                         WFBufferType& buf,
-                                                                         bool fromscratch)
+                                                                             WFBufferType& buf,
+                                                                             bool fromscratch)
 {
   UpdateTimer.start();
 
@@ -506,7 +507,7 @@ void MultiSlaterDeterminantFast::resetParameters(const opt_variables_type& activ
         }
       }
       int cnt                                 = 0;
-      ValueType* restrict C_p                  = C->data();
+      ValueType* restrict C_p                 = C->data();
       const RealType* restrict CSFexpansion_p = CSFexpansion->data();
       for (int i = 0; i < DetsPerCSF->size(); i++)
       {
@@ -656,7 +657,7 @@ void MultiSlaterDeterminantFast::evaluateDerivatives(ParticleSet& P,
               v2 += tmp2 * static_cast<ValueType>(dot(P.G[j], grads_dn(dnC, l)) - dot(myG_temp[j], grads_dn(dnC, l)));
             cnt++;
           }
-          ValueType dhpsi = (RealType)-0.5 * (q0 - dlogpsi[kk] * lapl_sum) - dlogpsi[kk] * gg - v1 - v2;
+          ValueType dhpsi  = (RealType)-0.5 * (q0 - dlogpsi[kk] * lapl_sum) - dlogpsi[kk] * gg - v1 - v2;
           dhpsioverpsi[kk] = dhpsi;
         }
       }
@@ -737,7 +738,8 @@ void MultiSlaterDeterminantFast::evaluateDerivatives(ParticleSet& P,
             v1 += (dot(P.G[j], grads_up(upC, k)) - dot(myG_temp[j], grads_up(upC, k)));
           for (size_t k = 0, j = N2; k < NP2; k++, j++)
             v2 += (dot(P.G[j], grads_dn(dnC, k)) - dot(myG_temp[j], grads_dn(dnC, k)));
-          ValueType dhpsi = (RealType)-0.5 * (tmp1 * laplSum_up[upC] + tmp2 * laplSum_dn[dnC] - dlogpsi[kk] * lapl_sum) -
+          ValueType dhpsi =
+              (RealType)-0.5 * (tmp1 * laplSum_up[upC] + tmp2 * laplSum_dn[dnC] - dlogpsi[kk] * lapl_sum) -
               dlogpsi[kk] * gg - (tmp1 * v1 + tmp2 * v2);
           dhpsioverpsi[kk] = dhpsi;
         }
@@ -745,8 +747,10 @@ void MultiSlaterDeterminantFast::evaluateDerivatives(ParticleSet& P,
     }
   }
 
-  Dets[0]->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi, *Dets[1], static_cast<ValueType>(psiCurrent), *C, *C2node_up, *C2node_dn);
-  Dets[1]->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi, *Dets[0], static_cast<ValueType>(psiCurrent), *C, *C2node_dn, *C2node_up);
+  Dets[0]->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi, *Dets[1], static_cast<ValueType>(psiCurrent), *C,
+                               *C2node_up, *C2node_dn);
+  Dets[1]->evaluateDerivatives(P, optvars, dlogpsi, dhpsioverpsi, *Dets[0], static_cast<ValueType>(psiCurrent), *C,
+                               *C2node_dn, *C2node_up);
 }
 
 void MultiSlaterDeterminantFast::evaluateDerivativesWF(ParticleSet& P,
@@ -773,9 +777,9 @@ void MultiSlaterDeterminantFast::evaluateDerivativesWF(ParticleSet& P,
         ValueVector_t& detValues_up = Dets[0]->detValues;
         ValueVector_t& detValues_dn = Dets[1]->detValues;
 
-        ValueType psiinv   = static_cast<ValueType>(PsiValueType(1.0) / psiCurrent);
+        ValueType psiinv = static_cast<ValueType>(PsiValueType(1.0) / psiCurrent);
 
-        int num     = CSFcoeff->size() - 1;
+        int num = CSFcoeff->size() - 1;
         int cnt = 0;
         //        this one is not optable
         cnt += (*DetsPerCSF)[0];
@@ -788,12 +792,12 @@ void MultiSlaterDeterminantFast::evaluateDerivativesWF(ParticleSet& P,
             cnt += (*DetsPerCSF)[ip];
             continue;
           }
-          ValueType cdet = 0.0;
+          ValueType cdet                          = 0.0;
           const RealType* restrict CSFexpansion_p = CSFexpansion->data();
           for (int k = 0; k < (*DetsPerCSF)[ip]; k++)
           {
-            size_t upC     = (*C2node_up)[cnt];
-            size_t dnC     = (*C2node_dn)[cnt];
+            size_t upC = (*C2node_up)[cnt];
+            size_t dnC = (*C2node_dn)[cnt];
             cdet += CSFexpansion_p[cnt] * detValues_up[upC] * detValues_dn[dnC] * psiinv;
             cnt++;
           }
@@ -814,7 +818,7 @@ void MultiSlaterDeterminantFast::evaluateDerivativesWF(ParticleSet& P,
           const size_t upC = (*C2node_up)[i];
           const size_t dnC = (*C2node_dn)[i];
           ValueType cdet   = detValues_up[upC] * detValues_dn[dnC] * psiinv;
-          dlogpsi[kk] = cdet;
+          dlogpsi[kk]      = cdet;
         }
       }
     }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -329,7 +329,7 @@ WaveFunctionComponent::GradType MultiSlaterDeterminantFast::evalGrad(ParticleSet
   return grad_iat;
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminantFast::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   if (usingBF)
   {
@@ -345,7 +345,7 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminantFast::ratioGrad(ParticleS
   return curRatio;
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminantFast::ratio_impl(ParticleSet& P, int iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratio_impl(ParticleSet& P, int iat)
 {
   const bool upspin = (iat < FirstIndex_dn);
   const int spin0   = (upspin) ? 0 : 1;
@@ -360,22 +360,22 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminantFast::ratio_impl(Particle
   const ValueType* restrict cptr        = C->data();
   const size_t nc                      = C->size();
 
-  ValueType psi = 0;
+  PsiValueType psi = 0;
   for (size_t i = 0; i < nc; ++i)
     psi += cptr[i] * detValues0[det0[i]] * detValues1[det1[i]];
   return psi;
 }
 
 // use ci_node for this routine only
-WaveFunctionComponent::ValueType MultiSlaterDeterminantFast::ratio(ParticleSet& P, int iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratio(ParticleSet& P, int iat)
 {
   if (usingBF)
   {
     APP_ABORT("Fast MSD+BF: ratio not implemented. \n");
   }
   UpdateMode       = ORB_PBYP_RATIO;
-  ValueType psiNew = ratio_impl(P, iat);
-  curRatio         = psiNew / psiCurrent;
+  PsiValueType psiNew = ratio_impl(P, iat);
+  curRatio         = psiNew / static_cast<PsiValueType>(psiCurrent);
   return curRatio;
 }
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -95,11 +95,11 @@ public:
     Dets[1]->setBF(bf);
   }
 
-  ValueType evaluate_vgl_impl(ParticleSet& P,
-                              ParticleSet::ParticleGradient_t& g_tmp,
-                              ParticleSet::ParticleLaplacian_t& l_tmp);
+  PsiValueType evaluate_vgl_impl(ParticleSet& P,
+                                 ParticleSet::ParticleGradient_t& g_tmp,
+                                 ParticleSet::ParticleLaplacian_t& l_tmp);
 
-  ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  PsiValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   LogValueType evaluateLog(ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
@@ -107,7 +107,7 @@ public:
 
   GradType evalGrad(ParticleSet& P, int iat) override;
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
-  ValueType evalGrad_impl(ParticleSet& P, int iat, bool newpos, GradType& g_at);
+  PsiValueType evalGrad_impl(ParticleSet& P, int iat, bool newpos, GradType& g_at);
 
   PsiValueType ratio(ParticleSet& P, int iat) override;
   PsiValueType ratio_impl(ParticleSet& P, int iat);
@@ -150,7 +150,7 @@ public:
   bool usingCSF;
   bool IsCloned;
   PsiValueType curRatio;
-  ValueType psiCurrent;
+  PsiValueType psiCurrent;
 
   // assume Dets[0]: up, Dets[1]:down
   std::vector<MultiDiracDeterminant*> Dets;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -106,11 +106,11 @@ public:
                            ParticleSet::ParticleLaplacian_t& L) override;
 
   GradType evalGrad(ParticleSet& P, int iat) override;
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
   ValueType evalGrad_impl(ParticleSet& P, int iat, bool newpos, GradType& g_at);
 
-  ValueType ratio(ParticleSet& P, int iat) override;
-  ValueType ratio_impl(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat) override;
+  PsiValueType ratio_impl(ParticleSet& P, int iat);
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
     // the base class routine may probably work, just never tested.
@@ -149,7 +149,7 @@ public:
   size_t ActiveSpin;
   bool usingCSF;
   bool IsCloned;
-  ValueType curRatio;
+  PsiValueType curRatio;
   ValueType psiCurrent;
 
   // assume Dets[0]: up, Dets[1]:down

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -224,7 +224,7 @@ WaveFunctionComponent::GradType MultiSlaterDeterminantWithBackflow::evalGrad(Par
   }
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::ratioGrad(ParticleSet& P,
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantWithBackflow::ratioGrad(ParticleSet& P,
                                                                                int iat,
                                                                                GradType& grad_iat)
 {
@@ -295,7 +295,7 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::ratioGrad(P
 }
 
 // use ci_node for this routine only
-WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::ratio(ParticleSet& P, int iat)
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantWithBackflow::ratio(ParticleSet& P, int iat)
 {
   APP_ABORT("MultiSlaterDeterminantWithBackflow:: pbyp routines not implemented ");
   UpdateMode = ORB_PBYP_RATIO;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -24,9 +24,9 @@ MultiSlaterDeterminantWithBackflow::MultiSlaterDeterminantWithBackflow(ParticleS
                                                                        BackflowTransformation* BF)
     : MultiSlaterDeterminant(targetPtcl, upspo, dnspo), BFTrans(BF)
 {
-  Optimizable = false;
+  Optimizable  = false;
   is_fermionic = true;
-  ClassName   = "MultiSlaterDeterminantWithBackflow";
+  ClassName    = "MultiSlaterDeterminantWithBackflow";
 }
 
 WaveFunctionComponentPtr MultiSlaterDeterminantWithBackflow::makeClone(ParticleSet& tqp) const
@@ -174,8 +174,8 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::evaluate(Pa
 }
 
 WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::evaluateLog(ParticleSet& P,
-                                                                                ParticleSet::ParticleGradient_t& G,
-                                                                                ParticleSet::ParticleLaplacian_t& L)
+                                                                                    ParticleSet::ParticleGradient_t& G,
+                                                                                    ParticleSet::ParticleLaplacian_t& L)
 {
   return LogValue = convertValueToLog(evaluate(P, G, L));
 }
@@ -225,8 +225,8 @@ WaveFunctionComponent::GradType MultiSlaterDeterminantWithBackflow::evalGrad(Par
 }
 
 WaveFunctionComponent::PsiValueType MultiSlaterDeterminantWithBackflow::ratioGrad(ParticleSet& P,
-                                                                               int iat,
-                                                                               GradType& grad_iat)
+                                                                                  int iat,
+                                                                                  GradType& grad_iat)
 {
   APP_ABORT("MultiSlaterDeterminantWithBackflow:: pbyp routines not implemented ");
   UpdateMode = ORB_PBYP_PARTIAL;
@@ -507,8 +507,8 @@ void MultiSlaterDeterminantWithBackflow::registerData(ParticleSet& P, WFBufferTy
 
 // FIX FIX FIX
 WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::updateBuffer(ParticleSet& P,
-                                                                                 WFBufferType& buf,
-                                                                                 bool fromscratch)
+                                                                                     WFBufferType& buf,
+                                                                                     bool fromscratch)
 {
   UpdateTimer.start();
   if (fromscratch || UpdateMode == ORB_PBYP_RATIO)
@@ -525,10 +525,10 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::updateBu
     BFTrans->QP.G = 0.0;
     BFTrans->QP.L = 0.0;
     spo_up->prepareFor(i);
-    logpsi = dets_up[i]->updateBuffer(BFTrans->QP, buf, fromscratch);
+    logpsi          = dets_up[i]->updateBuffer(BFTrans->QP, buf, fromscratch);
     detValues_up[i] = LogToValue<PsiValueType>::convert(logpsi);
-    grads_up[i] = BFTrans->QP.G;
-    lapls_up[i] = BFTrans->QP.L;
+    grads_up[i]     = BFTrans->QP.G;
+    lapls_up[i]     = BFTrans->QP.L;
     for (int k = FirstIndex_up; k < LastIndex_up; k++)
       lapls_up[i][k] += dot(grads_up[i][k], grads_up[i][k]);
   }
@@ -537,10 +537,10 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::updateBu
     BFTrans->QP.G = 0.0;
     BFTrans->QP.L = 0.0;
     spo_dn->prepareFor(i);
-    logpsi = dets_dn[i]->updateBuffer(BFTrans->QP, buf, fromscratch);
+    logpsi          = dets_dn[i]->updateBuffer(BFTrans->QP, buf, fromscratch);
     detValues_dn[i] = LogToValue<PsiValueType>::convert(logpsi);
-    grads_dn[i] = BFTrans->QP.G;
-    lapls_dn[i] = BFTrans->QP.L;
+    grads_dn[i]     = BFTrans->QP.G;
+    lapls_dn[i]     = BFTrans->QP.L;
     for (int k = FirstIndex_dn; k < LastIndex_dn; k++)
       lapls_dn[i][k] += dot(grads_dn[i][k], grads_dn[i][k]);
   }
@@ -701,7 +701,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
   {
     if (usingCSF)
     {
-      int n = P.getTotalNum();
+      int n            = P.getTotalNum();
       ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
 
       ValueType lapl_sum = 0.0;
@@ -751,8 +751,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
           v1 += tmp * static_cast<ValueType>(Dot(gmP, grads_up[upC]) + Dot(gmP, grads_dn[dnC]));
           cnt++;
         }
-        dlogpsi[kk] = cdet;
-        ValueType dhpsi = (RealType)-0.5 * (q0 - cdet * lapl_sum) - cdet * gg + v1;
+        dlogpsi[kk]      = cdet;
+        ValueType dhpsi  = (RealType)-0.5 * (q0 - cdet * lapl_sum) - cdet * gg + v1;
         dhpsioverpsi[kk] = dhpsi;
       }
       if (optmBF)
@@ -763,7 +763,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     }
     else
     {
-      int n = P.getTotalNum();
+      int n            = P.getTotalNum();
       ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
 
       ValueType lapl_sum = 0.0;
@@ -797,10 +797,10 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
           int kk = myVars.where(i);
           if (kk < 0)
             continue;
-          int upC        = C2node_up[ip];
-          int dnC        = C2node_dn[ip];
-          ValueType cdet = detValues_up[upC] * detValues_dn[dnC] * psiinv;
-          dlogpsi[kk] = cdet;
+          int upC         = C2node_up[ip];
+          int dnC         = C2node_dn[ip];
+          ValueType cdet  = detValues_up[upC] * detValues_dn[dnC] * psiinv;
+          dlogpsi[kk]     = cdet;
           ValueType dhpsi = ((RealType)-0.5 * cdet) *
               (tempstorage_up[upC] + tempstorage_dn[dnC] - lapl_sum +
                static_cast<ValueType>(2.0 * Dot(grads_up[upC], grads_dn[dnC])) +
@@ -867,8 +867,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
                 (dLa_up(upC, pa) + dLa_dn(dnC, pa) + dpsi2 * tempstorage_up[upC] + dpsi1 * tempstorage_dn[dnC] +
                  static_cast<ValueType>(2.0 * dot1));
           } // i
-          dhpsi = (RealType)-0.5 * (dhpsi + dlog * ((RealType)2.0 * ggP - lapl_sum));
-          dlogpsi[kk] = dlog;
+          dhpsi            = (RealType)-0.5 * (dhpsi + dlog * ((RealType)2.0 * ggP - lapl_sum));
+          dlogpsi[kk]      = dlog;
           dhpsioverpsi[kk] = dhpsi;
         } // pa
       }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
@@ -58,9 +58,9 @@ public:
   ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   LogValueType evaluateLog(ParticleSet& P //const DistanceTableData* dtable,
-                       ,
-                       ParticleSet::ParticleGradient_t& G,
-                       ParticleSet::ParticleLaplacian_t& L);
+                           ,
+                           ParticleSet::ParticleGradient_t& G,
+                           ParticleSet::ParticleLaplacian_t& L);
 
   GradType evalGrad(ParticleSet& P, int iat);
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
@@ -63,8 +63,8 @@ public:
                        ParticleSet::ParticleLaplacian_t& L);
 
   GradType evalGrad(ParticleSet& P, int iat);
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
   void acceptMove(ParticleSet& P, int iat);
   void restore(int iat);
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -93,7 +93,7 @@ public:
     return Dets[getDetID(VP.refPtcl)]->evaluateRatios(VP, ratios);
   }
 
-  virtual inline ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
+  virtual inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
   {
     return Dets[getDetID(iat)]->ratioGrad(P, iat, grad_iat);
   }
@@ -190,7 +190,7 @@ public:
       Dets[i]->mw_completeUpdates(extract_Det_list(WFC_list, i));
   }
 
-  virtual inline ValueType ratio(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->ratio(P, iat); }
+  virtual inline PsiValueType ratio(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->ratio(P, iat); }
 
   virtual void mw_calcRatio(const std::vector<WaveFunctionComponent*>& WFC_list,
                         const std::vector<ParticleSet*>& P_list,

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -68,7 +68,9 @@ public:
 
   virtual void resetTargetParticleSet(ParticleSet& P) override;
 
-  virtual LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) override;
+  virtual LogValueType evaluateLog(ParticleSet& P,
+                                   ParticleSet::ParticleGradient_t& G,
+                                   ParticleSet::ParticleLaplacian_t& L) override;
 
   virtual void mw_evaluateLog(const std::vector<WaveFunctionComponent*>& WFC_list,
                               const std::vector<ParticleSet*>& P_list,
@@ -141,8 +143,7 @@ public:
 
   virtual inline void restore(int iat) override { return Dets[getDetID(iat)]->restore(iat); }
 
-  virtual void mw_restore(const std::vector<WaveFunctionComponent*>& WFC_list,
-                          int iat) override
+  virtual void mw_restore(const std::vector<WaveFunctionComponent*>& WFC_list, int iat) override
   {
     const int det_id = getDetID(iat);
     Dets[det_id]->mw_restore(extract_Det_list(WFC_list, det_id), iat);
@@ -152,7 +153,7 @@ public:
   {
     Dets[getDetID(iat)]->acceptMove(P, iat);
 
-    LogValue   = 0.0;
+    LogValue = 0.0;
     for (int i = 0; i < Dets.size(); ++i)
       LogValue += Dets[i]->LogValue;
   }
@@ -164,7 +165,7 @@ public:
     constexpr RealType czero(0);
 
     for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw]->LogValue   = czero;
+      WFC_list[iw]->LogValue = czero;
 
     for (int i = 0; i < Dets.size(); ++i)
     {
@@ -193,9 +194,9 @@ public:
   virtual inline PsiValueType ratio(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->ratio(P, iat); }
 
   virtual void mw_calcRatio(const std::vector<WaveFunctionComponent*>& WFC_list,
-                        const std::vector<ParticleSet*>& P_list,
-                        int iat,
-                        std::vector<PsiValueType>& ratios) override
+                            const std::vector<ParticleSet*>& P_list,
+                            int iat,
+                            std::vector<PsiValueType>& ratios) override
   {
     const int det_id = getDetID(iat);
     Dets[det_id]->mw_calcRatio(extract_Det_list(WFC_list, det_id), P_list, iat, ratios);
@@ -226,7 +227,8 @@ public:
       Dets[i]->evaluateDerivatives(P, active, dlogpsi, dhpsioverpsi);
   }
 
-  void evaluateGradDerivatives(const ParticleSet::ParticleGradient_t& G_in, std::vector<ValueType>& dgradlogpsi) override
+  void evaluateGradDerivatives(const ParticleSet::ParticleGradient_t& G_in,
+                               std::vector<ValueType>& dgradlogpsi) override
   {
     for (int i = 0; i < Dets.size(); i++)
       Dets[i]->evaluateGradDerivatives(G_in, dgradlogpsi);
@@ -346,7 +348,8 @@ private:
   }
 
   // helper function for extracting a list of WaveFunctionComponent from a list of TrialWaveFunction
-  std::vector<WaveFunctionComponent*> extract_Det_list(const std::vector<WaveFunctionComponent*>& WFC_list, int det_id) const
+  std::vector<WaveFunctionComponent*> extract_Det_list(const std::vector<WaveFunctionComponent*>& WFC_list,
+                                                       int det_id) const
   {
     std::vector<WaveFunctionComponent*> Det_list;
     Det_list.reserve(WFC_list.size());
@@ -354,7 +357,6 @@ private:
       Det_list.push_back(dynamic_cast<SlaterDet*>(WFC)->Dets[det_id]);
     return Det_list;
   }
-
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -85,11 +85,11 @@ public:
   LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
-  inline ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     BFTrans->evaluatePbyPWithGrad(P, iat);
     //BFTrans->evaluate(P);
-    ValueType psi = 1.0;
+    PsiValueType psi = 1.0;
     for (int i = 0; i < Dets.size(); ++i)
       psi *= Dets[i]->ratioGrad(P, iat, grad_iat);
     return psi;
@@ -134,11 +134,11 @@ public:
   }
 
 
-  inline ValueType ratio(ParticleSet& P, int iat)
+  inline PsiValueType ratio(ParticleSet& P, int iat)
   {
     BFTrans->evaluatePbyP(P, iat);
     //BFTrans->evaluate(P);
-    ValueType ratio = 1.0;
+    PsiValueType ratio = 1.0;
     for (int i = 0; i < Dets.size(); ++i)
       ratio *= Dets[i]->ratio(P, iat);
     return ratio;

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -377,11 +377,11 @@ public:
     return Jgrad[iat];
   }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, PosType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, PosType& grad_iat)
   {
     evaluateTempExponents(P, iat);
     grad_iat += Jgrad_t[iat];
-    return std::exp(Jval_t - Jval);
+    return std::exp(static_cast<PsiValueType>(Jval_t - Jval));
   }
 
   void acceptMove(ParticleSet& P, int iat)
@@ -407,10 +407,10 @@ public:
 
   void restore(int iat) { C->restore(iat); }
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     evaluateTempExponents(P, iat);
-    return std::exp(Jval_t - Jval);
+    return std::exp(static_cast<PsiValueType>(Jval_t - Jval));
   }
 
   void registerData(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -91,11 +91,7 @@ protected:
 
 public:
   // constructor
-  CountingJastrow(ParticleSet& P, RegionType* c, const Matrix<RealType>& f) 
-      : F(f), C(c) 
-  {
-    num_els = P.getTotalNum();
-  }
+  CountingJastrow(ParticleSet& P, RegionType* c, const Matrix<RealType>& f) : F(f), C(c) { num_els = P.getTotalNum(); }
 
   void checkInVariables(opt_variables_type& active)
   {
@@ -125,13 +121,13 @@ public:
     // set F parameters from myVars
     for (int oi = 0; oi < opt_index[OPT_F].size(); ++oi)
     {
-      IJ    = opt_index[OPT_F][oi];
-      JI    = num_regions * (IJ % num_regions) + IJ / num_regions;
-      id    = opt_id[OPT_F][oi];
-      ia    = active.getLoc(id);
+      IJ         = opt_index[OPT_F][oi];
+      JI         = num_regions * (IJ % num_regions) + IJ / num_regions;
+      id         = opt_id[OPT_F][oi];
+      ia         = active.getLoc(id);
       myVars[id] = active[ia];
-      F(IJ) = std::real(myVars[id]);
-      F(JI) = std::real(myVars[id]);
+      F(IJ)      = std::real(myVars[id]);
+      F(JI)      = std::real(myVars[id]);
     }
     // reset parameters for counting regions
     C->resetParameters(active);
@@ -184,7 +180,7 @@ public:
         os.str("");
         os << "F_" << I << "_" << J;
         id_F = os.str();
-        myVars.insert(id_F, F(IJ), (opt_F && I < (num_regions-1)) );
+        myVars.insert(id_F, F(IJ), (opt_F && I < (num_regions - 1)));
         opt_index[OPT_F].push_back(IJ);
         opt_id[OPT_F].push_back(id_F);
       }
@@ -226,8 +222,8 @@ public:
 
 
   void recompute(ParticleSet& P)
-  { 
-    evaluateExponents(P); 
+  {
+    evaluateExponents(P);
     LogValue = Jval;
   }
 
@@ -251,7 +247,7 @@ public:
         for (int i = 0; i < num_els; ++i)
         {
           FCgrad(I, i) += F(I, J) * C->grad(J, i); // 3*nels*MV
-          FClap(I, i)  += F(I, J) * C->lap(J, i);  // nels*MV
+          FClap(I, i) += F(I, J) * C->lap(J, i);   // nels*MV
         }
       }
     }
@@ -261,8 +257,8 @@ public:
       Jval += FCsum[I] * C->sum[I]; // VV
       for (int i = 0; i < num_els; ++i)
       {
-        Jgrad[i] += 2 * FCsum[I] * C->grad(I, i);                                       // 3*nels*VV
-        Jlap[i]  += 2 * FCsum[I] * C->lap(I, i) + 2 * dot(FCgrad(I, i), C->grad(I, i)); // nels*VV
+        Jgrad[i] += 2 * FCsum[I] * C->grad(I, i);                                      // 3*nels*VV
+        Jlap[i] += 2 * FCsum[I] * C->lap(I, i) + 2 * dot(FCgrad(I, i), C->grad(I, i)); // nels*VV
       }
     }
     // print out results every so often
@@ -315,9 +311,9 @@ public:
     {
       for (int J = 0; J < num_regions; ++J)
       {
-        FCsum_t[I]  += F(I, J) * C->sum_t[J];
+        FCsum_t[I] += F(I, J) * C->sum_t[J];
         FCgrad_t[I] += F(I, J) * C->grad_t[J];
-        FClap_t[I]  += F(I, J) * C->lap_t[J];
+        FClap_t[I] += F(I, J) * C->lap_t[J];
       }
     }
     // evaluate components of the exponent
@@ -329,12 +325,12 @@ public:
         if (i == iat)
         {
           Jgrad_t[i] += C->grad_t[I] * 2 * FCsum_t[I];
-          Jlap_t[i]  += C->lap_t[I] * 2 * FCsum_t[I] + 2 * dot(C->grad_t[I], FCgrad_t[I]);
+          Jlap_t[i] += C->lap_t[I] * 2 * FCsum_t[I] + 2 * dot(C->grad_t[I], FCgrad_t[I]);
         }
         else
         {
           Jgrad_t[i] += C->grad(I, i) * 2 * FCsum_t[I];
-          Jlap_t[i]  += C->lap(I, i) * 2 * FCsum_t[I] + 2 * dot(C->grad(I, i), FCgrad(I, i));
+          Jlap_t[i] += C->lap(I, i) * 2 * FCsum_t[I] + 2 * dot(C->grad(I, i), FCgrad(I, i));
         }
       }
     }
@@ -396,7 +392,7 @@ public:
       FClap(I, iat)  = FClap_t[I];
     }
     // update exponent values to that at proposed position
-    Jval = Jval_t;
+    Jval     = Jval_t;
     LogValue = Jval;
     for (int i = 0; i < num_els; ++i)
     {
@@ -415,7 +411,7 @@ public:
 
   void registerData(ParticleSet& P, WFBufferType& buf)
   {
-    LogValueType logValue     = evaluateLog(P, P.G, P.L);
+    LogValueType logValue = evaluateLog(P, P.G, P.L);
     RealType* Jlap_begin  = &Jlap[0];
     RealType* Jlap_end    = Jlap_begin + Jlap.size();
     RealType* Jgrad_begin = &Jgrad[0][0];
@@ -429,7 +425,7 @@ public:
 
   LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
   {
-    LogValueType logValue     = evaluateLog(P, P.G, P.L);
+    LogValueType logValue = evaluateLog(P, P.G, P.L);
     RealType* Jlap_begin  = &Jlap[0];
     RealType* Jlap_end    = Jlap_begin + Jlap.size();
     RealType* Jgrad_begin = &Jgrad[0][0];
@@ -495,14 +491,15 @@ public:
         for (int i = 0; i < num_els; ++i)
         {
           PosType grad_i(P.G[i]);
-          dJF_gg  += x * (dot(C->grad(I, i), grad_i) * C->sum[J] + C->sum[I] * dot(C->grad(J, i), grad_i));
+          dJF_gg += x * (dot(C->grad(I, i), grad_i) * C->sum[J] + C->sum[I] * dot(C->grad(J, i), grad_i));
           dJF_lap += x * (C->lap(I, i) * C->sum[J] + 2 * dot(C->grad(I, i), C->grad(J, i)) + C->lap(J, i) * C->sum[I]);
         }
-        dlogpsi[ia]      += dJF_val;
+        dlogpsi[ia] += dJF_val;
         dhpsioverpsi[ia] += -0.5 * dJF_lap - dJF_gg;
-        if(debug && deriv_print_index < debug_seqlen)
+        if (debug && deriv_print_index < debug_seqlen)
         {
-          app_log() << "  dJ/dF["<< I << "]["<< J << "]; ia: " << ia << ",  dlogpsi: "  << dlogpsi[ia] << ", dhpsioverpsi: "<< dhpsioverpsi[ia] << std::endl;
+          app_log() << "  dJ/dF[" << I << "][" << J << "]; ia: " << ia << ",  dlogpsi: " << dlogpsi[ia]
+                    << ", dhpsioverpsi: " << dhpsioverpsi[ia] << std::endl;
         }
       }
     }
@@ -531,7 +528,7 @@ public:
         for (int i = 0; i < num_els; ++i)
         {
           PosType grad_i(P.G[i]);
-          FCggsum[I]  += dot(FCgrad(I, i), grad_i);
+          FCggsum[I] += dot(FCgrad(I, i), grad_i);
           FClapsum[I] += FClap(I, i);
         }
       }
@@ -624,11 +621,9 @@ public:
               app_log() << "      J: " << J << std::endl;
               app_log() << "      dlogpsi term          : " << dCsum(J, pI) * (2 * FCsum[J]) << std::endl;
               app_log() << "      dhpsi/psi, graddotgrad: "
-                        << -1.0 * (dCggsum(J, pI) * (2.0 * FCsum[J]) + dCsum(J, pI) * 2.0 * FCggsum[J])
-                        << std::endl;
+                        << -1.0 * (dCggsum(J, pI) * (2.0 * FCsum[J]) + dCsum(J, pI) * 2.0 * FCggsum[J]) << std::endl;
               app_log() << "      dhpsi/psi, laplacian  : "
-                        << -0.5 * (2.0 * dCsum(J, pI) * FClapsum[J] + dClapsum(J, pI) * (2.0 * FCsum[J]))
-                        << std::endl;
+                        << -0.5 * (2.0 * dCsum(J, pI) * FClapsum[J] + dClapsum(J, pI) * (2.0 * FCsum[J])) << std::endl;
             }
           }
         }
@@ -646,7 +641,8 @@ public:
         int ia         = myVars.getIndex(id);
         if (ia == -1)
           continue; // ignore inactive parameters
-        app_log() << "    ia: " << ia << ",  dlogpsi: "  << dlogpsi[ia] << ", dhpsioverpsi: "<< dhpsioverpsi[ia] << std::endl;
+        app_log() << "    ia: " << ia << ",  dlogpsi: " << dlogpsi[ia] << ", dhpsioverpsi: " << dhpsioverpsi[ia]
+                  << std::endl;
       }
       app_log() << "  C derivatives: " << std::endl;
       for (int I = 0; I < num_regions; ++I)
@@ -661,7 +657,8 @@ public:
           int ia = I_vars.Index[pI];
           if (ia == -1)
             continue; // ignore inactive
-          app_log() << "      ia: " << ia << ",  dlogpsi: "  << dlogpsi[ia] << ", dhpsioverpsi: "<< dhpsioverpsi[ia] << std::endl;
+          app_log() << "      ia: " << ia << ",  dlogpsi: " << dlogpsi[ia] << ", dhpsioverpsi: " << dhpsioverpsi[ia]
+                    << std::endl;
         }
       }
       deriv_print_index = deriv_print_index % debug_period;

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -153,11 +153,11 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     }
   }
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     UpdateMode = ORB_PBYP_RATIO;
     curAt      = computeU(P.getDistTable(myTableID).Temp_r.data());
-    return std::exp(Vat[iat] - curAt);
+    return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
   }
 
   inline void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -310,7 +310,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
    *
    * Using Temp_r. curAt, curGrad and curLap are computed.
    */
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     UpdateMode = ORB_PBYP_PARTIAL;
 
@@ -318,7 +318,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).Temp_dr, curGrad);
     curAt  = simd::accumulate_n(U.data(), Nions, valT());
     grad_iat += curGrad;
-    return std::exp(Vat[iat] - curAt);
+    return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
   }
 
   /** Rejected move. Nothing to do */

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -61,8 +61,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   ///Container for \f$F[ig*NumGroups+jg]\f$
   std::vector<FT*> F;
 
-  J1OrbitalSoA(const ParticleSet& ions, ParticleSet& els)
-    : myTableID(els.addTable(ions, DT_SOA)), Ions(ions)
+  J1OrbitalSoA(const ParticleSet& ions, ParticleSet& els) : myTableID(els.addTable(ions, DT_SOA)), Ions(ions)
   {
     initialize(els);
     ClassName = "J1OrbitalSoA";
@@ -141,13 +140,13 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       {
         int gid    = Ions.GroupID[iat];
         auto* func = F[gid];
-        if( func != nullptr)
+        if (func != nullptr)
         {
-           RealType r    = dist[iat];
-           RealType rinv = 1.0 / r;
-           PosType dr    = displ[iat];
-           func->evaluate(r, dudr, d2udr2);
-           grad_grad_psi[iel] -= rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
+          RealType r    = dist[iat];
+          RealType rinv = 1.0 / r;
+          PosType dr    = displ[iat];
+          func->evaluate(r, dudr, d2udr2);
+          grad_grad_psi[iel] -= rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
         }
       }
     }
@@ -273,15 +272,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       {
         if (F[jg] == nullptr)
           continue;
-        F[jg]->evaluateVGL(-1,
-                           Ions.first(jg),
-                           Ions.last(jg),
-                           dist,
-                           U.data(),
-                           dU.data(),
-                           d2U.data(),
-                           DistCompressed.data(),
-                           DistIndice.data());
+        F[jg]->evaluateVGL(-1, Ions.first(jg), Ions.last(jg), dist, U.data(), dU.data(), d2U.data(),
+                           DistCompressed.data(), DistIndice.data());
       }
     }
     else
@@ -501,7 +493,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
       for (int idim = 0; idim < OHMMS_DIM; idim++)
       {
-        grad_grad[idim][iat]       += dr[idim] * dr * rinv * rinv * grad_component;
+        grad_grad[idim][iat] += dr[idim] * dr * rinv * rinv * grad_component;
         grad_grad[idim][iat][idim] += rinv * dU[isrc];
 
         lapl_grad[idim][iat] -= lapl_component * rinv * dr[idim];

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -244,7 +244,7 @@ public:
   /** recompute internal data assuming distance table is fully ready */
   void recompute(ParticleSet& P);
 
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
   void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
   {
     for (int k = 0; k < ratios.size(); ++k)
@@ -254,7 +254,7 @@ public:
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios);
 
   GradType evalGrad(ParticleSet& P, int iat);
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
   void acceptMove(ParticleSet& P, int iat);
   inline void restore(int iat) {}
 
@@ -487,12 +487,12 @@ inline void J2OrbitalSoA<FT>::computeU3(const ParticleSet& P,
 }
 
 template<typename FT>
-typename J2OrbitalSoA<FT>::ValueType J2OrbitalSoA<FT>::ratio(ParticleSet& P, int iat)
+typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratio(ParticleSet& P, int iat)
 {
   //only ratio, ready to compute it again
   UpdateMode = ORB_PBYP_RATIO;
   cur_Uat    = computeU(P, iat, P.getDistTable(my_table_ID_).Temp_r.data());
-  return std::exp(Uat[iat] - cur_Uat);
+  return std::exp(static_cast<PsiValueType>(Uat[iat] - cur_Uat));
 }
 
 template<typename FT>
@@ -529,7 +529,7 @@ typename J2OrbitalSoA<FT>::GradType J2OrbitalSoA<FT>::evalGrad(ParticleSet& P, i
 }
 
 template<typename FT>
-typename J2OrbitalSoA<FT>::ValueType J2OrbitalSoA<FT>::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   UpdateMode = ORB_PBYP_PARTIAL;
 
@@ -537,7 +537,7 @@ typename J2OrbitalSoA<FT>::ValueType J2OrbitalSoA<FT>::ratioGrad(ParticleSet& P,
   cur_Uat = simd::accumulate_n(cur_u.data(), N, valT());
   DiffVal = Uat[iat] - cur_Uat;
   grad_iat += accumulateG(cur_du.data(), P.getDistTable(my_table_ID_).Temp_dr);
-  return std::exp(DiffVal);
+  return std::exp(static_cast<PsiValueType>(DiffVal));
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -42,8 +42,11 @@ class J2KECorrection
 
 public:
   J2KECorrection(const ParticleSet& targetPtcl, const std::vector<FT*>& F)
-      : num_groups_(targetPtcl.groups()), num_elecs_(targetPtcl.getTotalNum()),
-        vol(targetPtcl.Lattice.Volume), F_(F), SK_enabled(targetPtcl.SK != nullptr)
+      : num_groups_(targetPtcl.groups()),
+        num_elecs_(targetPtcl.getTotalNum()),
+        vol(targetPtcl.Lattice.Volume),
+        F_(F),
+        SK_enabled(targetPtcl.SK != nullptr)
   {
     // compute num_elec_in_groups_
     num_elec_in_groups_.reserve(3);
@@ -56,7 +59,8 @@ public:
 
   RT computeKEcorr()
   {
-    if (!SK_enabled) return 0;
+    if (!SK_enabled)
+      return 0;
 
     const int numPoints = 1000;
     RT uk               = 0.0;
@@ -643,8 +647,8 @@ void J2OrbitalSoA<FT>::recompute(ParticleSet& P)
 
 template<typename FT>
 typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(ParticleSet& P,
-                                                                  ParticleSet::ParticleGradient_t& G,
-                                                                  ParticleSet::ParticleLaplacian_t& L)
+                                                                      ParticleSet::ParticleGradient_t& G,
+                                                                      ParticleSet::ParticleLaplacian_t& L)
 {
   evaluateGL(P, G, L, true);
   return LogValue;
@@ -666,7 +670,7 @@ void J2OrbitalSoA<FT>::evaluateGL(ParticleSet& P,
     L[iat] += d2Uat[iat];
   }
 
-  LogValue = - LogValue * 0.5;
+  LogValue = -LogValue * 0.5;
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -409,7 +409,7 @@ public:
     return LogValue;
   }
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     UpdateMode = ORB_PBYP_RATIO;
 
@@ -417,7 +417,7 @@ public:
     const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
     cur_Uat = computeU(P, iat, P.GroupID[iat], eI_table.Temp_r.data(), ee_table.Temp_r.data(), ions_nearby_new);
     DiffVal = Uat[iat] - cur_Uat;
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
   }
 
   void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -462,7 +462,7 @@ public:
 
   GradType evalGrad(ParticleSet& P, int iat) { return GradType(dUat[iat]); }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     UpdateMode = ORB_PBYP_PARTIAL;
 
@@ -483,7 +483,7 @@ public:
               ions_nearby_new);
     DiffVal = Uat[iat] - cur_Uat;
     grad_iat += cur_dUat;
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
   }
 
   inline void restore(int iat) {}

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -110,7 +110,10 @@ public:
   using FuncType = FT;
 
   JeeIOrbitalSoA(const ParticleSet& ions, ParticleSet& elecs, bool is_master = false)
-    : ee_Table_ID_(elecs.addTable(elecs, DT_SOA)), ei_Table_ID_(elecs.addTable(ions, DT_SOA, true)), Ions(ions), NumVars(0)
+      : ee_Table_ID_(elecs.addTable(elecs, DT_SOA)),
+        ei_Table_ID_(elecs.addTable(ions, DT_SOA, true)),
+        Ions(ions),
+        NumVars(0)
   {
     ClassName = "JeeIOrbitalSoA";
     init(elecs);
@@ -424,12 +427,9 @@ public:
   {
     for (int k = 0; k < ratios.size(); ++k)
       ratios[k] = std::exp(Uat[VP.refPtcl] -
-                           computeU(VP.refPS,
-                                    VP.refPtcl,
-                                    VP.refPS.GroupID[VP.refPtcl],
+                           computeU(VP.refPS, VP.refPtcl, VP.refPS.GroupID[VP.refPtcl],
                                     VP.getDistTable(ei_Table_ID_).Distances[k],
-                                    VP.getDistTable(ee_Table_ID_).Distances[k],
-                                    ions_nearby_old));
+                                    VP.getDistTable(ee_Table_ID_).Distances[k], ions_nearby_old));
   }
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
@@ -468,19 +468,8 @@ public:
 
     const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
     const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
-    computeU3(P,
-              iat,
-              eI_table.Temp_r.data(),
-              eI_table.Temp_dr,
-              ee_table.Temp_r.data(),
-              ee_table.Temp_dr,
-              cur_Uat,
-              cur_dUat,
-              cur_d2Uat,
-              newUk,
-              newdUk,
-              newd2Uk,
-              ions_nearby_new);
+    computeU3(P, iat, eI_table.Temp_r.data(), eI_table.Temp_dr, ee_table.Temp_r.data(), ee_table.Temp_dr, cur_Uat,
+              cur_dUat, cur_d2Uat, newUk, newdUk, newd2Uk, ions_nearby_new);
     DiffVal = Uat[iat] - cur_Uat;
     grad_iat += cur_dUat;
     return std::exp(static_cast<PsiValueType>(DiffVal));
@@ -493,40 +482,18 @@ public:
     const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
     const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
     // get the old value, grad, lapl
-    computeU3(P,
-              iat,
-              eI_table.Distances[iat],
-              eI_table.Displacements[iat],
-              ee_table.Distances[iat],
-              ee_table.Displacements[iat],
-              Uat[iat],
-              dUat_temp,
-              d2Uat[iat],
-              oldUk,
-              olddUk,
-              oldd2Uk,
-              ions_nearby_old);
+    computeU3(P, iat, eI_table.Distances[iat], eI_table.Displacements[iat], ee_table.Distances[iat],
+              ee_table.Displacements[iat], Uat[iat], dUat_temp, d2Uat[iat], oldUk, olddUk, oldd2Uk, ions_nearby_old);
     if (UpdateMode == ORB_PBYP_RATIO)
     { //ratio-only during the move; need to compute derivatives
-      computeU3(P,
-                iat,
-                eI_table.Temp_r.data(),
-                eI_table.Temp_dr,
-                ee_table.Temp_r.data(),
-                ee_table.Temp_dr,
-                cur_Uat,
-                cur_dUat,
-                cur_d2Uat,
-                newUk,
-                newdUk,
-                newd2Uk,
-                ions_nearby_new);
+      computeU3(P, iat, eI_table.Temp_r.data(), eI_table.Temp_dr, ee_table.Temp_r.data(), ee_table.Temp_dr, cur_Uat,
+                cur_dUat, cur_d2Uat, newUk, newdUk, newd2Uk, ions_nearby_new);
     }
 
 #pragma omp simd
     for (int jel = 0; jel < Nelec; jel++)
     {
-      Uat[jel]   += newUk[jel] - oldUk[jel];
+      Uat[jel] += newUk[jel] - oldUk[jel];
       d2Uat[jel] += newd2Uk[jel] - oldd2Uk[jel];
     }
     for (int idim = 0; idim < OHMMS_DIM; ++idim)
@@ -592,26 +559,15 @@ public:
 
     for (int jel = 0; jel < Nelec; ++jel)
     {
-      computeU3(P,
-                jel,
-                eI_table.Distances[jel],
-                eI_table.Displacements[jel],
-                ee_table.Distances[jel],
-                ee_table.Displacements[jel],
-                Uat[jel],
-                dUat_temp,
-                d2Uat[jel],
-                newUk,
-                newdUk,
-                newd2Uk,
-                ions_nearby_new,
+      computeU3(P, jel, eI_table.Distances[jel], eI_table.Displacements[jel], ee_table.Distances[jel],
+                ee_table.Displacements[jel], Uat[jel], dUat_temp, d2Uat[jel], newUk, newdUk, newd2Uk, ions_nearby_new,
                 true);
       dUat(jel) = dUat_temp;
 // add the contribution from the upper triangle
 #pragma omp simd
       for (int kel = 0; kel < jel; kel++)
       {
-        Uat[kel]   += newUk[kel];
+        Uat[kel] += newUk[kel];
         d2Uat[kel] += newd2Uk[kel];
       }
       for (int idim = 0; idim < OHMMS_DIM; ++idim)
@@ -658,9 +614,7 @@ public:
             if (kel_counter == Nbuffer)
             {
               const FT& feeI(*F(ig, jg, kg));
-              Uj += feeI.evaluateV(kel_counter,
-                                   Distjk_Compressed.data(),
-                                   DistjI_Compressed.data(),
+              Uj += feeI.evaluateV(kel_counter, Distjk_Compressed.data(), DistjI_Compressed.data(),
                                    DistkI_Compressed.data());
               kel_counter = 0;
             }
@@ -703,19 +657,8 @@ public:
     valT* restrict hessF01 = mVGL.data(7);
     valT* restrict hessF02 = mVGL.data(8);
 
-    feeI.evaluateVGL(kel_counter,
-                     Distjk_Compressed.data(),
-                     DistjI_Compressed.data(),
-                     DistkI_Compressed.data(),
-                     val,
-                     gradF0,
-                     gradF1,
-                     gradF2,
-                     hessF00,
-                     hessF11,
-                     hessF22,
-                     hessF01,
-                     hessF02);
+    feeI.evaluateVGL(kel_counter, Distjk_Compressed.data(), DistjI_Compressed.data(), DistkI_Compressed.data(), val,
+                     gradF0, gradF1, gradF2, hessF00, hessF11, hessF22, hessF01, hessF02);
 
     // compute the contribution to jel, kel
     Uj               = simd::accumulate_n(val, kel_counter, Uj);
@@ -736,7 +679,7 @@ public:
       {
         // recycle hessF11
         hessF11[kel_index] += kI[kel_index] * jk[kel_index];
-        dUj_x              += gradF1[kel_index] * jI[kel_index];
+        dUj_x += gradF1[kel_index] * jI[kel_index];
         // destroy jk, kI
         const valT temp = jk[kel_index] * gradF0[kel_index];
         dUj_x += temp;
@@ -897,11 +840,11 @@ public:
     for (int iat = 0; iat < Nelec; ++iat)
     {
       LogValue += Uat[iat];
-      G[iat]   += dUat[iat];
-      L[iat]   += d2Uat[iat];
+      G[iat] += dUat[iat];
+      L[iat] += d2Uat[iat];
     }
 
-    LogValue = - LogValue * 0.5;
+    LogValue = -LogValue * 0.5;
   }
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
@@ -197,8 +197,8 @@ public:
    */
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    LogValue                         = 0.0;
-    U                                = 0.0;
+    LogValue            = 0.0;
+    U                   = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
     RealType dudr, d2udr2;
     for (int i = 0; i < d_table.sources(); i++)
@@ -223,8 +223,8 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   {
-    LogValue                         = 0.0;
-    U                                = 0.0;
+    LogValue            = 0.0;
+    U                   = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
     RealType dudr, d2udr2;
 
@@ -255,7 +255,7 @@ public:
   inline PsiValueType ratio(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
-    curVal                           = 0.0;
+    curVal              = 0.0;
     for (int i = 0; i < d_table.sources(); ++i)
       if (Fs[i] != nullptr)
         curVal += Fs[i]->evaluate(d_table.Temp[i].r1);
@@ -296,8 +296,8 @@ public:
   inline GradType evalGrad(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
-    int n                            = d_table.targets();
-    curGrad                          = 0.0;
+    int n               = d_table.targets();
+    curGrad             = 0.0;
     RealType ur, dudr, d2udr2;
     for (int i = 0, nn = iat; i < d_table.sources(); ++i, nn += n)
     {
@@ -349,7 +349,7 @@ public:
     {
       RealType rinv = d_table.rinv(nn);
       RealType uij  = func->evaluate(d_table.r(nn), dudr, d2udr2, d3udr3);
-      dudr   *= rinv;
+      dudr *= rinv;
       d2udr2 *= rinv * rinv;
       G += dudr * d_table.dr(nn);
       for (int dim_ion = 0; dim_ion < OHMMS_DIM; dim_ion++)
@@ -367,9 +367,9 @@ public:
   inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
-    int n                            = d_table.targets();
-    curVal                           = 0.0;
-    curGrad                          = 0.0;
+    int n               = d_table.targets();
+    curVal              = 0.0;
+    curGrad             = 0.0;
     RealType dudr, d2udr2;
     for (int i = 0; i < d_table.sources(); ++i)
     {
@@ -415,7 +415,7 @@ public:
         LogValue -= uij;
         U[j] += uij;
         dudr *= d_table.rinv(nn);
-        dU[j]  -= dudr * d_table.dr(nn);
+        dU[j] -= dudr * d_table.dr(nn);
         d2U[j] -= d2udr2 + 2.0 * dudr;
         //add gradient and laplacian contribution
         dG[j] -= dudr * d_table.dr(nn);

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbital.h
@@ -252,14 +252,14 @@ public:
    * @param P active particle set
    * @param iat particle that has been moved.
    */
-  inline ValueType ratio(ParticleSet& P, int iat)
+  inline PsiValueType ratio(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
     curVal                           = 0.0;
     for (int i = 0; i < d_table.sources(); ++i)
       if (Fs[i] != nullptr)
         curVal += Fs[i]->evaluate(d_table.Temp[i].r1);
-    return std::exp(U[iat] - curVal);
+    return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
   }
 
   inline void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -364,7 +364,7 @@ public:
     return G;
   }
 
-  inline ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
     int n                            = d_table.targets();
@@ -381,7 +381,7 @@ public:
       }
     }
     grad_iat += curGrad;
-    return std::exp(U[iat] - curVal);
+    return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
   }
 
   inline void restore(int iat) {}

--- a/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
@@ -243,7 +243,7 @@ public:
    * @param P active particle set
    * @param iat particle that has been moved.
    */
-  inline ValueType ratio(ParticleSet& P, int iat)
+  inline PsiValueType ratio(ParticleSet& P, int iat)
   {
     curVal                           = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
@@ -256,7 +256,7 @@ public:
       for (int s = s_offset[sg]; s < s_offset[sg + 1]; ++s)
         curVal += func->evaluate(d_table.Temp[s].r1);
     }
-    return std::exp(U[iat] - curVal);
+    return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
   }
 
   inline void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -360,7 +360,7 @@ public:
     return GradType();
   }
 
-  inline ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
     int tg                           = P.GroupID[iat]; //pick the target group
@@ -379,7 +379,7 @@ public:
         }
     }
     grad_iat += curGrad;
-    return std::exp(U[iat] - curVal);
+    return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
   }
 
   inline void restore(int iat) {}

--- a/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodySpinJastrowOrbital.h
@@ -207,8 +207,8 @@ public:
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    LogValue                         = 0.0;
-    U                                = 0.0;
+    LogValue            = 0.0;
+    U                   = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
     RealType dudr, d2udr2;
 #ifndef ENABLE_SOA
@@ -245,9 +245,9 @@ public:
    */
   inline PsiValueType ratio(ParticleSet& P, int iat)
   {
-    curVal                           = 0.0;
+    curVal              = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
-    int tg                           = P.GroupID[iat];
+    int tg              = P.GroupID[iat];
     for (int sg = 0; sg < F.rows(); ++sg)
     {
       FT* func = F(sg, tg);
@@ -263,7 +263,7 @@ public:
   {
     std::vector<RealType> myr(ratios.size(), U[VP.refPtcl]);
     const auto& d_table = VP.getDistTable(myTableIndex);
-    int tg                           = VP.GroupID[VP.refPtcl];
+    int tg              = VP.GroupID[VP.refPtcl];
 #ifndef ENABLE_SOA
     for (int sg = 0; sg < F.rows(); ++sg)
     {
@@ -320,9 +320,9 @@ public:
   inline GradType evalGrad(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
-    int n                            = d_table.targets();
-    int tg                           = P.GroupID[iat];
-    curGrad                          = 0.0;
+    int n               = d_table.targets();
+    int tg              = P.GroupID[iat];
+    curGrad             = 0.0;
     RealType ur, dudr, d2udr2;
     int nn = iat;
 #ifndef ENABLE_SOA
@@ -363,9 +363,9 @@ public:
   inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     const auto& d_table = P.getDistTable(myTableIndex);
-    int tg                           = P.GroupID[iat]; //pick the target group
-    curVal                           = 0.0;
-    curGrad                          = 0.0;
+    int tg              = P.GroupID[iat]; //pick the target group
+    curVal              = 0.0;
+    curGrad             = 0.0;
     RealType dudr, d2udr2;
     for (int sg = 0; sg < F.rows(); ++sg)
     {
@@ -393,10 +393,10 @@ public:
 
   void evaluateLogAndStore(ParticleSet& P, ParticleSet::ParticleGradient_t& dG, ParticleSet::ParticleLaplacian_t& dL)
   {
-    LogValue                         = 0.0;
-    U                                = 0.0;
-    dU                               = 0.0;
-    d2U                              = 0.0;
+    LogValue            = 0.0;
+    U                   = 0.0;
+    dU                  = 0.0;
+    d2U                 = 0.0;
     const auto& d_table = P.getDistTable(myTableIndex);
     RealType uij, dudr, d2udr2;
 #ifndef ENABLE_SOA
@@ -415,10 +415,10 @@ public:
               LogValue -= uij;
               U[jat] += uij;
               dudr *= d_table.rinv(nn);
-              dU[jat]  -= dudr * d_table.dr(nn);
+              dU[jat] -= dudr * d_table.dr(nn);
               d2U[jat] -= d2udr2 + 2.0 * dudr;
-              dG[jat]  -= dudr * d_table.dr(nn);
-              dL[jat]  -= d2udr2 + 2.0 * dudr;
+              dG[jat] -= dudr * d_table.dr(nn);
+              dL[jat] -= d2udr2 + 2.0 * dudr;
             }
           else
             nn += t_offset[jg + 1] - t_offset[jg];

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -255,12 +255,12 @@ RPAJastrow::LogValueType RPAJastrow::evaluateLog(ParticleSet& P,
   return LogValue;
 }
 
-RPAJastrow::ValueType RPAJastrow::ratio(ParticleSet& P, int iat)
+RPAJastrow::PsiValueType RPAJastrow::ratio(ParticleSet& P, int iat)
 {
   ValueType r(1.0);
   for (int i = 0; i < Psi.size(); i++)
     r *= Psi[i]->ratio(P, iat);
-  return r;
+  return static_cast<PsiValueType>(r);
 }
 
 RPAJastrow::GradType RPAJastrow::evalGrad(ParticleSet& P, int iat)
@@ -271,14 +271,14 @@ RPAJastrow::GradType RPAJastrow::evalGrad(ParticleSet& P, int iat)
   return grad;
 }
 
-RPAJastrow::ValueType RPAJastrow::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+RPAJastrow::PsiValueType RPAJastrow::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   ValueType r(1);
   for (int i = 0; i < Psi.size(); i++)
   {
     r *= Psi[i]->ratioGrad(P, iat, grad_iat);
   }
-  return r;
+  return static_cast<PsiValueType>(r);
 }
 
 

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -157,22 +157,20 @@ void RPAJastrow::makeLongRange()
   // create two-body kSpaceJastrow
   kSpaceJastrow::SymmetryType oneBodySymm, twoBodySymm;
   bool oneBodySpin, twoBodySpin;
-  oneBodySymm = kSpaceJastrow::ISOTROPIC;
-  twoBodySymm = kSpaceJastrow::ISOTROPIC;
-  oneBodySpin = false;
-  twoBodySpin = false;
-  LongRangeRPA = new kSpaceJastrow(targetPtcl, targetPtcl,
-    oneBodySymm, -1, "cG1", oneBodySpin,  // no one-body part
-    twoBodySymm, Kc, "cG2", twoBodySpin
-  );
+  oneBodySymm  = kSpaceJastrow::ISOTROPIC;
+  twoBodySymm  = kSpaceJastrow::ISOTROPIC;
+  oneBodySpin  = false;
+  twoBodySpin  = false;
+  LongRangeRPA = new kSpaceJastrow(targetPtcl, targetPtcl, oneBodySymm, -1, "cG1", oneBodySpin, // no one-body part
+                                   twoBodySymm, Kc, "cG2", twoBodySpin);
   // fill in CG2 coefficients
   std::vector<RealType> oneBodyCoefs, twoBodyCoefs;
   twoBodyCoefs.resize(myHandler->MaxKshell);
   //  need to cancel prefactor in kSpaceJastrow
   RealType prefactorInv = -targetPtcl.Lattice.Volume;
-  for (size_t is=0; is<myHandler->MaxKshell; is++)
+  for (size_t is = 0; is < myHandler->MaxKshell; is++)
   {
-    twoBodyCoefs[is] = prefactorInv*myHandler->Fk_symm[is];
+    twoBodyCoefs[is] = prefactorInv * myHandler->Fk_symm[is];
   }
   LongRangeRPA->setCoefficients(oneBodyCoefs, twoBodyCoefs);
   Psi.push_back(LongRangeRPA);
@@ -187,20 +185,20 @@ void RPAJastrow::makeShortRange()
   app_log() << "  Adding Short Range part of RPA function" << std::endl;
   //short-range uses realHandler
   RealType tiny = 1e-6;
-  Rcut = myHandler->get_rc() - tiny;
+  Rcut          = myHandler->get_rc() - tiny;
   //create numerical functor of type BsplineFunctor<RealType>.
   nfunc = new FuncType;
   SRA   = new ShortRangePartAdapter<RealType>(myHandler);
   SRA->setRmax(Rcut);
 #ifdef ENABLE_SOA
-  J2OrbitalSoA<BsplineFunctor<RealType> > *j2 = new J2OrbitalSoA<BsplineFunctor<RealType> >(targetPtcl,IsManager);
+  J2OrbitalSoA<BsplineFunctor<RealType>>* j2 = new J2OrbitalSoA<BsplineFunctor<RealType>>(targetPtcl, IsManager);
 #else
   TwoBodyJastrowOrbital<BsplineFunctor<RealType>>* j2 =
       new TwoBodyJastrowOrbital<BsplineFunctor<RealType>>(targetPtcl, IsManager);
 #endif
-  size_t nparam  = 12; // number of Bspline parameters
+  size_t nparam  = 12;  // number of Bspline parameters
   size_t npts    = 100; // number of 1D grid points for basis functions
-  RealType cusp = SRA->df(0);
+  RealType cusp  = SRA->df(0);
   RealType delta = Rcut / static_cast<double>(npts);
   std::vector<RealType> X(npts + 1), Y(npts + 1);
   for (size_t i = 0; i < npts; ++i)
@@ -212,7 +210,7 @@ void RPAJastrow::makeShortRange()
   Y[npts]              = 0.0;
   std::string functype = "rpa";
   std::string useit    = "no";
-  nfunc->initialize(nparam, X, Y, cusp, Rcut+tiny, functype, useit);
+  nfunc->initialize(nparam, X, Y, cusp, Rcut + tiny, functype, useit);
   for (size_t i = 0; i < npts; ++i)
   {
     X[i] = i * delta;
@@ -246,8 +244,8 @@ void RPAJastrow::resetTargetParticleSet(ParticleSet& P)
 }
 
 RPAJastrow::LogValueType RPAJastrow::evaluateLog(ParticleSet& P,
-                                             ParticleSet::ParticleGradient_t& G,
-                                             ParticleSet::ParticleLaplacian_t& L)
+                                                 ParticleSet::ParticleGradient_t& G,
+                                                 ParticleSet::ParticleLaplacian_t& L)
 {
   LogValue = 0.0;
   for (int i = 0; i < Psi.size(); i++)
@@ -352,8 +350,8 @@ WaveFunctionComponent* RPAJastrow::makeClone(ParticleSet& tpq) const
   }
 
   RPAJastrow* myClone = new RPAJastrow(tpq, IsManager);
-  myClone->Rcut = Rcut;
-  myClone->Kc = Kc;
+  myClone->Rcut       = Rcut;
+  myClone->Kc         = Kc;
   myClone->setHandler(tempHandler);
   if (!DropLongRange)
     myClone->makeLongRange();

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -76,9 +76,9 @@ struct RPAJastrow : public WaveFunctionComponent
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
   GradType evalGrad(ParticleSet& P, int iat);
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
   void acceptMove(ParticleSet& P, int iat);
 

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -71,8 +71,7 @@ public:
   ///container for the Jastrow functions
   std::vector<FT*> F;
 
-  TwoBodyJastrowOrbital(ParticleSet& p, int tid)
-    : TaskID(tid), KEcorr(0.0), my_table_ID_(p.addTable(p, DT_AOS))
+  TwoBodyJastrowOrbital(ParticleSet& p, int tid) : TaskID(tid), KEcorr(0.0), my_table_ID_(p.addTable(p, DT_AOS))
   {
     PtclRef = &p;
     init(p);
@@ -257,7 +256,7 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   {
-    LogValue                         = 0.0;
+    LogValue            = 0.0;
     const auto& d_table = P.getDistTable(my_table_ID_);
     RealType dudr, d2udr2;
     PosType gr;
@@ -293,7 +292,7 @@ public:
   PsiValueType ratio(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(my_table_ID_);
-    DiffVal                          = 0.0;
+    DiffVal             = 0.0;
     const int* pairid(PairID[iat]);
     for (int jat = 0, ij = iat * N; jat < N; jat++, ij++)
     {
@@ -543,7 +542,7 @@ public:
               RealType u = ufunc.evaluate(r);
 #if (OHMMS_DIM == 3)
               aparam += (1.0 / 4.0) * k * k * 4.0 * M_PI * r * std::sin(k * r) / k * u * dr;
-              uk     += 0.5 * 4.0 * M_PI * r * std::sin(k * r) / k * u * dr * (RealType)Nj / (RealType)(Ni + Nj);
+              uk += 0.5 * 4.0 * M_PI * r * std::sin(k * r) / k * u * dr * (RealType)Nj / (RealType)(Ni + Nj);
 #endif
 #if (OHMMS_DIM == 2)
               uk += 0.5 * 2.0 * M_PI * std::sin(k * r) / k * u * dr * (RealType)Nj / (RealType)(Ni + Nj);

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -290,7 +290,7 @@ public:
     }
   }
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     const auto& d_table = P.getDistTable(my_table_ID_);
     DiffVal                          = 0.0;
@@ -308,7 +308,7 @@ public:
         //DiffVal += U[ij]-F[pairid[jat]]->evaluate(d_table.Temp[jat].r1);
       }
     }
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
   }
 
   inline void evaluateRatios(VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -344,7 +344,7 @@ public:
     return gr;
   }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     const auto& d_table = P.getDistTable(my_table_ID_);
     RealType dudr, d2udr2;
@@ -371,7 +371,7 @@ public:
     grad_iat += gr;
     //curGrad0-=curGrad;
     //cout << "RATIOGRAD " << curGrad0 << std::endl;
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
   }
 
   inline void restore(int iat) {}

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
@@ -743,7 +743,7 @@ public:
       ratios[k] = std::exp(newval[k]);
   }
 
-  ValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat)
   {
     const auto& ee_table = P.getDistTable(ee_table_index_);
     const auto& eI_table = P.getDistTable(ei_table_index_);
@@ -779,7 +779,7 @@ public:
     for (int jat = 0; jat < Nelec; jat++)
       oldval -= U[iat * Nelec + jat];
     DiffVal = newval - oldval;
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
     //return std::exp(U[iat]-curVal);
     // DiffVal=0.0;
     // const int* pairid(PairID[iat]);
@@ -803,7 +803,7 @@ public:
     return gr;
   }
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     curVal                            = 0.0;
     curGrad_i                         = PosType();
@@ -867,7 +867,7 @@ public:
         grad_iat -= curGrad_i[jat];
       }
     }
-    return std::exp(DiffVal);
+    return std::exp(static_cast<PsiValueType>(DiffVal));
   }
 
   inline void restore(int iat) {}

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
@@ -104,12 +104,14 @@ public:
   RealType ChiesaKEcorrection() { return 0.0; }
 
   eeI_JastrowOrbital(ParticleSet& ions, ParticleSet& elecs, bool is_master)
-      : Write_Chiesa_Correction(is_master), KEcorr(0.0),
-        ee_table_index_(elecs.addTable(elecs, DT_AOS)), ei_table_index_(elecs.addTable(ions, DT_AOS))
+      : Write_Chiesa_Correction(is_master),
+        KEcorr(0.0),
+        ee_table_index_(elecs.addTable(elecs, DT_AOS)),
+        ei_table_index_(elecs.addTable(ions, DT_AOS))
   {
-    ClassName    = "eeI_JastrowOrbital";
-    eRef         = &elecs;
-    IRef         = &ions;
+    ClassName = "eeI_JastrowOrbital";
+    eRef      = &elecs;
+    IRef      = &ions;
     init(elecs);
     FirstTime = true;
     NumVars   = 0;
@@ -415,7 +417,7 @@ public:
     {
       IonData& ion = IonDataList[i];
 #ifndef ENABLE_SOA
-      int nn0      = eI_table.M[i];
+      int nn0 = eI_table.M[i];
       for (int j = 0; j < ion.elecs_inside.size(); j++)
       {
         int jel = ion.elecs_inside[j];
@@ -526,7 +528,7 @@ public:
   {
     const auto& ee_table = P.getDistTable(ee_table_index_);
     const auto& eI_table = P.getDistTable(ei_table_index_);
-    IonData& ion                      = IonDataList[isrc];
+    IonData& ion         = IonDataList[isrc];
     ion.elecs_inside.clear();
     int iel = 0;
     GradType G;
@@ -747,11 +749,11 @@ public:
   {
     const auto& ee_table = P.getDistTable(ee_table_index_);
     const auto& eI_table = P.getDistTable(ei_table_index_);
-    curVal                            = 0.0;
-    RealType newval                   = 0.0;
-    RealType oldval                   = 0.0;
+    curVal               = 0.0;
+    RealType newval      = 0.0;
+    RealType oldval      = 0.0;
 #ifndef ENABLE_SOA
-    int ee0                           = ee_table.M[iat] - (iat + 1);
+    int ee0 = ee_table.M[iat] - (iat + 1);
     for (int i = 0; i < Nion; i++)
     {
       IonData& ion  = IonDataList[i];
@@ -805,16 +807,16 @@ public:
 
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
-    curVal                            = 0.0;
-    curGrad_i                         = PosType();
-    curLap_i                          = 0.0;
-    curGrad_j                         = PosType();
-    curLap_j                          = 0.0;
+    curVal               = 0.0;
+    curGrad_i            = PosType();
+    curLap_i             = 0.0;
+    curGrad_j            = PosType();
+    curLap_j             = 0.0;
     const auto& ee_table = P.getDistTable(ee_table_index_);
     const auto& eI_table = P.getDistTable(ei_table_index_);
-    DiffVal                           = 0.0;
+    DiffVal              = 0.0;
 #ifndef ENABLE_SOA
-    int ee0                           = ee_table.M[iat] - (iat + 1);
+    int ee0 = ee_table.M[iat] - (iat + 1);
     for (int i = 0; i < Nion; i++)
     {
       IonData& ion      = IonDataList[i];
@@ -847,11 +849,11 @@ public:
             d2u_j = (hessF(0, 0) + 2.0 * r_ij_inv * gradF[0] -
                      2.0 * hessF(0, 2) * dot(ee_table.Temp[jat].dr1, eI_table.dr(nn0 + jat)) * r_ij_inv * r_Ij_inv +
                      hessF(2, 2) + 2.0 * r_Ij_inv * gradF[2]);
-            curVal[jat]    += u;
+            curVal[jat] += u;
             curGrad_j[jat] += du_j;
-            curLap_j[jat]  += d2u_j;
+            curLap_j[jat] += d2u_j;
             curGrad_i[jat] += du_i;
-            curLap_i[jat]  += d2u_i;
+            curLap_i[jat] += d2u_i;
             DiffVal -= u;
           }
         }
@@ -906,7 +908,7 @@ public:
                                   ParticleSet::ParticleLaplacian_t& L)
   {
     //      std::cerr << "evaluateLogAndStore called.\n";
-    LogValue                          = 0.0;
+    LogValue             = 0.0;
     const auto& ee_table = P.getDistTable(ee_table_index_);
     const auto& eI_table = P.getDistTable(ei_table_index_);
     // First, create lists of electrons within the sphere of each ion
@@ -971,10 +973,10 @@ public:
           L[kel] -= d2u_k;
           int jk = jel * Nelec + kel;
           int kj = kel * Nelec + jel;
-          U[jk]   += u;
-          U[kj]   += u;
-          dU[jk]  += du_j;
-          dU[kj]  += du_k;
+          U[jk] += u;
+          U[kj] += u;
+          dU[jk] += du_j;
+          dU[kj] += du_k;
           d2U[jk] += d2u_j;
           d2U[kj] += d2u_k;
           // G[jel] +=  gr_ee - gradF[1]*r_Ij_inv * eI_table.dr(nn0+jel);
@@ -1225,11 +1227,11 @@ public:
               d2u_k = (dh(0, 0) + 2.0 * r_jk_inv * dg[0] +
                        2.0 * dh(0, 2) * dot(ee_table.dr(ee0 + kel), eI_table.dr(nn0 + kel)) * r_jk_inv * r_Ik_inv +
                        dh(2, 2) + 2.0 * r_Ik_inv * dg[2]);
-              dLogPsi[p]         -= dval;
+              dLogPsi[p] -= dval;
               gradLogPsi(p, jel) -= du_j;
               gradLogPsi(p, kel) -= du_k;
-              lapLogPsi(p, jel)  -= d2u_j;
-              lapLogPsi(p, kel)  -= d2u_k;
+              lapLogPsi(p, jel) -= d2u_j;
+              lapLogPsi(p, kel) -= d2u_k;
             }
           }
         }

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -239,7 +239,7 @@ kSpaceJastrow::kSpaceJastrow(ParticleSet& ions,
   Optimizable   = true;
   Prefactor     = 1.0 / elecs.Lattice.Volume;
   NumIonSpecies = 0;
-  num_elecs      = elecs.getTotalNum();
+  num_elecs     = elecs.getTotalNum();
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
     NumIonSpecies = std::max(NumIonSpecies, ions.GroupID[iat] + 1);
   if (oneBodyCutoff > 0.0)
@@ -376,8 +376,8 @@ void kSpaceJastrow::resetTargetParticleSet(ParticleSet& P)
 ///////////////////////////////////////////////////////////////
 
 kSpaceJastrow::LogValueType kSpaceJastrow::evaluateLog(ParticleSet& P,
-                                                   ParticleSet::ParticleGradient_t& G,
-                                                   ParticleSet::ParticleLaplacian_t& L)
+                                                       ParticleSet::ParticleGradient_t& G,
+                                                       ParticleSet::ParticleLaplacian_t& L)
 {
   RealType J1(0.0), J2(0.0);
   int N = P.getTotalNum();
@@ -392,7 +392,7 @@ kSpaceJastrow::LogValueType kSpaceJastrow::evaluateLog(ParticleSet& P,
     for (int i = 0; i < nOne; i++)
     {
       ComplexType z = OneBodyCoefs[i] * qmcplusplus::conj(OneBody_e2iGr[i]);
-      J1     += Prefactor * real(z);
+      J1 += Prefactor * real(z);
       G[iat] += -Prefactor * real(z * eye) * OneBodyGvecs[i];
       L[iat] += -Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(z);
     }
@@ -503,7 +503,7 @@ kSpaceJastrow::PsiValueType kSpaceJastrow::ratioGrad(ParticleSet& P, int iat, Gr
   for (int i = 0; i < nOne; i++)
   {
     ComplexType z = OneBodyCoefs[i] * qmcplusplus::conj(OneBody_e2iGr[i]);
-    J1new    += Prefactor * real(z);
+    J1new += Prefactor * real(z);
     grad_iat += -Prefactor * real(z * eye) * OneBodyGvecs[i];
   }
   for (int i = 0; i < nOne; i++)
@@ -900,15 +900,15 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
             dlogpsi[kk] += ValueType(Prefactor * real(z));
             //convert(dot(OneBodyGvecs[i],P.G[iat]),tmp_dot);
             convert(dot(P.G[iat], OneBodyGvecs[i]), tmp_dot);
-            dhpsioverpsi[kk] +=
-                ValueType(0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(z) + Prefactor * real(z * eye) * tmp_dot);
+            dhpsioverpsi[kk] += ValueType(0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(z) +
+                                          Prefactor * real(z * eye) * tmp_dot);
             //	+ Prefactor*real(z*eye)*real(dot(OneBodyGvecs[i],P.G[iat]));
             //imaginary part of coeff,
-            dlogpsi[kk + 1] += ValueType( Prefactor * real(eye * z) );
+            dlogpsi[kk + 1] += ValueType(Prefactor * real(eye * z));
             //mius here due to i*i term
             //dhpsioverpsi[kk+1] += 0.5*Prefactor*dot(OneBodyGvecs[i],OneBodyGvecs[i])*real(eye*z) - Prefactor*real(z)*real(dot(OneBodyGvecs[i],P.G[iat]));
-            dhpsioverpsi[kk + 1] +=
-                ValueType( 0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(eye * z) - Prefactor * real(z) * tmp_dot);
+            dhpsioverpsi[kk + 1] += ValueType(0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(eye * z) -
+                                              Prefactor * real(z) * tmp_dot);
           }
         }
       }
@@ -931,7 +931,7 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
       int kk = myVars.where(TwoBodyVarMap[i]);
       if (kk >= 0)
       {
-        dlogpsi[kk] += ValueType( Prefactor * norm(TwoBody_rhoG[i]) );
+        dlogpsi[kk] += ValueType(Prefactor * norm(TwoBody_rhoG[i]));
       }
     }
     for (int iat = 0; iat < N; iat++)
@@ -949,8 +949,9 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
         {
           convert(dot(P.G[iat], Gvec), tmp_dot);
           //dhpsioverpsi[kk] -= Prefactor*dot(Gvec,Gvec)*(-real(z*qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) - Prefactor*2.0*real(dot(P.G[iat],Gvec))*imag(qmcplusplus::conj(TwoBody_rhoG[i])*z);
-          dhpsioverpsi[kk] -= ValueType( Prefactor * dot(Gvec, Gvec) * (-real(z * qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) -
-              Prefactor * 2.0 * tmp_dot * imag(qmcplusplus::conj(TwoBody_rhoG[i]) * z) );
+          dhpsioverpsi[kk] -=
+              ValueType(Prefactor * dot(Gvec, Gvec) * (-real(z * qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) -
+                        Prefactor * 2.0 * tmp_dot * imag(qmcplusplus::conj(TwoBody_rhoG[i]) * z));
         }
       }
     }
@@ -959,33 +960,23 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
 
 void kSpaceJastrow::printOneBody(std::ostream& os)
 {
-  for (int i=0;i<OneBodyCoefs.size();i++)
+  for (int i = 0; i < OneBodyCoefs.size(); i++)
   {
-    PosType     gvec  = OneBodyGvecs[i];
+    PosType gvec      = OneBodyGvecs[i];
     ComplexType coeff = OneBodyCoefs[i];
-    os <<std::fixed << std::setprecision( 6 )
-       << std::setw( 12 ) << gvec[0]
-       << std::setw( 12 ) << gvec[1]
-       << std::setw( 12 ) << gvec[2]
-       << std::setw( 24 ) << coeff.real()
-       << std::setw( 24 ) << coeff.imag()
-       << std::endl;
+    os << std::fixed << std::setprecision(6) << std::setw(12) << gvec[0] << std::setw(12) << gvec[1] << std::setw(12)
+       << gvec[2] << std::setw(24) << coeff.real() << std::setw(24) << coeff.imag() << std::endl;
   }
 }
 
 void kSpaceJastrow::printTwoBody(std::ostream& os)
 {
-  for (int i=0;i<TwoBodyCoefs.size();i++)
+  for (int i = 0; i < TwoBodyCoefs.size(); i++)
   {
-    PosType     gvec  = TwoBodyGvecs[i];
+    PosType gvec      = TwoBodyGvecs[i];
     ComplexType coeff = TwoBodyCoefs[i];
-    os <<std::fixed << std::setprecision( 6 )
-       << std::setw( 12 ) << gvec[0]
-       << std::setw( 12 ) << gvec[1]
-       << std::setw( 12 ) << gvec[2]
-       << std::setw( 24 ) << coeff.real()
-       << std::setw( 24 ) << coeff.imag()
-       << std::endl;
+    os << std::fixed << std::setprecision(6) << std::setw(12) << gvec[0] << std::setw(12) << gvec[1] << std::setw(12)
+       << gvec[2] << std::setw(24) << coeff.real() << std::setw(24) << coeff.imag() << std::endl;
   }
 }
 

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -490,7 +490,7 @@ kSpaceJastrow::GradType kSpaceJastrow::evalGrad(ParticleSet& P, int iat)
   return G;
 }
 
-kSpaceJastrow::ValueType kSpaceJastrow::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+kSpaceJastrow::PsiValueType kSpaceJastrow::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   ComplexType eye(0.0, 1.0);
   RealType J1new(0.0), J1old(0.0), J2new(0.0), J2old(0.0);
@@ -536,13 +536,13 @@ kSpaceJastrow::ValueType kSpaceJastrow::ratioGrad(ParticleSet& P, int iat, GradT
     grad_iat += -Prefactor * 2.0 * TwoBodyGvecs[i] * TwoBodyCoefs[i] *
         imag(qmcplusplus::conj(TwoBody_rhoG[i]) * TwoBody_e2iGr_new[i]);
   }
-  return std::exp(J1new + J2new - (J1old + J2old));
+  return std::exp(static_cast<PsiValueType>(J1new + J2new - (J1old + J2old)));
 }
 
 /* evaluate the ratio with P.R[iat]
  *
  */
-kSpaceJastrow::ValueType kSpaceJastrow::ratio(ParticleSet& P, int iat)
+kSpaceJastrow::PsiValueType kSpaceJastrow::ratio(ParticleSet& P, int iat)
 {
   RealType J1new(0.0), J1old(0.0), J2new(0.0), J2old(0.0);
   const PosType &rnew(P.activePos), &rold(P.R[iat]);
@@ -576,7 +576,7 @@ kSpaceJastrow::ValueType kSpaceJastrow::ratio(ParticleSet& P, int iat)
     ComplexType rho_G = TwoBody_rhoG[i] + TwoBody_e2iGr_new[i] - TwoBody_e2iGr_old[i];
     J2new += Prefactor * TwoBodyCoefs[i] * std::norm(rho_G);
   }
-  return std::exp(J1new + J2new - (J1old + J2old));
+  return std::exp(static_cast<PsiValueType>(J1new + J2new - (J1old + J2old)));
 }
 
 /** evaluate the ratio

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -165,10 +165,10 @@ public:
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
 
   GradType evalGrad(ParticleSet& P, int iat);
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
   void restore(int iat);
   void acceptMove(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -194,7 +194,7 @@ public:
   WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const;
 
   WaveFunctionComponentPtr makeThrScope(PtclGrpIndexes& pgi) const;
-  
+
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& active,
                            std::vector<ValueType>& dlogpsi,

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -19,6 +19,7 @@ namespace qmcplusplus
 {
 typedef LatticeGaussianProduct::ValueType ValueType;
 typedef LatticeGaussianProduct::GradType GradType;
+typedef LatticeGaussianProduct::PsiValueType PsiValueType;
 
 LatticeGaussianProduct::LatticeGaussianProduct(ParticleSet& centers, ParticleSet& ptcls) : CenterRef(centers)
 {
@@ -100,7 +101,7 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(Particl
  * @param P active particle set
  * @param iat particle that has been moved.
  */
-ValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
+PsiValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = ParticleCenter[iat];
@@ -112,7 +113,7 @@ ValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
   RealType newdist = d_table.Temp[icent].r1;
 #endif
   curVal           = ParticleAlpha[iat] * (newdist * newdist);
-  return std::exp(U[iat] - curVal);
+  return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
 }
 
 
@@ -141,7 +142,7 @@ GradType LatticeGaussianProduct::evalGrad(ParticleSet& P, int iat)
 //   {
 //   }
 
-ValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+PsiValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = ParticleCenter[iat];
@@ -158,7 +159,7 @@ ValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType& g
   curVal           = a * newdist * newdist;
   curGrad          = -2.0 * a * newdisp;
   grad_iat += curGrad;
-  return std::exp(U[iat] - curVal);
+  return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
 }
 
 void LatticeGaussianProduct::restore(int iat) {}

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -28,9 +28,9 @@ LatticeGaussianProduct::LatticeGaussianProduct(ParticleSet& centers, ParticleSet
   NumTargetPtcls = ptcls.getTotalNum();
   NumCenters     = centers.getTotalNum();
 #ifdef ENABLE_SOA
-  myTableID      = ptcls.addTable(CenterRef, DT_SOA);
+  myTableID = ptcls.addTable(CenterRef, DT_SOA);
 #else
-  myTableID      = ptcls.addTable(CenterRef, DT_AOS);
+  myTableID = ptcls.addTable(CenterRef, DT_AOS);
 #endif
   U.resize(NumTargetPtcls);
   dU.resize(NumTargetPtcls);
@@ -63,14 +63,14 @@ void LatticeGaussianProduct::reportStatus(std::ostream& os) {}
      *and \f[ L[i]+=\nabla^2_i J({\bf R}). \f]
      */
 LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(ParticleSet& P,
-                                             ParticleSet::ParticleGradient_t& G,
-                                             ParticleSet::ParticleLaplacian_t& L)
+                                                                         ParticleSet::ParticleGradient_t& G,
+                                                                         ParticleSet::ParticleLaplacian_t& L)
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = 0;
   LogValue            = 0.0;
   RealType dist       = 0.0;
-  PosType  disp       = 0.0;
+  PosType disp        = 0.0;
   for (int iat = 0; iat < NumTargetPtcls; iat++)
   {
     U[iat]     = 0.0;
@@ -81,11 +81,11 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(Particl
     {
 #ifdef ENABLE_SOA
       dist = d_table.Distances[iat][icent];
-      disp = -1.0*d_table.Displacements[iat][icent];
+      disp = -1.0 * d_table.Displacements[iat][icent];
 #else
-      int index     = d_table.M[icent] + iat;
-      dist = d_table.r(index);
-      disp = d_table.dr(index);
+      int index = d_table.M[icent] + iat;
+      dist      = d_table.r(index);
+      disp      = d_table.dr(index);
 #endif
       LogValue -= a * dist * dist;
       U[iat] += a * dist * dist;
@@ -112,7 +112,7 @@ PsiValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
 #else
   RealType newdist = d_table.Temp[icent].r1;
 #endif
-  curVal           = ParticleAlpha[iat] * (newdist * newdist);
+  curVal = ParticleAlpha[iat] * (newdist * newdist);
   return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
 }
 
@@ -123,13 +123,13 @@ GradType LatticeGaussianProduct::evalGrad(ParticleSet& P, int iat)
   int icent           = ParticleCenter[iat];
   if (icent == -1)
     return GradType();
-  RealType a      = ParticleAlpha[iat];
+  RealType a = ParticleAlpha[iat];
 #ifdef ENABLE_SOA
-  PosType newdisp = -1.0*d_table.Temp_dr[icent];
+  PosType newdisp = -1.0 * d_table.Temp_dr[icent];
 #else
-  PosType newdisp = d_table.Temp[icent].dr1;
+  PosType newdisp  = d_table.Temp[icent].dr1;
 #endif
-  curGrad         = -2.0 * a * newdisp;
+  curGrad = -2.0 * a * newdisp;
   return curGrad;
 }
 
@@ -148,16 +148,16 @@ PsiValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType
   int icent           = ParticleCenter[iat];
   if (icent == -1)
     return 1.0;
-  RealType a       = ParticleAlpha[iat];
+  RealType a = ParticleAlpha[iat];
 #ifdef ENABLE_SOA
   RealType newdist = d_table.Temp_r[icent];
-  PosType newdisp = -1.0*d_table.Temp_dr[icent];
+  PosType newdisp  = -1.0 * d_table.Temp_dr[icent];
 #else
   RealType newdist = d_table.Temp[icent].r1;
   PosType newdisp  = d_table.Temp[icent].dr1;
 #endif
-  curVal           = a * newdist * newdist;
-  curGrad          = -2.0 * a * newdisp;
+  curVal  = a * newdist * newdist;
+  curGrad = -2.0 * a * newdisp;
   grad_iat += curGrad;
   return std::exp(static_cast<PsiValueType>(U[iat] - curVal));
 }
@@ -172,12 +172,12 @@ void LatticeGaussianProduct::acceptMove(ParticleSet& P, int iat)
 }
 
 void LatticeGaussianProduct::evaluateLogAndStore(ParticleSet& P,
-                                     ParticleSet::ParticleGradient_t& dG,
-                                     ParticleSet::ParticleLaplacian_t& dL)
+                                                 ParticleSet::ParticleGradient_t& dG,
+                                                 ParticleSet::ParticleLaplacian_t& dL)
 {
   const auto& d_table = P.getDistTable(myTableID);
   RealType dist       = 0.0;
-  PosType  disp       = 0.0;
+  PosType disp        = 0.0;
   int icent           = 0;
   LogValue            = 0.0;
   U                   = 0.0;
@@ -190,11 +190,11 @@ void LatticeGaussianProduct::evaluateLogAndStore(ParticleSet& P,
     {
 #ifdef ENABLE_SOA
       dist = d_table.Distances[iat][icent];
-      disp = -1.0*d_table.Displacements[iat][icent];
+      disp = -1.0 * d_table.Displacements[iat][icent];
 #else
-      int index     = d_table.M[icent] + iat;
-      dist = d_table.r(index);
-      disp = d_table.dr(index);
+      int index = d_table.M[icent] + iat;
+      dist      = d_table.r(index);
+      disp      = d_table.dr(index);
 #endif
       LogValue -= a * dist * dist;
       U[iat] += a * dist * dist;
@@ -217,7 +217,9 @@ void LatticeGaussianProduct::registerData(ParticleSet& P, WFBufferType& buf)
   buf.add(FirstAddressOfdU, LastAddressOfdU);
 }
 
-LatticeGaussianProduct::LogValueType LatticeGaussianProduct::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
+LatticeGaussianProduct::LogValueType LatticeGaussianProduct::updateBuffer(ParticleSet& P,
+                                                                          WFBufferType& buf,
+                                                                          bool fromscratch = false)
 {
   evaluateLogAndStore(P, P.G, P.L);
   buf.put(U.first_address(), U.last_address());
@@ -241,9 +243,9 @@ void LatticeGaussianProduct::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 
 WaveFunctionComponentPtr LatticeGaussianProduct::makeClone(ParticleSet& tqp) const
 {
-  LatticeGaussianProduct* j1copy     = new LatticeGaussianProduct(CenterRef, tqp);
-  j1copy->ParticleAlpha  = ParticleAlpha;
-  j1copy->ParticleCenter = ParticleCenter;
+  LatticeGaussianProduct* j1copy = new LatticeGaussianProduct(CenterRef, tqp);
+  j1copy->ParticleAlpha          = ParticleAlpha;
+  j1copy->ParticleCenter         = ParticleCenter;
   return j1copy;
 }
 

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.h
@@ -66,7 +66,7 @@ public:
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  ValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat);
 
   void acceptMove(ParticleSet& P, int iat);
 
@@ -80,7 +80,7 @@ public:
 
   GradType evalGrad(ParticleSet& P, int iat);
 
-  ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
 
   WaveFunctionComponent* makeClone(ParticleSet& tqp) const;

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -60,11 +60,11 @@ public:
 
   virtual void restore(int iat) {}
 
-  virtual ValueType ratio(ParticleSet& P, int iat) { return 1.0; }
+  virtual PsiValueType ratio(ParticleSet& P, int iat) { return 1.0; }
 
   virtual GradType evalGrad(ParticleSet& P, int iat) { return GradType(coeff); }
 
-  virtual ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) { return 1.0; }
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) { return 1.0; }
 
   virtual void registerData(ParticleSet& P, WFBufferType& buf) {}
 

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -39,7 +39,9 @@ public:
     coeff[2] = 3.0;
   }
 
-  virtual LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  virtual LogValueType evaluateLog(ParticleSet& P,
+                                   ParticleSet::ParticleGradient_t& G,
+                                   ParticleSet::ParticleLaplacian_t& L)
   {
     APP_ABORT("LinearOrbital. evaluateLog");
     ValueType v = 0.0;

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -331,7 +331,7 @@ void TrialWaveFunction::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_
 
 TrialWaveFunction::ValueType TrialWaveFunction::calcRatio(ParticleSet& P, int iat, ComputeType ct)
 {
-  ValueType r(1.0);
+  PsiValueType r(1.0);
   for (int i = 0, ii = V_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
     myTimers[ii]->start();
@@ -340,7 +340,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatio(ParticleSet& P, int ia
       r *= Z[i]->ratio(P, iat);
     myTimers[ii]->stop();
   }
-  return r;
+  return static_cast<ValueType>(r);
 }
 
 void TrialWaveFunction::flex_calcRatio(const RefVector<TrialWaveFunction>& wf_list,
@@ -454,7 +454,7 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGradSource(
 TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   grad_iat = 0.0;
-  ValueType r(1.0);
+  PsiValueType r(1.0);
   for (int i = 0, ii = VGL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
   {
     myTimers[ii]->start();
@@ -464,7 +464,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
 
   LogValueType logratio = convertValueToLog(r);
   PhaseDiff = std::imag(logratio);
-  return r;
+  return static_cast<ValueType>(r);
 }
 
 void TrialWaveFunction::flex_calcRatioGrad(const RefVector<TrialWaveFunction>& wf_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -122,7 +122,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateLog(ParticleSet& P)
     ScopedTimer local_timer(myTimers[ii]);
     logpsi += Z[i]->evaluateLog(P, P.G, P.L);
   }
-  LogValue = std::real(logpsi);
+  LogValue   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
   return LogValue;
 }
@@ -227,7 +227,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
     }
     myTimers[ii]->stop();
   }
-  LogValue = std::real(logpsi);
+  LogValue   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
 
   //In case we need to recompute orbitals, initialize dummy vectors for G and L.
@@ -463,15 +463,15 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
   }
 
   LogValueType logratio = convertValueToLog(r);
-  PhaseDiff = std::imag(logratio);
+  PhaseDiff             = std::imag(logratio);
   return static_cast<ValueType>(r);
 }
 
 void TrialWaveFunction::flex_calcRatioGrad(const RefVector<TrialWaveFunction>& wf_list,
-                                       const RefVector<ParticleSet>& p_list,
-                                       int iat,
-                                       std::vector<PsiValueType>& ratios,
-                                       std::vector<GradType>& grad_new)
+                                           const RefVector<ParticleSet>& p_list,
+                                           int iat,
+                                           std::vector<PsiValueType>& ratios,
+                                           std::vector<GradType>& grad_new)
 {
   const int num_wf = wf_list.size();
   grad_new.resize(num_wf);
@@ -741,7 +741,7 @@ TrialWaveFunction::RealType TrialWaveFunction::updateBuffer(ParticleSet& P, WFBu
     myTimers[ii]->stop();
   }
 
-  LogValue = std::real(logpsi);
+  LogValue   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
   //printGL(P.G,P.L);
   buf.put(PhaseValue);
@@ -782,7 +782,7 @@ void TrialWaveFunction::flex_updateBuffer(const RefVector<TrialWaveFunction>& wf
     for (int iw = 0; iw < wf_list.size(); iw++)
     {
       wf_list[iw].get().LogValue += std::real(wfc_list[iw].get().LogValue);
-      wf_list[iw].get().PhaseValue +=  std::imag(wfc_list[iw].get().LogValue);
+      wf_list[iw].get().PhaseValue += std::imag(wfc_list[iw].get().LogValue);
     }
   }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -168,10 +168,15 @@ public:
                         ParticleSet::ParticleGradient_t& fixedG,
                         ParticleSet::ParticleLaplacian_t& fixedL);
 
-  /** function that computes psi(R_new) / psi(R_current). It returns a complex value if the wavefunction 
-  *   is complex. It differs from the ratio(ParticleSet& P, int iat) function in the way that the ratio
-  *   function takes the absolute value of psi(R_new) / psi(R_current). */
+  /** compute psi(R_new) / psi(R_current) ratio
+   * It returns a complex value if the wavefunction is complex.
+   * @param P the active ParticleSet
+   * @param iat the index of a particle moved to the new position.
+   * @param ct select ComputeType
+   * @return ratio value
+   */
   ValueType calcRatio(ParticleSet& P, int iat, ComputeType ct = ComputeType::ALL);
+
   /** batched verison of calcRatio */
   static void flex_calcRatio(const RefVector<TrialWaveFunction>& WF_list,
                              const RefVector<ParticleSet>& P_list,
@@ -202,6 +207,13 @@ public:
                           TinyVector<ParticleSet::ParticleGradient_t, OHMMS_DIM>& grad_grad,
                           TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad);
 
+  /** compute psi(R_new) / psi(R_current) ratio and \nabla ln(psi(R_new)) gradients
+   * It returns a complex value if the wavefunction is complex.
+   * @param P the active ParticleSet
+   * @param iat the index of a particle moved to the new position.
+   * @param grad_iat gradients
+   * @return ratio value
+   */
   ValueType calcRatioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
   /** batched verison of ratioGrad 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -112,10 +112,7 @@ public:
   void getPhases(std::vector<RealType>& pvals);
 
   inline RealType getPhaseDiff() const { return PhaseDiff; }
-  inline void resetPhaseDiff()
-  {
-    PhaseDiff = 0.0;
-  }
+  inline void resetPhaseDiff() { PhaseDiff = 0.0; }
   inline RealType getLogPsi() const { return LogValue; }
   inline void setLogPsi(RealType LogPsi_new) { LogValue = LogPsi_new; }
 
@@ -221,10 +218,10 @@ public:
    *  all vector sizes must match
    */
   static void flex_calcRatioGrad(const RefVector<TrialWaveFunction>& WF_list,
-                             const RefVector<ParticleSet>& P_list,
-                             int iat,
-                             std::vector<PsiValueType>& ratios,
-                             std::vector<GradType>& grad_new);
+                                 const RefVector<ParticleSet>& P_list,
+                                 int iat,
+                                 std::vector<PsiValueType>& ratios,
+                                 std::vector<GradType>& grad_new);
 
   GradType evalGrad(ParticleSet& P, int iat);
   /** batched verison of evalGrad

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -145,10 +145,7 @@ struct WaveFunctionComponent : public QMCTraits
   virtual void setDiffOrbital(DiffWaveFunctionComponentPtr d);
 
   ///assembles the full value
-  PsiValueType getValue() const
-  {
-    return LogToValue<PsiValueType>::convert(LogValue);
-  }
+  PsiValueType getValue() const { return LogToValue<PsiValueType>::convert(LogValue); }
 
   /** check in optimizable parameters
    * @param active a super set of optimizable variables
@@ -185,8 +182,8 @@ struct WaveFunctionComponent : public QMCTraits
    * move also uses this.
    */
   virtual LogValueType evaluateLog(ParticleSet& P,
-                               ParticleSet::ParticleGradient_t& G,
-                               ParticleSet::ParticleLaplacian_t& L) = 0;
+                                   ParticleSet::ParticleGradient_t& G,
+                                   ParticleSet::ParticleLaplacian_t& L) = 0;
 
   /** evaluate from scratch the same type WaveFunctionComponent of multiple walkers
    * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -301,7 +301,7 @@ struct WaveFunctionComponent : public QMCTraits
    * @param iat the index of a particle
    * @param grad_iat Gradient for the active particle
    */
-  virtual ValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     APP_ABORT("WaveFunctionComponent::ratioGrad is not implemented in " + ClassName + " class.");
     return ValueType();
@@ -406,7 +406,7 @@ struct WaveFunctionComponent : public QMCTraits
    *
    * Specialized for particle-by-particle move
    */
-  virtual ValueType ratio(ParticleSet& P, int iat) = 0;
+  virtual PsiValueType ratio(ParticleSet& P, int iat) = 0;
 
   /** compute the ratio of the new to old WaveFunctionComponent value of multiple walkers
    * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -41,6 +41,10 @@ using std::string;
 
 namespace qmcplusplus
 {
+
+using RealType = WaveFunctionComponent::RealType;
+using PsiValueType = WaveFunctionComponent::PsiValueType;
+
 TEST_CASE("BSpline functor zero", "[wavefunction]")
 {
   BsplineFunctor<double> bf;
@@ -119,9 +123,9 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   WaveFunctionComponent* orb = psi.getOrbitals()[0];
 
 #ifdef ENABLE_SOA
-  typedef J2OrbitalSoA<BsplineFunctor<WaveFunctionComponent::RealType>> J2Type;
+  typedef J2OrbitalSoA<BsplineFunctor<RealType>> J2Type;
 #else
-  typedef TwoBodyJastrowOrbital<BsplineFunctor<WaveFunctionComponent::RealType>> J2Type;
+  typedef TwoBodyJastrowOrbital<BsplineFunctor<RealType>> J2Type;
 #endif
   J2Type* j2 = dynamic_cast<J2Type*>(orb);
   REQUIRE(j2 != NULL);
@@ -205,13 +209,13 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
                      {11.40, 0, 0, 0}};
 
 
-  BsplineFunctor<WaveFunctionComponent::RealType>* bf = j2->F[0];
+  BsplineFunctor<RealType>* bf = j2->F[0];
 
   for (int i = 0; i < N; i++)
   {
-    WaveFunctionComponent::RealType dv  = 0.0;
-    WaveFunctionComponent::RealType ddv = 0.0;
-    WaveFunctionComponent::RealType val = bf->evaluate(Vals[i].r, dv, ddv);
+    RealType dv  = 0.0;
+    RealType ddv = 0.0;
+    RealType val = bf->evaluate(Vals[i].r, dv, ddv);
     REQUIRE(Vals[i].u == Approx(val));
     REQUIRE(Vals[i].du == Approx(dv));
     REQUIRE(Vals[i].ddu == Approx(ddv));
@@ -258,7 +262,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   REQUIRE(std::real(ratios[1]) == Approx(0.9871985577));
 
   elec_.makeMove(0, newpos - elec_.R[0]);
-  ValueType ratio_0 = j2->ratio(elec_, 0);
+  PsiValueType ratio_0 = j2->ratio(elec_, 0);
   elec_.rejectMove(0);
 
   REQUIRE(std::real(ratio_0) == Approx(0.9522052017));
@@ -275,7 +279,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
 
   //test acceptMove
   elec_.makeMove(1, newpos - elec_.R[1]);
-  ValueType ratio_1 = j2->ratio(elec_, 1);
+  PsiValueType ratio_1 = j2->ratio(elec_, 1);
   j2->acceptMove(elec_, 1);
   elec_.acceptMove(1);
 
@@ -351,9 +355,9 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
   WaveFunctionComponent* orb = psi.getOrbitals()[0];
 
 #ifdef ENABLE_SOA
-  typedef J1OrbitalSoA<BsplineFunctor<WaveFunctionComponent::RealType>> J1Type;
+  typedef J1OrbitalSoA<BsplineFunctor<RealType>> J1Type;
 #else
-  typedef OneBodyJastrowOrbital<BsplineFunctor<WaveFunctionComponent::RealType>> J1Type;
+  typedef OneBodyJastrowOrbital<BsplineFunctor<RealType>> J1Type;
 #endif
   J1Type* j1 = dynamic_cast<J1Type*>(orb);
   REQUIRE(j1 != NULL);
@@ -488,16 +492,16 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
 
 
 #ifdef ENABLE_SOA
-  BsplineFunctor<WaveFunctionComponent::RealType>* bf = j1->F[0];
+  BsplineFunctor<RealType>* bf = j1->F[0];
 #else
-  BsplineFunctor<WaveFunctionComponent::RealType>* bf  = j1->Fs[0];
+  BsplineFunctor<RealType>* bf  = j1->Fs[0];
 #endif
 
   for (int i = 0; i < N; i++)
   {
-    WaveFunctionComponent::RealType dv  = 0.0;
-    WaveFunctionComponent::RealType ddv = 0.0;
-    WaveFunctionComponent::RealType val = bf->evaluate(Vals[i].r, dv, ddv);
+    RealType dv  = 0.0;
+    RealType ddv = 0.0;
+    RealType val = bf->evaluate(Vals[i].r, dv, ddv);
     REQUIRE(Vals[i].u == Approx(val));
     REQUIRE(Vals[i].du == Approx(dv));
     REQUIRE(Vals[i].ddu == Approx(ddv));
@@ -544,14 +548,14 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
   REQUIRE(std::real(ratios[1]) == Approx(1.0040884258));
 
   elec_.makeMove(0, newpos - elec_.R[0]);
-  ValueType ratio_0 = j1->ratio(elec_, 0);
+  PsiValueType ratio_0 = j1->ratio(elec_, 0);
   elec_.rejectMove(0);
 
   REQUIRE(std::real(ratio_0) == Approx(0.9819208747));
 
   // test acceptMove results
   elec_.makeMove(1, newpos - elec_.R[1]);
-  ValueType ratio_1 = j1->ratio(elec_, 1);
+  PsiValueType ratio_1 = j1->ratio(elec_, 1);
   j1->acceptMove(elec_, 1);
   elec_.acceptMove(1);
 
@@ -613,16 +617,16 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
                        {11.40, 0, 0, 0}};
 
 #ifdef ENABLE_SOA
-  BsplineFunctor<WaveFunctionComponent::RealType>* bf2 = j12->F[0];
+  BsplineFunctor<RealType>* bf2 = j12->F[0];
 #else
-  BsplineFunctor<WaveFunctionComponent::RealType>* bf2 = j12->Fs[0];
+  BsplineFunctor<RealType>* bf2 = j12->Fs[0];
 #endif
 
   for (int i = 0; i < N2; i++)
   {
-    WaveFunctionComponent::RealType dv  = 0.0;
-    WaveFunctionComponent::RealType ddv = 0.0;
-    WaveFunctionComponent::RealType val = bf2->evaluate(Vals2[i].r, dv, ddv);
+    RealType dv  = 0.0;
+    RealType ddv = 0.0;
+    RealType val = bf2->evaluate(Vals2[i].r, dv, ddv);
     REQUIRE(Vals2[i].du == Approx(dv));
     REQUIRE(Vals2[i].u == Approx(val));
     REQUIRE(Vals2[i].ddu == Approx(ddv));

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -41,8 +41,7 @@ using std::string;
 
 namespace qmcplusplus
 {
-
-using RealType = WaveFunctionComponent::RealType;
+using RealType     = WaveFunctionComponent::RealType;
 using PsiValueType = WaveFunctionComponent::PsiValueType;
 
 TEST_CASE("BSpline functor zero", "[wavefunction]")
@@ -144,37 +143,20 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   WaveFunctionComponent::HessVector_t grad_grad_psi;
   grad_grad_psi.resize(elec_.getTotalNum());
   grad_grad_psi = 0.0;
-  
-  std::cout<<"eval hess"<<std::endl;
-  j2->evaluateHessian(elec_,grad_grad_psi);
+
+  std::cout << "eval hess" << std::endl;
+  j2->evaluateHessian(elec_, grad_grad_psi);
   std::vector<double> hess_values = {
-    -0.0627236,
-    0,
-    0,
-    0,
-    0.10652,
-    0,
-    0,
-    0,
-    0.10652,
-    -0.0627236,
-    0,
-    0,
-    0,
-    0.10652,
-    0,
-    0,
-    0,
-    0.10652,
+      -0.0627236, 0, 0, 0, 0.10652, 0, 0, 0, 0.10652, -0.0627236, 0, 0, 0, 0.10652, 0, 0, 0, 0.10652,
   };
 
-  int m=0;
-  for(int n=0; n<elec_.getTotalNum(); n++)
-    for(int i=0; i<OHMMS_DIM; i++)
-      for(int j=0; j<OHMMS_DIM; j++,m++)
-        {
-          REQUIRE(std::real(grad_grad_psi[n](i,j)) == Approx(hess_values[m]));
-        }
+  int m = 0;
+  for (int n = 0; n < elec_.getTotalNum(); n++)
+    for (int i = 0; i < OHMMS_DIM; i++)
+      for (int j = 0; j < OHMMS_DIM; j++, m++)
+      {
+        REQUIRE(std::real(grad_grad_psi[n](i, j)) == Approx(hess_values[m]));
+      }
 
 
   struct JValues
@@ -425,36 +407,19 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
   grad_grad_psi.resize(elec_.getTotalNum());
   grad_grad_psi = 0.0;
 
-  psi.evaluateHessian(elec_,grad_grad_psi);
-  
+  psi.evaluateHessian(elec_, grad_grad_psi);
+
   std::vector<double> hess_values = {
-    0.00888367,
-    0,
-    0,
-    0,
-    -0.0284893,
-    0,
-    0,
-    0,
-    -0.0284893,
-    0.00211188,
-    0,
-    0,
-    0,
-    -0.00923137,
-    0,
-    0,
-    0,
-    -0.00923137,
+      0.00888367, 0, 0, 0, -0.0284893, 0, 0, 0, -0.0284893, 0.00211188, 0, 0, 0, -0.00923137, 0, 0, 0, -0.00923137,
   };
 
-  int m=0;
-  for(int n=0; n<elec_.getTotalNum(); n++)
-    for(int i=0; i<OHMMS_DIM; i++)
-      for(int j=0; j<OHMMS_DIM; j++,m++)
-        {
-          REQUIRE(std::real(grad_grad_psi[n](i,j)) == Approx(hess_values[m]));
-        }
+  int m = 0;
+  for (int n = 0; n < elec_.getTotalNum(); n++)
+    for (int i = 0; i < OHMMS_DIM; i++)
+      for (int j = 0; j < OHMMS_DIM; j++, m++)
+      {
+        REQUIRE(std::real(grad_grad_psi[n](i, j)) == Approx(hess_values[m]));
+      }
 
   psi.evaluateLog(elec_); // evaluateHessian has side effects
 

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -238,8 +238,8 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 
 
   ParticleSet::GradType grad;
-  ValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
-  ValueType det_ratio1 = 0.178276269185;
+  PsiValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
+  PsiValueType det_ratio1 = 0.178276269185;
   REQUIRE(det_ratio1 == ValueApprox(det_ratio));
 
   ddb.acceptMove(elec, 0);
@@ -323,12 +323,12 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   }
 
   ParticleSet::GradType grad;
-  ValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
+  PsiValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
 
   simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  ValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
+  PsiValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
 #ifdef DUMP_INFO
   std::cout << "det 0 = " << std::exp(ddb.LogValue) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -341,11 +341,11 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   ddb.acceptMove(elec, 0);
 
 
-  ValueType det_ratio2 = ddb.ratioGrad(elec, 1, grad);
+  PsiValueType det_ratio2 = ddb.ratioGrad(elec, 1, grad);
   LogValueType det_update2;
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  ValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   std::cout << "det 1 = " << std::exp(ddb.LogValue) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -356,11 +356,11 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 
   ddb.acceptMove(elec, 1);
 
-  ValueType det_ratio3 = ddb.ratioGrad(elec, 2, grad);
+  PsiValueType det_ratio3 = ddb.ratioGrad(elec, 2, grad);
   LogValueType det_update3;
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  ValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   std::cout << "det 2 = " << std::exp(ddb.LogValue) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
@@ -450,12 +450,12 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
 
 
   ParticleSet::GradType grad;
-  ValueType det_ratio = ddc.ratioGrad(elec, 0, grad);
+  PsiValueType det_ratio = ddc.ratioGrad(elec, 0, grad);
 
   simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  ValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
+  PsiValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
 #ifdef DUMP_INFO
   std::cout << "det 0 = " << std::exp(ddc.LogValue) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -471,11 +471,11 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   ddc.completeUpdates();
 
   grad                 = ddc.evalGrad(elec, 1);
-  ValueType det_ratio2 = ddc.ratioGrad(elec, 1, grad);
+  PsiValueType det_ratio2 = ddc.ratioGrad(elec, 1, grad);
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   LogValueType det_update2;
   dm.invert_transpose(scratchT, a_update2, det_update2);
-  ValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
+  PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
   std::cout << "det 1 = " << std::exp(ddc.LogValue) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
@@ -489,11 +489,11 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   ddc.acceptMove(elec, 1);
 
   grad                 = ddc.evalGrad(elec, 2);
-  ValueType det_ratio3 = ddc.ratioGrad(elec, 2, grad);
+  PsiValueType det_ratio3 = ddc.ratioGrad(elec, 2, grad);
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
   LogValueType det_update3;
   dm.invert_transpose(scratchT, a_update3, det_update3);
-  ValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
+  PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
   std::cout << "det 2 = " << std::exp(ddc.LogValue) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -27,9 +27,8 @@ using std::string;
 
 namespace qmcplusplus
 {
-
-using RealType = QMCTraits::RealType;
-using ValueType = QMCTraits::ValueType;
+using RealType     = QMCTraits::RealType;
+using ValueType    = QMCTraits::ValueType;
 using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
 using PsiValueType = QMCTraits::QTFull::ValueType;
 
@@ -238,7 +237,7 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 
 
   ParticleSet::GradType grad;
-  PsiValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
+  PsiValueType det_ratio  = ddb.ratioGrad(elec, 0, grad);
   PsiValueType det_ratio1 = 0.178276269185;
   REQUIRE(det_ratio1 == ValueApprox(det_ratio));
 
@@ -325,10 +324,11 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   ParticleSet::GradType grad;
   PsiValueType det_ratio = ddb.ratioGrad(elec, 0, grad);
 
-  simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
 #ifdef DUMP_INFO
   std::cout << "det 0 = " << std::exp(ddb.LogValue) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -343,7 +343,8 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 
   PsiValueType det_ratio2 = ddb.ratioGrad(elec, 1, grad);
   LogValueType det_update2;
-  simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
@@ -358,7 +359,8 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 
   PsiValueType det_ratio3 = ddb.ratioGrad(elec, 2, grad);
   LogValueType det_update3;
-  simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
@@ -452,10 +454,11 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   ParticleSet::GradType grad;
   PsiValueType det_ratio = ddc.ratioGrad(elec, 0, grad);
 
-  simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update1.data(), a_update1.rows(), a_update1.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1  = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
 #ifdef DUMP_INFO
   std::cout << "det 0 = " << std::exp(ddc.LogValue) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
@@ -470,9 +473,10 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   // force update Ainv in ddc using SM-1 code path
   ddc.completeUpdates();
 
-  grad                 = ddc.evalGrad(elec, 1);
+  grad                    = ddc.evalGrad(elec, 1);
   PsiValueType det_ratio2 = ddc.ratioGrad(elec, 1, grad);
-  simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   LogValueType det_update2;
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
@@ -488,9 +492,10 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   // update of Ainv in ddc is delayed
   ddc.acceptMove(elec, 1);
 
-  grad                 = ddc.evalGrad(elec, 2);
+  grad                    = ddc.evalGrad(elec, 2);
   PsiValueType det_ratio3 = ddc.ratioGrad(elec, 2, grad);
-  simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(), scratchT.cols());
+  simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),
+                  scratchT.cols());
   LogValueType det_update3;
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -21,10 +21,10 @@
 namespace qmcplusplus
 {
 
-using RealType = QMCTraits::RealType;
-using ValueType = QMCTraits::ValueType;
-using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
-using PsiValueType = QMCTraits::QTFull::ValueType;
+using RealType = WaveFunctionComponent::RealType;
+using ValueType = WaveFunctionComponent::ValueType;
+using LogValueType = WaveFunctionComponent::LogValueType;
+using PsiValueType = WaveFunctionComponent::PsiValueType;
 
 TEST_CASE("ExampleHe", "[wavefunction]")
 {
@@ -132,7 +132,7 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   elec->makeMove(iat, zero_displ);
 
 
-  ValueType ratio = example_he->ratio(*elec, iat);
+  PsiValueType ratio = example_he->ratio(*elec, iat);
   REQUIRE(std::real(ratio) == Approx(1.0));
 
   ratio = example_he->ratioGrad(*elec, iat, grad0);

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -20,9 +20,8 @@
 
 namespace qmcplusplus
 {
-
-using RealType = WaveFunctionComponent::RealType;
-using ValueType = WaveFunctionComponent::ValueType;
+using RealType     = WaveFunctionComponent::RealType;
+using ValueType    = WaveFunctionComponent::ValueType;
 using LogValueType = WaveFunctionComponent::LogValueType;
 using PsiValueType = WaveFunctionComponent::PsiValueType;
 
@@ -169,7 +168,7 @@ TEST_CASE("ExampleHe", "[wavefunction]")
 
   // wavefunction value and derivatives at new position
   LogValueType new_logpsi = example_he->evaluateLog(*elec, new_grad, new_lap);
-  elec->R[0]          = oldpos;
+  elec->R[0]              = oldpos;
   elec->update();
 
   iat = 0;

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -36,7 +36,6 @@ using std::string;
 
 namespace qmcplusplus
 {
-
 using LogValueType = WaveFunctionComponent::LogValueType;
 using PsiValueType = WaveFunctionComponent::PsiValueType;
 

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -36,6 +36,10 @@ using std::string;
 
 namespace qmcplusplus
 {
+
+using LogValueType = WaveFunctionComponent::LogValueType;
+using PsiValueType = WaveFunctionComponent::PsiValueType;
+
 TEST_CASE("PolynomialFunctor3D functor zero", "[wavefunction]")
 {
   PolynomialFunctor3D functor;
@@ -150,19 +154,19 @@ TEST_CASE("PolynomialFunctor3D Jastrow", "[wavefunction]")
   REQUIRE(std::real(ratios[3]) == Approx(0.7987703724));
 
   elec_.makeMove(0, newpos - elec_.R[0]);
-  ValueType ratio_0 = j3->ratio(elec_, 0);
+  PsiValueType ratio_0 = j3->ratio(elec_, 0);
   elec_.rejectMove(0);
 
   elec_.makeMove(1, newpos - elec_.R[1]);
-  ValueType ratio_1 = j3->ratio(elec_, 1);
+  PsiValueType ratio_1 = j3->ratio(elec_, 1);
   elec_.rejectMove(1);
 
   elec_.makeMove(2, newpos - elec_.R[2]);
-  ValueType ratio_2 = j3->ratio(elec_, 2);
+  PsiValueType ratio_2 = j3->ratio(elec_, 2);
   elec_.rejectMove(2);
 
   elec_.makeMove(3, newpos - elec_.R[3]);
-  ValueType ratio_3 = j3->ratio(elec_, 3);
+  PsiValueType ratio_3 = j3->ratio(elec_, 3);
   elec_.rejectMove(3);
 
   REQUIRE(std::real(ratio_0) == Approx(0.8744938582));


### PR DESCRIPTION
Closes #1267 

In Jastrow factors, ratio value is exp(diff) which can overflow single precision. Initially I tough about changing to log but I realized that ratio value can be zero and taking log is ill defined. So just use high precision in return.

In this PR, at WaveFunctionComponent level, ratio and ratioGrad always return ratio value in PsiValueType to ensure no overflow. In the Jastrow factors, returns `std::exp(static_cast<PsiValueType>(diff))`

At the TrialWaveFunction, calcRatio and calcRatioGrad use PsiValueType in reduction and then returns ValueType. Thus there are no changes to drivers.

documentation has been added for calcRatio and calcRatioGrad.