### PR TITLE
Enable to print abs(r^2-dr^2) and epsilon for the hybrid_rep wavefunction…

### DIFF
--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -243,6 +243,8 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   elec_.getDistTable(0).get_first_neighbor(0, r, dr, false);
   std::cout << std::setprecision(14) << "check r^2 against dr^2. "
             << "r = " << r << " dr = " << dr << std::endl;
+  std::cout << "abs(r^2 - dr^2) = " << std::abs(r * r - dot(dr, dr))
+            << " epsilon = " << std::numeric_limits<double>::epsilon() << std::endl;
   REQUIRE(std::abs(r * r - dot(dr, dr)) < std::numeric_limits<double>::epsilon());
 
   // for vgl


### PR DESCRIPTION
## Proposed changes

 See #2578.
 Printing std::abs(r * r - dot(dr, dr)) and std::numeric_limits::epsilon() for the wavefunction unit test is needed to see detailed information of failure in the mixed-precision build on nitrogen and sulfur.

## What type(s) of changes does this code introduce?

- Other (please describe): Add test

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
