### PR TITLE
Fix nightly and unit tests

### DIFF
--- a/src/AFQMC/CMakeLists.txt
+++ b/src/AFQMC/CMakeLists.txt
@@ -43,6 +43,7 @@ IF(ENABLE_CUDA)
     Numerics/detail/CUDA/Kernels/zero_complex_part.cu
     Numerics/detail/CUDA/Kernels/batchedDot.cu
     Numerics/detail/CUDA/Kernels/copy_n_cast.cu
+    Numerics/detail/CUDA/Kernels/inplace_cast.cu
     Numerics/detail/CUDA/Kernels/ajw_to_waj.cu 
     Numerics/detail/CUDA/Kernels/vKKwij_to_vwKiKj.cu 
     Numerics/detail/CUDA/Kernels/KaKjw_to_QKajw.cu

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -18,7 +18,7 @@
 #include "io/hdf_archive.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include <stdio.h>
 #include <string>

--- a/src/AFQMC/HamiltonianOperations/HamiltonianOperations.hpp
+++ b/src/AFQMC/HamiltonianOperations/HamiltonianOperations.hpp
@@ -29,7 +29,7 @@
 //#include "AFQMC/HamiltonianOperations/KPTHCOps.hpp"
 #else
 #include "AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp"
-#include "AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp"
+//#include "AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp"
 #include "AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp"
 #endif
 
@@ -179,7 +179,7 @@ class HamiltonianOperations:
                                   SparseTensor<ComplexType,RealType>,
                                   SparseTensor<ComplexType,ComplexType>,
                                   Real3IndexFactorization,
-                                  Real3IndexFactorization_batched,
+//                                  Real3IndexFactorization_batched,
                                   Real3IndexFactorization_batched_v2
                              >
 #endif
@@ -199,7 +199,7 @@ class HamiltonianOperations:
     explicit HamiltonianOperations(STRC&& other) : variant(std::move(other)) {}
     explicit HamiltonianOperations(STCR&& other) : variant(std::move(other)) {}
     explicit HamiltonianOperations(Real3IndexFactorization&& other) : variant(std::move(other)) {}
-    explicit HamiltonianOperations(Real3IndexFactorization_batched&& other) : variant(std::move(other)) {}
+//    explicit HamiltonianOperations(Real3IndexFactorization_batched&& other) : variant(std::move(other)) {}
     explicit HamiltonianOperations(Real3IndexFactorization_batched_v2&& other) : variant(std::move(other)) {}
 #else
     explicit HamiltonianOperations(KP3IndexFactorization&& other) : variant(std::move(other)) {}
@@ -215,7 +215,7 @@ class HamiltonianOperations:
     explicit HamiltonianOperations(STRC const& other) = delete;
     explicit HamiltonianOperations(STCR const& other) = delete;
     explicit HamiltonianOperations(Real3IndexFactorization const& other) = delete;
-    explicit HamiltonianOperations(Real3IndexFactorization_batched const& other) = delete;
+//    explicit HamiltonianOperations(Real3IndexFactorization_batched const& other) = delete;
     explicit HamiltonianOperations(Real3IndexFactorization_batched_v2 const& other) = delete;
 #else
     explicit HamiltonianOperations(KP3IndexFactorization const& other) = delete;

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -1150,7 +1150,7 @@ class KP3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& Gw, MatB&& v, double a=1., double c=0., int nd=0) {
-      using GType = typename std::decay<MatA>::type::element ;
+      using GType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       int nkpts = nopk.size();
       assert(nd >= 0 && nd < nelpk.size());

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -41,6 +41,9 @@ namespace afqmc
 class KP3IndexFactorization
 {
 
+  using sp_pointer = SPComplexType*;  
+  using const_sp_pointer = SPComplexType const*;  
+
   using IVector = boost::multi::array<int,1>;
   using CVector = boost::multi::array<ComplexType,1>;
   using SpVector = boost::multi::array<SPComplexType,1>;
@@ -982,21 +985,24 @@ class KP3IndexFactorization
       using vType = typename std::decay<MatB>::type::element; 
       boost::multi::array_ref<vType,3>  v3D(to_address(v.origin()),{nwalk,nmo_tot,nmo_tot});
 
-#if MIXED_PRECISION
-      size_t mem_needs = Xw.num_elements();
-      set_shm_buffer(mem_needs);
-
-      SpMatrix_ref X(to_address(SM_TMats.origin()),Xw.extensions());
-      {
-        size_t i0, iN;
-        std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(Xw.num_elements()),size_t(comm->size()));
-        copy_n_cast(to_address(Xw.origin())+i0,iN-i0,X.origin()+i0);
-      }
-      comm->barrier();
-#else
-      //SpMatrix_ref X(make_device_ptr(Xw.origin()),Xw.extensions());
-      SpMatrix_ref X(to_address(Xw.origin()),Xw.extensions());
-#endif
+      sp_pointer Xptr(nullptr);
+      // I WANT C++17!!!!!!
+      using XType = typename std::decay<MatA>::type::element ;
+      if( std::is_same<SPComplexType,XType>::value ) {
+        Xptr = reinterpret_cast<sp_pointer>(to_address(Xw.origin()));
+      } else {
+        size_t mem_needs = Xw.num_elements();
+        set_shm_buffer(mem_needs);
+        Xptr = to_address(SM_TMats.origin());
+        {
+          size_t i0, iN;
+          std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(Xw.num_elements()),
+                                               size_t(comm->size()));
+          copy_n_cast(to_address(Xw.origin())+i0,iN-i0,Xptr+i0);
+        }
+        comm->barrier();
+      }  
+      SpMatrix_ref X(Xptr,Xw.extensions());
 
       // "rotate" X
       //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
@@ -1081,11 +1087,7 @@ class KP3IndexFactorization
                 for(int i=0; i<ni; i++) {
                   auto v3D_ni(to_address(v3D[nw][ni0+i].origin()) + nk0);
                   for(int k=0; k<nk; k++, ++v3D_ni)
-#if MIXED_PRECISION
                     *v3D_ni += static_cast<vType>(vki_n[k][i]);
-#else
-                    *v3D_ni += vki_n[k][i];
-#endif
                 }
               }
             } 
@@ -1117,11 +1119,7 @@ class KP3IndexFactorization
                 for(int k=0; k<nk; k++) {
                   auto v3D_nk = to_address(v3D[nw][nk0+k].origin()) + ni0;
                   for(int i=0; i<ni; i++, ++v3D_nk)
-#if MIXED_PRECISION
                     *v3D_nk += static_cast<vType>(vik3D_n[i][k]);
-#else
-                    *v3D_nk += vik3D_n[i][k];
-#endif
                 }
               }
             }
@@ -1152,6 +1150,8 @@ class KP3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& Gw, MatB&& v, double a=1., double c=0., int nd=0) {
+      using GType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       int nkpts = nopk.size();
       assert(nd >= 0 && nd < nelpk.size());
       int nwalk = Gw.size(1);
@@ -1176,35 +1176,32 @@ class KP3IndexFactorization
       SPComplexType halfa(0.5*a*scl,0.0);
       SPComplexType minusimhalfa(0.0,-0.5*a*scl);
       SPComplexType imhalfa(0.0,0.5*a*scl);
-      size_t local_memory_needs = 2*nchol_max*nwalk + std::max(nocca_max,noccb_max)*nwalk;
+      size_t local_memory_needs = 2*nchol_max*nwalk; 
       if(TMats.num_elements() < local_memory_needs) TMats.reextent({local_memory_needs,1});
       SpMatrix_ref vlocal(TMats.origin(),{2*nchol_max,nwalk});
       std::fill_n(vlocal.origin(),vlocal.num_elements(),SPComplexType(0.0));
-      SpMatrix_ref Gl(TMats.origin()+vlocal.num_elements(),{std::max(nocca_max,noccb_max),nwalk});
 
       assert(Gw.num_elements() == nwalk*(nocca_tot+noccb_tot)*nmo_tot);
-#if MIXED_PRECISION
-      size_t mem_needs = Gw.num_elements();
-      set_shm_buffer(mem_needs);
-
-      {
-        size_t i0, iN;
-        std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(Gw.num_elements()),size_t(comm->size()));
-        copy_n_cast(to_address(Gw.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+      const_sp_pointer Gptr(nullptr);
+      // I WANT C++17!!!!!!
+      if( std::is_same<SPComplexType,GType>::value ) {
+        Gptr = reinterpret_cast<const_sp_pointer>(to_address(Gw.origin())); 
+      } else {  
+        size_t mem_needs = Gw.num_elements();
+        set_shm_buffer(mem_needs);
+        {
+          size_t i0, iN;
+          std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(Gw.num_elements()),size_t(comm->size()));
+          copy_n_cast(to_address(Gw.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        }
+        Gptr = to_address(SM_TMats.origin()); 
+        comm->barrier();
       }
-      boost::multi::array_ref<SPComplexType,3> G3Da(to_address(SM_TMats.origin()),
-                                                        {nocca_tot,nmo_tot,nwalk} );
-      boost::multi::array_ref<SPComplexType,3> G3Db(to_address(SM_TMats.origin())+
-                                                        G3Da.num_elements()*(nspin-1),
-                                                        {noccb_tot,nmo_tot,nwalk} );
-#else
-      boost::multi::array_cref<ComplexType,3> G3Da(to_address(Gw.origin()),
-                                                        {nocca_tot,nmo_tot,nwalk} );
-      boost::multi::array_cref<ComplexType,3> G3Db(to_address(Gw.origin())+
-                                                        G3Da.num_elements()*(nspin-1),
-                                                        {noccb_tot,nmo_tot,nwalk} );
-#endif
 
+      boost::multi::array_cref<SPComplexType,3> G3Da(Gptr,
+                                                        {nocca_tot,nmo_tot,nwalk} );
+      boost::multi::array_cref<SPComplexType,3> G3Db(Gptr+G3Da.num_elements()*(nspin-1),
+                                                        {noccb_tot,nmo_tot,nwalk} );
 
       {
         size_t i0, iN;

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -337,7 +337,7 @@ class KP3IndexFactorization_batched
             P1[I][J] += H1[K][i][j] + vn0[K][i][j];
             P1[J][I] += H1[K][j][i] + vn0[K][j][i];
             // This is really cutoff dependent!!!
-#if AFQMC_MIXED_PRECISION
+#if MIXED_PRECISION
             if( std::abs(P1[I][J]-ma::conj(P1[J][I]))*2.0 > 1e-5 ) {
 #else
             if( std::abs(P1[I][J]-ma::conj(P1[J][I]))*2.0 > 1e-6 ) {

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -44,7 +44,7 @@ extern std::shared_ptr<device_allocator_generator_type> device_buffer_generator;
 // when an approach is found, integrate in original class through additional template parameter
 
 template<class LQKankMatrix>
-class KP3IndexFactorization_batched
+class KP3IndexFactorization_batched 
 {
   // allocators
   using Allocator = device_allocator<ComplexType>;
@@ -146,7 +146,7 @@ class KP3IndexFactorization_batched
         TG(tg_),
         allocator_(alloc_),
         sp_allocator_(alloc_),
-        buffer_allocator(device_buffer_generator.get()), // hard-wired to device like Allocator
+        device_buffer_allocator(device_buffer_generator.get()), // hard-wired to device like Allocator
         walker_type(type),
         global_nCV(gncv),
         global_origin(cv0),
@@ -433,9 +433,9 @@ class KP3IndexFactorization_batched
         APP_ABORT(" Error: Kr and/or Kl can only be calculated with addEJ=true.\n");
       }   
       StaticMatrix Kl({Knr,Knc},
-                        buffer_allocator->template get_allocator<SPComplexType>());
+                        device_buffer_allocator->template get_allocator<SPComplexType>());
       StaticMatrix Kr({Knr,Knc},
-                        buffer_allocator->template get_allocator<SPComplexType>());
+                        device_buffer_allocator->template get_allocator<SPComplexType>());
       fill_n(Kr.origin(),Knr*Knc,SPComplexType(0.0));
       fill_n(Kl.origin(),Knr*Knc,SPComplexType(0.0));
 
@@ -450,7 +450,7 @@ class KP3IndexFactorization_batched
       // later on, rewrite routine to loop over spins, to avoid storage of both spin
       // components simultaneously
       Static4Tensor GKK({nspin,nkpts,nkpts,nwalk*nmo_max*nocc_max},
-                        buffer_allocator->template get_allocator<SPComplexType>());
+                        device_buffer_allocator->template get_allocator<SPComplexType>());
       GKaKjw_to_GKKwaj(G3Da,GKK[0],nelpk[nd].sliced(0,nkpts),dev_nelpk[nd],dev_a0pk[nd]);
       if(walker_type==COLLINEAR)  
         GKaKjw_to_GKKwaj(G3Db,GKK[1],nelpk[nd].sliced(nkpts,2*nkpts),
@@ -519,12 +519,12 @@ class KP3IndexFactorization_batched
         kdiag.reserve(batch_size);
 
         StaticIVector IMats(iextensions<1u>{batch_size}, 
-                        buffer_allocator->template get_allocator<int>());
+                        device_buffer_allocator->template get_allocator<int>());
         fill_n(IMats.origin(),IMats.num_elements(),0);
         StaticVector dev_scl_factors(iextensions<1u>{batch_size},
-                        buffer_allocator->template get_allocator<SPComplexType>());
+                        device_buffer_allocator->template get_allocator<SPComplexType>());
         Static3Tensor T1({batch_size,nwalk*nocc_max,nocc_max*nchol_max},
-                        buffer_allocator->template get_allocator<SPComplexType>());
+                        device_buffer_allocator->template get_allocator<SPComplexType>());
         SPRealType scl = (walker_type==CLOSED?2.0:1.0);
         
         // I WANT C++17!!!!!!
@@ -532,7 +532,7 @@ class KP3IndexFactorization_batched
         if(needs_copy) 
             mem_ank = nkpts*nocc_max*nchol_max*nmo_max;
         StaticVector LBuff(iextensions<1u>{2*mem_ank},
-                    buffer_allocator->template get_allocator<SPComplexType>());
+                    device_buffer_allocator->template get_allocator<SPComplexType>());
         sp_pointer LQptr(nullptr), LQmptr(nullptr); 
         if(needs_copy) {
           // data will be copied here  
@@ -677,9 +677,9 @@ class KP3IndexFactorization_batched
                       ComplexType(0.0),E[n].origin()+2);
         }
         if(getKr) 
-          copy_n(Kr.origin(),Kr.num_elements(),KEright->origin());
+          copy_n_cast(Kr.origin(),Kr.num_elements(),make_device_ptr(KEright->origin()));
         if(getKl) 
-          copy_n(Kl.origin(),Kl.num_elements(),KEleft->origin());
+          copy_n_cast(Kl.origin(),Kl.num_elements(),make_device_ptr(KEleft->origin()));
       }
     }
 
@@ -1101,17 +1101,17 @@ class KP3IndexFactorization_batched
       SPComplexType imhalfa(0.0,0.5*a);
 
       Static3Tensor vKK({nkpts+number_of_symmetric_Q,nkpts,nwalk*nmo_max*nmo_max},
-                           buffer_allocator->template get_allocator<SPComplexType>()); 
+                           device_buffer_allocator->template get_allocator<SPComplexType>()); 
       fill_n(vKK.origin(),vKK.num_elements(),SPComplexType(0.0));
       Static4Tensor XQnw({nkpts,2,nchol_max,nwalk},  
-                           buffer_allocator->template get_allocator<SPComplexType>()); 
+                           device_buffer_allocator->template get_allocator<SPComplexType>()); 
       fill_n(XQnw.origin(),XQnw.num_elements(),SPComplexType(0.0));
 
       // "rotate" X  
       //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)  
 #if MIXED_PRECISION
       StaticMatrix Xdev(X.extensions(),
-                           buffer_allocator->template get_allocator<SPComplexType>()); 
+                           device_buffer_allocator->template get_allocator<SPComplexType>()); 
       copy_n_cast(make_device_ptr(X.origin()),X.num_elements(),Xdev.origin());
 #else
       SpMatrix_ref Xdev(make_device_ptr(X.origin()),X.extensions());
@@ -1266,26 +1266,29 @@ class KP3IndexFactorization_batched
       SPComplexType imhalfa(0.0,0.5*a*scl);
 
       assert(G.num_elements() == nwalk*(nocca_tot+noccb_tot)*nmo_tot);
-      C3Tensor_cref G3Da(make_device_ptr(G.origin()),{nocca_tot,nmo_tot,nwalk} );
-      C3Tensor_cref G3Db(make_device_ptr(G.origin())+G3Da.num_elements()*(nspin-1),
+      // MAM: use reshape when available, then no need to deal with types
+      using GType = typename std::decay<MatA>::type::element ;
+      boost::multi::array_ref<GType const,3,decltype(make_device_ptr(G.origin()))> 
+            G3Da(make_device_ptr(G.origin()),{nocca_tot,nmo_tot,nwalk} );
+      boost::multi::array_ref<GType const,3,decltype(make_device_ptr(G.origin()))>
+            G3Db(make_device_ptr(G.origin())+G3Da.num_elements()*(nspin-1),
                                                      {noccb_tot,nmo_tot,nwalk} );
-      {  
-        // assuming contiguous
-        ma::scal(c,v);
-      }
+      
+      // assuming contiguous
+      ma::scal(c,v);
 
       for(int spin=0; spin<nspin; spin++) {
         size_t cnt(0);
         Static3Tensor v1({nkpts+number_of_symmetric_Q,nchol_max,nwalk}, 
-                           buffer_allocator->template get_allocator<SPComplexType>()); 
+                           device_buffer_allocator->template get_allocator<SPComplexType>()); 
         Static3Tensor GQ({nkpts,nkpts*nocc_max*nmo_max,nwalk},
-                           buffer_allocator->template get_allocator<SPComplexType>()); 
+                           device_buffer_allocator->template get_allocator<SPComplexType>()); 
         fill_n(v1.origin(),v1.num_elements(),SPComplexType(0.0));
         fill_n(GQ.origin(),GQ.num_elements(),SPComplexType(0.0));
 
-        if(spin==0) 
+        if(spin==0)  
           GKaKjw_to_GQKajw(G3Da,GQ,nelpk[nd],dev_nelpk[nd],dev_a0pk[nd]);
-        else
+        else 
           GKaKjw_to_GQKajw(G3Db,GQ,nelpk[nd].sliced(nkpts,2*nkpts),
                                    dev_nelpk[nd].sliced(nkpts,2*nkpts),
                                    dev_a0pk[nd].sliced(nkpts,2*nkpts));
@@ -1354,7 +1357,7 @@ class KP3IndexFactorization_batched
 
     Allocator allocator_;
     SpAllocator sp_allocator_;
-    device_allocator_generator_type *buffer_allocator;
+    device_allocator_generator_type *device_buffer_allocator;
 
     WALKER_TYPES walker_type;
 

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -1511,6 +1511,7 @@ class KP3IndexFactorization_batched
     template<class MatA, class MatB>
     void vbias_from_v1(ComplexType a, MatA const& v1, MatB && vbias)
     {
+      using BType = typename std::decay<MatB>::type::element ;
       int nwalk = vbias.size(1);
       int nkpts = nopk.size();
       int nchol_max = *std::max_element(ncholpQ.begin(),ncholpQ.end());
@@ -1519,7 +1520,8 @@ class KP3IndexFactorization_batched
 // using make_device_ptr(vbias.origin()) to catch errors here
       vbias_from_v1(nwalk,nkpts,nchol_max,dev_Qmap.origin(),dev_kminus.origin(),
                              dev_ncholpQ.origin(),dev_Q2vbias.origin(),
-                             a,v1.origin(),to_address(make_device_ptr(vbias.origin())));
+                             static_cast<BType>(a),
+                             v1.origin(),to_address(make_device_ptr(vbias.origin())));
 
     }
 

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -36,9 +36,17 @@ namespace qmcplusplus
 namespace afqmc
 {
 
+// MAM: to make the working precision of this class a template parameter, 
+//      sed away SPComplexType by another type ( which is then defined through a template parameter)
+//      This should be enough, since some parts are kept at ComplexType precision
+//      defined through the cmake
+
 // Custom implementation for real build
 class Real3IndexFactorization
 {
+
+  using sp_pointer = SPComplexType*;
+  using const_sp_pointer = SPComplexType const*;
 
   using IVector = boost::multi::array<int,1>;
   using CVector = boost::multi::array<ComplexType,1>;
@@ -384,28 +392,53 @@ class Real3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
+      using XType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       assert( Likn.size(1) == X.size(0) );
       assert( Likn.size(0) == v.size(0) );
       assert( X.size(1) == v.size(1) );
       long ik0, ikN;
       std::tie(ik0,ikN) = FairDivideBoundary(long(TG.TG_local().rank()),long(Likn.size(0)),long(TG.TG_local().size()));
-#if MIXED_PRECISION
-      size_t mem_needs = X.num_elements()+v.num_elements();
-      set_shm_buffer(mem_needs);
-      boost::multi::array_ref<SPComplexType,2> vsp(to_address(SM_TMats.origin()), v.extensions());
-      boost::multi::array_ref<SPComplexType,2> Xsp(vsp.origin()+vsp.num_elements(), X.extensions());
-      long i0, iN;
-      std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),long(X.num_elements()),long(TG.TG_local().size()));
-      copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(Xsp.origin())+i0);
+      // setup buffer space if changing precision in X or v
+      size_t vmem(0),Xmem(0);
+      if(not std::is_same<XType,SPComplexType>::value) Xmem = X.num_elements();
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements();
+      set_shm_buffer(vmem+Xmem);
+      sp_pointer vptr(nullptr);
+      const_sp_pointer Xptr(nullptr);
+      // setup origin of Xsp and copy_n_cast if necessary
+      if(std::is_same<XType,SPComplexType>::value) {
+        Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.origin()));
+      } else {  
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                  long(X.num_elements()),long(TG.TG_local().size()));
+        copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        Xptr = to_address(SM_TMats.origin());  
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      } else {  
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                  long(v.num_elements()),long(TG.TG_local().size()));
+        vptr = to_address(SM_TMats.origin())+Xmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<SPComplexType const,2> Xsp(Xptr, X.extensions());
+      boost::multi::array_ref<SPComplexType,2> vsp(vptr, v.extensions());
       TG.TG_local().barrier();
+
       ma::product(SPValueType(a),Likn.sliced(ik0,ikN),Xsp,
                   SPValueType(c),vsp.sliced(ik0,ikN));
-      copy_n_cast(to_address(vsp[ik0].origin()),vsp.size(1)*(ikN-ik0),
-                  to_address(v[ik0].origin()));
-#else
-      ma::product(SPValueType(a),Likn.sliced(ik0,ikN),X,
-                  SPValueType(c),v.sliced(ik0,ikN));
-#endif
+
+      if(not std::is_same<vType,SPComplexType>::value) {
+        copy_n_cast(to_address(vsp[ik0].origin()),vsp.size(1)*(ikN-ik0),
+                to_address(v[ik0].origin()));
+      }
       TG.TG_local().barrier();
     }
 
@@ -439,61 +472,68 @@ class Real3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
+      using GType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
+      long ic0, icN;
+      // setup buffer space if changing precision in G or v
+      size_t vmem(0),Gmem(0);
+      if(not std::is_same<GType,SPComplexType>::value) Gmem = G.num_elements(); 
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements(); 
+      set_shm_buffer(vmem+Gmem);
+      const_sp_pointer Gptr(nullptr);
+      sp_pointer vptr(nullptr);  
+      // setup origin of Gsp and copy_n_cast if necessary
+      if(std::is_same<GType,SPComplexType>::value) {
+        Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.origin()));
+      } else { 
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                  long(G.num_elements()),long(TG.TG_local().size()));
+        copy_n_cast(to_address(G.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        Gptr = to_address(SM_TMats.origin()); 
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      } else { 
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                  long(v.num_elements()),long(TG.TG_local().size()));
+        vptr = to_address(SM_TMats.origin())+Gmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<SPComplexType const,2> Gsp(Gptr, G.extensions());
+      boost::multi::array_ref<SPComplexType,2> vsp(vptr, v.extensions());
+      TG.TG_local().barrier();
+
       if(haj.size(0) == 1) {
         assert( Lakn.size(0) == G.size(1) );
         assert( Lakn.size(1) == v.size(0) );
         assert( G.size(0) == v.size(1) );
-        long ic0, icN;
-        std::tie(ic0,icN) = FairDivideBoundary(long(TG.TG_local().rank()),long(Lakn.size(1)),long(TG.TG_local().size()));
+        std::tie(ic0,icN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                        long(Lakn.size(1)),long(TG.TG_local().size()));
 
-#if MIXED_PRECISION
-        size_t mem_needs = G.num_elements()+v.num_elements();
-        set_shm_buffer(mem_needs);
-        boost::multi::array_ref<SPComplexType,2> vsp(to_address(SM_TMats.origin()), v.extensions());
-        boost::multi::array_ref<SPComplexType,2> Gsp(vsp.origin()+vsp.num_elements(), G.extensions());
-        long i0, iN;
-        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),long(G.num_elements()),long(TG.TG_local().size()));
-        copy_n_cast(to_address(G.origin())+i0,iN-i0,to_address(Gsp.origin())+i0);
-        TG.TG_local().barrier();
         if(walker_type==CLOSED) a*=2.0;
         ma::product(SPValueType(a),ma::T(Lakn(Lakn.extension(0),{ic0,icN})),ma::T(Gsp),
                   SPValueType(c),vsp.sliced(ic0,icN));
-        copy_n_cast(to_address(vsp[ic0].origin()),vsp.size(1)*(icN-ic0),
-                  to_address(v[ic0].origin()));
-        TG.TG_local().barrier();
-#else
-        if(walker_type==CLOSED) a*=2.0;
-        ma::product(SPValueType(a),ma::T(Lakn(Lakn.extension(0),{ic0,icN})),ma::T(G),
-                  SPValueType(c),v.sliced(ic0,icN));
-#endif
       } else {
         // multideterminant is not half-rotated, so use Likn
         assert( Likn.size(0) == G.size(0) );
         assert( Likn.size(1) == v.size(0) );
         assert( G.size(1) == v.size(1) );
-        long ic0, icN;
-        std::tie(ic0,icN) = FairDivideBoundary(long(TG.TG_local().rank()),long(Likn.size(1)),long(TG.TG_local().size()));
+        std::tie(ic0,icN) = FairDivideBoundary(long(TG.TG_local().rank()),
+                                long(Likn.size(1)),long(TG.TG_local().size()));
 
-#if MIXED_PRECISION
-        size_t mem_needs = G.num_elements()+v.num_elements();
-        set_shm_buffer(mem_needs);
-        boost::multi::array_ref<SPComplexType,2> vsp(to_address(SM_TMats.origin()), v.extensions());
-        boost::multi::array_ref<SPComplexType,2> Gsp(vsp.origin()+vsp.num_elements(), G.extensions());
-        long i0, iN;
-        std::tie(i0,iN) = FairDivideBoundary(long(TG.TG_local().rank()),long(G.num_elements()),long(TG.TG_local().size()));
-        copy_n_cast(to_address(G.origin())+i0,iN-i0,to_address(Gsp.origin())+i0);
-        TG.TG_local().barrier();
         if(walker_type==CLOSED) a*=2.0;
         ma::product(SPValueType(a),ma::T(Likn(Likn.extension(0),{ic0,icN})),Gsp,
                   SPValueType(c),vsp.sliced(ic0,icN));
+      }
+      // copy data back if changing precision
+      if(not std::is_same<vType,SPComplexType>::value) {
         copy_n_cast(to_address(vsp[ic0].origin()),vsp.size(1)*(icN-ic0),
-                  to_address(v[ic0].origin()));
-        TG.TG_local().barrier();
-#else
-        if(walker_type==CLOSED) a*=2.0;
-        ma::product(SPValueType(a),ma::T(Likn(Likn.extension(0),{ic0,icN})),G,
-                  SPValueType(c),v.sliced(ic0,icN));
-#endif
+                to_address(v[ic0].origin()));
       }
       TG.TG_local().barrier();
     }

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -392,7 +392,7 @@ class Real3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
-      using XType = typename std::decay<MatA>::type::element ;
+      using XType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       assert( Likn.size(1) == X.size(0) );
       assert( Likn.size(0) == v.size(0) );
@@ -472,7 +472,7 @@ class Real3IndexFactorization
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
-      using GType = typename std::decay<MatA>::type::element ;
+      using GType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       long ic0, icN;
       // setup buffer space if changing precision in G or v

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -372,7 +372,7 @@ class Real3IndexFactorization_batched_v2
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
-      using XType = typename std::decay<MatA>::type::element ;
+      using XType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       assert( Likn.size(1) == X.size(0) );
       assert( Likn.size(0) == v.size(0) );
@@ -438,8 +438,8 @@ class Real3IndexFactorization_batched_v2
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
-      using GType = typename std::decay<MatA>::type::element ;
-      using vType = typename std::decay<MatB>::type::element ;
+      using GType = typename std::decay_t<typename MatA::element>;
+      using vType = typename std::decay_t<MatB>::element;
       if(walker_type==CLOSED) a*=2.0;
       // setup buffer space if changing precision in G or v
       size_t vmem(0),Gmem(0);

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -56,6 +56,7 @@ class Real3IndexFactorization_batched_v2
   // type defs
   using pointer = typename Allocator::pointer;
   using sp_pointer = typename SpAllocator::pointer;
+  using const_sp_pointer = typename SpAllocator::const_pointer;
   using sp_rpointer = typename SpRAllocator::pointer;
   using pointer_shared = typename Allocator_shared::pointer;
   using sp_pointer_shared = typename SpAllocator_shared::pointer;
@@ -357,21 +358,13 @@ class Real3IndexFactorization_batched_v2
              typename = void
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
-      assert( Likn.size(1) == X.size(0) );
-      assert( Likn.size(0) == v.size(0) );
-#if MIXED_PRECISION
-      StaticVector vsp(v.extensions(), 
-        buffer_allocator->template get_allocator<SPComplexType>());
-      StaticVector Xsp(X.extensions(), 
-        buffer_allocator->template get_allocator<SPComplexType>());
-      copy_n_cast(make_device_ptr(X.origin()),X.num_elements(),Xsp.origin());
-      if( std::abs(c-0.0) > 1e-6 )
-        copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
-      ma::product(SPValueType(a),Likn,Xsp,SPValueType(c),vsp);
-      copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else 
-      ma::product(SPValueType(a),Likn,X,SPValueType(c),v);
-#endif
+      using BType = typename std::decay<MatB>::type::element ;
+      using AType = typename std::decay<MatA>::type::element ;
+      boost::multi::array_ref<BType,2,decltype(v.origin())> v_(v.origin(),
+                                        {v.size(0),1});
+      boost::multi::array_ref<AType,2,decltype(X.origin())> X_(X.origin(),
+                                        {X.size(0),1});
+      return vHS(X_,v_,a,c);
     }
 
     template<class MatA, class MatB,
@@ -379,22 +372,43 @@ class Real3IndexFactorization_batched_v2
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
+      using XType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       assert( Likn.size(1) == X.size(0) );
       assert( Likn.size(0) == v.size(0) );
       assert( X.size(1) == v.size(1) );
-#if MIXED_PRECISION
-      StaticMatrix vsp(v.extensions(),
-        buffer_allocator->template get_allocator<SPComplexType>());
-      StaticMatrix Xsp(X.extensions(),
-        buffer_allocator->template get_allocator<SPComplexType>());
-      copy_n_cast(make_device_ptr(X.origin()),X.num_elements(),Xsp.origin());
-      if( std::abs(c-0.0) > 1e-6 )
-        copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
+      // setup buffer space if changing precision in X or v
+      size_t vmem(0),Xmem(0);
+      if(not std::is_same<XType,SPComplexType>::value) Xmem = X.num_elements();
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements();
+      StaticVector SPBuff(iextensions<1u>{Xmem+vmem},
+                buffer_allocator->template get_allocator<SPComplexType>());
+      sp_pointer vptr(nullptr);
+      const_sp_pointer Xptr(nullptr);
+      // setup origin of Gsp and copy_n_cast if necessary
+      using qmcplusplus::afqmc::pointer_cast;
+      if(std::is_same<XType,SPComplexType>::value) {
+        Xptr = pointer_cast<SPComplexType const>(make_device_ptr(X.origin()));
+      } else {
+        copy_n_cast(make_device_ptr(X.origin()),X.num_elements(),make_device_ptr(SPBuff.origin()));
+        Xptr = make_device_ptr(SPBuff.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      } else {
+        vptr = make_device_ptr(SPBuff.origin())+Xmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vptr);
+      }
+      // work  
+      boost::multi::array_cref<SPComplexType const,2,const_sp_pointer> Xsp(Xptr, X.extensions());
+      boost::multi::array_ref<SPComplexType,2,sp_pointer> vsp(vptr, v.extensions());
       ma::product(SPValueType(a),Likn,Xsp,SPValueType(c),vsp);
-      copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else
-      ma::product(SPValueType(a),Likn,X,SPValueType(c),v);
-#endif
+      if(not std::is_same<vType,SPComplexType>::value) {
+        copy_n_cast(make_device_ptr(vsp.origin()),v.num_elements(),
+                make_device_ptr(v.origin()));
+      }
     }
 
     template<class MatA, class MatB,
@@ -403,74 +417,19 @@ class Real3IndexFactorization_batched_v2
              typename = void
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
-      if(walker_type==CLOSED) a*=2.0;
-      if(haj.size(0) == 1) {
-        if(walker_type==COLLINEAR) {
-          int NMO, nel[2];
-          NMO = Lnak[0].size(2);
-          nel[0] = Lnak[0].size(1);
-          nel[1] = Lnak[1].size(1);
-          double c_[2];
-          c_[0] = c;
-          c_[1] = c;
-          if( std::abs(c-0.0) < 1e-8 ) c_[1] = 1.0;
-#if MIXED_PRECISION
-          StaticVector vsp(v.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-          if( std::abs(c-0.0) > 1e-6 )
-            copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
-#endif
-          for(int ispin=0, is0=0; ispin<2; ispin++) {
-            assert( Lnak[ispin].size(0) == v.size(0) );
-            assert( Lnak[ispin].size(1)*Lnak[ispin].size(2) == G.size(0) );
-            SpCMatrix_ref Ln(make_device_ptr(Lnak[ispin].origin()), {local_nCV,nel[ispin]*NMO});
-#if MIXED_PRECISION
-            StaticVector Gsp(iextensions<1u>{nel[ispin]*NMO},
-                buffer_allocator->template get_allocator<SPComplexType>());
-            copy_n_cast(make_device_ptr(G.origin())+is0,Gsp.num_elements(),Gsp.origin());
-            ma::product(SPComplexType(a),Ln,Gsp,SPComplexType(c_[ispin]),vsp);
-#else
-            ma::product(SPComplexType(a),Ln,G.sliced(is0,is0+nel[ispin]*NMO),SPComplexType(c_[ispin]),v);
-#endif
-            is0 += nel[ispin]*NMO;
-          }
-#if MIXED_PRECISION
-          copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#endif
-        } else {
-          assert( Lnak[0].size(1)*Lnak[0].size(2) == G.size(0) );
-          assert( Lnak[0].size(0) == v.size(0) );
-          SpCMatrix_ref Ln(make_device_ptr(Lnak[0].origin()), {local_nCV,Lnak[0].size(1)*Lnak[0].size(2)});
-#if MIXED_PRECISION
-          StaticVector vsp(v.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-          SpCVector_ref Gsp(vsp.origin()+vsp.num_elements(), G.extensions());
-          copy_n_cast(make_device_ptr(G.origin()),G.num_elements(),Gsp.origin());
-          if( std::abs(c-0.0) > 1e-6 )
-            copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
-          ma::product(SPComplexType(a),Ln,Gsp,SPComplexType(c),vsp);
-          copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else
-          ma::product(SPComplexType(a),Ln,G,SPComplexType(c),v);
-#endif
-        }
+      using BType = typename std::decay<MatB>::type::element ;
+      using AType = typename std::decay<MatA>::type::element ;
+      boost::multi::array_ref<BType,2,decltype(v.origin())> v_(v.origin(),
+                                        {v.size(0),1});
+      if((haj.size(0) == 1) && (walker_type!=COLLINEAR)) {  
+        boost::multi::array_ref<AType const,2,decltype(G.origin())> G_(G.origin(),
+                                          {1,G.size(0)});
+        return vbias(G_,v_,a,c,k);
       } else {
-        // multideterminant is not half-rotated, so use Likn
-        assert( Likn.size(0) == G.size(0) );
-        assert( Likn.size(1) == v.size(0) );
-
-#if MIXED_PRECISION
-        StaticVector vsp(v.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-        StaticVector Gsp(G.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-        copy_n_cast(make_device_ptr(G.origin()),G.num_elements(),Gsp.origin());
-        ma::product(SPValueType(a),ma::T(Likn),Gsp,SPValueType(c),vsp);
-        copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else
-        ma::product(SPValueType(a),ma::T(Likn),G,SPValueType(c),v);
-#endif
-      }
+        boost::multi::array_ref<AType const,2,decltype(G.origin())> G_(G.origin(),
+                                          {G.size(0),1});
+        return vbias(G_,v_,a,c,k);
+      }  
     }
 
     // v(n,w) = sum_ak L(ak,n) G(w,ak)
@@ -479,7 +438,37 @@ class Real3IndexFactorization_batched_v2
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
+      using GType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       if(walker_type==CLOSED) a*=2.0;
+      // setup buffer space if changing precision in G or v
+      size_t vmem(0),Gmem(0);
+      if(not std::is_same<GType,SPComplexType>::value) Gmem = G.num_elements();
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements();
+      StaticVector SPBuff(iextensions<1u>{Gmem+vmem},
+                buffer_allocator->template get_allocator<SPComplexType>());
+      sp_pointer vptr(nullptr);
+      const_sp_pointer Gptr(nullptr);
+      // setup origin of Gsp and copy_n_cast if necessary
+      using qmcplusplus::afqmc::pointer_cast;
+      if(std::is_same<GType,SPComplexType>::value) {
+        Gptr = pointer_cast<SPComplexType const>(make_device_ptr(G.origin()));
+      } else {
+        copy_n_cast(make_device_ptr(G.origin()),G.num_elements(),make_device_ptr(SPBuff.origin()));
+        Gptr = make_device_ptr(SPBuff.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = pointer_cast<SPComplexType>(make_device_ptr(v.origin()));
+      } else {
+        vptr = make_device_ptr(SPBuff.origin())+Gmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vptr);
+      }
+      // setup array references
+      boost::multi::array_cref<SPComplexType const,2,const_sp_pointer> Gsp(Gptr, G.extensions());
+      boost::multi::array_ref<SPComplexType,2,sp_pointer> vsp(vptr, v.extensions());
+
       if(haj.size(0) == 1) {
         int nwalk = v.size(1);
         if(walker_type==COLLINEAR) { 
@@ -491,46 +480,21 @@ class Real3IndexFactorization_batched_v2
           double c_[2];
           c_[0] = c;
           c_[1] = c;  
-          if( std::abs(c-0.0) < 1e-8 ) c_[1] = 1.0; 
-          StaticMatrix vsp(v.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-          if( std::abs(c-0.0) > 1e-6 )
-            copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
+          if( std::abs(c) < 1e-8 ) c_[1] = 1.0; 
           for(int ispin=0, is0=0; ispin<2; ispin++) {
             assert( Lnak[ispin].size(0) == v.size(0) );
             assert( Lnak[ispin].size(1) == G.size(0) );
             SpCMatrix_ref Ln(make_device_ptr(Lnak[ispin].origin()), {local_nCV,nel[ispin]*NMO});
-#if MIXED_PRECISION
-            StaticMatrix Gsp({nel[ispin]*NMO,nwalk},
-                buffer_allocator->template get_allocator<SPComplexType>());
-            copy_n_cast(make_device_ptr(G.origin())+is0*nwalk,Gsp.num_elements(),Gsp.origin());
-            ma::product(SPComplexType(a),Ln,Gsp,SPComplexType(c_[ispin]),vsp);
-#else
-            ma::product(SPComplexType(a),Ln,G.sliced(is0,is0+nel[ispin]*NMO),SPComplexType(c_[ispin]),v);
-#endif
+            ma::product(SPComplexType(a),Ln,Gsp.sliced(is0,is0+nel[ispin]*NMO),
+                        SPComplexType(c_[ispin]),vsp);
             is0 += nel[ispin]*NMO;
           }
-#if MIXED_PRECISION
-          copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#endif
         } else {
           assert( G.size(0) == v.size(1) );
           assert( Lnak[0].size(1)*Lnak[0].size(2) == G.size(1) );
           assert( Lnak[0].size(0) == v.size(0) );
           SpCMatrix_ref Ln(make_device_ptr(Lnak[0].origin()), {local_nCV,Lnak[0].size(1)*Lnak[0].size(2)});
-#if MIXED_PRECISION
-          StaticMatrix vsp(v.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-          StaticMatrix Gsp(G.extensions(),
-                buffer_allocator->template get_allocator<SPComplexType>());
-          copy_n_cast(make_device_ptr(G.origin()),G.num_elements(),Gsp.origin());
-          if( std::abs(c-0.0) > 1e-6 )
-            copy_n_cast(make_device_ptr(v.origin()),v.num_elements(),vsp.origin());
           ma::product(SPComplexType(a),Ln,ma::T(Gsp),SPComplexType(c),vsp);
-          copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else
-          ma::product(SPComplexType(a),Ln,ma::T(G),SPComplexType(c),v);
-#endif
         }
       } else {
         // multideterminant is not half-rotated, so use Likn
@@ -538,17 +502,11 @@ class Real3IndexFactorization_batched_v2
         assert( Likn.size(1) == v.size(0) );
         assert( G.size(1) == v.size(1) );
 
-#if MIXED_PRECISION
-        StaticMatrix vsp(v.extensions(),
-              buffer_allocator->template get_allocator<SPComplexType>());
-        StaticMatrix Gsp(G.extensions(),
-              buffer_allocator->template get_allocator<SPComplexType>());
-        copy_n_cast(make_device_ptr(G.origin()),G.num_elements(),Gsp.origin());
         ma::product(SPValueType(a),ma::T(Likn),Gsp,SPValueType(c),vsp);
-        copy_n_cast(vsp.origin(),vsp.num_elements(),make_device_ptr(v.origin()));
-#else
-        ma::product(SPValueType(a),ma::T(Likn),G,SPValueType(c),v);
-#endif
+      }
+      if(not std::is_same<vType,SPComplexType>::value) {
+        copy_n_cast(make_device_ptr(vsp.origin()),v.num_elements(),
+                make_device_ptr(v.origin()));
       }
     }
 

--- a/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
@@ -51,6 +51,10 @@ class SparseTensor
   using SpT1 = T1;
   using SpT2 = T2;
 #endif
+
+  using const_sp_pointer = SPComplexType const*;
+  using sp_pointer = SPComplexType*;
+
   using T1shm_csr_matrix = ma::sparse::csr_matrix<SpT1,int,std::size_t,
                                 shared_allocator<SpT1>,
                                 ma::sparse::is_root>;
@@ -273,30 +277,13 @@ class SparseTensor
              typename = void
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
-      assert( Spvn.size(1) == X.size(0) );
-      assert( Spvn.size(0) == v.size(0) );
-
-#if MIXED_PRECISION
-      size_t mem_needs = X.num_elements()+v.num_elements();  
-      set_buffer(mem_needs);
-      boost::multi::array_ref<SPComplexType,1> vsp(to_address(SM_TMats.origin()), v.extensions());  
-      boost::multi::array_ref<SPComplexType,1> Xsp(vsp.origin()+vsp.num_elements(), X.extensions());  
-      size_t i0, iN;
-      std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(X.num_elements()),size_t(comm->size()));
-      copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(Xsp.origin())+i0);
-      boost::multi::array_ref<SPComplexType,1> v_(to_address(vsp.origin()) + Spvn_view.local_origin()[0],
-                                        iextensions<1u>{Spvn_view.size(0)});
-      comm->barrier();
-      ma::product(SPValueType(a),Spvn_view,Xsp,SPValueType(c),v_);
-      copy_n_cast(to_address(v_.origin()),v_.num_elements(),to_address(v.origin())+Spvn_view.local_origin()[0]);
-      comm->barrier();
-#else
-      using Type = typename std::decay<MatB>::type::element;
-      // Spvn*X
-      boost::multi::array_ref<Type,1> v_(to_address(v.origin()) + Spvn_view.local_origin()[0],
-                                        iextensions<1u>{Spvn_view.size(0)});
-      ma::product(SPValueType(a),Spvn_view,X,SPValueType(c),v_);
-#endif
+      using BType = typename std::decay<MatB>::type::element ;
+      using AType = typename std::decay<MatA>::type::element ;
+      boost::multi::array_ref<BType,2,decltype(v.origin())> v_(v.origin(),
+                                        {v.size(0),1});
+      boost::multi::array_ref<AType,2,decltype(X.origin())> X_(X.origin(),
+                                        {X.size(0),1});
+      return vHS(X_,v_,a,c);
     }
 
     template<class MatA, class MatB,
@@ -304,31 +291,56 @@ class SparseTensor
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
+      using vType = typename std::decay<MatB>::type::element ;
+      using XType = typename std::decay<MatA>::type::element ;
       assert( Spvn.size(1) == X.size(0) );
       assert( Spvn.size(0) == v.size(0) );
       assert( X.size(1) == v.size(1) );
-#if MIXED_PRECISION
-      size_t mem_needs = X.num_elements()+v.num_elements();
-      set_buffer(mem_needs);
-      boost::multi::array_ref<SPComplexType,2> vsp(to_address(SM_TMats.origin()), v.extensions());
-      boost::multi::array_ref<SPComplexType,2> Xsp(vsp.origin()+vsp.num_elements(), X.extensions());
-      size_t i0, iN;
-      std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(X.num_elements()),size_t(comm->size()));
-      copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(Xsp.origin())+i0);
+
+      // setup buffer space if changing precision in X or v
+      size_t vmem(0),Xmem(0);
+      if(not std::is_same<XType,SPComplexType>::value) Xmem = X.num_elements();
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements();
+      set_buffer(vmem+Xmem);
+      const_sp_pointer Xptr(nullptr);
+      sp_pointer vptr(nullptr);
+      // setup origin of Xsp and copy_n_cast if necessary
+      if(std::is_same<XType,SPComplexType>::value) {
+        Xptr = reinterpret_cast<const_sp_pointer>(to_address(X.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(X.num_elements()),long(comm->size()));
+        copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        Xptr = to_address(SM_TMats.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(v.num_elements()),long(comm->size()));
+        vptr = to_address(SM_TMats.origin())+Xmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<SPComplexType,2> Xsp(Xptr, X.extensions());
+      boost::multi::array_ref<SPComplexType,2> vsp(vptr, v.extensions());
+      comm->barrier();
+
       boost::multi::array_ref<SPComplexType,2> v_(to_address(vsp[Spvn_view.local_origin()[0]].origin()),
                                         {long(Spvn_view.size(0)),long(vsp.size(1))});
-      comm->barrier();
       ma::product(SPValueType(a),Spvn_view,Xsp,SPValueType(c),v_);
-      copy_n_cast(to_address(v_.origin()),v_.num_elements(),
+
+      // copy data back if changing precision
+      if(not std::is_same<vType,SPComplexType>::value) {
+        copy_n(to_address(v_.origin()),v_.num_elements(),
                   to_address(v[Spvn_view.local_origin()[0]].origin()));
+      }
       comm->barrier();
-#else
-      using Type = typename std::decay<MatB>::type::element;
-      // Spvn*X
-      boost::multi::array_ref<Type,2> v_(to_address(v[Spvn_view.local_origin()[0]].origin()),
-                                        {long(Spvn_view.size(0)),long(v.size(1))});
-      ma::product(SPValueType(a),Spvn_view,X,SPValueType(c),v_);
-#endif
+
     }
 
     template<class MatA, class MatB,
@@ -337,35 +349,13 @@ class SparseTensor
              typename = void
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
-      if(not separateEJ) k=0;
-      assert( SpvnT[k].size(1) == G.size(0) );
-      assert( SpvnT[k].size(0) == v.size(0) );
-
-#if MIXED_PRECISION
-      size_t mem_needs = G.num_elements()+v.num_elements();
-      set_buffer(mem_needs);
-      boost::multi::array_ref<SPComplexType,1> vsp(to_address(SM_TMats.origin()), v.extensions());
-      boost::multi::array_ref<SPComplexType,1> Gsp(vsp.origin()+vsp.num_elements(), G.extensions());
-      size_t i0, iN;
-      std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(G.num_elements()),size_t(comm->size()));
-      using std::copy_n;
-      copy_n(to_address(G.origin())+i0,iN-i0,to_address(Gsp.origin())+i0);
-      boost::multi::array_ref<SPComplexType,1> v_(to_address(vsp.origin()) + SpvnT_view[k].local_origin()[0],
-                                        iextensions<1u>{SpvnT_view[k].size(0)});
-      comm->barrier();
-      if(walker_type==CLOSED) a*=2.0;
-      ma::product(SpT2(a), SpvnT_view[k], Gsp, SpT2(c), v_);
-      copy_n(to_address(v_.origin()),v_.num_elements(),
-                  to_address(v.origin()) + SpvnT_view[k].local_origin()[0]);
-      comm->barrier();
-#else
-      using Type = typename std::decay<MatB>::type::element ;
-      // SpvnT*G
-      boost::multi::array_ref<Type,1> v_(to_address(v.origin()) + SpvnT_view[k].local_origin()[0],
-                                        iextensions<1u>{SpvnT_view[k].size(0)});
-      if(walker_type==CLOSED) a*=2.0;
-      ma::product(SpT2(a), SpvnT_view[k], G, SpT2(c), v_);
-#endif
+      using BType = typename std::decay<MatB>::type::element ;
+      using AType = typename std::decay<MatA>::type::element ;
+      boost::multi::array_ref<BType,2,decltype(v.origin())> v_(v.origin(),
+                                        {v.size(0),1});
+      boost::multi::array_cref<AType,2,decltype(G.origin())> G_(G.origin(),
+                                        {G.size(0),1});
+      return vbias(G_,v_,a,c,k);
     }
 
     template<class MatA, class MatB,
@@ -373,35 +363,56 @@ class SparseTensor
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
+      using vType = typename std::decay<MatB>::type::element ;
+      using GType = typename std::decay<MatA>::type::element ;
       if(not separateEJ) k=0;
+      if(walker_type==CLOSED) a*=2.0;
       assert( SpvnT[k].size(1) == G.size(0) );
       assert( SpvnT[k].size(0) == v.size(0) );
       assert( G.size(1) == v.size(1) );
 
-#if MIXED_PRECISION
-      size_t mem_needs = G.num_elements()+v.num_elements();
-      set_buffer(mem_needs);
-      boost::multi::array_ref<SPComplexType,2> vsp(to_address(SM_TMats.origin()), v.extensions());
-      boost::multi::array_ref<SPComplexType,2> Gsp(vsp.origin()+vsp.num_elements(), G.extensions());
-      size_t i0, iN;
-      std::tie(i0,iN) = FairDivideBoundary(size_t(comm->rank()),size_t(G.num_elements()),size_t(comm->size()));
-      copy_n(to_address(G.origin())+i0,iN-i0,to_address(Gsp.origin())+i0);
+      // setup buffer space if changing precision in G or v
+      size_t vmem(0),Gmem(0);
+      if(not std::is_same<GType,SPComplexType>::value) Gmem = G.num_elements();
+      if(not std::is_same<vType,SPComplexType>::value) vmem = v.num_elements();
+      set_buffer(vmem+Gmem);
+      const_sp_pointer Gptr(nullptr);
+      sp_pointer vptr(nullptr);
+      // setup origin of Gsp and copy_n_cast if necessary
+      if(std::is_same<GType,SPComplexType>::value) {
+        Gptr = reinterpret_cast<const_sp_pointer>(to_address(G.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(G.num_elements()),long(comm->size()));
+        copy_n_cast(to_address(G.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        Gptr = to_address(SM_TMats.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,SPComplexType>::value) {
+        vptr = reinterpret_cast<sp_pointer>(to_address(v.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(v.num_elements()),long(comm->size()));
+        vptr = to_address(SM_TMats.origin())+Gmem;
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<SPComplexType,2> Gsp(Gptr, G.extensions());
+      boost::multi::array_ref<SPComplexType,2> vsp(vptr, v.extensions());
+      comm->barrier();
       boost::multi::array_ref<SPComplexType,2> v_(to_address(vsp[SpvnT_view[k].local_origin()[0]].origin()),
                                         {long(SpvnT_view[k].size(0)),long(vsp.size(1))});
-      comm->barrier();
-      if(walker_type==CLOSED) a*=2.0;
       ma::product(SpT2(a), SpvnT_view[k], Gsp, SpT2(c), v_);
-      copy_n(to_address(v_.origin()),v_.num_elements(),
-                  to_address(to_address(v[SpvnT_view[k].local_origin()[0]].origin()))); 
+
+      // copy data back if changing precision
+      if(not std::is_same<vType,SPComplexType>::value) {
+        copy_n(to_address(v_.origin()),v_.num_elements(),
+                  to_address(v[SpvnT_view[k].local_origin()[0]].origin())); 
+      }
       comm->barrier();
-#else
-      using Type = typename std::decay<MatB>::type::element ;
-      // SpvnT*G
-      boost::multi::array_ref<Type,2> v_(to_address(v[SpvnT_view[k].local_origin()[0]].origin()),
-                                        {long(SpvnT_view[k].size(0)),long(v.size(1))});
-      if(walker_type==CLOSED) a*=2.0;
-      ma::product(SpT2(a), SpvnT_view[k], G, SpT2(c), v_);
-#endif
     }
 
     template<class Mat, class MatB>

--- a/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
@@ -292,7 +292,7 @@ class SparseTensor
             >
     void vHS(MatA& X, MatB&& v, double a=1., double c=0.) {
       using vType = typename std::decay<MatB>::type::element ;
-      using XType = typename std::decay<MatA>::type::element ;
+      using XType = typename std::decay_t<typename MatA::element>;
       assert( Spvn.size(1) == X.size(0) );
       assert( Spvn.size(0) == v.size(0) );
       assert( X.size(1) == v.size(1) );
@@ -364,7 +364,7 @@ class SparseTensor
             >
     void vbias(const MatA& G, MatB&& v, double a=1., double c=0., int k=0) {
       using vType = typename std::decay<MatB>::type::element ;
-      using GType = typename std::decay<MatA>::type::element ;
+      using GType = typename std::decay_t<typename MatA::element>;
       if(not separateEJ) k=0;
       if(walker_type==CLOSED) a*=2.0;
       assert( SpvnT[k].size(1) == G.size(0) );

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -46,6 +46,9 @@ template<class T>
 class THCOps
 {
 
+  using pointer = ComplexType*;
+  using const_pointer = ComplexType const*;
+
   using TVector = boost::multi::array<T,1>;
   using CVector = boost::multi::array<ComplexType,1>;
   using CMatrix = boost::multi::array<ComplexType,2>;
@@ -550,7 +553,7 @@ std::cout<<"\n";
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==1)>,
              typename = void
             >
-    void vHS(MatA & X, MatB&& v, double a=1., double c=0.) {
+    void vHS(MatA const& X, MatB&& v, double a=1., double c=0.) {
         boost::multi::array_cref<ComplexType,2> X_(to_address(X.origin()),{X.size(0),1});
         boost::multi::array_ref<ComplexType,2> v_(to_address(v.origin()),{1,v.size(0)});
         vHS(X_,v_,a,c);
@@ -561,6 +564,8 @@ std::cout<<"\n";
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA & X, MatB&& v, double a=1., double c=0.) {
+      using XType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       int nwalk = X.size(1);
 #if defined(QMC_COMPLEX)
       int nchol = 2*Luv.size(1);
@@ -586,26 +591,59 @@ std::cout<<"\n";
 #else
       size_t memory_needs = nu*nwalk + nwalk*nu*nmo_;
 #endif
+
+      if(not std::is_same<XType,ComplexType>::value) memory_needs += X.num_elements();
+      if(not std::is_same<vType,ComplexType>::value) memory_needs += v.num_elements();
       set_shmbuffer(memory_needs);
-      boost::multi::array_ref<ComplexType,2> Tuw(to_address(SM_TMats.origin()),{nu,nwalk});
+      size_t cnt(0);
+      const_pointer Xptr(nullptr);
+      pointer vptr(nullptr);
+      // setup origin of Xsp and copy_n_cast if necessary
+      if(std::is_same<XType,ComplexType>::value) {
+        Xptr = reinterpret_cast<const_pointer>(to_address(X.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(X.num_elements()),long(comm->size()));
+        copy_n_cast(to_address(X.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        cnt += size_t(X.num_elements());
+        Xptr = to_address(SM_TMats.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,ComplexType>::value) {
+        vptr = reinterpret_cast<pointer>(to_address(v.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(v.num_elements()),long(comm->size()));
+        vptr = to_address(SM_TMats.origin())+cnt;
+        cnt += size_t(v.num_elements());
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<ComplexType,2> Xsp(Xptr, X.extensions());
+      boost::multi::array_ref<ComplexType,2> vsp(vptr, v.extensions());
+
+      boost::multi::array_ref<ComplexType,2> Tuw(to_address(SM_TMats.origin())+cnt,{nu,nwalk});
       // O[nwalk * nmu * nmu]
 #if defined(QMC_COMPLEX)
       // reinterpret as RealType matrices with 2x the columns
       boost::multi::array_ref<RealType,2> Luv_R(reinterpret_cast<RealType*>(to_address(Luv.origin())),
                                                  {Luv.size(0),2*Luv.size(1)});
-      boost::multi::array_cref<RealType,2> X_R(reinterpret_cast<RealType const*>(to_address(X.origin())),
-                                                 {X.size(0),2*X.size(1)});
+      boost::multi::array_cref<RealType,2> X_R(reinterpret_cast<RealType const*>(to_address(Xsp.origin())),
+                                                 {Xsp.size(0),2*Xsp.size(1)});
       boost::multi::array_ref<RealType,2> Tuw_R(reinterpret_cast<RealType*>(Tuw.origin()),
                                                  {nu,2*nwalk});
       ma::product(Luv_R.sliced(u0,uN),X_R,
                   Tuw_R.sliced(u0,uN));
 #else
-      ma::product(Luv.sliced(u0,uN),X,
+      ma::product(Luv.sliced(u0,uN),Xsp,
                   Tuw.sliced(u0,uN));
 #endif
       comm->barrier();
 #if defined(LOW_MEMORY)
-      boost::multi::array_ref<ComplexType,2> Qiu(to_address(SM_TMats.origin())+nwalk*nu,{nmo_,nu});
+      boost::multi::array_ref<ComplexType,2> Qiu(Tuw.origin()+Tuw.num_elements(),{nmo_,nu});
       for(int wi=0; wi<nwalk; wi++) {
         // Qiu[i][u] = T[u][wi] * conj(Piu[i][u])
         // v[wi][ik] = sum_u Qiu[i][u] * Piu[k][u]
@@ -615,15 +653,15 @@ std::cout<<"\n";
           for(int u=0; u<nu; u++, ++p_)
             Qiu[i][u] = Tuw[u][wi]*ma::conj(*p_);
         }
-        boost::multi::array_ref<ComplexType,2> v_(to_address(v[wi].origin()),{nmo_,nmo_});
+        boost::multi::array_ref<ComplexType,2> v_(to_address(vsp[wi].origin()),{nmo_,nmo_});
         // this can benefit significantly from 2-D partition of work
         // O[nmo * nmo * nmu]
         ma::product(a,Qiu.sliced(k0,kN),T(Piu),
                     c,v_.sliced(k0,kN));
       }
 #else
-      boost::multi::array_ref<ComplexType,2> Qiu(to_address(SM_TMats.origin())+nwalk*nu,{nwalk*nmo_,nu});
-      boost::multi::array_ref<ComplexType,3> Qwiu(to_address(SM_TMats.origin())+nwalk*nu,{nwalk,nmo_,nu});
+      boost::multi::array_ref<ComplexType,2> Qiu(Tuw.origin()+Tuw.num_elements(),{nwalk*nmo_,nu});
+      boost::multi::array_ref<ComplexType,3> Qwiu(Tuw.origin()+Tuw.num_elements(),{nwalk,nmo_,nu});
       // Qiu[i][u] = T[u][wi] * conj(Piu[i][u])
       // v[wi][ik] = sum_u Qiu[i][u] * Piu[k][u]
       // O[nmo * nmu]
@@ -633,12 +671,19 @@ std::cout<<"\n";
           for(int u=0; u<nu; u++, ++p_)
             Qwiu[wi][i][u] = Tuw[u][wi]*ma::conj(*p_);
         }
-      boost::multi::array_ref<ComplexType,2> v_(to_address(v.origin()),{nwalk*nmo_,nmo_});
+      boost::multi::array_ref<ComplexType,2> v_(to_address(vsp.origin()),{nwalk*nmo_,nmo_});
       // this can benefit significantly from 2-D partition of work
       // O[nmo * nmo * nmu]
       ma::product(a,Qiu.sliced(wk0,wkN),T(Piu),
                   c,v_.sliced(wk0,wkN));
 #endif
+      comm->barrier();
+      if(not std::is_same<vType,ComplexType>::value) {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(v.num_elements()),long(comm->size()));
+        copy_n_cast(vsp.origin()+i0,iN-i0,to_address(v.origin())+i0);
+      }
       comm->barrier();
     }
 
@@ -658,6 +703,8 @@ std::cout<<"\n";
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(MatA const& G, MatB&& v, double a=1., double c=0., int k=0) {
+      using GType = typename std::decay<MatA>::type::element ;
+      using vType = typename std::decay<MatB>::type::element ;
       if(k>0)
 	APP_ABORT(" Error: THC not yet implemented for multiple references.\n");
       int nwalk = G.size(0);
@@ -674,46 +721,83 @@ std::cout<<"\n";
       using ma::T;
       int c0,cN;
       std::tie(c0,cN) = FairDivideBoundary(comm->rank(),nchol,comm->size());
+
+      size_t memory_needs = nwalk*nu;
+      if(haj.size()==1) memory_needs += nu*nel_;
+      else memory_needs += nu*nmo_;
+      if(not std::is_same<GType,ComplexType>::value) memory_needs += G.num_elements();
+      if(not std::is_same<vType,ComplexType>::value) memory_needs += v.num_elements();
+      set_shmbuffer(memory_needs);
+      size_t cnt(0);
+      const_pointer Gptr(nullptr);
+      pointer vptr(nullptr);
+      // setup origin of Gsp and copy_n_cast if necessary
+      if(std::is_same<GType,ComplexType>::value) {
+        Gptr = reinterpret_cast<const_pointer>(to_address(G.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(G.num_elements()),long(comm->size()));
+        copy_n_cast(to_address(G.origin())+i0,iN-i0,to_address(SM_TMats.origin())+i0);
+        cnt += size_t(G.num_elements());
+        Gptr = to_address(SM_TMats.origin());
+      }
+      // setup origin of vsp and copy_n_cast if necessary
+      if(std::is_same<vType,ComplexType>::value) {
+        vptr = reinterpret_cast<pointer>(to_address(v.origin()));
+      } else {
+        long i0, iN;
+        std::tie(i0,iN) = FairDivideBoundary(long(comm->rank()),
+                                  long(v.num_elements()),long(comm->size()));
+        vptr = to_address(SM_TMats.origin())+cnt;
+        cnt += size_t(v.num_elements());
+        if( std::abs(c) > 1e-12 )
+          copy_n_cast(to_address(v.origin())+i0,iN-i0,vptr+i0);
+      }
+      // setup array references
+      boost::multi::array_cref<ComplexType const,2> Gsp(Gptr, G.extensions());
+      boost::multi::array_ref<ComplexType,2> vsp(vptr, v.extensions());
+
       if(haj.size()==1) {
-        size_t memory_needs = nwalk*nu + nel_*nu;
-        set_shmbuffer(memory_needs);
-        boost::multi::array_ref<ComplexType,2> Guu(to_address(SM_TMats.origin()),{nu,nwalk});
-        boost::multi::array_ref<ComplexType,2> T1(to_address(SM_TMats.origin())+nwalk*nu,{nu,nel_});
-        Guu_from_compact(G,Guu,T1);
+        boost::multi::array_ref<ComplexType,2> Guu(to_address(SM_TMats.origin())+cnt,{nu,nwalk});
+        boost::multi::array_ref<ComplexType,2> T1(Guu.origin()+Guu.num_elements(),{nu,nel_});
+        Guu_from_compact(Gsp,Guu,T1);
 #if defined(QMC_COMPLEX)
         // reinterpret as RealType matrices with 2x the columns
         boost::multi::array_ref<RealType,2> Luv_R(reinterpret_cast<RealType*>(to_address(Luv.origin())),
                                                  {Luv.size(0),2*Luv.size(1)});
         boost::multi::array_ref<RealType,2> Guu_R(reinterpret_cast<RealType*>(Guu.origin()),
                                                  {nu,2*nwalk});
-        boost::multi::array_ref<RealType,2> v_R(reinterpret_cast<RealType*>(to_address(v.origin())),
-                                                 {v.size(0),2*v.size(1)});
+        boost::multi::array_ref<RealType,2> vsp_R(reinterpret_cast<RealType*>(to_address(vsp.origin())),
+                                                 {vsp.size(0),2*vsp.size(1)});
         ma::product(a,T(Luv_R(Luv_R.extension(0),{c0,cN})),Guu_R,
-                    c,v_R.sliced(c0,cN));
+                    c,vsp_R.sliced(c0,cN));
 #else
         ma::product(a,T(Luv(Luv.extension(0),{c0,cN})),Guu,
-                    c,v.sliced(c0,cN));
+                    c,vsp.sliced(c0,cN));
 #endif
       } else {
-        size_t memory_needs = nwalk*nu + nmo_*nu;
-        set_shmbuffer(memory_needs);
-        boost::multi::array_ref<ComplexType,2> Guu(to_address(SM_TMats.origin()),{nu,nwalk});
-        boost::multi::array_ref<ComplexType,2> T1(to_address(SM_TMats.origin())+nwalk*nu,{nmo_,nu});
-        Guu_from_full(G,Guu,T1);
+        boost::multi::array_ref<ComplexType,2> Guu(to_address(SM_TMats.origin())+cnt,{nu,nwalk});
+        boost::multi::array_ref<ComplexType,2> T1(Guu.origin()+Guu.num_elements(),{nmo_,nu});
+        Guu_from_full(Gsp,Guu,T1);
 #if defined(QMC_COMPLEX)
         // reinterpret as RealType matrices with 2x the columns
         boost::multi::array_ref<RealType,2> Luv_R(reinterpret_cast<RealType*>(to_address(Luv.origin())),
                                                  {Luv.size(0),2*Luv.size(1)});
         boost::multi::array_ref<RealType,2> Guu_R(reinterpret_cast<RealType*>(Guu.origin()),
                                                  {nu,2*nwalk});
-        boost::multi::array_ref<RealType,2> v_R(reinterpret_cast<RealType*>(to_address(v.origin())),
-                                                 {v.size(0),2*v.size(1)});
+        boost::multi::array_ref<RealType,2> vsp_R(reinterpret_cast<RealType*>(to_address(vsp.origin())),
+                                                 {vsp.size(0),2*vsp.size(1)});
         ma::product(a,T(Luv_R(Luv_R.extension(0),{c0,cN})),Guu_R,
-                    c,v_R.sliced(c0,cN));
+                    c,vsp_R.sliced(c0,cN));
 #else
         ma::product(a,T(Luv(Luv.extension(0),{c0,cN})),Guu,
-                    c,v.sliced(c0,cN));
+                    c,vsp.sliced(c0,cN));
 #endif
+      }
+      if(not std::is_same<vType,ComplexType>::value) {
+        copy_n_cast(to_address(vsp[c0].origin()),vsp.size(1)*(cN-c0),
+                to_address(v[c0].origin()));
       }
       comm->barrier();
     }
@@ -782,7 +866,7 @@ std::cout<<"\n";
       ComplexType a = (walker_type==CLOSED)?ComplexType(2.0):ComplexType(1.0);
       for(int iw=0; iw<nw; ++iw) {
         boost::multi::array_cref<ComplexType,2> Giw(to_address(G[iw].origin()),{nel_,nmo_});
-        // transposing inetermediary to make dot products faster in the next step
+        // transposing intermediary to make dot products faster in the next step
         ma::product(ma::T(Piu({0,nmo_},{u0,uN})),
                   ma::T(Giw),
                   T1.sliced(u0,uN));

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -564,7 +564,7 @@ std::cout<<"\n";
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vHS(MatA & X, MatB&& v, double a=1., double c=0.) {
-      using XType = typename std::decay<MatA>::type::element ;
+      using XType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       int nwalk = X.size(1);
 #if defined(QMC_COMPLEX)
@@ -703,7 +703,7 @@ std::cout<<"\n";
              typename = typename std::enable_if_t<(std::decay<MatB>::type::dimensionality==2)>
             >
     void vbias(MatA const& G, MatB&& v, double a=1., double c=0., int k=0) {
-      using GType = typename std::decay<MatA>::type::element ;
+      using GType = typename std::decay_t<typename MatA::element>;
       using vType = typename std::decay<MatB>::type::element ;
       if(k>0)
 	APP_ABORT(" Error: THC not yet implemented for multiple references.\n");

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -21,7 +21,7 @@
 #include "io/hdf_multi.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -270,10 +270,10 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
       // KPFactorizedHamiltonian matrices are read by THCHamiltonian object when needed,
       // since their ownership is passed to the HamOps object.
 #ifdef ENABLE_CUDA
-      if(alt == "yes" || alt == "true")  
-        return Hamiltonian(RealDenseHamiltonian(AFinfo,cur,std::move(H1),TG,
-                                        NuclearCoulombEnergy,FrozenCoreEnergy));
-      else  
+//      if(alt == "yes" || alt == "true")  
+//        return Hamiltonian(RealDenseHamiltonian(AFinfo,cur,std::move(H1),TG,
+//                                        NuclearCoulombEnergy,FrozenCoreEnergy));
+//      else  
         return Hamiltonian(RealDenseHamiltonian_v2(AFinfo,cur,std::move(H1),TG,
                                         NuclearCoulombEnergy,FrozenCoreEnergy));
 #else

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -249,10 +249,13 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
   if(TG.TG_local().size() > 1 || not (batched=="yes" || batched == "true" ))
     return HamiltonianOperations(Real3IndexFactorization(TGwfn,type,std::move(H1),std::move(haj),
             std::move(Likn),std::move(Lakn),std::move(Lank),std::move(vn0),E0,nc0,global_ncvecs));
-  else
-    return HamiltonianOperations(Real3IndexFactorization_batched(type,std::move(H1),std::move(haj),
-            std::move(Likn),std::move(Lakn),std::move(Lank),std::move(vn0),E0,device_allocator<ComplexType>{},
-            nc0,global_ncvecs));
+  else {
+    throw std::runtime_error("Calling disabled class Real3IndexFactorization_batched.\n");
+    return HamiltonianOperations{}; 
+  }
+//    return HamiltonianOperations(Real3IndexFactorization_batched(type,std::move(H1),std::move(haj),
+//            std::move(Likn),std::move(Lakn),std::move(Lank),std::move(vn0),E0,device_allocator<ComplexType>{},
+//            nc0,global_ncvecs));
 
 }
 

--- a/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/AFQMC/Hamiltonians/tests/test_hamiltonian_factory.cpp
@@ -20,7 +20,7 @@
 #include "io/hdf_archive.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/AFQMC/Matrix/array_of_sequences.hpp
+++ b/src/AFQMC/Matrix/array_of_sequences.hpp
@@ -175,8 +175,9 @@ class array_of_sequences:
                 IsRoot r(Valloc_);
                 // calling barrier for safety right now
                 r.barrier();
+                size_type tot_sz = base::capacity();
                 if(r.root()){
-                        size_type tot_sz = base::capacity();
+/*
                         if(base::data_ && base::pointers_begin_ && base::pointers_end_) 
                                 for(size_type i = 0; i != base::size1_; ++i)
                                         for(auto p = base::data_ + base::pointers_begin_[i]; 
@@ -189,13 +190,15 @@ class array_of_sequences:
                                 }
                                 Palloc_.destroy(std::addressof(base::pointers_begin_[base::size1_]));
                         }
-                        if(base::data_)   
-                                Valloc_.deallocate(base::data_, tot_sz);
-                        if(base::pointers_begin_)   
-                                Palloc_.deallocate(base::pointers_begin_, base::size1_+1);
-                        if(base::pointers_end_)   
-                                Palloc_.deallocate(base::pointers_end_  , base::size1_);
+*/
                 }
+                r.barrier();
+                if(base::data_)   
+                        Valloc_.deallocate(base::data_, tot_sz);
+                if(base::pointers_begin_)   
+                        Palloc_.deallocate(base::pointers_begin_, base::size1_+1);
+                if(base::pointers_end_)   
+                        Palloc_.deallocate(base::pointers_end_  , base::size1_);
                 base::reset();
                 r.barrier();
         }
@@ -220,11 +223,16 @@ class array_of_sequences:
 
 		IsRoot r(Valloc_);
 		if(r.root()){
+                        auto pb(to_address(base::pointers_begin_));
+                        auto pe(to_address(base::pointers_end_));
 			for(size_type i = 0; i != base::size1_; ++i){
-				Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[i]), i*nnzpr_unique);
-				Palloc_ts::construct(Palloc_, std::addressof(base::pointers_end_[i]), i*nnzpr_unique);
+                                *(pb+i) = i*nnzpr_unique;
+                                *(pe+i) = i*nnzpr_unique;
+				//Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[i]), i*nnzpr_unique);
+				//Palloc_ts::construct(Palloc_, std::addressof(base::pointers_end_[i]), i*nnzpr_unique);
 			}
-                        Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[base::size1_]), base::size1_*nnzpr_unique);
+                        *(pb+base::size1_) = base::size1_*nnzpr_unique;
+                        //Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[base::size1_]), base::size1_*nnzpr_unique);
 		}
 		r.barrier();
 	}
@@ -253,12 +261,17 @@ class array_of_sequences:
                 IsRoot r(Valloc_);
                 if(r.root()){
 			IntType cnter(0);
+                        auto pb(to_address(base::pointers_begin_));
+                        auto pe(to_address(base::pointers_end_));
                         for(size_type i = 0; i != base::size1_; ++i){
-                                Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[i]), cnter); 
-                                Palloc_ts::construct(Palloc_, std::addressof(base::pointers_end_[i]), cnter);
+                                *(pb+i) = cnter;
+                                *(pe+i) = cnter;
+                                //Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[i]), cnter); 
+                                //Palloc_ts::construct(Palloc_, std::addressof(base::pointers_end_[i]), cnter);
 				cnter += static_cast<IntType>(nnzpr[i]); 
                         }
-                        Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[base::size1_]), cnter);
+                        *(pb+base::size1_) = cnter;
+                        //Palloc_ts::construct(Palloc_, std::addressof(base::pointers_begin_[base::size1_]), cnter);
                 }
 		r.barrier();
         }
@@ -348,7 +361,8 @@ class array_of_sequences:
                 assert(index >= 0);
                 assert(index < base::size1_);
 		if(base::pointers_end_[index] < base::pointers_begin_[index+1]) { 
-			Valloc_ts::construct(Valloc_,std::addressof(base::data_[base::pointers_end_[index]]), std::forward<Args>(args)...);
+			//Valloc_ts::construct(Valloc_,std::addressof(base::data_[base::pointers_end_[index]]), std::forward<Args>(args)...);
+                        ::new (static_cast<void*>(std::addressof(base::data_[base::pointers_end_[index]]))) value_type(std::forward<Args>(args)...);
 			++base::pointers_end_[index];
 		} else   throw std::out_of_range("row size exceeded the maximum");
 	}

--- a/src/AFQMC/Matrix/csr_matrix.hpp
+++ b/src/AFQMC/Matrix/csr_matrix.hpp
@@ -411,11 +411,13 @@ class ucsr_matrix:
 
 		IsRoot r(Valloc_);
 		if(r.root()){
-			for(size_type i = 0; i != base::size1_; ++i){
-				Palloc_ts::construct(Palloc_, to_address(base::pointers_begin_+i), i*nnzpr_unique);
-				Palloc_ts::construct(Palloc_, to_address(base::pointers_end_+i), i*nnzpr_unique);
-			}
-                        Palloc_ts::construct(Palloc_, to_address(base::pointers_begin_+base::size1_), base::size1_*nnzpr_unique);
+                        auto pb(to_address(base::pointers_begin_));
+                        auto pe(to_address(base::pointers_end_));
+		        for(size_type i = 0; i != base::size1_; ++i){
+                            *(pb+i) = i*nnzpr_unique;
+                            *(pe+i) = i*nnzpr_unique;
+		        }
+                        *(pb+base::size1_) = base::size1_*nnzpr_unique;
 		}
 		r.barrier();
 	}
@@ -450,12 +452,14 @@ class ucsr_matrix:
                 IsRoot r(Valloc_);
                 if(r.root()){
 			IntType cnter(0);
+                        auto pb(to_address(base::pointers_begin_));
+                        auto pe(to_address(base::pointers_end_));
                         for(size_type i = 0; i != base::size1_; ++i){
-                                Palloc_ts::construct(Palloc_, to_address(base::pointers_begin_+i), cnter); 
-                                Palloc_ts::construct(Palloc_, to_address(base::pointers_end_+i), cnter);
+                                *(pb+i) = cnter; 
+                                *(pe+i) = cnter; 
 				cnter += static_cast<IntType>(nnzpr[i]); 
                         }
-                        Palloc_ts::construct(Palloc_, to_address(base::pointers_begin_+base::size1_), cnter);
+                        *(pb+base::size1_) = cnter; 
                 }
 		r.barrier();
         }
@@ -617,8 +621,10 @@ IsRoot r_(Valloc_);
                 assert(get<0>(indices) >= 0);
                 assert(get<0>(indices) < base::size1_);
 		if(base::pointers_end_[get<0>(indices)] < base::pointers_begin_[get<0>(indices)+1]) { 
-			Valloc_ts::construct(Valloc_,to_address(base::data_ + base::pointers_end_[get<0>(indices)]), std::forward<Args>(args)...);
-			Ialloc_ts::construct(Ialloc_,to_address(base::jdata_ + base::pointers_end_[get<0>(indices)]), get<1>(indices));
+                        ::new (static_cast<void*>(to_address(base::data_ + base::pointers_end_[get<0>(indices)]))) value_type(std::forward<Args>(args)...); 
+			//Valloc_ts::construct(Valloc_,to_address(base::data_ + base::pointers_end_[get<0>(indices)]), std::forward<Args>(args)...);
+                        ::new (static_cast<void*>(to_address(base::jdata_ + base::pointers_end_[get<0>(indices)]))) index_type(get<1>(indices)); 
+			//Ialloc_ts::construct(Ialloc_,to_address(base::jdata_ + base::pointers_end_[get<0>(indices)]), get<1>(indices));
 			++base::pointers_end_[get<0>(indices)];
 		} else  {
                   APP_ABORT(" Error: row size exceeded the maximum \n\n\n");
@@ -951,7 +957,8 @@ class csr_matrix: public ucsr_matrix<ValType,IndxType,IntType,ValType_alloc,IsRo
 			size_type disp_ = std::distance(to_address(loc),to_address(base::jdata_ + base::pointers_end_[get<0>(indices)]));
 			if( disp_ > 0 && *loc == get<1>(indices)) { 
 				// value exists, construct in place 
-                        	base::Valloc_ts::construct(base::Valloc_,to_address(base::data_ + base::pointers_begin_[get<0>(indices)] + disp), std::forward<Args>(args)...);
+                        	//base::Valloc_ts::construct(base::Valloc_,to_address(base::data_ + base::pointers_begin_[get<0>(indices)] + disp), std::forward<Args>(args)...);
+                                ::new (static_cast<void*>(to_address(base::data_ + base::pointers_begin_[get<0>(indices)] + disp))) value_type(std::forward<Args>(args)...);
 			} else {
 				// new value, shift back and add in correct place
 				if(disp_ > 0) {
@@ -963,8 +970,10 @@ class csr_matrix: public ucsr_matrix<ValType,IndxType,IntType,ValType_alloc,IsRo
                                            to_address(base::jdata_+base::pointers_end_[get<0>(indices)] + 1));
 				}
                         	++base::pointers_end_[get<0>(indices)];
-                        	base::Valloc_ts::construct(base::Valloc_,to_address(base::data_+base::pointers_begin_[get<0>(indices)] + disp), std::forward<Args>(args)...);
-                        	base::Ialloc_ts::construct(base::Ialloc_, to_address(base::jdata_+base::pointers_begin_[get<0>(indices)] + disp), get<1>(indices));
+                        	//base::Valloc_ts::construct(base::Valloc_,to_address(base::data_+base::pointers_begin_[get<0>(indices)] + disp), std::forward<Args>(args)...);
+                                ::new (static_cast<void*>(to_address(base::data_ + base::pointers_begin_[get<0>(indices)] + disp))) value_type(std::forward<Args>(args)...);
+                        	//base::Ialloc_ts::construct(base::Ialloc_, to_address(base::jdata_+base::pointers_begin_[get<0>(indices)] + disp), get<1>(indices));
+                                ::new (static_cast<void*>(to_address(base::jdata_ + base::pointers_begin_[get<0>(indices)] + disp))) index_type(get<1>(indices));
 			}
                 } else throw std::out_of_range("row size exceeded the maximum");
         }	
@@ -980,8 +989,10 @@ class csr_matrix: public ucsr_matrix<ValType,IndxType,IntType,ValType_alloc,IsRo
                         if(base::pointers_begin_[get<0>(indices)] == 
                                 base::pointers_end_[get<0>(indices)] or 
                                 get<1>(indices) > base::jdata_[base::pointers_end_[get<0>(indices)]-1] ) { 
-                        	base::Valloc_ts::construct(base::Valloc_,to_address(base::data_+base::pointers_end_[get<0>(indices)]), std::forward<Args>(args)...);
-                        	base::Ialloc_ts::construct(base::Ialloc_, to_address(base::jdata_+base::pointers_end_[get<0>(indices)]), get<1>(indices));
+                        	//base::Valloc_ts::construct(base::Valloc_,to_address(base::data_+base::pointers_end_[get<0>(indices)]), std::forward<Args>(args)...);
+                                ::new (static_cast<void*>(to_address(base::data_ + base::pointers_end_[get<0>(indices)]))) value_type(std::forward<Args>(args)...);
+                        	//base::Ialloc_ts::construct(base::Ialloc_, to_address(base::jdata_+base::pointers_end_[get<0>(indices)]), get<1>(indices));
+                                ::new (static_cast<void*>(to_address(base::jdata_ + base::pointers_end_[get<0>(indices)]))) index_type(get<1>(indices));
                                 ++base::pointers_end_[get<0>(indices)];
                         } else // otherwise throw 
                             throw std::runtime_error("inconsistent column index in emplace_back");

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -182,9 +182,6 @@ template<class T = void> struct allocator_shm_ptr_with_raw_ptr_dispatch{
 
         shm_ptr_with_raw_ptr_dispatch<T> allocate(size_type n, const void* /*hint*/ = 0){
                 shm_ptr_with_raw_ptr_dispatch<T> ret = 0;
-//                ret.wSP_.reset(new mpi3::shared_window<T>{
-//                        comm_.make_shared_window<T>(comm_.root()?n:0)
-//                });
                 ret.wSP_.reset(new mpi3::shared_window<char>{
                         comm_,comm_.root()?(long(n*sizeof(T))):0,int(sizeof(T))
                 });
@@ -197,26 +194,15 @@ template<class T = void> struct allocator_shm_ptr_with_raw_ptr_dispatch{
         }
         bool operator==(allocator_shm_ptr_with_raw_ptr_dispatch const& other) const{return comm_ == other.comm_;}
         bool operator!=(allocator_shm_ptr_with_raw_ptr_dispatch const& other) const{return not(other == *this);}
-/*
-        template<class U, class... As>
-        void construct(U *p, As&&... as){
-          ::new((void*)p) U(std::forward<As>(as)...);
-        }
-        template< class U, class ... As >
-        void destroy(U *p, As&&... as){
-            p->~U();
-        }
-*/
+        // this routine synchronizes
         template<class U, class... As>
         void construct(U p, As&&... as){
-          //::new((void*)to_address(p)) U(std::forward<As>(as)...);
-//          uninitialized_fill_n(p,1,std::forward<As>(as)...);
+          uninitialized_fill_n(p,1,std::forward<As>(as)...);
         }
+        // this routine synchronizes
         template< class U, class... As >
         void destroy(U p, As&&... as){
-            destroy_n(p,1);
-            //using value = typename std::pointer_traits<U>::value_type; 
-            //(to_address(p))->~value();
+          destroy_n(p,1);
         }
 };
 

--- a/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
+++ b/src/AFQMC/Memory/SharedMemory/shm_ptr_with_raw_ptr_dispatch.hpp
@@ -360,6 +360,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy_n(Alloc &a, It1 f, Size n, s
 
 template<class Alloc, class It1, class Size, typename T>
 shm_ptr_with_raw_ptr_dispatch<T> alloc_uninitialized_copy_n(Alloc &a, It1 f, Size n, shm_ptr_with_raw_ptr_dispatch<T> d){
+        if(n==0) return d;
         d.wSP_->fence();
         using std::uninitialized_copy_n;
         if(d.wSP_->get_group().root()) uninitialized_copy_n(f, n, to_address(d));
@@ -394,6 +395,7 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_copy(Alloc &a, It1 f, It1 l, shm_
 
 template<class Alloc, class It1, typename T>
 shm_ptr_with_raw_ptr_dispatch<T> alloc_uninitialized_copy(Alloc &a, It1 f, It1 l, shm_ptr_with_raw_ptr_dispatch<T> d){
+        if(distance(f, l)==0) return d;
         d.wSP_->fence();
         using std::uninitialized_copy;
         if(d.wSP_->get_group().root()) uninitialized_copy(f, l, to_address(d));
@@ -438,7 +440,6 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_default_construct_n(Alloc &a, shm
         if(n==0) return f;
         f.wSP_->fence();
         if(f.wSP_->get_group().root()) {
-            using std::addressof;
             auto current(f);
             try{
                 for(; n > 0; ++current, --n) a.construct(current, T()); //(::new((void*)current) T());
@@ -454,7 +455,6 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_value_construct_n(Alloc &a, shm_p
         if(n==0) return f;
         f.wSP_->fence();
         if(f.wSP_->get_group().root()) {
-            using std::addressof;
             auto current(f);
             try{
                 for(; n > 0; ++current, --n) a.construct(current, T()); //(::new((void*)current) T());
@@ -467,9 +467,9 @@ shm_ptr_with_raw_ptr_dispatch<T> uninitialized_value_construct_n(Alloc &a, shm_p
 
 template<class Alloc, class T, class Size>
 shm_ptr_with_raw_ptr_dispatch<T> alloc_uninitialized_default_construct_n(Alloc &a, shm_ptr_with_raw_ptr_dispatch<T> f, Size n){
+        if(n==0) return f;
         f.wSP_->fence();
         if(f.wSP_->get_group().root()) {
-            using std::addressof;
             auto current(f);
             try{
                 for(; n > 0; ++current, --n) a.construct(current, T()); //(::new((void*)current) T());
@@ -482,9 +482,9 @@ shm_ptr_with_raw_ptr_dispatch<T> alloc_uninitialized_default_construct_n(Alloc &
 
 template<class Alloc, class T, class Size>
 shm_ptr_with_raw_ptr_dispatch<T> alloc_uninitialized_value_construct_n(Alloc &a, shm_ptr_with_raw_ptr_dispatch<T> f, Size n){
+        if(n==0) return f;
         f.wSP_->fence();
         if(f.wSP_->get_group().root()) {
-            using std::addressof;
             auto current(f);
             try{
                 for(; n > 0; ++current, --n) a.construct(current, T()); //(::new((void*)current) T());
@@ -505,10 +505,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
                     Alloc &a,
                     multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first, 
                     Size n, T const& val){
+  if(n==0) return first;  
   base(first).wSP_->fence();
   if(first.wSP_->get_group().root()) {
     auto current = first;
-    using std::addressof;
     try{
       for(; n > 0; ++current, --n)
         a.construct(base(current), val);
@@ -534,10 +534,10 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
                     Alloc &a,
                     multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> first,
                     Size n, T const& val){
+  if(n==0) return first;  
   base(first).wSP_->fence();
   if(first.wSP_->get_group().root()) {
     auto current = first;
-    using std::addressof;
     try{
       for(; n > 0; ++current, --n)
         a.construct(base(current), val);
@@ -565,12 +565,12 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
              multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q1>::type,T>::value,"Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type,T>::value,"Wrong dispatch.\n");
+  if(n==0) return dest;  
   base(dest).wSP_->fence();
   base(first).wSP_->fence();
   if(base(dest).wSP_->get_group().root()) {
     auto f = first;
     auto d = dest;
-    using std::addressof;
     for(; n > 0; ++f, ++d, --n)
       *d = *f; 
   }
@@ -585,11 +585,11 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> copy_n(
                          ForwardIt first,
                          Size n,
                          multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest ){
+  if(n==0) return dest;  
   base(dest).wSP_->fence();
   if(base(dest).wSP_->get_group().root()) {
     auto f = first;
     auto d = dest;
-    using std::addressof;
     for(; n > 0; ++f, ++d, --n)
       *d = *f;       
   }
@@ -606,11 +606,11 @@ multi::array_iterator<T, 1, T*> copy_n(
                          multi::array_iterator<T, 1, T*> dest ){
   static_assert(std::is_same<typename std::decay<Q1>::type,T>::value,"Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type,T>::value,"Wrong dispatch.\n");
+  if(n==0) return dest;  
   base(first).wSP_->fence();
   {
     auto f = first;
     auto d = dest;
-    using std::addressof;
     for(; n > 0; ++f, ++d, --n)
       *d = *f;       
   }
@@ -655,12 +655,12 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
                            Size n,
                            multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q>::type,T>::value,"Wrong dispatch.\n");
+  if(n==0) return dest;  
   base(first).wSP_->fence();
   base(dest).wSP_->fence();
   if(base(dest).wSP_->get_group().root()) {
     auto f = first;
     auto d = dest;
-    using std::addressof;
     try{
       for(; n > 0; ++f, ++d, --n)
         a.construct(base(d), *f);
@@ -679,12 +679,12 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
                            Size n,
                            multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> dest ){
   static_assert(std::is_same<typename std::decay<Q>::type,T>::value,"Wrong dispatch.\n");
+  if(n==0) return dest;  
   base(first).wSP_->fence();
   base(dest).wSP_->fence();
   if(base(dest).wSP_->get_group().root()) {
     auto f = first;
     auto d = dest;
-    using std::addressof;
     try{
       for(; n > 0; ++f, ++d, --n)
         a.construct(base(d), *f);
@@ -733,11 +733,11 @@ multi::array_iterator<T, 1, T*> uninitialized_copy(
                          multi::array_iterator<T, 1, T*> dest ){
   static_assert(std::is_same<typename std::decay<Q1>::type,T>::value,"Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type,T>::value,"Wrong dispatch.\n");
+  if(std::distance(first,last)==0) return dest;  
   assert( stride(first) == stride(last) );
   base(first).wSP_->fence();
   {
     auto d = dest;
-    using std::addressof;
     try{
       for(; first != last; ++first, ++d)
         a.construct(base(d), *first);
@@ -765,11 +765,11 @@ multi::array_iterator<T, 1, T*> alloc_uninitialized_copy(
                          multi::array_iterator<T, 1, T*> dest ){
   static_assert(std::is_same<typename std::decay<Q1>::type,T>::value,"Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type,T>::value,"Wrong dispatch.\n");
+  if(std::distance(first,last)==0) return dest;  
   assert( stride(first) == stride(last) );
   base(first).wSP_->fence();
   {
     auto d = dest;
-    using std::addressof;
     try{
       for(; first != last; ++first, ++d)
         a.construct(base(d), *first);
@@ -784,6 +784,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
                             Alloc& a,   
                             multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f, 
                             Size n){
+  if(n==0) return f;  
   base(f).wSP_->fence();
   if(base(f).wSP_->get_group().root()) {
       auto current(f);
@@ -801,6 +802,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> uninitialized
                             Alloc& a, 
                             multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f, 
                             Size n){
+  if(n==0) return f;  
   base(f).wSP_->fence();
   if(base(f).wSP_->get_group().root()) {
       auto current(f);
@@ -818,6 +820,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
                             Alloc& a,
                             multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
                             Size n){
+  if(n==0) return f;  
   base(f).wSP_->fence();
   if(base(f).wSP_->get_group().root()) {
       auto current(f);
@@ -835,6 +838,7 @@ multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> alloc_uniniti
                             Alloc& a,
                             multi::array_iterator<T, 1, shm::shm_ptr_with_raw_ptr_dispatch<T>> f,
                             Size n){
+  if(n==0) return f;  
   base(f).wSP_->fence();
   if(base(f).wSP_->get_group().root()) {
       auto current(f);

--- a/src/AFQMC/Memory/buffer_allocators.cpp
+++ b/src/AFQMC/Memory/buffer_allocators.cpp
@@ -22,7 +22,7 @@ namespace afqmc {
   auto host_buffer_generator = std::make_shared<host_allocator_generator_type> ( 
             host_memory_resource{},
             std::size_t(10*1024*1024),
-            device_constructor<char>{}
+            host_constructor<char>{}
         );
 //#if defined(ENABLE_ACCELERATOR)
 #if defined(ENABLE_CUDA)
@@ -56,7 +56,7 @@ namespace afqmc {
     if(localTG_buffer_generator == nullptr)
       localTG_buffer_generator = std::make_shared<localTG_allocator_generator_type> (
                       shm::memory_resource_shm_ptr_with_raw_ptr_dispatch{local},
-                      sz, device_constructor<char>{} );
+                      sz, shm_constructor<char>{local} );
 #endif
   }
 

--- a/src/AFQMC/Memory/buffer_allocators.h
+++ b/src/AFQMC/Memory/buffer_allocators.h
@@ -110,18 +110,18 @@ namespace afqmc
 
       template<class T>
       allocator<T> get_allocator(){
-        return allocator<T>{std::addressof(mr_)};
+        return allocator<T>{std::addressof(mr_),constr_};
       }
 
   };
 
 
   using host_allocator_generator_type = 
-            BufferAllocatorGenerator< host_memory_resource, device_constructor<char> >; 
+            BufferAllocatorGenerator< host_memory_resource, host_constructor<char> >; 
   using device_allocator_generator_type = 
             BufferAllocatorGenerator< device_memory_resource, device_constructor<char> >;  
   using localTG_allocator_generator_type = 
-            BufferAllocatorGenerator< shm_memory_resource, device_constructor<char> >;  
+            BufferAllocatorGenerator< shm_memory_resource, shm_constructor<char> >;  
 
   template<class T>
     using host_buffer_type = typename host_allocator_generator_type::template allocator<T>; 

--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -490,7 +490,9 @@ ForwardIt copy(device_pointer<T const> const Abeg, device_pointer<T const> const
 // if types of pointers are not the same (without cv qualifiers)!!!
 template<typename T, typename Q, typename Size>
 device_pointer<Q> copy_n_cast(device_pointer<T> const A, Size n, device_pointer<Q> B) {
-  kernels::copy_n_cast(to_address(A),n,to_address(B));
+//  if constexpr (std::is_same<std::decay_t<T>,Q>::value) copy_n(A,n,B); 
+//  else 
+    kernels::copy_n_cast(to_address(A),n,to_address(B));
   return B+n;
 }
 

--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -410,6 +410,12 @@ struct constructor{
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
 
+  constructor() = default; 
+  ~constructor() = default;
+  constructor(constructor const& other) = default;
+  template<class U>
+  constructor(constructor<U> const& other) {}
+
   template<class U, class... Args>
   void construct(U p, Args&&... args) {}
 

--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -511,6 +511,14 @@ Q* copy_n_cast(device_pointer<T> const A, Size n, Q* B) {
   return B+n;
 }
 
+/**************** inplace_cast *****************/
+template<typename T, typename Q, typename Size>
+void inplace_cast(device_pointer<T> A, Size n) {
+  T* A_(to_address(A));
+  Q* B_(reinterpret_cast<Q*>(A_));
+  kernels::inplace_cast(n,A_,B_);
+}
+
 /**************** fill_n *****************/
 //template<typename T, typename Size, typename... Args>
 //device_pointer<T> fill_n(device_pointer<T> first, Size n, Args&&...args){

--- a/src/AFQMC/Memory/raw_pointers.hpp
+++ b/src/AFQMC/Memory/raw_pointers.hpp
@@ -32,14 +32,16 @@ namespace afqmc {
   template<class T>
   inline static std::complex<T> const* to_address(std::complex<T> const* p) { return p; }
 
-  template<class Q, class T,
-           typename = typename std::enable_if_t<std::is_fundamental<Q>::value>,
-           typename = typename std::enable_if_t<std::is_fundamental<T>::value>>
-  inline static Q* pointer_cast(T* p) { return reinterpret_cast<Q*>(p); }
+//  template<class Q, class T,
+//           typename = typename std::enable_if_t<std::is_fundamental<Q>::value>,
+//           typename = typename std::enable_if_t<std::is_fundamental<T>::value>>
+//  inline static Q* pointer_cast(T* p) { return reinterpret_cast<Q*>(p); }
 
-  template<class Q, class T,
-           typename = typename std::enable_if_t<std::is_fundamental<Q>::value>>
-  inline static Q* pointer_cast(std::complex<T>* p) { return reinterpret_cast<Q*>(p); }
+//  template<class Q, class T>
+//  inline static Q* pointer_cast(std::complex<T>* p) { return reinterpret_cast<Q*>(p); }
+
+  template<class Q, class T>
+  inline static Q* pointer_cast(T* p) { return reinterpret_cast<Q*>(p); }
 
 
   /************* copy_n_cast ****************/

--- a/src/AFQMC/Numerics/batched_operations.hpp
+++ b/src/AFQMC/Numerics/batched_operations.hpp
@@ -227,7 +227,7 @@ void vbias_from_v1( int nwalk, int nkpts, int nchol_max, int* Qsym, int* kminus,
     // v-
     vb_ = (vb + (nc0+nc)*nwalk);
     // v- = -a*i*(v[Q]-v[-Q]) 
-    auto ialpha(alpha*std::complex<double>(0.0,1.0));
+    auto ialpha(alpha*std::complex<T>(0.0,1.0));
     for(int n=0; n<ntot; ++n)
       vb_[ n ] -= ialpha*static_cast<std::complex<T>>(v1_[ n ]);
     for(int n=0; n<ntot; ++n)

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/construct_X.cuh
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/construct_X.cuh
@@ -28,6 +28,28 @@ void construct_X( int nCV, int nsteps, int nwalk, bool free_projection,
                         std::complex<double>* HW,
                         std::complex<double>* MF,
                         std::complex<double>* X );
+void construct_X( int nCV, int nsteps, int nwalk, bool free_projection,
+                        double sqrtdt, double vbound,
+                        std::complex<double> const* vMF,
+                        std::complex<float> const* vbias,
+                        std::complex<double>* HW,
+                        std::complex<double>* MF,
+                        std::complex<float>* X );
+void construct_X( int nCV, int nsteps, int nwalk, bool free_projection,
+                        double sqrtdt, double vbound,
+                        std::complex<double> const* vMF,
+                        std::complex<float> const* vbias,
+                        std::complex<double>* HW,
+                        std::complex<double>* MF,
+                        std::complex<double>* X );
+void construct_X( int nCV, int nsteps, int nwalk, bool free_projection,
+                        double sqrtdt, double vbound,
+                        std::complex<double> const* vMF,
+                        std::complex<double> const* vbias,
+                        std::complex<double>* HW,
+                        std::complex<double>* MF,
+                        std::complex<float>* X );
+
 
 }
 

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/copy_n_cast.cuh
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/copy_n_cast.cuh
@@ -25,6 +25,14 @@ void copy_n_cast(double const* A, int n, float* B);
 void copy_n_cast(float const* A, int n, double* B);
 void copy_n_cast(std::complex<double> const* A, int n, std::complex<float>* B);
 void copy_n_cast(std::complex<float> const* A, int n, std::complex<double>* B);
+inline void copy_n_cast(std::complex<float> const* A, int n, std::complex<float>* B) {
+  std::cerr<<" Should not be calling copy_n_cast<T,T>. \n" <<std::endl;
+  throw std::runtime_error("Calling cast_n_copy(float const*,n,float*)");
+}
+inline void copy_n_cast(std::complex<double> const* A, int n, std::complex<double>* B) {
+  std::cerr<<" Should not be calling copy_n_cast<T,T>. \n" <<std::endl;
+  throw std::runtime_error("Calling cast_n_copy(double const*,n,double*)");
+}
 
 }
 

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/copy_n_cast.cuh
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/copy_n_cast.cuh
@@ -15,6 +15,7 @@
 #ifndef AFQMC_COPY_N_CAST_KERNELS_HPP
 #define AFQMC_COPY_N_CAST_KERNELS_HPP
 
+#include <stdexcept>
 #include<cassert>
 #include <complex>
 

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/inplace_cast.cu
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/inplace_cast.cu
@@ -1,0 +1,90 @@
+//////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License.  See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:
+//    Lawrence Livermore National Laboratory 
+//
+// File created by:
+// Miguel A. Morales, moralessilva2@llnl.gov 
+//    Lawrence Livermore National Laboratory 
+////////////////////////////////////////////////////////////////////////////////
+
+#include<cassert>
+#include <complex>
+#include<cuda.h>
+#include <thrust/complex.h>
+#include<cuda_runtime.h>
+#include "AFQMC/Memory/CUDA/cuda_utilities.h"
+#include "AFQMC/Numerics/detail/CUDA/Kernels/cuda_settings.h"
+
+namespace kernels
+{
+
+template<typename T, typename Q, typename Size>
+__global__ void kernel_inplace_cast(Size n, thrust::complex<T>* A, thrust::complex<Q>* B)
+{
+  Size nb(blockDim.x);
+  Size ni(threadIdx.x);
+  thrust::complex<Q> Bi;
+  if( sizeof(T) >= sizeof(Q) ) {
+// this is wrong if the compiler eliminates the intermediate Bi through optimization
+// will it???
+    for(Size i=0; i<n; i+=nb, ni+=nb) {
+      if(ni<n) Bi = static_cast<thrust::complex<Q>>(*(A+ni));
+      __syncthreads();   
+      if(ni<n) *(B+ni) = Bi;
+//      __syncthreads();  
+    }
+  } else if(sizeof(T) < sizeof(Q)) {
+    assert( sizeof(T)*2 <= sizeof(Q));
+    ni = n-1-ni;
+    for(Size i=0; i<n; i+=nb, ni-=nb) {
+      if(ni>=0) Bi = static_cast<thrust::complex<Q>>(*(A+ni));
+      __syncthreads();   
+      if(ni>=0) *(B+ni) = Bi;
+//      __syncthreads();  
+    }
+  }
+
+}
+
+void inplace_cast(unsigned long n, std::complex<float>* A, std::complex<double>* B)
+{
+  kernel_inplace_cast<<<1, MAX_THREADS_PER_DIM>>>(n,
+                                reinterpret_cast<thrust::complex<float> *>(A),
+                                reinterpret_cast<thrust::complex<double> *>(B));
+  qmc_cuda::cuda_check(cudaGetLastError());
+  qmc_cuda::cuda_check(cudaDeviceSynchronize());
+}
+
+void inplace_cast(unsigned long n, std::complex<double>* A, std::complex<float> *B)
+{
+  kernel_inplace_cast<<<1, MAX_THREADS_PER_DIM>>>(n,
+                                reinterpret_cast<thrust::complex<double> *>(A),
+                                reinterpret_cast<thrust::complex<float> *>(B));
+  qmc_cuda::cuda_check(cudaGetLastError());
+  qmc_cuda::cuda_check(cudaDeviceSynchronize());
+}
+
+void inplace_cast(long n, std::complex<float>* A, std::complex<double>* B)
+{
+  kernel_inplace_cast<<<1, MAX_THREADS_PER_DIM>>>(n,
+                                reinterpret_cast<thrust::complex<float> *>(A),
+                                reinterpret_cast<thrust::complex<double> *>(B));
+  qmc_cuda::cuda_check(cudaGetLastError());
+  qmc_cuda::cuda_check(cudaDeviceSynchronize());
+}
+
+void inplace_cast(long n, std::complex<double>* A, std::complex<float> *B)
+{
+  kernel_inplace_cast<<<1, MAX_THREADS_PER_DIM>>>(n,
+                                reinterpret_cast<thrust::complex<double> *>(A),
+                                reinterpret_cast<thrust::complex<float> *>(B));
+  qmc_cuda::cuda_check(cudaGetLastError());
+  qmc_cuda::cuda_check(cudaDeviceSynchronize());
+}
+
+}

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/inplace_cast.cuh
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/inplace_cast.cuh
@@ -12,13 +12,20 @@
 //    Lawrence Livermore National Laboratory
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef AFQMC_KERNELS_SETTINGS_HPP
-#define AFQMC_KERNELS_SETTINGS_HPP
+#ifndef AFQMC_INPLACE_CAST_KERNELS_HPP
+#define AFQMC_INPLACE_CAST_KERNELS_HPP
 
-#define BOOST_NO_AUTO_PTR
+#include<cassert>
+#include <complex>
 
-static const size_t DOT_BLOCK_SIZE = 32; 
-static const size_t REDUCE_BLOCK_SIZE = 32; 
-static const size_t MAX_THREADS_PER_DIM = 1024; 
+namespace kernels
+{
+
+void inplace_cast(unsigned long n, std::complex<float>* A, std::complex<double>* B);
+void inplace_cast(unsigned long n, std::complex<double>* A, std::complex<float>* B);
+void inplace_cast(long n, std::complex<float>* A, std::complex<double>* B);
+void inplace_cast(long n, std::complex<double>* A, std::complex<float>* B);
+
+}
 
 #endif

--- a/src/AFQMC/Numerics/detail/CUDA/Kernels/sampleGaussianRNG.cu
+++ b/src/AFQMC/Numerics/detail/CUDA/Kernels/sampleGaussianRNG.cu
@@ -33,16 +33,15 @@ void sampleGaussianRNG( double* V, int n, curandGenerator_t & gen)
   qmc_cuda::cuda_check(cudaDeviceSynchronize());
 }
 
-/*
  // Convert to double if really necessary
 void sampleGaussianRNG( float* V, int n, curandGenerator_t & gen) 
 {
-  qmc_cuda::curand_check(curandGenerateNormalFloat(gen,V,n,0.0,1.0),
-                                          "curandGenerateNormalFloat");
+  qmc_cuda::curand_check(curandGenerateNormal(gen,V,n,float(0.0),float(1.0)),
+                                          "curandGenerateNormal");
   qmc_cuda::cuda_check(cudaGetLastError());
   qmc_cuda::cuda_check(cudaDeviceSynchronize());
 }
-*/
+
 void sampleGaussianRNG( std::complex<double>* V, int n, curandGenerator_t & gen) 
 {
   qmc_cuda::curand_check(curandGenerateNormalDouble(gen,
@@ -55,16 +54,18 @@ void sampleGaussianRNG( std::complex<double>* V, int n, curandGenerator_t & gen)
   qmc_cuda::cuda_check(cudaGetLastError());
   qmc_cuda::cuda_check(cudaDeviceSynchronize());
 }
-/*
+
 void sampleGaussianRNG( std::complex<float>* V, int n, curandGenerator_t & gen) 
 {
-  qmc_cuda::curand_check(curandGenerateNormalFloat(gen,
-                        reinterpret_cast<float*>(V),2*n,0.0,1.0),
-                                          "curandGenerateNormalFloat");
+  qmc_cuda::curand_check(curandGenerateNormal(gen,
+                        reinterpret_cast<float*>(V),2*n,float(0.0),float(1.0)),
+                                          "curandGenerateNormal");
   qmc_cuda::cuda_check(cudaGetLastError());
   qmc_cuda::cuda_check(cudaDeviceSynchronize());
   // hack hack hack!!!
   kernels::zero_complex_part(n,V);
+  qmc_cuda::cuda_check(cudaGetLastError());
+  qmc_cuda::cuda_check(cudaDeviceSynchronize());
 } 
-*/
+
 }

--- a/src/AFQMC/Numerics/device_kernels.hpp
+++ b/src/AFQMC/Numerics/device_kernels.hpp
@@ -32,6 +32,7 @@
 #include "AFQMC/Numerics/detail/CUDA/Kernels/zero_complex_part.cuh"
 #include "AFQMC/Numerics/detail/CUDA/Kernels/batchedDot.cuh"
 #include "AFQMC/Numerics/detail/CUDA/Kernels/copy_n_cast.cuh"
+#include "AFQMC/Numerics/detail/CUDA/Kernels/inplace_cast.cuh"
 #include "AFQMC/Numerics/detail/CUDA/Kernels/ajw_to_waj.cuh" 
 #include "AFQMC/Numerics/detail/CUDA/Kernels/vKKwij_to_vwKiKj.cuh" 
 #include "AFQMC/Numerics/detail/CUDA/Kernels/KaKjw_to_QKajw.cuh"

--- a/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_dense_numerics.cpp
@@ -31,7 +31,7 @@
 
 // Avoid the need to link with other libraries just to get APP_ABORT
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x; exit(0);}
+#define APP_ABORT(x) {std::cout << x; throw;}
 
 #include <stdio.h>
 #include <string>

--- a/src/AFQMC/Numerics/tests/test_ma_blas.cpp
+++ b/src/AFQMC/Numerics/tests/test_ma_blas.cpp
@@ -19,7 +19,7 @@
 #include "Configuration.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x; exit(0);}
+#define APP_ABORT(x) {std::cout << x; throw;}
 
 #include <vector>
 #include<iostream>

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics.cpp
@@ -26,7 +26,7 @@
 #define MKL_Complex16   std::complex<double>
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x; exit(0);}
+#define APP_ABORT(x) {std::cout << x; throw;}
 
 #include<iostream>
 #include<vector>

--- a/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
+++ b/src/AFQMC/Numerics/tests/test_sparse_numerics_native.cpp
@@ -27,7 +27,7 @@
 #define MKL_Complex16   std::complex<double>
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x; exit(0);}
+#define APP_ABORT(x) {std::cout << x; throw;}
 
 #include<iostream>
 #include<vector>

--- a/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
+++ b/src/AFQMC/Numerics/tests/test_tensor_contraction.cpp
@@ -15,7 +15,7 @@
 #include "Configuration.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x; exit(0);}
+#define APP_ABORT(x) {std::cout << x; throw;}
 
 #include <vector>
 #include<iostream>

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.cpp
@@ -180,6 +180,7 @@ void AFQMCBasePropagator::reset_nextra(int nextra)
     APP_ABORT("Error: Problems in AFQMCBasePropagator::reset_nextra()\n");
 }
 
+/*
 void AFQMCBasePropagator::assemble_X(size_t nsteps, size_t nwalk, RealType sqrtdt, 
                           StaticMatrix& X, StaticMatrix & vbias, StaticMatrix& MF, 
                           StaticMatrix& HWs, bool addRAND) 
@@ -248,6 +249,7 @@ void AFQMCBasePropagator::assemble_X(size_t nsteps, size_t nwalk, RealType sqrtd
   TG.local_barrier();
 #endif
 }
+*/
 
 }
 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -61,12 +61,16 @@ class AFQMCBasePropagator: public AFQMCInfo
   using StaticVector = boost::multi::static_array<ComplexType,1,buffer_alloc_type>;
   using StaticMatrix = boost::multi::static_array<ComplexType,2,buffer_alloc_type>;
   using Static3Tensor = boost::multi::static_array<ComplexType,3,buffer_alloc_type>;
+  using StaticSPVector = boost::multi::static_array<SPComplexType,1,buffer_alloc_SPtype>;
+  using StaticSPMatrix = boost::multi::static_array<SPComplexType,2,buffer_alloc_SPtype>;
+  using StaticSP3Tensor = boost::multi::static_array<SPComplexType,3,buffer_alloc_SPtype>;
 
   using CVector = boost::multi::array<ComplexType,1,allocator>;  
   using CMatrix = boost::multi::array<ComplexType,2,allocator>;  
   using C3Tensor = boost::multi::array<ComplexType,3,allocator>;  
   using CVector_ref = boost::multi::array_ref<ComplexType,1,pointer>;  
   using CMatrix_ref = boost::multi::array_ref<ComplexType,2,pointer>;  
+  using SPCMatrix_ref = boost::multi::array_ref<SPComplexType,2,sp_pointer>;  
   using C3Tensor_ref = boost::multi::array_ref<ComplexType,3,pointer>;  
   using sharedCVector = ComplexVector<aux_allocator>; 
   using stdCVector = boost::multi::array<ComplexType,1>;  

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -54,6 +54,7 @@ class AFQMCBasePropagator: public AFQMCInfo
   using pointer = device_ptr<ComplexType>;
   // allocator for memory shared by all cores in working local group 
   using aux_allocator = localTG_allocator<ComplexType>;
+  using sp_pointer = typename device_allocator<SPComplexType>::pointer;
 
   using buffer_alloc_type = localTG_buffer_type<ComplexType>;
   using buffer_alloc_SPtype = localTG_buffer_type<SPComplexType>;

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -77,11 +77,14 @@ class AFQMCBasePropagator: public AFQMCInfo
   using stdCVector = boost::multi::array<ComplexType,1>;  
   using stdCMatrix = boost::multi::array<ComplexType,2>;  
   using stdCVector_ref = boost::multi::array_ref<ComplexType,1>;  
+  using stdSPCVector_ref = boost::multi::array_ref<SPComplexType,1>;  
   using stdCMatrix_ref = boost::multi::array_ref<ComplexType,2>;  
+  using stdSPCMatrix_ref = boost::multi::array_ref<SPComplexType,2>;  
   using stdC3Tensor_ref = boost::multi::array_ref<ComplexType,3>;  
   using CMatrix_ptr = boost::multi::array_ptr<ComplexType,2,pointer>;  
 
   using mpi3CVector = boost::multi::array<ComplexType,1,shared_allocator<ComplexType>>;  
+  using mpi3SPCVector = boost::multi::array<SPComplexType,1,shared_allocator<SPComplexType>>;  
   using mpi3CMatrix = boost::multi::array<ComplexType,2,shared_allocator<ComplexType>>;  
   using mpi3CTensor = boost::multi::array<ComplexType,3,shared_allocator<ComplexType>>;  
 
@@ -223,9 +226,10 @@ class AFQMCBasePropagator: public AFQMCInfo
     template<class WlkSet>
     void step(int steps, WlkSet& wset, RealType E1, RealType dt);
 
+    template<class MatA, class MatB, class MatC, class MatD>
     void assemble_X(size_t nsteps, size_t nwalk, RealType sqrtdt,
-                    StaticMatrix& X, StaticMatrix& vbias,
-                    StaticMatrix& MF, StaticMatrix& HW, bool addRAND=true);
+                          MatA&& X, MatB&& vbias, MatC&& MF,
+                          MatD&& HWs, bool addRAND=true);
 
     void reset_nextra(int nextra); 
 
@@ -238,10 +242,11 @@ class AFQMCBasePropagator: public AFQMCInfo
     template<class WSet>
     void apply_propagators_batched(char TA, WSet& wset, int ni, C3Tensor_ref& vHS3D);
 
-    ComplexType apply_bound_vbias(ComplexType v, RealType sqrtdt)
+    template<typename T>
+    T apply_bound_vbias(T v, RealType sqrtdt)
     {
-      return (std::abs(v)>vbias_bound*sqrtdt)?
-                (v/(std::abs(v)/static_cast<ValueType>(vbias_bound*sqrtdt))):(v);
+      return (std::abs(v)>std::abs(static_cast<T>(vbias_bound*sqrtdt)))?
+                (v/(std::abs(v)/static_cast<T>(vbias_bound*sqrtdt))):(v);
     }
 
     // taken from NOMSD 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -89,19 +89,31 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
 
   { // using scope to control lifetime of StaticArrays, avoiding unnecesary buffer space 
 
-    StaticMatrix G(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vbias({long(localnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix X({long(localnCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
+    StaticSPMatrix G(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all walkers
     AFQMCTimers[G_for_vbias_timer]->start();
+#if defined(MIXED_PRECISION)
+    {
+      int Gak0,GakN;
+      std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
+                    int(G.num_elements()),TG.getNCoresPerTG());
+      StaticMatrix Gc(G_ext,
+            buffer_allocator->template get_allocator<ComplexType>());
+      wfn.MixedDensityMatrix_for_vbias(wset,Gc);
+      copy_n_cast(make_device_ptr(Gc.origin())+Gak0,GakN-Gak0,
+                  make_device_ptr(G.origin())+Gak0);
+    }
+    TG.local_barrier();
+#else
     wfn.MixedDensityMatrix_for_vbias(wset,G);
+#endif
     AFQMCTimers[G_for_vbias_timer]->stop();
 //std::cout<<" G: " <<ma::dot(G(G.extension(0),0),G(G.extension(0),0)) <<std::endl;
 
+    StaticSPMatrix vbias({long(localnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
     // 2. Calculate vbias for initial configuration
     AFQMCTimers[vbias_timer]->start();
     if (free_projection) {
@@ -112,6 +124,8 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     AFQMCTimers[vbias_timer]->stop();
 //std::cout<<" vbias: " <<ma::dot(vbias(vbias.extension(0),0),vbias(vbias.extension(0),0)) <<std::endl;
 
+    StaticSPMatrix X({long(localnCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<SPComplexType>());
     // 3. Assemble X(nCV,nsteps,nwalk)
     AFQMCTimers[assemble_X_timer]->start();
     assemble_X(nsteps,nwalk,sqrtdt,X,vbias,MFfactor,hybrid_weight);
@@ -130,10 +144,10 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
           auto&& V(*wset.getFields(bp_step));
           if(nsteps==1) {
             copy_n(X[cv0].origin(),nwalk*(cvN-cv0),V[cv0].origin());
-            ma::scal(sqrtdt,V.sliced(cv0,cvN));
+            ma::scal(SPComplexType(sqrtdt),V.sliced(cv0,cvN));
           } else {
-            ma::add(ComplexType(0.0),   V.sliced(cv0,cvN),
-                  ComplexType(sqrtdt),X( {cv0,cvN}, {ni*nwalk,(ni+1)*nwalk} ),
+            ma::add(SPComplexType(0.0),   V.sliced(cv0,cvN),
+                  SPComplexType(sqrtdt),X( {cv0,cvN}, {ni*nwalk,(ni+1)*nwalk} ),
                                       V.sliced(cv0,cvN));
           }
           bp_step++;
@@ -145,7 +159,17 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
 
   // 4. Calculate vHS(M*M,nsteps,nwalk)/vHS(nsteps,nwalk,M*M)
     AFQMCTimers[vHS_timer]->start();
+#if defined(MIXED_PRECISION)
+    // is this clever or dirsty? seems to work well and saves memory!
+    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.origin())),vhs_ext);
+    wfn.vHS(X,vsp,sqrtdt);
+    TG.local_barrier();
+    if(TG.TG_local().root())
+      inplace_cast<SPComplexType,ComplexType>(vsp.origin(),vsp.num_elements());
+    TG.local_barrier();
+#else
     wfn.vHS(X,vHS,sqrtdt);
+#endif
     AFQMCTimers[vHS_timer]->stop();
 //std::cout<<" Pg vHS: " <<TG.Global().rank() <<" " <<ma::sum(vHS) <<"\n" <<std::endl;
 //std::cout<<" vHS: " <<ma::dot(vHS[0],vHS[0]) <<"\n\n" <<std::endl;
@@ -240,8 +264,8 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
 
   StaticMatrix vHS(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix X({long(globalnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
+  StaticSPMatrix X({long(globalnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
   C3Tensor_ref vHS3D(make_device_ptr(vHS.origin()),vhs3d_ext);
 
   auto&& Fields(*wset.getFields());
@@ -301,7 +325,17 @@ void AFQMCBasePropagator::BackPropagate(int nbpsteps, int nStabalize, WlkSet& ws
 
     // 2. Calculate vHS(M*M,nwalk)/vHS(nwalk,M*M) 
     //  X has been scaled by sqrtdt to avoid needing it here 
+#if defined(MIXED_PRECISION)
+    // is this clever or dirsty? seems to work well and saves memory!
+    SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.origin())),vhs_ext);
+    wfn.vHS(X,vsp);
+    TG.local_barrier();
+    if(TG.TG_local().root())
+      inplace_cast<SPComplexType,ComplexType>(vsp.origin(),vsp.num_elements());
+    TG.local_barrier();
+#else
     wfn.vHS(X,vHS);
+#endif
 //std::cout<<" BP vHS: " <<TG.Global().rank() <<" " <<ma::sum(vHS) <<"\n" <<std::endl;
 
     for(int nr=0; nr<nrefs; ++nr) {   
@@ -594,6 +628,78 @@ void AFQMCBasePropagator::apply_propagators_batched(char TA, WSet& wset, int ni,
     }
     TG.local_barrier();
   }
+
+template<class MatA, class MatB, class MatC, class MatD> 
+void AFQMCBasePropagator::assemble_X(size_t nsteps, size_t nwalk, RealType sqrtdt,
+                          MatA&& X, MatB&& vbias, MatC&& MF,
+                          MatD&& HWs, bool addRAND)
+{
+  using XType = typename std::decay<MatA>::type::element ;
+  using vType = typename std::decay<MatB>::type::element ;
+  // remember to call vbi = apply_bound_vbias(*vb);
+  // X[m,ni,iw] = rand[m,ni,iw] + im * ( vbias[m,iw] - vMF[m]  )
+  // HW[ni,iw] = sum_m [ im * ( vMF[m] - vbias[m,iw] ) * 
+  //                     ( rand[m,ni,iw] + halfim * ( vbias[m,iw] - vMF[m] ) ) ] 
+  //           = sum_m [ im * ( vMF[m] - vbias[m,iw] ) * 
+  //                     ( X[m,ni,iw] - halfim * ( vbias[m,iw] - vMF[m] ) ) ] 
+  // MF[ni,iw] = sum_m ( im * X[m,ni,iw] * vMF[m] )   
+
+  TG.local_barrier();
+  ComplexType im(0.0,1.0);
+  int nCV = int(X.size(0));
+  // generate random numbers
+  if(addRAND)
+  {
+    int i0,iN;
+    std::tie(i0,iN) = FairDivideBoundary(TG.TG_local().rank(),int(X.num_elements()),
+                                         TG.TG_local().size());
+    sampleGaussianFields_n(make_device_ptr(X.origin())+i0,iN-i0,*rng);
+  }
+
+  // construct X
+  fill_n(make_device_ptr(HWs.origin()),HWs.num_elements(),ComplexType(0));
+  fill_n(make_device_ptr(MF.origin()),MF.num_elements(),ComplexType(0));
+
+// leaving compiler switch until I decide how to do this better
+// basically hide this decision somewhere based on the value of pointer!!!
+#ifdef ENABLE_CUDA
+  kernels::construct_X(nCV,nsteps,nwalk,free_projection,sqrtdt,vbias_bound,
+                       to_address(vMF.origin()),
+                       to_address(vbias.origin()),
+                       to_address(HWs.origin()),
+                       to_address(MF.origin()),
+                       to_address(X.origin())
+                      );
+#else
+  boost::multi::array_ref<XType,3> X3D(to_address(X.origin()),
+                        {long(X.size(0)),long(nsteps),long(nwalk)});
+  int m0,mN;
+  std::tie(m0,mN) = FairDivideBoundary(TG.TG_local().rank(),nCV,TG.TG_local().size());
+  TG.local_barrier();
+  for(int m=m0; m<mN; ++m) {
+    auto X_m = X3D[m];
+    auto vb_ = to_address(vbias[m].origin());
+    auto vmf_t = sqrtdt*apply_bound_vbias(vMF[m],1.0);
+    auto vmf_ = sqrtdt*vMF[m];
+    // apply bounds to vbias
+    for(int iw=0; iw<nwalk; iw++)
+      vb_[iw] = apply_bound_vbias(vb_[iw],sqrtdt);
+    for(int ni=0; ni<nsteps; ni++) {
+      auto X_ = X3D[m][ni].origin();
+      auto hws_ = to_address(HWs[ni].origin());
+      auto mf_ = to_address(MF[ni].origin());
+      for(int iw=0; iw<nwalk; iw++) {
+        // No force bias term when doing free projection.
+        ComplexType vdiff = free_projection?ComplexType(0.0, 0.0):(im*(static_cast<ComplexType>(vb_[iw])-vmf_t));
+        X_[iw] += static_cast<XType>(vdiff);
+        hws_[iw] -= vdiff * ( static_cast<ComplexType>(X_[iw]) - 0.5*vdiff );
+        mf_[iw] += im * static_cast<ComplexType>(X_[iw]) * vmf_;
+      }
+    }
+  }
+  TG.local_barrier();
+#endif
+}
 
 }
 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -117,7 +117,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     // 2. Calculate vbias for initial configuration
     AFQMCTimers[vbias_timer]->start();
     if (free_projection) {
-      fill_n(vbias.origin(), localnCV*nwalk, ComplexType(0.0,0.0));
+      fill_n(vbias.origin(), localnCV*nwalk, SPComplexType(0.0,0.0));
     } else {
       wfn.vbias(G,vbias,sqrtdt);
     }

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
@@ -86,21 +86,42 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
             buffer_allocator->template get_allocator<ComplexType>());
   StaticMatrix new_energies({nwalk,3},
             buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vHS(vhs_ext,
+  StaticMatrix vHS_buff(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
+  SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vHS_buff.origin())),vhs_ext);
   {
-    StaticMatrix G(G_ext,
+    StaticSPMatrix G(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+
+    // 1. Calculate Green function for all (local) walkers
+    AFQMCTimers[G_for_vbias_timer]->start();
+#if defined(MIXED_PRECISION)
+    { // control scope of Gc 
+      int Gak0,GakN;
+      std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
+                    int(G.num_elements()),TG.getNCoresPerTG());
+      StaticMatrix Gc(G_ext,
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Gwork(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix X({long(nCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vbias({long(nCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix RNG({long(nCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vHSwork(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
+      wfn.MixedDensityMatrix_for_vbias(wset,Gc);
+      copy_n_cast(make_device_ptr(Gc.origin())+Gak0,GakN-Gak0,
+                  make_device_ptr(G.origin())+Gak0);
+    }
+    TG.local_barrier();
+#else
+    wfn.MixedDensityMatrix_for_vbias(wset,G);
+#endif
+    AFQMCTimers[G_for_vbias_timer]->stop();
+
+    StaticSPMatrix Gwork(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix X({long(nCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix vbias({long(nCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix RNG({long(nCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix vHSwork(vhs_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
     StaticMatrix MFfactor_t({nsteps,nwalk},
             buffer_allocator->template get_allocator<ComplexType>());
     StaticMatrix hybrid_weight_t({nsteps,nwalk},
@@ -120,10 +141,6 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     std::tie(vb0,vbN) = FairDivideBoundary(TG.getLocalTGRank(),
                             int(vbias.num_elements()),TG.getNCoresPerTG());
 
-    // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
-    wfn.MixedDensityMatrix_for_vbias(wset,G);
-    AFQMCTimers[G_for_vbias_timer]->stop();
     // generate random numbers
     {
       int i0,iN;
@@ -188,7 +205,15 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     }
   }
 
-  C3Tensor_ref vHS3D(make_device_ptr(vHS.origin()),vhs3d_ext);
+#if defined(MIXED_PRECISION)
+  // is this clever or dirsty? seems to work well and saves memory!
+  TG.local_barrier();
+  using qmcplusplus::afqmc::inplace_cast;
+  if(TG.TG_local().root())
+    inplace_cast<SPComplexType,ComplexType>(vHS.origin(),vHS.num_elements());
+  TG.local_barrier();
+#endif
+  C3Tensor_ref vHS3D(make_device_ptr(vHS_buff.origin()),vhs3d_ext);
 
   // From here on is similar to Shared 
   int nx = 1;

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
@@ -139,7 +139,7 @@ class AFQMCDistributedPropagatorDistCV: public AFQMCBasePropagator
 
   protected: 
 
-    mpi3CVector bpX;
+    mpi3SPCVector bpX;
     std::vector<int> bpx_counts, bpx_displ;
 
     bool buffer_reallocated=false;

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -426,8 +426,17 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
             buffer_allocator->template get_allocator<ComplexType>());
   StaticMatrix new_energies({nwalk,3},
             buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vrecv(vhs_ext,
+  StaticMatrix vrecv_buff(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
+  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()),vhs3d_ext);
+// in mixed precision, using vrecv_buff as 2 single precision arrays.
+// final result will be in first half of recasted array, will then cast_inplace 
+// to full precision
+#if defined(MIXED_PRECISION)
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
+#else
+  CMatrix_ref vrecv(make_device_ptr(vrecv_buff.origin()),vhs_ext);
+#endif
 
   // scope controlling lifetime of temporary arrays
   {
@@ -436,22 +445,46 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
             buffer_allocator->template get_allocator<ComplexType>());
     Static3Tensor globalhybrid_weight({nnodes,nsteps,nwalk},
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Gwork(G_ext,
+    StaticSPMatrix Gstore(G_ext,
+            sp_buffer_allocator->template get_allocator<SPComplexType>());
+
+    int Gak0,GakN;
+    std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
+                    int(Gstore.num_elements()),TG.getNCoresPerTG());
+
+    // 1. Calculate Green function for all (local) walkers
+    AFQMCTimers[G_for_vbias_timer]->start();
+#if defined(MIXED_PRECISION)
+    {
+      StaticMatrix Gstore_(G_ext,
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Gstore(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vbias({long(localnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix X({long(localnCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
+      wfn.MixedDensityMatrix_for_vbias(wset,Gstore_);
+      copy_n_cast(make_device_ptr(Gstore_.origin())+Gak0,GakN-Gak0,
+                  make_device_ptr(Gstore.origin())+Gak0);  
+    } 
+#else
+    wfn.MixedDensityMatrix_for_vbias(wset,Gstore);
+#endif
+    TG.local_barrier();
+    AFQMCTimers[G_for_vbias_timer]->stop();
+
+    StaticSPMatrix Gwork(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix vbias({long(localnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix X({long(localnCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+// reusing second half of vrecv buffer reinterpreted as a SPComplex Array
+#if defined(MIXED_PRECISION)
+    SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vrecv_buff.origin()))+
+                vrecv_buff.num_elements(),vhs_ext);
+#else
     StaticMatrix vHS(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
+#endif
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     int vak0,vakN;
-    int Gak0,GakN;
-    std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
-                    int(Gwork.num_elements()),TG.getNCoresPerTG());
     std::tie(vak0,vakN) = FairDivideBoundary(TG.getLocalTGRank(),
                     int(vHS.num_elements()),TG.getNCoresPerTG());
 
@@ -498,11 +531,6 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 
     MPI_Status st;
 
-    // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
-    wfn.MixedDensityMatrix_for_vbias(wset,Gstore);
-    AFQMCTimers[G_for_vbias_timer]->stop();
-
     for(int k=0; k<nnodes; ++k) {
 
       // 2. bcast G 
@@ -512,8 +540,13 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
                make_device_ptr(Gwork.origin())+Gak0);
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
+#if defined(MIXED_PRECISION)
+      NCCLCHECK(ncclBcast(to_address(Gwork.origin()+Gak0),2*(GakN-Gak0),ncclFloat,k,
+                          TG.ncclTG(),TG.ncclStream()));
+#else
       NCCLCHECK(ncclBcast(to_address(Gwork.origin()+Gak0),2*(GakN-Gak0),ncclDouble,k,
                           TG.ncclTG(),TG.ncclStream()));
+#endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()),"cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
@@ -562,9 +595,15 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       // 4. Reduce vHS
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
+#if defined(MIXED_PRECISION)
+      NCCLCHECK(ncclReduce((const void*)to_address(vHS.origin()+vak0),
+                    (void*)to_address(vrecv.origin()+vak0), 2*(vakN-vak0),
+                     ncclFloat, ncclSum,k,TG.ncclTG(),TG.ncclStream()));
+#else
       NCCLCHECK(ncclReduce((const void*)to_address(vHS.origin()+vak0),
                     (void*)to_address(vrecv.origin()+vak0), 2*(vakN-vak0),
                      ncclDouble, ncclSum,k,TG.ncclTG(),TG.ncclStream()));
+#endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()),"cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
@@ -605,12 +644,21 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     if(TG.TG().size() > 1) {
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
+#if defined(MIXED_PRECISION)
+      NCCLCHECK(ncclAllReduce((const void*)to_address(MFfactor.origin()),
+                    (void*)to_address(MFfactor.origin()), 2*MFfactor.num_elements(),
+                     ncclFloat, ncclSum,TG.ncclTG(),TG.ncclStream()));
+      NCCLCHECK(ncclAllReduce((const void*)to_address(hybrid_weight.origin()),
+                     (void*)to_address(hybrid_weight.origin()), 2*hybrid_weight.num_elements(),
+                     ncclFloat, ncclSum,TG.ncclTG(),TG.ncclStream()));
+#else
       NCCLCHECK(ncclAllReduce((const void*)to_address(MFfactor.origin()),
                     (void*)to_address(MFfactor.origin()), 2*MFfactor.num_elements(),
                      ncclDouble, ncclSum,TG.ncclTG(),TG.ncclStream()));
       NCCLCHECK(ncclAllReduce((const void*)to_address(hybrid_weight.origin()),
                      (void*)to_address(hybrid_weight.origin()), 2*hybrid_weight.num_elements(),
                      ncclDouble, ncclSum,TG.ncclTG(),TG.ncclStream()));
+#endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()),"cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
@@ -633,7 +681,13 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     AFQMCTimers[vHS_comm_overhead_timer]->stop();
   } // scope controlling lifetime of temporary arrays
 
-  C3Tensor_ref vHS3D(make_device_ptr(vrecv.origin()),vhs3d_ext);
+#if defined(MIXED_PRECISION)
+// cast_inplace vHS3D
+  TG.local_barrier();
+  if(TG.localTG.root())
+    inplace_cast<SPComplexType,ComplexType>(make_device_ptr(vrecv.origin()),vrecv.num_elements());
+  TG.local_barrier();
+#endif
 
   // From here on is similar to Shared 
   int nx = 1;

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -49,7 +49,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   using std::fill_n;
   using std::copy_n;
   AFQMCTimers[setup_timer]->start();
-  const ComplexType one(1.),zero(0.);
+  const SPComplexType one(1.),zero(0.);
   auto walker_type = wset.getWalkerType();
   int nsteps= nsteps_;
   int nwalk = wset.size();
@@ -91,8 +91,9 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
             buffer_allocator->template get_allocator<ComplexType>());
   StaticMatrix new_energies({nwalk,3},
             buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vrecv(vhs_ext,
+  StaticMatrix vrecv_buff(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
 
   { // using scope to control lifetime of StaticArrays, avoiding unnecesary buffer space 
 
@@ -100,18 +101,45 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
             buffer_allocator->template get_allocator<ComplexType>());
     Static3Tensor globalhybrid_weight({nnodes,nsteps,nwalk},
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Gwork(G_ext,
+    StaticSPMatrix Gwork(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+
+    // 1. Calculate Green function for all (local) walkers
+    AFQMCTimers[G_for_vbias_timer]->start();
+#if defined(MIXED_PRECISION)
+    { // control scope of Gc 
+      int Gak0,GakN;
+      std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
+                    int(Gwork.num_elements()),TG.getNCoresPerTG());
+      StaticMatrix Gc(G_ext,
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Grecv(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vbias({long(localnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix X({long(localnCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vHS(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vsend(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
+      wfn.MixedDensityMatrix_for_vbias(wset,Gc);
+      copy_n_cast(make_device_ptr(Gc.origin())+Gak0,GakN-Gak0,
+                  make_device_ptr(Gwork.origin())+Gak0);
+    }
+    TG.local_barrier();
+#else
+    wfn.MixedDensityMatrix_for_vbias(wset,Gwork);
+#endif
+    AFQMCTimers[G_for_vbias_timer]->stop();
+
+
+    StaticSPMatrix Grecv(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix vbias({long(localnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix X({long(localnCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+#if defined(MIXED_PRECISION)
+    // in MIXED_PRECISION, use second half of vrecv_buff for vsend 
+    SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.origin()))+
+                                    vrecv_buff.num_elements(),vhs_ext);
+#else
+    StaticSPMatrix vsend(vhs_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+#endif
+    StaticSPMatrix vHS(vhs_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     int vak0,vakN;
@@ -120,13 +148,13 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
                 int(Gwork.num_elements()),TG.getNCoresPerTG());
     std::tie(vak0,vakN) = FairDivideBoundary(TG.getLocalTGRank(),
                 int(vHS.num_elements()),TG.getNCoresPerTG());
-    MPI_Send_init(to_address(Gwork.origin())+Gak0,(GakN-Gak0)*sizeof(ComplexType),MPI_CHAR,
+    MPI_Send_init(to_address(Gwork.origin())+Gak0,(GakN-Gak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.prev_core(),3456,&TG.TG(),&req_Gsend);
-    MPI_Recv_init(to_address(Grecv.origin())+Gak0,(GakN-Gak0)*sizeof(ComplexType),MPI_CHAR,
+    MPI_Recv_init(to_address(Grecv.origin())+Gak0,(GakN-Gak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.next_core(),3456,&TG.TG(),&req_Grecv);
-    MPI_Send_init(to_address(vsend.origin())+vak0,(vakN-vak0)*sizeof(ComplexType),MPI_CHAR,
+    MPI_Send_init(to_address(vsend.origin())+vak0,(vakN-vak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.prev_core(),5678,&TG.TG(),&req_vsend);
-    MPI_Recv_init(to_address(vrecv.origin())+vak0,(vakN-vak0)*sizeof(ComplexType),MPI_CHAR,
+    MPI_Recv_init(to_address(vrecv.origin())+vak0,(vakN-vak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.next_core(),5678,&TG.TG(),&req_vrecv);
 
     fill_n(make_device_ptr(vsend.origin())+vak0,(vakN-vak0),zero);
@@ -140,13 +168,13 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       size_t m_(globalnCV*nwalk*nsteps*2);
       if(bpX.num_elements() < m_) {
         realloc=true;
-        bpX = std::move(mpi3CVector(iextensions<1u>{m_},
-                                  shared_allocator<ComplexType>{TG.TG_local()})); 
-        if(TG.TG_local().root()) fill_n(bpX.origin(),bpX.num_elements(),ComplexType(0.0));
+        bpX = std::move(mpi3SPCVector(iextensions<1u>{m_},
+                                  shared_allocator<SPComplexType>{TG.TG_local()})); 
+        if(TG.TG_local().root()) fill_n(bpX.origin(),bpX.num_elements(),SPComplexType(0.0));
       }
     }
-    stdCMatrix_ref Xsend(to_address(bpX.origin()), {long(globalnCV*xx),nwalk*nsteps});
-    stdCMatrix_ref Xrecv(Xsend.origin()+Xsend.num_elements(), 
+    stdSPCMatrix_ref Xsend(to_address(bpX.origin()), {long(globalnCV*xx),nwalk*nsteps});
+    stdSPCMatrix_ref Xrecv(Xsend.origin()+Xsend.num_elements(), 
                                                    {long(globalnCV*xx),nwalk*nsteps});
     int Xg0,XgN;
     std::tie(Xg0,XgN) = FairDivideBoundary(TG.getLocalTGRank(),globalnCV*nwalk*nsteps,TG.getNCoresPerTG());
@@ -156,9 +184,9 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     std::tie(cv0,cvN) = FairDivideBoundary(TG.getLocalTGRank(),localnCV,TG.getNCoresPerTG());
 
     if(bp_step >= 0 && bp_step<bp_max) {
-      MPI_Send_init(Xsend.origin()+Xg0,(XgN-Xg0)*sizeof(ComplexType),MPI_CHAR,
+      MPI_Send_init(Xsend.origin()+Xg0,(XgN-Xg0)*sizeof(SPComplexType),MPI_CHAR,
                 TG.prev_core(),3456,&TG.TG(),&req_X2send);
-      MPI_Recv_init(Xrecv.origin()+Xg0,(XgN-Xg0)*sizeof(ComplexType),MPI_CHAR,
+      MPI_Recv_init(Xrecv.origin()+Xg0,(XgN-Xg0)*sizeof(SPComplexType),MPI_CHAR,
                 TG.next_core(),3456,&TG.TG(),&req_X2recv);
     }
 
@@ -166,11 +194,6 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     AFQMCTimers[setup_timer]->stop();
 
     MPI_Status st;
-
-    // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
-    wfn.MixedDensityMatrix_for_vbias(wset,Gwork);
-    AFQMCTimers[G_for_vbias_timer]->stop();
 
     for(int k=0; k<nnodes; ++k) { 
   
@@ -275,10 +298,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
           auto&& V(*wset.getFields(bp_step));
           if(nsteps==1) {
             copy_n(Xrecv[cvg0].origin(),nwalk*(cvgN-cvg0),V[cvg0].origin());
-            ma::scal(sqrtdt,V.sliced(cvg0,cvgN));
+            ma::scal(SPComplexType(sqrtdt),V.sliced(cvg0,cvgN));
           } else {
-            ma::add(ComplexType(0.0),   V.sliced(cvg0,cvgN),
-                  ComplexType(sqrtdt),Xrecv( {cvg0,cvgN}, {ni*nwalk,(ni+1)*nwalk} ),
+            ma::add(SPComplexType(0.0),   V.sliced(cvg0,cvgN),
+                  SPComplexType(sqrtdt),Xrecv( {cvg0,cvgN}, {ni*nwalk,(ni+1)*nwalk} ),
                                       V.sliced(cvg0,cvgN));
           }
           bp_step++;
@@ -286,7 +309,6 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       }
       TG.TG_local().barrier();
     }
-
     // reduce MF and HWs
     if(TG.TG().size() > 1) {
       TG.TG().all_reduce_in_place_n(to_address(MFfactor.origin()),MFfactor.num_elements(),
@@ -305,7 +327,15 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     AFQMCTimers[vHS_comm_overhead_timer]->stop();
   }
 
-  C3Tensor_ref vHS3D(make_device_ptr(vrecv.origin()),vhs3d_ext);
+#if defined(MIXED_PRECISION)
+  // is this clever or dirsty? seems to work well and saves memory!
+  TG.local_barrier();
+  using qmcplusplus::afqmc::inplace_cast;
+  if(TG.TG_local().root())
+    inplace_cast<SPComplexType,ComplexType>(vrecv.origin(),vrecv.num_elements());
+  TG.local_barrier();
+#endif
+  C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()),vhs3d_ext);
 
   // From here on is similar to Shared 
   int nx = 1;
@@ -383,7 +413,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   using std::fill_n;
   using std::copy_n;
   AFQMCTimers[setup_timer]->start();
-  const ComplexType one(1.),zero(0.);
+  const SPComplexType one(1.),zero(0.);
   auto walker_type = wset.getWalkerType();
   int nsteps= nsteps_;
   int nwalk = wset.size();
@@ -429,15 +459,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   StaticMatrix vrecv_buff(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
   C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()),vhs3d_ext);
-// in mixed precision, using vrecv_buff as 2 single precision arrays.
-// final result will be in first half of recasted array, will then cast_inplace 
-// to full precision
-//#if defined(MIXED_PRECISION)
-//  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
-//#else
-//  CMatrix_ref vrecv(make_device_ptr(vrecv_buff.origin()),vhs_ext);
-//#endif
-  CMatrix_ref vrecv(make_device_ptr(vrecv_buff.origin()),vhs_ext);
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
 
   // scope controlling lifetime of temporary arrays
   {
@@ -446,10 +468,8 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
             buffer_allocator->template get_allocator<ComplexType>());
     Static3Tensor globalhybrid_weight({nnodes,nsteps,nwalk},
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix Gstore(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-//    StaticSPMatrix Gstore(G_ext,
-//            buffer_allocator->template get_allocator<SPComplexType>());
+    StaticSPMatrix Gstore(G_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
 
     int Gak0,GakN;
     std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
@@ -471,16 +491,6 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     TG.local_barrier();
     AFQMCTimers[G_for_vbias_timer]->stop();
 
-    StaticMatrix Gwork(G_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vbias({long(localnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix X({long(localnCV),long(nwalk*nsteps)},
-            buffer_allocator->template get_allocator<ComplexType>());
-    StaticMatrix vHS(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-
-/*
     StaticSPMatrix Gwork(G_ext,
             buffer_allocator->template get_allocator<SPComplexType>());
     StaticSPMatrix vbias({long(localnCV),long(nwalk)},
@@ -495,7 +505,6 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     StaticMatrix vHS(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
 #endif
-*/
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     int vak0,vakN;
@@ -511,12 +520,12 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       size_t m_(globalnCV*nwalk*nsteps);
       if(bpX.num_elements() < m_) {
         realloc=true;
-        bpX = std::move(mpi3CVector(iextensions<1u>{m_},
-                                  shared_allocator<ComplexType>{TG.TG_local()}));
-        if(TG.TG_local().root()) fill_n(bpX.origin(),bpX.num_elements(),ComplexType(0.0));
+        bpX = std::move(mpi3SPCVector(iextensions<1u>{m_},
+                                  shared_allocator<SPComplexType>{TG.TG_local()}));
+        if(TG.TG_local().root()) fill_n(bpX.origin(),bpX.num_elements(),SPComplexType(0.0));
       }
     }
-    stdCMatrix_ref Xrecv(to_address(bpX.origin()), {long(globalnCV*xx),nwalk*nsteps});
+    stdSPCMatrix_ref Xrecv(to_address(bpX.origin()), {long(globalnCV*xx),nwalk*nsteps});
     int Xg0,XgN;
     std::tie(Xg0,XgN) = FairDivideBoundary(TG.getLocalTGRank(),globalnCV*nwalk*nsteps,
                 TG.getNCoresPerTG());
@@ -645,8 +654,8 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
             copy_n(Xrecv[cvg0].origin(),nwalk*(cvgN-cvg0),V[cvg0].origin());
             ma::scal(sqrtdt,V.sliced(cvg0,cvgN));
           } else {
-            ma::add(ComplexType(0.0),   V.sliced(cvg0,cvgN),
-                  ComplexType(sqrtdt),Xrecv( {cvg0,cvgN}, {ni*nwalk,(ni+1)*nwalk} ),
+            ma::add(SPComplexType(0.0),   V.sliced(cvg0,cvgN),
+                  SPComplexType(sqrtdt),Xrecv( {cvg0,cvgN}, {ni*nwalk,(ni+1)*nwalk} ),
                                       V.sliced(cvg0,cvgN));
           }
           bp_step++;
@@ -654,25 +663,16 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       }
       TG.TG_local().barrier();
     }
-    // reduce MF and HWs
+    // reduce MF and HWs, always in DP
     if(TG.TG().size() > 1) {
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
-#if defined(MIXED_PRECISION)
-      NCCLCHECK(ncclAllReduce((const void*)to_address(MFfactor.origin()),
-                    (void*)to_address(MFfactor.origin()), 2*MFfactor.num_elements(),
-                     ncclFloat, ncclSum,TG.ncclTG(),TG.ncclStream()));
-      NCCLCHECK(ncclAllReduce((const void*)to_address(hybrid_weight.origin()),
-                     (void*)to_address(hybrid_weight.origin()), 2*hybrid_weight.num_elements(),
-                     ncclFloat, ncclSum,TG.ncclTG(),TG.ncclStream()));
-#else
       NCCLCHECK(ncclAllReduce((const void*)to_address(MFfactor.origin()),
                     (void*)to_address(MFfactor.origin()), 2*MFfactor.num_elements(),
                      ncclDouble, ncclSum,TG.ncclTG(),TG.ncclStream()));
       NCCLCHECK(ncclAllReduce((const void*)to_address(hybrid_weight.origin()),
                      (void*)to_address(hybrid_weight.origin()), 2*hybrid_weight.num_elements(),
                      ncclDouble, ncclSum,TG.ncclTG(),TG.ncclStream()));
-#endif
       qmc_cuda::cuda_check(cudaStreamSynchronize(TG.ncclStream()),"cudaStreamSynchronize(s)");
 #else
 #error "BUILD_AFQMC_WITH_NCCL only with ENABLE_CUDA"
@@ -696,11 +696,11 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   } // scope controlling lifetime of temporary arrays
 
 #if defined(MIXED_PRECISION)
-// cast_inplace vHS3D
-//  TG.local_barrier();
-//  if(TG.localTG().root())
-//    inplace_cast<SPComplexType,ComplexType>(make_device_ptr(vrecv.origin()),vrecv.num_elements());
-//  TG.local_barrier();
+  TG.local_barrier();
+  using qmcplusplus::afqmc::inplace_cast;
+  if(TG.TG_local().root())
+    inplace_cast<SPComplexType,ComplexType>(make_device_ptr(vrecv.origin()),vrecv.num_elements());
+  TG.local_barrier();
 #endif
 
   // From here on is similar to Shared 
@@ -770,7 +770,7 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps, int nStabaliz
 {
   using std::fill_n;
   using std::copy_n;
-  const ComplexType one(1.),zero(0.);
+  const SPComplexType one(1.),zero(0.);
   auto walker_type = wset.getWalkerType();
   const int nwalk = wset.size();
   const int globalnCV = wfn.global_number_of_cholesky_vectors();
@@ -790,19 +790,24 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps, int nStabaliz
   //  vHS:             [ NMO*NMO * nwalk ] (3 copies)     
   // memory_needs: nwalk * ( localnCV + NMO*NMO )
 
-  StaticMatrix X({long(localnCV),long(nwalk)},
+  StaticSPMatrix X({long(localnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+  StaticSPMatrix Xsend({long(globalnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+  StaticSPMatrix Xrecv({long(globalnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<SPComplexType>());
+  StaticMatrix vrecv_buff(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix Xsend({long(globalnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix Xrecv({long(globalnCV),long(nwalk)},
-            buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vHS(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vsend(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-  StaticMatrix vrecv(vhs_ext,
-            buffer_allocator->template get_allocator<ComplexType>());
-  C3Tensor_ref vHS3D(make_device_ptr(vHS.origin()),vhs3d_ext);
+  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
+#if defined(MIXED_PRECISION)
+  SPCMatrix_ref vsend(sp_pointer(make_device_ptr(vrecv_buff.origin()))+
+                                    vrecv_buff.num_elements(),vhs_ext);
+#else
+  StaticSPMatrix vsend(vhs_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
+#endif
+  StaticSPMatrix vHS(vhs_ext,
+            buffer_allocator->template get_allocator<SPComplexType>());
 
   // partition G and v for communications: all cores communicate a piece of the matrix
   int vak0,vakN;
@@ -811,13 +816,13 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps, int nStabaliz
                     int(Xsend.num_elements()),TG.getNCoresPerTG());
   std::tie(vak0,vakN) = FairDivideBoundary(TG.getLocalTGRank(),
                     int(vHS.num_elements()),TG.getNCoresPerTG());
-  MPI_Send_init(to_address(Xsend.origin())+X0,(XN-X0)*sizeof(ComplexType),MPI_CHAR,
+  MPI_Send_init(to_address(Xsend.origin())+X0,(XN-X0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.prev_core(),2345,&TG.TG(),&req_Xsend);
-  MPI_Recv_init(to_address(Xrecv.origin())+X0,(XN-X0)*sizeof(ComplexType),MPI_CHAR,
+  MPI_Recv_init(to_address(Xrecv.origin())+X0,(XN-X0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.next_core(),2345,&TG.TG(),&req_Xrecv);
-  MPI_Send_init(to_address(vsend.origin())+vak0,(vakN-vak0)*sizeof(ComplexType),MPI_CHAR,
+  MPI_Send_init(to_address(vsend.origin())+vak0,(vakN-vak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.prev_core(),6789,&TG.TG(),&req_bpvsend);
-  MPI_Recv_init(to_address(vrecv.origin())+vak0,(vakN-vak0)*sizeof(ComplexType),MPI_CHAR,
+  MPI_Recv_init(to_address(vrecv.origin())+vak0,(vakN-vak0)*sizeof(SPComplexType),MPI_CHAR,
                   TG.next_core(),6789,&TG.TG(),&req_bpvrecv);
   TG.local_barrier();
 
@@ -844,7 +849,7 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps, int nStabaliz
 
   assert(detR.size(0) == nwalk);
   assert(detR.size(1) == nrefs*nx);
-  std::fill_n(detR.origin(),detR.num_elements(),ComplexType(1.0,0.0));
+  std::fill_n(detR.origin(),detR.num_elements(),SPComplexType(1.0,0.0));
 
   // from now on, individual work on each walker/step
   const int ntasks_per_core = int(nx*nwalk)/TG.getNCoresPerTG();
@@ -929,6 +934,14 @@ void AFQMCDistributedPropagatorDistCV::BackPropagate(int nbpsteps, int nStabaliz
     MPI_Wait(&req_bpvsend,&st);
     TG.local_barrier();
 //std::cout<<" vrecv: " <<TG.Global().rank() <<" " <<ma::dot(vrecv[0],vrecv[0]) <<"\n\n" <<std::endl;
+
+#if defined(MIXED_PRECISION)
+    TG.local_barrier();
+    if(TG.TG_local().root())
+      inplace_cast<SPComplexType,ComplexType>(vrecv.origin(),vrecv.num_elements());
+    TG.local_barrier();
+#endif
+    C3Tensor_ref vHS3D(make_device_ptr(vrecv_buff.origin()),vhs3d_ext);
 
     for(int nr=0; nr<nrefs; ++nr) {
 

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -432,11 +432,12 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 // in mixed precision, using vrecv_buff as 2 single precision arrays.
 // final result will be in first half of recasted array, will then cast_inplace 
 // to full precision
-#if defined(MIXED_PRECISION)
-  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
-#else
+//#if defined(MIXED_PRECISION)
+//  SPCMatrix_ref vrecv(sp_pointer(make_device_ptr(vrecv_buff.origin())),vhs_ext);
+//#else
+//  CMatrix_ref vrecv(make_device_ptr(vrecv_buff.origin()),vhs_ext);
+//#endif
   CMatrix_ref vrecv(make_device_ptr(vrecv_buff.origin()),vhs_ext);
-#endif
 
   // scope controlling lifetime of temporary arrays
   {
@@ -445,8 +446,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
             buffer_allocator->template get_allocator<ComplexType>());
     Static3Tensor globalhybrid_weight({nnodes,nsteps,nwalk},
             buffer_allocator->template get_allocator<ComplexType>());
-    StaticSPMatrix Gstore(G_ext,
-            sp_buffer_allocator->template get_allocator<SPComplexType>());
+    StaticMatrix Gstore(G_ext,
+            buffer_allocator->template get_allocator<ComplexType>());
+//    StaticSPMatrix Gstore(G_ext,
+//            buffer_allocator->template get_allocator<SPComplexType>());
 
     int Gak0,GakN;
     std::tie(Gak0,GakN) = FairDivideBoundary(TG.getLocalTGRank(),
@@ -468,6 +471,16 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     TG.local_barrier();
     AFQMCTimers[G_for_vbias_timer]->stop();
 
+    StaticMatrix Gwork(G_ext,
+            buffer_allocator->template get_allocator<ComplexType>());
+    StaticMatrix vbias({long(localnCV),long(nwalk)},
+            buffer_allocator->template get_allocator<ComplexType>());
+    StaticMatrix X({long(localnCV),long(nwalk*nsteps)},
+            buffer_allocator->template get_allocator<ComplexType>());
+    StaticMatrix vHS(vhs_ext,
+            buffer_allocator->template get_allocator<ComplexType>());
+
+/*
     StaticSPMatrix Gwork(G_ext,
             buffer_allocator->template get_allocator<SPComplexType>());
     StaticSPMatrix vbias({long(localnCV),long(nwalk)},
@@ -482,6 +495,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     StaticMatrix vHS(vhs_ext,
             buffer_allocator->template get_allocator<ComplexType>());
 #endif
+*/
 
     // partition G and v for communications: all cores communicate a piece of the matrix
     int vak0,vakN;
@@ -683,10 +697,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 
 #if defined(MIXED_PRECISION)
 // cast_inplace vHS3D
-  TG.local_barrier();
-  if(TG.localTG.root())
-    inplace_cast<SPComplexType,ComplexType>(make_device_ptr(vrecv.origin()),vrecv.num_elements());
-  TG.local_barrier();
+//  TG.local_barrier();
+//  if(TG.localTG().root())
+//    inplace_cast<SPComplexType,ComplexType>(make_device_ptr(vrecv.origin()),vrecv.num_elements());
+//  TG.local_barrier();
 #endif
 
   // From here on is similar to Shared 

--- a/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
+++ b/src/AFQMC/SlaterDeterminantOperations/tests/test_sdet_ops.cpp
@@ -20,7 +20,7 @@
 
 // Avoid the need to link with other libraries just to get APP_ABORT
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include <stdio.h>
 #include <string>

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -53,8 +53,8 @@ class WalkerSetBase: public AFQMCInfo
   using const_pointer = const Ptr; 
   using Allocator = Alloc;
 
-  using bp_element = ComplexType; //typename std::pointer_traits<BPPtr>::element_type;
-  using bp_pointer = ComplexType*; //BPPtr;
+  using bp_element = SPComplexType; //typename std::pointer_traits<BPPtr>::element_type;
+  using bp_pointer = SPComplexType*; //BPPtr;
   using const_bp_element = const bp_element;
   using const_bp_pointer = const bp_pointer; 
   using BPAllocator = shared_allocator<bp_element>;//BPAlloc;
@@ -327,7 +327,7 @@ class WalkerSetBase: public AFQMCInfo
       bp_buffer.reextent({bp_walker_size,walker_buffer.size(0)});
       using std::fill_n;
       fill_n(to_address(bp_buffer.origin())+data_displ[WEIGHT_FAC]*bp_buffer.size(1),
-             wlk_desc[6]*bp_buffer.size(1),ComplexType(1.0));
+             wlk_desc[6]*bp_buffer.size(1),bp_element(1.0));
     }
     if(nbp > 0 && (data_displ[SMN]<0 || data_displ[SM_AUX]<0) ) {
       auto sz(walker_size);
@@ -552,7 +552,7 @@ class WalkerSetBase: public AFQMCInfo
       int his_pos = ((history_pos==0)?wlk_desc[6]-1:history_pos-1);
       if(wlk_desc[6]>0 && his_pos >= 0 && his_pos < wlk_desc[6]) { 
         auto BPW( boost::multi::static_array_cast<bp_element, bp_pointer>(bp_buffer) );
-        ma::scal(ComplexType(w0),BPW[data_displ[WEIGHT_HISTORY]+his_pos]);
+        ma::scal(bp_element(w0),BPW[data_displ[WEIGHT_HISTORY]+his_pos]);
       }
     }
   } 

--- a/src/AFQMC/Walkers/WalkerSetBase.icc
+++ b/src/AFQMC/Walkers/WalkerSetBase.icc
@@ -196,7 +196,7 @@ void WalkerSetBase<Alloc,Ptr>::reserve(int n)
   if(bp_buffer.size(1) < n || bp_buffer.size(0) != bp_walker_size) {
     bp_buffer.reextent({bp_walker_size,n});
     using std::fill_n;
-    fill_n(bp_buffer.origin(),bp_buffer.num_elements(),ComplexType(0));  
+    fill_n(bp_buffer.origin(),bp_buffer.num_elements(),bp_element(0));  
   }  
 }
 

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -18,7 +18,7 @@
 
 // Avoid the need to link with other libraries just to get APP_ABORT
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "Utilities/RandomGenerator.h"

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -25,7 +25,7 @@
 #include "Platforms/Host/OutputManager.h"
 
 #undef APP_ABORT
-#define APP_ABORT(x) {std::cout << x <<std::endl; exit(0);}
+#define APP_ABORT(x) {std::cout << x <<std::endl; throw;}
 
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -1,6 +1,10 @@
 #ifndef AFQMC_CONFIG_0_H 
 #define AFQMC_CONFIG_0_H 
 
+#if defined __INTEL_COMPILER
+#pragma warning disable 2196
+#endif
+
 #define BOOST_NO_AUTO_PTR
 
 #define ADD_TESTS_TIMERS

--- a/src/AFQMC/config.0.h
+++ b/src/AFQMC/config.0.h
@@ -24,8 +24,6 @@
 #define byRows   999
 #define byCols   111
 
-#define PsiT_IN_SHM
-
 // guard with directive that checks if boost version is >=1.65
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106500

--- a/src/AFQMC/config.h
+++ b/src/AFQMC/config.h
@@ -123,6 +123,7 @@ namespace afqmc
   using device_memory_resource = device::memory_resource;
   using shm_memory_resource = device::memory_resource;
   template<class T> using device_constructor = device::constructor<T>;
+  template<class T> using shm_constructor = device::constructor<T>;
 
 #else
   template<class T>  using device_allocator = std::allocator<T>;
@@ -146,9 +147,11 @@ namespace afqmc
   using device_memory_resource = boost::multi::memory::resource<>; 
   using shm_memory_resource = shm::memory_resource_shm_ptr_with_raw_ptr_dispatch; 
   template<class T>  using device_constructor = device_allocator<T>; 
+  template<class T>  using shm_constructor = shared_allocator<T>;  
 
 #endif
 
+  template<class T>  using host_constructor = std::allocator<T>; 
   using host_memory_resource = boost::multi::memory::resource<>; 
 
   // new types


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Addresses issue #2434 . Testes on intel 19, no testes on Clang10, will let it happen in the nightly tests. Also, addressed issue with potential false positive in AFQMC unit tests.

## What type(s) of changes does this code introduce?

- Bugfix
- Shared memory allocators now synchronize for construct/destroy.

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
