### PR TITLE
Add separated tolerance for r^2 == dr^2 check for the mixed precision…

### DIFF
--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -243,7 +243,11 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   elec_.getDistTable(0).get_first_neighbor(0, r, dr, false);
   std::cout << std::setprecision(14) << "check r^2 against dr^2. "
             << "r = " << r << " dr = " << dr << std::endl;
+#if defined(MIXED_PRECISION)
+  REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon() * 1e5);
+#else
   REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon());
+#endif
 
   // for vgl
   SPOSet::ValueMatrix_t psiM(elec_.R.size(), spo->getOrbitalSetSize());

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -246,7 +246,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   std::cout << "abs(r^2 - dr^2) = " << std::abs(r * r - dot(dr, dr))
             << " epsilon = " << std::numeric_limits<double>::epsilon() << std::endl;
 #if defined(MIXED_PRECISION)
-  REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon() * 1e5);
+  REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon() * 1e8);
 #else
   REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon());
 #endif


### PR DESCRIPTION
## Proposed changes

 Currently wavefunction unit test is failing for mixed precision build on nitrogen and sulfur because double precision tolerance for r^2 == dr^2 check in test_hybridrep.cpp is too small for the mixed precision.
 This PR is to add separated tolerance for mixed precision build as the number between double and float. 

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
