### PR TITLE
Nexus: fix a Jastrow read error/warning, add several QE inputs

### DIFF
--- a/nexus/lib/pwscf_input.py
+++ b/nexus/lib/pwscf_input.py
@@ -2330,6 +2330,12 @@ def generate_scf_input(prefix       = 'pwscf',
         pseudopotentials = pseudopotentials
         )
 
+    if noncolin or lspinorb:
+        pw.system.set(
+            noncolin = noncolin or lspinorb,
+            lspinorb = lspinorb
+            )
+    #end if
     if input_dft!=None:
         pw.system.input_dft = input_dft
     #end if

--- a/nexus/lib/pwscf_input.py
+++ b/nexus/lib/pwscf_input.py
@@ -2259,7 +2259,9 @@ def generate_scf_input(prefix       = 'pwscf',
                        use_folded   = True,
                        group_atoms  = False,
                        la2F         = None,
-                       nbnd         = None
+                       nbnd         = None,
+                       lspinorb     = False,
+                       noncolin     = False,
                        ):
     if pseudos is None:
         pseudos = []
@@ -2384,7 +2386,7 @@ def generate_scf_input(prefix       = 'pwscf',
         if not isinstance(start_mag,(dict,obj)):
             PwscfInput.class_error('input start_mag must be of type dict or obj')
         #end if
-        pw.system.start_mag = deepcopy(start_mag)
+        pw.system.starting_magnetization = deepcopy(start_mag)
         #if 'tot_magnetization' in pw.system:
         #    del pw.system.tot_magnetization
         ##end if
@@ -2582,7 +2584,7 @@ def generate_relax_input(prefix       = 'pwscf',
         if not isinstance(start_mag,(dict,obj)):
             PwscfInput.class_error('input start_mag must be of type dict or obj')
         #end if
-        pw.system.start_mag = deepcopy(start_mag)
+        pw.system.starting_magnetization = deepcopy(start_mag)
         #if 'tot_magnetization' in pw.system:
         #    del pw.system.tot_magnetization
         ##end if
@@ -2648,6 +2650,7 @@ def generate_relax_input(prefix       = 'pwscf',
 def generate_vcrelax_input(
     press          = None, # None = use pw.x default
     cell_factor    = None, 
+    cell_dofree    = None,
     forc_conv_thr  = None,
     ion_dynamics   = None,
     press_conv_thr = None,
@@ -2674,6 +2677,9 @@ def generate_vcrelax_input(
     # end if
     if press_conv_thr is not None:
         pw.cell.set(press_conv_thr=press_conv_thr)
+    # end if
+    if cell_dofree is not None:
+        pw.cell.set(cell_dofree=cell_dofree)
     # end if
 
     return pw

--- a/nexus/lib/qmcpack_property_analyzers.py
+++ b/nexus/lib/qmcpack_property_analyzers.py
@@ -253,7 +253,7 @@ class WavefunctionAnalyzer(PropertyAnalyzer):
                         else:
                             rcut = rcut_cell
                         #end if
-                        coeff = corr.coefficients.coeff
+                        coeff = corr.coefficients.coeff.flatten()
                         jastrows[jname][jn] = Jastrow1B(func,coeff,rcut)
                     #end for
                 #end if
@@ -270,7 +270,7 @@ class WavefunctionAnalyzer(PropertyAnalyzer):
                         #end if
                         s1 = corr.speciesa
                         s2 = corr.speciesb
-                        coeff = corr.coefficients.coeff
+                        coeff = corr.coefficients.coeff.flatten()
                         jastrows[jname][jn] = Jastrow2B(func,coeff,s1,s2,rcut)
                     #end for
                 #end if


### PR DESCRIPTION
## Proposed changes

Fixing an error in nexus' QmcpackAnalyzer, which occasionally fails to read Jastrow coeffiecients, resulting in warning. The solution came from @jtkrogel.

Also, fix QE input handling of starting magnetization, and add support for the following QE inputs: cell_dofree, lspinorb, noncolin.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

- CADES

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
