### PR TITLE
remove bind2nd

### DIFF
--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -157,7 +157,10 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   Value /= num_sites;
   if (per_xyz)
   {
-    std::transform(xyz2.begin(), xyz2.end(), xyz2.begin(), bind2nd(std::multiplies<RealType>(), 1. / num_sites));
+    for (int idir = 0; idir < OHMMS_DIM; idir++)
+    {
+      xyz2[idir] /= num_sites;
+    }
   }
 
   return Value;

--- a/tests/scripts/check_deriv.py
+++ b/tests/scripts/check_deriv.py
@@ -10,7 +10,7 @@ def real_or_comp(str_rep):
   """
   val = None
   if str_rep.strip().startswith('('):
-    ri_list = map(float,str_rep.replace('(','').replace(')','').split(','))
+    ri_list = list(map(float,str_rep.replace('(','').replace(')','').split(',')))
     val = ri_list[0] + 1j*ri_list[1]
   else:
     val = float(str_rep)
@@ -49,7 +49,7 @@ def parse_deriv_block(mm,header,nmax_deriv=1024):
     if ider >= nmax_deriv:
       raise RuntimeError('please increase nmax_deriv')
     iparam = int( tokens[0] )
-    numeric,analytic,diff = map(real_or_comp,tokens[1:])
+    numeric,analytic,diff = list(map(real_or_comp,tokens[1:]))
     for name,val in zip(cols,[iparam,numeric,analytic,diff]):
       data[name].append(val)
     # end for 


### PR DESCRIPTION
also fix short-sho-grad_lap-1-1-check with Python 3

closes #2483 

tested by running
```
ctest -R short-*sho*
```

Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Fedora 32 workstation with E5-2620 v2; icc (ICC) 19.1.2.254 20200623

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
