### PR TITLE
Add checks and tests for PBC Coulomb forces

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -181,7 +181,8 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
                                                            ParticleSet::ParticlePos_t& hf_terms,
                                                            ParticleSet::ParticlePos_t& pulay_terms)
 {
-  hf_terms -= forces;
+  if (ComputeForces and !is_active)
+    hf_terms -= forces;
   //No pulay term.
   return Value;
 }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -180,10 +180,15 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
                                                            ParticleSet::ParticlePos_t& hf_terms,
                                                            ParticleSet::ParticlePos_t& pulay_terms)
 {
-  forces = 0.0;
-  Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
-  hf_terms -= forces;
-  //And no Pulay contribution.
+  if (ComputeForces)
+  {
+    forces = 0.0;
+    Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
+    hf_terms -= forces;
+    //And no Pulay contribution.
+  }
+  else
+    Value = evalLR(P) + evalSR(P) + myConst;
   return Value;
 }
 


### PR DESCRIPTION
## Proposed changes

This adds a few checks to protect from crashes in PBC force calculations, some of which would happen in PBC calculations with Nelec != Nnuc. Also add a few simple unit tests to protect the checks. 

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

GNU (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, Intel Xeon

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
