### PR TITLE
Move sincos under qmcplusplus namespace

### DIFF
--- a/src/Numerics/SmoothFunctions.cpp
+++ b/src/Numerics/SmoothFunctions.cpp
@@ -47,8 +47,8 @@ T smoothing(smoothing_functions func_id, T x, T& dx, T& d2x)
     /// (1+cos(PI*(1-cos(PI*x))/2))/2
     const T chalf(0.5), cone(1), pihalf(M_PI * chalf), pipihalf(M_PI * M_PI * chalf);
     T s, c, scos, ccos;
-    sincos(T(M_PI) * x, &s, &c);
-    sincos(pihalf * (cone - c), &scos, &ccos);
+    qmcplusplus::sincos(T(M_PI) * x, &s, &c);
+    qmcplusplus::sincos(pihalf * (cone - c), &scos, &ccos);
 
     dx  = -chalf * pipihalf * scos * s;
     d2x = -pihalf * pipihalf * (ccos * pihalf * s * s + scos * c);

--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -95,7 +95,7 @@ void StructFact::FillRhok(ParticleSet& P)
 #pragma omp simd
       for (int ki = 0; ki < nk; ki++)
       {
-        sincos(dot(KLists.kpts_cart[ki], pos), &eikr_i_ptr[ki], &eikr_r_ptr[ki]);
+        qmcplusplus::sincos(dot(KLists.kpts_cart[ki], pos), &eikr_i_ptr[ki], &eikr_r_ptr[ki]);
         rhok_r_ptr[ki] += eikr_r_ptr[ki];
         rhok_i_ptr[ki] += eikr_i_ptr[ki];
       }
@@ -114,7 +114,7 @@ void StructFact::FillRhok(ParticleSet& P)
       for (int ki = 0; ki < nk; ki++)
       {
         RealType s, c;
-        sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
+        qmcplusplus::sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
         rhok_r_ptr[ki] += c;
         rhok_i_ptr[ki] += s;
       }
@@ -140,7 +140,7 @@ void StructFact::FillRhok(ParticleSet& P)
     ComplexType* restrict rhok_ref = rhok[P.GroupID[i]];
     for (int ki = 0; ki < KLists.numk; ki++)
     {
-      sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
+      qmcplusplus::sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
       eikr_ref[ki] = ComplexType(c, s);
       rhok_ref[ki] += eikr_ref[ki];
     }
@@ -154,12 +154,12 @@ void StructFact::makeMove(int active, const PosType& pos)
 #if defined(USE_REAL_STRUCT_FACTOR)
 #pragma omp simd
   for (int ki = 0; ki < KLists.numk; ki++)
-    sincos(dot(KLists.kpts_cart[ki], pos), &eikr_i_temp[ki], &eikr_r_temp[ki]);
+    qmcplusplus::sincos(dot(KLists.kpts_cart[ki], pos), &eikr_i_temp[ki], &eikr_r_temp[ki]);
 #else
   RealType s, c; //get sin and cos
   for (int ki = 0; ki < KLists.numk; ++ki)
   {
-    sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
+    qmcplusplus::sincos(dot(KLists.kpts_cart[ki], pos), &s, &c);
     eikr_temp[ki] = ComplexType(c, s);
   }
 #endif
@@ -192,7 +192,7 @@ void StructFact::acceptMove(int active, int gid, const PosType& rold)
     for (int ki = 0; ki < KLists.numk; ++ki)
     {
       RealType s, c;
-      sincos(dot(KLists.kpts_cart[ki], rold), &s, &c);
+      qmcplusplus::sincos(dot(KLists.kpts_cart[ki], rold), &s, &c);
       rhok_ptr_r[ki] += eikr_r_temp[ki] - c;
       rhok_ptr_i[ki] += eikr_i_temp[ki] - s;
     }

--- a/src/Platforms/CPU/e2iphi.h
+++ b/src/Platforms/CPU/e2iphi.h
@@ -108,7 +108,7 @@ template<typename T>
 inline void eval_e2iphi(int n, const T* restrict phi, T* restrict phase_r, T* restrict phase_i)
 {
   for (int i = 0; i < n; i++)
-    sincos(phi[i], phase_i + i, phase_r + i);
+    qmcplusplus::sincos(phi[i], phase_i + i, phase_r + i);
 }
 template<typename T>
 inline void eval_e2iphi(int n, const T* restrict phi, std::complex<T>* restrict z)
@@ -116,7 +116,7 @@ inline void eval_e2iphi(int n, const T* restrict phi, std::complex<T>* restrict 
   T s, c;
   for (int i = 0; i < n; i++)
   {
-    sincos(phi[i], &s, &c);
+    qmcplusplus::sincos(phi[i], &s, &c);
     z[i] = std::complex<T>(c, s);
   }
 }

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -17,6 +17,7 @@
 #include "QMCHamiltonians/CoulombPBCAA_CUDA.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "QMCDrivers/WalkerProperties.h"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -147,7 +148,7 @@ void CoulombPBCAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
       PosType r = walkers[0]->R[ir];
       double s, c;
       double phase = dot(k, r);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       rhok += std::complex<double>(c, s);
     }
     fprintf(stderr, "GPU:   %d   %14.6f  %14.6f\n", ik, RhokHost[2 * ik + 0], RhokHost[2 * ik + 1]);

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -18,6 +18,7 @@
 #include "QMCHamiltonians/CoulombPBCAB_CUDA.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "QMCDrivers/WalkerProperties.h"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -127,7 +128,7 @@ void CoulombPBCAB_CUDA::setupLongRangeGPU()
         PosType ipos   = SortedIons[ion];
         RealType phase = dot(k, ipos);
         double s, c;
-        sincos(phase, &s, &c);
+        qmcplusplus::sincos(phase, &s, &c);
         RhokIons_host[2 * ik + 0] += c;
         RhokIons_host[2 * ik + 1] += s;
       }
@@ -207,7 +208,7 @@ void CoulombPBCAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   //     	PosType r = walkers[0]->R[ir];
   //     	double s, c;
   //     	double phase = dot(k,r);
-  //     	sincos(phase, &s, &c);
+  //     	qmcplusplus::sincos(phase, &s, &c);
   //     	rhok += std::complex<double>(c,s);
   //       }
   //       fprintf (stderr, "GPU:   %d   %14.6f  %14.6f\n",

--- a/src/QMCWaveFunctions/AtomicOrbital.h
+++ b/src/QMCWaveFunctions/AtomicOrbital.h
@@ -214,7 +214,7 @@ inline bool AtomicOrbital<StorageType>::evaluate(PosType r, ComplexValueVector_t
     // fprintf (stderr, "phase[%d] = %1.2f pi\n", i, phase/M_PI);
     // fprintf (stderr, "img = [%f,%f,%f]\n", img[0], img[1], img[2]);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     vals[i] *= std::complex<double>(c, s);
   }
   SumTimer.stop();
@@ -279,7 +279,7 @@ inline bool AtomicOrbital<StorageType>::evaluate(PosType r, RealValueVector_t& v
     // 	    ulmVec[index].imag() * YlmVec[lm].imag());
     double phase = -2.0 * M_PI * dot(TwistAngles[i], img);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     vals[i] = real(std::complex<double>(c, s) * tmp);
   }
   SumTimer.stop();
@@ -373,7 +373,7 @@ inline bool AtomicOrbital<StorageType>::evaluate(PosType r,
     // Compute e^{-i k.L} phase factor
     double phase = -2.0 * M_PI * dot(TwistAngles[i], img);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e2mikr(c, s);
     StorageType tmp_val, tmp_lapl, grad_rhat, grad_thetahat, grad_phihat;
     tmp_val = tmp_lapl = grad_rhat = grad_thetahat = grad_phihat = StorageType();
@@ -488,7 +488,7 @@ inline bool AtomicOrbital<StorageType>::evaluate(PosType r,
     // Compute e^{-i k.L} phase factor
     double phase = -2.0 * M_PI * dot(TwistAngles[i], img);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e2mikr(c, s);
     for (int l = 0; l <= lMax; l++)
       for (int m = -l; m <= l; m++, lm++, index++)

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
@@ -22,6 +22,7 @@
 #include <Numerics/Bessel.h>
 #include <QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h>
 #include "OhmmsData/AttributeSet.h"
+#include <config/stdlib/math.hpp>
 
 //#include <QMCHamiltonians/Ylm.h>
 //#define PRINT_RADIAL
@@ -90,7 +91,7 @@ struct Gvectors
 
 #pragma omp simd aligned(px, py, pz, v_r, v_i)
     for (size_t iat = 0; iat < RSoA.size(); iat++)
-      sincos(px[iat] * gv_x + py[iat] * gv_y + pz[iat] * gv_z, v_i + iat, v_r + iat);
+      qmcplusplus::sincos(px[iat] * gv_x + py[iat] * gv_y + pz[iat] * gv_z, v_i + iat, v_r + iat);
   }
 
   template<typename PT>
@@ -101,7 +102,7 @@ struct Gvectors
     for (size_t ig = 0; ig < NumGvecs; ig++)
     {
       ST s, c;
-      sincos(dot(gvecs_cart[ig], pos), &s, &c);
+      qmcplusplus::sincos(dot(gvecs_cart[ig], pos), &s, &c);
       ValueType pw0(c, s);
       val += cG[ig] * pw0;
     }
@@ -116,7 +117,7 @@ struct Gvectors
     for (size_t ig = 0; ig < NumGvecs; ig++)
     {
       ST s, c;
-      sincos(dot(gvecs_cart[ig], pos), &s, &c);
+      qmcplusplus::sincos(dot(gvecs_cart[ig], pos), &s, &c);
       ValueType pw0(c, s);
       phi += cG[ig] * pw0;
       d2phi += cG[ig] * pw0 * (-dot(gvecs_cart[ig], gvecs_cart[ig]));

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -15,6 +15,7 @@
 #include <QMCWaveFunctions/BsplineFactory/SplineC2C.h>
 #include <spline2/MultiBsplineEval.hpp>
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -67,7 +68,7 @@ inline void SplineC2C<ST>::assign_v(const PointType& r,
     ST s, c;
     const ST val_r = myV[2 * j];
     const ST val_i = myV[2 * j + 1];
-    sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
+    qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
     psi[j + first_spo] = ComplexT(val_r * c - val_i * s, val_i * c + val_r * s);
   }
 }
@@ -180,7 +181,7 @@ inline void SplineC2C<ST>::assign_vgl(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -246,7 +247,7 @@ inline void SplineC2C<ST>::assign_vgl_from_l(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g0[jr];
@@ -341,7 +342,7 @@ void SplineC2C<ST>::assign_vgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -493,7 +494,7 @@ void SplineC2C<ST>::assign_vghgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
@@ -17,6 +17,7 @@
 #include <QMCWaveFunctions/BsplineFactory/SplineC2R.h>
 #include <spline2/MultiBsplineEval.hpp>
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -73,7 +74,7 @@ inline void SplineC2R<ST>::assign_v(const PointType& r,
     const size_t ji = jr + 1;
     const ST val_r  = myV[jr];
     const ST val_i  = myV[ji];
-    sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
+    qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
     psi_s[jr] = val_r * c - val_i * s;
     psi_s[ji] = val_i * c + val_r * s;
   }
@@ -85,7 +86,7 @@ inline void SplineC2R<ST>::assign_v(const PointType& r,
     ST s, c;
     const ST val_r = myV[2 * j];
     const ST val_i = myV[2 * j + 1];
-    sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
+    qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
     psi_s[j] = val_r * c - val_i * s;
   }
 }
@@ -212,7 +213,7 @@ inline void SplineC2R<ST>::assign_vgl(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -265,7 +266,7 @@ inline void SplineC2R<ST>::assign_vgl(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -340,7 +341,7 @@ inline void SplineC2R<ST>::assign_vgl_from_l(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g0[jr];
@@ -391,7 +392,7 @@ inline void SplineC2R<ST>::assign_vgl_from_l(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g0[jr];
@@ -486,7 +487,7 @@ void SplineC2R<ST>::assign_vgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -590,7 +591,7 @@ void SplineC2R<ST>::assign_vgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -742,7 +743,7 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -976,7 +977,7 @@ void SplineC2R<ST>::assign_vghgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.cpp
@@ -14,6 +14,7 @@
 #include <spline2/MultiBsplineEval.hpp>
 #include <spline2/MultiBsplineEval_OMPoffload.hpp>
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -55,7 +56,7 @@ inline void assign_v(ST x,
     const size_t ji = jr + 1;
     //phase
     ST s, c, p = -(x * kx[j] + y * ky[j] + z * kz[j]);
-    sincos(p, &s, &c);
+    qmcplusplus::sincos(p, &s, &c);
 
     const ST val_r        = val[jr];
     const ST val_i        = val[ji];
@@ -130,7 +131,7 @@ inline void assign_vgl(ST x,
 
     //phase
     ST s, c, p = -(x * kX + y * kY + z * kZ);
-    sincos(p, &s, &c);
+    qmcplusplus::sincos(p, &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -228,7 +229,7 @@ inline void SplineC2ROMP<ST>::assign_v(const PointType& r,
     const size_t ji = jr + 1;
     const ST val_r  = myV[jr];
     const ST val_i  = myV[ji];
-    sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
+    qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
     psi_s[jr] = val_r * c - val_i * s;
     psi_s[ji] = val_i * c + val_r * s;
   }
@@ -240,7 +241,7 @@ inline void SplineC2ROMP<ST>::assign_v(const PointType& r,
     ST s, c;
     const ST val_r = myV[2 * j];
     const ST val_i = myV[2 * j + 1];
-    sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
+    qmcplusplus::sincos(-(x * kx[j] + y * ky[j] + z * kz[j]), &s, &c);
     psi_s[j] = val_r * c - val_i * s;
   }
 }
@@ -567,7 +568,7 @@ inline void SplineC2ROMP<ST>::assign_vgl_from_l(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g0[jr];
@@ -618,7 +619,7 @@ inline void SplineC2ROMP<ST>::assign_vgl_from_l(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g0[jr];
@@ -1053,7 +1054,7 @@ void SplineC2ROMP<ST>::assign_vgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -1157,7 +1158,7 @@ void SplineC2ROMP<ST>::assign_vgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -1309,7 +1310,7 @@ void SplineC2ROMP<ST>::assign_vghgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];
@@ -1543,7 +1544,7 @@ void SplineC2ROMP<ST>::assign_vghgh(const PointType& r,
 
     //phase
     ST s, c;
-    sincos(-(x * kX + y * kY + z * kZ), &s, &c);
+    qmcplusplus::sincos(-(x * kX + y * kY + z * kZ), &s, &c);
 
     //dot(PrimLattice.G,myG[j])
     const ST dX_r = g00 * g0[jr] + g01 * g1[jr] + g02 * g2[jr];

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -18,6 +18,7 @@
 #include <CPU/e2iphi.h>
 #include "QMCWaveFunctions/EinsplineSet.h"
 #include <einspline/multi_bspline.h>
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -37,7 +38,7 @@ inline void EinsplineSetExtended<StorageType>::computePhaseFactors(const TinyVec
   //    double s, c;
   //    for (int i=0; i<kPoints.size(); i++) {
   //      phase[i] = -dot(r, kPoints[i]);
-  //      sincos (phase[i], &s, &c);
+  //      qmcplusplus::sincos (phase[i], &s, &c);
   //      eikr[i] = std::complex<double>(c,s);
   //    }
   //#endif
@@ -166,7 +167,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
     PosType k = kPoints[j];
     double s, c;
     double phase = -dot(r, k);
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
     StorageValueVector[j] *= e_mikr;
   }
@@ -215,7 +216,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
         PosType k = kPoints[j];
         double s, c;
         double phase = -dot(r, k);
-        sincos(phase, &s, &c);
+        qmcplusplus::sincos(phase, &s, &c);
         std::complex<double> e_mikr(c, s);
         valVec[j] *= e_mikr;
       }
@@ -277,7 +278,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
     PosType k = kPoints[i];
     double s, c;
     double phase = -dot(r, k);
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
     convert(e_mikr * StorageValueVector[i], psi[i]);
   }
@@ -351,7 +352,7 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
       ck[n] = k[n];
     double s, c;
     double phase = -dot(r, k);
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
     StorageValueVector[j] = e_mikr * u;
     StorageGradVector[j]  = e_mikr * (-eye * u * ck + gradu);
@@ -415,7 +416,7 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
           ck[n] = k[n];
         double s, c;
         double phase = -dot(r, k);
-        sincos(phase, &s, &c);
+        qmcplusplus::sincos(phase, &s, &c);
         std::complex<double> e_mikr(c, s);
         valVec[j]  = e_mikr * u;
         gradVec[j] = e_mikr * (-eye * u * ck + gradu);
@@ -540,7 +541,7 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
       ck[n] = k[n];
     double s, c;
     double phase = -dot(r, k);
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
     convert(e_mikr * u, psi[j]);
     convert(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
@@ -585,7 +586,7 @@ void EinsplineSetExtended<StorageType>::evaluateVGH(const ParticleSet& P,
       ck[n] = k[n];
     double s, c;
     double phase = -dot(r, k);
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
     convert(e_mikr * u, psi[j]);
     convert(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
@@ -675,7 +676,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       StorageValueVector[j] = e_mikr * u;
       StorageGradVector[j]  = e_mikr * (-eye * u * ck + gradu);
@@ -738,7 +739,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
             ck[n] = k[n];
           double s, c;
           double phase = -dot(r, k);
-          sincos(phase, &s, &c);
+          qmcplusplus::sincos(phase, &s, &c);
           std::complex<double> e_mikr(c, s);
           valVec[j]  = e_mikr * u;
           gradVec[j] = e_mikr * (-eye * u * ck + gradu);
@@ -872,7 +873,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       StorageValueVector[j] = e_mikr * u;
       StorageGradVector[j]  = e_mikr * (-eye * u * ck + gradu);
@@ -939,7 +940,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
             ck[n] = k[n];
           double s, c;
           double phase = -dot(r, k);
-          sincos(phase, &s, &c);
+          qmcplusplus::sincos(phase, &s, &c);
           std::complex<double> e_mikr(c, s);
           valVec[j]  = e_mikr * u;
           gradVec[j] = e_mikr * (-eye * u * ck + gradu);
@@ -1020,7 +1021,7 @@ void EinsplineSetExtended<StorageType>::evaluateGradSource(const ParticleSet& P,
           PosType k = kPoints[j];
           double s, c;
           double phase = -dot(r, k);
-          sincos(phase, &s, &c);
+          qmcplusplus::sincos(phase, &s, &c);
           std::complex<double> e_mikr(c, s);
           StorageValueVector[j] *= e_mikr;
           dpsi(i, dpsiIndex)[dim] = real(StorageValueVector[j]);
@@ -1080,7 +1081,7 @@ void EinsplineSetExtended<StorageType>::evaluateGradSource(const ParticleSet& P,
             ck[n] = k[n];
           double s, c;
           double phase = -dot(r, k);
-          sincos(phase, &s, &c);
+          qmcplusplus::sincos(phase, &s, &c);
           std::complex<double> e_mikr(c, s);
           StorageValueVector[j]   = e_mikr * u;
           StorageGradVector[j]    = e_mikr * (-eye * u * ck + gradu);
@@ -1256,7 +1257,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       convert(e_mikr * u, psi(i, j));
       //convert(e_mikr * u, psi(j,i));
@@ -1305,7 +1306,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       convert(e_mikr * u, psi(i, j));
       //convert(e_mikr * u, psi(j,i));
@@ -1494,7 +1495,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       //            for (int n=0; n<OHMMS_DIM; n++)       ck[n] = k[n];
       //            double s,c;
       //            double phase = -dot(r, k);
-      //            sincos (phase, &s, &c);
+      //            qmcplusplus::sincos (phase, &s, &c);
       //            std::complex<double> e_mikr (c,s);
       //            valVec[j]   = e_mikr*u;
       //            gradVec[j]  = e_mikr*(-eye*u*ck + gradu);
@@ -1509,7 +1510,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       StorageValueVector[j] = e_mikr * u;
       StorageGradVector[j]  = e_mikr * (-eye * u * ck + gradu);
@@ -1636,7 +1637,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
         ck[n] = k[n];
       double s, c;
       double phase = -dot(r, k);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
       convert(e_mikr * u, psi(i, j));
       convert(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -662,7 +662,7 @@ public:
 ////    double s, c;
 ////    for (int i=0; i<kPoints.size(); i++) {
 ////      phase[i] = -dot(r, kPoints[i]);
-////      sincos (phase[i], &s, &c);
+////      qmcplusplus::sincos (phase[i], &s, &c);
 ////      eikr[i] = std::complex<double>(c,s);
 ////    }
 ////#endif

--- a/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
@@ -25,6 +25,7 @@
 #include "OhmmsData/HDFStringAttrib.h"
 #include "ParticleIO/ESHDFParticleParser.h"
 #include "ParticleBase/RandomSeqGenerator.h"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -585,7 +586,7 @@ EinsplineSetBuilder::ReadBands
           ru[2] = (RealType)iz / (RealType)(nz-1);
           double phi = -2.0*M_PI*dot (ru, TwistAngles[ti]);
           double s, c;
-          sincos(phi, &s, &c);
+          qmcplusplus::sincos(phi, &s, &c);
           std::complex<double> phase(c,s);
           std::complex<double> z = phase*rawData(ix,iy,iz);
           splineData(ix,iy,iz) = z.imag();
@@ -756,7 +757,7 @@ EinsplineSetBuilder::ReadBands
               ru[2] = (RealType)iz / (RealType)(nz-1);
               double phi = -2.0*M_PI*dot (ru, TwistAngles[ti]);
               double s, c;
-              sincos(phi, &s, &c);
+              qmcplusplus::sincos(phi, &s, &c);
               std::complex<double> phase(c,s);
               std::complex<double> z = phase*rawData(ix,iy,iz);
               splineData(ix,iy,iz) = z.real();

--- a/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp
@@ -631,7 +631,7 @@ void EinsplineSetBuilder::ReadBands_ESHDF(int spin, EinsplineSetExtended<double>
 //			ru[2] = (RealType)iz / (RealType)nz;
 //			double phi = -2.0*M_PI*dot (ru, TwistAngles[ti]);
 //			double s, c;
-//			sincos(phi, &s, &c);
+//			qmcplusplus::sincos(phi, &s, &c);
 //			complex<double> phase(c,s);
 //			complex<double> z = phase*rawData(ix,iy,iz);
 //			splineData(ix,iy,iz) = z.real();

--- a/src/QMCWaveFunctions/EinsplineSetCuda.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetCuda.cpp
@@ -23,6 +23,7 @@
 #include "Configuration.h"
 #include "QMCWaveFunctions/detail/CUDA_legacy/AtomicOrbitalCuda.h"
 #include "QMCWaveFunctions/detail/CUDA_legacy/PhaseFactors.h"
+#include <config/stdlib/math.hpp>
 #ifdef HAVE_MKL
 #include <mkl_vml.h>
 #endif
@@ -2292,7 +2293,7 @@ void EinsplineSetHybrid<std::complex<double>>::evaluate(std::vector<Walker_t*>& 
           ck[n] = k[n];
         double s, c;
         double phase = -dot(newpos[iw], k);
-        sincos(phase, &s, &c);
+        qmcplusplus::sincos(phase, &s, &c);
         std::complex<double> e_mikr(c, s);
         CPUzvals[j] = e_mikr * u;
         CPUzgrad[j] = e_mikr * (-eye * u * ck + gradu);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/SPOSet.h"
 #include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
+#include <config/stdlib/math.hpp>
 
 
 namespace qmcplusplus
@@ -45,7 +46,7 @@ struct EGOSet : public SPOSet
     RealType sinkr, coskr;
     for (int ik = 0; ik < KptMax; ik++)
     {
-      sincos(dot(K[ik], r), &sinkr, &coskr);
+      qmcplusplus::sincos(dot(K[ik], r), &sinkr, &coskr);
       psi[ik] = ValueType(coskr, sinkr);
     }
   }
@@ -63,7 +64,7 @@ struct EGOSet : public SPOSet
     RealType sinkr, coskr;
     for (int ik = 0; ik < KptMax; ik++)
     {
-      sincos(dot(K[ik], r), &sinkr, &coskr);
+      qmcplusplus::sincos(dot(K[ik], r), &sinkr, &coskr);
       psi[ik]   = ValueType(coskr, sinkr);
       dpsi[ik]  = ValueType(-sinkr, coskr) * K[ik];
       d2psi[ik] = ValueType(mK2[ik] * coskr, mK2[ik] * sinkr);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -88,7 +88,7 @@ struct RealEGOSet : public SPOSet
     psi[0] = 1.0;
     for (int ik = 0, j = 1; ik < KptMax; ik++)
     {
-      sincos(dot(K[ik], r), &sinkr, &coskr);
+      qmcplusplus::sincos(dot(K[ik], r), &sinkr, &coskr);
       psi[j++] = coskr;
       psi[j++] = sinkr;
     }
@@ -111,7 +111,7 @@ struct RealEGOSet : public SPOSet
     for (int ik = 0, j1 = 1; ik < KptMax; ik++, j1 += 2)
     {
       int j2 = j1 + 1;
-      sincos(dot(K[ik], r), &sinkr, &coskr);
+      qmcplusplus::sincos(dot(K[ik], r), &sinkr, &coskr);
       psi[j1]   = coskr;
       psi[j2]   = sinkr;
       dpsi[j1]  = -sinkr * K[ik];
@@ -138,7 +138,7 @@ struct RealEGOSet : public SPOSet
     for (int ik = 0, j1 = 1; ik < KptMax; ik++, j1 += 2)
     {
       int j2 = j1 + 1;
-      sincos(dot(K[ik], r), &sinkr, &coskr);
+      qmcplusplus::sincos(dot(K[ik], r), &sinkr, &coskr);
       psi[j1]  = coskr;
       psi[j2]  = sinkr;
       dpsi[j1] = -sinkr * K[ik];
@@ -193,7 +193,7 @@ struct RealEGOSet : public SPOSet
       for (int ik = 0, j1 = 1; ik < KptMax; ik++, j1 += 2)
       {
         int j2 = j1 + 1;
-        sincos(dot(K[ik], P.R[iat]), &sinkr, &coskr);
+        qmcplusplus::sincos(dot(K[ik], P.R[iat]), &sinkr, &coskr);
         psi[j1]  = coskr;
         psi[j2]  = sinkr;
         dpsi[j1] = -sinkr * K[ik];
@@ -236,7 +236,7 @@ struct RealEGOSet : public SPOSet
       for (int ik = 0, j1 = 1; ik < KptMax; ik++, j1 += 2)
       {
         int j2 = j1 + 1;
-        sincos(dot(K[ik], P.R[iat]), &sinkr, &coskr);
+        qmcplusplus::sincos(dot(K[ik], P.R[iat]), &sinkr, &coskr);
         psi[j1]  = coskr;
         psi[j2]  = sinkr;
         dpsi[j1] = -sinkr * K[ik];

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -17,6 +17,7 @@
 
 #include "QMCWaveFunctions/Jastrow/kSpaceJastrow.h"
 #include "LongRange/StructFact.h"
+#include <config/stdlib/math.hpp>
 #include "CPU/e2iphi.h"
 #include <sstream>
 #include <algorithm>
@@ -365,7 +366,7 @@ void kSpaceJastrow::resetTargetParticleSet(ParticleSet& P)
     {
       RealType phase, s, c;
       phase = dot(TwoBodyGvecs[i], P.R[iat]);
-      sincos(phase, &s, &c);
+      qmcplusplus::sincos(phase, &s, &c);
       TwoBody_rhoG[i] += ComplexType(c, s);
     }
   }

--- a/src/QMCWaveFunctions/MuffinTin.cpp
+++ b/src/QMCWaveFunctions/MuffinTin.cpp
@@ -424,7 +424,7 @@ void MuffinTinClass::evaluate(TinyVector<double, 3> r, Vector<std::complex<doubl
     // Multiply by phase factor for k-point translation
     double phase = -dot(L, kPoints[iorb]);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     phi[iorb] *= std::complex<double>(c, s);
   }
 }
@@ -553,7 +553,7 @@ void MuffinTinClass::evaluate(TinyVector<double, 3> r,
     // Multiply by phase factor for k-point translation
     double phase = -dot(L, kPoints[iorb]);
     double s, c;
-    sincos(phase, &s, &c);
+    qmcplusplus::sincos(phase, &s, &c);
     phi[iorb] *= std::complex<double>(c, s);
     grad[iorb] *= std::complex<double>(c, s);
     lapl[iorb] *= std::complex<double>(c, s);
@@ -658,7 +658,7 @@ void MuffinTinClass::evaluateCore(TinyVector<double, 3> r, Vector<std::complex<d
     phi[first + i] = ylm * (u);
     // double phase = dot (r, Core_kVecs[i]);
     // double s, c;
-    // sincos(phase, &s, &c);
+    // qmcplusplus::sincos(phase, &s, &c);
     // phi[first+i] *= std::complex<double>(c,s);
   }
 }

--- a/src/QMCWaveFunctions/einspline_helper.hpp
+++ b/src/QMCWaveFunctions/einspline_helper.hpp
@@ -21,6 +21,7 @@
 #include <OhmmsPETE/OhmmsArray.h>
 #include <mpi/collectives.h>
 #include <CPU/SIMD/simd.hpp>
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -88,7 +89,7 @@ inline void fix_phase_c2r(const Array<std::complex<T>, 3>& in, Array<T1, 3>& out
       for (int iz = 0; iz < nz; iz++)
       {
         T1 ruz = static_cast<T1>(iz) * nz_i;
-        sincos(two_pi * (rux + ruy + ruz), &s, &c);
+        qmcplusplus::sincos(two_pi * (rux + ruy + ruz), &s, &c);
         *out_ptr = static_cast<T1>(c * in_ptr->real() - s * in_ptr->imag());
         ++out_ptr;
         ++in_ptr;
@@ -105,7 +106,7 @@ inline void fix_phase_c2r(const Array<std::complex<T>, 3>& in, Array<T1, 3>& out
   //                ru[2] = (RealType)iz / (RealType)nz;
   //                double phi = -2.0*M_PI*dot (ru, TwistAngles[ti]);
   //                double s, c;
-  //                sincos(phi, &s, &c);
+  //                qmcplusplus::sincos(phi, &s, &c);
   //                std::complex<double> phase(c,s);
   //                std::complex<double> z = phase*rawData(ix,iy,iz);
   //                splineData(ix,iy,iz) = z.real();
@@ -151,7 +152,7 @@ inline void fix_phase_rotate_c2r(Array<std::complex<T>, 3>& in,
       for (int iz = 0; iz < nz; iz++)
       {
         T ruz = static_cast<T>(iz) * nz_i * twist[2];
-        sincos(two_pi * (rux + ruy + ruz), &s, &c);
+        qmcplusplus::sincos(two_pi * (rux + ruy + ruz), &s, &c);
         std::complex<T> eikr(c, s);
         *in_ptr *= eikr;
         rNorm += in_ptr->real() * in_ptr->real();
@@ -287,7 +288,7 @@ inline void compute_phase(const Array<std::complex<T>, 3>& in, const TinyVector<
       for (size_t iz = 0; iz < nz; ++iz)
       {
         const T ruz = static_cast<T>(iz) * nz_i * twist[2];
-        sincos(two_pi * (rux + ruy + ruz), &s, &c);
+        qmcplusplus::sincos(two_pi * (rux + ruy + ruz), &s, &c);
         const T re = c * in_ptr[iz].real() - s * in_ptr[iz].imag();
         const T im = s * in_ptr[iz].real() + c * in_ptr[iz].imag();
         rsum += re * re;
@@ -337,7 +338,7 @@ inline void fix_phase_rotate(const Array<std::complex<T>, 3>& e2pi, Array<std::c
   {
     T arg = std::atan2(iNorm, rNorm);
     T phase_i, phase_r;
-    sincos(0.125 * M_PI - 0.5 * arg, &phase_i, &phase_r);
+    qmcplusplus::sincos(0.125 * M_PI - 0.5 * arg, &phase_i, &phase_r);
     //#pragma omp for
     for (int ix = 0; ix < nx; ix++)
     {

--- a/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/lcao/LCAOrbitalBuilder.cpp
@@ -35,6 +35,7 @@
 #include "io/hdf_archive.h"
 #include "Message/CommOperators.h"
 #include "Utilities/ProgressReportEngine.h"
+#include <config/stdlib/math.hpp>
 
 namespace qmcplusplus
 {
@@ -959,7 +960,7 @@ void LCAOrbitalBuilder::EvalPeriodicImagePhaseFactors(PosType SuperTwist,
         Val[2] = TransX * Lattice(0, 2) + TransY * Lattice(1, 2) + TransZ * Lattice(2, 2);
 
         phase = dot(SuperTwist, Val);
-        sincos(phase, &s, &c);
+        qmcplusplus::sincos(phase, &s, &c);
 
         LocPeriodicImagePhaseFactors.emplace_back(c, s);
       }

--- a/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/lcao/SoaAtomicBasisSet.h
@@ -14,6 +14,8 @@
 #ifndef QMCPLUSPLUS_SOA_SPHERICALORBITAL_BASISSET_H
 #define QMCPLUSPLUS_SOA_SPHERICALORBITAL_BASISSET_H
 
+#include <config/stdlib/math.hpp>
+
 namespace qmcplusplus
 {
 /* A basis set for a center type 
@@ -154,7 +156,7 @@ struct SoaAtomicBasisSet
 
     RealType phasearg = SuperTwist[0]*Tv[0]+SuperTwist[1]*Tv[1]+SuperTwist[2]*Tv[2]; 
     RealType s, c;
-    sincos(-phasearg,&s,&c);
+    qmcplusplus::sincos(-phasearg,&s,&c);
     const ValueType correctphase(c,s);
 #endif
 
@@ -615,7 +617,7 @@ struct SoaAtomicBasisSet
 
     RealType phasearg = SuperTwist[0]*Tv[0]+SuperTwist[1]*Tv[1]+SuperTwist[2]*Tv[2]; 
     RealType s, c;
-    sincos(-phasearg,&s,&c);
+    qmcplusplus::sincos(-phasearg,&s,&c);
     const ValueType correctphase(c,s);
 
 #endif

--- a/src/config/stdlib/math.hpp
+++ b/src/config/stdlib/math.hpp
@@ -20,21 +20,30 @@
 #include <mass.h>
 #endif
 
+namespace qmcplusplus
+{
+
+/// sincos function wrapper
 #if __APPLE__
 
 inline void sincos(double a, double* s, double* c)
 {
-  __sincos(a,s,c);
+  ::__sincos(a,s,c);
 }
 
 inline void sincos(float a, float* s, float* c)
 {
-  __sincosf(a,s,c);
+  ::__sincosf(a,s,c);
 }
 
 #else // not __APPLE__
 
 #if defined(HAVE_SINCOS)
+
+inline void sincos(double a, double* s, double* c)
+{
+  ::sincos(a,s,c);
+}
 
 inline void sincos(float a, float* s, float* c)
 {
@@ -42,10 +51,10 @@ inline void sincos(float a, float* s, float* c)
   // there is no sincosf in libmass
   // libmass sincos is faster than libm sincosf
   double ds,dc;
-  sincos((double)a,&ds,&dc);
+  ::sincos((double)a,&ds,&dc);
   *s=ds; *c=dc;
 #else
-  sincosf(a,s,c);
+  ::sincosf(a,s,c);
 #endif
 }
 
@@ -62,8 +71,6 @@ inline void sincos(T a, T* restrict s, T*  restrict c)
 
 #endif // __APPLE__
 
-namespace qmcplusplus
-{
 /** return i^n
  *
  * std::pow(int,int) is not standard


### PR DESCRIPTION
## Proposed changes
currently sincos calls may or may not go through <config/stdlib/math.hpp> wrapper.
To enforce our wrapper layer, sincos(float/double) functions have been added to qmcplusplus namespace.
all the calls are modified to call qmcplusplus::sincos explicitly and avoid calling ambiguous sincos without a namespace.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
