### PR TITLE
Fix PBC-LCAO real tests when run with complex code

### DIFF
--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -861,8 +861,17 @@ void LCAOrbitalBuilder::LoadFullCoefsFromH5(hdf_archive& hin,
   setname = name;
   readRealMatrixFromH5(hin, setname, Creal);
 
-  setname = std::string(name) + "_imag";
-  readRealMatrixFromH5(hin, setname, Ccmplx);
+  bool IsComplex = true;
+  hin.read(IsComplex, "/parameters/IsComplex");
+  if (IsComplex==false)
+  {
+    Ccmplx=0.0;
+  }
+  else
+  {
+    setname = std::string(name) + "_imag";
+    readRealMatrixFromH5(hin, setname, Ccmplx);
+  }
 
   for (int i = 0; i < Ctemp.rows(); i++)
     for (int j = 0; j < Ctemp.cols(); j++)
@@ -876,8 +885,7 @@ void LCAOrbitalBuilder::LoadFullCoefsFromH5(hdf_archive& hin,
                                             bool MultiDet)
 {
   bool IsComplex = false;
-  //FIXME: need to check the path to IsComplex in h5
-  hin.read(IsComplex, "IsComplex");
+  hin.read(IsComplex, "/parameters/IsComplex");
   if (IsComplex &&
       (std::abs(SuperTwist[0]) >= 1e-6 || std::abs(SuperTwist[1]) >= 1e-6 || std::abs(SuperTwist[2]) >= 1e-6))
   {

--- a/tests/solids/diamondC_1x1x1-Gaussian_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1-Gaussian_pp/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+ IF (NOT QMC_CUDA)
 
 # Reference VMC run in qmc-ref "-10.495941  0.000073"
   LIST(APPEND DIAMOND_SCALARS "totenergy" "-10.495941 0.0065")
@@ -50,3 +51,6 @@
                     1 LONG_DIAMOND_DMC_SCALARS # DMC
                     )
 
+  ELSE()
+    MESSAGE_VERBOSE("Skipping Periodic LCAO as not supported by CUDA build (QMC_CUDA=1)")
+  ENDIF()

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+ IF (NOT QMC_CUDA)
 
 # Reference VMC run in qmc-ref "-21.70152 +/- 0.00042"
   LIST(APPEND DIAMOND_SCALARS "totenergy" "-21.70152 0.015")
@@ -49,3 +50,6 @@
                     1 LONG_DIAMOND_DMC_SCALARS # DMC
                     )
 
+  ELSE()
+    MESSAGE_VERBOSE("Skipping Periodic LCAO as not supported by CUDA build (QMC_CUDA=1)")
+  ENDIF()

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp_kpts/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp_kpts/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+ IF (NOT QMC_CUDA)
+   IF (QMC_COMPLEX)
+
 # Reference VMC run in qmc_ref_long.s000.scalar.dat
 # VMC short run with No Jastrow. Compare directly to Hartree Fock Energy of: E=-21.20673553792076
 #Data generated using utils/make_ref_data.sh DIAMOND qmc_short.s000.scalar.dat ../qmc-ref/qmc_ref_long.s000.scalar.dat
@@ -65,3 +68,11 @@ LIST(APPEND LONG_DIAMOND_DMC_SCALARS "ionion" "-25.551326757000 0.001000000000")
                     1 LONG_DIAMOND_DMC_SCALARS # DMC
                     )
 
+
+
+    ELSE()
+      MESSAGE_VERBOSE("Skipping Complex Periodic LCAO  if Complex code not build (QMC_COMPLEX=0)")
+    ENDIF()
+  ELSE()
+    MESSAGE_VERBOSE("Skipping Periodic LCAO as not supported by CUDA build (QMC_CUDA=1)")
+  ENDIF()


### PR DESCRIPTION

## Proposed changes


Closes #2566. When Real wavefunction is run with complex code, the complex coeffs were not found. Now the complex coeffs are set to 0. 
Protections for tests have been added so they do not run with CUDA build.  

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
Laptop
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
