### PR TITLE
sphinxcontrib-bibtex version fix for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,4 @@
-sphinxcontrib.bibtex
+sphinx>=3.0
+sphinx_rtd_theme
+sphinxcontrib-bibtex<2.0
+


### PR DESCRIPTION
## Proposed changes

Require use of old version of sphinxcontrib-bibtex. Temporary fix until we learn how to use v2.0 with rtd and also make any required updates.

rtd settings also changed to use the requirements file.

## What type(s) of changes does this code introduce?

- Bugfix
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
