### PR TITLE
Remove resetTargetParticleSet in QMCWaveFunctions

### DIFF
--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -87,9 +87,6 @@ void AGPDeterminant::reportStatus(std::ostream& os)
   //do nothing
 }
 
-
-void AGPDeterminant::resetTargetParticleSet(ParticleSet& P) { GeminalBasis->resetTargetParticleSet(P); }
-
 /** Calculate the log value of the Dirac determinant for particles
  *@param P input configuration containing N particles
  *@param G a vector containing N gradients
@@ -418,7 +415,6 @@ WaveFunctionComponentPtr AGPDeterminant::makeClone(ParticleSet& tqp) const
 {
   AGPDeterminant* myclone = new AGPDeterminant(0);
   myclone->GeminalBasis   = GeminalBasis->makeClone();
-  myclone->GeminalBasis->resetTargetParticleSet(tqp);
   myclone->resize(Nup, Ndown);
   myclone->Lambda = Lambda;
   if (Nup != Ndown)

--- a/src/QMCWaveFunctions/AGPDeterminant.h
+++ b/src/QMCWaveFunctions/AGPDeterminant.h
@@ -51,8 +51,6 @@ public:
   void resetParameters(const opt_variables_type& active);
   void reportStatus(std::ostream& os);
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   ///reset the size: with the number of particles and number of orbtials
   void resize(int nup, int ndown);
 

--- a/src/QMCWaveFunctions/BasisSetBase.h
+++ b/src/QMCWaveFunctions/BasisSetBase.h
@@ -117,8 +117,6 @@ struct BasisSetBase : public OrbitalSetTraits<T>
   /**@}*/
   ///resize the basis set
   virtual void setBasisSetSize(int nbs) = 0;
-  ///reset the target particle set
-  virtual void resetTargetParticleSet(ParticleSet& P) = 0;
 
   virtual void evaluateWithHessian(const ParticleSet& P, int iat)            = 0;
   virtual void evaluateWithThirdDeriv(const ParticleSet& P, int iat)         = 0;

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -113,8 +113,6 @@ public:
 
   void resetParameters(const opt_variables_type& active) override {}
 
-  void resetTargetParticleSet(ParticleSet& e) override {}
-
   void setOrbitalSetSize(int norbs) override { OrbitalSetSize = norbs; }
 
   virtual void evaluate_notranspose(const ParticleSet& P,

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -94,13 +94,6 @@ void CompositeSPOSet::report()
 }
 
 
-void CompositeSPOSet::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int c = 0; c < components.size(); ++c)
-    components[c]->resetTargetParticleSet(P);
-}
-
-
 SPOSet* CompositeSPOSet::makeClone() const
 {
   // base class and shallow copy

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -48,8 +48,6 @@ public:
   ///size is determined by component sposets and nothing else
   inline void setOrbitalSetSize(int norbs) {}
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   SPOSet* makeClone() const;
 
   /** add sposet clones from another Composite SPOSet

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -24,7 +24,6 @@ public:
   virtual void checkOutVariables(const opt_variables_type& active) override {}
   virtual void resetParameters(const opt_variables_type& active) override {}
   virtual void reportStatus(std::ostream& os) override {}
-  virtual void resetTargetParticleSet(ParticleSet& P) override {}
 
   PsiValueType FakeGradRatio;
 

--- a/src/QMCWaveFunctions/DiffWaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/DiffWaveFunctionComponent.cpp
@@ -39,17 +39,6 @@ void DiffWaveFunctionComponent::evaluateDerivRatios(ParticleSet& VP,
   APP_ABORT("Implement DiffWaveFunctionComponent::evaluateDerivRatios for this orbital");
 }
 
-void NumericalDiffOrbital::resetTargetParticleSet(ParticleSet& P)
-{
-  int nptcls = P.getTotalNum();
-  dg_p.resize(nptcls);
-  dl_p.resize(nptcls);
-  dg_m.resize(nptcls);
-  dl_m.resize(nptcls);
-  gradLogPsi.resize(nptcls);
-  lapLogPsi.resize(nptcls);
-}
-
 void NumericalDiffOrbital::checkOutVariables(const opt_variables_type& optvars)
 {
   //do nothing
@@ -115,20 +104,6 @@ void AnalyticDiffOrbital::resetParameters(const opt_variables_type& optvars)
     return;
   for (int i = 0; i < refOrbital.size(); ++i)
     refOrbital[i]->resetParameters(optvars);
-}
-
-void AnalyticDiffOrbital::resetTargetParticleSet(ParticleSet& P)
-{
-  if (MyIndex < 0)
-    return;
-  for (int i = 0; i < refOrbital.size(); ++i)
-    refOrbital[i]->resetTargetParticleSet(P);
-  int nptcls = P.getTotalNum();
-  if (gradLogPsi.size() != nptcls)
-  {
-    gradLogPsi.resize(nptcls);
-    lapLogPsi.resize(nptcls);
-  }
 }
 
 void AnalyticDiffOrbital::checkOutVariables(const opt_variables_type& optvars)

--- a/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
@@ -69,9 +69,6 @@ struct DiffWaveFunctionComponent
    */
   virtual void initialize() {}
 
-  ///prepare internal data for a new particle sets
-  virtual void resetTargetParticleSet(ParticleSet& P) = 0;
-
   /** evaluate derivatives at \f$\{R\}\f$
    * @param P current configuration
    * @param optvars optimizable variables
@@ -130,7 +127,6 @@ struct NumericalDiffOrbital : public DiffWaveFunctionComponent
 {
   NumericalDiffOrbital(WaveFunctionComponent* orb = 0) : DiffWaveFunctionComponent(orb) {}
 
-  void resetTargetParticleSet(ParticleSet& P);
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& optvars,
                            std::vector<RealType>& dlogpsi,
@@ -150,7 +146,6 @@ struct AnalyticDiffOrbital : public DiffWaveFunctionComponent
 {
   AnalyticDiffOrbital(WaveFunctionComponent* orb = 0) : DiffWaveFunctionComponent(orb) {}
 
-  void resetTargetParticleSet(ParticleSet& P);
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& optvars,
                            std::vector<RealType>& dlogpsi,

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -47,8 +47,6 @@ inline void EinsplineSetExtended<StorageType>::computePhaseFactors(const TinyVec
 
 EinsplineSet::UnitCellType EinsplineSet::GetLattice() { return SuperLattice; }
 
-void EinsplineSet::resetTargetParticleSet(ParticleSet& e) {}
-
 void EinsplineSet::resetSourceParticleSet(ParticleSet& ions) {}
 
 void EinsplineSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; }
@@ -137,10 +135,6 @@ inline void EinsplineMultiEval(multi_UBspline_3d_z* restrict spline,
 
 template<typename StorageType>
 void EinsplineSetExtended<StorageType>::resetParameters(const opt_variables_type& active)
-{}
-
-template<typename StorageType>
-void EinsplineSetExtended<StorageType>::resetTargetParticleSet(ParticleSet& e)
 {}
 
 template<typename StorageType>

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -78,7 +78,6 @@ public:
 public:
   UnitCellType GetLattice();
   virtual void resetParameters(const opt_variables_type& active) {}
-  void resetTargetParticleSet(ParticleSet& e);
   void resetSourceParticleSet(ParticleSet& ions);
   void setOrbitalSetSize(int norbs);
   inline std::string Type() { return "EinsplineSet"; }
@@ -486,7 +485,6 @@ public:
 #endif
 
   void resetParameters(const opt_variables_type& active);
-  void resetTargetParticleSet(ParticleSet& e);
   void setOrbitalSetSize(int norbs);
   std::string Type();
 

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -37,7 +37,6 @@ struct EGOSet : public SPOSet
   SPOSet* makeClone() const override { return new EGOSet(*this); }
 
   void resetParameters(const opt_variables_type& optVariables) override {}
-  inline void resetTargetParticleSet(ParticleSet& P) override {}
   void setOrbitalSetSize(int norbs) override {}
 
   inline void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -146,7 +146,6 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
       sdet->setBF(BFTrans);
       if (BFTrans->isOptimizable())
         sdet->Optimizable = true;
-      sdet->resetTargetParticleSet(targetPtcl);
     }
     else
     {

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -42,7 +42,6 @@ struct RealEGOSet : public SPOSet
   RealEGOSet(const std::vector<PosType>& k, const std::vector<RealType>& k2);
 
   void resetParameters(const opt_variables_type& optVariables) override {}
-  inline void resetTargetParticleSet(ParticleSet& P) override {}
   void setOrbitalSetSize(int norbs) override {}
 
   SPOSet* makeClone() const override { return new RealEGOSet(*this); }

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -42,8 +42,6 @@ public:
 
   void reportStatus(std::ostream& os) override {}
 
-  void resetTargetParticleSet(ParticleSet& P) override {}
-
   LogValueType evaluateLog(ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;

--- a/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
@@ -352,9 +352,7 @@ public:
     /*
     dummyQP2.R = P.R;
     dummyQP2.update();
-    resetTargetParticleSet(dummyQP2);
     evaluate(P,dummyQP);
-    resetTargetParticleSet(P);
     std::cout <<"index: ";
     for(int i=0; i<indexQP.size(); i++) std::cout <<indexQP[i] <<" ";
     std::cout << std::endl;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -79,13 +79,6 @@ public:
 
   virtual void resetParameters(const opt_variables_type& active) override { Phi->resetParameters(active); }
 
-  // To be removed with AoS
-  void resetTargetParticleSet(ParticleSet& P) override final
-  {
-    Phi->resetTargetParticleSet(P);
-    targetPtcl = &P;
-  }
-
   inline void reportStatus(std::ostream& os) override final {}
 
   // expose CPU interfaces
@@ -182,8 +175,6 @@ protected:
   int NumOrbitals;
   ///number of particles which belong to this Dirac determinant
   int NumPtcls;
-  /// targetPtcl pointer. YE: to be removed.
-  ParticleSet* targetPtcl;
 
   /// register all the timers
   void registerTimers()

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -178,7 +178,6 @@ public:
 
 
   inline void reportStatus(std::ostream& os) {}
-  void resetTargetParticleSet(ParticleSet& P) { Phi->resetTargetParticleSet(P); }
 
   ///reset the size: with the number of particles and number of orbtials
   virtual void resize(int nel, int morb);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -57,8 +57,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
   SPOSetProxyForMSD* spo_dn_C = new SPOSetProxyForMSD(spo_dn->refPhi->makeClone(), FirstIndex_dn, LastIndex_dn);
   spo_up_C->occup             = spo_up->occup;
   spo_dn_C->occup             = spo_dn->occup;
-  spo_up_C->refPhi->resetTargetParticleSet(tqp);
-  spo_dn_C->refPhi->resetTargetParticleSet(tqp);
   MultiSlaterDeterminant* clone = new MultiSlaterDeterminant(tqp, spo_up_C, spo_dn_C);
   clone->C2node_up              = C2node_up;
   clone->C2node_dn              = C2node_dn;
@@ -82,7 +80,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
     //       }
     SingleDet_t* adet = new SingleDet_t((SPOSetPtr)clone->spo_up, 0);
     adet->set(clone->FirstIndex_up, clone->nels_up);
-    adet->resetTargetParticleSet(tqp);
     clone->dets_up.push_back(adet);
   }
   //     spo = clone->spo_dn;
@@ -98,7 +95,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
     //       }
     SingleDet_t* adet = new SingleDet_t((SPOSetPtr)clone->spo_dn, 0);
     adet->set(clone->FirstIndex_dn, clone->nels_dn);
-    adet->resetTargetParticleSet(tqp);
     clone->dets_dn.push_back(adet);
   }
   clone->Optimizable = Optimizable;
@@ -109,13 +105,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
 
 
 MultiSlaterDeterminant::~MultiSlaterDeterminant() {}
-void MultiSlaterDeterminant::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < dets_up.size(); i++)
-    dets_up[i]->resetTargetParticleSet(P);
-  for (int i = 0; i < dets_dn.size(); i++)
-    dets_dn[i]->resetTargetParticleSet(P);
-}
 
 void MultiSlaterDeterminant::resize(int n1, int n2)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
@@ -80,8 +80,6 @@ public:
   virtual void resetParameters(const opt_variables_type& active);
   virtual void reportStatus(std::ostream& os);
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   ///set BF pointers
   virtual void setBF(BackflowTransformation* BFTrans) {}
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -88,7 +88,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminantFast::makeClone(ParticleSet& tqp)
     BackflowTransformation* tr = BFTrans->makeClone(tqp);
     clone->setBF(tr);
   }
-  clone->resetTargetParticleSet(tqp);
 
   //Set IsCloned so that only the main object handles the optimizable data
   clone->IsCloned = true;
@@ -127,21 +126,6 @@ MultiSlaterDeterminantFast::~MultiSlaterDeterminantFast()
   }
   //clean up determinants too!
 }
-
-void MultiSlaterDeterminantFast::resetTargetParticleSet(ParticleSet& P)
-{
-  if (usingBF)
-  {
-    for (int i = 0; i < Dets.size(); i++)
-      Dets[i]->resetTargetParticleSet(BFTrans->QP);
-  }
-  else
-  {
-    for (int i = 0; i < Dets.size(); i++)
-      Dets[i]->resetTargetParticleSet(P);
-  }
-}
-
 
 void MultiSlaterDeterminantFast::testMSD(ParticleSet& P, int iat)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -81,8 +81,6 @@ public:
   void resetParameters(const opt_variables_type& active) override;
   void reportStatus(std::ostream& os) override;
 
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   //builds orbital rotation parameters using MultiSlater member variables
   void buildOptVariables();
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -37,8 +37,6 @@ WaveFunctionComponentPtr MultiSlaterDeterminantWithBackflow::makeClone(ParticleS
   SPOSetProxyForMSD* spo_dn_C = new SPOSetProxyForMSD(spo_dn->refPhi->makeClone(), FirstIndex_dn, LastIndex_dn);
   spo_up_C->occup             = spo_up->occup;
   spo_dn_C->occup             = spo_dn->occup;
-  spo_up_C->refPhi->resetTargetParticleSet(tr->QP);
-  spo_dn_C->refPhi->resetTargetParticleSet(tr->QP);
   MultiSlaterDeterminantWithBackflow* clone = new MultiSlaterDeterminantWithBackflow(tqp, spo_up_C, spo_dn_C, tr);
   clone->C2node_up                          = C2node_up;
   clone->C2node_dn                          = C2node_dn;
@@ -53,20 +51,17 @@ WaveFunctionComponentPtr MultiSlaterDeterminantWithBackflow::makeClone(ParticleS
   {
     DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_up[i]->makeCopy((SPOSetPtr)clone->spo_up);
     dclne->BFTrans                      = tr;
-    dclne->resetTargetParticleSet(tr->QP);
     clone->dets_up.push_back(dclne);
   }
   for (int i = 0; i < dets_dn.size(); i++)
   {
     DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_dn[i]->makeCopy((SPOSetPtr)clone->spo_dn);
     dclne->BFTrans                      = tr;
-    dclne->resetTargetParticleSet(tr->QP);
     clone->dets_dn.push_back(dclne);
   }
   clone->Optimizable = Optimizable;
   clone->C           = C;
   clone->myVars      = myVars;
-  clone->resetTargetParticleSet(tr->QP);
   return clone;
 }
 

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxy.cpp
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxy.cpp
@@ -27,8 +27,6 @@ SPOSetProxy::SPOSetProxy(SPOSetPtr const& spos, int first, int last) : refPhi(sp
 
 void SPOSetProxy::resetParameters(const opt_variables_type& optVariables) { refPhi->resetParameters(optVariables); }
 
-void SPOSetProxy::resetTargetParticleSet(ParticleSet& P) { refPhi->resetTargetParticleSet(P); }
-
 void SPOSetProxy::setOrbitalSetSize(int norbs)
 {
   //psiM.resize(norbs,OrbitalSetSize);

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxy.h
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxy.h
@@ -49,7 +49,6 @@ struct SPOSetProxy : public SPOSet
    */
   SPOSetProxy(SPOSetPtr const& spos, int first, int last);
   void resetParameters(const opt_variables_type& optVariables) override;
-  void resetTargetParticleSet(ParticleSet& P) override;
   void setOrbitalSetSize(int norbs) override;
   void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override;
   void evaluateVGL(const ParticleSet& P, int iat, ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) override;

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.cpp
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.cpp
@@ -29,8 +29,6 @@ void SPOSetProxyForMSD::resetParameters(const opt_variables_type& optVariables)
   refPhi->resetParameters(optVariables);
 }
 
-void SPOSetProxyForMSD::resetTargetParticleSet(ParticleSet& P) { refPhi->resetTargetParticleSet(P); }
-
 void SPOSetProxyForMSD::setOrbitalSetSize(int norbs)
 {
   //psiM.resize(norbs,OrbitalSetSize);

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.h
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.h
@@ -61,7 +61,6 @@ struct SPOSetProxyForMSD : public SPOSet
    */
   SPOSetProxyForMSD(SPOSetPtr const& spos, int first, int last);
   void resetParameters(const opt_variables_type& optVariables) override;
-  void resetTargetParticleSet(ParticleSet& P) override;
   void setOrbitalSetSize(int norbs) override;
   void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override;
   void evaluateVGL(const ParticleSet& P, int iat, ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi) override;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -98,20 +98,6 @@ void SlaterDet::resetParameters(const opt_variables_type& active)
 
 void SlaterDet::reportStatus(std::ostream& os) {}
 
-void SlaterDet::resetTargetParticleSet(ParticleSet& P)
-{
-  std::map<std::string, SPOSetPtr>::iterator sit(mySPOSet.begin());
-  while (sit != mySPOSet.end())
-  {
-    (*sit).second->resetTargetParticleSet(P);
-    ++sit;
-  }
-  //BasisSet->resetTargetParticleSet(P);
-  //LOGMSG("\nSlaterDet::resetTargetParticleSet")
-  for (int i = 0; i < Dets.size(); i++)
-    Dets[i]->resetTargetParticleSet(P);
-}
-
 void SlaterDet::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
 {
   for (int i = 0; i < Dets.size(); ++i)
@@ -209,14 +195,12 @@ WaveFunctionComponentPtr SlaterDet::makeClone(ParticleSet& tqp) const
       SPOSetPtr spo = (*Mit).second;
       SPOSetPtr spo_clone;
       spo_clone = spo->makeClone();
-      spo_clone->resetTargetParticleSet(tqp);
       myclone->add(spo_clone, spo->getName());
       for (int i = 0; i < Dets.size(); ++i)
       {
         if (spo == Dets[i]->getPhi())
         {
           Determinant_t* newD = Dets[i]->makeCopy(spo_clone);
-          newD->resetTargetParticleSet(tqp);
           myclone->add(newD, i);
         }
       }
@@ -227,12 +211,10 @@ WaveFunctionComponentPtr SlaterDet::makeClone(ParticleSet& tqp) const
   {
     SPOSetPtr spo       = Dets[0]->getPhi();
     SPOSetPtr spo_clone = spo->makeClone();
-    spo_clone->resetTargetParticleSet(tqp);
     myclone->add(spo_clone, spo->getName());
     for (int i = 0; i < Dets.size(); ++i)
     {
       Determinant_t* newD = Dets[i]->makeCopy(spo_clone);
-      newD->resetTargetParticleSet(tqp);
       myclone->add(newD, i);
     }
   }

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -66,8 +66,6 @@ public:
 
   void reportStatus(std::ostream& os) override;
 
-  virtual void resetTargetParticleSet(ParticleSet& P) override;
-
   virtual LogValueType evaluateLog(ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L) override;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -350,22 +350,13 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
     if (multiDet)
     {
       if (FastMSD)
-      {
         multislaterdetfast_0->setBF(BFTrans);
-        multislaterdetfast_0->resetTargetParticleSet(BFTrans->QP);
-        //           if(BFTrans->isOptimizable()) multislaterdetfast_0->Optimizable = true;
-      }
       else
-      {
         multislaterdet_0->setBF(BFTrans);
-        multislaterdet_0->resetTargetParticleSet(BFTrans->QP);
-        //           if(BFTrans->isOptimizable()) multislaterdet_0->Optimizable = true;
-      }
     }
     else
     {
       slaterdet_0->setBF(BFTrans);
-      slaterdet_0->resetTargetParticleSet(targetPtcl);
       if (BFTrans->isOptimizable())
         slaterdet_0->Optimizable = true;
     }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -37,18 +37,6 @@ void SlaterDetWithBackflow::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<V
     Dets[i]->evaluateRatiosAlltoOne(P, ratios);
 }
 
-void SlaterDetWithBackflow::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < Dets.size(); i++)
-    Dets[i]->resetTargetParticleSet(BFTrans->QP);
-  std::map<std::string, SPOSetPtr>::iterator sit(mySPOSet.begin());
-  while (sit != mySPOSet.end())
-  {
-    (*sit).second->resetTargetParticleSet(BFTrans->QP);
-    ++sit;
-  }
-}
-
 SlaterDetWithBackflow::LogValueType SlaterDetWithBackflow::evaluateLog(ParticleSet& P,
                                                                        ParticleSet::ParticleGradient_t& G,
                                                                        ParticleSet::ParticleLaplacian_t& L)
@@ -91,7 +79,6 @@ void SlaterDetWithBackflow::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 WaveFunctionComponentPtr SlaterDetWithBackflow::makeClone(ParticleSet& tqp) const
 {
   BackflowTransformation* tr = BFTrans->makeClone(tqp);
-  //    tr->resetTargetParticleSet(tqp);
   SlaterDetWithBackflow* myclone = new SlaterDetWithBackflow(tqp, tr);
   myclone->Optimizable           = Optimizable;
   if (mySPOSet.size() > 1) //each determinant owns its own set
@@ -108,19 +95,15 @@ WaveFunctionComponentPtr SlaterDetWithBackflow::makeClone(ParticleSet& tqp) cons
         {
           found     = true;
           spo_clone = myclone->Dets[j]->getPhi();
-          //            spo_clone->resetTargetParticleSet(tqp);
         }
       // If it hasn't, clone it now
       if (!found)
       {
         spo_clone = spo->makeClone();
-        //          spo_clone->resetTargetParticleSet(tqp);
         myclone->add(spo_clone, spo->getName());
       }
       // Make a copy of the determinant.
       DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)Dets[i]->makeCopy(spo_clone);
-      //       dclne->BFTrans=tr;
-      //       dclne->resetTargetParticleSet(tqp);
       myclone->add(dclne, i);
     }
   }
@@ -128,18 +111,14 @@ WaveFunctionComponentPtr SlaterDetWithBackflow::makeClone(ParticleSet& tqp) cons
   {
     SPOSetPtr spo       = Dets[0]->getPhi();
     SPOSetPtr spo_clone = spo->makeClone();
-    //      spo_clone->resetTargetParticleSet(tqp);
     myclone->add(spo_clone, spo->getName());
     for (int i = 0; i < Dets.size(); ++i)
     {
       DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)Dets[i]->makeCopy(spo_clone);
-      //        dclne->setBF(tr);
-      //        dclne->resetTargetParticleSet(tr->QP);
       myclone->add(dclne, i);
     }
   }
   myclone->setBF(tr);
-  myclone->resetTargetParticleSet(tqp);
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -44,7 +44,6 @@ public:
       Dets[i]->setBF(BFTrans);
   }
 
-  void resetTargetParticleSet(ParticleSet& P);
   void checkInVariables(opt_variables_type& active)
   {
     //if(Optimizable) {

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
@@ -102,10 +102,6 @@ struct SHOSet : public SPOSet
   /// number of orbitals is determined only by initial request
   inline void setOrbitalSetSize(int norbs) {}
 
-  /// does not affect ParticleSet information
-  inline void resetTargetParticleSet(ParticleSet& P) {}
-
-
   ///unimplemented functions call this to abort
   inline void not_implemented(const std::string& method)
   {

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -205,9 +205,6 @@ public:
   }
 
 
-  void resetTargetParticleSet(ParticleSet& P) {}
-
-
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     evaluateExponents(P);

--- a/src/QMCWaveFunctions/Jastrow/DiffOneBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffOneBodyJastrowOrbital.h
@@ -124,9 +124,6 @@ public:
     }
   }
 
-  ///reset the distance table
-  void resetTargetParticleSet(ParticleSet& P) {}
-
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& active,
                            std::vector<ValueType>& dlogpsi,

--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -113,9 +113,6 @@ public:
     }
   }
 
-  ///reset the distance table
-  void resetTargetParticleSet(ParticleSet& P) {}
-
   void checkOutVariables(const opt_variables_type& active)
   {
     myVars.clear();

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -381,7 +381,6 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   }
 
   /**@{ WaveFunctionComponent virtual functions that are not essential for the development */
-  void resetTargetParticleSet(ParticleSet& P) {}
   void reportStatus(std::ostream& os)
   {
     for (size_t i = 0, n = F.size(); i < n; ++i)

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -167,13 +167,6 @@ public:
   /** add functor for (ia,ib) pair */
   void addFunc(int ia, int ib, FT* j);
 
-
-  void resetTargetParticleSet(ParticleSet& P)
-  {
-    if (dPsi)
-      dPsi->resetTargetParticleSet(P);
-  }
-
   /** check in an optimizable parameter
    * @param o a super set of optimizable variables
    */

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -299,10 +299,6 @@ public:
     }
   }
 
-
-  //evaluate the distance table with els
-  void resetTargetParticleSet(ParticleSet& P) {}
-
   /** check in an optimizable parameter
    * @param o a super set of optimizable variables
    */

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -232,12 +232,6 @@ void RPAJastrow::reportStatus(std::ostream& os)
     Psi[i]->reportStatus(os);
 }
 
-void RPAJastrow::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < Psi.size(); i++)
-    Psi[i]->resetTargetParticleSet(P);
-}
-
 RPAJastrow::LogValueType RPAJastrow::evaluateLog(ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& G,
                                                  ParticleSet::ParticleLaplacian_t& L)

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -69,8 +69,6 @@ struct RPAJastrow : public WaveFunctionComponent
     */
   void resetParameters(const opt_variables_type& active);
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   PsiValueType ratio(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -357,21 +357,6 @@ void kSpaceJastrow::setCoefficients(std::vector<RealType>& oneBodyCoefs, std::ve
   }
 }
 
-void kSpaceJastrow::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < TwoBodyGvecs.size(); i++)
-  {
-    TwoBody_rhoG[i] = ComplexType();
-    for (int iat = 0; iat < num_elecs; iat++)
-    {
-      RealType phase, s, c;
-      phase = dot(TwoBodyGvecs[i], P.R[iat]);
-      qmcplusplus::sincos(phase, &s, &c);
-      TwoBody_rhoG[i] += ComplexType(c, s);
-    }
-  }
-}
-
 ///////////////////////////////////////////////////////////////
 //                  Evaluation functions                     //
 ///////////////////////////////////////////////////////////////

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -160,8 +160,6 @@ public:
   void checkOutVariables(const opt_variables_type& active);
   void resetParameters(const opt_variables_type& active);
   void reportStatus(std::ostream& os);
-  //evaluate the distance table with els
-  void resetTargetParticleSet(ParticleSet& P);
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -93,12 +93,6 @@ public:
     APP_ABORT("LCAOrbitalSet should not call resetParameters");
   }
 
-  ///reset the target particleset
-  void resetTargetParticleSet(ParticleSet& P) override
-  {
-    //myBasisSet->resetTargetParticleSet(P);
-  }
-
   /** set the OrbitalSetSize
     */
   virtual void setOrbitalSetSize(int norbs) override

--- a/src/QMCWaveFunctions/LCAO/SoaAtomicBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaAtomicBasisSet.h
@@ -127,12 +127,6 @@ struct SoaAtomicBasisSet
     Rmax = (rmax > 0) ? rmax : MultiRnl->rmax();
   }
 
-  /** reset the target ParticleSet
-       *
-       * Do nothing. Leave it to a composite object which owns this
-       */
-  void resetTargetParticleSet(ParticleSet& P) {}
-
   ///set the current offset
   inline void setCenter(int c, int offset) {}
 

--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
@@ -149,24 +149,6 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
     }
   }
 
-#if 0
-  inline int getBasisSetSize()
-  {
-    return BasisSetSize;
-  }
-
-  void resetParameters(const opt_variables_type& active)
-  {
-    //reset each unique basis functions
-    for(int i=0; i<LOBasisSet.size(); i++)
-      LOBasisSet[i]->resetParameters(active);
-  }
-
-  /** reset the distance table with a new target P
-   */
-  void resetTargetParticleSet(ParticleSet& P) { }
-#endif
-
   /** compute VGL 
    * @param P quantum particleset
    * @param iat active particle

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -38,7 +38,6 @@ LatticeGaussianProduct::LatticeGaussianProduct(ParticleSet& centers, ParticleSet
 LatticeGaussianProduct::~LatticeGaussianProduct() {}
 
 //evaluate the distance table with P
-void LatticeGaussianProduct::resetTargetParticleSet(ParticleSet& P) {}
 void LatticeGaussianProduct::checkInVariables(opt_variables_type& active) {}
 void LatticeGaussianProduct::checkOutVariables(const opt_variables_type& active) {}
 void LatticeGaussianProduct::resetParameters(const opt_variables_type& active) {}

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.h
@@ -62,8 +62,6 @@ public:
    */
   void resetParameters(const opt_variables_type& active);
 
-  void resetTargetParticleSet(ParticleSet& P);
-
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   PsiValueType ratio(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -28,7 +28,6 @@ public:
   virtual void checkOutVariables(const opt_variables_type& active) {}
   virtual void resetParameters(const opt_variables_type& active) {}
   virtual void reportStatus(std::ostream& os) {}
-  virtual void resetTargetParticleSet(ParticleSet& P) {}
 
   TinyVector<ValueType, 3> coeff;
 

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -42,13 +42,6 @@ void PWOrbitalSet::resetParameters(const opt_variables_type& optVariables)
 
 void PWOrbitalSet::setOrbitalSetSize(int norbs) {}
 
-void PWOrbitalSet::resetTargetParticleSet(ParticleSet& P)
-{
-  // Not sure what to do here, if anything
-  //app_error() << "PWOrbitalSet::resetTargetParticleSet not yet coded." << std::endl;
-  //OHMMS::Controller->abort();
-}
-
 void PWOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
 {
   myBasisSet     = bset;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -71,8 +71,6 @@ public:
 
   void setOrbitalSetSize(int norbs) override;
 
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   inline ValueType evaluate(int ib, const PosType& pos)
   {
     myBasisSet->evaluate(pos);

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -45,13 +45,6 @@ void PWRealOrbitalSet::resetParameters(const opt_variables_type& active)
 
 void PWRealOrbitalSet::setOrbitalSetSize(int norbs) {}
 
-void PWRealOrbitalSet::resetTargetParticleSet(ParticleSet& P)
-{
-  //  Not sure what to do here, if anything
-  //app_error() << "PWRealOrbitalSet::resetTargetParticleSet not yet coded." << std::endl;
-  //OHMMS::Controller->abort();
-}
-
 void PWRealOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)
 {
   myBasisSet     = bset;

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -83,8 +83,6 @@ public:
 
   void setOrbitalSetSize(int norbs) override;
 
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   inline ValueType evaluate(int ib, const PosType& pos)
   {
     myBasisSet->evaluate(pos);

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -203,10 +203,9 @@ public:
       apply_rotation(param, true);
     }
   }
+
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions
-  void resetTargetParticleSet(ParticleSet& P) override { Phi->resetTargetParticleSet(P); }
-
   void setOrbitalSetSize(int norbs) override { Phi->setOrbitalSetSize(norbs); }
 
   //  void setBasisSet(basis_type* bs);

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -179,14 +179,6 @@ public:
                                      const std::vector<std::vector<int>>& lookup_tbl)
   {}
 
-
-  /** reset the target particleset
-   *  this is used to reset the pointer to ion-electron distance table needed by LCAO basis set.
-   *  Ye: Only AoS needs it, SoA LCAO doesn't need this. Reseting pointers is a state machine very hard to maintain.
-   *  This interface should be removed with AOS.
-   */
-  virtual void resetTargetParticleSet(ParticleSet& P) {};
-
   /** set the OrbitalSetSize
    * @param norbs number of single-particle orbitals
    * Ye: I prefer to remove this interface in the future. SPOSet builders need to handle the size correctly.

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -185,7 +185,7 @@ public:
    *  Ye: Only AoS needs it, SoA LCAO doesn't need this. Reseting pointers is a state machine very hard to maintain.
    *  This interface should be removed with AOS.
    */
-  virtual void resetTargetParticleSet(ParticleSet& P) = 0;
+  virtual void resetTargetParticleSet(ParticleSet& P) {};
 
   /** set the OrbitalSetSize
    * @param norbs number of single-particle orbitals

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -41,8 +41,6 @@ void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&&
 
 void SpinorSet::resetParameters(const opt_variables_type& optVariables){};
 
-void SpinorSet::resetTargetParticleSet(ParticleSet& P){};
-
 void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
 
 

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -35,13 +35,6 @@ public:
   /// reset parameters to the values from optimizer
   void resetParameters(const opt_variables_type& optVariables) override;
 
-  /** reset the target particleset
-   *  this is used to reset the pointer to ion-electron distance table needed by LCAO basis set.
-   *  Ye: Only AoS needs it, SoA LCAO doesn't need this. Reseting pointers is a state machine very hard to maintain.
-   *  This interface should be removed with AOS.
-   */
-  void resetTargetParticleSet(ParticleSet& P) override;
-
   /** set the OrbitalSetSize
    * @param norbs number of single-particle orbitals
    */

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -62,12 +62,6 @@ TrialWaveFunction::~TrialWaveFunction()
   //delete_iter(myTimers.begin(),myTimers.end());
 }
 
-void TrialWaveFunction::resetTargetParticleSet(ParticleSet& P)
-{
-  for (int i = 0; i < Z.size(); i++)
-    Z[i]->resetTargetParticleSet(P);
-}
-
 void TrialWaveFunction::startOptimization()
 {
   for (int i = 0; i < Z.size(); i++)

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -147,9 +147,6 @@ public:
    */
   void reportStatus(std::ostream& os);
 
-  /** recursively change the ParticleSet whose G and L are evaluated */
-  void resetTargetParticleSet(ParticleSet& P);
-
   /** evalaute the log (internally gradients and laplacian) of the trial wavefunction. gold reference */
   RealType evaluateLog(ParticleSet& P);
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -167,11 +167,6 @@ struct WaveFunctionComponent : public QMCTraits
   /** print the state, e.g., optimizables */
   virtual void reportStatus(std::ostream& os) = 0;
 
-  /** reset properties, e.g., distance tables, for a new target ParticleSet
-   * @param P ParticleSet
-   */
-  virtual void resetTargetParticleSet(ParticleSet& P) {};
-
   /** evaluate the value of the WaveFunctionComponent from scratch
    * @param P  active ParticleSet
    * @param G Gradients, \f$\nabla\ln\Psi\f$

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -170,7 +170,7 @@ struct WaveFunctionComponent : public QMCTraits
   /** reset properties, e.g., distance tables, for a new target ParticleSet
    * @param P ParticleSet
    */
-  virtual void resetTargetParticleSet(ParticleSet& P) = 0;
+  virtual void resetTargetParticleSet(ParticleSet& P) {};
 
   /** evaluate the value of the WaveFunctionComponent from scratch
    * @param P  active ParticleSet

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -31,7 +31,6 @@ public:
 
   virtual void report() {}
   virtual void resetParameters(const opt_variables_type& optVariables) {}
-  virtual void resetTargetParticleSet(ParticleSet& P) {}
   virtual void setOrbitalSetSize(int norbs);
 
   virtual void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi);


### PR DESCRIPTION
## Proposed changes
As the name of the function indicates, it is a state machine. Fortunately, it is no more connected for a while and thus deleted fully.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'