### PR TITLE
Avoid checklists in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,30 +7,29 @@ Describe what this PR changes and why.  If it closes an issue, link to it here
 with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 ## What type(s) of changes does this code introduce?
-_Put an `x` in the boxes that apply._
+_Delete the items that do not apply_
 
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Code style update (formatting, renaming)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] Documentation content changes
-- [ ] Other (please describe):
+- Bugfix
+- New feature
+- Code style update (formatting, renaming)
+- Refactoring (no functional changes, no api changes)
+- Build related changes
+- Documentation content changes
+- Other (please describe):
 
 ### Does this introduce a breaking change?
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
 
 ## What systems has this change been tested on?
 
 ## Checklist
 
-_Put an x in the boxes that apply. You can also fill these out after creating
-the PR. If you're unsure about any of them, don't hesitate to ask.  This is
+_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
 simply a reminder of what we are going to look for before merging your code._
 
-- [ ] this PR is up to date with current the current state of 'develop'
-- [ ] code added or changed in the PR has been clang-formatted
-- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
-- [ ] documentation has been added (if appropriate)
+- Yes/No. This PR is up to date with current the current state of 'develop'
+- Yes/No. Code added or changed in the PR has been clang-formatted
+- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
+- Yes/No. Documentation has been added (if appropriate)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Update formatting to avoid checklist progress feature in PR listings.
Per GitHub support, these can not be disabled.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): GitHub

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
