### PR TITLE
Replace cuda/hip specific memory allocation and copying routines with arch versions.

### DIFF
--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -101,16 +101,31 @@ void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t 
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
 }
 
-void malloc(void** devPtr, size_t size)
+void malloc(void** devPtr, size_t size, std::string message)
 {
   if (cudaSuccess != cudaMalloc(devPtr, size))
   {
     std::cerr << " Error allocating " << size * 1024.0 / 1024.0 << " MBs on GPU." << std::endl;
+    if (message != "")
+    {
+      std::cerr << " Error from : " << message << std::endl;
+    }
     throw std::runtime_error("Error: cudaMalloc returned error code.");
   }
 }
 
-void free(void* p) { cudaFree(p); }
+void free(void* p, std::string message)
+{
+  if (cudaSuccess != cudaFree(p))
+  {
+    if (message != "")
+    {
+      std::cerr << " Error from: " << message << std::endl;
+    }
+    throw std::runtime_error("Error: cudaFree returned error code.");
+  }
+
+}
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -89,13 +89,13 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
   }
 }
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind)
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
 {
   if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind)))
     throw std::runtime_error("Error: cudaMemcpy returned error code.");
 }
 
-void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t width, size_t height, MEMCOPYKIND kind)
+void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t width, size_t height, MEMCOPYKIND kind, std::string message)
 {
   if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -95,7 +95,14 @@ void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::st
     throw std::runtime_error("Error: cudaMemcpy returned error code.");
 }
 
-void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t width, size_t height, MEMCOPYKIND kind, std::string message)
+void memcopy2D(void* dst,
+               size_t dpitch,
+               const void* src,
+               size_t spitch,
+               size_t width,
+               size_t height,
+               MEMCOPYKIND kind,
+               std::string message)
 {
   if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -89,7 +89,7 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
   }
 }
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const std::string& message)
 {
   if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind))) {
     if (message != "")
@@ -107,7 +107,7 @@ void memcopy2D(void* dst,
                size_t width,
                size_t height,
                MEMCOPYKIND kind,
-               std::string message)
+               const std::string& message)
 {
   if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
   {
@@ -120,7 +120,7 @@ void memcopy2D(void* dst,
 
 }
 
-void malloc(void** devPtr, size_t size, std::string message)
+void malloc(void** devPtr, size_t size, const std::string& message)
 {
   cudaError_t status = cudaMalloc(devPtr, size);
   if (status != cudaSuccess)

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -92,7 +92,10 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
 void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
 {
   if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind))) {
-    std::cerr << message << std::endl;
+    if (message != "")
+    {
+      std::cerr << "Error: " << message << std::endl;
+    }
     throw std::runtime_error("Error: cudaMemcpy returned error code.");
   }
 }
@@ -108,7 +111,10 @@ void memcopy2D(void* dst,
 {
   if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
   {
-    std::cerr << message << std::endl;
+    if (message != "")
+    {
+      std::cerr << "Error: " << message << std::endl;
+    }
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
   }
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -91,8 +91,10 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
 
 void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
 {
-  if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind)))
+  if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind))) {
+    std::cerr << message << std::endl;
     throw std::runtime_error("Error: cudaMemcpy returned error code.");
+  }
 }
 
 void memcopy2D(void* dst,
@@ -105,7 +107,11 @@ void memcopy2D(void* dst,
                std::string message)
 {
   if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
+  {
+    std::cerr << message << std::endl;
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
+  }
+
 }
 
 void malloc(void** devPtr, size_t size, std::string message)

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -103,28 +103,25 @@ void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t 
 
 void malloc(void** devPtr, size_t size, std::string message)
 {
-  if (cudaSuccess != cudaMalloc(devPtr, size))
+  cudaError_t status = cudaMalloc(devPtr, size);
+  if (status != cudaSuccess)
   {
     std::cerr << " Error allocating " << size * 1024.0 / 1024.0 << " MBs on GPU." << std::endl;
     if (message != "")
     {
-      std::cerr << " Error from : " << message << std::endl;
+      std::cerr << " Error from : " << message << " " << cudaGetErrorString(status) << std::endl;
     }
     throw std::runtime_error("Error: cudaMalloc returned error code.");
   }
 }
 
-void free(void* p, std::string message)
+void free(void* p)
 {
-  if (cudaSuccess != cudaFree(p))
+  cudaError_t status = cudaFree(p);
+  if (status != cudaSuccess)
   {
-    if (message != "")
-    {
-      std::cerr << " Error from: " << message << std::endl;
-    }
-    throw std::runtime_error("Error: cudaFree returned error code.");
+    std::cerr << " Error from calling cudaFree: " << cudaGetErrorString(status) << std::endl;
   }
-
 }
 
 } // namespace arch

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -91,7 +91,9 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
 
 void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const std::string& message)
 {
-  if (cudaSuccess != cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind))) {
+  cudaError_t status = cudaMemcpy(dst, src, count, tocudaMemcpyKind(kind));
+  if (status != cudaSuccess)
+  {
     if (message != "")
     {
       std::cerr << "Error: " << message << std::endl;
@@ -110,7 +112,8 @@ void memcopy2D(void* dst,
                MEMCOPYKIND kind,
                const std::string& message)
 {
-  if (cudaSuccess != cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind)))
+  cudaError_t status = cudaMemcpy2D(dst, dpitch, src, spitch, width, height, tocudaMemcpyKind(kind));
+  if (status != cudaSuccess)
   {
     if (message != "")
     {
@@ -119,7 +122,6 @@ void memcopy2D(void* dst,
     std::cerr << " Error when calling cudaMemcpy2D: " << cudaGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
   }
-
 }
 
 void malloc(void** devPtr, size_t size, const std::string& message)

--- a/src/AFQMC/Memory/CUDA/cuda_arch.cpp
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.cpp
@@ -96,6 +96,7 @@ void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const s
     {
       std::cerr << "Error: " << message << std::endl;
     }
+    std::cerr << " Error when calling cudaMemcpy: " << cudaGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: cudaMemcpy returned error code.");
   }
 }
@@ -115,6 +116,7 @@ void memcopy2D(void* dst,
     {
       std::cerr << "Error: " << message << std::endl;
     }
+    std::cerr << " Error when calling cudaMemcpy2D: " << cudaGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
   }
 
@@ -128,17 +130,22 @@ void malloc(void** devPtr, size_t size, const std::string& message)
     std::cerr << " Error allocating " << size * 1024.0 / 1024.0 << " MBs on GPU." << std::endl;
     if (message != "")
     {
-      std::cerr << " Error from : " << message << " " << cudaGetErrorString(status) << std::endl;
+      std::cerr << " Error from: " << message  << std::endl;
     }
+    std::cerr << " Error when calling cudaMalloc: " << cudaGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: cudaMalloc returned error code.");
   }
 }
 
-void free(void* p)
+void free(void* p, const std::string& message)
 {
   cudaError_t status = cudaFree(p);
   if (status != cudaSuccess)
   {
+    if (message != "")
+    {
+      std::cerr << " Error from: " << message  << std::endl;
+    }
     std::cerr << " Error from calling cudaFree: " << cudaGetErrorString(status) << std::endl;
   }
 }

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -77,7 +77,7 @@ void memcopy2D(void* dst,
 
 void malloc(void** devPtr, size_t size, const std::string& message = "");
 
-void free(void* p, std::string& message = "");
+void free(void* p, const std::string& message = "");
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -74,9 +74,9 @@ void memcopy2D(void* dst,
                size_t height,
                MEMCOPYKIND kind = memcopyDefault);
 
-void malloc(void** devPtr, size_t size, std::string message="");
+void malloc(void** devPtr, size_t size, std::string message = "");
 
-void free(void* p, std::string message="");
+void free(void* p, std::string message = "");
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -77,7 +77,7 @@ void memcopy2D(void* dst,
 
 void malloc(void** devPtr, size_t size, const std::string& message = "");
 
-void free(void* p);
+void free(void* p, std::string& message = "");
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -74,9 +74,9 @@ void memcopy2D(void* dst,
                size_t height,
                MEMCOPYKIND kind = memcopyDefault);
 
-void malloc(void** devPtr, size_t size);
+void malloc(void** devPtr, size_t size, std::string message="");
 
-void free(void* p);
+void free(void* p, std::string message="");
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -72,7 +72,7 @@ void memcopy2D(void* dst,
                size_t spitch,
                size_t width,
                size_t height,
-               MEMCOPYKIND kind = memcopyDefault,
+               MEMCOPYKIND kind    = memcopyDefault,
                std::string message = "");
 
 void malloc(void** devPtr, size_t size, std::string message = "");

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -77,7 +77,7 @@ void memcopy2D(void* dst,
 
 void malloc(void** devPtr, size_t size, std::string message = "");
 
-void free(void* p, std::string message = "");
+void free(void* p);
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -64,7 +64,7 @@ cudaMemcpyKind tocudaMemcpyKind(MEMCOPYKIND v);
 
 void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed = 911ULL);
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, std::string message = "");
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, const std::string& message = "");
 
 void memcopy2D(void* dst,
                size_t dpitch,
@@ -73,9 +73,9 @@ void memcopy2D(void* dst,
                size_t width,
                size_t height,
                MEMCOPYKIND kind    = memcopyDefault,
-               std::string message = "");
+               const std::string& message = "");
 
-void malloc(void** devPtr, size_t size, std::string message = "");
+void malloc(void** devPtr, size_t size, const std::string& message = "");
 
 void free(void* p);
 

--- a/src/AFQMC/Memory/CUDA/cuda_arch.h
+++ b/src/AFQMC/Memory/CUDA/cuda_arch.h
@@ -64,7 +64,7 @@ cudaMemcpyKind tocudaMemcpyKind(MEMCOPYKIND v);
 
 void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed = 911ULL);
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault);
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, std::string message = "");
 
 void memcopy2D(void* dst,
                size_t dpitch,
@@ -72,7 +72,8 @@ void memcopy2D(void* dst,
                size_t spitch,
                size_t width,
                size_t height,
-               MEMCOPYKIND kind = memcopyDefault);
+               MEMCOPYKIND kind = memcopyDefault,
+               std::string message = "");
 
 void malloc(void** devPtr, size_t size, std::string message = "");
 

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -88,7 +88,8 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
 
 void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const std::string& message)
 {
-  if (hipSuccess != hipMemcpy(dst, src, count, tohipMemcpyKind(kind)))
+  hipError_t status = hipMemcpy(dst, src, count, tohipMemcpyKind(kind));
+  if (status != hipSuccess)
   {
     if (message != "")
     {
@@ -108,7 +109,8 @@ void memcopy2D(void* dst,
                MEMCOPYKIND kind,
                const std::string& message)
 {
-  if (hipSuccess != hipMemcpy2D(dst, dpitch, src, spitch, width, height, tohipMemcpyKind(kind)))
+  hipError_t status = hipMemcpy2D(dst, dpitch, src, spitch, width, height, tohipMemcpyKind(kind));
+  if (status != hipSuccess)
   {
     if (message != "")
     {

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -86,28 +86,53 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
   }
 }
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind)
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
 {
   if (hipSuccess != hipMemcpy(dst, src, count, tohipMemcpyKind(kind)))
+  {
+    std::cerr << message << std::endl;
     throw std::runtime_error("Error: hipMemcpy returned error code.");
+  }
 }
 
-void memcopy2D(void* dst, size_t dpitch, const void* src, size_t spitch, size_t width, size_t height, MEMCOPYKIND kind)
+void memcopy2D(void* dst,
+               size_t dpitch,
+               const void* src,
+               size_t spitch,
+               size_t width,
+               size_t height,
+               MEMCOPYKIND kind,
+               std::string message)
 {
   if (hipSuccess != hipMemcpy2D(dst, dpitch, src, spitch, width, height, tohipMemcpyKind(kind)))
+  {
+    std::cerr << message << std::endl;
     throw std::runtime_error("Error: hipMemcpy2D returned error code.");
+  }
 }
 
-void malloc(void** devPtr, size_t size)
+void malloc(void** devPtr, size_t size, std::string message)
 {
-  if (hipSuccess != hipMalloc(devPtr, size))
+  hipError_t status = hipMalloc(devPtr, size);
+  if (status != hipSuccess)
   {
     std::cerr << " Error allocating " << size * 1024.0 / 1024.0 << " MBs on GPU." << std::endl;
+    if (message != "")
+    {
+      std::cerr << " Error from : " << message << " " << hipGetErrorString(status) << std::endl;
+    }
     throw std::runtime_error("Error: hipMalloc returned error code.");
   }
 }
 
-void free(void* p) { hipFree(p); }
+void free(void* p)
+{
+  hipError_t status = hipFree(p);
+  if (status != hipSuccess)
+  {
+    std::cerr << " Error from calling cudaFree: " << hipGetErrorString(status) << std::endl;
+  }
+}
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -86,7 +86,7 @@ void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed)
   }
 }
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::string message)
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const std::string& message)
 {
   if (hipSuccess != hipMemcpy(dst, src, count, tohipMemcpyKind(kind)))
   {
@@ -105,7 +105,7 @@ void memcopy2D(void* dst,
                size_t width,
                size_t height,
                MEMCOPYKIND kind,
-               std::string message)
+               const std::string& message)
 {
   if (hipSuccess != hipMemcpy2D(dst, dpitch, src, spitch, width, height, tohipMemcpyKind(kind)))
   {
@@ -117,7 +117,7 @@ void memcopy2D(void* dst,
   }
 }
 
-void malloc(void** devPtr, size_t size, std::string message)
+void malloc(void** devPtr, size_t size, const std::string& message)
 {
   hipError_t status = hipMalloc(devPtr, size);
   if (status != hipSuccess)

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -94,6 +94,7 @@ void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, const s
     {
       std::cerr << "Error: " << message << std::endl;
     }
+    std::cerr << " Error when calling hipMemcpy: " << hipGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: hipMemcpy returned error code.");
   }
 }
@@ -113,6 +114,7 @@ void memcopy2D(void* dst,
     {
       std::cerr << "Error: " << message << std::endl;
     }
+    std::cerr << " Error when calling hipMemcpy2D: " << hipGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: hipMemcpy2D returned error code.");
   }
 }
@@ -125,18 +127,23 @@ void malloc(void** devPtr, size_t size, const std::string& message)
     std::cerr << " Error allocating " << size * 1024.0 / 1024.0 << " MBs on GPU." << std::endl;
     if (message != "")
     {
-      std::cerr << " Error from : " << message << " " << hipGetErrorString(status) << std::endl;
+      std::cerr << " Error from : " << message << std::endl;
     }
+    std::cerr << " Error when call hipMalloc " << < hipGetErrorString(status) << std::endl;
     throw std::runtime_error("Error: hipMalloc returned error code.");
   }
 }
 
-void free(void* p)
+void free(void* p, const std::string& message)
 {
   hipError_t status = hipFree(p);
   if (status != hipSuccess)
   {
-    std::cerr << " Error from calling cudaFree: " << hipGetErrorString(status) << std::endl;
+    if (message != "")
+    {
+      std::cerr << " Error from : " << message << std::endl;
+    }
+    std::cerr << " Error when calling hipFree: " << hipGetErrorString(status) << std::endl;
   }
 }
 

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -90,7 +90,10 @@ void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind, std::st
 {
   if (hipSuccess != hipMemcpy(dst, src, count, tohipMemcpyKind(kind)))
   {
-    std::cerr << message << std::endl;
+    if (message != "")
+    {
+      std::cerr << "Error: " << message << std::endl;
+    }
     throw std::runtime_error("Error: hipMemcpy returned error code.");
   }
 }
@@ -106,7 +109,10 @@ void memcopy2D(void* dst,
 {
   if (hipSuccess != hipMemcpy2D(dst, dpitch, src, spitch, width, height, tohipMemcpyKind(kind)))
   {
-    std::cerr << message << std::endl;
+    if (message != "")
+    {
+      std::cerr << "Error: " << message << std::endl;
+    }
     throw std::runtime_error("Error: hipMemcpy2D returned error code.");
   }
 }

--- a/src/AFQMC/Memory/HIP/hip_arch.h
+++ b/src/AFQMC/Memory/HIP/hip_arch.h
@@ -75,7 +75,7 @@ void memcopy2D(void* dst,
 
 void malloc(void** devPtr, size_t size, const std::string& message = "");
 
-void free(void* p);
+void free(void* p, const std::string& message = "");
 
 } // namespace arch
 

--- a/src/AFQMC/Memory/HIP/hip_arch.h
+++ b/src/AFQMC/Memory/HIP/hip_arch.h
@@ -62,7 +62,7 @@ hipMemcpyKind tohipMemcpyKind(MEMCOPYKIND v);
 
 void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed = 911ULL);
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, std::string message = "");
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, const std::string& message = "");
 
 void memcopy2D(void* dst,
                size_t dpitch,
@@ -71,9 +71,9 @@ void memcopy2D(void* dst,
                size_t width,
                size_t height,
                MEMCOPYKIND kind    = memcopyDefault,
-               std::string message = "");
+               const std::string& message = "");
 
-void malloc(void** devPtr, size_t size, std::string message = "");
+void malloc(void** devPtr, size_t size, const std::string& message = "");
 
 void free(void* p);
 

--- a/src/AFQMC/Memory/HIP/hip_arch.h
+++ b/src/AFQMC/Memory/HIP/hip_arch.h
@@ -62,7 +62,7 @@ hipMemcpyKind tohipMemcpyKind(MEMCOPYKIND v);
 
 void INIT(boost::mpi3::shared_communicator& node, unsigned long long int iseed = 911ULL);
 
-void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault);
+void memcopy(void* dst, const void* src, size_t count, MEMCOPYKIND kind = memcopyDefault, std::string message = "");
 
 void memcopy2D(void* dst,
                size_t dpitch,
@@ -70,9 +70,10 @@ void memcopy2D(void* dst,
                size_t spitch,
                size_t width,
                size_t height,
-               MEMCOPYKIND kind = memcopyDefault);
+               MEMCOPYKIND kind    = memcopyDefault,
+               std::string message = "");
 
-void malloc(void** devPtr, size_t size);
+void malloc(void** devPtr, size_t size, std::string message = "");
 
 void free(void* p);
 

--- a/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
@@ -56,7 +56,7 @@ template<typename T, typename Q>
 inline static void copy(int n, T const* x, int incx, device_pointer<Q> y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
-  arch::memcopy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, cudaMemcpyHostToDevice, "lapack_cuda_gpu_ptr::copy")
+  arch::memcopy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, arch::memcopyH2D, "lapack_cuda_gpu_ptr::copy");
 }
 
 template<typename T, typename Q>
@@ -64,7 +64,7 @@ inline static void copy(int n, device_pointer<Q> x, int incx, T* y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   assert(sizeof(Q) == sizeof(T));
-  arch::memcopy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, cudaMemcpyDeviceToHost, "lapack_cuda_gpu_ptr::copy")
+  arch::memcopy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, arch::memcopyD2H, "lapack_cuda_gpu_ptr::copy");
 }
 
 // scal Specializations
@@ -326,7 +326,7 @@ inline static void gemmBatched(char Atrans,
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
-  // replace with single call to arch::malloc and cudaMemcpy
+  // replace with single call to arch::malloc and arch::memcopy
   T **A_d, **B_d, **C_d;
   Q1** A_h;
   Q2** B_h;
@@ -343,9 +343,9 @@ inline static void gemmBatched(char Atrans,
   arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
   arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
   arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
-  cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);
+  arch::memcopy(A_d, A_h, batchSize * sizeof(*A_h), arch::memcopyH2D);
+  arch::memcopy(B_d, B_h, batchSize * sizeof(*B_h), arch::memcopyH2D);
+  arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
   cudaFree(A_d);
@@ -382,7 +382,7 @@ inline static void gemmBatched(char Atrans,
   static_assert(std::is_same<typename std::decay<Q1>::type, T2>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
   assert(Atrans == 'N' || Atrans == 'n');
-  // replace with single call to arch::malloc and cudaMemcpy
+  // replace with single call to arch::malloc and arch::memcopy
   T2** A_d;
   T** B_d;
   T2** C_d;
@@ -401,9 +401,9 @@ inline static void gemmBatched(char Atrans,
   arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
   arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
   arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
-  cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);
+  arch::memcopy(A_d, A_h, batchSize * sizeof(*A_h), arch::memcopyH2D);
+  arch::memcopy(B_d, B_h, batchSize * sizeof(*B_h), arch::memcopyH2D);
+  arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
   cudaFree(A_d);
@@ -462,21 +462,21 @@ template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyDeviceToDevice, "blas_cuda_gpu_ptr::copy2D")
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, arch::memcopyD2D, "blas_cuda_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, T const* src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyHostToDevice, "blas_cuda_gpu_ptr::copy2D")
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N, arch::memcopyH2D, "blas_cuda_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, T2* dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  arch::memcopy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyDeviceToHost, "blas_cuda_gpu_ptr::copy2D")
+  arch::memcopy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, arch::memcopyD2H, "blas_cuda_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>

--- a/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
@@ -348,9 +348,9 @@ inline static void gemmBatched(char Atrans,
   arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
-  cudaFree(A_d);
-  cudaFree(B_d);
-  cudaFree(C_d);
+  arch::free(A_d);
+  arch::free(B_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] B_h;
   delete[] C_h;
@@ -406,9 +406,9 @@ inline static void gemmBatched(char Atrans,
   arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
-  cudaFree(A_d);
-  cudaFree(B_d);
-  cudaFree(C_d);
+  arch::free(A_d);
+  arch::free(B_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] B_h;
   delete[] C_h;

--- a/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
@@ -56,9 +56,7 @@ template<typename T, typename Q>
 inline static void copy(int n, T const* x, int incx, device_pointer<Q> y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
-  if (cudaSuccess !=
-      cudaMemcpy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, cudaMemcpyHostToDevice))
-    throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
+  arch::memcopy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, cudaMemcpyHostToDevice, "lapack_cuda_gpu_ptr::copy")
 }
 
 template<typename T, typename Q>
@@ -66,9 +64,7 @@ inline static void copy(int n, device_pointer<Q> x, int incx, T* y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   assert(sizeof(Q) == sizeof(T));
-  if (cudaSuccess !=
-      cudaMemcpy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy2D returned error code.");
+  arch::memcopy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, cudaMemcpyDeviceToHost, "lapack_cuda_gpu_ptr::copy")
 }
 
 // scal Specializations
@@ -466,28 +462,21 @@ template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (cudaSuccess !=
-      cudaMemcpy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N,
-                   cudaMemcpyDeviceToDevice))
-    throw std::runtime_error("Error: cudaMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyDeviceToDevice, "blas_cuda_gpu_ptr::copy2D")
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, T const* src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (cudaSuccess !=
-      cudaMemcpy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyHostToDevice))
-    throw std::runtime_error("Error: cudaMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyHostToDevice, "blas_cuda_gpu_ptr::copy2D")
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, T2* dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (cudaSuccess !=
-      cudaMemcpy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, cudaMemcpyDeviceToHost, "blas_cuda_gpu_ptr::copy2D")
 }
 
 template<typename T, typename T2>

--- a/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/blas_cuda_gpu_ptr.hpp
@@ -21,6 +21,7 @@
 //#include "AFQMC/Memory/CUDA/cuda_gpu_pointer.hpp"
 #include "AFQMC/Utilities/type_conversion.hpp"
 #include "AFQMC/Memory/device_pointers.hpp"
+#include "AFQMC/Memory/arch.hpp"
 #include "AFQMC/Numerics/detail/CUDA/cublas_wrapper.hpp"
 //#include "AFQMC/Numerics/detail/CUDA/cublasXt_wrapper.hpp"
 // hand coded kernels for blas extensions
@@ -329,7 +330,7 @@ inline static void gemmBatched(char Atrans,
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
-  // replace with single call to cudaMalloc and cudaMemcpy
+  // replace with single call to arch::malloc and cudaMemcpy
   T **A_d, **B_d, **C_d;
   Q1** A_h;
   Q2** B_h;
@@ -343,9 +344,9 @@ inline static void gemmBatched(char Atrans,
     B_h[i] = to_address(B[i]);
     C_h[i] = to_address(C[i]);
   }
-  cudaMalloc((void**)&A_d, batchSize * sizeof(*A_h));
-  cudaMalloc((void**)&B_d, batchSize * sizeof(*B_h));
-  cudaMalloc((void**)&C_d, batchSize * sizeof(*C_h));
+  arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
+  arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
+  arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
   cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
   cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
   cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);
@@ -385,7 +386,7 @@ inline static void gemmBatched(char Atrans,
   static_assert(std::is_same<typename std::decay<Q1>::type, T2>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
   assert(Atrans == 'N' || Atrans == 'n');
-  // replace with single call to cudaMalloc and cudaMemcpy
+  // replace with single call to arch::malloc and cudaMemcpy
   T2** A_d;
   T** B_d;
   T2** C_d;
@@ -401,9 +402,9 @@ inline static void gemmBatched(char Atrans,
     B_h[i] = to_address(B[i]);
     C_h[i] = to_address(C[i]);
   }
-  cudaMalloc((void**)&A_d, batchSize * sizeof(*A_h));
-  cudaMalloc((void**)&B_d, batchSize * sizeof(*B_h));
-  cudaMalloc((void**)&C_d, batchSize * sizeof(*C_h));
+  arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
+  arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
+  arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
   cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
   cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
   cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);

--- a/src/AFQMC/Numerics/detail/CUDA/lapack_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/lapack_cuda_gpu_ptr.hpp
@@ -102,7 +102,7 @@ inline static void getrfBatched(const int n,
                                                       to_address(info), batchSize);
   if (CUBLAS_STATUS_SUCCESS != status)
     throw std::runtime_error("Error: cublas_getrf returned error code.");
-  cudaFree(A_d);
+  arch::free(A_d);
   delete[] A_h;
 }
 
@@ -139,7 +139,7 @@ inline static void getri(int n,
     throw std::runtime_error("Error: cusolver_getrs returned error code.");
   arch::memcopy(to_address(a), to_address(work), n * n * sizeof(T), arch::memcopyD2D);
   arch::memcopy(&status, info, sizeof(int), arch::memcopyD2H);
-  cudaFree(info);
+  arch::free(info);
 }
 
 // getriBatched
@@ -170,8 +170,8 @@ inline static void getriBatched(int n,
                                                       ldc, to_address(info), batchSize);
   if (CUBLAS_STATUS_SUCCESS != status)
     throw std::runtime_error("Error: cublas_getri returned error code.");
-  cudaFree(A_d);
-  cudaFree(C_d);
+  arch::free(A_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] C_h;
 }
@@ -203,8 +203,8 @@ inline static void matinvBatched(int n,
                                                        to_address(info), batchSize);
   if (CUBLAS_STATUS_SUCCESS != status)
     throw std::runtime_error("Error: cublas_matinv returned error code.");
-  cudaFree(A_d);
-  cudaFree(C_d);
+  arch::free(A_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] C_h;
 }
@@ -242,7 +242,7 @@ inline static void geqrf(int M,
     std::cerr.flush();
     throw std::runtime_error("Error: cublas_geqrf returned error code.");
   }
-  cudaFree(piv);
+  arch::free(piv);
 }
 
 // gelqf
@@ -299,7 +299,7 @@ void static gqr(int M,
     std::cerr.flush();
     throw std::runtime_error("Error: cublas_gqr returned error code.");
   }
-  cudaFree(piv);
+  arch::free(piv);
 }
 
 template<typename T, typename I>
@@ -375,7 +375,7 @@ inline static void geqrfBatched(int M,
                                                       to_address(inf.data()), batchSize);
   if (CUBLAS_STATUS_SUCCESS != status)
     throw std::runtime_error("Error: cublas_geqrfBatched returned error code.");
-  cudaFree(B_d);
+  arch::free(B_d);
   delete[] B_h;
 }
 
@@ -423,9 +423,9 @@ inline static void geqrfStrided(int M,
     assert(inf[i] == 0);
   if (CUBLAS_STATUS_SUCCESS != status)
     throw std::runtime_error("Error: cublas_geqrfBatched returned error code.");
-  cudaFree(A_d);
+  arch::free(A_d);
   delete[] A_h;
-  cudaFree(T_d);
+  arch::free(T_d);
   delete[] T_h;
 }
 
@@ -464,7 +464,7 @@ inline static void gesvd(char jobU,
     std::cerr.flush();
     throw std::runtime_error("Error: cublas_gesvd returned error code.");
   }
-  cudaFree(devSt);
+  arch::free(devSt);
 }
 
 template<typename T, typename R>
@@ -496,7 +496,7 @@ inline static void gesvd(char jobU,
     std::cerr.flush();
     throw std::runtime_error("Error: cublas_gesvd returned error code.");
   }
-  cudaFree(devSt);
+  arch::free(devSt);
 }
 
 

--- a/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
@@ -569,9 +569,9 @@ inline static void gemmBatched(char Atrans,
   arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
   arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
   arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
-  cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
-  cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);
+  arch::memcopy(A_d, A_h, batchSize * sizeof(*A_h), arch::memcopyH2D);
+  arch::memcopy(B_d, B_h, batchSize * sizeof(*B_h), arch::memcopyH2D);
+  arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
   cudaFree(A_d);

--- a/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
@@ -566,9 +566,9 @@ inline static void gemmBatched(char Atrans,
     B_h[i] = to_address(B[i]);
     C_h[i] = to_address(C[i]);
   }
-  cudaMalloc((void**)&A_d, batchSize * sizeof(*A_h));
-  cudaMalloc((void**)&B_d, batchSize * sizeof(*B_h));
-  cudaMalloc((void**)&C_d, batchSize * sizeof(*C_h));
+  arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
+  arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
+  arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
   cudaMemcpy(A_d, A_h, batchSize * sizeof(*A_h), cudaMemcpyHostToDevice);
   cudaMemcpy(B_d, B_h, batchSize * sizeof(*B_h), cudaMemcpyHostToDevice);
   cudaMemcpy(C_d, C_h, batchSize * sizeof(*C_h), cudaMemcpyHostToDevice);

--- a/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/old_blas_cuda.hpp
@@ -574,9 +574,9 @@ inline static void gemmBatched(char Atrans,
   arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   cublas::cublas_gemmBatched(*(A[0]).handles.cublas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                              C_d, ldc, batchSize);
-  cudaFree(A_d);
-  cudaFree(B_d);
-  cudaFree(C_d);
+  arch::free(A_d);
+  arch::free(B_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] B_h;
   delete[] C_h;

--- a/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
@@ -49,10 +49,10 @@ void csrmv(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (cudaSuccess != cudaMemcpy(std::addressof(pb), to_address(pntrb), sizeof(int), cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy returned error code in csrmv.");
-  if (cudaSuccess != cudaMemcpy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy returned error code in csrmv.");
+  if (cudaSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
+  if (cudaSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
   int nnz = pe - pb;
   if (CUSPARSE_STATUS_SUCCESS !=
       cusparse::cusparse_csrmv(*A.handles.cusparse_handle, transa, M, K, nnz, alpha,
@@ -81,10 +81,10 @@ void csrmm(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (cudaSuccess != cudaMemcpy(std::addressof(pb), to_address(pntrb), sizeof(int), cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy returned error code in csrmm.");
-  if (cudaSuccess != cudaMemcpy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), cudaMemcpyDeviceToHost))
-    throw std::runtime_error("Error: cudaMemcpy returned error code in csrmm.");
+  if (cudaSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
+  if (cudaSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
   int nnz = pe - pb;
   if (transa == 'N')
   {

--- a/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
@@ -49,10 +49,8 @@ void csrmv(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (cudaSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
-  if (cudaSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
+  arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H, "sparse_cuda_gpu_ptr::csrmv");
+  arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H, "sparse_cuda_gpu_ptr::csrmv");
   int nnz = pe - pb;
   if (CUSPARSE_STATUS_SUCCESS !=
       cusparse::cusparse_csrmv(*A.handles.cusparse_handle, transa, M, K, nnz, alpha,
@@ -81,10 +79,8 @@ void csrmm(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (cudaSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
-  if (cudaSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
+  arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H, "lapack_sparse_gpu_ptr::csrmm");
+  arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H, "lapack_sparse_gpu_ptr::csrmm");
   int nnz = pe - pb;
   if (transa == 'N')
   {

--- a/src/AFQMC/Numerics/detail/HIP/blas_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/blas_hip_gpu_ptr.hpp
@@ -50,9 +50,7 @@ template<typename T, typename Q>
 inline static void copy(int n, T const* x, int incx, device_pointer<Q> y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
-  if (hipSuccess !=
-      hipMemcpy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, hipMemcpyHostToDevice))
-    throw std::runtime_error("Error: hipMemcpy2D returned error code.");
+  arch::memcopy2D(to_address(y), sizeof(Q) * incy, x, sizeof(T) * incx, sizeof(T), n, arch::memcopyH2D, "blas_hip_gpu_ptr::copy");
 }
 
 template<typename T, typename Q>
@@ -60,9 +58,7 @@ inline static void copy(int n, device_pointer<Q> x, int incx, T* y, int incy)
 {
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   assert(sizeof(Q) == sizeof(T));
-  if (hipSuccess !=
-      hipMemcpy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy2D returned error code.");
+  arch::memcopy2D(y, sizeof(T) * incy, to_address(x), sizeof(Q) * incx, sizeof(T), n, arch::memcopyD2H, "blas_hip_gpu_ptr::copy");
 }
 
 // scal Specializations
@@ -325,7 +321,7 @@ inline static void gemmBatched(char Atrans,
 {
   static_assert(std::is_same<typename std::decay<Q1>::type, T>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
-  // replace with single call to hipMalloc and hipMemcpy
+  // replace with single call to arch::malloc and arch::memcopy
   T **A_d, **B_d, **C_d;
   Q1** A_h;
   Q2** B_h;
@@ -339,17 +335,17 @@ inline static void gemmBatched(char Atrans,
     B_h[i] = to_address(B[i]);
     C_h[i] = to_address(C[i]);
   }
-  hipMalloc((void**)&A_d, batchSize * sizeof(*A_h));
-  hipMalloc((void**)&B_d, batchSize * sizeof(*B_h));
-  hipMalloc((void**)&C_d, batchSize * sizeof(*C_h));
-  hipMemcpy(A_d, A_h, batchSize * sizeof(*A_h), hipMemcpyHostToDevice);
-  hipMemcpy(B_d, B_h, batchSize * sizeof(*B_h), hipMemcpyHostToDevice);
-  hipMemcpy(C_d, C_h, batchSize * sizeof(*C_h), hipMemcpyHostToDevice);
+  arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
+  arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
+  arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
+  arch::memcopy(A_d, A_h, batchSize * sizeof(*A_h), arch::memcopyH2D);
+  arch::memcopy(B_d, B_h, batchSize * sizeof(*B_h), arch::memcopyH2D);
+  arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   hipblas::hipblas_gemmBatched(*(A[0]).handles.hipblas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                                C_d, ldc, batchSize);
-  hipFree(A_d);
-  hipFree(B_d);
-  hipFree(C_d);
+  arch::free(A_d);
+  arch::free(B_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] B_h;
   delete[] C_h;
@@ -381,7 +377,7 @@ inline static void gemmBatched(char Atrans,
   static_assert(std::is_same<typename std::decay<Q1>::type, T2>::value, "Wrong dispatch.\n");
   static_assert(std::is_same<typename std::decay<Q2>::type, T>::value, "Wrong dispatch.\n");
   assert(Atrans == 'N' || Atrans == 'n');
-  // replace with single call to hipMalloc and hipMemcpy
+  // replace with single call to arch::malloc and arch::memcopy
   T2** A_d;
   T** B_d;
   T2** C_d;
@@ -397,17 +393,17 @@ inline static void gemmBatched(char Atrans,
     B_h[i] = to_address(B[i]);
     C_h[i] = to_address(C[i]);
   }
-  hipMalloc((void**)&A_d, batchSize * sizeof(*A_h));
-  hipMalloc((void**)&B_d, batchSize * sizeof(*B_h));
-  hipMalloc((void**)&C_d, batchSize * sizeof(*C_h));
-  hipMemcpy(A_d, A_h, batchSize * sizeof(*A_h), hipMemcpyHostToDevice);
-  hipMemcpy(B_d, B_h, batchSize * sizeof(*B_h), hipMemcpyHostToDevice);
-  hipMemcpy(C_d, C_h, batchSize * sizeof(*C_h), hipMemcpyHostToDevice);
+  arch::malloc((void**)&A_d, batchSize * sizeof(*A_h));
+  arch::malloc((void**)&B_d, batchSize * sizeof(*B_h));
+  arch::malloc((void**)&C_d, batchSize * sizeof(*C_h));
+  arch::memcopy(A_d, A_h, batchSize * sizeof(*A_h), arch::memcopyH2D);
+  arch::memcopy(B_d, B_h, batchSize * sizeof(*B_h), arch::memcopyH2D);
+  arch::memcopy(C_d, C_h, batchSize * sizeof(*C_h), arch::memcopyH2D);
   hipblas::hipblas_gemmBatched(*(A[0]).handles.hipblas_handle, Atrans, Btrans, M, N, K, alpha, A_d, lda, B_d, ldb, beta,
                                C_d, ldc, batchSize);
-  hipFree(A_d);
-  hipFree(B_d);
-  hipFree(C_d);
+  arch::free(A_d);
+  arch::free(B_d);
+  arch::free(C_d);
   delete[] A_h;
   delete[] B_h;
   delete[] C_h;
@@ -461,28 +457,24 @@ template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (hipSuccess !=
-      hipMemcpy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N,
-                  hipMemcpyDeviceToDevice))
-    throw std::runtime_error("Error: hipMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N,
+                  arch::memcopyD2D, "blas_hip_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, T const* src, int lda, device_pointer<T2> dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (hipSuccess !=
-      hipMemcpy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N, hipMemcpyHostToDevice))
-    throw std::runtime_error("Error: hipMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(to_address(dst), sizeof(T2) * ldb, src, sizeof(T) * lda, M * sizeof(T), N,
+                  arch::memcopyH2D, "blas_hip_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>
 inline static void copy2D(int N, int M, device_pointer<T> src, int lda, T2* dst, int ldb)
 {
   static_assert(std::is_same<typename std::decay<T>::type, T2>::value, "Wrong dispatch.\n");
-  if (hipSuccess !=
-      hipMemcpy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N, hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy2D returned error code in copy2D.");
+  arch::memcopy2D(dst, sizeof(T2) * ldb, to_address(src), sizeof(T) * lda, M * sizeof(T), N,
+                  arch::memcopyD2H, "blas_hip_gpu_ptr::copy2D");
 }
 
 template<typename T, typename T2>

--- a/src/AFQMC/Numerics/detail/HIP/lapack_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/lapack_hip_gpu_ptr.hpp
@@ -135,11 +135,7 @@ inline static void getri(int n,
 
   // info isn't returned from ?getrs.
   int* info;
-  if (hipSuccess != arch::malloc((void**)&info, sizeof(int)))
-  {
-    std::cerr << " Error getri: Error allocating on GPU." << std::endl;
-    throw std::runtime_error("Error: arch::malloc returned error code.");
-  }
+  arch::malloc((void**)&info, sizeof(int), "lapack_hip_gpu_ptr::getri");
 
   kernels::set_identity(n, n, to_address(work), n);
   //std::cout << (*work).num_elements() << " " << (*a).num_elements() << std::endl;

--- a/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
@@ -46,10 +46,8 @@ void csrmv(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (hipSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
-  if (hipSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
+  arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H, "sparse_hip_gpu_ptr::csrmv");
+  arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H, "sparse_hip_gpu_ptr::csrmv");
   int nnz = pe - pb;
   if (HIPSPARSE_STATUS_SUCCESS !=
       hipsparse::hipsparse_csrmv(*A.handles.hipsparse_handle, transa, M, K, nnz, alpha,
@@ -78,10 +76,8 @@ void csrmm(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (hipSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
-  if (hipSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
-    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
+  arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H, "sparse_hip_gpu_ptr::csrmm");
+  arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H, "sparse_hip_gpu_ptr::csrmm");
   int nnz = pe - pb;
   if (transa == 'N')
   {

--- a/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/sparse_hip_gpu_ptr.hpp
@@ -46,10 +46,10 @@ void csrmv(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (hipSuccess != hipMemcpy(std::addressof(pb), to_address(pntrb), sizeof(int), hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy returned error code in csrmv.");
-  if (hipSuccess != hipMemcpy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy returned error code in csrmv.");
+  if (hipSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
+  if (hipSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmv.");
   int nnz = pe - pb;
   if (HIPSPARSE_STATUS_SUCCESS !=
       hipsparse::hipsparse_csrmv(*A.handles.hipsparse_handle, transa, M, K, nnz, alpha,
@@ -78,10 +78,10 @@ void csrmm(const char transa,
   static_assert(std::is_same<typename std::decay<Q>::type, T>::value, "Wrong dispatch.\n");
   // somehow need to check if the matrix is compact!
   int pb, pe;
-  if (hipSuccess != hipMemcpy(std::addressof(pb), to_address(pntrb), sizeof(int), hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy returned error code in csrmm.");
-  if (hipSuccess != hipMemcpy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), hipMemcpyDeviceToHost))
-    throw std::runtime_error("Error: hipMemcpy returned error code in csrmm.");
+  if (hipSuccess != arch::memcopy(std::addressof(pb), to_address(pntrb), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
+  if (hipSuccess != arch::memcopy(std::addressof(pe), to_address(pntre + (M - 1)), sizeof(int), arch::memcopyD2H))
+    throw std::runtime_error("Error: arch::memcopy returned error code in csrmm.");
   int nnz = pe - pb;
   if (transa == 'N')
   {


### PR DESCRIPTION
## Proposed changes

Uses arch::malloc/free/memcopy consistently throughout the code. Previously cuda/hipMalloc etc were called in many places without checking the error code, this PR replaces these calls with already existing arch::malloc which does the error checking internally.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

clang10+rocm3.6 and gcc/7.3.1+cuda9.2.88

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
