### PR TITLE
Exception must be handled inside MPI scope.

### DIFF
--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -44,13 +44,13 @@ void output_hardware_info(Communicate* comm, Libxml2Document& doc, xmlNodePtr ro
 int main(int argc, char** argv)
 {
   using namespace qmcplusplus;
+#ifdef HAVE_MPI
+  mpi3::environment env(argc, argv);
+  OHMMS::Controller->initialize(env);
+#endif
   try
   {
     //qmc_common  and MPI is initialized
-#ifdef HAVE_MPI
-    mpi3::environment env(argc, argv);
-    OHMMS::Controller->initialize(env);
-#endif
     qmcplusplus::qmc_common.initialize(argc, argv);
     int clones = 1;
 #ifdef QMC_CUDA
@@ -245,7 +245,6 @@ int main(int argc, char** argv)
       delete qmc;
     if (useGPU)
       Finalize_CUDA();
-    OHMMS::Controller->finalize();
   }
   catch (const std::exception& e)
   {
@@ -258,6 +257,7 @@ int main(int argc, char** argv)
     APP_ABORT("Unhandled Exception");
   }
 
+  OHMMS::Controller->finalize();
   return 0;
 }
 


### PR DESCRIPTION
## Proposed changes
Closes #2247
OpenMPI nicely warns me of calling MPI_Abort after MPI_Finalize.
From https://en.cppreference.com/w/cpp/language/throw
> As the control flow moves up the call stack, destructors are invoked for all objects with automatic storage duration constructed, but not yet destroyed, since the corresponding try-block was entered, in reverse order of completion of their constructors.

Since #2014, the env was inside the try scope and its destructor called MPI_Finalize in the try scope before calling MPI_Abort in the catch.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'