### PR TITLE
Delete pointers owned by ParticleSetPool

### DIFF
--- a/src/Message/tests/test_communciate.cpp
+++ b/src/Message/tests/test_communciate.cpp
@@ -19,7 +19,7 @@ TEST_CASE("test_communicate_split_one", "[message]")
 {
   Communicate* c = OHMMS::Controller;
 
-  Communicate* c2 = new Communicate(*c, 1);
+  auto c2 = std::make_unique<Communicate>(*c, 1);
 
   REQUIRE(c2->size() == c->size());
   REQUIRE(c2->rank() == c->rank());

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -79,10 +79,6 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
   //initPropertyList();
 }
 
-///default destructor
-MCWalkerConfiguration::~MCWalkerConfiguration() { destroyWalkers(WalkerList.begin(), WalkerList.end()); }
-
-
 void MCWalkerConfiguration::createWalkers(int n)
 {
   const int old_nw = getActiveWalkers();

--- a/src/Particle/MCWalkerConfiguration.h
+++ b/src/Particle/MCWalkerConfiguration.h
@@ -123,9 +123,6 @@ public:
   ///default constructor: copy only ParticleSet
   MCWalkerConfiguration(const MCWalkerConfiguration& mcw);
 
-  ///default destructor
-  ~MCWalkerConfiguration();
-
   /** create numWalkers Walkers
    *
    * Append Walkers to WalkerList.

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -32,7 +32,7 @@
 namespace qmcplusplus
 {
 ParticleSetPool::ParticleSetPool(Communicate* c, const char* aname)
-    : MPIObjectBase(c), SimulationCell(nullptr), TileMatrix(0)
+    : MPIObjectBase(c), TileMatrix(0)
 {
   TileMatrix.diagonal(1);
   ClassName = "ParticleSetPool";
@@ -41,7 +41,7 @@ ParticleSetPool::ParticleSetPool(Communicate* c, const char* aname)
 
 ParticleSetPool::ParticleSetPool(ParticleSetPool&& other)
     : MPIObjectBase(other.myComm),
-      SimulationCell(other.SimulationCell),
+      SimulationCell(std::move(other.SimulationCell)),
       TileMatrix(other.TileMatrix),
       myPool(std::move(other.myPool))
 {
@@ -49,6 +49,15 @@ ParticleSetPool::ParticleSetPool(ParticleSetPool&& other)
   myName    = other.myName;
 }
 
+ParticleSetPool::~ParticleSetPool()
+{
+  PoolType::const_iterator it(myPool.begin()), it_end(myPool.end());
+  while (it != it_end)
+  {
+    delete (*it).second;
+    it++;
+  }
+}
 
 ParticleSet* ParticleSetPool::getParticleSet(const std::string& pname)
 {
@@ -77,13 +86,14 @@ MCWalkerConfiguration* ParticleSetPool::getWalkerSet(const std::string& pname)
   return dynamic_cast<MCWalkerConfiguration*>(mc);
 }
 
-void ParticleSetPool::addParticleSet(ParticleSet* p)
+void ParticleSetPool::addParticleSet(std::unique_ptr<ParticleSet>&& p)
 {
   PoolType::iterator pit(myPool.find(p->getName()));
   if (pit == myPool.end())
   {
-    LOGMSG("  Adding " << p->getName() << " ParticleSet to the pool")
-    myPool[p->getName()] = p;
+    auto& pname = p->getName();
+    LOGMSG("  Adding " << pname << " ParticleSet to the pool")
+    myPool[pname] = p.release();
   }
   else
   {
@@ -105,10 +115,10 @@ bool ParticleSetPool::putLattice(xmlNodePtr cur)
 {
   ReportEngine PRE("ParticleSetPool", "putLattice");
   bool printcell = false;
-  if (SimulationCell == 0)
+  if (!SimulationCell)
   {
     app_debug() << "  Creating global supercell " << std::endl;
-    SimulationCell = new ParticleSet::ParticleLayout_t;
+    SimulationCell = std::make_unique<ParticleSet::ParticleLayout_t>();
     printcell      = true;
   }
   else
@@ -371,7 +381,7 @@ ParticleSet* ParticleSetPool::createESParticleSet(xmlNodePtr cur, const std::str
 
   if (SimulationCell == 0)
   {
-    SimulationCell = new ParticleSet::ParticleLayout_t(ions->Lattice);
+    SimulationCell = std::make_unique<ParticleSet::ParticleLayout_t>(ions->Lattice);
   }
 
   if (qp == 0)

--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -39,6 +39,7 @@ public:
    * @param aname xml tag
    */
   ParticleSetPool(Communicate* c, const char* aname = "particleset");
+  ~ParticleSetPool();
 
   ParticleSetPool(const ParticleSetPool&) = delete;
   ParticleSetPool& operator=(const ParticleSetPool&) = delete;
@@ -60,8 +61,8 @@ public:
   ///return true, if the pool is empty
   inline bool empty() const { return myPool.empty(); }
 
-  ///add a ParticleSet* to the pool
-  void addParticleSet(ParticleSet* p);
+  ///add a ParticleSet* to the pool with ownership transferred
+  void addParticleSet(std::unique_ptr<ParticleSet>&& p);
   /** get a named ParticleSet
    * @param pname name of the ParticleSet
    * @return a MCWalkerConfiguration object with pname
@@ -105,15 +106,15 @@ private:
    * - <simulationcell> element
    * - the first particleset created with ES-HDF
    */
-  ParticleSet::ParticleLayout_t* SimulationCell;
+  std::unique_ptr<ParticleSet::ParticleLayout_t> SimulationCell;
   /** tiling matrix
    */
   Tensor<int, OHMMS_DIM> TileMatrix;
-  /** List of ParticleSet
+  /** List of ParticleSet owned
    *
-   * Each ParticleSet has to have a unique name which is used as a key for the map
+   * Each ParticleSet has to have a unique name which is used as a key for the map.
    */
-  std::map<std::string, ParticleSet*> myPool;
+  PoolType myPool;
   /** xml node for random initialization.
    *
    * randomize() process initializations just before starting qmc sections

--- a/src/Particle/tests/test_particle_pool.cpp
+++ b/src/Particle/tests/test_particle_pool.cpp
@@ -60,9 +60,9 @@ TEST_CASE("ParticleSetPool", "[qmcapp]")
   ParticleSet* ws = pp.getWalkerSet("ion0");
   REQUIRE(ws != NULL);
 
-  ParticleSet* ps2 = new ParticleSet();
+  auto ps2 = std::make_unique<ParticleSet>();
   ps2->setName("particle_set_2");
-  pp.addParticleSet(ps2);
+  pp.addParticleSet(std::move(ps2));
 
   // should do nothing, since no random particlesets were specified
   pp.randomize();

--- a/src/Particle/tests/test_sample_stack.cpp
+++ b/src/Particle/tests/test_sample_stack.cpp
@@ -41,14 +41,14 @@ TEST_CASE("SampleStack", "[particle]")
   REQUIRE(samples.getNumSamples() == 0);
 
   using Walker_t     = ParticleSet::Walker_t;
-  using WalkerList_t = std::vector<Walker_t*>;
+  using WalkerList_t = std::vector<std::unique_ptr<Walker_t>>;
 
   WalkerList_t walker_list;
 
   // Add size one list
-  walker_list.push_back(new Walker_t(total_num));
+  walker_list.push_back(std::make_unique<Walker_t>(total_num));
   walker_list[0]->R[0][0] = 1.1;
-  for (auto wi : walker_list)
+  for (auto& wi : walker_list)
   {
     samples.appendSample(MCSample(*wi));
   }

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -128,7 +128,7 @@ void MCPopulation::createWalkers(IndexType num_walkers, RealType reserve)
   walker_elec_particle_sets_.resize(num_walkers_plus_reserve);
   std::for_each(walker_elec_particle_sets_.begin(), walker_elec_particle_sets_.end(),
                 [this](std::unique_ptr<ParticleSet>& elec_ps_ptr) {
-                  elec_ps_ptr.reset(new ParticleSet(*elec_particle_set_));
+                  elec_ps_ptr = std::make_unique<ParticleSet>(*elec_particle_set_);
                 });
 
   auto it_weps = walker_elec_particle_sets_.begin();
@@ -231,7 +231,7 @@ WalkerElementsRef MCPopulation::spawnWalker()
     //walkers_.back()->Properties = elec_particle_set_->Properties;
     //walkers_.back()->registerData();
 
-    walker_elec_particle_sets_.emplace_back(new ParticleSet(*elec_particle_set_));
+    walker_elec_particle_sets_.emplace_back(std::make_unique<ParticleSet>(*elec_particle_set_));
     walker_trial_wavefunctions_.push_back(UPtr<TrialWaveFunction>{});
     walker_trial_wavefunctions_.back().reset(trial_wf_->makeClone(*(walker_elec_particle_sets_.back())));
     walker_hamiltonians_.push_back(UPtr<QMCHamiltonian>{});

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -447,9 +447,10 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   Lattice.LR_dim_cutoff = 15;
   Lattice.reset();
 
-
-  ParticleSet ions;
-  ParticleSet elec;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions(*ions_uptr);
+  ParticleSet& elec(*elec_uptr);
 
   ions.setName("ion0");
   ions.create(1);
@@ -486,8 +487,8 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   elec.createSK();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec);
-  ptcl.addParticleSet(&ions);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   ions.resetGroups();
   elec.resetGroups();

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -47,14 +47,12 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
   xmlNodePtr root = doc.getRoot();
 
   ParticleSetPool pp(c);
-  ParticleSet* qp = createElectronParticleSet();
-  pp.addParticleSet(qp);
+  std::unique_ptr<ParticleSet> qp(createElectronParticleSet());
+  pp.addParticleSet(std::move(qp));
 
   WaveFunctionPool wfp(pp, c);
 
-  WaveFunctionFactory::PtclPoolType ptcl_pool;
-  ptcl_pool["e"]                  = qp;
-  WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *qp, ptcl_pool, c);
+  WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *pp.getPool()["e"], pp.getPool(), c);
   wfp.getPool()["psi0"] = wf_factory;
   wfp.setPrimary(wf_factory->getTWF());
 

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -32,8 +32,10 @@ void test_lcao_spinor()
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(1);
@@ -62,8 +64,8 @@ void test_lcao_spinor()
   elec_.update();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   const char* particles = "<tmp> \
    <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" source=\"ion\" precision=\"float\"> \
@@ -204,8 +206,10 @@ void test_lcao_spinor_excited()
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(1);
@@ -234,8 +238,8 @@ void test_lcao_spinor_excited()
   elec_.update();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   const char* particles = "<tmp> \
    <sposet_builder name=\"spinorbuilder\" type=\"molecularspinor\" href=\"lcao_spinor.h5\" source=\"ion\" precision=\"float\"> \

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -38,8 +38,10 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(2);
@@ -82,8 +84,8 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   elec_.createSK(); // needed by AoS J2 for ChiesaKEcorrection
 
   ParticleSetPool ptcl{c};
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   // make a ParticleSet Clone
   ParticleSet elec_clone(elec_);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -34,8 +34,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   OHMMS::Controller->initialize(0, NULL);
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(4);
@@ -88,8 +90,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   elec_.createSK(); // needed by AoS J2 for ChiesaKEcorrection
 
   ParticleSetPool ptcl{c};
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   // make a ParticleSet Clone
   ParticleSet elec_clone(elec_);

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -33,8 +33,10 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(2);
@@ -87,8 +89,8 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
@@ -241,8 +243,10 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(4);
@@ -288,8 +292,8 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_2x1x1
   const char* particles = "<tmp> \

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -431,7 +431,7 @@ TEST_CASE("EinsplineSetBuilder CheckLattice", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet* elec = new ParticleSet;
+  auto elec = std::make_unique<ParticleSet>();
 
   elec->setName("elec");
   std::vector<int> agroup(2);
@@ -451,7 +451,7 @@ TEST_CASE("EinsplineSetBuilder CheckLattice", "[wavefunction]")
   elec->Lattice.R(2, 2) = 1.0;
 
   EinsplineSetBuilder::PtclPoolType ptcl_map;
-  ptcl_map["e"] = elec;
+  ptcl_map["e"] = elec.get();
 
   xmlNodePtr cur = NULL;
   EinsplineSetBuilder esb(*elec, ptcl_map, c, cur);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -41,8 +41,10 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(2);
@@ -87,8 +89,8 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   tspecies(chargeIdx, upIdx) = -1;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   elec_.update();
   ions_.update();

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -30,7 +30,7 @@ TEST_CASE("ExampleHe", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet* elec = new ParticleSet;
+  auto elec = std::make_unique<ParticleSet>();
   std::vector<int> agroup(1);
   int nelec = 2;
   agroup[0] = nelec;
@@ -52,9 +52,9 @@ TEST_CASE("ExampleHe", "[wavefunction]")
 
 
   WaveFunctionFactory::PtclPoolType particle_set_map;
-  particle_set_map["e"] = elec;
+  particle_set_map["e"] = elec.get();
 
-  ParticleSet* ions = new ParticleSet;
+  auto ions = std::make_unique<ParticleSet>();
   ions->setName("ion0");
   ions->create(1);
   ions->R[0][0] = 0.0;
@@ -66,7 +66,7 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   int chargeIdx               = he_species.addAttribute("charge");
   tspecies(chargeIdx, He_Idx) = 2.0;
   tspecies(massIdx, upIdx)    = 1.0;
-  particle_set_map["ion0"]    = ions;
+  particle_set_map["ion0"]    = ions.get();
 
 
   WaveFunctionFactory wff("psi0", *elec, particle_set_map, c);

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -34,8 +34,10 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(2);
@@ -84,8 +86,8 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
@@ -158,8 +160,10 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(4);
@@ -214,8 +218,8 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_2x1x1
   const char* particles = "<tmp> \

--- a/src/QMCWaveFunctions/tests/test_kspace_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_kspace_jastrow.cpp
@@ -82,7 +82,7 @@ TEST_CASE("kspace jastrow", "[wavefunction]")
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout_t* SimulationCell = new ParticleSet::ParticleLayout_t;
+  auto SimulationCell = std::make_unique<ParticleSet::ParticleLayout_t>();
   LatticeParser lp(*SimulationCell);
   lp.put(part1);
   SimulationCell->print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
+++ b/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
@@ -91,7 +91,7 @@ TEST_CASE("lattice gaussian", "[wavefunction]")
   // read lattice
   xmlNodePtr root  = doc.getRoot();
   xmlNodePtr part1 = xmlFirstElementChild(root);
-  ParticleSet::ParticleLayout_t* SimulationCell = new ParticleSet::ParticleLayout_t;
+  auto SimulationCell = std::make_unique<ParticleSet::ParticleLayout_t>();
   LatticeParser lp(*SimulationCell);
   lp.put(part1);
   SimulationCell->print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -34,8 +34,10 @@ void test_LiH_msd(const std::string& spo_xml_string,
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion0");
   ions_.create({1, 1});
@@ -62,8 +64,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(spo_xml_string);

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -33,8 +33,10 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions;
-  ParticleSet elec;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions(*ions_uptr);
+  ParticleSet& elec(*elec_uptr);
 
   ions.setName("ion");
   ions.create(2);
@@ -86,8 +88,8 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec);
-  ptcl.addParticleSet(&ions);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
@@ -172,8 +174,10 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions;
-  ParticleSet elec;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions(*ions_uptr);
+  ParticleSet& elec(*elec_uptr);
 
   ions.setName("ion");
   ions.create(2);
@@ -231,8 +235,8 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec);
-  ptcl.addParticleSet(&ions);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \

--- a/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
@@ -95,7 +95,7 @@ TEST_CASE("RPA Jastrow", "[wavefunction]")
   xmlNodePtr part1 = xmlFirstElementChild(root);
 
   // read lattice
-  ParticleSet::ParticleLayout_t* SimulationCell = new ParticleSet::ParticleLayout_t;
+  auto SimulationCell = std::make_unique<ParticleSet::ParticleLayout_t>();
   LatticeParser lp(*SimulationCell);
   lp.put(part1);
   SimulationCell->print(app_log(), 0);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -31,7 +31,8 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet elec;
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& elec(*elec_uptr);
   elec.setName("e");
   elec.create({1, 1});
   elec.R[0] = 0.0;
@@ -43,7 +44,8 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   tspecies(massIdx, upIdx)   = 1.0;
   tspecies(massIdx, downIdx) = 1.0;
 
-  ParticleSet ions;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions(*ions_uptr);
   ions.setName("ion0");
   ions.create(1);
   ions.R[0]            = 0.0;
@@ -55,8 +57,8 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   elec.update();
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec);
-  ptcl.addParticleSet(&ions);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(spo_xml_string);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -31,8 +31,10 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string, const std::string
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion0");
   ions_.create({1,1});
@@ -59,8 +61,8 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string, const std::string
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(spo_xml_string);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -31,8 +31,10 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   Communicate* c;
   c = OHMMS::Controller;
 
-  ParticleSet ions_;
-  ParticleSet elec_;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion");
   ions_.create(4);
@@ -78,8 +80,8 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   // Need 1 electron and 1 proton, somehow
   //ParticleSet target = ParticleSet();
   ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(&elec_);
-  ptcl.addParticleSet(&ions_);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(spo_xml_string);

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -23,7 +23,7 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
-  ParticleSet* qp = new ParticleSet;
+  auto qp = std::make_unique<ParticleSet>();
   std::vector<int> agroup(1);
   agroup[0] = 2;
   qp->setName("e");
@@ -45,7 +45,7 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   qp->update();
 
   WaveFunctionFactory::PtclPoolType particle_set_map;
-  particle_set_map["e"] = qp;
+  particle_set_map["e"] = qp.get();
 
 
   WaveFunctionFactory wff("psi0", *qp, particle_set_map, c);


### PR DESCRIPTION
## Proposed changes
Make sure ParticleSet gold copy owned by ParticleSetPool got freed properly.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'