### PR TITLE
Remove state sequence constraint on OhmmsVector 

### DIFF
--- a/src/Containers/OhmmsPETE/OhmmsVector.h
+++ b/src/Containers/OhmmsPETE/OhmmsVector.h
@@ -109,8 +109,12 @@ public:
   // Attach to pre-allocated memory
   inline void attachReference(T* ref, size_t n)
   {
-    if (nAllocated)
-      throw std::runtime_error("Pointer attaching is not allowed on Vector with allocated memory.");
+    if (nAllocated) {
+      free();
+      std::cerr << "Allocated OhmmsVector attachReference called.\n" << std::endl;
+      // Nice idea but "default" constructed WFC elements in the batched driver make this a mess.
+      //throw std::runtime_error("Pointer attaching is not allowed on Vector with allocated memory.");
+    }
     nLocal     = n;
     nAllocated = 0;
     X          = ref;

--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -164,7 +164,11 @@ struct VectorSoaContainer
   __forceinline void attachReference(size_t n, size_t n_padded, T* ptr)
   {
     if (nAllocated)
-      throw std::runtime_error("Pointer attaching is not allowed on VectorSoaContainer with allocated memory.");
+    {
+      free();
+      std::cerr << "OhmmsVectorSoa attachReference called on previously allocated vector.\n" << std::endl;
+      // Nice idea but "default" constructed WFC elements in the batched driver make this a mess.
+    }
     nLocal  = n;
     nGhosts = n_padded;
     myData  = ptr;


### PR DESCRIPTION
DiracDeterminants and potentially other WFC for MPI sent walkers in DMCBatched don't register data as this wipes out certain state they get by being "copies" of the gold or good walkers, but they still have the some OhmmsVector allocations from construction.  This is due to trying to remove some of the state trasforms that walkers pointlessly go through in legacy, someday it should be possible to just construct on from data coming over MPI rather than have to have one that has gone through a long series of state changes and then has just certain data copied into it from the Walker.DataSet. 

However a check in OhmmsVector assumes that the path to an attach reference will always pass through a registerData or be done by an unallocated OhmmsVector. This breakls future PRs for the batchedDMC. That code will be in a future PR so the review burden is easier take my word for it that this is necessary and the simplest way to accomplish what needs to done then.

When I rewrite Walker and remove the DataSet in favor of buffering only walkers to be sent or being recieved this will likely be removed.

## Proposed changes

removal of the check in OhmmsVector that would not WFC belonging to a walker spawned for an mpi recieve to attach to received data since they had not previously registered data with a buffer attach.

## What type(s) of changes does this code introduce?
- Removal of state sequence constraint for OhmmsVector

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Leconte

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- Yeso Code added or changed in the PR has been clang-formatted
- N/A This PR adds tests to cover any new code, or to catch a bug that is being fixed