### PR TITLE
Remove AFQMC statistical test

### DIFF
--- a/tests/solids/CMakeLists.txt
+++ b/tests/solids/CMakeLists.txt
@@ -24,7 +24,7 @@ IF (QMC_COMPLEX)
    SUBDIRS("diamondC_1x1x1-Gaussian_pp_Tw_cplx_MSD")
    SUBDIRS("Al-1x1x1-Gaussian_pp_ShiftedTwist")
 ENDIF()
-IF (BUILD_AFQMC AND QMC_COMPLEX)
+IF (BUILD_AFQMC AND QMC_COMPLEX AND NOT ENABLE_CUDA)
    SUBDIRS("diamondC_afqmc_1x1x1_complex")
 ENDIF()
 


### PR DESCRIPTION

## Proposed changes

AFQMC statistical tests were developed when there was no CUDA code. These are failing on the cdash but shouldn't be run. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix



### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

lassen

## Checklist


- Yes This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
