### PR TITLE
Restructure how CLI arguments are read for qmcfinitesize

### DIFF
--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -57,38 +57,43 @@ int main(int argc, char** argv)
   std::cout.precision(12);
 
   std::unique_ptr<SkParserBase> skparser(nullptr);
-  int iargc = 2;
 
-  while (iargc + 1 < argc)
+  if (argc<4)
   {
-    std::string a(argv[iargc]);
-    std::string anxt(argv[iargc + 1]);
-    if (a == "--ascii")
-    {
-      skparser = std::make_unique<SkParserASCII>();
-      skparser->parse(anxt);
-    }
-    else if (a == "--scalardat")
-    {
-      skparser = std::make_unique<SkParserScalarDat>();
-      skparser->parse(anxt);
-    }
-    else if (a == "--hdf5")
-    {
-      skparser = std::make_unique<SkParserHDF5>();
-      skparser->parse(anxt);
-    }
-    else if (a == "--help")
-    {
       std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
       std::cout << "  [skformat]\n";
       std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
       std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
       std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
       return 0;
-    }
-    iargc++;
   }
+  else
+  {
+    int iargc = 2;
+    while (iargc + 1 < argc)
+    {
+      std::string a(argv[iargc]);
+      std::string anxt(argv[iargc + 1]);
+      if (a == "--ascii")
+      {
+        skparser = std::make_unique<SkParserASCII>();
+        skparser->parse(anxt);
+      }
+      else if (a == "--scalardat")
+      {
+        skparser = std::make_unique<SkParserScalarDat>();
+        skparser->parse(anxt);
+      }
+      else if (a == "--hdf5")
+      {
+        skparser = std::make_unique<SkParserHDF5>();
+        skparser->parse(anxt);
+      }
+      iargc++;
+    }
+  }
+
+
 
   if (skparser == NULL)
   {

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -58,14 +58,18 @@ int main(int argc, char** argv)
 
   std::unique_ptr<SkParserBase> skparser(nullptr);
 
-  if (argc<4)
+  /* For a successful execution of the code, atleast 3 arguments will need to be
+   * provided along with the exectuable. Therefore, print usage information if
+   * argc is less than 4.
+   */
+  if (argc < 4)
   {
-      std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
-      std::cout << "  [skformat]\n";
-      std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
-      std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
-      std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
-      return 0;
+    std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
+    std::cout << "  [skformat]\n";
+    std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
+    std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
+    std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
+    return 0;
   }
   else
   {
@@ -92,7 +96,6 @@ int main(int argc, char** argv)
       iargc++;
     }
   }
-
 
 
   if (skparser == NULL)

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -58,22 +58,21 @@ int main(int argc, char** argv)
 
   std::unique_ptr<SkParserBase> skparser(nullptr);
 
+  bool show_usage = false;
+  bool show_warn  = false;
   /* For a successful execution of the code, atleast 3 arguments will need to be
    * provided along with the exectuable. Therefore, print usage information if
    * argc is less than 4.
    */
   if (argc < 4)
   {
-    std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
-    std::cout << "  [skformat]\n";
-    std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
-    std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
-    std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
-    return 0;
+    std::cout << "Insufficient number of arguments.\n\n";
+    show_usage = true;
   }
   else
   {
-    int iargc = 2;
+    int iargc      = 2;
+    bool skf_found = false;
     while (iargc + 1 < argc)
     {
       std::string a(argv[iargc]);
@@ -82,21 +81,47 @@ int main(int argc, char** argv)
       {
         skparser = std::make_unique<SkParserASCII>();
         skparser->parse(anxt);
+        if (skf_found)
+          show_warn = true;
+        skf_found = true;
       }
       else if (a == "--scalardat")
       {
         skparser = std::make_unique<SkParserScalarDat>();
         skparser->parse(anxt);
+        if (skf_found)
+          show_warn = true;
+        skf_found = true;
       }
       else if (a == "--hdf5")
       {
         skparser = std::make_unique<SkParserHDF5>();
         skparser->parse(anxt);
+        if (skf_found)
+          show_warn = true;
+        skf_found = true;
       }
-      iargc++;
+      else
+      {
+        std::cout << "Unrecognized flag '" << a << "'.\n\n";
+        show_usage = true;
+      }
+      iargc += 2;
     }
   }
 
+  if (show_usage)
+  {
+    std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
+    std::cout << "  [skformat]\n";
+    std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
+    std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
+    std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
+    return 0;
+  }
+
+  if (show_warn)
+    std::cout << "WARNING:  multiple skformats were provided. All but the last will be ignored.\n\n";
 
   if (skparser == NULL)
   {


### PR DESCRIPTION

## Proposed changes

Minor change, however, helpful for new users running the tool.
The usage is printed when number of arguments is less than what is needed for successful execution.
Also fixes issue where 'qmcfinitesize --help' prints nothing.

## What type(s) of changes does this code introduce?

- Other (please describe): Minor "fix". Before this PR 'qmcfinitesize --help' leads to no printout

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
