### PR TITLE
Update cray-libsci handling in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,11 +434,6 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   ENDIF(ENABLE_MKL)
   IF ( HAVE_MKL )
     # Skip adding Math::BLAS_LAPACK target which has been imported by FindMKL.
-  ELSEIF (CMAKE_SYSTEM_NAME STREQUAL "CrayLinuxEnvironment")
-    # Cray specific environment variable indicates we are on a cray. Assume libsci will be linked
-    # preferable to attempt a compile/link
-    MESSAGE(STATUS "Assuming Cray libsci or other BLAS/LAPACK will be linked by compiler wrappers")
-    ADD_LIBRARY(Math::BLAS_LAPACK INTERFACE IMPORTED)
   ELSE()
     # The last search for Blas/Lapack
     find_package(LAPACK REQUIRED)

--- a/config/build_tulip.sh
+++ b/config/build_tulip.sh
@@ -17,7 +17,7 @@ cd $folder
 cmake -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC \
       -DQMC_MIXED_PRECISION=1 -DENABLE_OFFLOAD=ON \
       -DENABLE_CUDA=ON -DCUDA_ARCH=sm_70 -DCUDA_HOST_COMPILER=`which gcc` \
-      -DCUDA_TOOLKIT_ROOT_DIR=$CUDA_HOME \
+      -DCUDA_TOOLKIT_ROOT_DIR=$CUDA_HOME -DBLA_VENDOR=OpenBLAS \
       -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment \
       .. && make -j32
 cd ..
@@ -34,7 +34,7 @@ mkdir $folder
 cd $folder
 cmake -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC \
       -DQMC_MIXED_PRECISION=1 -DENABLE_OFFLOAD=ON \
-      -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment \
+      -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DBLA_VENDOR=OpenBLAS \
       .. && make -j32
 cd ..
 
@@ -47,7 +47,7 @@ mkdir $folder
 cd $folder
 cmake -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC \
       -DQMC_MIXED_PRECISION=1 -DENABLE_OFFLOAD=ON -DQMC_COMPLEX=1 \
-      -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment \
+      -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DBLA_VENDOR=OpenBLAS \
       .. && make -j32
 cd ..
 module unload craype-accel-amd-gfx906

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -42,13 +42,11 @@ public:
   using mGradType  = TinyVector<mValueType, DIM>;
 
   template<typename DT>
-  using OffloadAllocator = OMPallocator<DT, aligned_allocator<DT>>;
-  template<typename DT>
   using OffloadPinnedAllocator        = OMPallocator<DT, PinnedAlignedAllocator<DT>>;
   using OffloadPinnedValueVector_t    = Vector<ValueType, OffloadPinnedAllocator<ValueType>>;
   using OffloadPinnedValueMatrix_t    = Matrix<ValueType, OffloadPinnedAllocator<ValueType>>;
   using OffloadPinnedPsiValueVector_t = Vector<PsiValueType, OffloadPinnedAllocator<PsiValueType>>;
-  using OffloadVGLVector_t            = VectorSoaContainer<ValueType, DIM + 2, OffloadAllocator<ValueType>>;
+  using OffloadVGLVector_t            = VectorSoaContainer<ValueType, DIM + 2, OffloadPinnedAllocator<ValueType>>;
 
   /** constructor
    *@param spos the single-particle orbital set


### PR DESCRIPTION
## Proposed changes
FindLAPACK handles correctly BLAS/LAPACK passed in via compiler wrappers by marking the search successful and leaving entries just empty. So we don't need to write bypass logic in our cmake. By removing that, we gain the capability of overriding BLAS/LAPACK from cray compiler wrappers. Due to Cray moving to newer Modules environment, the old way of unload cray-libsci becomes not feasible.

This PR also includes a small optimization beneficial overall and actually seems to fix issues of using Cray compiler.

## What type(s) of changes does this code introduce?
- Optimization and compiler fix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Tulip.
Cori. Theta is not tested due to maintenance but the software stack is very close to Cori. In general, we use ENABLE_MKL anyway.
Bora.

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'