### PR TITLE
Include ompReduction.h in SplineC2COMP.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ make -j 8
  * Key QMC build options
 
 ```
-     QMC_CUDA            Enable CUDA and GPU acceleration (1:yes, 0:no)
+     QMC_CUDA            Enable legacy CUDA code path for NVIDIA GPU acceleration (1:yes, 0:no)
      QMC_COMPLEX         Build the complex (general twist/k-point) version (1:yes, 0:no)
      QMC_MIXED_PRECISION Build the mixed precision (mixing double/float) version
                          (1:yes (GPU default), 0:no (CPU default)).
@@ -147,11 +147,13 @@ make -j 8
                          The GPU support is quite mature.
                          Use always double for host side base and full precision
                          and use float and double for CUDA base and full precision.
-     ENABLE_TIMERS       Enable fine-grained timers (1:yes, 0:no (default)).
-                         Timers are off by default to avoid potential slowdown in small
-                         systems. For large systems (100+ electrons) there is no risk.
-     ENABLE_SOA          Enable CPU optimization based on Structure-
-                         of-Array (SoA) datatypes (1:yes (default), 0:no). ```
+     ENABLE_CUDA         ON/OFF(default). Enable CUDA code path for NVIDIA GPU acceleration.
+                         Production quality for AFQMC. Pre-production quality for real-space.
+                         Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
+     ENABLE_OFFLOAD      ON/OFF(default). Experimental feature. Enable OpenMP target offload for GPU acceleration.
+     ENABLE_TIMERS       ON/OFF(default). Enable fine-grained timers. Timers are off by default
+                         to avoid potential slowdown in small systems.
+                         For large systems (100+ electrons) there is no risk.
 ```
 
  * Additional QMC options
@@ -161,7 +163,7 @@ make -j 8
      QMC_DATA            Specify data directory for QMCPACK performance and integration tests
      QMC_INCLUDE         Add extra include paths
      QMC_EXTRA_LIBS      Add extra link libraries
-     QMC_BUILD_STATIC    Add -static flags to build
+     QMC_BUILD_STATIC    ON/OFF(default). Add -static flags to build
      QMC_SYMLINK_TEST_FILES Set to zero to require test files to be copied. Avoids space
                             saving default use of symbolic links for test files. Useful
                             if the build is on a separate filesystem from the source, as

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -300,6 +300,7 @@ the path to the source directory.
                           particularly for large electron counts.
     ENABLE_CUDA           ON/OFF(default). Enable CUDA code path for NVIDIA GPU acceleration.
                           Production quality for AFQMC. Pre-production quality for real-space.
+                          Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
     ENABLE_OFFLOAD        ON/OFF(default). Enable OpenMP target offload for GPU acceleration.
     ENABLE_TIMERS         ON/OFF(default). Enable fine-grained timers. Timers are off by default
                           to avoid potential slowdown in small systems.

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMP.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMP.cpp
@@ -14,6 +14,7 @@
 #include <spline2/MultiBsplineEval.hpp>
 #include <spline2/MultiBsplineEval_OMPoffload.hpp>
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
+#include "Platforms/OpenMP/ompReduction.hpp"
 #include <config/stdlib/math.hpp>
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -19,7 +19,6 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
 #include "Platforms/OpenMP/ompBLAS.hpp"
-#include "Platforms/OpenMP/ompReduction.hpp"
 #include <cuda_runtime_api.h>
 #include "CUDA/cuBLAS.hpp"
 #include "CUDA/cuBLAS_missing_functions.hpp"

--- a/tests/test_automation/nightly_test_scripts/nightly_anl_bora.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_anl_bora.sh
@@ -76,7 +76,7 @@ CTEST_FLAGS="-DQMC_DATA=$QMC_DATA -DENABLE_TIMERS=1"
 # compiler dependent options
 if [[ $sys == *"ClangDev"* ]]; then
   #define and load compiler
-  module load llvm/dev-latest
+  module load llvm/master-latest
   module load openmpi/4.0.2-llvm
   export CC=mpicc
   export CXX=mpicxx
@@ -85,11 +85,11 @@ if [[ $sys == *"ClangDev"* ]]; then
   if [[ $sys == *"Offload-CUDA"* ]]; then
     CTEST_FLAGS="$CTEST_FLAGS -DQMC_OPTIONS='-DENABLE_OFFLOAD=ON;-DUSE_OBJECT_TARGET=ON;-DCUDA_HOST_COMPILER=`which gcc`;-DCUDA_PROPAGATE_HOST_FLAGS=OFF;-DQMC_NIO_MAX_SIZE=16'"
     CTEST_FLAGS="$CTEST_FLAGS -DENABLE_CUDA=1 -DCUDA_ARCH=sm_61"
-    CTEST_LABLES="-L deterministic -LE unstable"
-    export N_CONCURRENT_TESTS=4
+    CTEST_LABELS="-L deterministic -LE unstable"
+    export N_CONCURRENT_TESTS=1
   else
     CTEST_FLAGS="$CTEST_FLAGS -DQE_BIN=$QE_BIN"
-    CTEST_LABLES="-L 'deterministic|performance' -LE unstable"
+    CTEST_LABELS="-L 'deterministic|performance' -LE unstable"
     export N_CONCURRENT_TESTS=16
   fi
 elif [[ $sys == *"Intel"* ]]; then
@@ -102,12 +102,12 @@ elif [[ $sys == *"Intel"* ]]; then
   CTEST_FLAGS="$CTEST_FLAGS -DCMAKE_C_FLAGS=-xCOMMON-AVX512 -DCMAKE_CXX_FLAGS=-xCOMMON-AVX512"
   if [[ $sys == *"-CUDA2"* ]]; then
     CTEST_FLAGS="$CTEST_FLAGS -DENABLE_CUDA=1 -DCUDA_ARCH=sm_61 -DQMC_OPTIONS='-DQMC_NIO_MAX_SIZE=16'"
-    CTEST_LABLES="-L 'deterministic|performance' -LE unstable"
-    export N_CONCURRENT_TESTS=4
+    CTEST_LABELS="-L 'deterministic|performance' -LE unstable"
+    export N_CONCURRENT_TESTS=1
   elif [[ $sys == *"-legacy-CUDA"* ]]; then
     CTEST_FLAGS="$CTEST_FLAGS -DQMC_CUDA=1 -DCUDA_ARCH=sm_61 -DQMC_OPTIONS='-DQMC_NIO_MAX_SIZE=16'"
-    CTEST_LABLES="-L 'deterministic|performance' -LE unstable"
-    export N_CONCURRENT_TESTS=4
+    CTEST_LABELS="-L 'deterministic|performance' -LE unstable"
+    export N_CONCURRENT_TESTS=1
   else
     CTEST_FLAGS="$CTEST_FLAGS -DQE_BIN=$QE_BIN"
     export N_CONCURRENT_TESTS=16
@@ -133,7 +133,7 @@ mkdir $folder
 cd $folder
 
 numactl -N $NUMA_ID \
-ctest $CTEST_FLAGS $CTEST_LABLES -S $PWD/../CMake/ctest_script.cmake,release -VV -E 'long' --timeout 800 &> $place/log/$entry/$mydate/${QMCPACK_TEST_SUBMIT_NAME}.log
+ctest $CTEST_FLAGS $CTEST_LABELS -S $PWD/../CMake/ctest_script.cmake,release -VV -E 'long' --timeout 800 &> $place/log/$entry/$mydate/${QMCPACK_TEST_SUBMIT_NAME}.log
 
 cd ..
 echo --- Finished $sys `date`


### PR DESCRIPTION
## Proposed changes
ompReduction.h header was missing in SplineC2COMP.cpp. It doesn't matter for Clang which supports complex reduction with and without openmp user defined reduction (UDR).

In addition, this PR put the README.md aligned with installation.rst and update nightly test script on Bora.

## What type(s) of changes does this code introduce?
- Bugfix
- Documentation content changes

### Does this introduce a breaking change?
- Yes. I noticed IBM XL fails on complex build. With UDR, I got linker error. Without UDR, I got compiler ICE.

## What systems has this change been tested on?
Summit.