### PR TITLE
Use fixed batch leader in NLPP

### DIFF
--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -26,7 +26,6 @@
 #include "LongRange/StructFact.h"
 #include "Particle/HDFWalkerOutput.h"
 #include "Particle/MCSample.h"
-#include "QMCDrivers/QMCDriver.h"
 #include <io/hdf_hyperslab.h>
 #include "HDFVersion.h"
 #include <map>

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -18,7 +18,6 @@
 #include "Configuration.h"
 #include "Particle/VirtualParticleSet.h"
 #include "Particle/DistanceTableData.h"
-#include "QMCHamiltonians/NonLocalECPComponent.h"
 #include "Particle/createDistanceTable.h"
 #include "QMCHamiltonians/NLPPJob.h"
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -186,6 +186,7 @@ void NonLocalECPComponent::flex_evaluateOne(const RefVector<NonLocalECPComponent
                                             const RefVector<ParticleSet>& p_list,
                                             const RefVector<TrialWaveFunction>& psi_list,
                                             const RefVector<const NLPPJob<RealType>>& joblist,
+                                            TrialWaveFunction& psi_leader,
                                             std::vector<RealType>& pairpots,
                                             bool use_DLA)
 {
@@ -218,10 +219,10 @@ void NonLocalECPComponent::flex_evaluateOne(const RefVector<NonLocalECPComponent
 
       VirtualParticleSet::flex_makeMoves(vp_list, deltaV_list, joblist, true);
       if (use_DLA)
-        TrialWaveFunction::flex_evaluateRatios(psi_list, const_vp_list, psiratios_list,
+        psi_leader.flex_evaluateRatios(psi_list, const_vp_list, psiratios_list,
                                                TrialWaveFunction::ComputeType::FERMIONIC);
       else
-        TrialWaveFunction::flex_evaluateRatios(psi_list, const_vp_list, psiratios_list);
+        psi_leader.flex_evaluateRatios(psi_list, const_vp_list, psiratios_list);
     }
     else
     {

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -184,6 +184,7 @@ public:
                                const RefVector<ParticleSet>& p_list,
                                const RefVector<TrialWaveFunction>& psi_list,
                                const RefVector<const NLPPJob<RealType>>& joblist,
+                               TrialWaveFunction& psi_leader,
                                std::vector<RealType>& pairpots,
                                bool use_DLA);
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -169,11 +169,9 @@ public:
    *
    * @param ecp_component_list a list of ECP components
    * @param p_list a list of electron particle set.
-   * @param iat_list a list of ion indices.
    * @param psi_list a list of trial wave function object
-   * @param iel_list a list of electron indices
-   * @param r_list a list of the distances between ion iat and electron iel.
-   * @param dr_list a list of displacements from ion iat to electron iel.
+   * @param joblist a list of ion-electron pairs
+   * @param psi_leader the batch leader of psi_list
    * @param pairpots a list of contribution to $\frac{V\Psi_T}{\Psi_T}$ from ion iat and electron iel.
    * @param use_DLA if ture, use determinant localization approximation (DLA).
    *

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -326,7 +326,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVector<OperatorBase>& O_list,
         }
       }
 
-      NonLocalECPComponent::flex_evaluateOne(ecp_component_list, p_list, psi_list, batch_list, pairpots, use_DLA);
+      NonLocalECPComponent::flex_evaluateOne(ecp_component_list, p_list, psi_list, batch_list, Psi, pairpots, use_DLA);
 
       for (size_t j = 0; j < ecp_potential_list.size(); j++)
       {

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -976,7 +976,7 @@ void TrialWaveFunction::flex_evaluateRatios(const RefVector<TrialWaveFunction>& 
 {
   if (wf_list.size() > 1)
   {
-    auto& wavefunction_components = wf_list[0].get().Z;
+    auto& wavefunction_components = Z;
     std::vector<std::vector<ValueType>> t(ratios_list.size());
     for (int iw = 0; iw < wf_list.size(); iw++)
     {

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -274,10 +274,10 @@ public:
   /** compulte multiple ratios to handle non-local moves and other virtual moves
    */
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios, ComputeType ct = ComputeType::ALL);
-  static void flex_evaluateRatios(const RefVector<TrialWaveFunction>& WF_list,
-                                  const RefVector<const VirtualParticleSet>& VP_list,
-                                  const RefVector<std::vector<ValueType>>& ratios_list,
-                                  ComputeType ct = ComputeType::ALL);
+  void flex_evaluateRatios(const RefVector<TrialWaveFunction>& WF_list,
+                           const RefVector<const VirtualParticleSet>& VP_list,
+                           const RefVector<std::vector<ValueType>>& ratios_list,
+                           ComputeType ct = ComputeType::ALL);
 
   /** compute both ratios and deriatives of ratio with respect to the optimizables*/
   void evaluateDerivRatios(VirtualParticleSet& P,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -274,6 +274,9 @@ public:
   /** compulte multiple ratios to handle non-local moves and other virtual moves
    */
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios, ComputeType ct = ComputeType::ALL);
+  /** batched verison of evaluateRatios
+   * Note: unlike other flex_ static functions, *this is the batch leader instead of WF_list[0].
+   */
   void flex_evaluateRatios(const RefVector<TrialWaveFunction>& WF_list,
                            const RefVector<const VirtualParticleSet>& VP_list,
                            const RefVector<std::vector<ValueType>>& ratios_list,


### PR DESCRIPTION
## Proposed changes
In NLPP, the batch leader, wf_list[0], for ratio computation changes dynamically and causes excessive memory usage because batch leader is responsible for scratch memory. This PR fixes batch leader during NLPP evaluation.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'