### PR TITLE
SOECPotential implementation

### DIFF
--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -68,6 +68,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   std::string use_DLA("no");
   std::string pbc("yes");
   std::string forces("no");
+  std::string physicalSO("no");
 
   OhmmsAttributeSet pAttrib;
   pAttrib.add(ecpFormat, "format");
@@ -151,6 +152,13 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   }
   if (hasSOPot)
   {
+    if (physicalSO == "yes")
+      app_log() << "    Spin-Orbit potential included in local energy" << std::endl;
+    else if (physicalSO == "no")
+      app_log() << "    Spin-Orbit potential is not included in local energy" << std::endl;
+    else
+      APP_ABORT("physicalSO must be set to yes/no. Unknown option give\n");
+
     SOECPotential* apot = new SOECPotential(IonConfig, targetPtcl, targetPsi);
     int nknot_max       = 0;
     int sknot_max       = 0;
@@ -167,7 +175,10 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
               << "    Maximum grid on a sphere for SOECPotential: " << nknot_max << std::endl;
     app_log() << "    Maximum grid for Simpson's rule for spin integral: " << sknot_max << std::endl;
 
-    targetH.addOperator(apot, "SOECP"); //default is physical operator
+    if (physicalSO == "yes")
+      targetH.addOperator(apot, "SOECP"); //default is physical operator
+    else
+      targetH.addOperator(apot, "SOECP", false);
   }
   if (hasL2Pot)
   {

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -76,6 +76,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   pAttrib.add(use_DLA, "DLA");
   pAttrib.add(pbc, "pbc");
   pAttrib.add(forces, "forces");
+  pAttrib.add(physicalSO, "physicalSO");
   pAttrib.put(cur);
 
   bool doForces = (forces == "yes") || (forces == "true");

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -152,6 +152,9 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   }
   if (hasSOPot)
   {
+#ifndef QMC_COMPLEX
+    APP_ABORT("SOECPotential evaluations require complex build. Rebuild with -D QMC_COMPLEX=1\n");
+#endif
     if (physicalSO == "yes")
       app_log() << "    Spin-Orbit potential included in local energy" << std::endl;
     else if (physicalSO == "no")

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -25,15 +25,19 @@ namespace qmcplusplus
  *\param psi Trial wave function
 */
 SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi)
-    : myRNG(&Random), IonConfig(ions), Psi(psi), Peln(els), ElecNeighborIons(els), IonNeighborElecs(ions)
+    : myRNG(nullptr), 
+      IonConfig(ions), 
+      Psi(psi), 
+      Peln(els), 
+      ElecNeighborIons(els), 
+      IonNeighborElecs(ions)
 {
-  //set_energy_domain(potential);
-  //two_body_quantum_domain(ions,els);
+  set_energy_domain(potential);
+  two_body_quantum_domain(ions,els);
   myTableIndex = els.addTable(ions, DT_SOA_PREFERRED);
   NumIons      = ions.getTotalNum();
   PP.resize(NumIons, nullptr);
   PPset.resize(IonConfig.getSpeciesSet().getTotalNum(), 0);
-  //UpdateMode.set(NONLOCAL,1);
 }
 
 //destructor
@@ -41,9 +45,54 @@ SOECPotential::~SOECPotential() { delete_iter(PPset.begin(), PPset.end()); }
 
 void SOECPotential::resetTargetParticleSet(ParticleSet& P) {}
 
-SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P) { return 0.0; }
+SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P) 
+{
+  Value = 0.0;
+  for (int ipp=0; ipp < PPset.size(); ipp++)
+    if(PPset[ipp])
+      PPset[ipp]->randomize_grid(*myRNG);
+  const auto& myTable = P.getDistTable(myTableIndex);
+  for (int iat = 0; iat < NumIons; iat++)
+    IonNeighborElecs.getNeighborList(iat).clear();
+  for (int jel = 0; jel < P.getTotalNum(); jel++)
+    ElecNeighborIons.getNeighborList(jel).clear();
 
-OperatorBase* SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return 0; }
+  if (myTable.DTType == DT_SOA)
+  {
+    for (int jel = 0; jel < P.getTotalNum(); jel++)
+    {
+      const auto& dist               = myTable.getDistRow(jel);
+      const auto& displ              = myTable.getDisplRow(jel);
+      std::vector<int>& NeighborIons = ElecNeighborIons.getNeighborList(jel);
+      for (int iat = 0; iat < NumIons; iat++)
+        if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
+        {
+          RealType pairpot = PP[iat]->evaluateOne(P, iat, Psi, jel, dist[iat], -displ[iat]);
+          Value += pairpot;
+          NeighborIons.push_back(iat);
+          IonNeighborElecs.getNeighborList(iat).push_back(jel);
+        }
+    }
+  }
+  else
+  {
+    APP_ABORT("SOECPotential::evaluate(): AOS is deprecated. Distance tables must be SOA\n");
+  }
+} 
+
+OperatorBase* SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi) 
+{
+  SOECPotential* myclone = new SOECPotential(IonConfig, qp, psi);
+  for (int ig = 0; ig < PPset.size(); ++ig)
+  {
+    if (PPset[ig])
+    {
+      SOECPComponent* ppot = PPset[ig]->makeClone(qp);
+      myclone->addComponent(ig,ppot);
+    }
+  }
+  return myclone;
+}
 
 void SOECPotential::addComponent(int groupID, SOECPComponent* ppot)
 {
@@ -54,6 +103,5 @@ void SOECPotential::addComponent(int groupID, SOECPComponent* ppot)
     }
   PPset[groupID] = ppot;
 }
-
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -32,7 +32,7 @@ public:
 
   Return_t evaluate(ParticleSet& P);
 
-  bool put(xmlNodePtr cur) { return true; }
+  bool put(xmlNodePtr cur) override { return true; }
 
   bool get(std::ostream& os) const
   {
@@ -43,6 +43,8 @@ public:
   OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
 
   void addComponent(int groupID, SOECPComponent* pp);
+
+  void setRandomGenerator(RandomGenerator_t* rng) override { myRNG = rng; }
 
 protected:
   RandomGenerator_t* myRNG;


### PR DESCRIPTION
## Proposed changes

This PR implements the evaluation of the Spin-Orbit Potential, that was introduced in  #2312 . Just like the ECPotential Builder manages and creates the Local and NonLocalPotentials, it now creates another potential for the total Spin-Orbit contributions if it notices that any of the pseudo xml files include SO terms. 

An input flag is also given to determine whether the spin-orbit terms should be physical or not, i.e. <pairpot type="pseudo" ... physicalSO="yes/no">. This would allow for perturbative style treatment similar to [arXiv:1809.04133](https://arxiv.org/abs/1809.04133), where the SO contribution is not included in the total energy. If physicalSO="yes", it will be included in the local energy. 

## What type(s) of changes does this code introduce?

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

my workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
