### PR TITLE
Nexus: Improve support for twist averaging

### DIFF
--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -948,6 +948,10 @@ QMCA examples:
                           action='store_true',default=False,
                           help='Average over all files, ignoring differences in path (default=%default).'
                           )
+        parser.add_option('--twist_info',dest='twist_info',
+                          default='use',
+                          help='Use twist weights in twist_info.dat files or not.  Options: "use", "ignore", "require".  "use" means use when present, "ignore" means do not use, "require" means must be used (default=%default).'
+                          )
 
         unsupported = set('histogram image reblock report'.split())
 
@@ -1036,6 +1040,10 @@ QMCA examples:
         #end if
         if opt.image=='None':
             opt.image=None
+        #end if
+        twist_info_options = ('use','ignore','require')
+        if opt.twist_info not in twist_info_options:
+            self.error('twist_info option is invalid\ntwist_info must be one of: {}\nyou provided: {}'.format(twist_info_options,opt.twist_info))
         #end if
         opt.all_quantities = False
         qabbr = self.quantity_abbreviations
@@ -1217,7 +1225,31 @@ QMCA examples:
                     prefixes = batch_prefixes[batch_prefix]
                     adata = obj()
                     ns=0
-                    weights = len(prefixes)*[1.0]
+                    uniform_weights = len(prefixes)*[1.0]
+                    if opt.twist_info=='ignore':
+                        weights = uniform_weights
+                    else:
+                        weights = []
+                        for prefix in sorted(prefixes):
+                            twist_info_file = prefix+'.twist_info.dat'
+                            if os.path.exists(twist_info_file):
+                                fobj = open(twist_info_file)
+                                try:
+                                    weight = float(fobj.read().strip().split()[0])
+                                    weights.append(weight)
+                                except:
+                                    None
+                                #end try
+                            #end if
+                        #end for
+                        if len(weights)!=len(prefixes):
+                            if opt.twist_info=='require':
+                                self.error('twist_info files are either missing or mis-formatted for batch prefix {}'.format(batch_prefix))
+                            else:
+                                weights = uniform_weights
+                            #end if
+                        #end if
+                    #end if
                     for series in serieslist:
                         np = 0
                         for prefix in sorted(prefixes):

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -944,6 +944,10 @@ QMCA examples:
                           action='store_true',default=False,
                           help='Suppress warning messages (default=%default).'
                           )
+        parser.add_option('--average_all',dest='average_all',
+                          action='store_true',default=False,
+                          help='Suppress warning messages (default=%default).'
+                          )
 
         unsupported = set('histogram image reblock report'.split())
 
@@ -1149,47 +1153,105 @@ QMCA examples:
                     self.error('files with mixed extensions encountered for series {0}\nextensions encountered: {1}\nplease provide files with only one of the following extensions: {2}'.format(series,sorted(list(filetypes)),allowed_extensions.list()))
                 #end if
             #end for
+            
             weights = opt.weights
             prefixes = sorted(list(data.keys()))
-            if weights is None:
-                weights = len(prefixes)*[1.0]
-            elif len(weights)!=len(prefixes):
-                self.error('one weight must be provided per file prefix for averaging\nyou provided {0} weights for {1} prefixes\nweights provided: {2}\nprefixes provided: {3}'.format(len(weights),len(prefixes),weights,prefixes))
-            #end if
-            adata = obj()
-            file_map = obj()
-            file_list = []
-            ns=0
-            for series in serieslist:
-                np = 0
-                for prefix in sorted(data.keys()):
-                    pdata = data[prefix]
-                    w = weights[np]
-                    d = pdata[series]
-                    if np==0:
-                        avg = d.copy()
-                        di = d.info
-                        avg.info.set(
-                            filename = di.filename.replace(di.prefix,'avg'),
-                            filepath = di.filepath.replace(di.prefix,'avg'),
-                            index    = ns,
-                            prefix   = 'avg'
-                            )
-                        avg.zero()
-                    #end if
-                    avg.accumulate(d,w)
-                    np+=1
-                #end for
-                avg.normalize()
-                file_list.append(avg.info.filepath)
-                file_map[avg.info.filepath] = avg
-                adata[series] = avg
-                ns+=1
+
+            # identify batches of prefixes for averaging
+            batch_prefixes = obj()
+            for prefix in prefixes:
+                path,file = os.path.split(prefix)
+                tokens = file.split('.')
+                batch_prefix = os.path.join(path,tokens[0])
+                if batch_prefix not in batch_prefixes:
+                    batch_prefixes[batch_prefix] = []
+                #end if
+                batch_prefixes[batch_prefix].append(prefix)
             #end for
-            self.file_list = file_list
-            self.file_map  = file_map
-            self.data = obj(avg=adata)
-            self.prefix_list = ['avg']
+
+            # perform the averaging
+            file_list   = []
+            file_map    = obj()
+            prefix_list = []
+            avg_data    = obj()
+            if opt.average_all or weights is not None or len(batch_prefixes)==1:
+                # average all data together
+                if weights is None:
+                    weights = len(prefixes)*[1.0]
+                elif len(weights)!=len(prefixes):
+                    self.error('one weight must be provided per file prefix for averaging\nyou provided {0} weights for {1} prefixes\nweights provided: {2}\nprefixes provided: {3}'.format(len(weights),len(prefixes),weights,prefixes))
+                #end if
+                adata = obj()
+                ns=0
+                for series in serieslist:
+                    np = 0
+                    for prefix in sorted(data.keys()):
+                        pdata = data[prefix]
+                        w = weights[np]
+                        d = pdata[series]
+                        if np==0:
+                            avg = d.copy()
+                            di = d.info
+                            avg.info.set(
+                                filename = di.filename.replace(di.prefix,'avg'),
+                                filepath = di.filepath.replace(di.prefix,'avg'),
+                                index    = ns,
+                                prefix   = 'avg'
+                                )
+                            avg.zero()
+                        #end if
+                        avg.accumulate(d,w)
+                        np+=1
+                    #end for
+                    avg.normalize()
+                    file_list.append(avg.info.filepath)
+                    file_map[avg.info.filepath] = avg
+                    adata[series] = avg
+                    ns+=1
+                #end for
+                prefix_list.append('avg')
+                avg_data.avg = adata
+            else:
+                # average data by shared batch prefix
+                for batch_prefix in sorted(batch_prefixes.keys()):
+                    prefixes = batch_prefixes[batch_prefix]
+                    adata = obj()
+                    ns=0
+                    weights = len(prefixes)*[1.0]
+                    for series in serieslist:
+                        np = 0
+                        for prefix in sorted(prefixes):
+                            pdata = data[prefix]
+                            w = weights[np]
+                            d = pdata[series]
+                            if np==0:
+                                avg = d.copy()
+                                di = d.info
+                                avg.info.set(
+                                    filename = di.filename.replace(di.prefix,batch_prefix),
+                                    filepath = di.filepath.replace(di.prefix,batch_prefix),
+                                    index    = ns,
+                                    prefix   = batch_prefix,
+                                    )
+                                avg.zero()
+                            #end if
+                            avg.accumulate(d,w)
+                            np+=1
+                        #end for
+                        avg.normalize()
+                        file_list.append(avg.info.filepath)
+                        file_map[avg.info.filepath] = avg
+                        adata[series] = avg
+                        ns+=1
+                    #end for
+                    prefix_list.append(batch_prefix)
+                    avg_data[batch_prefix] = adata
+                #end for
+            #end if
+            self.file_list   = file_list
+            self.file_map    = file_map
+            self.prefix_list = prefix_list
+            self.data        = avg_data
         #end if
         if opt.join is not None:
             series_join = list(range(opt.join[0],opt.join[1]+1))

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -946,7 +946,7 @@ QMCA examples:
                           )
         parser.add_option('--average_all',dest='average_all',
                           action='store_true',default=False,
-                          help='Suppress warning messages (default=%default).'
+                          help='Average over all files, ignoring differences in path (default=%default).'
                           )
 
         unsupported = set('histogram image reblock report'.split())

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -512,7 +512,7 @@ class Qmcpack(Simulation):
                 kpoints         = s.kpoints.copy()
                 kpoints_qmcpack = s.kpoints_qmcpack()
                 for file in input.filenames:
-                    if file.startswith('qmc.g'):
+                    if file.startswith(self.identifier+'.g'):
                         tokens = file.split('.')
                         twist_index = int(tokens[1].replace('g',''))
                         twist_filename = '{}.{}.twist_info.dat'.format(tokens[0],tokens[1])

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -506,6 +506,25 @@ class Qmcpack(Simulation):
                 self.infile = input.filenames[-1]
                 self.input  = input
                 self.job.app_command = self.app_command()
+                # write twist info files
+                s = self.system.structure
+                kweights        = s.kweights.copy()
+                kpoints         = s.kpoints.copy()
+                kpoints_qmcpack = s.kpoints_qmcpack()
+                for file in input.filenames:
+                    if file.startswith('qmc.g'):
+                        tokens = file.split('.')
+                        twist_index = int(tokens[1].replace('g',''))
+                        twist_filename = '{}.{}.twist_info.dat'.format(tokens[0],tokens[1])
+                        kw  = kweights[twist_index]
+                        kp  = kpoints[twist_index]
+                        kpq = kpoints_qmcpack[twist_index]
+                        contents = ' {: 16.6f}  {: 16.12f} {: 16.12f} {: 16.12f}  {: 16.12f} {: 16.12f} {: 16.12f}\n'.format(kw,*kp,*kpq)
+                        fobj = open(os.path.join(self.locdir,twist_filename),'w')
+                        fobj.write(contents)
+                        fobj.close()
+                    #end if
+                #end for
             #end if
         #end if
     #end def write_prep

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -3182,11 +3182,11 @@ class Structure(Sobj):
     
     # test needed
     def recenter_k(self,kpoints=None,kaxes=None,kcenter=None,remove_duplicates=False):
-        use_self = kpoints==None
+        use_self = kpoints is None
         if use_self:
             kpoints=self.kpoints
         #end if
-        if kaxes==None:
+        if kaxes is None:
             kaxes=self.kaxes
         #end if
         if len(kpoints)>0:
@@ -3821,9 +3821,23 @@ class Structure(Sobj):
     #end def kpoints_unit
 
 
-    def kpoints_reduced(self):
-        return self.kpoints*self.scale/(2*pi)
+    def kpoints_reduced(self,kpoints=None):
+        if kpoints is None:
+            kpoints = self.kpoints
+        #end if
+        return kpoints*self.scale/(2*pi)
     #end def kpoints_reduced
+
+
+    def kpoints_qmcpack(self,kpoints=None):
+        if kpoints is None:
+            kpoints = self.kpoints.copy()
+        #end if
+        kpoints = self.recenter_k(kpoints,kcenter=(0,0,0))
+        kpoints = self.kpoints_unit(kpoints)
+        kpoints = -kpoints
+        return kpoints
+    #end def kpoints_qmcpack
 
 
     # test needed


### PR DESCRIPTION
## Proposed changes

Add enhancements to better support twist averaging with Nexus and `qmca`.

Nexus now writes `*.twist_info.dat` files alongside the replicated QMCPACK inputs used in twist averaging.  The files contain the twist weight, which can be non-uniform for symmetrized twists, along with the twist/k-point in real space and QMCPACK's unconventional representation of the twist (placed in the interval [-0.5,0.5) in lattice cell units and then inverted).  Example contents for a set of twists:
```
>cat pbe/dmcJ2_prod/*twist_info.dat 
         1.000000   -0.000000000000   0.000000000000   0.000000000000   -0.000000000000  -0.000000000000  -0.000000000000
         2.000000    0.129939294061   0.000000000000   0.000000000000   -0.333333333333  -0.000000000000  -0.000000000000
         2.000000   -0.000000000000   0.150040972757   0.000000000000    0.000000000000  -0.333333333333  -0.000000000000
         4.000000    0.129939294061   0.150040972757   0.000000000000   -0.333333333333  -0.333333333333  -0.000000000000
         2.000000   -0.000000000000   0.000000000000   0.124584774488   -0.000000000000  -0.000000000000  -0.250000000000
         4.000000    0.129939294061   0.000000000000   0.124584774488   -0.333333333333  -0.000000000000  -0.250000000000
         4.000000   -0.000000000000   0.150040972757   0.124584774488    0.000000000000  -0.333333333333  -0.250000000000
         8.000000    0.129939294061   0.150040972757   0.124584774488   -0.333333333333  -0.333333333333  -0.250000000000
         1.000000   -0.000000000000   0.000000000000   0.249169548976   -0.000000000000  -0.000000000000   0.500000000000
         2.000000    0.129939294061   0.000000000000   0.249169548976   -0.333333333333  -0.000000000000   0.500000000000
         2.000000   -0.000000000000   0.150040972757   0.249169548976    0.000000000000  -0.333333333333   0.500000000000
         4.000000    0.129939294061   0.150040972757   0.249169548976   -0.333333333333  -0.333333333333   0.500000000000
```

The purpose of these files is to aid in the automatic post-processing of twist averaged quantities.  So far, support for automatic twist averaging has been added to `qmca`, but it can be extended to other tools.

First, `qmca` was updated to support batched twist averaging with uniform weights.  In the past, `qmca` would just average all files, regardless of origin, if twist averaging was requested, e.g.:
```
>qmca -a -q e */dmcJ2_prod/*scalar*
 
avg  series 0  LocalEnergy           =  -272.438869 +/- 0.002825 
avg  series 1  LocalEnergy           =  -273.028049 +/- 0.057622 
avg  series 2  LocalEnergy           =  -273.110526 +/- 0.003222 
``` 
The updated behavior is to separately twist average files in batches by prefix, which is generally what is desired:
```
>qmca -a -q e */dmcJ2_prod/*scalar*
 
lda/dmcJ2_prod/qmc  series 0  LocalEnergy           =   -272.445358 +/- 0.003855
lda/dmcJ2_prod/qmc  series 1  LocalEnergy           =   -273.019131 +/- 0.061363
lda/dmcJ2_prod/qmc  series 2  LocalEnergy           =   -273.107525 +/- 0.003560
 
pbe/dmcJ2_prod/qmc  series 0  LocalEnergy           =   -272.432380 +/- 0.003892
pbe/dmcJ2_prod/qmc  series 1  LocalEnergy           =   -273.036967 +/- 0.054645
pbe/dmcJ2_prod/qmc  series 2  LocalEnergy           =   -273.112143 +/- 0.005135
```
Previously, `qmca` would have to be run separately on each batch.  The old averaging behavior can be recovered by using the new `--average_all` flag, or by providing a list of weights by hand.  

Next, `qmca` was updated to use the weight information in the `twist_info.dat` files.  It will automatically use the information, if present, and simply revert to uniform weights otherwise.  When the data are present, correct twist averaged results are given:
```
>qmca -a -q e */dmcJ2_prod/*scalar*
 
lda/dmcJ2_prod/qmc  series 0  LocalEnergy           =  -272.517860 +/- 0.004121 
lda/dmcJ2_prod/qmc  series 1  LocalEnergy           =  -273.084502 +/- 0.060538 
lda/dmcJ2_prod/qmc  series 2  LocalEnergy           =  -273.185813 +/- 0.006438 
 
pbe/dmcJ2_prod/qmc  series 0  LocalEnergy           =  -272.501622 +/- 0.004524 
pbe/dmcJ2_prod/qmc  series 1  LocalEnergy           =  -273.107584 +/- 0.053235 
pbe/dmcJ2_prod/qmc  series 2  LocalEnergy           =  -273.180993 +/- 0.008095 
```

Documentation has been added for the expanded functionality directly to `qmca`, see `qmca -h`.  All existing Nexus tests, including those for `qmca`, pass.


## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Documentation has been added (if appropriate)
