### PR TITLE
Fix call to GradCost in complex build

### DIFF
--- a/src/Optimize/VariableSet.cpp
+++ b/src/Optimize/VariableSet.cpp
@@ -233,7 +233,7 @@ void VariableSet::setDefaults(bool optimize_all)
     Index[i] = optimize_all ? i : -1;
 }
 
-void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader)
+void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader) const
 {
   std::string pad_str = std::string(leftPadSpaces, ' ');
   int max_name_len    = 0;

--- a/src/Optimize/VariableSet.h
+++ b/src/Optimize/VariableSet.h
@@ -356,7 +356,7 @@ struct VariableSet
    */
   void setDefaults(bool optimize_all);
 
-  void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false);
+  void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
 };
 } // namespace optimize
 

--- a/src/Optimize/testDerivOptimization.h
+++ b/src/Optimize/testDerivOptimization.h
@@ -140,7 +140,7 @@ public:
   }
 
 
-  void dfunc(std::vector<Return_t> RT, std::vector<Return_t>& FG)
+  void dfunc(const std::vector<Return_t>& RT, std::vector<Return_t>& FG)
   {
     ///To test we simply output the analytic and numeric gradients of the cost function. Make sure they agree.
     std::vector<Return_t> Dummy(FG);
@@ -163,7 +163,7 @@ public:
       else
         app_log() << vname << " " << RT[k] << "  " << Dummy[k] << "  " << FG[k] << "   inf" << std::endl;
       if (output_param_file_)
-        param_deriv_file_ << FG[k] << " ";
+        param_deriv_file_ << std::setprecision(10) << FG[k] << " ";
     }
     if (output_param_file_)
       param_deriv_file_ << std::endl;

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -43,11 +43,11 @@ QMCCostFunction::~QMCCostFunction()
   delete_iter(HDerivRecords.begin(), HDerivRecords.end());
 }
 
-void QMCCostFunction::GradCost(std::vector<Return_t>& PGradient, const std::vector<Return_t>& PM, Return_rt FiniteDiff)
+void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient, const std::vector<Return_rt>& PM, Return_rt FiniteDiff)
 {
   if (FiniteDiff > 0)
   {
-    QMCTraits::ValueType dh = 1.0 / (2.0 * FiniteDiff);
+    QMCTraits::RealType dh = 1.0 / (2.0 * FiniteDiff);
     for (int i = 0; i < NumOptimizables; i++)
     {
       for (int j = 0; j < NumOptimizables; j++)

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -36,8 +36,8 @@ public:
   ///Destructor
   ~QMCCostFunction();
 
-  void getConfigurations(const std::string& aroot);
-  void checkConfigurations();
+  void getConfigurations(const std::string& aroot) override;
+  void checkConfigurations() override;
 #ifdef HAVE_LMY_ENGINE
   void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
                                   DescentEngine& descentEngineObj,
@@ -45,9 +45,9 @@ public:
 #endif
 
 
-  void resetPsi(bool final_reset = false);
-  void GradCost(std::vector<Return_t>& PGradient, const std::vector<Return_t>& PM, Return_rt FiniteDiff = 0);
-  Return_rt fillOverlapHamiltonianMatrices(Matrix<Return_rt>& Left, Matrix<Return_rt>& Right);
+  void resetPsi(bool final_reset = false) override;
+  void GradCost(std::vector<Return_rt>& PGradient, const std::vector<Return_rt>& PM, Return_rt FiniteDiff = 0) override;
+  Return_rt fillOverlapHamiltonianMatrices(Matrix<Return_rt>& Left, Matrix<Return_rt>& Right) override;
 
 protected:
   std::vector<QMCHamiltonian*> H_KE_Node;
@@ -59,7 +59,7 @@ protected:
   std::vector<Matrix<Return_rt>*> HDerivRecords;
   Return_rt CSWeight;
 
-  Return_rt correlatedSampling(bool needGrad = true);
+  Return_rt correlatedSampling(bool needGrad = true) override;
 
 #ifdef HAVE_LMY_ENGINE
   int total_samples();


### PR DESCRIPTION
In the complex build, the call to `GradCost` in `testDerivOptimization` was calling the empty base class version `QMCCostFunctionBase` due to a parameter mismatch.  The parameter gradients would come out as all zero.
Add 'override' to catch the issue, fix the signature, and add more override's to keep clang happy.

Change a parameter to const and pass-by-reference in `testDerivOptimization`.
Increase the number of digits printed out in the parameter gradient file.

Add const to the `print` function in `VariableSet` (from debugging a Jastrow optimization issue).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)
- 
### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
