### PR TITLE
Optimize EwaldRef

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -52,9 +52,9 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
   {
     update_source(ref);
 
-    ewardref::RealMat A;
-    ewardref::PosArray R;
-    ewardref::ChargeArray Q;
+    ewaldref::RealMat A;
+    ewaldref::PosArray R;
+    ewaldref::ChargeArray Q;
 
     A = Ps.Lattice.R;
 
@@ -66,7 +66,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       Q[i] = Zat[i];
     }
 
-    RealType Vii_ref = ewardref::ewaldEnergy(A,R,Q);
+    RealType Vii_ref = ewaldref::ewaldEnergy(A,R,Q);
     RealType Vdiff_per_atom = std::abs(Value-Vii_ref)/NumCenters;
     app_log()<<"Checking ion-ion Ewald energy against reference..."<<std::endl;
     if(Vdiff_per_atom > Ps.Lattice.LR_tol)

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -52,9 +52,9 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
   {
     update_source(ref);
 
-    RealMat A;
-    PosArray R;
-    ChargeArray Q;
+    ewardref::RealMat A;
+    ewardref::PosArray R;
+    ewardref::ChargeArray Q;
 
     A = Ps.Lattice.R;
 
@@ -66,7 +66,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       Q[i] = Zat[i];
     }
 
-    RealType Vii_ref = ewaldEnergy(A,R,Q);
+    RealType Vii_ref = ewardref::ewaldEnergy(A,R,Q);
     RealType Vdiff_per_atom = std::abs(Value-Vii_ref)/NumCenters;
     app_log()<<"Checking ion-ion Ewald energy against reference..."<<std::endl;
     if(Vdiff_per_atom > Ps.Lattice.LR_tol)

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -181,12 +181,6 @@ public:
     real_t K2 = dot(Kv, Kv);
     return kfactor * std::exp(kconst * K2) / K2;
   }
-
-  void computePhase(const RealVec& Kv, const RealVec& r, real_t& sin, real_t& cos) const
-  {
-    real_t Kr = dot(Kv, r);
-    sincos(Kr, &sin, &cos);
-  }
 };
 
 
@@ -300,7 +294,6 @@ real_t gridSumTile(const PosArray& R,
   std::vector<real_t> qqs(count);
 
   real_t v = 0.0;
-  IntVec iv(0);
   size_t icount = 0;
   for (size_t i = row_first; i < row_last; ++i)
     for (size_t j = col_first; j < std::min(col_last, i); ++j)
@@ -313,7 +306,7 @@ real_t gridSumTile(const PosArray& R,
       {
         RealVec r(R[i] - R[j]);
         KspaceEwaldTerm kfunc(r, b, kconst, kfactor);
-        iv = 0;
+        IntVec iv(0);
         v += qq * kfunc(iv);
       }
       icount++;
@@ -336,9 +329,7 @@ real_t gridSumTile(const PosArray& R,
       for (int_t j = -indmax; j < indmax + 1; ++j)
         for (int_t k = -indmax; k < indmax + 1; ++k)
         {
-          iv[0] = i;
-          iv[1] = j;
-          iv[2] = k;
+          IntVec iv(i, j, k);
           RealVec Kv;
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 
@@ -364,9 +355,7 @@ real_t gridSumTile(const PosArray& R,
       for (int_t k = -indmax; k < indmax + 1; ++k)
         for (int_t i = -indmax - 1; i < indmax + 2; ++i)
         {
-          iv[0] = i;
-          iv[1] = j;
-          iv[2] = k;
+          IntVec iv(i, j, k);
           RealVec Kv;
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 
@@ -392,9 +381,7 @@ real_t gridSumTile(const PosArray& R,
       for (int_t i = -indmax - 1; i < indmax + 2; ++i)
         for (int_t j = -indmax - 1; j < indmax + 2; ++j)
         {
-          iv[0] = i;
-          iv[1] = j;
-          iv[2] = k;
+          IntVec iv(i, j, k);
           RealVec Kv;
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -160,6 +160,35 @@ public:
   }
 };
 
+class KspaceEwaldTermForTile
+{
+private:
+  /// The k-space cell axes
+  const RealMat b;
+  /// The constant -\kappa^2/2 in Drummond 2008 formula 6
+  const real_t kconst;
+  /// The constant 4\pi/\Omega in Drummond 2008 formula 6
+  const real_t kfactor;
+
+public:
+  KspaceEwaldTermForTile(const RealMat& b_in, real_t kconst_in, real_t kfactor_in)
+      : b(b_in), kconst(kconst_in), kfactor(kfactor_in)
+  {}
+
+  real_t computeK2Exponetial(const IntVec& i, RealVec& Kv) const
+  {
+    Kv        = dot(i, b);
+    real_t K2 = dot(Kv, Kv);
+    return kfactor * std::exp(kconst * K2) / K2;
+  }
+
+  void computePhase(const RealVec& Kv, const RealVec& r, real_t& sin, real_t& cos) const
+  {
+    real_t Kr = dot(Kv, r);
+    sincos(Kr, &sin, &cos);
+  }
+};
+
 
 /** Perform a sum over successively larger cubic integer grids
  *  in DIM dimensional space for arbitrary functors.
@@ -237,6 +266,160 @@ real_t gridSum(T& function, bool zero = true, real_t tol = 1e-11)
     v += dv;
   }
 
+  //std::cout << "debug ref YYYY val = " << v << " iter " << iter_count << std::endl;
+
+  return v;
+}
+
+template<typename T>
+bool isLargerThanTol(const std::vector<T>& vals, const std::vector<T>& tols)
+{
+  for (size_t i = 0; i < vals.size(); i++)
+    if (vals[i] > tols[i])
+      return true;
+  return false;
+}
+
+real_t gridSumTile(const PosArray& R,
+                   const ChargeArray& Q,
+                   size_t row_first,
+                   size_t row_last,
+                   size_t col_first,
+                   size_t col_last,
+                   const RealMat& b,
+                   real_t kconst,
+                   real_t kfactor,
+                   bool zero  = true,
+                   real_t tol = 1e-11)
+{
+  size_t count(0);
+  for (size_t i = row_first; i < row_last; ++i)
+    for (size_t j = col_first; j < std::min(col_last, i); ++j)
+      count++;
+
+  std::vector<real_t> dva(count, std::numeric_limits<real_t>::max());
+  std::vector<real_t> tols(count);
+  std::vector<real_t> qqs(count);
+
+  real_t v = 0.0;
+  IntVec iv(0);
+  size_t icount = 0;
+  for (size_t i = row_first; i < row_last; ++i)
+    for (size_t j = col_first; j < std::min(col_last, i); ++j)
+    {
+      real_t qq    = Q[i] * Q[j];
+      qqs[icount]  = qq;
+      tols[icount] = tol / qq;
+      // Add the value at the origin, if requested.
+      if (zero)
+      {
+        RealVec r(R[i] - R[j]);
+        KspaceEwaldTerm kfunc(r, b, kconst, kfactor);
+        iv = 0;
+        v += qq * kfunc(iv);
+      }
+      icount++;
+    }
+
+  KspaceEwaldTermForTile kfuncTile(b, kconst, kfactor);
+
+  int_t indmax = 0;
+  // Sum over cubic surface shells until the tolerance is reached.
+  while (isLargerThanTol(dva, tols))
+  {
+    std::fill(dva.begin(), dva.end(), 0.0);
+
+    std::vector<real_t> row_phase_sin(row_last - row_first), row_phase_cos(row_last - row_first);
+    std::vector<real_t> col_phase_sin(col_last - col_first), col_phase_cos(col_last - col_first);
+
+    // Surface shell contribution.
+    // Sum over new surface planes perpendicular to the x direction.
+    for (int_t i : {-indmax - 1, indmax + 1})
+      for (int_t j = -indmax; j < indmax + 1; ++j)
+        for (int_t k = -indmax; k < indmax + 1; ++k)
+        {
+          iv[0] = i;
+          iv[1] = j;
+          iv[2] = k;
+          RealVec Kv;
+          real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
+
+          for (size_t i = 0; i < row_last - row_first; ++i)
+            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+          for (size_t j = 0; j < col_last - col_first; ++j)
+            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+
+          size_t icount = 0;
+          for (size_t i = row_first; i < row_last; ++i)
+            for (size_t j = col_first; j < std::min(col_last, i); ++j)
+            {
+              real_t f = K2prefactor *
+                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
+                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
+              v += f * qqs[icount];
+              dva[icount] += std::abs(f);
+              icount++;
+            }
+        }
+    // Sum over new surface planes perpendicular to the y direction.
+    for (int_t j : {-indmax - 1, indmax + 1})
+      for (int_t k = -indmax; k < indmax + 1; ++k)
+        for (int_t i = -indmax - 1; i < indmax + 2; ++i)
+        {
+          iv[0] = i;
+          iv[1] = j;
+          iv[2] = k;
+          RealVec Kv;
+          real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
+
+          for (size_t i = 0; i < row_last - row_first; ++i)
+            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+          for (size_t j = 0; j < col_last - col_first; ++j)
+            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+
+          size_t icount = 0;
+          for (size_t i = row_first; i < row_last; ++i)
+            for (size_t j = col_first; j < std::min(col_last, i); ++j)
+            {
+              real_t f = K2prefactor *
+                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
+                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
+              v += f * qqs[icount];
+              dva[icount] += std::abs(f);
+              icount++;
+            }
+        }
+    // Sum over new surface planes perpendicular to the z direction.
+    for (int_t k : {-indmax - 1, indmax + 1})
+      for (int_t i = -indmax - 1; i < indmax + 2; ++i)
+        for (int_t j = -indmax - 1; j < indmax + 2; ++j)
+        {
+          iv[0] = i;
+          iv[1] = j;
+          iv[2] = k;
+          RealVec Kv;
+          real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
+
+          for (size_t i = 0; i < row_last - row_first; ++i)
+            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+          for (size_t j = 0; j < col_last - col_first; ++j)
+            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+
+          size_t icount = 0;
+          for (size_t i = row_first; i < row_last; ++i)
+            for (size_t j = col_first; j < std::min(col_last, i); ++j)
+            {
+              real_t f = K2prefactor *
+                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
+                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
+              v += f * qqs[icount];
+              dva[icount] += std::abs(f);
+              icount++;
+            }
+        }
+    indmax++;
+  }
+  //std::cout << "debug  YYYY val = " << v / qqs[0] << " iter " << indmax << std::endl;
   return v;
 }
 
@@ -318,11 +501,60 @@ real_t ewaldSum(const RealVec& r, const RealMat& a, real_t tol = 1e-10)
   // Compute the real-space sum (includes zero)
   real_t rval = gridSum(rfunc, true, tol);
   // Compute the k-space sum (excludes zero)
+  //std::cout << "debug ref YYYY matters " << std::endl;
   real_t kval = gridSum(kfunc, false, tol);
 
   // Sum all contributions to get the Ewald pair interaction
   real_t es = cval + rval + kval;
 
+  return es;
+}
+
+real_t ewaldSumTile(const RealMat& a,
+                    const PosArray& R,
+                    const ChargeArray& Q,
+                    size_t row_first,
+                    size_t row_last,
+                    size_t col_first,
+                    size_t col_last,
+                    real_t tol = 1e-10)
+{
+  NewTimer& EwaldTimer(*TimerManager.createTimer("EwaldRefTile"));
+  ScopedTimer totalEwaldTimer(&EwaldTimer);
+
+  // Real-space cell volume
+  const real_t volume = std::abs(det(a));
+  // k-space cell axes
+  const RealMat b = 2 * M_PI * transpose(inverse(a));
+  // real space cutoff
+  const real_t rconv = 8 * std::pow(3. * volume / (4 * M_PI), 1. / 3);
+  // k-space cutoff (kappa)
+  const real_t kconv = 2 * M_PI / rconv;
+
+  // Set constants for real-/k-space Ewald pair functors
+  const real_t rconst  = 1. / (std::sqrt(2.) * kconv);
+  const real_t kconst  = -std::pow(kconv, 2) / 2;
+  const real_t kfactor = 4 * M_PI / volume;
+
+  real_t es(0);
+  for (size_t i = row_first; i < row_last; ++i)
+    for (size_t j = col_first; j < std::min(col_last, i); ++j)
+    {
+      RealVec r(R[i] - R[j]);
+      real_t qq = Q[i] * Q[j];
+      // Create real-/k-space fuctors for terms within the sums in formula 6
+      RspaceEwaldTerm rfunc(r, a, rconst);
+
+      // Compute the constant term
+      real_t cval = -2 * M_PI * std::pow(kconv, 2) / volume;
+      // Compute the real-space sum (includes zero)
+      real_t rval = gridSum(rfunc, true, tol / qq);
+
+      // Sum all contributions to get the Ewald pair interaction
+      es += qq * (cval + rval);
+    }
+
+  es += gridSumTile(R, Q, row_first, row_last, col_first, col_last, b, kconst, kfactor, false, tol);
   return es;
 }
 
@@ -345,7 +577,7 @@ real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, re
   NewTimer& EwaldTimer(*TimerManager.createTimer("EwaldRef"));
   ScopedTimer totalEwaldTimer(&EwaldTimer);
   // Number of particles
-  int_t N = R.size();
+  const int_t N = R.size();
 
   // Maximum self-interaction charge product
   real_t qqmax = 0.0;
@@ -362,14 +594,15 @@ real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, re
   for (size_t i = 0; i < N; ++i)
     ve += Q[i] * Q[i] * vm / 2;
 
+  real_t ve_ewald(0);
 // Sum the interaction terms for all particle pairs
-#pragma omp parallel for reduction(+ : ve)
+#pragma omp parallel for reduction(+ : ve_ewald)
   for (size_t i = 1; i < N / 2 + 1; ++i)
   {
     for (size_t j = 0; j < i; ++j)
     {
       const real_t qq = Q[i] * Q[j];
-      ve += qq * ewaldSum(R[i] - R[j], a, tol / qq);
+      ve_ewald += qq * ewaldSum(R[i] - R[j], a, tol / qq);
     }
 
     const size_t i_reverse = N - i;
@@ -379,9 +612,17 @@ real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, re
     for (size_t j = 0; j < i_reverse; ++j)
     {
       const real_t qq = Q[i_reverse] * Q[j];
-      ve += qq * ewaldSum(R[i_reverse] - R[j], a, tol / qq);
+      ve_ewald += qq * ewaldSum(R[i_reverse] - R[j], a, tol / qq);
     }
   }
+
+  real_t ewald_new = ewaldSumTile(a, R, Q, 0, N, 0, N, tol);
+
+  std::cout << "YYY debug N=" << N << " new " << ewald_new << " ref " << ve_ewald << " diff "
+            << (ewald_new - ve_ewald) / ve_ewald << std::endl;
+
+  ve += ve_ewald;
+
   return ve;
 }
 

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -343,9 +343,9 @@ real_t gridSumTile(const PosArray& R,
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 
           for (size_t i = 0; i < row_last - row_first; ++i)
-            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+            sincos(dot(Kv, R[i + row_first]), &row_phase_sin[i], &row_phase_cos[i]);
           for (size_t j = 0; j < col_last - col_first; ++j)
-            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+            sincos(-dot(Kv, R[j + col_first]), &col_phase_sin[j], &col_phase_cos[j]);
 
           size_t icount = 0;
           for (size_t i = row_first; i < row_last; ++i)
@@ -371,9 +371,9 @@ real_t gridSumTile(const PosArray& R,
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 
           for (size_t i = 0; i < row_last - row_first; ++i)
-            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+            sincos(dot(Kv, R[i + row_first]), &row_phase_sin[i], &row_phase_cos[i]);
           for (size_t j = 0; j < col_last - col_first; ++j)
-            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+            sincos(-dot(Kv, R[j + col_first]), &col_phase_sin[j], &col_phase_cos[j]);
 
           size_t icount = 0;
           for (size_t i = row_first; i < row_last; ++i)
@@ -399,9 +399,9 @@ real_t gridSumTile(const PosArray& R,
           real_t K2prefactor = kfuncTile.computeK2Exponetial(iv, Kv);
 
           for (size_t i = 0; i < row_last - row_first; ++i)
-            sincos(dot(Kv, R[i]), &row_phase_sin[i], &row_phase_cos[i]);
+            sincos(dot(Kv, R[i + row_first]), &row_phase_sin[i], &row_phase_cos[i]);
           for (size_t j = 0; j < col_last - col_first; ++j)
-            sincos(-dot(Kv, R[j]), &col_phase_sin[j], &col_phase_cos[j]);
+            sincos(-dot(Kv, R[j + col_first]), &col_phase_sin[j], &col_phase_cos[j]);
 
           size_t icount = 0;
           for (size_t i = row_first; i < row_last; ++i)

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -289,9 +289,10 @@ real_t gridSumTile(const PosArray& R,
     for (size_t j = col_first; j < std::min(col_last, i); ++j)
       count++;
 
-  std::vector<real_t> dva(count, std::numeric_limits<real_t>::max());
   std::vector<real_t> tols(count);
+  std::vector<real_t> dva(count, std::numeric_limits<real_t>::max());
   std::vector<real_t> qqs(count);
+  std::vector<real_t> cosKvRij(count);
 
   real_t v = 0.0;
   size_t icount = 0;
@@ -342,13 +343,16 @@ real_t gridSumTile(const PosArray& R,
           for (size_t i = row_first; i < row_last; ++i)
             for (size_t j = col_first; j < std::min(col_last, i); ++j)
             {
-              real_t f = K2prefactor *
-                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
-                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
-              v += f * qqs[icount];
-              dva[icount] += std::abs(f);
+              cosKvRij[icount] =
+                  row_phase_cos[i - row_first] * col_phase_cos[j - col_first] - row_phase_sin[i - row_first] * col_phase_sin[j - col_first];
               icount++;
             }
+          for (size_t icount = 0; icount < count; ++icount)
+          {
+            real_t f = K2prefactor * cosKvRij[icount];
+            v += f * qqs[icount];
+            dva[icount] += std::abs(f);
+          }
         }
     // Sum over new surface planes perpendicular to the y direction.
     for (int_t j : {-indmax - 1, indmax + 1})
@@ -368,13 +372,16 @@ real_t gridSumTile(const PosArray& R,
           for (size_t i = row_first; i < row_last; ++i)
             for (size_t j = col_first; j < std::min(col_last, i); ++j)
             {
-              real_t f = K2prefactor *
-                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
-                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
-              v += f * qqs[icount];
-              dva[icount] += std::abs(f);
+              cosKvRij[icount] =
+                  row_phase_cos[i - row_first] * col_phase_cos[j - col_first] - row_phase_sin[i - row_first] * col_phase_sin[j - col_first];
               icount++;
             }
+          for (size_t icount = 0; icount < count; ++icount)
+          {
+            real_t f = K2prefactor * cosKvRij[icount];
+            v += f * qqs[icount];
+            dva[icount] += std::abs(f);
+          }
         }
     // Sum over new surface planes perpendicular to the z direction.
     for (int_t k : {-indmax - 1, indmax + 1})
@@ -394,13 +401,16 @@ real_t gridSumTile(const PosArray& R,
           for (size_t i = row_first; i < row_last; ++i)
             for (size_t j = col_first; j < std::min(col_last, i); ++j)
             {
-              real_t f = K2prefactor *
-                  (row_phase_cos[i - row_first] * col_phase_cos[j - col_first] -
-                   row_phase_sin[i - row_first] * col_phase_sin[j - col_first]);
-              v += f * qqs[icount];
-              dva[icount] += std::abs(f);
+              cosKvRij[icount] =
+                  row_phase_cos[i - row_first] * col_phase_cos[j - col_first] - row_phase_sin[i - row_first] * col_phase_sin[j - col_first];
               icount++;
             }
+          for (size_t icount = 0; icount < count; ++icount)
+          {
+            real_t f = K2prefactor * cosKvRij[icount];
+            v += f * qqs[icount];
+            dva[icount] += std::abs(f);
+          }
         }
     indmax++;
   }

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -34,6 +34,8 @@
 
 namespace qmcplusplus
 {
+namespace ewardref
+{
 /// Reference Ewald implemented for 3D only
 enum
 {
@@ -61,16 +63,12 @@ class RspaceMadelungTerm
 {
 private:
   /// The real-space cell axes
-  RealMat a;
+  const RealMat a;
   /// The constant \kappa in Drummond 2008 formula 7
-  real_t rconst;
+  const real_t rconst;
 
 public:
-  RspaceMadelungTerm(RealMat a_in, real_t rconst_in)
-  {
-    a      = a_in;
-    rconst = rconst_in;
-  }
+  RspaceMadelungTerm(const RealMat& a_in, real_t rconst_in) : a(a_in), rconst(rconst_in) {}
 
   real_t operator()(const IntVec& i) const
   {
@@ -87,19 +85,16 @@ class KspaceMadelungTerm
 {
 private:
   /// The k-space cell axes
-  RealMat b;
+  const RealMat b;
   /// The constant 1/(4\kappa^2) in Drummond 2008 formula 7
-  real_t kconst;
+  const real_t kconst;
   /// The constant 4\pi/\Omega in Drummond 2008 formula 7
-  real_t kfactor;
+  const real_t kfactor;
 
 public:
-  KspaceMadelungTerm(RealMat b_in, real_t kconst_in, real_t kfactor_in)
-  {
-    b       = b_in;
-    kconst  = kconst_in;
-    kfactor = kfactor_in;
-  }
+  KspaceMadelungTerm(const RealMat& b_in, real_t kconst_in, real_t kfactor_in)
+      : b(b_in), kconst(kconst_in), kfactor(kfactor_in)
+  {}
 
   real_t operator()(const IntVec& i) const
   {
@@ -116,19 +111,14 @@ class RspaceEwaldTerm
 {
 private:
   /// The inter-particle separation vector
-  RealVec r;
+  const RealVec r;
   /// The real-space cell axes
-  RealMat a;
+  const RealMat a;
   /// The constant 1/(\sqrt{2}kappa) in Drummond 2008 formula 6
-  real_t rconst;
+  const real_t rconst;
 
 public:
-  RspaceEwaldTerm(RealVec r_in, RealMat a_in, real_t rconst_in)
-  {
-    r      = r_in;
-    a      = a_in;
-    rconst = rconst_in;
-  }
+  RspaceEwaldTerm(RealVec r_in, RealMat a_in, real_t rconst_in) : r(r_in), a(a_in), rconst(rconst_in) {}
 
   real_t operator()(const IntVec& i) const
   {
@@ -147,22 +137,18 @@ class KspaceEwaldTerm
 {
 private:
   /// The inter-particle separation vector
-  RealVec r;
+  const RealVec r;
   /// The k-space cell axes
-  RealMat b;
+  const RealMat b;
   /// The constant -\kappa^2/2 in Drummond 2008 formula 6
-  real_t kconst;
+  const real_t kconst;
   /// The constant 4\pi/\Omega in Drummond 2008 formula 6
-  real_t kfactor;
+  const real_t kfactor;
 
 public:
-  KspaceEwaldTerm(RealVec r_in, RealMat b_in, real_t kconst_in, real_t kfactor_in)
-  {
-    r       = r_in;
-    b       = b_in;
-    kconst  = kconst_in;
-    kfactor = kfactor_in;
-  }
+  KspaceEwaldTerm(const RealVec& r_in, const RealMat& b_in, real_t kconst_in, real_t kfactor_in)
+      : r(r_in), b(b_in), kconst(kconst_in), kfactor(kfactor_in)
+  {}
 
   real_t operator()(const IntVec& i) const
   {
@@ -307,7 +293,7 @@ real_t madelungSum(RealMat a, real_t tol = 1e-10)
  *
  *  @param tol: Tolerance for the Ewald pair interaction in Ha.
  */
-real_t ewaldSum(RealVec r, RealMat a, real_t tol = 1e-10)
+real_t ewaldSum(const RealVec& r, const RealMat& a, real_t tol = 1e-10)
 {
   // Real-space cell volume
   real_t volume = std::abs(det(a));
@@ -354,7 +340,7 @@ real_t ewaldSum(RealVec r, RealMat a, real_t tol = 1e-10)
  *
  *  @param tol: Tolerance for the total potential energy in Ha.
  */
-real_t ewaldEnergy(RealMat a, PosArray R, ChargeArray Q, real_t tol = 1e-10)
+real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, real_t tol = 1e-10)
 {
   NewTimer& EwaldTimer(*TimerManager.createTimer("EwaldRef"));
   ScopedTimer totalEwaldTimer(&EwaldTimer);
@@ -399,6 +385,7 @@ real_t ewaldEnergy(RealMat a, PosArray R, ChargeArray Q, real_t tol = 1e-10)
   return ve;
 }
 
+} // namespace ewardref
 } // namespace qmcplusplus
 
 #endif


### PR DESCRIPTION
Further improve the situation of #2158, 2-4x speed up although it is still slow.
Changes are
1. Rearrange loops to reuse results.
2. Improve vectorization.

Now with 128 atom NiO, EwaldRef takes 297 sec on 16 core Xeon which should not be too bad for production runs.
If MPI is really needed, we can replace the current threading level with MPI and put threading in the inner levels. This will not help single MPI runs which most our tests do.
If we add MPI, the check code must be moved to the builder instead of the Coulomb class.