### PR TITLE
DMC with dynamic spin variables

### DIFF
--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -59,6 +59,7 @@ SET(QMCDRIVERS
   DMC/DMCDriverInput.cpp
   DMC/WalkerControlFactory.cpp
   DMC/WalkerReconfiguration.cpp
+  DMC/SODMCUpdatePbyPFast.cpp
   RMC/RMC.cpp
   RMC/RMCUpdatePbyP.cpp
   RMC/RMCUpdateAll.cpp

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -121,6 +121,11 @@ void DMC::resetUpdateEngines()
       Rng[ip] = new RandomGenerator_t(*RandomNumberControl::Children[ip]);
       hClones[ip]->setRandomGenerator(Rng[ip]);
 #endif
+      tolower(SpinMoves);
+      if (SpinMoves != "yes" && SpinMoves != "no")
+      {
+        APP_ABORT("SpinMoves must be yes/no\n");
+      }
       if (SpinMoves == "yes")
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE])

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -88,6 +88,13 @@ void DMC::resetUpdateEngines()
     estimatorClones.resize(NumThreads, 0);
     traceClones.resize(NumThreads, 0);
     FairDivideLow(W.getActiveWalkers(), NumThreads, wPerNode);
+
+    tolower(SpinMoves);
+    if (SpinMoves != "yes" && SpinMoves != "no")
+    {
+      APP_ABORT("SpinMoves must be yes/no\n");
+    }
+
     {
       //log file
       std::ostringstream o;
@@ -121,11 +128,6 @@ void DMC::resetUpdateEngines()
       Rng[ip] = new RandomGenerator_t(*RandomNumberControl::Children[ip]);
       hClones[ip]->setRandomGenerator(Rng[ip]);
 #endif
-      tolower(SpinMoves);
-      if (SpinMoves != "yes" && SpinMoves != "no")
-      {
-        APP_ABORT("SpinMoves must be yes/no\n");
-      }
       if (SpinMoves == "yes")
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE])

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -58,6 +58,9 @@ private:
   std::string UseFastGrad;
   ///input to control maximum age allowed for walkers.
   IndexType mover_MaxAge;
+  ///turn on spin moves
+  std::string SpinMoves;
+  RealType SpinMass;
 
   void resetUpdateEngines();
   /// Copy Constructor (disabled)

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
@@ -1,0 +1,54 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
+//
+// File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_SODMC_UPDATE_PARTICLEBYPARTCLE_H
+#define QMCPLUSPLUS_SODMC_UPDATE_PARTICLEBYPARTCLE_H
+#include "QMCDrivers/QMCUpdateBase.h"
+#include "Utilities/NewTimer.h"
+namespace qmcplusplus
+{
+class SODMCUpdatePbyPWithRejectionFast : public QMCUpdateBase
+{
+public:
+  /// Constructor.
+  SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
+                                   TrialWaveFunction& psi,
+                                   QMCHamiltonian& h,
+                                   RandomGenerator_t& rg);
+  ///destructor
+  ~SODMCUpdatePbyPWithRejectionFast();
+
+  void advanceWalker(Walker_t& thisWalker, bool recompute);
+
+private:
+  TimerList_t myTimers;
+};
+
+
+enum SODMCTimers
+{
+  SODMC_buffer,
+  SODMC_movePbyP,
+  SODMC_hamiltonian,
+  SODMC_collectables,
+  SODMC_tmoves
+};
+
+extern TimerNameList_t<SODMCTimers> SODMCTimerNames;
+
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2020 Jeongnim Kim and QMCPACK developers.
 //
 // File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -1,0 +1,194 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "QMCDrivers/DMC/SODMCUpdatePbyP.h"
+#include "Particle/MCWalkerConfiguration.h"
+#include "Particle/HDFWalkerIO.h"
+#include "ParticleBase/ParticleUtility.h"
+#include "ParticleBase/RandomSeqGenerator.h"
+#include "QMCDrivers/DriftOperators.h"
+#if !defined(REMOVE_TRACEMANAGER)
+#include "Estimators/TraceManager.h"
+#else
+typedef int TraceManager;
+#endif
+//#define TEST_INNERBRANCH
+
+
+namespace qmcplusplus
+{
+TimerNameList_t<SODMCTimers> SODMCTimerNames = {{SODMC_buffer, "SODMCUpdatePbyP::Buffer"},
+                                                {SODMC_movePbyP, "SODMCUpdatePbyP::movePbyP"},
+                                                {SODMC_hamiltonian, "SODMCUpdatePbyP::Hamiltonian"},
+                                                {SODMC_collectables, "SODMCUpdatePbyP::Collectables"},
+                                                {SODMC_tmoves, "SODMCUpdatePbyP::Tmoves"}};
+
+
+/// Constructor.
+SODMCUpdatePbyPWithRejectionFast::SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
+                                                                   TrialWaveFunction& psi,
+                                                                   QMCHamiltonian& h,
+                                                                   RandomGenerator_t& rg)
+    : QMCUpdateBase(w, psi, h, rg)
+{
+  setup_timers(myTimers, SODMCTimerNames, timer_level_medium);
+}
+
+/// destructor
+SODMCUpdatePbyPWithRejectionFast::~SODMCUpdatePbyPWithRejectionFast() {}
+
+void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool recompute)
+{
+  myTimers[SODMC_buffer]->start();
+  Walker_t::WFBuffer_t& w_buffer(thisWalker.DataSet);
+  W.loadWalker(thisWalker, true);
+  Psi.copyFromBuffer(W, w_buffer);
+  myTimers[SODMC_buffer]->stop();
+  //create a 3N-Dimensional Gaussian with variance=1
+  makeGaussRandomWithEngine(deltaR, RandomGen);
+  makeGaussRandomWithEngine(deltaS, RandomGen);
+  int nAcceptTemp(0);
+  int nRejectTemp(0);
+  //copy the old energy and scale factor of drift
+  FullPrecRealType eold(thisWalker.Properties(LOCALENERGY));
+  FullPrecRealType enew(eold);
+  RealType rr_proposed = 0.0;
+  RealType rr_accepted = 0.0;
+  RealType gf_acc      = 1.0;
+  myTimers[SODMC_movePbyP]->start();
+  for (int ig = 0; ig < W.groups(); ++ig) //loop over species
+  {
+    RealType tauovermass = Tau * MassInvS[ig];
+    RealType oneover2tau = 0.5 / (tauovermass);
+    RealType sqrttau     = std::sqrt(tauovermass);
+    for (int iat = W.first(ig); iat < W.last(ig); ++iat)
+    {
+      //get the displacement
+      TrialWaveFunction::LogValueType spingrad_iat;
+      GradType grad_iat = Psi.evalGradWithSpin(W, iat, spingrad_iat);
+      PosType dr;
+      ParticleSet::Scalar_t ds;
+      DriftModifier->getDrift(tauovermass, grad_iat, dr);
+      ds = tauovermass/spinMass*std::real(spingrad_iat); //using raw spin grad, no UNR modifier
+      dr += sqrttau * deltaR[iat];
+      ds += std::sqrt(tauovermass/spinMass)*deltaS[iat];
+      RealType rr = tauovermass * dot(deltaR[iat], deltaR[iat]);
+      rr_proposed += rr;
+      if (rr > m_r2max)
+      {
+        ++nRejectTemp;
+        continue;
+      }
+      if (!W.makeMoveAndCheckWithSpin(iat, dr, ds))
+        continue;
+      ValueType ratio = Psi.calcRatioGradWithSpin(W, iat, grad_iat, spingrad_iat);
+      //node is crossed reject the move
+      if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
+      {
+        ++nRejectTemp;
+        ++nNodeCrossing;
+        W.rejectMove(iat);
+        Psi.rejectMove(iat);
+      }
+      else
+      {
+        FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
+        logGf += -0.5*deltaS[iat]*deltaS[iat];
+        //Use the force of the particle iat
+        DriftModifier->getDrift(tauovermass, grad_iat, dr);
+        ds = tauovermass/spinMass*std::real(spingrad_iat);
+        dr                     = W.R[iat] - W.activePos - dr;
+        ds                     = W.spins[iat] - W.activeSpinVal - ds;
+        FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
+        logGb                 += -spinMass*oneover2tau*ds*ds;
+        RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
+        if (RandomGen() < prob)
+        {
+          ++nAcceptTemp;
+          Psi.acceptMove(W, iat, true);
+          W.acceptMove(iat, true);
+          rr_accepted += rr;
+          gf_acc *= prob; //accumulate the ratio
+        }
+        else
+        {
+          ++nRejectTemp;
+          W.rejectMove(iat);
+          Psi.rejectMove(iat);
+        }
+      }
+    }
+  }
+  Psi.completeUpdates();
+  W.donePbyP();
+  myTimers[SODMC_movePbyP]->stop();
+
+  if (nAcceptTemp > 0)
+  {
+    //need to overwrite the walker properties
+    myTimers[SODMC_buffer]->start();
+    thisWalker.Age  = 0;
+    RealType logpsi = Psi.updateBuffer(W, w_buffer, recompute);
+    W.saveWalker(thisWalker);
+    myTimers[SODMC_buffer]->stop();
+    myTimers[SODMC_hamiltonian]->start();
+    enew = H.evaluateWithToperator(W);
+    myTimers[SODMC_hamiltonian]->stop();
+    thisWalker.resetProperty(logpsi, Psi.getPhase(), enew, rr_accepted, rr_proposed, 1.0);
+    thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
+    myTimers[SODMC_collectables]->start();
+    H.auxHevaluate(W, thisWalker);
+    H.saveProperty(thisWalker.getPropertyBase());
+    myTimers[SODMC_collectables]->stop();
+  }
+  else
+  {
+    //all moves are rejected: does not happen normally with reasonable wavefunctions
+    thisWalker.Age++;
+    thisWalker.Properties(R2ACCEPTED) = 0.0;
+    //weight is set to 0 for traces
+    // consistent w/ no evaluate/auxHevaluate
+    RealType wtmp     = thisWalker.Weight;
+    thisWalker.Weight = 0.0;
+    H.rejectedMove(W, thisWalker);
+    thisWalker.Weight = wtmp;
+    ++nAllRejected;
+    enew   = eold; //copy back old energy
+    gf_acc = 1.0;
+    thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
+  }
+#if !defined(REMOVE_TRACEMANAGER)
+  Traces->buffer_sample(W.current_step);
+#endif
+  myTimers[SODMC_tmoves]->start();
+  const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
+  if (NonLocalMoveAcceptedTemp > 0)
+  {
+    RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
+    // debugging lines
+    //W.update(true);
+    //RealType logpsi2 = Psi.evaluateLog(W);
+    //if(logpsi!=logpsi2) std::cout << " logpsi " << logpsi << " logps2i " << logpsi2 << " diff " << logpsi2-logpsi << std::endl;
+    W.saveWalker(thisWalker);
+    NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+  }
+  myTimers[SODMC_tmoves]->stop();
+  nAccept += nAcceptTemp;
+  nReject += nRejectTemp;
+
+  setMultiplicity(thisWalker);
+}
+
+} // namespace qmcplusplus

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -177,10 +177,6 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
   if (NonLocalMoveAcceptedTemp > 0)
   {
     RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
-    // debugging lines
-    //W.update(true);
-    //RealType logpsi2 = Psi.evaluateLog(W);
-    //if(logpsi!=logpsi2) std::cout << " logpsi " << logpsi << " logps2i " << logpsi2 << " diff " << logpsi2-logpsi << std::endl;
     W.saveWalker(thisWalker);
     NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
   }

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2020 Jeongnim Kim and QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -182,7 +182,12 @@ void VMC::resetRun()
       Rng[ip] = new RandomGenerator_t(*(RandomNumberControl::Children[ip]));
 #endif
       hClones[ip]->setRandomGenerator(Rng[ip]);
-
+      
+      tolower(SpinMoves);
+      if (SpinMoves != "yes" && SpinMoves != "no") 
+      {
+        APP_ABORT("SpinMoves must be yes/no\n");
+      }
       if (SpinMoves == "yes") 
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE]) 

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -141,4 +141,104 @@ TEST_CASE("DMC", "[drivers][dmc]")
   delete doc;
   delete p_bke;
 }
+
+TEST_CASE("SODMC", "[drivers][dmc]")
+{
+  Communicate* c;
+  OHMMS::Controller->initialize(0, NULL);
+  c = OHMMS::Controller;
+
+  ParticleSet ions;
+  MCWalkerConfiguration elec;
+
+  ions.setName("ion");
+  ions.create(1);
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  elec.setName("elec");
+  std::vector<int> agroup(1);
+  agroup[0] = 1;
+  elec.create(agroup);
+  elec.R[0][0] = 1.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+  elec.spins[0] = 0.0;
+  elec.createWalkers(1);
+
+  SpeciesSet& tspecies         = elec.getSpeciesSet();
+  int upIdx                    = tspecies.addSpecies("u");
+  int chargeIdx                = tspecies.addAttribute("charge");
+  int massIdx                  = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx)   = -1;
+  tspecies(massIdx, upIdx)     = 1.0;
+
+#ifdef ENABLE_SOA
+  elec.addTable(ions, DT_SOA);
+#else
+  elec.addTable(ions, DT_AOS);
+#endif
+  elec.update();
+
+  CloneManager::clear_for_unit_tests();
+
+  TrialWaveFunction psi(c);
+  ConstantOrbital* orb  = new ConstantOrbital;
+  psi.addComponent(orb, "Constant");
+  psi.registerData(elec, elec.WalkerList[0]->DataSet);
+  elec.WalkerList[0]->DataSet.allocate();
+
+  FakeRandom rg;
+
+  QMCHamiltonian h;
+  BareKineticEnergy<double>* p_bke = new BareKineticEnergy<double>(elec);
+  h.addOperator(p_bke, "Kinetic");
+  h.addObservables(elec); // get double free error on 'h.Observables' w/o this
+
+  elec.resetWalkerProperty(); // get memory corruption w/o this
+
+  HamiltonianPool hpool(c);
+
+  WaveFunctionPool wpool(c);
+
+  //EstimatorManagerBase emb(c);
+
+
+  DMC dmc_omp(elec, psi, h, wpool, c);
+
+  const char* dmc_input = "<qmc method=\"dmc\"> \
+   <parameter name=\"steps\">1</parameter> \
+   <parameter name=\"blocks\">1</parameter> \
+   <parameter name=\"timestep\">0.1</parameter> \
+   <parameter name=\"SpinMoves\">yes</parameter> \
+   <parameter name=\"SpinMass\">0.25</parameter> \
+  </qmc> \
+  ";
+  Libxml2Document* doc  = new Libxml2Document;
+  bool okay             = doc->parseFromString(dmc_input);
+  REQUIRE(okay);
+  xmlNodePtr root = doc->getRoot();
+
+  dmc_omp.process(root); // need to call 'process' for QMCDriver, which in turn calls 'put'
+
+  dmc_omp.run();
+
+  // With the constant wavefunction, no moves should be rejected
+  double ar = dmc_omp.acceptRatio();
+  REQUIRE(ar == Approx(1.0));
+
+  // Each electron moved sqrt(tau)*gaussian_rng()
+  //  See Particle>Base/tests/test_random_seq.cpp for the gaussian random numbers
+  //  Values from diffuse.py for moving one step
+
+  REQUIRE(elec[0]->R[0][0] == Approx(0.627670258894097));
+  REQUIRE(elec.R[0][1] == Approx(0.0));
+  REQUIRE(elec.R[0][2] == Approx(-0.372329741105903));
+
+  REQUIRE(elec.spins[0] == Approx(-0.74465948215809097));
+
+  delete doc;
+  delete p_bke;
+}
 } // namespace qmcplusplus


### PR DESCRIPTION
This PR adds the required changes for DMC with dynamic spin moves. This alongside  #2147 finishes the VMC/DMC capability and completes step 5 of #1770. 

Similar to the VMC implementation, you simply need to add SpinMoves=yes to the DMC XML input, and equivalently the SpinMass can be changed in order to effectively modify the timestep for the spin variables, as outlined in  Melton, Bennett, & Mitas J. Chem. Phys. 144, 244113 (2016); https://doi.org/10.1063/1.4954726

Spin-orbit ECP evaluation to come