### PR TITLE
Smart pointers of SPOSet in singledet and multidet

### DIFF
--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -517,12 +517,12 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   auto spo_up = std::make_unique<EGOSet>(kup, k2up);
   auto spo_dn = std::make_unique<EGOSet>(kdn, k2dn);
 
-  SpinorSet* spinor_set = new SpinorSet();
+  auto spinor_set = std::make_unique<SpinorSet>();
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 1);
 
-  DiracDeterminant<>* dd = new DiracDeterminant<>(spinor_set);
+  DiracDeterminant<>* dd = new DiracDeterminant<>(std::move(spinor_set));
   dd->resize(nelec, norb);
 
   psi.addComponent(dd);

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.cpp
@@ -69,14 +69,11 @@ WaveFunctionComponent* ElectronGasComplexOrbitalBuilder::buildComponent(xmlNodeP
     nc = egGrid.getShellIndex(nup);
   egGrid.createGrid(nc, nup, twist);
   targetPtcl.setTwist(twist);
-  //create a E(lectron)G(as)O(rbital)Set
-  EGOSet* psiu = new EGOSet(egGrid.kpt, egGrid.mk2);
-  EGOSet* psid = new EGOSet(egGrid.kpt, egGrid.mk2);
   //create up determinant
-  Det_t* updet = new Det_t(psiu);
+  Det_t* updet = new Det_t(std::make_unique<EGOSet>(egGrid.kpt, egGrid.mk2));
   updet->set(0, nup);
   //create down determinant
-  Det_t* downdet = new Det_t(psid);
+  Det_t* downdet = new Det_t(std::make_unique<EGOSet>(egGrid.kpt, egGrid.mk2));
   downdet->set(nup, nup);
   //create a Slater determinant
   //SlaterDeterminant_t *sdet  = new SlaterDeterminant_t;

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -100,8 +100,8 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
   //create a E(lectron)G(as)O(rbital)Set
   int nkpts = (nup - 1) / 2;
   egGrid.createGrid(nc, nkpts);
-  RealEGOSet* psiu = new RealEGOSet(egGrid.kpt, egGrid.mk2);
-  RealEGOSet* psid = nullptr;
+  auto psiu = std::make_unique<RealEGOSet>(egGrid.kpt, egGrid.mk2);
+  std::unique_ptr<RealEGOSet> psid;
   if (ndn > 0)
   {
     if (nup != ndn)
@@ -110,7 +110,7 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
       HEGGrid<RealType, OHMMS_DIM> egGrid2(targetPtcl.Lattice);
       egGrid2.createGrid(nc2, nkpts2);
     }
-    psid = new RealEGOSet(egGrid.kpt, egGrid.mk2);
+    psid = std::make_unique<RealEGOSet>(egGrid.kpt, egGrid.mk2);
   }
 
   //create a Slater determinant
@@ -125,12 +125,12 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
     DiracDeterminantWithBackflow *updet, *downdet;
     app_log() << "Creating Backflow transformation in ElectronGasOrbitalBuilder::put(xmlNodePtr cur).\n";
     //create up determinant
-    updet = new DiracDeterminantWithBackflow(targetPtcl, psiu, BFTrans, 0);
+    updet = new DiracDeterminantWithBackflow(targetPtcl, std::move(psiu), BFTrans, 0);
     updet->set(0, nup);
     if (ndn > 0)
     {
       //create down determinant
-      downdet = new DiracDeterminantWithBackflow(targetPtcl, psid, BFTrans, nup);
+      downdet = new DiracDeterminantWithBackflow(targetPtcl, std::move(psid), BFTrans, nup);
       downdet->set(nup, ndn);
     }
     PtclPoolType dummy;
@@ -147,12 +147,12 @@ WaveFunctionComponent* ElectronGasOrbitalBuilder::buildComponent(xmlNodePtr cur)
   {
     DiracDeterminant<>*updet, *downdet;
     //create up determinant
-    updet = new DiracDeterminant<>(psiu);
+    updet = new DiracDeterminant<>(std::move(psiu));
     updet->set(0, nup);
     if (ndn > 0)
     {
       //create down determinant
-      downdet = new DiracDeterminant<>(psid);
+      downdet = new DiracDeterminant<>(std::move(psid));
       downdet->set(nup, ndn);
     }
     sdet->add(updet, 0);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -29,8 +29,8 @@ namespace qmcplusplus
  *@param first index of the first particle
  */
 template<typename DU_TYPE>
-DiracDeterminant<DU_TYPE>::DiracDeterminant(SPOSetPtr const spos, int first)
-    : DiracDeterminantBase("DiracDeterminant", spos, first), ndelay(1), invRow_id(-1)
+DiracDeterminant<DU_TYPE>::DiracDeterminant(std::shared_ptr<SPOSet>&& spos, int first)
+    : DiracDeterminantBase("DiracDeterminant", std::move(spos), first), ndelay(1), invRow_id(-1)
 {}
 
 /** set the index of the first particle in the determinant and reset the size of the determinant
@@ -689,9 +689,9 @@ void DiracDeterminant<DU_TYPE>::evaluateDerivatives(ParticleSet& P,
 }
 
 template<typename DU_TYPE>
-DiracDeterminant<DU_TYPE>* DiracDeterminant<DU_TYPE>::makeCopy(SPOSetPtr spo) const
+DiracDeterminant<DU_TYPE>* DiracDeterminant<DU_TYPE>::makeCopy(std::shared_ptr<SPOSet>&& spo) const
 {
-  DiracDeterminant<DU_TYPE>* dclone = new DiracDeterminant<DU_TYPE>(spo);
+  DiracDeterminant<DU_TYPE>* dclone = new DiracDeterminant<DU_TYPE>(std::move(spo));
   dclone->set(FirstIndex, LastIndex - FirstIndex, ndelay);
   return dclone;
 }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -52,7 +52,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  DiracDeterminant(SPOSetPtr const spos, int first = 0);
+  DiracDeterminant(std::shared_ptr<SPOSet>&& spos, int first = 0);
 
   // copy constructor and assign operator disabled
   DiracDeterminant(const DiracDeterminant& s) = delete;
@@ -173,7 +173,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  DiracDeterminant* makeCopy(SPOSet* spo) const override;
+  DiracDeterminant* makeCopy(std::shared_ptr<SPOSet>&& spo) const override;
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -27,10 +27,12 @@ class DiracDeterminantBase : public WaveFunctionComponent
 {
 public:
   /** constructor
-   *@param spos the single-particle orbital set
+   *@param spos the single-particle orbital set.
+   *  shared_ptr is intended neither for sharing between spin up and down electrons nor for sharing between clones.
+   *  The sharing aspect is for the determinants used by the the multi-determinant slow implementation.
    *@param first index of the first particle
    */
-  DiracDeterminantBase(const std::string& class_name, SPOSetPtr const spos, int first = 0)
+  DiracDeterminantBase(const std::string& class_name, std::shared_ptr<SPOSet>&& spos, int first = 0)
       : WaveFunctionComponent(class_name),
         UpdateTimer(*timer_manager.createTimer(class_name + "::update", timer_level_fine)),
         RatioTimer(*timer_manager.createTimer(class_name + "::ratio", timer_level_fine)),
@@ -38,11 +40,11 @@ public:
         BufferTimer(*timer_manager.createTimer(class_name + "::buffer", timer_level_fine)),
         SPOVTimer(*timer_manager.createTimer(class_name + "::spoval", timer_level_fine)),
         SPOVGLTimer(*timer_manager.createTimer(class_name + "::spovgl", timer_level_fine)),
-        Phi(spos),
+        Phi(std::move(spos)),
         FirstIndex(first),
-        LastIndex(first + spos->size()),
-        NumOrbitals(spos->size()),
-        NumPtcls(spos->size())
+        LastIndex(first + Phi->size()),
+        NumOrbitals(Phi->size()),
+        NumPtcls(Phi->size())
   {
     Optimizable  = Phi->isOptimizable();
     is_fermionic = true;
@@ -150,7 +152,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  virtual DiracDeterminantBase* makeCopy(SPOSet* spo) const = 0;
+  virtual DiracDeterminantBase* makeCopy(std::shared_ptr<SPOSet>&& spo) const = 0;
 
 #ifdef QMC_CUDA
   // expose GPU interfaces
@@ -171,8 +173,11 @@ public:
 protected:
   /// Timers
   NewTimer &UpdateTimer, &RatioTimer, &InverseTimer, &BufferTimer, &SPOVTimer, &SPOVGLTimer;
-  /// a set of single-particle orbitals used to fill in the  values of the matrix
-  const std::unique_ptr<SPOSet> Phi;
+  /** a set of single-particle orbitals used to fill in the  values of the matrix
+   *  shared_ptr is intended neither for sharing between spin up and down electrons nor for sharing between clones.
+   *  The sharing aspect is for the determinants used by the the multi-determinant slow implementation.
+   */
+  const std::shared_ptr<SPOSet> Phi;
   ///index of the first particle with respect to the particle set
   int FirstIndex;
   ///index of the last particle with respect to the particle set

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -57,7 +57,7 @@ public:
   DiracDeterminantBase& operator=(const DiracDeterminantBase& s) = delete;
 
   // get the SPO pointer
-  inline SPOSetPtr getPhi() const { return Phi; }
+  inline SPOSetPtr getPhi() const { return Phi.get(); }
 
   // get FirstIndex, Last Index
   inline int getFirstIndex() const { return FirstIndex; }
@@ -172,7 +172,7 @@ protected:
   /// Timers
   NewTimer &UpdateTimer, &RatioTimer, &InverseTimer, &BufferTimer, &SPOVTimer, &SPOVGLTimer;
   /// a set of single-particle orbitals used to fill in the  values of the matrix
-  SPOSetPtr const Phi;
+  const std::unique_ptr<SPOSet> Phi;
   ///index of the first particle with respect to the particle set
   int FirstIndex;
   ///index of the last particle with respect to the particle set

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -23,8 +23,8 @@ namespace qmcplusplus
  *@param first index of the first particle
  */
 template<typename DET_ENGINE_TYPE>
-DiracDeterminantBatched<DET_ENGINE_TYPE>::DiracDeterminantBatched(SPOSetPtr const spos, int first)
-    : DiracDeterminantBase("DiracDeterminantBatched", spos, first),
+DiracDeterminantBatched<DET_ENGINE_TYPE>::DiracDeterminantBatched(std::shared_ptr<SPOSet>&& spos, int first)
+    : DiracDeterminantBase("DiracDeterminantBatched", std::move(spos), first),
       ndelay(1),
       D2HTimer(*timer_manager.createTimer("DiracDeterminantBatched::D2H", timer_level_fine)),
       H2DTimer(*timer_manager.createTimer("DiracDeterminantBatched::H2D", timer_level_fine))
@@ -744,9 +744,9 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::evaluateDerivatives(ParticleSet& 
 }
 
 template<typename DET_ENGINE_TYPE>
-DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYPE>::makeCopy(SPOSetPtr spo) const
+DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYPE>::makeCopy(std::shared_ptr<SPOSet>&& spo) const
 {
-  DiracDeterminantBatched<DET_ENGINE_TYPE>* dclone = new DiracDeterminantBatched<DET_ENGINE_TYPE>(spo);
+  DiracDeterminantBatched<DET_ENGINE_TYPE>* dclone = new DiracDeterminantBatched<DET_ENGINE_TYPE>(std::move(spo));
   dclone->set(FirstIndex, LastIndex - FirstIndex, ndelay);
   return dclone;
 }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -52,7 +52,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  DiracDeterminantBatched(SPOSetPtr const spos, int first = 0);
+  DiracDeterminantBatched(std::shared_ptr<SPOSet>&& spos, int first = 0);
 
   // copy constructor and assign operator disabled
   DiracDeterminantBatched(const DiracDeterminantBatched& s) = delete;
@@ -162,7 +162,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  DiracDeterminantBatched* makeCopy(SPOSet* spo) const override;
+  DiracDeterminantBatched* makeCopy(std::shared_ptr<SPOSet>&& spo) const override;
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.cpp
@@ -30,8 +30,8 @@
 
 namespace qmcplusplus
 {
-DiracDeterminantCUDA::DiracDeterminantCUDA(SPOSetPtr const spos, int first)
-    : DiracDeterminantBase("DiracDeterminantCUDA", spos, first),
+DiracDeterminantCUDA::DiracDeterminantCUDA(std::shared_ptr<SPOSet>&& spos, int first)
+    : DiracDeterminantBase("DiracDeterminantCUDA", std::move(spos), first),
       UpdateJobList_d("DiracDeterminant::UpdateJobList_d"),
       srcList_d("DiracDeterminant::srcList_d"),
       destList_d("DiracDeterminant::destList_d"),

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -38,7 +38,7 @@ public:
   typedef SPOSet::GradMatrix_t GradMatrix_t;
   typedef ParticleSet::Walker_t Walker_t;
 
-  DiracDeterminantCUDA(SPOSetPtr const spos, int first = 0);
+  DiracDeterminantCUDA(std::shared_ptr<SPOSet>&& spos, int first = 0);
   DiracDeterminantCUDA(const DiracDeterminantCUDA& s) = delete;
 
 protected:
@@ -149,7 +149,7 @@ protected:
 
 public:
   // safe-guard all CPU interfaces
-  DiracDeterminantCUDA* makeCopy(SPOSet* spo) const
+  DiracDeterminantCUDA* makeCopy(std::shared_ptr<SPOSet>&& spo) const
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::makeCopy is illegal!");
     return nullptr;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -28,10 +28,10 @@ namespace qmcplusplus
  *@param first index of the first particle
  */
 DiracDeterminantWithBackflow::DiracDeterminantWithBackflow(ParticleSet& ptcl,
-                                                           SPOSetPtr const spos,
+                                                           std::shared_ptr<SPOSet>&& spos,
                                                            BackflowTransformation* BF,
                                                            int first)
-    : DiracDeterminantBase("DiracDeterminantWithBackflow", spos, first)
+    : DiracDeterminantBase("DiracDeterminantWithBackflow", std::move(spos), first)
 {
   Optimizable  = true;
   is_fermionic = true;
@@ -998,11 +998,11 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
   }
 }
 
-DiracDeterminantWithBackflow* DiracDeterminantWithBackflow::makeCopy(SPOSetPtr spo) const
+DiracDeterminantWithBackflow* DiracDeterminantWithBackflow::makeCopy(std::shared_ptr<SPOSet>&& spo) const
 {
   //    BackflowTransformation *BF = BFTrans->makeClone();
   // mmorales: particle set is only needed to get number of particles, so using QP set here
-  DiracDeterminantWithBackflow* dclone = new DiracDeterminantWithBackflow(BFTrans->QP, spo, BFTrans, FirstIndex);
+  DiracDeterminantWithBackflow* dclone = new DiracDeterminantWithBackflow(BFTrans->QP, std::move(spo), BFTrans, FirstIndex);
   dclone->resize(NumPtcls, NumOrbitals);
   dclone->Optimizable = Optimizable;
   return dclone;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -50,7 +50,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  DiracDeterminantWithBackflow(ParticleSet& ptcl, SPOSetPtr const spos, BackflowTransformation* BF, int first = 0);
+  DiracDeterminantWithBackflow(ParticleSet& ptcl, std::shared_ptr<SPOSet>&& spos, BackflowTransformation* BF, int first = 0);
 
   ///default destructor
   ~DiracDeterminantWithBackflow();
@@ -138,7 +138,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  DiracDeterminantWithBackflow* makeCopy(SPOSet* spo) const;
+  DiracDeterminantWithBackflow* makeCopy(std::shared_ptr<SPOSet>&& spo) const;
 
   inline ValueType rcdot(TinyVector<RealType, OHMMS_DIM>& lhs, TinyVector<ValueType, OHMMS_DIM>& rhs)
   {

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -346,7 +346,7 @@ WaveFunctionComponentPtr MultiDiracDeterminant::makeClone(ParticleSet& tqp) cons
  *@param spos the single-particle orbital set
  *@param first index of the first particle
  */
-MultiDiracDeterminant::MultiDiracDeterminant(SPOSetPtr const& spos, int first)
+MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, int first)
     : WaveFunctionComponent("MultiDiracDeterminant"),
       UpdateTimer(*timer_manager.createTimer(ClassName + "update")),
       RatioTimer(*timer_manager.createTimer(ClassName + "ratio")),
@@ -361,11 +361,11 @@ MultiDiracDeterminant::MultiDiracDeterminant(SPOSetPtr const& spos, int first)
       ExtraStuffTimer(*timer_manager.createTimer(ClassName + "ExtraStuff")),
       NP(0),
       FirstIndex(first),
-      Phi(spos),
+      Phi(std::move(spos)),
       ciConfigList(nullptr),
       ReferenceDeterminant(0)
 {
-  (spos->isOptimizable() == true) ? Optimizable = true : Optimizable = false;
+  (Phi->isOptimizable() == true) ? Optimizable = true : Optimizable = false;
 
   IsCloned = false;
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -329,7 +329,7 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
   Optimizable          = s.Optimizable;
 
   registerTimers();
-  Phi = (s.Phi->makeClone());
+  Phi.reset(s.Phi->makeClone());
   this->resize(s.NumPtcls, s.NumOrbitals);
   this->DetCalculator.resize(s.NumPtcls);
 }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -75,7 +75,7 @@ public:
    */
   SPOSetPtr clonePhi() const;
 
-  SPOSetPtr getPhi() { return Phi; };
+  SPOSetPtr getPhi() { return Phi.get(); };
 
   inline IndexType rows() const { return NumPtcls; }
 
@@ -403,7 +403,7 @@ public:
   ///index of the particle (or row)
   int WorkingIndex;
   ///a set of single-particle orbitals used to fill in the  values of the matrix
-  SPOSetPtr Phi;
+  std::unique_ptr<SPOSet> Phi;
   /// number of determinants handled by this object
   int NumDets;
   ///bool to cleanup

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -56,7 +56,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  MultiDiracDeterminant(SPOSetPtr const& spos, int first = 0);
+  MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, int first = 0);
 
   ///default destructor
   ~MultiDiracDeterminant();

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -19,8 +19,8 @@
 namespace qmcplusplus
 {
 MultiSlaterDeterminant::MultiSlaterDeterminant(ParticleSet& targetPtcl,
-                                               SPOSetProxyPtr upspo,
-                                               SPOSetProxyPtr dnspo,
+                                               std::unique_ptr<SPOSetProxyForMSD>&& upspo,
+                                               std::unique_ptr<SPOSetProxyForMSD>&& dnspo,
                                                const std::string& class_name)
     : WaveFunctionComponent(class_name),
       RatioTimer(*timer_manager.createTimer(ClassName + "ratio")),
@@ -33,8 +33,8 @@ MultiSlaterDeterminant::MultiSlaterDeterminant(ParticleSet& targetPtcl,
       Ratio1AllTimer(*timer_manager.createTimer(ClassName + "detEval_ratio(all)")),
       AccRejTimer(*timer_manager.createTimer(ClassName + "Accept_Reject")),
       evalOrbTimer(*timer_manager.createTimer(ClassName + "evalOrbGrad")),
-      spo_up(upspo),
-      spo_dn(dnspo)
+      spo_up(std::move(upspo)),
+      spo_dn(std::move(dnspo))
 {
   registerTimers();
   //Optimizable=true;
@@ -56,11 +56,11 @@ MultiSlaterDeterminant::MultiSlaterDeterminant(ParticleSet& targetPtcl,
 WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) const
 {
   typedef DiracDeterminant<> SingleDet_t;
-  SPOSetProxyForMSD* spo_up_C   = new SPOSetProxyForMSD(spo_up->refPhi->makeClone(), FirstIndex_up, LastIndex_up);
-  SPOSetProxyForMSD* spo_dn_C   = new SPOSetProxyForMSD(spo_dn->refPhi->makeClone(), FirstIndex_dn, LastIndex_dn);
+  auto spo_up_C = std::make_unique<SPOSetProxyForMSD>(std::unique_ptr<SPOSet>(spo_up->refPhi->makeClone()), FirstIndex_up, LastIndex_up);
+  auto spo_dn_C = std::make_unique<SPOSetProxyForMSD>(std::unique_ptr<SPOSet>(spo_dn->refPhi->makeClone()), FirstIndex_dn, LastIndex_dn);
   spo_up_C->occup               = spo_up->occup;
   spo_dn_C->occup               = spo_dn->occup;
-  MultiSlaterDeterminant* clone = new MultiSlaterDeterminant(tqp, spo_up_C, spo_dn_C);
+  MultiSlaterDeterminant* clone = new MultiSlaterDeterminant(tqp, std::move(spo_up_C), std::move(spo_dn_C));
   clone->C2node_up              = C2node_up;
   clone->C2node_dn              = C2node_dn;
   clone->resize(dets_up.size(), dets_dn.size());
@@ -81,7 +81,7 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
     //           spo->occup(i,nq++) = k;
     //         }
     //       }
-    SingleDet_t* adet = new SingleDet_t((SPOSetPtr)clone->spo_up, 0);
+    SingleDet_t* adet = new SingleDet_t(std::static_pointer_cast<SPOSet>(clone->spo_up), 0);
     adet->set(clone->FirstIndex_up, clone->nels_up);
     clone->dets_up.push_back(adet);
   }
@@ -96,7 +96,7 @@ WaveFunctionComponentPtr MultiSlaterDeterminant::makeClone(ParticleSet& tqp) con
     //           spo->occup(i,nq++) = k;
     //         }
     //       }
-    SingleDet_t* adet = new SingleDet_t((SPOSetPtr)clone->spo_dn, 0);
+    SingleDet_t* adet = new SingleDet_t(std::static_pointer_cast<SPOSet>(clone->spo_dn), 0);
     adet->set(clone->FirstIndex_dn, clone->nels_dn);
     clone->dets_dn.push_back(adet);
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
@@ -56,7 +56,6 @@ public:
 
   typedef DiracDeterminantBase* DiracDeterminantBasePtr;
   typedef SPOSet* SPOSetPtr;
-  typedef SPOSetProxyForMSD* SPOSetProxyPtr;
   typedef OrbitalSetTraits<ValueType>::IndexVector_t IndexVector_t;
   typedef OrbitalSetTraits<ValueType>::ValueVector_t ValueVector_t;
   typedef OrbitalSetTraits<ValueType>::GradVector_t GradVector_t;
@@ -71,8 +70,8 @@ public:
 
   ///constructor
   MultiSlaterDeterminant(ParticleSet& targetPtcl,
-                         SPOSetProxyPtr upspo,
-                         SPOSetProxyPtr dnspo,
+                         std::unique_ptr<SPOSetProxyForMSD>&& upspo,
+                         std::unique_ptr<SPOSetProxyForMSD>&& dnspo,
                          const std::string& class_name = "MultiSlaterDeterminant");
 
   ///destructor
@@ -126,8 +125,8 @@ public:
 
   std::map<std::string, int> SPOSetID;
 
-  SPOSetProxyPtr spo_up;
-  SPOSetProxyPtr spo_dn;
+  std::shared_ptr<SPOSetProxyForMSD> spo_up;
+  std::shared_ptr<SPOSetProxyForMSD> spo_dn;
 
   std::vector<DiracDeterminantBasePtr> dets_up;
   std::vector<DiracDeterminantBasePtr> dets_dn;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -18,8 +18,6 @@
 #include <Configuration.h>
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Fermion/MultiDiracDeterminant.h"
-#include "QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h"
-#include "QMCWaveFunctions/Fermion/SPOSetProxyForMSD.h"
 #include "Utilities/TimerManager.h"
 #include "QMCWaveFunctions/Fermion/BackflowTransformation.h"
 
@@ -57,7 +55,6 @@ public:
   NewTimer &Ratio1Timer, &Ratio1GradTimer, &Ratio1AllTimer, &AccRejTimer;
 
   typedef SPOSet* SPOSetPtr;
-  typedef SPOSetProxyForMSD* SPOSetProxyPtr;
   typedef OrbitalSetTraits<ValueType>::IndexVector_t IndexVector_t;
   typedef OrbitalSetTraits<ValueType>::ValueVector_t ValueVector_t;
   typedef OrbitalSetTraits<ValueType>::GradVector_t GradVector_t;
@@ -182,9 +179,6 @@ public:
   Matrix<RealType> dpsia_up, dLa_up;
   Matrix<RealType> dpsia_dn, dLa_dn;
   Array<GradType, OHMMS_DIM> dGa_up, dGa_dn;
-
-  // debug, erase later
-  //      MultiSlaterDeterminant *msd;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -19,10 +19,10 @@
 namespace qmcplusplus
 {
 MultiSlaterDeterminantWithBackflow::MultiSlaterDeterminantWithBackflow(ParticleSet& targetPtcl,
-                                                                       SPOSetProxyPtr upspo,
-                                                                       SPOSetProxyPtr dnspo,
+                                                                       std::unique_ptr<SPOSetProxyForMSD>&& upspo,
+                                                                       std::unique_ptr<SPOSetProxyForMSD>&& dnspo,
                                                                        BackflowTransformation* BF)
-    : MultiSlaterDeterminant(targetPtcl, upspo, dnspo, "MultiSlaterDeterminantWithBackflow"), BFTrans(BF)
+    : MultiSlaterDeterminant(targetPtcl, std::move(upspo), std::move(dnspo), "MultiSlaterDeterminantWithBackflow"), BFTrans(BF)
 {
   Optimizable  = false;
   is_fermionic = true;
@@ -32,11 +32,11 @@ WaveFunctionComponentPtr MultiSlaterDeterminantWithBackflow::makeClone(ParticleS
 {
   // mmorales: the proxy classes read from the particle set inside BFTrans
   BackflowTransformation* tr  = BFTrans->makeClone(tqp);
-  SPOSetProxyForMSD* spo_up_C = new SPOSetProxyForMSD(spo_up->refPhi->makeClone(), FirstIndex_up, LastIndex_up);
-  SPOSetProxyForMSD* spo_dn_C = new SPOSetProxyForMSD(spo_dn->refPhi->makeClone(), FirstIndex_dn, LastIndex_dn);
+  auto spo_up_C = std::make_unique<SPOSetProxyForMSD>(std::unique_ptr<SPOSet>(spo_up->refPhi->makeClone()), FirstIndex_up, LastIndex_up);
+  auto spo_dn_C = std::make_unique<SPOSetProxyForMSD>(std::unique_ptr<SPOSet>(spo_dn->refPhi->makeClone()), FirstIndex_dn, LastIndex_dn);
   spo_up_C->occup             = spo_up->occup;
   spo_dn_C->occup             = spo_dn->occup;
-  MultiSlaterDeterminantWithBackflow* clone = new MultiSlaterDeterminantWithBackflow(tqp, spo_up_C, spo_dn_C, tr);
+  MultiSlaterDeterminantWithBackflow* clone = new MultiSlaterDeterminantWithBackflow(tqp, std::move(spo_up_C), std::move(spo_dn_C), tr);
   clone->C2node_up                          = C2node_up;
   clone->C2node_dn                          = C2node_dn;
   clone->resize(dets_up.size(), dets_dn.size());
@@ -48,13 +48,13 @@ WaveFunctionComponentPtr MultiSlaterDeterminantWithBackflow::makeClone(ParticleS
   }
   for (int i = 0; i < dets_up.size(); i++)
   {
-    DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_up[i]->makeCopy((SPOSetPtr)clone->spo_up);
+    DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_up[i]->makeCopy(std::static_pointer_cast<SPOSet>(clone->spo_up));
     dclne->BFTrans                      = tr;
     clone->dets_up.push_back(dclne);
   }
   for (int i = 0; i < dets_dn.size(); i++)
   {
-    DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_dn[i]->makeCopy((SPOSetPtr)clone->spo_dn);
+    DiracDeterminantWithBackflow* dclne = (DiracDeterminantWithBackflow*)dets_dn[i]->makeCopy(std::static_pointer_cast<SPOSet>(clone->spo_dn));
     dclne->BFTrans                      = tr;
     clone->dets_dn.push_back(dclne);
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
@@ -33,8 +33,8 @@ class MultiSlaterDeterminantWithBackflow : public MultiSlaterDeterminant
 public:
   ///constructor
   MultiSlaterDeterminantWithBackflow(ParticleSet& targetPtcl,
-                                     SPOSetProxyPtr upspo,
-                                     SPOSetProxyPtr dnspo,
+                                     std::unique_ptr<SPOSetProxyForMSD>&& upspo,
+                                     std::unique_ptr<SPOSetProxyForMSD>&& dnspo,
                                      BackflowTransformation* tr);
 
   ///destructor

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.cpp
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.cpp
@@ -17,7 +17,7 @@
 #include "SPOSetProxyForMSD.h"
 namespace qmcplusplus
 {
-SPOSetProxyForMSD::SPOSetProxyForMSD(SPOSetPtr const& spos, int first, int last) : refPhi(spos)
+SPOSetProxyForMSD::SPOSetProxyForMSD(std::unique_ptr<SPOSet>&& spos, int first, int last) : refPhi(std::move(spos))
 {
   className      = "SPOSetProxy";
   OrbitalSetSize = last - first;

--- a/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.h
+++ b/src/QMCWaveFunctions/Fermion/SPOSetProxyForMSD.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
 struct SPOSetProxyForMSD : public SPOSet
 {
   ///pointer to the SPOSet which evaluate the single-particle states
-  SPOSetPtr refPhi;
+  std::unique_ptr<SPOSet> refPhi;
   ///container for the values
   ValueMatrix_t psiM;
   ///container for the gradients
@@ -59,7 +59,7 @@ struct SPOSetProxyForMSD : public SPOSet
    * @param first the first particle index
    * @param last the last particle index
    */
-  SPOSetProxyForMSD(SPOSetPtr const& spos, int first, int last);
+  SPOSetProxyForMSD(std::unique_ptr<SPOSet>&& spos, int first, int last);
   void resetParameters(const opt_variables_type& optVariables) override;
   void setOrbitalSetSize(int norbs) override;
   void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -209,7 +209,7 @@ WaveFunctionComponentPtr SlaterDet::makeClone(ParticleSet& tqp) const
   myclone->Optimizable = Optimizable;
   for (int i = 0; i < Dets.size(); ++i)
   {
-    Determinant_t* newD = Dets[i]->makeCopy(Dets[i]->getPhi()->makeClone());
+    Determinant_t* newD = Dets[i]->makeCopy(std::unique_ptr<SPOSet>(Dets[i]->getPhi()->makeClone()));
     myclone->add(newD, i);
   }
   return myclone;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -410,6 +410,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
     psi = sposet_builder_factory_.createSPOSet(cur);
   }
   psi->checkObject();
+  psi = psi->makeClone();
 
   int firstIndex = targetPtcl.first(spin_group);
   int lastIndex  = targetPtcl.last(spin_group);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -215,6 +215,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
 
       SPOSetPtr spo_alpha = sposet_builder_factory_.getSPOSet(spo_alpha_name);
       SPOSetPtr spo_beta  = sposet_builder_factory_.getSPOSet(spo_beta_name);
+      std::unique_ptr<SPOSet> spo_alpha_clone, spo_beta_clone;
       if (spo_alpha == nullptr)
       {
         app_error() << "In SlaterDetBuilder: SPOSet \"" << spo_alpha_name
@@ -222,7 +223,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         abort();
       }
       else
-        spo_alpha = spo_alpha->makeClone();
+        spo_alpha_clone.reset(spo_alpha->makeClone());
 
       if (spo_beta == nullptr)
       {
@@ -231,7 +232,7 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         abort();
       }
       else
-        spo_beta = spo_beta->makeClone();
+        spo_beta_clone.reset(spo_beta->makeClone());
 
       FastMSD = (fastAlg == "yes");
       if (FastMSD)
@@ -244,9 +245,9 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         MultiDiracDeterminant* up_det = 0;
         MultiDiracDeterminant* dn_det = 0;
         app_log() << "      Creating base determinant (up) for MSD expansion. \n";
-        up_det = new MultiDiracDeterminant(spo_alpha, 0);
+        up_det = new MultiDiracDeterminant(std::move(spo_alpha_clone), 0);
         app_log() << "      Creating base determinant (down) for MSD expansion. \n";
-        dn_det = new MultiDiracDeterminant(spo_beta, 1);
+        dn_det = new MultiDiracDeterminant(std::move(spo_beta_clone), 1);
 
         multislaterdetfast_0 = new MultiSlaterDeterminantFast(targetPtcl, up_det, dn_det);
         success              = createMSDFast(multislaterdetfast_0, cur);
@@ -254,19 +255,17 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
       else
       {
         app_summary() << "    Using a list of determinants for multi-deterimant expansion." << std::endl;
-        SPOSetProxyForMSD* spo_up;
-        SPOSetProxyForMSD* spo_dn;
-        spo_up = new SPOSetProxyForMSD(spo_alpha, targetPtcl.first(0), targetPtcl.last(0));
-        spo_dn = new SPOSetProxyForMSD(spo_beta, targetPtcl.first(1), targetPtcl.last(1));
+        auto spo_up = std::make_unique<SPOSetProxyForMSD>(std::move(spo_alpha_clone), targetPtcl.first(0), targetPtcl.last(0));
+        auto spo_dn = std::make_unique<SPOSetProxyForMSD>(std::move(spo_beta_clone), targetPtcl.first(1), targetPtcl.last(1));
         if (UseBackflow)
         {
           app_summary() << "    Using backflow transformation." << std::endl;
-          multislaterdet_0 = new MultiSlaterDeterminantWithBackflow(targetPtcl, spo_up, spo_dn, BFTrans);
+          multislaterdet_0 = new MultiSlaterDeterminantWithBackflow(targetPtcl, std::move(spo_up), std::move(spo_dn), BFTrans);
           success          = createMSD(multislaterdet_0, cur);
         }
         else
         {
-          multislaterdet_0 = new MultiSlaterDeterminant(targetPtcl, spo_up, spo_dn);
+          multislaterdet_0 = new MultiSlaterDeterminant(targetPtcl, std::move(spo_up), std::move(spo_dn));
           success          = createMSD(multislaterdet_0, cur);
         }
       }
@@ -410,7 +409,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
     psi = sposet_builder_factory_.createSPOSet(cur);
   }
   psi->checkObject();
-  psi = psi->makeClone();
+  std::unique_ptr<SPOSet> psi_clone(psi->makeClone());
 
   int firstIndex = targetPtcl.first(spin_group);
   int lastIndex  = targetPtcl.last(spin_group);
@@ -445,12 +444,12 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   //TODO: the switch logic should be improved as we refine the input tags.
 #if defined(QMC_CUDA)
   app_summary() << "      Using legacy CUDA acceleration." << std::endl;
-  adet = new DiracDeterminantCUDA(psi, firstIndex);
+  adet = new DiracDeterminantCUDA(std::move(psi_clone), firstIndex);
 #else
   if (UseBackflow)
   {
     app_summary() << "      Using backflow transformation." << std::endl;
-    adet = new DiracDeterminantWithBackflow(targetPtcl, psi, BFTrans, firstIndex);
+    adet = new DiracDeterminantWithBackflow(targetPtcl, std::move(psi_clone), BFTrans, firstIndex);
   }
   else
   {
@@ -462,7 +461,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
       {
         app_summary() << "      Running on an NVIDIA GPU via CUDA acceleration and OpenMP offload." << std::endl;
         adet = new DiracDeterminantBatched<
-            MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>(psi, firstIndex);
+            MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>(std::move(psi_clone), firstIndex);
       }
       else
 #endif
@@ -470,7 +469,7 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
         app_summary() << "      Running on an accelerator via OpenMP offload. Only SM1 update is supported. "
                          "delay_rank is ignored."
                       << std::endl;
-        adet = new DiracDeterminantBatched<>(psi, firstIndex);
+        adet = new DiracDeterminantBatched<>(std::move(psi_clone), firstIndex);
       }
     }
     else
@@ -479,13 +478,13 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
       if (useGPU == "yes")
       {
         app_summary() << "      Running on an NVIDIA GPU via CUDA acceleration." << std::endl;
-        adet = new DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(psi, firstIndex);
+        adet = new DiracDeterminant<DelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(std::move(psi_clone), firstIndex);
       }
       else
 #endif
       {
         app_summary() << "      Running on CPU." << std::endl;
-        adet = new DiracDeterminant<>(psi, firstIndex);
+        adet = new DiracDeterminant<>(std::move(psi_clone), firstIndex);
       }
     }
   }
@@ -496,8 +495,6 @@ bool SlaterDetBuilder::putDeterminant(xmlNodePtr cur, int spin_group)
   targetPsi.setndelay(delay_rank);
 #endif
   slaterdet_0->add(adet, spin_group);
-  if (psi->isOptimizable())
-    slaterdet_0->Optimizable = true;
 
   app_log() << std::endl;
   app_log().flush();
@@ -689,55 +686,59 @@ bool SlaterDetBuilder::createMSD(MultiSlaterDeterminant* multiSD, xmlNodePtr cur
   if (!success)
     return false;
   multiSD->resize(uniqueConfg_up.size(), uniqueConfg_dn.size());
-  SPOSetProxyForMSD* spo = multiSD->spo_up;
-  spo->occup.resize(uniqueConfg_up.size(), multiSD->nels_up);
-  for (int i = 0; i < uniqueConfg_up.size(); i++)
   {
-    int nq               = 0;
-    ci_configuration& ci = uniqueConfg_up[i];
-    for (int k = 0; k < ci.occup.size(); k++)
+    auto& spo = multiSD->spo_up;
+    spo->occup.resize(uniqueConfg_up.size(), multiSD->nels_up);
+    for (int i = 0; i < uniqueConfg_up.size(); i++)
     {
-      if (ci.occup[k])
+      int nq               = 0;
+      ci_configuration& ci = uniqueConfg_up[i];
+      for (int k = 0; k < ci.occup.size(); k++)
       {
-        spo->occup(i, nq++) = k;
+        if (ci.occup[k])
+        {
+          spo->occup(i, nq++) = k;
+        }
       }
+      DiracDeterminantBase* adet;
+      if (UseBackflow)
+      {
+        adet = new DiracDeterminantWithBackflow(targetPtcl, std::static_pointer_cast<SPOSet>(spo), 0, 0);
+      }
+      else
+      {
+        adet = new DiracDeterminant<>(std::static_pointer_cast<SPOSet>(spo), 0);
+      }
+      adet->set(multiSD->FirstIndex_up, multiSD->nels_up);
+      multiSD->dets_up.push_back(adet);
     }
-    DiracDeterminantBase* adet;
-    if (UseBackflow)
-    {
-      adet = new DiracDeterminantWithBackflow(targetPtcl, (SPOSetPtr)spo, 0, 0);
-    }
-    else
-    {
-      adet = new DiracDeterminant<>((SPOSetPtr)spo, 0);
-    }
-    adet->set(multiSD->FirstIndex_up, multiSD->nels_up);
-    multiSD->dets_up.push_back(adet);
   }
-  spo = multiSD->spo_dn;
-  spo->occup.resize(uniqueConfg_dn.size(), multiSD->nels_dn);
-  for (int i = 0; i < uniqueConfg_dn.size(); i++)
   {
-    int nq               = 0;
-    ci_configuration& ci = uniqueConfg_dn[i];
-    for (int k = 0; k < ci.occup.size(); k++)
+    auto& spo = multiSD->spo_dn;
+    spo->occup.resize(uniqueConfg_dn.size(), multiSD->nels_dn);
+    for (int i = 0; i < uniqueConfg_dn.size(); i++)
     {
-      if (ci.occup[k])
+      int nq               = 0;
+      ci_configuration& ci = uniqueConfg_dn[i];
+      for (int k = 0; k < ci.occup.size(); k++)
       {
-        spo->occup(i, nq++) = k;
+        if (ci.occup[k])
+        {
+          spo->occup(i, nq++) = k;
+        }
       }
+      DiracDeterminantBase* adet;
+      if (UseBackflow)
+      {
+        adet = new DiracDeterminantWithBackflow(targetPtcl, std::static_pointer_cast<SPOSet>(spo), 0, 0);
+      }
+      else
+      {
+        adet = new DiracDeterminant<>(std::static_pointer_cast<SPOSet>(spo), 0);
+      }
+      adet->set(multiSD->FirstIndex_dn, multiSD->nels_dn);
+      multiSD->dets_dn.push_back(adet);
     }
-    DiracDeterminantBase* adet;
-    if (UseBackflow)
-    {
-      adet = new DiracDeterminantWithBackflow(targetPtcl, (SPOSetPtr)spo, 0, 0);
-    }
-    else
-    {
-      adet = new DiracDeterminant<>((SPOSetPtr)spo, 0);
-    }
-    adet->set(multiSD->FirstIndex_dn, multiSD->nels_dn);
-    multiSD->dets_dn.push_back(adet);
   }
   if (multiSD->CSFcoeff.size() == 1 || multiSD->C.size() == 1)
     optimizeCI = false;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -82,7 +82,7 @@ WaveFunctionComponentPtr SlaterDetWithBackflow::makeClone(ParticleSet& tqp) cons
   myclone->Optimizable           = Optimizable;
   for (int i = 0; i < Dets.size(); ++i)
   {
-    DiracDeterminantBase* dclne = Dets[i]->makeCopy(Dets[i]->getPhi()->makeClone());
+    DiracDeterminantBase* dclne = Dets[i]->makeCopy(std::unique_ptr<SPOSet>(Dets[i]->getPhi()->makeClone()));
     myclone->add(dclne, i);
   }
   myclone->setBF(tr);

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -124,14 +124,15 @@ WaveFunctionComponent* PWOrbitalBuilder::putSlaterDet(xmlNodePtr cur)
       if (lit == spomap.end())
       {
         app_log() << "  Create a PWOrbitalSet" << std::endl;
-        SPOSetPtr psi(createPW(cur, spin_group));
-        spomap[ref] = psi;
-        adet        = new Det_t(psi, firstIndex);
+        std::unique_ptr<SPOSet> psi(createPW(cur, spin_group));
+        spomap[ref] = psi.get();
+        adet        = new Det_t(std::move(psi), firstIndex);
       }
       else
       {
         app_log() << "  Reuse a PWOrbitalSet" << std::endl;
-        adet = new Det_t((*lit).second, firstIndex);
+        std::unique_ptr<SPOSet> psi((*lit).second->makeClone());
+        adet = new Det_t(std::move(psi), firstIndex);
       }
       app_log() << "    spin=" << spin_group << " id=" << id << " ref=" << ref << std::endl;
       if (adet)

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -32,8 +32,7 @@ PWOrbitalBuilder::PWOrbitalBuilder(Communicate* comm, ParticleSet& els, PtclPool
     : WaveFunctionComponentBuilder(comm, els),
       ptclPool(psets),
       hfileID(-1),
-      rootNode(NULL),
-      myBasisSet(nullptr)
+      rootNode(NULL)
 {
   myParam = new PWParameterSet(myComm);
 }
@@ -192,9 +191,9 @@ bool PWOrbitalBuilder::createPWBasis(xmlNodePtr cur)
   HDFAttribIO<TinyVector<double, OHMMS_DIM>> hdfobj_twist(TwistAngle_DP);
   hdfobj_twist.read(hfileID, "/electrons/kpoint_0/reduced_k");
   TwistAngle = TwistAngle_DP;
-  if (myBasisSet == nullptr)
+  if (!myBasisSet)
   {
-    myBasisSet = new PWBasis(TwistAngle);
+    myBasisSet = std::make_unique<PWBasis>(TwistAngle);
   }
   //Read the planewave basisset.
   //Note that the same data is opened here for each twist angle-avoids duplication in the
@@ -285,7 +284,7 @@ SPOSet* PWOrbitalBuilder::createPW(xmlNodePtr cur, int spinIndex)
       occBand[i] = i;
   }
   //going to take care of occ
-  psi->resize(myBasisSet, nb, true);
+  psi->resize(new PWBasis(*myBasisSet), nb, true);
   if (myParam->hasComplexData(hfileID)) //input is complex
   {
     //app_log() << "  PW coefficients are complex." << std::endl;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h
@@ -35,10 +35,8 @@ class PWOrbitalBuilder : public WaveFunctionComponentBuilder
 private:
 #if defined(QMC_COMPLEX)
   typedef PWOrbitalSet SPOSetType;
-  typedef PWOrbitalSet::PWBasisPtr PWBasisPtr;
 #else
   typedef PWRealOrbitalSet SPOSetType;
-  typedef PWRealOrbitalSet::PWBasisPtr PWBasisPtr;
 #endif
 
   std::map<std::string, SPOSetPtr> spomap;
@@ -56,7 +54,7 @@ private:
   ///parameter set
   PWParameterSet* myParam;
   //will do something for twist
-  PWBasisPtr myBasisSet;
+  std::unique_ptr<PWBasis> myBasisSet;
   ////Storage for the orbitals and basis is created in PWOSet.
   //std::map<std::string,SPOSetPtr> PWOSet;
 public:

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -62,9 +62,10 @@ void check_matrix(Matrix<T1, ALLOC1>& a, Matrix<T2, ALLOC2>& b)
 
 TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(3);
-  DetType ddb(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(3);
+  DetType ddb(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
 
   int norb = 3;
   ddb.set(0, norb);
@@ -119,9 +120,10 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 
 TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(4);
-  DetType ddb(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(4);
+  DetType ddb(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
 
   int norb = 4;
   ddb.set(0, norb);
@@ -245,9 +247,10 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
 
 TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(4);
-  DetType ddc(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(4);
+  DetType ddc(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddc.getPhi());
 
   int norb = 4;
   // maximum delay 2

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -105,9 +105,9 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   SPOSet* spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo != nullptr);
 
-  auto* det_up = new DiracDet(spo->makeClone());
+  auto* det_up = new DiracDet(std::unique_ptr<SPOSet>(spo->makeClone()));
   det_up->set(0, 2);
-  auto* det_dn = new DiracDet(spo->makeClone());
+  auto* det_dn = new DiracDet(std::unique_ptr<SPOSet>(spo->makeClone()));
   det_dn->set(2, 2);
 
   auto* slater_det = new SlaterDet(elec_);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -105,9 +105,9 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   SPOSet* spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo != nullptr);
 
-  auto* det_up = new DiracDet(spo);
+  auto* det_up = new DiracDet(spo->makeClone());
   det_up->set(0, 2);
-  auto* det_dn = new DiracDet(spo);
+  auto* det_dn = new DiracDet(spo->makeClone());
   det_dn->set(2, 2);
 
   auto* slater_det = new SlaterDet(elec_);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -111,9 +111,9 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   SPOSet* spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo != nullptr);
 
-  auto* det_up = new DiracDet(spo);
+  auto* det_up = new DiracDet(spo->makeClone());
   det_up->set(0, 2, ndelay);
-  auto* det_dn = new DiracDet(spo);
+  auto* det_dn = new DiracDet(spo->makeClone());
   det_dn->set(2, 2, ndelay);
 
   auto* slater_det = new SlaterDet(elec_);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -111,9 +111,9 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   SPOSet* spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo != nullptr);
 
-  auto* det_up = new DiracDet(spo->makeClone());
+  auto* det_up = new DiracDet(std::unique_ptr<SPOSet>(spo->makeClone()));
   det_up->set(0, 2, ndelay);
-  auto* det_dn = new DiracDet(spo->makeClone());
+  auto* det_dn = new DiracDet(std::unique_ptr<SPOSet>(spo->makeClone()));
   det_dn->set(2, 2, ndelay);
 
   auto* slater_det = new SlaterDet(elec_);

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -498,10 +498,10 @@ TEST_CASE("DiracDeterminant_spinor_update", "[wavefunction][fermion]")
   auto spo_up = std::make_unique<EGOSet>(kup, k2up);
   auto spo_dn = std::make_unique<EGOSet>(kdn, k2dn);
 
-  SpinorSet* spinor_set = new SpinorSet();
+  auto spinor_set = std::make_unique<SpinorSet>();
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
 
-  DetType dd(spinor_set);
+  DetType dd(std::move(spinor_set));
   dd.resize(nelec, norb);
   app_log() << " nelec=" << nelec << " norb=" << norb << std::endl;
 

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -60,9 +60,10 @@ void check_matrix(Matrix<T1>& a, Matrix<T2>& b)
 
 TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(3);
-  DetType ddb(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(3);
+  DetType ddb(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
 
   int norb = 3;
   ddb.set(0, norb);
@@ -117,9 +118,10 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 
 TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(4);
-  DetType ddb(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(4);
+  DetType ddb(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddb.getPhi());
 
   int norb = 4;
   ddb.set(0, norb);
@@ -243,9 +245,10 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
 
 TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
 {
-  FakeSPO* spo = new FakeSPO();
-  spo->setOrbitalSetSize(4);
-  DetType ddc(spo);
+  auto spo_init = std::make_unique<FakeSPO>();
+  spo_init->setOrbitalSetSize(4);
+  DetType ddc(std::move(spo_init));
+  auto spo = dynamic_cast<FakeSPO*>(ddc.getPhi());
 
   int norb = 4;
   // maximum delay 2


### PR DESCRIPTION
## Proposed changes
Use smart pointers of SPOSet in single det and multi dets. Reduce potential memory leak.
1. single det class uses shared_ptr. The sharing aspect is only intended for a list of single dets in multi-det slow code path. In most cases, it should be used as unique_ptr. Comments added in the source code.
2. Multi det uses unique_ptr.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'