### PR TITLE
Spin update fix

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -710,6 +710,7 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
 void ParticleSet::saveWalker(Walker_t& awalker)
 {
   awalker.R = R;
+  awalker.spins = spins;
 #if !defined(SOA_MEMORY_OPTIMIZED)
   awalker.G = G;
   awalker.L = L;

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -236,6 +236,12 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   REQUIRE(elec.spins[0] == Approx(-0.74465948215809097));
 
+  //Now we're going to test that the step updated the walker variables.
+  REQUIRE(elec.WalkerList[0]->R[0][0] == Approx(elec.R[0][0]));
+  REQUIRE(elec.WalkerList[0]->R[0][1] == Approx(elec.R[0][1]));
+  REQUIRE(elec.WalkerList[0]->R[0][2] == Approx(elec.R[0][2]));
+  REQUIRE(elec.WalkerList[0]->spins[0] == Approx(elec.spins[0]));
+  
   delete doc;
 }
 } // namespace qmcplusplus


### PR DESCRIPTION

## Proposed changes
Fix the fact that saveWalker does not update spin variables.  This should be the last known bug for SOVMC with and without drift.

## What type(s) of changes does this code introduce?
Bug fix and additional asserts in unit test to catch the bug.

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Workstation.
## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
