### PR TITLE
Fix restart miniapp linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,6 +255,8 @@ ENDIF()
   #ENDIF(QMC_BUILD_STATIC)
   #SUBDIRS(einspline)
 
+  SUBDIRS(MinimalContainers)
+
   if(QMC_BUILD_SANDBOX_ONLY)
 
     MESSAGE(STATUS "Minimal build: only Sandbox")
@@ -280,8 +282,6 @@ ENDIF()
   SUBDIRS(QMCTools)
   #ENDIF(BUILD_QMCTOOLS)
 
-  SUBDIRS(MinimalContainers)
-  
   if (BUILD_UNIT_TESTS) #{
     #Unit test directories
     INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/external_codes/catch)
@@ -310,6 +310,7 @@ ENDIF()
     SUBDIRS(CUDA/tests)
     SUBDIRS(OpenMP/tests)
     SUBDIRS(Optimize/tests)
+    SUBDIRS(MinimalContainers/tests)
   endif() #}
 
 endif() #}}}

--- a/src/MinimalContainers/CMakeLists.txt
+++ b/src/MinimalContainers/CMakeLists.txt
@@ -2,5 +2,3 @@
 SET(MINCONT_SRC ConstantSizeMatrix.cpp)
 
 ADD_LIBRARY(qmcminimalcontainers ${MINCONT_SRC} )
-
-SUBDIRS(tests)

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbital.h
@@ -71,7 +71,7 @@ public:
   ///container for the Jastrow functions
   std::vector<FT*> F;
 
-  TwoBodyJastrowOrbital(ParticleSet& p, int tid) : TaskID(tid), KEcorr(0.0), my_table_ID_(p.addTable(p, DT_AOS))
+  TwoBodyJastrowOrbital(ParticleSet& p, int tid) : TaskID(tid), my_table_ID_(p.addTable(p, DT_AOS)), KEcorr(0.0)
   {
     PtclRef = &p;
     init(p);

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowOrbital.h
@@ -50,10 +50,10 @@ class eeI_JastrowOrbital : public WaveFunctionComponent
 {
   //flag to prevent parallel output
   bool Write_Chiesa_Correction;
-  ///table index for i-el
-  const int ei_table_index_;
   ///table index for el-el
   const int ee_table_index_;
+  ///table index for i-el
+  const int ei_table_index_;
   //nuber of particles
   int Nelec, Nion;
   //N*N
@@ -105,9 +105,9 @@ public:
 
   eeI_JastrowOrbital(ParticleSet& ions, ParticleSet& elecs, bool is_master)
       : Write_Chiesa_Correction(is_master),
-        KEcorr(0.0),
         ee_table_index_(elecs.addTable(elecs, DT_AOS)),
-        ei_table_index_(elecs.addTable(ions, DT_AOS))
+        ei_table_index_(elecs.addTable(ions, DT_AOS)),
+        KEcorr(0.0)
   {
     ClassName = "eeI_JastrowOrbital";
     eRef      = &elecs;

--- a/src/Sandbox/einspline_spo.hpp
+++ b/src/Sandbox/einspline_spo.hpp
@@ -53,7 +53,7 @@ namespace qmcplusplus
       aligned_vector<hContainer_type*> hess;
 
       ///default constructor
-      einspline_spo():nBlocks(0),nSplines(0),firstBlock(0),lastBlock(0), Owner(false){}
+      einspline_spo(): nBlocks(0), firstBlock(0), lastBlock(0), nSplines(0), Owner(false){}
       ///disable copy constructor 
       einspline_spo(const einspline_spo& in)=delete;
       ///disable copy operator


### PR DESCRIPTION
Rearrange MinimalContainers cmake.
The source code change is only for reducing GCC reorder warnings.