### PR TITLE
Fix overflow of long type warning

### DIFF
--- a/src/Utilities/tests/test_pooled_memory.cpp
+++ b/src/Utilities/tests/test_pooled_memory.cpp
@@ -34,7 +34,7 @@ TEST_CASE("pack scalar", "[utilities]")
 {
   PooledMemory<double> p;
   int i0    = 1;
-  long i1   = (1L << 31) - 1;
+  long i1   = (1L << 30) + (1L << 29);
   float i2  = 0.33;
   double i3 = 0.23;
   complex<float> i4(0.23, 0.33);


### PR DESCRIPTION
## Proposed changes
`1L << 31` overflows long type. Use `(1L << 30) + (1L << 29)` instead

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
raspberrypi4

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'