### PR TITLE
Raise clang minimal version to 7

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -1,7 +1,7 @@
 # Check compiler version
-IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4 )
+IF ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0 )
   MESSAGE(STATUS "Compiler Version ${CMAKE_CXX_COMPILER_VERSION}")
-  MESSAGE(FATAL_ERROR "Requires clang 3.4 or higher ")
+  MESSAGE(FATAL_ERROR "Requires clang 7.0 or higher ")
 ENDIF()
 
 # Set the std


### PR DESCRIPTION
## Proposed changes
7 is needed to get omp task compiled correctly.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
@prckent  tested it.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
