### PR TITLE
Nexus: Allow for atom symbol indexing

### DIFF
--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -4989,7 +4989,13 @@ class Structure(Sobj):
     def get_atomic_numbers(self):
         an = []
         for e in self.elem:
-            an.append(ptable[e].atomic_number)
+            if e[1:].isdigit():
+                an.append(ptable[e[0:1]].atomic_number)
+            elif e[2:].isdigit():
+                an.append(ptable[e[0:2]].atomic_number)
+            else:
+                an.append(ptable[e].atomic_number)
+            #end if
         #end for
         return array(an,dtype='intc')
     #end def get_atomic_numbers

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -4989,12 +4989,11 @@ class Structure(Sobj):
     def get_atomic_numbers(self):
         an = []
         for e in self.elem:
-            if e[1:].isdigit(): # Index concatenated to one-character atomic symbol (e.g., C1)
-                an.append(ptable[e[0:1]].atomic_number)
-            elif e[2:].isdigit(): # Index concatenated to two-character atomic symbol (e.g., Ne1)
-                an.append(ptable[e[0:2]].atomic_number)
+            iselem,esymb = is_element(e,symbol=True)
+            if not iselem:
+                self.error('Atomic symbol, {}, not recognized'.format(esymb))
             else:
-                an.append(ptable[e].atomic_number)
+                an.append(ptable[esymb].atomic_number)
             #end if
         #end for
         return array(an,dtype='intc')

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -4989,9 +4989,9 @@ class Structure(Sobj):
     def get_atomic_numbers(self):
         an = []
         for e in self.elem:
-            if e[1:].isdigit():
+            if e[1:].isdigit(): # Index concatenated to one-character atomic symbol (e.g., C1)
                 an.append(ptable[e[0:1]].atomic_number)
-            elif e[2:].isdigit():
+            elif e[2:].isdigit(): # Index concatenated to two-character atomic symbol (e.g., Ne1)
                 an.append(ptable[e[0:2]].atomic_number)
             else:
                 an.append(ptable[e].atomic_number)


### PR DESCRIPTION
Previously, if get_atomic_numbers is called after the user supplies an indexed atomic symbol for an element in structure.elem (e.g., elem=['Si1', 'Si2'] etc.), the code would abort. The following PR, allows the user to use indexed labels.