### PR TITLE
cmake: Drop redundant settings for policies CMP0065 and below

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,6 @@
 ######################################################################
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-cmake_policy(SET CMP0003 NEW)
-IF(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
-  cmake_policy(SET CMP0056 NEW)
-  # This policy insures that the CMAKE_EXE_LINKER_FLAGS of the calling project
-  # are used in try_compile test cmake projects.
-  # CHECK_CXX_SOURCE_COMPILES and others depend on try_compile
-endif(NOT $ENV{CRAYPE_VERSION} MATCHES ".")
-IF(CMAKE_GENERATOR MATCHES "Ninja")
-  cmake_policy(SET CMP0058 NEW)
-ENDIF(CMAKE_GENERATOR MATCHES "Ninja")
 # CMP0074: CMake find_package will use <PackageName>_ROOT CMake variable
 # and environment variable in search path.
 # various Find<Package>.cmake modules may not follow this policy


### PR DESCRIPTION
## Proposed changes

Since #1124 our call to `cmake_minimum_required(VERSION)` already sets policies CMP0065 and below to `NEW`.  Remove explicit settings.

## What type(s) of changes does this code introduce?

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Linux.

## Checklist

- [X] This PR is up to date with current the current state of 'develop'
- [X] N/A: Code added or changed in the PR has been clang-formatted
- [X] N/A: This PR adds tests to cover any new code, or to catch a bug that is being fixed
- [X] N/A: Documentation has been added (if appropriate)
