### PR TITLE
fix violation of ODR in test_longrange

### DIFF
--- a/src/LongRange/tests/test_srcoul.cpp
+++ b/src/LongRange/tests/test_srcoul.cpp
@@ -21,7 +21,7 @@ namespace qmcplusplus
 
 using mRealType = LRHandlerBase::mRealType;
 
-struct EslerCoulomb3D
+struct EslerCoulomb3D_ForSRCOUL
 { // stripped down version of LRCoulombSingleton::CoulombFunctor for 3D
   double norm;
   inline double operator()(double r, double rinv) {return rinv;}
@@ -52,7 +52,7 @@ TEST_CASE("srcoul", "[lrhandler]")
   ref.LRBox = Lattice;  // !!!! crucial for S(k) update
   StructFact *SK = new StructFact(ref, Lattice.LR_kc);
   ref.SK = SK;
-  LRHandlerSRCoulomb<EslerCoulomb3D, LPQHISRCoulombBasis> handler(ref);
+  LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 
   handler.initBreakup(ref);
   REQUIRE(handler.MaxKshell == 78);
@@ -95,14 +95,14 @@ TEST_CASE("srcoul df", "[lrhandler]")
   ref.LRBox = Lattice;  // !!!! crucial for S(k) update
   StructFact *SK = new StructFact(ref, Lattice.LR_kc);
   ref.SK = SK;
-  LRHandlerSRCoulomb<EslerCoulomb3D, LPQHISRCoulombBasis> handler(ref);
+  LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 
   handler.initBreakup(ref);
   REQUIRE(handler.MaxKshell == 78);
   REQUIRE(Approx(handler.LR_rc) == 2.5);
   REQUIRE(Approx(handler.LR_kc) == 12);
 
-  EslerCoulomb3D fref;
+  EslerCoulomb3D_ForSRCOUL fref;
   fref.reset(ref);
   mRealType r, dr, rinv;
   mRealType rm, rp; // minus (m), plus (p)
@@ -126,7 +126,7 @@ TEST_CASE("srcoul df", "[lrhandler]")
     REQUIRE(handler.srDf(r, rinv) == Approx(dvsr));
     // test long-range piece
     dvlr = (vlrp-vlrm)/(2*dr);
-    REQUIRE(handler.lrDf(r) == Approx(dvlr));
+    REQUIRE(handler.lrDf(r) == Approx(dvlr).epsilon(0.003));
     // test total derivative
     REQUIRE(dvsr+dvlr == Approx(fref.df(r)));
   }

--- a/src/LongRange/tests/test_srcoul.cpp
+++ b/src/LongRange/tests/test_srcoul.cpp
@@ -126,7 +126,7 @@ TEST_CASE("srcoul df", "[lrhandler]")
     REQUIRE(handler.srDf(r, rinv) == Approx(dvsr));
     // test long-range piece
     dvlr = (vlrp-vlrm)/(2*dr);
-    REQUIRE(handler.lrDf(r) == Approx(dvlr).epsilon(0.003));
+    REQUIRE(handler.lrDf(r) == Approx(dvlr));
     // test total derivative
     REQUIRE(dvsr+dvlr == Approx(fref.df(r)));
   }


### PR DESCRIPTION
test_srcoul.cpp and test_temp.cpp both defined EslerCoulomb3D. If the EslerCoulomb3D:df functions are not actually inlined (for instance in a debug build) ODR is violated and you have undefined behavior. Clang + ld or lld will link the first defined df function (in test_temp.cpp) at link time resulting in test failure. Inline is not a guarantee.
