### PR TITLE
Fix determinant tool for negative number

### DIFF
--- a/utils/determinants_tools.py
+++ b/utils/determinants_tools.py
@@ -30,8 +30,22 @@ from collections import namedtuple
 Determinants = namedtuple('Determinants', ['alpha', 'beta'])
 CSF = namedtuple('CSF', ['double', 'single'])
 
-def sanitize(det_spin, bit_kind_size):
-     return [s + (1 << bit_kind_size) if s < 0  else s for s in det_spin]
+def sanitize_numpy(det_spin, bit_kind_size):
+     '''
+     This function transform signed numpy variable to native "positive" python number
+     In the case of :
+        -positive Numpy number, we just cast it to Python data-type
+        -negative Numpy number, we do the two-compelement trick. 
+                                Because this value cannot fit on the initial Numpy datatype, 
+                                it will silently casted to int.
+
+     >>> import numpy as np
+     >>> sanitize_numpy([np.int8(1)], 8)
+     [1]
+     >>> sanitize_numpy([np.int8(-1)], 8)
+     [255]
+     '''
+     return [ (s + (1 << bit_kind_size)) if s < 0 else int(s) for s in det_spin]
 
 def int_to_bitmask(s, bit_kind_size):
     '''

--- a/utils/determinants_tools.py
+++ b/utils/determinants_tools.py
@@ -30,7 +30,7 @@ from collections import namedtuple
 Determinants = namedtuple('Determinants', ['alpha', 'beta'])
 CSF = namedtuple('CSF', ['double', 'single'])
 
-def sanitize_numpy(det_spin, bit_kind_size):
+def sanitize(det_spin, bit_kind_size):
      '''
      This function transform signed numpy variable to native "positive" python number
      In the case of :


### PR DESCRIPTION
## Proposed changes

This PR fix the `determinant_tool` which analyses the determinants stored in HDF5 to print information about them.
This tool was broken for a negative number (and the bug was ofc in the only non-tested function...). 

In HDF5, for legacy reasons, we store the determinant as a list of signed integers in the HDF5. All the algorithms in this script assume unsigned integers, so we need to convert them prior to any analysis.  

The bugs were in the mismatch of data-type. Some of the value was converted to Python native data-type where others were still numpy data-type. This PR fixes this issue.  The only change is `s -> int(s)` in line 34 / 48.



## What type(s) of changes does this code introduce?
- Bugfix


### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

Python3. Didn't add new dependency. 

## Checklist

-  This PR is up to date with current the current state of 'develop'
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
