### PR TITLE
Fully adopt RefVector in WFC and SPOSet

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
@@ -819,8 +819,8 @@ void SplineC2ROMP<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedAllocat
 }
 
 template<typename ST>
-void SplineC2ROMP<ST>::mw_evaluateVGL(const std::vector<SPOSet*>& sa_list,
-                                      const std::vector<ParticleSet*>& P_list,
+void SplineC2ROMP<ST>::mw_evaluateVGL(const RefVector<SPOSet>& sa_list,
+                                      const RefVector<ParticleSet>& P_list,
                                       int iat,
                                       const RefVector<ValueVector_t>& psi_v_list,
                                       const RefVector<GradVector_t>& dpsi_v_list,
@@ -832,7 +832,7 @@ void SplineC2ROMP<ST>::mw_evaluateVGL(const std::vector<SPOSet*>& sa_list,
   // pack particle positions
   for (int iw = 0; iw < nwalkers; ++iw)
   {
-    const PointType& r = P_list[iw]->activeR(iat);
+    const PointType& r = P_list[iw].get().activeR(iat);
     PointType ru(PrimLattice.toUnit_floor(r));
     multi_pos_copy[iw * 6]     = r[0];
     multi_pos_copy[iw * 6 + 1] = r[1];

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
@@ -241,8 +241,8 @@ public:
                            GradVector_t& dpsi,
                            ValueVector_t& d2psi) override;
 
-  virtual void mw_evaluateVGL(const std::vector<SPOSet*>& sa_list,
-                              const std::vector<ParticleSet*>& P_list,
+  virtual void mw_evaluateVGL(const RefVector<SPOSet>& sa_list,
+                              const RefVector<ParticleSet>& P_list,
                               int iat,
                               const RefVector<ValueVector_t>& psi_v_list,
                               const RefVector<GradVector_t>& dpsi_v_list,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -186,8 +186,8 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
-                                             const std::vector<ParticleSet*>& P_list,
+void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVector<WaveFunctionComponent>& WFC_list,
+                                             const RefVector<ParticleSet>& P_list,
                                              int iat,
                                              std::vector<PsiValueType>& ratios,
                                              std::vector<GradType>& grad_new)
@@ -202,20 +202,20 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const std::vector<WaveFunctionCompo
   RefVector<ValueVector_t> d2psi_v_list;
   d2psi_v_list.reserve(WFC_list.size());
 
-  for (auto wfc : WFC_list)
+  for (WaveFunctionComponent& wfc : WFC_list)
   {
-    auto det = static_cast<DiracDeterminant<DU_TYPE>*>(wfc);
-    phi_list.push_back(det->Phi);
-    psi_v_list.push_back(det->psiV);
-    dpsi_v_list.push_back(det->dpsiV);
-    d2psi_v_list.push_back(det->d2psiV);
+    auto& det = static_cast<DiracDeterminant<DU_TYPE>&>(wfc);
+    phi_list.push_back(det.Phi);
+    psi_v_list.push_back(det.psiV);
+    dpsi_v_list.push_back(det.dpsiV);
+    d2psi_v_list.push_back(det.d2psiV);
   }
 
-  Phi->mw_evaluateVGL(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+  Phi->mw_evaluateVGL(phi_list, convert_ref_to_ptr_list(P_list), iat, psi_v_list, dpsi_v_list, d2psi_v_list);
   SPOVGLTimer.stop();
 
   for (int iw = 0; iw < WFC_list.size(); iw++)
-    ratios[iw] = static_cast<DiracDeterminant<DU_TYPE>*>(WFC_list[iw])->ratioGrad_compute(iat, grad_new[iw]);
+    ratios[iw] = static_cast<DiracDeterminant<DU_TYPE>&>(WFC_list[iw].get()).ratioGrad_compute(iat, grad_new[iw]);
 }
 
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -193,7 +193,7 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVector<WaveFunctionCompone
                                              std::vector<GradType>& grad_new)
 {
   SPOVGLTimer.start();
-  std::vector<SPOSet*> phi_list;
+  RefVector<SPOSet> phi_list;
   phi_list.reserve(WFC_list.size());
   RefVector<ValueVector_t> psi_v_list;
   psi_v_list.reserve(WFC_list.size());
@@ -205,13 +205,13 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVector<WaveFunctionCompone
   for (WaveFunctionComponent& wfc : WFC_list)
   {
     auto& det = static_cast<DiracDeterminant<DU_TYPE>&>(wfc);
-    phi_list.push_back(det.Phi);
+    phi_list.push_back(*det.Phi);
     psi_v_list.push_back(det.psiV);
     dpsi_v_list.push_back(det.dpsiV);
     d2psi_v_list.push_back(det.d2psiV);
   }
 
-  Phi->mw_evaluateVGL(phi_list, convert_ref_to_ptr_list(P_list), iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+  Phi->mw_evaluateVGL(phi_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
   SPOVGLTimer.stop();
 
   for (int iw = 0; iw < WFC_list.size(); iw++)

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -106,8 +106,8 @@ public:
 
   PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad) override final;
 
-  void mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
-                    const std::vector<ParticleSet*>& P_list,
+  void mw_ratioGrad(const RefVector<WaveFunctionComponent>& WFC_list,
+                    const RefVector<ParticleSet>& P_list,
                     int iat,
                     std::vector<PsiValueType>& ratios,
                     std::vector<GradType>& grad_new) override;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -128,21 +128,21 @@ public:
    */
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override;
 
-  void mw_acceptMove(const std::vector<WaveFunctionComponent*>& WFC_list,
-                     const std::vector<ParticleSet*>& P_list,
+  void mw_acceptMove(const RefVector<WaveFunctionComponent>& WFC_list,
+                     const RefVector<ParticleSet>& P_list,
                      int iat,
                      bool safe_to_delay = false) override
   {
     for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw]->acceptMove(*P_list[iw], iat, safe_to_delay);
+      WFC_list[iw].get().acceptMove(P_list[iw], iat, safe_to_delay);
   }
 
   void completeUpdates() override;
 
-  void mw_completeUpdates(const std::vector<WaveFunctionComponent*>& WFC_list) override
+  void mw_completeUpdates(const RefVector<WaveFunctionComponent>& WFC_list) override
   {
     for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw]->completeUpdates();
+      WFC_list[iw].get().completeUpdates();
   }
 
   /** move was rejected. copy the real container to the temporary to move on

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -128,22 +128,22 @@ SlaterDet::LogValueType SlaterDet::evaluateLog(ParticleSet& P,
   return LogValue;
 }
 
-void SlaterDet::mw_evaluateLog(const std::vector<WaveFunctionComponent*>& WFC_list,
-                               const std::vector<ParticleSet*>& P_list,
-                               const std::vector<ParticleSet::ParticleGradient_t*>& G_list,
-                               const std::vector<ParticleSet::ParticleLaplacian_t*>& L_list)
+void SlaterDet::mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
+                               const RefVector<ParticleSet>& P_list,
+                               const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                               const RefVector<ParticleSet::ParticleLaplacian_t>& L_list)
 {
-  constexpr RealType czero(0);
+  constexpr LogValueType czero(0);
 
-  for (int iw = 0; iw < WFC_list.size(); iw++)
-    WFC_list[iw]->LogValue   = czero;
+  for (WaveFunctionComponent& wfc : WFC_list)
+    wfc.LogValue = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
-    const std::vector<WaveFunctionComponent*> Det_list(extract_Det_list(WFC_list, i));
+    const auto Det_list(extract_DetRef_list(WFC_list, i));
     Dets[i]->mw_evaluateLog(Det_list, P_list, G_list, L_list);
     for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw]->LogValue += Det_list[iw]->LogValue;
+      WFC_list[iw].get().LogValue += Det_list[iw].get().LogValue;
   }
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -72,10 +72,10 @@ public:
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L) override;
 
-  virtual void mw_evaluateLog(const std::vector<WaveFunctionComponent*>& wfc_list,
-                              const std::vector<ParticleSet*>& P_list,
-                              const std::vector<ParticleSet::ParticleGradient_t*>& G_list,
-                              const std::vector<ParticleSet::ParticleLaplacian_t*>& L_list) override;
+  virtual void mw_evaluateLog(const RefVector<WaveFunctionComponent>& wfc_list,
+                              const RefVector<ParticleSet>& P_list,
+                              const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) override;
 
   virtual void recompute(ParticleSet& P) override;
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -117,14 +117,14 @@ public:
     return Dets[getDetID(iat)]->ratioGradWithSpin(P, iat, grad_iat, spingrad_iat);
   }
 
-  virtual void mw_ratioGrad(const std::vector<WaveFunctionComponent*>& wfc_list,
-                            const std::vector<ParticleSet*>& P_list,
+  virtual void mw_ratioGrad(const RefVector<WaveFunctionComponent>& wfc_list,
+                            const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios,
                             std::vector<GradType>& grad_now) override
   {
     const int det_id = getDetID(iat);
-    Dets[det_id]->mw_ratioGrad(extract_Det_list(wfc_list, det_id), P_list, iat, ratios, grad_now);
+    Dets[det_id]->mw_ratioGrad(extract_DetRef_list(wfc_list, det_id), P_list, iat, ratios, grad_now);
   }
 
   virtual GradType evalGrad(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->evalGrad(P, iat); }
@@ -216,13 +216,13 @@ public:
 
   virtual inline PsiValueType ratio(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->ratio(P, iat); }
 
-  virtual void mw_calcRatio(const std::vector<WaveFunctionComponent*>& wfc_list,
-                            const std::vector<ParticleSet*>& P_list,
+  virtual void mw_calcRatio(const RefVector<WaveFunctionComponent>& wfc_list,
+                            const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios) override
   {
     const int det_id = getDetID(iat);
-    Dets[det_id]->mw_calcRatio(extract_Det_list(wfc_list, det_id), P_list, iat, ratios);
+    Dets[det_id]->mw_calcRatio(extract_DetRef_list(wfc_list, det_id), P_list, iat, ratios);
   }
 
   virtual WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const override;

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -50,14 +50,14 @@ void SPOSet::evaluate(const ParticleSet& P, PosType& r, ValueVector_t& psi)
   APP_ABORT("Need specialization for SPOSet::evaluate(const ParticleSet& P, PosType &r)\n");
 }
 
-void SPOSet::mw_evaluateValue(const std::vector<SPOSet*>& spo_list,
-                              const std::vector<ParticleSet*>& P_list,
+void SPOSet::mw_evaluateValue(const RefVector<SPOSet>& spo_list,
+                              const RefVector<ParticleSet>& P_list,
                               int iat,
                               const RefVector<ValueVector_t>& psi_v_list)
 {
 #pragma omp parallel for
   for (int iw = 0; iw < spo_list.size(); iw++)
-    spo_list[iw]->evaluateValue(*P_list[iw], iat, psi_v_list[iw]);
+    spo_list[iw].get().evaluateValue(P_list[iw], iat, psi_v_list[iw]);
 }
 
 void SPOSet::evaluateDetRatios(const VirtualParticleSet& VP,
@@ -85,8 +85,8 @@ void SPOSet::mw_evaluateDetRatios(const RefVector<SPOSet>& spo_list,
 
 }
 
-void SPOSet::mw_evaluateVGL(const std::vector<SPOSet*>& spo_list,
-                            const std::vector<ParticleSet*>& P_list,
+void SPOSet::mw_evaluateVGL(const RefVector<SPOSet>& spo_list,
+                            const RefVector<ParticleSet>& P_list,
                             int iat,
                             const RefVector<ValueVector_t>& psi_v_list,
                             const RefVector<GradVector_t>& dpsi_v_list,
@@ -94,7 +94,7 @@ void SPOSet::mw_evaluateVGL(const std::vector<SPOSet*>& spo_list,
 {
 #pragma omp parallel for
   for (int iw = 0; iw < spo_list.size(); iw++)
-    spo_list[iw]->evaluateVGL(*P_list[iw], iat, psi_v_list[iw], dpsi_v_list[iw], d2psi_v_list[iw]);
+    spo_list[iw].get().evaluateVGL(P_list[iw], iat, psi_v_list[iw], dpsi_v_list[iw], d2psi_v_list[iw]);
 }
 
 void SPOSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix_t& grad_grad_grad_logdet)

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -250,8 +250,8 @@ public:
    * @param iat active particle
    * @param psi_v_list the list of value vector pointers in a walker batch
    */
-  virtual void mw_evaluateValue(const std::vector<SPOSet*>& spo_list,
-                                const std::vector<ParticleSet*>& P_list,
+  virtual void mw_evaluateValue(const RefVector<SPOSet>& spo_list,
+                                const RefVector<ParticleSet>& P_list,
                                 int iat,
                                 const RefVector<ValueVector_t>& psi_v_list);
 
@@ -300,8 +300,8 @@ public:
    * @param dpsi_v_list the list of gradient vector pointers in a walker batch
    * @param d2psi_v_list the list of laplacian vector pointers in a walker batch
    */
-  virtual void mw_evaluateVGL(const std::vector<SPOSet*>& spo_list,
-                              const std::vector<ParticleSet*>& P_list,
+  virtual void mw_evaluateVGL(const RefVector<SPOSet>& spo_list,
+                              const RefVector<ParticleSet>& P_list,
                               int iat,
                               const RefVector<ValueVector_t>& psi_v_list,
                               const RefVector<GradVector_t>& dpsi_v_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -363,8 +363,7 @@ void TrialWaveFunction::flex_calcRatio(const RefVector<TrialWaveFunction>& wf_li
       {
         ScopedTimer local_timer(wf_list[0].get().get_timers()[ii]);
         const auto wfc_list(extractWFCRefList(wf_list, i));
-        wavefunction_components[i]->mw_calcRatio(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list),
-                                                 iat, ratios_z);
+        wavefunction_components[i]->mw_calcRatio(wfc_list, p_list, iat, ratios_z);
         for (int iw = 0; iw < wf_list.size(); iw++)
           ratios[iw] *= ratios_z[iw];
       }
@@ -519,8 +518,7 @@ void TrialWaveFunction::flex_calcRatioGrad(const RefVector<TrialWaveFunction>& w
       ScopedTimer localtimer(wf_list[0].get().get_timers()[ii]);
       //ScopedTimer local_timer(myTimers[ii]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
-      wavefunction_components[i]->mw_ratioGrad(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list), iat,
-                                               ratios_z, grad_new);
+      wavefunction_components[i]->mw_ratioGrad(wfc_list, p_list, iat, ratios_z, grad_new);
       for (int iw = 0; iw < wf_list.size(); iw++)
         ratios[iw] *= ratios_z[iw];
     }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -154,8 +154,7 @@ void TrialWaveFunction::flex_evaluateLog(const RefVector<TrialWaveFunction>& wf_
     {
       ScopedTimer local_timer(wf_list[0].get().myTimers[ii]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
-      wavefunction_components[i]->mw_evaluateLog(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list),
-                                                 convert_ref_to_ptr_list(g_list), convert_ref_to_ptr_list(l_list));
+      wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
       auto accumulateLogAndPhase = [](TrialWaveFunction& twf, WaveFunctionComponent& wfc) {
         twf.LogValue += std::real(wfc.LogValue);
         twf.PhaseValue += std::imag(wfc.LogValue);

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -400,8 +400,8 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, 
   return grad_iat;
 }
 
-void TrialWaveFunction::flex_evalGrad(const std::vector<std::reference_wrapper<TrialWaveFunction>>& wf_list,
-                                      const std::vector<std::reference_wrapper<ParticleSet>>& p_list,
+void TrialWaveFunction::flex_evalGrad(const RefVector<TrialWaveFunction>& wf_list,
+                                      const RefVector<ParticleSet>& p_list,
                                       int iat,
                                       std::vector<GradType>& grad_now)
 {
@@ -565,7 +565,7 @@ void TrialWaveFunction::flex_rejectMove(const RefVector<TrialWaveFunction>& wf_l
     for (int i = 0; i < num_wfc; i++)
     {
       const auto wfc_list(extractWFCRefList(wf_list, i));
-      wavefunction_components[i]->mw_restore(convert_ref_to_ptr_list(wfc_list), iat);
+      wavefunction_components[i]->mw_restore(wfc_list, iat);
     }
   }
   else if (wf_list.size() == 1)
@@ -614,8 +614,7 @@ void TrialWaveFunction::flex_acceptMove(const RefVector<TrialWaveFunction>& wf_l
     {
       ScopedTimer localtimer(wf_list[0].get().get_timers()[ii]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
-      wavefunction_components[i]->mw_acceptMove(convert_ref_to_ptr_list(wfc_list), convert_ref_to_ptr_list(p_list), iat,
-                                                safe_to_delay);
+      wavefunction_components[i]->mw_acceptMove(wfc_list, p_list, iat, safe_to_delay);
       for (int iw = 0; iw < wf_list.size(); iw++)
       {
         wf_list[iw].get().LogValue += std::real(wfc_list[iw].get().LogValue);
@@ -637,19 +636,19 @@ void TrialWaveFunction::completeUpdates()
   }
 }
 
-void TrialWaveFunction::flex_completeUpdates(const std::vector<TrialWaveFunction*>& wf_list) const
+void TrialWaveFunction::flex_completeUpdates(const RefVector<TrialWaveFunction>& wf_list) const
 {
   if (wf_list.size() > 1)
   {
     for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
     {
       ScopedTimer local_timer(myTimers[ii]);
-      std::vector<WaveFunctionComponent*> wfc_list(extractWFCPtrList(wf_list, i));
+      const auto wfc_list(extractWFCRefList(wf_list, i));
       Z[i]->mw_completeUpdates(wfc_list);
     }
   }
   else if (wf_list.size() == 1)
-    wf_list[0]->completeUpdates();
+    wf_list[0].get().completeUpdates();
 }
 
 void TrialWaveFunction::checkInVariables(opt_variables_type& active)
@@ -730,7 +729,7 @@ void TrialWaveFunction::flex_registerData(const UPtrVector<TrialWaveFunction>& w
     std::vector<WaveFunctionComponent*> wfc_list(extractWFCPtrList(wf_list, i));
 
     wavefunction_components[i]->mw_registerData(wfc_list, convertUPtrToPtrVector(P_list),
-                                                convert_ref_to_ptr_list(buf_list));
+                                                buf_list);
   }
 
   auto addPhaseAndLog = [](WFBufferType& wfb, TrialWaveFunction& twf) {
@@ -1052,34 +1051,6 @@ std::vector<WaveFunctionComponent*> TrialWaveFunction::extractWFCPtrList(const U
   for (auto& WF : WF_list)
     WFC_list.push_back(WF->Z[id]);
   return WFC_list;
-}
-
-std::vector<WaveFunctionComponent*> TrialWaveFunction::extractWFCPtrList(const std::vector<TrialWaveFunction*>& WF_list,
-                                                                         int id) const
-{
-  std::vector<WaveFunctionComponent*> WFC_list;
-  WFC_list.reserve(WF_list.size());
-  for (auto WF : WF_list)
-    WFC_list.push_back(WF->Z[id]);
-  return WFC_list;
-}
-
-std::vector<ParticleSet::ParticleGradient_t*> TrialWaveFunction::extractGPtrList(
-    const std::vector<TrialWaveFunction*>& WF_list) const
-{
-  std::vector<ParticleSet::ParticleGradient_t*> G_list;
-  for (auto WF : WF_list)
-    G_list.push_back(&(WF->G));
-  return G_list;
-}
-
-std::vector<ParticleSet::ParticleLaplacian_t*> TrialWaveFunction::extractLPtrList(
-    const std::vector<TrialWaveFunction*>& WF_list) const
-{
-  std::vector<ParticleSet::ParticleLaplacian_t*> L_list;
-  for (auto WF : WF_list)
-    L_list.push_back(&(WF->L));
-  return L_list;
 }
 
 RefVector<ParticleSet::ParticleGradient_t> TrialWaveFunction::extractGRefList(

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -273,7 +273,7 @@ public:
                               bool safe_to_delay = false);
   void completeUpdates();
   /* flexible batched version of completeUpdates.  */
-  void flex_completeUpdates(const std::vector<TrialWaveFunction*>& WF_list) const;
+  void flex_completeUpdates(const RefVector<TrialWaveFunction>& WF_list) const;
 
   /** register all the wavefunction components in buffer.
    *  See WaveFunctionComponent::registerData for more detail */
@@ -383,18 +383,10 @@ private:
   /** @{
    *  @brief helper function for extracting a list of WaveFunctionComponent from a list of TrialWaveFunction
    */
-  std::vector<WaveFunctionComponent*> extractWFCPtrList(const std::vector<TrialWaveFunction*>& WF_list, int id) const;
-
   static std::vector<WaveFunctionComponent*> extractWFCPtrList(const UPtrVector<TrialWaveFunction>& WF_list, int id);
 
   static RefVector<WaveFunctionComponent> extractWFCRefList(const RefVector<TrialWaveFunction>& WF_list, int id);
   /** }@ */
-
-  // helper function for extrating a list of gradients from a list of TrialWaveFunction
-  std::vector<ParticleSet::ParticleGradient_t*> extractGPtrList(const std::vector<TrialWaveFunction*>& wf_list) const;
-
-  // helper function for extracting a list of laplacian from a list of TrialWaveFunction
-  std::vector<ParticleSet::ParticleLaplacian_t*> extractLPtrList(const std::vector<TrialWaveFunction*>& wf_list) const;
 
   // helper function for extrating a list of gradients from a list of TrialWaveFunction
   static RefVector<ParticleSet::ParticleGradient_t> extractGRefList(const RefVector<TrialWaveFunction>& wf_list);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -192,14 +192,14 @@ struct WaveFunctionComponent : public QMCTraits
    * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
    * @@param values the log WF values of walkers in a batch
    */
-  virtual void mw_evaluateLog(const std::vector<WaveFunctionComponent*>& WFC_list,
-                              const std::vector<ParticleSet*>& P_list,
-                              const std::vector<ParticleSet::ParticleGradient_t*>& G_list,
-                              const std::vector<ParticleSet::ParticleLaplacian_t*>& L_list)
+  virtual void mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
+                              const RefVector<ParticleSet>& P_list,
+                              const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list)
   {
 #pragma omp parallel for
     for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw]->evaluateLog(*P_list[iw], *G_list[iw], *L_list[iw]);
+      WFC_list[iw].get().evaluateLog(P_list[iw], G_list[iw], L_list[iw]);
   }
 
   /** recompute the value of the WaveFunctionComponents which require critical accuracy.

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -331,31 +331,13 @@ struct WaveFunctionComponent : public QMCTraits
    * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
    * @param grad_now the list of new gradients in a walker batch, \f$\nabla\ln\Psi\f$
    */
-  virtual void mw_ratioGrad(const std::vector<WaveFunctionComponent*>& WFC_list,
-                            const std::vector<ParticleSet*>& P_list,
-                            int iat,
-                            std::vector<PsiValueType>& ratios,
-                            std::vector<GradType>& grad_new)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      ratios[iw] = WFC_list[iw]->ratioGrad(*P_list[iw], iat, grad_new[iw]);
-  }
-
-  /** compute the ratio of the new to old WaveFunctionComponent value and the new gradient of multiple walkers
-   * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch
-   * @param P_list the list of ParticleSet pointers in a walker batch
-   * @param iat particle index
-   * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
-   * @param grad_now the list of new gradients in a walker batch, \f$\nabla\ln\Psi\f$
-   */
   virtual void mw_ratioGrad(const RefVector<WaveFunctionComponent>& WFC_list,
                             const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios,
                             std::vector<GradType>& grad_new)
   {
-    //#pragma omp parallel for
+#pragma omp parallel for
     for (int iw = 0; iw < WFC_list.size(); iw++)
       ratios[iw] = WFC_list[iw].get().ratioGrad(P_list[iw], iat, grad_new[iw]);
   }
@@ -434,28 +416,12 @@ struct WaveFunctionComponent : public QMCTraits
    * @param iat particle index
    * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
    */
-  virtual void mw_calcRatio(const std::vector<WaveFunctionComponent*>& WFC_list,
-                            const std::vector<ParticleSet*>& P_list,
-                            int iat,
-                            std::vector<PsiValueType>& ratios)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      ratios[iw] = WFC_list[iw]->ratio(*P_list[iw], iat);
-  }
-
-  /** compute the ratio of the new to old WaveFunctionComponent value of multiple walkers
-   * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch
-   * @param P_list the list of ParticleSet pointers in a walker batch
-   * @param iat particle index
-   * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
-   */
   virtual void mw_calcRatio(const RefVector<WaveFunctionComponent>& WFC_list,
                             const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios)
   {
-    //#pragma omp parallel for
+#pragma omp parallel for
     for (int iw = 0; iw < WFC_list.size(); iw++)
       ratios[iw] = WFC_list[iw].get().ratio(P_list[iw], iat);
   }

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -357,14 +357,14 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   // interchange positions
   elec_2.R[0] = elec_.R[1];
   elec_2.R[1] = elec_.R[0];
-  std::vector<ParticleSet*> P_list;
-  P_list.push_back(&elec_);
-  P_list.push_back(&elec_2);
+  RefVector<ParticleSet> P_list;
+  P_list.push_back(elec_);
+  P_list.push_back(elec_2);
 
   std::unique_ptr<SPOSet> spo_2(spo->makeClone());
-  std::vector<SPOSet*> spo_list;
-  spo_list.push_back(spo.get());
-  spo_list.push_back(spo_2.get());
+  RefVector<SPOSet> spo_list;
+  spo_list.push_back(*spo);
+  spo_list.push_back(*spo_2);
 
   SPOSet::ValueVector_t psi(spo->getOrbitalSetSize());
   SPOSet::GradVector_t dpsi(spo->getOrbitalSetSize());

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -315,14 +315,14 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   elec_2.R[0] = elec_.R[1];
   elec_2.R[1] = elec_.R[0];
   elec_2.update();
-  std::vector<ParticleSet*> P_list;
-  P_list.push_back(&elec_);
-  P_list.push_back(&elec_2);
+  RefVector<ParticleSet> P_list;
+  P_list.push_back(elec_);
+  P_list.push_back(elec_2);
 
   std::unique_ptr<SPOSet> spo_2(spo->makeClone());
-  std::vector<SPOSet*> spo_list;
-  spo_list.push_back(spo.get());
-  spo_list.push_back(spo_2.get());
+  RefVector<SPOSet> spo_list;
+  spo_list.push_back(*spo);
+  spo_list.push_back(*spo_2);
 
   SPOSet::ValueVector_t psi(spo->getOrbitalSetSize());
   SPOSet::GradVector_t dpsi(spo->getOrbitalSetSize());


### PR DESCRIPTION
## Proposed changes
Replace std::vector<T*> with RefVector<T> for clear ownership.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'