### PR TITLE
Remove "short" title on test name "deterministic-short-LiH_solid_1x1x1_pp-gamma-vmc_hf_noj-1-1"

### DIFF
--- a/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
@@ -220,7 +220,7 @@ ELSE()
  ENDIF()
 ENDIF()
 
-  QMC_RUN_AND_CHECK(deterministic-short-LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
+  QMC_RUN_AND_CHECK(deterministic-LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
                     "${CMAKE_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
                     det_hf_vmc_LiH-gamma
                     det_hf_vmc_LiH-gamma.xml


### PR DESCRIPTION
## Proposed changes

This PR is to change test name "deterministic-short-LiH_solid_1x1x1_pp-gamma-vmc_hf_noj-1-1" to "deterministic-LiH_solid_1x1x1_pp-gamma-vmc_hf_noj-1-1" in order to unify test name template for the deterministic test. 

## What type(s) of changes does this code introduce?

- Other (please describe): Add test

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
