### PR TITLE
Enable sample collection in VMCBatched driver

### DIFF
--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -272,7 +272,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     VMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE], qmc_common.qmc_counter);
     new_driver.reset(
-        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, comm));
+        fac.create(population, *primaryPsi, *primaryH, wavefunction_pool, qmc_system.getSampleStack(), comm));
   }
   else if (das.new_run_type == QMCRunType::DMC)
   {

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -68,6 +68,7 @@ public:
              TrialWaveFunction& psi,
              QMCHamiltonian& h,
              WaveFunctionPool& ppool,
+             SampleStack& samples_,
              Communicate* comm);
 
   void process(xmlNodePtr node);
@@ -100,6 +101,8 @@ public:
 
   QMCDriverNew::AdjustedWalkerCounts calcDefaultLocalWalkers(QMCDriverNew::AdjustedWalkerCounts awc) const;
 
+  void enable_sample_collection();
+
 private:
   int prevSteps;
   int prevStepsBetweenSamples;
@@ -111,6 +114,9 @@ private:
   VMCBatched(const VMCBatched&) = delete;
   /// Copy operator (disabled).
   VMCBatched& operator=(const VMCBatched&) = delete;
+
+  SampleStack& samples_;
+  bool collect_samples_;
 
   friend class qmcplusplus::testing::VMCBatchedTest;
   ;

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -101,6 +101,7 @@ public:
 
   QMCDriverNew::AdjustedWalkerCounts calcDefaultLocalWalkers(QMCDriverNew::AdjustedWalkerCounts awc) const;
 
+  /// Compute the number of samples to collect and enable collecting samples during the VMC run
   void enable_sample_collection();
 
 private:
@@ -115,7 +116,9 @@ private:
   /// Copy operator (disabled).
   VMCBatched& operator=(const VMCBatched&) = delete;
 
+  /// Storage for samples (later used in optimizer)
   SampleStack& samples_;
+  /// Sample collection flag
   bool collect_samples_;
 
   friend class qmcplusplus::testing::VMCBatchedTest;

--- a/src/QMCDrivers/VMC/VMCFactoryNew.cpp
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.cpp
@@ -24,6 +24,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
                                           TrialWaveFunction& psi,
                                           QMCHamiltonian& h,
                                           WaveFunctionPool& wf_pool,
+                                          SampleStack& samples,
                                           Communicate* comm)
 {
   QMCDriverInput qmcdriver_input(qmc_counter_);
@@ -34,7 +35,7 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation& pop,
 
   if (vmc_mode_ == 0 || vmc_mode_ == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, comm);
+    qmc = new VMCBatched(std::move(qmcdriver_input), std::move(vmcdriver_input), pop, psi, h, wf_pool, samples, comm);
   }
   else
   {

--- a/src/QMCDrivers/VMC/VMCFactoryNew.h
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.h
@@ -43,6 +43,7 @@ public:
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
                              WaveFunctionPool& wf_pool,
+                             SampleStack& samples,
                              Communicate* comm);
 };
 } // namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_VMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_VMCBatched.cpp
@@ -20,6 +20,7 @@
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
 #include "Concurrency/Info.hpp"
 #include "Concurrency/UtilityFunctions.hpp"
+#include "Particle/SampleStack.h"
 
 namespace qmcplusplus
 {
@@ -69,8 +70,9 @@ public:
                               hamiltonian_pool.getPrimary(), comm->rank());
       QMCDriverInput qmcdriver_copy(qmcdriver_input);
       VMCDriverInput vmcdriver_input("yes");
+      SampleStack samples;
       VMCBatched vmc_batched(std::move(qmcdriver_copy), std::move(vmcdriver_input), population,
-                             *(wavefunction_pool.getPrimary()), *(hamiltonian_pool.getPrimary()), wavefunction_pool,
+                             *(wavefunction_pool.getPrimary()), *(hamiltonian_pool.getPrimary()), wavefunction_pool, samples,
                              comm);
       vmc_batched.set_walkers_per_rank(walkers_per_rank, "testing");
       if (num_crowds < 8)


### PR DESCRIPTION
## Proposed changes

Updated version of #2493 

As pointed out by @ye-luo, we don't need to keep the specification for the number of samples backwards compatible (for now).  This simplifies the logic.

Now the number of samples is controlled by the number of blocks, number of steps, number of walkers, and the number of nodes.   The number of substeps can be used to adjust the number of steps between each sample.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature

### Does this introduce a breaking change?

- No


## What systems has this change been tested on?
Laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
