### PR TITLE
Fix link error in debug build with RunTimeManager

### DIFF
--- a/src/Utilities/RunTimeManager.cpp
+++ b/src/Utilities/RunTimeManager.cpp
@@ -22,6 +22,9 @@ namespace qmcplusplus
 {
 RunTimeManager<CPUClock> run_time_manager;
 
+template class RunTimeManager<CPUClock>;
+template class RunTimeManager<FakeCPUClock>;
+
 template<class CLOCK>
 double LoopTimer<CLOCK>::get_time_per_iteration()
 {

--- a/src/Utilities/RunTimeManager.h
+++ b/src/Utilities/RunTimeManager.h
@@ -37,6 +37,9 @@ private:
 
 extern RunTimeManager<CPUClock> run_time_manager;
 
+extern template class RunTimeManager<CPUClock>;
+extern template class RunTimeManager<FakeCPUClock>;
+
 template<class CLOCK = CPUClock>
 class LoopTimer
 {
@@ -85,8 +88,8 @@ public:
   std::string time_limit_message(const std::string& driverName, int block);
 };
 
-extern template class RunTimeManager<CPUClock>;
-extern template class RunTimeManager<FakeCPUClock>;
+extern template class RunTimeControl<CPUClock>;
+extern template class RunTimeControl<FakeCPUClock>;
 
 } // namespace qmcplusplus
 #endif


### PR DESCRIPTION
## Proposed changes
Add explicit template instantiations for RunTimeManager.

The release build works without these, but the debug build fails with a linker error.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop, gcc and clang

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
