### PR TITLE
removing uneeded parameter to commonpipline from Jenkinsfile_vm

### DIFF
--- a/tests/test_automation/Jenkinsfile_ornl_vm
+++ b/tests/test_automation/Jenkinsfile_ornl_vm
@@ -1,4 +1,4 @@
 library 'qmcpack_shared_jenkins'
 
-common_pipeline(name:"cpu", spack_path:"/var/lib/jenkins/spack", prefix:"vm", workspace_root:"${env.JENKINS_HOME}/workspace/test_root")
+common_pipeline(name:"cpu", spack_path:"/var/lib/jenkins/spack", prefix:"vm")
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Removes unecessary custom workspace parameter from common pipeline call in the testing vm Jenkins file.  Will also trigger testing of new CI security upgrade from the private CI repos.
This change allows removal of all but one script approval for the CI runner, no dangerous approvals are required at all.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

CI testing VM x86_64

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- N/A Code added or changed in the PR has been clang-formatted
- No This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate). Coming in a separate PR for Mk2 entire CI setup
