### PR TITLE
Fix convert4qmc when eigenval_0 is missing in h5.

### DIFF
--- a/src/QMCTools/LCAOHDFParser.cpp
+++ b/src/QMCTools/LCAOHDFParser.cpp
@@ -116,18 +116,24 @@ void LCAOHDFParser::parse(const std::string& fname)
   Matrix<double> myvec(1, numMO);
 
   hin.push("Super_Twist");
-  hin.read(myvec, "eigenval_0");
-  for (int i = 0; i < numMO; i++)
-    EigVal_alpha[i] = myvec[0][i];
-
-  //Reading Eigenvals for Spin unRestricted calculation. This section is needed to set the occupation numbers
-  if (!SpinRestricted)
+  if (hin.readEntry(myvec, "eigenval_0"))
   {
-    hin.read(myvec, "eigenval_1");
+    // eigenval_0 exists on file
     for (int i = 0; i < numMO; i++)
-      EigVal_beta[i] = myvec[0][i];
-  }
+      EigVal_alpha[i] = myvec[0][i];
 
+    //Reading Eigenvals for Spin unRestricted calculation. This section is needed to set the occupation numbers
+    if (!SpinRestricted)
+    {
+      hin.read(myvec, "eigenval_1");
+      for (int i = 0; i < numMO; i++)
+        EigVal_beta[i] = myvec[0][i];
+    }
+  }
+  else
+  {
+    app_warning() << "eigenval_0 doesn't exist in h5 file. Treat all values zero." << std::endl;
+  }
   hin.close();
 
 

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -31,8 +31,7 @@ int main(int argc, char** argv)
 {
   if (argc < 2)
   {
-    std::cout << "Usage: convert [-gaussian|-casino|-gamess|-orbitals] filename "
-              << std::endl;
+    std::cout << "Usage: convert [-gaussian|-casino|-gamess|-orbitals] filename " << std::endl;
     std::cout << "[-nojastrow -hdf5 -prefix title -addCusp -production -NbImages NimageX NimageY NimageZ]" << std::endl;
     std::cout << "[-psi_tag psi0 -ion_tag ion0 -gridtype log|log0|linear -first ri -last rf]" << std::endl;
     std::cout << "[-size npts -multidet multidet.h5 -ci file.out -threshold cimin -TargetState state_number "
@@ -50,298 +49,304 @@ int main(int argc, char** argv)
   mpi3::environment env(argc, argv);
   OHMMS::Controller->initialize(env);
 #endif
-  if (OHMMS::Controller->rank() != 0)
+  try
   {
-    outputManager.shutOff();
-  }
-  Random.init(0, 1, -1);
-  std::cout.setf(std::ios::scientific, std::ios::floatfield);
-  std::cout.setf(std::ios::right, std::ios::adjustfield);
-  std::cout.precision(12);
-  QMCGaussianParserBase::init();
-  QMCGaussianParserBase* parser = 0;
-  int iargc                     = 0;
-  std::string in_file(argv[1]);
+    if (OHMMS::Controller->rank() != 0)
+    {
+      outputManager.shutOff();
+    }
+    Random.init(0, 1, -1);
+    std::cout.setf(std::ios::scientific, std::ios::floatfield);
+    std::cout.setf(std::ios::right, std::ios::adjustfield);
+    std::cout.precision(12);
+    QMCGaussianParserBase::init();
+    QMCGaussianParserBase* parser = 0;
+    int iargc                     = 0;
+    std::string in_file(argv[1]);
 
 
-  std::string punch_file;
-  std::string psi_tag("psi0");
-  std::string ion_tag("ion0");
-  std::string jastrow("j");
-  std::string prefix;
+    std::string punch_file;
+    std::string psi_tag("psi0");
+    std::string ion_tag("ion0");
+    std::string jastrow("j");
+    std::string prefix;
 
 
-  int TargetState = 0;
-  bool addJastrow = true;
-  bool usehdf5    = false;
-  bool h5         = false;
-  bool useprefix  = false;
-  bool debug      = false;
-  bool prod       = false;
-  bool ci = false, zeroCI = false, orderByExcitation = false, addCusp = false, multidet = false,
-       optDetCoeffs = false;
-  double thres      = 1e-20;
-  int readNO        = 0; // if > 0, read Natural Orbitals from gamess output
-  int readGuess     = 0; // if > 0, read Initial Guess from gamess output
-  std::vector<int> Image;
-  while (iargc < argc)
-  {
-    std::string a(argv[iargc]);
-    if (a == "-gaussian")
+    int TargetState = 0;
+    bool addJastrow = true;
+    bool usehdf5    = false;
+    bool h5         = false;
+    bool useprefix  = false;
+    bool debug      = false;
+    bool prod       = false;
+    bool ci = false, zeroCI = false, orderByExcitation = false, addCusp = false, multidet = false, optDetCoeffs = false;
+    double thres  = 1e-20;
+    int readNO    = 0; // if > 0, read Natural Orbitals from gamess output
+    int readGuess = 0; // if > 0, read Initial Guess from gamess output
+    std::vector<int> Image;
+    while (iargc < argc)
     {
-      parser  = new GaussianFCHKParser(argc, argv);
-      in_file = argv[++iargc];
+      std::string a(argv[iargc]);
+      if (a == "-gaussian")
+      {
+        parser  = new GaussianFCHKParser(argc, argv);
+        in_file = argv[++iargc];
+      }
+      else if (a == "-gamess")
+      {
+        parser  = new GamesAsciiParser(argc, argv);
+        in_file = argv[++iargc];
+      }
+      else if (a == "-orbitals")
+      {
+        parser  = new LCAOHDFParser(argc, argv);
+        h5      = true;
+        in_file = argv[++iargc];
+      }
+      else if (a == "-casino")
+      {
+        parser  = new CasinoParser(argc, argv);
+        in_file = argv[++iargc];
+      }
+      else if (a == "-b")
+      {
+        parser  = new BParser(argc, argv);
+        in_file = argv[++iargc];
+      }
+      else if (a == "-hdf5")
+      {
+        usehdf5 = true;
+      }
+      else if (a == "-psi_tag")
+      {
+        psi_tag = argv[++iargc];
+      }
+      else if (a == "-production")
+      {
+        prod = true;
+      }
+      else if (a == "-ion_tag")
+      {
+        ion_tag = argv[++iargc];
+      }
+      else if (a == "-prefix")
+      {
+        prefix    = argv[++iargc];
+        useprefix = true;
+      }
+      else if (a == "-ci")
+      {
+        ci         = true;
+        punch_file = argv[++iargc];
+      }
+      else if (a == "-multidet")
+      {
+        multidet   = true;
+        punch_file = argv[++iargc];
+      }
+      else if (a == "-NbImages")
+      {
+        int temp;
+        temp = atoi(argv[++iargc]);
+        temp += 1 - temp % 2;
+        Image.push_back(temp);
+        temp = atoi(argv[++iargc]);
+        temp += 1 - temp % 2;
+        Image.push_back(temp);
+        temp = atoi(argv[++iargc]);
+        temp += 1 - temp % 2;
+        Image.push_back(temp);
+      }
+      else if (a == "-addCusp")
+      {
+        addCusp = true;
+      }
+      else if (a == "-threshold")
+      {
+        thres = atof(argv[++iargc]);
+      }
+      else if (a == "-optDetCoeffs")
+      {
+        optDetCoeffs = true;
+      }
+      else if (a == "-TargetState")
+      {
+        TargetState = atoi(argv[++iargc]);
+      }
+      else if (a == "-NaturalOrbitals")
+      {
+        readNO = atoi(argv[++iargc]);
+      }
+      else if (a == "-readInitialGuess")
+      {
+        readGuess = atoi(argv[++iargc]);
+      }
+      else if (a == "-zeroCI")
+      {
+        zeroCI = true;
+      }
+      else if (a == "-orderByExcitation")
+      {
+        orderByExcitation = true;
+      }
+      else if (a == "-cutoff")
+      {
+        orderByExcitation = true;
+      }
+      else if (a == "-debug")
+      {
+        debug = true;
+      }
+      else if (a == "-nojastrow")
+      {
+        addJastrow = false;
+        jastrow    = "noj";
+      }
+      ++iargc;
     }
-    else if (a == "-gamess")
+    if (readNO > 0 && readGuess > 0)
     {
-      parser  = new GamesAsciiParser(argc, argv);
-      in_file = argv[++iargc];
+      std::cerr << "Can only use one of: -NaturalOrbitals or -readInitialGuess. \n";
+      abort();
     }
-    else if (a == "-orbitals")
+    //Failed to create a parser. Try with the extension
+    std::string ext = getExtension(in_file);
+    if (parser == 0)
     {
-      parser  = new LCAOHDFParser(argc, argv);
-      h5= true;
-      in_file = argv[++iargc];
+      if (ext == "data")
+      {
+        WARNMSG("Creating CasinoParser")
+        parser = new CasinoParser(argc, argv);
+      }
+      else if (ext == "Fchk")
+      {
+        WARNMSG("Creating GaussianFCHKParser")
+        parser = new GaussianFCHKParser(argc, argv);
+      }
+      else if (ext == "h5")
+      {
+        WARNMSG("Creating LCAOHDFParser")
+        parser = new LCAOHDFParser(argc, argv);
+      }
+      else if (ext == "10")
+      {
+        WARNMSG("Creating BParser")
+        parser = new BParser(argc, argv);
+      }
+      else if (ext == "out")
+      {
+        WARNMSG("Creating GamesAsciiParser")
+        parser = new GamesAsciiParser(argc, argv);
+      }
+      else
+      {
+        std::cerr << "Unknown extension: " << ext << std::endl;
+        exit(1);
+      }
     }
-    else if (a == "-casino")
+    if (useprefix != true)
     {
-      parser  = new CasinoParser(argc, argv);
-      in_file = argv[++iargc];
+      prefix = in_file;
+      std::string delimiter;
+      if (ext == "h5")
+        delimiter = ".h5";
+      else
+        delimiter = ".out";
+      int pos = 0;
+      std::string token;
+      pos   = prefix.find(delimiter);
+      token = prefix.substr(0, pos);
+      prefix.erase(0, pos + delimiter.length());
+      prefix = token;
     }
-    else if (a == "-b")
+    std::cout << "Using " << prefix << " to name output files" << std::endl;
+
+    parser->Title       = prefix;
+    parser->debug       = debug;
+    parser->DoCusp      = addCusp;
+    parser->UseHDF5     = usehdf5;
+    parser->singledetH5 = h5;
+    if (h5)
     {
-      parser  = new BParser(argc, argv);
-      in_file = argv[++iargc];
+      parser->UseHDF5 = false;
+      parser->h5file  = in_file;
     }
-    else if (a == "-hdf5")
+    if (usehdf5)
+      parser->h5file = parser->Title + ".orbs.h5";
+    parser->IonSystem.setName(ion_tag);
+    if (debug)
     {
-      usehdf5 = true;
+      parser->UseHDF5 = false;
+      parser->h5file  = "";
     }
-    else if (a == "-psi_tag")
+    parser->multideterminant = false;
+    if (ci)
+      parser->multideterminant = ci;
+    if (multidet)
     {
-      psi_tag = argv[++iargc];
+      parser->multideterminant = multidet;
+      parser->multidetH5       = multidet;
     }
-    else if (a == "-production")
+    parser->multih5file       = punch_file;
+    parser->production        = prod;
+    parser->ci_threshold      = thres;
+    parser->optDetCoeffs      = optDetCoeffs;
+    parser->target_state      = TargetState;
+    parser->readNO            = readNO;
+    parser->orderByExcitation = orderByExcitation;
+    parser->zeroCI            = zeroCI;
+    parser->readGuess         = readGuess;
+    parser->outputFile        = punch_file;
+    parser->Image             = Image;
+    parser->parse(in_file);
+    if (prod)
     {
-      prod = true;
-    }
-    else if (a == "-ion_tag")
-    {
-      ion_tag = argv[++iargc];
-    }
-    else if (a == "-prefix")
-    {
-      prefix    = argv[++iargc];
-      useprefix = true;
-    }
-    else if (a == "-ci")
-    {
-      ci         = true;
-      punch_file = argv[++iargc];
-    }
-    else if (a == "-multidet")
-    {
-      multidet   = true;
-      punch_file = argv[++iargc];
-    }
-    else if (a == "-NbImages")
-    {
-      int temp;
-      temp = atoi(argv[++iargc]);
-      temp += 1 - temp % 2;
-      Image.push_back(temp);
-      temp = atoi(argv[++iargc]);
-      temp += 1 - temp % 2;
-      Image.push_back(temp);
-      temp = atoi(argv[++iargc]);
-      temp += 1 - temp % 2;
-      Image.push_back(temp);
-    }
-    else if (a == "-addCusp")
-    {
-      addCusp = true;
-    }
-    else if (a == "-threshold")
-    {
-      thres = atof(argv[++iargc]);
-    }
-    else if (a == "-optDetCoeffs")
-    {
-      optDetCoeffs = true;
-    }
-    else if (a == "-TargetState")
-    {
-      TargetState = atoi(argv[++iargc]);
-    }
-    else if (a == "-NaturalOrbitals")
-    {
-      readNO = atoi(argv[++iargc]);
-    }
-    else if (a == "-readInitialGuess")
-    {
-      readGuess = atoi(argv[++iargc]);
-    }
-    else if (a == "-zeroCI")
-    {
-      zeroCI = true;
-    }
-    else if (a == "-orderByExcitation")
-    {
-      orderByExcitation = true;
-    }
-    else if (a == "-cutoff")
-    {
-      orderByExcitation = true;
-    }
-    else if (a == "-debug")
-    {
-      debug = true;
-    }
-    else if (a == "-nojastrow")
-    {
-      addJastrow = false;
-      jastrow    = "noj";
-    }
-    ++iargc;
-  }
-  if (readNO > 0 && readGuess > 0)
-  {
-    std::cerr << "Can only use one of: -NaturalOrbitals or -readInitialGuess. \n";
-    abort();
-  }
-  //Failed to create a parser. Try with the extension
-  std::string ext = getExtension(in_file);
-  if (parser == 0)
-  {
-    if (ext == "data")
-    {
-      WARNMSG("Creating CasinoParser")
-      parser = new CasinoParser(argc, argv);
-    }
-    else if (ext == "Fchk")
-    {
-      WARNMSG("Creating GaussianFCHKParser")
-      parser = new GaussianFCHKParser(argc, argv);
-    }
-    else if (ext == "h5")
-    {
-      WARNMSG("Creating LCAOHDFParser")
-      parser = new LCAOHDFParser(argc, argv);
-    }
-    else if (ext == "10")
-    {
-      WARNMSG("Creating BParser")
-      parser = new BParser(argc, argv);
-    }
-    else if (ext == "out")
-    {
-      WARNMSG("Creating GamesAsciiParser")
-      parser = new GamesAsciiParser(argc, argv);
+      parser->addJastrow = addJastrow;
+      parser->WFS_name   = jastrow;
+      if (parser->PBC)
+      {
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
+                  << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        parser->dumpPBC(psi_tag, ion_tag);
+      }
+      else
+        parser->dump(psi_tag, ion_tag);
+      parser->dumpStdInputProd(psi_tag, ion_tag);
     }
     else
     {
-      std::cerr << "Unknown extension: " << ext << std::endl;
-      exit(1);
-    }
-  }
-  if (useprefix != true)
-  {
-    prefix = in_file;
-    std::string delimiter;
-    if (ext=="h5")
-      delimiter = ".h5";
-    else
-      delimiter = ".out";
-    int pos = 0;
-    std::string token;
-    pos   = prefix.find(delimiter);
-    token = prefix.substr(0, pos);
-    prefix.erase(0, pos + delimiter.length());
-    prefix = token;
-  }
-  std::cout << "Using " << prefix << " to name output files" << std::endl;
-  
-  parser->Title   = prefix;
-  parser->debug   = debug;
-  parser->DoCusp  = addCusp;
-  parser->UseHDF5 = usehdf5;
-  parser->singledetH5 = h5;
-  if (h5)
-  {
-    parser->UseHDF5 = false;
-    parser->h5file  = in_file;
-  }
-  if (usehdf5)
-    parser->h5file = parser->Title + ".orbs.h5";
-  parser->IonSystem.setName(ion_tag);
-  if (debug)
-  {
-    parser->UseHDF5 = false;
-    parser->h5file  = "";
-  }
-  parser->multideterminant = false;
-  if (ci)
-    parser->multideterminant = ci;
-  if (multidet)
-  {
-    parser->multideterminant = multidet;
-    parser->multidetH5 = multidet;
-  }
-  parser->multih5file       = punch_file;
-  parser->production        = prod;
-  parser->ci_threshold      = thres;
-  parser->optDetCoeffs      = optDetCoeffs;
-  parser->target_state      = TargetState;
-  parser->readNO            = readNO;
-  parser->orderByExcitation = orderByExcitation;
-  parser->zeroCI            = zeroCI;
-  parser->readGuess         = readGuess;
-  parser->outputFile        = punch_file;
-  parser->Image             = Image;
-  parser->parse(in_file);
-  if (prod)
-  {
-    parser->addJastrow = addJastrow;
-    parser->WFS_name   = jastrow;
-    if (parser->PBC)
-    {
-      std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
-                << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-      parser->dumpPBC(psi_tag, ion_tag);
-    }
-    else
-      parser->dump(psi_tag, ion_tag);
-    parser->dumpStdInputProd(psi_tag, ion_tag);
-  }
-  else
-  {
-    parser->addJastrow = false;
-    jastrow            = "noj";
-    parser->WFS_name   = jastrow;
-    if (parser->PBC)
-    {
-      std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
-                << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-      parser->dumpPBC(psi_tag, ion_tag);
-    }
-    else
-      parser->dump(psi_tag, ion_tag);
-    parser->dumpStdInput(psi_tag, ion_tag);
+      parser->addJastrow = false;
+      jastrow            = "noj";
+      parser->WFS_name   = jastrow;
+      if (parser->PBC)
+      {
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
+                  << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        parser->dumpPBC(psi_tag, ion_tag);
+      }
+      else
+        parser->dump(psi_tag, ion_tag);
+      parser->dumpStdInput(psi_tag, ion_tag);
 
-    parser->addJastrow = true;
-    jastrow            = "j";
-    parser->WFS_name   = jastrow;
-    if (parser->PBC)
-    {
-      std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
-                << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-      parser->dumpPBC(psi_tag, ion_tag);
+      parser->addJastrow = true;
+      jastrow            = "j";
+      parser->WFS_name   = jastrow;
+      if (parser->PBC)
+      {
+        std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
+                  << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
+        parser->dumpPBC(psi_tag, ion_tag);
+      }
+      else
+        parser->dump(psi_tag, ion_tag);
+      parser->dumpStdInput(psi_tag, ion_tag);
     }
-    else
-      parser->dump(psi_tag, ion_tag);
-    parser->dumpStdInput(psi_tag, ion_tag);
   }
-
+  catch (const std::exception& e)
+  {
+    app_error() << e.what() << std::endl;
+    APP_ABORT("Unhandled Exception");
+  }
 
   OHMMS::Controller->finalize();
   return 0;


### PR DESCRIPTION
## Proposed changes

QP format h5 doesn't include eigenvalues. Made the parsing in convert4qmc more flexible.
Should make converter_test_LiH_qp pass.

In convert4qmc main(), add a try catch block for exceptions.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
