### PR TITLE
Remove clearEnsemble from setMaxSamples in SampleStack

### DIFF
--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -76,6 +76,7 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
       UpdateMode(Update_Walker),
       Polymer(0)
 {
+  samples.clearEnsemble();
   samples.setMaxSamples(mcw.getMaxSamples());
   GlobalNumWalkers = mcw.GlobalNumWalkers;
   WalkerOffsets    = mcw.WalkerOffsets;
@@ -353,7 +354,7 @@ void MCWalkerConfiguration::resizeWalkerHistories()
 /** allocate the SampleStack
  * @param n number of samples per thread
  */
-void MCWalkerConfiguration::setNumSamples(int n) { samples.setMaxSamples(n); }
+void MCWalkerConfiguration::setNumSamples(int n) { samples.clearEnsemble(); samples.setMaxSamples(n); }
 
 /** save the current walkers to SampleStack
  */

--- a/src/Particle/SampleStack.cpp
+++ b/src/Particle/SampleStack.cpp
@@ -24,7 +24,6 @@ SampleStack::SampleStack() : total_num_(0), max_samples_(10), current_sample_cou
  */
 void SampleStack::setMaxSamples(int n)
 {
-  clearEnsemble();
   max_samples_ = n;
   //do not add anything
   if (n == 0)
@@ -55,7 +54,7 @@ void SampleStack::saveEnsemble(std::vector<MCSample>& walker_list)
   }
 }
 
-void SampleStack::appendSample(MCSample &&sample)
+void SampleStack::appendSample(MCSample&& sample)
 {
   // Ignore samples in excess of the expected number of samples
   if (current_sample_count_ < max_samples_)
@@ -97,6 +96,8 @@ void SampleStack::clearEnsemble()
   max_samples_          = 0;
   current_sample_count_ = 0;
 }
+
+void SampleStack::resetSampleCount() { current_sample_count_ = 0; }
 
 
 } // namespace qmcplusplus

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -58,6 +58,8 @@ public:
   ///clear the ensemble
   void clearEnsemble();
   //@}
+  ///  Set the sample count to zero but preserve the storage
+  void resetSampleCount();
 
 private:
   int total_num_;

--- a/src/Particle/tests/test_sample_stack.cpp
+++ b/src/Particle/tests/test_sample_stack.cpp
@@ -25,7 +25,6 @@ namespace qmcplusplus
 {
 TEST_CASE("SampleStack", "[particle]")
 {
-
   SampleStack samples;
 
   const int total_num = 2; // number of particles
@@ -34,6 +33,11 @@ TEST_CASE("SampleStack", "[particle]")
   // reserve storage
   samples.setMaxSamples(8);
   REQUIRE(samples.getMaxSamples() == 8);
+  REQUIRE(samples.getNumSamples() == 0);
+
+  // increase storage
+  samples.setMaxSamples(10);
+  REQUIRE(samples.getMaxSamples() == 10);
   REQUIRE(samples.getNumSamples() == 0);
 
   using Walker_t     = ParticleSet::Walker_t;
@@ -55,6 +59,13 @@ TEST_CASE("SampleStack", "[particle]")
   REQUIRE(w1.R[0][0] == Approx(1.1));
 
   // Should test that more members of the Walker are saved correctly
+
+  samples.resetSampleCount();
+  REQUIRE(samples.getNumSamples() == 0);
+
+  // clear storage
+  samples.clearEnsemble();
+  REQUIRE(samples.getNumSamples() == 0);
 }
 
 


### PR DESCRIPTION
## Proposed changes

Previously, the call to setMaxSamples would delete the storage by calling clearEnsemble, and then reserve and allocate new storage.

Removing the clearEnsemble call from setMaxSamples will allow calling setMaxSamples multiple times with no reallocation (assuming the input value is the same).

Preserve the behavior where MCWalkerConfiguration calls it by adding the clearEnsemble call.

Add a method to reset the sample count to zero.  This will avoid a reallocation of the memory between optimization loop iterations.


## What type(s) of changes does this code introduce?


- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
