### PR TITLE
Add second flex_evaluateDeltaLog

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -159,6 +159,23 @@ public:
   /** recompute the value of the orbitals which require critical accuracy */
   void recompute(ParticleSet& P);
 
+  /** evaluate the log value of a many-body wave function
+   * @param P input configuration containing N particles
+   * @param recomputeall recompute all orbitals from scratch
+   * @return the value of \f$ \log( \Pi_i \Psi_i) \f$  many-body wave function
+   *
+   * @if recompute == true
+   *   all orbitals have "evaluateLog" called on them, including the non-optimized ones.
+   * @else
+   *   default value.  call evaluateLog only on optimizable orbitals.  OK if nonlocal pp's aren't used.
+   *
+   * To save time, logpsi, G, and L are only computed for orbitals that change over the course of the optimization.
+   * It is assumed that the fixed components are stored elsewhere.  See evaluateDeltaLog(P,logpsi_fixed_r,logpsi_opt,fixedG,fixedL)
+   * defined below.  Nonlocal pseudopotential evaluation requires temporary information like matrix inverses, so while
+   * the logpsi, G, and L don't change, evaluateLog is called anyways to compute these auxiliary quantities from scratch.
+   * logpsi, G, and L associated with these non-optimizable orbitals are discarded explicitly and with dummy variables.
+   */
+
   RealType evaluateDeltaLog(ParticleSet& P, bool recompute = false);
 
   /** evaluate the sum of log value of optimizable many-body wavefunctions
@@ -206,6 +223,36 @@ public:
                                          std::vector<RealType>& logpsi_opt_list,
                                          RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
                                          RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
+
+  /** evaluate the log value for optimizable parts of a many-body wave function
+   * @param wf_list vector of wavefunctions
+   * @param p_list vector of input particle configurations
+   * @param logpsi_list vector of log(std::abs(psi)) of the variable orbitals
+   * @param dummyG_list vector of gradients of log(psi) of the fixed wave functions.
+   * @param dummyL_list vector of laplacians of log(psi) of the fixed wave functions
+   *
+   * The dummyG_list and dummyL_list are only referenced if recompute is true.
+   * If recompute is false, the storage of these lists are needed, but the values can be discarded.
+   *
+   * @if recompute == true
+   *   all orbitals have "evaluateLog" called on them, including the non-optimized ones.
+   * @else
+   *   default value.  call evaluateLog only on optimizable orbitals.  OK if nonlocal pp's aren't used.
+   *
+   * To save time, logpsi, G, and L are only computed for orbitals that change over the course of the optimization.
+   * It is assumed that the fixed components are stored elsewhere.  See flex_evaluateDeltaLogSetup defined above.
+   * Nonlocal pseudopotential evaluation requires temporary information like matrix inverses, so while
+   * the logpsi, G, and L don't change, evaluateLog is called anyways to compute these auxiliary quantities from scratch.
+   * logpsi, G, and L associated with these non-optimizable orbitals are discarded explicitly and with dummy variables.
+   */
+
+
+  static void flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>& wf_list,
+                                    const RefVector<ParticleSet>& p_list,
+                                    std::vector<RealType>& logpsi_list,
+                                    RefVector<ParticleSet::ParticleGradient_t>& dummyG_list,
+                                    RefVector<ParticleSet::ParticleLaplacian_t>& dummyL_list,
+                                    bool recompute = false);
 
 
   /** compute psi(R_new) / psi(R_current) ratio

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -391,6 +391,37 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   CHECK(elec2b.G[0][0] == ValueApprox(elec2.G[0][0]));
   CHECK(elec2b.G[1][1] == ValueApprox(elec2.G[1][1]));
 
+
+  // these lists not used if 'recompute' is false
+  RefVector<ParticleSet::ParticleGradient_t> dummyG_list;
+  RefVector<ParticleSet::ParticleLaplacian_t> dummyL_list;
+
+  std::vector<RealType> logpsi_variable_list(nentry);
+  TrialWaveFunction::flex_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list, dummyG_list, dummyL_list, false);
+
+  RealType logpsi1 = psi.evaluateDeltaLog(p_list[0], false);
+  CHECK(logpsi1 == Approx(logpsi_variable_list[0]));
+
+  RealType logpsi2 = psi2.evaluateDeltaLog(p_list[1], false);
+  CHECK(logpsi2 == Approx(logpsi_variable_list[1]));
+
+
+  // Now check with 'recompute = true'
+  auto dummyG_list2_ptr = create_particle_gradient(nelec, nentry);
+  auto dummyL_list2_ptr = create_particle_laplacian(nelec, nentry);
+  auto dummyG_list2     = convertUPtrToRefVector(dummyG_list2_ptr);
+  auto dummyL_list2     = convertUPtrToRefVector(dummyL_list2_ptr);
+
+  std::vector<RealType> logpsi_variable_list2(nentry);
+
+  TrialWaveFunction::flex_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list2, dummyG_list2, dummyL_list2, true);
+
+  RealType logpsi1b = psi.evaluateDeltaLog(p_list[0], true);
+  CHECK(logpsi1b == Approx(logpsi_variable_list2[0]));
+
+  RealType logpsi2b = psi2.evaluateDeltaLog(p_list[1], true);
+  CHECK(logpsi2b == Approx(logpsi_variable_list2[1]));
+
   SPOSetBuilderFactory::clear();
 }
 


### PR DESCRIPTION
## Proposed changes
This the the function to be called during correlated sampling.

Note that compared to evaluteDeltaLog, the dummy G and L are passed in as parameters rather than allocated in the function.  This pushes the temporary allocations to the caller of this function, and avoids performing memory allocation here.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
