### PR TITLE
Label all statistical test result checks as unstable

### DIFF
--- a/tests/scripts/test_labels.py
+++ b/tests/scripts/test_labels.py
@@ -564,6 +564,20 @@ except:
 #end try
 
 
+# mark all statistical tests as unstable
+#   some of these work well, and others do not
+#   cause of intermittent statistical failures needs further investiagion
+try: 
+    if test.startswith('short-') or test.startswith('long-') or test.startswith('estimator-'):
+        if 'unstable' not in labels:
+            labels.append('unstable')
+        #end if
+    #end if
+except:
+    error()
+#end try
+
+
 # make a ctest list of the labels
 try:
     ctest_labels = ''


### PR DESCRIPTION
## Proposed changes

Move all statistical tests into the unstable category.  All tests should still run and report on CDash based on non-failure of QMCPACK execution.


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

laptop

