### PR TITLE
Python3 in Summit build scripts

### DIFF
--- a/config/build_olcf_summit_XL.sh
+++ b/config/build_olcf_summit_XL.sh
@@ -16,6 +16,7 @@ module load cuda
 module load essl
 module load netlib-lapack
 module load hdf5
+module load python/3.6.6-anaconda3-5.3.0
 
 #the XL built fftw is buggy, use the gcc version
 #module load fftw

--- a/config/load_olcf_summit_modules.sh
+++ b/config/load_olcf_summit_modules.sh
@@ -11,5 +11,5 @@ export FFTW_ROOT=$OLCF_FFTW_ROOT
 module load cmake
 module load boost
 module load cuda
-module load python/2.7.15-anaconda2-5.3.0
+module load python/3.6.6-anaconda3-5.3.0
 


### PR DESCRIPTION
Required to configure successfully. Default OLCF Summit Python3 module.
