### PR TITLE
Update ORNL testing scripts, add AOMP and ClangDev

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,23 @@ performance and easiest configuration.
 Nightly testing currently includes the following software versions on x86:
 
 * Compilers
-  * GCC 10.1.0, 7.3.0
-  * Clang/LLVM 10.0.0, 6.0.1
+  * GCC 10.2.0, 7.3.0
+  * Clang/LLVM 10.0.1, 6.0.1
   * Intel 19.1.1.217 configured to use C++ library from GCC 8.3.0 
   * PGI 19.4 configured to use C++ library from GCC 8.3.0
-* Boost 1.73.0, 1.67.0
+* Boost 1.74.0, 1.68.0
 * HDF5 1.10.5, 1.8.19
 * FFTW 3.3.8, 3.3.4
-* CMake 3.17.1, 3.10.2
+* CMake 3.18.2, 3.12.1
 * MPI
-  * OpenMPI 4.0.3, 3.0.1
+  * OpenMPI 4.0.4, 3.1.2
   * Intel MPI 19.1.1.217
 * CUDA 10.2.89
+
+Workflow tests are performed with Quantum Espresso v6.4.1 and PySCF v1.7.4. These check trial wavefunction generation and
+conversion through to actual QMC runs.
+
+On a developmental basis we also check the latest Clang development version, AMD AOMP and Intel OneAPI compilers.
 
 # Building with CMake
 

--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -9,7 +9,18 @@
 
 echo --- START setup script `date`
 
+# Bug avoidance 20200902
+if [ -e /usr/lib/aomp/bin/clang ]; then
+    echo AOMP Clang install detected. This will break llvm install.
+    echo Suggest temporarily: sudo chmod og-rx /usr/lib/aomp
+    exit 1
+fi
+
+
 if [ -e `dirname "$0"`/ornl_versions.sh ]; then
+    echo --- Contents of ornl_versions.sh
+    cat `dirname "$0"`/ornl_versions.sh
+    echo --- End of contents of ornl_versions.sh
     source `dirname "$0"`/ornl_versions.sh
 else
     echo Did not find version numbers script ornl_versions.sh
@@ -60,7 +71,27 @@ EOF
 # Use flash /scratch for builds
 	rm -r -f /scratch/$USER/spack_build_stage
 	mkdir /scratch/$USER/spack_build_stage
-	;;
+
+	#Use system installed SSL. See https://spack.readthedocs.io/en/latest/getting_started.html#openssl
+
+# externals option does not work for spack 0c63c94103acae33c4f3adfe7b90d2ea1165ce46 2020-07-24	
+	cat >>$HOME/.spack/packages.yaml<<EOF
+packages:
+    openssl:
+        externals:
+        - spec: openssl@1.1.1c
+          prefix: /usr
+          buildable: False
+EOF
+#	cat >>$HOME/.spack/packages.yaml<<EOF
+#packages:
+#EOF
+# Experiment to See if clang builds and other problems clear 20200827
+	cat >>$HOME/.spack/packages.yaml<<EOF
+    all:
+        target: [x86_64]
+EOF
+;;
     sulfur )
 	cat >$HOME/.spack/config.yaml<<EOF
 config:
@@ -75,22 +106,31 @@ EOF
 # Use flash /scratch for builds
 	rm -r -f /scratch/$USER/spack_build_stage
 	mkdir /scratch/$USER/spack_build_stage
-	# Workaround linux-rhel8-cascadelake problem on sulfur for GCC in spack circa 202006
-#	cat >$HOME/.spack/packages.yaml<<EOF
+	#Use system installed SSL. See https://spack.readthedocs.io/en/latest/getting_started.html#openssl
+	cat >>$HOME/.spack/packages.yaml<<EOF
+packages:
+    openssl:
+        externals:
+        - spec: openssl@1.1.1c
+          prefix: /usr
+          buildable: False
+EOF
+# Workaround linux-rhel8-cascadelake problem on sulfur for GCC in spack circa 202006
+#	cat >>$HOME/.spack/packages.yaml<<EOF
 #packages:
 #  all:
 #    target: [skylake_avx512]
 #EOF
-	cat >$HOME/.spack/packages.yaml<<EOF
-packages:
-  all:
-    target: [x86_64]
+	cat >>$HOME/.spack/packages.yaml<<EOF
+    all:
+        target: [x86_64]
 EOF
 	;;
     *)
 	echo "*** WARNING: Unknown host in initial ourhostname case statement. No custom onfiguration"
 	;;
 esac
+
 
 
 if [ ! -e $HOME/apps ]; then
@@ -102,14 +142,16 @@ git clone https://github.com/spack/spack.git
 
 cd $HOME/apps/spack
 # For reproducibility, use a specific version of Spack
-# Use tagged releases https://github.com/spack/spack/releases
-# git checkout v0.13.3
-#git checkout b9dc263801ab8b9ce46e83adec8002c299fe2e44
-#Author: Justin S <3630356+codeandkey@users.noreply.github.com>
-#Date:   Fri Jan 3 15:52:59 2020 -0600
+# Prefer to use tagged releases https://github.com/spack/spack/releases
+#git checkout 0c63c94103acae33c4f3adfe7b90d2ea1165ce46
+#Author: Dennis Klein <dennis.klein.github@gmail.com>
+#Date:   Fri Jul 24 19:00:55 2020 +0200
 #
-#    py-intervaltree: new package at 3.0.2 (#14277)
-#git checkout v0.13.4
+#    Relax architecture compatibility check (#15972)
+#
+#    * Relax architecture compatibility check
+#    * Add test coverage for the spack.abi module
+echo --- Git version and last log entry
 git log -1
 
 module() { eval `/usr/bin/modulecmd bash $*`; }
@@ -124,6 +166,7 @@ export PATH=$SPACK_ROOT/bin:$PATH
 # recent compilers with better architecture support.
 # e.g. yum install gcc-toolset-9
 if [ -e /opt/rh/gcc-toolset-9/root/bin/gcc ]; then
+    echo --- Added gcc-toolset-9 to path for RHEL provided GCC9 compilers
     export PATH=/opt/rh/gcc-toolset-9/root/bin/:$PATH
 fi
 
@@ -150,9 +193,9 @@ module list
 spack compiler find
 echo --- Convenience
 spack install git%gcc@${gcc_vnew}
-spack install python%gcc@${gcc_vnew} # Needed by libflame, good safety measure
-spack load python%gcc@${gcc_vnew}
 echo --- gcc@${gcc_vnew} consumers
+spack install python@${python_version}%gcc@${gcc_vnew} # Needed by libflame, good safety measure
+spack load python@${python_version}%gcc@${gcc_vnew}
 spack install libxml2@${libxml2_vnew}%gcc@${gcc_vnew}
 spack install cmake@${cmake_vnew}%gcc@${gcc_vnew}
 spack install boost@${boost_vnew}%gcc@${gcc_vnew}
@@ -160,6 +203,7 @@ spack install openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_vnew}%gcc@
 #spack HDF5 package requires fortran and hl (high level) support to be specifically enabled for use with QE
 spack install hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
 spack install fftw@${fftw_vnew}%gcc@${gcc_vnew} -mpi #Avoid MPI for simplicity
+spack unload python@${python_version}%gcc@${gcc_vnew}
 spack unload gcc@${gcc_vnew}
 echo --- gcc@${gcc_vold}
 spack install gcc@${gcc_vold}
@@ -167,7 +211,10 @@ echo --- load gcc@${gcc_vold}
 spack load gcc@${gcc_vold}
 module list
 spack compiler find
+
 echo --- gcc@${gcc_vold} consumers
+spack install python@${python_version}%gcc@${gcc_vold}
+spack load python@${python_version}%gcc@${gcc_vold}
 spack install --no-checksum libxml2@${libxml2_vold}%gcc@${gcc_vold}
 spack install cmake@${cmake_vold}%gcc@${gcc_vold}
 spack install boost@${boost_vold}%gcc@${gcc_vold}
@@ -175,7 +222,8 @@ spack install openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_vold}%gcc@
 #spack HDF5 package requires fortran and hl (high level) support to be specifically enabled for use with QE
 spack install hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
 spack install fftw@${fftw_vold}%gcc@${gcc_vold} -mpi #Avoid MPI for simplicity
-spack install python%gcc@${gcc_vold}
+spack unload python@${python_version}%gcc@${gcc_vold}
+spack unload gcc@${gcc_vold}
 echo --- gcc@${gcc_vcuda}
 spack install gcc@${gcc_vcuda}
 spack load gcc@${gcc_vcuda}
@@ -194,26 +242,26 @@ spack load gcc@${gcc_vpgi}
 spack compiler find
 spack unload gcc@${gcc_vpgi}
 echo --- llvm@${llvm_vnew}
-spack install llvm@${llvm_vnew}
+spack install llvm@${llvm_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 spack load llvm@${llvm_vnew}
 spack compiler find
 spack unload llvm@${llvm_vnew}
 echo --- llvm@${llvm_vold}
-spack install llvm@${llvm_vold}%gcc@${gcc_vold}
+spack install llvm@${llvm_vold}%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
 spack load llvm@${llvm_vold}%gcc@$gcc_vold
 spack compiler find
 spack unload llvm@${llvm_vold}%gcc@$gcc_vold
 echo --- llvm@${llvm_vcuda}
-spack install llvm@${llvm_vcuda}
+spack install llvm@${llvm_vcuda} ^python@${python_version}%gcc@${gcc_vnew}
 spack load llvm@${llvm_vcuda}
 spack compiler find
 spack unload llvm@${llvm_vcuda}
 echo --- BLAS+LAPACK
 # Additional development required here due to only partial AMD Rome coverage and
 # spack support for optimized BLAS and LAPACK, problems building libflame etc.
-spack install blis%gcc@${gcc_vnew}
+spack install blis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 if [ "$ourplatform" == "AMD" ]; then
-    spack install amdblis%gcc@${gcc_vnew}
+    spack install amdblis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 fi
 
 # Spack has no amdlibflame package for LAPACK
@@ -221,40 +269,60 @@ fi
 #spack install libflame%gcc@${gcc_vnew} ^blis%gcc@${gcc_vnew} # Needs env python to work to build. Python is loaded above.
 spack install netlib-lapack%gcc@${gcc_vnew} # Netlib failback
 #spack install openblas%gcc@${gcc_vnew} # Historically crashed in Performance tests with large thread counts on AMD
-
+echo --- Modules installed so far
+spack find
 echo --- Python setup for NEXUS `date`
 echo --- New python modules
 #spack install py-numpy^blis%gcc@${gcc_vnew} # will pull in libflame (problems 2020-03-27)
-spack install py-numpy%gcc@${gcc_vnew} # Will pull in OpenBLAS
-spack install py-scipy%gcc@${gcc_vnew} 
-spack install py-mpi4py%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_vnew}%gcc@${gcc_vnew}
-#spack install py-mpi4py^openmpi@${ompi_vnew}%gcc@${gcc_vnew} 
-#spack install py-h5py^openmpi@${ompi_vnew}%gcc@${gcc_vnew}
-spack install py-h5py%gcc@${gcc_vnew}  -mpi ^hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
-spack install py-pandas%gcc@${gcc_vnew} 
-spack install py-lxml%gcc@${gcc_vnew} 
+spack load python@${python_version}%gcc@${gcc_vnew} 
+spack install py-numpy%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew} # Will pull in OpenBLAS
+spack install py-scipy%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
+#spack install py-mpi4py%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_vnew}%gcc@${gcc_vnew} 
+spack install py-setuptools%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
+spack install py-mpi4py%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^py-setuptools%gcc@${gcc_vnew}  ^python@${python_version}%gcc@${gcc_vnew}
+spack install py-h5py%gcc@${gcc_vnew}  -mpi ^python@${python_version}%gcc@${gcc_vnew} ^hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break 
+spack install py-pandas%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
+spack install py-lxml%gcc@${gcc_vnew}  ^python@${python_version}%gcc@${gcc_vnew}
 spack activate py-numpy%gcc@${gcc_vnew} 
 spack activate py-scipy%gcc@${gcc_vnew} 
 spack activate py-h5py%gcc@${gcc_vnew} 
 spack activate py-pandas%gcc@${gcc_vnew} 
 spack activate py-lxml%gcc@${gcc_vnew} 
-spack unload python
+spack unload python@${python_version}%gcc@${gcc_vnew} 
 echo --- Old python modules
-spack load python%gcc@${gcc_vold} 
-spack install py-numpy%gcc@${gcc_vold} # Will pull in OpenBLAS
-spack install py-scipy%gcc@${gcc_vold} 
-spack install py-mpi4py%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_vold}%gcc@${gcc_vold}
-#spack install py-mpi4py^openmpi@${ompi_vold}%gcc@${gcc_vold} 
-#spack install py-h5py^openmpi@${ompi_vold}%gcc@${gcc_vold}
-spack install py-h5py%gcc@${gcc_vold}  -mpi ^hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
-spack install py-pandas%gcc@${gcc_vold} 
-spack install py-lxml%gcc@${gcc_vold} 
+spack load python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 1
+spack find
+spack install py-numpy%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} # Will pull in OpenBLAS
+echo --- Modules installed so far 2
+spack find
+spack install py-scipy%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 3
+spack find
+spack install py-setuptools%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 4
+spack find
+#BAD gives dupe python spack install py-mpi4py%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_vold}%gcc@${gcc_vold}
+spack install py-mpi4py%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^py-setuptools%gcc@${gcc_vold}  ^python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 5
+spack find
+spack install py-h5py%gcc@${gcc_vold}  -mpi ^python@${python_version}%gcc@${gcc_vold} ^hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
+echo --- Modules installed so far 6
+spack find
+spack install py-pandas%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 7
+spack find
+spack install py-lxml%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+echo --- Modules installed so far 8
+spack find
 spack activate py-numpy%gcc@${gcc_vold} 
 spack activate py-scipy%gcc@${gcc_vold} 
 spack activate py-h5py%gcc@${gcc_vold} 
 spack activate py-pandas%gcc@${gcc_vold} 
 spack activate py-lxml%gcc@${gcc_vold} 
-spack unload python
+spack unload python@${python_version}%gcc@${gcc_vold} 
+echo --- Remove build dependencies
+spack gc --yes-to-all
 echo --- PGI setup reminder
 echo "To configure the PGI compilers with one of the newly installed C++ libraries:"
 echo "spack load gcc@${gcc_vpgi} # For example"

--- a/tests/test_automation/nightly_test_scripts/ornl_update.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Update packages that track master
+# Currently only llvm
+# Intended to be run nightly/weekly etc.
+
+echo --- Update Script START `date`
+
+if [ -e `dirname "$0"`/ornl_versions.sh ]; then
+    source `dirname "$0"`/ornl_versions.sh
+else
+    echo Did not find version numbers script ornl_versions.sh
+    exit 1
+fi
+
+spack uninstall -y llvm@master
+spack install llvm@master ^python@${python_version}%gcc@${gcc_vnew}
+
+echo --- Update Script END `date`

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -7,19 +7,18 @@
 # GCC
 # Zen2 optimziations are only in gcc 9.1+, with improved scheduling in 9.2+
 # Dates at https://gcc.gnu.org/releases.html
-gcc_vnew=10.1.0 # 2020-05-07
-#gcc_vnew=9.3.0 # 2020-03-12
+gcc_vnew=10.2.0 # 2020-07-23
 gcc_vold=7.3.0 # 2018-01-25
 
 #gcc_vcuda=8.2.1 #  For CUDA 10.2 compatibility  https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-gcc_vcuda=8.3.0 #  Not officially supported with RHEL8.1 but 8.2.1 is not available in spack
+gcc_vcuda=8.3.0 #  Use 8.3.0 instead since available in spack
 gcc_vintel=8.3.0 # Compiler for C++ library used by Intel compiler
 gcc_vpgi=8.3.0 # Use makelocalrc to configure PGI with this compiler
 
 # LLVM 
 # Zen2 scheduling optimizations are only in LLVM 10+
 # Dates at http://releases.llvm.org/
-llvm_vnew=10.0.0 # 2020-03-24
+llvm_vnew=10.0.1 # 2020-08-06
 llvm_vold=6.0.1 # 2018-07-05
 llvm_vcuda=8.0.0 # For CUDA 10.2 compatibility https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
 
@@ -31,13 +30,13 @@ hdf5_vold=1.8.19 # Released 2017-06-16
 
 # CMake 
 # Dates at https://cmake.org/files/
-cmake_vnew=3.17.1 # Released 2020-04-09
-cmake_vold=3.10.2 # Released 2018-01-18
+cmake_vnew=3.18.2 # Released 2020-08-20
+cmake_vold=3.12.1 # Released 2018-08-09
 
 # OpenMPI
 # Dates at https://www.open-mpi.org/software/ompi/v4.0/
-ompi_vnew=4.0.3 # Released 2020-03-03
-ompi_vold=3.0.1 # Released 2018-03-29
+ompi_vnew=4.0.4 # Released 2020-06-10
+ompi_vold=3.1.2 # Released 2018-08-22
 
 # Libxml2
 libxml2_vnew=2.9.10 # Released 2019-10-30 See http://xmlsoft.org/sources/
@@ -50,5 +49,12 @@ fftw_vold=3.3.4 # Released 2014-03-16
 
 # BOOST
 # Dates at https://www.boost.org/users/history/
-boost_vnew=1.73.0 # Released 2020-04-28
-boost_vold=1.67.0 # Released 2018-04-14
+boost_vnew=1.74.0 # Released 2020-08-14
+boost_vold=1.68.0 # Released 2018-08-09
+
+
+# Python
+# Use a single version to reduce dependencies
+# Can not use spack python default 3.7.x as of 20200831 due to hidden 3.8 requirement in LLVM master
+python_version=3.8.5
+


### PR DESCRIPTION
#  Proposed changes

Current versions of the nightly scripts and spack setup run on nitrogen and sulfur. When the problems are understood, later PRs will help resolve some of the observed PySCF issues. Later PRs will expand ClangDev builds once proven stable.

* Minor version increases
* Added AOMP compiler and offload builds for gfx906.
* Check for AOMP presence to workaround LLVM 10 inability to install due to libomptarget using compilers outside of spack sandbox. 
* Added Clang development version builds, currently for one CPU build configuration only.
* Effort to avoid near duplicate package installations with spack, which can result in ambiguities and also slows installation. Duplicate python installs are currently avoided, but a duplicate of the old openmpi version is created. This can be tolerated since we aren't running old openmpi tests currently on nitrogen or sulfur.

Known issues: 

* LLVM 8 no longer builds, presumably due to changes in spack.
* Additional logging printouts in setup script to help identify source of duplicate package installs

## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur, nitrogen

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
