### PR TITLE
Build with timer on by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ SET(BUILD_FCIQMC 0 CACHE BOOL "Build with FCIQMC")
 #SET(BUILD_QMCTOOLS 1)
 #SET(MPIP_PROFILE 0)
 OPTION(QMC_BUILD_STATIC "Link to static libraries" OFF)
-OPTION(ENABLE_TIMERS "Enable internal timers" OFF)
+OPTION(ENABLE_TIMERS "Enable internal timers" ON)
 OPTION(ENABLE_STACKTRACE "Enable use of boost::stacktrace" OFF)
 
 ######################################################################

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ make -j 8
                          Production quality for AFQMC. Pre-production quality for real-space.
                          Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
      ENABLE_OFFLOAD      ON/OFF(default). Experimental feature. Enable OpenMP target offload for GPU acceleration.
-     ENABLE_TIMERS       ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level none
+     ENABLE_TIMERS       ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level coarse
                          to avoid potential slowdown in tiny systems.
                          For systems beyond tiny sizes (100+ electrons) there is no risk.
 ```

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ make -j 8
                          Production quality for AFQMC. Pre-production quality for real-space.
                          Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
      ENABLE_OFFLOAD      ON/OFF(default). Experimental feature. Enable OpenMP target offload for GPU acceleration.
-     ENABLE_TIMERS       ON/OFF(default). Enable fine-grained timers. Timers are off by default
-                         to avoid potential slowdown in small systems.
-                         For large systems (100+ electrons) there is no risk.
+     ENABLE_TIMERS       ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level none
+                         to avoid potential slowdown in tiny systems.
+                         For systems beyond tiny sizes (100+ electrons) there is no risk.
 ```
 
  * Additional QMC options

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -302,7 +302,7 @@ the path to the source directory.
                           Production quality for AFQMC. Pre-production quality for real-space.
                           Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
     ENABLE_OFFLOAD        ON/OFF(default). Enable OpenMP target offload for GPU acceleration.
-    ENABLE_TIMERS         ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level none
+    ENABLE_TIMERS         ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level coarse
                           to avoid potential slowdown in tiny systems.
                           For systems beyond tiny sizes (100+ electrons) there is no risk.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -302,9 +302,9 @@ the path to the source directory.
                           Production quality for AFQMC. Pre-production quality for real-space.
                           Use CUDA_ARCH, default sm_70, to set the actual GPU architecture.
     ENABLE_OFFLOAD        ON/OFF(default). Enable OpenMP target offload for GPU acceleration.
-    ENABLE_TIMERS         ON/OFF(default). Enable fine-grained timers. Timers are off by default
-                          to avoid potential slowdown in small systems.
-                          For large systems (100+ electrons) there is no risk.
+    ENABLE_TIMERS         ON(default)/OFF. Enable fine-grained timers. Timers are on by default but at level none
+                          to avoid potential slowdown in tiny systems.
+                          For systems beyond tiny sizes (100+ electrons) there is no risk.
 
 - General build options
 

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -392,7 +392,7 @@ bool QMCMain::validateXML()
   }
   if (qmc_common.use_density)
   {
-    app_log() << "  hamiltonian has MPC. Will read density if it is found." << std::endl;
+    app_log() << "  hamiltonian has MPC. Will read density if it is found." << std::endl << std::endl;
   }
 
   //initialize the random number generator

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -114,7 +114,15 @@ QMCMain::QMCMain(Communicate* c)
                 << "\n  CUDA base precision = " << GET_MACRO_VAL(CUDA_PRECISION)
                 << "\n  CUDA full precision = " << GET_MACRO_VAL(CUDA_PRECISION_FULL)
 #endif
-                << "\n\n  Structure-of-arrays (SoA) optimization enabled" << std::endl;
+                << std::endl;
+
+  // Record features configured in cmake or selected via command-line arguments to the printout
+#ifdef ENABLE_OFFLOAD
+  app_summary() << "\n  OpenMP target offload to accellerators enabled" << std::endl;
+#endif
+#ifdef ENABLE_TIMERS
+  app_summary() << "\n  Current timer level is " << timer_manager.get_timer_threshold_string() << std::endl;
+#endif
   app_summary() << std::endl;
   app_summary().flush();
 }

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -85,26 +85,7 @@ int main(int argc, char** argv)
           if (pos != std::string::npos)
           {
             std::string timer_level = c.substr(pos + 1);
-            if (timer_level == "none")
-            {
-              timer_manager.set_timer_threshold(timer_level_none);
-            }
-            else if (timer_level == "coarse")
-            {
-              timer_manager.set_timer_threshold(timer_level_coarse);
-            }
-            else if (timer_level == "medium")
-            {
-              timer_manager.set_timer_threshold(timer_level_medium);
-            }
-            else if (timer_level == "fine")
-            {
-              timer_manager.set_timer_threshold(timer_level_fine);
-            }
-            else
-            {
-              std::cerr << "Unknown timer level: " << timer_level << std::endl;
-            }
+            timer_manager.set_timer_threshold(timer_level);
           }
         }
         if (c.find("-verbosity") < c.size())

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -42,7 +42,7 @@ enum timer_levels
   timer_level_coarse,
   timer_level_medium,
   timer_level_fine,
-  num_timer_levels  // this is not a timer level but to count the elements in this enum
+  num_timer_levels // this is not a timer level but to count the elements in this enum
 };
 
 extern bool timer_max_level_exceeded;

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -41,7 +41,8 @@ enum timer_levels
                     // It is for setting a threshold to turn all timers off.
   timer_level_coarse,
   timer_level_medium,
-  timer_level_fine
+  timer_level_fine,
+  num_timer_levels  // this is not a timer level but to count the elements in this enum
 };
 
 extern bool timer_max_level_exceeded;

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -351,6 +351,8 @@ void TimerManager<TIMER>::print_stack(Communicate* comm)
                p.timeList[i] / (static_cast<double>(p.callList[i]) + std::numeric_limits<double>::epsilon()));
       app_log() << tmpout;
     }
+    app_log() << std::endl;
+    app_log() << "Use enable-timers command line option to increase or decrease level of timing information" << std::endl;
   }
 #endif
 }

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -28,6 +28,8 @@ namespace qmcplusplus
 {
 TimerManager<NewTimer> timer_manager;
 
+std::array<std::string, num_timer_levels> timer_level_names = {"none", "coarse", "medium", "fine"};
+
 const char TIMER_STACK_SEPARATOR = '/';
 
 template<class TIMER>
@@ -85,6 +87,25 @@ void TimerManager<TIMER>::set_timer_threshold(const timer_levels threshold)
   for (int i = 0; i < TimerList.size(); i++)
     TimerList[i]->set_active_by_timer_threshold(timer_threshold);
 }
+
+template<class TIMER>
+void TimerManager<TIMER>::set_timer_threshold(const std::string& threshold)
+{
+  const auto it = std::find(timer_level_names.begin(), timer_level_names.end(), threshold);
+  if (it != timer_level_names.end())
+    set_timer_threshold(static_cast<timer_levels>(std::distance(timer_level_names.begin(), it)));
+  else
+  {
+    std::cerr << "Unknown timer level: " << threshold << " , current level :" << timer_level_names[timer_threshold] << std::endl;
+  }
+}
+
+template<class TIMER>
+std::string TimerManager<TIMER>::get_timer_threshold_string() const
+{
+  return timer_level_names[timer_threshold];
+}
+
 
 template<class TIMER>
 void TimerManager<TIMER>::collate_flat_profile(Communicate* comm, FlatProfileData& p)
@@ -223,6 +244,7 @@ void TimerManager<TIMER>::collate_stack_profile(Communicate* comm, StackProfileD
 template<class TIMER>
 void TimerManager<TIMER>::print(Communicate* comm)
 {
+  if (timer_threshold <= timer_level_none) return;
 #ifdef ENABLE_TIMERS
 #ifdef USE_STACK_TIMERS
   if (comm == nullptr || comm->rank() == 0)

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -248,6 +248,8 @@ void TimerManager<TIMER>::print(Communicate* comm)
   if (timer_threshold <= timer_level_none)
     return;
 #ifdef ENABLE_TIMERS
+  app_log() << std::endl;
+  app_log() << "Use --enable-timers=<value> command line option to increase or decrease level of timing information" << std::endl;
 #ifdef USE_STACK_TIMERS
   if (comm == nullptr || comm->rank() == 0)
     app_log() << "Stack timer profile" << std::endl;
@@ -351,8 +353,6 @@ void TimerManager<TIMER>::print_stack(Communicate* comm)
                p.timeList[i] / (static_cast<double>(p.callList[i]) + std::numeric_limits<double>::epsilon()));
       app_log() << tmpout;
     }
-    app_log() << std::endl;
-    app_log() << "Use enable-timers command line option to increase or decrease level of timing information" << std::endl;
   }
 #endif
 }

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -96,7 +96,8 @@ void TimerManager<TIMER>::set_timer_threshold(const std::string& threshold)
     set_timer_threshold(static_cast<timer_levels>(std::distance(timer_level_names.begin(), it)));
   else
   {
-    std::cerr << "Unknown timer level: " << threshold << " , current level :" << timer_level_names[timer_threshold] << std::endl;
+    std::cerr << "Unknown timer level: " << threshold << " , current level: " << timer_level_names[timer_threshold]
+              << std::endl;
   }
 }
 
@@ -244,7 +245,8 @@ void TimerManager<TIMER>::collate_stack_profile(Communicate* comm, StackProfileD
 template<class TIMER>
 void TimerManager<TIMER>::print(Communicate* comm)
 {
-  if (timer_threshold <= timer_level_none) return;
+  if (timer_threshold <= timer_level_none)
+    return;
 #ifdef ENABLE_TIMERS
 #ifdef USE_STACK_TIMERS
   if (comm == nullptr || comm->rank() == 0)

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -28,7 +28,7 @@ namespace qmcplusplus
 {
 TimerManager<NewTimer> timer_manager;
 
-std::array<std::string, num_timer_levels> timer_level_names = {"none", "coarse", "medium", "fine"};
+const std::array<std::string, num_timer_levels> timer_level_names = {"none", "coarse", "medium", "fine"};
 
 const char TIMER_STACK_SEPARATOR = '/';
 
@@ -249,7 +249,8 @@ void TimerManager<TIMER>::print(Communicate* comm)
     return;
 #ifdef ENABLE_TIMERS
   app_log() << std::endl;
-  app_log() << "Use --enable-timers=<value> command line option to increase or decrease level of timing information" << std::endl;
+  app_log() << "Use --enable-timers=<value> command line option to increase or decrease level of timing information"
+            << std::endl;
 #ifdef USE_STACK_TIMERS
   if (comm == nullptr || comm->rank() == 0)
     app_log() << "Stack timer profile" << std::endl;

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -63,6 +63,7 @@ protected:
 
   void print_flat(Communicate* comm);
   void print_stack(Communicate* comm);
+
 public:
 #ifdef USE_VTUNE_TASKS
   __itt_domain* task_domain;

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -61,12 +61,14 @@ protected:
 
   void initializeTimer(TIMER& t);
 
+  void print_flat(Communicate* comm);
+  void print_stack(Communicate* comm);
 public:
 #ifdef USE_VTUNE_TASKS
   __itt_domain* task_domain;
 #endif
 
-  TimerManager() : timer_threshold(timer_level_coarse), max_timer_id(1), max_timers_exceeded(false)
+  TimerManager() : timer_threshold(timer_level_none), max_timer_id(1), max_timers_exceeded(false)
   {
 #ifdef USE_VTUNE_TASKS
     task_domain = __itt_domain_create("QMCPACK");
@@ -90,13 +92,13 @@ public:
   }
 
   void set_timer_threshold(const timer_levels threshold);
+  void set_timer_threshold(const std::string& threshold);
+  std::string get_timer_threshold_string() const;
 
   bool maximum_number_of_timers_exceeded() const { return max_timers_exceeded; }
 
   void reset();
   void print(Communicate* comm);
-  void print_flat(Communicate* comm);
-  void print_stack(Communicate* comm);
 
   typedef std::map<std::string, int> nameList_t;
   typedef std::vector<double> timeList_t;

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -69,7 +69,7 @@ public:
   __itt_domain* task_domain;
 #endif
 
-  TimerManager() : timer_threshold(timer_level_none), max_timer_id(1), max_timers_exceeded(false)
+  TimerManager() : timer_threshold(timer_level_coarse), max_timer_id(1), max_timers_exceeded(false)
   {
 #ifdef USE_VTUNE_TASKS
     task_domain = __itt_domain_create("QMCPACK");


### PR DESCRIPTION
## Proposed changes
Default level is "coarse".
I don't see timing difference running a 16 electron system with timer=none and without timer built in (current develop branch).
Closes #2663 
offload info printing is added and closes #2664 

## What type(s) of changes does this code introduce?
- Build related changes
- Documentation content changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes.  Code added or changed in the PR has been clang-formatted