### PR TITLE
Use invRow device poionters when evaluating NLPP ratios in batches

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMP.h
@@ -97,10 +97,10 @@ private:
   Vector<TT, OffloadPinnedAllocator<TT>> mw_psiinv_pos_copy;
   ///position scratch space, used to avoid allocation on the fly and faster transfer
   Vector<ST, OffloadPinnedAllocator<ST>> multi_pos_copy;
-  ///reference particle id of all the quadrature points
-  Vector<int, OffloadPinnedAllocator<int>> mw_ref_id;
-  ///multi purpose H2D buffer
+  ///multi purpose H2D buffer for mw_evaluateVGLandDetRatioGrads
   Matrix<char, OffloadPinnedAllocator<char>> buffer_H2D;
+  ///multi purpose H2D buffer for mw_evaluateDetRatios
+  Vector<char, OffloadPinnedAllocator<char>> det_ratios_buffer_H2D;
 
   void evaluateVGLMultiPos(const Vector<ST, OffloadPinnedAllocator<ST>>& multi_pos_copy,
                            const RefVector<ValueVector_t>& psi_v_list,
@@ -233,7 +233,7 @@ public:
   virtual void mw_evaluateDetRatios(const RefVector<SPOSet>& spo_list,
                                     const RefVector<const VirtualParticleSet>& vp_list,
                                     const RefVector<ValueVector_t>& psi_list,
-                                    const RefVector<const ValueVector_t>& psiinv_list,
+                                    const std::vector<const ValueType*>& invRow_ptr_list,
                                     std::vector<std::vector<ValueType>>& ratios_list) override;
 
   /** assign_vgl_from_l can be used when myL is precomputed and myV,myG,myL in cartesian

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -393,26 +393,27 @@ void DiracDeterminant<DU_TYPE>::mw_evaluateRatios(const RefVector<WaveFunctionCo
 
   RefVector<SPOSet> phi_list;
   RefVector<ValueVector_t> psiV_list;
-  RefVector<const ValueVector_t> invRow_list;
+  std::vector<const ValueType*> invRow_ptr_list;
   phi_list.reserve(nw);
   psiV_list.reserve(nw);
-  invRow_list.reserve(nw);
+  invRow_ptr_list.reserve(nw);
 
   for (size_t iw = 0; iw < nw; iw++)
   {
     auto& det = static_cast<DiracDeterminant<DU_TYPE>&>(wfc_list[iw].get());
     const VirtualParticleSet& vp(vp_list[iw]);
     const int WorkingIndex = vp.refPtcl - FirstIndex;
-    std::copy_n(det.psiM[WorkingIndex], det.invRow.size(), det.invRow.data());
     // build lists
     phi_list.push_back(*det.Phi);
     psiV_list.push_back(det.psiV);
-    invRow_list.push_back(det.invRow);
+    invRow_ptr_list.push_back(det.psiM[WorkingIndex]);
   }
   RatioTimer.stop();
 
   SPOVTimer.start();
-  Phi->mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_list, ratios);
+  if (Phi->isOMPoffload())
+    throw std::runtime_error("DiracDeterminant doesn't support calling mw_evaluateDetRatios of SPOSet with OpenMP offload used!");
+  Phi->mw_evaluateDetRatios(phi_list, vp_list, psiV_list, invRow_ptr_list, ratios);
   SPOVTimer.stop();
 }
 

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -392,6 +392,8 @@ public:
 
   inline OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
+  inline T* getRow_psiMinv_offload(int row_id) { return psiMinv_dev_ptr + row_id * psiMinv.cols(); }
+
   /** compute the inverse of the transpose of matrix A
    * @param logdetT orbital value matrix
    * @param Ainv inverse matrix

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMP.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMP.h
@@ -105,6 +105,8 @@ public:
 
   OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
+  inline T* getRow_psiMinv_offload(int row_id) { return psiMinv_dev_ptr + row_id * psiMinv.cols(); }
+
   /** compute the inverse of the transpose of matrix A
    * @param logdetT orbital value matrix
    * @param Ainv inverse matrix

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -67,12 +67,15 @@ void SPOSet::evaluateDetRatios(const VirtualParticleSet& VP,
 void SPOSet::mw_evaluateDetRatios(const RefVector<SPOSet>& spo_list,
                                   const RefVector<const VirtualParticleSet>& vp_list,
                                   const RefVector<ValueVector_t>& psi_list,
-                                  const RefVector<const ValueVector_t>& psiinv_list,
+                                  const std::vector<const ValueType*>& invRow_ptr_list,
                                   std::vector<std::vector<ValueType>>& ratios_list)
 {
 #pragma omp parallel for
   for (int iw = 0; iw < spo_list.size(); iw++)
-    spo_list[iw].get().evaluateDetRatios(vp_list[iw], psi_list[iw], psiinv_list[iw], ratios_list[iw]);
+  {
+    Vector<ValueType> invRow(const_cast<ValueType*>(invRow_ptr_list[iw]), psi_list[iw].get().size());
+    spo_list[iw].get().evaluateDetRatios(vp_list[iw], psi_list[iw], invRow, ratios_list[iw]);
+  }
 }
 
 void SPOSet::mw_evaluateVGL(const RefVector<SPOSet>& spo_list,

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -240,13 +240,13 @@ public:
    * @param spo_list the list of SPOSet pointers in a walker batch
    * @param vp_list a list of virtual particle sets in a walker batch
    * @param psi_list a list of values of the SPO, used as a scratch space if needed
-   * @param psiinv_list a list of the row of inverse slater matrix corresponding to the particle moved virtually
+   * @param invRow_ptr_list a list of pointers to the rows of inverse slater matrix corresponding to the particles moved virtually
    * @param ratios_list a list of returning determinant ratios
    */
   virtual void mw_evaluateDetRatios(const RefVector<SPOSet>& spo_list,
                                     const RefVector<const VirtualParticleSet>& vp_list,
                                     const RefVector<ValueVector_t>& psi_list,
-                                    const RefVector<const ValueVector_t>& psiinv_list,
+                                    const std::vector<const ValueType*>& invRow_ptr_list,
                                     std::vector<std::vector<ValueType>>& ratios_list);
 
   /** evaluate the values, gradients and laplacians of this single-particle orbital set

--- a/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
@@ -38,6 +38,15 @@
                     0 DIAMOND2_SCALARS # VMC
                     )
 
+  QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch-4b_sdbatch_jas
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
+                    qmc_short
+                    qmc_short_sdbatch_vmcbatch_4b.in.xml
+                    1 4
+                    TRUE
+                    0 DIAMOND2_SCALARS # VMC
+                    )
+
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-delayed_update-vmc_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
                     qmc_short

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_4b.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_4b.in.xml
@@ -41,7 +41,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant>
+            <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
@@ -41,7 +41,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant>
+            <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>


### PR DESCRIPTION
## Proposed changes
Before this PR, the invRow values on host are copied from host to a buffer, then transferred to the device and consumed by the offload SPO. With batched determinants, invRows are already on the device and no tranfer is needed. This PR removes the transfer.

add an integration test for batched VMC + batched DiracDeterminant by modifying the batched VMC + non-batched DiracDeterminant test.

## What type(s) of changes does this code introduce?
- Other (please describe): performance optimization.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit, Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed