### PR TITLE
Fix soecp evaluation

### DIFF
--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -119,7 +119,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
                                                                const PosType& dr)
 {
   //quadrature sum for angular integral
-  RealType fourpi = 2.0 * TWOPI;
+  constexpr RealType fourpi = 2.0 * TWOPI;
   for (int j = 0; j < nknot; j++)
   {
     deltaV[j] = r * rrotsgrid_m[j] - dr;

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -119,11 +119,12 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
                                                                const PosType& dr)
 {
   //quadrature sum for angular integral
+  RealType fourpi = 2.0 * TWOPI;
   for (int j = 0; j < nknot; j++)
   {
     deltaV[j] = r * rrotsgrid_m[j] - dr;
     W.makeMoveWithSpin(iel, deltaV[j], snew - sold);
-    psiratio[j] = Psi.calcRatio(W, iel) * sgridweight_m[j] * 2.0 * TWOPI;
+    psiratio[j] = Psi.calcRatio(W, iel) * sgridweight_m[j] * fourpi;
     W.rejectMove(iel);
     Psi.resetPhaseDiff();
   }

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -123,7 +123,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
   {
     deltaV[j] = r * rrotsgrid_m[j] - dr;
     W.makeMoveWithSpin(iel, deltaV[j], snew - sold);
-    psiratio[j] = Psi.calcRatio(W, iel) * sgridweight_m[j];
+    psiratio[j] = Psi.calcRatio(W, iel) * sgridweight_m[j] * 2.0 * TWOPI;
     W.rejectMove(iel);
     Psi.resetPhaseDiff();
   }
@@ -150,12 +150,12 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
           tmp[0]         = rr[2];
           tmp[1]         = rr[0];
           tmp[2]         = rr[1];
-          ComplexType cY = std::conj(Ylm(l, m1, tmp));
+          ComplexType Y  = Ylm(l, m1, tmp);
           tmp[0]         = rrotsgrid_m[j][2];
           tmp[1]         = rrotsgrid_m[j][0];
           tmp[2]         = rrotsgrid_m[j][1];
-          ComplexType Y  = Ylm(l, m2, tmp);
-          msums += cY * Y * ldots;
+          ComplexType cY = std::conj(Ylm(l, m2, tmp));
+          msums += Y * cY * ldots;
         }
       }
       lsum += vrad[il] * msums;
@@ -205,7 +205,7 @@ SOECPComponent::RealType SOECPComponent::evaluateOne(ParticleSet& W,
   sint += RealType(1. / 3.) * dS * getAngularIntegral(sold, smin, W, Psi, iel, r, dr);
   sint += RealType(1. / 3.) * dS * getAngularIntegral(sold, smax, W, Psi, iel, r, dr);
 
-  RealType pairpot = std::real(sint);
+  RealType pairpot = std::real(sint) / TWOPI;
   return pairpot;
 }
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -562,7 +562,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
       }
     }
   }
-  REQUIRE(Value1 == Approx(0.1644374207));
+  REQUIRE(Value1 == Approx(-0.3214176962));
 }
 #endif
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This fixes a bug in the evaluation of the SOECPComponents. Essentially there was a mismatch in the normalization of integrals involved as well as a swapped conjugation of spherical harmonics. When I implemented the reference evaluation, I made the same mistake. I noticed this when comparing against my QWalk implementation and some calculations from DIRAC. This fix is reflected in the evaluation and unit tests. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my workstation, gcc 9.2 
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
