### PR TITLE
No need of app_error().flush()

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -413,7 +413,6 @@ bool QMCFixedSampleLinearOptimize::run()
         }
       }
       app_log().flush();
-      app_error().flush();
       if (failedTries > 20)
         break;
       //APP_ABORT("QMCFixedSampleLinearOptimize::run TOO MANY FAILURES");
@@ -432,7 +431,6 @@ bool QMCFixedSampleLinearOptimize::run()
         optTarget->Params(i) = currentParameters[i];
     }
     app_log().flush();
-    app_error().flush();
   }
 
   finish();

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -423,7 +423,6 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
         }
       }
       app_log().flush();
-      app_error().flush();
       if (failedTries > 20)
         break;
       //APP_ABORT("QMCFixedSampleLinearOptimizeBatched::run TOO MANY FAILURES");
@@ -442,7 +441,6 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
         optTarget->Params(i) = currentParameters[i];
     }
     app_log().flush();
-    app_error().flush();
   }
 
   finish();

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -437,7 +437,6 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     if (dot(ks - kp, ks - kp) > 1.0e-6)
     {
       app_error() << "Primitive and super k-points do not agree.  Error in coding.\n";
-      app_error().flush();
       APP_ABORT("EinsplineSetBuilder::AnalyzeTwists2");
     }
     PosType frac = FracPart(superTwist);
@@ -531,7 +530,6 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     {
       app_error() << "Cannot use this super twist with real wavefunctions.\n"
                   << "Please recompile with QMC_COMPLEX=1.\n";
-      app_error().flush();
       APP_ABORT("EinsplineSetBuilder::AnalyzeTwists2");
     }
   }


### PR DESCRIPTION
## Proposed changes
1. error stream/file in C/C++ is unbuffered. No need to flush.
2. our app_error() always print "ERROR " as long as it is invoked. app_error().flush() triggered this and misled users.

## What type(s) of changes does this code introduce?
- Bugfix
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'