### PR TITLE
Fix AFQMC return type compiler warning

### DIFF
--- a/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
+++ b/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
@@ -37,7 +37,7 @@ namespace afqmc
  * @return true if successful. false indiciates name not found in dump.
  */
 template<typename T>
-int readComplexOrReal(hdf_archive& dump, std::string name, std::vector<T>& out)
+bool readComplexOrReal(hdf_archive& dump, std::string name, std::vector<T>& out)
 {
   std::vector<int> shape;
   int ndim = 1; // vector
@@ -59,6 +59,7 @@ int readComplexOrReal(hdf_archive& dump, std::string name, std::vector<T>& out)
   } else {
     app_log() << " Error reading " << name << " dataspace. Shape mismatch.\n";
     APP_ABORT("");
+    return false;
   }
 #else
   if(shape.size() == ndim+1) {
@@ -94,6 +95,7 @@ bool readComplexOrReal(hdf_archive& dump, std::string name, boost::multi::array<
   } else {
     app_log() << " Error reading " << name << " dataspace. Shape mismatch.\n";
     APP_ABORT("");
+    return false;
   }
 #else
   if(shape.size() == ndim+1) {

--- a/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
+++ b/src/AFQMC/Utilities/hdf5_consistency_helper.hpp
@@ -65,6 +65,7 @@ bool readComplexOrReal(hdf_archive& dump, std::string name, std::vector<T>& out)
   if(shape.size() == ndim+1) {
     app_log() << " Error: Found complex integrals with QMC_COMPLEX=0.\n";
     APP_ABORT(" Please recompile with QMC_COMPLEX=1 or generate real integrals if appropriate.\n");
+    return false;
   } else {
     dump.readEntry(out, name);
     return true;
@@ -101,6 +102,7 @@ bool readComplexOrReal(hdf_archive& dump, std::string name, boost::multi::array<
   if(shape.size() == ndim+1) {
     app_log() << " Error: Found complex integrals with QMC_COMPLEX=0.\n";
     APP_ABORT(" Please recompile with QMC_COMPLEX=1 or generate real integrals if appropriate.\n");
+    return false;
   } else {
     dump.readEntry(out, name);
     return true;


### PR DESCRIPTION

## Proposed changes

Fixes "warning: control reaches end of non-void function" in the nightlies.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

xeon. I needed some combination of -Wall -Wextra -Wpedantic to reproduce the warning.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
