### PR TITLE
added preprocessing flag to guard stacktrace, turned off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ SET(BUILD_FCIQMC 0 CACHE BOOL "Build with FCIQMC")
 #SET(MPIP_PROFILE 0)
 SET(QMC_BUILD_STATIC 0 CACHE BOOL "Link to static libraries")
 SET(ENABLE_TIMERS 0 CACHE BOOL "Enable internal timers")
+SET(ENABLE_STACKTRACE 0 CACHE BOOL "Enable use of boost::stacktrace")
 
 ######################################################################
 # Install options

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -29,16 +29,12 @@
 // guard with directive that checks if boost version is >=1.65
 // uncomment to enable stacktrace
 //#define ENABLE_STACKTRACE
-#if defined(ENABLE_STACKTRACE)
- #include <boost/version.hpp>
- #if BOOST_VERSION >= 106500
-  #include <boost/stacktrace.hpp>
-  #define print_stacktrace std::cout << boost::stacktrace::stacktrace();
- #else
-  #define print_stacktrace std::cout << "stacktrace not enabled.\n";  
- #endif
+#include <boost/version.hpp>
+#if (BOOST_VERSION >= 106500) && defined(ENABLE_STACKTRACE)
+#include <boost/stacktrace.hpp>
+#define print_stacktrace std::cout << boost::stacktrace::stacktrace();
 #else
- #define print_stacktrace std::cout << "stacktrace not enabled.\n"; 
+#define print_stacktrace std::cout << "stacktrace not enabled.\n"; 
 #endif
 
 namespace qmcplusplus

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -27,12 +27,18 @@
 #define PsiT_IN_SHM
 
 // guard with directive that checks if boost version is >=1.65
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 106500
-#include <boost/stacktrace.hpp>
-#define print_stacktrace std::cout << boost::stacktrace::stacktrace();
+// uncomment to enable stacktrace
+//#define ENABLE_STACKTRACE
+#if defined(ENABLE_STACKTRACE)
+ #include <boost/version.hpp>
+ #if BOOST_VERSION >= 106500
+  #include <boost/stacktrace.hpp>
+  #define print_stacktrace std::cout << boost::stacktrace::stacktrace();
+ #else
+  #define print_stacktrace std::cout << "stacktrace not enabled.\n";  
+ #endif
 #else
-#define print_stacktrace std::cout << "stacktrace not enabled.\n"; 
+ #define print_stacktrace std::cout << "stacktrace not enabled.\n"; 
 #endif
 
 namespace qmcplusplus

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -126,6 +126,9 @@
 /* Using CUDA for GPU execution, next generation */
 #cmakedefine ENABLE_CUDA @ENABLE_CUDA@
 
+/* Using boost::stacktrace */ 
+#cmakedefine ENABLE_STACKTRACE @ENABLE_STACKTRACE@
+
 /* Setting base precision for CUDA kernels */
 #cmakedefine CUDA_PRECISION @CUDA_PRECISION@
 

--- a/src/qmcpack.settings
+++ b/src/qmcpack.settings
@@ -16,6 +16,7 @@ ENABLE_CUDA            = @ENABLE_CUDA@
 ENABLE_PHDF5           = @ENABLE_PHDF5@
 ENABLE_MKL             = @ENABLE_MKL@
 ENABLE_MASS            = @ENABLE_MASS@
+ENABLE_STACKTRACE      = @ENABLE_STACKTRACE@ 
 
 #system variables
 QMC_HOSTNAME           = @QMC_HOSTNAME@


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Added ENABLE_STACKTRACE to guard the use of boost/stacktrace in AFQMC code. Since this is only used for development, it needs to be turned on manually for now. In the future, if needed, we could add controls from cmake. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
