### PR TITLE
Fix cuda testing

### DIFF
--- a/src/Particle/InitMolecularSystem.cpp
+++ b/src/Particle/InitMolecularSystem.cpp
@@ -61,8 +61,10 @@ bool InitMolecularSystem::put(xmlNodePtr cur)
   else
     initMolecule(ions, els);
 
+#if !defined(QMC_CUDA)
   makeUniformRandom(els->spins);
   els->spins *= 2 * M_PI;
+#endif
 
   app_log() << "</init>" << std::endl;
   app_log().flush();

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -443,8 +443,10 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
     //for(int i=0; i<qp->getTotalNum(); ++i)
     //  std::cout << qp->GroupID[i] << " " << qp->R[i] << std::endl;
 
+#if !defined(QMC_CUDA)
     makeUniformRandom(qp->spins);
     qp->spins *= 2 * M_PI;
+#endif
 
     if (qp->Lattice.SuperCellEnum)
       qp->createSK();

--- a/src/Particle/tests/test_particle_pool.cpp
+++ b/src/Particle/tests/test_particle_pool.cpp
@@ -122,7 +122,9 @@ TEST_CASE("ParticleSetPool random", "[qmcapp]")
   pp.randomize();
 
   REQUIRE(elec->R[0][0] != 0.0);
+#if !defined(QMC_CUDA)
   REQUIRE(elec->spins[0] != 0.0);
+#endif
 }
 
 TEST_CASE("ParticleSetPool putTileMatrix", "[qmcapp]")

--- a/src/ParticleIO/XMLParticleIO.cpp
+++ b/src/ParticleIO/XMLParticleIO.cpp
@@ -314,8 +314,10 @@ bool XMLParticleParser::putSpecial(xmlNodePtr cur)
       makeUniformRandom(ref_.R);
       ref_.R.setUnit(PosUnit::Lattice);
       ref_.convert2Cart(ref_.R);
+#if !defined(QMC_CUDA)
       makeUniformRandom(ref_.spins);
       ref_.spins *= 2 * M_PI;
+#endif
     }
     else // put them [0,1) in the cell
       ref_.applyBC(ref_.R);

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -49,9 +49,7 @@ DMC::DMC(MCWalkerConfiguration& w,
       KillNodeCrossing(0),
       BranchInterval(-1),
       Reconfiguration("no"),
-      mover_MaxAge(-1),
-      SpinMoves("no"),
-      SpinMass(1.0)
+      mover_MaxAge(-1)
 {
   RootName = "dmc";
   QMCType  = "DMC";
@@ -62,8 +60,6 @@ DMC::DMC(MCWalkerConfiguration& w,
   m_param.add(NonLocalMove, "nonlocalmove", "string");
   m_param.add(NonLocalMove, "nonlocalmoves", "string");
   m_param.add(mover_MaxAge, "MaxAge", "double");
-  m_param.add(SpinMoves,"SpinMoves","string");
-  m_param.add(SpinMass,"SpinMass","double");
 }
 
 void DMC::resetUpdateEngines()
@@ -90,12 +86,6 @@ void DMC::resetUpdateEngines()
     estimatorClones.resize(NumThreads, 0);
     traceClones.resize(NumThreads, 0);
     FairDivideLow(W.getActiveWalkers(), NumThreads, wPerNode);
-
-    tolower(SpinMoves);
-    if (SpinMoves != "yes" && SpinMoves != "no")
-    {
-      APP_ABORT("SpinMoves must be yes/no\n");
-    }
 
     {
       //log file

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -58,9 +58,6 @@ private:
   std::string UseFastGrad;
   ///input to control maximum age allowed for walkers.
   IndexType mover_MaxAge;
-  ///turn on spin moves
-  std::string SpinMoves;
-  RealType SpinMass;
 
   void resetUpdateEngines();
   /// Copy Constructor (disabled)

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -118,6 +118,10 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
   
   m_param.add(nTargetPopulation, "samples", "real");
 
+  SpinMoves = "no";
+  SpinMass = 1.0;
+  m_param.add(SpinMoves,"SpinMoves","string");
+  m_param.add(SpinMass,"SpinMass","double");
 
   Tau = 0.1;
   //m_param.add(Tau,"timeStep","AU");
@@ -517,14 +521,15 @@ bool QMCDriver::putQMCInfo(xmlNodePtr cur)
   if (!AppendRun)
     CurrentStep = 0;
 
- 
+  tolower(SpinMoves);
+  if (SpinMoves != "yes" && SpinMoves != "no")
+    myComm->barrier_and_abort("SpinMoves must be yes/no!\n");
+#if defined(QMC_CUDA)
+  if (SpinMoves == "yes")
+    myComm->barrier_and_abort("Spin moves are not supported in legacy CUDA build.");
+#endif
 
- 
-
- 
   //if walkers are initialized via <mcwalkerset/>, use the existing one
-
-
   if (qmc_common.qmc_counter || qmc_common.is_restart)
   {
     app_log() << "Using existing walkers " << std::endl;

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -329,10 +329,9 @@ protected:
   ///temporary storage for random displacement
   ParticleSet::ParticlePos_t deltaR;
 
-  ///temporary buffer to accumulate data
-  //ostrstream log_buffer;
-
-  //PooledData<RealType> HamPool;
+  ///turn on spin moves
+  std::string SpinMoves;
+  RealType SpinMass;
 
   ///Copy Constructor (disabled).
   QMCDriver(const QMCDriver&) = delete;

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -41,7 +41,7 @@ VMC::VMC(MCWalkerConfiguration& w,
          QMCHamiltonian& h,
          WaveFunctionPool& ppool,
          Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm), UseDrift("yes"), SpinMoves("no"), SpinMass(1.0)
+    : QMCDriver(w, psi, h, ppool, comm), UseDrift("yes")
 {
   RootName = "vmc";
   QMCType  = "VMC";
@@ -50,8 +50,6 @@ VMC::VMC(MCWalkerConfiguration& w,
   m_param.add(UseDrift, "useDrift", "string");
   m_param.add(UseDrift, "usedrift", "string");
   m_param.add(UseDrift, "use_drift", "string");
-  m_param.add(SpinMoves, "SpinMoves", "string");
-  m_param.add(SpinMass, "SpinMass", "double");
 
   prevSteps               = nSteps;
   prevStepsBetweenSamples = nStepsBetweenSamples;
@@ -183,11 +181,6 @@ void VMC::resetRun()
 #endif
       hClones[ip]->setRandomGenerator(Rng[ip]);
       
-      tolower(SpinMoves);
-      if (SpinMoves != "yes" && SpinMoves != "no") 
-      {
-        APP_ABORT("SpinMoves must be yes/no\n");
-      }
       if (SpinMoves == "yes") 
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE]) 

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -38,9 +38,6 @@ private:
   RealType logoffset, logepsilon;
   ///option to enable/disable drift equation or RN for VMC
   std::string UseDrift;
-  ///turn on spin moves
-  std::string SpinMoves;
-  RealType SpinMass;
   ///check the run-time environments
   void resetRun();
   ///copy constructor

--- a/src/QMCTools/CMakeLists.txt
+++ b/src/QMCTools/CMakeLists.txt
@@ -22,7 +22,6 @@
 PROJECT(qmctools)
 
 SET(MOSRCS
-  ../Particle/InitMolecularSystem.cpp
   QMCGaussianParserBase.cpp
   GaussianFCHKParser.cpp
   GamesXmlParser.cpp

--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -25,7 +25,6 @@
 #include "io/hdf_archive.h"
 #include <set>
 #include <map>
-#include "Particle/InitMolecularSystem.h"
 #include <sstream>
 #include <bitset>
 #include <iomanip>


### PR DESCRIPTION
## Proposed changes
closes #2390
Skip spin initialization in CUDA builds to restore deterministic tests.
Now if SpinMoves is requested, legacy CUDA aborts.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'