### PR TITLE
Finish removing gdf option for afqmctools

### DIFF
--- a/utils/afqmctools/afqmctools/inputs/from_pyscf.py
+++ b/utils/afqmctools/afqmctools/inputs/from_pyscf.py
@@ -19,7 +19,7 @@ from afqmctools.wavefunction.pbc import write_wfn_pbc
 
 
 def write_qmcpack(chkfile, hamil_file, threshold, comm=None,
-                  ortho_ao=False, gdf=False, kpoint=False, verbose=False,
+                  ortho_ao=False, kpoint=False, verbose=False,
                   cas=None, qmc_input=None, wfn_file=None,
                   write_hamil=True, ndet_max=None, real_chol=False,
                   phdf=False, low=0.1, high=0.95, dense=False):

--- a/utils/afqmctools/bin/pyscf_to_afqmc.py
+++ b/utils/afqmctools/bin/pyscf_to_afqmc.py
@@ -136,7 +136,7 @@ def main(args):
     write_qmcpack(options.chk_file, options.hamil_file, options.thresh,
                   comm=comm,
                   ortho_ao=options.ortho_ao,
-                  kpoint=options.kpoint_sym, gdf=options.gdf,
+                  kpoint=options.kpoint_sym, 
                   verbose=options.verbose, cas=options.cas,
                   qmc_input=options.qmc_input,
                   wfn_file=options.wfn_file,


### PR DESCRIPTION

## Proposed changes

PR #2294 removed the `gdf` command line option to `pyscf_to_afqmc.py`, but the option was still being passed to `write_qmcpack` which was breaking it.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
