### PR TITLE
Fix zero down spin

### DIFF
--- a/manual/dmc.tex
+++ b/manual/dmc.tex
@@ -185,7 +185,7 @@ problems near nodal surfaces.
   \item ZSGMA: Implements the ``ZSGMA'' algorithm of Ref.~\cite{ZenBoosting2016} with $\alpha=0.2$. The cutoff energy is modified by a factor including the
   electron count, $E_{\rm cut}=\alpha \sqrt{N/\tau}$, which greatly improves size consistency over Eq.~39 of Ref.~\cite{Umrigar1993}. See Eq.~6 in Ref.~\cite{ZenBoosting2016} and for
   an application to molecular crystals Ref.~\cite{ZenFast2018}.
-  \item YL: An unpublished algorithm due to Ye Luo. $E_{\rm cut}=\sigma\times\mathrm{min}(\mathrm{sigmaBound},\sqrt{1/\tau})$. This option takes into account both size consistency and wavefunction quality via the term $\sigma$. $\mathrm{maxSigma}$ is default to 10.
+  \item YL: An unpublished algorithm due to Ye Luo. $E_{\rm cut}=\sigma\times\mathrm{min}(\mathrm{sigmaBound},\sqrt{1/\tau})$. This option takes into account both size consistency and wavefunction quality via the term $\sigma$. $\mathrm{sigmaBound}$ is default to 10.
 \end{itemize}
 
 \end{itemize}

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -112,7 +112,13 @@ ParticleSet::~ParticleSet()
     delete SK;
 }
 
-void ParticleSet::create(int numPtcl) { resize(numPtcl); }
+void ParticleSet::create(int numPtcl)
+{
+  resize(numPtcl);
+  SubPtcl.resize(2);
+  SubPtcl[0] = 0;
+  SubPtcl[1] = numPtcl;
+}
 
 void ParticleSet::create(const std::vector<int>& agroup)
 {

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -182,6 +182,16 @@ void ParticleSet::resetGroups()
     else
       APP_ABORT("ParticleSet::resetGroups() Failed. GroupID is out of bound.");
   }
+  // safety check if any group of particles has size 0, instruct users to fix the input.
+  for (int group_id = 0; group_id < nspecies; group_id++)
+    if (ng[group_id] == 0)
+    {
+      std::ostringstream err_msg;
+      err_msg << "ParticleSet::resetGroups() Failed. ParticleSet '" << myName << "' "
+              << "has group '" << mySpecies.speciesName[group_id] << "' containing 0 particles. "
+              << "Remove this group from input!" << std::endl;
+      APP_ABORT(err_msg.str());
+    }
   SubPtcl.resize(nspecies + 1);
   SubPtcl[0] = 0;
   for (int i = 0; i < nspecies; ++i)

--- a/src/QMCApp/InitMolecularSystem.cpp
+++ b/src/QMCApp/InitMolecularSystem.cpp
@@ -111,8 +111,10 @@ void InitMolecularSystem::initMolecule(ParticleSet* ions, ParticleSet* els)
   ParticleSet::ParticlePos_t chi(els->getTotalNum());
   //makeGaussRandom(chi);
   makeSphereRandom(chi);
-  int numUp   = els->last(0);
-  int numDown = els->last(1) - els->first(0);
+  // the upper limit of the electron index with spin up
+  const int numUp   = els->last(0);
+  // the upper limit of the electron index with spin down. Pay attention to the no spin down electron case.
+  const int numDown = els->last(els->groups()>1?1:0) - els->first(0);
   int item    = 0;
   int nup_tot = 0, ndown_tot = numUp;
   std::vector<LoneElectron> loneQ;
@@ -138,6 +140,7 @@ void InitMolecularSystem::initMolecule(ParticleSet* ions, ParticleSet* els)
       }
       for (int k = 0; k < v2; k++)
       {
+        // initialize electron positions in pairs
         if (nup_tot < numUp)
           els->R[nup_tot++] = ions->R[iat] + sep * chi[item++];
         if (ndown_tot < numDown)

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -196,7 +196,8 @@ bool ParticleSetPool::put(xmlNodePtr cur)
 
 void ParticleSetPool::randomize()
 {
-  app_log() << "ParticleSetPool::randomize " << std::endl;
+  app_log() << "ParticleSetPool::randomize " << randomize_nodes.size() << " ParticleSet"
+            << (randomize_nodes.size()==1?"":"s") << "." << std::endl;
   bool success = true;
   for (int i = 0; i < randomize_nodes.size(); ++i)
   {

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -79,7 +79,7 @@ void QMCUpdateBase::setDefaults()
   myParams.add(m_r2max, "maxDisplSq", "double"); //maximum displacement
   //store 1/mass per species
   SpeciesSet tspecies(W.getSpeciesSet());
-  assert(W.getSpeciesSet() == W.groups());
+  assert(tspecies.getTotalNum() == W.groups());
   int massind = tspecies.addAttribute("mass");
   MassInvS.resize(tspecies.getTotalNum());
   for (int ig = 0; ig < tspecies.getTotalNum(); ++ig)

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -79,16 +79,15 @@ void QMCUpdateBase::setDefaults()
   myParams.add(m_r2max, "maxDisplSq", "double"); //maximum displacement
   //store 1/mass per species
   SpeciesSet tspecies(W.getSpeciesSet());
+  assert(W.getSpeciesSet() == W.groups());
   int massind = tspecies.addAttribute("mass");
   MassInvS.resize(tspecies.getTotalNum());
   for (int ig = 0; ig < tspecies.getTotalNum(); ++ig)
     MassInvS[ig] = 1.0 / tspecies(massind, ig);
   MassInvP.resize(W.getTotalNum());
   for (int ig = 0; ig < W.groups(); ++ig)
-  {
     for (int iat = W.first(ig); iat < W.last(ig); ++iat)
       MassInvP[iat] = MassInvS[ig];
-  }
 
   InitWalkersTimer = TimerManager.createTimer("QMCUpdateBase::WalkerInit", timer_level_medium);
 }

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -56,6 +56,13 @@ TEST_CASE("QMCUpdate", "[drivers]")
   elec.create(1);
   elec.createWalkers(1);
 
+  SpeciesSet& tspecies         = elec.getSpeciesSet();
+  int upIdx                    = tspecies.addSpecies("u");
+  int chargeIdx                = tspecies.addAttribute("charge");
+  int massIdx                  = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx)   = -1;
+  tspecies(massIdx, upIdx)     = 1.0;
+
   FakeRandom rg;
 
   QMCHamiltonian h;

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -68,13 +68,10 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);
@@ -171,13 +168,10 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dm
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -69,13 +69,10 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -68,13 +68,10 @@ TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -69,13 +69,10 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -64,13 +64,8 @@ TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
 
   SpeciesSet& tspecies = elec.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
-  int downIdx          = tspecies.addSpecies("d");
-  //int chargeIdx = tspecies.addAttribute("charge");
   int massIdx = tspecies.addAttribute("mass");
-  //tspecies(chargeIdx, upIdx) = -1;
-  //tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)   = 1.0;
-  tspecies(massIdx, downIdx) = 1.0;
 
 #ifdef ENABLE_SOA
   elec.addTable(ions, DT_SOA);
@@ -160,7 +155,8 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
 
   elec.Lattice = Lattice;
   elec.setName("e");
-  elec.create(2);
+  std::vector<int> agroup(2, 1);
+  elec.create(agroup);
   elec.R[0][0] = 2.0;
   elec.R[0][1] = 0.0;
   elec.R[0][2] = 0.0;

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -73,13 +73,10 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -153,13 +150,10 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -148,16 +148,12 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int pMembersizeIdx           = tspecies.addAttribute("membersize");
   tspecies(pMembersizeIdx, upIdx)   = 1;
-  tspecies(pMembersizeIdx, downIdx) = 0;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
   elec.update();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
@@ -150,16 +150,12 @@ TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int pMembersizeIdx           = tspecies.addAttribute("membersize");
   tspecies(pMembersizeIdx, upIdx)   = 1;
-  tspecies(pMembersizeIdx, downIdx) = 0;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
   elec.update();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -74,16 +74,12 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int MembersizeIdx            = tspecies.addAttribute("membersize");
   tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(MembersizeIdx, downIdx) = 0;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -92,6 +88,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 #else
   elec.addTable(ions, DT_AOS);
 #endif
+  elec.resetGroups();
   elec.update();
 
 
@@ -164,16 +161,12 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int MembersizeIdx            = tspecies.addAttribute("membersize");
   tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(MembersizeIdx, downIdx) = 1;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -182,6 +175,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
 #else
   elec.addTable(ions, DT_AOS);
 #endif
+  elec.resetGroups();
   elec.update();
 
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -74,16 +74,12 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int MembersizeIdx            = tspecies.addAttribute("membersize");
   tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(MembersizeIdx, downIdx) = 0;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -173,16 +169,12 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   int MembersizeIdx            = tspecies.addAttribute("membersize");
   tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(MembersizeIdx, downIdx) = 1;
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -191,6 +183,7 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
 #else
   elec.addTable(ions, DT_AOS);
 #endif
+  elec.resetGroups();
   elec.update();
 
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -216,7 +216,8 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
 
   elec.Lattice = Lattice;
   elec.setName("e");
-  elec.create(2);
+  std::vector<int> agroup(2, 1);
+  elec.create(agroup);
   elec.R[0][0] = 2.0;
   elec.R[0][1] = 0.0;
   elec.R[0][2] = 0.0;

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -61,16 +61,11 @@ TEST_CASE("Bare Force", "[hamiltonian]")
 
   SpeciesSet& tspecies = elec.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
-  int downIdx          = tspecies.addSpecies("d");
   //int chargeIdx = tspecies.addAttribute("charge");
   int massIdx                   = tspecies.addAttribute("mass");
   int eChargeIdx                = tspecies.addAttribute("charge");
   tspecies(eChargeIdx, upIdx)   = -1.0;
-  tspecies(eChargeIdx, downIdx) = -1.0;
-  //tspecies(chargeIdx, upIdx) = -1;
-  //tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)   = 1.0;
-  tspecies(massIdx, downIdx) = 1.0;
 
 
   // The call to resetGroups is needed transfer the SpeciesSet
@@ -188,16 +183,10 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
 
   SpeciesSet& tspecies = elec.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
-  int downIdx          = tspecies.addSpecies("d");
-  //int chargeIdx = tspecies.addAttribute("charge");
   int massIdx                   = tspecies.addAttribute("mass");
   int eChargeIdx                = tspecies.addAttribute("charge");
   tspecies(eChargeIdx, upIdx)   = -1.0;
-  tspecies(eChargeIdx, downIdx) = -1.0;
-  //tspecies(chargeIdx, upIdx) = -1;
-  //tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)   = 1.0;
-  tspecies(massIdx, downIdx) = 1.0;
 
   elec.Lattice = Lattice;
   elec.createSK();
@@ -289,16 +278,10 @@ TEST_CASE("Ceperley Force", "[hamiltonian]")
 
   SpeciesSet& tspecies = elec.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
-  int downIdx          = tspecies.addSpecies("d");
-  //int chargeIdx = tspecies.addAttribute("charge");
   int massIdx                   = tspecies.addAttribute("mass");
   int eChargeIdx                = tspecies.addAttribute("charge");
   tspecies(eChargeIdx, upIdx)   = -1.0;
-  tspecies(eChargeIdx, downIdx) = -1.0;
-  //tspecies(chargeIdx, upIdx) = -1;
-  //tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)   = 1.0;
-  tspecies(massIdx, downIdx) = 1.0;
 
 
   //elec.Lattice = Lattice;
@@ -394,15 +377,11 @@ TEST_CASE("Ion-ion Force", "[hamiltonian]")
 
   SpeciesSet& elecSpecies              = elec.getSpeciesSet();
   int upIdx                            = elecSpecies.addSpecies("u");
-  int downIdx                          = elecSpecies.addSpecies("d");
   int massIdx                          = elecSpecies.addAttribute("mass");
   int eChargeIdx                       = elecSpecies.addAttribute("charge");
   int uMembersizeIdx                   = elecSpecies.addAttribute("membersize");
-  int dMembersizeIdx                   = elecSpecies.addAttribute("membersize");
   elecSpecies(eChargeIdx, upIdx)       = -1.0;
-  elecSpecies(eChargeIdx, downIdx)     = -1.0;
   elecSpecies(massIdx, upIdx)          = 1.0;
-  elecSpecies(massIdx, downIdx)        = 1.0;
   elecSpecies(uMembersizeIdx, upIdx)   = 2;
   elec.resetGroups();
 

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -81,13 +81,10 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
 
@@ -179,13 +176,10 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
   elec.Lattice = Lattice;
   elec.createSK();
 
@@ -293,13 +287,10 @@ TEST_CASE("fccz h3", "[hamiltonian]")
 
   SpeciesSet& tspecies         = elec.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
   tspecies(massIdx, upIdx)     = 1.0;
-  tspecies(massIdx, downIdx)   = 1.0;
   elec.Lattice = Lattice;
   elec.createSK();
 

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -85,10 +85,8 @@ TEST_CASE("Einspline SPO from HDF", "[wavefunction]")
 
   SpeciesSet& tspecies         = elec_.getSpeciesSet();
   int upIdx                    = tspecies.addSpecies("u");
-  int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
   tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(chargeIdx, downIdx) = -1;
 
 #ifdef ENABLE_SOA
   elec_.addTable(ions_, DT_SOA);


### PR DESCRIPTION
Closes #945
If zero particle count is spotted in a particleset, the code now instructs users to clean up the input.
In the #945 Na atom case, both particle set and SPO check zeros and stop the code before hitting a segfault.

A lot of changes in this PR are fixing unit tests which contain particleset with one set of subparticles but specifying two species (u and d).