### PR TITLE
Nexus: fix twist averaging with single batch prefix

### DIFF
--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -1184,28 +1184,34 @@ QMCA examples:
             avg_data    = obj()
             if opt.average_all or weights is not None or len(batch_prefixes)==1:
                 # average all data together
-                uniform_weights = len(prefixes)*[1.0]
-                if opt.twist_info=='ignore':
-                    weights = uniform_weights
-                else:
-                    weights = []
-                    for prefix in sorted(prefixes):
-                        twist_info_file = prefix+'.twist_info.dat'
-                        if os.path.exists(twist_info_file):
-                            fobj = open(twist_info_file)
-                            try:
-                                weight = float(fobj.read().strip().split()[0])
-                                weights.append(weight)
-                            except:
-                                None
-                            #end try
-                        #end if
-                    #end for
+                if weights is not None:
                     if len(weights)!=len(prefixes):
-                        if opt.twist_info=='require':
-                            self.error('twist_info files are either missing or mis-formatted for batch prefix {}'.format(batch_prefix))
-                        else:
-                            weights = uniform_weights
+                        self.error('one weight must be provided per file prefix for averaging\nyou provided {0} weights for {1} prefixes\nweights provided: {2}\nprefixes provided: {3}'.format(len(weights),len(prefixes),weights,prefixes))
+                    #end if
+                else:
+                    uniform_weights = len(prefixes)*[1.0]
+                    if opt.twist_info=='ignore':
+                        weights = uniform_weights
+                    else:
+                        weights = []
+                        for prefix in sorted(prefixes):
+                            twist_info_file = prefix+'.twist_info.dat'
+                            if os.path.exists(twist_info_file):
+                                fobj = open(twist_info_file)
+                                try:
+                                    weight = float(fobj.read().strip().split()[0])
+                                    weights.append(weight)
+                                except:
+                                    None
+                                #end try
+                            #end if
+                        #end for
+                        if len(weights)!=len(prefixes):
+                            if opt.twist_info=='require':
+                                self.error('twist_info files are either missing or mis-formatted for batch prefix {}'.format(batch_prefix))
+                            else:
+                                weights = uniform_weights
+                            #end if
                         #end if
                     #end if
                 #end if

--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -1184,10 +1184,30 @@ QMCA examples:
             avg_data    = obj()
             if opt.average_all or weights is not None or len(batch_prefixes)==1:
                 # average all data together
-                if weights is None:
-                    weights = len(prefixes)*[1.0]
-                elif len(weights)!=len(prefixes):
-                    self.error('one weight must be provided per file prefix for averaging\nyou provided {0} weights for {1} prefixes\nweights provided: {2}\nprefixes provided: {3}'.format(len(weights),len(prefixes),weights,prefixes))
+                uniform_weights = len(prefixes)*[1.0]
+                if opt.twist_info=='ignore':
+                    weights = uniform_weights
+                else:
+                    weights = []
+                    for prefix in sorted(prefixes):
+                        twist_info_file = prefix+'.twist_info.dat'
+                        if os.path.exists(twist_info_file):
+                            fobj = open(twist_info_file)
+                            try:
+                                weight = float(fobj.read().strip().split()[0])
+                                weights.append(weight)
+                            except:
+                                None
+                            #end try
+                        #end if
+                    #end for
+                    if len(weights)!=len(prefixes):
+                        if opt.twist_info=='require':
+                            self.error('twist_info files are either missing or mis-formatted for batch prefix {}'.format(batch_prefix))
+                        else:
+                            weights = uniform_weights
+                        #end if
+                    #end if
                 #end if
                 adata = obj()
                 ns=0


### PR DESCRIPTION
## Proposed changes

Fix twist averaging when analyzing only a single calculation with twist_info files.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes/No. This PR is up to date with current the current state of 'develop'

