### PR TITLE
Fix Clang and libcxx compilation

### DIFF
--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -18,6 +18,8 @@
 #include "TimerManager.h"
 #include <limits>
 #include <cstdio>
+#include <algorithm>
+#include <array>
 #include <libxml/xmlwriter.h>
 #include "Configuration.h"
 #include <Message/OpenMP.h>

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -20,7 +20,6 @@
 
 #include <vector>
 #include <string>
-#include <algorithm>
 #include <map>
 #include "NewTimer.h"
 #include "config.h"


### PR DESCRIPTION
## Proposed changes

close #2676

Due to missing include <array>

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
