### PR TITLE
Use H5Eset/get_auto version 2 APIs

### DIFF
--- a/src/Numerics/HDFNumericAttrib.h
+++ b/src/Numerics/HDFNumericAttrib.h
@@ -159,14 +159,14 @@ struct HDFAttribIO<int> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1  = H5Dopen(grp, name);
     hid_t ret = H5Dread(h1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ref);
     H5Dclose(h1);
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -191,17 +191,17 @@ struct HDFAttribIO<double> : public HDFAttribIOBase
 
   inline void read(hid_t grp, const char* name)
   {
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1 = H5Dopen(grp, name);
     if (h1 >= 0)
     {
       hid_t ret = H5Dread(h1, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ref);
       H5Dclose(h1);
     }
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -236,17 +236,17 @@ struct HDFAttribIO<TinyVector<double, D>> : public HDFAttribIOBase
 
   inline void read(hid_t grp, const char* name)
   {
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1 = H5Dopen(grp, name);
     if (h1 > -1)
     {
       hid_t ret = H5Dread(h1, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &(ref[0]));
       H5Dclose(h1);
     }
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -319,14 +319,14 @@ struct HDFAttribIO<TinyVector<int, D>> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1  = H5Dopen(grp, name);
     hid_t ret = H5Dread(h1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &(ref[0]));
     H5Dclose(h1);
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -352,10 +352,10 @@ struct HDFAttribIO<std::vector<TinyVector<int, D>>> : public HDFAttribIOBase
 
   inline void read(hid_t grp, const char* name)
   {
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1 = H5Dopen(grp, name);
     if (h1 >= 0)
     {
@@ -371,7 +371,7 @@ struct HDFAttribIO<std::vector<TinyVector<int, D>>> : public HDFAttribIOBase
       hid_t ret = H5Dread(h1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &(ref[0][0]));
       H5Dclose(h1);
     }
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -398,10 +398,10 @@ struct HDFAttribIO<std::vector<TinyVector<double, D>>> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1  = H5Dopen(grp, name);
     hid_t ret = -1;
     if (h1 >= 0)
@@ -418,7 +418,7 @@ struct HDFAttribIO<std::vector<TinyVector<double, D>>> : public HDFAttribIOBase
       ret = H5Dread(h1, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &(ref[0][0]));
       H5Dclose(h1);
     }
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -808,10 +808,10 @@ struct HDFAttribIO<Array<double, D>> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1 = H5Dopen(grp, name);
     if (h1 > 0)
     {
@@ -823,7 +823,7 @@ struct HDFAttribIO<Array<double, D>> : public HDFAttribIOBase
       H5Sclose(dataspace);
       H5Dclose(h1);
     }
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 

--- a/src/Numerics/HDFSTLAttrib.h
+++ b/src/Numerics/HDFSTLAttrib.h
@@ -171,10 +171,10 @@ struct HDFAttribIO<std::vector<std::complex<double>>> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t h1        = H5Dopen(grp, name);
     hid_t dataspace = H5Dget_space(h1);
     //hsize_t dims_out[1];
@@ -200,7 +200,7 @@ struct HDFAttribIO<std::vector<std::complex<double>>> : public HDFAttribIOBase
     hid_t ret = H5Dread(h1, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ref[0]);
     H5Sclose(dataspace);
     H5Dclose(h1);
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 

--- a/src/OhmmsData/HDFStringAttrib.h
+++ b/src/OhmmsData/HDFStringAttrib.h
@@ -43,10 +43,10 @@ struct HDFAttribIO<std::string> : public HDFAttribIOBase
   inline void read(hid_t grp, const char* name)
   {
     // Turn off error printing
-    H5E_auto_t func;
+    H5E_auto2_t func;
     void* client_data;
-    H5Eget_auto(&func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     hid_t dataset = H5Dopen(grp, name);
     if (dataset > -1)
     {
@@ -70,7 +70,7 @@ struct HDFAttribIO<std::string> : public HDFAttribIOBase
       H5Dclose(dataset);
     }
     // Turn error printing back on
-    H5Eset_auto(func, client_data);
+    H5Eset_auto2(H5E_DEFAULT, func, client_data);
   }
 };
 
@@ -84,7 +84,7 @@ struct HDFAttribIO<std::ostringstream> : public HDFAttribIOBase
 
   inline void write(hid_t grp, const char* name)
   {
-    herr_t status = H5Eset_auto(NULL, NULL);
+    herr_t status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status        = H5Gget_objinfo(grp, name, 0, NULL);
     hsize_t str80 = H5Tcopy(H5T_C_S1);
     H5Tset_size(str80, ref.str().size());

--- a/src/QMCApp/ParticleSetPool.cpp
+++ b/src/QMCApp/ParticleSetPool.cpp
@@ -321,16 +321,16 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
       //
       //old_func:  function pointer to current function that
       //           displays when H5 encounters error.
-      herr_t (*old_func)(void*);
+      H5E_auto2_t old_func;
       //old_client_data:  null pointer to associated error stream.
       void* old_client_data;
       //Grab the current handler info.
-      H5Eget_auto(&old_func, &old_client_data);
+      H5Eget_auto2(H5E_DEFAULT, &old_func, &old_client_data);
       //Now kill error notifications.
-      H5Eset_auto(NULL, NULL);
+      H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
       h5 = H5Fopen(h5name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
       //and restore to defaults.
-      H5Eset_auto(old_func, old_client_data);
+      H5Eset_auto2(H5E_DEFAULT, old_func, old_client_data);
       if (h5 < 0)
       {
         app_error() << "Could not open HDF5 file \"" << h5name

--- a/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
@@ -32,10 +32,10 @@ bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
 {
   update_token(__FILE__, __LINE__, "ReadOrbitalInfo");
   // Handle failed file open gracefully by temporarily replacing error handler
-  H5E_auto_t old_efunc;
+  H5E_auto2_t old_efunc;
   void* old_efunc_data;
-  H5Eget_auto(&old_efunc, &old_efunc_data);
-  H5Eset_auto(NULL, NULL);
+  H5Eget_auto2(H5E_DEFAULT, &old_efunc, &old_efunc_data);
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
   H5FileID = H5Fopen(H5FileName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   //  H5FileID = H5Fopen(H5FileName.c_str(),H5F_ACC_RDWR,H5P_DEFAULT);
   if (H5FileID < 0)
@@ -44,7 +44,7 @@ bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
                 << "\" in EinsplineSetBuilder::ReadOrbitalInfo.  Aborting.\n";
     APP_ABORT("EinsplineSetBuilder::ReadOrbitalInfo");
   }
-  H5Eset_auto(old_efunc, old_efunc_data);
+  H5Eset_auto2(H5E_DEFAULT, old_efunc, old_efunc_data);
 
   // Read format
   std::string format;

--- a/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.cpp
+++ b/src/QMCWaveFunctions/MolecularOrbitals/NGOBuilder.cpp
@@ -68,7 +68,7 @@ bool NGOBuilder::putCommon(xmlNodePtr cur)
     //current version
     HDFVersion res_version(0, 1);
     HDFVersion in_version(0, 0); //start using major=0 and minor=4
-    herr_t status = H5Eset_auto(NULL, NULL);
+    herr_t status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     in_version.read(m_fileid, hdf::version);
     if (in_version < res_version)
     {

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -351,7 +351,7 @@ void PWOrbitalBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, 
 {
   std::ostringstream splineTag;
   splineTag << "eigenstates_" << nG[0] << "_" << nG[1] << "_" << nG[2];
-  herr_t status = H5Eset_auto(NULL, NULL);
+  herr_t status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
   app_log() << " splineTag " << splineTag.str() << std::endl;
   hid_t es_grp_id;
   status = H5Gget_objinfo(hfileID, splineTag.str().c_str(), 0, NULL);

--- a/src/io/hdf_archive.cpp
+++ b/src/io/hdf_archive.cpp
@@ -24,7 +24,7 @@ hdf_archive::~hdf_archive()
     H5Pclose(access_id);
 #endif
   close();
-  H5Eset_auto(err_func, client_data);
+  H5Eset_auto2(H5E_DEFAULT, err_func, client_data);
 }
 
 void hdf_archive::close()

--- a/src/io/hdf_archive.h
+++ b/src/io/hdf_archive.h
@@ -59,7 +59,7 @@ private:
   ///transfer property
   hid_t xfer_plist;
   ///error type
-  H5E_auto_t err_func;
+  H5E_auto2_t err_func;
   ///error handling
   void* client_data;
   ///FILO to handle H5Group
@@ -78,14 +78,14 @@ public:
   template<class Comm = Communicate*>
   hdf_archive(Comm c, bool request_pio = false) : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
-    H5Eget_auto(&err_func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     set_access_plist(request_pio, c);
   }
   hdf_archive() : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
-    H5Eget_auto(&err_func, &client_data);
-    H5Eset_auto(NULL, NULL);
+    H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     set_access_plist();
   }
   ///destructor


### PR DESCRIPTION
Changed from using H5Eset_auto and H5Eget_auto to H5Eset_auto2 and H5Eget_auto2. The version 2 APIs were introduced in HDF5 1.8.0. QMCPACK already specifies version 2 APIs (H5Dcreate2), so this introduces no new requirements in terms of minimum HDF5 version required.

These changes are needed because the HDF5 DAOS VOL connector does not have the version 1 APIs implemented and hence will not work DAOS when using HDF5.