### PR TITLE
Add epsilon control to ComplexApprox and LogComplexApprox

### DIFF
--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -9,11 +9,14 @@ namespace Catch {
 class ComplexApprox
 {
     std::complex<double> m_value;
-    double m_epsilon;
+    /// threshold for real part
+    double m_epsilon_r;
+    /// threshold for imaginary part
+    double m_epsilon_i;
 
-    bool approx_compare(const double lhs, const double rhs) const
+    bool approx_compare(const double lhs, const double rhs, const bool real_part) const
     {
-        return Approx(lhs).epsilon(m_epsilon) == rhs;
+        return Approx(lhs).epsilon(real_part ? m_epsilon_r : m_epsilon_i) == rhs;
     }
 
 public:
@@ -35,31 +38,40 @@ public:
 
    void init_epsilon() {
       // Copied from catch.hpp - would be better to copy it from Approx object
-      m_epsilon = std::numeric_limits<float>::epsilon()*100;
+      m_epsilon_r = m_epsilon_i = std::numeric_limits<float>::epsilon()*100;
     }
 
-    ComplexApprox& epsilon(double new_epsilon)
+    ComplexApprox& epsilon(double new_epsilon_r, double new_epsilon_i = 0.0)
     {
-      m_epsilon = new_epsilon;
+      m_epsilon_r = new_epsilon_r;
+      if (new_epsilon_i == 0.0)
+        m_epsilon_i = new_epsilon_r;
+      else
+        m_epsilon_i = new_epsilon_i;
       return *this;
     }
 
-    double epsilon() const
+    double epsilon_r() const
     {
-      return m_epsilon;
+      return m_epsilon_r;
+    }
+
+    double epsilon_i() const
+    {
+      return m_epsilon_i;
     }
 
     friend bool operator == (std::complex<double> const& lhs, ComplexApprox const& rhs)
     {
-        bool is_equal = rhs.approx_compare(lhs.real(), rhs.m_value.real());
-        is_equal &= rhs.approx_compare(lhs.imag(), rhs.m_value.imag());
+        bool is_equal = rhs.approx_compare(lhs.real(), rhs.m_value.real(), true);
+        is_equal &= rhs.approx_compare(lhs.imag(), rhs.m_value.imag(), false);
         return is_equal;
     }
 
     friend bool operator == (std::complex<float> const& lhs, ComplexApprox const& rhs)
     {
-        bool is_equal = rhs.approx_compare(lhs.real(), rhs.m_value.real());
-        is_equal &= rhs.approx_compare(lhs.imag(), rhs.m_value.imag());
+        bool is_equal = rhs.approx_compare(lhs.real(), rhs.m_value.real(), true);
+        is_equal &= rhs.approx_compare(lhs.imag(), rhs.m_value.imag(), false);
         return is_equal;
     }
 

--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -12,14 +12,14 @@ class ComplexApprox
     double m_epsilon;
 
     bool approx_compare_zero(const double dist, const double magnitude) const
-     {
-        /* need to workaround catch to provide consistent behavior for a real value.
-          bool Approx::equalityComparisonImpl(const double other) const {
-          return marginComparison(m_value, other, m_margin) || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(m_value)));
-          }
-        */
-        return Approx(dist).epsilon(0.0).margin(m_epsilon * (1.0 + magnitude)) == 0.0;
-     }
+    {
+      /* need to workaround catch to provide consistent behavior for a real value.
+        bool Approx::equalityComparisonImpl(const double other) const {
+        return marginComparison(m_value, other, m_margin) || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(m_value)));
+        }
+      */
+      return Approx(dist).epsilon(0.0).margin(m_epsilon * (1.0 + magnitude)) == 0.0;
+    }
 
 public:
     ComplexApprox(const std::complex<double> &value) : m_value(value) {

--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -61,7 +61,7 @@ public:
 
     friend bool operator == (std::complex<float> const& lhs, ComplexApprox const& rhs)
     {
-        return rhs.approx_compare_zero(std::abs(lhs - rhs.m_value), std::abs(rhs.m_value));
+        return rhs.approx_compare_zero(std::abs(std::complex<double>(lhs) - rhs.m_value), std::abs(rhs.m_value));
     }
 
     friend bool operator == (ComplexApprox const &lhs, std::complex<double> const& rhs)

--- a/external_codes/catch/log_complex_approx.hpp
+++ b/external_codes/catch/log_complex_approx.hpp
@@ -10,21 +10,7 @@ namespace Catch {
 class LogComplexApprox
 {
     std::complex<double> m_value;
-    /// threshold for real part
-    double m_epsilon_r;
-    /// threshold for polar compare imaginary part
-    double m_epsilon_p;
-
-    bool approx_compare_real(const double lhs, const double rhs) const
-    {
-        return Approx(lhs).epsilon(m_epsilon_r) == rhs;
-    }
-
-    bool approx_compare_polar(const double lhs, const double rhs) const
-    {
-        return Approx(std::sin(lhs - rhs)).epsilon(m_epsilon_p) == 0.0 &&
-               Approx(std::cos(lhs - rhs)).epsilon(m_epsilon_p) == 1.0;
-    }
+    double m_epsilon;
 
 public:
 
@@ -44,41 +30,30 @@ public:
       init_epsilon();
     }
 
-   void init_epsilon() {
+    void init_epsilon() {
       // Copied from catch.hpp - would be better to copy it from Approx object
-      m_epsilon_r = m_epsilon_p = std::numeric_limits<float>::epsilon()*100;
+      m_epsilon = std::numeric_limits<float>::epsilon()*100;
     }
 
-    LogComplexApprox& epsilon(double new_epsilon_r, double new_epsilon_p = 0.0)
+    LogComplexApprox& epsilon(double new_epsilon)
     {
-      m_epsilon_r = new_epsilon_r;
-      if (new_epsilon_p == 0.0)
-        m_epsilon_p = new_epsilon_r;
-      else
-        m_epsilon_p = new_epsilon_p;
+      m_epsilon = new_epsilon;
       return *this;
     }
 
-    double epsilon_r() const
+    double epsilon() const
     {
-      return m_epsilon_r;
-    }
-
-    double epsilon_p() const
-    {
-      return m_epsilon_p;
+      return m_epsilon;
     }
 
     friend bool operator == (std::complex<double> const& lhs, LogComplexApprox const& rhs)
     {
-        return rhs.approx_compare_real(lhs.real(), rhs.m_value.real()) &&
-               rhs.approx_compare_polar(lhs.imag(), rhs.m_value.imag());
+        return std::exp(lhs) == ComplexApprox(std::exp(rhs.m_value)).epsilon(rhs.m_epsilon);
     }
 
     friend bool operator == (std::complex<float> const& lhs, LogComplexApprox const& rhs)
     {
-        return rhs.approx_compare_real(lhs.real(), rhs.m_value.real()) &&
-               rhs.approx_compare_polar(lhs.imag(), rhs.m_value.imag());
+        return std::exp(lhs) == ComplexApprox(std::exp(rhs.m_value)).epsilon(rhs.m_epsilon);
     }
 
     friend bool operator == (LogComplexApprox const &lhs, std::complex<double> const& rhs)

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -186,10 +186,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "YYY r_fermionic_val " << std::setprecision(16) << r_fermionic_val << std::endl;
   std::cout << "YYY r_bosonic_val " << std::setprecision(16) << r_bosonic_val << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::real(r_all_val) == Approx(0.1248738460467855));
-  REQUIRE(std::abs(std::imag(r_all_val)) < 5e-6);
-  REQUIRE(std::real(r_fermionic_val) == Approx(0.1362181543980086).epsilon(5e-5));
-  REQUIRE(std::abs(std::imag(r_fermionic_val)) < 5e-6);
+  REQUIRE(r_all_val == ComplexApprox(std::complex<RealType>(0.1248738460467855, 0)).epsilon(2e-5, 1e-4));
+  REQUIRE(r_fermionic_val == ComplexApprox(std::complex<RealType>(0.1362181543980086, 0)).epsilon(5e-5, 1e-4));
 #else
   REQUIRE(r_all_val == Approx(0.1248738460469678));
   REQUIRE(r_fermionic_val == ValueApprox(0.1362181543982075));
@@ -232,8 +230,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " " << WF_list[0]->getPhase()<< std::endl;
   std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " " << WF_list[1]->getPhase()<< std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-4.546410485374186, -3.141586279080522)));
+  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)).epsilon(2e-5, 5e-5));
+  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-4.546410485374186, -3.141586279080522)).epsilon(2e-5, 5e-5));
 #else
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965042, 6.283185307179586)));
   REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-5.932711221043984, 6.283185307179586)));
@@ -253,9 +251,9 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
 #if defined(QMC_COMPLEX)
-  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031926441)).epsilon(7e-3));
-  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031928415)).epsilon(7e-3));
-  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032018344)).epsilon(7e-3));
+  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031926441)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031928415)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032018344)).epsilon(8e-5, 5e-2));
   REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(118.02653358655,-0.0022419843505538)).epsilon(5e-4));
   REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(118.02653358655,-0.0022419843498631)).epsilon(5e-4));
   REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-118.46325895634,0.0022419843493758)).epsilon(5e-4));
@@ -280,8 +278,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
             << grad_temp[0] << " " << grad_temp[1] << " " << grad_temp[2]
             << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791,-0.00034808849808193)).epsilon(7e-3));
-  REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059,-6.4240180082292e-05)).epsilon(5e-4));
+  REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791,-0.00034808849808193)).epsilon(1e-4, 2e-2));
+  REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059,-6.4240180082292e-05)).epsilon(1e-5, 5e-4));
   REQUIRE(grad_temp[0] == ComplexApprox(ValueType(1.4567170375539,0.00027263382943948)));
   REQUIRE(grad_temp[1] == ComplexApprox(ValueType(1.4567170375539,0.00027263382945093)));
   REQUIRE(grad_temp[2] == ComplexApprox(ValueType(-1.2930978490431,-0.00027378452214318)));
@@ -332,13 +330,13 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
             << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(ratios[0] == ComplexApprox(ValueType(1, 0)).epsilon(5e-5));
-  REQUIRE(grad_new[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(7e-3));
-  REQUIRE(grad_new[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(7e-3));
-  REQUIRE(grad_new[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(7e-3));
+  REQUIRE(grad_new[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5, 5e-2));
   REQUIRE(ratios[1] == ComplexApprox(ValueType(0.12487384604679, 0)));
-  REQUIRE(grad_new[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(2e-2));
-  REQUIRE(grad_new[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(2e-2));
-  REQUIRE(grad_new[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(2e-2));
+  REQUIRE(grad_new[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5, 5e-2));
 #else
   REQUIRE(ratios[0] == Approx(1).epsilon(5e-5));
   REQUIRE(grad_new[0][0] == Approx(713.69119517463).epsilon(1e-4));
@@ -355,8 +353,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " " << WF_list[0]->getPhase() << std::endl;
   std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " " << WF_list[1]->getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296886, -3.141586279081995)).epsilon(1e-4));
+  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)).epsilon(2e-5, 5e-5));
+  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296886, -3.141586279081995)).epsilon(2e-5, 5e-5));
 #else
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965155, 6.283185307179586)));
   REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965223, 6.283185307179586)));
@@ -364,12 +362,12 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
 
   psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
-  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(7e-3));
-  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(7e-3));
-  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(7e-3));
-  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(2e-2));
-  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(2e-2));
-  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(2e-2));
+  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5, 5e-2));
 #else
   REQUIRE(grad_old[0][0] == Approx(713.69119517463).epsilon(1e-4));
   REQUIRE(grad_old[0][1] == Approx(713.69119517463).epsilon(1e-4));

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -186,8 +186,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "YYY r_fermionic_val " << std::setprecision(16) << r_fermionic_val << std::endl;
   std::cout << "YYY r_bosonic_val " << std::setprecision(16) << r_bosonic_val << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(r_all_val == ComplexApprox(std::complex<RealType>(0.1248738460467855, 0)).epsilon(2e-5, 1e-4));
-  REQUIRE(r_fermionic_val == ComplexApprox(std::complex<RealType>(0.1362181543980086, 0)).epsilon(5e-5, 1e-4));
+  REQUIRE(r_all_val == ComplexApprox(std::complex<RealType>(0.1248738460467855, 0)).epsilon(2e-5));
+  REQUIRE(r_fermionic_val == ComplexApprox(std::complex<RealType>(0.1362181543980086, 0)).epsilon(2e-5));
 #else
   REQUIRE(r_all_val == Approx(0.1248738460469678));
   REQUIRE(r_fermionic_val == ValueApprox(0.1362181543982075));
@@ -230,8 +230,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " " << WF_list[0]->getPhase()<< std::endl;
   std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " " << WF_list[1]->getPhase()<< std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)).epsilon(2e-5, 5e-5));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-4.546410485374186, -3.141586279080522)).epsilon(2e-5, 5e-5));
+  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)));
+  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-4.546410485374186, -3.141586279080522)));
 #else
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965042, 6.283185307179586)));
   REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-5.932711221043984, 6.283185307179586)));
@@ -251,12 +251,12 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
 #if defined(QMC_COMPLEX)
-  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031926441)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031928415)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032018344)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(118.02653358655,-0.0022419843505538)).epsilon(5e-4));
-  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(118.02653358655,-0.0022419843498631)).epsilon(5e-4));
-  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-118.46325895634,0.0022419843493758)).epsilon(5e-4));
+  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031926441)).epsilon(8e-5));
+  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031928415)).epsilon(8e-5));
+  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032018344)).epsilon(8e-5));
+  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(118.02653358655,-0.0022419843505538)));
+  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(118.02653358655,-0.0022419843498631)));
+  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-118.46325895634,0.0022419843493758)));
 #else
   REQUIRE(grad_old[0][0] == Approx(713.69119517454).epsilon(2e-4));
   REQUIRE(grad_old[0][1] == Approx(713.69119517455).epsilon(2e-4));
@@ -278,8 +278,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
             << grad_temp[0] << " " << grad_temp[1] << " " << grad_temp[2]
             << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791,-0.00034808849808193)).epsilon(1e-4, 2e-2));
-  REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059,-6.4240180082292e-05)).epsilon(1e-5, 5e-4));
+  REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791,-0.00034808849808193)).epsilon(1e-4));
+  REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059,-6.4240180082292e-05)).epsilon(1e-5));
   REQUIRE(grad_temp[0] == ComplexApprox(ValueType(1.4567170375539,0.00027263382943948)));
   REQUIRE(grad_temp[1] == ComplexApprox(ValueType(1.4567170375539,0.00027263382945093)));
   REQUIRE(grad_temp[2] == ComplexApprox(ValueType(-1.2930978490431,-0.00027378452214318)));
@@ -330,13 +330,13 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
             << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(ratios[0] == ComplexApprox(ValueType(1, 0)).epsilon(5e-5));
-  REQUIRE(grad_new[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_new[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_new[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5));
+  REQUIRE(grad_new[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5));
+  REQUIRE(grad_new[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5));
   REQUIRE(ratios[1] == ComplexApprox(ValueType(0.12487384604679, 0)));
-  REQUIRE(grad_new[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_new[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_new[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_new[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5));
+  REQUIRE(grad_new[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5));
+  REQUIRE(grad_new[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5));
 #else
   REQUIRE(ratios[0] == Approx(1).epsilon(5e-5));
   REQUIRE(grad_new[0][0] == Approx(713.69119517463).epsilon(1e-4));
@@ -353,8 +353,8 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
   std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " " << WF_list[0]->getPhase() << std::endl;
   std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " " << WF_list[1]->getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)).epsilon(2e-5, 5e-5));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296886, -3.141586279081995)).epsilon(2e-5, 5e-5));
+  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)));
+  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-6.626861768296886, -3.141586279081995)));
 #else
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965155, 6.283185307179586)));
   REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) == LogComplexApprox(std::complex<RealType>(-8.013162503965223, 6.283185307179586)));
@@ -362,12 +362,12 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
 
   psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
-  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5, 5e-2));
-  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5, 5e-2));
+  REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653,0.020838031942702)).epsilon(8e-5));
+  REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654,0.020838031944677)).epsilon(8e-5));
+  REQUIRE(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889,-0.020838032035842)).epsilon(8e-5));
+  REQUIRE(grad_old[1][0] == ComplexApprox(ValueType(713.71203320656,0.020838031892613)).epsilon(8e-5));
+  REQUIRE(grad_old[1][1] == ComplexApprox(ValueType(713.71203320657,0.020838031894628)).epsilon(8e-5));
+  REQUIRE(grad_old[1][2] == ComplexApprox(ValueType(-768.42842826892,-0.020838031981896)).epsilon(8e-5));
 #else
   REQUIRE(grad_old[0][0] == Approx(713.69119517463).epsilon(1e-4));
   REQUIRE(grad_old[0][1] == Approx(713.69119517463).epsilon(1e-4));


### PR DESCRIPTION
## Proposed changes

Now the pass tolerance of ComplexApprox and LogComplexApprox imaginary and polar parts can be inputted independently. Note that these two files are from us even placed in the catch folder.
Hopefully it addresses #2402. We will need the nightly tests to confirm.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora, checked Intel and clang
Ryzen-box, checked gcc.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
