### PR TITLE
Nexus: fix matplotlib import in qmca

### DIFF
--- a/nexus/bin/qmc-fit
+++ b/nexus/bin/qmc-fit
@@ -17,17 +17,6 @@ except ImportError:
 #end try
 
 try:
-    import matplotlib
-    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
-    for gui in gui_envs:
-        try:
-            matplotlib.use(gui,warn=False, force=True)
-            from matplotlib import pyplot
-            break
-        except:
-            continue
-        #end try
-    #end for
     import matplotlib.pyplot as plt
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -62,31 +62,17 @@ except (ImportError,RuntimeError):
 
 
 # matplotlib imports
-success = False
+matplotlib_import_success = False
 try:
-    import matplotlib
-    gui_envs = ['GTKAgg','TKAgg','Qt4Agg','WXAgg']
-    for gui in gui_envs:
-        try:
-            matplotlib.use(gui,warn=False, force=True)
-            from matplotlib import pyplot
-            success = True
-            break
-        except:
-            continue
-        #end try
-    #end for
     import matplotlib.pyplot as plt
 
     params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
           'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
     plt.rcParams.update(params)
+    matplotlib_import_success = True
 except (ImportError,RuntimeError):
-    success = False
+    matplotlib_import_success = False
 #end try
-if not success:
-    plt = unavailable('matplotlib.pyplot')
-#end if
 
 
 
@@ -210,6 +196,13 @@ class QBase(DevBase):
         pad = n*'  '
         self._logfile.write(pad+text.replace('\n','\n'+pad)+'\n')
     #end def log
+
+
+    def check_matplotlib_import(self):
+        if not self.options.nowarn and not matplotlib_import_success:
+            self.warn('Python library matplotlib raised uncaught exceptions during import.  Plots may or may not work.')
+        #end if
+    #end def check_matplotlib_import
 #end class QBase
 
 
@@ -679,6 +672,7 @@ class DatAnalyzer(QBase):
 
 
     def plot_trace(self,quantity,style,prefix,shift):
+        self.check_matplotlib_import()
         if not quantity in self.data:
             self.error('quantity '+quantity+' is not present in the data for {0}'.format(self.info.filepath),'QMCA')
         #end if
@@ -945,6 +939,10 @@ QMCA examples:
         parser.add_option('--fp',dest='precision',
                           default=None,
                           help='Sets the floating point precision of displayed statistical results.  Must be a floating point format string such as 16.8f, 8.6e, or similar (default=%default).'
+                          )
+        parser.add_option('--nowarn',dest='nowarn',
+                          action='store_true',default=False,
+                          help='Suppress warning messages (default=%default).'
                           )
 
         unsupported = set('histogram image reblock report'.split())
@@ -1291,6 +1289,7 @@ QMCA examples:
             #end for
         #end if
         if plots:
+            self.check_matplotlib_import()
             color       = 'b'
             line        = '-'
             marker      = '.'
@@ -1419,7 +1418,6 @@ QMCA examples:
             plt.show()
         #end if
     #end def analyze_data
-
 #end class QMCA
 
 


### PR DESCRIPTION
## Proposed changes

Update the matplotlib import pattern in the `qmca` and `qmc-fit` executables.  The matplotlib library in the past sometimes required cycling through backend options to find a working solution.  This functionality has been subsumed within matplotlib itself since the Nexus imports were made, and the specialized imports are no longer necessary.  

This PR removes the additional backend search and instead of aborting when a matplotlib import error is caught, a warning is instead printed:  
```
Warning:
    Python library matplotlib raised uncaught exceptions during import.  Plots may or may not work.
```
This is motivated by experience that has shown that matplotlib may still successfully generate plots even when such exceptions are thrown.  The warning can be suppressed via an additional command line flag to `qmca`.  

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'

