### PR TITLE
Change the default walkers per rank to one

### DIFF
--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -78,7 +78,7 @@ protected:
   input::PeriodStride config_dump_period_;
   IndexType starting_step_              = 0;
   IndexType num_crowds_                 = 0;
-  IndexType walkers_per_rank_           = 0;
+  IndexType walkers_per_rank_           = 1;
   IndexType requested_samples_          = 0;
   IndexType sub_steps_                  = 1;
   // max unecessary in this context


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
If `walkers_per_rank_` defaults to zero, a vmc_batch section without 'walkers' specified will divide by zero in `calc_default_local_walkers`. The `num_crowds_` variable gets set to zero, and there is a division by `num_crowds_`.

This also makes the code behave consistent with the manual (minimum of one walker per rank)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
