### PR TITLE
[WIP] Add QMCOptimizeBatched driver

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -585,6 +585,7 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     qmc_driver->run();
     t1->stop();
     app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
+    qmc_driver->endSection();
     last_driver    = std::move(qmc_driver);
     return true;
   }

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -31,9 +31,11 @@ SET(QMCDRIVERS
   QMCDriverInput.cpp
   QMCDriverNew.cpp
   WFOpt/QMCOptimize.cpp
+  WFOpt/QMCOptimizeBatched.cpp
   WFOpt/QMCLinearOptimize.cpp
   WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
   WFOpt/QMCFixedSampleLinearOptimize.cpp
+  WFOpt/QMCWFOptFactoryNew.cpp
   Optimizers/DescentEngine.cpp
   Optimizers/HybridEngine.cpp
   WFOpt/QMCCostFunctionBase.cpp

--- a/src/QMCDrivers/DriverTraits.h
+++ b/src/QMCDrivers/DriverTraits.h
@@ -17,7 +17,9 @@ enum class QMCRunType
   CS_LINEAR_OPTIMIZE,
   WF_TEST,
   VMC_BATCH,
-  DMC_BATCH
+  DMC_BATCH,
+  OPTIMIZE_BATCH,
+  LINEAR_OPTIMIZE_BATCH
 };
 
 /** enum to set the bit to determine the QMC mode 

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -35,6 +35,8 @@
 #include "QMCDrivers/DMC/DMCFactoryNew.h"
 #include "QMCDrivers/RMC/RMCFactory.h"
 #include "QMCDrivers/WFOpt/QMCOptimize.h"
+#include "QMCDrivers/WFOpt/QMCOptimizeBatched.h"
+#include "QMCDrivers/WFOpt/QMCWFOptFactoryNew.h"
 #include "QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h"
 #include "QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.h"
 #include "QMCDrivers/WaveFunctionTester.h"
@@ -90,12 +92,19 @@ QMCDriverFactory::DriverAssemblyState QMCDriverFactory::readSection(int curSerie
   if (curName != "qmc")
     qmc_mode = curName;
   int nchars = qmc_mode.size();
-  if (qmc_mode.find("linear") < nchars)
+  if (qmc_mode.find("linear") < nchars) {
+    das.new_run_type = QMCRunType::LINEAR_OPTIMIZE_BATCH;
+  }
+  else if (qmc_mode.find("linear") < nchars)
   {
     if (qmc_mode.find("cslinear") < nchars)
       das.new_run_type = QMCRunType::CS_LINEAR_OPTIMIZE;
     else
       das.new_run_type = QMCRunType::LINEAR_OPTIMIZE;
+  }
+  else if (qmc_mode.find("opt_batch") < nchars)
+  {
+    das.new_run_type = QMCRunType::OPTIMIZE_BATCH;
   }
   else if (qmc_mode.find("opt") < nchars)
   {
@@ -295,6 +304,12 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     QMCOptimize* opt = new QMCOptimize(qmc_system, *primaryPsi, *primaryH, hamiltonian_pool, wavefunction_pool, comm);
     //ZeroVarianceOptimize *opt = new ZeroVarianceOptimize(qmc_system,*primaryPsi,*primaryH );
+    opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
+    new_driver.reset(opt);
+  }
+  else if (das.new_run_type == QMCRunType::OPTIMIZE_BATCH)
+  {
+    QMCOptimizeBatched* opt = QMCWFOptFactoryNew(cur, qmc_common.qmc_counter, qmc_system, *primaryPsi, *primaryH, hamiltonian_pool, wavefunction_pool, population, qmc_system.getSampleStack(), comm);
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
     new_driver.reset(opt);
   }

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -272,7 +272,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     VMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE], qmc_common.qmc_counter);
     new_driver.reset(
-        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, comm));
+        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, qmc_system.getSampleStack(), comm));
   }
   else if (das.new_run_type == QMCRunType::DMC)
   {

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -130,6 +130,7 @@ public:
   RealType get_max_disp_sq() const { return max_disp_sq_; }
   IndexType get_max_blocks() const { return max_blocks_; }
   IndexType get_max_steps() const { return max_steps_; }
+  void set_max_steps(IndexType max_steps) { max_steps_ = max_steps; }
   IndexType get_warmup_steps() const { return warmup_steps_; }
   IndexType get_steps_between_samples() const { return steps_between_samples_; }
   IndexType get_samples_per_thread() const { return samples_per_thread_; }

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -58,6 +58,7 @@ public:
   virtual BranchEngineType* getBranchEngine()                           = 0;
   virtual std::string getEngineName()                                   = 0;
   virtual unsigned long getDriverMode()                                 = 0;
+  virtual void endSection() {}
   virtual ~QMCDriverInterface() {}
 };
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -406,6 +406,10 @@ public:
    */
   bool finalize(int block, bool dumpwalkers = true);
 
+  virtual void endSection();
+  /// Release RNG's back to global control
+  void releaseRng();
+
   int rotation;
   const std::string& get_root_name() const { return root_name_; }
   std::string getRotationName(std::string RootName);

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -68,6 +68,7 @@ public:
              TrialWaveFunction& psi,
              QMCHamiltonian& h,
              WaveFunctionPool& ppool,
+             SampleStack& samples,
              Communicate* comm);
 
   void process(xmlNodePtr node);
@@ -99,6 +100,7 @@ public:
   auto getCDLW();
 
   QMCDriverNew::AdjustedWalkerCounts calcDefaultLocalWalkers(QMCDriverNew::AdjustedWalkerCounts awc) const;
+  void calcSamples(int& adjusted_steps_between_samples, int& adjusted_steps, int& samples_per_node) const;
 
 private:
   int prevSteps;
@@ -111,6 +113,10 @@ private:
   VMCBatched(const VMCBatched&) = delete;
   /// Copy operator (disabled).
   VMCBatched& operator=(const VMCBatched&) = delete;
+
+  SampleStack& samples_;
+
+  int steps_between_samples_;
 
   friend class qmcplusplus::testing::VMCBatchedTest;
   ;

--- a/src/QMCDrivers/VMC/VMCFactoryNew.cpp
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.cpp
@@ -24,6 +24,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
                                           TrialWaveFunction& psi,
                                           QMCHamiltonian& h,
                                           WaveFunctionPool& wf_pool,
+                                          SampleStack& samples,
                                           Communicate* comm)
 {
   QMCDriverInput qmcdriver_input(qmc_counter_);
@@ -34,7 +35,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
 
   if (vmc_mode_ == 0 || vmc_mode_ == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, comm);
+    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, samples, comm);
   }
   else
   {

--- a/src/QMCDrivers/VMC/VMCFactoryNew.h
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.h
@@ -43,6 +43,7 @@ public:
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
                              WaveFunctionPool& wf_pool,
+                             SampleStack& samples,
                              Communicate* comm);
 };
 } // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
@@ -1,0 +1,245 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "QMCDrivers/WFOpt/QMCOptimizeBatched.h"
+#include "Particle/HDFWalkerIO.h"
+#include "OhmmsData/AttributeSet.h"
+#include "Message/CommOperators.h"
+#include "Optimize/CGOptimization.h"
+#include "Optimize/testDerivOptimization.h"
+#include "Optimize/DampedDynamics.h"
+#include "QMCDrivers/VMC/VMCBatched.h"
+#include "QMCDrivers/WFOpt/QMCCostFunction.h"
+#include "QMCHamiltonians/HamiltonianPool.h"
+
+namespace qmcplusplus
+{
+QMCOptimizeBatched::QMCOptimizeBatched(MCWalkerConfiguration& w,
+                                       TrialWaveFunction& psi,
+                                       QMCHamiltonian& h,
+                                       HamiltonianPool& hpool,
+                                       WaveFunctionPool& ppool,
+                                       QMCDriverInput&& qmcdriver_input,
+                                       VMCDriverInput&& vmcdriver_input,
+                                       MCPopulation& population,
+                                       SampleStack& samples,
+                                       Communicate* comm)
+    : QMCDriver(w, psi, h, ppool, comm),
+      PartID(0),
+      NumParts(1),
+      hamPool(hpool),
+      optSolver(0),
+      vmcEngine(0),
+      wfNode(NULL),
+      optNode(NULL),
+      qmcdriver_input_(qmcdriver_input),
+      vmcdriver_input_(vmcdriver_input),
+      population_(population),
+      samples_(samples)
+{
+  IsQMCDriver = false;
+  //set the optimization flag
+  qmc_driver_mode.set(QMC_OPTIMIZE, 1);
+  //read to use vmc output (just in case)
+  RootName = "pot";
+  QMCType  = "QMCOptimizeBatched";
+  //default method is cg
+  optmethod = "cg";
+}
+
+/** Clean up the vector */
+QMCOptimizeBatched::~QMCOptimizeBatched()
+{
+  delete vmcEngine;
+  delete optSolver;
+}
+
+/** Add configuration files for the optimization
+ * @param a root of a hdf5 configuration file
+ */
+void QMCOptimizeBatched::addConfiguration(const std::string& a)
+{
+  if (a.size())
+    ConfigFile.push_back(a);
+}
+
+/** Reimplement QMCDriver::run
+ */
+bool QMCOptimizeBatched::run()
+{
+  QMCCostFunction* cost = dynamic_cast<QMCCostFunction*>(optTarget.get());
+  cost->makeClones(W, Psi, H);
+  //generate samples
+  generateSamples();
+
+  NumOfVMCWalkers = W.getActiveWalkers();
+
+  app_log() << "<opt stage=\"setup\">" << std::endl;
+  app_log() << "  <log>" << std::endl;
+  //reset the rootname
+  optTarget->setRootName(RootName);
+  optTarget->setWaveFunctionNode(wfNode);
+  optTarget->setRng(vmcEngine->getRng());
+  app_log() << "   Reading configurations from h5FileRoot " << std::endl;
+  //get configuration from the previous run
+  Timer t1;
+  optTarget->getConfigurations(h5FileRoot);
+  optTarget->checkConfigurations();
+  app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
+  app_log() << "  </log>" << std::endl;
+  app_log() << "</opt>" << std::endl;
+  app_log() << "<opt stage=\"main\" walkers=\"" << optTarget->getNumSamples() << "\">" << std::endl;
+  app_log() << "  <log>" << std::endl;
+  optTarget->setTargetEnergy(branchEngine->getEref());
+  t1.restart();
+  bool success = optSolver->optimize(optTarget.get());
+  app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
+  ;
+  app_log() << "  </log>" << std::endl;
+  optTarget->reportParameters();
+
+  int nw_removed = W.getActiveWalkers() - NumOfVMCWalkers;
+  app_log() << "   Restore the number of walkers to " << NumOfVMCWalkers << ", removing " << nw_removed << " walkers."
+            << std::endl;
+  if (nw_removed > 0)
+    W.destroyWalkers(nw_removed);
+  else
+    W.createWalkers(-nw_removed);
+
+  app_log() << "</opt>" << std::endl;
+  app_log() << "</optimization-report>" << std::endl;
+  MyCounter++;
+  return (optTarget->getReportCounter() > 0);
+}
+
+void QMCOptimizeBatched::generateSamples()
+{
+  Timer t1;
+  app_log() << "<optimization-report>" << std::endl;
+
+  vmcEngine->qmc_driver_mode_.set(QMC_WARMUP, 1);
+  vmcEngine->qmc_driver_mode_.set(QMC_OPTIMIZE, 1);
+  vmcEngine->qmc_driver_mode_.set(QMC_WARMUP, 0);
+
+  // TODO - understand what this does
+  //vmcEngine->setValue("current", 0); //reset CurrentStep
+  app_log() << "<vmc stage=\"main\" blocks=\"" << nBlocks << "\">" << std::endl;
+  t1.restart();
+  branchEngine->flush(0);
+  branchEngine->reset();
+  vmcEngine->run();
+  app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
+  app_log() << "</vmc>" << std::endl;
+  //write parameter history and energies to the parameter file in the trial wave function through opttarget
+  //
+  // TODO - understand what this does - values are not used, but the side effects may be important?
+  //FullPrecRealType e, w, var;
+  //vmcEngine->Estimators->getEnergyAndWeight(e, w, var);
+
+  h5FileRoot = RootName;
+}
+
+void QMCOptimizeBatched::endSection() { vmcEngine->endSection(); }
+
+/** Parses the xml input file for parameter definitions for the wavefunction optimization.
+ * @param q current xmlNode
+ * @return true if successful
+ */
+bool QMCOptimizeBatched::put(xmlNodePtr q)
+{
+  std::string vmcMove("pbyp");
+  std::string useGPU("no");
+  OhmmsAttributeSet oAttrib;
+  oAttrib.add(vmcMove, "move");
+  oAttrib.add(useGPU, "gpu");
+  oAttrib.put(q);
+  xmlNodePtr qsave = q;
+  xmlNodePtr cur   = qsave->children;
+  int pid          = OHMMS::Controller->rank();
+  while (cur != NULL)
+  {
+    std::string cname((const char*)(cur->name));
+    if (cname == "mcwalkerset")
+    {
+      mcwalkerNodePtr.push_back(cur);
+    }
+    else if (cname.find("optimize") < cname.size())
+    {
+      const XMLAttrString att(cur, "method");
+      if (!att.empty())
+        optmethod = att;
+      optNode = cur;
+    }
+    cur = cur->next;
+  }
+  //no walkers exist, add 10
+  if (W.getActiveWalkers() == 0)
+    addWalkers(omp_get_max_threads());
+  NumOfVMCWalkers = W.getActiveWalkers();
+  //create VMC engine
+  if (vmcEngine == 0)
+  {
+    QMCDriverInput qmcdriver_input_copy = qmcdriver_input_;
+    VMCDriverInput vmcdriver_input_copy = vmcdriver_input_;
+    vmcEngine = new VMCBatched(std::move(qmcdriver_input_copy), std::move(vmcdriver_input_copy), population_, Psi, H,
+                               psiPool, samples_, myComm);
+    vmcEngine->setUpdateMode(vmcMove[0] == 'p');
+  }
+  vmcEngine->setStatus(RootName, h5FileRoot, AppendRun);
+  vmcEngine->process(qsave);
+  if (optSolver == 0)
+  {
+    if (optmethod == "anneal")
+    {
+      app_log() << " Annealing optimization using DampedDynamics" << std::endl;
+      optSolver = new DampedDynamics<RealType>;
+    }
+    else if ((optmethod == "flexOpt") | (optmethod == "flexopt") | (optmethod == "macopt"))
+    {
+      app_log() << "Conjugate-gradient optimization using FlexOptimization" << std::endl;
+      app_log() << " This method has been removed. " << std::endl;
+      APP_ABORT("QMCOptimizeBatched::put");
+    }
+    else if (optmethod == "BFGS")
+    {
+      app_log() << " This method is not implemented correctly yet. " << std::endl;
+      APP_ABORT("QMCOptimizeBatched::put");
+    }
+    else if (optmethod == "test")
+    {
+      app_log() << "Conjugate-gradient optimization using tester Optimization: " << std::endl;
+      optSolver = new testDerivOptimization<RealType>;
+    }
+    else
+    {
+      app_log() << " Conjugate-gradient optimization using CGOptimization" << std::endl;
+      optSolver = new CGOptimization<RealType>;
+    } //set the stream
+    optSolver->setOstream(&app_log());
+  }
+  if (optNode == NULL)
+    optSolver->put(qmcNode);
+  else
+    optSolver->put(optNode);
+  bool success = true;
+  //allways reset optTarget
+  optTarget = std::make_unique<QMCCostFunction>(W, Psi, H, myComm);
+  optTarget->setStream(&app_log());
+  success = optTarget->put(q);
+
+  return success;
+}
+} // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/QMCOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCOptimizeBatched.h
@@ -1,0 +1,109 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file QMCOptimizeBatched.h
+ * @brief Definition of QMCDriver which performs VMC (using batched driver) and optimization.
+ */
+#ifndef QMCPLUSPLUS_QMCOPTIMIZATION_VMCBATCHED_H
+#define QMCPLUSPLUS_QMCOPTIMIZATION_VMCBATCHED_H
+
+#include <memory>
+#include "QMCDrivers/QMCDriver.h"
+#include "QMCDrivers/QMCDriverNew.h"
+#include "QMCDrivers/QMCDriverInput.h"
+#include "QMCDrivers/VMC/VMCDriverInput.h"
+#include "Optimize/OptimizeBase.h"
+
+namespace qmcplusplus
+{
+///forward declaration of a cost function
+class QMCCostFunctionBase;
+class HamiltonianPool;
+class MCPopulation;
+
+/** @ingroup QMCDrivers
+ * @brief Implements wave-function optimization
+ *
+ * Optimization by correlated sampling method with configurations
+ * generated from VMC.
+ */
+
+class QMCOptimizeBatched : public QMCDriver
+{
+public:
+  ///Constructor.
+  QMCOptimizeBatched(MCWalkerConfiguration& w,
+                     TrialWaveFunction& psi,
+                     QMCHamiltonian& h,
+                     HamiltonianPool& hpool,
+                     WaveFunctionPool& ppool,
+                     QMCDriverInput&& qmcdriver_input,
+                     VMCDriverInput&& vmcdriver_input,
+                     MCPopulation& population,
+                     SampleStack& samples,
+                     Communicate* comm);
+
+  ///Destructor
+  ~QMCOptimizeBatched();
+
+  ///Run the Optimization algorithm.
+  bool run();
+  ///process xml node
+  bool put(xmlNodePtr cur);
+  ///add a configuration file to the list of files
+  void addConfiguration(const std::string& a);
+
+  void setWaveFunctionNode(xmlNodePtr cur) { wfNode = cur; }
+  QMCRunType getRunType() { return QMCRunType::OPTIMIZE_BATCH; }
+
+  void endSection();
+
+private:
+  ///index to denote the partition id
+  int PartID;
+  ///total number of partitions that will share a set of configuratons
+  int NumParts;
+  ///total number of VMC walkers
+  int NumOfVMCWalkers;
+  ///need to know HamiltonianPool to use OMP
+  HamiltonianPool& hamPool;
+  ///target cost function to optimize
+  //QMCCostFunction* optTarget;
+  std::unique_ptr<QMCCostFunctionBase> optTarget;
+  ///solver
+  MinimizerBase<RealType>* optSolver;
+  ///vmc engine
+  QMCDriverNew* vmcEngine;
+  ///xml node to be dumped
+  xmlNodePtr wfNode;
+  ///xml node for optimizer
+  xmlNodePtr optNode;
+  ///method for optimization, default conjugate gradient
+  std::string optmethod;
+  ///list of files storing configurations
+  std::vector<std::string> ConfigFile;
+  ///Copy Constructor (disabled).
+  QMCOptimizeBatched(const QMCOptimizeBatched&) = delete;
+  ///Copy operator (disabled).
+  QMCOptimizeBatched& operator=(const QMCOptimizeBatched&) = delete;
+
+  void generateSamples();
+
+  QMCDriverInput qmcdriver_input_;
+  VMCDriverInput vmcdriver_input_;
+  MCPopulation& population_;
+  SampleStack& samples_;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.cpp
+++ b/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.cpp
@@ -1,0 +1,31 @@
+
+#include "QMCDrivers/WFOpt/QMCWFOptFactoryNew.h"
+#include "QMCDrivers/WFOpt/QMCOptimize.h"
+#include "QMCDrivers/QMCDriverInput.h"
+#include "QMCDrivers/VMC/VMCDriverInput.h"
+#include "QMCDrivers/WFOpt/QMCOptimizeBatched.h"
+
+namespace qmcplusplus
+{
+QMCOptimizeBatched* QMCWFOptFactoryNew(xmlNodePtr cur,
+                                       const int qmc_counter,
+                                       MCWalkerConfiguration& w,
+                                       TrialWaveFunction& psi,
+                                       QMCHamiltonian& h,
+                                       HamiltonianPool& hpool,
+                                       WaveFunctionPool& wf_pool,
+                                       MCPopulation& pop,
+                                       SampleStack& samples,
+                                       Communicate* comm)
+{
+  QMCDriverInput qmcdriver_input(qmc_counter);
+  qmcdriver_input.readXML(cur);
+  VMCDriverInput vmcdriver_input(qmc_counter);
+  vmcdriver_input.readXML(cur);
+
+  QMCOptimizeBatched* opt = new QMCOptimizeBatched(w, psi, h, hpool, wf_pool, std::move(qmcdriver_input),
+                                                   std::move(vmcdriver_input), pop, samples, comm);
+  return opt;
+}
+
+} // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.h
+++ b/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.h
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_WFOPTFACTORYNEW_H
+#define QMCPLUSPLUS_WFOPTFACTORYNEW_H
+
+#include "QMCDrivers/QMCDriverInterface.h"
+
+class Communicate;
+
+namespace qmcplusplus
+{
+class MCPopulation;
+class QMCOptimizeBatched;
+class WaveFunctionPool;
+class QMCHamiltonian;
+class TrialWaveFunction;
+class SampleStack;
+class MCWalkerConfiguration;
+class HamiltonianPool;
+class QMCOptimize;
+
+QMCOptimizeBatched* QMCWFOptFactoryNew(xmlNodePtr cur,
+                                       const int qmc_counter,
+                                       MCWalkerConfiguration& w,
+                                       TrialWaveFunction& psi,
+                                       QMCHamiltonian& h,
+                                       HamiltonianPool& hpool,
+                                       WaveFunctionPool& wf_pool,
+                                       MCPopulation& pop,
+                                       SampleStack& samples,
+                                       Communicate* comm);
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/QMCDrivers/tests/test_VMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_VMCBatched.cpp
@@ -69,9 +69,10 @@ public:
                               hamiltonian_pool.getPrimary(), comm->rank());
       QMCDriverInput qmcdriver_copy(qmcdriver_input);
       VMCDriverInput vmcdriver_input("yes");
+      SampleStack samples;
       VMCBatched vmc_batched(std::move(qmcdriver_copy), std::move(vmcdriver_input), population,
                              *(wavefunction_pool.getPrimary()), *(hamiltonian_pool.getPrimary()), wavefunction_pool,
-                             comm);
+                             samples, comm);
       vmc_batched.set_walkers_per_rank(walkers_per_rank, "testing");
       if (num_crowds < 8)
         vmc_batched.set_num_crowds(Concurrency::maxThreads(), "Insufficient threads available to match test input");


### PR DESCRIPTION

## Proposed changes

The QMCOptimize driver was copied to QMCOptimizeBatched and converted to work with batched VMC for the collection of samples.  This is intended to have the minimal number of changes needed to compile and run without crashing.
    
This code only works for one thread.  The old VMC driver collected samples on each thread.  The new VMC driver collects a single vector of samples.  A future commit will distribute the samples to the per-thread structure to enable threaded evaluation of the cost function.
    
There are a couple of TODO items in QMCOptimizeBatched::generateSamples where the calls on vmc engine for the new batched driver are commented out.  The effects of those calls should be investigated further to determine if they need replacement functionality.

This was branched from PR #2493 (and contains the changes for #2492).  The "WIP" part is added because it gets a little confusing to see all the changes from the previous PR's also included.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?

laptop.  The code builds and it runs one NiO test without crashing.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Ye. This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
