### PR TITLE
Collect samples in VMCBatched driver

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -585,6 +585,7 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     qmc_driver->run();
     t1->stop();
     app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
+    qmc_driver->endSection();
     last_driver    = std::move(qmc_driver);
     return true;
   }

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -272,7 +272,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     VMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE], qmc_common.qmc_counter);
     new_driver.reset(
-        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, comm));
+        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, qmc_system.getSampleStack(), comm));
   }
   else if (das.new_run_type == QMCRunType::DMC)
   {

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -130,6 +130,7 @@ public:
   RealType get_max_disp_sq() const { return max_disp_sq_; }
   IndexType get_max_blocks() const { return max_blocks_; }
   IndexType get_max_steps() const { return max_steps_; }
+  void set_max_steps(IndexType max_steps) { max_steps_ = max_steps; }
   IndexType get_warmup_steps() const { return warmup_steps_; }
   IndexType get_steps_between_samples() const { return steps_between_samples_; }
   IndexType get_samples_per_thread() const { return samples_per_thread_; }

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -58,6 +58,7 @@ public:
   virtual BranchEngineType* getBranchEngine()                           = 0;
   virtual std::string getEngineName()                                   = 0;
   virtual unsigned long getDriverMode()                                 = 0;
+  virtual void endSection() {}
   virtual ~QMCDriverInterface() {}
 };
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -406,6 +406,10 @@ public:
    */
   bool finalize(int block, bool dumpwalkers = true);
 
+  virtual void endSection();
+  /// Release RNG's back to global control
+  void releaseRng();
+
   int rotation;
   const std::string& get_root_name() const { return root_name_; }
   std::string getRotationName(std::string RootName);

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -68,6 +68,7 @@ public:
              TrialWaveFunction& psi,
              QMCHamiltonian& h,
              WaveFunctionPool& ppool,
+             SampleStack& samples,
              Communicate* comm);
 
   void process(xmlNodePtr node);
@@ -99,6 +100,7 @@ public:
   auto getCDLW();
 
   QMCDriverNew::AdjustedWalkerCounts calcDefaultLocalWalkers(QMCDriverNew::AdjustedWalkerCounts awc) const;
+  void calcSamples(int& adjusted_steps_between_samples, int& adjusted_steps, int& samples_per_node) const;
 
 private:
   int prevSteps;
@@ -111,6 +113,10 @@ private:
   VMCBatched(const VMCBatched&) = delete;
   /// Copy operator (disabled).
   VMCBatched& operator=(const VMCBatched&) = delete;
+
+  SampleStack& samples_;
+
+  int steps_between_samples_;
 
   friend class qmcplusplus::testing::VMCBatchedTest;
   ;

--- a/src/QMCDrivers/VMC/VMCFactoryNew.cpp
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.cpp
@@ -24,6 +24,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
                                           TrialWaveFunction& psi,
                                           QMCHamiltonian& h,
                                           WaveFunctionPool& wf_pool,
+                                          SampleStack& samples,
                                           Communicate* comm)
 {
   QMCDriverInput qmcdriver_input(qmc_counter_);
@@ -34,7 +35,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
 
   if (vmc_mode_ == 0 || vmc_mode_ == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, comm);
+    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, samples, comm);
   }
   else
   {

--- a/src/QMCDrivers/VMC/VMCFactoryNew.h
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.h
@@ -43,6 +43,7 @@ public:
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
                              WaveFunctionPool& wf_pool,
+                             SampleStack& samples,
                              Communicate* comm);
 };
 } // namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_VMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_VMCBatched.cpp
@@ -69,9 +69,10 @@ public:
                               hamiltonian_pool.getPrimary(), comm->rank());
       QMCDriverInput qmcdriver_copy(qmcdriver_input);
       VMCDriverInput vmcdriver_input("yes");
+      SampleStack samples;
       VMCBatched vmc_batched(std::move(qmcdriver_copy), std::move(vmcdriver_input), population,
                              *(wavefunction_pool.getPrimary()), *(hamiltonian_pool.getPrimary()), wavefunction_pool,
-                             comm);
+                             samples, comm);
       vmc_batched.set_walkers_per_rank(walkers_per_rank, "testing");
       if (num_crowds < 8)
         vmc_batched.set_num_crowds(Concurrency::maxThreads(), "Insufficient threads available to match test input");


### PR DESCRIPTION
## Proposed changes
Compute the samples to collect and associated quantities in calcSamples. The number of steps and the steps between samples might get adjusted to collect the required number of samples and to load balance the samples.

Because the number of steps may be adjusted, a method to set the max steps was added to QMCDriverInput.

Pass a SampleStack structure into the VMCBatched driver.

This branch was created from the branch in PR #2492 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
