### PR TITLE
Define LRCoulombSingleton handler ownership.

### DIFF
--- a/src/Particle/LongRange/LRCoulombSingleton.cpp
+++ b/src/Particle/LongRange/LRCoulombSingleton.cpp
@@ -108,7 +108,7 @@ struct PseudoCoulombFunctor
 };
 
 
-LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getHandler(ParticleSet& ref)
+std::unique_ptr<LRCoulombSingleton::LRHandlerType> LRCoulombSingleton::getHandler(ParticleSet& ref)
 {
   if (CoulombHandler == 0)
   {
@@ -150,15 +150,16 @@ LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getHandler(ParticleSet& r
     CoulombHandler = std::make_unique<TwoDEwaldHandler>(ref);
 #endif
     CoulombHandler->initBreakup(ref);
-    return CoulombHandler->makeClone(ref);
+    return std::unique_ptr<LRHandlerType>(CoulombHandler->makeClone(ref));
   }
   else
   {
     app_log() << "  Clone CoulombHandler. " << std::endl;
-    return CoulombHandler->makeClone(ref);
+    return std::unique_ptr<LRHandlerType>(CoulombHandler->makeClone(ref));
   }
 }
-LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getDerivHandler(ParticleSet& ref)
+
+std::unique_ptr<LRCoulombSingleton::LRHandlerType> LRCoulombSingleton::getDerivHandler(ParticleSet& ref)
 {
 #if OHMMS_DIM != 3
   APP_ABORT("energy derivative implemented for 3D only");
@@ -184,18 +185,13 @@ LRCoulombSingleton::LRHandlerType* LRCoulombSingleton::getDerivHandler(ParticleS
     {
       APP_ABORT("\n  Long range breakup method for derivatives not recognized.\n");
     }
-    // CoulombDerivHandler = new LRDerivHandler<CoulombFunctor<mRealType>, LPQHIBasis> (ref);
-    //CoulombDerivHandler= new EwaldHandler(ref);
     CoulombDerivHandler->initBreakup(ref);
-    //return CoulombDerivHandler;
-
-    return CoulombDerivHandler->makeClone(ref);
+    return std::unique_ptr<LRHandlerType>(CoulombDerivHandler->makeClone(ref));
   }
   else
   {
     app_log() << "  Clone CoulombDerivHandler. " << std::endl;
-    return CoulombDerivHandler->makeClone(ref);
-    // return CoulombDerivHandler;
+    return std::unique_ptr<LRHandlerType>(CoulombDerivHandler->makeClone(ref));
   }
 }
 

--- a/src/Particle/LongRange/LRCoulombSingleton.h
+++ b/src/Particle/LongRange/LRCoulombSingleton.h
@@ -50,9 +50,9 @@ struct LRCoulombSingleton
   ///Stores the force/stress optimized LR handler.
   static std::unique_ptr<LRHandlerType> CoulombDerivHandler;
   ///This returns an energy optimized LR handler.  If non existent, it creates one.
-  static LRHandlerType* getHandler(ParticleSet& ref);
+  static std::unique_ptr<LRHandlerType> getHandler(ParticleSet& ref);
   ///This returns a force/stress optimized LR handler.  If non existent, it creates one.
-  static LRHandlerType* getDerivHandler(ParticleSet& ref);
+  static std::unique_ptr<LRHandlerType> getDerivHandler(ParticleSet& ref);
 
   //The following two helper functions are provided to spline the short-range component
   //of the coulomb potential and its derivative.  This is much faster than evaluating

--- a/src/Particle/LongRange/LRCoulombSingleton.h
+++ b/src/Particle/LongRange/LRCoulombSingleton.h
@@ -19,6 +19,7 @@
 #ifndef QMCPLUSPLUS_LRCOULOMBSINGLETON_H
 #define QMCPLUSPLUS_LRCOULOMBSINGLETON_H
 
+#include <memory>
 #include <config.h>
 #include "LongRange/LRHandlerTemp.h"
 #include "LongRange/LRHandlerSRCoulomb.h"
@@ -37,12 +38,17 @@ struct LRCoulombSingleton
   typedef LinearGrid<pRealType> GridType;
   typedef OneDimCubicSpline<pRealType> RadFunctorType;
 
-  enum lr_type {ESLER=0, EWALD, NATOLI};
+  enum lr_type
+  {
+    ESLER = 0,
+    EWALD,
+    NATOLI
+  };
   static lr_type this_lr_type;
   ///Stores the energ optimized LR handler.
-  static LRHandlerType* CoulombHandler;
+  static std::unique_ptr<LRHandlerType> CoulombHandler;
   ///Stores the force/stress optimized LR handler.
-  static LRHandlerType* CoulombDerivHandler;
+  static std::unique_ptr<LRHandlerType> CoulombDerivHandler;
   ///This returns an energy optimized LR handler.  If non existent, it creates one.
   static LRHandlerType* getHandler(ParticleSet& ref);
   ///This returns a force/stress optimized LR handler.  If non existent, it creates one.

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -24,10 +24,8 @@ namespace qmcplusplus
 {
 CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
     : ForceBase(ref, ref),
-      AA(0),
       myGrid(0),
       rVs(0),
-      dAA(0),
       myGridforce(0),
       rVsforce(0),
       is_active(active),
@@ -308,14 +306,14 @@ void CoulombPBCAA::initBreakup(ParticleSet& P)
   myRcut  = AA->get_rc(); //Basis.get_rc();
   if (rVs == 0)
   {
-    rVs = LRCoulombSingleton::createSpline4RbyVs(AA, myRcut, myGrid);
+    rVs = LRCoulombSingleton::createSpline4RbyVs(AA.get(), myRcut, myGrid);
   }
   if (ComputeForces)
   {
     dAA = LRCoulombSingleton::getDerivHandler(P);
     if (rVsforce == 0)
     {
-      rVsforce = LRCoulombSingleton::createSpline4RbyVs(dAA, myRcut, myGridforce);
+      rVsforce = LRCoulombSingleton::createSpline4RbyVs(dAA.get(), myRcut, myGridforce);
     }
   }
 

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -36,12 +36,18 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
   typedef LRCoulombSingleton::RadFunctorType RadFunctorType;
   typedef LRHandlerType::mRealType mRealType;
 
+  // using shared_ptr on AA, dAA is a compromise
+  // When ion-ion is_active = false, makeClone calls the copy constructor.
+  // AA, dAA are shared between clones.
+  // When elec-elec is_active = true, makeClone calls the constructor
+  // AA, dAA are not shared between clones and behave more like unique_ptr
+
   // energy-optimized
-  LRHandlerType* AA;
+  std::shared_ptr<LRHandlerType> AA;
   GridType* myGrid;
   RadFunctorType* rVs;
   // force-optimized
-  LRHandlerType* dAA;
+  std::shared_ptr<LRHandlerType> dAA;
   GridType* myGridforce;
   RadFunctorType* rVsforce;
 

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -470,7 +470,7 @@ void CoulombPBCAB::initBreakup(ParticleSet& P)
   // create the spline function for the short-range part assuming pure potential
   if (V0 == nullptr)
   {
-    V0 = LRCoulombSingleton::createSpline4RbyVs(AB, myRcut, myGrid);
+    V0 = LRCoulombSingleton::createSpline4RbyVs(AB.get(), myRcut, myGrid);
     if (Vat.size())
     {
       APP_ABORT("CoulombPBCAB::initBreakup.  Vat is not empty\n");
@@ -484,9 +484,9 @@ void CoulombPBCAB::initBreakup(ParticleSet& P)
   {
     dAB = LRCoulombSingleton::getDerivHandler(P);
     if (fV0 == nullptr)
-      fV0 = LRCoulombSingleton::createSpline4RbyVs(dAB, myRcut, myGrid);
+      fV0 = LRCoulombSingleton::createSpline4RbyVs(dAB.get(), myRcut, myGrid);
     if (dfV0 == nullptr)
-      dfV0 = LRCoulombSingleton::createSpline4RbyVsDeriv(dAB, myRcut, myGrid);
+      dfV0 = LRCoulombSingleton::createSpline4RbyVsDeriv(dAB.get(), myRcut, myGrid);
     if (fVat.size())
     {
       APP_ABORT("CoulombPBCAB::initBreakup.  Vat is not empty\n");

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -42,9 +42,9 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///source particle set
   ParticleSet& PtclA;
   ///long-range Handler
-  LRHandlerType* AB;
+  std::unique_ptr<LRHandlerType> AB;
   ///long-range derivative handler
-  LRHandlerType* dAB;
+  std::unique_ptr<LRHandlerType> dAB;
   ///locator of the distance table
   const int myTableIndex;
   ///number of species of A particle set

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.h
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.h
@@ -38,7 +38,7 @@ struct ForceChiesaPBCAA : public OperatorBase, public ForceBase
   ///source particle set
   ParticleSet& PtclA;
   ///long-range Handler
-  LRHandlerType* dAB;
+  std::unique_ptr<LRHandlerType> dAB;
   ///number of species of A particle set
   int NumSpeciesA;
   ///number of species of B particle set

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
   ParticleSetPool ptcl = ParticleSetPool(c);
 
 
-  CoulombPBCAB_CUDA cab = CoulombPBCAB_CUDA(ions, elec);
+  CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
   double consts = cab.evalConsts();
@@ -158,7 +158,7 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
   ParticleSetPool ptcl = ParticleSetPool(c);
 
 
-  CoulombPBCAB_CUDA cab = CoulombPBCAB_CUDA(ions, elec);
+  CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
   double consts = cab.evalConsts();
@@ -227,7 +227,7 @@ TEST_CASE("Coulomb PBC A-A CUDA BCC H", "[hamiltonian][CUDA]")
   ions.updateLists_GPU();
 
 
-  CoulombPBCAA_CUDA caa = CoulombPBCAA_CUDA(ions, true);
+  CoulombPBCAA_CUDA caa(ions, true);
 
   // Background charge term
   double consts = caa.evalConsts();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
@@ -53,10 +53,10 @@ TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
   int pMembersizeIdx                = ion_species.addAttribute("membersize");
   ion_species(pChargeIdx, pIdx)     = 1;
   ion_species(pMembersizeIdx, pIdx) = 1;
-  ions.Lattice = Lattice;
+  ions.Lattice                      = Lattice;
   ions.createSK();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
 
@@ -68,8 +68,7 @@ TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
   double val = caa.evaluate(ions);
   REQUIRE(val == Approx(-1.418927)); // not validated
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
 }
 
 TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
@@ -102,10 +101,10 @@ TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
   int pMembersizeIdx                = ion_species.addAttribute("membersize");
   ion_species(pChargeIdx, pIdx)     = 1;
   ion_species(pMembersizeIdx, pIdx) = 2;
-  ions.Lattice = Lattice;
+  ions.Lattice                      = Lattice;
   ions.createSK();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
   CoulombPBCAA caa = CoulombPBCAA(ions, false);
@@ -117,8 +116,7 @@ TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
   double val = caa.evaluate(elec);
   REQUIRE(val == Approx(-0.963074)); // not validated
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
 }
 
 TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
@@ -140,19 +138,19 @@ TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
   elec.R[0][1] = 0.5;
   elec.R[0][2] = 0.0;
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  int pMembersizeIdx           = tspecies.addAttribute("membersize");
-  tspecies(pMembersizeIdx, upIdx)   = 1;
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies            = elec.getSpeciesSet();
+  int upIdx                       = tspecies.addSpecies("u");
+  int chargeIdx                   = tspecies.addAttribute("charge");
+  int massIdx                     = tspecies.addAttribute("mass");
+  int pMembersizeIdx              = tspecies.addAttribute("membersize");
+  tspecies(pMembersizeIdx, upIdx) = 1;
+  tspecies(chargeIdx, upIdx)      = -1;
+  tspecies(massIdx, upIdx)        = 1.0;
 
   elec.createSK();
   elec.update();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(elec);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(elec);
   LRCoulombSingleton::CoulombHandler->initBreakup(elec);
 
   CoulombPBCAA caa = CoulombPBCAA(elec, false);
@@ -164,8 +162,7 @@ TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
   double val = caa.evaluate(elec);
   REQUIRE(val == Approx(-1.418927)); // not validated
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
 }
 
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   ParticleSetPool ptcl = ParticleSetPool(c);
 
 
-  CoulombPBCAB cab = CoulombPBCAB(ions, elec);
+  CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
   double consts = cab.evalConsts();
@@ -167,7 +167,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   ParticleSetPool ptcl = ParticleSetPool(c);
 
 
-  CoulombPBCAB cab = CoulombPBCAB(ions, elec);
+  CoulombPBCAB cab(ions, elec);
 
   // Background charge term
   double consts = cab.evalConsts();

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -49,13 +49,13 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
   //  ions.Lattice.LR_dim_cutoff=40;
 
-  SpeciesSet& ion_species       = ions.getSpeciesSet();
-  int pIdx                      = ion_species.addSpecies("H");
-  int pChargeIdx                = ion_species.addAttribute("charge");
-  int pMembersizeIdx            = ion_species.addAttribute("membersize");
-  ion_species(pChargeIdx, pIdx) = 1;
+  SpeciesSet& ion_species           = ions.getSpeciesSet();
+  int pIdx                          = ion_species.addSpecies("H");
+  int pChargeIdx                    = ion_species.addAttribute("charge");
+  int pMembersizeIdx                = ion_species.addAttribute("membersize");
+  ion_species(pChargeIdx, pIdx)     = 1;
   ion_species(pMembersizeIdx, pIdx) = 1;
-  ions.Lattice = Lattice;
+  ions.Lattice                      = Lattice;
   ions.createSK();
 
 
@@ -66,14 +66,14 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   elec.R[0][1] = 0.0;
   elec.R[0][2] = 0.0;
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  int MembersizeIdx            = tspecies.addAttribute("membersize");
-  tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies           = elec.getSpeciesSet();
+  int upIdx                      = tspecies.addSpecies("u");
+  int chargeIdx                  = tspecies.addAttribute("charge");
+  int massIdx                    = tspecies.addAttribute("mass");
+  int MembersizeIdx              = tspecies.addAttribute("membersize");
+  tspecies(MembersizeIdx, upIdx) = 1;
+  tspecies(chargeIdx, upIdx)     = -1;
+  tspecies(massIdx, upIdx)       = 1.0;
 
   elec.createSK();
 
@@ -83,7 +83,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
   ParticleSetPool ptcl = ParticleSetPool(c);
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
 
@@ -91,10 +91,10 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
   // Self energy plus Background charge term
   double consts = cab.evalConsts();
-  REQUIRE(consts == Approx(0.0523598776*2)); //not validated
+  REQUIRE(consts == Approx(0.0523598776 * 2)); //not validated
 
   double val_ei = cab.evaluate(elec);
-  REQUIRE(val_ei == Approx(-0.008302+0.0523598776*2)); //Not validated
+  REQUIRE(val_ei == Approx(-0.008302 + 0.0523598776 * 2)); //Not validated
 
   CoulombPBCAA caa_elec = CoulombPBCAA(elec, false);
   CoulombPBCAA caa_ion  = CoulombPBCAA(ions, false);
@@ -107,8 +107,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   REQUIRE(sum == Approx(-2.741436)); // Can be validated via Ewald summation elsewhere
                                      // -2.74136517454081
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
 }
 
 TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
@@ -135,13 +134,13 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   ions.R[1][2] = 1.88972614;
 
 
-  SpeciesSet& ion_species       = ions.getSpeciesSet();
-  int pIdx                      = ion_species.addSpecies("H");
-  int pChargeIdx                = ion_species.addAttribute("charge");
-  int pMembersizeIdx            = ion_species.addAttribute("membersize");
-  ion_species(pChargeIdx, pIdx) = 1;
+  SpeciesSet& ion_species           = ions.getSpeciesSet();
+  int pIdx                          = ion_species.addSpecies("H");
+  int pChargeIdx                    = ion_species.addAttribute("charge");
+  int pMembersizeIdx                = ion_species.addAttribute("membersize");
+  ion_species(pChargeIdx, pIdx)     = 1;
   ion_species(pMembersizeIdx, pIdx) = 2;
-  ions.Lattice = Lattice;
+  ions.Lattice                      = Lattice;
   ions.createSK();
 
 
@@ -156,14 +155,14 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   elec.R[1][2] = 0.0;
 
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  int MembersizeIdx            = tspecies.addAttribute("membersize");
-  tspecies(MembersizeIdx, upIdx)   = 1;
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies           = elec.getSpeciesSet();
+  int upIdx                      = tspecies.addSpecies("u");
+  int chargeIdx                  = tspecies.addAttribute("charge");
+  int massIdx                    = tspecies.addAttribute("mass");
+  int MembersizeIdx              = tspecies.addAttribute("membersize");
+  tspecies(MembersizeIdx, upIdx) = 1;
+  tspecies(chargeIdx, upIdx)     = -1;
+  tspecies(massIdx, upIdx)       = 1.0;
 
   elec.createSK();
 
@@ -174,18 +173,18 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
 
   ParticleSetPool ptcl = ParticleSetPool(c);
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
   CoulombPBCAB cab = CoulombPBCAB(ions, elec);
 
   // Background charge term
   double consts = cab.evalConsts();
-  REQUIRE(consts == Approx(0.0277076538*4)); //not validated
+  REQUIRE(consts == Approx(0.0277076538 * 4)); //not validated
 
 
   double val_ei = cab.evaluate(elec);
-  REQUIRE(val_ei == Approx(-2.223413+0.0277076538*4)); //Not validated
+  REQUIRE(val_ei == Approx(-2.223413 + 0.0277076538 * 4)); //Not validated
 
 
   CoulombPBCAA caa_elec = CoulombPBCAA(elec, false);
@@ -194,13 +193,12 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   double val_ii         = caa_ion.evaluate(ions);
   double sum            = val_ee + val_ii + val_ei;
 
-  REQUIRE(val_ee == Approx(-0.012808-0.0277076538*2));
-  REQUIRE(val_ii == Approx(-0.907659-0.0277076538*2));
+  REQUIRE(val_ee == Approx(-0.012808 - 0.0277076538 * 2));
+  REQUIRE(val_ii == Approx(-0.907659 - 0.0277076538 * 2));
   REQUIRE(sum == Approx(-3.143880)); // Can be validated via Ewald summation elsewhere
                                      // -3.14349127313640
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
 
-  CoulombPBCAB cab = CoulombPBCAB(ions, elec);
+  CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
   double consts = cab.evalConsts();
@@ -176,7 +176,7 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
-  CoulombPBCAB cab = CoulombPBCAB(ions, elec);
+  CoulombPBCAB cab(ions, elec);
 
   // Background charge term
   double consts = cab.evalConsts();

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
   int pIdx                      = ion_species.addSpecies("H");
   int pChargeIdx                = ion_species.addAttribute("charge");
   ion_species(pChargeIdx, pIdx) = 1;
-  ions.Lattice = Lattice;
+  ions.Lattice                  = Lattice;
   ions.createSK();
 
 
@@ -73,12 +73,12 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
   elec.R[1][2] = 0.0;
 
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
 
   elec.createSK();
 
@@ -90,9 +90,9 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
   // settings to the ParticleSet
   elec.resetGroups();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
-  LRCoulombSingleton::CoulombDerivHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombDerivHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombDerivHandler->initBreakup(ions);
 
   ForceChiesaPBCAA force(ions, elec);
@@ -118,12 +118,8 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
   REQUIRE(force.forces[1][1] == Approx(-0.078308730));
   REQUIRE(force.forces[1][2] == Approx(0.000000000));
 
-
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
-
-  delete LRCoulombSingleton::CoulombDerivHandler;
-  LRCoulombSingleton::CoulombDerivHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
+  LRCoulombSingleton::CoulombDerivHandler.reset(nullptr);
 }
 
 // test SR and LR pieces separately
@@ -154,7 +150,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   int pIdx                      = ion_species.addSpecies("H");
   int pChargeIdx                = ion_species.addAttribute("charge");
   ion_species(pChargeIdx, pIdx) = 1;
-  ions.Lattice = Lattice;
+  ions.Lattice                  = Lattice;
   ions.createSK();
 
 
@@ -167,13 +163,13 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   elec.R[1][1] = 0.5;
   elec.R[1][2] = 0.0;
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
-  elec.Lattice = Lattice;
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
+  elec.Lattice               = Lattice;
   elec.createSK();
 
   // The call to resetGroups is needed transfer the SpeciesSet
@@ -181,9 +177,9 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   ions.resetGroups();
   elec.resetGroups();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
-  LRCoulombSingleton::CoulombDerivHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombDerivHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombDerivHandler->initBreakup(ions);
 
   ForceChiesaPBCAA force(ions, elec);
@@ -215,9 +211,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
   TrialWaveFunction psi(c);
-  std::unique_ptr<ForceChiesaPBCAA> clone(
-    dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec,psi))
-  );
+  std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi)));
   clone->evaluate(elec);
   REQUIRE(clone->addionion == force.addionion);
   REQUIRE(clone->forces_IonIon[0][0] == Approx(-0.0228366));
@@ -227,11 +221,8 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   REQUIRE(clone->forces_IonIon[1][1] == Approx(0.0228366));
   REQUIRE(clone->forces_IonIon[1][2] == Approx(0.0000000));
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
-
-  delete LRCoulombSingleton::CoulombDerivHandler;
-  LRCoulombSingleton::CoulombDerivHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
+  LRCoulombSingleton::CoulombDerivHandler.reset(nullptr);
 }
 
 // 3 H atoms randomly distributed in a box
@@ -265,7 +256,7 @@ TEST_CASE("fccz h3", "[hamiltonian]")
   int pIdx                      = ion_species.addSpecies("H");
   int pChargeIdx                = ion_species.addAttribute("charge");
   ion_species(pChargeIdx, pIdx) = 1;
-  ions.Lattice = Lattice;
+  ions.Lattice                  = Lattice;
   ions.createSK();
 
   elec.setName("elec");
@@ -277,13 +268,13 @@ TEST_CASE("fccz h3", "[hamiltonian]")
   elec.R[1][1] = 0.5;
   elec.R[1][2] = 0.0;
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
-  elec.Lattice = Lattice;
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
+  elec.Lattice               = Lattice;
   elec.createSK();
 
   // The call to resetGroups is needed transfer the SpeciesSet
@@ -291,9 +282,9 @@ TEST_CASE("fccz h3", "[hamiltonian]")
   ions.resetGroups();
   elec.resetGroups();
 
-  LRCoulombSingleton::CoulombHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
-  LRCoulombSingleton::CoulombDerivHandler = new EwaldHandler3D(ions);
+  LRCoulombSingleton::CoulombDerivHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombDerivHandler->initBreakup(ions);
 
   ForceChiesaPBCAA force(ions, elec);
@@ -324,11 +315,8 @@ TEST_CASE("fccz h3", "[hamiltonian]")
   REQUIRE(force.forces[2][1] == Approx(0.1379375923));
   REQUIRE(force.forces[2][2] == Approx(0.000000000));
 
-  delete LRCoulombSingleton::CoulombHandler;
-  LRCoulombSingleton::CoulombHandler = 0;
-
-  delete LRCoulombSingleton::CoulombDerivHandler;
-  LRCoulombSingleton::CoulombDerivHandler = 0;
+  LRCoulombSingleton::CoulombHandler.reset(nullptr);
+  LRCoulombSingleton::CoulombDerivHandler.reset(nullptr);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -171,7 +171,7 @@ void QMCFiniteSize::initBreakup()
   myRcut = AA->get_rc();
   if (rVs == 0)
   {
-    rVs = LRCoulombSingleton::createSpline4RbyVs(AA, myRcut, myGrid);
+    rVs = LRCoulombSingleton::createSpline4RbyVs(AA.get(), myRcut, myGrid);
   }
 }
 

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
@@ -61,7 +61,7 @@ private:
   RealType h; //this is for finite differencing.
   vector<PosType> sphericalgrid;
   GridType* myGrid;
-  LRHandlerType* AA;
+  std::unique_ptr<LRHandlerType> AA;
   RadFunctorType* rVs;
   bool processPWH(xmlNodePtr cur);
   void wfnPut(xmlNodePtr cur);


### PR DESCRIPTION
## Proposed changes
The ownership of handler in LRCoulombSingleton is vague due to using pointers. 
getHandler returns initial pointer if a new handler is created or a clone of the initial handler.
In this PR, the initial handler is owned by the LRCoulombSingleton and getHandler always returns a clone of the owned handler.
So far all the handlers are not const enough. So In CoulombPBC classes, every class has to own a handler clone, I cannot judge this is really needed or handlers can be shared (thread-safe). So far no change of the old behaviour. When all the long range pieces code are refactored in the future, several C++ design aspects must be closely looked at.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted