### PR TITLE
Add a scoped profiler to allow profiling target specific QMC drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ SET(BUILD_FCIQMC 0 CACHE BOOL "Build with FCIQMC")
 OPTION(QMC_BUILD_STATIC "Link to static libraries" OFF)
 OPTION(ENABLE_TIMERS "Enable internal timers" ON)
 OPTION(ENABLE_STACKTRACE "Enable use of boost::stacktrace" OFF)
-OPTION(USE_VTUNE_API "Enable use of VTune ittnotify APIs" ON)
+OPTION(USE_VTUNE_API "Enable use of VTune ittnotify APIs" OFF)
 CMAKE_DEPENDENT_OPTION(USE_VTUNE_TASKS "USE VTune ittnotify task annotation" OFF "ENABLE_TIMERS AND USE_VTUNE_API" OFF)
 CMAKE_DEPENDENT_OPTION(USE_NVTX_API "Enable/disable NVTX regions in CUDA code." OFF "ENABLE_TIMERS AND (QMC_CUDA OR ENABLE_CUDA)" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,9 @@ SET(BUILD_FCIQMC 0 CACHE BOOL "Build with FCIQMC")
 OPTION(QMC_BUILD_STATIC "Link to static libraries" OFF)
 OPTION(ENABLE_TIMERS "Enable internal timers" ON)
 OPTION(ENABLE_STACKTRACE "Enable use of boost::stacktrace" OFF)
+OPTION(USE_VTUNE_API "Enable use of VTune ittnotify APIs" ON)
+CMAKE_DEPENDENT_OPTION(USE_VTUNE_TASKS "USE VTune ittnotify task annotation" OFF "ENABLE_TIMERS AND USE_VTUNE_API" OFF)
+CMAKE_DEPENDENT_OPTION(USE_NVTX_API "Enable/disable NVTX regions in CUDA code." OFF "ENABLE_TIMERS AND (QMC_CUDA OR ENABLE_CUDA)" OFF)
 
 ######################################################################
 # Install options
@@ -710,22 +713,22 @@ IF(QMC_CUDA OR ENABLE_CUDA)
   SET(HAVE_CUDA 1)
   MESSAGE("   CUDA_NVCC_FLAGS=${CUDA_NVCC_FLAGS}")
 ELSE(QMC_CUDA OR ENABLE_CUDA)
-  MESSAGE(STATUS "Disabling CUDA")
+  MESSAGE(STATUS "CUDA disabled")
 ENDIF(QMC_CUDA OR ENABLE_CUDA)
 
-OPTION(USE_NVTX_API "Enable/disable NVTX regions in CUDA code." OFF)
 IF(USE_NVTX_API)
-  IF(HAVE_CUDA OR ENABLE_OFFLOAD)
-    FIND_LIBRARY(NVTX_API_LIB
-      NAME nvToolsExt
-      HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-      PATH_SUFFIXES lib lib64)
-    IF(NOT NVTX_API_LIB)
-      MESSAGE(FATAL_ERROR "USE_NVTX_API set but NVTX_API_LIB not found")
-    ENDIF(NOT NVTX_API_LIB)
-    MESSAGE("CUDA nvToolsExt library: ${NVTX_API_LIB}")
-    LINK_LIBRARIES(${NVTX_API_LIB})
-  ENDIF(HAVE_CUDA OR ENABLE_OFFLOAD)
+  MESSAGE(STATUS "Enabling use of CUDA NVTX APIs")
+  FIND_LIBRARY(NVTX_API_LIB
+    NAME nvToolsExt
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+    PATH_SUFFIXES lib lib64)
+  IF(NOT NVTX_API_LIB)
+    MESSAGE(FATAL_ERROR "USE_NVTX_API set but NVTX_API_LIB not found")
+  ENDIF(NOT NVTX_API_LIB)
+  MESSAGE("CUDA nvToolsExt library: ${NVTX_API_LIB}")
+  LINK_LIBRARIES(${NVTX_API_LIB})
+ELSE()
+  MESSAGE(STATUS "CUDA NVTX APIs disabled")
 ENDIF(USE_NVTX_API)
 
 #-------------------------------------------------------------------
@@ -763,25 +766,20 @@ ENDIF(ENABLE_HIP)
 #include qmcpack/src build/src
 INCLUDE_DIRECTORIES( ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
 
-IF (USE_VTUNE_TASKS)
-  IF (NOT ENABLE_TIMERS)
-    MESSAGE(FATAL_ERROR "USE_VTUNE_TASKS is set, but timers are not enabled.  Set ENABLE_TIMERS=ON.")
-  ENDIF()
-  SET(USE_VTUNE_API 1)
-ENDIF()
-
 IF (USE_VTUNE_API)
-  include(CheckIncludeFileCXX)
-  CHECK_INCLUDE_FILE_CXX(ittnotify.h HAVE_ITTNOTIFY_H)
-  IF (NOT HAVE_ITTNOTIFY_H)
-    MESSAGE(FATAL_ERROR "USE_VTUNE_API is defined, but the ittnotify.h include file is not found.  Check that the correct include directory is present in CMAKE_CXX_FLAGS.")
-  ENDIF()
+  MESSAGE(STATUS "Enabling use of VTune ittnotify APIs")
+  FIND_PATH(VTUNE_ITTNOTIFY_INCLUDE_DIR ittnotify.h HINTS ${VTUNE_ROOT} $ENV{VTUNE_ROOT} PATH_SUFFIXES include REQUIRED)
+  MESSAGE(STATUS "Found VTUNE_ITTNOTIFY_INCLUDE_DIR ${VTUNE_ITTNOTIFY_INCLUDE_DIR}")
+  FIND_LIBRARY(VTUNE_ITTNOTIFY_LIBRARY ittnotify HINTS ${VTUNE_ROOT} $ENV{VTUNE_ROOT} PATH_SUFFIXES lib64 lib REQUIRED)
+  MESSAGE(STATUS "Found VTUNE_ITTNOTIFY_LIBRARY ${VTUNE_ITTNOTIFY_LIBRARY}")
 
-  FIND_LIBRARY(VTUNE_ITTNOTIFY_LIBRARY ittnotify)
-  IF (NOT VTUNE_ITTNOTIFY_LIBRARY)
-    MESSAGE(FATAL_ERROR "USE_VTUNE_API is defined, but the ittnotify library is not found.  Check that correct library path is present in CMAKE_LIBRARY_PATH.")
+  INCLUDE_DIRECTORIES(${VTUNE_ITTNOTIFY_INCLUDE_DIR})
+  LINK_LIBRARIES(${VTUNE_ITTNOTIFY_LIBRARY})
+  IF (USE_VTUNE_TASKS)
+    MESSAGE(STATUS "VTune ittnotify tasks enabled")
   ENDIF()
-  LINK_LIBRARIES("${VTUNE_ITTNOTIFY_LIBRARY}")
+ELSE()
+  MESSAGE(STATUS "VTune ittnotify APIs disabled")
 ENDIF()
 
 OPTION(QMC_EXP_THREADING "Experimental non openmp threading models" OFF)

--- a/docs/external_tools.rst
+++ b/docs/external_tools.rst
@@ -30,29 +30,15 @@ VTune API
 ~~~~~~~~~
 
 If the variable ``USE_VTUNE_API`` is set, QMCPACK will check that the
-include file (``ittnotify.h``) and the library (``libittnotify.a``) can
-be found.
-To provide CMake with the VTune paths, add the include path to ``CMAKE_CXX_FLAGS`` and the library path to ``CMAKE_LIBRARY_PATH``.
+include file (``ittnotify.h``) and the library (``libittnotify.a``) can be found.
+To provide CMake with the VTune search paths, add ``VTUNE_ROOT`` which contains ``include`` and ``lib64`` sub-directories.
 
 An example of options to be passed to CMake:
 
 ::
 
-  -DCMAKE_CXX_FLAGS=-I/opt/intel/vtune_amplifier_xe/include \
-  -DCMAKE_LIBRARY_PATH=/opt/intel/vtune_amplifier_xe/lib64
-
-NVIDIA Tools Extensions
------------------------
-
-NVIDIA's Tools Extensions (NVTX) API enables programmers to annotate their source code when used with the NVIDIA profilers.
-
-NVTX API
-~~~~~~~~
-
-If the variable ``USE_NVTX_API`` is set, QMCPACK will add the library (``libnvToolsExt.so``) to the QMCPACK target. To add NVTX annotations
-to a function, it is necessary to include the ``nvToolsExt.h`` header file and then make the appropriate calls into the NVTX API. For more information
-about the NVTX API, see https://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvtx. Any additional calls to the NVTX API should be guarded by
-the ``USE_NVTX_API`` compiler define.
+  -DUSE_VTUNE_API=ON \
+  -DVTUNE_ROOT=/opt/intel/vtune_amplifier_xe
 
 Timers as Tasks
 ~~~~~~~~~~~~~~~
@@ -70,6 +56,19 @@ For the command line, set the ``enable-user-tasks`` knob to ``true``. For exampl
 
 Collection with the timers set at "fine" can generate too much task data in the profile.
 Collection with the timers at "medium" collects a more reasonable amount of task data.
+
+NVIDIA Tools Extensions
+-----------------------
+
+NVIDIA's Tools Extensions (NVTX) API enables programmers to annotate their source code when used with the NVIDIA profilers.
+
+NVTX API
+~~~~~~~~
+
+If the variable ``USE_NVTX_API`` is set, QMCPACK will add the library (``libnvToolsExt.so``) to the QMCPACK target. To add NVTX annotations
+to a function, it is necessary to include the ``nvToolsExt.h`` header file and then make the appropriate calls into the NVTX API. For more information
+about the NVTX API, see https://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvtx. Any additional calls to the NVTX API should be guarded by
+the ``USE_NVTX_API`` compiler define.
 
 Scitools Understand
 -------------------

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -36,6 +36,8 @@ Quantum Monte Carlo Methods
   +----------------+--------------+--------------+-------------+---------------------------------+
   | ``trace``      | text         |              | no          | ???                             |
   +----------------+--------------+--------------+-------------+---------------------------------+
+  | ``profiling``  | text         | yes/no       | no          | Activate resume/pause control   |
+  +----------------+--------------+--------------+-------------+---------------------------------+
   | ``checkpoint`` | integer      | -1, 0, n     | -1          | Checkpoint frequency            |
   +----------------+--------------+--------------+-------------+---------------------------------+
   | ``record``     | integer      | n            | 0           | Save configuration ever n steps |
@@ -58,6 +60,12 @@ Additional information:
 -  ``gpu``: When the executable is compiled with CUDA, the target
    computing device can be chosen by this switch. With a regular
    CPU-only compilation, this option is not effective.
+
+-  ``profiling``: Performance profiling tools by default profile complete application executions.
+   This is largely unnecessary if the focus is a QMC section instead of any initialization.
+   Setting this flag to ``yes`` for the QMC sections of interest and starting the tool with
+   data collection paused from the beginning help reducing the profiling workflow
+   and amount of collected data.
 
 -  ``checkpoint``: This enables and disables checkpointing and
    specifying the frequency of output. Possible values are:

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -227,11 +227,11 @@ Additional information:
   recompute) by default when not using mixed precision. Recomputing
   introduces a performance penalty dependent on system size.
 
--  ``spinMoves`` Determines whether or not the spin variables are sampled following 
+- ``spinMoves`` Determines whether or not the spin variables are sampled following
   :cite:`Melton2016-1` and :cite:`Melton2016-2`. If a relativistic calculation is desired using pseudopotentials,
   spin variable sampling is required.
 
--  ``spinMass`` If spin sampling is on using ``spinMoves`` == yes, the spin mass determines the rate 
+- ``spinMass`` If spin sampling is on using ``spinMoves`` == yes, the spin mass determines the rate
   of spin sampling, resulting in an effective spin timestep :math:`\tau_s = \frac{\tau}{\mu_s}`.
 
 An example VMC section for a simple VMC run:
@@ -778,7 +778,7 @@ Additional information and recommendations:
  
  -  For reporting quantities such as a final energy and associated uncertainty,
     an average over many descent steps can be taken. The parameters for 
-   ``collection_step`` and ``compute_step`` help automate this task. 
+    ``collection_step`` and ``compute_step`` help automate this task.
     After the descent iteration specified by ``collection_step``, a 
     history of local energy values will be kept for determining a final 
     error and average, which will be computed and given in the output 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -62,10 +62,15 @@ Additional information:
    CPU-only compilation, this option is not effective.
 
 -  ``profiling``: Performance profiling tools by default profile complete application executions.
-   This is largely unnecessary if the focus is a QMC section instead of any initialization.
+   This is largely unnecessary if the focus is a QMC section instead of any initialization
+   and additional QMC sections for equilibrating walkers.
    Setting this flag to ``yes`` for the QMC sections of interest and starting the tool with
    data collection paused from the beginning help reducing the profiling workflow
-   and amount of collected data.
+   and amount of collected data. Additional restriction may be imposed by profiling tools.
+   For example, NVIDIA profilers can only be turned on and off once and thus only the first QMC
+   section with ``profiling="yes"`` will be profiled.
+   VTune instead allows pause and resume for unlimited times and thus multiple selected QMC sections
+   can be profiled in a single run.
 
 -  ``checkpoint``: This enables and disables checkpointing and
    specifying the frequency of output. Possible values are:

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -610,10 +610,7 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     infoSummary.flush();
     infoLog.flush();
     Timer qmcTimer;
-    NewTimer* t1 = timer_manager.createTimer(qmc_driver->getEngineName(), timer_level_coarse);
-    t1->start();
     qmc_driver->run();
-    t1->stop();
     app_log() << "  QMC Execution time = " << std::setprecision(4) << qmcTimer.elapsed() << " secs" << std::endl;
     last_branch_engine_legacy_driver      = qmc_driver->getBranchEngine();
     last_branch_engine_new_unified_driver = qmc_driver->getNewBranchEngine();

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -41,11 +41,8 @@ typedef int TraceManager;
 namespace qmcplusplus
 {
 /// Constructor.
-DMC::DMC(MCWalkerConfiguration& w,
-         TrialWaveFunction& psi,
-         QMCHamiltonian& h,
-         Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "DMC"),
+DMC::DMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling)
+    : QMCDriver(w, psi, h, comm, "DMC", enable_profiling),
       KillNodeCrossing(0),
       BranchInterval(-1),
       L2("no"),
@@ -60,7 +57,7 @@ DMC::DMC(MCWalkerConfiguration& w,
   m_param.add(NonLocalMove, "nonlocalmove", "string");
   m_param.add(NonLocalMove, "nonlocalmoves", "string");
   m_param.add(mover_MaxAge, "MaxAge", "double");
-  m_param.add(L2,"L2_diffusion","string");
+  m_param.add(L2, "L2_diffusion", "string");
 }
 
 void DMC::resetUpdateEngines()
@@ -142,15 +139,15 @@ void DMC::resetUpdateEngines()
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE])
         {
-          bool do_L2  = L2=="yes";
-          if(!do_L2)
+          bool do_L2 = L2 == "yes";
+          if (!do_L2)
           {
-            app_log()<<"Using DMCUpdatePbyPWithRejectionFast\n";
+            app_log() << "Using DMCUpdatePbyPWithRejectionFast\n";
             Movers[ip] = new DMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
           }
           else
           {
-            app_log()<<"Using DMCUpdatePbyPL2\n";
+            app_log() << "Using DMCUpdatePbyPL2\n";
             Movers[ip] = new DMCUpdatePbyPL2(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
           }
           Movers[ip]->put(qmcNode);

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -94,7 +94,13 @@ void DMC::resetUpdateEngines()
       copy(wPerNode.begin(), wPerNode.end(), std::ostream_iterator<int>(o, " "));
       o << "\n";
       if (qmc_driver_mode[QMC_UPDATE_MODE])
+      {
         o << "  Updates by particle-by-particle moves";
+        if (L2 == "yes")
+          app_log() << "Using DMCUpdatePbyPL2" << std::endl;
+        else
+          app_log() << "Using DMCUpdatePbyPWithRejectionFast" << std::endl;
+      }
       else
         o << "  Updates by walker moves";
       // Appears to be set in constructor reported here and used nowhere
@@ -139,17 +145,11 @@ void DMC::resetUpdateEngines()
       {
         if (qmc_driver_mode[QMC_UPDATE_MODE])
         {
-          bool do_L2 = L2 == "yes";
-          if (!do_L2)
-          {
-            app_log() << "Using DMCUpdatePbyPWithRejectionFast\n";
-            Movers[ip] = new DMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
-          }
-          else
-          {
-            app_log() << "Using DMCUpdatePbyPL2\n";
+          if (L2 == "yes")
             Movers[ip] = new DMCUpdatePbyPL2(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
-          }
+          else
+            Movers[ip] = new DMCUpdatePbyPWithRejectionFast(*wClones[ip], *psiClones[ip], *hClones[ip], *Rng[ip]);
+
           Movers[ip]->put(qmcNode);
           Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
           Movers[ip]->initWalkersForPbyP(W.begin() + wPerNode[ip], W.begin() + wPerNode[ip + 1]);

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -31,7 +31,7 @@ class DMC : public QMCDriver, public CloneManager
 {
 public:
   /// Constructor.
-  DMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
+  DMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling);
 
   bool run();
   bool put(xmlNodePtr cur);

--- a/src/QMCDrivers/DMC/DMCDriverInput.cpp
+++ b/src/QMCDrivers/DMC/DMCDriverInput.cpp
@@ -21,7 +21,10 @@ void DMCDriverInput::readXML(xmlNodePtr node)
   std::string reconfig_str;
   parameter_set_.add(reconfig_str, "reconfiguration", "string");
   if (!reconfig_str.empty() && reconfig_str != "no" && reconfig_str != "runwhileincorrect")
-    throw std::runtime_error("Reconfiguration is currently broken and gives incorrect results. Set reconfiguration=\"no\" or remove the reconfiguration option from the DMC input section. To run performance tests, please set reconfiguration to \"runwhileincorrect\" instead of \"yes\" to restore consistent behaviour.");
+    throw std::runtime_error(
+        "Reconfiguration is currently broken and gives incorrect results. Set reconfiguration=\"no\" or remove the "
+        "reconfiguration option from the DMC input section. To run performance tests, please set reconfiguration to "
+        "\"runwhileincorrect\" instead of \"yes\" to restore consistent behaviour.");
   reconfiguration_ = (reconfig_str == "runwhileincorrect");
   parameter_set_.add(NonLocalMove, "nonlocalmove", "string");
   parameter_set_.add(NonLocalMove, "nonlocalmoves", "string");
@@ -41,14 +44,14 @@ void DMCDriverInput::readXML(xmlNodePtr node)
   parameter_set_.add(reserve_, "reserve", "double");
 
   parameter_set_.put(node);
-  
+
   // TODO: similar check for alpha and gamma
-  if(max_age_ < 0)
+  if (max_age_ < 0)
     throw std::runtime_error("Illegal input for MaxAge in DMC input section");
-  if(branch_interval_ < 0)
+  if (branch_interval_ < 0)
     throw std::runtime_error("Illegal input for branchInterval or substeps in DMC input section");
 
-  if(reserve_ < 1.0)
+  if (reserve_ < 1.0)
     throw std::runtime_error("You can only reserve walkers above the target walker count");
 }
 

--- a/src/QMCDrivers/DMC/DMCDriverInput.h
+++ b/src/QMCDrivers/DMC/DMCDriverInput.h
@@ -36,6 +36,7 @@ public:
   double get_alpha() const { return alpha_; }
   double get_gamma() const { return gamma_; }
   RealType get_reserve() const { return reserve_; }
+
 private:
   /** @ingroup Parameters for DMC Driver
    *  @{
@@ -59,11 +60,10 @@ private:
   IndexType max_age_ = 10;
   /// reserved walkers for population growth
   RealType reserve_ = 1.0;
-  double alpha_ = 0.0;
-  double gamma_ = 0.0;
+  double alpha_     = 0.0;
+  double gamma_     = 0.0;
   /** @} */
 public:
-
   friend std::ostream& operator<<(std::ostream& o_stream, const DMCDriverInput& vmci);
 };
 

--- a/src/QMCDrivers/DMC/DMCFactory.cpp
+++ b/src/QMCDrivers/DMC/DMCFactory.cpp
@@ -27,13 +27,14 @@ namespace qmcplusplus
 QMCDriver* DMCFactory::create(MCWalkerConfiguration& w,
                               TrialWaveFunction& psi,
                               QMCHamiltonian& h,
-                              Communicate* comm)
+                              Communicate* comm,
+                              bool enable_profiling)
 {
 #ifdef QMC_CUDA
   if (GPU)
-    return new DMCcuda(w, psi, h, comm);
+    return new DMCcuda(w, psi, h, comm, enable_profiling);
 #endif
-  QMCDriver* qmc = new DMC(w, psi, h, comm);
+  QMCDriver* qmc = new DMC(w, psi, h, comm, enable_profiling);
   qmc->setUpdateMode(PbyPUpdate);
   return qmc;
 }

--- a/src/QMCDrivers/DMC/DMCFactory.h
+++ b/src/QMCDrivers/DMC/DMCFactory.h
@@ -31,7 +31,8 @@ public:
   QMCDriver* create(MCWalkerConfiguration& w,
                     TrialWaveFunction& psi,
                     QMCHamiltonian& h,
-                    Communicate* comm);
+                    Communicate* comm,
+                    bool enable_profiling);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -82,7 +82,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
       DriftModifier->getDrift(tauovermass, grad_iat, dr);
       dr += sqrttau * deltaR[iat];
       bool is_valid = W.makeMoveAndCheck(iat, dr);
-      RealType rr = tauovermass * dot(deltaR[iat], deltaR[iat]);
+      RealType rr   = tauovermass * dot(deltaR[iat], deltaR[iat]);
       rr_proposed += rr;
       if (!is_valid || rr > m_r2max)
       {

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -37,8 +37,9 @@ using WP = WalkerProperties::Indexes;
 DMCcuda::DMCcuda(MCWalkerConfiguration& w,
                  TrialWaveFunction& psi,
                  QMCHamiltonian& h,
-                 Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "DMCcuda"),
+                 Communicate* comm,
+                 bool enable_profiling)
+    : QMCDriver(w, psi, h, comm, "DMCcuda", enable_profiling),
       myWarmupSteps(0),
       Mover(0),
       NLop(w.getTotalNum()),

--- a/src/QMCDrivers/DMC/DMC_CUDA.h
+++ b/src/QMCDrivers/DMC/DMC_CUDA.h
@@ -34,7 +34,8 @@ public:
   DMCcuda(MCWalkerConfiguration& w,
           TrialWaveFunction& psi,
           QMCHamiltonian& h,
-          Communicate* comm);
+          Communicate* comm,
+          bool enable_profiling);
   bool run();
   bool put(xmlNodePtr cur);
   void resetUpdateEngine();
@@ -68,7 +69,7 @@ private:
   ///use T-moves
   int UseTMove;
 
-  NewTimer& ResizeTimer, &DriftDiffuseTimer, &BranchTimer, &HTimer;
+  NewTimer &ResizeTimer, &DriftDiffuseTimer, &BranchTimer, &HTimer;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -46,7 +46,8 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
                      TrialWaveFunction& psi,
                      QMCHamiltonian& h,
                      Communicate* comm,
-                     const std::string& QMC_driver_type)
+                     const std::string& QMC_driver_type,
+                     bool enable_profiling)
     : MPIObjectBase(comm),
       Estimators(0),
       Traces(0),
@@ -58,7 +59,7 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
       H(h),
       wOut(0),
       driver_scope_timer_(timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
-      driver_scope_profiler_(false)
+      driver_scope_profiler_(enable_profiling)
 {
   ResetRandom  = false;
   AppendRun    = false;

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -56,7 +56,9 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
       W(w),
       Psi(psi),
       H(h),
-      wOut(0)
+      wOut(0),
+      driver_scope_timer_(timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
+      driver_scope_profiler_(false)
 {
   ResetRandom  = false;
   AppendRun    = false;

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -99,7 +99,8 @@ public:
             TrialWaveFunction& psi,
             QMCHamiltonian& h,
             Communicate* comm,
-            const std::string& QMC_driver_type);
+            const std::string& QMC_driver_type,
+            bool enable_profiling = false);
 
   virtual ~QMCDriver() override;
 

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -25,6 +25,7 @@
 #include "OhmmsData/ParameterSet.h"
 #include "Utilities/PooledData.h"
 #include "Utilities/TimerManager.h"
+#include "Utilities/ScopedProfiler.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/WaveFunctionPool.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
@@ -359,7 +360,13 @@ protected:
   std::string getRotationName(std::string RootName);
   std::string getLastRotationName(std::string RootName);
   const std::string& get_root_name() const override { return RootName; }
+
+private:
   NewTimer* checkpointTimer;
+  ///time the driver lifetime
+  ScopedTimer driver_scope_timer_;
+  ///profile the driver lifetime
+  ScopedProfiler driver_scope_profiler_;
 };
 /**@}*/
 } // namespace qmcplusplus

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -64,6 +64,7 @@ QMCDriverFactory::DriverAssemblyState QMCDriverFactory::readSection(xmlNodePtr c
   std::string multi_tag("no");
   std::string warp_tag("no");
   std::string append_tag("no");
+  std::string profiling_tag("no");
 #if defined(QMC_CUDA)
   std::string gpu_tag("yes");
 #else
@@ -75,10 +76,12 @@ QMCDriverFactory::DriverAssemblyState QMCDriverFactory::readSection(xmlNodePtr c
   aAttrib.add(multi_tag, "multiple");
   aAttrib.add(warp_tag, "warp");
   aAttrib.add(append_tag, "append");
+  aAttrib.add(profiling_tag, "profiling");
   aAttrib.add(gpu_tag, "gpu");
   aAttrib.add(das.traces_tag, "trace");
   aAttrib.put(cur);
   das.append_run                 = (append_tag == "yes");
+  das.enable_profiling           = (profiling_tag == "yes");
   das.what_to_do[SPACEWARP_MODE] = (warp_tag == "yes");
   das.what_to_do[MULTIPLE_MODE]  = (multi_tag == "yes");
   das.what_to_do[UPDATE_MODE]    = (update_mode == "pbyp");
@@ -232,7 +235,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     //VMCFactory fac(curQmcModeBits[UPDATE_MODE],cur);
     VMCFactory fac(das.what_to_do.to_ulong(), cur);
-    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm));
+    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling));
     //TESTING CLONE
     //TrialWaveFunction* psiclone=primaryPsi->makeClone(qmc_system);
     //qmcDriver = fac.create(qmc_system,*psiclone,*primaryH,particle_pool,hamiltonian_pool);
@@ -246,7 +249,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   else if (das.new_run_type == QMCRunType::DMC)
   {
     DMCFactory fac(das.what_to_do[UPDATE_MODE], das.what_to_do[GPU_MODE], cur);
-    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm));
+    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling));
   }
   else if (das.new_run_type == QMCRunType::DMC_BATCH)
   {

--- a/src/QMCDrivers/QMCDriverFactory.h
+++ b/src/QMCDrivers/QMCDriverFactory.h
@@ -42,6 +42,7 @@ public:
   {
     std::bitset<QMC_MODE_MAX> what_to_do;
     bool append_run         = false;
+    bool enable_profiling   = false;
     std::string traces_tag  = "none";
     QMCRunType new_run_type = QMCRunType::DUMMY;
   };

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -67,11 +67,10 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   parameter_set.add(max_disp_sq_, "maxDisplSq", "double");
 
   OhmmsAttributeSet aAttrib;
-
   // first stage in from QMCDriverFactory
   aAttrib.add(qmc_method_, "method");
   aAttrib.add(update_mode_, "move");
-
+  aAttrib.add(scoped_profiling_, "profiling");
 
   aAttrib.add(k_delay_, "kdelay");
   // This does all the parameter parsing setup in the constructor

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -60,6 +60,8 @@ protected:
 
   int qmc_section_count_;
 
+  bool scoped_profiling_ = false;
+
   /** @ingroup Input Parameters for QMCDriver base class
    *  @{
    *  All input determined variables should be here
@@ -145,6 +147,7 @@ public:
 
   const std::string& get_qmc_method() const { return qmc_method_; }
   const std::string& get_update_mode() const { return update_mode_; }
+  bool get_scoped_profiling() const { return scoped_profiling_; }
 
   const std::string get_drift_modifier() const { return drift_modifier_; }
   RealType get_drift_modifier_unr_a() const { return drift_modifier_unr_a_; }

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -59,9 +59,9 @@ public:
   virtual unsigned long getDriverMode()                                 = 0;
   virtual ~QMCDriverInterface() {}
 
-  virtual void setBranchEngine(std::unique_ptr<BranchEngineType>&& be) { }
+  virtual void setBranchEngine(std::unique_ptr<BranchEngineType>&& be) {}
   virtual std::unique_ptr<BranchEngineType> getBranchEngine() { return nullptr; }
-  virtual void setNewBranchEngine(std::unique_ptr<SFNBranch>&& be) { }
+  virtual void setNewBranchEngine(std::unique_ptr<SFNBranch>&& be) {}
   virtual std::unique_ptr<SFNBranch> getNewBranchEngine() { return nullptr; }
 };
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -57,6 +57,8 @@ QMCDriverNew::QMCDriverNew(QMCDriverInput&& input,
       estimator_manager_(nullptr),
       wOut(0),
       timers_(timer_prefix),
+      driver_scope_timer_(timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
+      driver_scope_profiler_(qmcdriver_input_.get_scoped_profiling()),
       setNonLocalMoveHandler_(snlm_handler)
 {
   rotation = 0;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -31,6 +31,7 @@
 #include "Configuration.h"
 #include "Utilities/PooledData.h"
 #include "Utilities/TimerManager.h"
+#include "Utilities/ScopedProfiler.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/WaveFunctionPool.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
@@ -388,6 +389,11 @@ protected:
 
 
   DriverTimers timers_;
+
+  ///time the driver lifetime
+  ScopedTimer driver_scope_timer_;
+  ///profile the driver lifetime
+  ScopedProfiler driver_scope_profiler_;
 
 public:
   ///Copy Constructor (disabled).

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -36,11 +36,8 @@ typedef int TraceManager;
 namespace qmcplusplus
 {
 /// Constructor.
-VMC::VMC(MCWalkerConfiguration& w,
-         TrialWaveFunction& psi,
-         QMCHamiltonian& h,
-         Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "VMC"), UseDrift("yes")
+VMC::VMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling)
+    : QMCDriver(w, psi, h, comm, "VMC", enable_profiling), UseDrift("yes")
 {
   RootName = "vmc";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -25,7 +25,7 @@ class VMC : public QMCDriver, public CloneManager
 {
 public:
   /// Constructor.
-  VMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
+  VMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling);
   bool run();
   bool put(xmlNodePtr cur);
   QMCRunType getRunType() { return QMCRunType::VMC; }

--- a/src/QMCDrivers/VMC/VMCDriverInput.cpp
+++ b/src/QMCDrivers/VMC/VMCDriverInput.cpp
@@ -13,9 +13,7 @@
 
 namespace qmcplusplus
 {
-VMCDriverInput::VMCDriverInput(bool use_drift)
-    : use_drift_(use_drift)
-{}
+VMCDriverInput::VMCDriverInput(bool use_drift) : use_drift_(use_drift) {}
 
 void VMCDriverInput::readXML(xmlNodePtr node)
 {
@@ -27,7 +25,7 @@ void VMCDriverInput::readXML(xmlNodePtr node)
   parameter_set_.add(samples_per_thread_, "samplesperthread", "int");
   parameter_set_.add(steps_between_samples_, "stepsbetweensamples", "int");
   parameter_set_.put(node);
-  if(use_drift == "no")
+  if (use_drift == "no")
     use_drift_ = false;
 }
 

--- a/src/QMCDrivers/VMC/VMCDriverInput.h
+++ b/src/QMCDrivers/VMC/VMCDriverInput.h
@@ -36,7 +36,7 @@ protected:
    *  Do not write out blocks of gets for variables like this
    *  there is are code_generation tools in QMCPACK_ROOT/utils/code_tools
    */
-  bool use_drift_ = true;
+  bool use_drift_                  = true;
   IndexType samples_per_thread_    = -1;
   IndexType samples_               = -1;
   IndexType steps_between_samples_ = -1;

--- a/src/QMCDrivers/VMC/VMCFactory.cpp
+++ b/src/QMCDrivers/VMC/VMCFactory.cpp
@@ -36,19 +36,20 @@ namespace qmcplusplus
 QMCDriverInterface* VMCFactory::create(MCWalkerConfiguration& w,
                                        TrialWaveFunction& psi,
                                        QMCHamiltonian& h,
-                                       Communicate* comm)
+                                       Communicate* comm,
+                                       bool enable_profiling)
 {
   int np = omp_get_max_threads();
   //(SPACEWARP_MODE,MULTIPE_MODE,UPDATE_MODE)
   QMCDriverInterface* qmc = nullptr;
 #ifdef QMC_CUDA
   if (VMCMode & 16)
-    qmc = new VMCcuda(w, psi, h, comm);
+    qmc = new VMCcuda(w, psi, h, comm, enable_profiling);
   else
 #endif
       if (VMCMode == 0 || VMCMode == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMC(w, psi, h, comm);
+    qmc = new VMC(w, psi, h, comm, enable_profiling);
   }
   //else if(VMCMode == 2) //(0,1,0)
   //{

--- a/src/QMCDrivers/VMC/VMCFactory.h
+++ b/src/QMCDrivers/VMC/VMCFactory.h
@@ -32,7 +32,8 @@ public:
   QMCDriverInterface* create(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,
                              QMCHamiltonian& h,
-                             Communicate* comm);
+                             Communicate* comm,
+                             bool enable_profiling);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/VMC/VMC_CUDA.cpp
+++ b/src/QMCDrivers/VMC/VMC_CUDA.cpp
@@ -33,8 +33,9 @@ namespace qmcplusplus
 VMCcuda::VMCcuda(MCWalkerConfiguration& w,
                  TrialWaveFunction& psi,
                  QMCHamiltonian& h,
-                 Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "VMCcuda"),
+                 Communicate* comm,
+                 bool enable_profiling)
+    : QMCDriver(w, psi, h, comm, "VMCcuda", enable_profiling),
       UseDrift("yes"),
       myPeriod4WalkerDump(0),
       w_beta(0.0),

--- a/src/QMCDrivers/VMC/VMC_CUDA.h
+++ b/src/QMCDrivers/VMC/VMC_CUDA.h
@@ -32,7 +32,8 @@ public:
   VMCcuda(MCWalkerConfiguration& w,
           TrialWaveFunction& psi,
           QMCHamiltonian& h,
-          Communicate* comm);
+          Communicate* comm,
+          bool enable_profiling);
 
   bool run();
   bool runWithDrift();

--- a/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
@@ -326,7 +326,7 @@ bool QMCCorrelatedSamplingLinearOptimize::put(xmlNodePtr q)
   if (vmcEngine == 0)
   {
 #if defined(QMC_CUDA)
-    vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm);
+    vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm, false);
     vmcCSEngine = dynamic_cast<VMCcuda*>(vmcEngine.get());
     vmcCSEngine->setOpt(true);
 #else

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -41,7 +41,7 @@ public:
 #ifdef HAVE_LMY_ENGINE
   void engine_checkConfigurations(cqmc::engine::LMYEngine<Return_t>* EngineObj,
                                   DescentEngine& descentEngineObj,
-                                  const std::string& MinMethod);
+                                  const std::string& MinMethod) override;
 #endif
 
 
@@ -63,7 +63,7 @@ protected:
 
 #ifdef HAVE_LMY_ENGINE
   int total_samples();
-  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj);
+  Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
 #endif
 };
 } // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -123,39 +123,39 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration
   //app_log() << "construct QMCFixedSampleLinearOptimize" << endl;
   std::vector<double> shift_scales(3, 1.0);
   EngineObj = new cqmc::engine::LMYEngine<ValueType>(&vdeps,
-                                          false, // exact sampling
-                                          true,  // ground state?
-                                          false, // variance correct,
-                                          true,
-                                          true,  // print matrices,
-                                          true,  // build matrices
-                                          false, // spam
-                                          false, // use var deps?
-                                          true,  // chase lowest
-                                          false, // chase closest
-                                          false, // eom
-                                          false,
-                                          false,  // eom related
-                                          false,  // eom related
-                                          false,  // use block?
-                                          120000, // number of samples
-                                          0,      // number of parameters
-                                          60,     // max krylov iter
-                                          0,      // max spam inner iter
-                                          1,      // spam appro degree
-                                          0,      // eom related
-                                          0,      // eom related
-                                          0,      // eom related
-                                          0.0,    // omega
-                                          0.0,    // var weight
-                                          1.0e-6, // convergence threshold
-                                          0.99,   // minimum S singular val
-                                          0.0, 0.0,
-                                          10.0, // max change allowed
-                                          1.00, // identity shift
-                                          1.00, // overlap shift
-                                          0.3,  // max parameter change
-                                          shift_scales, app_log());
+                                                     false, // exact sampling
+                                                     true,  // ground state?
+                                                     false, // variance correct,
+                                                     true,
+                                                     true,  // print matrices,
+                                                     true,  // build matrices
+                                                     false, // spam
+                                                     false, // use var deps?
+                                                     true,  // chase lowest
+                                                     false, // chase closest
+                                                     false, // eom
+                                                     false,
+                                                     false,  // eom related
+                                                     false,  // eom related
+                                                     false,  // use block?
+                                                     120000, // number of samples
+                                                     0,      // number of parameters
+                                                     60,     // max krylov iter
+                                                     0,      // max spam inner iter
+                                                     1,      // spam appro degree
+                                                     0,      // eom related
+                                                     0,      // eom related
+                                                     0,      // eom related
+                                                     0.0,    // omega
+                                                     0.0,    // var weight
+                                                     1.0e-6, // convergence threshold
+                                                     0.99,   // minimum S singular val
+                                                     0.0, 0.0,
+                                                     10.0, // max change allowed
+                                                     1.00, // identity shift
+                                                     1.00, // overlap shift
+                                                     0.3,  // max parameter change
+                                                     shift_scales, app_log());
 #endif
 
 
@@ -202,23 +202,23 @@ bool QMCFixedSampleLinearOptimize::run()
     app_log() << "Doing hybrid run" << std::endl;
     return hybrid_run();
 #else
-myComm->barrier_and_abort(" Error: Hybrid method does not work with QMC_COMPLEX=1. \n");
+    myComm->barrier_and_abort(" Error: Hybrid method does not work with QMC_COMPLEX=1. \n");
 #endif
   }
 
-if (current_optimizer_type_ == OptimizerType::DESCENT)
+  if (current_optimizer_type_ == OptimizerType::DESCENT)
 #if !defined(QMC_COMPLEX)
     return descent_run();
 #else
-myComm->barrier_and_abort(" Error: Descent method does not work with QMC_COMPLEX=1. \n");
+    myComm->barrier_and_abort(" Error: Descent method does not work with QMC_COMPLEX=1. \n");
 #endif
 
 
-// if requested, perform the update via the adaptive three-shift or single-shift method
+  // if requested, perform the update via the adaptive three-shift or single-shift method
   if (current_optimizer_type_ == OptimizerType::ADAPTIVE)
     return adaptive_three_shift_run();
 
-  
+
 #endif
 
   if (current_optimizer_type_ == OptimizerType::ONESHIFTONLY)
@@ -477,7 +477,10 @@ bool QMCFixedSampleLinearOptimize::put(xmlNodePtr q)
     return processOptXML(q, vmcMove, ReportToH5 == "yes", useGPU == "yes");
 }
 
-bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml, const std::string& vmcMove, bool reportH5, bool useGPU)
+bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml,
+                                                 const std::string& vmcMove,
+                                                 bool reportH5,
+                                                 bool useGPU)
 {
   m_param.put(opt_xml);
   tolower(targetExcitedStr);
@@ -494,21 +497,22 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml, const std::
 
   if (current_optimizer_type_ == OptimizerType::DESCENT)
   {
-    if(!descentEngineObj)
+    if (!descentEngineObj)
     {
-        descentEngineObj = std::make_unique<DescentEngine>(myComm, opt_xml);
+      descentEngineObj = std::make_unique<DescentEngine>(myComm, opt_xml);
     }
 
     else
     {
-        descentEngineObj->processXML(opt_xml);
+      descentEngineObj->processXML(opt_xml);
     }
   }
 
 
   // sanity check
-  if (targetExcited && current_optimizer_type_ != OptimizerType::ADAPTIVE && current_optimizer_type_ != OptimizerType::DESCENT)
-     myComm->barrier_and_abort("targetExcited = \"yes\" requires that MinMethod = \"adaptive or descent");
+  if (targetExcited && current_optimizer_type_ != OptimizerType::ADAPTIVE &&
+      current_optimizer_type_ != OptimizerType::DESCENT)
+    myComm->barrier_and_abort("targetExcited = \"yes\" requires that MinMethod = \"adaptive or descent");
 
 #ifdef ENABLE_OPENMP
   if (current_optimizer_type_ == OptimizerType::ADAPTIVE && (omp_get_max_threads() > 1))
@@ -567,10 +571,10 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml, const std::
   // {
 #if defined(QMC_CUDA)
   if (useGPU)
-    vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm);
+    vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm, false);
   else
 #endif
-    vmcEngine = std::make_unique<VMC>(W, Psi, H, myComm);
+    vmcEngine = std::make_unique<VMC>(W, Psi, H, myComm, false);
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');
   // }
 
@@ -1110,7 +1114,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
 
   // find the best shift and the corresponding update direction
   const std::vector<ValueType>* bestDirection = 0;
-  int best_shift                             = -1;
+  int best_shift                              = -1;
   for (int k = 0; k < costValues.size() && std::abs((initCost - initCost) / initCost) < max_relative_cost_change; k++)
     if (is_best_cost(k, costValues, shifts_i, initCost) && good_update.at(k))
     {
@@ -1163,7 +1167,7 @@ bool QMCFixedSampleLinearOptimize::adaptive_three_shift_run()
     formic::ColVec<RealType> update_dirs(numParams, 0.0);
     for (int i = 0; i < numParams; i++)
       // take the real part since blocked LM currently does not support complex parameter optimization
-      update_dirs.at(i) = std::real( bestDirection->at(i + 1) + parameterDirections.at(central_index).at(i + 1) ); 
+      update_dirs.at(i) = std::real(bestDirection->at(i + 1) + parameterDirections.at(central_index).at(i + 1));
     previous_update.insert(previous_update.begin(), update_dirs);
 
     // eliminate the oldest saved update if necessary
@@ -1347,16 +1351,15 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
 //Function for optimizing using gradient descent
 bool QMCFixedSampleLinearOptimize::descent_run()
 {
+  const bool saved_grads_flag = optTarget->getneedGrads();
 
-    const bool saved_grads_flag = optTarget->getneedGrads();
-
-    //Make sure needGrads is true before engine_checkConfigurations is called
-    optTarget->setneedGrads(true);
+  //Make sure needGrads is true before engine_checkConfigurations is called
+  optTarget->setneedGrads(true);
 
   //Compute Lagrangian derivatives needed for parameter updates with engine_checkConfigurations, which is called inside engine_start
   engine_start(EngineObj, *descentEngineObj, MinMethod);
 
-  
+
   int descent_num = descentEngineObj->getDescentNum();
 
   if (descent_num == 0)
@@ -1409,7 +1412,7 @@ bool QMCFixedSampleLinearOptimize::hybrid_run()
     //of vectors to the BLM engine.
     if (previous_optimizer_type_ == OptimizerType::DESCENT)
     {
-        descentEngineObj->resetStorageCount();
+      descentEngineObj->resetStorageCount();
       std::vector<std::vector<ValueType>> hybridBLM_Input = descentEngineObj->retrieveHybridBLM_Input();
 #if !defined(QMC_COMPLEX)
       //FIXME once complex is fixed in BLM engine
@@ -1417,13 +1420,13 @@ bool QMCFixedSampleLinearOptimize::hybrid_run()
 #endif
     }
     adaptive_three_shift_run();
- 
+
     app_log() << "Update descent engine parameter values after Blocked LM step" << std::endl;
-    for(int i = 0; i < numParams; i++) 
-    {    
-        ValueType val = optTarget->Params(i);
-        descentEngineObj->setParamVal(i,val);
-    } 
+    for (int i = 0; i < numParams; i++)
+    {
+      ValueType val = optTarget->Params(i);
+      descentEngineObj->setParamVal(i, val);
+    }
   }
 
   if (current_optimizer_type_ == OptimizerType::DESCENT)

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
@@ -667,10 +667,10 @@ bool QMCLinearOptimize::put(xmlNodePtr q)
   {
 #if defined(QMC_CUDA)
     if (useGPU == "yes")
-      vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm);
+      vmcEngine = std::make_unique<VMCcuda>(W, Psi, H, myComm, false);
     else
 #endif
-      vmcEngine = std::make_unique<VMC>(W, Psi, H, myComm);
+      vmcEngine = std::make_unique<VMC>(W, Psi, H, myComm, false);
     vmcEngine->setUpdateMode(vmcMove[0] == 'p');
   }
 

--- a/src/QMCDrivers/WFOpt/QMCOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimize.cpp
@@ -32,10 +32,7 @@
 
 namespace qmcplusplus
 {
-QMCOptimize::QMCOptimize(MCWalkerConfiguration& w,
-                         TrialWaveFunction& psi,
-                         QMCHamiltonian& h,
-                         Communicate* comm)
+QMCOptimize::QMCOptimize(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm)
     : QMCDriver(w, psi, h, comm, "QMCOptimize"),
       PartID(0),
       NumParts(1),
@@ -185,10 +182,10 @@ bool QMCOptimize::put(xmlNodePtr q)
   {
 #if defined(QMC_CUDA)
     if (useGPU == "yes")
-      vmcEngine = new VMCcuda(W, Psi, H, myComm);
+      vmcEngine = new VMCcuda(W, Psi, H, myComm, false);
     else
 #endif
-      vmcEngine = new VMC(W, Psi, H, myComm);
+      vmcEngine = new VMC(W, Psi, H, myComm, false);
     vmcEngine->setUpdateMode(vmcMove[0] == 'p');
   }
   vmcEngine->setStatus(RootName, h5FileRoot, AppendRun);

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -91,7 +91,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(elec, psi, h, c);
+  DMC dmc_omp(elec, psi, h, c, false);
 
   const char* dmc_input = "<qmc method=\"dmc\"> \
    <parameter name=\"steps\">1</parameter> \
@@ -179,7 +179,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(elec, psi, h, c);
+  DMC dmc_omp(elec, psi, h, c, false);
 
   const char* dmc_input = "<qmc method=\"dmc\"> \
    <parameter name=\"steps\">1</parameter> \

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -90,7 +90,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(elec, psi, h, c);
+  VMC vmc_omp(elec, psi, h, c, false);
 
   const char* vmc_input = "<qmc method=\"vmc\" move=\"pbyp\"> \
    <parameter name=\"substeps\">1</parameter> \
@@ -177,7 +177,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(elec, psi, h, c);
+  VMC vmc_omp(elec, psi, h, c, false);
 
   const char* vmc_input = "<qmc method=\"vmc\" move=\"pbyp\"> \
    <parameter name=\"substeps\">1</parameter> \

--- a/src/Utilities/ScopedProfiler.h
+++ b/src/Utilities/ScopedProfiler.h
@@ -1,0 +1,40 @@
+#ifndef QMCPLUSPLUS_SCOPEDPROFILER_H
+#define QMCPLUSPLUS_SCOPEDPROFILER_H
+
+#include "config.h"
+#ifdef ENABLE_CUDA
+#include "CUDA/cudaError.h"
+#include <cuda_profiler_api.h>
+#endif
+
+namespace qmcplusplus
+{
+
+//non-nested
+class ScopedProfiler
+{
+public:
+  ScopedProfiler(bool active) : isActive(active)
+  {
+    if (isActive)
+    {
+#ifdef ENABLE_CUDA
+      cudaErrorCheck(cudaProfilerStart(), "cudaProfilerStart failed!");
+#endif
+    }
+  }
+
+  ~ScopedProfiler()
+  {
+    if (isActive)
+    {
+#ifdef ENABLE_CUDA
+      cudaErrorCheck(cudaProfilerStop(), "cudaProfilerStop failed!");
+#endif
+    }
+  }
+private:
+  const bool isActive;
+};
+}
+#endif

--- a/src/Utilities/ScopedProfiler.h
+++ b/src/Utilities/ScopedProfiler.h
@@ -6,6 +6,9 @@
 #include "CUDA/cudaError.h"
 #include <cuda_profiler_api.h>
 #endif
+#ifdef USE_VTUNE_API
+#include <ittnotify.h>
+#endif
 
 namespace qmcplusplus
 {
@@ -21,6 +24,9 @@ public:
 #ifdef ENABLE_CUDA
       cudaErrorCheck(cudaProfilerStart(), "cudaProfilerStart failed!");
 #endif
+#ifdef USE_VTUNE_API
+      __itt_resume();
+#endif
     }
   }
 
@@ -30,6 +36,9 @@ public:
     {
 #ifdef ENABLE_CUDA
       cudaErrorCheck(cudaProfilerStop(), "cudaProfilerStop failed!");
+#endif
+#ifdef USE_VTUNE_API
+      __itt_pause();
 #endif
     }
   }


### PR DESCRIPTION
## Proposed changes
Review after #2820. Since #2820, a driver life cycle is better managed and we can introduce scoped profiling to target specific drivers.
See more detail in the doc update about `profiling="yes"` feature introduced for QMC drivers.

check Nsight Systems for GPU profiling.
Update VTune for CPU profiling. VTUNE_ROOT is introduced in CMake.

## What type(s) of changes does this code introduce?
- New feature
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'