### PR TITLE
Remove unused WF optimization parameters

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
@@ -65,7 +65,6 @@ QMCCorrelatedSamplingLinearOptimize::QMCCorrelatedSamplingLinearOptimize(MCWalke
   //read to use vmc output (just in case)
   RootName = "pot";
   QMCType  = "QMCCorrelatedSamplingLinearOptimize";
-  m_param.add(WarmupBlocks, "warmupBlocks", "int");
   m_param.add(stabilizerScale, "stabilizerscale", "double");
   m_param.add(bigChange, "bigchange", "double");
   m_param.add(w_beta, "beta", "double");

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -100,7 +100,6 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration
   //read to use vmc output (just in case)
   RootName = "pot";
   QMCType  = "QMCFixedSampleLinearOptimize";
-  m_param.add(WarmupBlocks, "warmupBlocks", "int");
   m_param.add(Max_iterations, "max_its", "int");
   m_param.add(nstabilizers, "nstabilizers", "int");
   m_param.add(stabilizerScale, "stabilizerscale", "double");

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
@@ -49,7 +49,6 @@ QMCLinearOptimize::QMCLinearOptimize(MCWalkerConfiguration& w,
     : QMCDriver(w, psi, h, ppool, comm),
       PartID(0),
       NumParts(1),
-      WarmupBlocks(10),
       hamPool(hpool),
       wfNode(NULL),
       optNode(NULL),
@@ -172,11 +171,6 @@ void QMCLinearOptimize::finish()
 void QMCLinearOptimize::generateSamples()
 {
   app_log() << "<optimization-report>" << std::endl;
-  //if(WarmupBlocks)
-  //{
-  //  app_log() << "<vmc stage=\"warm-up\" blocks=\"" << WarmupBlocks << "\">" << std::endl;
-  //  //turn off QMC_OPTIMIZE
-  //  vmcEngine->setValue("blocks",WarmupBlocks);
   vmcEngine->qmc_driver_mode.set(QMC_WARMUP, 1);
   //  vmcEngine->run();
   //  vmcEngine->setValue("blocks",nBlocks);

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.h
@@ -72,9 +72,7 @@ public:
   int PartID;
   ///total number of partitions that will share a set of configuratons
   int NumParts;
-  ///total number of Warmup Blocks
-  int WarmupBlocks;
-  ///total number of Warmup Blocks
+  ///total number of VMC walkers
   int NumOfVMCWalkers;
   ///Number of iterations maximum before generating new configurations.
   int Max_iterations;

--- a/src/QMCDrivers/WFOpt/QMCOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimize.cpp
@@ -41,8 +41,6 @@ QMCOptimize::QMCOptimize(MCWalkerConfiguration& w,
     : QMCDriver(w, psi, h, ppool, comm),
       PartID(0),
       NumParts(1),
-      WarmupBlocks(10),
-      SkipSampleGeneration("no"),
       hamPool(hpool),
       optSolver(0),
       vmcEngine(0),
@@ -57,8 +55,6 @@ QMCOptimize::QMCOptimize(MCWalkerConfiguration& w,
   QMCType  = "QMCOptimize";
   //default method is cg
   optmethod = "cg";
-  m_param.add(WarmupBlocks, "warmupBlocks", "int");
-  m_param.add(SkipSampleGeneration, "skipVMC", "string");
 }
 
 /** Clean up the vector */

--- a/src/QMCDrivers/WFOpt/QMCOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCOptimize.h
@@ -64,12 +64,8 @@ private:
   int PartID;
   ///total number of partitions that will share a set of configuratons
   int NumParts;
-  ///total number of Warmup Blocks
-  int WarmupBlocks;
-  ///total number of Warmup Blocks
+  ///total number of VMC walkers
   int NumOfVMCWalkers;
-  ///yes/no applicable only first time
-  std::string SkipSampleGeneration;
   ///need to know HamiltonianPool to use OMP
   HamiltonianPool& hamPool;
   ///target cost function to optimize


### PR DESCRIPTION


Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

The 'skipVMC' and 'warmupBlocks' parameters are unused in the code (and the tests and examples).   Remove them.



## What type(s) of changes does this code introduce?

- Other (please describe): Code cleanup

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- N/A This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
