### PR TITLE
Fix linear dependency issue 

### DIFF
--- a/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/tests/test_from_pyscf.py
@@ -1,10 +1,12 @@
 import os
 import unittest
+import h5py
 from pyscf import gto, scf
 from afqmctools.hamiltonian.mol import generate_hamiltonian
 from afqmctools.inputs.from_pyscf import write_qmcpack
 from afqmctools.inputs.energy import calculate_hf_energy
 from afqmctools.utils.pyscf_utils import load_from_pyscf_chk_mol
+from afqmctools.utils.linalg import get_ortho_ao_mol
 
 class TestEnergy(unittest.TestCase):
 
@@ -14,10 +16,26 @@ class TestEnergy(unittest.TestCase):
         mf.chkfile = 'scf.chk'
         energy = mf.kernel()
         self.assertAlmostEqual(energy, -126.60452499805)
-        write_qmcpack('scf.chk', 'afqmc.h5', 1e-5, wfn_file='afqmc.h5',
-                      dense=True, real_chol=True, verbose=2)
+        write_qmcpack('scf.chk', 'afqmc.h5', 1e-8, wfn_file='afqmc.h5',
+                      dense=True, real_chol=True)
         etot, e1b, e2b = calculate_hf_energy('afqmc.h5', 'afqmc.h5')
         self.assertAlmostEqual(etot, -126.60452499805)
+
+    def test_from_pyscf_lindep(self):
+        atom = gto.M(atom='Ne 0 0 0', basis='aug-ccpvtz', verbose=0)
+        from pyscf.scf.addons import remove_linear_dep_
+        mf = scf.RHF(atom)
+        remove_linear_dep_(mf, 0.1, 0.1)
+        mf.chkfile = 'scf.chk'
+        energy = mf.kernel()
+        X = get_ortho_ao_mol(atom.intor('int1e_ovlp_sph'), 0.1)
+        with h5py.File('scf.chk', 'r+') as fh5:
+            fh5['scf/orthoAORot'] = X
+        self.assertAlmostEqual(energy,  -128.11089429105502)
+        write_qmcpack('scf.chk', 'afqmc.h5', 1e-8, wfn_file='afqmc.h5',
+                      dense=True, real_chol=True, ortho_ao=True)
+        etot, e1b, e2b = calculate_hf_energy('afqmc.h5', 'afqmc.h5')
+        self.assertAlmostEqual(etot, -128.11089429105502)
 
     def tearDown(self):
         cwd = os.getcwd()

--- a/utils/afqmctools/afqmctools/wavefunction/mol.py
+++ b/utils/afqmctools/afqmctools/wavefunction/mol.py
@@ -43,7 +43,10 @@ def write_wfn_mol(scf_data, ortho_ao, filename, wfn=None,
         wfn_type = 'NOMSD'
         coeffs = numpy.array([1.0+0j])
         if ortho_ao:
-            Xinv = scipy.linalg.inv(X)
+            if X.shape[0] != X.shape[1]:
+                Xinv = scipy.linalg.pinv(X)
+            else:
+                Xinv = scipy.linalg.inv(X)
             if uhf:
                 # We are assuming C matrix is energy ordered.
                 wfn[0,:,:nalpha] = numpy.dot(Xinv, C[0])[:,:nalpha]

--- a/utils/afqmctools/bin/pyscf_to_afqmc.py
+++ b/utils/afqmctools/bin/pyscf_to_afqmc.py
@@ -35,20 +35,18 @@ def parse_args(args, comm):
                             help='Output file name for QMCPACK hamiltonian.')
         parser.add_argument('-w', '--wavefunction', dest='wfn_file',
                             type=str, default=None,
-                            help='Output file name for QMCPACK hamiltonian.')
+                            help='Output file name for QMCPACK wavefunction. '
+                                 'By default will write to hamil_file.')
         parser.add_argument('-q', '--qmcpack-input', dest='qmc_input',
                             type=str, default=None,
-                            help='Generate skeleton QMCPACK input file.')
+                            help='Generate skeleton QMCPACK input xml file.')
         parser.add_argument('-t', '--cholesky-threshold', dest='thresh',
                             type=float, default=1e-5,
                             help='Cholesky convergence threshold.')
         parser.add_argument('-k', '--kpoint', dest='kpoint_sym',
                             action='store_true', default=False,
                             help='Generate explicit kpoint dependent integrals.')
-        parser.add_argument('-g', '--gdf', dest='gdf',
-                            action='store_true', default=False,
-                            help='Use Gaussian density fitting.')
-        parser.add_argument('-a', '--ao', dest='ortho_ao',
+        parser.add_argument('-a', '--ao', '--ortho-ao', dest='ortho_ao',
                             action='store_true', default=False,
                             help='Transform to ortho AO basis. Default assumes '
                             'we work in MO basis')
@@ -65,7 +63,7 @@ def parse_args(args, comm):
                             'generate.')
         parser.add_argument('-r', '--real-ham', dest='real_chol',
                             action='store_true', default=False,
-                            help='Write integrals as real numbers')
+                            help='Write integrals as real numbers.')
         parser.add_argument('-p', '--phdf', dest='phdf',
                             action='store_true', default=False,
                             help='Use parallel hdf5.')

--- a/utils/afqmctools/bin/wfn_to_hdf5.py
+++ b/utils/afqmctools/bin/wfn_to_hdf5.py
@@ -7,7 +7,7 @@ import time
 from afqmctools.wavefunction.mol import write_qmcpack_wfn
 from afqmctools.wavefunction.converter import (
         read_qmcpack_ascii_wavefunction,
-        read_qmcpack_ci_wavefunction
+        read_dmc_ci_wavefunction
         )
 
 
@@ -72,7 +72,7 @@ def main(args):
     nelec = (nalpha, nbeta)
     if options.qmcpack:
         wfn, walker_type, nmo, nelec = (
-                read_qmcpack_ci_wavefunction(input_file, nelec, nmo, options.ndets)
+                read_dmc_ci_wavefunction(input_file, nelec, nmo, options.ndets)
                 )
     else:
         wfn, walker_type = read_qmcpack_ascii_wavefunction(input_file, nmo, nelec)


### PR DESCRIPTION
## Proposed changes
Follow up for #2292 which deals with case when overlap is singular and we want to work in orthogonalised AO basis. Replaces inverse with pseudo inverse in this case as transformation matrix is rectangular. 
Also tidied some help message in converter.

## What type(s) of changes does this code introduce?


- [X] Bugfix


### Does this introduce a breaking change?

- [ ] Yes
- [X] No

## What systems has this change been tested on?

Laptop

## Checklist

- [X] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [X] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
