### PR TITLE
Bug fix for molecular linear dependency issue #2291

### DIFF
--- a/utils/afqmctools/afqmctools/hamiltonian/converter.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/converter.py
@@ -138,9 +138,9 @@ def read_qmcpack_hamiltonian(filename, get_chol=True):
             'minus_k': minus_k,
             'qk_k2': qkk2
             }
+        return hamil
     except KeyError:
         pass
-
     try:
         hc, chol, enuc, nmo, nelec = read_qmcpack_sparse(filename,
                                                          get_chol=get_chol)
@@ -151,12 +151,13 @@ def read_qmcpack_hamiltonian(filename, get_chol=True):
             'nmo': nmo,
             'nelec': nelec
             }
+        return hamil
     except KeyError:
         pass
-
     try:
         hcore, chol, enuc = read_qmcpack_dense(filename)
         hamil = {'hcore': hcore, 'chol': chol, 'enuc': enuc}
+        return hamil
     except KeyError:
         print("Error reading Hamiltonian file. Unknown format.")
         hamil = None

--- a/utils/afqmctools/afqmctools/hamiltonian/mol.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/mol.py
@@ -81,9 +81,9 @@ def generate_hamiltonian(scf_data, chol_cut=1e-5, verbose=False, cas=None,
         print (" # Orthogonalising Cholesky vectors.")
     start = time.time()
     # Step 2.a Orthogonalise Cholesky vectors.
-    ao2mo_chol(chol_vecs, X)
+    chol_vecs = ao2mo_chol(chol_vecs, X)
     if verbose:
-        print (" # Time to orthogonalise: %f"%(time.time() - start))
+        print(" # Time to orthogonalise: %f"%(time.time() - start))
     enuc = mol.energy_nuc()
     # Step 3. (Optionally) freeze core / virtuals.
     nelec = mol.nelec
@@ -130,10 +130,17 @@ def freeze_core(h1e, chol, ecore, nc, ncas, verbose=True):
     return h1e, chol, efzc
 
 def ao2mo_chol(eri, C):
-    nb = C.shape[-1]
-    for i, cv in enumerate(eri):
-        half = numpy.dot(cv.reshape(nb,nb), C)
-        eri[i] = numpy.dot(C.T, half).ravel()
+    nao = C.shape[0]
+    nmo = C.shape[1]
+    nik = nmo*nmo
+    nchol = eri.shape[0]
+    eri_ = eri.ravel()
+    for i in range(nchol):
+        cv = eri[i].reshape(nao,nao)
+        half = numpy.dot(cv, C)
+        # if nao < nmo we overwrite the data
+        eri_[i*nik:(i+1)*nik] = numpy.dot(C.T, half).ravel()
+    return eri_[:nchol*nik].reshape((nchol,nik))
 
 def chunked_cholesky(mol, max_error=1e-6, verbose=False, cmax=10):
     """Modified cholesky decomposition from pyscf eris.

--- a/utils/afqmctools/afqmctools/hamiltonian/mol.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/mol.py
@@ -55,7 +55,7 @@ def generate_hamiltonian(scf_data, chol_cut=1e-5, verbose=False, cas=None,
             print(" # UHF integrals are not allowed. Use ortho AO option (-a/--ao).")
             sys.exit()
         X = scf_data['mo_coeff']
-    df_ints = scf_data['df_ints']
+    df_ints = scf_data.get('df_ints', None)
     C = scf_data['mo_coeff']
     # 3. Pyscf mol object.
     mol = scf_data['mol']

--- a/utils/afqmctools/afqmctools/hamiltonian/mol.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/mol.py
@@ -81,7 +81,7 @@ def generate_hamiltonian(scf_data, chol_cut=1e-5, verbose=False, cas=None,
         print (" # Orthogonalising Cholesky vectors.")
     start = time.time()
     # Step 2.a Orthogonalise Cholesky vectors.
-    chol_vecs = ao2mo_chol(chol_vecs, X)
+    chol_trans = ao2mo_chol(chol_vecs, X)
     if verbose:
         print(" # Time to orthogonalise: %f"%(time.time() - start))
     enuc = mol.energy_nuc()
@@ -93,7 +93,7 @@ def generate_hamiltonian(scf_data, chol_cut=1e-5, verbose=False, cas=None,
         if ncas == -1:
             ncas = nbasis - nfzc
         nfzv = nbasis - ncas - nfzc
-        h1e, chol_vecs, enuc = freeze_core(h1e, chol_vecs, enuc, nfzc, ncas,
+        h1e, chol_vecs, enuc = freeze_core(h1e, chol_trans, enuc, nfzc, ncas,
                                            verbose)
         h1e = h1e[0]
         nelec = (mol.nelec[0]-nfzc, mol.nelec[1]-nfzc)
@@ -102,7 +102,7 @@ def generate_hamiltonian(scf_data, chol_cut=1e-5, verbose=False, cas=None,
         orbs = numpy.identity(h1e.shape[-1])
         orbs = orbs[nfzc:nbasis-nfzv,nfzc:nbasis-nfzv]
         scf_data['mo_coeff'] = C[nfzc:nbasis-nfzv,nfzc:nbasis-nfzv]
-    return h1e, chol_vecs, nelec, enuc, X
+    return h1e, chol_trans, nelec, enuc, X
 
 
 def freeze_core(h1e, chol, ecore, nc, ncas, verbose=True):

--- a/utils/afqmctools/afqmctools/hamiltonian/tests/test_mol.py
+++ b/utils/afqmctools/afqmctools/hamiltonian/tests/test_mol.py
@@ -5,6 +5,7 @@ from pyscf import gto, ao2mo, scf, mcscf
 from afqmctools.hamiltonian.converter import read_qmcpack_sparse
 import afqmctools.hamiltonian.mol as mol
 from afqmctools.utils.linalg import modified_cholesky_direct
+from afqmctools.utils.testing import generate_hamiltonian
 
 class TestMol(unittest.TestCase):
 
@@ -38,6 +39,14 @@ class TestMol(unittest.TestCase):
         chol = mol.chunked_cholesky(atom, max_error=1e-5)
         mol.ao2mo_chol(chol, mf.mo_coeff)
         self.assertAlmostEqual(numpy.linalg.norm(chol), 3.52947146946)
+
+    def test_ao2mo_chol_rect(self):
+        numpy.random.seed(7)
+        h1e, chol, enuc, eri = generate_hamiltonian(17, 4)
+        X = numpy.random.random((17,15))
+        nchol = chol.shape[0]
+        chol_ = mol.ao2mo_chol(chol, X)
+        self.assertEqual(chol_.shape, (nchol, 15*15))
 
     def test_frozen_core(self):
         atom = gto.M(atom='Ne 0 0 0', basis='sto-3g', verbose=0)

--- a/utils/afqmctools/afqmctools/inputs/energy.py
+++ b/utils/afqmctools/afqmctools/inputs/energy.py
@@ -1,0 +1,64 @@
+import numpy
+from afqmctools.hamiltonian.converter import read_qmcpack_hamiltonian
+from afqmctools.wavefunction.converter import read_qmcpack_wavefunction
+
+
+def calculate_hf_energy(hamil_file, wfn_file):
+    hamil = read_qmcpack_hamiltonian(hamil_file)
+    wfn, psi0, nelec = read_qmcpack_wavefunction(wfn_file)
+    if isinstance(hamil['chol'], numpy.ndarray):
+        chol = hamil['chol']
+    else:
+        chol = hamil['chol'].toarray()
+    return local_energy_mol(hamil['hcore'], chol, hamil['enuc'], wfn[1][0], nelec)
+
+def local_energy_mol(hcore, chol, enuc, psi, nelec):
+    r"""Calculate local for generic two-body hamiltonian.
+
+    This uses the cholesky decomposed two-electron integrals.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    """
+    na, nb = nelec
+    nbasis = hcore.shape[0]
+    assert psi.shape[1] == na + nb
+    assert psi.shape[0] == nbasis
+    assert chol.shape[0] == nbasis*nbasis
+
+    # (M^2, nchol)
+    nchol = chol.shape[-1]
+    # Half-rotated green's functions
+    O = numpy.dot(psi[:,:na].T, psi[:,:na].conj())
+    Ga = numpy.dot(numpy.linalg.inv(O), psi[:,:na].T)
+    O = numpy.dot(psi[:,na:].T, psi[:,na:].conj())
+    Gb = numpy.dot(numpy.linalg.inv(O), psi[:,na:].T)
+
+    # Construct half rotated cholesky
+    # L[ak,n] = \sum_i A*[i,a] L[i,k,n]
+    rchol_a = numpy.tensordot(psi[:,:na].conj(),
+                              chol.reshape((nbasis,nbasis,-1)),
+                              axes=((0),(0))).reshape(nbasis*na,-1)
+    rchol_b = numpy.tensordot(psi[:,na:].conj(),
+                              chol.reshape((nbasis,nbasis,-1)),
+                              axes=((0),(0))).reshape(nbasis*nb,-1)
+    Xa = rchol_a.T.dot(Ga.ravel())
+    Xb = rchol_b.T.dot(Gb.ravel())
+    ecoul = numpy.dot(Xa,Xa)
+    ecoul += numpy.dot(Xb,Xb)
+    ecoul += 2*numpy.dot(Xa,Xb)
+    # T_{abn} = \sum_k Theta_{ak} LL_{ak,n}
+    # LL_{ak,n} = \sum_i L_{ik,n} A^*_{ia}
+    Ta = numpy.tensordot(Ga, rchol_a.reshape((na,nbasis,-1)), axes=((1),(1)))
+    exxa = numpy.tensordot(Ta, Ta, axes=((0,1,2),(1,0,2)))
+    Tb = numpy.tensordot(Gb, rchol_b.reshape((nb,nbasis,-1)), axes=((1),(1)))
+    exxb = numpy.tensordot(Tb, Tb, axes=((0,1,2),(1,0,2)))
+    exx = exxa + exxb
+    e2b = 0.5 * (ecoul - exx)
+    Ga = numpy.dot(psi[:,:na].conj(), Ga)
+    Gb = numpy.dot(psi[:,na:].conj(), Gb)
+    e1b = numpy.sum(hcore*(Ga+Gb))
+    return (e1b + e2b + enuc, e1b + enuc, e2b)

--- a/utils/afqmctools/afqmctools/inputs/from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/from_pyscf.py
@@ -8,6 +8,7 @@ except ImportError:
 from afqmctools.hamiltonian.supercell import write_hamil_supercell
 from afqmctools.hamiltonian.kpoint import write_hamil_kpoints
 from afqmctools.hamiltonian.mol import write_hamil_mol
+from afqmctools.inputs.energy import calculate_hf_energy
 from afqmctools.utils.qmcpack_utils import write_xml_input
 from afqmctools.utils.pyscf_utils import (
         load_from_pyscf_chk,
@@ -17,7 +18,7 @@ from afqmctools.wavefunction.mol import write_wfn_mol
 from afqmctools.wavefunction.pbc import write_wfn_pbc
 
 
-def write_qmcpack(comm, chkfile, hamil_file, threshold,
+def write_qmcpack(chkfile, hamil_file, threshold, comm=None,
                   ortho_ao=False, gdf=False, kpoint=False, verbose=False,
                   cas=None, qmc_input=None, wfn_file=None,
                   write_hamil=True, ndet_max=None, real_chol=False,
@@ -48,13 +49,12 @@ def write_qmcpack(comm, chkfile, hamil_file, threshold,
             nelec = write_wfn_pbc(scf_data, ortho_ao, wfn_file, verbose=verbose,
                                   ndet_max=ndet_max, low=low, high=high)
     else:
-        if comm.rank == 0 and verbose:
+        if verbose:
             print(" # Generating Hamiltonian and wavefunction from pyscf mol"
                   " object.")
-        if comm.size > 1:
-            if comm.rank == 0:
-                print(" # Error molecular integral generation must be done "
-                      "in serial.")
+        if comm is not None and comm.size > 1:
+            print(" # Error molecular integral generation must be done "
+                  "in serial.")
             sys.exit()
         scf_data = load_from_pyscf_chk_mol(chkfile)
         if write_hamil:
@@ -63,6 +63,12 @@ def write_qmcpack(comm, chkfile, hamil_file, threshold,
                             ortho_ao=ortho_ao, real_chol=real_chol,
                             dense=dense)
         write_wfn_mol(scf_data, ortho_ao, wfn_file)
+        if verbose > 1:
+            print(" # Recomputing single-determinant Hartree--Fock energy.")
+            etot, e1b, e2b = calculate_hf_energy(hamil_file, wfn_file)
+            print(" # ETotal : {: 13.10f}".format(etot.real))
+            print(" # E1Body : {: 13.10f}".format(e1b.real))
+            print(" # E2Body : {: 13.10f}".format(e2b.real))
 
-    if comm.rank == 0 and qmc_input is not None:
+    if qmc_input is not None and (comm is None or comm.rank == 0):
         write_xml_input(qmc_input, hamil_file, wfn_file=wfn_file)

--- a/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+from pyscf import gto, scf
+from afqmctools.hamiltonian.mol import generate_hamiltonian
+from afqmctools.inputs.from_pyscf import write_qmcpack
+from afqmctools.inputs.energy import calculate_hf_energy
+from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
+
+class TestEnergy(unittest.TestCase):
+
+    def test_from_pyscf(self):
+        atom = gto.M(atom='Ne 0 0 0', basis='sto-3g', verbose=0)
+        mf = scf.RHF(atom)
+        mf.chkfile = 'scf.chk'
+        energy = mf.kernel()
+        self.assertAlmostEqual(energy, -126.60452499805)
+        write_qmcpack('scf.chk', 'afqmc.h5', 1e-5, wfn_file='afqmc.h5',
+                      dense=True, real_chol=True, verbose=2)
+        assert False
+        # etot, e1b, e2b = calculate_hf_energy('afqmc.h5', 'afqmc.h5')
+        # self.assertAlmostEqual(etot, -126.60452499805)
+
+    def tearDown(self):
+        cwd = os.getcwd()
+        files = ['afqmc.h5', 'scf.chk']
+        for f in files:
+            try:
+                os.remove(cwd+'/'+f)
+            except OSError:
+                pass

--- a/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
@@ -16,9 +16,8 @@ class TestEnergy(unittest.TestCase):
         self.assertAlmostEqual(energy, -126.60452499805)
         write_qmcpack('scf.chk', 'afqmc.h5', 1e-5, wfn_file='afqmc.h5',
                       dense=True, real_chol=True, verbose=2)
-        assert False
-        # etot, e1b, e2b = calculate_hf_energy('afqmc.h5', 'afqmc.h5')
-        # self.assertAlmostEqual(etot, -126.60452499805)
+        etot, e1b, e2b = calculate_hf_energy('afqmc.h5', 'afqmc.h5')
+        self.assertAlmostEqual(etot, -126.60452499805)
 
     def tearDown(self):
         cwd = os.getcwd()

--- a/utils/afqmctools/afqmctools/utils/io.py
+++ b/utils/afqmctools/afqmctools/utils/io.py
@@ -10,8 +10,11 @@ def to_qmcpack_complex(array):
     shape = array.shape
     return array.view(numpy.float64).reshape(shape+(2,))
 
-def from_qmcpack_cplx(arr):
-    return arr.view(numpy.complex128).ravel()
+def from_qmcpack_complex(data, shape=None):
+    if shape is not None:
+        return data.view(numpy.complex128).ravel().reshape(shape)
+    else:
+        return data.view(numpy.complex128).ravel()
 
 def add_dataset(fh5, name, value):
     try:

--- a/utils/afqmctools/afqmctools/utils/qmcpack_utils.py
+++ b/utils/afqmctools/afqmctools/utils/qmcpack_utils.py
@@ -1,6 +1,5 @@
 import h5py
 import xml.etree.ElementTree as et
-from afqmctools.wavefunction.mol import read_qmcpack_wfn
 
 def write_xml_input(qmc_in, hamil_file, wfn_file, id_name='qmc', series=0,
                     rng_seed=None, options=None):

--- a/utils/afqmctools/afqmctools/wavefunction/converter.py
+++ b/utils/afqmctools/afqmctools/wavefunction/converter.py
@@ -1,7 +1,9 @@
 import ast
 import h5py
 import numpy
+import scipy.sparse
 import struct
+from afqmctools.utils.io import from_qmcpack_complex
 
 def read_qmcpack_ascii_wavefunction(filename, nmo, nelec):
     na, nb = nelec
@@ -146,7 +148,7 @@ def get_occupied(det, nel, nmo):
         shift += 64
     return occs
 
-def read_qmcpack_ci_wavefunction(input_file, nelec, nmo, ndets=None):
+def read_dmc_ci_wavefunction(input_file, nelec, nmo, ndets=None):
     if ndets is None:
         ndets = -1
     na, nb = nelec
@@ -191,7 +193,7 @@ def write_phf_rhf(fname, cf):
         cfx[0::2] = cf.reshape((nb*no,), order='F')[:]
     cf_ = struct.pack('d'*(nb*no*2), *cfx)
 
-    with open(fname, 'wb') as f
+    with open(fname, 'wb') as f:
         f.write(i1_)
         f.write(ia_)
         f.write(i1_)
@@ -226,10 +228,100 @@ def write_phf_uhf(fname, cf):
         cfx[2*nb*no+0::2] = cf[1].reshape((nb*no,), order='F')[:]
     cf_ = struct.pack('d'*(nb*no*4), *cfx)
 
-    with open(fname, 'wb') as f
+    with open(fname, 'wb') as f:
         f.write(i1_)
         f.write(ia_)
         f.write(i1_)
         f.write(i2_)
         f.write(cf_)
         f.write(i2_)
+
+def read_qmcpack_wavefunction(filename):
+    try:
+        with h5py.File(filename, 'r') as fh5:
+            wgroup = fh5['Wavefunction/NOMSD']
+            wfn, psi0, nelec = read_qmcpack_nomsd_hdf5(wgroup)
+    except KeyError:
+        with h5py.File(filename, 'r') as fh5:
+            wgroup = fh5['Wavefunction/PHMSD']
+            wfn, psi0, nelec = read_qmcpack_phmsd_hdf5(wgroup)
+    except KeyError:
+        print("Wavefunction not found.")
+        sys.exit()
+    return wfn, psi0, nelec
+
+def read_qmcpack_nomsd_hdf5(wgroup):
+    dims = wgroup['dims']
+    nmo = dims[0]
+    na = dims[1]
+    nb = dims[2]
+    walker_type = dims[3]
+    if walker_type == 2:
+        uhf = True
+    else:
+        uhf = False
+    nci = dims[4]
+    coeffs = from_qmcpack_complex(wgroup['ci_coeffs'][:], (nci,))
+    psi0a = from_qmcpack_complex(wgroup['Psi0_alpha'][:], (nmo,na))
+    if uhf:
+        psi0b = from_qmcpack_complex(wgroup['Psi0_beta'][:], (nmo,nb))
+    psi0 = numpy.zeros((nmo,na+nb),dtype=numpy.complex128)
+    psi0[:,:na] = psi0a.copy()
+    if uhf:
+        psi0[:,na:] = psi0b.copy()
+    else:
+        psi0[:,na:] = psi0a[:,:nb].copy()
+    wfn = numpy.zeros((nci,nmo,na+nb), dtype=numpy.complex128)
+    for idet in range(nci):
+        ix = 2*idet if uhf else idet
+        pa = orbs_from_dset(wgroup['PsiT_{:d}/'.format(idet)])
+        wfn[idet,:,:na] = pa
+        if uhf:
+            ix = 2*idet + 1
+            wfn[idet,:,na:] = orbs_from_dset(wgroup['PsiT_{:d}/'.format(ix)])
+        else:
+            wfn[idet,:,na:] = pa[:,:nb]
+    return (coeffs,wfn), psi0, (na, nb)
+
+def read_qmcpack_phmsd_hdf5(wgroup):
+    dims = wgroup['dims']
+    nmo = dims[0]
+    na = dims[1]
+    nb = dims[2]
+    walker_type = dims[3]
+    if walker_type == 2:
+        uhf = True
+    else:
+        uhf = False
+    nci = dims[4]
+    coeffs = from_qmcpack_complex(wgroup['ci_coeffs'][:], (nci,))
+    occs = wgroup['occs'][:].reshape((nci,na+nb))
+    occa = occs[:,:na]
+    occb = occs[:,na:]-nmo
+    wfn = (coeffs, occa, occb)
+    psi0a = from_qmcpack_complex(wgroup['Psi0_alpha'][:], (nmo,na))
+    if uhf:
+        psi0b = from_qmcpack_complex(wgroup['Psi0_beta'][:], (nmo,nb))
+    psi0 = numpy.zeros((nmo,na+nb),dtype=numpy.complex128)
+    psi0[:,:na] = psi0a.copy()
+    if uhf:
+        psi0[:,na:] = psi0b.copy()
+    else:
+        psi0[:,na:] = psi0a.copy()
+    return wfn, psi0, (na,nb)
+
+def orbs_from_dset(dset):
+    """Will read actually A^{H} but return A.
+    """
+    dims = dset['dims'][:]
+    wfn_shape = (dims[0],dims[1])
+    nnz = dims[2]
+    data = from_qmcpack_complex(dset['data_'][:],(nnz,))
+    indices = dset['jdata_'][:]
+    pbb = dset['pointers_begin_'][:]
+    pbe = dset['pointers_end_'][:]
+    indptr = numpy.zeros(dims[0]+1)
+    indptr[:-1] = pbb
+    indptr[-1] = pbe[-1]
+    wfn = scipy.sparse.csr_matrix((data,indices,indptr),shape=wfn_shape)
+    return wfn.toarray().conj().T.copy()

--- a/utils/afqmctools/afqmctools/wavefunction/mol.py
+++ b/utils/afqmctools/afqmctools/wavefunction/mol.py
@@ -35,9 +35,9 @@ def write_wfn_mol(scf_data, ortho_ao, filename, wfn=None,
     uhf = scf_data['isUHF']
     # For RHF only nalpha entries will be filled.
     if uhf:
-        norb = C[0].shape[0]
+        norb = C[0].shape[-1]
     else:
-        norb = C.shape[0]
+        norb = C.shape[-1]
     if wfn is None:
         wfn = numpy.zeros((1,norb,nalpha+nbeta), dtype=numpy.complex128)
         wfn_type = 'NOMSD'

--- a/utils/afqmctools/afqmctools/wavefunction/mol.py
+++ b/utils/afqmctools/afqmctools/wavefunction/mol.py
@@ -302,14 +302,6 @@ def gen_multi_det_wavefunction(mc, weight_cutoff=0.95, verbose=False,
     return coeffs, [occups,occdns]
 
 
-def read_qmcpack_wfn(filename, nskip=9):
-    with open(filename) as f:
-        content = f.readlines()[nskip:]
-    useable = numpy.array([c.split() for c in content]).flatten()
-    tuples = [ast.literal_eval(u) for u in useable]
-    orbs = [complex(t[0], t[1]) for t in tuples]
-    return numpy.array(orbs)
-
 def write_phmsd_wfn(filename, occs, nmo, ncore=0):
     output = open(filename, 'w')
     namelist = "&FCI\n UHF = 0\n NCI = %d\n TYPE = occ\n&END" % len(occs)

--- a/utils/afqmctools/bin/pyscf_to_afqmc.py
+++ b/utils/afqmctools/bin/pyscf_to_afqmc.py
@@ -135,8 +135,9 @@ def main(args):
             options.wfn_file = 'wfn.dat'
         else:
             options.wfn_file = options.hamil_file
-    write_qmcpack(comm, options.chk_file, options.hamil_file,
-                  options.thresh, ortho_ao=options.ortho_ao,
+    write_qmcpack(options.chk_file, options.hamil_file, options.thresh,
+                  comm=comm,
+                  ortho_ao=options.ortho_ao,
                   kpoint=options.kpoint_sym, gdf=options.gdf,
                   verbose=options.verbose, cas=options.cas,
                   qmc_input=options.qmc_input,


### PR DESCRIPTION
## Proposed changes

Fix for AO->MO transformation matrix which has lost MOs due to linear dependencies. Addresses  #2291.
I added a test for this and in the process needed the ability to recompute the HF energy. The HF energy can be printed by the used if the verbosity is set to high (-vvv).
  
## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [X] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

## What systems has this change been tested on?
Unit tests and problematic case raised in issue. Tested on macbook pro python3.7.4, pyscf v1.7.0

## Checklist

- [X] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [X] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [X] documentation has been added (if appropriate)
