### PR TITLE
Updated ORNL nightly scripts and spack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ performance and easiest configuration.
 Nightly testing currently includes the following software versions on x86:
 
 * Compilers
-  * GCC 9.2.0, 7.3.0
-  * Clang/LLVM 9.0.0, 5.0.1
-  * Intel 2019.1.0.166, 2019.0.5.281 configured to use C++ library from GCC 7.4.0 
+  * GCC 10.1.0, 7.3.0
+  * Clang/LLVM 10.0.0, 6.0.1
+  * Intel 19.1.1.217 configured to use C++ library from GCC 8.3.0 
   * PGI 19.4 configured to use C++ library from GCC 8.3.0
-* Boost 1.70.0, 1.65.1
+* Boost 1.73.0, 1.67.0
 * HDF5 1.10.5, 1.8.19
 * FFTW 3.3.8, 3.3.4
-* CMake 3.16.2, 3.10.2
+* CMake 3.17.1, 3.10.2
 * MPI
-  * OpenMPI 4.0.2, 3.10.2
-  * Intel MPI 2019.1.0.166, 2019.0.5.281
+  * OpenMPI 4.0.3, 3.0.1
+  * Intel MPI 19.1.1.217
 * CUDA 10.2.89
 
 # Building with CMake

--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -75,6 +75,17 @@ EOF
 # Use flash /scratch for builds
 	rm -r -f /scratch/$USER/spack_build_stage
 	mkdir /scratch/$USER/spack_build_stage
+	# Workaround linux-rhel8-cascadelake problem on sulfur for GCC in spack circa 202006
+#	cat >$HOME/.spack/packages.yaml<<EOF
+#packages:
+#  all:
+#    target: [skylake_avx512]
+#EOF
+	cat >$HOME/.spack/packages.yaml<<EOF
+packages:
+  all:
+    target: [x86_64]
+EOF
 	;;
     *)
 	echo "*** WARNING: Unknown host in initial ourhostname case statement. No custom onfiguration"
@@ -108,6 +119,14 @@ cd bin
 export SPACK_ROOT=$HOME/apps/spack
 export PATH=$SPACK_ROOT/bin:$PATH
 . $SPACK_ROOT/share/spack/setup-env.sh
+
+# IMPORTANT: Install+Use a GCC toolset on Red Hat systems to use
+# recent compilers with better architecture support.
+# e.g. yum install gcc-toolset-9
+if [ -e /opt/rh/gcc-toolset-9/root/bin/gcc ]; then
+    export PATH=/opt/rh/gcc-toolset-9/root/bin/:$PATH
+fi
+
 
 echo --- Spack list
 spack find

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -7,8 +7,8 @@
 # GCC
 # Zen2 optimziations are only in gcc 9.1+, with improved scheduling in 9.2+
 # Dates at https://gcc.gnu.org/releases.html
-#gcc_vnew=10.1.0 # 2020-05-07
-gcc_vnew=9.3.0 # 2020-03-12
+gcc_vnew=10.1.0 # 2020-05-07
+#gcc_vnew=9.3.0 # 2020-03-12
 gcc_vold=7.3.0 # 2018-01-25
 
 #gcc_vcuda=8.2.1 #  For CUDA 10.2 compatibility  https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
@@ -24,6 +24,8 @@ llvm_vold=6.0.1 # 2018-07-05
 llvm_vcuda=8.0.0 # For CUDA 10.2 compatibility https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
 
 # HDF5
+# Dates at https://portal.hdfgroup.org/display/support/Downloads
+#hdf5_vnew=1.12.0 # Released 2020-02-28 . Not supported by py-h5py 2.10.0, latest in spack on 20200604
 hdf5_vnew=1.10.5 # Releeased 2019-02-28
 hdf5_vold=1.8.19 # Released 2017-06-16
 


### PR DESCRIPTION
## Proposed changes

Updated scripts including workaround for presumed GCC AVX512 bug on sulfur (Intel CascadeLake 6248R), GCC10 -fallow-argument-mismatch configuration edit for illegal interfaces in parts of QE, and initial spack build with RHEL GCC9 toolchain.

This configuration was used overnight (17-18 June) with good success on cdash. Deterministic failures are predominantly mixed precision related and due to QMCPACK variability.

## What type(s) of changes does this code introduce?

- Bugfix
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur and nitrogen.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
