### PR TITLE
Spin-orbit documentation

### DIFF
--- a/docs/bibs/methods.bib
+++ b/docs/bibs/methods.bib
@@ -105,3 +105,33 @@
   volume        = {132},
   year          = {2010}
 }
+
+@article{Melton2016-1,
+  title = {Spin-orbit interactions in electronic structure quantum Monte Carlo methods},
+  author = {Melton, Cody A. and Zhu, Minyi and Guo, Shi and Ambrosetti, Alberto and Pederiva, Francesco and Mitas, Lubos},
+  journal = {Phys. Rev. A},
+  volume = {93},
+  issue = {4},
+  pages = {042502},
+  numpages = {5},
+  year = {2016},
+  month = {Apr},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.93.042502},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.93.042502}
+}
+
+
+@article{Melton2016-2,
+	Author = {Melton,Cody A. and Bennett,M. Chandler and Mitas,Lubos},
+	Doi = {10.1063/1.4954726},
+	Eprint = {https://doi.org/10.1063/1.4954726},
+	Journal = {The Journal of Chemical Physics},
+	Number = {24},
+	Pages = {244113},
+	Title = {Quantum Monte Carlo with variable spins},
+	Url = {https://doi.org/10.1063/1.4954726},
+	Volume = {144},
+	Year = {2016},
+	Bdsk-Url-1 = {https://doi.org/10.1063/1.4954726}}
+

--- a/docs/bibs/spin-orbit.bib
+++ b/docs/bibs/spin-orbit.bib
@@ -1,0 +1,45 @@
+
+@article{Dolg2012,
+	Author = {Dolg, Michael and Cao, Xiaoyan},
+	Doi = {10.1021/cr2001383},
+	Eprint = {https://doi.org/10.1021/cr2001383},
+	Journal = {Chemical Reviews},
+	Note = {PMID: 21913696},
+	Number = {1},
+	Pages = {403-480},
+	Title = {Relativistic Pseudopotentials: Their Development and Scope of Applications},
+	Url = {https://doi.org/10.1021/cr2001383},
+	Volume = {112},
+	Year = {2012},
+	Bdsk-Url-1 = {https://doi.org/10.1021/cr2001383}
+}
+
+@article{Melton2016-1,
+  title = {Spin-orbit interactions in electronic structure quantum Monte Carlo methods},
+  author = {Melton, Cody A. and Zhu, Minyi and Guo, Shi and Ambrosetti, Alberto and Pederiva, Francesco and Mitas, Lubos},
+  journal = {Phys. Rev. A},
+  volume = {93},
+  issue = {4},
+  pages = {042502},
+  numpages = {5},
+  year = {2016},
+  month = {Apr},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.93.042502},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.93.042502}
+}
+
+
+@article{Melton2016-2,
+	Author = {Melton,Cody A. and Bennett,M. Chandler and Mitas,Lubos},
+	Doi = {10.1063/1.4954726},
+	Eprint = {https://doi.org/10.1063/1.4954726},
+	Journal = {The Journal of Chemical Physics},
+	Number = {24},
+	Pages = {244113},
+	Title = {Quantum Monte Carlo with variable spins},
+	Url = {https://doi.org/10.1063/1.4954726},
+	Volume = {144},
+	Year = {2016},
+	Bdsk-Url-1 = {https://doi.org/10.1063/1.4954726}}
+

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -68,6 +68,9 @@ level.
    Python-based environments with graphs produced via matplotlib
    (included with Nexus)
 
+-  Spin-orbit coupling from relativistic pseudopotentials following the 
+   approach of Melton, Bennett, and Mitas. 
+
 SoA optimizations and improved algorithms
 -----------------------------------------
 

--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -285,6 +285,19 @@ use a specific identifying file extension; instead they are simply
 suffixed with “``.xml``.” The tabular data format of CASINO is also
 supported.
 
+In addition to the semilocal pseudopotential above, spin-orbit 
+interactions can also be included through the use of spin-orbit
+pseudopotentials. The spin-orbit contribution can be written as
+
+.. math::
+  :label: eqn32
+
+  V^{\rm SO} = \sum_{ij} \left(\sum_{\ell = 1}^{\ell_{max}-1} \frac{2}{2\ell+1} V^{\rm SO}_\ell \left( \left|r_i - \tilde{r}_j \right| \right) \sum_{m,m'=-\ell}^{\ell} | Y_{\ell m} \rangle  \langle Y_{\ell m} | \vec{\ell} \cdot \vec{s} | Y_{\ell m'}\rangle\langle Y_{\ell m'}|\right)\:.
+
+Here, :math:`\vec{s}` is the spin operator. For each atom with a spin-orbit contribution,
+the radial functions :math:`V_{\ell}^{\rm SO}` can be included in the pseudopotential 
+“``.xml``” file.
+
 ``pairpot type=pseudo`` element:
 
   +------------------+-----------------+
@@ -295,29 +308,31 @@ supported.
 
 attributes:
 
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | **Name**                    | **Datatype** | **Values**            | **Default**            | **Description**                             |
-  +=============================+==============+=======================+========================+=============================================+
-  | ``type``:math:`^r`          | text         | **pseudo**            |                        | Must be pseudo                              |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``name/id``:math:`^r`       | text         | *anything*            | PseudoPot              | *No current function*                       |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``source``:math:`^r`        | text         | ``particleset.name``  | i                      | Ion ``particleset`` name                    |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``target``:math:`^r`        | text         | ``particleset.name``  | ``hamiltonian.target`` | Electron ``particleset`` name               |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``pbc``:math:`^o`           | boolean      | yes/no                | yes*                   | Use Ewald summation                         |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``forces``                  | boolean      | yes/no                | no                     | *Deprecated*                                |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``wavefunction``:math:`^r`  | text         | ``wavefunction.name`` | invalid                | Identify wavefunction                       |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``format``:math:`^r`        | text         | xml/table             | table                  | Select file format                          |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``algorithm``:math:`^o`     | text         | batched/default       | default                | Choose NLPP algorithm                       |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
-  | ``DLA``:math:`^o`           | text         | yes/no                | no                     | Use determinant localization approximation  |
-  +-----------------------------+--------------+-----------------------+------------------------+---------------------------------------------+
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | **Name**                    | **Datatype** | **Values**            | **Default**            | **Description**                                  |
+  +=============================+==============+=======================+========================+==================================================+
+  | ``type``:math:`^r`          | text         | **pseudo**            |                        | Must be pseudo                                   |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``name/id``:math:`^r`       | text         | *anything*            | PseudoPot              | *No current function*                            |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``source``:math:`^r`        | text         | ``particleset.name``  | i                      | Ion ``particleset`` name                         |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``target``:math:`^r`        | text         | ``particleset.name``  | ``hamiltonian.target`` | Electron ``particleset`` name                    |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``pbc``:math:`^o`           | boolean      | yes/no                | yes*                   | Use Ewald summation                              |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``forces``                  | boolean      | yes/no                | no                     | *Deprecated*                                     |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``wavefunction``:math:`^r`  | text         | ``wavefunction.name`` | invalid                | Identify wavefunction                            |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``format``:math:`^r`        | text         | xml/table             | table                  | Select file format                               |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``algorithm``:math:`^o`     | text         | batched/default       | default                | Choose NLPP algorithm                            |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``DLA``:math:`^o`           | text         | yes/no                | no                     | Use determinant localization approximation       |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
+  | ``physicalSO``:math:`^o`    | boolean      | yes/no                | no                     | Include the SO contribution in the local energy  |
+  +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
 
 Additional information:
 
@@ -357,6 +372,10 @@ Additional information:
    (DLA) :cite:`Zen2019DLA` uses only the fermionic part of
    the wavefunction when calculating NLPP.
 
+-  **physicalSO** If the spin-orbit components are included in the 
+   ``.xml`` file, this flag allows control over whether the SO contribution
+   is included in the local energy. 
+
 .. code-block::
   :caption: QMCPXML element for pseudopotential electron-ion interaction (psf files).
   :name: Listing 19
@@ -370,6 +389,14 @@ Additional information:
     <pairpot name="PseudoPot" type="pseudo"  source="i" wavefunction="psi0" format="xml">
       <pseudo elementType="Li" href="Li.xml"/>
       <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+
+.. code-block::
+  :caption: QMCPXML element for pseudopotential including the spin-orbit interaction.
+  :name: Listing 21
+  
+    <pairpot name="PseudoPot" type="pseudo" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
+      <pseudo elementType="Pb" href="Pb.xml"/>
     </pairpot>
 
 Details of ``<pseudo/>`` input elements are shown in the following. It

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ User's Guide and Developer's Manual
    analyzing
    LCAO
    sCI
+   spin_orbit
    afqmc
    examples
    lab_qmc_statistics

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -137,6 +137,10 @@ Variational Monte Carlo
   +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
   | ``blocks_between_recompute``   | integer      | :math:`\geq 0`          | dep.        | Wavefunction recompute frequency              |
   +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``spinMoves``                  | text         | yes,no                  | no          | Whether or not to sample the electron spins   |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``spinMass``                   | real         | :math:`> 0`             | 1.0         | Effective mass for spin sampling              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
 
 Additional information:
 
@@ -202,6 +206,14 @@ Additional information:
   from scratch: =1 by default when using mixed precision. =0 (no
   recompute) by default when not using mixed precision. Recomputing
   introduces a performance penalty dependent on system size.
+
+-  ``spinMoves`` Determines whether or not the spin variables are sampled following 
+  :cite:`Melton2016-1` and :cite:`Melton2016-2`. If a relativistic calculation is desired using pseudopotentials,
+  spin variable sampling is required.
+
+-  ``spinMass`` If spin sampling is on using ``spinMoves`` == yes, the spin mass determines the rate 
+  of spin sampling, resulting in an effective spin timestep :math:`\tau_s = \frac{\tau}{\mu_s}` where 
+  :math:`\tau` is the normal spatial timestep and :math:`\mu_s` is the value of the spin mass.
 
 An example VMC section for a simple VMC run:
 
@@ -1000,29 +1012,33 @@ parameters:
 .. _table9:
 .. table::
 
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | **Name**                       | **Datatype** | **Values**              | **Default** | **Description**                     |
-  +================================+==============+=========================+=============+=====================================+
-  | ``targetwalkers``              | integer      | :math:`> 0`             | dep.        | Overall total number of walkers     |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``blocks``                     | integer      | :math:`\geq 0`          | 1           | Number of blocks                    |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``steps``                      | integer      | :math:`\geq 0`          | 1           | Number of steps per block           |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``warmupsteps``                | integer      | :math:`\geq 0`          | 0           | Number of steps for warming up      |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``timestep``                   | real         | :math:`> 0`             | 0.1         | Time step for each electron move    |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``nonlocalmoves``              | string       | yes, no, v0, v1, v3     | no          | Run with T-moves                    |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``branching_cutoff_scheme``    |              |                         |             |                                     |
-  |                                |              |                         |             |                                     |
-  |                                | string       | classic/DRV/ZSGMA/YL    | classic     | Branch cutoff scheme                |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``maxcpusecs``                 | real         | :math:`\geq 0`          | 3.6e5       | Maximum allowed walltime in seconds |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
-  | ``blocks_between_recompute``   | integer      | :math:`\geq 0`          | dep.        | Wavefunction recompute frequency    |
-  +--------------------------------+--------------+-------------------------+-------------+-------------------------------------+
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | **Name**                       | **Datatype** | **Values**              | **Default** | **Description**                               |
+  +================================+==============+=========================+=============+===============================================+
+  | ``targetwalkers``              | integer      | :math:`> 0`             | dep.        | Overall total number of walkers               |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``blocks``                     | integer      | :math:`\geq 0`          | 1           | Number of blocks                              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``steps``                      | integer      | :math:`\geq 0`          | 1           | Number of steps per block                     |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``warmupsteps``                | integer      | :math:`\geq 0`          | 0           | Number of steps for warming up                |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``timestep``                   | real         | :math:`> 0`             | 0.1         | Time step for each electron move              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``nonlocalmoves``              | string       | yes, no, v0, v1, v3     | no          | Run with T-moves                              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``branching_cutoff_scheme``    |              |                         |             |                                               |
+  |                                |              |                         |             |                                               |
+  |                                | string       | classic/DRV/ZSGMA/YL    | classic     | Branch cutoff scheme                          |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``maxcpusecs``                 | real         | :math:`\geq 0`          | 3.6e5       | Maximum allowed walltime in seconds           |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``blocks_between_recompute``   | integer      | :math:`\geq 0`          | dep.        | Wavefunction recompute frequency              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``spinMoves``                  | text         | yes,no                  | no          | Whether or not to sample the electron spins   |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
+  | ``spinMass``                   | real         | :math:`> 0`             | 1.0         | Effective mass for spin sampling              |
+  +--------------------------------+--------------+-------------------------+-------------+-----------------------------------------------+
 
 .. centered:: Table 9 Main DMC input parameters.
 
@@ -1104,6 +1120,16 @@ Additional information:
 -  ``maxcpusecs``: The default is 100 hours. Once the specified time has
    elapsed, the program will finalize the simulation even if all blocks
    are not completed.
+
+
+-  ``spinMoves`` Determines whether or not the spin variables are sampled following :cite:`Melton2016-1` 
+  and :cite:`Melton2016-2`. If a relativistic calculation is desired using pseudopotentials,
+  spin variable sampling is required.
+
+-  ``spinMass`` If spin sampling is on using ``spinMoves`` == yes, the spin mass determines the rate 
+   of spin sampling, resulting in an effective spin timestep :math:`\tau_s = \frac{\tau}{\mu_s}` where 
+   :math:`\tau` is the normal spatial timestep and :math:`\mu_s` is the value of the spin mass.
+
 
 -  ``energyUpdateInterval``: The default is to update the trial energy
    at every step. Otherwise the trial energy is updated every

--- a/docs/spin_orbit.rst
+++ b/docs/spin_orbit.rst
@@ -1,0 +1,243 @@
+.. _spin-orbit:
+
+Spin-Orbit Calculations in QMC
+==============================
+
+Introduction
+------------
+
+In order to introduce relativistic effects in real materials, 
+in principle the full Dirac equation must be solved where the resulting wave function is a four-component spinor. 
+For the valence electrons that participate in chemistry, 
+the single particle spinors can be well approximated by two-component spinors as two of the components are negligible. Note that this is not true for the deeper core electrons, where all four components contribute. 
+In light of this fact, relativistic pseudopotentials have been developed to remove the core electrons while providing an effective potential for the valence electrons :cite:`Dolg2012`.
+This allows relativistic effects to be studied in QMC methods using two-component spinor wave functions.
+
+In QMCPACK, spin-orbit interactions have been implemented following the methodology described in :cite:`Melton2016-1`
+and :cite:`Melton2016-2`.
+We briefly describe some of the details below.
+
+Single-Particle Spinors
+-----------------------
+The single particle spinors used in QMCPACK take the form 
+
+.. math::
+  :label: eq1
+
+    \phi(\mathbf{r},s) &=& \, \phi^\uparrow(\mathbf{r}) \chi^\uparrow(s) + \phi^{\downarrow}(\mathbf{r})\chi^\downarrow(s) \\
+                       &=& \, \phi^\uparrow(\mathbf{r}) e^{i s} + \phi^{\downarrow}(\mathbf{r}) e^{-i s}\:,
+
+where :math:`s` is the spin variable and using the complex spin representation.
+In order to carry out spin-orbit calculations in solids, the single-particle spinors
+can be obtained using Quantum Espresso. After carrying out the spin-orbit calculation in QE
+(with flags ``noncolin`` = .true., ``lspinorb`` = .true., and a relativistic ``.UPF`` pseudopotential), 
+the spinors can be obtained by using the converter *convertpw4qmc*:
+
+::
+
+    convertpw4qmc data-file-schema.xml
+
+where the ``data-file-schema.xml`` file is output from your QE calculation. 
+This will produce an ``eshdf.h5`` file which contains the up and down components of the spinors per k-point.
+
+Trial Wavefunction
+------------------
+Using the generated single particle spinors, we build the many-body wavefunction in a similar fashion to the normal non-relativistic calculations, namely
+
+.. math::
+  :label: eqn2
+
+  \Psi_T(\mathbf{R},\mathbf{S}) = e^J \sum\limits_\alpha c_\alpha \det_\alpha\left[ \phi_i(\mathbf{r}_j, s_j) \right]\:,
+
+where we now utilize determinants of spinors, as opposed to the usual product of up and down determinants. An example xml input block for the trial wave function is show below:
+
+.. code-block::
+  :caption: wavefunction specification for a single determinant trial wave funciton
+  :name: Listing 1
+
+  <?xml version="1.0"?>
+  <qmcsystem>
+    <wavefunction name="psi0" target="e">
+      <sposet_builder name="spo_builder" type="spinorbspline" href="eshdf.h5" tilematrix="100010001" twistnum="0" source="ion0" size="10">
+        <sposet type="bspline" name="myspo" size="10">
+          <occupation mode="ground"/>
+        </sposet>
+      </sposet_builder>
+      <determinantset>
+        <slaterdeterminant>
+          <determinant id="det" group="u" sposet="myspo" size="10"\>
+        </slaterdeterminant>
+      </determinantset>
+      <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+          <correlation elementType="O" size="8" cusp="0.0">
+             <coefficients id="eO" type="Array">                  
+             </coefficients>
+          </correlation>
+       </jastrow> 
+      <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+        <correlation speciesA="u" speciesB="u" size="8">
+          <coefficients id="uu" type="Array">                  
+          </coefficients>
+        </correlation> 
+      </jastrow> 
+    </wavefunction>
+  </qmcsystem>
+  
+We note that we only specify an "up" determinant, since we no longer 
+need a product of up and down determinants.
+In the Jastrow specification, we only need to provide 
+the jastrow terms for the same spin as there is no longer a
+distinction between the up and down spins. 
+
+We also make a small modification in the particleset specification:
+
+.. code-block::
+  :caption: specification for the electron particle when performing spin-orbit calculations
+  :name: Listing 2
+
+  <particleset name="e" random="yes" randomsrc="ion0">
+     <group name="u" size="10" mass="1.0">
+        <parameter name="charge"              >    -1                    </parameter>
+        <parameter name="mass"                >    1.0                   </parameter>
+     </group>
+  </particleset>
+
+Note that we only provide a single electron group to represent all electrons  in the system, as opposed to the usual separation of up and down electrons. 
+
+*note*: In the current implementation, spinor wavefunctions are only 
+supported at the single determinant level. Multideterminant spinor wave functions will be supported in a future release. 
+
+
+QMC Methods
+-----------
+In this formalism, the spin degree of freedom becomes
+a continuous variable similar to the spatial degrees of freedom.
+In order to sample the spins, we introduce a *spin kinetic energy* operator 
+
+.. math:: 
+  :label: eqn3
+
+  T_s = \sum_{i=1}^{N_e} -\frac{1}{2\mu_s} \left[ \frac{\partial^2}{\partial s_i^2} +  1\right]\:, 
+
+where :math:`\mu_s` is a spin mass. This operator vanishes when acting on
+an arbitrary spinor or anti-symmetric product of spinors due to the offset.
+This avoids any unphysical contribution to the local energy. However, this does contribute to the Green's function in DMC, 
+
+.. math::
+  :label: eqn4
+
+  G(\mathbf{R}' \mathbf{S}' \leftarrow \mathbf{R}\mathbf{S}; \tau, \mu_s) \propto G(\mathbf{R}'\leftarrow\mathbf{R}; \tau) \exp\left[ -\frac{\mu_s}{2\tau}\left| \mathbf{S}' - \mathbf{S} - \frac{\tau}{\mu_s}\mathbf{v}_{\mathbf{S}}(\mathbf{S})\right|^2\right] \:,
+
+where :math:`G(\mathbf{R}'\leftarrow\mathbf{R}; \tau)` is the usual 
+Green's function for the spatial evolution and the *spin kinetic energy* 
+operator introduces a Green's function for the spin variables. 
+Note that this includes a contribution from the *spin drift* :math:`\mathbf{v}_{\mathbf{S}}(\mathbf{S}) =  \nabla_{\mathbf{S}} \ln \Psi_T(\mathbf{S})`.
+
+In both the VMC and DMC methods, the spin sampling is controlled by two input
+parameters in the ``xml`` blocks. 
+
+.. code-block::
+
+  <qmc method="vmc/dmc">
+    <parameter name="steps"    >    50   </parameter>
+    <parameter name="blocks"   >    50   </parameter>
+    <parameter name="walkers"  >    10   </parameter>
+    <parameter name="timestep" >  0.01   </parameter>
+    <parameter name="spinMoves">   yes   </parameter>
+    <parameter name="spinMass" >   1.0   </parameter>
+  </qmc>
+
+The ``spinMoves`` flag turns on the spin sampling, which is off by default. 
+The ``spinMass`` flag sets the :math:`\mu_s` parameter used in the 
+particle updates, and effectively controls the rate of sampling for the spin 
+coordinates relative to the spatial coordinates. 
+A larger/smaller spin mass corresponds to slower/faster spin sampling relative to the spatial coordinates.
+
+Spin-Orbit Effective Core Potentials
+------------------------------------
+
+The spin-orbit contribution to the Hamiltonian can be introduced 
+through the use of Effective Core Potentials (ECPs). 
+As described in :cite:`Melton2016-2`, the relativistic (semilocal) ECPs take the general form
+
+.. math::
+  :label: eq5
+  
+  W^{\rm RECP} = W_{LJ}(r) + \sum_{\ell j m_j} W_{\ell j}(r) | \ell j m_j \rangle \langle \ell j m_j | \:,
+
+where the projectors :math:`|\ell j m_j\rangle` are the so-called spin spherical haronics. 
+An equivalent formulation is to decouple the fully relativistic effective core potential (RECP) into *averaged relativistic* (ARECP)  and *spin-orbit* (SORECP) contributions:
+
+.. math::
+  :label: eq6
+
+  W^{\rm RECP} &=& \, W^{\rm ARECP} + W^{\rm SOECP} \\
+  W^{\rm ARECP} &=& \, W^{\rm ARECP}_L(r) + \sum_{\ell m_\ell} W_\ell^{ARECP}(r) | \ell m_\ell \rangle \langle \ell m_\ell| \\
+  W^{\rm SORECP} &=& \sum_\ell \frac{2}{2\ell + 1} \Delta W^{\rm SORECP}_\ell(r) \sum\limits_{m_\ell,m_\ell'} |\ell m_\ell\rangle \langle \ell m_\ell | \vec{\ell} \cdot \vec{s} | \ell m_\ell' \rangle \langle \ell m_\ell'|\:.
+
+Note that the :math:`W^{\rm ARECP}` takes exactly the same form as 
+the semilocal pseudopotentials used in standard QMC calculations. 
+In the pseudopotential ``.xml`` file format, the :math:`W^{\rm ARECP}_\ell(r)` terms are tabulated as usual.
+If spin-orbit terms are included in the ``.xml`` file, the file must tabulate the entire radial spin-orbit prefactor :math:`\frac{2}{2\ell + 1}\Delta  W^{\rm SORECP}_\ell(r)`.
+We note the following relations between the two representations of the relativistic potentials
+
+.. math::
+  :label: eq7
+
+  W^{\rm ARECP}_\ell(r) &=& \frac{\ell+1}{2\ell+1} W^{\rm RECP}_{\ell,j=\ell+1/2}(r) + \frac{\ell}{2\ell+1} W^{\rm RECP}_{\ell,j=\ell-1/2}(r) \\
+  \Delta W^{\rm SORECP}_\ell(r) &=& W^{\rm RECP}_{\ell,j=\ell+1/2}(r) - W^{\rm RECP}_{\ell,j=\ell-1/2}(r)
+
+The structure of the spin-orbit ``.xml`` is 
+
+.. code-block::
+
+  <?xml version="1.0" encoding="UTF-8"?>
+  <pseudo>
+    <header ... relativistic="yes" ... />
+    <grid ... />
+    <semilocal units="hartree" format="r*V" npots-down="4" npots-up="0" l-local="3" npots="2">
+      <vps l="s" .../>
+      <vps l="p" .../>
+      <vps l="d" .../>
+      <vps l="f" .../>
+      <vps_so l="p" .../>
+      <vps_so l="d" .../>
+    </semilocal>
+  </pseudo>
+
+This is included in the Hamiltonian in the same way as the usual pseudopotentials. 
+If the ``<vps_so>`` elements are found, the spin-orbit contributions will be present in the calculation. 
+By default, the spin-orbit terms will *not* be included in the local energy, but will be accumulated as an estimator. 
+In order to include the spin-orbit directly in the local energy (and therefore propogated into the walker weights in DMC for example),
+the ``physicalSO`` flag should be set to yes in the Hamiltonian input, for example
+
+.. code-block::
+  
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <pairpot name="IonIon" type="coulomb" source=ion0" target="ion0" physical="true"/>
+    <pairpot name="PseudoPot" type="pseudo" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
+      <pseudo elementType="Pb" href="Pb.xml"/>
+    </pairpot>
+  </hamiltonian>
+
+The contribution from the spin-orbit will be printed to the ``.stat.h5`` and ``.scalar.dat`` files for post-processing.
+An example output is shown below
+
+::
+
+  LocalEnergy           =           -3.4419 +/-           0.0014
+  Variance              =            0.1132 +/-           0.0013
+  Kinetic               =            1.1252 +/-           0.0027
+  LocalPotential        =           -4.5671 +/-           0.0028
+  ElecElec              =            1.6881 +/-           0.0025
+  LocalECP              =           -6.5021 +/-           0.0062
+  NonLocalECP           =            0.3286 +/-           0.0025
+  LocalEnergy_sq        =           11.9601 +/-           0.0086
+  SOECP                 =          -0.08163 +/-           0.0003
+
+The ``NonLocalECP`` represents the :math:`W^{\rm ARECP}`, ``SOECP`` represents the :math:`W^{\rm SORECP}`, and the sum is the full :math:`W^{\rm RECP}` contribution.
+
+
+
+.. bibliography:: /bibs/spin-orbit.bib


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This PR adds some of the needed documentation in order to carry out spin-orbit calculations in QMCPACK for VMC/DMC. I added information in each of the relevant sections (Hamiltonian and Observables, Quantum Monte Carlo methods, etc) as well as a dedicated Spin-Orbit calculations in QMC section. I documented each of the relevant changes in the qmcpack input files in order to carry out one of these calculations, as well as provide some of the theory since this is likely unfamiliar to many users. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Documentation content changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macbook

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
