### PR TITLE
Use ParticleSet::flex_update in batched cost function

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -281,7 +281,6 @@ void QMCCostFunctionBatched::checkConfigurations()
     {
       ParticleSet* wRef = new ParticleSet(W);
       samples_.loadSample(wRef->R, iw);
-      wRef->update();
       p_ptr_list_[iw]  = wRef;
       wf_ptr_list_[iw] = Psi.makeClone(*wRef);
       h_ptr_list_[iw]  = H.makeClone(*wRef, *wf_ptr_list_[iw]);
@@ -292,6 +291,8 @@ void QMCCostFunctionBatched::checkConfigurations()
     RefVector<TrialWaveFunction> wf_list = convertPtrToRefVector(wf_ptr_list_);
     RefVector<ParticleSet> p_list        = convertPtrToRefVector(p_ptr_list_);
     RefVector<QMCHamiltonian> h_list     = convertPtrToRefVector(h_ptr_list_);
+
+    ParticleSet::flex_update(p_list);
 
     TrialWaveFunction::flex_evaluateDeltaLogSetup(wf_list, p_list, log_psi_fixed_, log_psi_opt_, ref_dLogPsi,
                                                   ref_d2LogPsi);
@@ -418,7 +419,6 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
     {
       ParticleSet* wRef = p_ptr_list_[iw];
       samples_.loadSample(wRef->R, iw);
-      wRef->update(true);
     }
 
     outputManager.resume();
@@ -426,6 +426,8 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
     RefVector<TrialWaveFunction> wf_list = convertPtrToRefVector(wf_ptr_list_);
     RefVector<ParticleSet> p_list        = convertPtrToRefVector(p_ptr_list_);
     RefVector<QMCHamiltonian> h0_list    = convertPtrToRefVector(h0_ptr_list_);
+
+    ParticleSet::flex_update(p_list, true);
 
 
     RefVector<ParticleSet::ParticleGradient_t> dummyG_list;


### PR DESCRIPTION
In the batched cost function, use ParticleSet::flex_update instead of calling 'update' on each particle set individually.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
