### PR TITLE
Change project name in sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'QMC Manual'
+project = 'QMCPACK Manual'
 copyright = '2020, QMCPACK Developers'
 author = 'QMCPACK Developers'
 


### PR DESCRIPTION
## Proposed changes

Simple change to naming that should become visible at https://qmcpack.readthedocs.io/en/develop/

As I test I have also enabled readthedocs to build the PR

## What type(s) of changes does this code introduce?
- Build related changes
- Documentation content changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
