### PR TITLE
Use process_time not deprecated clock in Nexus

### DIFF
--- a/nexus/lib/observables.py
+++ b/nexus/lib/observables.py
@@ -3,7 +3,7 @@
 # Python standard library imports
 import os
 import inspect
-from time import clock
+from time import process_time
 from copy import deepcopy
 
 # Non-standard Python imports
@@ -34,7 +34,7 @@ class VLog(DevBase):
         )
 
     def __init__(self):
-        self.tstart    = clock()
+        self.tstart    = process_time()
         self.tlast     = self.tstart
         self.mstart    = memory.resident(children=True)
         self.mlast     = self.mstart
@@ -59,7 +59,7 @@ class VLog(DevBase):
                     self.mlast = mnow
                 #end if
                 if time:
-                    tnow = clock()
+                    tnow = process_time()
                     msg += '  (t elap {:7.3f}, tot {:7.3f})'.format(tnow-self.tlast,tnow-self.tstart)
                     self.tlast = tnow
                 #end if


### PR DESCRIPTION
## Proposed changes

Replace use of deprecated clock function by process_time. clock was deprecated in python v3.3 and has been removed in the latest versions. process_time has been available since v3.3 https://docs.python.org/3.5/library/time.html#time.clock 

ntest_nexus_observables was failing on sulfur for this reason. clock was only used in observables.py

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur with python@3.8.5%gcc@10.2.0

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- No - already present. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
