### PR TITLE
Catch wrong number of ranks to MPI unit tests.

### DIFF
--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -110,8 +110,6 @@ public:
   MCPopulation(MCPopulation&&) = default;
   MCPopulation& operator=(MCPopulation&&) = default;
 
-  ~MCPopulation() {
-  }
   /** @ingroup PopulationControl
    *
    *  State Requirement:

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -71,7 +71,6 @@ IF(NOT QMC_CUDA AND ENABLE_SOA)
     #this is dependent on the directory creation and sym linking of earlier driver tests
     SET(DRIVER_TEST_SRC SetupPools.cpp test_WalkerControlMPI.cpp)
     ADD_EXECUTABLE(${UTEST_EXE} ${DRIVER_TEST_SRC})
-    USE_FAKE_RNG(${UTEST_EXE})
     #Way too many depenedencies make for very slow test linking
     TARGET_LINK_LIBRARIES(${UTEST_EXE} qmc qmcdriver_unit qmcham_unit qmcwfs qmcbase qmcutil qmcfakerng ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
     # Right now the unified driver mpi tests are hard coded for 3 MPI ranks

--- a/src/QMCDrivers/tests/SetupPools.cpp
+++ b/src/QMCDrivers/tests/SetupPools.cpp
@@ -22,7 +22,7 @@ SetupPools::SetupPools()
 {
   comm = OHMMS::Controller;
 
-  std::cout << "SetupPools::SetupPools()\n";
+  std::cout << "For purposes of multithreaded testing max threads is forced to 8" << '\n';
   Concurrency::OverrideMaxThreads<> override(8);
   
   particle_pool.reset(new ParticleSetPool(mpp(comm)));

--- a/src/QMCDrivers/tests/SetupPools.h
+++ b/src/QMCDrivers/tests/SetupPools.h
@@ -15,6 +15,7 @@
 #include "QMCApp/tests/MinimalParticlePool.h"
 #include "QMCApp/tests/MinimalWaveFunctionPool.h"
 #include "QMCApp/tests/MinimalHamiltonianPool.h"
+#include "Message/Communicate.h"
 #include "type_traits/template_types.hpp"
 
 namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_WalkerControlMPI.h
+++ b/src/QMCDrivers/tests/test_WalkerControlMPI.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers.
+// Copyright (c) 2020 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //

--- a/src/Utilities/MPIExceptionWrapper.hpp
+++ b/src/Utilities/MPIExceptionWrapper.hpp
@@ -38,7 +38,7 @@ void MPIExceptionWrapper::operator()(F&& f, Args&&... args)
   {
     f(std::forward<Args>(args)...);
   }
-  catch (const std::runtime_error& re)
+  catch (const std::exception& re)
   {
     APP_ABORT(re.what());
   }

--- a/src/Utilities/MPIExceptionWrapper.hpp
+++ b/src/Utilities/MPIExceptionWrapper.hpp
@@ -1,0 +1,55 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef MPIEXECPTIONWRAPPER_H
+#define MPIEXECPTIONWRAPPER_H
+
+#include "Message/Communicate.h"
+
+namespace qmcplusplus
+{
+
+class MPIExceptionWrapper
+{
+public:
+  MPIExceptionWrapper() {};
+
+  /** Call an arbitrary function that can throw an exception catch it, extract message,
+   *  and call APP_ABORT
+   *
+   */
+  template<typename F, typename... Args>
+  void operator()(F&& f, Args&&... args);
+
+};
+
+template<typename F, typename... Args>
+void MPIExceptionWrapper::operator()(F&& f, Args&&... args)
+{
+  try
+  {
+    f(std::forward<Args>(args)...);
+  }
+  catch (const std::runtime_error& re)
+  {
+    APP_ABORT(re.what());
+  }
+  catch (...)
+  {
+    APP_ABORT("MPIExceptionWrapper caught an unknown exception!");
+  }
+
+}
+
+}
+
+
+#endif /* MPIEXECPTIONWRAPPER_H */

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -23,3 +23,16 @@ TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 
 #ADD_TEST(NAME ${UTEST_NAME} COMMAND "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
 ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+
+IF(HAVE_MPI)
+  SET(UTEST_EXE test_${SRC_DIR}_mpi)
+  SET(UTEST_NAME deterministic-unit_test_${SRC_DIR}_mpi)
+  #this is dependent on the directory creation and sym linking of earlier driver tests
+  SET(MPI_UTILITY_TEST_SRC test_mpi_exception_wrapper.cpp)
+  ADD_EXECUTABLE(${UTEST_EXE} ${MPI_UTILITY_TEST_SRC})
+  USE_FAKE_RNG(${UTEST_EXE})
+  #Way too many depenedencies make for very slow test linking
+  TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
+  # Right now the unified driver mpi tests are hard coded for 3 MPI ranks
+  ADD_MPI_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}" 3)
+ENDIF(HAVE_MPI)

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ IF(HAVE_MPI)
   #this is dependent on the directory creation and sym linking of earlier driver tests
   SET(MPI_UTILITY_TEST_SRC test_mpi_exception_wrapper.cpp)
   ADD_EXECUTABLE(${UTEST_EXE} ${MPI_UTILITY_TEST_SRC})
-  USE_FAKE_RNG(${UTEST_EXE})
   #Way too many depenedencies make for very slow test linking
   TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
   # Right now the unified driver mpi tests are hard coded for 3 MPI ranks

--- a/src/Utilities/tests/test_mpi_exception_wrapper.cpp
+++ b/src/Utilities/tests/test_mpi_exception_wrapper.cpp
@@ -1,0 +1,54 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "Message/catch_mpi_main.hpp"
+
+#include "Utilities/MPIExceptionWrapper.hpp"
+#include "Message/Communicate.h"
+
+namespace qmcplusplus
+{
+/** Openmp generally works but is not guaranteed with std::atomic
+ */
+void mpiTestFunctionWrapped(Communicate* comm, std::vector<double> &fake_args)
+{
+  CHECK(fake_args.size() == 4);
+  
+  if (comm->size() != 3)
+    throw std::runtime_error("Bad Rank Count, test_mpi_exception_wrapper can only be run with 3 MPI ranks.");
+}
+
+TEST_CASE("MPIExceptionWrapper function case", "[Utilities]")
+{
+  Communicate* comm = OHMMS::Controller;
+
+  MPIExceptionWrapper mew;
+  std::vector<double> test_vec{1, 2, 3, 4};
+  mew(mpiTestFunctionWrapped, comm, test_vec);
+
+  // would really like to check for the MPIAbort but that kills the test program.
+}
+
+TEST_CASE("MPIExceptionWrapper lambda case", "[Utilities]")
+{
+  Communicate* comm = OHMMS::Controller;
+
+  MPIExceptionWrapper mew;
+  std::vector<double> test_vec{1, 2, 3, 4};
+  auto lambdaTestFunction = [](Communicate* comm, std::vector<double>& fake_args) {
+    CHECK(fake_args.size() == 4);
+    if (comm->size() != 3)
+      throw std::runtime_error("Bad Rank Count, test_mpi_exception_wrapper can only be run with 3 MPI ranks.");
+  };
+  mew(lambdaTestFunction, comm, test_vec);
+}
+
+} // namespace qmcplusplus


### PR DESCRIPTION
I also introduce a very simple abstraction Utilities/MPIExceptionWrapper.hpp to wrap unit test code using MPI exceptions thrown therein aren't lost and APP_ABORT is called.  This will help make sure we aren't chasing ghosts because someone has called the test directly with the "wrong" number of ranks or somehow overridden the rank count set by ADD_MPI_UNIT_TEST.