### PR TITLE
Adjust CheckQuadratureRuleReal tolerance

### DIFF
--- a/src/Numerics/Quadrature.h
+++ b/src/Numerics/Quadrature.h
@@ -313,7 +313,7 @@ struct Quadrature3D
             }
             if ((l1 == l2) && (m1 == m2))
               sum -= 1.0;
-            if (std::abs(sum) > 15 * std::numeric_limits<float>::epsilon())
+            if (std::abs(sum) > 16 * std::numeric_limits<float>::epsilon())
             {
               app_error() << "Broken real spherical quadrature for " << grid.size() << "-point rule.\n" << std::endl;
               app_error() << "  Should be zero:  " << sum << std::endl;


### PR DESCRIPTION
## Proposed changes
Adjust tolerance to pass gcc8 and 50 quadrature point rule check in mixed precision on CI nodes.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
ALCF CI nodes.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'