### PR TITLE
Async ratio and grad computation + Require Intel >=19

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -1,7 +1,7 @@
 # Check compiler version
 SET(INTEL_COMPILER 1)
-IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0 )
-MESSAGE(FATAL_ERROR "Requires Intel 18.0 or higher ")
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0 )
+MESSAGE(FATAL_ERROR "Requires Intel 19.0 or higher ")
 ENDIF()
 
 # Set the std

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -103,8 +103,10 @@ public:
   using WaveFunctionComponent::mw_completeUpdates;
   using WaveFunctionComponent::mw_evalGrad;
   using WaveFunctionComponent::mw_ratioGrad;
+  using WaveFunctionComponent::mw_ratioGradAsync;
   using WaveFunctionComponent::ratio;
   using WaveFunctionComponent::ratioGrad;
+  using WaveFunctionComponent::ratioGradAsync;
   using WaveFunctionComponent::restore;
 
   using WaveFunctionComponent::evalGradSource;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -20,6 +20,9 @@
 
 namespace qmcplusplus
 {
+// for return types
+using PsiValueType = WaveFunctionComponent::PsiValueType;
+
 SlaterDet::SlaterDet(ParticleSet& targetPtcl, const std::string& class_name) : WaveFunctionComponent(class_name)
 {
   Optimizable  = false;
@@ -82,6 +85,40 @@ void SlaterDet::resetParameters(const opt_variables_type& active)
 }
 
 void SlaterDet::reportStatus(std::ostream& os) {}
+
+PsiValueType SlaterDet::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+{
+  return Dets[getDetID(iat)]->ratioGrad(P, iat, grad_iat);
+}
+void SlaterDet::ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat)
+{
+  Dets[getDetID(iat)]->ratioGradAsync(P, iat, ratio, grad_iat);
+}
+
+PsiValueType SlaterDet::ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat)
+{
+  return Dets[getDetID(iat)]->ratioGradWithSpin(P, iat, grad_iat, spingrad_iat);
+}
+
+void SlaterDet::mw_ratioGrad(const RefVector<WaveFunctionComponent>& wfc_list,
+                             const RefVector<ParticleSet>& P_list,
+                             int iat,
+                             std::vector<PsiValueType>& ratios,
+                             std::vector<GradType>& grad_now)
+{
+  const int det_id = getDetID(iat);
+  Dets[det_id]->mw_ratioGrad(extract_DetRef_list(wfc_list, det_id), P_list, iat, ratios, grad_now);
+}
+
+void SlaterDet::mw_ratioGradAsync(const RefVector<WaveFunctionComponent>& wfc_list,
+                                  const RefVector<ParticleSet>& P_list,
+                                  int iat,
+                                  std::vector<PsiValueType>& ratios,
+                                  std::vector<GradType>& grad_now)
+{
+  const int det_id = getDetID(iat);
+  Dets[det_id]->mw_ratioGradAsync(extract_DetRef_list(wfc_list, det_id), P_list, iat, ratios, grad_now);
+}
 
 void SlaterDet::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
 {

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -98,28 +98,25 @@ public:
     return Dets[det_id]->mw_evaluateRatios(extract_DetRef_list(wfc_list, det_id), vp_list, ratios);
   }
 
-  virtual inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
-  {
-    return Dets[getDetID(iat)]->ratioGrad(P, iat, grad_iat);
-  }
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
+  virtual void ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat) override;
 
-  virtual inline PsiValueType ratioGradWithSpin(ParticleSet& P,
-                                                int iat,
-                                                GradType& grad_iat,
-                                                ComplexType& spingrad_iat) override
-  {
-    return Dets[getDetID(iat)]->ratioGradWithSpin(P, iat, grad_iat, spingrad_iat);
-  }
+  virtual PsiValueType ratioGradWithSpin(ParticleSet& P,
+                                         int iat,
+                                         GradType& grad_iat,
+                                         ComplexType& spingrad_iat) override;
 
   virtual void mw_ratioGrad(const RefVector<WaveFunctionComponent>& wfc_list,
                             const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios,
-                            std::vector<GradType>& grad_now) override
-  {
-    const int det_id = getDetID(iat);
-    Dets[det_id]->mw_ratioGrad(extract_DetRef_list(wfc_list, det_id), P_list, iat, ratios, grad_now);
-  }
+                            std::vector<GradType>& grad_now) override;
+
+  void mw_ratioGradAsync(const RefVector<WaveFunctionComponent>& wfc_list,
+                         const RefVector<ParticleSet>& P_list,
+                         int iat,
+                         std::vector<PsiValueType>& ratios,
+                         std::vector<GradType>& grad_now) override;
 
   virtual GradType evalGrad(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->evalGrad(P, iat); }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -46,7 +46,7 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking)
       PhaseDiff(0.0),
       LogValue(0.0),
       OneOverM(1.0),
-      use_tasking(tasking)
+      use_tasking_(tasking)
 {
   for (auto& suffix : suffixes)
   {
@@ -555,7 +555,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
   ScopedTimer local_timer(TWF_timers_[VGL_TIMER]);
   grad_iat = 0.0;
   PsiValueType r(1.0);
-  if (use_tasking)
+  if (use_tasking_)
   {
     std::vector<GradType> grad_components(Z.size(), 0.0);
     std::vector<PsiValueType> ratio_components(Z.size(), 0.0);
@@ -621,7 +621,7 @@ void TrialWaveFunction::flex_calcRatioGrad(const RefVector<TrialWaveFunction>& w
     const int num_wfc             = wf_list[0].get().Z.size();
     auto& wavefunction_components = wf_list[0].get().Z;
 
-    if (wf_list[0].get().use_tasking)
+    if (wf_list[0].get().use_tasking_)
     {
       std::vector<std::vector<PsiValueType>> ratios_components(num_wfc, std::vector<PsiValueType>(wf_list.size()));
       std::vector<std::vector<GradType>> grads_components(num_wfc, std::vector<GradType>(wf_list.size()));
@@ -1076,7 +1076,7 @@ void TrialWaveFunction::reset() {}
 
 TrialWaveFunction* TrialWaveFunction::makeClone(ParticleSet& tqp) const
 {
-  TrialWaveFunction* myclone   = new TrialWaveFunction(myName, use_tasking);
+  TrialWaveFunction* myclone   = new TrialWaveFunction(myName, use_tasking_);
   myclone->BufferCursor        = BufferCursor;
   myclone->BufferCursor_scalar = BufferCursor_scalar;
   for (int i = 0; i < Z.size(); ++i)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -557,7 +557,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
   PsiValueType r(1.0);
   if (use_tasking_)
   {
-    std::vector<GradType> grad_components(Z.size(), 0.0);
+    std::vector<GradType> grad_components(Z.size(), GradType(0.0));
     std::vector<PsiValueType> ratio_components(Z.size(), 0.0);
     for (int i = 0, ii = VGL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
     {

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -449,7 +449,7 @@ public:
 
   const std::string& getName() const { return myName; }
 
-  const bool use_tasking() const { return use_tasking_; }
+  bool use_tasking() const { return use_tasking_; }
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -449,6 +449,8 @@ public:
 
   const std::string& getName() const { return myName; }
 
+  const bool use_tasking() const { return use_tasking_; }
+
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
 
@@ -474,7 +476,7 @@ private:
   RealType OneOverM;
 
   /// if true, using internal tasking implementation
-  const bool use_tasking;
+  const bool use_tasking_;
 
   ///a list of WaveFunctionComponents constituting many-body wave functions
   std::vector<WaveFunctionComponent*> Z;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -97,7 +97,7 @@ public:
   ///differential laplacians
   ParticleSet::ParticleLaplacian_t L;
 
-  TrialWaveFunction(const std::string& aname = "psi0");
+  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false);
 
   // delete copy constructor
   TrialWaveFunction(const TrialWaveFunction&) = delete;
@@ -447,7 +447,7 @@ public:
    */
   void flex_evaluateGL(const std::vector<TrialWaveFunction*>& WF_list, const std::vector<ParticleSet*>& P_list) const;
 
-  const std::string& getName() const {return myName;}
+  const std::string& getName() const { return myName; }
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
@@ -474,7 +474,7 @@ private:
   RealType OneOverM;
 
   /// if true, using internal tasking implementation
-  bool use_tasking;
+  const bool use_tasking;
 
   ///a list of WaveFunctionComponents constituting many-body wave functions
   std::vector<WaveFunctionComponent*> Z;

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -20,6 +20,9 @@
 
 namespace qmcplusplus
 {
+// for return types
+using PsiValueType = WaveFunctionComponent::PsiValueType;
+
 WaveFunctionComponent::WaveFunctionComponent(const std::string& class_name, const std::string& obj_name)
     : IsOptimizing(false),
       Optimizable(true),
@@ -45,6 +48,40 @@ WaveFunctionComponent::WaveFunctionComponent(const std::string& class_name, cons
 //   //if(d2LogPsi.size()) dLogPsi.resize(d2LogPsi.size());
 //   //if(dPsi) dPsi=old.dPsi->makeClone();
 // }
+
+
+PsiValueType WaveFunctionComponent::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+{
+  APP_ABORT("WaveFunctionComponent::ratioGrad is not implemented in " + ClassName + " class.");
+  return ValueType();
+}
+
+void WaveFunctionComponent::ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat)
+{
+#pragma omp task default(none) firstprivate(iat) shared(P, ratio, grad_iat)
+  ratio = ratioGrad(P, iat, grad_iat);
+}
+
+void WaveFunctionComponent::mw_ratioGrad(const RefVector<WaveFunctionComponent>& WFC_list,
+                                         const RefVector<ParticleSet>& P_list,
+                                         int iat,
+                                         std::vector<PsiValueType>& ratios,
+                                         std::vector<GradType>& grad_new)
+{
+#pragma omp parallel for
+  for (int iw = 0; iw < WFC_list.size(); iw++)
+    ratios[iw] = WFC_list[iw].get().ratioGrad(P_list[iw], iat, grad_new[iw]);
+}
+
+void WaveFunctionComponent::mw_ratioGradAsync(const RefVector<WaveFunctionComponent>& WFC_list,
+                                              const RefVector<ParticleSet>& P_list,
+                                              int iat,
+                                              std::vector<PsiValueType>& ratios,
+                                              std::vector<GradType>& grad_new)
+{
+#pragma omp task default(none) firstprivate(WFC_list, P_list, iat) shared(ratios, grad_new)
+  mw_ratioGrad(WFC_list, P_list, iat, ratios, grad_new);
+}
 
 
 void WaveFunctionComponent::setDiffOrbital(DiffWaveFunctionComponentPtr d) { dPsi = d; }

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -289,11 +289,9 @@ struct WaveFunctionComponent : public QMCTraits
    * @param iat the index of a particle
    * @param grad_iat Gradient for the active particle
    */
-  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
-  {
-    APP_ABORT("WaveFunctionComponent::ratioGrad is not implemented in " + ClassName + " class.");
-    return ValueType();
-  }
+  virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
+
+  virtual void ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat);
 
   /** evaluate the ratio of the new to old WaveFunctionComponent value and the new spin gradient
    * Default implementation assumes that WaveFunctionComponent does not explicitly depend on Spin.
@@ -318,12 +316,13 @@ struct WaveFunctionComponent : public QMCTraits
                             const RefVector<ParticleSet>& P_list,
                             int iat,
                             std::vector<PsiValueType>& ratios,
-                            std::vector<GradType>& grad_new)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      ratios[iw] = WFC_list[iw].get().ratioGrad(P_list[iw], iat, grad_new[iw]);
-  }
+                            std::vector<GradType>& grad_new);
+
+  virtual void mw_ratioGradAsync(const RefVector<WaveFunctionComponent>& WFC_list,
+                                 const RefVector<ParticleSet>& P_list,
+                                 int iat,
+                                 std::vector<PsiValueType>& ratios,
+                                 std::vector<GradType>& grad_new);
 
   /** a move for iat-th particle is accepted. Update the current content.
    * @param P target ParticleSet

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -62,7 +62,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
   app_summary() << std::endl;
   app_summary() << " Many-body wavefunction" << std::endl;
   app_summary() << " -------------------" << std::endl;
-  app_summary() << "  Name: " << myName << std::endl;
+  app_summary() << "  Name: " << myName << "   tasking: " << (targetPsi->use_tasking() ? "yes" : "no") << std::endl;
   app_summary() << std::endl;
 
   ReportEngine PRE(ClassName, "build");

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -44,9 +44,10 @@ namespace qmcplusplus
 WaveFunctionFactory::WaveFunctionFactory(const std::string& psiName,
                                          ParticleSet& qp,
                                          PtclPoolType& pset,
-                                         Communicate* c)
+                                         Communicate* c,
+                                         bool tasking)
     : MPIObjectBase(c),
-      targetPsi(std::make_unique<TrialWaveFunction>(psiName)),
+      targetPsi(std::make_unique<TrialWaveFunction>(psiName, tasking)),
       targetPtcl(qp),
       ptclPool(pset),
       myNode(NULL)

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -33,11 +33,13 @@ public:
   typedef std::map<std::string, ParticleSet*> PtclPoolType;
 
   /** constructor
+   * @param psiName name for both the factory and psi
    * @param qp quantum particleset
    * @param pset pool of particlesets
    * @param c  communicator
+   * @param c  using tasking inside TWF
    */
-  WaveFunctionFactory(const std::string& psiName, ParticleSet& qp, PtclPoolType& pset, Communicate* c);
+  WaveFunctionFactory(const std::string& psiName, ParticleSet& qp, PtclPoolType& pset, Communicate* c, bool tasking = false);
 
   ///read from xmlNode
   bool put(xmlNodePtr cur);

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -42,12 +42,13 @@ WaveFunctionPool::~WaveFunctionPool()
 
 bool WaveFunctionPool::put(xmlNodePtr cur)
 {
-  std::string id("psi0"), target("e"), role("extra");
+  std::string id("psi0"), target("e"), role("extra"), tasking("no");
   OhmmsAttributeSet pAttrib;
   pAttrib.add(id, "id");
   pAttrib.add(id, "name");
   pAttrib.add(target, "target");
   pAttrib.add(target, "ref");
+  pAttrib.add(tasking, "tasking");
   pAttrib.add(role, "role");
   pAttrib.put(cur);
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
@@ -80,7 +81,7 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   bool isPrimary                  = true;
   if (pit == myPool.end())
   {
-    psiFactory = new WaveFunctionFactory(id, *qp, ptcl_pool_.getPool(), myComm);
+    psiFactory = new WaveFunctionFactory(id, *qp, ptcl_pool_.getPool(), myComm, tasking == "yes");
     isPrimary  = (myPool.empty() || role == "primary");
     myPool[id] = psiFactory;
   }

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -55,6 +55,14 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   if (tasking != "yes" && tasking != "no")
     myComm->barrier_and_abort("Incorrect input value of 'tasking' attribute. It can only be 'yes' or 'no'.");
 
+#if defined(__INTEL_COMPILER)
+  if (tasking == "yes")
+  {
+    tasking = "no";
+    app_warning() << "Asynchronous tasking has to be turned off on builds using Intel compilers." << std::endl;
+  }
+#endif
+
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
 
   // Ye: the overall logic of the "check" is still not clear to me.

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -51,6 +51,10 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   pAttrib.add(tasking, "tasking");
   pAttrib.add(role, "role");
   pAttrib.put(cur);
+
+  if (tasking != "yes" && tasking != "no")
+    myComm->barrier_and_abort("Incorrect input value of 'tasking' attribute. It can only be 'yes' or 'no'.");
+
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
 
   // Ye: the overall logic of the "check" is still not clear to me.
@@ -76,6 +80,7 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   {
     APP_ABORT("WaveFunctionPool::put Target ParticleSet is not found.");
   }
+
   std::map<std::string, WaveFunctionFactory*>::iterator pit(myPool.find(id));
   WaveFunctionFactory* psiFactory = 0;
   bool isPrimary                  = true;

--- a/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
@@ -38,6 +38,16 @@
                     0 DIAMOND2_SCALARS # VMC
                     )
 
+  # 4 batches of 4 walkers with asynchronous WF computation
+  QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch-4b-asynctwf_sdj
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
+                    qmc_short
+                    qmc_short_vmcbatch_4b_asynctwf.in.xml
+                    1 4
+                    TRUE
+                    0 DIAMOND2_SCALARS # VMC
+                    )
+
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch-4b_sdbatch_jas
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
                     qmc_short

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b_asynctwf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b_asynctwf.in.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="qmc_short" series="0">
+      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+   </project>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  6.74632230        6.74632230        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="8" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="4" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+                     3.37316115        3.37316115        0.00000000
+                     5.05974172        5.05974172        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e" tasking="yes">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <slaterdeterminant>
+               <determinant id="updet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="8">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.137281409 -0.1032026175 -0.0857843003 -0.07105398747 -0.05719926375 
+-0.04090373292 -0.0259365816 -0.01321962532
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2969700506 0.2407083361 0.1830009217 0.1355563432 0.09514725057 0.06112611044 
+0.03450633959 0.01532305926
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4704510359 0.3531940571 0.2579420961 0.1820538307 0.1211946391 0.07487030513 
+0.04028963542 0.01742251234
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml" algorithm="batched">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+   </qmcsystem>
+   <qmc method="vmc_batch" move="pbyp">
+      <parameter name="total_walkers"             >    16              </parameter>
+      <parameter name="crowds"              >    4               </parameter>
+      <parameter name="blocks"              >    1000            </parameter>
+      <parameter name="steps"               >    2.0             </parameter>
+      <parameter name="subSteps"            >    2               </parameter>
+      <parameter name="timestep"            >    0.3             </parameter>
+      <parameter name="warmupSteps"         >    100             </parameter>
+   </qmc>
+</simulation>


### PR DESCRIPTION
## Proposed changes
add WFC::mw_ratioGradAsync and WFC::ratioGradAsync to support leverage asynchronous OpenMP tasking.
This is a very very preliminary implementation.
Would like to merge this to test more compilers from nightly tests.
`<wavefunction tasking="yes">` triggers the async code path.

Add a safeguard for Intel compiler and raise minimal requirement to 19.0

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'