### PR TITLE
Add XML selection of LR Handler

### DIFF
--- a/src/LongRange/LRCoulombSingleton.cpp
+++ b/src/LongRange/LRCoulombSingleton.cpp
@@ -30,6 +30,7 @@ namespace qmcplusplus
 //initialization of the static data
 LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::CoulombHandler      = 0;
 LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::CoulombDerivHandler = 0;
+LRCoulombSingleton::lr_type LRCoulombSingleton::this_lr_type = ESLER;
 /** CoulombFunctor
  *
  * An example for a Func for LRHandlerTemp. Four member functions have to be provided
@@ -119,11 +120,25 @@ LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getHandler(ParticleSet& r
     }
     else //if(ref.LRBox.SuperCellEnum == SUPERCELL_BULK)
     {
-      app_log() << "\n  Creating CoulombHandler with the optimal breakup. " << std::endl;
-      CoulombHandler = new LRHandlerTemp<CoulombFunctor<mRealType>, LPQHIBasis>(ref);
-      //  app_log() << "\n  Creating CoulombHandler with the Ewald3D breakup. " << std::endl;
-      //  CoulombHandler= new EwaldHandler3D(ref);
-      //  CoulombHandler = new LRHandlerSRCoulomb<CoulombFunctor<mRealType>, LPQHISRCoulombBasis>(ref);
+      if(this_lr_type == ESLER)
+      {  
+        app_log() << "\n  Creating CoulombHandler with the Esler Optimized Breakup. " << std::endl;
+        CoulombHandler = new LRHandlerTemp<CoulombFunctor<mRealType>, LPQHIBasis>(ref);
+      }
+      else if (this_lr_type == EWALD)
+      {
+        app_log() << "\n  Creating CoulombHandler with the 3D Ewald Breakup. " << std::endl;
+        CoulombHandler= new EwaldHandler3D(ref); 
+      }
+      else if (this_lr_type == NATOLI)
+      {
+        app_log() << "\n  Creating CoulombHandler with the Natoli Optimized Breakup. " << std::endl;
+        CoulombHandler = new LRHandlerSRCoulomb<CoulombFunctor<mRealType>, LPQHISRCoulombBasis>(ref);
+      }
+      else
+      {
+        APP_ABORT("\n  Long range breakup method not recognized.\n");
+      } 
     }
 //        else if(ref.LRBox.SuperCellEnum == SUPERCELL_SLAB)
 //        {
@@ -143,7 +158,7 @@ LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getHandler(ParticleSet& r
     return CoulombHandler->makeClone(ref);
   }
 }
-LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getDerivHandler(ParticleSet& ref, std::string method)
+LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getDerivHandler(ParticleSet& ref)
 {
 #if OHMMS_DIM != 3
   APP_ABORT("energy derivative implemented for 3D only");
@@ -151,17 +166,23 @@ LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getDerivHandler(ParticleS
   //APP_ABORT("SR Coulomb Basis Handler has cloning issues.  Stress also has some kinks");
   if (CoulombDerivHandler == 0)
   {
-    if (method == "ewald")
+    if (this_lr_type == EWALD)
     {
-      app_log() << "\n  Creating CoulombDerivHandler with the Ewald3D breakup. " << std::endl;
+      app_log() << "\n  Creating CoulombDerivHandler with the 3D Ewald Breakup. " << std::endl;
       CoulombDerivHandler= new EwaldHandler3D(ref);
-    } else if (method == "srcoul")
+    } 
+    else if (this_lr_type == NATOLI)
     {
-      app_log() << "\n  Creating CoulombHandler with the optimal breakup of SR piece. " << std::endl;
+      app_log() << "\n  Creating CoulombDerivHandler with the Natoli Optimized Breakup. " << std::endl;
       CoulombDerivHandler = new LRHandlerSRCoulomb<CoulombFunctor<mRealType>, LPQHISRCoulombBasis>(ref);
-    } else
+    } 
+    else if (this_lr_type == ESLER)
     {
-      APP_ABORT("unknown derivative breakup method: "+method);
+      APP_ABORT("\n  Derivatives are not supported with Esler Optimized Breakup.\n"); 
+    }
+    else
+    {
+      APP_ABORT("\n  Long range breakup method for derivatives not recognized.\n");
     }
     // CoulombDerivHandler = new LRDerivHandler<CoulombFunctor<mRealType>, LPQHIBasis> (ref);
     //CoulombDerivHandler= new EwaldHandler(ref);

--- a/src/LongRange/LRCoulombSingleton.h
+++ b/src/LongRange/LRCoulombSingleton.h
@@ -37,6 +37,8 @@ struct LRCoulombSingleton
   typedef LinearGrid<pRealType> GridType;
   typedef OneDimCubicSpline<pRealType> RadFunctorType;
 
+  enum lr_type {ESLER=0, EWALD, NATOLI};
+  static lr_type this_lr_type;
   ///Stores the energ optimized LR handler.
   static LRHandlerType* CoulombHandler;
   ///Stores the force/stress optimized LR handler.
@@ -44,7 +46,7 @@ struct LRCoulombSingleton
   ///This returns an energy optimized LR handler.  If non existent, it creates one.
   static LRHandlerType* getHandler(ParticleSet& ref);
   ///This returns a force/stress optimized LR handler.  If non existent, it creates one.
-  static LRHandlerType* getDerivHandler(ParticleSet& ref, std::string method="ewald");
+  static LRHandlerType* getDerivHandler(ParticleSet& ref);
 
   //The following two helper functions are provided to spline the short-range component
   //of the coulomb potential and its derivative.  This is much faster than evaluating

--- a/src/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/ParticleIO/ParticleLayoutIO.cpp
@@ -23,6 +23,7 @@
 #include "ParticleIO/ParticleLayoutIO.h"
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
+#include "LongRange/LRCoulombSingleton.h"
 
 namespace qmcplusplus
 {
@@ -41,6 +42,8 @@ bool LatticeParser::put(xmlNodePtr cur)
   bool lattice_defined = false;
   bool bconds_defined  = false;
   int boxsum           = 0;
+
+  std::string handler_type("");
 
   app_log() << " Lattice" << std::endl;
   app_log() << " -------" << std::endl;
@@ -103,6 +106,20 @@ bool LatticeParser::put(xmlNodePtr cur)
       else if (aname == "LR_dim_cutoff")
       {
         putContent(ref_.LR_dim_cutoff, cur);
+      }
+      else if ( aname == "LR_handler" )
+      {
+        putContent(handler_type, cur);
+        tolower(handler_type);
+        if(handler_type=="ewald")
+          LRCoulombSingleton::this_lr_type = LRCoulombSingleton::EWALD;
+        else if (handler_type=="esler")
+          LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
+        else if (handler_type=="natoli")
+          LRCoulombSingleton::this_lr_type = LRCoulombSingleton::NATOLI;
+        else
+          APP_ABORT("\n  Long range breakup handler not recognized.\n");
+         
       }
       else if (aname == "LR_tol")
       {

--- a/src/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/ParticleIO/ParticleLayoutIO.cpp
@@ -43,7 +43,7 @@ bool LatticeParser::put(xmlNodePtr cur)
   bool bconds_defined  = false;
   int boxsum           = 0;
 
-  std::string handler_type("");
+  std::string handler_type("opt_breakup");
 
   app_log() << " Lattice" << std::endl;
   app_log() << " -------" << std::endl;

--- a/src/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/ParticleIO/ParticleLayoutIO.cpp
@@ -113,9 +113,9 @@ bool LatticeParser::put(xmlNodePtr cur)
         tolower(handler_type);
         if(handler_type=="ewald")
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::EWALD;
-        else if (handler_type=="esler")
+        else if (handler_type=="opt_breakup")
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
-        else if (handler_type=="natoli")
+        else if (handler_type=="opt_breakup_original")
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::NATOLI;
         else
           APP_ABORT("\n  Long range breakup handler not recognized.\n");

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -28,6 +28,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCApp/InitMolecularSystem.h"
+#include "LongRange/LRCoulombSingleton.h"
 
 namespace qmcplusplus
 {
@@ -262,12 +263,14 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
   std::string source("i");
   std::string bc("p p p");
   std::string spotype("0");
+  std::string lr_handler("esler");
   OhmmsAttributeSet attribs;
   attribs.add(h5name, "href");
   attribs.add(eshdf_tilematrix, "tilematrix");
   attribs.add(source, "source");
   attribs.add(bc, "bconds");
   attribs.add(lr_cut, "LR_dim_cutoff");
+  attribs.add(lr_handler, "LR_handler");
   attribs.add(spotype, "type");
   attribs.put(cur);
 
@@ -290,6 +293,25 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
       if (is >> c)
         ions->Lattice.BoxBConds[idim++] = (c == 'p');
     }
+
+    tolower(lr_handler);
+    if( lr_handler == "ewald")
+    {
+      LRCoulombSingleton::this_lr_type = LRCoulombSingleton::EWALD;
+    }
+    else if ( lr_handler == "esler")
+    {
+      LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
+    }
+    else if ( lr_handler == "natoli")
+    {
+      LRCoulombSingleton::this_lr_type = LRCoulombSingleton::NATOLI;
+    }
+    else
+    {
+      APP_ABORT("Long range breakup handler not recognized\n");
+    }
+
     //initialize ions from hdf5
     hid_t h5 = -1;
     if (myComm->rank() == 0)

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -263,7 +263,7 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
   std::string source("i");
   std::string bc("p p p");
   std::string spotype("0");
-  std::string lr_handler("esler");
+  std::string lr_handler("opt_breakup");
   OhmmsAttributeSet attribs;
   attribs.add(h5name, "href");
   attribs.add(eshdf_tilematrix, "tilematrix");

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -299,11 +299,11 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
     {
       LRCoulombSingleton::this_lr_type = LRCoulombSingleton::EWALD;
     }
-    else if ( lr_handler == "esler")
+    else if ( lr_handler == "opt_breakup")
     {
       LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
     }
-    else if ( lr_handler == "natoli")
+    else if ( lr_handler == "opt_breakup_original")
     {
       LRCoulombSingleton::this_lr_type = LRCoulombSingleton::NATOLI;
     }

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -181,7 +181,6 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
 {
 #if OHMMS_DIM == 3
   std::string a("ion0"), targetName("e"), title("ForceBase"), pbc("yes"), PsiName = "psi0";
-  std::string lrmethod("ewald");
   OhmmsAttributeSet hAttrib;
   std::string mode("bare");
   //hAttrib.add(title,"id");
@@ -190,7 +189,6 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   hAttrib.add(targetName, "target");
   hAttrib.add(pbc, "pbc");
   hAttrib.add(mode, "mode");
-  hAttrib.add(lrmethod, "lrmethod");
   hAttrib.add(PsiName, "psi");
   hAttrib.put(cur);
   app_log() << "HamFac forceBase mode " << mode << std::endl;
@@ -224,7 +222,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   {
     if (applyPBC == true)
     {
-      ForceChiesaPBCAA* force_chi = new ForceChiesaPBCAA(*source, *target, true, lrmethod);
+      ForceChiesaPBCAA* force_chi = new ForceChiesaPBCAA(*source, *target, true);
       force_chi->put(cur);
       targetH->addOperator(force_chi, title, false);
     }

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -22,8 +22,8 @@
 
 namespace qmcplusplus
 {
-ForceChiesaPBCAA::ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool firsttime, std::string lrmethod_in)
-    : ForceBase(ions, elns), PtclA(ions), first_time(firsttime), d_aa_ID(ions.addTable(ions, DT_SOA_PREFERRED)), d_ei_ID(elns.addTable(ions, DT_SOA_PREFERRED)), lrmethod(lrmethod_in)
+ForceChiesaPBCAA::ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool firsttime)
+    : ForceBase(ions, elns), PtclA(ions), first_time(firsttime), d_aa_ID(ions.addTable(ions, DT_SOA_PREFERRED)), d_ei_ID(elns.addTable(ions, DT_SOA_PREFERRED))
 {
   ReportEngine PRE("ForceChiesaPBCAA", "ForceChiesaPBCAA");
   myName = "Chiesa_Force_Base_PBCAB";
@@ -97,7 +97,7 @@ void ForceChiesaPBCAA::initBreakup(ParticleSet& P)
     totQ += Zat[iat] = Zspec[PtclA.GroupID[iat]];
   for (int iat = 0; iat < NptclB; iat++)
     totQ += Qat[iat] = Qspec[P.GroupID[iat]];
-  dAB = LRCoulombSingleton::getDerivHandler(P, lrmethod);
+  dAB = LRCoulombSingleton::getDerivHandler(P);
 }
 
 void ForceChiesaPBCAA::evaluateLR(ParticleSet& P)
@@ -244,7 +244,6 @@ bool ForceChiesaPBCAA::put(xmlNodePtr cur)
   addionion = (ionionforce == "yes") || (ionionforce == "true");
   app_log() << "ionionforce = " << ionionforce << std::endl;
   app_log() << "addionion=" << addionion << std::endl;
-  app_log() << "lrmethod= " << lrmethod << std::endl;
   ParameterSet fcep_param_set;
   fcep_param_set.add(Rcut, "rcut", "real");
   fcep_param_set.add(N_basis, "nbasis", "int");

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.h
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.h
@@ -59,7 +59,7 @@ struct ForceChiesaPBCAA : public OperatorBase, public ForceBase
 
   bool first_time;
 
-  ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool firsttime = true, std::string lrmethod="ewald");
+  ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool firsttime = true);
 
   Return_t evaluate(ParticleSet& P);
 
@@ -114,8 +114,6 @@ private:
   // AA table ID
   const int d_aa_ID;
   const int d_ei_ID;
-  // long-range breakup method ("ewald" or "srcoul")
-  std::string lrmethod;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -36,6 +36,7 @@ namespace qmcplusplus
 TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
 
   Communicate* c;
   OHMMS::Controller->initialize(0, NULL);
@@ -105,7 +106,7 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
 TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
-
+  LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
   Communicate* c;
   OHMMS::Controller->initialize(0, NULL);
   c = OHMMS::Controller;
@@ -196,6 +197,7 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
 TEST_CASE("Coulomb PBC A-A CUDA BCC H", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::this_lr_type = LRCoulombSingleton::ESLER;
 
   Communicate* c;
   OHMMS::Controller->initialize(0, NULL);

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -158,7 +158,7 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   Lattice.R.diagonal(5.0);
   Lattice.LR_dim_cutoff = 25;
   Lattice.reset();
-
+  LRCoulombSingleton::this_lr_type=LRCoulombSingleton::EWALD;
 
   ParticleSet ions;
   ParticleSet elec;


### PR DESCRIPTION
First cut of this.  This PR adds the XML tag "LR_handler" to the lattice description and to the wave function specification when parsing ion sets and lattices from an ESHDF5 file.  

This will break with XML files which follow Juha's declaration of LR handler type in the Chiesa force estimator...  but hopefully this is an overall simplification.  

Example of a lattice declaration:  
`<simulationcell>
         <parameter name="lattice" units="bohr">
                  3.77945227        0.00000000        0.00000000
                 -0.00000000        3.77945227        0.00000000
                 -0.00000000       -0.00000000        3.77945227
         </parameter>
         <parameter name="bconds">
            p p p
         </parameter>
         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
         <parameter name="LR_handler"       >    ewald                 </parameter>
      </simulationcell>
`
Supported types for LR_handler are:
1.  "esler" for current optimized breakup behavior.  The code will default to this if the option is not specified.
2. "ewald" for the Ewald3D handler
3. "natoli" for the original Natoli/Ceperley optimized breakup.  

