### PR TITLE
allow complex build for multideterminants with xml input

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -512,12 +512,14 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
       if (useGPU == "yes")
       {
         app_log() << "  Using DiracDeterminantBatched with MatrixDelayedUpdateCUDA engine" << std::endl;
-        adet = new DiracDeterminantBatched<MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>(psi, firstIndex);
+        adet = new DiracDeterminantBatched<
+            MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>(psi, firstIndex);
       }
       else
 #endif
       {
-        app_log() << "  Using DiracDeterminantBatched with MatrixUpdateOMP engine. Only SM1 updates are supported." << std::endl;
+        app_log() << "  Using DiracDeterminantBatched with MatrixUpdateOMP engine. Only SM1 updates are supported."
+                  << std::endl;
         adet = new DiracDeterminantBatched<>(psi, firstIndex);
       }
     }
@@ -1186,7 +1188,6 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
         RealType ci_real = 0.0, ci_imag = 0.0;
         confAttrib.add(ci_real, "coeff_real");
         confAttrib.add(ci_imag, "coeff_imag");
-        ValueType ci(ci_real, ci_imag);
 #else
         RealType ci = 0.0;
         confAttrib.add(ci, "coeff");
@@ -1197,6 +1198,9 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
         confAttrib.add(tag, "id");
         confAttrib.put(cur);
 
+#ifdef QMC_COMPLEX
+        ValueType ci(ci_real, ci_imag);
+#endif
 
         //Will always loop through the whole determinant set as no assumption on the order of the determinant is made
         if (std::abs(ci) < cutoff)
@@ -1390,7 +1394,7 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
   ConfigTag.resize(ndets);
 
   readCoeffs(hin, CIcoeff, ndets);
-  
+
   ///IF OPTIMIZED COEFFICIENTS ARE PRESENT IN opt_coeffs Path
   ///THEY ARE READ FROM DIFFERENT HDF5 the replace the previous coeff
   ///It is important to still read all old coeffs and only replace the optimized ones


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
This is a simple fix to allow the multideterminant code to actually detect the CI coefficients from xlm input. Currently, all CI coefficients would be found as zero, because the ci coefficient was set before a put for the real and imaginary parts, so it was never correctly set. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted

