### PR TITLE
Update QMCWaveFunctions/tests scripts for Python 3

### DIFF
--- a/src/QMCWaveFunctions/tests/Carbon1x1x1-tw1_gen_mos.py
+++ b/src/QMCWaveFunctions/tests/Carbon1x1x1-tw1_gen_mos.py
@@ -45,26 +45,26 @@ e_scf=mf.kernel()
 import numpy as np
 coords=np.zeros((1,3))
 
-print '    // BEGIN generated C++ input from %s (pyscf version %s) on %s\n'%(__file__,__version__,datetime.datetime.now())
+print('    // BEGIN generated C++ input from %s (pyscf version %s) on %s\n'%(__file__,__version__,datetime.datetime.now()))
 for i in range(7):
 
     coords[0][0]=-10+3.333333*i
     coords[0][1]=-10+3.333333*i
     coords[0][2]=-10+3.333333*i
 
-    print '    //Move electron 0 to position %s a.u.:'%(str(coords))
-    print '    elec.R[0] = { %s, %s, %s };'%(str(coords[0][0]),str(coords[0][1]),str(coords[0][2]))
-    print '    elec.update();'
-    print '    sposet->evaluate(elec, 0, values);\n'
+    print('    //Move electron 0 to position %s a.u.:'%(str(coords)))
+    print('    elec.R[0] = { %s, %s, %s };'%(str(coords[0][0]),str(coords[0][1]),str(coords[0][2])))
+    print('    elec.update();')
+    print('    sposet->evaluate(elec, 0, values);\n')
 
-    print '    // Position %s a.u.'%(str(coords))
+    print('    // Position %s a.u.'%(str(coords)))
     ao = cell.pbc_eval_gto('GTOval', coords, kpt=kpts[0])
 
     for spo_idx in range(len(mf.mo_coeff[0])):
 
-        print '    // Verifying values of SPO %s'%(str(spo_idx))
-        print '    REQUIRE(std::real(values[%d]) == Approx(%s));'%(spo_idx,str(numpy.dot(numpy.array(mf.mo_coeff)[0].T,ao[0].T)[spo_idx].real))
-        print '    REQUIRE(std::imag(values[%d]) == Approx(%s));\n'%(spo_idx,str(numpy.dot(numpy.array(mf.mo_coeff)[0].T,ao[0].T)[spo_idx].imag))
+        print('    // Verifying values of SPO %s'%(str(spo_idx)))
+        print('    REQUIRE(std::real(values[%d]) == Approx(%s));'%(spo_idx,str(numpy.dot(numpy.array(mf.mo_coeff)[0].T,ao[0].T)[spo_idx].real)))
+        print('    REQUIRE(std::imag(values[%d]) == Approx(%s));\n'%(spo_idx,str(numpy.dot(numpy.array(mf.mo_coeff)[0].T,ao[0].T)[spo_idx].imag)))
 
-print '    // END generated C++ input from %s (pyscf version %s) on %s'%(__file__,__version__,datetime.datetime.now())
+print('    // END generated C++ input from %s (pyscf version %s) on %s'%(__file__,__version__,datetime.datetime.now()))
 

--- a/src/QMCWaveFunctions/tests/egas_spinor_test.py
+++ b/src/QMCWaveFunctions/tests/egas_spinor_test.py
@@ -45,15 +45,15 @@ def spinor_matrix(R,s,kup,kdn):
   M=np.zeros((len(R),len(kup)),dtype=complex);
 
  
-  for iat in xrange(0,len(R)):
-    for norb in xrange(0,len(kup)):
+  for iat in range(0,len(R)):
+    for norb in range(0,len(kup)):
       M[iat][norb]=spinor_val(R[iat],s[iat],kup[norb],kdn[norb])
 
   return M
 
 def compute_row_spinor_val(r,s,kup,kdn):
   row=np.zeros(len(kup),dtype=complex)
-  for norb in xrange(0,len(kup)):
+  for norb in range(0,len(kup)):
     row[norb]=spinor_val(r,s,kup[norb],kdn[norb])
   return row
 
@@ -61,7 +61,7 @@ def compute_row_spinor_grad(r,s,kup,kdn):
   rowx=np.zeros(len(kup),dtype=complex)
   rowy=np.zeros(len(kup),dtype=complex)
   rowz=np.zeros(len(kup),dtype=complex)
-  for norb in xrange(0,len(kup)):
+  for norb in range(0,len(kup)):
     g=spinor_grad(r,s,kup[norb],kdn[norb])
     rowx[norb]=g[0]
     rowy[norb]=g[1]
@@ -70,13 +70,13 @@ def compute_row_spinor_grad(r,s,kup,kdn):
     
 def compute_row_spinor_lapl(r,s,kup,kdn):
   row=np.zeros(len(kup),dtype=complex)
-  for norb in xrange(0,len(kup)):
+  for norb in range(0,len(kup)):
     row[norb]=spinor_lapl(r,s,kup[norb],kdn[norb])
   return row
 
 def compute_row_spinor_spingrad(r,s,kup,kdn):
   row=np.zeros(len(kup),dtype=complex)
-  for norb in xrange(0,len(kup)):
+  for norb in range(0,len(kup)):
     row[norb]=spinor_spingrad(r,s,kup[norb],kdn[norb])
   return row
 
@@ -106,22 +106,22 @@ Mtmp = np.copy(Mref)
 det_ref=np.linalg.det(Mref)
 log_ref=np.log(det_ref)
 
-print "############ REFERENCE CONFIG #################"
-print " R = ",R
-print " spins = ",spins
-print "   -----TOTAL MATRIX QUANTITIES-----"
-print "  M = ", Mref
-print " "
-print "  det(M) = ",det_ref
-print " "
-print "  log(det) = ",log_ref
+print("############ REFERENCE CONFIG #################")
+print(" R = ",R)
+print(" spins = ",spins)
+print("   -----TOTAL MATRIX QUANTITIES-----")
+print("  M = ", Mref)
+print(" ")
+print("  det(M) = ",det_ref)
+print(" ")
+print("  log(det) = ",log_ref)
 
 #### Now we're going to compute the 3 gradient components:
 G=np.zeros((3,3),dtype=complex)
 L=np.zeros(3,dtype=complex)
 SG=np.zeros(3,dtype=complex)
 
-for iat in xrange(0,3):
+for iat in range(0,3):
   r=R[iat]
   s=spins[iat]
   gxr,gyr,gzr=compute_row_spinor_grad(r,s,kup,kdn)
@@ -143,37 +143,37 @@ for iat in xrange(0,3):
   Mtmp[iat]=compute_row_spinor_spingrad(r,s,kup,kdn)
   SG[iat]=np.linalg.det(Mtmp)/det_ref
 
-print " "
-print "  G = ",G
-print " "
-print "  L = ",L
-print " "
-print " SG = ",SG
-print "---------------------------------------"
+print(" ")
+print("  G = ",G)
+print(" ")
+print("  L = ",L)
+print(" ")
+print(" SG = ",SG)
+print("---------------------------------------")
 
 iel = 1
 #Now print results for iat move.
-print " VALUE  =  ", det_ref
-print "  GX = ",G[iel][0]
-print "  GY = ",G[iel][1]
-print "  GZ = ",G[iel][2]
-print "  SG = ",SG[iel]
+print(" VALUE  =  ", det_ref)
+print("  GX = ",G[iel][0])
+print("  GY = ",G[iel][1])
+print("  GZ = ",G[iel][2])
+print("  SG = ",SG[iel])
 
-print " "
-print "Now we make a particle/spin move for particle ",iel
+print(" ")
+print("Now we make a particle/spin move for particle ",iel)
 #### Now we're going to compute the ratio and gradients at a proposed move location.  
 dr=np.array([0.1,-0.05,0.2]);
 ds=0.3;
 
-print "  dr = ",dr
-print "  ds = ",ds
+print("  dr = ",dr)
+print("  ds = ",ds)
 
 rnew=R[iel]+dr
 snew=spins[iel]+ds
 
-print " "
-print " r_old = ",R[iel]," r_new = ",rnew
-print " s_old = ",spins[iel]," s_new = ",snew
+print(" ")
+print(" r_old = ",R[iel]," r_new = ",rnew)
+print(" s_old = ",spins[iel]," s_new = ",snew)
 
 Mtmp=np.copy(Mref)
 Mtmp[iel]=compute_row_spinor_val(rnew,snew,kup,kdn)
@@ -194,10 +194,10 @@ gz_new=np.linalg.det(Mtmp)/det_new
 Mtmp[iel]=compute_row_spinor_spingrad(rnew,snew,kup,kdn)
 sg_new=np.linalg.det(Mtmp)/det_new
 
-print " NEW VALUE = ",det_new
-print " NEW LOG(VALUE) = ",np.log(det_new)
-print " RATIO  =  ", det_new/det_ref
-print "  GX = ", gx_new
-print "  GY = ", gy_new
-print "  GZ = ", gz_new
-print "  SG = ", sg_new
+print(" NEW VALUE = ",det_new)
+print(" NEW LOG(VALUE) = ",np.log(det_new))
+print(" RATIO  =  ", det_new/det_ref)
+print("  GX = ", gx_new)
+print("  GY = ", gy_new)
+print("  GZ = ", gz_new)
+print("  SG = ", sg_new)

--- a/src/QMCWaveFunctions/tests/gen_inverse.py
+++ b/src/QMCWaveFunctions/tests/gen_inverse.py
@@ -8,7 +8,7 @@ def output_for_cpp(A,var_name='a'):
   N = A.shape[0]
   for i in range(N):
     for j in range(N):
-      print '%s(%d,%d) = %12.10g;'%(var_name,i,j,A[i,j])
+      print('%s(%d,%d) = %12.10g;'%(var_name,i,j,A[i,j]))
 
 
 A = np.array([
@@ -23,16 +23,16 @@ A = np.array([
 #[0.8, 4.1, 3.2, 1.1]
 #])
 
-print A
+print(A)
 
-print 'det A',np.abs(np.linalg.det(A))
-print 'log det A',np.log(np.abs(np.linalg.det(A)))
+print('det A',np.abs(np.linalg.det(A)))
+print('log det A',np.log(np.abs(np.linalg.det(A))))
 Ainv = np.linalg.inv(A)
-print Ainv
+print(Ainv)
 
 output_for_cpp(Ainv)
 
-print ''
+print('')
 row = np.array([1.9, 2.0, 3.1])
 #row  = np.array([[1.9, 2.0, 3.1],
 #                 [0.1, 4.2, 1.4]])
@@ -46,12 +46,12 @@ B = A.copy()
 B[:,0] = row
 #B[:,0] = row[0]
 #B[:,1] = row[1]
-print 'Updated A with column to get matrix B:'
-print B
-print 'det B',np.abs(np.linalg.det(B))
-print 'log det B',np.log(np.abs(np.linalg.det(B)))
-print 'det ratio',np.linalg.det(B)/np.linalg.det(A);
+print('Updated A with column to get matrix B:')
+print(B)
+print('det B',np.abs(np.linalg.det(B)))
+print('log det B',np.log(np.abs(np.linalg.det(B))))
+print('det ratio',np.linalg.det(B)/np.linalg.det(A))
 Binv = np.linalg.inv(B)
 
-print ''
+print('')
 output_for_cpp(Binv,var_name='b')

--- a/src/QMCWaveFunctions/tests/gen_mo.py
+++ b/src/QMCWaveFunctions/tests/gen_mo.py
@@ -12,45 +12,45 @@ def gen_He():
   for pos in ([0.1, 0.0, 0.0], [1.0, 0.0, 0.0]):
     atomic_orbs = gto.eval_v(*pos)
 
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,atomic_orbs[0])
-    print ''
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,atomic_orbs[0]))
+    print('')
 
     v,g,l = gto.eval_vgl(*pos)
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,v[0])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,g[0][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,g[0][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,g[0][2])
-    print '  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(0,l[0])
-    print ''
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,v[0]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,g[0][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,g[0][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,g[0][2]))
+    print('  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(0,l[0]))
+    print('')
    
     v,g,h = gto.eval_vgh(*pos)
     gh    = gto.eval_gradhess(*pos)
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,v[0])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,g[0][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,g[0][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,g[0][2])
-    print '  //Hessian (xx,xy,xz,yy,yz,zz) '
-    print '  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(0,h[0][0])
-    print '  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(0,h[0][1])
-    print '  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(0,h[0][2])
-    print '  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(0,h[0][3])
-    print '  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(0,h[0][4])
-    print '  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(0,h[0][5])
-    print '  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) '
-    print '  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(0,gh[0][0])
-    print '  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(0,gh[0][1])
-    print '  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(0,gh[0][2])
-    print '  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(0,gh[0][3])
-    print '  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(0,gh[0][4])
-    print '  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(0,gh[0][5])
-    print '  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(0,gh[0][6])
-    print '  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(0,gh[0][7])
-    print '  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(0,gh[0][8])
-    print '  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(0,gh[0][9])
-    print ''
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,v[0]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,g[0][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,g[0][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,g[0][2]))
+    print('  //Hessian (xx,xy,xz,yy,yz,zz) ')
+    print('  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(0,h[0][0]))
+    print('  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(0,h[0][1]))
+    print('  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(0,h[0][2]))
+    print('  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(0,h[0][3]))
+    print('  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(0,h[0][4]))
+    print('  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(0,h[0][5]))
+    print('  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) ')
+    print('  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(0,gh[0][0]))
+    print('  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(0,gh[0][1]))
+    print('  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(0,gh[0][2]))
+    print('  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(0,gh[0][3]))
+    print('  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(0,gh[0][4]))
+    print('  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(0,gh[0][5]))
+    print('  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(0,gh[0][6]))
+    print('  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(0,gh[0][7]))
+    print('  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(0,gh[0][8]))
+    print('  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(0,gh[0][9]))
+    print('')
   
        
 
@@ -61,19 +61,19 @@ def gen_Ne():
     atomic_orbs = gto.eval_v(*pos)
     mol_orbs =  np.dot(MO_matrix, atomic_orbs)
 
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mol_orbs[0])
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mol_orbs[0]))
 
     v,g,l = gto.eval_vgl(*pos)
     mo_v = np.dot(MO_matrix, v)
     mo_g = np.dot(MO_matrix, g)
     mo_l = np.dot(MO_matrix, l)
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mo_v[0])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,mo_g[0][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,mo_g[0][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,mo_g[0][2])
-    print '  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(0,mo_l[0])
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mo_v[0]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,mo_g[0][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,mo_g[0][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,mo_g[0][2]))
+    print('  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(0,mo_l[0]))
 
   
     v,g,h = gto.eval_vgh(*pos)
@@ -82,30 +82,30 @@ def gen_Ne():
     mo_g = np.dot(MO_matrix,g)
     mo_h = np.dot(MO_matrix,h)
     mo_gh = np.dot(MO_matrix,gh)
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mo_v[0])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,mo_g[0][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,mo_g[0][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,mo_g[0][2])
-    print '  //Hessian (xx,xy,xz,yy,yz,zz) '
-    print '  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(0,mo_h[0][0])
-    print '  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(0,mo_h[0][1])
-    print '  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(0,mo_h[0][2])
-    print '  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(0,mo_h[0][3])
-    print '  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(0,mo_h[0][4])
-    print '  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(0,mo_h[0][5])
-    print '  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) '
-    print '  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(0,mo_gh[0][0])
-    print '  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(0,mo_gh[0][1])
-    print '  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(0,mo_gh[0][2])
-    print '  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(0,mo_gh[0][3])
-    print '  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(0,mo_gh[0][4])
-    print '  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(0,mo_gh[0][5])
-    print '  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(0,mo_gh[0][6])
-    print '  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(0,mo_gh[0][7])
-    print '  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(0,mo_gh[0][8])
-    print '  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(0,mo_gh[0][9])
-    print ''
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(0,mo_v[0]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(0,mo_g[0][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(0,mo_g[0][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(0,mo_g[0][2]))
+    print('  //Hessian (xx,xy,xz,yy,yz,zz) ')
+    print('  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(0,mo_h[0][0]))
+    print('  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(0,mo_h[0][1]))
+    print('  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(0,mo_h[0][2]))
+    print('  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(0,mo_h[0][3]))
+    print('  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(0,mo_h[0][4]))
+    print('  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(0,mo_h[0][5]))
+    print('  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) ')
+    print('  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(0,mo_gh[0][0]))
+    print('  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(0,mo_gh[0][1]))
+    print('  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(0,mo_gh[0][2]))
+    print('  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(0,mo_gh[0][3]))
+    print('  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(0,mo_gh[0][4]))
+    print('  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(0,mo_gh[0][5]))
+    print('  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(0,mo_gh[0][6]))
+    print('  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(0,mo_gh[0][7]))
+    print('  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(0,mo_gh[0][8]))
+    print('  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(0,mo_gh[0][9]))
+    print('')
    
 
 def gen_HCN():
@@ -118,22 +118,22 @@ def gen_HCN():
   #print 'first MO',MO_matrix[0,:]
   #print 'atomic_orbs',atomic_orbs
   mol_orbs =  np.dot(MO_matrix, atomic_orbs)
-  print '  // Generated from gen_mo.py for position %s'%str(pos)
+  print('  // Generated from gen_mo.py for position %s'%str(pos))
   for i in range(7):
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mol_orbs[i])
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mol_orbs[i]))
 
   v,g,l = gtos.eval_vgl(*pos)
   mo_v = np.dot(MO_matrix, v)
   mo_g = np.dot(MO_matrix, g)
   mo_l = np.dot(MO_matrix, l)
-  print '  // Generated from gen_mo.py for position %s'%str(pos)
+  print('  // Generated from gen_mo.py for position %s'%str(pos))
   for i in range(7):
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mo_v[i])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(i,mo_g[i][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(i,mo_g[i][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(i,mo_g[i][2])
-    print '  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(i,mo_l[i])
-    print ''
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mo_v[i]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(i,mo_g[i][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(i,mo_g[i][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(i,mo_g[i][2]))
+    print('  REQUIRE(d2psi[%d] == Approx(%15.10g));'%(i,mo_l[i]))
+    print('')
 
   v,g,h = gtos.eval_vgh(*pos)
   gh    = gtos.eval_gradhess(*pos)
@@ -142,30 +142,30 @@ def gen_HCN():
   mo_h = np.dot(MO_matrix,h)
   mo_gh = np.dot(MO_matrix,gh)
   for i in range(7):
-    print '  // Generated from gen_mo.py for position %s'%str(pos)
-    print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mo_v[i])
-    print '  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(i,mo_g[i][0])
-    print '  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(i,mo_g[i][1])
-    print '  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(i,mo_g[i][2])
-    print '  //Hessian (xx,xy,xz,yy,yz,zz) '
-    print '  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(i,mo_h[i][0])
-    print '  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(i,mo_h[i][1])
-    print '  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(i,mo_h[i][2])
-    print '  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(i,mo_h[i][3])
-    print '  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(i,mo_h[i][4])
-    print '  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(i,mo_h[i][5])
-    print '  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) '
-    print '  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(i,mo_gh[i][0])
-    print '  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(i,mo_gh[i][1])
-    print '  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(i,mo_gh[i][2])
-    print '  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(i,mo_gh[i][3])
-    print '  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(i,mo_gh[i][4])
-    print '  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(i,mo_gh[i][5])
-    print '  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(i,mo_gh[i][6])
-    print '  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(i,mo_gh[i][7])
-    print '  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(i,mo_gh[i][8])
-    print '  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(i,mo_gh[i][9])
-    print ''
+    print('  // Generated from gen_mo.py for position %s'%str(pos))
+    print('  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mo_v[i]))
+    print('  REQUIRE(dpsi[%d][0] == Approx(%15.10g));'%(i,mo_g[i][0]))
+    print('  REQUIRE(dpsi[%d][1] == Approx(%15.10g));'%(i,mo_g[i][1]))
+    print('  REQUIRE(dpsi[%d][2] == Approx(%15.10g));'%(i,mo_g[i][2]))
+    print('  //Hessian (xx,xy,xz,yy,yz,zz) ')
+    print('  REQUIRE(dhpsi[%d][0] == Approx(%15.10g));'%(i,mo_h[i][0]))
+    print('  REQUIRE(dhpsi[%d][1] == Approx(%15.10g));'%(i,mo_h[i][1]))
+    print('  REQUIRE(dhpsi[%d][2] == Approx(%15.10g));'%(i,mo_h[i][2]))
+    print('  REQUIRE(dhpsi[%d][3] == Approx(%15.10g));'%(i,mo_h[i][3]))
+    print('  REQUIRE(dhpsi[%d][4] == Approx(%15.10g));'%(i,mo_h[i][4]))
+    print('  REQUIRE(dhpsi[%d][5] == Approx(%15.10g));'%(i,mo_h[i][5]))
+    print('  //GradHessian (xxx,xxy,xxz,xyy,xyz,xzz,yyy,yyz,yzz,zzz) ')
+    print('  REQUIRE(dghpsi[%d][0] == Approx(%15.10g));'%(i,mo_gh[i][0]))
+    print('  REQUIRE(dghpsi[%d][1] == Approx(%15.10g));'%(i,mo_gh[i][1]))
+    print('  REQUIRE(dghpsi[%d][2] == Approx(%15.10g));'%(i,mo_gh[i][2]))
+    print('  REQUIRE(dghpsi[%d][3] == Approx(%15.10g));'%(i,mo_gh[i][3]))
+    print('  REQUIRE(dghpsi[%d][4] == Approx(%15.10g));'%(i,mo_gh[i][4]))
+    print('  REQUIRE(dghpsi[%d][5] == Approx(%15.10g));'%(i,mo_gh[i][5]))
+    print('  REQUIRE(dghpsi[%d][6] == Approx(%15.10g));'%(i,mo_gh[i][6]))
+    print('  REQUIRE(dghpsi[%d][7] == Approx(%15.10g));'%(i,mo_gh[i][7]))
+    print('  REQUIRE(dghpsi[%d][8] == Approx(%15.10g));'%(i,mo_gh[i][8]))
+    print('  REQUIRE(dghpsi[%d][9] == Approx(%15.10g));'%(i,mo_gh[i][9]))
+    print('')
   
 
 def gen_HCN_force():
@@ -180,10 +180,10 @@ def gen_HCN_force():
   Natom=ionpos.shape[0];
   norb=7
 
-  print '  // Generated from gen_mo.py for position %s'%str(pos)
+  print('  // Generated from gen_mo.py for position %s'%str(pos))
 
-  for iat in xrange(0,Natom):
-    for idim in xrange(0,3):
+  for iat in range(0,Natom):
+    for idim in range(0,3):
       ionpos_p=np.array(ionpos)
       ionpos_m=np.array(ionpos)
       
@@ -212,15 +212,15 @@ def gen_HCN_force():
       dmo_v = 0.5*deltainv*(mo_v_p-mo_v_m)
       dmo_g = 0.5*deltainv*(mo_g_p-mo_g_m)
       dmo_l = 0.5*deltainv*(mo_l_p-mo_l_m)
-      print "//============== Ion ",iat," Component ",idim,"==================="
-      for iorb in xrange(0,norb):
-        print '  REQUIRE( dionpsi[0][%d][%d]       == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb])
-        print '  REQUIRE( diongradpsi[0][%d](%d,0) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0])
-        print '  REQUIRE( diongradpsi[0][%d](%d,1) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][1])
-        print '  REQUIRE( diongradpsi[0][%d](%d,2) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][2])
-        print '  REQUIRE( dionlaplpsi[0][%d][%d]  == Approx(%15.10g) );  '%(iorb,idim,dmo_l[iorb])
+      print("//============== Ion ",iat," Component ",idim,"===================")
+      for iorb in range(0,norb):
+        print('  REQUIRE( dionpsi[0][%d][%d]       == Approx(%15.10g) );  '%(iorb,idim,dmo_v[iorb]))
+        print('  REQUIRE( diongradpsi[0][%d](%d,0) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][0]))
+        print('  REQUIRE( diongradpsi[0][%d](%d,1) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][1]))
+        print('  REQUIRE( diongradpsi[0][%d](%d,2) == Approx(%15.10g) );  '%(iorb,idim,dmo_g[iorb][2]))
+        print('  REQUIRE( dionlaplpsi[0][%d][%d]  == Approx(%15.10g) );  '%(iorb,idim,dmo_l[iorb]))
     
-  print '  // Generated from gen_mo.py for position %s'%str(pos)
+  print('  // Generated from gen_mo.py for position %s'%str(pos))
  # for i in range(7):
  #   print '  REQUIRE(values[%d] == Approx(%15.10g));'%(i,mol_orbs[i])
 

--- a/src/QMCWaveFunctions/tests/read_qmcpack.py
+++ b/src/QMCWaveFunctions/tests/read_qmcpack.py
@@ -27,7 +27,7 @@ def read_basis_groups(atomic_basis_set):
     basis_set = []
     for basis_group in basis_groups:
         if basis_group.attrib['type'] != 'Gaussian':
-            print 'Expecting Gaussian type basisGroup'
+            print('Expecting Gaussian type basisGroup')
         #print basis_group.attrib['n']
         n = int(basis_group.attrib['n'])
         #print basis_group.attrib['l']
@@ -70,11 +70,9 @@ def parse_qmc_wf(fname, element_list):
     MO_coeff_node = tree.find('.//determinant/coefficient')
     MO_matrix = None
     if MO_coeff_node is None:
-        print 'Molecular orbital coefficients not found'
+        print('Molecular orbital coefficients not found')
     else:
-        #print 'MO_coeff = ',MO_coeff_node
         MO_size = int(MO_coeff_node.attrib['size'])
-        #print 'MO coeff size = ',MO_size
 
         MO_text = MO_coeff_node.text
         MO_text_entries = MO_text.split()
@@ -82,7 +80,6 @@ def parse_qmc_wf(fname, element_list):
 
         #MO_matrix = np.array(MO_values).reshape( (basis_size, MO_size) )
         MO_matrix = np.array(MO_values).reshape( (MO_size, basis_size) )
-        #print 'MO_values = ',MO_values
 
     return basis_sets, MO_matrix
 
@@ -158,17 +155,17 @@ if __name__ == '__main__':
 
     gtos = gaussian_orbitals.GTO_centers(pos_list, elements, basis_sets)
     atomic_orbs =  gtos.eval_v(1.0, 0.0, 0.0)
-    print np.dot(MO_matrix, atomic_orbs)
+    print(np.dot(MO_matrix, atomic_orbs))
 
     #ccp = read_cusp_correction_file("hcn_downdet.cuspInfo.xml")
     #print ccp
 
     # Ethanol - example with repeated atoms
     pos_list, elements = read_structure_file("ethanol.structure.xml")
-    print len(pos_list), pos_list
-    print 'elements',elements
+    print(len(pos_list), pos_list)
+    print('elements', elements)
 
     basis_sets, MO_matrix = parse_qmc_wf("ethanol.wfnoj.xml", elements)
-    print MO_matrix.shape
+    print(MO_matrix.shape)
 
 


### PR DESCRIPTION
The change are mostly changing print statements to print functions.
A few places xrange was replaced by range.

In gen_bspline_jastrow.py, there is a workaround for a Sympy bug ( https://github.com/sympy/sympy/issues/19262 )

Closes #2728


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- Yes - These scripts will not work with Python 2.  The rest of the code made a jump to python 3 a while ago.

## What systems has this change been tested on?

laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- N/A Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
