### PR TITLE
Set QMCType via constructor

### DIFF
--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -39,10 +39,9 @@ CSVMC::CSVMC(MCWalkerConfiguration& w,
              QMCHamiltonian& h,
              WaveFunctionPool& ppool,
              Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm), UseDrift("yes"), multiEstimator(0), Mover(0)
+    : QMCDriver(w, psi, h, ppool, comm, "CSVMC"), UseDrift("yes"), multiEstimator(0), Mover(0)
 {
   RootName = "csvmc";
-  QMCType  = "CSVMC";
   m_param.add(UseDrift, "useDrift", "string");
   m_param.add(UseDrift, "usedrift", "string");
   m_param.add(UseDrift, "use_drift", "string");

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -45,14 +45,13 @@ DMC::DMC(MCWalkerConfiguration& w,
          QMCHamiltonian& h,
          WaveFunctionPool& ppool,
          Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "DMC"),
       KillNodeCrossing(0),
       BranchInterval(-1),
       Reconfiguration("no"),
       mover_MaxAge(-1)
 {
   RootName = "dmc";
-  QMCType  = "DMC";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   m_param.add(KillWalker, "killnode", "string");
   m_param.add(Reconfiguration, "reconfiguration", "string");

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -40,10 +40,10 @@ DMCBatched::DMCBatched(QMCDriverInput&& qmcdriver_input,
                        Communicate* comm)
     : QMCDriverNew(std::move(qmcdriver_input), pop, psi, h, wf_pool,
                    "DMCBatched::", comm,
+                   "DMCBatched",
                    std::bind(&DMCBatched::setNonLocalMoveHandler, this, _1)),
       dmcdriver_input_(input)
 {
-  QMCType = "DMCBatched";
 }
 // clang-format on
 

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -39,7 +39,7 @@ DMCcuda::DMCcuda(MCWalkerConfiguration& w,
                  QMCHamiltonian& h,
                  WaveFunctionPool& ppool,
                  Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "DMCcuda"),
       myWarmupSteps(0),
       Mover(0),
       NLop(w.getTotalNum()),
@@ -49,7 +49,6 @@ DMCcuda::DMCcuda(MCWalkerConfiguration& w,
       HTimer(*timer_manager.createTimer("DMCcuda::Hamiltonian"))
 {
   RootName = "dmc";
-  QMCType  = "DMCcuda";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   qmc_driver_mode.set(QMC_WARMUP, 0);
   //m_param.add(myWarmupSteps,"warmupSteps","int");

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -46,13 +46,15 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
                      TrialWaveFunction& psi,
                      QMCHamiltonian& h,
                      WaveFunctionPool& ppool,
-                     Communicate* comm)
+                     Communicate* comm,
+                     const std::string& QMC_driver_type)
     : MPIObjectBase(comm),
       Estimators(0),
       Traces(0),
       branchEngine(0),
       DriftModifier(0),
       qmcNode(NULL),
+      QMCType(QMC_driver_type),
       W(w),
       Psi(psi),
       H(h),
@@ -154,7 +156,6 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
 #endif
 #endif
   m_param.add(nBlocksBetweenRecompute, "blocks_between_recompute", "int");
-  QMCType = "invalid";
   ////add each OperatorBase to W.PropertyList so that averages can be taken
   //H.add2WalkerProperty(W);
   //if (storeConfigs) ForwardWalkingHistory.storeConfigsForForwardWalking(w);

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -98,7 +98,8 @@ public:
             TrialWaveFunction& psi,
             QMCHamiltonian& h,
             WaveFunctionPool& ppool,
-            Communicate* comm);
+            Communicate* comm,
+            const std::string& QMC_driver_type);
 
   virtual ~QMCDriver();
 
@@ -286,8 +287,8 @@ protected:
   ///pointer to qmc node in xml file
   xmlNodePtr qmcNode;
 
-  ///type of qmc: assigned by subclasses
-  std::string QMCType;
+  ///type of QMC driver
+  const std::string QMCType;
   ///the root of h5File
   std::string h5FileRoot;
   ///root of all the output files

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -46,10 +46,12 @@ QMCDriverNew::QMCDriverNew(QMCDriverInput&& input,
                            WaveFunctionPool& ppool,
                            const std::string timer_prefix,
                            Communicate* comm,
+                           const std::string& QMC_driver_type,
                            SetNonLocalMoveHandler snlm_handler)
     : MPIObjectBase(comm),
       qmcdriver_input_(input),
       branch_engine_(nullptr),
+      QMCType(QMC_driver_type),
       population_(population),
       Psi(psi),
       H(h),
@@ -59,7 +61,6 @@ QMCDriverNew::QMCDriverNew(QMCDriverInput&& input,
       timers_(timer_prefix),
       setNonLocalMoveHandler_(snlm_handler)
 {
-  QMCType  = "invalid";
   rotation = 0;
 
   // This needs to be done here to keep dependency on CrystalLattice out of the QMCDriverInput.

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -122,6 +122,7 @@ public:
                WaveFunctionPool& ppool,
                const std::string timer_prefix,
                Communicate* comm,
+               const std::string& QMC_driver_type,
                SetNonLocalMoveHandler = &QMCDriverNew::defaultSetNonLocalMoveHandler);
 
   QMCDriverNew(QMCDriverNew&&) = default;
@@ -337,7 +338,7 @@ protected:
   RealType m_sqrttau;
 
   ///type of qmc: assigned by subclasses
-  std::string QMCType;
+  const std::string QMCType;
   ///root of all the output files
   std::string root_name_;
 

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -40,10 +40,14 @@ RMC::RMC(MCWalkerConfiguration& w,
          QMCHamiltonian& h,
          WaveFunctionPool& ppool,
          Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm), prestepsVMC(-1), rescaleDrift("no"), beta(-1), beads(-1), fromScratch(true)
+    : QMCDriver(w, psi, h, ppool, comm, "RMC"),
+      prestepsVMC(-1),
+      rescaleDrift("no"),
+      beta(-1),
+      beads(-1),
+      fromScratch(true)
 {
   RootName = "rmc";
-  QMCType  = "RMC";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   qmc_driver_mode.set(QMC_WARMUP, 0);
   m_param.add(rescaleDrift, "drift", "string");

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -41,10 +41,9 @@ VMC::VMC(MCWalkerConfiguration& w,
          QMCHamiltonian& h,
          WaveFunctionPool& ppool,
          Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm), UseDrift("yes")
+    : QMCDriver(w, psi, h, ppool, comm, "VMC"), UseDrift("yes")
 {
   RootName = "vmc";
-  QMCType  = "VMC";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   qmc_driver_mode.set(QMC_WARMUP, 0);
   m_param.add(UseDrift, "useDrift", "string");

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -28,14 +28,11 @@ VMCBatched::VMCBatched(QMCDriverInput&& qmcdriver_input,
                        WaveFunctionPool& ppool,
                        SampleStack& samples,
                        Communicate* comm)
-    : QMCDriverNew(std::move(qmcdriver_input), pop, psi, h, ppool, "VMCBatched::", comm),
+    : QMCDriverNew(std::move(qmcdriver_input), pop, psi, h, ppool, "VMCBatched::", comm, "VMCBatched"),
       vmcdriver_input_(input),
       samples_(samples),
       collect_samples_(false)
 {
-  QMCType = "VMCBatched";
-  // qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
-  // qmc_driver_mode.set(QMC_WARMUP, 0);
 }
 
 void VMCBatched::advanceWalkers(const StateForThread& sft,

--- a/src/QMCDrivers/VMC/VMCLinearOpt.cpp
+++ b/src/QMCDrivers/VMC/VMCLinearOpt.cpp
@@ -40,7 +40,7 @@ VMCLinearOpt::VMCLinearOpt(MCWalkerConfiguration& w,
                            HamiltonianPool& hpool,
                            WaveFunctionPool& ppool,
                            Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "VMCLinearOpt"),
       UseDrift("yes"),
       NumOptimizables(0),
       w_beta(0.0),
@@ -50,7 +50,6 @@ VMCLinearOpt::VMCLinearOpt(MCWalkerConfiguration& w,
 //     myRNWarmupSteps(0), logoffset(2.0), logepsilon(0), beta_errorbars(0), alpha_errorbars(0),
 {
   RootName = "vmc";
-  QMCType  = "VMCLinearOpt";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   qmc_driver_mode.set(QMC_WARMUP, 0);
   DumpConfig = false;

--- a/src/QMCDrivers/VMC/VMC_CUDA.cpp
+++ b/src/QMCDrivers/VMC/VMC_CUDA.cpp
@@ -35,7 +35,7 @@ VMCcuda::VMCcuda(MCWalkerConfiguration& w,
                  QMCHamiltonian& h,
                  WaveFunctionPool& ppool,
                  Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "VMCcuda"),
       UseDrift("yes"),
       myPeriod4WalkerDump(0),
       w_beta(0.0),
@@ -44,7 +44,6 @@ VMCcuda::VMCcuda(MCWalkerConfiguration& w,
       forOpt(false)
 {
   RootName = "vmc";
-  QMCType  = "VMCcuda";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);
   qmc_driver_mode.set(QMC_WARMUP, 0);
   m_param.add(UseDrift, "useDrift", "string");

--- a/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
@@ -64,7 +64,6 @@ QMCCorrelatedSamplingLinearOptimize::QMCCorrelatedSamplingLinearOptimize(MCWalke
   qmc_driver_mode.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   RootName = "pot";
-  QMCType  = "QMCCorrelatedSamplingLinearOptimize";
   m_param.add(stabilizerScale, "stabilizerscale", "double");
   m_param.add(bigChange, "bigchange", "double");
   m_param.add(w_beta, "beta", "double");

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -53,7 +53,7 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration
                                                            HamiltonianPool& hpool,
                                                            WaveFunctionPool& ppool,
                                                            Communicate* comm)
-    : QMCLinearOptimize(w, psi, h, hpool, ppool, comm),
+    : QMCLinearOptimize(w, psi, h, hpool, ppool, comm, "QMCFixedSampleLinearOptimize"),
 #ifdef HAVE_LMY_ENGINE
       vdeps(1, std::vector<double>()),
 #endif
@@ -99,7 +99,6 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration
   qmc_driver_mode.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   RootName = "pot";
-  QMCType  = "QMCFixedSampleLinearOptimize";
   m_param.add(Max_iterations, "max_its", "int");
   m_param.add(nstabilizers, "nstabilizers", "int");
   m_param.add(stabilizerScale, "stabilizerscale", "double");

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -62,7 +62,8 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(MCWalke
                                std::move(vmcdriver_input),
                                population,
                                samples,
-                               comm),
+                               comm,
+                               "QMCFixedSampleLinearOptimizeBatched"),
 #ifdef HAVE_LMY_ENGINE
       vdeps(1, std::vector<double>()),
 #endif
@@ -108,7 +109,6 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(MCWalke
   qmc_driver_mode.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   RootName = "pot";
-  QMCType  = "QMCFixedSampleLinearOptimizeBatched";
   m_param.add(Max_iterations, "max_its", "int");
   m_param.add(nstabilizers, "nstabilizers", "int");
   m_param.add(stabilizerScale, "stabilizerscale", "double");

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
@@ -45,8 +45,9 @@ QMCLinearOptimize::QMCLinearOptimize(MCWalkerConfiguration& w,
                                      QMCHamiltonian& h,
                                      HamiltonianPool& hpool,
                                      WaveFunctionPool& ppool,
-                                     Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+                                     Communicate* comm,
+                                     const std::string& QMC_driver_type)
+    : QMCDriver(w, psi, h, ppool, comm, QMC_driver_type),
       PartID(0),
       NumParts(1),
       hamPool(hpool),

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.h
@@ -54,7 +54,8 @@ public:
                     QMCHamiltonian& h,
                     HamiltonianPool& hpool,
                     WaveFunctionPool& ppool,
-                    Communicate* comm);
+                    Communicate* comm,
+                    const std::string& QMC_driver_type = "QMCLinearOptimize");
 
   ///Destructor
   virtual ~QMCLinearOptimize() = default;

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
@@ -40,8 +40,9 @@ QMCLinearOptimizeBatched::QMCLinearOptimizeBatched(MCWalkerConfiguration& w,
                                                    VMCDriverInput&& vmcdriver_input,
                                                    MCPopulation& population,
                                                    SampleStack& samples,
-                                                   Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+                                                   Communicate* comm,
+                                                   const std::string& QMC_driver_type)
+    : QMCDriver(w, psi, h, ppool, comm, QMC_driver_type),
       PartID(0),
       NumParts(1),
       hamPool(hpool),

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
@@ -62,7 +62,8 @@ public:
                            VMCDriverInput&& vmcdriver_input,
                            MCPopulation& population,
                            SampleStack& samples,
-                           Communicate* comm);
+                           Communicate* comm,
+                           const std::string& QMC_driver_type = "QMCLinearOptimizeBatched");
 
   ///Destructor
   virtual ~QMCLinearOptimizeBatched() = default;

--- a/src/QMCDrivers/WFOpt/QMCOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimize.cpp
@@ -38,7 +38,7 @@ QMCOptimize::QMCOptimize(MCWalkerConfiguration& w,
                          HamiltonianPool& hpool,
                          WaveFunctionPool& ppool,
                          Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "QMCOptimize"),
       PartID(0),
       NumParts(1),
       hamPool(hpool),
@@ -52,7 +52,6 @@ QMCOptimize::QMCOptimize(MCWalkerConfiguration& w,
   qmc_driver_mode.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   RootName = "pot";
-  QMCType  = "QMCOptimize";
   //default method is cg
   optmethod = "cg";
 }

--- a/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
@@ -38,7 +38,7 @@ QMCOptimizeBatched::QMCOptimizeBatched(MCWalkerConfiguration& w,
                                        MCPopulation& population,
                                        SampleStack& samples,
                                        Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "QMCOptimizeBatched"),
       PartID(0),
       NumParts(1),
       hamPool(hpool),
@@ -56,7 +56,6 @@ QMCOptimizeBatched::QMCOptimizeBatched(MCWalkerConfiguration& w,
   qmc_driver_mode.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   RootName = "pot";
-  QMCType  = "QMCOptimizeBatched";
   //default method is cg
   optmethod = "cg";
 }

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -41,7 +41,7 @@ WaveFunctionTester::WaveFunctionTester(MCWalkerConfiguration& w,
                                        ParticleSetPool& ptclPool,
                                        WaveFunctionPool& ppool,
                                        Communicate* comm)
-    : QMCDriver(w, psi, h, ppool, comm),
+    : QMCDriver(w, psi, h, ppool, comm, "WaveFunctionTester"),
       PtclPool(ptclPool),
       checkRatio("no"),
       checkClone("no"),

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -34,9 +34,15 @@ public:
                           WaveFunctionPool& ppool,
                           SampleStack samples,
                           Communicate* comm)
-      : QMCDriverNew(std::move(input), population, psi, h, ppool, "QMCDriverTestWrapper::", comm)
+      : QMCDriverNew(std::move(input),
+                     population,
+                     psi,
+                     h,
+                     ppool,
+                     "QMCDriverTestWrapper::",
+                     comm,
+                     "QMCDriverNewTestWrapper")
   {
-    QMCType = "QMCTesting";
   }
 
   ~QMCDriverNewTestWrapper() {}


### PR DESCRIPTION
## Proposed changes
I wanted to add a driver scope timer but the current way of destroying a driver makes it super hard.
Stage what I changed so far. QMCType becomes const and set via constructor.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted