### PR TITLE
Nexus: add interoperability support for old (Python 2) workflow data

### DIFF
--- a/nexus/bin/nxs-redo
+++ b/nexus/bin/nxs-redo
@@ -30,6 +30,16 @@ if help:
 #end if
 
 paths = dict()
+if len(paths_in)==1 and os.path.exists(paths_in[0]) and os.path.isfile(paths_in[0]):
+    text = open(paths_in[0],'r').read()
+    paths_in = []
+    for line in text.splitlines():
+        tokens = line.split()
+        if len(tokens)>0:
+            paths_in.append(tokens[-1])
+        #end if
+    #end for
+#end if
 for path in paths_in:
     if os.path.exists(path) and os.path.isdir(path):
         simdir    = False

--- a/nexus/lib/generic.py
+++ b/nexus/lib/generic.py
@@ -359,7 +359,11 @@ class object_interface(object):
             fpath='./'+self.__class__.__name__+'.p'
         #end if
         fobj = open(fpath,'rb')
-        tmp = pickle.load(fobj)
+        try:
+            tmp = pickle.load(fobj)
+        except:
+            tmp = pickle.load(fobj,encoding='latin1')
+        #end try
         fobj.close()
         d = self.__dict__
         d.clear()
@@ -370,7 +374,6 @@ class object_interface(object):
         del tmp
         return
     #end def load
-
 
 
     # log, warning, and error messages


### PR DESCRIPTION
After the move to Python 3, old Python 2 workflows could not be read or expanded upon with the updated code.  A number of projects are mid-stride (straddling Python 2 and Python 3 Nexus through the execution of the project) and users will benefit by being able to load archived workflows created during the Python 2 era.

This PR adds a simple fix based on how pickle files are loaded by trying to load with an encoding compatible with the Python 2 files if the original load fails.