### PR TITLE
Workaround intel compiler bug

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -857,7 +857,8 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             ParticleSet::ParticleGradient_t& g2     = grads_dn[dnC];
             for (int k = 0; k < n; k++)
             {
-              dot1 -= dpsi1 * dot(gmP[k], g2[k]) + dpsi2 * dot(gmP[k], g1[k]);
+              dot1 -= static_cast<ParticleSet::SingleParticleValue_t>(dpsi1) * dot(gmP[k], g2[k]) +
+                  static_cast<ParticleSet::SingleParticleValue_t>(dpsi2) * dot(gmP[k], g1[k]);
               dot1 += dot((g2[k] - gmP[k]), dGa_up(upC, pa, k)) + dot((g1[k] - gmP[k]), dGa_dn(dnC, pa, k));
             }
             dlog += cdet * (dpsi1 + dpsi2);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -855,13 +855,11 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
             ValueType dpsi2                         = dpsia_dn(dnC, pa);
             ParticleSet::ParticleGradient_t& g1     = grads_up[upC];
             ParticleSet::ParticleGradient_t& g2     = grads_dn[dnC];
-#if (__INTEL_COMPILER == 1900 && !defined(QMC_COMPLEX))
-#pragma omp simd reduction(+ : dot1)
-#endif
             for (int k = 0; k < n; k++)
-              dot1 += dot((g2[k] - gmP[k]), dGa_up(upC, pa, k)) + dot((g1[k] - gmP[k]), dGa_dn(dnC, pa, k)) -
-                  static_cast<ParticleSet::SingleParticleValue_t>(dpsi1) * (dot(gmP[k], g2[k])) -
-                  static_cast<ParticleSet::SingleParticleValue_t>(dpsi2) * (dot(gmP[k], g1[k]));
+            {
+              dot1 -= dpsi1 * dot(gmP[k], g2[k]) + dpsi2 * dot(gmP[k], g1[k]);
+              dot1 += dot((g2[k] - gmP[k]), dGa_up(upC, pa, k)) + dot((g1[k] - gmP[k]), dGa_dn(dnC, pa, k));
+            }
             dlog += cdet * (dpsi1 + dpsi2);
             dhpsi += cdet *
                 (dLa_up(upC, pa) + dLa_dn(dnC, pa) + dpsi2 * tempstorage_up[upC] + dpsi1 * tempstorage_dn[dnC] +


### PR DESCRIPTION
The old workaround for "internal compiler error" cannot be further expanded and I put a new cleaner workaround here.
The order of the two lines of dot1 does matter with intel >=19 compilers.
Since intel is switching to clang based compiler, I doubt effort any will be put in the old compiler.