### PR TITLE
Add nexus ntest to jenkins_oxygen_cpu.sh

### DIFF
--- a/tests/test_automation/jenkins_oxygen_cpu.sh
+++ b/tests/test_automation/jenkins_oxygen_cpu.sh
@@ -48,6 +48,12 @@ if [[ ${ret} -ne 0 ]] ; then
   exit_code=${ret}
 fi
 
+ctest -R ntest --output-on-failure --timeout 120
+ret=$?
+if [[ ${ret} -ne 0 ]] ; then
+  exit_code=${ret}
+fi
+
 echo ""
 echo ""
 echo "starting new test for real mixed precision"


### PR DESCRIPTION
Full precision real build only since nexus ntest tests are independent of QMCPACK.

Closes #2263 
