### PR TITLE
Make enable_sample_collection independent of calling order for VMCBatched setup

### DIFF
--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -282,6 +282,11 @@ void VMCBatched::process(xmlNodePtr node)
   walkers_per_crowd_ = awc.walkers_per_crowd;
   num_crowds_        = awc.num_crowds;
 
+  if (collect_samples_)
+  {
+    samples_.setMaxSamples(compute_samples_per_node());
+  }
+
   app_log() << "VMCBatched Driver running with total_walkers=" << awc.global_walkers << '\n'
             << "                               walkers_per_rank=" << walkers_per_rank_ << '\n'
             << "                               num_crowds=" << num_crowds_ << '\n';
@@ -293,6 +298,14 @@ void VMCBatched::process(xmlNodePtr node)
 
   Base::process(node);
 }
+
+int VMCBatched::compute_samples_per_node() const
+{
+  int nblocks = qmcdriver_input_.get_max_blocks();
+  int nsteps  = qmcdriver_input_.get_max_steps();
+  return nblocks * nsteps * walkers_per_rank_;
+}
+
 
 /** Runs the actual VMC section
  *
@@ -401,12 +414,9 @@ bool VMCBatched::run()
 
 void VMCBatched::enable_sample_collection()
 {
-  int nblocks          = qmcdriver_input_.get_max_blocks();
-  int nsteps           = qmcdriver_input_.get_max_steps();
-  int samples_per_node = nblocks * nsteps * walkers_per_rank_;
-  samples_.setMaxSamples(samples_per_node);
+  samples_.setMaxSamples(compute_samples_per_node());
   collect_samples_ = true;
-  app_log() << "VMCBatched Driver collecting samples, samples_per_node = " << samples_per_node << '\n';
+  app_log() << "VMCBatched Driver collecting samples, samples_per_node = " << compute_samples_per_node() << '\n';
 }
 
 

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -101,7 +101,7 @@ public:
 
   QMCDriverNew::AdjustedWalkerCounts calcDefaultLocalWalkers(QMCDriverNew::AdjustedWalkerCounts awc) const;
 
-  /// Compute the number of samples to collect and enable collecting samples during the VMC run
+  /// Enable collecting samples during the VMC run
   void enable_sample_collection();
 
 private:
@@ -116,10 +116,13 @@ private:
   /// Copy operator (disabled).
   VMCBatched& operator=(const VMCBatched&) = delete;
 
+
   /// Storage for samples (later used in optimizer)
   SampleStack& samples_;
   /// Sample collection flag
   bool collect_samples_;
+  /// Number of samples to collect based on input parameters and walkers per node
+  int compute_samples_per_node() const;
 
   friend class qmcplusplus::testing::VMCBatchedTest;
   ;


### PR DESCRIPTION
## Proposed changes
The number of samples collected depends on the number of walkers per node (MPI rank). This value is not known until setup is complete (and calcDefaultLocalWalkers has been called). This means enable_sample_collection could not be safely called until after this point.

This change removes that ordering dependency.  The tradeoff is that setMaxSamples is called in two places.  The change 7a64cb57d5451752510cd67bafb93a5de97fec6a (PR #2557) means that potentially calling setMaxSamples twice should have no effects (extra memory allocations, etc).


## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
