### PR TITLE
Fix reference Ewald

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -68,6 +68,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
 
     RealType Vii_ref = ewaldEnergy(A,R,Q);
     RealType Vdiff_per_atom = std::abs(Value-Vii_ref)/NumCenters;
+    app_log()<<"Checking ion-ion Ewald energy against reference..."<<std::endl;
     if(Vdiff_per_atom > Ps.Lattice.LR_tol)
     {
       app_log()<<std::setprecision(14);
@@ -88,6 +89,10 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       app_log()<<std::endl;
 
       APP_ABORT("ion-ion check failed")
+    }
+    else
+    {
+      app_log()<<"  Check passed."<<std::endl;
     }
   }
   prefix = "F_AA";

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -199,11 +199,12 @@ class KspaceEwaldTerm
 template<typename T>
 RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
 {
-  RealType dv = 1e99;
-  RealType v  = 0.0;
-  IntType im  = 0;
-  IntType jm  = 0;
-  IntType km  = 0;
+  RealType dv  = 1e99;
+  RealType dva = 1e99;
+  RealType v   = 0.0;
+  IntType im   = 0;
+  IntType jm   = 0;
+  IntType km   = 0;
   IntVec  iv;
   // Add the value at the origin, if requested.
   if(zero)
@@ -212,9 +213,10 @@ RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
     v += function(iv);
   }
   // Sum over cubic surface shells until the tolerance is reached.
-  while(std::abs(dv)>tol)
+  while(std::abs(dva)>tol)
   {
-    dv = 0.0; // Surface shell contribution.
+    dva = 0.0;
+    dv  = 0.0; // Surface shell contribution.
     // Sum over new surface planes perpendicular to the x direction.
     im += 1;
     for(IntType i: {-im,im})
@@ -224,7 +226,9 @@ RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
           iv[0] = i;
           iv[1] = j;
           iv[2] = k;
-          dv += function(iv);
+          RealType f = function(iv);
+          dv  += f;
+          dva += std::abs(f);
         }
     // Sum over new surface planes perpendicular to the y direction.
     jm += 1;
@@ -235,7 +239,9 @@ RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
           iv[0] = i;
           iv[1] = j;
           iv[2] = k;
-          dv += function(iv);
+          RealType f = function(iv);
+          dv  += f;
+          dva += std::abs(f);
         }
     // Sum over new surface planes perpendicular to the z direction.
     km += 1;
@@ -246,7 +252,9 @@ RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
           iv[0] = i;
           iv[1] = j;
           iv[2] = k;
-          dv += function(iv);
+          RealType f = function(iv);
+          dv  += f;
+          dva += std::abs(f);
         }
     v += dv;
   }

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -199,8 +199,8 @@ class KspaceEwaldTerm
 template<typename T>
 RealType gridSum(T& function,bool zero=true,RealType tol=1e-11)
 {
-  RealType dv  = 1e99;
-  RealType dva = 1e99;
+  RealType dv  = std::numeric_limits<RealType>::max();
+  RealType dva = std::numeric_limits<RealType>::max();
   RealType v   = 0.0;
   IntType im   = 0;
   IntType jm   = 0;

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -43,7 +43,7 @@ enum
 /// Type for integers
 using IntType     = int;
 /// Type for floating point numbers
-using RealType    = QMCTraits::RealType;
+using RealType    = QMCTraits::FullPrecRealType;
 /// Type for integer vectors of length DIM
 using IntVec      = TinyVector<IntType, DIM>;
 /// Type for floating point vectors of length DIM


### PR DESCRIPTION
closes #2142.

The sums in the reference implementation were terminated whenever the contribution over a cubic shell was less than a specified tolerance.  In the cubic NiO series for some cell sizes, the contribution over a cubic shell can vanish.  This lead to the behavior documented in #2142.

The ion-ion energy per 4 atom NiO cell is listed below for the original reference and native QMCPACK implementations:
```
         Reference         QMCPACK        
 4 atom  -239.29814998004  -239.2981423734
 8 atom  -239.29814997992  -239.2981710054
16 atom  -239.29814997956  -239.2980872025
32 atom  -186.17910785715  -239.2983961978
64 atom  -217.33657911019  -239.2981926791
```

The fix is to instead sum the absolute value of each of the point contributions over the shell and terminate only when this absolute sum over the shell is below the tolerance.  Following the fix, the ion-ion energies become:
```
         Reference         QMCPACK        
 4 atom  -239.29814998008  -239.29814237331
 8 atom  -239.29814998008  -239.29817100545
16 atom  -239.29814998007  -239.29808720243
32 atom  -239.29817132488  -239.29839619770
64 atom  -239.29814998041  -239.29819267906
```

Notice that for the 32 atom cell, the reference value still deviates from the baseline somewhat, though it returns for the 64 atom case.  I can't tell whether this case is simply more sensitive or whether the deviation is due to some differences in internal numerics in the representation of the cell and/or atomic positions for this particular tiling.  QMCPACK also shows the largest deviation from the reference for this case:

![IonIon_err](https://user-images.githubusercontent.com/24547905/70647373-cbaa1100-1c16-11ea-8767-27c4cfa99e52.png)

On a separate note, I observe that the reference Ewald check takes on the order of minutes for the 64 atom case and might become prohibitive for larger system sizes.