### PR TITLE
Proper error message for insufficient MPI ranks for an ensemble job

### DIFF
--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -188,6 +188,15 @@ int main(int argc, char** argv)
     Communicate* qmcComm = OHMMS::Controller;
     if (inputs.size() > 1)
     {
+      if (inputs.size() > OHMMS::Controller->size())
+      {
+        std::ostringstream msg;
+        msg << "main(). Current " << OHMMS::Controller->size() << " MPI ranks cannot accommodate all the "
+            << inputs.size() << " individual calculations in the ensemble. "
+            << "Increase the number of MPI ranks or reduce the number of calculations."
+            << std::endl;
+        OHMMS::Controller->barrier_and_abort(msg.str());
+      }
       qmcComm               = new Communicate(*OHMMS::Controller, inputs.size());
       qmc_common.mpi_groups = inputs.size();
     }


### PR DESCRIPTION
## Proposed changes
From user report
https://groups.google.com/d/msg/qmcpack/Zv3d7v3AxsE/RM38gZQQBAAJ
The global communicator is split by the number of jobs in an ensemble. If the number of MPI ranks is insufficient, the code should stop with a proper error.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'