### PR TITLE
Generalized 2 particle cusp

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -199,6 +199,7 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ2(xmlNodePtr cur)
       int ia        = species.findSpecies(spA);
       int ib        = species.findSpecies(spB);
       int chargeInd = species.addAttribute("charge");
+      int massInd   = species.addAttribute("mass");
       std::string illegal_species;
       if (ia == species.size())
         illegal_species = spA;
@@ -218,8 +219,14 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ2(xmlNodePtr cur)
                   true);
       if (cusp < -1e6)
       {
-        RealType qq = species(chargeInd, ia) * species(chargeInd, ib);
-        cusp        = (ia == ib) ? -0.25 * qq : -0.5 * qq;
+        RealType qq       = species(chargeInd, ia) * species(chargeInd, ib);
+        RealType red_mass = species(massInd, ia) * species(massInd, ib) / (species(massInd, ia) + species(massInd, ib));
+#if OHMMS_DIM == 1
+        RealType dim_factor = 1.0 / (OHMMS_DIM + 1);
+#else
+        RealType dim_factor = (ia == ib) ? 1.0 / (OHMMS_DIM + 1) : 1.0 / (OHMMS_DIM - 1);
+#endif
+        cusp = -2 * qq * red_mass * dim_factor;
       }
       app_summary() << "    Radial function for species: " << spA << " - " << spB << std::endl;
       app_debug() << "    RadialJastrowBuilder adds a functor with cusp = " << cusp << std::endl;

--- a/src/QMCWaveFunctions/tests/test_wf.cpp
+++ b/src/QMCWaveFunctions/tests/test_wf.cpp
@@ -71,8 +71,11 @@ TEST_CASE("Pade Jastrow", "[wavefunction]")
   int upIdx                    = tspecies.addSpecies("u");
   int downIdx                  = tspecies.addSpecies("d");
   int chargeIdx                = tspecies.addAttribute("charge");
+  int massIdx                  = tspecies.addAttribute("mass");
   tspecies(chargeIdx, upIdx)   = -1;
   tspecies(chargeIdx, downIdx) = -1;
+  tspecies(massIdx, upIdx)     = 1;
+  tspecies(massIdx, downIdx)   = 1;
 
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();


### PR DESCRIPTION
## Proposed changes
This generalizes the hard coded cusp condition to -2 q_i q_j mu_ij / (d \pm 1). In the 1D case, the denominator is always taken to be the plus case ([see footnote 45](https://arxiv.org/abs/2003.06506)). 

## What type(s) of changes does this code introduce?
- Bugfix
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Workstation (i7 2600s)
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No? This PR adds tests to cover any new code, or to catch a bug that is being fixed
Should a test be added with various particle masses? 
- N/A. Documentation has been added (if appropriate)
