### PR TITLE
Update HDF5 not found message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,7 +690,7 @@ IF(HDF5_FOUND)
   ENDIF()
   SET(QMC_UTIL_LIBS ${QMC_UTIL_LIBS} ${HDF5_LIBRARIES})
 ELSE(HDF5_FOUND)
-  MESSAGE(FATAL_ERROR "Require HDF5 1.6.4 or higher. Set HDF5_ROOT")
+  MESSAGE(FATAL_ERROR "HDF5 not found. Set HDF5_ROOT")
 ENDIF(HDF5_FOUND)
 
 #make sure we can find boost if it's not in /usr


### PR DESCRIPTION
The suggested HDF5 version is out of date.  Version 1.8 or newer is needed, or the code will not compile.  The HDF5_VERSION variable (from FindHDF5) does not get set with 1.6 - checking the version is not going to be useful.  The last 1.6 version was released in 2009, so people running into this version is unlikely to be an issue anyway.

No suggested version is given, since the version choice affects parallel IO performance, not correctness.

Prompted by #2251