### PR TITLE
Allow empty particleset in the input

### DIFF
--- a/manual/particleset.tex
+++ b/manual/particleset.tex
@@ -77,6 +77,8 @@ The \ixml{particleset} blocks specify the particles in the QMC simulations: thei
 \begin{itemize}
 \item \ixml{name}/\ixml{id} \\
 Unique name for the particle set. Default is ``e" for electrons. ``i" or ``ion0" is typically used for ions. 
+For special cases where an empty particle set is needed, the special name ``empty" can be used to bypass
+the zero-size error check.
 \end{itemize}
 % Line 192 in ParticleIO/XMLParticleIO.cpp
 % Lines 144-145 in QMCApp/ParticleSetPool.cpp

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -149,7 +149,10 @@ void ParticleSet::set_quantum_domain(quantum_domains qdomain)
 void ParticleSet::resetGroups()
 {
   int nspecies = mySpecies.getTotalNum();
-  if (nspecies == 0)
+  // Usually an empty ParticleSet indicates an error in the input file,
+  // but in some cases it is useful.  Allow an empty ParticleSet if it
+  // has the special name "empty".
+  if (nspecies == 0 && getName() != "empty")
   {
     APP_ABORT("ParticleSet::resetGroups() Failed. No species exisits");
   }
@@ -191,7 +194,7 @@ void ParticleSet::resetGroups()
   }
   // safety check if any group of particles has size 0, instruct users to fix the input.
   for (int group_id = 0; group_id < nspecies; group_id++)
-    if (ng[group_id] == 0)
+    if (ng[group_id] == 0 && getName() != "empty")
     {
       std::ostringstream err_msg;
       err_msg << "ParticleSet::resetGroups() Failed. ParticleSet '" << myName << "' "


### PR DESCRIPTION
To handle #2224, allow an empty ParticleSet to be created if it has the special name "empty".
Replaces #2234 

Example input:
```
<particleset name="empty" random="no">
    <group name="u" size="0">
      <parameter name="charge">0</parameter>
    </group>
  </particleset>
```