### PR TITLE
Catchable APP_ABORT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,9 +142,6 @@ INCLUDE_DIRECTORIES("${qmcpack_SOURCE_DIR}/external_codes/boost_multi")
     Numerics/OptimizableFunctorBase.cpp
     Numerics/SmoothFunctions.cpp
     QMCFactory/OneDimGridFactory.cpp
-    Message/Communicate.cpp
-    Message/AppAbort.cpp
-    Message/MPIObjectBase.cpp
     Optimize/VariableSet.cpp
     io/hdf_archive.cpp
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,7 @@ INCLUDE_DIRECTORIES("${qmcpack_SOURCE_DIR}/external_codes/boost_multi")
     Numerics/SmoothFunctions.cpp
     QMCFactory/OneDimGridFactory.cpp
     Message/Communicate.cpp
+    Message/AppAbort.cpp
     Message/MPIObjectBase.cpp
     Optimize/VariableSet.cpp
     io/hdf_archive.cpp

--- a/src/Message/AppAbort.cpp
+++ b/src/Message/AppAbort.cpp
@@ -11,9 +11,10 @@
 
 #include "Message/AppAbort.h"
 #include <iostream>
+#include "config.h"
 
 #ifdef HAVE_MPI
-#include "mpi3/environment.hpp"
+#include <mpi.h>
 
 void breakableAppAbort(const std::string& str_msg)
 {

--- a/src/Message/AppAbort.cpp
+++ b/src/Message/AppAbort.cpp
@@ -13,15 +13,17 @@
 #include <iostream>
 
 #ifdef HAVE_MPI
-void breakableAppAbort(std::string str_msg)
+#include <mpi.h>
+
+void breakableAppAbort(const std::string& str_msg)
 {
-  std::cerr << str_msg << std::endl;
+  std::cerr << str_msg << '\n';
   MPI_Abort(MPI_COMM_WORLD, 1);
 }
 #else
-void breakableAppAbort(std::string str_msg)
+void breakableAppAbort(const std::string& str_msg)
 {
-  std::cerr << str_msg << std::endl;
+  std::cerr << str_msg << '\n';
   exit(1);
 }
 #endif

--- a/src/Message/AppAbort.cpp
+++ b/src/Message/AppAbort.cpp
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License.  See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// Refactored from: Communicate.cpp
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Message/AppAbort.h"
+#include <iostream>
+
+#ifdef HAVE_MPI
+void breakableAppAbort(std::string str_msg)
+{
+  std::cerr << str_msg << std::endl;
+  MPI_Abort(MPI_COMM_WORLD, 1);
+}
+#else
+void breakableAppAbort(std::string str_msg)
+{
+  std::cerr << str_msg << std::endl;
+  exit(1);
+}
+#endif

--- a/src/Message/AppAbort.cpp
+++ b/src/Message/AppAbort.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 #ifdef HAVE_MPI
-#include <mpi.h>
+#include "mpi3/environment.hpp"
 
 void breakableAppAbort(const std::string& str_msg)
 {

--- a/src/Message/AppAbort.h
+++ b/src/Message/AppAbort.h
@@ -12,10 +12,6 @@
 #ifndef QMCPLUSPLUS_APPABORT_H
 #define QMCPLUSPLUS_APPABORT_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <string>
 #include <sstream>
 

--- a/src/Message/AppAbort.h
+++ b/src/Message/AppAbort.h
@@ -17,7 +17,7 @@
 
 /** break on this function to catch any APP_ABORT call in debugger
  */
-void breakableAppAbort(std::string str_msg);
+void breakableAppAbort(const std::string& str_msg);
 
 /** Widely used but deprecated fatal error macros from legacy code
  *

--- a/src/Message/AppAbort.h
+++ b/src/Message/AppAbort.h
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License.  See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Communicate.h
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_APPABORT_H
+#define QMCPLUSPLUS_APPABORT_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string>
+#include <sstream>
+
+/** break on this function to catch any APP_ABORT call in debugger
+ */
+void breakableAppAbort(std::string str_msg);
+
+/** Widely used but deprecated fatal error macros from legacy code
+ *
+ *  they allow rather odd use of the << operator for the msg argument
+ *  so removing them is non trivial.
+ */
+#define APP_ABORT(msg)                                   \
+  {                                                      \
+    std::ostringstream error_message;                    \
+    error_message << "Fatal Error. Aborting at " << msg; \
+    breakableAppAbort(error_message.str());              \
+  }
+
+#define APP_ABORT_TRACE(f, l, msg)                                                  \
+  {                                                                                 \
+    std::ostringstream error_message;                                               \
+    error_message << "Fatal Error. Aborting at " << l << "::" << f << "\n " << msg; \
+    breakableAppAbort(error_message.str());                                         \
+  }
+
+#endif

--- a/src/Message/CMakeLists.txt
+++ b/src/Message/CMakeLists.txt
@@ -11,8 +11,9 @@
 
 
 SET(COMM_SRCS
-    Communicate.cpp
-    MPIObjectBase.cpp
+  Communicate.cpp
+  AppAbort.cpp
+  MPIObjectBase.cpp
 )
 
 ADD_LIBRARY(message ${COMM_SRCS})

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -131,12 +131,6 @@ void Communicate::cleanupMessage(void*) {}
 void Communicate::abort() const { comm.abort(1); }
 
 void Communicate::barrier() const { comm.barrier(); }
-
-void breakableAppAbort(std::string str_msg)
-{
-  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
-  MPI_Abort(MPI_COMM_WORLD, 1);
-}
 #else
 
 void Communicate::initialize(int argc, char** argv) { std::string when = "qmc." + getDateAndTime("%Y%m%d_%H%M"); }
@@ -155,12 +149,6 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
     : myMPI(MPI_COMM_NULL), d_mycontext(0), d_ncontexts(1), d_groupid(0)
 {
   GroupLeaderComm = new Communicate();
-}
-
-void breakableAppAbort(std::string str_msg)
-{
-  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
-  exit(1);
 }
 #endif // !HAVE_MPI
 

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -17,6 +17,8 @@
 
 #include "Message/Communicate.h"
 #include <iostream>
+#include <sstream>
+#include <string>
 #include <cstdio>
 #include <fstream>
 #include "config.h"
@@ -154,7 +156,19 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
   GroupLeaderComm = new Communicate();
 }
 
+void breakableAppAbort(std::string str_msg)
+{
+  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
+  MPI_Abort(MPI_COMM_WORLD, 1);
+}
+
 #endif // !HAVE_MPI
+
+void breakableAppAbort(std::string str_msg)
+{
+  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
+  exit(1);
+}
 
 void Communicate::barrier_and_abort(const std::string& msg) const
 {

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -36,12 +36,7 @@ Communicate* OHMMS::Controller = new Communicate;
 
 //default constructor: ready for a serial execution
 Communicate::Communicate()
-    : myMPI(MPI_COMM_NULL),
-      d_mycontext(0),
-      d_ncontexts(1),
-      d_groupid(0),
-      d_ngroups(1),
-      GroupLeaderComm(nullptr)
+    : myMPI(MPI_COMM_NULL), d_mycontext(0), d_ncontexts(1), d_groupid(0), d_ngroups(1), GroupLeaderComm(nullptr)
 {}
 
 #ifdef HAVE_MPI

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -132,6 +132,11 @@ void Communicate::abort() const { comm.abort(1); }
 
 void Communicate::barrier() const { comm.barrier(); }
 
+void breakableAppAbort(std::string str_msg)
+{
+  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
+  MPI_Abort(MPI_COMM_WORLD, 1);
+}
 #else
 
 void Communicate::initialize(int argc, char** argv) { std::string when = "qmc." + getDateAndTime("%Y%m%d_%H%M"); }
@@ -155,16 +160,9 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
 void breakableAppAbort(std::string str_msg)
 {
   std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
-  MPI_Abort(MPI_COMM_WORLD, 1);
-}
-
-#endif // !HAVE_MPI
-
-void breakableAppAbort(std::string str_msg)
-{
-  std::cerr << "Fatal Error. Aborting at " << str_msg << std::endl;
   exit(1);
 }
+#endif // !HAVE_MPI
 
 void Communicate::barrier_and_abort(const std::string& msg) const
 {

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2020 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
@@ -10,6 +10,7 @@
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Cynthia Gu, zg1@ornl.gov, Oak Ridge National Laboratory
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -18,23 +18,10 @@
 
 #ifndef OHMMS_COMMUNICATE_H
 #define OHMMS_COMMUNICATE_H
-#include <string>
-#include <sstream>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-
-/** break on this function to catch any APP_ABORT call in debugger
- */
-void breakableAppAbort(std::string str_msg);
-
-#define APP_ABORT(msg)                      \
-  {                                         \
-    std::ostringstream error_message;       \
-    error_message << msg;                   \
-    breakableAppAbort(error_message.str()); \
-  }
 
 #ifdef HAVE_MPI
 #include "mpi3/environment.hpp"
@@ -49,12 +36,6 @@ struct CommunicatorTraits
   typedef MPI_Request request;
 };
 
-#define APP_ABORT_TRACE(f, l, msg)                                                           \
-  {                                                                                          \
-    std::cerr << "Fatal Error. Aborting at " << l << "::" << f << "\n " << msg << std::endl; \
-    MPI_Abort(MPI_COMM_WORLD, 1);                                                            \
-  }
-
 #else
 struct CommunicatorTraits
 {
@@ -64,13 +45,6 @@ struct CommunicatorTraits
   static const int MPI_COMM_NULL    = 0;
   static const int MPI_REQUEST_NULL = 1;
 };
-
-#define APP_ABORT_TRACE(f, l, msg)                                                           \
-  {                                                                                          \
-    std::cerr << "Fatal Error. Aborting at " << l << "::" << f << "\n " << msg << std::endl; \
-    exit(1);                                                                                 \
-  }
-
 #endif
 
 #include <string>
@@ -78,6 +52,8 @@ struct CommunicatorTraits
 #include <utility>
 #include <unistd.h>
 #include <cstring>
+
+#include "Message/AppAbort.h"
 
 /**@class Communicate
  * @ingroup Message

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -29,6 +29,13 @@
  */
 void breakableAppAbort(std::string str_msg);
 
+#define APP_ABORT(msg)                      \
+  {                                         \
+    std::ostringstream error_message;       \
+    error_message << msg;                   \
+    breakableAppAbort(error_message.str()); \
+  }
+
 #ifdef HAVE_MPI
 #include "mpi3/environment.hpp"
 namespace mpi3 = boost::mpi3;
@@ -41,13 +48,6 @@ struct CommunicatorTraits
   typedef MPI_Status status;
   typedef MPI_Request request;
 };
-
-#define APP_ABORT(msg)                      \
-  {                                         \
-    std::ostringstream error_message;       \
-    error_message << msg;                   \
-    breakableAppAbort(error_message.str()); \
-  }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \
   {                                                                                          \
@@ -64,13 +64,6 @@ struct CommunicatorTraits
   static const int MPI_COMM_NULL    = 0;
   static const int MPI_REQUEST_NULL = 1;
 };
-
-#define APP_ABORT(msg)                      \
-  {                                         \
-    std::ostringstream error_message;       \
-    error_message << msg;                   \
-    breakableAppAbort(error_message.str()); \
-  }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \
   {                                                                                          \

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -17,9 +17,15 @@
 
 #ifndef OHMMS_COMMUNICATE_H
 #define OHMMS_COMMUNICATE_H
+#include <string>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+/** because APP_ABORT is incompatible with a normal debug build and lldb break points
+ */
+void breakableAppAbort(std::string str_msg);
 
 #ifdef HAVE_MPI
 #include "mpi3/environment.hpp"
@@ -33,10 +39,12 @@ struct CommunicatorTraits
   typedef MPI_Status status;
   typedef MPI_Request request;
 };
+
 #define APP_ABORT(msg)                                            \
   {                                                               \
-    std::cerr << "Fatal Error. Aborting at " << msg << std::endl; \
-    MPI_Abort(MPI_COMM_WORLD, 1);                                 \
+    std::ostringstream error_message;                             \
+    error_message << msg;                                         \
+    breakableAppAbort(error_message.str());                       \
   }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \
@@ -57,9 +65,9 @@ struct CommunicatorTraits
 
 #define APP_ABORT(msg)                                            \
   {                                                               \
-    std::cerr << "Fatal Error. Aborting at " << msg << std::endl; \
-    std::cerr.flush();                                            \
-    exit(1);                                                      \
+    std::ostringstream error_message;                             \
+    error_message << msg;                                         \
+    breakableAppAbort(error_message.str());                       \
   }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2020 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
@@ -10,6 +10,7 @@
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -18,6 +19,7 @@
 #ifndef OHMMS_COMMUNICATE_H
 #define OHMMS_COMMUNICATE_H
 #include <string>
+#include <sstream>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -25,7 +25,7 @@
 #include "config.h"
 #endif
 
-/** because APP_ABORT is incompatible with a normal debug build and lldb break points
+/** break on this function to catch any APP_ABORT call in debugger
  */
 void breakableAppAbort(std::string str_msg);
 
@@ -42,11 +42,11 @@ struct CommunicatorTraits
   typedef MPI_Request request;
 };
 
-#define APP_ABORT(msg)                                            \
-  {                                                               \
-    std::ostringstream error_message;                             \
-    error_message << msg;                                         \
-    breakableAppAbort(error_message.str());                       \
+#define APP_ABORT(msg)                      \
+  {                                         \
+    std::ostringstream error_message;       \
+    error_message << msg;                   \
+    breakableAppAbort(error_message.str()); \
   }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \
@@ -65,11 +65,11 @@ struct CommunicatorTraits
   static const int MPI_REQUEST_NULL = 1;
 };
 
-#define APP_ABORT(msg)                                            \
-  {                                                               \
-    std::ostringstream error_message;                             \
-    error_message << msg;                                         \
-    breakableAppAbort(error_message.str());                       \
+#define APP_ABORT(msg)                      \
+  {                                         \
+    std::ostringstream error_message;       \
+    error_message << msg;                   \
+    breakableAppAbort(error_message.str()); \
   }
 
 #define APP_ABORT_TRACE(f, l, msg)                                                           \
@@ -107,7 +107,7 @@ public:
   ///constructor with communicator
   Communicate(const mpi3::communicator& in_comm);
 #endif
-  
+
   /** constructor that splits in_comm
    */
   Communicate(const Communicate& in_comm, int nparts);


### PR DESCRIPTION
## Proposed changes

The APP_ABORT macro creates a situation where you can't simply break on any fatal error in QMCPACK. In gdb and lldb you won't catch at breakpoint set to a line in a macro definition. So if you want to catch all fatal errors in the debugger APP_ABORT is a problem. The macro is wide spread and tracking down where it actually was called from can be a pain.

This PR creates an actual function called by APP_ABORT so a breakpoint can be set to catch calls to APP_ABORT with the calling context intact.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
