### PR TITLE
Restrict use of last_driver and clean up the life cycle of driver objects

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -331,7 +331,7 @@ void QMCMain::executeLoop(xmlNodePtr cur)
       tcur = tcur->next;
     }
   }
-  // Clean up the last driver. No further reuse needed.
+  // Destroy the last driver at the end of a loop with no further reuse of a driver needed.
   last_driver.reset(nullptr);
 }
 
@@ -615,8 +615,10 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     qmc_driver->run();
     t1->stop();
     app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
+    // transfer the states of a driver before its destruction
     last_branch_engine_legacy_driver      = qmc_driver->getBranchEngine();
     last_branch_engine_new_unified_driver = qmc_driver->getNewBranchEngine();
+    // save the driver in a driver loop
     if (reuse)
       last_driver = std::move(qmc_driver);
     return true;

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -47,7 +47,12 @@ private:
   ///flag to indicate that a qmc is the first QMC
   bool FirstQMC;
 
+  /// the last driver object. Should be in a loop only.
   std::unique_ptr<QMCDriverInterface> last_driver;
+  /// last branch engine used by legacy drivers
+  std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver;
+  /// last branch engine used by new unified drivers
+  std::unique_ptr<SFNBranch> last_branch_engine_new_unified_driver;
 
   ///xml mcwalkerset elements for output
   std::vector<xmlNodePtr> m_walkerset;

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -22,6 +22,8 @@
 #include "QMCDrivers/QMCDriverFactory.h"
 #include "QMCApp/QMCMainState.h"
 #include "QMCApp/QMCAppBase.h"
+#include "QMCDrivers/SimpleFixedNodeBranch.h"
+#include "QMCDrivers/SFNBranch.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -276,7 +276,7 @@ void CSVMC::resetRun()
         app_log() << os.str() << std::endl;
 
       CSMovers[ip]->put(qmcNode);
-      CSMovers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+      CSMovers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
     }
   }
 #if !defined(REMOVE_TRACEMANAGER)
@@ -301,7 +301,7 @@ void CSVMC::resetRun()
   {
     //int ip=omp_get_thread_num();
     CSMovers[ip]->put(qmcNode);
-    CSMovers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+    CSMovers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
     if (qmc_driver_mode[QMC_UPDATE_MODE])
       CSMovers[ip]->initCSWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1], nWarmupSteps > 0);
     else

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -130,7 +130,7 @@ void DMC::resetUpdateEngines()
           Movers[ip] = new SODMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
           Movers[ip]->setSpinMass(SpinMass);
           Movers[ip]->put(qmcNode);
-          Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+          Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
           Movers[ip]->initWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);
         }
         else
@@ -154,7 +154,7 @@ void DMC::resetUpdateEngines()
             Movers[ip] = new DMCUpdatePbyPL2(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
           }
           Movers[ip]->put(qmcNode);
-          Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+          Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
           Movers[ip]->initWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);
         }
         else
@@ -164,7 +164,7 @@ void DMC::resetUpdateEngines()
           else
             Movers[ip] = new DMCUpdateAllWithRejection(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
           Movers[ip]->put(qmcNode);
-          Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+          Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
           Movers[ip]->initWalkers(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);
         }
       }

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -346,7 +346,7 @@ void DMCcuda::resetUpdateEngine()
     W.loadEnsemble();
     branchEngine->initWalkerController(W, false, false);
     Mover = new DMCUpdatePbyPWithRejectionFast(W, Psi, H, Random);
-    Mover->resetRun(branchEngine, Estimators, nullptr, DriftModifier);
+    Mover->resetRun(branchEngine.get(), Estimators, nullptr, DriftModifier);
     //Mover->initWalkersForPbyP(W.begin(),W.end());
   }
   else

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -50,7 +50,6 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
     : MPIObjectBase(comm),
       Estimators(0),
       Traces(0),
-      branchEngine(0),
       DriftModifier(0),
       qmcNode(NULL),
       QMCType(QMC_driver_type),
@@ -203,9 +202,9 @@ void QMCDriver::process(xmlNodePtr cur)
   int numCopies = (H1.empty()) ? 1 : H1.size();
   W.resetWalkerProperty(numCopies);
   //create branchEngine first
-  if (branchEngine == 0)
+  if (!branchEngine)
   {
-    branchEngine = new BranchEngineType(Tau, W.getGlobalNumWalkers());
+    branchEngine = std::make_unique<BranchEngineType>(Tau, W.getGlobalNumWalkers());
   }
   //execute the put function implemented by the derived classes
   put(cur);

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -153,10 +153,10 @@ public:
   }
 
   ///set the BranchEngineType
-  void setBranchEngine(BranchEngineType* be) { branchEngine = be; }
+  void setBranchEngine(std::unique_ptr<BranchEngineType>&& be) override { branchEngine = std::move(be); }
 
   ///return BranchEngineType*
-  BranchEngineType* getBranchEngine() { return branchEngine; }
+  std::unique_ptr<BranchEngineType> getBranchEngine() override { return std::move(branchEngine); }
 
   int addObservable(const std::string& aname)
   {
@@ -189,7 +189,7 @@ public:
 
 protected:
   ///branch engine
-  BranchEngineType* branchEngine;
+  std::unique_ptr<BranchEngineType> branchEngine;
   ///drift modifer
   DriftModifierBase* DriftModifier;
   ///randomize it

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -100,7 +100,7 @@ public:
             Communicate* comm,
             const std::string& QMC_driver_type);
 
-  virtual ~QMCDriver();
+  virtual ~QMCDriver() override;
 
   ///return current step
   inline int current() const { return CurrentStep; }
@@ -108,7 +108,7 @@ public:
   /** set the update mode
    * @param pbyp if true, use particle-by-particle update
    */
-  inline void setUpdateMode(bool pbyp) { qmc_driver_mode[QMC_UPDATE_MODE] = pbyp; }
+  inline void setUpdateMode(bool pbyp) override { qmc_driver_mode[QMC_UPDATE_MODE] = pbyp; }
 
   /** Set the status of the QMCDriver
    * @param aname the root file name
@@ -120,7 +120,7 @@ public:
    * of previous QMC runs for the simulation and "suffix"
    * is the suffix for the output file.
    */
-  void setStatus(const std::string& aname, const std::string& h5name, bool append);
+  void setStatus(const std::string& aname, const std::string& h5name, bool append) override;
 
   /** add QMCHamiltonian/TrialWaveFunction pair for multiple
    * @param h QMCHamiltonian
@@ -129,22 +129,22 @@ public:
    * *Multiple* drivers use multiple H/Psi pairs to perform correlated sampling
    * for energy difference evaluations.
    */
-  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi);
+  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override;
 
   /** initialize with xmlNode
    */
-  void process(xmlNodePtr cur);
+  void process(xmlNodePtr cur) override;
 
   /** return a xmlnode with update **/
   xmlNodePtr getQMCNode();
 
-  void putWalkers(std::vector<xmlNodePtr>& wset);
+  void putWalkers(std::vector<xmlNodePtr>& wset) override;
 
-  inline void putTraces(xmlNodePtr txml) { traces_xml = txml; }
+  inline void putTraces(xmlNodePtr txml) override { traces_xml = txml; }
 
-  inline void requestTraces(bool traces) { allow_traces = traces; }
+  inline void requestTraces(bool traces) override { allow_traces = traces; }
 
-  std::string getEngineName() { return QMCType; }
+  std::string getEngineName() override { return QMCType; }
 
   template<class PDT>
   void setValue(const std::string& aname, PDT x)
@@ -183,9 +183,9 @@ public:
   inline std::vector<RandomGenerator_t*>& getRng() { return Rng; }
 
   ///return the i-th random generator
-  inline RandomGenerator_t& getRng(int i) { return (*Rng[i]); }
+  inline RandomGenerator_t& getRng(int i) override { return (*Rng[i]); }
 
-  unsigned long getDriverMode() { return qmc_driver_mode.to_ulong(); }
+  unsigned long getDriverMode() override { return qmc_driver_mode.to_ulong(); }
 
 protected:
   ///branch engine
@@ -344,7 +344,7 @@ protected:
    *
    * virtual function with a default implementation
    */
-  virtual void recordBlock(int block);
+  virtual void recordBlock(int block) override;
 
   /** finalize a qmc section
    * @param block current block
@@ -358,7 +358,7 @@ protected:
   int rotation;
   std::string getRotationName(std::string RootName);
   std::string getLastRotationName(std::string RootName);
-  const std::string& get_root_name() const { return RootName; }
+  const std::string& get_root_name() const override { return RootName; }
   NewTimer* checkpointTimer;
 };
 /**@}*/

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -192,34 +192,34 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::newQMCDriver(std::unique_p
   case QMCRunType::LINEAR_OPTIMIZE:
   case QMCRunType::CS_LINEAR_OPTIMIZE:
   case QMCRunType::WF_TEST: {
-    QMCDriver::BranchEngineType* branchEngine = nullptr;
+    std::unique_ptr<QMCDriver::BranchEngineType> branchEngine;
     if (last_driver)
     {
-      branchEngine = last_driver->getBranchEngine();
+      branchEngine = std::move(last_driver->getBranchEngine());
       branchEngine->resetRun(cur);
     }
     if (branchEngine)
-      new_driver->setBranchEngine(branchEngine);
+      new_driver->setBranchEngine(std::move(branchEngine));
   }
   break;
   case QMCRunType::VMC_BATCH:
   case QMCRunType::DMC_BATCH:
   case QMCRunType::OPTIMIZE_BATCH:
   case QMCRunType::LINEAR_OPTIMIZE_BATCH: {
-    SFNBranch* branchEngine = nullptr;
+    std::unique_ptr<SFNBranch> branchEngine;
     if (last_driver)
     {
       //Checking the QMCRunType gives us the type information
       QMCDriverNew& old_unified_driver = static_cast<QMCDriverNew&>(*last_driver);
 
-      branchEngine = old_unified_driver.getNewBranchEngine();
+      branchEngine = std::move(old_unified_driver.getNewBranchEngine());
       // Someone helpful added a resetRun call here, a call from legacy CUDA that if it did help I need to know why.
       // It did seem to fix an issue with legacy which is interesting....
     }
     if (branchEngine)
     {
       QMCDriverNew& new_unified_driver = static_cast<QMCDriverNew&>(*new_driver);
-      new_unified_driver.setNewBranchEngine(branchEngine);
+      new_unified_driver.setNewBranchEngine(std::move(branchEngine));
     }
   }
   break;

--- a/src/QMCDrivers/QMCDriverFactory.h
+++ b/src/QMCDrivers/QMCDriverFactory.h
@@ -32,8 +32,6 @@ namespace qmcplusplus
 //forward declaration
 class MCWalkerConfiguration;
 class QMCDriverInterface;
-class SimpleFixedNodeBranch;
-class SFNBranch;
 class WaveFunctionPool;
 class HamiltonianPool;
 
@@ -52,22 +50,8 @@ public:
   //QMCDriverFactory() ;
 
   /** read the current QMC Section */
-  DriverAssemblyState readSection(xmlNodePtr cur);
+  DriverAssemblyState readSection(xmlNodePtr cur) const;
 
-  /** set the active qmcDriver
-   *  The unique_ptr's take care of killing the old driver if it exists */
-  std::unique_ptr<QMCDriverInterface> newQMCDriver(
-      std::unique_ptr<SimpleFixedNodeBranch>&& last_branch_engine_legacy_driver,
-      std::unique_ptr<SFNBranch>&& last_branch_engine_new_unified_driver,
-      xmlNodePtr cur,
-      DriverAssemblyState& das,
-      MCWalkerConfiguration& qmc_system,
-      ParticleSetPool& particle_pool,
-      WaveFunctionPool& wave_function_pool,
-      HamiltonianPool& hamiltonian_pool,
-      Communicate* comm);
-
-private:
   /** create a new QMCDriver
    *
    *  Broken out for unit tests
@@ -78,7 +62,7 @@ private:
                                                       ParticleSetPool& particle_pool,
                                                       WaveFunctionPool& wave_function_pool,
                                                       HamiltonianPool& hamiltonian_pool,
-                                                      Communicate* comm);
+                                                      Communicate* comm) const;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/QMCDriverFactory.h
+++ b/src/QMCDrivers/QMCDriverFactory.h
@@ -32,6 +32,8 @@ namespace qmcplusplus
 //forward declaration
 class MCWalkerConfiguration;
 class QMCDriverInterface;
+class SimpleFixedNodeBranch;
+class SFNBranch;
 class WaveFunctionPool;
 class HamiltonianPool;
 
@@ -50,19 +52,20 @@ public:
   //QMCDriverFactory() ;
 
   /** read the current QMC Section */
-  DriverAssemblyState readSection(int curSeries, xmlNodePtr cur);
+  DriverAssemblyState readSection(xmlNodePtr cur);
 
   /** set the active qmcDriver
    *  The unique_ptr's take care of killing the old driver if it exists */
-  std::unique_ptr<QMCDriverInterface> newQMCDriver(std::unique_ptr<QMCDriverInterface> last_driver,
-                                                   int curSeries,
-                                                   xmlNodePtr cur,
-                                                   DriverAssemblyState& das,
-                                                   MCWalkerConfiguration& qmc_system,
-                                                   ParticleSetPool& particle_pool,
-                                                   WaveFunctionPool& wave_function_pool,
-                                                   HamiltonianPool& hamiltonian_pool,
-                                                   Communicate* comm);
+  std::unique_ptr<QMCDriverInterface> newQMCDriver(
+      std::unique_ptr<SimpleFixedNodeBranch>&& last_branch_engine_legacy_driver,
+      std::unique_ptr<SFNBranch>&& last_branch_engine_new_unified_driver,
+      xmlNodePtr cur,
+      DriverAssemblyState& das,
+      MCWalkerConfiguration& qmc_system,
+      ParticleSetPool& particle_pool,
+      WaveFunctionPool& wave_function_pool,
+      HamiltonianPool& hamiltonian_pool,
+      Communicate* comm);
 
 private:
   /** create a new QMCDriver

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -16,13 +16,14 @@
 #include <vector>
 #include <libxml/parser.h>
 #include "QMCDrivers/DriverTraits.h"
+#include "QMCDrivers/SimpleFixedNodeBranch.h"
+#include "QMCDrivers/SFNBranch.h"
 #include "Utilities/RandomGenerator.h"
 
 namespace qmcplusplus
 {
 class QMCHamiltonian;
 class TrialWaveFunction;
-struct SimpleFixedNodeBranch;
 
 /** Creates a common base class pointer for QMCDriver and QMCDriverNew
  *  to share.
@@ -54,11 +55,14 @@ public:
   virtual void process(xmlNodePtr cur)                                  = 0;
   virtual QMCRunType getRunType()                                       = 0;
   virtual const std::string& get_root_name() const                      = 0;
-  virtual void setBranchEngine(BranchEngineType* be)                    = 0;
-  virtual BranchEngineType* getBranchEngine()                           = 0;
   virtual std::string getEngineName()                                   = 0;
   virtual unsigned long getDriverMode()                                 = 0;
   virtual ~QMCDriverInterface() {}
+
+  virtual void setBranchEngine(std::unique_ptr<BranchEngineType>&& be) { }
+  virtual std::unique_ptr<BranchEngineType> getBranchEngine() { return nullptr; }
+  virtual void setNewBranchEngine(std::unique_ptr<SFNBranch>&& be) { }
+  virtual std::unique_ptr<SFNBranch> getNewBranchEngine() { return nullptr; }
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -50,7 +50,6 @@ QMCDriverNew::QMCDriverNew(QMCDriverInput&& input,
                            SetNonLocalMoveHandler snlm_handler)
     : MPIObjectBase(comm),
       qmcdriver_input_(std::move(input)),
-      branch_engine_(nullptr),
       QMCType(QMC_driver_type),
       population_(std::move(population)),
       Psi(psi),
@@ -136,7 +135,7 @@ void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts aw
 
   if (!branch_engine_)
   {
-    branch_engine_ = new SFNBranch(qmcdriver_input_.get_tau(), population_.get_num_global_walkers());
+    branch_engine_ = std::make_unique<SFNBranch>(qmcdriver_input_.get_tau(), population_.get_num_global_walkers());
   }
 
   //create and initialize estimator

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -156,22 +156,11 @@ public:
 
   void putWalkers(std::vector<xmlNodePtr>& wset);
 
-  /** placate the legacy base class interface
-   */
-  void setBranchEngine(SimpleFixedNodeBranch* be)
-  {
-    throw std::runtime_error("You can not use the legacy SimpleFixedNodeBranch class with QMCDriverNew");
-  }
-
   ///set the BranchEngineType
-  void setNewBranchEngine(SFNBranch* be) { branch_engine_ = be; }
-
-  /** placate the legacy base class interface
-   */
-  SimpleFixedNodeBranch* getBranchEngine() { return nullptr; }
+  void setNewBranchEngine(std::unique_ptr<SFNBranch>&& be) override { branch_engine_ = std::move(be); }
 
   ///return BranchEngineType*
-  SFNBranch* getNewBranchEngine() { return branch_engine_; }
+  std::unique_ptr<SFNBranch> getNewBranchEngine() override { return std::move(branch_engine_); }
 
   int addObservable(const std::string& aname);
 
@@ -305,7 +294,7 @@ protected:
   std::string h5_file_root_;
 
   ///branch engine
-  SFNBranch* branch_engine_;
+  std::unique_ptr<SFNBranch> branch_engine_;
   ///drift modifer
   std::unique_ptr<DriftModifierBase> drift_modifier_;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -126,7 +126,7 @@ public:
 
   QMCDriverNew(QMCDriverNew&&) = default;
 
-  virtual ~QMCDriverNew();
+  virtual ~QMCDriverNew() override;
 
   ///return current step
   inline IndexType current() const { return current_step_; }
@@ -141,7 +141,7 @@ public:
    * of previous QMC runs for the simulation and "suffix"
    * is the suffix for the output file.
    */
-  void setStatus(const std::string& aname, const std::string& h5name, bool append);
+  void setStatus(const std::string& aname, const std::string& h5name, bool append) override;
 
   /** add QMCHamiltonian/TrialWaveFunction pair for multiple
    * @param h QMCHamiltonian
@@ -150,11 +150,11 @@ public:
    * *Multiple* drivers use multiple H/Psi pairs to perform correlated sampling
    * for energy difference evaluations.
    */
-  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi);
+  void add_H_and_Psi(QMCHamiltonian* h, TrialWaveFunction* psi) override;
 
   void createRngsStepContexts(int num_crowds);
 
-  void putWalkers(std::vector<xmlNodePtr>& wset);
+  void putWalkers(std::vector<xmlNodePtr>& wset) override;
 
   ///set the BranchEngineType
   void setNewBranchEngine(std::unique_ptr<SFNBranch>&& be) override { branch_engine_ = std::move(be); }
@@ -177,17 +177,17 @@ public:
   //       inline std::vector<std::unique_ptr RandomGenerator_t*>& getRng() { return Rng; }
 
   ///return the i-th random generator
-  inline RandomGenerator_t& getRng(int i) { return (*Rng[i]); }
+  inline RandomGenerator_t& getRng(int i) override { return (*Rng[i]); }
 
-  std::string getEngineName() { return QMCType; }
-  unsigned long getDriverMode() { return qmc_driver_mode_.to_ulong(); }
+  std::string getEngineName() override { return QMCType; }
+  unsigned long getDriverMode() override { return qmc_driver_mode_.to_ulong(); }
 
   IndexType get_living_walkers() const { return population_.get_walkers().size(); }
 
   /** @ingroup Legacy interface to be dropped
    *  @{
    */
-  bool put(xmlNodePtr cur) { return false; };
+  bool put(xmlNodePtr cur) override { return false; };
 
   /** QMCDriverNew driver second (3rd, 4th...) stage of constructing a valid driver
    *
@@ -197,7 +197,7 @@ public:
    *  \todo remove cur, the driver and all its child nodes should be completely processed before
    *        this stage of driver initialization is hit.
    */
-  virtual void process(xmlNodePtr cur) = 0;
+  virtual void process(xmlNodePtr cur) override = 0;
 
   /** Do common section starting tasks
    *
@@ -214,10 +214,10 @@ public:
   /** should be set in input don't see a reason to set individually
    * @param pbyp if true, use particle-by-particle update
    */
-  inline void setUpdateMode(bool pbyp) { qmc_driver_mode_[QMC_UPDATE_MODE] = pbyp; }
+  inline void setUpdateMode(bool pbyp) override { qmc_driver_mode_[QMC_UPDATE_MODE] = pbyp; }
 
-  void putTraces(xmlNodePtr txml) {}
-  void requestTraces(bool allow_traces) {}
+  void putTraces(xmlNodePtr txml) override {}
+  void requestTraces(bool allow_traces) override {}
   /** }@ */
 
 protected:
@@ -412,7 +412,7 @@ public:
    *
    * virtual function with a default implementation
    */
-  virtual void recordBlock(int block);
+  virtual void recordBlock(int block) override;
 
   /** finalize a qmc section
    * @param block current block
@@ -424,7 +424,7 @@ public:
   bool finalize(int block, bool dumpwalkers = true);
 
   int rotation;
-  const std::string& get_root_name() const { return root_name_; }
+  const std::string& get_root_name() const override { return root_name_; }
   std::string getRotationName(std::string RootName);
   std::string getLastRotationName(std::string RootName);
 

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -252,7 +252,7 @@ void RMC::resetRun()
   for (int ip = 0; ip < NumThreads; ++ip)
   {
     Movers[ip]->put(qmcNode);
-    Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+    Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
     // wClones[ip]->reptile = new Reptile(*wClones[ip], W.begin()+wPerNode[ip],W.begin()+wPerNode[ip+1]);
     wClones[ip]->reptile = W.ReptileList[ip];
     //app_log()<<"Thread # "<<ip<< std::endl;

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -256,7 +256,7 @@ void VMC::resetRun()
   {
     //int ip=omp_get_thread_num();
     Movers[ip]->put(qmcNode);
-    Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
+    Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
     if (qmc_driver_mode[QMC_UPDATE_MODE])
       Movers[ip]->initWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);
     else

--- a/src/QMCDrivers/VMC/VMCLinearOpt.cpp
+++ b/src/QMCDrivers/VMC/VMCLinearOpt.cpp
@@ -535,7 +535,7 @@ void VMCLinearOpt::resetRun()
         //             CSMovers[ip]=
         Movers[ip] = new VMCUpdatePbyP(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
         //           }
-        //Movers[ip]->resetRun(branchEngine,estimatorClones[ip]);
+        //Movers[ip]->resetRun(branchEngine.get(),estimatorClones[ip]);
       }
       else
       {
@@ -557,7 +557,7 @@ void VMCLinearOpt::resetRun()
         //             CSMovers[ip]=
         Movers[ip] = new VMCUpdateAll(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
         //           }
-        //Movers[ip]->resetRun(branchEngine,estimatorClones[ip]);
+        //Movers[ip]->resetRun(branchEngine.get(),estimatorClones[ip]);
       }
       if (ip == 0)
         app_log() << os.str() << std::endl;
@@ -578,8 +578,8 @@ void VMCLinearOpt::resetRun()
     int ip = omp_get_thread_num();
     Movers[ip]->put(qmcNode);
     //       CSMovers[ip]->put(qmcNode);
-    Movers[ip]->resetRun(branchEngine, estimatorClones[ip], traceClones[ip], DriftModifier);
-    //       CSMovers[ip]->resetRun(branchEngine,estimatorClones[ip]);
+    Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
+    //       CSMovers[ip]->resetRun(branchEngine.get(),estimatorClones[ip]);
     if (qmc_driver_mode[QMC_UPDATE_MODE])
       Movers[ip]->initWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);
     else

--- a/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
@@ -57,8 +57,8 @@ TEST_CASE("QMCDriverFactory create VMC Driver", "[qmcapp]")
 
   std::unique_ptr<QMCDriverInterface> qmc_driver;
 
-  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
-                                           hamiltonian_pool, comm);
+  qmc_driver =
+      driver_factory.createQMCDriver(node, das, *qmc_system, particle_pool, wavefunction_pool, hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -88,8 +88,8 @@ TEST_CASE("QMCDriverFactory create VMCBatched driver", "[qmcapp]")
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
-                                           hamiltonian_pool, comm);
+  qmc_driver =
+      driver_factory.createQMCDriver(node, das, *qmc_system, particle_pool, wavefunction_pool, hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -119,8 +119,8 @@ TEST_CASE("QMCDriverFactory create DMC driver", "[qmcapp]")
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
-                                           hamiltonian_pool, comm);
+  qmc_driver =
+      driver_factory.createQMCDriver(node, das, *qmc_system, particle_pool, wavefunction_pool, hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -150,8 +150,8 @@ TEST_CASE("QMCDriverFactory create DMCBatched driver", "[qmcapp]")
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
-                                           hamiltonian_pool, comm);
+  qmc_driver =
+      driver_factory.createQMCDriver(node, das, *qmc_system, particle_pool, wavefunction_pool, hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 

--- a/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
@@ -42,7 +42,7 @@ TEST_CASE("QMCDriverFactory create VMC Driver", "[qmcapp]")
   bool okay = doc.parseFromString(valid_vmc_input_sections[valid_vmc_input_vmc_index]);
   REQUIRE(okay);
   xmlNodePtr node                           = doc.getRoot();
-  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(0, node);
+  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(node);
   REQUIRE(das.new_run_type == QMCRunType::VMC);
 
   MinimalParticlePool mpp;
@@ -55,11 +55,10 @@ TEST_CASE("QMCDriverFactory create VMC Driver", "[qmcapp]")
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
-  std::unique_ptr<QMCDriverInterface> last_driver;
   std::unique_ptr<QMCDriverInterface> qmc_driver;
 
-  qmc_driver = driver_factory.newQMCDriver(std::move(last_driver), 0, node, das, *qmc_system, particle_pool,
-                                           wavefunction_pool, hamiltonian_pool, comm);
+  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
+                                           hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -75,7 +74,7 @@ TEST_CASE("QMCDriverFactory create VMCBatched driver", "[qmcapp]")
   bool okay = doc.parseFromString(valid_vmc_input_sections[valid_vmc_input_vmc_batch_index]);
   REQUIRE(okay);
   xmlNodePtr node                           = doc.getRoot();
-  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(0, node);
+  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(node);
   REQUIRE(das.new_run_type == QMCRunType::VMC_BATCH);
 
   MinimalParticlePool mpp;
@@ -88,10 +87,9 @@ TEST_CASE("QMCDriverFactory create VMCBatched driver", "[qmcapp]")
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
-  std::unique_ptr<QMCDriverInterface> last_driver;
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(std::move(last_driver), 0, node, das, *qmc_system, particle_pool,
-                                           wavefunction_pool, hamiltonian_pool, comm);
+  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
+                                           hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -107,7 +105,7 @@ TEST_CASE("QMCDriverFactory create DMC driver", "[qmcapp]")
   bool okay = doc.parseFromString(valid_dmc_input_sections[valid_dmc_input_dmc_index]);
   REQUIRE(okay);
   xmlNodePtr node                           = doc.getRoot();
-  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(0, node);
+  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(node);
   REQUIRE(das.new_run_type == QMCRunType::DMC);
 
   MinimalParticlePool mpp;
@@ -120,10 +118,9 @@ TEST_CASE("QMCDriverFactory create DMC driver", "[qmcapp]")
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
-  std::unique_ptr<QMCDriverInterface> last_driver;
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(std::move(last_driver), 0, node, das, *qmc_system, particle_pool,
-                                           wavefunction_pool, hamiltonian_pool, comm);
+  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
+                                           hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 
@@ -139,7 +136,7 @@ TEST_CASE("QMCDriverFactory create DMCBatched driver", "[qmcapp]")
   bool okay = doc.parseFromString(valid_dmc_input_sections[valid_dmc_input_dmc_batch_index]);
   REQUIRE(okay);
   xmlNodePtr node                           = doc.getRoot();
-  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(0, node);
+  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(node);
   REQUIRE(das.new_run_type == QMCRunType::DMC_BATCH);
 
   MinimalParticlePool mpp;
@@ -152,10 +149,9 @@ TEST_CASE("QMCDriverFactory create DMCBatched driver", "[qmcapp]")
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
-  std::unique_ptr<QMCDriverInterface> last_driver;
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(std::move(last_driver), 0, node, das, *qmc_system, particle_pool,
-                                           wavefunction_pool, hamiltonian_pool, comm);
+  qmc_driver = driver_factory.newQMCDriver(nullptr, nullptr, node, das, *qmc_system, particle_pool, wavefunction_pool,
+                                           hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 

--- a/src/QMCDrivers/tests/test_QMCDriverFactory_CUDA.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverFactory_CUDA.cpp
@@ -63,7 +63,7 @@ TEST_CASE("QMCDriverFactory create VMC_CUDA Driver", "[qmcapp]")
   bool okay = doc.parseFromString(driver_xml);
   REQUIRE(okay);
   xmlNodePtr node                           = doc.getRoot();
-  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(0, node);
+  QMCDriverFactory::DriverAssemblyState das = driver_factory.readSection(node);
   REQUIRE(das.new_run_type == QMCRunType::VMC);
 
   MinimalParticlePool mpp;
@@ -75,10 +75,9 @@ TEST_CASE("QMCDriverFactory create VMC_CUDA Driver", "[qmcapp]")
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
-  std::unique_ptr<QMCDriverInterface> last_driver;
   std::unique_ptr<QMCDriverInterface> qmc_driver;
-  qmc_driver = driver_factory.newQMCDriver(std::move(last_driver), 0, node, das, *qmc_system, particle_pool,
-                                           wavefunction_pool, hamiltonian_pool, comm);
+  qmc_driver = driver_factory.createQMCDriver(node, das, *qmc_system, particle_pool,
+                                              wavefunction_pool, hamiltonian_pool, comm);
   REQUIRE(qmc_driver != nullptr);
 }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -149,22 +149,32 @@ protected:
 
 public:
   // safe-guard all CPU interfaces
-  DiracDeterminantCUDA* makeCopy(SPOSet* spo) const { APP_ABORT("Calling DiracDeterminantCUDA::makeCopy is illegal!"); }
+  DiracDeterminantCUDA* makeCopy(SPOSet* spo) const
+  {
+    APP_ABORT("Calling DiracDeterminantCUDA::makeCopy is illegal!");
+    return nullptr;
+  }
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     APP_ABORT("Calling DiracDeterminantCUDA::evaluateLog is illegal!");
+    return 0;
   }
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) { APP_ABORT("Calling DiracDeterminantCUDA::acceptMove is illegal!"); }
 
   void restore(int iat) { APP_ABORT("Calling DiracDeterminantCUDA::restore is illegal!"); }
 
-  PsiValueType ratio(ParticleSet& P, int iat) { APP_ABORT("Calling DiracDeterminantCUDA::ratio is illegal!"); }
+  PsiValueType ratio(ParticleSet& P, int iat)
+  {
+    APP_ABORT("Calling DiracDeterminantCUDA::ratio is illegal!");
+    return 0;
+  }
 
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
     APP_ABORT("Calling DiracDeterminantCUDA::ratioGrad is illegal!");
+    return 0;
   }
 
   void registerData(ParticleSet& P, WFBufferType& buf)
@@ -175,6 +185,7 @@ public:
   LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
   {
     APP_ABORT("Calling DiracDeterminantCUDA::updateBuffer is illegal!");
+    return 0;
   }
 
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -151,46 +151,46 @@ public:
   // safe-guard all CPU interfaces
   DiracDeterminantCUDA* makeCopy(SPOSet* spo) const
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::makeCopy is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::makeCopy is illegal!");
     return nullptr;
   }
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::evaluateLog is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::evaluateLog is illegal!");
     return 0;
   }
 
-  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) { APP_ABORT("Calling DiracDeterminantCUDA::acceptMove is illegal!"); }
+  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) { throw std::runtime_error("Calling DiracDeterminantCUDA::acceptMove is illegal!"); }
 
-  void restore(int iat) { APP_ABORT("Calling DiracDeterminantCUDA::restore is illegal!"); }
+  void restore(int iat) { throw std::runtime_error("Calling DiracDeterminantCUDA::restore is illegal!"); }
 
   PsiValueType ratio(ParticleSet& P, int iat)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::ratio is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::ratio is illegal!");
     return 0;
   }
 
   PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::ratioGrad is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::ratioGrad is illegal!");
     return 0;
   }
 
   void registerData(ParticleSet& P, WFBufferType& buf)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::registerData is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::registerData is illegal!");
   }
 
   LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::updateBuffer is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::updateBuffer is illegal!");
     return 0;
   }
 
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf)
   {
-    APP_ABORT("Calling DiracDeterminantCUDA::copyFromBuffer is illegal!");
+    throw std::runtime_error("Calling DiracDeterminantCUDA::copyFromBuffer is illegal!");
   }
 
   void update(MCWalkerConfiguration* W, std::vector<Walker_t*>& walkers, int iat, std::vector<bool>* acc, int k);


### PR DESCRIPTION
## Proposed changes
Once a QMC section execution is completed, the driver is saved in last_driver object.
On a following QMC section, a new driver is created and last_driver is only release when it is being overwritten again.
In this PR, last_drive is only kept when a QMC input section is in a loop and gets cleaned up when the loop finishes.
If not a loop, a QMC driver object is destructed once that section execution is completed.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'