### PR TITLE
Remove two SPOSet map in SlaterDetBuilder and SlaterDet

### DIFF
--- a/src/QMCWaveFunctions/DiffWaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/DiffWaveFunctionComponent.cpp
@@ -67,20 +67,20 @@ void NumericalDiffOrbital::evaluateDerivatives(ParticleSet& P,
     int jj = ind_map[j];
     if (jj < 0)
       continue;
-    LogValueType plus=0.0;
-    LogValueType minus=0.0;
-    RealType curvar=std::real(optvars[jj]);
-    dg_p=0.0;
-    dl_p=0.0;
-    dg_m=0.0;
-    dl_m=0.0;
+    LogValueType plus  = 0.0;
+    LogValueType minus = 0.0;
+    RealType curvar    = std::real(optvars[jj]);
+    dg_p               = 0.0;
+    dl_p               = 0.0;
+    dg_m               = 0.0;
+    dl_m               = 0.0;
     //accumulate plus and minus displacement
     for (int i = 0; i < refOrbital.size(); ++i)
     {
-      v[jj]=std::real(optvars[jj])+delta;
+      v[jj] = std::real(optvars[jj]) + delta;
       refOrbital[i]->resetParameters(v);
-      plus+=refOrbital[i]->evaluateLog(P,dg_p,dl_p);
-      v[jj]=std::real(optvars[jj])-delta;
+      plus += refOrbital[i]->evaluateLog(P, dg_p, dl_p);
+      v[jj] = std::real(optvars[jj]) - delta;
       refOrbital[i]->resetParameters(v);
       minus += refOrbital[i]->evaluateLog(P, dg_m, dl_m);
       //restore the variable to the original state

--- a/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
@@ -78,17 +78,15 @@ struct DiffWaveFunctionComponent
   virtual void evaluateDerivatives(ParticleSet& P,
                                    const opt_variables_type& optvars,
                                    std::vector<ValueType>& dlogpsi,
-                                   std::vector<ValueType>& dhpsioverpsi)=0;
+                                   std::vector<ValueType>& dhpsioverpsi) = 0;
 
   /** evaluate derivatives at \f$\{R\}\f$
    * @param P current configuration
    * @param optvars optimizable variables
    * @param dlogpsi derivative of the log of the wavefunction
    */
-  virtual void evaluateDerivativesWF(ParticleSet& P,
-                                     const opt_variables_type& optvars,
-                                     std::vector<ValueType>& dlogpsi) 
-  { 
+  virtual void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, std::vector<ValueType>& dlogpsi)
+  {
     app_error() << "Need specialization of DiffOrbitalBase::evaluateDerivativesWF.\n";
     abort();
   }
@@ -98,7 +96,7 @@ struct DiffWaveFunctionComponent
   virtual void multiplyDerivsByOrbR(std::vector<ValueType>& dlogpsi)
   {
     for (int i = 0; i < refOrbital.size(); ++i)
-      for(int j=0; j<refOrbital[i]->myVars.size(); j++)
+      for (int j = 0; j < refOrbital[i]->myVars.size(); j++)
       {
         int loc = refOrbital[j]->myVars.where(j);
         dlogpsi[loc] *= refOrbital[i]->getValue();

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
@@ -81,8 +81,6 @@ WaveFunctionComponent* ElectronGasComplexOrbitalBuilder::buildComponent(xmlNodeP
   //create a Slater determinant
   //SlaterDeterminant_t *sdet  = new SlaterDeterminant_t;
   SlaterDet* sdet = new SlaterDet(targetPtcl);
-  sdet->add(psiu, "u");
-  sdet->add(psid, "d");
   sdet->add(updet, 0);
   sdet->add(downdet, 1);
   return sdet;

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -119,51 +119,47 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
     sdet = new SlaterDetWithBackflow(targetPtcl, BFTrans);
   else
     sdet = new SlaterDeterminant_t(targetPtcl);
-  //add SPOSets
-  sdet->add(psiu, "u");
-  if (ndn > 0)
-    sdet->add(psid, "d");
+
+  if (UseBackflow)
   {
-    if (UseBackflow)
+    DiracDeterminantWithBackflow *updet, *downdet;
+    app_log() << "Creating Backflow transformation in ElectronGasOrbitalBuilder::put(xmlNodePtr cur).\n";
+    //create up determinant
+    updet = new DiracDeterminantWithBackflow(targetPtcl, psiu, BFTrans, 0);
+    updet->set(0, nup);
+    if (ndn > 0)
     {
-      DiracDeterminantWithBackflow *updet, *downdet;
-      app_log() << "Creating Backflow transformation in ElectronGasOrbitalBuilder::put(xmlNodePtr cur).\n";
-      //create up determinant
-      updet = new DiracDeterminantWithBackflow(targetPtcl, psiu, BFTrans, 0);
-      updet->set(0, nup);
-      if (ndn > 0)
-      {
-        //create down determinant
-        downdet = new DiracDeterminantWithBackflow(targetPtcl, psid, BFTrans, nup);
-        downdet->set(nup, ndn);
-      }
-      PtclPoolType dummy;
-      BackflowBuilder bfbuilder(targetPtcl, dummy);
-      BFTrans = bfbuilder.buildBackflowTransformation(BFNode);
-      sdet->add(updet, 0);
-      if (ndn > 0)
-        sdet->add(downdet, 1);
-      sdet->setBF(BFTrans);
-      if (BFTrans->isOptimizable())
-        sdet->Optimizable = true;
+      //create down determinant
+      downdet = new DiracDeterminantWithBackflow(targetPtcl, psid, BFTrans, nup);
+      downdet->set(nup, ndn);
     }
-    else
-    {
-      DiracDeterminant<>*updet, *downdet;
-      //create up determinant
-      updet = new DiracDeterminant<>(psiu);
-      updet->set(0, nup);
-      if (ndn > 0)
-      {
-        //create down determinant
-        downdet = new DiracDeterminant<>(psid);
-        downdet->set(nup, ndn);
-      }
-      sdet->add(updet, 0);
-      if (ndn > 0)
-        sdet->add(downdet, 1);
-    }
+    PtclPoolType dummy;
+    BackflowBuilder bfbuilder(targetPtcl, dummy);
+    BFTrans = bfbuilder.buildBackflowTransformation(BFNode);
+    sdet->add(updet, 0);
+    if (ndn > 0)
+      sdet->add(downdet, 1);
+    sdet->setBF(BFTrans);
+    if (BFTrans->isOptimizable())
+      sdet->Optimizable = true;
   }
+  else
+  {
+    DiracDeterminant<>*updet, *downdet;
+    //create up determinant
+    updet = new DiracDeterminant<>(psiu);
+    updet->set(0, nup);
+    if (ndn > 0)
+    {
+      //create down determinant
+      downdet = new DiracDeterminant<>(psid);
+      downdet->set(nup, ndn);
+    }
+    sdet->add(updet, 0);
+    if (ndn > 0)
+      sdet->add(downdet, 1);
+  }
+
   return sdet;
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -39,20 +39,6 @@ SlaterDet::~SlaterDet()
   ///clean up SPOSet
 }
 
-///add a new SPOSet to the list of determinants
-void SlaterDet::add(SPOSet* sposet, const std::string& aname)
-{
-  if (mySPOSet.find(aname) == mySPOSet.end())
-  {
-    mySPOSet[aname] = sposet;
-    sposet->setName(aname);
-  }
-  else
-  {
-    APP_ABORT(" SlaterDet::add(SPOSet*, const std::string&) Cannot reuse the " + aname);
-  }
-}
-
 ///add a new DiracDeterminant to the list of determinants
 void SlaterDet::add(Determinant_t* det, int ispin)
 {
@@ -185,38 +171,10 @@ WaveFunctionComponentPtr SlaterDet::makeClone(ParticleSet& tqp) const
 {
   SlaterDet* myclone   = new SlaterDet(tqp);
   myclone->Optimizable = Optimizable;
-  if (mySPOSet.size() > 1)
+  for (int i = 0; i < Dets.size(); ++i)
   {
-    std::map<std::string, SPOSetPtr>::const_iterator Mit, Lit;
-    Mit = mySPOSet.begin();
-    Lit = mySPOSet.end();
-    while (Mit != Lit)
-    {
-      SPOSetPtr spo = (*Mit).second;
-      SPOSetPtr spo_clone;
-      spo_clone = spo->makeClone();
-      myclone->add(spo_clone, spo->getName());
-      for (int i = 0; i < Dets.size(); ++i)
-      {
-        if (spo == Dets[i]->getPhi())
-        {
-          Determinant_t* newD = Dets[i]->makeCopy(spo_clone);
-          myclone->add(newD, i);
-        }
-      }
-      Mit++;
-    }
-  }
-  else
-  {
-    SPOSetPtr spo       = Dets[0]->getPhi();
-    SPOSetPtr spo_clone = spo->makeClone();
-    myclone->add(spo_clone, spo->getName());
-    for (int i = 0; i < Dets.size(); ++i)
-    {
-      Determinant_t* newD = Dets[i]->makeCopy(spo_clone);
-      myclone->add(newD, i);
-    }
+    Determinant_t* newD = Dets[i]->makeCopy(Dets[i]->getPhi()->makeClone());
+    myclone->add(newD, i);
   }
   return myclone;
 }

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -47,9 +47,6 @@ public:
   ///destructor
   ~SlaterDet();
 
-  ///add a SPOSet
-  void add(SPOSetPtr sposet, const std::string& aname) {}
-
   ///add a new DiracDeterminant to the list of determinants
   virtual void add(Determinant_t* det, int ispin);
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -38,7 +38,6 @@ public:
   std::vector<Determinant_t*> Dets;
   ///the last particle of each group
   std::vector<int> Last;
-  std::map<std::string, SPOSetPtr> mySPOSet;
 
   /**  constructor
    * @param targetPtcl target Particleset
@@ -49,7 +48,7 @@ public:
   ~SlaterDet();
 
   ///add a SPOSet
-  void add(SPOSetPtr sposet, const std::string& aname);
+  void add(SPOSetPtr sposet, const std::string& aname) {}
 
   ///add a new DiracDeterminant to the list of determinants
   virtual void add(Determinant_t* det, int ispin);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -454,27 +454,15 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
                 << std::endl;
   app_summary() << std::endl;
 
-  std::map<std::string, SPOSetPtr>& spo_ref(slaterdet_0->mySPOSet);
-  std::map<std::string, SPOSetPtr>::iterator lit(spo_ref.find(sposet));
-  SPOSetPtr psi = 0;
-  if (lit == spo_ref.end())
+  SPOSetPtr psi = get_sposet(sposet);
+  //check if the named sposet exists
+  if (psi == 0)
   {
-    psi = get_sposet(sposet); //check if the named sposet exists
-    if (psi == 0)
-    {
-      //SPOSet[detname]=psi;
-      app_log() << "      Create a new SPO set " << sposet << std::endl;
-      psi = mySPOSetBuilderFactory->createSPOSet(cur);
-    }
-    //psi->put(cur);
-    psi->checkObject();
-    slaterdet_0->add(psi, detname);
+    app_log() << "      Create a new SPO set " << sposet << std::endl;
+    psi = mySPOSetBuilderFactory->createSPOSet(cur);
   }
-  else
-  {
-    app_log() << "      Reusing a SPO set " << sposet << std::endl;
-    psi = (*lit).second;
-  }
+  psi->checkObject();
+  slaterdet_0->add(psi, detname);
 
   int firstIndex = targetPtcl.first(spin_group);
   int lastIndex  = targetPtcl.last(spin_group);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -17,7 +17,6 @@
 
 #include <type_traits>
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
-#include "QMCWaveFunctions/SPOSetScanner.h"
 #include "QMCWaveFunctions/Fermion/SlaterDetBuilder.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "OhmmsData/AttributeSet.h"
@@ -137,15 +136,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
   while (cur != NULL)
   {
     getNodeName(cname, cur);
-    if (cname == sposcanner_tag)
-    {
-      if (myComm->rank() == 0)
-      {
-        SPOSetScanner ascanner(spomap, targetPtcl, ptclPool);
-        ascanner.put(cur);
-      }
-    }
-    else if (cname == sd_tag)
+    if (cname == sd_tag)
     {
       app_summary() << std::endl;
       app_summary() << "   Single Slater determinant" << std::endl;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -203,7 +203,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         abort();
       }
       SPOSetPtr spo_alpha = get_sposet(spo_alpha_name);
-      SPOSetPtr spo_beta = get_sposet(spo_beta_name);
+      SPOSetPtr spo_beta  = get_sposet(spo_beta_name);
       if (spo_alpha == nullptr)
       {
         app_error() << "In SlaterDetBuilder: SPOSet \"" << spo_alpha_name
@@ -324,7 +324,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   SpeciesSet& myspecies = targetPtcl.mySpecies;
 
   std::string spin_name = myspecies.speciesName[spin_group];
-  std::string sposet;
+  std::string sposet_name;
   std::string basisName("invalid");
   std::string detname("0"), refname("0");
   std::string s_detSize("0");
@@ -332,7 +332,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   OhmmsAttributeSet aAttrib;
   aAttrib.add(basisName, basisset_tag);
   aAttrib.add(detname, "id");
-  aAttrib.add(sposet, "sposet");
+  aAttrib.add(sposet_name, "sposet");
   aAttrib.add(refname, "ref");
   aAttrib.add(s_detSize, "DetSize");
 
@@ -378,21 +378,21 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   }
 
   //old input does not have sposet
-  if (sposet.empty())
-    sposet = detname;
+  if (sposet_name.empty())
+    sposet_name = detname;
 
   app_summary() << std::endl;
   app_summary() << "     Determinant" << std::endl;
   app_summary() << "     -----------" << std::endl;
-  app_summary() << "      Name: " << detname << "   Spin group: " << spin_group << "   SPO name: " << sposet
+  app_summary() << "      Name: " << detname << "   Spin group: " << spin_group << "   SPO name: " << sposet_name
                 << std::endl;
   app_summary() << std::endl;
 
-  SPOSetPtr psi = get_sposet(sposet);
+  SPOSetPtr psi = get_sposet(sposet_name);
   //check if the named sposet exists
   if (psi == 0)
   {
-    app_log() << "      Create a new SPO set " << sposet << std::endl;
+    app_log() << "      Create a new SPO set " << sposet_name << std::endl;
     psi = mySPOSetBuilderFactory->createSPOSet(cur);
   }
   psi->checkObject();

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -81,42 +81,10 @@ WaveFunctionComponentPtr SlaterDetWithBackflow::makeClone(ParticleSet& tqp) cons
   BackflowTransformation* tr = BFTrans->makeClone(tqp);
   SlaterDetWithBackflow* myclone = new SlaterDetWithBackflow(tqp, tr);
   myclone->Optimizable           = Optimizable;
-  if (mySPOSet.size() > 1) //each determinant owns its own set
+  for (int i = 0; i < Dets.size(); ++i)
   {
-    for (int i = 0; i < Dets.size(); ++i)
-    {
-      SPOSetPtr spo = Dets[i]->getPhi();
-      // Check to see if this determinants SPOSet has already been
-      // cloned
-      bool found = false;
-      SPOSetPtr spo_clone;
-      for (int j = 0; j < i; j++)
-        if (spo == Dets[j]->getPhi())
-        {
-          found     = true;
-          spo_clone = myclone->Dets[j]->getPhi();
-        }
-      // If it hasn't, clone it now
-      if (!found)
-      {
-        spo_clone = spo->makeClone();
-        myclone->add(spo_clone, spo->getName());
-      }
-      // Make a copy of the determinant.
-      DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)Dets[i]->makeCopy(spo_clone);
-      myclone->add(dclne, i);
-    }
-  }
-  else
-  {
-    SPOSetPtr spo       = Dets[0]->getPhi();
-    SPOSetPtr spo_clone = spo->makeClone();
-    myclone->add(spo_clone, spo->getName());
-    for (int i = 0; i < Dets.size(); ++i)
-    {
-      DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)Dets[i]->makeCopy(spo_clone);
-      myclone->add(dclne, i);
-    }
+    DiracDeterminantBase* dclne = Dets[i]->makeCopy(Dets[i]->getPhi()->makeClone());
+    myclone->add(dclne, i);
   }
   myclone->setBF(tr);
   return myclone;

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -115,7 +115,7 @@ public:
 
   void checkObject() const override
   {
-    if (!(OrbitalSetSize == C->rows() && BasisSetSize == C->cols()))
+    if (!Identity && !(OrbitalSetSize == C->rows() && BasisSetSize == C->cols()))
       APP_ABORT("   LCAOrbitalSet::checkObject Linear coeffient for LCAOrbitalSet is not consistent with the input.");
   }
 

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -20,7 +20,6 @@
 #include "QMCWaveFunctions/PlaneWave/PWParameterSet.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
-#include "QMCWaveFunctions/SPOSetScanner.h"
 #include "OhmmsData/ParameterSet.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Numerics/HDFSTLAttrib.h"
@@ -88,11 +87,6 @@ WaveFunctionComponent* PWOrbitalBuilder::buildComponent(xmlNodePtr cur)
       }
       success = createPWBasis(cur);
       slater_det = putSlaterDet(cur);
-    }
-    else if (cname == sposcanner_tag)
-    {
-      SPOSetScanner ascanner(spomap, targetPtcl, ptclPool);
-      ascanner.put(cur);
     }
     cur = cur->next;
   }

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -130,9 +130,7 @@ WaveFunctionComponent* PWOrbitalBuilder::putSlaterDet(xmlNodePtr cur)
       if (lit == spomap.end())
       {
         app_log() << "  Create a PWOrbitalSet" << std::endl;
-        ;
         SPOSetPtr psi(createPW(cur, spin_group));
-        sdet->add(psi, ref);
         spomap[ref] = psi;
         adet        = new Det_t(psi, firstIndex);
       }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -22,7 +22,6 @@ RotatedSPOs::RotatedSPOs(SPOSet* spos)
     : SPOSet(spos->isOMPoffload(), spos->hasIonDerivs(), true),
       Phi(spos),
       params_supplied(false),
-      IsCloned(false),
       nel_major_(0)
 {
   className      = "RotatedSPOs";
@@ -83,7 +82,7 @@ void RotatedSPOs::buildOptVariables(const std::vector<std::pair<int, int>>& rota
     p = m_act_rot_inds[i].first;
     q = m_act_rot_inds[i].second;
     std::stringstream sstr;
-    sstr << Phi->getName() << "_orb_rot_" << (p < 10 ? "0" : "") << (p < 100 ? "0" : "") << (p < 1000 ? "0" : "") << p
+    sstr << myName << "_orb_rot_" << (p < 10 ? "0" : "") << (p < 100 ? "0" : "") << (p < 1000 ? "0" : "") << p
          << "_" << (q < 10 ? "0" : "") << (q < 100 ? "0" : "") << (q < 1000 ? "0" : "") << q;
 
     // If the user input parameters, use those. Otherwise, initialize the parameters to zero
@@ -1041,11 +1040,11 @@ SPOSet* RotatedSPOs::makeClone() const
 {
   RotatedSPOs* myclone = new RotatedSPOs(Phi->makeClone());
 
-  myclone->IsCloned        = true;
   myclone->params          = this->params;
   myclone->params_supplied = this->params_supplied;
   myclone->m_act_rot_inds  = this->m_act_rot_inds;
   myclone->myVars          = this->myVars;
+  myclone->myName          = this->myName;
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -106,20 +106,20 @@ public:
                            const std::vector<std::vector<int>>& lookup_tbl) override;
 
   void evaluateDerivativesWF(ParticleSet& P,
-                           const opt_variables_type& optvars,
-                           std::vector<ValueType>& dlogpsi,
-                           const QTFull::ValueType& psiCurrent,
-                           const std::vector<ValueType>& Coeff,
-                           const std::vector<size_t>& C2node_up,
-                           const std::vector<size_t>& C2node_dn,
-                           const ValueVector_t& detValues_up,
-                           const ValueVector_t& detValues_dn,
-                           const ValueMatrix_t& M_up,
-                           const ValueMatrix_t& M_dn,
-                           const ValueMatrix_t& Minv_up,
-                           const ValueMatrix_t& Minv_dn,
-                           const std::vector<int>& detData_up,
-                           const std::vector<std::vector<int>>& lookup_tbl) override;
+                             const opt_variables_type& optvars,
+                             std::vector<ValueType>& dlogpsi,
+                             const QTFull::ValueType& psiCurrent,
+                             const std::vector<ValueType>& Coeff,
+                             const std::vector<size_t>& C2node_up,
+                             const std::vector<size_t>& C2node_dn,
+                             const ValueVector_t& detValues_up,
+                             const ValueVector_t& detValues_dn,
+                             const ValueMatrix_t& M_up,
+                             const ValueMatrix_t& M_dn,
+                             const ValueMatrix_t& Minv_up,
+                             const ValueMatrix_t& Minv_dn,
+                             const std::vector<int>& detData_up,
+                             const std::vector<std::vector<int>>& lookup_tbl) override;
 
   //helper function to evaluatederivative; evaluate orbital rotation parameter derivative using table method
   void table_method_eval(std::vector<ValueType>& dlogpsi,
@@ -152,20 +152,20 @@ public:
                          const std::vector<std::vector<int>>& lookup_tbl);
 
   void table_method_evalWF(std::vector<ValueType>& dlogpsi,
-                         const size_t nel,
-                         const size_t nmo,
-                         const ValueType& psiCurrent,
-                         const std::vector<RealType>& Coeff,
-                         const std::vector<size_t>& C2node_up,
-                         const std::vector<size_t>& C2node_dn,
-                         const ValueVector_t& detValues_up,
-                         const ValueVector_t& detValues_dn,
-                         const ValueMatrix_t& M_up,
-                         const ValueMatrix_t& M_dn,
-                         const ValueMatrix_t& Minv_up,
-                         const ValueMatrix_t& Minv_dn,
-                         const std::vector<int>& detData_up,
-                         const std::vector<std::vector<int>>& lookup_tbl);
+                           const size_t nel,
+                           const size_t nmo,
+                           const ValueType& psiCurrent,
+                           const std::vector<RealType>& Coeff,
+                           const std::vector<size_t>& C2node_up,
+                           const std::vector<size_t>& C2node_dn,
+                           const ValueVector_t& detValues_up,
+                           const ValueVector_t& detValues_dn,
+                           const ValueMatrix_t& M_up,
+                           const ValueMatrix_t& M_dn,
+                           const ValueMatrix_t& Minv_up,
+                           const ValueMatrix_t& Minv_dn,
+                           const std::vector<int>& detData_up,
+                           const std::vector<std::vector<int>>& lookup_tbl);
 
   void checkInVariables(opt_variables_type& active) override
   {
@@ -238,7 +238,11 @@ public:
     Phi->evaluateDetRatios(VP, psi, psiinv, ratios);
   }
 
-  void evaluateVGH(const ParticleSet& P, int iat, ValueVector_t& psi, GradVector_t& dpsi, HessVector_t& grad_grad_psi) override
+  void evaluateVGH(const ParticleSet& P,
+                   int iat,
+                   ValueVector_t& psi,
+                   GradVector_t& dpsi,
+                   HessVector_t& grad_grad_psi) override
   {
     assert(psi.size() <= OrbitalSetSize);
     Phi->evaluateVGH(P, iat, psi, dpsi, grad_grad_psi);

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -43,8 +43,6 @@ public:
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
 
-  bool IsCloned;
-
   /// the number of electrons of the majority spin
   size_t nel_major_;
 
@@ -173,7 +171,7 @@ public:
     for (int k = 0; k < myVars.size(); ++k)
       myVars[k] = 0.0;
 
-    if (Optimizable && !IsCloned)
+    if (Optimizable)
     {
       if (myVars.size())
         active.insertFrom(myVars);
@@ -183,7 +181,7 @@ public:
 
   void checkOutVariables(const opt_variables_type& active) override
   {
-    if (Optimizable && !IsCloned)
+    if (Optimizable)
     {
       myVars.getIndex(active);
     }
@@ -192,7 +190,7 @@ public:
   ///reset
   void resetParameters(const opt_variables_type& active) override
   {
-    if (Optimizable && !IsCloned)
+    if (Optimizable)
     {
       std::vector<RealType> param(m_act_rot_inds.size());
       for (int i = 0; i < m_act_rot_inds.size(); i++)

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -15,6 +15,10 @@
 #include <QMCWaveFunctions/SPOSetBuilder.h>
 #include "OhmmsData/AttributeSet.h"
 
+#if !defined(QMC_COMPLEX)
+#include "QMCWaveFunctions/RotatedSPOs.h"
+#endif
+
 namespace qmcplusplus
 {
 SPOSetBuilder::SPOSetBuilder(const std::string& SPO_type_name_in, Communicate* comm)
@@ -42,9 +46,12 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input_info)
 
 SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
 {
-  std::string spo_object_name("");
+  std::string spo_object_name;
+  std::string optimize("no");
+
   OhmmsAttributeSet attrib;
   attrib.add(spo_object_name, "name");
+  attrib.add(optimize, "optimize");
   attrib.put(cur);
 
   app_summary() << std::endl;
@@ -69,14 +76,42 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   else
     sposet = createSPOSet(cur, input_info);
 
-  // remember created sposets
-  if (sposet)
+  if (!sposet)
+    APP_ABORT("SPOSetBuilder::createSPOSet sposet creation failed");
+
+  if (optimize == "rotation" || optimize == "yes")
   {
-    //sposet->put(cur); //initialize C and other internal containers
-    sposets.push_back(sposet);
+#ifdef QMC_COMPLEX
+    app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";
+    abort();
+#else
+    // create sposet with rotation
+    auto* rot_spo   = new RotatedSPOs(sposet);
+    xmlNodePtr tcur = cur->xmlChildrenNode;
+    while (tcur != NULL)
+    {
+      std::string cname((const char*)(tcur->name));
+      if (cname == "opt_vars")
+      {
+        rot_spo->params_supplied = true;
+        putContent(rot_spo->params, tcur);
+      }
+      tcur = tcur->next;
+    }
+
+    // pass sposet name and rename sposet before rotation
+    if (!sposet->getName().empty())
+    {
+      rot_spo->setName(sposet->getName());
+      sposet->setName(sposet->getName() + "_before_rotation");
+    }
+    if (sposet->getName().empty())
+      sposet->setName(spo_object_name + "_before_rotation");
+
+    // overwrite sposet
+    sposet = rot_spo;
+#endif
   }
-  else
-    APP_ABORT("SPOSetBuilder::createSPOSet  sposet creation failed");
 
   if (!spo_object_name.empty() && sposet->getName().empty())
     sposet->setName(spo_object_name);
@@ -85,6 +120,9 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   if (!spo_object_name.empty() && sposet->getName() != spo_object_name)
     app_warning() << "SPOSet object name mismatched! input name: " << spo_object_name
                   << "   object name: " << sposet->getName() << std::endl;
+
+  // builder owns created sposets
+  sposets.push_back(sposet);
 
   return sposet;
 }

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -47,15 +47,15 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   attrib.add(spo_object_name, "name");
   attrib.put(cur);
 
-  if (spo_object_name.empty())
-    app_warning() << "SPOSet object name not given in the input!" << std::endl;
-
   app_summary() << std::endl;
-  app_summary() << "   Single particle orbitals (SPO)" << std::endl;
-  app_summary() << "   ------------------------------" << std::endl;
-  app_summary() << "    Name: " << spo_object_name << "   Type: " << SPO_type_name
+  app_summary() << "     Single particle orbitals (SPO)" << std::endl;
+  app_summary() << "     ------------------------------" << std::endl;
+  app_summary() << "      Name: " << spo_object_name << "   Type: " << SPO_type_name
                 << "   Builder class name: " << ClassName << std::endl;
   app_summary() << std::endl;
+
+  if (spo_object_name.empty())
+    app_warning() << "SPOSet object name not given in the input!" << std::endl;
 
   // read specialized sposet construction requests
   //   and translate them into a set of orbital indices

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -57,7 +57,7 @@ void SPOSetBuilderFactory::clear()
 SPOSet* get_sposet(const std::string& name)
 {
   int nfound  = 0;
-  SPOSet* spo = 0;
+  SPOSet* spo = nullptr;
   std::map<std::string, SPOSetBuilder*>::iterator it;
   for (it = SPOSetBuilderFactory::spo_builders.begin(); it != SPOSetBuilderFactory::spo_builders.end(); ++it)
   {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -23,10 +23,6 @@
 #if OHMMS_DIM == 3
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 
-#if !defined(QMC_COMPLEX)
-#include "QMCWaveFunctions/RotatedSPOs.h"
-#endif
-
 #if defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/EinsplineSpinorSetBuilder.h"
 #include "QMCWaveFunctions/LCAO/LCAOSpinorBuilder.h"
@@ -249,13 +245,10 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
   std::string bname("");
   std::string sname("");
   std::string type("");
-  std::string rotation("no");
   OhmmsAttributeSet aAttrib;
   aAttrib.add(bname, "basisset");
   aAttrib.add(sname, "name");
   aAttrib.add(type, "type");
-  aAttrib.add(rotation, "optimize");
-  //aAttrib.put(rcur);
   aAttrib.put(cur);
 
   //tolower(type);
@@ -285,28 +278,6 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
   {
     SPOSet* spo = bb->createSPOSet(cur);
     spo->setName(sname);
-    if (rotation == "yes")
-    {
-#ifdef QMC_COMPLEX
-      app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";
-      abort();
-#else
-      auto* rot_spo   = new RotatedSPOs(spo);
-      xmlNodePtr tcur = cur->xmlChildrenNode;
-      while (tcur != NULL)
-      {
-        std::string cname((const char*)(tcur->name));
-        if (cname == "opt_vars")
-        {
-          rot_spo->params_supplied = true;
-          putContent(rot_spo->params, tcur);
-        }
-        tcur = tcur->next;
-      }
-      spo = rot_spo;
-      spo->setName(sname);
-#endif
-    }
     return spo;
   }
   else

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -17,6 +17,7 @@
 
 
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "QMCWaveFunctions/SPOSetScanner.h"
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
 #if OHMMS_DIM == 3
@@ -346,6 +347,14 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
     {
       SPOSet* spo = bb->createSPOSet(element);
       nsposets++;
+    }
+    else if (cname == "spo_scanner")
+    {
+      if (myComm->rank() == 0)
+      {
+        SPOSetScanner ascanner(bb->sposets, targetPtcl, ptclPool);
+        ascanner.put(element);
+      }
     }
     element = element->next;
   }

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -282,7 +282,6 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
   }
   if (bb)
   {
-    app_log() << "  Building SPOSet '" << sname << "' with '" << bname << "' basis set." << std::endl;
     SPOSet* spo = bb->createSPOSet(cur);
     spo->setName(sname);
     if (rotation == "yes")
@@ -318,7 +317,23 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
 
 void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 {
-  app_log() << "  Building a collection of SPOSets" << std::endl;
+  std::string collection_name;
+  std::string collection_type;
+  OhmmsAttributeSet attrib;
+  attrib.add(collection_name, "name");
+  attrib.add(collection_type, "type");
+  attrib.put(cur);
+
+  // use collection_type as collection_name if collection_name is not given
+  if (collection_name.empty())
+    collection_name = collection_type;
+
+  app_summary() << std::endl;
+  app_summary() << "   Single particle orbitals (SPO) collections" << std::endl;
+  app_summary() << "   ------------------------------------------" << std::endl;
+  app_summary() << "    Name: " << collection_name << "   Type input: " << collection_type << std::endl;
+  app_summary() << std::endl;
+
   // create the SPOSet builder
   SPOSetBuilder* bb = createSPOSetBuilder(cur);
   // going through a list of sposet entries

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -21,7 +21,6 @@
 
 namespace qmcplusplus
 {
-
 ///writes info about contained sposets to stdout
 void write_spo_builders(const std::string& pad = "");
 

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -25,13 +25,12 @@ namespace qmcplusplus
 class SPOSetScanner
 {
 public:
-  typedef std::map<std::string, ParticleSet*> PtclPoolType;
-  typedef std::map<std::string, SPOSetPtr> SPOMapType;
-  typedef QMCTraits::RealType RealType;
-  typedef QMCTraits::ValueType ValueType;
-  typedef OrbitalSetTraits<ValueType>::ValueVector_t ValueVector_t;
-  typedef OrbitalSetTraits<ValueType>::GradVector_t GradVector_t;
-  typedef OrbitalSetTraits<ValueType>::HessVector_t HessVector_t;
+  using PtclPoolType = std::map<std::string, ParticleSet*>;
+  using RealType = QMCTraits::RealType;
+  using ValueType = QMCTraits::ValueType;
+  using ValueVector_t = OrbitalSetTraits<ValueType>::ValueVector_t;
+  using GradVector_t = OrbitalSetTraits<ValueType>::GradVector_t;
+  using HessVector_t = OrbitalSetTraits<ValueType>::HessVector_t;
 
   RealType myfabs(RealType s) { return std::fabs(s); }
   template<typename T>
@@ -45,14 +44,14 @@ public:
     return TinyVector<T, OHMMS_DIM>(myfabs(s[0]), myfabs(s[1]), myfabs(s[2]));
   }
 
-  SPOMapType& SPOMap;
+  std::vector<SPOSet*>& sposets;
   ParticleSet& target;
   PtclPoolType& PtclPool;
   ParticleSet* ions;
 
   // construction/destruction
-  SPOSetScanner(SPOMapType& spomap, ParticleSet& targetPtcl, PtclPoolType& psets)
-      : SPOMap(spomap), target(targetPtcl), PtclPool(psets), ions(0){};
+  SPOSetScanner(std::vector<SPOSet*>& sposets_in, ParticleSet& targetPtcl, PtclPoolType& psets)
+      : sposets(sposets_in), target(targetPtcl), PtclPool(psets), ions(0){};
   //~SPOSetScanner(){};
 
   // processing scanning
@@ -72,11 +71,9 @@ public:
 
     // scanning the SPO sets
     xmlNodePtr cur_save = cur;
-    SPOSetPtr mySPOSet;
-    for (SPOMapType::iterator spo_iter = SPOMap.begin(); spo_iter != SPOMap.end(); spo_iter++)
+    for (auto* sposet : sposets)
     {
-      app_log() << "  Processing SPO " << spo_iter->first << std::endl;
-      mySPOSet = spo_iter->second;
+      app_log() << "  Processing SPO " << sposet->getName() << std::endl;
       // scanning the paths
       cur = cur_save->children;
       while (cur != NULL)
@@ -87,12 +84,12 @@ public:
         aAttrib.put(cur);
         std::string cname;
         getNodeName(cname, cur);
-        std::string prefix(spo_iter->first + "_" + cname + "_" + trace_name);
+        std::string prefix(sposet->getName() + "_" + cname + "_" + trace_name);
         if (cname == "path")
         {
           app_log() << "    Scanning a " << cname << " called " << trace_name << " and writing to "
                     << prefix + "_v/g/l/report.dat" << std::endl;
-          scan_path(cur, mySPOSet, prefix);
+          scan_path(cur, *sposet, prefix);
         }
         else
         {
@@ -106,7 +103,7 @@ public:
   }
 
   // scanning a path
-  void scan_path(xmlNodePtr cur, SPOSetPtr mySPOSet, std::string prefix)
+  void scan_path(xmlNodePtr cur, SPOSet& sposet, std::string prefix)
   {
     std::string file_name;
     file_name = prefix + "_v.dat";
@@ -147,7 +144,7 @@ public:
     // prepare a fake particle set
     ValueVector_t SPO_v, SPO_l, SPO_v_avg, SPO_l_avg;
     GradVector_t SPO_g, SPO_g_avg;
-    int OrbitalSize(mySPOSet->size());
+    int OrbitalSize(sposet.size());
     SPO_v.resize(OrbitalSize);
     SPO_g.resize(OrbitalSize);
     SPO_l.resize(OrbitalSize);
@@ -168,7 +165,7 @@ public:
       target.R[ind][1] = (to_pos[1] - from_pos[1]) * Delta * icount + from_pos[1];
       target.R[ind][2] = (to_pos[2] - from_pos[2]) * Delta * icount + from_pos[2];
       target.makeMove(ind, zero_pos);
-      mySPOSet->evaluateVGL(target, ind, SPO_v, SPO_g, SPO_l);
+      sposet.evaluateVGL(target, ind, SPO_v, SPO_g, SPO_l);
       std::ostringstream o;
       o << "x_y_z  " << std::fixed << std::setprecision(7) << target.R[ind][0] << " " << target.R[ind][1] << " "
         << target.R[ind][2];

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -25,12 +25,12 @@ namespace qmcplusplus
 class SPOSetScanner
 {
 public:
-  using PtclPoolType = std::map<std::string, ParticleSet*>;
-  using RealType = QMCTraits::RealType;
-  using ValueType = QMCTraits::ValueType;
+  using PtclPoolType  = std::map<std::string, ParticleSet*>;
+  using RealType      = QMCTraits::RealType;
+  using ValueType     = QMCTraits::ValueType;
   using ValueVector_t = OrbitalSetTraits<ValueType>::ValueVector_t;
-  using GradVector_t = OrbitalSetTraits<ValueType>::GradVector_t;
-  using HessVector_t = OrbitalSetTraits<ValueType>::HessVector_t;
+  using GradVector_t  = OrbitalSetTraits<ValueType>::GradVector_t;
+  using HessVector_t  = OrbitalSetTraits<ValueType>::HessVector_t;
 
   RealType myfabs(RealType s) { return std::fabs(s); }
   template<typename T>

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -408,10 +408,10 @@ public:
                            bool project = false);
 
   static void flex_evaluateParameterDerivatives(const RefVector<TrialWaveFunction>& wf_list,
-                                         const RefVector<ParticleSet>& p_list,
-                                         const opt_variables_type& optvars,
-                                         RecordArray<ValueType>& dlogpsi,
-                                         RecordArray<ValueType>& dhpsioverpsi);
+                                                const RefVector<ParticleSet>& p_list,
+                                                const opt_variables_type& optvars,
+                                                RecordArray<ValueType>& dlogpsi,
+                                                RecordArray<ValueType>& dhpsioverpsi);
 
   void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, std::vector<ValueType>& dlogpsi);
 

--- a/src/QMCWaveFunctions/WaveFunctionComponentBuilder.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBuilder.cpp
@@ -53,6 +53,4 @@ std::string WaveFunctionComponentBuilder::backflow_tag = "backflow";
 
 std::string WaveFunctionComponentBuilder::multisd_tag = "multideterminant";
 
-std::string WaveFunctionComponentBuilder::sposcanner_tag = "spo_scanner";
-
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
@@ -73,8 +73,6 @@ public:
   static std::string backflow_tag;
   /// the element name for a multi slater determinant wavefunction
   static std::string multisd_tag;
-  /// the element name for a SPO scanner
-  static std::string sposcanner_tag;
 
   //@}
 

--- a/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
+++ b/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
@@ -37,6 +37,9 @@ class MinimalWaveFunctionPool
 
 public:
   MinimalWaveFunctionPool() : comm_(nullptr) {}
+
+  ~MinimalWaveFunctionPool() { SPOSetBuilderFactory::clear(); }
+
   WaveFunctionPool operator()(Communicate* comm, ParticleSetPool* particle_pool)
   {
     comm_ = comm;

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -118,7 +118,7 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   SlaterDet* sd              = dynamic_cast<SlaterDet*>(orb);
   REQUIRE(sd != NULL);
   REQUIRE(sd->Dets.size() == 2);
-  SPOSetPtr spo = sd->mySPOSet.begin()->second;
+  SPOSetPtr spo = sd->getPhi(0);
   REQUIRE(spo != NULL);
   //SPOSet *spo = einSet.createSPOSetFromXML(ein1);
   //REQUIRE(spo != NULL);
@@ -263,7 +263,7 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   SlaterDet* sd              = dynamic_cast<SlaterDet*>(orb);
   REQUIRE(sd != NULL);
   REQUIRE(sd->Dets.size() == 2);
-  SPOSetPtr spo = sd->mySPOSet.begin()->second;
+  SPOSetPtr spo = sd->getPhi(0);
   REQUIRE(spo != NULL);
   //SPOSet *spo = einSet.createSPOSetFromXML(ein1);
   //REQUIRE(spo != NULL);


### PR DESCRIPTION
## Proposed changes
The two maps owned and maintained in SlaterDetBuilder and SlaterDet are not necessary any more as SPOSet will eventually be unique_ptr no more shared by determinants as we are approaching clean spo determinant input style and memory clean code. In a spin restricted case, the sposet object for spin up and down no more share the same pointer but share coefficients only. So we are not loosing anything in this change.

Additional changes:
1. Moved RotatedSPO interception from SPOSetBuilderFactory to SPOSetBuilder which is more natural.
2. SPOSetScanner moved from SlaterDetBuilder to SPOSetBuilderFactory.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora. Tested all short tests.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted