### PR TITLE
Fix converter uninitialized variables

### DIFF
--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -66,6 +66,12 @@ QMCGaussianParserBase::QMCGaussianParserBase()
       X(0),
       Y(0),
       Z(0),
+      ci_size(0),
+      ci_nca(0),
+      ci_ncb(0),
+      ci_nea(0),
+      ci_neb(0),
+      ci_nstates(0),
       ci_threshold(1e-20),
       optDetCoeffs(false),
       usingCSF(false)
@@ -111,6 +117,12 @@ QMCGaussianParserBase::QMCGaussianParserBase(int argc, char** argv)
       X(0),
       Y(0),
       Z(0),
+      ci_size(0),
+      ci_nca(0),
+      ci_ncb(0),
+      ci_nea(0),
+      ci_neb(0),
+      ci_nstates(0),
       ci_threshold(1e-20),
       optDetCoeffs(false),
       usingCSF(false)
@@ -731,7 +743,6 @@ void QMCGaussianParserBase::createSPOSets(xmlNodePtr spoUP, xmlNodePtr spoDN)
   down_size << NumberOfBeta;
   b_size << numMO;
   nstates_alpha << ci_nstates + ci_nca;
-  ;
   nstates_beta << ci_nstates + ci_ncb;
 
   xmlNewProp(spoUP, (const xmlChar*)"name", (const xmlChar*)"spo-up");

--- a/tests/converter/converter_test.py
+++ b/tests/converter/converter_test.py
@@ -62,6 +62,14 @@ def run_test(test_name, c4q_exe, h5diff_exe, conv_inp, gold_file, expect_fail, e
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 
+    file_out = open('stdout.txt', 'w')
+    file_out.write(stdout)
+    file_out.close()
+    if len(stderr) > 0 :
+        file_err = open('stderr.txt', 'w')
+        file_err.write(stderr)
+        file_err.close()
+
     # For Python 3
     stderr = stderr.decode()
 


### PR DESCRIPTION
## Proposed changes
Recent change in convert4qmc surfaced a bug. It is caused by uninitialized variables.
I don't know why gcc didn't catch it by -Wmaybe-uninitialized -Wuninitialized

This PR also adds converter output printing to files.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ye-Dell-Laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'