### PR TITLE
Fix NLPP derivatives

### DIFF
--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -82,11 +82,16 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVector<OperatorB
   std::vector<ValueType> tmp_dhpsioverpsi(nparam);
   for (int iw = 0; iw < O_list.size(); iw++)
   {
-    O_list[iw].get().evaluateValueAndDerivatives(P_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
     for (int j = 0; j < nparam; j++)
     {
-      dlogpsi.setValue(j, iw, tmp_dlogpsi[j]);
-      dhpsioverpsi.setValue(j, iw, tmp_dhpsioverpsi[j]);
+      tmp_dlogpsi[j] = dlogpsi.getValue(j, iw);
+    }
+
+    O_list[iw].get().evaluateValueAndDerivatives(P_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
+
+    for (int j = 0; j < nparam; j++)
+    {
+      dhpsioverpsi.setValue(j, iw, dhpsioverpsi.getValue(j, iw) + tmp_dhpsioverpsi[j]);
     }
   }
 }


### PR DESCRIPTION
The `mw_evaluateWithParameterDerivatives` code needs to handle `dlogpsi` as an input, and `dhpsioverpsi` as an output (more precisely, an input that needs to be updated)

For the batch cost function in `checkConfigurations`, the `includeNonLocalH` value needs to be passed to the lambda so the NLPP value can be removed from the fixed energy when present.  Unfortunately, most of the diff is due to formatting changes from clang-format.

For the correlated sampling part, `compute_nlpp` needs to be passed to the lambda, and the branch that calls `QMCHamiltonain::flex_evaluateValueAndDerivatives` added.



## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
