### PR TITLE
Add deterministic test for PBC-Gaussian 1x1x1 and 2x1x1 diamond

### DIFF
--- a/tests/solids/diamondC_1x1x1-Gaussian_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1-Gaussian_pp/CMakeLists.txt
@@ -51,6 +51,38 @@
                     1 LONG_DIAMOND_DMC_SCALARS # DMC
                     )
 
+# Deterministic test
+  IF (QMC_MIXED_PRECISION)
+   LIST(APPEND DET_DIAMOND_SCALARS "totenergy" "-10.26918214 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "kinetic" "10.15418453 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "potential" "-20.42336667 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "eeenergy" "-1.32915939 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "ionion" "-12.77567016 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "localecp" "-6.76235562 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "nonlocalecp" "0.44381850 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "samples" "9 0.0")
+  ELSE()
+   LIST(APPEND DET_DIAMOND_SCALARS "totenergy" "-10.26902520 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "kinetic" "10.15433651 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "potential" "-20.42336170 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "eeenergy" "-1.32916126 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "ionion" "-12.77566743 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "localecp" "-6.76235283 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "nonlocalecp" "0.44381981 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "samples" "9 0.0")
+  ENDIF()
+
+
+  QMC_RUN_AND_CHECK(deterministic-diamondC_1x1x1_pp-vmc_gaussian_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1-Gaussian_pp"
+                    det_qmc_short
+                    det_qmc_short.in.xml
+                    1 1
+                    TRUE
+                    0 DET_DIAMOND_SCALARS # VMC
+                    )
+
+
   ELSE()
     MESSAGE_VERBOSE("Skipping Periodic LCAO as not supported by CUDA build (QMC_CUDA=1)")
   ENDIF()

--- a/tests/solids/diamondC_1x1x1-Gaussian_pp/det_qmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1-Gaussian_pp/det_qmc_short.in.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_qmc_short" series="0"/>
+  <random seed="87"/>
+  <include href="C_Diamond.structure.xml"/>
+  <include href="C_Diamond.wfj-Twist0.xml"/>
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
+    <pairpot name="PseudoPot" type="pseudo" source="ion0" wavefunction="psi0" format="xml">
+      <pseudo elementType="C" href="C.BFD.xml"/>
+    </pairpot>
+  </hamiltonian>
+   <qmc method="vmc" move="pbyp">
+      <parameter name="walkers"             >    1              </parameter>
+      <parameter name="blocks"              >    3             </parameter>
+      <parameter name="steps"               >    3             </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    3              </parameter>
+   </qmc>
+</simulation>

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp/CMakeLists.txt
@@ -50,6 +50,36 @@
                     1 LONG_DIAMOND_DMC_SCALARS # DMC
                     )
 
+# Deterministic test
+  IF (QMC_MIXED_PRECISION)
+   LIST(APPEND DET_DIAMOND_SCALARS "totenergy" "-22.70088280 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "kinetic" "15.76914410 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "potential" "-38.47002690 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "eeenergy" "-5.67929898 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "ionion" "-25.55133345 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "localecp" "-12.01435100 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "nonlocalecp" "4.77495368 0.000005")
+   LIST(APPEND DET_DIAMOND_SCALARS "samples" "9 0.0")
+  ELSE()
+   LIST(APPEND DET_DIAMOND_SCALARS "totenergy" "-22.70066423 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "kinetic" "15.76939694 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "potential" "-38.47006117 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "eeenergy" "-5.67929898 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "ionion" "-25.55132719 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "localecp" "-12.01437633 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "nonlocalecp" "4.77494133 0.000001")
+   LIST(APPEND DET_DIAMOND_SCALARS "samples" "9 0.0")
+  ENDIF()
+
+  QMC_RUN_AND_CHECK(deterministic-diamondC_2x1x1_pp-vmc_gaussian_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1-Gaussian_pp"
+                    det_qmc_short
+                    det_qmc_short.in.xml
+                    1 1
+                    TRUE
+                    0 DET_DIAMOND_SCALARS # VMC
+                    )
+
   ELSE()
     MESSAGE_VERBOSE("Skipping Periodic LCAO as not supported by CUDA build (QMC_CUDA=1)")
   ENDIF()

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp/det_qmc_short.in.xml
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp/det_qmc_short.in.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_qmc_short" series="0"/>
+  <random seed="532"/>
+  <include href="C_Diamond.structure.xml"/>
+  <include href="C_Diamond.wfj-Twist0.xml"/>
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
+    <pairpot name="PseudoPot" type="pseudo" source="ion0" wavefunction="psi0" format="xml">
+      <pseudo elementType="C" href="C.BFD.xml"/>
+    </pairpot>
+  </hamiltonian>
+   <qmc method="vmc" move="pbyp">
+      <parameter name="walkers"             >    1             </parameter>
+      <parameter name="blocks"              >    3             </parameter>
+      <parameter name="steps"               >    3             </parameter>
+      <parameter name="subSteps"            >    2              </parameter>
+      <parameter name="timestep"            >    0.3            </parameter>
+      <parameter name="warmupSteps"         >    3            </parameter>
+   </qmc>
+</simulation>
+


### PR DESCRIPTION
## Proposed changes

As requested in #2611, deterministic tests for PBC-Gaussian 1x1x1 and 2x1x1 diamond are added.
References were generated in QMCPACK 3.9.2 and current develop version. 
Tests are all passed including mixed precision build but tolerance for the mixed precision will be adjusted after checking tolerances in cdash. 

Closes #2611 

## What type(s) of changes does this code introduce?

- Add test

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

 Workstation (Intel Xeon)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
