### PR TITLE
Bypass createESParticleSet check if target has been built

### DIFF
--- a/src/QMCApp/WaveFunctionPool.cpp
+++ b/src/QMCApp/WaveFunctionPool.cpp
@@ -51,6 +51,11 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   pAttrib.put(cur);
   ParticleSet* qp = ptcl_pool_->getParticleSet(target);
 
+  // Ye: the overall logic of the "check" is still not clear to me.
+  // The following code path should only be used when there is no cell, ion, electron info provided in the XML input.
+  // As long as any info is provided in the XML file, no need to call createESParticleSet
+  // EinsplineBuilder has code to verify cell and ion position. No need to do here.
+  if (!qp)
   { //check ESHDF should be used to initialize both target and associated ionic system
     xmlNodePtr tcur = cur->children;
     while (tcur != NULL)
@@ -63,6 +68,7 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
       tcur = tcur->next;
     }
   }
+
   if (qp == 0)
   {
     APP_ABORT("WaveFunctionPool::put Target ParticleSet is not found.");


### PR DESCRIPTION
#2224 hit this code path but I cannot see a good reason.
I added the desired behaviour in the source comment.

After this fix, #2224 will hit
```
Fatal Error. Aborting at Einspline needs the source particleset
```
and we can implement the desired behaviour discussed in #2224.