### PR TITLE
Add NVTX calls for timers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,7 +723,7 @@ ENDIF(QMC_CUDA OR ENABLE_CUDA)
 
 OPTION(USE_NVTX_API "Enable/disable NVTX regions in CUDA code." OFF)
 IF(USE_NVTX_API)
-  IF(HAVE_CUDA)
+  IF(HAVE_CUDA OR ENABLE_OFFLOAD)
     FIND_LIBRARY(NVTX_API_LIB
       NAME nvToolsExt
       HINTS ${CUDA_TOOLKIT_ROOT_DIR}
@@ -733,7 +733,7 @@ IF(USE_NVTX_API)
     ENDIF(NOT NVTX_API_LIB)
     MESSAGE("CUDA nvToolsExt library: ${NVTX_API_LIB}")
     LINK_LIBRARIES(${NVTX_API_LIB})
-  ENDIF(HAVE_CUDA)
+  ENDIF(HAVE_CUDA OR ENABLE_OFFLOAD)
 ENDIF(USE_NVTX_API)
 
 #-------------------------------------------------------------------

--- a/src/Utilities/NewTimer.cpp
+++ b/src/Utilities/NewTimer.cpp
@@ -45,6 +45,10 @@ void TimerType<CLOCK>::start()
     __itt_task_begin(manager->task_domain, __itt_null, parent_task, task_name);
 #endif
 
+#ifdef USE_NVTX_API
+    nvtxRangePushA(name.c_str());
+#endif
+
     bool is_true_master(true);
     for (int level = omp_get_level(); level > 0; level--)
       if (omp_get_ancestor_thread_num(level) != 0)
@@ -88,6 +92,10 @@ void TimerType<CLOCK>::stop()
 
 #ifdef USE_VTUNE_TASKS
     __itt_task_end(manager->task_domain);
+#endif
+
+#ifdef USE_NVTX_API
+    nvtxRangePop();
 #endif
 
     bool is_true_master(true);

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -28,6 +28,10 @@
 #include <ittnotify.h>
 #endif
 
+#ifdef USE_NVTX_API
+#include <nvToolsExt.h>
+#endif
+
 #define USE_STACK_TIMERS
 
 namespace qmcplusplus


### PR DESCRIPTION
Use NVTX calls to allow timer regions to show up on NVidia profiling tools.

These also work with OpenMP offload.  The CMakeLists.txt file has been updated to allow USE_NVTX_API with ENABLE_OFFLOAD.  This may require CUDA_TOOLKIT_ROOT_DIR to be specified when running cmake.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
