### PR TITLE
Adjust RNG life cycle in QMCDriverNew

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -585,6 +585,7 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     qmc_driver->run();
     t1->stop();
     app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
+    qmc_driver->endSection();
     last_driver    = std::move(qmc_driver);
     return true;
   }

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -58,6 +58,7 @@ public:
   virtual BranchEngineType* getBranchEngine()                           = 0;
   virtual std::string getEngineName()                                   = 0;
   virtual unsigned long getDriverMode()                                 = 0;
+  virtual void endSection() {}
   virtual ~QMCDriverInterface() {}
 };
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -406,6 +406,10 @@ public:
    */
   bool finalize(int block, bool dumpwalkers = true);
 
+  virtual void endSection();
+  /// Release RNG's back to global control
+  void releaseRng();
+
   int rotation;
   const std::string& get_root_name() const { return root_name_; }
   std::string getRotationName(std::string RootName);


### PR DESCRIPTION
## Proposed changes
For optimization (and other cases where the driver is reused), returning the RNG pointers to global control in the destructor is not the correct lifecycle.

Add 'endSection' to QMCDriverInterface to allow drivers to release resources, etc, that have been allocated or set up in earlier functions (most likely in 'put' or 'process')
The QMCMain::runQMC routine contains the sequence of calls that create the driver, set it up, run it, etc.

Increase the size of the RngCompatibility vector to the number of threads in order to use it with old drivers (for the optimizer - to mix the new driver to generate the samples with the old driver to evaluate the samples


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Preemptive bugfix for a new feature

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
