### PR TITLE
Protect OpenMP user-defined reduction with macro.

### DIFF
--- a/src/Platforms/OpenMP/ompBLAS.cpp
+++ b/src/Platforms/OpenMP/ompBLAS.cpp
@@ -19,8 +19,8 @@ namespace qmcplusplus
 namespace ompBLAS
 {
 
-#pragma omp declare reduction(+: std::complex<float>: omp_out += omp_in)
-#pragma omp declare reduction(+: std::complex<double>: omp_out += omp_in)
+PRAGMA_OFFLOAD("omp declare reduction(+: std::complex<float>: omp_out += omp_in)")
+PRAGMA_OFFLOAD("omp declare reduction(+: std::complex<double>: omp_out += omp_in)")
 
 template<typename T>
 ompBLAS_status gemv_impl(ompBLAS_handle& handle,


### PR DESCRIPTION
## Proposed changes
Protect OpenMP user-defined reduction with macro for compilers incapable of handling it.
user-defined reduction is not an offload-only feature but a generic one in OpenMP.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
