### PR TITLE
WaveFunctionTester RNG bug fix 

### DIFF
--- a/manual/additional_tools.tex
+++ b/manual/additional_tools.tex
@@ -128,12 +128,12 @@ The wftester is implemented as a QMCDriver, so one invokes \qmcpack in the norma
 
 Here's a summary of some of the tests provided:
 \begin{itemize}
-\item Ratio test.  Invoked with \begin{verbatim}<parameter name="ratio">yes</parameter>\end{verbatim}  This computes the implemented wave function ratio associated with a single-particle move using two different methods.
-\item Clone test. Invoked with \begin{verbatim}<parameter name="clone">yes</parameter>\end{verbatim}  This checks the cloning of TrialWaveFunction, ParticleSet, Hamiltonian, and Walkers.  
+\item Ratio Test.  Invoked with \begin{verbatim}<parameter name="ratio">yes</parameter>\end{verbatim}  This computes the implemented wave function ratio associated with a single-particle move using two different methods.
+\item Clone Test. Invoked with \begin{verbatim}<parameter name="clone">yes</parameter>\end{verbatim}  This checks the cloning of TrialWaveFunction, ParticleSet, Hamiltonian, and Walkers.  
 \item Elocal Test.  Invoked with \begin{verbatim}<parameter name="printEloc">yes</parameter>\end{verbatim}  For an input electron configuration (can be random), print the value of TrialWaveFunction, LocalEnergy, and all local observables for this configuration.  
 \item Derivative Test.  Invoked with \begin{verbatim}<parameter name="ratio">deriv</parameter>}\end{verbatim}  Computes electron gradients, laplacians, and wave function parameter derivatives using implemented calls and compares them to finite-difference results.   
-\item Ion gradient test.  Invoked with \begin{verbatim}<parameter name="source">ion0</parameter>\end{verbatim}  Calls the implemented evaluateGradSource functions and compares them against finite-difference results.  
-\item ``Basic test".  Invoked with \begin{verbatim}<parameter name="basic">yes</parameter>\end{verbatim}  Performs ratio, gradient, and laplacian tests against finite-difference and direct computation of wave function values.  
+\item Ion Gradient Test.  Invoked with \begin{verbatim}<parameter name="source">ion0</parameter>\end{verbatim}  Calls the implemented evaluateGradSource functions and compares them against finite-difference results.  
+\item ``Basic Test".  Invoked with \begin{verbatim}<parameter name="basic">yes</parameter>\end{verbatim}  Performs ratio, gradient, and laplacian tests against finite-difference and direct computation of wave function values.  
 
 \end{itemize}
 

--- a/manual/additional_tools.tex
+++ b/manual/additional_tools.tex
@@ -112,3 +112,30 @@ When using an ionized state, the three reference states are all set as ``1s(2)2p
 Unfortunately, if the generated UPF file is used in QE, the calculation may be incorrect because of the presence of ``ghost'' states. Potentially these can be removed by adjusting the local channel (e.g., by setting \ishell{--local_channel 1}, which chooses the p channel as the local channel instead of d.
 For this reason, validation of UPF PPs is always required from the third row and is strongly encouraged in general. For example, check that the expected ionization potential and electron affinities are obtained for the atom and that dimer properties are consistent with those obtained by a quantum chemistry code or a plane-wave code that does not use the Kleinman-Bylander projectors.
 \input{pseudopotentials}
+
+\subsection{wftester}\label{sec:wftester}
+While not really a stand-alone application, wftester (short for ``Wave Function Tester") is a helpful tool for testing pre-existing and experimental estimators and observables.  It provides the user with derived quantities from the Hamiltonian and wave function, but evaluated at a small set of configurations. 
+
+The wftester is implemented as a QMCDriver, so one invokes \qmcpack in the normal manner with a correct input XML, the difference being the addition of an additional qmc input block.  This is the main advantage of this tool--it allows testing of realistic systems and realistic combinations of observables.  It can also be invoked before launching into optimization, VMC, or DMC runs, as it is a valid <qmc> block.
+
+ As an example, the following code generates a random walker configuration and compares the trial wave function ratio computed in two different ways:
+
+\begin{lstlisting}[style=QMCPXML,caption=The following executes the wavefunction ratio test in ``wftester" ]
+  <qmc method="wftester">
+    <parameter name="ratio">    yes    </parameter>
+  </qmc>
+\end{lstlisting}
+
+Here's a summary of some of the tests provided:
+\begin{itemize}
+\item Ratio test.  Invoked with \begin{verbatim}<parameter name="ratio">yes</parameter>\end{verbatim}  This computes the implemented wave function ratio associated with a single-particle move using two different methods.
+\item Clone test. Invoked with \begin{verbatim}<parameter name="clone">yes</parameter>\end{verbatim}  This checks the cloning of TrialWaveFunction, ParticleSet, Hamiltonian, and Walkers.  
+\item Elocal Test.  Invoked with \begin{verbatim}<parameter name="printEloc">yes</parameter>\end{verbatim}  For an input electron configuration (can be random), print the value of TrialWaveFunction, LocalEnergy, and all local observables for this configuration.  
+\item Derivative Test.  Invoked with \begin{verbatim}<parameter name="ratio">deriv</parameter>}\end{verbatim}  Computes electron gradients, laplacians, and wave function parameter derivatives using implemented calls and compares them to finite-difference results.   
+\item Ion gradient test.  Invoked with \begin{verbatim}<parameter name="source">ion0</parameter>\end{verbatim}  Calls the implemented evaluateGradSource functions and compares them against finite-difference results.  
+\item ``Basic test".  Invoked with \begin{verbatim}<parameter name="basic">yes</parameter>\end{verbatim}  Performs ratio, gradient, and laplacian tests against finite-difference and direct computation of wave function values.  
+
+\end{itemize}
+
+The output of the various tests will be to standard out or ``wftest.000" after successful execution of qmcpack.  
+ 

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -102,6 +102,10 @@ bool WaveFunctionTester::run()
   app_log() << "Starting a Wavefunction tester.  Additional information in " << fname << std::endl;
 
   put(qmcNode);
+
+  RandomGenerator_t* Rng1        = new RandomGenerator_t();
+  H.setRandomGenerator(Rng1);
+
   if (checkSlaterDetOption == "no")
     checkSlaterDet = false;
   if (checkRatio == "yes")
@@ -1410,6 +1414,7 @@ void WaveFunctionTester::runRatioV()
 
 void WaveFunctionTester::runGradSourceTest()
 {
+   
   app_log() << " ===== runGradSourceTest =====\n";
   ParticleSetPool::PoolType::iterator p;
   for (p = PtclPool.getPool().begin(); p != PtclPool.getPool().end(); p++)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This fixes a problem where the random number generator was no longer properly initialized for use in WaveFunctionTester.  This meant that simple Hamiltonian evaluation would crash if it had a non-local pseudopotential.  The random number generator is now initialized before launching the various tests.  

A little documentation on the various tests and syntax for running wftester is also added to the manual.  

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Documentation content changes


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
Intel Xeon Haswell
## Checklist



- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)

NOTE:  I'm going to hold off on adding an integration test until I have a better idea of how best to do it.  Standing this back up now is needed for force debugging. 
