### PR TITLE
Nexus: more informative error message for twist-based optimization

### DIFF
--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -145,7 +145,11 @@ class Qmcpack(Simulation):
         if result_name=='jastrow' or result_name=='wavefunction':
             analyzer = self.load_analyzer_image()
             if not 'results' in analyzer or not 'optimization' in analyzer.results:
-                self.error('analyzer did not compute results required to determine jastrow')
+                if self.should_twist_average:
+                    self.error('Wavefunction optimization was performed for each twist separately.\nCurrently, the transfer of per-twist wavefunction parameters from\none QMCPACK simulation to another is not supported.  Please either\nredo the optimization with a single twist (see "twist" or "twistnum"\noptions), or request that this feature be implemented.')
+                else:
+                    self.error('analyzer did not compute results required to determine jastrow')
+                #end if
             #end if
             opt_file = analyzer.results.optimization.optimal_file
             opt_file = str(opt_file)


### PR DESCRIPTION
## Proposed changes

Display a more informative error message when a user attempts to pass optimized wavefunctions per twist to a subsequent calculation.  Partially addresses #2378.

Prior message:
```
  Qmcpack error:
    analyzer did not compute results required to determine jastrow
  exiting.
```

Updated message:
```
  Qmcpack error:
    Wavefunction optimization was performed for each twist separately.
    Currently, the transfer of per-twist wavefunction parameters from
    one QMCPACK simulation to another is not supported.  Please either
    redo the optimization with a single twist (see "twist" or "twistnum"
    options), or request that this feature be implemented.
  exiting.
```

## What type(s) of changes does this code introduce?

- Other (please describe):
Updated error message.

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Laptop.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed

