### PR TITLE
Optimize offload kernels for Clang

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
@@ -45,7 +45,7 @@ inline void assign_v(ST x,
   TT* restrict psi_s     = results_scratch_ptr;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp parallel for simd
+#pragma omp for simd
 #else
 #pragma omp simd
 #endif
@@ -113,7 +113,7 @@ inline void assign_vgl(ST x,
   TT* restrict dpsi  = results_scratch_ptr + orb_size;
   TT* restrict d2psi = results_scratch_ptr + orb_size * 4;
 #ifdef ENABLE_OFFLOAD
-#pragma omp for
+#pragma omp for simd
 #else
 #pragma omp simd
 #endif
@@ -296,7 +296,9 @@ void SplineC2ROMP<ST>::evaluateValue(const ParticleSet& P, const int iat, ValueV
         ST a[4], b[4], c[4];
         spline2::computeLocationAndFractional(spline_ptr, rux, ruy, ruz, ix, iy, iz, a, b, c);
 
+        PRAGMA_OFFLOAD("omp parallel")
         spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_ptr + first, first, last);
+        PRAGMA_OFFLOAD("omp parallel")
         C2R::assign_v(x, y, z, psi_ptr, orb_size, offload_scratch_ptr, myKcart_ptr, myKcart_padded_size,
                       first_spo_local, nComplexBands_local, first / 2, last / 2);
       }
@@ -376,8 +378,10 @@ void SplineC2ROMP<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
         spline2::computeLocationAndFractional(spline_ptr, ST(pos_scratch[iat * 6 + 3]), ST(pos_scratch[iat * 6 + 4]),
                                               ST(pos_scratch[iat * 6 + 5]), ix, iy, iz, a, b, c);
 
+        PRAGMA_OFFLOAD("omp parallel")
         spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_iat_ptr + first, first,
                                            last);
+        PRAGMA_OFFLOAD("omp parallel")
         C2R::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
                       psi_iat_ptr, orb_size, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size,
                       first_spo_local, nComplexBands_local, first / 2, last / 2);
@@ -492,8 +496,10 @@ void SplineC2ROMP<ST>::mw_evaluateDetRatios(const RefVector<SPOSet>& spo_list,
         spline2::computeLocationAndFractional(spline_ptr, ST(pos_scratch[iat * 6 + 3]), ST(pos_scratch[iat * 6 + 4]),
                                               ST(pos_scratch[iat * 6 + 5]), ix, iy, iz, a, b, c);
 
+        PRAGMA_OFFLOAD("omp parallel")
         spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_iat_ptr + first, first,
                                            last);
+        PRAGMA_OFFLOAD("omp parallel")
         C2R::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
                       psi_iat_ptr, orb_size, offload_scratch_iat_ptr, myKcart_ptr, myKcart_padded_size,
                       first_spo_local, nComplexBands_local, first / 2, last / 2);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
@@ -45,7 +45,7 @@ inline void assign_v(ST x,
   TT* restrict psi_s     = results_scratch_ptr;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp for simd
+#pragma omp for simd nowait
 #else
 #pragma omp simd
 #endif
@@ -113,7 +113,7 @@ inline void assign_vgl(ST x,
   TT* restrict dpsi  = results_scratch_ptr + orb_size;
   TT* restrict d2psi = results_scratch_ptr + orb_size * 4;
 #ifdef ENABLE_OFFLOAD
-#pragma omp for simd
+#pragma omp for simd nowait
 #else
 #pragma omp simd
 #endif
@@ -705,13 +705,12 @@ void SplineC2ROMP<ST>::evaluateVGL(const ParticleSet& P,
                             GGt_ptr[4], GGt_ptr[5] + GGt_ptr[7], GGt_ptr[8]};
 
       PRAGMA_OFFLOAD("omp parallel")
-      {
-        spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                             offload_scratch_ptr + first, offload_scratch_ptr + padded_size + first,
-                                             offload_scratch_ptr + padded_size * 4 + first, padded_size, first, last);
-        C2R::assign_vgl(x, y, z, results_scratch_ptr, mKK_ptr, orb_size, offload_scratch_ptr, padded_size, symGGt, G,
-                        myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local, first / 2, last / 2);
-      }
+      spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
+                                           offload_scratch_ptr + first, offload_scratch_ptr + padded_size + first,
+                                           offload_scratch_ptr + padded_size * 4 + first, padded_size, first, last);
+      PRAGMA_OFFLOAD("omp parallel")
+      C2R::assign_vgl(x, y, z, results_scratch_ptr, mKK_ptr, orb_size, offload_scratch_ptr, padded_size, symGGt, G,
+                      myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local, first / 2, last / 2);
     }
   }
 
@@ -785,16 +784,15 @@ void SplineC2ROMP<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedAllocat
                               GGt_ptr[4], GGt_ptr[5] + GGt_ptr[7], GGt_ptr[8]};
 
         PRAGMA_OFFLOAD("omp parallel")
-        {
-          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                               offload_scratch_iw_ptr + first,
-                                               offload_scratch_iw_ptr + padded_size + first,
-                                               offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
-                                               last);
-          C2R::assign_vgl(pos_copy_ptr[iw * 6], pos_copy_ptr[iw * 6 + 1], pos_copy_ptr[iw * 6 + 2], psi_iw_ptr, mKK_ptr,
-                          orb_size, offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
-                          first_spo_local, nComplexBands_local, first / 2, last / 2);
-        }
+        spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
+                                             offload_scratch_iw_ptr + first,
+                                             offload_scratch_iw_ptr + padded_size + first,
+                                             offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
+                                             last);
+        PRAGMA_OFFLOAD("omp parallel")
+        C2R::assign_vgl(pos_copy_ptr[iw * 6], pos_copy_ptr[iw * 6 + 1], pos_copy_ptr[iw * 6 + 2], psi_iw_ptr, mKK_ptr,
+                        orb_size, offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
+                        first_spo_local, nComplexBands_local, first / 2, last / 2);
       }
   }
 
@@ -935,16 +933,15 @@ void SplineC2ROMP<ST>::mw_evaluateVGLandDetRatioGrads(const RefVector<SPOSet>& s
                               GGt_ptr[4], GGt_ptr[5] + GGt_ptr[7], GGt_ptr[8]};
 
         PRAGMA_OFFLOAD("omp parallel")
-        {
-          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                               offload_scratch_iw_ptr + first,
-                                               offload_scratch_iw_ptr + padded_size + first,
-                                               offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
-                                               last);
-          C2R::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, mKK_ptr, orb_size,
-                          offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
-                          first_spo_local, nComplexBands_local, first / 2, last / 2);
-        }
+        spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
+                                             offload_scratch_iw_ptr + first,
+                                             offload_scratch_iw_ptr + padded_size + first,
+                                             offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
+                                             last);
+        PRAGMA_OFFLOAD("omp parallel")
+        C2R::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, mKK_ptr, orb_size,
+                        offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
+                        first_spo_local, nComplexBands_local, first / 2, last / 2);
 
         // FIXME :: copy results_scratch to phi_vgl_v  and do reduction
         ValueType* restrict psi   = psi_iw_ptr;

--- a/src/spline2/MultiBsplineVGLH_OMPoffload.hpp
+++ b/src/spline2/MultiBsplineVGLH_OMPoffload.hpp
@@ -285,7 +285,7 @@ inline void evaluate_vgh_impl_v2(const typename qmcplusplus::bspline_traits<T, 3
   const intptr_t zs = spline_m->z_stride;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp for simd
+#pragma omp for simd nowait
 #else
 #pragma omp simd aligned(vals, grads, hess)
 #endif

--- a/src/spline2/MultiBsplineVGLH_OMPoffload.hpp
+++ b/src/spline2/MultiBsplineVGLH_OMPoffload.hpp
@@ -285,7 +285,7 @@ inline void evaluate_vgh_impl_v2(const typename qmcplusplus::bspline_traits<T, 3
   const intptr_t zs = spline_m->z_stride;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp for
+#pragma omp for simd
 #else
 #pragma omp simd aligned(vals, grads, hess)
 #endif

--- a/src/spline2/MultiBsplineValue_OMPoffload.hpp
+++ b/src/spline2/MultiBsplineValue_OMPoffload.hpp
@@ -80,7 +80,7 @@ inline void evaluate_v_impl_v2(const typename qmcplusplus::bspline_traits<T, 3>:
   const intptr_t zs = spline_m->z_stride;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp for simd
+#pragma omp for simd nowait
 #else
 #pragma omp simd aligned(vals)
 #endif

--- a/src/spline2/MultiBsplineValue_OMPoffload.hpp
+++ b/src/spline2/MultiBsplineValue_OMPoffload.hpp
@@ -80,7 +80,7 @@ inline void evaluate_v_impl_v2(const typename qmcplusplus::bspline_traits<T, 3>:
   const intptr_t zs = spline_m->z_stride;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp parallel for simd
+#pragma omp for simd
 #else
 #pragma omp simd aligned(vals)
 #endif

--- a/src/spline2/MultiBsplineValue_OMPoffload.hpp
+++ b/src/spline2/MultiBsplineValue_OMPoffload.hpp
@@ -80,7 +80,7 @@ inline void evaluate_v_impl_v2(const typename qmcplusplus::bspline_traits<T, 3>:
   const intptr_t zs = spline_m->z_stride;
 
 #ifdef ENABLE_OFFLOAD
-#pragma omp for
+#pragma omp parallel for simd
 #else
 #pragma omp simd aligned(vals)
 #endif


### PR DESCRIPTION
## Proposed changes
Optimize offload kernels for Clang. Workaround a current code generation/optimization issue in Clang.
The impact on XL is negligible.

Currently I'm forced to split "parallel" and "for" to have "parallel" and "target teams distribute" in the same compiler translation unit.
Eventually, I prefer to move "omp parallel" to the "omp for" side and perhaps use "omp loop" eventually.

## What type(s) of changes does this code introduce?
- Other (please describe): performance optimization.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'