### PR TITLE
Nexus: Default Hybrid Rep params

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -4349,10 +4349,8 @@ def generate_particlesets(electrons   = 'e',
                 size         = len(gpos)
                 )
             if hybridrep:
-                rcut = hybrid_rcut[ion_spec]
-                lmax = hybrid_lmax[ion_spec]
-                g.lmax           = lmax
-                g.cutoff_radius  = rcut
+                g.lmax           = hybrid_lmax[ion_spec]
+                g.cutoff_radius  = hybrid_rcut[ion_spec]
             #end if
             groups.append(g)
         #end for

--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -4351,15 +4351,8 @@ def generate_particlesets(electrons   = 'e',
             if hybridrep:
                 rcut = hybrid_rcut[ion_spec]
                 lmax = hybrid_lmax[ion_spec]
-                # this code should be in qmcpack 
-                # it should not be required of the user
-                dr = 0.02
-                rspline = rcut + 2*dr
-                nspline = int(floor(rspline/dr)) + 1
                 g.lmax           = lmax
                 g.cutoff_radius  = rcut
-                g.spline_radius  = rspline
-                g.spline_npoints = nspline
             #end if
             groups.append(g)
         #end for


### PR DESCRIPTION
This PR removes the setting of spline_radius and spline_npoints values
by nexus given that QMCPACK sets its own defaults for these quantities.

Thank you @jtkrogel for your assistance with this PR.