### PR TITLE
Fix accept ratio and block cpu time in batch vmc

### DIFF
--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -548,7 +548,7 @@ void QMCDriverNew::endBlock()
   estimator_manager_->collectScalarEstimators(all_scalar_estimators);
   cpu_block_time /= crowds_.size();
 
-  estimator_manager_->stopBlockNew(total_accept_ratio, total_block_weight, cpu_block_time*total_block_weight);
+  estimator_manager_->stopBlockNew(total_accept_ratio, total_block_weight, cpu_block_time * total_block_weight);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -545,11 +545,10 @@ void QMCDriverNew::endBlock()
     total_accept_ratio += crowd->get_accept_ratio() * crowd->get_estimator_manager_crowd().get_block_weight();
     cpu_block_time += crowd->get_estimator_manager_crowd().get_cpu_block_time();
   }
-  total_accept_ratio /= total_block_weight;
   estimator_manager_->collectScalarEstimators(all_scalar_estimators);
   cpu_block_time /= crowds_.size();
 
-  estimator_manager_->stopBlockNew(total_accept_ratio, total_block_weight, cpu_block_time);
+  estimator_manager_->stopBlockNew(total_accept_ratio, total_block_weight, cpu_block_time*total_block_weight);
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
The acceptance ratio does not appear to be correct in the output.   The larger the value of "steps" in the input, the smaller the acceptance ratio that is reported in the scalar.dat file.
Items in the estimators are divided by the block weight in `EstimatorManagerNew::makeBlockAverages`.   The acceptance ratio
should not be divided by the block weight before putting it into the estimator manager.
The block CPU time needs to protected from the "divide by block weight" by multiplying by the block weight before putting it into the estimator manager.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
