### PR TITLE
Force estimator fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ SET (EXECUTABLE_OUTPUT_PATH ${qmcpack_BINARY_DIR}/bin CACHE PATH "Single output 
 
 ######################################################################
 # Set the compiler-time parameters
+# WALKER_MAX_PROPERTIES max number of observables + 12 or so standard
+#   props. Things like forces are per particle so you may need this to
+#   rather large.  Each property increases walker size by
+#   sizeof(FULLPRECREALTYPE)
 # OHMMS_DIM =  dimension of the problem
 # OHMMS_INDEXTYPE = type of index
 # OHMMS_PRECISION  = base precision, float, double etc
@@ -163,7 +167,7 @@ SET (EXECUTABLE_OUTPUT_PATH ${qmcpack_BINARY_DIR}/bin CACHE PATH "Single output 
 # QMC_MPI =  enable MPI
 # QMC_OMP = enable OMP
 ######################################################################
-SET(WALKER_MAX_PROPERTIES 32 CACHE STRING "Maximum number of properties tracked by walkers")
+SET(WALKER_MAX_PROPERTIES 256 CACHE INT "Maximum number of properties tracked by walkers")
 MARK_AS_ADVANCED(WALKER_MAX_PROPERTIES)
 SET(OHMMS_DIM 3 CACHE STRING "Select physical dimension")
 SET(OHMMS_INDEXTYPE int)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ SET (EXECUTABLE_OUTPUT_PATH ${qmcpack_BINARY_DIR}/bin CACHE PATH "Single output 
 # QMC_MPI =  enable MPI
 # QMC_OMP = enable OMP
 ######################################################################
-SET(WALKER_MAX_PROPERTIES 256 CACHE INT "Maximum number of properties tracked by walkers")
+SET(WALKER_MAX_PROPERTIES 256 CACHE STRING "Maximum number of properties tracked by walkers")
 MARK_AS_ADVANCED(WALKER_MAX_PROPERTIES)
 SET(OHMMS_DIM 3 CACHE STRING "Select physical dimension")
 SET(OHMMS_INDEXTYPE int)

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -441,7 +441,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     {
       const auto& dist  = d_ie.getDistRow(iat);
       const auto& displ = d_ie.getDisplRow(iat);
-      int gid           = Ions.GroupID[isrc];
+      int gid           = source.GroupID[isrc];
       RealType r        = dist[isrc];
       RealType rinv     = 1.0 / r;
       PosType dr        = displ[isrc];
@@ -467,7 +467,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     {
       const auto& dist  = d_ie.getDistRow(iat);
       const auto& displ = d_ie.getDisplRow(iat);
-      int gid           = Ions.GroupID[isrc];
+      int gid           = source.GroupID[isrc];
       RealType r        = dist[isrc];
       RealType rinv     = 1.0 / r;
       PosType dr        = displ[isrc];

--- a/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaLocalizedBasisSet.h
@@ -338,7 +338,9 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
       gzzz[ib] = 0;
     }
 
-    const auto& IonID(ions_.GroupID);
+    // Since jion is indexed on the source ions not the ions_ the distinction between
+    // ions_ and ions is extremely important.
+    const auto& IonID(ions.GroupID);
     const auto& d_table = P.getDistTable(myTableIndex);
     const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
     const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
@@ -346,6 +348,7 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     //Since LCAO's are written only in terms of (r-R), ionic derivatives only exist for the atomic center
     //that we wish to take derivatives of.  Moreover, we can obtain an ion derivative by multiplying an electron
     //derivative by -1.0.  Handling this sign is left to LCAOrbitalSet.  For now, just note this is the electron VGL function.
+    
     LOBasisSet[IonID[jion]]->evaluateVGHGH(P.Lattice, dist[jion], displ[jion], BasisOffset[jion], vghgh);
   }
   /** add a new set of Centered Atomic Orbitals


### PR DESCRIPTION
Additional fixes addressing issues with #2238 
many of the evalSource... functions show assumption that the ions reference held as state and the ions passed in are nearly equivalent, at least from forces they are not and segmentation faults result.  Of course some of this may have appeared to work in Release builds, but it wasn't.  I still have crashes with the legacy driver, forces, and OMP_NUM_THREADS > 0, but they are caused by accesses within the omp sections (race condition?) and I leave that to someone else.