### PR TITLE
Add top level timers for TrialWaveFunction and Hamiltonian

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -72,7 +72,7 @@ ParticleSet::ParticleSet(const DynamicCoordinateKind kind)
       coordinates_(createDynamicCoordinates(kind))
 {
   initPropertyList();
-  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_fine);
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_medium);
 }
 
 ParticleSet::ParticleSet(const ParticleSet& p)
@@ -112,7 +112,7 @@ ParticleSet::ParticleSet(const ParticleSet& p)
     //createSK();
     //SK->DoUpdate=p.SK->DoUpdate;
   }
-  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_fine);
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_medium);
   myTwist = p.myTwist;
 
   G = p.G;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -41,10 +41,22 @@ template<>
 int ParticleSet::Walker_t::cuda_DataSize = 0;
 #endif
 
-const TimerNameList_t<ParticleSet::PSTimers> ParticleSet::PSTimerNames = {{PS_newpos, "ParticleSet::computeNewPosDT"},
-                                                                          {PS_donePbyP, "ParticleSet::donePbyP"},
-                                                                          {PS_accept, "ParticleSet::acceptMove"},
-                                                                          {PS_update, "ParticleSet::update"}};
+enum PSetTimers
+{
+  PS_newpos,
+  PS_donePbyP,
+  PS_accept,
+  PS_update
+};
+
+static const TimerNameList_t<PSetTimers>
+generatePSetTimerNames(std::string& obj_name)
+{
+  return {{PS_newpos, "ParticleSet:" + obj_name + "::computeNewPosDT"},
+          {PS_donePbyP, "ParticleSet:" + obj_name + "::donePbyP"},
+          {PS_accept, "ParticleSet:" + obj_name + "::acceptMove"},
+          {PS_update, "ParticleSet:" + obj_name + "::update"}};
+}
 
 ParticleSet::ParticleSet(const DynamicCoordinateKind kind)
     : quantum_domain(classical),
@@ -60,7 +72,7 @@ ParticleSet::ParticleSet(const DynamicCoordinateKind kind)
       coordinates_(createDynamicCoordinates(kind))
 {
   initPropertyList();
-  setup_timers(myTimers, PSTimerNames, timer_level_fine);
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_fine);
 }
 
 ParticleSet::ParticleSet(const ParticleSet& p)
@@ -100,7 +112,7 @@ ParticleSet::ParticleSet(const ParticleSet& p)
     //createSK();
     //SK->DoUpdate=p.SK->DoUpdate;
   }
-  setup_timers(myTimers, PSTimerNames, timer_level_fine);
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_fine);
   myTwist = p.myTwist;
 
   G = p.G;

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -663,16 +663,6 @@ protected:
   /// Descriptions from distance table creation.  Same order as DistTables.
   std::vector<std::string> distTableDescriptions;
 
-  enum PSTimers
-  {
-    PS_newpos,
-    PS_donePbyP,
-    PS_accept,
-    PS_update
-  };
-
-  static const TimerNameList_t<PSTimers> PSTimerNames;
-
   TimerList_t myTimers;
 
   SingleParticlePos_t myTwist;

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -35,7 +35,7 @@ QMCHamiltonian::QMCHamiltonian(const std::string& aname)
       numCollectables(0),
       myName(aname),
       nlpp_ptr(nullptr),
-      ham_timer_(timer_manager.createTimer("Hamiltonian:" + aname, timer_level_fine))
+      ham_timer_(timer_manager.createTimer("Hamiltonian:" + aname, timer_level_medium))
 #if !defined(REMOVE_TRACEMANAGER)
       ,
       streaming_position(false),

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -35,7 +35,7 @@ QMCHamiltonian::QMCHamiltonian(const std::string& aname)
       numCollectables(0),
       myName(aname),
       nlpp_ptr(nullptr),
-      ham_timer_(timer_manager.createTimer("Hamiltonian::" + aname, timer_level_fine))
+      ham_timer_(timer_manager.createTimer("Hamiltonian:" + aname, timer_level_fine))
 #if !defined(REMOVE_TRACEMANAGER)
       ,
       streaming_position(false),
@@ -95,7 +95,7 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to H, physical Hamiltonian " << std::endl;
     h->myName = aname;
     H.push_back(h);
-    std::string tname = "Hamiltonian::" + aname;
+    std::string tname = "Hamiltonian:" + aname;
     my_timers_.push_back(timer_manager.createTimer(tname, timer_level_fine));
   }
   else

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -34,23 +34,22 @@ QMCHamiltonian::QMCHamiltonian(const std::string& aname)
     : myIndex(0),
       numCollectables(0),
       myName(aname),
-      nlpp_ptr(nullptr)
+      nlpp_ptr(nullptr),
+      ham_timer_(timer_manager.createTimer("Hamiltonian::" + aname, timer_level_fine))
 #if !defined(REMOVE_TRACEMANAGER)
       ,
-      id_sample(0),
-      pid_sample(0),
-      step_sample(0),
-      gen_sample(0),
-      age_sample(0),
-      mult_sample(0),
-      weight_sample(0),
-      position_sample(0)
-{
-  streaming_position = false;
-}
-#else
-{}
+      streaming_position(false),
+      id_sample(nullptr),
+      pid_sample(nullptr),
+      step_sample(nullptr),
+      gen_sample(nullptr),
+      age_sample(nullptr),
+      mult_sample(nullptr),
+      weight_sample(nullptr),
+      position_sample(nullptr)
 #endif
+{
+}
 
 ///// copy constructor is distable by declaring it as private
 //QMCHamiltonian::QMCHamiltonian(const QMCHamiltonian& qh) {}
@@ -97,7 +96,7 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
     h->myName = aname;
     H.push_back(h);
     std::string tname = "Hamiltonian::" + aname;
-    myTimers.push_back(timer_manager.createTimer(tname, timer_level_fine));
+    my_timers_.push_back(timer_manager.createTimer(tname, timer_level_fine));
   }
   else
   {
@@ -468,10 +467,11 @@ void QMCHamiltonian::finalize_traces()
  */
 QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
 {
+  ScopedTimer local_timer(ham_timer_);
   LocalEnergy = 0.0;
   for (int i = 0; i < H.size(); ++i)
   {
-    myTimers[i]->start();
+    ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluate(P);
     if (std::isnan(LocalEnergyComponent))
       APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->myName + " returns NaN\n");
@@ -480,7 +480,6 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
 #if !defined(REMOVE_TRACEMANAGER)
     H[i]->collect_scalar_traces();
 #endif
-    myTimers[i]->stop();
     H[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
   KineticEnergy                      = H[0]->Value;
@@ -513,13 +512,14 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::flex_evaluate(cons
   std::vector<FullPrecRealType> local_energies(H_list.size(), 0.0);
   if (H_list.size() > 1)
   {
+    ScopedTimer local_timer(H_list[0].get().ham_timer_);
     for (int iw = 0; iw < H_list.size(); iw++)
       H_list[iw].get().LocalEnergy = 0.0;
 
     int num_ham_operators = H_list[0].get().H.size();
     for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
     {
-      ScopedTimer local_timer(H_list[0].get().myTimers[i_ham_op]);
+      ScopedTimer h_timer(H_list[0].get().my_timers_[i_ham_op]);
       const auto HC_list(extract_HC_list(H_list, i_ham_op));
 
       // // This lambda accomplishes two things
@@ -667,16 +667,16 @@ void QMCHamiltonian::rejectedMove(ParticleSet& P, Walker_t& ThisWalker)
 
 QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleSet& P)
 {
+  ScopedTimer local_timer(ham_timer_);
   LocalEnergy = 0.0;
   for (int i = 0; i < H.size(); ++i)
   {
-    myTimers[i]->start();
+    ScopedTimer h_timer(my_timers_[i]);
     LocalEnergy += H[i]->evaluateWithToperator(P);
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
     H[i]->collect_scalar_traces();
 #endif
-    myTimers[i]->stop();
   }
   KineticEnergy                      = H[0]->Value;
   P.PropertyList[WP::LOCALENERGY]    = LocalEnergy;
@@ -698,7 +698,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::flex_evaluateWithT
     int num_ham_operators = h_list[0].get().H.size();
     for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
     {
-      ScopedTimer local_timer(h_list[0].get().myTimers[i_ham_op]);
+      ScopedTimer local_timer(h_list[0].get().my_timers_[i_ham_op]);
       const auto HC_list(extract_HC_list(h_list, i_ham_op));
 
       HC_list[0].get().mw_evaluateWithToperator(HC_list, p_list);
@@ -854,6 +854,7 @@ QMCHamiltonian* QMCHamiltonian::makeClone(ParticleSet& qp, TrialWaveFunction& ps
 #ifdef QMC_CUDA
 void QMCHamiltonian::evaluate(MCWalkerConfiguration& W, std::vector<RealType>& energyVector)
 {
+  ScopedTimer local_timer(ham_timer_);
   std::vector<Walker_t*>& walkers = W.WalkerList;
   int nw                          = walkers.size();
   if (LocalEnergyVector.size() != nw)
@@ -868,10 +869,9 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W, std::vector<RealType>& e
     LocalEnergyVector[i] = 0.0;
   for (int i = 0; i < H.size(); ++i)
   {
-    myTimers[i]->start();
+    ScopedTimer h_timer(my_timers_[i]);
     H[i]->addEnergy(W, LocalEnergyVector);
     //H[i]->setObservables(Observables);
-    myTimers[i]->stop();
   }
   //KineticEnergyVector=H[0]->ValueVector;
   for (int iw = 0; iw < walkers.size(); iw++)
@@ -895,6 +895,7 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W,
                               std::vector<RealType>& energyVector,
                               std::vector<std::vector<NonLocalData>>& Txy)
 {
+  ScopedTimer local_timer(ham_timer_);
   std::vector<Walker_t*>& walkers = W.WalkerList;
   int nw                          = walkers.size();
   if (LocalEnergyVector.size() != nw)
@@ -910,9 +911,8 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W,
   //  LocalEnergyVector[i] = 0.0;
   for (int i = 0; i < H.size(); ++i)
   {
-    myTimers[i]->start();
+    ScopedTimer h_timer(my_timers_[i]);
     H[i]->addEnergy(W, LocalEnergyVector, Txy);
-    myTimers[i]->stop();
   }
   KineticEnergyVector = H[0]->ValueVector;
   for (int iw = 0; iw < walkers.size(); iw++)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -356,8 +356,10 @@ private:
   NonLocalECPotential* nlpp_ptr;
   ///vector of Hamiltonians
   std::vector<OperatorBase*> auxH;
-  ///timers
-  std::vector<NewTimer*> myTimers;
+  /// Total timer for H evaluation
+  NewTimer* ham_timer_;
+  /// timers for H components
+  std::vector<NewTimer*> my_timers_;
   ///types of component operators
   std::map<std::string, std::string> operator_types;
   ///data

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -50,7 +50,7 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname)
   for (auto& suffix : suffixes)
   {
     std::string timer_name = "WaveFunction:" + myName + "::" + suffix;
-    TWF_timers_.push_back(timer_manager.createTimer(timer_name));
+    TWF_timers_.push_back(timer_manager.createTimer(timer_name, timer_level_medium));
   }
 }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -49,7 +49,7 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname)
 {
   for (auto& suffix : suffixes)
   {
-    std::string timer_name = "WaveFunction::" + myName + "_" + suffix;
+    std::string timer_name = "WaveFunction:" + myName + "::" + suffix;
     TWF_timers_.push_back(timer_manager.createTimer(timer_name));
   }
 }
@@ -82,18 +82,15 @@ void TrialWaveFunction::addComponent(WaveFunctionComponent* aterm)
 {
   Z.push_back(aterm);
 
-  std::string aname = aterm->ClassName + "::";
+  std::string aname = aterm->ClassName;
   if (!aterm->myName.empty())
-    aname += aterm->myName + "_";
+    aname += ":" + aterm->myName;
 
   if (aterm->is_fermionic)
     app_log() << "  Added a fermionic WaveFunctionComponent " << aname << std::endl;
 
   for (auto& suffix : suffixes)
-  {
-    std::string timer_name = aname + suffix;
-    WFC_timers_.push_back(timer_manager.createTimer(timer_name));
-  }
+    WFC_timers_.push_back(timer_manager.createTimer(aname + "::" + suffix));
 }
 
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -447,8 +447,6 @@ public:
    */
   void flex_evaluateGL(const std::vector<TrialWaveFunction*>& WF_list, const std::vector<ParticleSet*>& P_list) const;
 
-  std::vector<NewTimer*>& get_timers() { return myTimers; }
-
   const std::string& getName() const {return myName;}
 
 private:
@@ -481,7 +479,10 @@ private:
   ///a list of WaveFunctionComponents constituting many-body wave functions
   std::vector<WaveFunctionComponent*> Z;
 
-  std::vector<NewTimer*> myTimers;
+  /// timers at TrialWaveFunction function call level
+  std::vector<NewTimer*> TWF_timers_;
+  /// timers at WaveFunctionComponent function call level
+  std::vector<NewTimer*> WFC_timers_;
   std::vector<RealType> myTwist;
 
   /** @{

--- a/src/QMCWaveFunctions/TrialWaveFunction_CUDA.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction_CUDA.cpp
@@ -41,9 +41,9 @@ void TrialWaveFunction::recompute(MCWalkerConfiguration& W, bool firstTime)
 {
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->recompute(W, firstTime);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -100,9 +100,9 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 0; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->ratio(W, iat, psi_ratios, newG);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -121,9 +121,9 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->ratio(W, iat, psi_ratios, newG, newL);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -142,9 +142,9 @@ void TrialWaveFunction::calcRatio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->calcRatio(W, iat, psi_ratios, newG, newL);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -158,14 +158,14 @@ void TrialWaveFunction::addRatio(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = 1; i < Z.size() - 1; i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->addRatio(W, iat, k, psi_ratios, newG, newL);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
   gpu::synchronize();
-  myTimers[1 + TIMER_SKIP * (Z.size() - 1)]->start();
+  WFC_timers_[1 + TIMER_SKIP * (Z.size() - 1)]->start();
   Z[Z.size() - 1]->addRatio(W, iat, k, psi_ratios, newG, newL);
-  myTimers[1 + TIMER_SKIP * (Z.size() - 1)]->stop();
+  WFC_timers_[1 + TIMER_SKIP * (Z.size() - 1)]->stop();
 }
 
 void TrialWaveFunction::det_lookahead(MCWalkerConfiguration& W,
@@ -179,9 +179,9 @@ void TrialWaveFunction::det_lookahead(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->det_lookahead(W, psi_ratios, grad, lapl, iat, k, kd, nw);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -220,9 +220,9 @@ void TrialWaveFunction::ratio(std::vector<Walker_t*>& walkers,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->ratio(walkers, iatList, rNew, psi_ratios, newG, newL);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -232,9 +232,9 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W, int iat, std::vector<Val
     psi_ratios[iw] = 1.0;
   for (int i = 0, ii = V_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->ratio(W, iat, psi_ratios);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -246,9 +246,9 @@ void TrialWaveFunction::update(MCWalkerConfiguration* W,
 {
   for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->update(W, walkers, iat, acc, k);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -256,9 +256,9 @@ void TrialWaveFunction::update(const std::vector<Walker_t*>& walkers, const std:
 {
   for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->update(walkers, iatList);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -273,9 +273,9 @@ void TrialWaveFunction::gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, 
     }
   for (int i = 0, ii = VGL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->gradLapl(W, grads, lapl);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
   for (int iw = 0; iw < W.WalkerList.size(); iw++)
     for (int ptcl = 0; ptcl < grads.cols(); ptcl++)
@@ -294,9 +294,9 @@ void TrialWaveFunction::NLratios(MCWalkerConfiguration& W,
     psi_ratios[i] = 1.0;
   for (int i = 0, ii = NL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->NLratios(W, jobList, quadPoints, psi_ratios);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -310,9 +310,9 @@ void TrialWaveFunction::NLratios(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = NL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     Z[i]->NLratios(W, Rlist, ElecList, NumCoreElecs, QuadPosList, RatioList, numQuadPoints);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -322,10 +322,10 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W, std::vector<R
     logpsi_opt[iw] = RealType();
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     if (Z[i]->Optimizable)
       Z[i]->addLog(W, logpsi_opt);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -346,7 +346,7 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W,
   // First, sum optimizable part, using fixedG and fixedL as temporaries
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     if (Z[i]->Optimizable)
     {
       Z[i]->addLog(W, logpsi_opt);
@@ -369,7 +369,7 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W,
       Z[i]->addLog(W, logpsi_fixed);
       Z[i]->gradLapl(W, fixedG, fixedL);
     }
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
   // Add on the fixed part to the total laplacian and gradient
   for (int iw = 0; iw < W.WalkerList.size(); iw++)
@@ -392,13 +392,13 @@ void TrialWaveFunction::evaluateOptimizableLog(MCWalkerConfiguration& W,
   // Sum optimizable part of log Psi
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     if (Z[i]->Optimizable)
     {
       Z[i]->addLog(W, logpsi_opt);
       Z[i]->gradLapl(W, optG, optL);
     }
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 
@@ -410,10 +410,10 @@ void TrialWaveFunction::evaluateDerivatives(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = DERIVS_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    myTimers[ii]->start();
+    WFC_timers_[ii]->start();
     if (Z[i]->Optimizable)
       Z[i]->evaluateDerivatives(W, optvars, dlogpsi, dhpsioverpsi);
-    myTimers[ii]->stop();
+    WFC_timers_[ii]->stop();
   }
 }
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Add top level timers for TrialWaveFunction and Hamiltonian to have more organized timer output.
```
    DMCBatched::InitWalkers                       0.0340     0.0254              1       0.034037331
      Hamiltonian::ElecElec                       0.0001     0.0001              1       0.000065253
      Hamiltonian::IonIon                         0.0000     0.0000              1       0.000001764
      Hamiltonian::Kinetic                        0.0000     0.0000              1       0.000002104
      Hamiltonian::LocalECP                       0.0000     0.0000              1       0.000030988
      Hamiltonian::NonLocalECP                    0.0026     0.0002              1       0.002607762
        ParticleSet::computeNewPosDT              0.0012     0.0012           1020       0.000001153
        WaveFunction::J1OrbitalSoA_J1_V           0.0001     0.0001           1020       0.000000086
        WaveFunction::J2OrbitalSoA_J2_V           0.0002     0.0002           1020       0.000000238
        WaveFunction::SlaterDet_V                 0.0009     0.0001           1020       0.000000855
          DiracDeterminantBatched::ratio          0.0000     0.0000           1020       0.000000036
          DiracDeterminantBatched::spoval         0.0007     0.0007           1020       0.000000701
      ParticleSet::update                         0.0049     0.0049              8       0.000614434
      WaveFunction::J1OrbitalSoA_J1_buffer        0.0000     0.0000              5       0.000000403
      WaveFunction::J1OrbitalSoA_J1_recompute     0.0000     0.0000              1       0.000017403
      WaveFunction::J2OrbitalSoA_J2_buffer        0.0000     0.0000              5       0.000000471
      WaveFunction::J2OrbitalSoA_J2_recompute     0.0001     0.0001              1       0.000070222
      WaveFunction::SlaterDet_buffer              0.0004     0.0000              5       0.000073158
        DiracDeterminantBatched::buffer           0.0000     0.0000             16       0.000001859
        DiracDeterminantBatched::spovgl           0.0003     0.0003              8       0.000039906
      WaveFunction::SlaterDet_recompute           0.0006     0.0000              1       0.000569415
        DiracDeterminantBatched::inverse          0.0001     0.0001              8       0.000010488
        DiracDeterminantBatched::spovgl           0.0005     0.0005              8       0.000058764
```
timers of WFC in the same operation will be listed together. New timer name ClassName[:ObjectName][::Function]
```
    QMCUpdateBase::WalkerInit               0.0015     0.0000              1       0.001477957
      Hamiltonian:h0                        0.0007     0.0000              1       0.000728130
        Hamiltonian:ElecElec                0.0000     0.0000              1       0.000023127
        Hamiltonian:IonIon                  0.0000     0.0000              1       0.000000000
        Hamiltonian:Kinetic                 0.0000     0.0000              1       0.000001192
        Hamiltonian:LocalECP                0.0000     0.0000              1       0.000015020
        Hamiltonian:NonLocalECP             0.0007     0.0000              1       0.000684977
          ParticleSet:none::update          0.0002     0.0002             25       0.000008936
          WaveFunction:psi0::NLratio        0.0004     0.0000             25       0.000017319
            J1OrbitalSoA:J1::NLratio        0.0000     0.0000             25       0.000001087
            J2OrbitalSoA:J2::NLratio        0.0001     0.0001             25       0.000002775
            SlaterDet::NLratio              0.0003     0.0000             25       0.000012474
              DiracDeterminant::ratio       0.0000     0.0000             25       0.000000038
              DiracDeterminant::spoval      0.0003     0.0003             25       0.000011816
      ParticleSet:none::update              0.0004     0.0004              1       0.000359058
      WaveFunction:psi0::buffer             0.0000     0.0000              3       0.000003656
        J1OrbitalSoA:J1::buffer             0.0000     0.0000              3       0.000000000
        J2OrbitalSoA:J2::buffer             0.0000     0.0000              3       0.000000318
        SlaterDet::buffer                   0.0000     0.0000              3       0.000002384
          DiracDeterminant::buffer          0.0000     0.0000              4       0.000000238
      WaveFunction:psi0::recompute          0.0004     0.0000              1       0.000363111
        J1OrbitalSoA:J1::recompute          0.0000     0.0000              1       0.000010967
        J2OrbitalSoA:J2::recompute          0.0000     0.0000              1       0.000036955
        SlaterDet::recompute                0.0003     0.0000              1       0.000313044
          DiracDeterminant::inverse         0.0001     0.0001              2       0.000043511
          DiracDeterminant::spovgl          0.0002     0.0002              2       0.000109434
```
Hamiltonian will also need similar change as #2740 to expose correct class name and object names.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'