### PR TITLE
Update CADES build script modules

### DIFF
--- a/config/build_ornl_cades.sh
+++ b/config/build_ornl_cades.sh
@@ -7,24 +7,24 @@
 ## * Execute this script in trunk/                            ##
 ##   ./config/build_ornl_cades.sh                             ##
 ##                                                            ##
-## Last verified: Mar 11, 2020                                ##
+## Last verified: Nov 12, 2020                                ##
 ################################################################
 
 # module files resulting from module imports below:
 # Currently Loaded Modulefiles:
-#   1) python/3.6.3           3) openmpi/3.1.5          5) gcc/6.3.0              7) fftw/3.3.5-pe3         9) boost/1.67.0-pe3
-#   2) intel/18.0.0           4) PE-intel/3.0           6) hdf5_parallel/1.10.3   8) cmake/3.11.0          10) libxml2/2.9.9
+#   1) python/3.6.3           3) openmpi/3.1.5          5) gcc/6.3.0              7) hdf5_parallel/1.10.3   9) cmake/3.12.0          11) libxml2/2.9.9
+#   2) intel/18.0.0           4) PE-intel/3.0           6) intel/19.0.3           8) fftw/3.3.5            10) boost/1.67.0
 
 source $MODULESHOME/init/bash
 module purge
 module load python
 module load PE-intel/3.0
-module load intel/18.0.0
 module load gcc/6.3.0
+module load intel/19.0.3
 module load hdf5_parallel/1.10.3
-module load fftw/3.3.5-pe3
-module load cmake
-module load boost/1.67.0-pe3
+module load fftw/3.3.5
+module load cmake/3.12.0
+module load boost/1.67.0
 module load libxml2/2.9.9
 module list
 


### PR DESCRIPTION
## Proposed changes

Updates modules to be loaded at CADES

## What type(s) of changes does this code introduce?

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

CADES. CPU real (non-skylake) build was tested to pass deterministic tests, and the Skylake build seems to run project calculations fluently. 

Parallel HDF5 modules are broken/not compatible with (at least) Intel19. Trying to load them causes a warning, but CMake successfully reverts to serial HDF5. Maybe this needs to be sorted out with CADES support.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
