### PR TITLE
Update batched_driver performance tests walker input tag

### DIFF
--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -121,10 +121,10 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
  */
 void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc)
 {
-  app_log() << this->QMCType << " Driver running with target_walkers =" << awc.global_walkers << std::endl
-            << "                               walkers_per_rank =" << awc.walkers_per_rank << std::endl
-            << "                               num_crowds =" << awc.walkers_per_crowd.size() << std::endl
-            << "                    on rank 0, walkers_per_crowd =" << awc.walkers_per_crowd << std::endl
+  app_log() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
+            << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl
+            << "                               num_crowds = " << awc.walkers_per_crowd.size() << std::endl
+            << "                    on rank 0, walkers_per_crowd = " << awc.walkers_per_crowd << std::endl
             << std::endl;
 
   // set num_global_walkers explicitly and then make local walkers.

--- a/tests/performance/NiO/CMakeLists.txt
+++ b/tests/performance/NiO/CMakeLists.txt
@@ -121,6 +121,7 @@ ELSE()
         SET(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-w16-J3)
         SET(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-J3)
         ADD_NIO_TEST(${PERF_TEST} 1 16 ${TEST_DIR} ${TEST_SOURCE_DIR} ${INPUT_FILE} ${H5_FILE} "${ADJUST_INPUT} -w 16 -j ${TEST_DIR}/J123.xml")
+
         # Batched driver
         SET(DRIVER_TYPE batched_driver)
         ## delayed update

--- a/tests/performance/adjust_qmcpack_input.py
+++ b/tests/performance/adjust_qmcpack_input.py
@@ -80,6 +80,9 @@ def change_to_unified_drivers(tree):
   for qmc in qmc_nodes:
     replace_attribute(qmc, 'method', 'vmc', 'vmc_batch')
     replace_attribute(qmc, 'method', 'dmc', 'dmc_batch')
+    nodes = qmc.findall("./parameter[@name='walkers']")
+    if nodes:
+      add_or_change_attribute(nodes[0], 'name', 'walkers_per_rank')
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description="Adjust QMCPACK input files")
@@ -122,11 +125,11 @@ if __name__ == '__main__':
     j3_tree = ET.parse(args.J123)
     change_jastrow(tree, j3_tree)
 
-  if args.unified:
-    change_to_unified_drivers(tree)
-
   if args.walker:
     change_number_of_walkers(tree,args.walker)
+
+  if args.unified:
+    change_to_unified_drivers(tree)
 
   if args.output:
     tree.write(args.output)


### PR DESCRIPTION
## Proposed changes
batched drivers need `walkers_per_rank` instead `walkers` input tag.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'