### PR TITLE
Set gradient and laplacian in particle set

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -322,6 +322,16 @@ void TrialWaveFunction::flex_evaluateDeltaLogSetup(const RefVector<TrialWaveFunc
         logpsi_fixed_list[iw] += std::real(wfc_list[iw].get().LogValue);
     }
   }
+
+  // Temporary workaround to have P.G/L always defined.
+  // remove when KineticEnergy use WF.G/L instead of P.G/L
+  auto addAndCopyToP = [](ParticleSet& pset, TrialWaveFunction& twf, ParticleSet::ParticleGradient_t& grad,
+                          ParticleSet::ParticleLaplacian_t& lapl) {
+    pset.G = twf.G + grad;
+    pset.L = twf.L + lapl;
+  };
+  for (int iw = 0; iw < wf_list.size(); iw++)
+    addAndCopyToP(p_list[iw], wf_list[iw], fixedG_list[iw], fixedL_list[iw]);
 }
 
 


### PR DESCRIPTION
## Proposed changes
In flex_evaluateDeltaLogSetup, need to set the gradient and laplacian in the particle set.  The unit test needs to use separate particle sets for the old evaluateDeltaLog and in the particle set list for the new routine.

Reading through the flex_evaluateLog code, I realized this had been left out of #2596



## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Ye. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
