### PR TITLE
Nexus: fix test path issues

### DIFF
--- a/nexus/bin/nxs-sim
+++ b/nexus/bin/nxs-sim
@@ -2,7 +2,36 @@
 
 import os
 from optparse import OptionParser
-from generic import obj
+
+
+def find_nexus_modules():
+    import sys
+    nexus_lib = os.path.abspath(os.path.join(__file__,'..','..','lib'))
+    assert(os.path.exists(nexus_lib))
+    sys.path.append(nexus_lib)
+#end def find_nexus_modules
+
+
+def import_nexus_module(module_name):
+    import inspect
+    import importlib
+    return importlib.import_module(module_name)
+#end def import_nexus_module
+
+
+# Load Nexus modules
+try:
+    # Attempt specialized path-based imports.
+    #  (The executable should still work even if Nexus is not installed)
+    find_nexus_modules()
+
+    generic = import_nexus_module('generic')
+    obj   = generic.obj
+    del generic
+except:
+    # Failing path-based imports, import installed Nexus modules.
+    from generic import obj
+#end try
 
 
 

--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -2314,6 +2314,12 @@ if __name__=='__main__':
         os.environ['PYTHONPATH']=options.pythonpath
     #end if
 
+    # guard against missing numpy (required)
+    if len(tests)>0 and not numpy_available:
+        print('\nNumPy is required to run the tests.\nPlease install NumPy and try again.\n')
+        exit(1)
+    #end if
+
     # run each test and print the test outcome
     if not ctest:
         print('')

--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -87,7 +87,7 @@ def import_from_unit_test_module(module_name,test_name):
 
 # import core testing functions (shared between nxs-test and unit tests)
 from testing import *
-
+import testing as nexus_testing
 
 
 
@@ -1772,10 +1772,7 @@ def user_examples(label):
     for script in einfo['scripts']:
         # run the example script
         command = './'+script+' --generate_only --sleep=0.01'
-        out,err,rc = execute(command)
-        if rc>0:
-            nfail('example script failed to run\nattempted command: {0}\nlocation: {1}\nscript out:\n{2}\nscript err:\n{3}'.format(command,tpath,'  '+out.replace('\n','\n  '),'  '+err.replace('\n','\n  ')))
-        #end if
+        out,err,rc = nexus_testing.execute(command)
     #end for
     os.chdir(cwd)
 

--- a/nexus/lib/testing.py
+++ b/nexus/lib/testing.py
@@ -662,3 +662,33 @@ def create_path(path,basepath=None):
     #end if
     assert(os.path.isdir(path))
 #end def create_path
+
+
+
+def execute(command):
+    from execute import execute as nexus_execute
+    out,err,rc = nexus_execute(command)
+    if rc!=0:
+        msg = '''Executed system command failed.
+
+Command:
+========
+{}
+
+stdout:
+=======
+{}
+
+stderr:
+=======
+{}
+
+Return code:
+============
+{}
+
+'''.format(command,out,err,rc)
+        failed(msg)
+    #end if
+    return out,err,rc
+#end def execute

--- a/nexus/lib/testing.py
+++ b/nexus/lib/testing.py
@@ -1,5 +1,10 @@
 
-import numpy as np
+try:
+    import numpy as np
+    numpy_available = True
+except:
+    numpy_available = False
+#end try
 
 
 def_atol =  0.0

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/opt/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/opt/opt.in.xml
@@ -105,6 +105,8 @@
          <parameter name="minwalkers"          >    0.1                </parameter>
          <parameter name="alloweddifference"   >    0.0001             </parameter>
          <parameter name="bigchange"           >    15.0               </parameter>
+         <parameter name="nonlocalpp"          >    yes                </parameter>
+         <parameter name="use_nonlocalpp_deriv">    yes                </parameter>
       </qmc>
    </loop>
 </simulation>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/opt/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/opt/opt.in.xml
@@ -96,6 +96,8 @@
          <parameter name="minwalkers"          >    0.1                </parameter>
          <parameter name="alloweddifference"   >    0.0001             </parameter>
          <parameter name="bigchange"           >    15.0               </parameter>
+         <parameter name="nonlocalpp"          >    yes                </parameter>
+         <parameter name="use_nonlocalpp_deriv">    yes                </parameter>
       </qmc>
    </loop>
 </simulation>

--- a/nexus/tests/unit/test_nxs_redo.py
+++ b/nexus/tests/unit/test_nxs_redo.py
@@ -1,11 +1,10 @@
 
 import testing
-from testing import create_file,create_path
+from testing import create_file,create_path,execute
 
 
 def test_redo():
     import os
-    from execute import execute
 
     tpath = testing.setup_unit_test_output_directory('nxs_redo','test_redo')
     

--- a/nexus/tests/unit/test_nxs_sim.py
+++ b/nexus/tests/unit/test_nxs_sim.py
@@ -1,13 +1,12 @@
 
 import testing
 from testing import divert_nexus,restore_nexus,clear_all_sims
-from testing import text_eq
+from testing import execute,text_eq
 
 
 
 def test_sim():
     import os
-    from execute import execute
     from nexus_base import nexus_core
     from test_simulation_module import get_sim
 

--- a/nexus/tests/unit/test_qdens.py
+++ b/nexus/tests/unit/test_qdens.py
@@ -1,12 +1,11 @@
 
 import testing
-from testing import text_eq
+from testing import execute,text_eq
 
 
 
 def test_density():
     import os
-    from execute import execute
 
     tpath = testing.setup_unit_test_output_directory('qdens','test_density')
 

--- a/nexus/tests/unit/test_qmc_fit.py
+++ b/nexus/tests/unit/test_qmc_fit.py
@@ -1,14 +1,13 @@
 
 import versions
 import testing
-from testing import text_eq
+from testing import execute,text_eq
 
 
 
 if versions.scipy_available:
     def test_fit():
         import os
-        from execute import execute
 
         tpath = testing.setup_unit_test_output_directory('qmc_fit','test_fit')
 

--- a/nexus/tests/unit/test_qmc_fit.py
+++ b/nexus/tests/unit/test_qmc_fit.py
@@ -13,7 +13,6 @@ if versions.scipy_available:
         tpath = testing.setup_unit_test_output_directory('qmc_fit','test_fit')
 
         exe = testing.executable_path('qmc-fit')
-
         
         qa_files_path = testing.unit_test_file_path('qmcpack_analyzer','diamond_gamma/dmc')
         command = 'rsync -a {} {}'.format(qa_files_path,tpath)
@@ -23,7 +22,7 @@ if versions.scipy_available:
         dmc_infile = os.path.join(dmc_path,'dmc.in.xml')
         assert(os.path.exists(dmc_infile))
 
-        command = "qmc-fit ts --noplot -e 10 -s 1 -t '0.02 0.01 0.005' {}/*scalar*".format(dmc_path)
+        command = "{} ts --noplot -e 10 -s 1 -t '0.02 0.01 0.005' {}/*scalar*".format(exe,dmc_path)
 
         out,err,rc = execute(command)
 

--- a/nexus/tests/unit/test_qmca.py
+++ b/nexus/tests/unit/test_qmca.py
@@ -1,6 +1,6 @@
 
 import testing
-from testing import text_eq
+from testing import execute,text_eq
 
 
 test_info = dict()
@@ -10,7 +10,6 @@ directories = dict()
 def get_test_info():
     if len(test_info)==0:
         import os
-        from execute import execute
 
         tpath = testing.setup_unit_test_output_directory('qmca','test_qmca')
         
@@ -73,8 +72,6 @@ def leave():
 
 
 def test_help():
-    from execute import execute
-
     exe = get_exe()
 
     help_text = 'Usage: qmca'
@@ -91,8 +88,6 @@ def test_help():
 
 
 def test_examples():
-    from execute import execute
-
     exe = get_exe()
 
     example_text = 'QMCA examples'
@@ -105,8 +100,6 @@ def test_examples():
 
 
 def test_unit_conversion():
-    from execute import execute
-
     exe = get_exe()
 
     enter('vmc')
@@ -126,8 +119,6 @@ def test_unit_conversion():
 
 
 def test_selected_quantities():
-    from execute import execute
-
     exe = get_exe()
 
     enter('vmc')
@@ -150,8 +141,6 @@ def test_selected_quantities():
 
 
 def test_all_quantities():
-    from execute import execute
-
     exe = get_exe()
 
     enter('vmc')
@@ -189,8 +178,6 @@ def test_all_quantities():
 
 
 def test_energy_variance():
-    from execute import execute
-
     exe = get_exe()
 
     enter('opt')
@@ -216,8 +203,6 @@ opt series 5 -10.46086055 +/- 0.00375811  0.39354343 +/- 0.00913372  0.0376
 
 
 def test_multiple_equilibration():
-    from execute import execute
-
     exe = get_exe()
 
     enter('dmc')
@@ -241,8 +226,6 @@ dmc series 3 -10.52807733 +/- 0.00122687  0.38565052 +/- 0.00196074  0.0366
 
 
 def test_join():
-    from execute import execute
-
     exe = get_exe()
 
     enter('dmc')
@@ -264,8 +247,6 @@ dmc  series 1 -10.53022752 +/- 0.00073527  0.38410495 +/- 0.00082972  0.0365
 
 
 def test_multiple_directories():
-    from execute import execute
-
     exe = get_exe()
 
     enter('multi')
@@ -298,8 +279,6 @@ vmc/vmc series 0 -10.45972798 +/- 0.00380164  0.39708591 +/- 0.00971200  0.0380
 
 
 def test_twist_average():
-    from execute import execute
-
     exe = get_exe()
 
     enter('vmc_twist')
@@ -320,8 +299,6 @@ avg series 0 -11.34367335 +/- 0.00257603  0.57340688 +/- 0.00442552  0.0505
 
 
 def test_weighted_twist_average():
-    from execute import execute
-
     exe = get_exe()
 
     enter('vmc_twist')


### PR DESCRIPTION
This PR addresses #2186.  All Nexus executables now successfully run without Nexus being installed.  

All tests except the user examples pass when both `PATH` and `PYTHONPATH` are empty.  The user example tests pass provided Nexus is installed  (`PYTHONPATH=/your/path/to/nexus/lib`).  

Additionally, `nxs-test` can be used in query mode (e.g. `nxs-test --list` or `nxs-test --ctestlist`) without having a NumPy installation, as is needed to supply correct labels to `ctest` during QMCPACK configuration.

A small fix was applied to the QMCPACK reference optimization inputs to account for the updated defaults in #2128.   

