### PR TITLE
Symlink all the files from test folders to the build folder

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -22,14 +22,19 @@ FUNCTION( COPY_DIRECTORY SRC_DIR DST_DIR )
     EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E copy_directory "${SRC_DIR}" "${DST_DIR}" )
 ENDFUNCTION()
 
-# Function to copy a directory using symlinks for the files. This saves storage
-# space with large test files.
+# Function to copy a directory using symlinks for the files to save storage space.
+# Subdirectories are ignored.
 # SRC_DIR must be an absolute path
 # The -s flag copies using symlinks
-# The -T ${DST_DIR} ensures the destination is copied as the directory, and not
-#  placed as a subdirectory if the destination already exists.
+# The -t ${DST_DIR} ensures the destination must be a directory
 FUNCTION( COPY_DIRECTORY_USING_SYMLINK SRC_DIR DST_DIR )
-    EXECUTE_PROCESS( COMMAND cp -as --remove-destination "${SRC_DIR}" -T "${DST_DIR}" )
+    FILE(MAKE_DIRECTORY "${DST_DIR}")
+    # Find all the files but not subdirectories
+    FILE(GLOB FILE_ONLY_NAMES LIST_DIRECTORIES FALSE "${SRC_DIR}/*")
+    FOREACH(F IN LISTS FILE_ONLY_NAMES)
+      #MESSAGE("Creating symlink from  ${F} to directory ${DST_DIR}")
+      EXECUTE_PROCESS( COMMAND cp -ds --remove-destination -t . "${F}" WORKING_DIRECTORY ${DST_DIR})
+    ENDFOREACH()
 ENDFUNCTION()
 
 # Copy files, but symlink the *.h5 files (which are the large ones)
@@ -53,8 +58,8 @@ ENDFUNCTION()
 # Control copy vs. symlink with top-level variable
 FUNCTION( COPY_DIRECTORY_MAYBE_USING_SYMLINK SRC_DIR DST_DIR )
   IF (QMC_SYMLINK_TEST_FILES)
-    #COPY_DIRECTORY_USING_SYMLINK("${SRC_DIR}" "${DST_DIR}")
-    COPY_DIRECTORY_SYMLINK_H5("${SRC_DIR}" "${DST_DIR}" )
+    COPY_DIRECTORY_USING_SYMLINK("${SRC_DIR}" "${DST_DIR}")
+    #COPY_DIRECTORY_SYMLINK_H5("${SRC_DIR}" "${DST_DIR}" )
   ELSE()
     COPY_DIRECTORY("${SRC_DIR}" "${DST_DIR}")
   ENDIF()

--- a/tests/molecules/He_ae/CMakeLists.txt
+++ b/tests/molecules/He_ae/CMakeLists.txt
@@ -10,7 +10,7 @@ ELSE()
     "${CMAKE_SOURCE_DIR}/tests/molecules/He_ae"
     det_He_opt.xml
     1 1
-    check_opt.py -s 1 -p det_He_opt -r qmc-ref/det_He_opt.s001.opt.xml
+    check_opt.py -s 1 -p det_He_opt -r reference.det_He_opt.s001.opt.xml
     )
 
  LIST(APPEND He_VMC_SCALARS "totenergy" "-3.25291030 0.000001")

--- a/tests/molecules/He_ae/reference.det_He_opt.s001.opt.xml
+++ b/tests/molecules/He_ae/reference.det_He_opt.s001.opt.xml
@@ -1,0 +1,1 @@
+qmc-ref/det_He_opt.s001.opt.xml


### PR DESCRIPTION
## Proposed changes
The scheme copying the test source folder to the build folder is suboptimal. First, the cmake step takes long on a slow filesystem.
Second, a lot of copied files are actually unused, specially qmc-ref.
In this PR, all the files from the test source folder will be symlinked. All the subdirectories are ignored.
If a needed file is outside the test source folder or in a subdirectory, making a soft link to the test source folder resolves the issue.

On my desktop with an SSD, the cmake time change is not noticeable but the whole build folder drop from 800MB to only 40MB.

Copying precisely only the needed files has been attempted but more complicated than I thought. We do know the exact input file but not other files still used in the calculation/check.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'