### PR TITLE
Consolidate SPOSet input handling

### DIFF
--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -17,7 +17,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "Utilities/IteratorUtility.h"
 #include "Utilities/string_utils.h"
-#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 
 namespace qmcplusplus
@@ -27,15 +27,15 @@ using MatrixOperators::product;
 using MatrixOperators::product_AtB;
 
 
-DensityMatrices1B::DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl)
-    : Lattice(P.Lattice), Psi(psi), Pq(P), Pc(Pcl)
+DensityMatrices1B::DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl, const WaveFunctionFactory& factory)
+    : Lattice(P.Lattice), Psi(psi), Pq(P), Pc(Pcl), wf_factory_(factory)
 {
   reset();
 }
 
 
 DensityMatrices1B::DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi)
-    : OperatorBase(master), Lattice(P.Lattice), Psi(psi), Pq(P), Pc(master.Pc)
+    : OperatorBase(master), Lattice(P.Lattice), Psi(psi), Pq(P), Pc(master.Pc), wf_factory_(master.wf_factory_)
 {
   reset();
   set_state(master);
@@ -252,7 +252,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
 
   for (int i = 0; i < sposets.size(); ++i)
   {
-    basis_functions.add(get_sposet(sposets[i]));
+    basis_functions.add(wf_factory_.getSPOSet(sposets[i]));
   }
   basis_size = basis_functions.size();
 

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -17,6 +17,7 @@
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCWaveFunctions/CompositeSPOSet.h"
 #include "ParticleBase/RandomSeqGenerator.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 namespace qmcplusplus
 {
@@ -155,7 +156,7 @@ public:
 
 
   //constructor/destructor
-  DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl);
+  DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl, const WaveFunctionFactory& factory);
   DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi);
   ~DensityMatrices1B();
 
@@ -227,6 +228,10 @@ public:
   bool same(Matrix_t& m1, Matrix_t& m2, RealType tol = 1e-6);
   void compare(const std::string& name, Vector_t& v1, Vector_t& v2, bool write = false, bool diff_only = true);
   void compare(const std::string& name, Matrix_t& m1, Matrix_t& m2, bool write = false, bool diff_only = true);
+
+private:
+  /// reference to the sposet_builder_factory
+  const WaveFunctionFactory& wf_factory_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -279,7 +279,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       else if (potType == "orbitalimages")
       {
         app_log() << "  Adding OrbitalImages" << std::endl;
-        OrbitalImages* apot = new OrbitalImages(targetPtcl, ptclPool, myComm);
+        OrbitalImages* apot = new OrbitalImages(targetPtcl, ptclPool, myComm, *psi_it->second);
         apot->put(cur);
         targetH->addOperator(apot, potName, false);
       }
@@ -308,7 +308,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         {
           APP_ABORT("Unknown source \"" + source + "\" for DensityMatrices1B");
         }
-        DensityMatrices1B* apot = new DensityMatrices1B(targetPtcl, *targetPsi, Pc);
+        DensityMatrices1B* apot = new DensityMatrices1B(targetPtcl, *targetPsi, Pc, *psi_it->second);
         apot->put(cur);
         targetH->addOperator(apot, potName, false);
       }

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -13,13 +13,13 @@
 
 #include "OrbitalImages.h"
 #include "OhmmsData/AttributeSet.h"
-#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "Utilities/unit_conversion.h"
 
 
 namespace qmcplusplus
 {
-OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm) : psetpool(PSP)
+OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory) : psetpool(PSP), wf_factory_(factory)
 {
   //keep the electron particle to get the cell later, if necessary
   Peln = &P;
@@ -185,7 +185,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
     APP_ABORT("OrbitalImages::put  must have at least one sposet");
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    SPOSet* sposet = get_sposet(sposet_names[i]);
+    SPOSet* sposet = wf_factory_.getSPOSet(sposet_names[i]);
     if (sposet == 0)
       APP_ABORT("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist");
     sposets.push_back(sposet);

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -16,6 +16,7 @@
 
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCWaveFunctions/SPOSet.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 namespace qmcplusplus
 {
@@ -169,7 +170,7 @@ public:
   ///indices of orbitals within each sposet to evaluate
   std::vector<std::vector<int>*> sposet_indices;
 
-  ///sposets obtained by name from SPOSetBuilderFactory
+  ///sposets obtained by name from WaveFunctionFactory
   std::vector<SPOSet*> sposets;
 
   ///evaluate points at grid cell centers instead of edges
@@ -216,7 +217,7 @@ public:
 
 
   //constructor/destructor
-  OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm);
+  OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory);
   ~OrbitalImages(){};
 
   //standard interface
@@ -268,6 +269,10 @@ public:
                          value_types_enum value_type,
                          derivative_types_enum derivative_type = value_d,
                          int dimension                         = 0);
+
+private:
+  /// reference to the sposet_builder_factory
+  const WaveFunctionFactory& wf_factory_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -36,13 +36,7 @@ bool AGPDeterminantBuilder::createAGP(BasisBuilderT* abuilder, xmlNodePtr cur)
   while (cur != NULL)
   {
     std::string cname((const char*)(cur->name));
-    if (cname == basisset_tag)
-    {
-      basisSet = abuilder->addBasisSet(cur);
-      if (!basisSet)
-        return false;
-    }
-    else if (cname == "coefficient" || cname == "coefficients")
+    if (cname == "coefficient" || cname == "coefficients")
     {
       if (agpDet == 0)
       {
@@ -110,7 +104,6 @@ WaveFunctionComponent* AGPDeterminantBuilder::buildComponent(xmlNodePtr cur)
   xmlNodePtr curRoot = cur;
   bool success       = true;
   std::string cname, tname;
-  xmlNodePtr bPtr = NULL;
   xmlNodePtr cPtr = NULL;
   xmlNodePtr uPtr = NULL;
   OhmmsAttributeSet oAttrib;
@@ -121,11 +114,7 @@ WaveFunctionComponent* AGPDeterminantBuilder::buildComponent(xmlNodePtr cur)
   while (cur != NULL)
   {
     getNodeName(cname, cur);
-    if (cname == basisset_tag)
-    {
-      bPtr = cur;
-    }
-    else if (cname.find("coeff") < cname.size())
+if (cname.find("coeff") < cname.size())
     {
       cPtr = cur;
     }
@@ -135,11 +124,11 @@ WaveFunctionComponent* AGPDeterminantBuilder::buildComponent(xmlNodePtr cur)
     }
     cur = cur->next;
   }
-  if (bPtr == NULL || cPtr == NULL)
+  if (cPtr == NULL)
   {
     std::ostringstream err_msg;
     err_msg << "  AGPDeterminantBuilder::put Cannot create AGPDeterminant." << std::endl
-            << "    Missing <basisset/> or <coefficients/>" << std::endl;
+            << "    Missing <coefficients/>" << std::endl;
     APP_ABORT(err_msg.str());
     return nullptr;
   }

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -147,7 +147,6 @@ WaveFunctionComponent* AGPDeterminantBuilder::buildComponent(xmlNodePtr cur)
   {
     mySPOSetBuilderFactory = new SPOSetBuilderFactory(myComm, targetPtcl, ptclPool);
     mySPOSetBuilderFactory->createSPOSetBuilder(curRoot);
-    mySPOSetBuilderFactory->loadBasisSetFromXML(bPtr);
   }
   // mmorales: this needs to be fixed after changes to BasisSetfactory
   //    BasisSetBase<RealType>* myBasisSet=mySPOSetBuilderFactory->getBasisSet();

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -232,7 +232,7 @@ SPOSet* CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   CompositeSPOSet* spo_now = new CompositeSPOSet;
   for (int i = 0; i < spolist.size(); ++i)
   {
-    SPOSet* spo = get_sposet(spolist[i]);
+    SPOSet* spo = sposet_builder_factory_.get_sposet(spolist[i]);
     if (spo)
       spo_now->add(spo);
   }

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -232,7 +232,7 @@ SPOSet* CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   CompositeSPOSet* spo_now = new CompositeSPOSet;
   for (int i = 0; i < spolist.size(); ++i)
   {
-    SPOSet* spo = sposet_builder_factory_.get_sposet(spolist[i]);
+    SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
     if (spo)
       spo_now->add(spo);
   }

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -18,6 +18,7 @@
 #include "QMCWaveFunctions/SPOSet.h"
 #include "QMCWaveFunctions/BasisSetBase.h"
 #include "QMCWaveFunctions/SPOSetBuilder.h"
+#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 
 namespace qmcplusplus
 {
@@ -92,12 +93,15 @@ public:
 
 struct CompositeSPOSetBuilder : public SPOSetBuilder
 {
-  CompositeSPOSetBuilder(Communicate* comm) : SPOSetBuilder("Composite", comm) {}
+  CompositeSPOSetBuilder(Communicate* comm, const SPOSetBuilderFactory& factory) : SPOSetBuilder("Composite", comm), sposet_builder_factory_(factory) {}
 
   //SPOSetBuilder interface
   SPOSet* createSPOSetFromXML(xmlNodePtr cur);
 
   SPOSet* createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input);
+
+  /// reference to the sposet_builder_factory
+  const SPOSetBuilderFactory& sposet_builder_factory_;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -232,9 +232,12 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   iter = SPOSetMap.find(aset);
   if ((iter != SPOSetMap.end()) && (!NewOcc))
   {
-    app_log() << "SPOSet parameters match in EinsplineSetBuilder:  "
-              << "cloning EinsplineSet object.\n";
-    return iter->second->makeClone();
+    app_log() << "SPOSet parameters match in EinsplineSetBuilder. cloning EinsplineSet object." << std::endl;
+    app_warning() << "!!!!!!! Deprecated input style. Implict sharing one SPOSet for spin-up and spin-down electrions has been deprecated."
+                  << "Use sposet_collection to construct an explict sposet for explicit sharing." << std::endl;
+    OrbitalSet = iter->second->makeClone();
+    OrbitalSet->setName("");
+    return OrbitalSet;
   }
 
   if (FullBands[spinSet] == 0)

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -233,7 +233,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   if ((iter != SPOSetMap.end()) && (!NewOcc))
   {
     app_log() << "SPOSet parameters match in EinsplineSetBuilder. cloning EinsplineSet object." << std::endl;
-    app_warning() << "!!!!!!! Deprecated input style. Implict sharing one SPOSet for spin-up and spin-down electrions has been deprecated."
+    app_warning() << "!!!!!!! Deprecated input style: implict sharing one SPOSet for spin-up and spin-down electrions has been deprecated. Create a single SPO set outside determinantset instead."
                   << "Use sposet_collection to construct an explict sposet for explicit sharing." << std::endl;
     OrbitalSet = iter->second->makeClone();
     OrbitalSet->setName("");

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -88,11 +88,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
   while (cur != NULL) //check the basis set
   {
     getNodeName(cname, cur);
-    if (cname == basisset_tag)
-    {
-      mySPOSetBuilderFactory->loadBasisSetFromXML(cur);
-    }
-    else if (cname == sposet_tag)
+    if (cname == sposet_tag)
     {
       app_log() << "Creating SPOSet in SlaterDetBuilder::put(xmlNodePtr cur).\n";
       std::string spo_name;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -80,7 +80,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
 
   if (sposet_builder_factory_.empty())
   { //always create one, using singleton and just to access the member functions
-    app_warning() << "!!!!!!! Deprecated input style. Creating SPOSetBuilder inside determinantset" << std::endl;
+    app_warning() << "!!!!!!! Deprecated input style: creating SPO set inside determinantset. Support for this usage will soon be removed. SPO sets should be built outside." << std::endl;
     sposet_builder_factory_.createSPOSetBuilder(curRoot);
   }
 
@@ -91,7 +91,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
     getNodeName(cname, cur);
     if (cname == sposet_tag)
     {
-      app_warning() << "!!!!!!! Deprecated input style. Creating SPO set inside determinantset" << std::endl;
+      app_warning() << "!!!!!!! Deprecated input style: creating SPO set inside determinantset. Support for this usage will soon be removed. SPO sets should be built outside." << std::endl;
       app_log() << "Creating SPOSet in SlaterDetBuilder::put(xmlNodePtr cur).\n";
       std::string spo_name;
       OhmmsAttributeSet spoAttrib;
@@ -396,7 +396,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   //check if the named sposet exists
   if (psi == 0)
   {
-    app_warning() << "!!!!!!! Deprecated input style. Creating SPO set inside determinantset" << std::endl;
+    app_warning() << "!!!!!!! Deprecated input style: creating SPO set inside determinantset. Support for this usage will soon be removed. SPO sets should be built outside." << std::endl;
     app_log() << "      Create a new SPO set " << sposet_name << std::endl;
     psi = sposet_builder_factory_.createSPOSet(cur);
   }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -206,8 +206,8 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
       spoAttrib.add(fastAlg, "Fast");
       spoAttrib.put(cur);
 
-      SPOSetPtr spo_alpha = sposet_builder_factory_.get_sposet(spo_alpha_name);
-      SPOSetPtr spo_beta  = sposet_builder_factory_.get_sposet(spo_beta_name);
+      SPOSetPtr spo_alpha = sposet_builder_factory_.getSPOSet(spo_alpha_name);
+      SPOSetPtr spo_beta  = sposet_builder_factory_.getSPOSet(spo_beta_name);
       if (spo_alpha == nullptr)
       {
         app_error() << "In SlaterDetBuilder: SPOSet \"" << spo_alpha_name
@@ -392,7 +392,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
                 << std::endl;
   app_summary() << std::endl;
 
-  SPOSetPtr psi = sposet_builder_factory_.get_sposet(sposet_name);
+  SPOSetPtr psi = sposet_builder_factory_.getSPOSet(sposet_name);
   //check if the named sposet exists
   if (psi == 0)
   {

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -77,10 +77,11 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
   std::map<std::string, SPOSetPtr> spomap;
   bool multiDet = false;
 
-  if (!mySPOSetBuilderFactory)
+  if (SPOSetBuilderFactory::spo_builders.size() == 0)
   { //always create one, using singleton and just to access the member functions
-    mySPOSetBuilderFactory = std::make_unique<SPOSetBuilderFactory>(myComm, targetPtcl, ptclPool);
-    mySPOSetBuilderFactory->createSPOSetBuilder(curRoot);
+    app_warning() << "!!!!!!! Deprecated input style. Creating SPOSetBuilder inside determinantset" << std::endl;
+    SPOSetBuilderFactory mySPOSetBuilderFactory(myComm, targetPtcl, ptclPool);
+    mySPOSetBuilderFactory.createSPOSetBuilder(curRoot);
   }
 
   //check the basis set
@@ -90,13 +91,14 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
     getNodeName(cname, cur);
     if (cname == sposet_tag)
     {
+      app_warning() << "!!!!!!! Deprecated input style. Creating SPO set inside determinantset" << std::endl;
       app_log() << "Creating SPOSet in SlaterDetBuilder::put(xmlNodePtr cur).\n";
       std::string spo_name;
       OhmmsAttributeSet spoAttrib;
       spoAttrib.add(spo_name, "name");
       spoAttrib.put(cur);
       app_log() << "spo_name = " << spo_name << std::endl;
-      SPOSetPtr spo = mySPOSetBuilderFactory->createSPOSet(cur);
+      SPOSetPtr spo = SPOSetBuilderFactory::createSPOSet(cur);
       if (spomap.find(spo_name) != spomap.end())
       {
         app_error() << "SPOSet name \"" << spo_name << "\" is already in use.\n";
@@ -394,8 +396,9 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   //check if the named sposet exists
   if (psi == 0)
   {
+    app_warning() << "!!!!!!! Deprecated input style. Creating SPO set inside determinantset" << std::endl;
     app_log() << "      Create a new SPO set " << sposet_name << std::endl;
-    psi = mySPOSetBuilderFactory->createSPOSet(cur);
+    psi = SPOSetBuilderFactory::createSPOSet(cur);
   }
   psi->checkObject();
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -43,7 +43,7 @@ public:
    * \param psi reference to the wavefunction
    * \param ions reference to the ions
    */
-  SlaterDetBuilder(Communicate* comm, ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets);
+  SlaterDetBuilder(Communicate* comm, SPOSetBuilderFactory& factory, ParticleSet& els, TrialWaveFunction& psi, PtclPoolType& psets);
 
   /** initialize the Antisymmetric wave function for electrons
    *@param cur the current xml node
@@ -52,6 +52,8 @@ public:
   WaveFunctionComponent* buildComponent(xmlNodePtr cur) override;
 
 private:
+  /// reference to the sposet_builder_factory, should be const once the legacy input style is removed
+  SPOSetBuilderFactory& sposet_builder_factory_;
   ///reference to TrialWaveFunction, should go away as the CUDA code.
   TrialWaveFunction& targetPsi;
   ///reference to a PtclPoolType

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -56,7 +56,6 @@ private:
   TrialWaveFunction& targetPsi;
   ///reference to a PtclPoolType
   PtclPoolType& ptclPool;
-  std::unique_ptr<SPOSetBuilderFactory> mySPOSetBuilderFactory;
   SlaterDeterminant_t* slaterdet_0;
   MultiSlaterDeterminant_t* multislaterdet_0;
   MultiSlaterDeterminantFast* multislaterdetfast_0;

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
@@ -33,13 +33,18 @@ SPOSet* LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
   ReportEngine PRE(ClassName, "createSPO(xmlNodePtr)");
   std::string spo_name(""), optimize("no");
+  std::string basisset_name("LCAOBSet");
   OhmmsAttributeSet spoAttrib;
   spoAttrib.add(spo_name, "name");
   spoAttrib.add(optimize, "optimize");
+  spoAttrib.add(basisset_name, "basisset");
   spoAttrib.put(cur);
 
-  if (myBasisSet == nullptr)
-    PRE.error("Missing basisset.", true);
+  BasisSet_t* myBasisSet = nullptr;
+  if (basisset_map_.find(basisset_name) == basisset_map_.end())
+    myComm->barrier_and_abort("basisset \"" + basisset_name + "\" cannot be found\n");
+  else
+    myBasisSet = basisset_map_[basisset_name].get();
 
   if (optimize == "yes")
     app_log() << "  SPOSet " << spo_name << " is optimizable\n";

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.h
@@ -58,7 +58,6 @@ private:
    * after this, we have up/dn LCAOrbitalSet that can be registered to the SpinorSet
    */
   bool putFromH5(LCAOrbitalSet& up, LCAOrbitalSet& dn, xmlNodePtr);
-  bool putOccupation(int norbs, xmlNodePtr cur);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -152,7 +152,8 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
   // deprecated h5 basis set handling when basisset element is missing
   if (basisset_map_.size() == 0 && h5_path != "")
   {
-    app_warning() << "!!!!!!! Deprecated input style. Missing basisset element. "
+    app_warning() << "!!!!!!! Deprecated input style: missing basisset element. "
+                  << "LCAO needs an explicit basisset XML element. "
                   << "Fallback on loading an implicit one." << std::endl;
     basisset_map_["LCAOBSet"] = loadBasisSetFromH5(cur);
   }

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -151,7 +151,11 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
 
   // deprecated h5 basis set handling when basisset element is missing
   if (basisset_map_.size() == 0 && h5_path != "")
+  {
+    app_warning() << "!!!!!!! Deprecated input style. Missing basisset element. "
+                  << "Fallback on loading an implicit one." << std::endl;
     basisset_map_["LCAOBSet"] = loadBasisSetFromH5(cur);
+  }
 
   if (basisset_map_.size() == 0)
     throw std::runtime_error("No basisset found in the XML input!");

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h
@@ -47,14 +47,10 @@ protected:
   ParticleSet& targetPtcl;
   ///source ParticleSet
   ParticleSet& sourcePtcl;
-  ///localized basis set
-  BasisSet_t* myBasisSet;
   /// localized basis set map
   std::map<std::string, std::unique_ptr<BasisSet_t>> basisset_map_;
-  ///apply cusp correction to molecular orbitals
-  int radialOrbType;
+  /// if true, add cusp correction to orbitals
   bool cuspCorr;
-  std::string cuspInfo;
   ///Path to HDF5 Wavefunction
   std::string h5_path;
   ///Number of periodic Images for Orbital evaluation
@@ -69,8 +65,6 @@ protected:
   /// Enable cusp correction
   bool doCuspCorrection;
 
-  ///load basis set from hdf5 file
-  std::unique_ptr<BasisSet_t> loadBasisSetFromH5();
   /** create basis set
      *
      * Use ao_traits<T,I,J> to match (ROT)x(SH) combo
@@ -109,8 +103,14 @@ protected:
   void readRealMatrixFromH5(hdf_archive& hin,
                             const std::string& setname,
                             Matrix<LCAOrbitalBuilder::RealType>& Creal) const;
+
 private:
+  ///load a basis set from XML input
   std::unique_ptr<BasisSet_t> loadBasisSetFromXML(xmlNodePtr cur, xmlNodePtr parent);
+  ///load a basis set from h5 file
+  std::unique_ptr<BasisSet_t> loadBasisSetFromH5(xmlNodePtr parent);
+  ///determine radial orbital type based on "keyword" and "transform" attributes
+  int determineRadialOrbType(xmlNodePtr cur) const;
 };
 
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h
@@ -18,6 +18,7 @@
 #ifndef QMCPLUSPLUS_SOA_LCAO_ORBITAL_BUILDER_H
 #define QMCPLUSPLUS_SOA_LCAO_ORBITAL_BUILDER_H
 
+#include <map>
 #include "QMCWaveFunctions/BasisSetBase.h"
 #include "QMCWaveFunctions/LCAO/LCAOrbitalSet.h"
 #include "QMCWaveFunctions/SPOSetBuilder.h"
@@ -32,14 +33,13 @@ namespace qmcplusplus
 class LCAOrbitalBuilder : public SPOSetBuilder
 {
 public:
-  typedef typename LCAOrbitalSet::basis_type BasisSet_t;
+  using BasisSet_t = LCAOrbitalSet::basis_type;
   /** constructor
      * \param els reference to the electrons
      * \param ions reference to the ions
      */
   LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Communicate* comm, xmlNodePtr cur);
   ~LCAOrbitalBuilder();
-  void loadBasisSetFromXML(xmlNodePtr cur);
   SPOSet* createSPOSetFromXML(xmlNodePtr cur);
 
 protected:
@@ -49,6 +49,8 @@ protected:
   ParticleSet& sourcePtcl;
   ///localized basis set
   BasisSet_t* myBasisSet;
+  /// localized basis set map
+  std::map<std::string, std::unique_ptr<BasisSet_t>> basisset_map_;
   ///apply cusp correction to molecular orbitals
   int radialOrbType;
   bool cuspCorr;
@@ -68,7 +70,7 @@ protected:
   bool doCuspCorrection;
 
   ///load basis set from hdf5 file
-  void loadBasisSetFromH5();
+  std::unique_ptr<BasisSet_t> loadBasisSetFromH5();
   /** create basis set
      *
      * Use ao_traits<T,I,J> to match (ROT)x(SH) combo
@@ -107,6 +109,8 @@ protected:
   void readRealMatrixFromH5(hdf_archive& hin,
                             const std::string& setname,
                             Matrix<LCAOrbitalBuilder::RealType>& Creal) const;
+private:
+  std::unique_ptr<BasisSet_t> loadBasisSetFromXML(xmlNodePtr cur, xmlNodePtr parent);
 };
 
 

--- a/src/QMCWaveFunctions/SPOSetBuilder.h
+++ b/src/QMCWaveFunctions/SPOSetBuilder.h
@@ -61,8 +61,6 @@ public:
 
   SPOSetBuilder(const std::string& SPO_type_name_in, Communicate* comm);
   virtual ~SPOSetBuilder() {}
-  /// load from XML if there is a basisset
-  virtual void loadBasisSetFromXML(xmlNodePtr cur) {}
 
   /// reserve space for states (usually only one set, multiple for e.g. spin dependent einspline)
   void reserve_states(int nsets = 1);

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -41,11 +41,6 @@
 
 namespace qmcplusplus
 {
-void SPOSetBuilderFactory::clear()
-{
-  spo_builders.clear();
-  last_builder = nullptr;
-}
 
 SPOSet* SPOSetBuilderFactory::get_sposet(const std::string& name) const
 {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -260,19 +260,8 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
   else if (spo_builders.find(type) != spo_builders.end())
     bb = spo_builders[type];
   else
-  {
-    std::string cname("");
-    xmlNodePtr tcur = cur->children;
-    if (tcur != NULL)
-      getNodeName(cname, tcur);
-    if (cname == basisset_tag)
-    {
-      bb = createSPOSetBuilder(cur);
-      bb->loadBasisSetFromXML(tcur);
-    }
-    else
-      bb = createSPOSetBuilder(cur);
-  }
+    bb = createSPOSetBuilder(cur);
+
   if (bb)
   {
     SPOSet* spo = bb->createSPOSet(cur);
@@ -307,12 +296,6 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
 
   // create the SPOSet builder
   SPOSetBuilder* bb = createSPOSetBuilder(cur);
-
-  // going through a list of basisset entries
-  processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
-    if (cname == "basisset")
-      bb->loadBasisSetFromXML(cur);
-  });
 
   // going through a list of sposet entries
   int nsposets = 0;

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -42,7 +42,7 @@
 namespace qmcplusplus
 {
 
-SPOSet* SPOSetBuilderFactory::get_sposet(const std::string& name) const
+SPOSet* SPOSetBuilderFactory::getSPOSet(const std::string& name) const
 {
   int nfound  = 0;
   SPOSet* spo = nullptr;
@@ -62,13 +62,12 @@ SPOSet* SPOSetBuilderFactory::get_sposet(const std::string& name) const
   if (nfound > 1)
   {
     write_spo_builders();
-    APP_ABORT_TRACE(__FILE__, __LINE__, "get_sposet: requested sposet " + name + " is not unique");
+    throw std::runtime_error("getSPOSet: requested sposet " + name + " is not unique!");
   }
-  //else if(spo==NULL)
-  //{
-  //  write_spo_builders();
-  //  myComm->barrier_and_abort("get_sposet: requested sposet "+name+" does not exist");
-  //}
+  // keep this commented until legacy input styles are moved.
+  // In legacy input styles, this look up may fail and need to build SPOSet on the fly.
+  //else if (nfound == 0)
+  //  throw std::runtime_error("getSPOSet: requested sposet " + name + " is not found!");
   return spo;
 }
 
@@ -253,7 +252,7 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
     throw std::runtime_error("Cannot find any SPOSetBuilder to build SPOSet!");
 }
 
-void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
+void SPOSetBuilderFactory::buildSPOSetCollection(xmlNodePtr cur)
 {
   std::string collection_name;
   std::string collection_type;
@@ -286,7 +285,7 @@ void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)
   });
 
   if (nsposets == 0)
-    myComm->barrier_and_abort("SPOSetBuilderFactory::build_sposet_collection  no <sposet/> elements found");
+    myComm->barrier_and_abort("SPOSetBuilderFactory::buildSPOSetCollection  no <sposet/> elements found");
 
   // going through a list of spo_scanner entries
   processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -241,26 +241,18 @@ SPOSetBuilder* SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
 
 SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
 {
-  std::string bname("");
   std::string sname("");
   std::string type("");
   OhmmsAttributeSet aAttrib;
-  aAttrib.add(bname, "basisset");
   aAttrib.add(sname, "name");
   aAttrib.add(type, "type");
   aAttrib.put(cur);
 
-  //tolower(type);
-
-  SPOSetBuilder* bb;
-  if (bname == "")
-    bname = type;
+  SPOSetBuilder* bb = nullptr;
   if (type == "")
     bb = last_builder;
   else if (spo_builders.find(type) != spo_builders.end())
     bb = spo_builders[type];
-  else
-    bb = createSPOSetBuilder(cur);
 
   if (bb)
   {
@@ -269,10 +261,7 @@ SPOSet* SPOSetBuilderFactory::createSPOSet(xmlNodePtr cur)
     return spo;
   }
   else
-  {
-    myComm->barrier_and_abort("SPOSetBuilderFactory::createSPOSet Failed to create a SPOSet. SPOSetBuilder is empty.");
-    return 0;
-  }
+    throw std::runtime_error("Cannot find any SPOSetBuilder to build SPOSet!");
 }
 
 void SPOSetBuilderFactory::build_sposet_collection(xmlNodePtr cur)

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -39,13 +39,13 @@ public:
 
   SPOSet* createSPOSet(xmlNodePtr cur);
 
-/**returns a named sposet from the pool
+  /** returns a named sposet from the pool
    *  only use in serial portion of execution
    *  ie during initialization prior to threaded code
    */
-  SPOSet* get_sposet(const std::string& name) const;
+  SPOSet* getSPOSet(const std::string& name) const;
 
-  void build_sposet_collection(xmlNodePtr cur);
+  void buildSPOSetCollection(xmlNodePtr cur);
 
   bool empty() const { return spo_builders.size() == 0; }
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -52,8 +52,6 @@ public:
 
   SPOSetBuilder* createSPOSetBuilder(xmlNodePtr rootNode);
 
-  void loadBasisSetFromXML(xmlNodePtr cur) { last_builder->loadBasisSetFromXML(cur); }
-
   SPOSet* createSPOSet(xmlNodePtr cur);
 
   void build_sposet_collection(xmlNodePtr cur);

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -21,25 +21,13 @@
 
 namespace qmcplusplus
 {
-///writes info about contained sposets to stdout
-void write_spo_builders(const std::string& pad = "");
-
-/**returns a named sposet from the global pool
-   *  only use in serial portion of execution
-   *  ie during initialization prior to threaded code
-   */
-SPOSet* get_sposet(const std::string& name);
-
 class SPOSetBuilderFactory : public MPIObjectBase
 {
 public:
   typedef std::map<std::string, ParticleSet*> PtclPoolType;
 
-  ///set of basis set builders resolved by type
-  static std::map<std::string, SPOSetBuilder*> spo_builders;
-
   /// Reset the map and last_builder pointers.  Mostly for unit tests.
-  static void clear();
+  void clear();
 
   /** constructor
    * \param comm communicator
@@ -52,13 +40,27 @@ public:
 
   SPOSetBuilder* createSPOSetBuilder(xmlNodePtr rootNode);
 
-  static SPOSet* createSPOSet(xmlNodePtr cur);
+  SPOSet* createSPOSet(xmlNodePtr cur);
+
+/**returns a named sposet from the pool
+   *  only use in serial portion of execution
+   *  ie during initialization prior to threaded code
+   */
+  SPOSet* get_sposet(const std::string& name) const;
 
   void build_sposet_collection(xmlNodePtr cur);
 
+  bool empty() const { return spo_builders.size() == 0; }
+
 private:
+///writes info about contained sposets to stdout
+void write_spo_builders(const std::string& pad = "") const;
+
+  ///set of basis set builders resolved by type
+  std::map<std::string, SPOSetBuilder*> spo_builders;
+
   ///store the last builder, use if type not provided
-  static SPOSetBuilder* last_builder;
+  SPOSetBuilder* last_builder;
 
   ///reference to the target particle
   ParticleSet& targetPtcl;

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -52,7 +52,7 @@ public:
 
   SPOSetBuilder* createSPOSetBuilder(xmlNodePtr rootNode);
 
-  SPOSet* createSPOSet(xmlNodePtr cur);
+  static SPOSet* createSPOSet(xmlNodePtr cur);
 
   void build_sposet_collection(xmlNodePtr cur);
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -26,9 +26,6 @@ class SPOSetBuilderFactory : public MPIObjectBase
 public:
   typedef std::map<std::string, ParticleSet*> PtclPoolType;
 
-  /// Reset the map and last_builder pointers.  Mostly for unit tests.
-  void clear();
-
   /** constructor
    * \param comm communicator
    * \param els reference to the electrons

--- a/src/QMCWaveFunctions/WaveFunctionComponentBuilder.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBuilder.cpp
@@ -45,8 +45,6 @@ std::string WaveFunctionComponentBuilder::spo_tag = "psi";
 
 std::string WaveFunctionComponentBuilder::sposet_tag = "sposet";
 
-std::string WaveFunctionComponentBuilder::basisset_tag = "basisset";
-
 std::string WaveFunctionComponentBuilder::ionorb_tag = "ionwf";
 
 std::string WaveFunctionComponentBuilder::backflow_tag = "backflow";

--- a/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
@@ -65,8 +65,6 @@ public:
   static std::string spo_tag;
   /// the element name for single-particle orbital set
   static std::string sposet_tag;
-  /// the element name for the basis set: basis set contains multiple basis elements
-  static std::string basisset_tag;
   /// the element name for an ion wavefunction
   static std::string ionorb_tag;
   /// the element name for a backflow transformation

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -87,7 +87,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
   {
     std::string cname((const char*)(cur->name));
     if (cname == "sposet_builder" || cname == "sposet_collection")
-      sposet_builder_factory_.build_sposet_collection(cur);
+      sposet_builder_factory_.buildSPOSetCollection(cur);
     else if (cname == WaveFunctionComponentBuilder::detset_tag)
     {
       success = addFermionTerm(cur);

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -50,7 +50,8 @@ WaveFunctionFactory::WaveFunctionFactory(const std::string& psiName,
       targetPsi(std::make_unique<TrialWaveFunction>(psiName, tasking)),
       targetPtcl(qp),
       ptclPool(pset),
-      myNode(NULL)
+      myNode(NULL),
+      sposet_builder_factory_(c, qp, pset)
 {
   ClassName = "WaveFunctionFactory";
   myName    = psiName;
@@ -86,10 +87,7 @@ bool WaveFunctionFactory::build(xmlNodePtr cur, bool buildtree)
   {
     std::string cname((const char*)(cur->name));
     if (cname == "sposet_builder" || cname == "sposet_collection")
-    {
-      SPOSetBuilderFactory factory(myComm, targetPtcl, ptclPool);
-      factory.build_sposet_collection(cur);
-    }
+      sposet_builder_factory_.build_sposet_collection(cur);
     else if (cname == WaveFunctionComponentBuilder::detset_tag)
     {
       success = addFermionTerm(cur);
@@ -200,7 +198,7 @@ bool WaveFunctionFactory::addFermionTerm(xmlNodePtr cur)
     detbuilder = new PWOrbitalBuilder(myComm, targetPtcl, ptclPool);
   }
   else
-    detbuilder = new SlaterDetBuilder(myComm, targetPtcl, *targetPsi, ptclPool);
+    detbuilder = new SlaterDetBuilder(myComm, sposet_builder_factory_, targetPtcl, *targetPsi, ptclPool);
   targetPsi->addComponent(detbuilder->buildComponent(cur));
   addNode(detbuilder, cur);
   return true;

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -47,6 +47,8 @@ public:
   xmlNodePtr getNode() const { return myNode; }
   ///get targetPsi
   TrialWaveFunction* getTWF() const { return targetPsi.get(); }
+  ///get SPOSet
+  SPOSet* getSPOSet(const std::string& name) const { return sposet_builder_factory_.get_sposet(name); }
 
 private:
   /** process xmlNode to populate targetPsi
@@ -73,6 +75,9 @@ private:
   xmlNodePtr myNode;
   ///builder tree
   UPtrVector<WaveFunctionComponentBuilder> psiBuilder;
+
+  /// factory for all the sposet builders in this WF
+  SPOSetBuilderFactory sposet_builder_factory_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -48,7 +48,7 @@ public:
   ///get targetPsi
   TrialWaveFunction* getTWF() const { return targetPsi.get(); }
   ///get SPOSet
-  SPOSet* getSPOSet(const std::string& name) const { return sposet_builder_factory_.get_sposet(name); }
+  SPOSet* getSPOSet(const std::string& name) const { return sposet_builder_factory_.getSPOSet(name); }
 
 private:
   /** process xmlNode to populate targetPsi

--- a/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
+++ b/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
@@ -38,8 +38,6 @@ class MinimalWaveFunctionPool
 public:
   MinimalWaveFunctionPool() : comm_(nullptr) {}
 
-  ~MinimalWaveFunctionPool() { SPOSetBuilderFactory::clear(); }
-
   WaveFunctionPool operator()(Communicate* comm, ParticleSetPool& particle_pool)
   {
     comm_ = comm;

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -127,8 +127,6 @@ void test_He(bool transform)
     REQUIRE(dpsi[0][1] == Approx(0));
     REQUIRE(dpsi[0][2] == Approx(0));
     REQUIRE(d2psi[0] == Approx(-0.2618497452));
-
-    SPOSetBuilderFactory::clear();
   }
 }
 
@@ -252,8 +250,6 @@ void test_Ne(bool transform)
     REQUIRE(dpsi[0][1] == Approx(0));
     REQUIRE(dpsi[0][2] == Approx(0));
     REQUIRE(d2psi[0] == Approx(-0.01551755818));
-
-    SPOSetBuilderFactory::clear();
   }
 }
 
@@ -665,8 +661,6 @@ void test_HCN(bool transform)
     REQUIRE(dionpsi[0][4][2] == Approx(-7.300043903e-05));
     REQUIRE(dionpsi[0][5][2] == Approx(2.910525987e-06));
     REQUIRE(dionpsi[0][6][2] == Approx(-1.56074936e-05));
-
-    SPOSetBuilderFactory::clear();
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -87,7 +87,6 @@ void test_He(bool transform)
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
     //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
@@ -207,7 +206,6 @@ void test_Ne(bool transform)
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
     //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
@@ -336,7 +334,6 @@ void test_HCN(bool transform)
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
 

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -66,7 +66,7 @@ void test_lcao_spinor()
   ptcl.addParticleSet(&ions_);
 
   const char* particles = "<tmp> \
-   <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" source=\"ion\" precision=\"float\"> \
+   <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" transform=\"yes\" source=\"ion\" precision=\"float\"> \
      <sposet name=\"myspo\" size=\"1\"/> \
    </sposet_builder> \
    </tmp> \
@@ -232,7 +232,7 @@ void test_lcao_spinor_excited()
   ptcl.addParticleSet(&ions_);
 
   const char* particles = "<tmp> \
-   <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" source=\"ion\" precision=\"float\"> \
+   <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" transform=\"yes\" source=\"ion\" precision=\"float\"> \
      <sposet name=\"myspo\" size=\"1\"> \
        <occupation mode=\"excited\"> \
          -1 2 \

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -185,8 +185,6 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
 
   CHECK(dlogpsi2[0] == ValueApprox(dlogpsi_list.getValue(0, 1)));
   CHECK(dhpsioverpsi2[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 1)));
-
-  SPOSetBuilderFactory::clear();
 }
 
 
@@ -421,8 +419,6 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
 
   RealType logpsi2b = psi2.evaluateDeltaLog(p_list[1], true);
   CHECK(logpsi2b == Approx(logpsi_variable_list2[1]));
-
-  SPOSetBuilderFactory::clear();
 }
 
 

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -86,8 +86,6 @@ void test_cartesian_ao()
 
     //generated from ao_order_test.py
     REQUIRE(values[0] == Approx(0.48224527310155046).epsilon(1E-6));
-
-    SPOSetBuilderFactory::clear();
   }
 }
 
@@ -155,8 +153,6 @@ void test_dirac_ao()
 
     //from ao_order_test.py
     REQUIRE(values[0] == Approx(0.35953790416302006).epsilon(1E-6));
-
-    SPOSetBuilderFactory::clear();
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -73,7 +73,6 @@ void test_cartesian_ao()
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector_t values;
@@ -143,7 +142,6 @@ void test_dirac_ao()
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector_t values;

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -102,7 +102,6 @@ void test_C_diamond()
     REQUIRE(bb != NULL);
 
     OhmmsXPathObject slater_base("//sposet", doc2.getXPathContext());
-    bb->loadBasisSetFromXML(MO_base[0]);
     SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector_t values;

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -880,8 +880,6 @@ void test_C_diamond()
     REQUIRE(std::imag(values[25]) == Approx(-0.10326287192308459));
 
     // END generated C++ input from Carbon1x1x1-tw1_gen_mos.py (pyscf version 1.6.2) on 2019-11-19 15:08:42.847403
-
-    SPOSetBuilderFactory::clear();
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -117,7 +117,6 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
   REQUIRE(bb != nullptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  bb->loadBasisSetFromXML(MO_base[0]);
   SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
   LCAOrbitalSet* lcob = dynamic_cast<LCAOrbitalSet*>(sposet);
@@ -295,7 +294,6 @@ TEST_CASE("HCN MO with cusp", "[wavefunction]")
   REQUIRE(bb != nullptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  bb->loadBasisSetFromXML(MO_base[0]);
   SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
   SPOSet::ValueVector_t values;
@@ -474,7 +472,6 @@ TEST_CASE("Ethanol MO with cusp", "[wavefunction]")
   REQUIRE(bb != nullptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  bb->loadBasisSetFromXML(MO_base[0]);
   SPOSet* sposet = bb->createSPOSet(slater_base[0]);
 
 

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -233,8 +233,6 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
   CHECK((*lcob->C)(0, 1) == Approx(0.0));
   CHECK((*lcob->C)(0, 2) == Approx(0.0));
   CHECK((*lcob->C)(0, 3) != 0.0);
-
-  SPOSetBuilderFactory::clear();
 }
 
 TEST_CASE("HCN MO with cusp", "[wavefunction]")
@@ -410,8 +408,6 @@ TEST_CASE("HCN MO with cusp", "[wavefunction]")
   REQUIRE(all_grad[0][1][1] == Approx(0.0000000000));
   REQUIRE(all_grad[0][1][2] == Approx(0.0000000000));
   REQUIRE(all_lap[0][1] == Approx(19.8720529007));
-
-  SPOSetBuilderFactory::clear();
 }
 
 // Test case with multiple atoms of the same type
@@ -555,8 +551,6 @@ TEST_CASE("Ethanol MO with cusp", "[wavefunction]")
   REQUIRE(all_grad[0][11][1] == Approx(0.9883840215));
   REQUIRE(all_grad[0][11][2] == Approx(1.7863218842));
   REQUIRE(all_lap[0][11] == Approx(-33.5202249813));
-
-  SPOSetBuilderFactory::clear();
 }
 
 

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -162,7 +162,7 @@ TEST_CASE("SPO input spline from xml He_sto3g", "[wavefunction]")
           </basisGroup> \
         </atomicBasisSet> \
       </basisset> \
-      <sposet name=\"spo\" size=\"1\"> \
+      <sposet name=\"spo\" basisset=\"LCAOBSet\" size=\"1\"> \
         <occupation mode=\"ground\"/> \
         <coefficient size=\"1\" id=\"updetC\"> \
           1.00000000000000e+00 \

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -67,7 +67,7 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   WaveFunctionFactory wf_factory("psi0", elec, ptcl.getPool(), c);
   wf_factory.put(ein_xml);
 
-  SPOSet* spo_ptr(get_sposet("spo"));
+  SPOSet* spo_ptr(wf_factory.getSPOSet("spo"));
   REQUIRE(spo_ptr);
   std::unique_ptr<SPOSet> sposet(spo_ptr->makeClone());
 
@@ -107,8 +107,6 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   REQUIRE(dpsi[0][1] == ValueApprox(0.0));
   REQUIRE(dpsi[0][2] == ValueApprox(0.0));
   REQUIRE(d2psi[0] == ValueApprox(-0.2618497452));
-
-  SPOSetBuilderFactory::clear();
 }
 
 TEST_CASE("SPO input spline from xml He_sto3g", "[wavefunction]")

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -71,12 +71,10 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string, const std::string
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
   wf_factory.put(ein_xml);
 
-  SPOSet* spo_ptr(get_sposet(check_sponame));
+  SPOSet* spo_ptr(wf_factory.getSPOSet(check_sponame));
   REQUIRE(spo_ptr != nullptr);
   REQUIRE(spo_ptr->getOrbitalSetSize() == check_spo_size);
   REQUIRE(spo_ptr->getBasisSetSize() == check_basisset_size);
-
-  SPOSetBuilderFactory::clear();
 }
 
 TEST_CASE("SPO input spline from xml LiH_msd", "[wavefunction]")

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -90,7 +90,7 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
   wf_factory.put(ein_xml);
 
-  SPOSet* spo_ptr(get_sposet("spo"));
+  SPOSet* spo_ptr(wf_factory.getSPOSet("spo"));
   REQUIRE(spo_ptr);
   std::unique_ptr<SPOSet> spo(spo_ptr->makeClone());
 
@@ -135,8 +135,6 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   REQUIRE(std::imag(d2psiM[1][0]) == Approx(-1.3757134676));
   REQUIRE(std::imag(d2psiM[1][1]) == Approx(-2.4919104576));
 #endif
-
-  SPOSetBuilderFactory::clear();
 }
 
 TEST_CASE("SPO input spline from HDF diamond_2x1x1", "[wavefunction]")


### PR DESCRIPTION
## Proposed changes
1. Make all SPOSetBuilderFactory static functions and variables scoped.
2. #2070 input style 2 and 3 all prints `!!!!!!! Deprecated input style`
3. basisset handling is moved into LCAOrbitalSet constructor. basisset can be named now.
Another step to memory clean code.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
