### PR TITLE
Add flex_evaluateDeltaLog

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -280,12 +280,12 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
 }
 
 
-void TrialWaveFunction::flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
-                                              const RefVector<ParticleSet>& p_list,
-                                              std::vector<RealType>& logpsi_fixed_list,
-                                              std::vector<RealType>& logpsi_opt_list,
-                                              RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
-                                              RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list)
+void TrialWaveFunction::flex_evaluateDeltaLogSetup(const RefVector<TrialWaveFunction>& wf_list,
+                                                   const RefVector<ParticleSet>& p_list,
+                                                   std::vector<RealType>& logpsi_fixed_list,
+                                                   std::vector<RealType>& logpsi_opt_list,
+                                                   RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
+                                                   RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list)
 {
   constexpr RealType czero(0);
   int num_particles = p_list[0].get().getTotalNum();

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -250,7 +250,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
 }
 
 
-/** evalaute the sum of log value of optimizable many-body wavefunctions
+/** evaluate the sum of log value of optimizable many-body wavefunctions
 * @param P  input configuration containing N particles
 * @param logpsi_fixed log(std::abs(psi)) of the invariant orbitals
 * @param logpsi_opt log(std::abs(psi)) of the variable orbitals
@@ -260,7 +260,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
 * This function is introduced for optimization only.
 * fixedG and fixedL save the terms coming from the wave functions
 * that are invarient during optimizations.
-* It is expected that evaluateLog(P,false) is called later
+* It is expected that evaluateDeltaLog(P,false) is called later
 * and the external object adds the varying G and L and the fixed terms.
 */
 void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
@@ -293,6 +293,21 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
   convert(logpsi_opt, logpsi_opt_r);
 }
 
+/** evaluate the sum of log value of optimizable many-body wavefunctions
+* @param wf_list vector of wavefunctions
+* @param p_list vector of input particle configurations
+* @param logpsi_fixed_list vector of log(std::abs(psi)) of the invariant orbitals
+* @param logpsi_opt_list vector of log(std::abs(psi)) of the variable orbitals
+* @param fixedG_list vector of gradients of log(psi) of the fixed wave functions
+* @param fixedL_list vector of laplacians of log(psi) of the fixed wave functions
+*
+* This function is introduced for optimization only.
+* fixedG and fixedL save the terms coming from the wave functions
+* that are invarient during optimizations.
+* It is expected that flex_evaluateDeltaLog(P,false) is called later
+* and the external object adds the varying G and L and the fixed terms.
+*/
+
 void TrialWaveFunction::flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
                                               const RefVector<ParticleSet>& p_list,
                                               std::vector<RealType>& logpsi_fixed_list,
@@ -318,27 +333,21 @@ void TrialWaveFunction::flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>
     initGandL(wf_list[iw], g_list[iw], l_list[iw]);
   auto& wavefunction_components = wf_list[0].get().Z;
   const int num_wfc             = wf_list[0].get().Z.size();
-  int ii                        = RECOMPUTE_TIMER;
-  for (int i = 0; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
   {
     ScopedTimer local_timer(wf_list[0].get().myTimers[ii]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     if (wavefunction_components[i]->Optimizable)
     {
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
-
       for (int iw = 0; iw < wf_list.size(); iw++)
-      {
         logpsi_opt_list[iw] += std::real(wfc_list[iw].get().LogValue);
-      }
     }
     else
     {
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, fixedG_list, fixedL_list);
       for (int iw = 0; iw < wf_list.size(); iw++)
-      {
         logpsi_fixed_list[iw] += std::real(wfc_list[iw].get().LogValue);
-      }
     }
   }
 }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -249,20 +249,6 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
   return LogValue;
 }
 
-
-/** evaluate the sum of log value of optimizable many-body wavefunctions
-* @param P  input configuration containing N particles
-* @param logpsi_fixed log(std::abs(psi)) of the invariant orbitals
-* @param logpsi_opt log(std::abs(psi)) of the variable orbitals
-* @param fixedG gradients of log(psi) of the fixed wave functions
-* @param fixedL laplacians of log(psi) of the fixed wave functions
-*
-* This function is introduced for optimization only.
-* fixedG and fixedL save the terms coming from the wave functions
-* that are invarient during optimizations.
-* It is expected that evaluateDeltaLog(P,false) is called later
-* and the external object adds the varying G and L and the fixed terms.
-*/
 void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
                                          RealType& logpsi_fixed_r,
                                          RealType& logpsi_opt_r,
@@ -293,20 +279,6 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
   convert(logpsi_opt, logpsi_opt_r);
 }
 
-/** evaluate the sum of log value of optimizable many-body wavefunctions
-* @param wf_list vector of wavefunctions
-* @param p_list vector of input particle configurations
-* @param logpsi_fixed_list vector of log(std::abs(psi)) of the invariant orbitals
-* @param logpsi_opt_list vector of log(std::abs(psi)) of the variable orbitals
-* @param fixedG_list vector of gradients of log(psi) of the fixed wave functions
-* @param fixedL_list vector of laplacians of log(psi) of the fixed wave functions
-*
-* This function is introduced for optimization only.
-* fixedG and fixedL save the terms coming from the wave functions
-* that are invarient during optimizations.
-* It is expected that flex_evaluateDeltaLog(P,false) is called later
-* and the external object adds the varying G and L and the fixed terms.
-*/
 
 void TrialWaveFunction::flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
                                               const RefVector<ParticleSet>& p_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -170,7 +170,7 @@ public:
    *
    * This function is introduced for optimization only.
    * fixedG and fixedL save the terms coming from the wave functions
-   * that are invarient during optimizations.
+   * that are invariant during optimizations.
    * It is expected that evaluateDeltaLog(P,false) is called later
    * and the external object adds the varying G and L and the fixed terms.
    */
@@ -188,18 +188,24 @@ public:
    * @param fixedG_list vector of gradients of log(psi) of the fixed wave functions
    * @param fixedL_list vector of laplacians of log(psi) of the fixed wave functions
    *
-   * This function is introduced for optimization only.
-   * fixedG and fixedL save the terms coming from the wave functions
-   * that are invarient during optimizations.
+   * For wavefunction optimization, it can speed evaluation to split the log value,
+   * the gradient, and the laplacian computed from wavefunction components with optimizable
+   * parameters from components that do not.  This function computes the log value of
+   * both parts, and the gradient and laplacian of the fixed components.
+   * During correlated sampling steps only the components with optimizable
+   * parameters need to have the gradient and laplacian re-evaluated.
+   *
+   * Parameters fixedG_list and fixedL_list save the terms coming from the components
+   * that do not have optimizable parameters.
    * It is expected that flex_evaluateDeltaLog(P,false) is called later
    * and the external object adds the varying G and L and the fixed terms.
    */
-  static void flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
-                                    const RefVector<ParticleSet>& p_list,
-                                    std::vector<RealType>& logpsi_fixed_list,
-                                    std::vector<RealType>& logpsi_opt_list,
-                                    RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
-                                    RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
+  static void flex_evaluateDeltaLogSetup(const RefVector<TrialWaveFunction>& wf_list,
+                                         const RefVector<ParticleSet>& p_list,
+                                         std::vector<RealType>& logpsi_fixed_list,
+                                         std::vector<RealType>& logpsi_opt_list,
+                                         RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
+                                         RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
 
 
   /** compute psi(R_new) / psi(R_current) ratio

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -167,6 +167,14 @@ public:
                         ParticleSet::ParticleGradient_t& fixedG,
                         ParticleSet::ParticleLaplacian_t& fixedL);
 
+  static void flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
+                             const RefVector<ParticleSet>& p_list,
+                             std::vector<RealType>& logpsi_fixed_list,
+                             std::vector<RealType>& logpsi_opt_list,
+                             RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
+                             RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
+
+
   /** compute psi(R_new) / psi(R_current) ratio
    * It returns a complex value if the wavefunction is complex.
    * @param P the active ParticleSet

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -161,18 +161,45 @@ public:
 
   RealType evaluateDeltaLog(ParticleSet& P, bool recompute = false);
 
+  /** evaluate the sum of log value of optimizable many-body wavefunctions
+   * @param P  input configuration containing N particles
+   * @param logpsi_fixed log(std::abs(psi)) of the invariant orbitals
+   * @param logpsi_opt log(std::abs(psi)) of the variable orbitals
+   * @param fixedG gradients of log(psi) of the fixed wave functions
+   * @param fixedL laplacians of log(psi) of the fixed wave functions
+   *
+   * This function is introduced for optimization only.
+   * fixedG and fixedL save the terms coming from the wave functions
+   * that are invarient during optimizations.
+   * It is expected that evaluateDeltaLog(P,false) is called later
+   * and the external object adds the varying G and L and the fixed terms.
+   */
   void evaluateDeltaLog(ParticleSet& P,
                         RealType& logpsi_fixed,
                         RealType& logpsi_opt,
                         ParticleSet::ParticleGradient_t& fixedG,
                         ParticleSet::ParticleLaplacian_t& fixedL);
 
+  /** evaluate the sum of log value of optimizable many-body wavefunctions
+   * @param wf_list vector of wavefunctions
+   * @param p_list vector of input particle configurations
+   * @param logpsi_fixed_list vector of log(std::abs(psi)) of the invariant orbitals
+   * @param logpsi_opt_list vector of log(std::abs(psi)) of the variable orbitals
+   * @param fixedG_list vector of gradients of log(psi) of the fixed wave functions
+   * @param fixedL_list vector of laplacians of log(psi) of the fixed wave functions
+   *
+   * This function is introduced for optimization only.
+   * fixedG and fixedL save the terms coming from the wave functions
+   * that are invarient during optimizations.
+   * It is expected that flex_evaluateDeltaLog(P,false) is called later
+   * and the external object adds the varying G and L and the fixed terms.
+   */
   static void flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
-                             const RefVector<ParticleSet>& p_list,
-                             std::vector<RealType>& logpsi_fixed_list,
-                             std::vector<RealType>& logpsi_opt_list,
-                             RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
-                             RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
+                                    const RefVector<ParticleSet>& p_list,
+                                    std::vector<RealType>& logpsi_fixed_list,
+                                    std::vector<RealType>& logpsi_opt_list,
+                                    RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
+                                    RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
 
 
   /** compute psi(R_new) / psi(R_current) ratio

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -192,8 +192,7 @@ UPtrVector<ParticleSet::ParticleGradient_t> create_particle_gradient(int nelec, 
   UPtrVector<ParticleSet::ParticleGradient_t> G_list;
   for (int i = 0; i < nentry; i++)
   {
-    G_list.push_back(std::make_unique<ParticleSet::ParticleGradient_t>());
-    G_list.back()->resize(nelec);
+    G_list.emplace_back(std::make_unique<ParticleSet::ParticleGradient_t>(nelec));
   }
   return G_list;
 }
@@ -203,8 +202,7 @@ UPtrVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec
   UPtrVector<ParticleSet::ParticleLaplacian_t> L_list;
   for (int i = 0; i < nentry; i++)
   {
-    L_list.push_back(std::make_unique<ParticleSet::ParticleLaplacian_t>());
-    L_list.back()->resize(nelec);
+    L_list.emplace_back(std::make_unique<ParticleSet::ParticleLaplacian_t>(nelec));
   }
   return L_list;
 }

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -191,9 +191,8 @@ UPtrVector<ParticleSet::ParticleGradient_t> create_particle_gradient(int nelec, 
 {
   UPtrVector<ParticleSet::ParticleGradient_t> G_list;
   for (int i = 0; i < nentry; i++)
-  {
     G_list.emplace_back(std::make_unique<ParticleSet::ParticleGradient_t>(nelec));
-  }
+
   return G_list;
 }
 
@@ -201,9 +200,8 @@ UPtrVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec
 {
   UPtrVector<ParticleSet::ParticleLaplacian_t> L_list;
   for (int i = 0; i < nentry; i++)
-  {
     L_list.emplace_back(std::make_unique<ParticleSet::ParticleLaplacian_t>(nelec));
-  }
+
   return L_list;
 }
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -205,7 +205,7 @@ UPtrVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec
   return L_list;
 }
 
-TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
+TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
 {
   using ValueType = QMCTraits::ValueType;
   using RealType  = QMCTraits::RealType;
@@ -245,7 +245,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
   wf_list.push_back(psi);
   p_list.push_back(elec);
 
-  // Evaluate new flex_evaluateDeltaLog
+  // Evaluate new flex_evaluateDeltaLogSetup
 
   std::vector<RealType> logpsi_fixed_list(nentry);
   std::vector<RealType> logpsi_opt_list(nentry);
@@ -255,7 +255,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
   auto fixedG_list     = convertUPtrToRefVector(fixedG_list_ptr);
   auto fixedL_list     = convertUPtrToRefVector(fixedL_list_ptr);
 
-  psi.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
+  psi.flex_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
 
 
   // Evaluate old (single item) evaluateDeltaLog
@@ -311,7 +311,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
   auto fixedG_list2     = convertUPtrToRefVector(fixedG_list2_ptr);
   auto fixedL_list2     = convertUPtrToRefVector(fixedL_list2_ptr);
 
-  psi2.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
+  psi2.flex_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
 
   // Evaluate old (single item) evaluateDeltaLog corresponding to the second wavefunction/particleset
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -186,4 +186,187 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   CHECK(dhpsioverpsi2[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 1)));
 }
 
+
+RefVector<ParticleSet::ParticleGradient_t> create_particle_gradient(int nelec, int nentry)
+{
+  RefVector<ParticleSet::ParticleGradient_t> fixedG_list;
+  for (int i = 0; i < nentry; i++)
+  {
+    ParticleSet::ParticleGradient_t* G1 = new ParticleSet::ParticleGradient_t();
+    G1->resize(nelec);
+    fixedG_list.push_back(*G1);
+  }
+  return fixedG_list;
+}
+
+RefVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec, int nentry)
+{
+  RefVector<ParticleSet::ParticleLaplacian_t> fixedL_list;
+  for (int i = 0; i < nentry; i++)
+  {
+    ParticleSet::ParticleLaplacian_t* L1 = new ParticleSet::ParticleLaplacian_t();
+    L1->resize(nelec);
+    fixedL_list.push_back(*L1);
+  }
+  return fixedL_list;
+}
+
+TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
+{
+  using ValueType = QMCTraits::ValueType;
+  using RealType  = QMCTraits::RealType;
+
+  OHMMS::Controller->initialize(0, NULL);
+  Communicate* c = OHMMS::Controller;
+  ParticleSet elec;
+  ParticleSet ions;
+  std::unique_ptr<WaveFunctionFactory> wff;
+  // This He wavefunction has two components
+  // The orbitals are fixed and have not optimizable parameters.
+  // The Jastrow factor does have an optimizable parameter.
+  setup_He_wavefunction(c, elec, ions, wff);
+  TrialWaveFunction& psi(*(wff->targetPsi));
+  ions.update();
+  elec.update();
+
+  ParticleSet elec2(elec);
+  elec2.R[0][0] = 0.9;
+  elec2.update();
+
+  TrialWaveFunction psi2(c);
+  WaveFunctionComponent* orb1 = psi.getOrbitals()[0]->makeClone(elec2);
+
+  psi2.addComponent(orb1, "orb1");
+  WaveFunctionComponent* orb2 = psi.getOrbitals()[1]->makeClone(elec2);
+  psi2.addComponent(orb2, "orb2");
+
+
+  // Prepare to compare using list with one wavefunction and particleset
+
+  int nentry = 1;
+  int nelec  = 2;
+
+  RefVector<TrialWaveFunction> wf_list;
+  RefVector<ParticleSet> p_list;
+  wf_list.push_back(psi);
+  p_list.push_back(elec);
+
+  // Evaluate new flex_evaluateDeltaLog
+
+  std::vector<RealType> logpsi_fixed_list(nentry);
+  std::vector<RealType> logpsi_opt_list(nentry);
+
+  auto fixedG_list = create_particle_gradient(nelec, nentry);
+  auto fixedL_list = create_particle_laplacian(nelec, nentry);
+
+  psi.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
+
+
+  // Evaluate old (single item) evaluateDeltaLog
+
+  RealType logpsi_fixed_r1;
+  RealType logpsi_opt_r1;
+  ParticleSet::ParticleGradient_t fixedG1;
+  ParticleSet::ParticleLaplacian_t fixedL1;
+  fixedG1.resize(nelec);
+  fixedL1.resize(nelec);
+
+  psi.evaluateDeltaLog(elec, logpsi_fixed_r1, logpsi_opt_r1, fixedG1, fixedL1);
+
+  CHECK(logpsi_fixed_r1 == Approx(logpsi_fixed_list[0]));
+  CHECK(logpsi_opt_r1 == Approx(logpsi_opt_list[0]));
+
+  CHECK(fixedG1[0][0] == ValueApprox(fixedG_list[0].get()[0][0]));
+  CHECK(fixedG1[0][1] == ValueApprox(fixedG_list[0].get()[0][1]));
+  CHECK(fixedG1[0][2] == ValueApprox(fixedG_list[0].get()[0][2]));
+  CHECK(fixedG1[1][0] == ValueApprox(fixedG_list[0].get()[1][0]));
+  CHECK(fixedG1[1][1] == ValueApprox(fixedG_list[0].get()[1][1]));
+  CHECK(fixedG1[1][2] == ValueApprox(fixedG_list[0].get()[1][2]));
+
+  CHECK(fixedL1[0] == ValueApprox(fixedL_list[0].get()[0]));
+  CHECK(fixedL1[1] == ValueApprox(fixedL_list[0].get()[1]));
+
+  // Prepare to compare using list with two wavefunctions and particlesets
+
+  nentry = 2;
+
+  wf_list.push_back(psi2);
+  p_list.push_back(elec2);
+
+  ParticleSet::ParticleGradient_t G2;
+  ParticleSet::ParticleLaplacian_t L2;
+  G2.resize(nelec);
+  L2.resize(nelec);
+  fixedG_list.push_back(G2);
+  fixedL_list.push_back(L2);
+
+  std::vector<RealType> logpsi_fixed_list2(nentry);
+  std::vector<RealType> logpsi_opt_list2(nentry);
+
+  RealType logpsi_fixed_r1b;
+  RealType logpsi_opt_r1b;
+  psi2.evaluateDeltaLog(elec, logpsi_fixed_r1b, logpsi_opt_r1b, fixedG1, fixedL1);
+
+  CHECK(logpsi_fixed_r1 == Approx(logpsi_fixed_r1b));
+  CHECK(logpsi_opt_r1 == Approx(logpsi_opt_r1b));
+
+  auto fixedG_list2 = create_particle_gradient(nelec, nentry);
+  auto fixedL_list2 = create_particle_laplacian(nelec, nentry);
+
+  psi2.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
+
+  // Evaluate old (single item) evaluateDeltaLog corresponding to the second wavefunction/particleset
+
+  RealType logpsi_fixed_r2;
+  RealType logpsi_opt_r2;
+  ParticleSet::ParticleGradient_t fixedG2;
+  ParticleSet::ParticleLaplacian_t fixedL2;
+  fixedG2.resize(nelec);
+  fixedL2.resize(nelec);
+
+  psi2.setLogPsi(0.0);
+  psi2.evaluateDeltaLog(elec2, logpsi_fixed_r2, logpsi_opt_r2, fixedG2, fixedL2);
+
+
+  CHECK(logpsi_fixed_r1 == Approx(logpsi_fixed_r1b));
+
+  CHECK(logpsi_fixed_list[0] == Approx(logpsi_fixed_list2[0]));
+
+  CHECK(logpsi_fixed_r1 == Approx(logpsi_fixed_list2[0]));
+  CHECK(logpsi_opt_r1 == Approx(logpsi_opt_list2[0]));
+
+  CHECK(logpsi_fixed_r2 == Approx(logpsi_fixed_list2[1]));
+  CHECK(logpsi_opt_r2 == Approx(logpsi_opt_list2[1]));
+
+  // Laplacian for first entry in the wavefunction/particleset list
+  CHECK(fixedL1[0] == ValueApprox(fixedL_list2[0].get()[0]));
+  CHECK(fixedL1[1] == ValueApprox(fixedL_list2[0].get()[1]));
+  // Laplacian for second entry in the wavefunction/particleset list
+  CHECK(fixedL2[0] == ValueApprox(fixedL_list2[1].get()[0]));
+  CHECK(fixedL2[1] == ValueApprox(fixedL_list2[1].get()[1]));
+
+
+  // First entry wavefunction/particleset list
+  // Gradient for first electron
+  CHECK(fixedG1[0][0] == ValueApprox(fixedG_list2[0].get()[0][0]));
+  CHECK(fixedG1[0][1] == ValueApprox(fixedG_list2[0].get()[0][1]));
+  CHECK(fixedG1[0][2] == ValueApprox(fixedG_list2[0].get()[0][2]));
+  // Gradient for second electron
+  CHECK(fixedG1[1][0] == ValueApprox(fixedG_list2[0].get()[1][0]));
+  CHECK(fixedG1[1][1] == ValueApprox(fixedG_list2[0].get()[1][1]));
+  CHECK(fixedG1[1][2] == ValueApprox(fixedG_list2[0].get()[1][2]));
+
+
+  // Second entry wavefunction/particleset list
+  // Gradient for first electron
+  CHECK(fixedG2[0][0] == ValueApprox(fixedG_list2[1].get()[0][0]));
+  CHECK(fixedG2[0][1] == ValueApprox(fixedG_list2[1].get()[0][1]));
+  CHECK(fixedG2[0][2] == ValueApprox(fixedG_list2[1].get()[0][2]));
+  // Gradient for second electron
+  CHECK(fixedG2[1][0] == ValueApprox(fixedG_list2[1].get()[1][0]));
+  CHECK(fixedG2[1][1] == ValueApprox(fixedG_list2[1].get()[1][1]));
+  CHECK(fixedG2[1][2] == ValueApprox(fixedG_list2[1].get()[1][2]));
+}
+
+
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -187,28 +187,26 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
 }
 
 
-RefVector<ParticleSet::ParticleGradient_t> create_particle_gradient(int nelec, int nentry)
+UPtrVector<ParticleSet::ParticleGradient_t> create_particle_gradient(int nelec, int nentry)
 {
-  RefVector<ParticleSet::ParticleGradient_t> fixedG_list;
+  UPtrVector<ParticleSet::ParticleGradient_t> G_list;
   for (int i = 0; i < nentry; i++)
   {
-    ParticleSet::ParticleGradient_t* G1 = new ParticleSet::ParticleGradient_t();
-    G1->resize(nelec);
-    fixedG_list.push_back(*G1);
+    G_list.push_back(std::make_unique<ParticleSet::ParticleGradient_t>());
+    G_list.back()->resize(nelec);
   }
-  return fixedG_list;
+  return G_list;
 }
 
-RefVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec, int nentry)
+UPtrVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec, int nentry)
 {
-  RefVector<ParticleSet::ParticleLaplacian_t> fixedL_list;
+  UPtrVector<ParticleSet::ParticleLaplacian_t> L_list;
   for (int i = 0; i < nentry; i++)
   {
-    ParticleSet::ParticleLaplacian_t* L1 = new ParticleSet::ParticleLaplacian_t();
-    L1->resize(nelec);
-    fixedL_list.push_back(*L1);
+    L_list.push_back(std::make_unique<ParticleSet::ParticleLaplacian_t>());
+    L_list.back()->resize(nelec);
   }
-  return fixedL_list;
+  return L_list;
 }
 
 TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
@@ -256,8 +254,10 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
   std::vector<RealType> logpsi_fixed_list(nentry);
   std::vector<RealType> logpsi_opt_list(nentry);
 
-  auto fixedG_list = create_particle_gradient(nelec, nentry);
-  auto fixedL_list = create_particle_laplacian(nelec, nentry);
+  auto fixedG_list_ptr = create_particle_gradient(nelec, nentry);
+  auto fixedL_list_ptr = create_particle_laplacian(nelec, nentry);
+  auto fixedG_list     = convertUPtrToRefVector(fixedG_list_ptr);
+  auto fixedL_list     = convertUPtrToRefVector(fixedL_list_ptr);
 
   psi.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
 
@@ -310,8 +310,10 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLog", "[wavefunction]")
   CHECK(logpsi_fixed_r1 == Approx(logpsi_fixed_r1b));
   CHECK(logpsi_opt_r1 == Approx(logpsi_opt_r1b));
 
-  auto fixedG_list2 = create_particle_gradient(nelec, nentry);
-  auto fixedL_list2 = create_particle_laplacian(nelec, nentry);
+  auto fixedG_list2_ptr = create_particle_gradient(nelec, nentry);
+  auto fixedL_list2_ptr = create_particle_laplacian(nelec, nentry);
+  auto fixedG_list2     = convertUPtrToRefVector(fixedG_list2_ptr);
+  auto fixedL_list2     = convertUPtrToRefVector(fixedL_list2_ptr);
 
   psi2.flex_evaluateDeltaLog(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
 


### PR DESCRIPTION
## Proposed changes 

Add flex_evaluateDeltaLog  as part of moving all the calls in QMCCostFunction::checkConfigurations to have flex versions.

Question: The flex_evaluateLog function has a special case for a single element wavefunction/particleset list.  Is this important?  The flex_evaluateDeltaLog code does not have this special case.



## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes  This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
