### PR TITLE
Fix test_TrialWaveFunction_He unit test segfault

### DIFF
--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -29,7 +29,7 @@ void setup_He_wavefunction(Communicate* c,
                            ParticleSet& elec,
                            ParticleSet& ions,
                            std::unique_ptr<WaveFunctionFactory>& wff,
-                           std::unique_ptr<WaveFunctionFactory::PtclPoolType>& particle_set_map)
+                           WaveFunctionFactory::PtclPoolType& particle_set_map)
 {
   std::vector<int> agroup(2);
   int nelec = 2;
@@ -57,8 +57,7 @@ void setup_He_wavefunction(Communicate* c,
   tspecies(e_chargeIdx, downIdx) = -1.0;
   elec.resetGroups();
 
-  particle_set_map = std::make_unique<WaveFunctionFactory::PtclPoolType>();
-  (*particle_set_map)["e"] = &elec;
+  particle_set_map["e"] = &elec;
 
   ions.setName("ion0");
   ions.create(1);
@@ -71,11 +70,11 @@ void setup_He_wavefunction(Communicate* c,
   int chargeIdx               = he_species.addAttribute("charge");
   tspecies(chargeIdx, He_Idx) = 2.0;
   tspecies(massIdx, upIdx)    = 2.0;
-  (*particle_set_map)["ion0"]    = &ions;
+  particle_set_map["ion0"]    = &ions;
 
   elec.addTable(ions, DT_SOA);
 
-  wff = std::make_unique<WaveFunctionFactory>(&elec, *particle_set_map, c);
+  wff = std::make_unique<WaveFunctionFactory>(&elec, particle_set_map, c);
 
   const char* wavefunction_xml = "<wavefunction name=\"psi0\" target=\"e\">  \
      <jastrow name=\"Jee\" type=\"Two-Body\" function=\"pade\"> \
@@ -127,7 +126,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   ParticleSet elec;
   ParticleSet ions;
   std::unique_ptr<WaveFunctionFactory> wff;
-  std::unique_ptr<WaveFunctionFactory::PtclPoolType> particle_set_map;
+  WaveFunctionFactory::PtclPoolType particle_set_map;
   setup_He_wavefunction(c, elec, ions, wff, particle_set_map);
   TrialWaveFunction& psi(*(wff->targetPsi));
 
@@ -219,7 +218,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   ParticleSet elec;
   ParticleSet ions;
   std::unique_ptr<WaveFunctionFactory> wff;
-  std::unique_ptr<WaveFunctionFactory::PtclPoolType> particle_set_map;
+  WaveFunctionFactory::PtclPoolType particle_set_map;
   // This He wavefunction has two components
   // The orbitals are fixed and have not optimizable parameters.
   // The Jastrow factor does have an optimizable parameter.


### PR DESCRIPTION
## Proposed changes
Fixes #2600

The SPOSetBuilderFactory contains a static map that needs to be cleared between tests.

This commit also removes a potential lifetime issue with particle_set_map.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?

laptop, Intel 19.0 compiler

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
