### PR TITLE
app_warning to standard output

### DIFF
--- a/src/Platforms/Host/OutputManager.h
+++ b/src/Platforms/Host/OutputManager.h
@@ -66,7 +66,7 @@ inline std::ostream& app_log() { return infoLog.getStream(); }
 
 inline std::ostream& app_error() { return infoError.getStream() << "ERROR "; }
 
-inline std::ostream& app_warning() { return infoError.getStream() << "WARNING "; }
+inline std::ostream& app_warning() { return infoLog.getStream() << "WARNING "; }
 
 inline std::ostream& app_debug_stream() { return infoDebug.getStream(); }
 

--- a/src/QMCTools/GamesXmlParser.cpp
+++ b/src/QMCTools/GamesXmlParser.cpp
@@ -192,7 +192,7 @@ void GamesXmlParser::getGeometry(std::vector<xmlNodePtr>& aPtrList)
         while (tcur != NULL)
         {
           std::string tname((const char*)tcur->name);
-          double x, y, z;
+          double x(0), y(0), z(0);
           if (tname == "XCOORD")
             putContent(x, tcur);
           else if (tname == "YCOORD")


### PR DESCRIPTION
## Proposed changes
Closes #2712 
Print app_warning to infoLog which is stdcout

PS: kill an additional uninitialized values warning.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'