### PR TITLE
Fix memory leak in slaterdet

### DIFF
--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -199,7 +199,7 @@ public:
 
   UPtrVector<MCPWalker>& get_walkers() { return walkers_; }
   const UPtrVector<MCPWalker>& get_walkers() const { return walkers_; }
-  UPtrVector<MCPWalker>& get_dead_walkers() { return dead_walkers_; }
+  const UPtrVector<MCPWalker>& get_dead_walkers() const { return dead_walkers_; }
 
   UPtrVector<QMCHamiltonian>& get_hamiltonians() { return walker_hamiltonians_; }
   UPtrVector<QMCHamiltonian>& get_dead_hamiltonians() { return dead_walker_hamiltonians_; }

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -183,7 +183,8 @@ public:
   std::string getEngineName() override { return QMCType; }
   unsigned long getDriverMode() override { return qmc_driver_mode_.to_ulong(); }
 
-  IndexType get_living_walkers() const { return population_.get_walkers().size(); }
+  IndexType get_num_living_walkers() const { return population_.get_walkers().size(); }
+  IndexType get_num_dead_walkers() const { return population_.get_dead_walkers().size(); }
 
   /** @ingroup Legacy interface to be dropped
    *  @{

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -825,10 +825,10 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
       {
         ParticleSet::ParticleGradient_t G(nat), tmpG(nat), G1(nat);
         ParticleSet::ParticleLaplacian_t L(nat), tmpL(nat), L1(nat);
-        DiracDeterminantBase* det = sd->Dets[isd];
-        LogValueType logpsi2          = det->evaluateLog(W, G, L); // this won't work with backflow
-        fail_log << "  Slater Determiant " << isd << " (for particles " << det->getFirstIndex() << " to "
-                 << det->getLastIndex() << ") log psi = " << logpsi2 << std::endl;
+        DiracDeterminantBase& det = *sd->Dets[isd];
+        LogValueType logpsi2      = det.evaluateLog(W, G, L); // this won't work with backflow
+        fail_log << "  Slater Determiant " << isd << " (for particles " << det.getFirstIndex() << " to "
+                 << det.getLastIndex() << ") log psi = " << logpsi2 << std::endl;
         // Should really check the condition number on the matrix determinant.
         // For now, just ignore values that too small.
         if (std::real(logpsi2) < -40.0)
@@ -843,7 +843,7 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
           W.R[it->index] = it->r;
           W.update();
 
-          LogValueType logpsi0 = det->evaluateLog(W, tmpG, tmpL);
+          LogValueType logpsi0 = det.evaluateLog(W, tmpG, tmpL);
 #if defined(QMC_COMPLEX)
           ValueType logpsi(logpsi0.real(), logpsi0.imag());
 #else
@@ -856,7 +856,7 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
         }
         fd.computeFiniteDiff(delta, positions, logpsi_vals, G1, L1);
 
-        if (!checkGradients(det->getFirstIndex(), det->getLastIndex(), G, L, G1, L1, fail_log, 2))
+        if (!checkGradients(det.getFirstIndex(), det.getLastIndex(), G, L, G1, L1, fail_log, 2))
         {
           all_okay = false;
         }
@@ -874,7 +874,7 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
 
           ParticleSet::ParticleGradient_t G(nat), tmpG(nat), G1(nat);
           ParticleSet::ParticleLaplacian_t L(nat), tmpL(nat), L1(nat);
-          RealType logpsi3 = det->evaluateLog(W, G, L);
+          RealType logpsi3 = det.evaluateLog(W, G, L);
           FiniteDifference::ValueVector logpsi_vals;
           FiniteDifference::PosChangeVector::iterator it;
           for (it = positions.begin(); it != positions.end(); it++)
@@ -897,7 +897,7 @@ bool WaveFunctionTester::checkGradientAtConfiguration(MCWalkerConfiguration::Wal
           }
           fd.computeFiniteDiff(delta, positions, logpsi_vals, G1, L1);
 
-          if (!checkGradients(det->getFirstIndex(), det->getLastIndex(), G, L, G1, L1, fail_log, 3))
+          if (!checkGradients(det.getFirstIndex(), det.getLastIndex(), G, L, G1, L1, fail_log, 3))
           {
             all_okay = false;
           }

--- a/src/QMCDrivers/tests/ValidQMCInputSections.h
+++ b/src/QMCDrivers/tests/ValidQMCInputSections.h
@@ -88,10 +88,10 @@ constexpr std::array<const char*, 2> valid_dmc_input_sections{
 )",
      R"(
   <qmc method="dmc_batch" move="pbyp">
-    <parameter name="crowds">                 8 </parameter>
+    <parameter name="crowds">                 4 </parameter>
     <estimator name="LocalEnergy" hdf5="no" />
-    <parameter name="total_walkers">                32 </parameter>
-    <parameter name="reserve">                1.5 </parameter>
+    <parameter name="total_walkers">          8 </parameter>
+    <parameter name="reserve">             1.25 </parameter>
     <parameter name="warmupSteps">            5 </parameter>
     <parameter name="substeps">               5 </parameter>
     <parameter name="steps">                  1 </parameter>

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -92,11 +92,9 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
 
   dmcdriver.process(node);
   CHECK(dmcdriver.getNewBranchEngine() != nullptr);
-  CHECK(dmcdriver.get_living_walkers() == 32);
-  //  CHECK(population.get_num_global_walkers() == 32);
-  //  CHECK(population.get_num_local_walkers() == 32);
-  //  QMCTraits::IndexType reserved_walkers = population.get_num_local_walkers() + population.get_dead_walkers().size();
-  //  CHECK(reserved_walkers == 48);
+  CHECK(dmcdriver.get_num_living_walkers() == 8);
+  const QMCTraits::IndexType reserved_walkers = dmcdriver.get_num_living_walkers() + dmcdriver.get_num_dead_walkers();
+  CHECK(reserved_walkers == 10);
   // What else should we expect after process
 }
 

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -67,7 +67,7 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   REQUIRE(qmcdriver.getBranchEngine() == nullptr);
   qmcdriver.process(node);
   REQUIRE(qmcdriver.getNewBranchEngine() != nullptr);
-  REQUIRE(qmcdriver.get_living_walkers() == 1);
+  REQUIRE(qmcdriver.get_num_living_walkers() == 1);
 
   // What else should we expect after process
 }

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -32,7 +32,7 @@ SlaterDet::SlaterDet(ParticleSet& targetPtcl, const std::string& class_name) : W
   for (int i = 0; i < Last.size(); ++i)
     Last[i] = targetPtcl.last(i) - 1;
 
-  Dets.resize(targetPtcl.groups(), nullptr);
+  Dets.resize(targetPtcl.groups());
 }
 
 ///destructor
@@ -49,7 +49,7 @@ void SlaterDet::add(Determinant_t* det, int ispin)
     APP_ABORT("SlaterDet::add(Determinant_t* det, int ispin) is alreaded instantiated.");
   }
   else
-    Dets[ispin] = det;
+    Dets[ispin].reset(det);
   Optimizable = Optimizable || det->Optimizable;
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -35,7 +35,7 @@ class SlaterDet : public WaveFunctionComponent
 public:
   typedef DiracDeterminantBase Determinant_t;
   ///container for the DiracDeterminants
-  std::vector<Determinant_t*> Dets;
+  std::vector<std::unique_ptr<Determinant_t>> Dets;
   ///the last particle of each group
   std::vector<int> Last;
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -116,7 +116,7 @@ void SlaterDetWithBackflow::testDerivGL(ParticleSet& P)
   RealType dh       = 0.00001;
   for (int k = 0; k < Dets.size(); k++)
   {
-    DiracDeterminantWithBackflow* Dets_ = (DiracDeterminantWithBackflow*)Dets[k];
+    DiracDeterminantWithBackflow* Dets_ = dynamic_cast<DiracDeterminantWithBackflow*>(Dets[k].get());
     Dets_->testGGG(P);
     for (int i = 0; i < Nvars; i++)
     {
@@ -139,7 +139,7 @@ void SlaterDetWithBackflow::testDerivGL(ParticleSet& P)
     L2 = 0.0;
     for (int k = 0; k < Dets.size(); k++)
     {
-      DiracDeterminantWithBackflow* Dets_ = (DiracDeterminantWithBackflow*)Dets[k];
+      DiracDeterminantWithBackflow* Dets_ = dynamic_cast<DiracDeterminantWithBackflow*>(Dets[k].get());
       Dets_->evaluateDerivatives(P, wfVars, dlogpsi, dhpsi, &G0, &L0, i);
     }
     for (int j = 0; j < Nvars; j++)


### PR DESCRIPTION
## Proposed changes
The driver unit test was failing on graphic card with 8 GB memory, the root cause was that the DiracDeterminant objects are not freed in properly in SlaterDet. The second change is reducing the number of walkers + reserve in unit test from 32+16 to 8+2, the reduction of memory usage allows GPUs with 4GB memory to pass that unit test and it should help out cdash to be more green.

More clean up fix by changing raw pointer to lvalue unique_ptr will come after. Much more affected files and more testing needed.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
