### PR TITLE
Refactor MCWalkerConfiguration

### DIFF
--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(PARTICLE
   ParticleSet.BC.cpp
   DynamicCoordinatesBuilder.cpp
   MCWalkerConfiguration.cpp
+  #WalkerConfigurations.cpp
   SampleStack.cpp
   createDistanceTableAA.cpp
   createDistanceTableAB.cpp

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -21,7 +21,7 @@ SET(PARTICLE
   ParticleSet.BC.cpp
   DynamicCoordinatesBuilder.cpp
   MCWalkerConfiguration.cpp
-  #WalkerConfigurations.cpp
+  WalkerConfigurations.cpp
   SampleStack.cpp
   createDistanceTableAA.cpp
   createDistanceTableAB.cpp

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -47,7 +47,6 @@ MCWalkerConfiguration::MCWalkerConfiguration(const DynamicCoordinateKind kind)
       iatList_GPU("iatList_GPU"),
       AcceptList_GPU("MCWalkerConfiguration::AcceptList_GPU"),
 #endif
-      OwnWalkers(true),
       ReadyForPbyP(false),
       GlobalNumWalkers(0),
       UpdateMode(Update_Walker),
@@ -69,7 +68,6 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
       iatList_GPU("iatList_GPU"),
       AcceptList_GPU("MCWalkerConfiguration::AcceptList_GPU"),
 #endif
-      OwnWalkers(true),
       ReadyForPbyP(false),
       GlobalNumWalkers(mcw.GlobalNumWalkers),
       UpdateMode(Update_Walker),
@@ -86,8 +84,7 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
 ///default destructor
 MCWalkerConfiguration::~MCWalkerConfiguration()
 {
-  if (OwnWalkers)
-    destroyWalkers(WalkerList.begin(), WalkerList.end());
+  destroyWalkers(WalkerList.begin(), WalkerList.end());
 }
 
 
@@ -171,13 +168,10 @@ void MCWalkerConfiguration::resize(int numWalkers, int numPtcls)
 ///returns the next valid iterator
 MCWalkerConfiguration::iterator MCWalkerConfiguration::destroyWalkers(iterator first, iterator last)
 {
-  if (OwnWalkers)
+  iterator it = first;
+  while (it != last)
   {
-    iterator it = first;
-    while (it != last)
-    {
-      delete *it++;
-    }
+    delete *it++;
   }
   return WalkerList.erase(first, last);
 }
@@ -185,7 +179,6 @@ MCWalkerConfiguration::iterator MCWalkerConfiguration::destroyWalkers(iterator f
 void MCWalkerConfiguration::createWalkers(iterator first, iterator last)
 {
   destroyWalkers(WalkerList.begin(), WalkerList.end());
-  OwnWalkers = true;
   while (first != last)
   {
     WalkerList.push_back(new Walker_t(**first));
@@ -220,34 +213,6 @@ void MCWalkerConfiguration::copyWalkers(iterator first, iterator last, iterator 
   {
     (*it++)->makeCopy(**first++);
   }
-}
-
-
-void MCWalkerConfiguration::copyWalkerRefs(Walker_t* head, Walker_t* tail)
-{
-  if (OwnWalkers)
-  //destroy the current walkers
-  {
-    destroyWalkers(WalkerList.begin(), WalkerList.end());
-    WalkerList.clear();
-    OwnWalkers = false; //set to false to prevent deleting the Walkers
-  }
-  if (WalkerList.size() < 2)
-  {
-    WalkerList.push_back(0);
-    WalkerList.push_back(0);
-  }
-  WalkerList[0] = head;
-  WalkerList[1] = tail;
-}
-
-void MCWalkerConfiguration::fakeWalkerList(Walker_t* first, Walker_t* second)
-{
-  if (WalkerList.size() != 0)
-    throw std::runtime_error("This should only be called in tests and only with a fresh MCWC!");
-  OwnWalkers = false;
-  WalkerList.push_back(first);
-  WalkerList.push_back(second);
 }
 
 /** Make Metropolis move to the walkers and save in a temporary array.

--- a/src/Particle/MCWalkerConfiguration.h
+++ b/src/Particle/MCWalkerConfiguration.h
@@ -23,10 +23,10 @@
 #ifndef QMCPLUSPLUS_MCWALKERCONFIGURATION_H
 #define QMCPLUSPLUS_MCWALKERCONFIGURATION_H
 #include "Particle/ParticleSet.h"
+#include "Particle/WalkerConfigurations.h"
 #include "Particle/Walker.h"
 #include "Particle/SampleStack.h"
 #include "Utilities/IteratorUtility.h"
-//#include "Particle/Reptile.h"
 
 #ifdef QMC_CUDA
 #include "type_traits/CUDATypes.h"
@@ -57,7 +57,7 @@ class Reptile;
 
  *</ul>
  */
-class MCWalkerConfiguration : public ParticleSet
+class MCWalkerConfiguration : public ParticleSet, public WalkerConfigurations
 {
 public:
   /**enumeration for update*/
@@ -68,6 +68,7 @@ public:
     Update_Particle ///move a particle by particle
   };
 
+  using Walker_t = WalkerConfigurations::Walker_t;
   ///container type of the Properties of a Walker
   typedef Walker_t::PropertyContainer_t PropertyContainer_t;
   ///container type of Walkers
@@ -78,16 +79,6 @@ public:
   typedef WalkerList_t::const_iterator const_iterator;
 
   typedef std::vector<Reptile*> ReptileList_t;
-  /** starting index of the walkers in a processor group
-   *
-   * WalkerOffsets[0]=0 and WalkerOffsets[WalkerOffsets.size()-1]=total number of walkers in a group
-   * WalkerOffsets[processorid+1]-WalkerOffsets[processorid] is equal to the number of walkers on a processor,
-   * i.e., W.getActiveWalkers().
-   * WalkerOffsets is added to handle parallel I/O with hdf5
-   */
-  std::vector<int> WalkerOffsets;
-
-  MCDataType<FullPrecRealType> EnsembleProperty;
 
   // Data for GPU-acceleration via CUDA
   // These hold a list of pointers to the positions, gradients, and
@@ -140,110 +131,22 @@ public:
    * Append Walkers to WalkerList.
    */
   void createWalkers(int numWalkers);
-  /** create walkers
-   * @param first walker iterator
-   * @param last walker iterator
-   */
-  void createWalkers(iterator first, iterator last);
-  /** copy walkers
-   * @param first input walker iterator
-   * @param last input walker iterator
-   * @param start first target iterator
-   *
-   * No memory allocation is allowed.
-   */
-  void copyWalkers(iterator first, iterator last, iterator start);
-
-  /** destroy Walkers from itstart to itend
-   *@param first starting iterator of the walkers
-   *@param last ending iterator of the walkers
-   */
-  iterator destroyWalkers(iterator first, iterator last);
-
-  /** destroy Walkers
-   *@param nw number of walkers to be destroyed
-   */
-  void destroyWalkers(int nw);
-
   ///clean up the walker list and make a new list
   void resize(int numWalkers, int numPtcls);
+
+  ///clean up the walker list
+  using WalkerConfigurations::clear;
+  ///resize Walker::PropertyHistory and Walker::PHindex:
+  void resizeWalkerHistories();
 
   ///make random moves for all the walkers
   //void sample(iterator first, iterator last, value_type tauinv);
   ///make a random move for a walker
   void sample(iterator it, RealType tauinv);
 
-  ///return the number of active walkers
-  inline size_t getActiveWalkers() const { return WalkerList.size(); }
-  ///return the total number of active walkers among a MPI group
-  inline size_t getGlobalNumWalkers() const { return GlobalNumWalkers; }
-  ///return the total number of active walkers among a MPI group
-  inline void setGlobalNumWalkers(size_t nw)
-  {
-    GlobalNumWalkers            = nw;
-    EnsembleProperty.NumSamples = nw;
-    EnsembleProperty.Weight     = nw;
-  }
-
-  inline void setWalkerOffsets(const std::vector<int>& o) { WalkerOffsets = o; }
-
   ///return the number of particles per walker
   inline int getParticleNum() const { return R.size(); }
-
-  /// return the first iterator
-  inline iterator begin() { return WalkerList.begin(); }
-  /// return the last iterator, [begin(), end())
-  inline iterator end() { return WalkerList.end(); }
-
-  /// return the first const_iterator
-  inline const_iterator begin() const { return WalkerList.begin(); }
-
-  /// return the last const_iterator  [begin(), end())
-  inline const_iterator end() const { return WalkerList.end(); }
   /**@}*/
-
-  /** clear the WalkerList without destroying them
-   *
-   * Provide std::vector::clear interface
-   */
-  inline void clear() { WalkerList.clear(); }
-
-  /** insert elements
-   * @param it locator where the inserting begins
-   * @param first starting iterator
-   * @param last ending iterator
-   *
-   * Provide std::vector::insert interface
-   */
-  template<class INPUT_ITER>
-  inline void insert(iterator it, INPUT_ITER first, INPUT_ITER last)
-  {
-    WalkerList.insert(it, first, last);
-  }
-
-  /** add Walker_t* at the end
-   * @param awalker pointer to a walker
-   *
-   * Provide std::vector::push_back interface
-   */
-  inline void push_back(Walker_t* awalker) { WalkerList.push_back(awalker); }
-
-  ///resize Walker::PropertyHistory and Walker::PHindex:
-  void resizeWalkerHistories();
-
-  /** delete the last Walker_t*
-   *
-   * Provide std::vector::pop_back interface
-   */
-  inline void pop_back()
-  {
-    delete WalkerList.back();
-    WalkerList.pop_back();
-  }
-
-  inline Walker_t* operator[](int i) { return WalkerList[i]; }
-
-  inline const Walker_t* operator[](int i) const { return WalkerList[i]; }
 
   /** set LocalEnergy
    * @param e current average Local Energy
@@ -258,9 +161,15 @@ public:
 
   inline void setPolymer(MultiChain* chain) { Polymer = chain; }
 
-  /** reset the Walkers
-   */
-  void reset();
+  template<typename ForwardIter>
+  inline void putConfigurations(ForwardIter target)
+  {
+    int ds = OHMMS_DIM * TotalNum;
+    for (iterator it = WalkerList.begin(); it != WalkerList.end(); ++it, target += ds)
+    {
+      copy(get_first_address((*it)->R), get_last_address((*it)->R), target);
+    }
+  }
 
   void resetWalkerProperty(int ncopy = 1);
 
@@ -300,24 +209,6 @@ public:
   /// Transitional forwarding methods
   int getMaxSamples() const;
   //@}
-
-  template<typename ForwardIter>
-  inline void putConfigurations(ForwardIter target)
-  {
-    int ds = OHMMS_DIM * TotalNum;
-    for (iterator it = WalkerList.begin(); it != WalkerList.end(); ++it, target += ds)
-    {
-      copy(get_first_address((*it)->R), get_last_address((*it)->R), target);
-    }
-  }
-
-  inline void resetWalkerParents()
-  {
-    for (iterator it = WalkerList.begin(); it != WalkerList.end(); ++it)
-    {
-      (*it)->ParentID = (*it)->ID;
-    }
-  }
 
 #ifdef QMC_CUDA
   inline void setklinear() { klinear = true; }
@@ -400,10 +291,6 @@ public:
 protected:
   ///true if the buffer is ready for particle-by-particle updates
   bool ReadyForPbyP;
-  ///number of walkers on a node
-  int LocalNumWalkers;
-  ///number of walkers shared by a MPI group
-  size_t GlobalNumWalkers;
   ///update-mode index
   int UpdateMode;
 #ifdef QMC_CUDA
@@ -426,8 +313,6 @@ protected:
   RealType LocalEnergy;
 
 public:
-  ///a collection of walkers
-  WalkerList_t WalkerList;
   ///a collection of reptiles contained in MCWalkerConfiguration.
   ReptileList_t ReptileList;
   Reptile* reptile;

--- a/src/Particle/MCWalkerConfiguration.h
+++ b/src/Particle/MCWalkerConfiguration.h
@@ -165,21 +165,6 @@ public:
    */
   void destroyWalkers(int nw);
 
-  /** copy the pointers to the Walkers to WalkerList
-   * @param head pointer to the head walker
-   * @param tail pointer to the tail walker
-   *
-   * \todo I believe this can/should be deleted
-   * Special function introduced to work with Reptation method.
-   * Clear the current WalkerList and add two walkers, head and tail.
-   * OwnWalkers are set to false.
-   */
-  void copyWalkerRefs(Walker_t* head, Walker_t* tail);
-
-  /** make fake walker list for testing
-   */
-  void fakeWalkerList(Walker_t* first, Walker_t* second);
-
   ///clean up the walker list and make a new list
   void resize(int numWalkers, int numPtcls);
 
@@ -413,8 +398,6 @@ public:
 #endif
 
 protected:
-  ///boolean for cleanup
-  bool OwnWalkers;
   ///true if the buffer is ready for particle-by-particle updates
   bool ReadyForPbyP;
   ///number of walkers on a node

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -36,30 +36,6 @@ class DistanceTableData;
 
 class StructFact;
 
-/** Monte Carlo Data of an ensemble
- *
- * The quantities are shared by all the nodes in a group
- * - NumSamples number of samples
- * - Weight     total weight of a sample
- * - Energy     average energy of a sample
- * - Variance   variance
- * - LivingFraction fraction of walkers alive each step.
- */
-template<typename T>
-struct MCDataType
-{
-  T NumSamples;
-  T RNSamples;
-  T Weight;
-  T Energy;
-  T AlternateEnergy;
-  T Variance;
-  T R2Accepted;
-  T R2Proposed;
-  T LivingFraction;
-};
-
-
 /** Specialized paritlce class for atomistic simulations
  *
  * Derived from QMCTraits, ParticleBase<PtclOnLatticeTraits> and OhmmsElementBase.
@@ -88,9 +64,6 @@ public:
   quantum_domains quantum_domain;
 
   //@{ public data members
-  ///property of an ensemble represented by this ParticleSet
-  //MCDataType<FullPrecRealType> EnsembleProperty;
-
   ///ParticleLayout
   ParticleLayout_t Lattice, PrimitiveLattice;
   ///Long-range box

--- a/src/Particle/WalkerConfigurations.cpp
+++ b/src/Particle/WalkerConfigurations.cpp
@@ -1,0 +1,158 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Jordan E. Vincent, University of Illinois at Urbana-Champaign
+//                    Bryan Clark, bclark@Princeton.edu, Princeton University
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Cynthia Gu, zg1@ornl.gov, Oak Ridge National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "WalkerConfigurations.h"
+#include <map>
+#include "Utilities/IteratorUtility.h"
+
+namespace qmcplusplus
+{
+WalkerConfigurations::WalkerConfigurations() : LocalNumWalkers(0), GlobalNumWalkers(0) {}
+
+///default destructor
+WalkerConfigurations::~WalkerConfigurations() { destroyWalkers(WalkerList.begin(), WalkerList.end()); }
+
+
+void WalkerConfigurations::createWalkers(int n, size_t numPtcls)
+{
+  if (WalkerList.empty())
+  {
+    while (n)
+    {
+      Walker_t* awalker = new Walker_t(numPtcls);
+      WalkerList.push_back(awalker);
+      --n;
+    }
+  }
+  else
+  {
+    if (WalkerList.size() >= n)
+    {
+      int iw = WalkerList.size(); //copy from the back
+      for (int i = 0; i < n; ++i)
+      {
+        WalkerList.push_back(new Walker_t(*WalkerList[--iw]));
+      }
+    }
+    else
+    {
+      int nc  = n / WalkerList.size();
+      int nw0 = WalkerList.size();
+      for (int iw = 0; iw < nw0; ++iw)
+      {
+        for (int ic = 0; ic < nc; ++ic)
+          WalkerList.push_back(new Walker_t(*WalkerList[iw]));
+      }
+      n -= nc * nw0;
+      while (n > 0)
+      {
+        WalkerList.push_back(new Walker_t(*WalkerList[--nw0]));
+        --n;
+      }
+    }
+  }
+}
+
+
+void WalkerConfigurations::resize(int numWalkers, size_t numPtcls)
+{
+  int dn = numWalkers - WalkerList.size();
+  if (dn > 0)
+    createWalkers(dn, numPtcls);
+  if (dn < 0)
+  {
+    int nw = -dn;
+    if (nw < WalkerList.size())
+    {
+      iterator it = WalkerList.begin();
+      while (nw)
+      {
+        delete *it;
+        ++it;
+        --nw;
+      }
+      WalkerList.erase(WalkerList.begin(), WalkerList.begin() - dn);
+    }
+  }
+}
+
+///returns the next valid iterator
+WalkerConfigurations::iterator WalkerConfigurations::destroyWalkers(iterator first, iterator last)
+{
+  iterator it = first;
+  while (it != last)
+  {
+    delete *it++;
+  }
+  return WalkerList.erase(first, last);
+}
+
+void WalkerConfigurations::createWalkers(iterator first, iterator last)
+{
+  destroyWalkers(WalkerList.begin(), WalkerList.end());
+  while (first != last)
+  {
+    WalkerList.push_back(new Walker_t(**first));
+    ++first;
+  }
+}
+
+void WalkerConfigurations::destroyWalkers(int nw)
+{
+  if (nw > WalkerList.size())
+  {
+    app_warning() << "  Cannot remove walkers. Current Walkers = " << WalkerList.size() << std::endl;
+    return;
+  }
+  nw     = WalkerList.size() - nw;
+  int iw = nw;
+  while (iw < WalkerList.size())
+  {
+    delete WalkerList[iw++];
+  }
+  WalkerList.erase(WalkerList.begin() + nw, WalkerList.end());
+}
+
+void WalkerConfigurations::copyWalkers(iterator first, iterator last, iterator it)
+{
+  while (first != last)
+  {
+    (*it++)->makeCopy(**first++);
+  }
+}
+
+/** Make Metropolis move to the walkers and save in a temporary array.
+ * @param it the iterator of the first walker to work on
+ * @param tauinv  inverse of the time step
+ *
+ * R + D + X
+ */
+void WalkerConfigurations::reset()
+{
+  iterator it(WalkerList.begin()), it_end(WalkerList.end());
+  while (it != it_end)
+  //(*it)->reset();++it;}
+  {
+    (*it)->Weight       = 1.0;
+    (*it)->Multiplicity = 1.0;
+    ++it;
+  }
+}
+
+} // namespace qmcplusplus

--- a/src/Particle/WalkerConfigurations.h
+++ b/src/Particle/WalkerConfigurations.h
@@ -1,0 +1,201 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Jordan E. Vincent, University of Illinois at Urbana-Champaign
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Cynthia Gu, zg1@ornl.gov, Oak Ridge National Laboratory
+//                    Raymond Clay III, j.k.rofling@gmail.com, Lawrence Livermore National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file WalkerConfigurations.h
+ * @brief Declaration of a WalkerConfigurations
+ */
+#ifndef QMCPLUSPLUS_WALKERCONFIGURATIONS_H
+#define QMCPLUSPLUS_WALKERCONFIGURATIONS_H
+#include "Configuration.h"
+#include "Particle/Walker.h"
+#include "Utilities/IteratorUtility.h"
+
+namespace qmcplusplus
+{
+/** Monte Carlo Data of an ensemble
+ *
+ * The quantities are shared by all the nodes in a group
+ * - NumSamples number of samples
+ * - Weight     total weight of a sample
+ * - Energy     average energy of a sample
+ * - Variance   variance
+ * - LivingFraction fraction of walkers alive each step.
+ */
+template<typename T>
+struct MCDataType
+{
+  T NumSamples;
+  T RNSamples;
+  T Weight;
+  T Energy;
+  T AlternateEnergy;
+  T Variance;
+  T R2Accepted;
+  T R2Proposed;
+  T LivingFraction;
+};
+
+/** A set of light weight walkers that are carried between driver sections and restart
+ */
+class WalkerConfigurations
+{
+public:
+  /// walker type
+  using Walker_t         = Walker<QMCTraits, PtclOnLatticeTraits>;
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
+  ///container type of Walkers
+  using WalkerList_t = std::vector<Walker_t*>;
+  /// FIX: a type alias of iterator for an object should not be for just one of many objects it holds.
+  using iterator = WalkerList_t::iterator;
+  ///const_iterator of Walker container
+  using const_iterator = WalkerList_t::const_iterator;
+
+  /** starting index of the walkers in a processor group
+   *
+   * WalkerOffsets[0]=0 and WalkerOffsets[WalkerOffsets.size()-1]=total number of walkers in a group
+   * WalkerOffsets[processorid+1]-WalkerOffsets[processorid] is equal to the number of walkers on a processor,
+   * i.e., W.getActiveWalkers().
+   * WalkerOffsets is added to handle parallel I/O with hdf5
+   */
+  std::vector<int> WalkerOffsets;
+
+  MCDataType<FullPrecRealType> EnsembleProperty;
+
+  WalkerConfigurations();
+  ~WalkerConfigurations();
+  WalkerConfigurations(const WalkerConfigurations&) = delete;
+  WalkerConfigurations& operator=(const WalkerConfigurations&) = delete;
+  WalkerConfigurations(WalkerConfigurations&&)                 = default;
+  WalkerConfigurations& operator=(WalkerConfigurations&&) = default;
+
+  /** create numWalkers Walkers
+   *
+   * Append Walkers to WalkerList.
+   */
+  void createWalkers(int numWalkers, size_t numPtcls);
+  /** create walkers
+   * @param first walker iterator
+   * @param last walker iterator
+   */
+  void createWalkers(iterator first, iterator last);
+  /** copy walkers
+   * @param first input walker iterator
+   * @param last input walker iterator
+   * @param start first target iterator
+   *
+   * No memory allocation is allowed.
+   */
+  void copyWalkers(iterator first, iterator last, iterator start);
+
+  /** destroy Walkers from itstart to itend
+   *@param first starting iterator of the walkers
+   *@param last ending iterator of the walkers
+   */
+  iterator destroyWalkers(iterator first, iterator last);
+
+  /** destroy Walkers
+   *@param nw number of walkers to be destroyed
+   */
+  void destroyWalkers(int nw);
+
+  ///clean up the walker list and make a new list
+  void resize(int numWalkers, size_t numPtcls);
+
+  ///return the number of active walkers
+  inline size_t getActiveWalkers() const { return WalkerList.size(); }
+  ///return the total number of active walkers among a MPI group
+  inline size_t getGlobalNumWalkers() const { return GlobalNumWalkers; }
+  ///return the total number of active walkers among a MPI group
+  inline void setGlobalNumWalkers(size_t nw)
+  {
+    GlobalNumWalkers            = nw;
+    EnsembleProperty.NumSamples = nw;
+    EnsembleProperty.Weight     = nw;
+  }
+
+  inline void setWalkerOffsets(const std::vector<int>& o) { WalkerOffsets = o; }
+
+  /// return the first iterator
+  inline iterator begin() { return WalkerList.begin(); }
+  /// return the last iterator, [begin(), end())
+  inline iterator end() { return WalkerList.end(); }
+
+  /// return the first const_iterator
+  inline const_iterator begin() const { return WalkerList.begin(); }
+
+  /// return the last const_iterator  [begin(), end())
+  inline const_iterator end() const { return WalkerList.end(); }
+  /**@}*/
+
+  /** clear the WalkerList without destroying them
+   *
+   * Provide std::vector::clear interface
+   */
+  inline void clear() { WalkerList.clear(); }
+
+  /** insert elements
+   * @param it locator where the inserting begins
+   * @param first starting iterator
+   * @param last ending iterator
+   *
+   * Provide std::vector::insert interface
+   */
+  template<class INPUT_ITER>
+  inline void insert(iterator it, INPUT_ITER first, INPUT_ITER last)
+  {
+    WalkerList.insert(it, first, last);
+  }
+
+  /** add Walker_t* at the end
+   * @param awalker pointer to a walker
+   *
+   * Provide std::vector::push_back interface
+   */
+  inline void push_back(Walker_t* awalker) { WalkerList.push_back(awalker); }
+
+  /** delete the last Walker_t*
+   *
+   * Provide std::vector::pop_back interface
+   */
+  inline void pop_back()
+  {
+    delete WalkerList.back();
+    WalkerList.pop_back();
+  }
+
+  inline Walker_t* operator[](int i) { return WalkerList[i]; }
+
+  inline const Walker_t* operator[](int i) const { return WalkerList[i]; }
+
+  /** reset the Walkers
+   */
+  void reset();
+
+protected:
+  ///number of walkers on a node
+  int LocalNumWalkers;
+  ///number of walkers shared by a MPI group
+  size_t GlobalNumWalkers;
+
+public:
+  ///a collection of walkers
+  WalkerList_t WalkerList;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/Particle/tests/test_walker.cpp
+++ b/src/Particle/tests/test_walker.cpp
@@ -72,7 +72,9 @@ TEST_CASE("walker HDF read and write", "[particle]")
 
   // This method sets ownership to false so class does not attempt to
   // free the walker elements.
-  W.copyWalkerRefs(&w1, &w2);
+  W.createWalkers(2);
+  W[0]->R = w1.R;
+  W[1]->R = w2.R;
 
   REQUIRE(W.getActiveWalkers() == 2);
 

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -24,28 +24,28 @@ MCPopulation::MCPopulation()
 {}
 
 MCPopulation::MCPopulation(int num_ranks,
-                           MCWalkerConfiguration& mcwc,
+                           WalkerConfigurations& mcwc,
                            ParticleSet* elecs,
                            TrialWaveFunction* trial_wf,
                            QMCHamiltonian* hamiltonian,
                            int this_rank)
     : trial_wf_(trial_wf), elec_particle_set_(elecs), hamiltonian_(hamiltonian), num_ranks_(num_ranks), rank_(this_rank)
 {
-  num_global_walkers_ = mcwc.GlobalNumWalkers;
-  num_local_walkers_  = mcwc.LocalNumWalkers;
-  num_particles_      = mcwc.getParticleNum();
+  num_global_walkers_ = mcwc.getGlobalNumWalkers();
+  num_local_walkers_  = mcwc.getActiveWalkers();
+  num_particles_      = elecs->getTotalNum();
 
   // MCWalkerConfiguration doesn't give actual number of groups
-  num_groups_ = mcwc.groups();
+  num_groups_ = elecs->groups();
   particle_group_indexes_.resize(num_groups_);
   for (int i = 0; i < num_groups_; ++i)
   {
-    particle_group_indexes_[i].first  = mcwc.first(i);
-    particle_group_indexes_[i].second = mcwc.last(i);
+    particle_group_indexes_[i].first  = elecs->first(i);
+    particle_group_indexes_[i].second = elecs->last(i);
   }
   ptclgrp_mass_.resize(num_groups_);
   for (int ig = 0; ig < num_groups_; ++ig)
-    ptclgrp_mass_[ig] = mcwc.Mass[ig];
+    ptclgrp_mass_[ig] = elecs->Mass[ig];
   ptclgrp_inv_mass_.resize(num_groups_);
   for (int ig = 0; ig < num_groups_; ++ig)
     ptclgrp_inv_mass_[ig] = 1.0 / ptclgrp_mass_[ig];

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -96,7 +96,7 @@ public:
    *  in QMCDriverFactory.
    */
   MCPopulation(int num_ranks,
-               MCWalkerConfiguration& mcwc,
+               WalkerConfigurations& mcwc,
                ParticleSet* elecs,
                TrialWaveFunction* trial_wf,
                QMCHamiltonian* hamiltonian_,

--- a/src/QMCDrivers/tests/test_SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/tests/test_SimpleFixedNodeBranch.cpp
@@ -66,7 +66,9 @@ public:
     MCPWalker w2(1);
     w2.R[0] = 0.5;
 
-    mcwc_->fakeWalkerList(&w1, &w2);
+    mcwc_->createWalkers(2);
+    (*mcwc_)[0]->R = w1.R;
+    (*mcwc_)[1]->R = w2.R;
 
     SimpleFixedNodeBranch sfnb(tau_, num_global_walkers_);
 


### PR DESCRIPTION
## Proposed changes
MCWalkerConfiguration was overloaded. It is both a particleset and a list of lightweight walkers. The later role has been moved to WalkerConfigurations which is the object carried between QMC sections and restart.
the batched drivers will only interact with WalkerConfigurations instead of the whole MCWalkerConfiguration.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'