### PR TITLE
Expose skipChecks in einspline orbs

### DIFF
--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -222,6 +222,8 @@ attribute:
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
 | ``source``                  | Text       | Any                      | Ion0    | Particle set with atomic positions.       |
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
+| ``skip_checks``             | Text       | Yes/no                   | No      | skips checks for ion information in h5    |
++-----------------------------+------------+--------------------------+---------+-------------------------------------------+
 
 .. centered:: Table 3 Options for the ``determinantset`` xml-block associated with B-spline single particle orbital sets.
 
@@ -272,6 +274,10 @@ Additional information:
   access host memory via zero-copy. Although the performance penalty
   introduced by it is significant, it allows large calculations to go
   through.
+ 
+- ``skip_checks``. When converting the wave function from convertpw4qmc instead
+  of pw2qmcpack, there is missing ionic information. This flag bypasses the requirement
+  that the ionic information in the eshdf.h5 file match the input xml. 
 
 .. _gaussianbasis:
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -114,6 +114,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   int sortBands(1);
   int spinSet      = 0;
   int TwistNum_inp = 0;
+  bool skipChecks = false;
 
   std::string sourceName;
   std::string spo_prec("double");
@@ -146,6 +147,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add(truncate, "truncate");
     a.add(use_einspline_set_extended, "use_old_spline");
     a.add(myName, "tag");
+    a.add(skipChecks, "skipChecks");
 #if defined(QMC_CUDA)
     a.add(gpu::MaxGPUSpineSizeMB, "Spline_Size_Limit_MB");
 #endif
@@ -253,7 +255,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 
   // set the internal parameters
   if (spinSet == 0)
-    set_metadata(numOrbs, TwistNum_inp);
+    set_metadata(numOrbs, TwistNum_inp, skipChecks);
   //if (use_complex_orb == "yes") UseRealOrbitals = false; // override given user input
 
   // look for <backflow>, would be a lot easier with xpath, but I cannot get it to work
@@ -288,7 +290,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   //////////////////////////////////
   Timer mytimer;
   mytimer.restart();
-  OccupyBands(spinSet, sortBands, numOrbs);
+  OccupyBands(spinSet, sortBands, numOrbs,skipChecks);
   if (spinSet == 0)
     TileIons();
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -120,6 +120,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   std::string spo_prec("double");
   std::string truncate("no");
   std::string hybrid_rep("no");
+  std::string skip_checks("no");
   std::string use_einspline_set_extended(
       "no"); // use old spline library for high-order derivatives, e.g. needed for backflow optimization
 #if defined(QMC_CUDA) || defined(ENABLE_OFFLOAD)
@@ -147,7 +148,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add(truncate, "truncate");
     a.add(use_einspline_set_extended, "use_old_spline");
     a.add(myName, "tag");
-    a.add(skipChecks, "skip_checks");
+    a.add(skip_checks, "skip_checks");
 #if defined(QMC_CUDA)
     a.add(gpu::MaxGPUSpineSizeMB, "Spline_Size_Limit_MB");
 #endif
@@ -162,6 +163,10 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     if (myName.empty())
       myName = "einspline";
   }
+
+  if (skip_checks == "yes")
+    skipChecks = true;
+
 
   SourcePtcl = ParticleSets[sourceName];
   if (SourcePtcl == 0)

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -114,7 +114,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   int sortBands(1);
   int spinSet      = 0;
   int TwistNum_inp = 0;
-  bool skipChecks = false;
+  bool skipChecks  = false;
 
   std::string sourceName;
   std::string spo_prec("double");
@@ -235,7 +235,8 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   if ((iter != SPOSetMap.end()) && (!NewOcc))
   {
     app_log() << "SPOSet parameters match in EinsplineSetBuilder. cloning EinsplineSet object." << std::endl;
-    app_warning() << "!!!!!!! Deprecated input style: implict sharing one SPOSet for spin-up and spin-down electrions has been deprecated. Create a single SPO set outside determinantset instead."
+    app_warning() << "!!!!!!! Deprecated input style: implict sharing one SPOSet for spin-up and spin-down electrions "
+                     "has been deprecated. Create a single SPO set outside determinantset instead."
                   << "Use sposet_collection to construct an explict sposet for explicit sharing." << std::endl;
     OrbitalSet = iter->second->makeClone();
     OrbitalSet->setName("");
@@ -290,7 +291,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   //////////////////////////////////
   Timer mytimer;
   mytimer.restart();
-  OccupyBands(spinSet, sortBands, numOrbs,skipChecks);
+  OccupyBands(spinSet, sortBands, numOrbs, skipChecks);
   if (spinSet == 0)
     TileIons();
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -147,7 +147,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add(truncate, "truncate");
     a.add(use_einspline_set_extended, "use_old_spline");
     a.add(myName, "tag");
-    a.add(skipChecks, "skipChecks");
+    a.add(skipChecks, "skip_checks");
 #if defined(QMC_CUDA)
     a.add(gpu::MaxGPUSpineSizeMB, "Spline_Size_Limit_MB");
 #endif


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This exposes the skipChecks to the xml input. This is a workaround for the fact the eshdf from convertpw4qmc does not include the atomic number. 

Addresses the issue in #2811 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

-- No

## What systems has this change been tested on?
my workstation, gnu 9.2.0

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
