### PR TITLE
Add tolerance option to check_traces.py

### DIFF
--- a/tests/scripts/check_traces.py
+++ b/tests/scripts/check_traces.py
@@ -1274,9 +1274,9 @@ if __name__=='__main__':
                       default='0',
                       help='Exclude a number of DMC steps from being checked.  This option is temporary and will be removed once a bug in the DMC weights for the first step is fixed (default=%default).'
                       )
-    parser.add_option('--mixed_precision',dest='mixed_precision',
-                      action='store_true',default='False',
-                      help='Increase tolerance for mixed precision test (default=%default).'
+    parser.add_option('--tol',dest='tolerance',
+                      default='1e-8',
+                      help='Tolerance to check (default=%default).'
                       )
 
     opt,paths = parser.parse_args()
@@ -1294,10 +1294,7 @@ if __name__=='__main__':
         sys.exit(0)
     #end if
 
-    tol = 1e-8
-    if options.mixed_precision:
-        tol = 1e-6
-    #end if
+    tol = float(options.tolerance)
 
     if len(paths)==0:
         options.path = './'

--- a/tests/scripts/check_traces.py
+++ b/tests/scripts/check_traces.py
@@ -633,7 +633,7 @@ class TracesFileHDF(DataFile):
 
     # Perform internal consistency check between per-walker single 
     #   particle energies and per-walker total energies.
-    def check_particle_sums(self,tol=1e-8):
+    def check_particle_sums(self,tol):
         t = self.real_traces
 
         # Determine quantities present as "scalars" (total values) and also per-particle
@@ -874,7 +874,7 @@ class TracesAnalyzer(DevBase):
 
     # Check that per-particle quantities sum to total/scalar quantities 
     #   in each traces.h5 file separately.
-    def check_particle_sums(self,tol=1e-8):
+    def check_particle_sums(self,tol):
         same = True
         for trace_file in self.data:
             log('Checking traces file: {}'.format(os.path.basename(trace_file.filepath)),n=2)
@@ -888,7 +888,7 @@ class TracesAnalyzer(DevBase):
 
 
     # Check aggregated traces data against scalar.dat
-    def check_scalar_dat(self,tol=1e-8):
+    def check_scalar_dat(self,tol):
         valid = self.check_scalar_file('scalar.dat',self.scalar_dat,tol)
         self.scalar_dat_valid = valid
         self.pass_fail(valid,n=2)
@@ -897,7 +897,7 @@ class TracesAnalyzer(DevBase):
 
 
     # Check aggregated traces data against stat.h5
-    def check_stat_h5(self,tol=1e-8):
+    def check_stat_h5(self,tol):
         valid = self.check_scalar_file('stat.h5',self.stat_h5,tol)
         self.stat_h5_valid = valid
         self.pass_fail(valid,n=2)
@@ -906,7 +906,7 @@ class TracesAnalyzer(DevBase):
 
 
     # Shared checking implementation for scalar.dat and stat.h5
-    def check_scalar_file(self,file_type,scalar_file,tol=1e-8):
+    def check_scalar_file(self,file_type,scalar_file,tol):
 
         # Check that expected quantities are present
         qnames = scalar_file.quantities
@@ -959,7 +959,7 @@ class TracesAnalyzer(DevBase):
 
 
     # Check aggregated traces data against dmc.dat
-    def check_dmc_dat(self,tol=1e-8):
+    def check_dmc_dat(self,tol):
 
         # Some DMC steps are excluded due to a known bug in QMCPACK weights
         dmc_steps_exclude = self.options.dmc_steps_exclude
@@ -1274,6 +1274,10 @@ if __name__=='__main__':
                       default='0',
                       help='Exclude a number of DMC steps from being checked.  This option is temporary and will be removed once a bug in the DMC weights for the first step is fixed (default=%default).'
                       )
+    parser.add_option('--mixed_precision',dest='mixed_precision',
+                      action='store_true',default='False',
+                      help='Increase tolerance for mixed precision test (default=%default).'
+                      )
 
     opt,paths = parser.parse_args()
 
@@ -1288,6 +1292,11 @@ if __name__=='__main__':
     if options.examples:
         log(examples)
         sys.exit(0)
+    #end if
+
+    tol = 1e-8
+    if options.mixed_precision:
+        tol = 1e-6
     #end if
 
     if len(paths)==0:
@@ -1368,19 +1377,19 @@ if __name__=='__main__':
         if method=='vmc':
             if options.particle_sum:
                 log('\nChecking sums of single particle energies',n=1)
-                ta.check_particle_sums()
+                ta.check_particle_sums(tol)
             #end if
 
             log('\nChecking scalar.dat',n=1)
-            ta.check_scalar_dat()
+            ta.check_scalar_dat(tol)
 
             log('\nChecking stat.h5',n=1)
-            ta.check_stat_h5()
+            ta.check_stat_h5(tol)
 
         elif method=='dmc':
             if options.particle_sum:
                 log('\nChecking sums of single particle energies',n=1)
-                ta.check_particle_sums()
+                ta.check_particle_sums(tol)
             #end if
 
             log('\nSkipping checks of scalar.dat and stat.h5',n=1)
@@ -1390,7 +1399,7 @@ if __name__=='__main__':
                 'from the traces.',n=2)
 
             log('\nChecking dmc.dat',n=1)
-            ta.check_dmc_dat()
+            ta.check_dmc_dat(tol)
         #end if
 
         failed |= ta.failed

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -891,7 +891,7 @@ ENDIF()
       "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
       qmc_trace_scalars.in.xml
       1 1
-      check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1 --mixed_precision
+      check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1 --tol=1e-6
       )
    ELSE()     
     SIMPLE_RUN_AND_CHECK(
@@ -910,7 +910,7 @@ ENDIF()
       "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
       qmc_trace_scalars_selective.in.xml
       1 1
-      check_traces.py -p qmc_trace_scalars_selective -s '0,1' -m 'vmc,dmc' -q 'Kinetic,ElecElec' --dmc_steps_exclude=1 --mixed_precision
+      check_traces.py -p qmc_trace_scalars_selective -s '0,1' -m 'vmc,dmc' -q 'Kinetic,ElecElec' --dmc_steps_exclude=1 --tol=1e-6
       )
    ELSE()
     SIMPLE_RUN_AND_CHECK(

--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -884,7 +884,16 @@ ENDIF()
   set(traces_python_reqs numpy;h5py)
   CHECK_PYTHON_REQS(traces_python_reqs diamond-traces add_traces_tests)
   if (add_traces_tests)
+   IF (QMC_MIXED_PRECISION)
     # traces with only scalars on
+    SIMPLE_RUN_AND_CHECK(
+      deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars
+      "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+      qmc_trace_scalars.in.xml
+      1 1
+      check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1 --mixed_precision
+      )
+   ELSE()     
     SIMPLE_RUN_AND_CHECK(
       deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars
       "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
@@ -892,8 +901,18 @@ ENDIF()
       1 1
       check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1
       )
+   ENDIF()
 
+   IF (QMC_MIXED_PRECISION)
     # traces with only selective scalars
+    SIMPLE_RUN_AND_CHECK(
+      deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars_sel
+      "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+      qmc_trace_scalars_selective.in.xml
+      1 1
+      check_traces.py -p qmc_trace_scalars_selective -s '0,1' -m 'vmc,dmc' -q 'Kinetic,ElecElec' --dmc_steps_exclude=1 --mixed_precision
+      )
+   ELSE()
     SIMPLE_RUN_AND_CHECK(
       deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars_sel
       "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
@@ -901,6 +920,7 @@ ENDIF()
       1 1
       check_traces.py -p qmc_trace_scalars_selective -s '0,1' -m 'vmc,dmc' -q 'Kinetic,ElecElec' --dmc_steps_exclude=1
       )
+   ENDIF()
   endif()
 
 # CUDA references


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

 Current deterministic test for traces check is failing in mixed-precision build because current tolerance (1e-8) is too small to handle numeric sensitivity on mixed precision build.
 This PR is to test for mixed precision build with separated tolerance of 1e-6, which is small enough as much to work as deterministic test. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Other (please describe): Add test

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

 Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
