### PR TITLE
change ValueType to ComplexType  for spin drift

### DIFF
--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -75,7 +75,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
     for (int iat = W.first(ig); iat < W.last(ig); ++iat)
     {
       //get the displacement
-      ValueType spingrad_iat;
+      ComplexType spingrad_iat;
       GradType grad_iat = Psi.evalGradWithSpin(W, iat, spingrad_iat);
       PosType dr;
       ParticleSet::Scalar_t ds;

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBase.h
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierBase.h
@@ -24,10 +24,10 @@ namespace qmcplusplus
 class DriftModifierBase
 {
 public:
-  using RealType  = QMCTraits::RealType;
-  using PosType   = QMCTraits::PosType;
-  using GradType  = QMCTraits::GradType;
-  using ValueType = QMCTraits::ValueType;
+  using RealType    = QMCTraits::RealType;
+  using PosType     = QMCTraits::PosType;
+  using GradType    = QMCTraits::GradType;
+  using ComplexType = QMCTraits::ComplexType;
 
   /** evaluate a drift with a real force
    * @param tau timestep
@@ -36,7 +36,7 @@ public:
    */
   virtual void getDrift(RealType tau, const GradType& qf, PosType& drift) const = 0;
 
-  virtual void getDrift(RealType tau, const ValueType& qf, ParticleSet::Scalar_t& drift) const = 0;
+  virtual void getDrift(RealType tau, const ComplexType& qf, ParticleSet::Scalar_t& drift) const = 0;
 
   virtual void getDrifts(RealType tau, const std::vector<GradType>& qf, std::vector<PosType>&) const = 0;
 

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -27,7 +27,7 @@ void DriftModifierUNR::getDrift(RealType tau, const GradType& qf, PosType& drift
   drift *= sc;
 }
 
-void DriftModifierUNR::getDrift(RealType tau, const ValueType& qf, ParticleSet::Scalar_t& drift) const
+void DriftModifierUNR::getDrift(RealType tau, const ComplexType& qf, ParticleSet::Scalar_t& drift) const
 {
   // convert the complex WF gradient to real
   convert(qf, drift);

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.h
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.h
@@ -27,7 +27,7 @@ public:
 
   void getDrift(RealType tau, const GradType& qf, PosType& drift) const final;
 
-  void getDrift(RealType tau, const ValueType& qf, ParticleSet::Scalar_t& drift) const final;
+  void getDrift(RealType tau, const ComplexType& qf, ParticleSet::Scalar_t& drift) const final;
 
   bool parseXML(xmlNodePtr cur) final;
 

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
@@ -65,7 +65,7 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         ParticleSet::Scalar_t ds;
         if (UseDrift)
         {
-          ValueType spingrad_now;
+          ComplexType spingrad_now;
           GradType grad_now = Psi.evalGradWithSpin(W, iat, spingrad_now);
           DriftModifier->getDrift(tauovermass, grad_now, dr);
           DriftModifier->getDrift(tauovermass / spinMass, spingrad_now, ds);
@@ -86,7 +86,7 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         if (UseDrift)
         {
           GradType grad_new;
-          ValueType spingrad_new;
+          ComplexType spingrad_new;
           prob = std::norm(Psi.calcRatioGradWithSpin(W, iat, grad_new, spingrad_new));
           DriftModifier->getDrift(tauovermass, grad_new, dr);
           dr             = W.R[iat] - W.activePos - dr;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -100,15 +100,15 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGradWithSpin(ParticleSet& P,
                                                                                          int iat,
-                                                                                         ValueType& spingrad)
+                                                                                         ComplexType& spingrad)
 {
   Phi->evaluate_spin(P, iat, psiV, dspin_psiV);
   RatioTimer.start();
   const int WorkingIndex = iat - FirstIndex;
   invRow_id              = WorkingIndex;
   updateEng.getInvRow(psiM, WorkingIndex, invRow);
-  GradType g       = simd::dot(invRow.data(), dpsiM[WorkingIndex], invRow.size());
-  ValueType spin_g = simd::dot(invRow.data(), dspin_psiV.data(), invRow.size());
+  GradType g         = simd::dot(invRow.data(), dpsiM[WorkingIndex], invRow.size());
+  ComplexType spin_g = simd::dot(invRow.data(), dspin_psiV.data(), invRow.size());
   RatioTimer.stop();
 
   spingrad += spin_g;
@@ -154,7 +154,7 @@ template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratioGradWithSpin(ParticleSet& P,
                                                                                               int iat,
                                                                                               GradType& grad_iat,
-                                                                                              ValueType& spingrad_iat)
+                                                                                              ComplexType& spingrad_iat)
 {
   SPOVGLTimer.start();
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -104,7 +104,7 @@ public:
 
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
 
-  PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ValueType& spingrad) override final;
+  PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad) override final;
 
   void mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
                     const std::vector<ParticleSet*>& P_list,
@@ -114,7 +114,7 @@ public:
 
   GradType evalGrad(ParticleSet& P, int iat) override;
 
-  GradType evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad) override final;
+  GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) override final;
 
   GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -73,20 +73,11 @@ public:
   virtual void setBF(BackflowTransformation* BFTrans) {}
 
   ///optimizations  are disabled
-  virtual inline void checkInVariables(opt_variables_type& active) override
-  {
-    Phi->checkInVariables(active);
-  }
+  virtual inline void checkInVariables(opt_variables_type& active) override { Phi->checkInVariables(active); }
 
-  virtual inline void checkOutVariables(const opt_variables_type& active) override
-  {
-    Phi->checkOutVariables(active);
-  }
+  virtual inline void checkOutVariables(const opt_variables_type& active) override { Phi->checkOutVariables(active); }
 
-  virtual void resetParameters(const opt_variables_type& active) override
-  {
-    Phi->resetParameters(active);
-  }
+  virtual void resetParameters(const opt_variables_type& active) override { Phi->resetParameters(active); }
 
   // To be removed with AoS
   void resetTargetParticleSet(ParticleSet& P) override final
@@ -108,23 +99,23 @@ public:
   using WaveFunctionComponent::updateBuffer;
 
   using WaveFunctionComponent::acceptMove;
-  using WaveFunctionComponent::mw_acceptMove;
   using WaveFunctionComponent::completeUpdates;
-  using WaveFunctionComponent::mw_completeUpdates;
   using WaveFunctionComponent::evalGrad;
-  using WaveFunctionComponent::mw_evalGrad;
-  using WaveFunctionComponent::ratio;
+  using WaveFunctionComponent::mw_acceptMove;
   using WaveFunctionComponent::mw_calcRatio;
-  using WaveFunctionComponent::ratioGrad;
+  using WaveFunctionComponent::mw_completeUpdates;
+  using WaveFunctionComponent::mw_evalGrad;
   using WaveFunctionComponent::mw_ratioGrad;
-  using WaveFunctionComponent::restore;
   using WaveFunctionComponent::mw_restore;
+  using WaveFunctionComponent::ratio;
+  using WaveFunctionComponent::ratioGrad;
+  using WaveFunctionComponent::restore;
 
   using WaveFunctionComponent::evalGradSource;
   using WaveFunctionComponent::evaluateHessian;
   using WaveFunctionComponent::evaluateRatios;
-  using WaveFunctionComponent::mw_evaluateRatios;
   using WaveFunctionComponent::evaluateRatiosAlltoOne;
+  using WaveFunctionComponent::mw_evaluateRatios;
 
   // used by DiracDeterminantWithBackflow
   virtual void evaluateDerivatives(ParticleSet& P,
@@ -144,12 +135,12 @@ public:
     return 0;
   }
 
-  virtual PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ValueType& spingrad) override
+  virtual PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad) override
   {
     APP_ABORT("  DiracDeterminantBase::ratioGradWithSpins():  Implementation required\n");
     return 0.0;
-  } 
-  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad) override
+  }
+  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) override
   {
     APP_ABORT("  DiracDeterminantBase::evalGradWithSpins():  Implementation required\n");
     return GradType();

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -112,7 +112,7 @@ public:
   virtual inline PsiValueType ratioGradWithSpin(ParticleSet& P,
                                                 int iat,
                                                 GradType& grad_iat,
-                                                ValueType& spingrad_iat) override
+                                                ComplexType& spingrad_iat) override
   {
     return Dets[getDetID(iat)]->ratioGradWithSpin(P, iat, grad_iat, spingrad_iat);
   }
@@ -129,7 +129,7 @@ public:
 
   virtual GradType evalGrad(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->evalGrad(P, iat); }
 
-  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad) override
+  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) override
   {
     return Dets[getDetID(iat)]->evalGradWithSpin(P, iat, spingrad);
   }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -389,7 +389,7 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGrad(ParticleSet& P, int iat)
   return grad_iat;
 }
 
-TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad)
+TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad)
 {
   GradType grad_iat;
   spingrad = 0;
@@ -481,7 +481,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
 TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGradWithSpin(ParticleSet& P,
                                                                       int iat,
                                                                       GradType& grad_iat,
-                                                                      ValueType& spingrad_iat)
+                                                                      ComplexType& spingrad_iat)
 {
   spingrad_iat = 0.0;
   PsiValueType r(1.0);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -63,6 +63,7 @@ class TrialWaveFunction : public MPIObjectBase
 public:
   // derived types from WaveFunctionComponent
   typedef WaveFunctionComponent::RealType RealType;
+  typedef WaveFunctionComponent::ComplexType ComplexType;
   using FullPrecRealType = WaveFunctionComponent::FullPrecRealType;
   typedef WaveFunctionComponent::ValueType ValueType;
   typedef WaveFunctionComponent::PosType PosType;
@@ -226,7 +227,7 @@ public:
    * @param spingrad_iat spin gradient for iat
    * @return ratio value
    */
-  ValueType calcRatioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ValueType& spingrad_iat);
+  ValueType calcRatioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat);
 
   /** batched verison of ratioGrad 
    *
@@ -248,7 +249,7 @@ public:
    * @return \nabla ln(psi) (complex)
    *
    */
-  GradType evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad);
+  GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad);
 
   /** batched verison of evalGrad
     *

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -234,7 +234,7 @@ struct WaveFunctionComponent : public QMCTraits
    * @param iat particle index
    * @return the spin gradient of the iat-th particle
    */
-  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ValueType& spingrad) { return evalGrad(P, iat); }
+  virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) { return evalGrad(P, iat); }
 
   /** compute the current gradients for the iat-th particle of multiple walkers
    * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch
@@ -319,7 +319,7 @@ struct WaveFunctionComponent : public QMCTraits
    * @param grad_iat realspace gradient for the active particle
    * @param spingrad_iat spin gradient for the active particle
    */
-  virtual PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ValueType& spingrad_iat)
+  virtual PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat)
   {
     return ratioGrad(P, iat, grad_iat);
   }

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -34,6 +34,7 @@ namespace qmcplusplus
 {
 using RealType     = QMCTraits::RealType;
 using ValueType    = QMCTraits::ValueType;
+using ComplexType  = QMCTraits::ComplexType;
 using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
 using PsiValueType = QMCTraits::QTFull::ValueType;
 
@@ -640,7 +641,7 @@ TEST_CASE("DiracDeterminant_spinor_update", "[wavefunction][fermion]")
 
   ParticleGradient_t G;
   ParticleLaplacian_t L;
-  ParticleAttrib<ValueType> SG;
+  ParticleAttrib<ComplexType> SG;
 
   G.resize(nelec);
   L.resize(nelec);


### PR DESCRIPTION

## Proposed changes

PR #2388 should have actually changed it to ComplexType, since spindrift is always complex. 

## What type(s) of changes does this code introduce?

-datatype for spindrift

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
linux, intel build

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
