### PR TITLE
PyscfToQmcpack: Solve Python3 error

### DIFF
--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -517,7 +517,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
     GroupCell.create_dataset("LatticeVectors",(3,3),dtype="f8",data=loc_cell.lattice_vectors())
 
     def get_mo(mo_coeff, cart):
-        return order_mo_coef(mo_coeff) if cart else zip(*mo_coeff)
+        return order_mo_coef(mo_coeff) if cart else list(zip(*mo_coeff))
 
     #Supertwist Coordinate
     GroupDet.create_dataset("Coord",(1,3),dtype="f8",data=sp_twist)


### PR DESCRIPTION
When using  `PyscfToQmcpack` with Python3 and a non-cartesian basis, a Python bug was present leading the crash of the scrips with:

```
  File "diamondC_1x1x1_pp_LCAO.py", line 66, in <module>
    from PyscfToQmcpack import savetoqmcpack
  File "/private/tmp/tetet/PyscfToQmcpack.py", line 550, in savetoqmcpack
    eigenset_unsorted=GroupDet.create_dataset("eigenset_unsorted_0",(NbMO,NbAO),dtype="f8",data=mo_coeff_unsorted)
  File "/Users/tapplencourt/miniconda/miniconda3/lib/python3.7/site-packages/h5py/_hl/group.py", line 136, in create_dataset
    dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)
  File "/Users/tapplencourt/miniconda/miniconda3/lib/python3.7/site-packages/h5py/_hl/dataset.py", line 95, in make_new_dset
    raise ValueError("Shape tuple is incompatible with data")
ValueError: Shape tuple is incompatible with data
```

It was due to the fact, that between in Python3 the `zip` function returns now an `Iterator` and not a `List`.  That triggered a bug in the current implementation (we used more than one the output of the `get_mo` function.)

This bug is fixed in the current PR.