### PR TITLE
Amend PR #2395 and restore git hash printing in header.

### DIFF
--- a/src/OpenMP/tests/CMakeLists.txt
+++ b/src/OpenMP/tests/CMakeLists.txt
@@ -18,8 +18,8 @@ SET(SRC_DIR openmp)
 SET(UTEST_EXE test_${SRC_DIR})
 SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
-
-ADD_EXECUTABLE(${UTEST_EXE} catch_main test_vector.cpp test_math.cpp test_deep_copy.cpp test_class_member.cpp)
+ADD_EXECUTABLE(${UTEST_EXE} test_vector.cpp test_math.cpp test_deep_copy.cpp test_class_member.cpp)
+TARGET_LINK_LIBRARIES(${UTEST_EXE} catch_main)
 
 ADD_UNIT_TEST(${UTEST_NAME} "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
 

--- a/src/qmc_common.cpp
+++ b/src/qmc_common.cpp
@@ -16,9 +16,10 @@
 
 
 #include <qmc_common.h>
-#include <Platforms/sysutil.h>
+#include "config.h"
 #include "qmcpack_version.h"
-#include "Configuration.h"
+#include "Message/Communicate.h"
+#include "Platforms/Host/OutputManager.h"
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
## Proposed changes
I pushed a wrong fix in #2395. It should be corrected now.
Once I have some bandwidth, I will add a CI instance for ENABLE_OFFLOAD.

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'