### PR TITLE
Nexus: fix module overwrite bug in qmca

### DIFF
--- a/nexus/bin/qmca
+++ b/nexus/bin/qmca
@@ -1218,12 +1218,12 @@ QMCA examples:
                 adata = obj()
                 ns=0
                 for series in serieslist:
-                    np = 0
+                    npf = 0
                     for prefix in sorted(data.keys()):
                         pdata = data[prefix]
-                        w = weights[np]
+                        w = weights[npf]
                         d = pdata[series]
-                        if np==0:
+                        if npf==0:
                             avg = d.copy()
                             di = d.info
                             avg.info.set(
@@ -1235,7 +1235,7 @@ QMCA examples:
                             avg.zero()
                         #end if
                         avg.accumulate(d,w)
-                        np+=1
+                        npf+=1
                     #end for
                     avg.normalize()
                     file_list.append(avg.info.filepath)
@@ -1277,12 +1277,12 @@ QMCA examples:
                         #end if
                     #end if
                     for series in serieslist:
-                        np = 0
+                        npf = 0
                         for prefix in sorted(prefixes):
                             pdata = data[prefix]
-                            w = weights[np]
+                            w = weights[npf]
                             d = pdata[series]
-                            if np==0:
+                            if npf==0:
                                 avg = d.copy()
                                 di = d.info
                                 avg.info.set(
@@ -1294,7 +1294,7 @@ QMCA examples:
                                 avg.zero()
                             #end if
                             avg.accumulate(d,w)
-                            np+=1
+                            npf+=1
                         #end for
                         avg.normalize()
                         file_list.append(avg.info.filepath)
@@ -1433,11 +1433,11 @@ QMCA examples:
             for quantity in quantities:
                 for mode in range(len(modes)):
                     if modes[mode]:
-                        np = 0
+                        npf = 0
                         for prefix in prefix_list:
-                            first_prefix = np==0
-                            last_prefix  = np==len(self.data)-1
-                            np+=1
+                            first_prefix = npf==0
+                            last_prefix  = npf==len(self.data)-1
+                            npf+=1
                             if first_prefix or not opt.overlay:
                                 fig = plt.figure()
                                 ax = fig.add_subplot(111)


### PR DESCRIPTION
## Proposed changes

The `--save_average` option in `qmca` was broken due to a local namespace collision with the globally assigned name for the `numpy` module (imported as `np`).  The fix is to use a different local variable name.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

