### PR TITLE
Avoid int to string conversion warning for WALKER_MAX_PROPERTIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ SET (EXECUTABLE_OUTPUT_PATH ${qmcpack_BINARY_DIR}/bin CACHE PATH "Single output 
 # QMC_MPI =  enable MPI
 # QMC_OMP = enable OMP
 ######################################################################
-SET(WALKER_MAX_PROPERTIES 32 CACHE int "Maximum number of properties tracked by walkers")
+SET(WALKER_MAX_PROPERTIES 32 CACHE STRING "Maximum number of properties tracked by walkers")
 MARK_AS_ADVANCED(WALKER_MAX_PROPERTIES)
 SET(OHMMS_DIM 3 CACHE STRING "Select physical dimension")
 SET(OHMMS_INDEXTYPE int)


### PR DESCRIPTION
Fixes the following by using the same prescription as for other cached ints, i.e. a string.
```
-- CMAKE_BUILD_TYPE is RELEASE
CMake Warning (dev) at CMakeLists.txt:166 (SET):
  implicitly converting 'int' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- defining the float point precision
 ```