### PR TITLE
Workaround CUDA_ADD_LIBRARY bug.

### DIFF
--- a/src/QMCHamiltonians/CMakeLists.txt
+++ b/src/QMCHamiltonians/CMakeLists.txt
@@ -85,9 +85,11 @@ IF(OHMMS_DIM MATCHES 3)
   ENDIF(HAVE_LIBFFTW)
 
   IF(QMC_CUDA)
-    SET(HAMSRCS ${HAMSRCS}
+    SET(HAMSRCS_CUDA
       CudaCoulomb.cu 
       NLPP.cu
+    )
+    SET(HAMSRCS ${HAMSRCS}
       CoulombPBCAA_CUDA.cpp
       CoulombPBCAB_CUDA.cpp
       MPC_CUDA.cpp
@@ -100,16 +102,16 @@ IF(OHMMS_DIM MATCHES 3)
 
 ENDIF(OHMMS_DIM MATCHES 3)
 
+ADD_LIBRARY(qmcham ${HAMSRCS})
+ADD_LIBRARY(qmcham_unit ${HAMSRCS})
 IF(QMC_CUDA)
-  CUDA_ADD_LIBRARY(qmcham ${HAMSRCS})
-  CUDA_ADD_LIBRARY(qmcham_unit ${HAMSRCS})
-ELSE(QMC_CUDA)
-  ADD_LIBRARY(qmcham ${HAMSRCS})
-  ADD_LIBRARY(qmcham_unit ${HAMSRCS})
+  CUDA_ADD_LIBRARY(qmcham_cuda ${HAMSRCS_CUDA})
+  TARGET_LINK_LIBRARIES(qmcham qmcham_cuda)
+  TARGET_LINK_LIBRARIES(qmcham_unit qmcham_cuda)
 ENDIF(QMC_CUDA)
 
 USE_FAKE_RNG(qmcham_unit)
-target_link_libraries(qmcham_unit qmcfakerng)
+TARGET_LINK_LIBRARIES(qmcham_unit qmcfakerng)
 #IF(QMC_BUILD_STATIC)
 
 #IF(QMC_BUILD_STATIC)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

CUDA_ADD_LIBRARY seems not stateless.
```
  ADD_LIBRARY(qmcham ${HAMSRCS})
  ADD_LIBRARY(qmcham_unit ${HAMSRCS})
```
caused qmcham_unit target to build the cuda part of qmcham and caused a race with actually qmcham building its CUDA part.
This can be reproduced by `make test_drivers` and
```
src/QMCHamiltonians/CMakeFiles/qmcham.dir/qmcham_generated_NLPP.cu.o
```
shows up.

This PR takes out the *cu portion of ${HAMSRCS} and makes it a library which both qmcham and qmcham_unit depend on.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

My workstation

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
