### PR TITLE
Reference Space Warp Transformation for ZVZB Forces

### DIFF
--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -88,15 +88,16 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   wf_grad     = 0;
   sw_pulay    = 0;
   sw_grad     = 0;
-  Force_t el_grad;
-  el_grad.resize(P.getTotalNum());
-  el_grad = 0;
   //This function returns d/dR of the sum of all observables in the physical hamiltonian.
   //Note that the sign will be flipped based on definition of force = -d/dR.
   Value = ham.evaluateIonDerivs(P, ions, psi, hf_force, pulay_force, wf_grad);
 
   if (useSpaceWarp)
   {
+    Force_t el_grad;
+    el_grad.resize(P.getTotalNum());
+    el_grad = 0;
+
     ham.evaluateElecGrad(P, psi, el_grad, delta);
     swt.computeSWT(P, ions, el_grad, P.G, sw_pulay, sw_grad);
   }

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -116,18 +116,19 @@ void ACForce::addObservables(PropertySetType& plist, BufferType& collectables)
       plist.add(wfgradname1.str());
       plist.add(wfgradname2.str());
 
-      if(useSpaceWarp)
-      {
-        std::ostringstream swctname1;
-        std::ostringstream swctname2;
-        std::ostringstream swctname3;
-        swctname1 << prefix << "_swct1_" << iat << "_" << x;
-        swctname2 << prefix << "_swct2_" << iat << "_" << x;
-        swctname3 << prefix << "_swct3_" << iat << "_" << x;
-        plist.add(swctname1.str());
-        plist.add(swctname2.str());
-        plist.add(swctname3.str());
-      }
+      //Remove when ACForce is production ready.
+//      if(useSpaceWarp)
+//      {
+//        std::ostringstream swctname1;
+//        std::ostringstream swctname2;
+//        std::ostringstream swctname3;
+//        swctname1 << prefix << "_swct1_" << iat << "_" << x;
+//        swctname2 << prefix << "_swct2_" << iat << "_" << x;
+//        swctname3 << prefix << "_swct3_" << iat << "_" << x;
+//        plist.add(swctname1.str());
+//        plist.add(swctname2.str());
+//        plist.add(swctname3.str());
+//      }
     }
   }
 };
@@ -141,15 +142,17 @@ void ACForce::setObservables(PropertySetType& plist)
       //Flipping the sign, since these terms currently store d/dR values.
       // add the minus one to be a force.
       plist[myindex++] = -hf_force[iat][iondim];
-      plist[myindex++] = -pulay_force[iat][iondim];
-      plist[myindex++] = -Value * wf_grad[iat][iondim];
-      plist[myindex++] = -wf_grad[iat][iondim];
-      if(useSpaceWarp)
-      {
-        plist[myindex++] = -sw_pulay[iat][iondim];
-        plist[myindex++] = -Value*sw_grad[iat][iondim];
-        plist[myindex++] = -sw_grad[iat][iondim];
-      }
+      plist[myindex++] = -(pulay_force[iat][iondim]+sw_pulay[iat][iondim]);
+      plist[myindex++] = -Value * (wf_grad[iat][iondim]+sw_grad[iat][iondim]);
+      plist[myindex++] = -(wf_grad[iat][iondim]+sw_grad[iat][iondim]);
+     
+      //Remove when ACForce is production ready
+//      if(useSpaceWarp)
+//      {
+//        plist[myindex++] = -sw_pulay[iat][iondim];
+//        plist[myindex++] = -Value*sw_grad[iat][iondim];
+//        plist[myindex++] = -sw_grad[iat][iondim];
+//      }
     }
   }
 };
@@ -161,15 +164,15 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
     for (int iondim = 0; iondim < OHMMS_DIM; iondim++)
     {
       plist[myindex++] = -hf_force[iat][iondim];
-      plist[myindex++] = -pulay_force[iat][iondim];
-      plist[myindex++] = -Value * wf_grad[iat][iondim];
-      plist[myindex++] = -wf_grad[iat][iondim];
-      if(useSpaceWarp)
-      {
-        plist[myindex++] = -sw_pulay[iat][iondim];
-        plist[myindex++] = -Value*sw_grad[iat][iondim];
-        plist[myindex++] = -sw_grad[iat][iondim];
-      }
+      plist[myindex++] = -(pulay_force[iat][iondim]+sw_pulay[iat][iondim]);
+      plist[myindex++] = -Value * (wf_grad[iat][iondim]+sw_grad[iat][iondim]);
+      plist[myindex++] = -(wf_grad[iat][iondim]+sw_grad[iat][iondim]);
+//      if(useSpaceWarp)
+//      {
+//        plist[myindex++] = -sw_pulay[iat][iondim];
+//        plist[myindex++] = -Value*sw_grad[iat][iondim];
+//        plist[myindex++] = -sw_grad[iat][iondim];
+//      }
     }
   }
 };

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -53,7 +53,8 @@ bool ACForce::put(xmlNodePtr cur)
   RealType swpow(4);
   OhmmsAttributeSet attr;
   attr.add(useSpaceWarpString,"spacewarp"); //"yes" or "no"
-  attr.add(swpow, "swpow"); //REal number"
+  attr.add(swpow, "swpow"); //Real number"
+  attr.add(delta, "delta"); //Real number"
   attr.put(cur); 
 
   useSpaceWarp = (useSpaceWarpString == "yes") || (useSpaceWarpString == "true");
@@ -87,7 +88,7 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   
   if(useSpaceWarp)
   {
-    computeElecGradEL(P,el_grad);
+    ham.evaluateElecGrad(P,psi,el_grad,delta);
     swt.computeSWT(P,ions,el_grad,P.G,sw_pulay,sw_grad);
   }
   return 0.0;
@@ -173,37 +174,4 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
   }
 };
 
-void ACForce::computeElecGradEL(ParticleSet& P, ACForce::Force_t& Egrad)
-{
-  int nelec=P.getTotalNum();
-  RealType ep(0.0);
-  RealType em(0.0);
-  RealType e0(0.0);
-  for(int iel=0; iel<nelec; iel++)
-  {
-    for(int dim=0; dim<OHMMS_DIM; dim++)
-    {
-      RealType r0=P.R[iel][dim];
-      ep=0; em=0; 
-      //Plus
-      RealType rp=r0+delta;
-      P.R[iel][dim]=rp;
-      P.update();
-      psi.evaluateLog(P);
-      ep=ham.evaluate2(P);
-
-      //minus
-      RealType rm=r0-delta;
-      P.R[iel][dim]=rm;
-      P.update();
-      psi.evaluateLog(P);
-      em=ham.evaluate2(P);
-
-      Egrad[iel][dim]=(ep-em)/(2.0*delta);
-      P.R[iel][dim]=r0;
-      P.update();
-      psi.evaluateLog(P);
-    }
-  }
-};
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -25,13 +25,12 @@ ACForce::ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& ps
       psi(psi_in),
       ham(H),
       FirstForceIndex(-1),
-      Nions(0),
+      Nions(ions.getTotalNum()),
       useSpaceWarp(false),
       swt(target, source)
 {
   prefix = "ACForce";
   myName = prefix;
-  Nions  = ions.getTotalNum();
 
   hf_force.resize(Nions);
   pulay_force.resize(Nions);
@@ -126,7 +125,7 @@ void ACForce::addObservables(PropertySetType& plist, BufferType& collectables)
       plist.add(wfgradname1.str());
       plist.add(wfgradname2.str());
 
-      //Remove when ACForce is production ready.
+      //TODO: Remove when ACForce is production ready.
       //      if(useSpaceWarp)
       //      {
       //        std::ostringstream swctname1;
@@ -156,7 +155,7 @@ void ACForce::setObservables(PropertySetType& plist)
       plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
 
-      //Remove when ACForce is production ready
+      //TODO: Remove when ACForce is production ready
       //      if(useSpaceWarp)
       //      {
       //        plist[myindex++] = -sw_pulay[iat][iondim];
@@ -177,6 +176,7 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
       plist[myindex++] = -(pulay_force[iat][iondim] + sw_pulay[iat][iondim]);
       plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
+      //TODO: Remove when ACForce is production ready
       //      if(useSpaceWarp)
       //      {
       //        plist[myindex++] = -sw_pulay[iat][iondim];

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -62,7 +62,8 @@ bool ACForce::put(xmlNodePtr cur)
    
   if(useSpaceWarp) app_log()<<"ACForce is using space warp with power="<<swpow<<std::endl;
   else  app_log()<<"ACForce is not using space warp\n";  
-  
+ 
+  return true; 
 }
 
 void ACForce::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& ham_in)

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -30,7 +30,7 @@ ACForce::ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& ps
   wf_grad.resize(Nions);
   sw_pulay.resize(Nions);
   sw_grad.resize(Nions);
-  delta=1e-6;
+  delta=1e-4;
 };
 
 OperatorBase* ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
@@ -143,18 +143,17 @@ void ACForce::computeElecGradEL(ParticleSet& P, ACForce::Force_t& Egrad)
   int nelec=P.getTotalNum();
   RealType ep(0.0);
   RealType em(0.0);
-
+  RealType e0(0.0);
   for(int iel=0; iel<nelec; iel++)
   {
     for(int dim=0; dim<OHMMS_DIM; dim++)
     {
       RealType r0=P.R[iel][dim];
-      
+      ep=0; em=0; 
       //Plus
       RealType rp=r0+delta;
       P.R[iel][dim]=rp;
       P.update();
-
       psi.evaluateLog(P);
       ep=ham.evaluate2(P);
 

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -42,7 +42,7 @@ OperatorBase* ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 
 OperatorBase* ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi_in, QMCHamiltonian& ham_in)
 {
-  OperatorBase* myclone = new ACForce(qp, ions, psi_in, ham_in);
+  OperatorBase* myclone = new ACForce(ions, qp, psi_in, ham_in);
   return myclone;
 }
 

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -71,14 +71,20 @@ void ACForce::addObservables(PropertySetType& plist, BufferType& collectables)
       std::ostringstream pulayname;
       std::ostringstream wfgradname1;
       std::ostringstream wfgradname2;
+      std::ostringstream swctname1;
+      std::ostringstream swctname2;
       hfname << prefix << "_hf_" << iat << "_" << x;
       pulayname << prefix << "_pulay_" << iat << "_" << x;
       wfgradname1 << prefix << "_Ewfgrad_" << iat << "_" << x;
       wfgradname2 << prefix << "_wfgrad_" << iat << "_" << x;
+      swctname1 << prefix << "_swct1_" << iat << "_" << x;
+      swctname2 << prefix << "_swct2_" << iat << "_" << x;
       plist.add(hfname.str());
       plist.add(pulayname.str());
       plist.add(wfgradname1.str());
       plist.add(wfgradname2.str());
+      plist.add(swctname1.str());
+      plist.add(swctname2.str());
     }
   }
 };
@@ -95,6 +101,8 @@ void ACForce::setObservables(PropertySetType& plist)
       plist[myindex++] = -pulay_force[iat][iondim];
       plist[myindex++] = -Value * wf_grad[iat][iondim];
       plist[myindex++] = -wf_grad[iat][iondim];
+      plist[myindex++] = 0;
+      plist[myindex++] = 0;
     }
   }
 };
@@ -109,6 +117,8 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
       plist[myindex++] = -pulay_force[iat][iondim];
       plist[myindex++] = -Value * wf_grad[iat][iondim];
       plist[myindex++] = -wf_grad[iat][iondim];
+      plist[myindex++] = 0; 
+      plist[myindex++] = 0;
     }
   }
 };

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -19,6 +19,7 @@
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
+#include "QMCHamiltonians/SpaceWarpTransformation.h"
 
 namespace qmcplusplus
 {
@@ -54,6 +55,9 @@ struct ACForce : public OperatorBase
   /** Evaluate **/
   Return_t evaluate(ParticleSet& P);
 
+  void computeElecGradEL(ParticleSet& P, Force_t& gradEL); //This computes the 3N electron gradients of EL by finite differences.  
+  RealType delta; //finite difference time step
+
   //** Internal variables **/
   //  I'm assuming that psi, ions, elns, and the hamiltonian are bound to this
   //  instantiation.  Making sure no crosstalk happens is the job of whatever clones this.
@@ -70,7 +74,9 @@ struct ACForce : public OperatorBase
   Force_t hf_force;
   Force_t pulay_force;
   Force_t wf_grad;
+  Force_t sw_force;
 
+  SpaceWarpTransformation swt;
   //Class info.
   std::string prefix;
   //We also set the following from the OperatorBase class.

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -55,7 +55,8 @@ struct ACForce : public OperatorBase
   /** Evaluate **/
   Return_t evaluate(ParticleSet& P);
 
-  RealType delta; //finite difference time step
+  ///Finite difference timestep
+  RealType delta; 
 
   //** Internal variables **/
   //  I'm assuming that psi, ions, elns, and the hamiltonian are bound to this
@@ -65,11 +66,11 @@ struct ACForce : public OperatorBase
   TrialWaveFunction& psi;
   QMCHamiltonian& ham;
 
-  //For indexing observables
+  ///For indexing observables
   IndexType FirstForceIndex;
   const IndexType Nions;
 
-  //Temporary Nion x 3 dimensional arrays for force storage.
+  ///Temporary Nion x 3 dimensional arrays for force storage.
   Force_t hf_force;
   Force_t pulay_force;
   Force_t wf_grad;
@@ -77,7 +78,10 @@ struct ACForce : public OperatorBase
   Force_t sw_grad;
 
   bool useSpaceWarp;
+
+  ///The space warp transformation class.
   SpaceWarpTransformation swt;
+
   //Class info.
   std::string prefix;
   //We also set the following from the OperatorBase class.

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -67,7 +67,7 @@ struct ACForce : public OperatorBase
 
   //For indexing observables
   IndexType FirstForceIndex;
-  IndexType Nions;
+  const IndexType Nions;
 
   //Temporary Nion x 3 dimensional arrays for force storage.
   Force_t hf_force;

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -74,7 +74,8 @@ struct ACForce : public OperatorBase
   Force_t hf_force;
   Force_t pulay_force;
   Force_t wf_grad;
-  Force_t sw_force;
+  Force_t sw_pulay;
+  Force_t sw_grad;
 
   SpaceWarpTransformation swt;
   //Class info.

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -34,7 +34,7 @@ struct ACForce : public OperatorBase
   //ACForce(const ACForce& ac)  {};
 
   /** I/O Routines */
-  bool put(xmlNodePtr cur) { return true; };
+  bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const { return true; };
 
   /** Cloning **/
@@ -77,6 +77,7 @@ struct ACForce : public OperatorBase
   Force_t sw_pulay;
   Force_t sw_grad;
 
+  bool useSpaceWarp;
   SpaceWarpTransformation swt;
   //Class info.
   std::string prefix;

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -55,7 +55,6 @@ struct ACForce : public OperatorBase
   /** Evaluate **/
   Return_t evaluate(ParticleSet& P);
 
-  void computeElecGradEL(ParticleSet& P, Force_t& gradEL); //This computes the 3N electron gradients of EL by finite differences.  
   RealType delta; //finite difference time step
 
   //** Internal variables **/

--- a/src/QMCHamiltonians/CMakeLists.txt
+++ b/src/QMCHamiltonians/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(HAMSRCS
   SpinDensity.cpp
   SpeciesKineticEnergy.cpp
   LatticeDeviationEstimator.cpp
+  SpaceWarpTransformation.cpp
   )
 
 IF(OHMMS_DIM MATCHES 3)

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -211,6 +211,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
     }
     TrialWaveFunction& psi = *psi_it->second->getTWF();
     ACForce* acforce       = new ACForce(*source, *target, psi, *targetH);
+    acforce->put(cur);
     targetH->addOperator(acforce, title, false);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -150,7 +150,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid
 #endif
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
-      if(!keepGrid)
+      if (!keepGrid)
         PPset[ipp]->randomize_grid(*myRNG);
   //loop over all the ions
   const auto& myTable = P.getDistTable(myTableIndex);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -104,6 +104,12 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluate(ParticleSet& P)
   return Value;
 }
 
+NonLocalECPotential::Return_t NonLocalECPotential::evaluate2(ParticleSet& P)
+{
+  evaluateImpl(P, false, true);
+  return Value;
+}
+
 void NonLocalECPotential::mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list)
 {
   mw_evaluateImpl(O_list, P_list, false);
@@ -127,7 +133,7 @@ void NonLocalECPotential::mw_evaluateWithToperator(const RefVector<OperatorBase>
     mw_evaluateImpl(O_list, P_list, false);
 }
 
-void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove)
+void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid)
 {
   if (Tmove)
     nonLocalOps.reset();
@@ -144,7 +150,8 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove)
 #endif
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
-      PPset[ipp]->randomize_grid(*myRNG);
+      if(!keepGrid)
+        PPset[ipp]->randomize_grid(*myRNG);
   //loop over all the ions
   const auto& myTable = P.getDistTable(myTableIndex);
   // clear all the electron and ion neighbor lists

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -104,7 +104,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluate(ParticleSet& P)
   return Value;
 }
 
-NonLocalECPotential::Return_t NonLocalECPotential::evaluate2(ParticleSet& P)
+NonLocalECPotential::Return_t NonLocalECPotential::evaluateDeterministic(ParticleSet& P)
 {
   evaluateImpl(P, false, true);
   return Value;

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -151,8 +151,9 @@ private:
   /** the actual implementation, used by evaluate and evaluateWithToperator
    * @param P particle set
    * @param Tmove whether Txy for Tmove is updated
+   * @param keepGrid.  If true, does not randomize the quadrature grid before evaluation.  
    */
-  void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid=false);
+  void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
 
   /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
    * @param O_list the list of NonLocalECPotential in a walker batch

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -45,7 +45,7 @@ public:
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
-
+  Return_t evaluate2(ParticleSet& P) override;
   void mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list) override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;
@@ -154,7 +154,7 @@ private:
    * @param P particle set
    * @param Tmove whether Txy for Tmove is updated
    */
-  void evaluateImpl(ParticleSet& P, bool Tmove);
+  void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid=false);
 
   /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
    * @param O_list the list of NonLocalECPotential in a walker batch

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -45,7 +45,7 @@ public:
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
-  Return_t evaluate2(ParticleSet& P) override;
+  Return_t evaluateDeterministic(ParticleSet& P) override;
   void mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list) override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -35,7 +35,7 @@ OperatorBase::OperatorBase() : myIndex(-1), Dependants(0), Value(0.0), tWalker(0
   UpdateMode.set(PRIMARY, 1);
 }
 
-OperatorBase::Return_t OperatorBase::evaluate2(ParticleSet& P)
+OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P)
 {
   return evaluate(P);
 }

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -35,10 +35,10 @@ OperatorBase::OperatorBase() : myIndex(-1), Dependants(0), Value(0.0), tWalker(0
   UpdateMode.set(PRIMARY, 1);
 }
 
-OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P)
-{
-  return evaluate(P);
-}
+/** The correct behavior of this routine requires estimators with non-deterministic components
+ * in their evaluate() function to override this function.
+ */
+OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P) { return evaluate(P); }
 /** Take o_list and p_list update evaluation result variables in o_list?
  *
  * really should reduce vector of local_energies. matching the ordering and size of o list

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -35,6 +35,10 @@ OperatorBase::OperatorBase() : myIndex(-1), Dependants(0), Value(0.0), tWalker(0
   UpdateMode.set(PRIMARY, 1);
 }
 
+OperatorBase::Return_t OperatorBase::evaluate2(ParticleSet& P)
+{
+  return evaluate(P);
+}
 /** Take o_list and p_list update evaluation result variables in o_list?
  *
  * really should reduce vector of local_energies. matching the ordering and size of o list

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -246,6 +246,7 @@ struct OperatorBase : public QMCTraits
    *@return the value of the Hamiltonian component
    */
   virtual Return_t evaluate(ParticleSet& P) = 0;
+  virtual Return_t evaluate2(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
   virtual void mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list);
 

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -246,6 +246,10 @@ struct OperatorBase : public QMCTraits
    *@return the value of the Hamiltonian component
    */
   virtual Return_t evaluate(ParticleSet& P) = 0;
+  /** Evaluate the local energy contribution of this component, deterministically based on current state.
+   *@param P input configuration containing N particles
+   *@return the value of the Hamiltonian component
+   */
   virtual Return_t evaluateDeterministic(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
   virtual void mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list);

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -246,7 +246,7 @@ struct OperatorBase : public QMCTraits
    *@return the value of the Hamiltonian component
    */
   virtual Return_t evaluate(ParticleSet& P) = 0;
-  virtual Return_t evaluate2(ParticleSet& P);
+  virtual Return_t evaluateDeterministic(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
   virtual void mw_evaluate(const RefVector<OperatorBase>& O_list, const RefVector<ParticleSet>& P_list);
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -817,34 +817,38 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::flex_evaluateWithT
   }
   return local_energies;
 }
-void QMCHamiltonian::evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, ParticleSet::ParticlePos_t& Egrad, RealType delta)
+void QMCHamiltonian::evaluateElecGrad(ParticleSet& P,
+                                      TrialWaveFunction& psi,
+                                      ParticleSet::ParticlePos_t& Egrad,
+                                      RealType delta)
 {
-  int nelec=P.getTotalNum();
+  int nelec = P.getTotalNum();
   RealType ep(0.0);
   RealType em(0.0);
   RealType e0(0.0);
-  for(int iel=0; iel<nelec; iel++)
+  for (int iel = 0; iel < nelec; iel++)
   {
-    for(int dim=0; dim<OHMMS_DIM; dim++)
+    for (int dim = 0; dim < OHMMS_DIM; dim++)
     {
-      RealType r0=P.R[iel][dim];
-      ep=0; em=0; 
+      RealType r0 = P.R[iel][dim];
+      ep          = 0;
+      em          = 0;
       //Plus
-      RealType rp=r0+delta;
-      P.R[iel][dim]=rp;
+      RealType rp   = r0 + delta;
+      P.R[iel][dim] = rp;
       P.update();
       psi.evaluateLog(P);
-      ep=evaluateDeterministic(P);
+      ep = evaluateDeterministic(P);
 
       //minus
-      RealType rm=r0-delta;
-      P.R[iel][dim]=rm;
+      RealType rm   = r0 - delta;
+      P.R[iel][dim] = rm;
       P.update();
       psi.evaluateLog(P);
-      em=evaluateDeterministic(P);
+      em = evaluateDeterministic(P);
 
-      Egrad[iel][dim]=(ep-em)/(2.0*delta);
-      P.R[iel][dim]=r0;
+      Egrad[iel][dim] = (ep - em) / (2.0 * delta);
+      P.R[iel][dim]   = r0;
       P.update();
       psi.evaluateLog(P);
     }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -501,14 +501,14 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
   return LocalEnergy;
 }
 
-QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate2(ParticleSet& P)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleSet& P)
 {
   ScopedTimer local_timer(ham_timer_);
   LocalEnergy = 0.0;
   for (int i = 0; i < H.size(); ++i)
   {
     ScopedTimer h_timer(my_timers_[i]);
-    const auto LocalEnergyComponent = H[i]->evaluate2(P);
+    const auto LocalEnergyComponent = H[i]->evaluateDeterministic(P);
     if (std::isnan(LocalEnergyComponent))
       APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->myName + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
@@ -834,14 +834,14 @@ void QMCHamiltonian::evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, Pa
       P.R[iel][dim]=rp;
       P.update();
       psi.evaluateLog(P);
-      ep=evaluate2(P);
+      ep=evaluateDeterministic(P);
 
       //minus
       RealType rm=r0-delta;
       P.R[iel][dim]=rm;
       P.update();
       psi.evaluateLog(P);
-      em=evaluate2(P);
+      em=evaluateDeterministic(P);
 
       Egrad[iel][dim]=(ep-em)/(2.0*delta);
       P.R[iel][dim]=r0;

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -817,7 +817,39 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::flex_evaluateWithT
   }
   return local_energies;
 }
+void QMCHamiltonian::evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, ParticleSet::ParticlePos_t& Egrad, RealType delta)
+{
+  int nelec=P.getTotalNum();
+  RealType ep(0.0);
+  RealType em(0.0);
+  RealType e0(0.0);
+  for(int iel=0; iel<nelec; iel++)
+  {
+    for(int dim=0; dim<OHMMS_DIM; dim++)
+    {
+      RealType r0=P.R[iel][dim];
+      ep=0; em=0; 
+      //Plus
+      RealType rp=r0+delta;
+      P.R[iel][dim]=rp;
+      P.update();
+      psi.evaluateLog(P);
+      ep=evaluate2(P);
 
+      //minus
+      RealType rm=r0-delta;
+      P.R[iel][dim]=rm;
+      P.update();
+      psi.evaluateLog(P);
+      em=evaluate2(P);
+
+      Egrad[iel][dim]=(ep-em)/(2.0*delta);
+      P.R[iel][dim]=r0;
+      P.update();
+      psi.evaluateLog(P);
+    }
+  }
+}
 QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
                                                                    ParticleSet& ions,
                                                                    TrialWaveFunction& psi,

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -231,10 +231,10 @@ public:
    */
   FullPrecRealType evaluate(ParticleSet& P);
 
-  /** evaluate Local Energy deterministically.  Defaults to evaluate(P) for operators without a stochastic component. For the nonlocal PP, the quadrature grid is not rerandomized.  
+  /** evaluate Local Energy deterministically.  Defaults to evaluate(P) for operators 
+   * without a stochastic component. For the nonlocal PP, the quadrature grid is not rerandomized.  
    * @param P ParticleSet
    * @return Local energy. 
-   *
    */
   FullPrecRealType evaluateDeterministic(ParticleSet& P);
   /** batched version of evaluate for LocalEnergy 

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -230,7 +230,13 @@ public:
    * P.R, P.G and P.L are used to evaluate the LocalEnergy.
    */
   FullPrecRealType evaluate(ParticleSet& P);
-  FullPrecRealType evaluate2(ParticleSet& P); //This is the same as evaluate(), but doesn't update the quadrature grid for a PP point.
+
+  /** evaluate Local Energy deterministically.  Defaults to evaluate(P) for operators without a stochastic component. For the nonlocal PP, the quadrature grid is not rerandomized.  
+   * @param P ParticleSet
+   * @return Local energy. 
+   *
+   */
+  FullPrecRealType evaluateDeterministic(ParticleSet& P); 
   /** batched version of evaluate for LocalEnergy 
    *
    *  Encapsulation is ignored for H_list hamiltonians method uses its status as QMCHamiltonian to break encapsulation.

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -230,7 +230,7 @@ public:
    * P.R, P.G and P.L are used to evaluate the LocalEnergy.
    */
   FullPrecRealType evaluate(ParticleSet& P);
-
+  FullPrecRealType evaluate2(ParticleSet& P); //This is the same as evaluate(), but doesn't update the quadrature grid for a PP point.
   /** batched version of evaluate for LocalEnergy 
    *
    *  Encapsulation is ignored for H_list hamiltonians method uses its status as QMCHamiltonian to break encapsulation.

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -282,6 +282,15 @@ public:
       RecordArray<ValueType>& dhpsioverpsi);
 
 
+  /** Evaluate the electron gradient of the local energy.
+  * @param psi Trial Wave Function
+  * @param P electron particle set
+  * @param EGrad an Nelec x 3 real array which corresponds to d/d[r_i]_j E_L
+  * @param A finite difference step size if applicable.  Default is to use finite diff with delta=1e-5.
+  * @return EGrad.  Function itself returns nothing.
+  */    
+  void evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, ParticleSet::ParticlePos_t& EGrad, RealType delta=1e-5);
+
   /** evaluate local energy and derivatives w.r.t ionic coordinates.  
   * @param P target particle set (electrons)
   * @param ions source particle set (ions)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -236,7 +236,7 @@ public:
    * @return Local energy. 
    *
    */
-  FullPrecRealType evaluateDeterministic(ParticleSet& P); 
+  FullPrecRealType evaluateDeterministic(ParticleSet& P);
   /** batched version of evaluate for LocalEnergy 
    *
    *  Encapsulation is ignored for H_list hamiltonians method uses its status as QMCHamiltonian to break encapsulation.
@@ -294,8 +294,11 @@ public:
   * @param EGrad an Nelec x 3 real array which corresponds to d/d[r_i]_j E_L
   * @param A finite difference step size if applicable.  Default is to use finite diff with delta=1e-5.
   * @return EGrad.  Function itself returns nothing.
-  */    
-  void evaluateElecGrad(ParticleSet& P, TrialWaveFunction& psi, ParticleSet::ParticlePos_t& EGrad, RealType delta=1e-5);
+  */
+  void evaluateElecGrad(ParticleSet& P,
+                        TrialWaveFunction& psi,
+                        ParticleSet::ParticlePos_t& EGrad,
+                        RealType delta = 1e-5);
 
   /** evaluate local energy and derivatives w.r.t ionic coordinates.  
   * @param P target particle set (electrons)

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -13,14 +13,14 @@ SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, ParticleSet&
   gradval.resize(Nelec,Nions);
 }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r, RealType inpow)
+SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r)
 {
-  return std::pow(r,-inpow);
+  return std::pow(r,-swpow);
 }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r, RealType inpow)
+SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
 {
-  return -inpow*std::pow(r,-(inpow+1));
+  return -swpow*std::pow(r,-(swpow+1));
 }
 
 void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSet& ions)
@@ -32,8 +32,8 @@ void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSe
     const auto& dr   = d_ab.getDisplRow(iel);
     for (size_t ionid = 0; ionid < Nions; ++ionid)
     {
-      warpval[iel][ionid]=f(dist[ionid],swpow);
-      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid],swpow)/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
+      warpval[iel][ionid]=f(dist[ionid]);
+      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid])/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
     }
   }
  

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -1,11 +1,107 @@
 #include "QMCHamiltonians/SpaceWarpTransformation.h"
-
+#include "Particle/DistanceTableData.h"
+#include "type_traits/scalar_traits.h"
 namespace qmcplusplus
 {
+
+SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions):
+      myTableIndex(elns.addTable(ions))
+{
+  Nelec=elns.getTotalNum();
+  Nions=ions.getTotalNum(); 
+  warpval.resize(Nelec,Nions);
+  gradval.resize(Nelec,Nions);
+  app_log()<<"SpaceWarp transformation with 1/r^4 initialized\n"; 
+}
 
 SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r)
 {
   return 1.0/(r*r*r*r);
 }
+
+SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
+{
+  return -4.0/(r*r*r*r*r);
+}
+
+void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSet& ions)
+{
+  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+  for (size_t iel = 0; iel < Nelec; ++iel)
+  {
+    const auto& dist = d_ab.getDistRow(iel);
+    const auto& dr   = d_ab.getDisplRow(iel);
+    for (size_t ionid = 0; ionid < Nions; ++ionid)
+    {
+      warpval[iel][ionid]=f(dist[ionid]);
+      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid])/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
+    }
+  }
+
+}
+
+void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w)
+{
+  for(size_t iel=0; iel<Nelec; iel++)
+  {
+    RealType warpdenom=0.0;
+    PosType  denomgrad=0.0;
+    for(size_t ionid=0; ionid<Nions; ionid++)
+    {
+      warpdenom+=warpval[iel][ionid];
+      denomgrad+=gradval[iel][ionid];
+    }
+    w[iel]=warpval[iel][iat]/warpdenom;
+    grad_w[iel]=gradval[iel][iat]/warpdenom - w[iel]*denomgrad/warpdenom;
+  }
+}
+
+void SpaceWarpTransformation::computeSWT(ParticleSet& P, ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution)
+{
+  el_contribution=0;
+  psi_contribution=0;
+  ParticleScalar_t w;
+  Force_t gradw;
+  w.resize(Nelec);
+  gradw.resize(Nelec);
+
+  PosType gwfn=0;
+  computeSWTIntermediates(P,ions);
+    
+  for(size_t iat=0; iat<Nions; iat++)
+  {
+    getSWT(iat,w,gradw);
+    
+    for(size_t iel=0; iel<Nelec; iel++)
+    {
+      el_contribution+=w[iel]*dEl[iel];
+
+      #if defined(QMC_COMPLEX)
+      convert(dlogpsi[iel],gwfn);
+      #else
+      gwfn=dlogpsi[iel];
+      #endif 
+      psi_contribution[iat]=w[iel]*gwfn+0.5*gradw[iel];
+    }
+    
+  }
+}
+
+/*void SpaceWarpTransformation::sw(ParticleSet& P, ParticleSet& ions, int iat, ParticleScalar_t& sw_vals, Force_t& sw_grads)
+{
+  int Nelec=P.getTotalNum();
+  int Nions=ions.getTotalNum();
+  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+  for (size_t iel = 0; iel < Nelec; ++iel)
+  {
+    const auto& dist = d_ab.getDistRow(iel);
+    const auto& dr   = d_ab.getDisplRow(iel);
+    mRealType esum   = czero;
+    for (size_t ionid = 0; ionid < ionid; ++ionid)
+    {
+     
+    }
+  }
+}*/
 
 }

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -3,26 +3,19 @@
 #include "type_traits/scalar_traits.h"
 namespace qmcplusplus
 {
-
-SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions):
-      myTableIndex(elns.addTable(ions)), Nelec(elns.getTotalNum()), Nions(ions.getTotalNum()), swpow(4.0)
+SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions)
+    : myTableIndex(elns.addTable(ions)), Nelec(elns.getTotalNum()), Nions(ions.getTotalNum()), swpow(4.0)
 {
-  warpval.resize(Nelec,Nions);
-  gradval.resize(Nelec,Nions);
+  warpval.resize(Nelec, Nions);
+  gradval.resize(Nelec, Nions);
 }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r)
-{
-  return std::pow(r,-swpow);
-}
+SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r) { return std::pow(r, -swpow); }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
-{
-  return -swpow*std::pow(r,-(swpow+1));
-}
-//Space warp functions have the form w_I(r_i) = F(|r_i-R_I)/Sum_J F(|r_i-R_J|).  Hence the intermediate we will 
-//precompute is the matrix "warpval[i][J] = F(|r_i-R_J|) and gradval[i][J]=Grad(F(|r_i-R_J|)).  
-//This allows the calculation of any space warp value or gradient by a matrix lookup, combined with a sum over columns.  
+SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r) { return -swpow * std::pow(r, -(swpow + 1)); }
+//Space warp functions have the form w_I(r_i) = F(|r_i-R_I)/Sum_J F(|r_i-R_J|).  Hence the intermediate we will
+//precompute is the matrix "warpval[i][J] = F(|r_i-R_J|) and gradval[i][J]=Grad(F(|r_i-R_J|)).
+//This allows the calculation of any space warp value or gradient by a matrix lookup, combined with a sum over columns.
 void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions)
 {
   const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
@@ -32,59 +25,64 @@ void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, const Part
     const auto& dr   = d_ab.getDisplRow(iel);
     for (size_t ionid = 0; ionid < Nions; ++ionid)
     {
-      warpval[iel][ionid]=f(dist[ionid]);
-      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid])/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
+      warpval[iel][ionid] = f(dist[ionid]);
+      gradval[iel][ionid] = -dr[ionid] *
+          (df(dist[ionid]) / dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(.
     }
   }
- 
 }
 
-//This function handles parsing of the intermediate matrices and construction of the w_I(r_i) and Grad_i(w_I(r_i)) functions 
+//This function handles parsing of the intermediate matrices and construction of the w_I(r_i) and Grad_i(w_I(r_i)) functions
 // that appear in the space warp transformation formulas.
 void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w)
 {
-  for(size_t iel=0; iel<Nelec; iel++)
+  for (size_t iel = 0; iel < Nelec; iel++)
   {
-    RealType warpdenom=0.0;
-    PosType  denomgrad=0.0;
-    for(size_t ionid=0; ionid<Nions; ionid++)
+    RealType warpdenom = 0.0;
+    PosType denomgrad  = 0.0;
+    for (size_t ionid = 0; ionid < Nions; ionid++)
     {
-      warpdenom+=warpval[iel][ionid];
-      denomgrad+=gradval[iel][ionid];
+      warpdenom += warpval[iel][ionid];
+      denomgrad += gradval[iel][ionid];
     }
-    w[iel]=warpval[iel][iat]/warpdenom;
-    grad_w[iel]=gradval[iel][iat]/warpdenom - w[iel]*denomgrad/warpdenom;
+    w[iel]      = warpval[iel][iat] / warpdenom;
+    grad_w[iel] = gradval[iel][iat] / warpdenom - w[iel] * denomgrad / warpdenom;
   }
 }
 //This function returns Sum_i w_I(r_i) Grad_i(E_L) (as el_contribution)  and Sum_i[ w_I(r_i)Grad_i(logpsi)+0.5*Grad_i(w_I(r_i)) (as psi_contribution).  See Eq (15) and (16) respectively.
-void SpaceWarpTransformation::computeSWT(ParticleSet& P, const ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution)
+void SpaceWarpTransformation::computeSWT(ParticleSet& P,
+                                         const ParticleSet& ions,
+                                         Force_t& dEl,
+                                         ParticleGradient_t& dlogpsi,
+                                         Force_t& el_contribution,
+                                         Force_t& psi_contribution)
 {
-  el_contribution=0;
-  psi_contribution=0;
+  el_contribution  = 0;
+  psi_contribution = 0;
   ParticleScalar_t w;
   Force_t gradw;
   w.resize(Nelec);
   gradw.resize(Nelec);
 
-  PosType gwfn=0;
-  computeSWTIntermediates(P,ions);
-    
-  for(size_t iat=0; iat<Nions; iat++)
-  {
-    w=0; gradw=0;
-    getSWT(iat,w,gradw);
-    for(size_t iel=0; iel<Nelec; iel++)
-    {
-      el_contribution[iat]+=w[iel]*dEl[iel];
+  PosType gwfn = 0;
+  computeSWTIntermediates(P, ions);
 
-      #if defined(QMC_COMPLEX)
-      convert(dlogpsi[iel],gwfn);
-      #else
-      gwfn=dlogpsi[iel];
-      #endif 
-      psi_contribution[iat]+=w[iel]*gwfn+0.5*gradw[iel];
+  for (size_t iat = 0; iat < Nions; iat++)
+  {
+    w     = 0;
+    gradw = 0;
+    getSWT(iat, w, gradw);
+    for (size_t iel = 0; iel < Nelec; iel++)
+    {
+      el_contribution[iat] += w[iel] * dEl[iel];
+
+#if defined(QMC_COMPLEX)
+      convert(dlogpsi[iel], gwfn);
+#else
+      gwfn = dlogpsi[iel];
+#endif
+      psi_contribution[iat] += w[iel] * gwfn + 0.5 * gradw[iel];
     }
-    
   }
   //REMOVE ME
   //app_log()<<"FINAL SPACE WARP TRANSFORM\n";
@@ -97,4 +95,4 @@ void SpaceWarpTransformation::computeSWT(ParticleSet& P, const ParticleSet& ions
   //app_log()<<" psipiece = "<<psi_contribution<<std::endl;
 }
 
-}
+} // namespace qmcplusplus

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -4,11 +4,9 @@
 namespace qmcplusplus
 {
 
-SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions):
-      myTableIndex(elns.addTable(ions)), swpow(4.0)
+SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions):
+      myTableIndex(elns.addTable(ions)), Nelec(elns.getTotalNum()), Nions(ions.getTotalNum()), swpow(4.0)
 {
-  Nelec=elns.getTotalNum();
-  Nions=ions.getTotalNum(); 
   warpval.resize(Nelec,Nions);
   gradval.resize(Nelec,Nions);
 }
@@ -25,7 +23,7 @@ SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
 //Space warp functions have the form w_I(r_i) = F(|r_i-R_I)/Sum_J F(|r_i-R_J|).  Hence the intermediate we will 
 //precompute is the matrix "warpval[i][J] = F(|r_i-R_J|) and gradval[i][J]=Grad(F(|r_i-R_J|)).  
 //This allows the calculation of any space warp value or gradient by a matrix lookup, combined with a sum over columns.  
-void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSet& ions)
+void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions)
 {
   const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
   for (size_t iel = 0; iel < Nelec; ++iel)
@@ -59,7 +57,7 @@ void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad
   }
 }
 //This function returns Sum_i w_I(r_i) Grad_i(E_L) (as el_contribution)  and Sum_i[ w_I(r_i)Grad_i(logpsi)+0.5*Grad_i(w_I(r_i)) (as psi_contribution).  See Eq (15) and (16) respectively.
-void SpaceWarpTransformation::computeSWT(ParticleSet& P, ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution)
+void SpaceWarpTransformation::computeSWT(ParticleSet& P, const ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution)
 {
   el_contribution=0;
   psi_contribution=0;

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -22,7 +22,9 @@ SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
 {
   return -swpow*std::pow(r,-(swpow+1));
 }
-
+//Space warp functions have the form w_I(r_i) = F(|r_i-R_I)/Sum_J F(|r_i-R_J|).  Hence the intermediate we will 
+//precompute is the matrix "warpval[i][J] = F(|r_i-R_J|) and gradval[i][J]=Grad(F(|r_i-R_J|)).  
+//This allows the calculation of any space warp value or gradient by a matrix lookup, combined with a sum over columns.  
 void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSet& ions)
 {
   const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
@@ -39,6 +41,8 @@ void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSe
  
 }
 
+//This function handles parsing of the intermediate matrices and construction of the w_I(r_i) and Grad_i(w_I(r_i)) functions 
+// that appear in the space warp transformation formulas.
 void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w)
 {
   for(size_t iel=0; iel<Nelec; iel++)
@@ -54,7 +58,7 @@ void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad
     grad_w[iel]=gradval[iel][iat]/warpdenom - w[iel]*denomgrad/warpdenom;
   }
 }
-
+//This function returns Sum_i w_I(r_i) Grad_i(E_L) (as el_contribution)  and Sum_i[ w_I(r_i)Grad_i(logpsi)+0.5*Grad_i(w_I(r_i)) (as psi_contribution).  See Eq (15) and (16) respectively.
 void SpaceWarpTransformation::computeSWT(ParticleSet& P, ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution)
 {
   el_contribution=0;
@@ -94,22 +98,5 @@ void SpaceWarpTransformation::computeSWT(ParticleSet& P, ParticleSet& ions, Forc
   //app_log()<<"Space warp logpsi piece\n";
   //app_log()<<" psipiece = "<<psi_contribution<<std::endl;
 }
-
-/*void SpaceWarpTransformation::sw(ParticleSet& P, ParticleSet& ions, int iat, ParticleScalar_t& sw_vals, Force_t& sw_grads)
-{
-  int Nelec=P.getTotalNum();
-  int Nions=ions.getTotalNum();
-  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
-  for (size_t iel = 0; iel < Nelec; ++iel)
-  {
-    const auto& dist = d_ab.getDistRow(iel);
-    const auto& dr   = d_ab.getDisplRow(iel);
-    mRealType esum   = czero;
-    for (size_t ionid = 0; ionid < ionid; ++ionid)
-    {
-     
-    }
-  }
-}*/
 
 }

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -1,0 +1,11 @@
+#include "QMCHamiltonians/SpaceWarpTransformation.h"
+
+namespace qmcplusplus
+{
+
+SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r)
+{
+  return 1.0/(r*r*r*r);
+}
+
+}

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -5,23 +5,22 @@ namespace qmcplusplus
 {
 
 SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions):
-      myTableIndex(elns.addTable(ions))
+      myTableIndex(elns.addTable(ions)), swpow(4.0)
 {
   Nelec=elns.getTotalNum();
   Nions=ions.getTotalNum(); 
   warpval.resize(Nelec,Nions);
   gradval.resize(Nelec,Nions);
-  app_log()<<"SpaceWarp transformation with 1/r^4 initialized\n"; 
 }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r)
+SpaceWarpTransformation::RealType SpaceWarpTransformation::f(RealType r, RealType inpow)
 {
-  return 1.0/(r*r*r*r);
+  return std::pow(r,-inpow);
 }
 
-SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r)
+SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r, RealType inpow)
 {
-  return -4.0/(r*r*r*r*r);
+  return -inpow*std::pow(r,-(inpow+1));
 }
 
 void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSet& ions)
@@ -33,8 +32,8 @@ void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSe
     const auto& dr   = d_ab.getDisplRow(iel);
     for (size_t ionid = 0; ionid < Nions; ++ionid)
     {
-      warpval[iel][ionid]=f(dist[ionid]);
-      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid])/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
+      warpval[iel][ionid]=f(dist[ionid],swpow);
+      gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid],swpow)/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
     }
   }
  

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -37,7 +37,7 @@ void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, ParticleSe
       gradval[iel][ionid]=-dr[ionid]*(df(dist[ionid])/dist[ionid]); //because there's a -1 in distance table displacement definition.  R-r :(. 
     }
   }
-
+ 
 }
 
 void SpaceWarpTransformation::getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w)
@@ -70,21 +70,30 @@ void SpaceWarpTransformation::computeSWT(ParticleSet& P, ParticleSet& ions, Forc
     
   for(size_t iat=0; iat<Nions; iat++)
   {
+    w=0; gradw=0;
     getSWT(iat,w,gradw);
-    
     for(size_t iel=0; iel<Nelec; iel++)
     {
-      el_contribution+=w[iel]*dEl[iel];
+      el_contribution[iat]+=w[iel]*dEl[iel];
 
       #if defined(QMC_COMPLEX)
       convert(dlogpsi[iel],gwfn);
       #else
       gwfn=dlogpsi[iel];
       #endif 
-      psi_contribution[iat]=w[iel]*gwfn+0.5*gradw[iel];
+      psi_contribution[iat]+=w[iel]*gwfn+0.5*gradw[iel];
     }
     
   }
+  //REMOVE ME
+  //app_log()<<"FINAL SPACE WARP TRANSFORM\n";
+  //app_log()<<" Using dEl="<<dEl<<std::endl;
+  //app_log()<<" Using dlogpsi="<<dlogpsi<<std::endl;
+
+  //app_log()<<"Space warp EL piece\n";
+  //app_log()<<" EL = "<<el_contribution<<std::endl;
+  //app_log()<<"Space warp logpsi piece\n";
+  //app_log()<<" psipiece = "<<psi_contribution<<std::endl;
 }
 
 /*void SpaceWarpTransformation::sw(ParticleSet& P, ParticleSet& ions, int iat, ParticleScalar_t& sw_vals, Force_t& sw_grads)

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -23,11 +23,13 @@ namespace qmcplusplus
  *       J. Chem. Phys., 133, 23411 (2010), https://doi.org/10.1063/1.3516208 
  *
  */
-struct SpaceWarpTransformation : public QMCTraits
+class SpaceWarpTransformation : public QMCTraits
 {
   typedef ParticleSet::ParticleScalar_t ParticleScalar_t;
   typedef ParticleSet::ParticlePos_t Force_t;
   typedef ParticleSet::ParticleGradient_t ParticleGradient_t;
+
+  public:
 
   SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions);
   ~SpaceWarpTransformation(){};
@@ -43,16 +45,6 @@ struct SpaceWarpTransformation : public QMCTraits
   {
     swpow = swpow_in;
   }; 
-
-  /** Computes intermediate matrices required to build all space warp components and gradients.
-   *  The intermediates calculated are "warpval" and "gradval".
-   *
-   * \param[in] P, the electron particle set.  
-   * \param[in] ions, the ion particle set.  
-   */
-  void computeSWTIntermediates(ParticleSet& P,
-                               const ParticleSet& ions); 
-                                                         
 
   /** Generates required space warp quantities to generate the actual "Space Warp" contribution to the
    *  iat-th force component.
@@ -81,7 +73,19 @@ struct SpaceWarpTransformation : public QMCTraits
                   Force_t& el_contribution,
                   Force_t& psi_contribution); 
                                               
-                                              
+  private:
+
+                                            
+  /** Computes intermediate matrices required to build all space warp components and gradients.
+   *  The intermediates calculated are "warpval" and "gradval".
+   *
+   * \param[in] P, the electron particle set.  
+   * \param[in] ions, the ion particle set.  
+   */
+  void computeSWTIntermediates(ParticleSet& P,
+                               const ParticleSet& ions); 
+                                                         
+
 
   const int myTableIndex;
   const int Nelec;

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -1,0 +1,36 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Raymond Clay
+//
+// File created by: Raymond Clay, Sandia National Laboratory, rclay@sandia.gov
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_SPACEWARP_H
+#define QMCPLUSPLUS_SPACEWARP_H
+
+#include "Configuration.h"
+
+namespace qmcplusplus
+{
+/** @ingroup hamiltonian
+ *\brief Calculates the AA Coulomb potential using PBCs
+ *
+ * Functionally identical to CoulombPBCAB but uses a templated version of
+ * LRHandler.
+ */
+struct SpaceWarpTransformation : public QMCTraits
+{
+  SpaceWarpTransformation(){};
+  ~SpaceWarpTransformation(){};
+
+  RealType f(RealType r); 
+};
+}
+#endif
+
+

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -29,7 +29,7 @@ struct SpaceWarpTransformation : public QMCTraits
   typedef ParticleSet::ParticlePos_t Force_t;
   typedef ParticleSet::ParticleGradient_t ParticleGradient_t;
 
-  SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions);
+  SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
  
@@ -38,19 +38,19 @@ struct SpaceWarpTransformation : public QMCTraits
 
   void setPow(RealType swpow_in){swpow=swpow_in;}; //This sets the exponent for the power law space warp transformation.
 
-  void computeSWTIntermediates(ParticleSet& P, ParticleSet& ions); //This computes the intermediate matrices required to build all 
+  void computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions); //This computes the intermediate matrices required to build all 
                                                       //space warp components and gradients.
 
   void getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w); //For each ion component iat, this generates all the required space warp quantities to 
                                                               //generate the "space warp" contribution to the iat-th force component.
                                                               
-  void computeSWT(ParticleSet& elec, ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
+  void computeSWT(ParticleSet& elec, const ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
                                                                                                                         //this to compute the ZV (el_contribution) and ZB (psi_contribution) 
                                                                                                                         //space warp contributions.                                                               
 
-  int myTableIndex;
-  int Nelec;
-  int Nions;
+  const int myTableIndex;
+  const int Nelec;
+  const int Nions;
 
   RealType swpow; //Power of space warp transformation.  Right now, r^{-swpow}.
   Matrix<RealType> warpval;  //Nelec x Nion matrix of F(|r_i-R_J|)

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -33,9 +33,10 @@ struct SpaceWarpTransformation : public QMCTraits
   SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
-  RealType f(RealType r); 
-  RealType df(RealType r); 
+  RealType f(RealType r, RealType a); 
+  RealType df(RealType r, RealType a); 
 
+  void setPow(RealType swpow_in){swpow=swpow_in;};
   void computeSWTIntermediates(ParticleSet& P, ParticleSet& ions); //This computes the intermediate matrices required to build all 
                                                       //space warp components and gradients.
 
@@ -49,6 +50,8 @@ struct SpaceWarpTransformation : public QMCTraits
   int myTableIndex;
   int Nelec;
   int Nions;
+
+  RealType swpow; //Power of space warp transformation.  Right now, r^{-swpow}.
   Matrix<RealType> warpval;  //Nelec x Nion matrix of F(|r_i-R_J|)
   Matrix<PosType>  gradval;  //Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
 };

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -14,6 +14,7 @@
 #define QMCPLUSPLUS_SPACEWARP_H
 
 #include "Configuration.h"
+#include "Particle/ParticleSet.h"
 
 namespace qmcplusplus
 {
@@ -25,10 +26,31 @@ namespace qmcplusplus
  */
 struct SpaceWarpTransformation : public QMCTraits
 {
-  SpaceWarpTransformation(){};
+  typedef ParticleSet::ParticleScalar_t ParticleScalar_t;
+  typedef ParticleSet::ParticlePos_t Force_t;
+  typedef ParticleSet::ParticleGradient_t ParticleGradient_t;
+
+  SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
   RealType f(RealType r); 
+  RealType df(RealType r); 
+
+  void computeSWTIntermediates(ParticleSet& P, ParticleSet& ions); //This computes the intermediate matrices required to build all 
+                                                      //space warp components and gradients.
+
+  void getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w); //For each ion component iat, this generates all the required space warp quantities to 
+                                                              //generate the "space warp" contribution to the iat-th force component.
+                                                              
+  void computeSWT(ParticleSet& elec, ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
+                                                                                                                        //this to compute the ZV (el_contribution) and ZB (psi_contribution) 
+                                                                                                                        //space warp contributions.                                                               
+
+  int myTableIndex;
+  int Nelec;
+  int Nions;
+  Matrix<RealType> warpval;  //Nelec x Nion matrix of F(|r_i-R_J|)
+  Matrix<PosType>  gradval;  //Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
 };
 }
 #endif

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -19,10 +19,9 @@
 namespace qmcplusplus
 {
 /** @ingroup hamiltonian
- *\brief Calculates the AA Coulomb potential using PBCs
+ *\brief This implements the differential space warp transformation for ZVZB estimators given by Sorella & Capriotti
+ *       J. Chem. Phys., 133, 23411 (2010), https://doi.org/10.1063/1.3516208 
  *
- * Functionally identical to CoulombPBCAB but uses a templated version of
- * LRHandler.
  */
 struct SpaceWarpTransformation : public QMCTraits
 {
@@ -33,10 +32,12 @@ struct SpaceWarpTransformation : public QMCTraits
   SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
-  RealType f(RealType r); 
-  RealType df(RealType r); 
+ 
+  RealType f(RealType r);  //space warp transformation function F.
+  RealType df(RealType r); //The gradient of F(r)
 
-  void setPow(RealType swpow_in){swpow=swpow_in;};
+  void setPow(RealType swpow_in){swpow=swpow_in;}; //This sets the exponent for the power law space warp transformation.
+
   void computeSWTIntermediates(ParticleSet& P, ParticleSet& ions); //This computes the intermediate matrices required to build all 
                                                       //space warp components and gradients.
 

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -32,31 +32,40 @@ struct SpaceWarpTransformation : public QMCTraits
   SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
- 
+
   RealType f(RealType r);  //space warp transformation function F.
   RealType df(RealType r); //The gradient of F(r)
 
-  void setPow(RealType swpow_in){swpow=swpow_in;}; //This sets the exponent for the power law space warp transformation.
+  void setPow(RealType swpow_in)
+  {
+    swpow = swpow_in;
+  }; //This sets the exponent for the power law space warp transformation.
 
-  void computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions); //This computes the intermediate matrices required to build all 
-                                                      //space warp components and gradients.
+  void computeSWTIntermediates(ParticleSet& P,
+                               const ParticleSet& ions); //This computes the intermediate matrices required to build all
+                                                         //space warp components and gradients.
 
-  void getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w); //For each ion component iat, this generates all the required space warp quantities to 
-                                                              //generate the "space warp" contribution to the iat-th force component.
-                                                              
-  void computeSWT(ParticleSet& elec, const ParticleSet& ions, Force_t& dEl, ParticleGradient_t& dlogpsi, Force_t& el_contribution, Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
-                                                                                                                        //this to compute the ZV (el_contribution) and ZB (psi_contribution) 
-                                                                                                                        //space warp contributions.                                                               
+  void getSWT(int iat,
+              ParticleScalar_t& w,
+              Force_t& grad_w); //For each ion component iat, this generates all the required space warp quantities to
+                                //generate the "space warp" contribution to the iat-th force component.
+
+  void computeSWT(ParticleSet& elec,
+                  const ParticleSet& ions,
+                  Force_t& dEl,
+                  ParticleGradient_t& dlogpsi,
+                  Force_t& el_contribution,
+                  Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
+                                              //this to compute the ZV (el_contribution) and ZB (psi_contribution)
+                                              //space warp contributions.
 
   const int myTableIndex;
   const int Nelec;
   const int Nions;
 
-  RealType swpow; //Power of space warp transformation.  Right now, r^{-swpow}.
-  Matrix<RealType> warpval;  //Nelec x Nion matrix of F(|r_i-R_J|)
-  Matrix<PosType>  gradval;  //Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
+  RealType swpow;           //Power of space warp transformation.  Right now, r^{-swpow}.
+  Matrix<RealType> warpval; //Nelec x Nion matrix of F(|r_i-R_J|)
+  Matrix<PosType> gradval;  //Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
 };
-}
+} // namespace qmcplusplus
 #endif
-
-

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -32,40 +32,64 @@ struct SpaceWarpTransformation : public QMCTraits
   SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
+  RealType f(RealType r);  ///< Space warp transformation function F.  Argument is distance.
+  RealType df(RealType r); ///< The derivative of F w.r.t. r.
 
-  RealType f(RealType r);  //space warp transformation function F.
-  RealType df(RealType r); //The gradient of F(r)
-
-  void setPow(RealType swpow_in)
+  /** Sets the exponent for power law space warp transformation
+   *
+   * \param[in] swpow_in the exponent
+   */ 
+  inline void setPow(RealType swpow_in)
   {
     swpow = swpow_in;
-  }; //This sets the exponent for the power law space warp transformation.
+  }; 
 
+  /** Computes intermediate matrices required to build all space warp components and gradients.
+   *  The intermediates calculated are "warpval" and "gradval".
+   *
+   * \param[in] P, the electron particle set.  
+   * \param[in] ions, the ion particle set.  
+   */
   void computeSWTIntermediates(ParticleSet& P,
-                               const ParticleSet& ions); //This computes the intermediate matrices required to build all
-                                                         //space warp components and gradients.
+                               const ParticleSet& ions); 
+                                                         
 
+  /** Generates required space warp quantities to generate the actual "Space Warp" contribution to the
+   *  iat-th force component.
+   *  \param[in] iat the ion index for the force.  
+   *  \param[out] w, w_iat(r_i) for each i, where i is the electron index. 
+   *  \param[out] grad_w,  grad_i w_iat(r_i) for each i, where i is the electron index.
+   */
   void getSWT(int iat,
               ParticleScalar_t& w,
-              Force_t& grad_w); //For each ion component iat, this generates all the required space warp quantities to
-                                //generate the "space warp" contribution to the iat-th force component.
-
+              Force_t& grad_w); 
+                                
+  /** Takes in precomputed grad(E_L) and grad(logPsi) and computes the ZV and ZB space warp contributions 
+   *  to the force.
+   *
+   *  \param[in] elec, electron particle set. 
+   *  \param[in] ions, ion particle set.
+   *  \param[in] dEl, grad_i(E_L) for each electron i. E_L is the local energy.
+   *  \param[in] dlogpsi, grad_i(logPsi) for each electron i.  
+   *  \param[out] el_contribution, The zero-variance contribution from space warp.
+   *  \param[out] psi_contribution, the zero-bias contribution from space warp.  Modifies the grad_I(logPsi) terms.
+   */   
   void computeSWT(ParticleSet& elec,
                   const ParticleSet& ions,
                   Force_t& dEl,
                   ParticleGradient_t& dlogpsi,
                   Force_t& el_contribution,
-                  Force_t& psi_contribution); //Takes in precomputed grad(E_L) and grad(logPsi), and uses
-                                              //this to compute the ZV (el_contribution) and ZB (psi_contribution)
-                                              //space warp contributions.
+                  Force_t& psi_contribution); 
+                                              
+                                              
 
   const int myTableIndex;
   const int Nelec;
   const int Nions;
 
-  RealType swpow;           //Power of space warp transformation.  Right now, r^{-swpow}.
-  Matrix<RealType> warpval; //Nelec x Nion matrix of F(|r_i-R_J|)
-  Matrix<PosType> gradval;  //Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
+  RealType swpow;           ///< Power of space warp transformation.  Right now, r^{-swpow}.
+  Matrix<RealType> warpval; ///< Nelec x Nion matrix of F(|r_i-R_J|)
+  Matrix<PosType> gradval;  ///< Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -29,22 +29,28 @@ class SpaceWarpTransformation : public QMCTraits
   typedef ParticleSet::ParticlePos_t Force_t;
   typedef ParticleSet::ParticleGradient_t ParticleGradient_t;
 
-  public:
-
+public:
   SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions);
-  ~SpaceWarpTransformation(){};
 
-  RealType f(RealType r);  ///< Space warp transformation function F.  Argument is distance.
-  RealType df(RealType r); ///< The derivative of F w.r.t. r.
+  /** Space warp transformation function F(r).
+   *
+   * \param[in] r, the distance
+   * \param[out] value of F(r)
+   */
+  RealType f(RealType r);
+
+  /** Derivative of space warp transformation function F(r) w.r.t. r.
+   *
+   * \param[in] r, the distance
+   * \param[out] value of F'(r)
+   */
+  RealType df(RealType r);
 
   /** Sets the exponent for power law space warp transformation
    *
    * \param[in] swpow_in the exponent
-   */ 
-  inline void setPow(RealType swpow_in)
-  {
-    swpow = swpow_in;
-  }; 
+   */
+  inline void setPow(RealType swpow_in) { swpow = swpow_in; };
 
   /** Generates required space warp quantities to generate the actual "Space Warp" contribution to the
    *  iat-th force component.
@@ -52,10 +58,8 @@ class SpaceWarpTransformation : public QMCTraits
    *  \param[out] w, w_iat(r_i) for each i, where i is the electron index. 
    *  \param[out] grad_w,  grad_i w_iat(r_i) for each i, where i is the electron index.
    */
-  void getSWT(int iat,
-              ParticleScalar_t& w,
-              Force_t& grad_w); 
-                                
+  void getSWT(int iat, ParticleScalar_t& w, Force_t& grad_w);
+
   /** Takes in precomputed grad(E_L) and grad(logPsi) and computes the ZV and ZB space warp contributions 
    *  to the force.
    *
@@ -65,35 +69,35 @@ class SpaceWarpTransformation : public QMCTraits
    *  \param[in] dlogpsi, grad_i(logPsi) for each electron i.  
    *  \param[out] el_contribution, The zero-variance contribution from space warp.
    *  \param[out] psi_contribution, the zero-bias contribution from space warp.  Modifies the grad_I(logPsi) terms.
-   */   
+   */
   void computeSWT(ParticleSet& elec,
                   const ParticleSet& ions,
                   Force_t& dEl,
                   ParticleGradient_t& dlogpsi,
                   Force_t& el_contribution,
-                  Force_t& psi_contribution); 
-                                              
-  private:
+                  Force_t& psi_contribution);
 
-                                            
+private:
   /** Computes intermediate matrices required to build all space warp components and gradients.
    *  The intermediates calculated are "warpval" and "gradval".
    *
    * \param[in] P, the electron particle set.  
    * \param[in] ions, the ion particle set.  
    */
-  void computeSWTIntermediates(ParticleSet& P,
-                               const ParticleSet& ions); 
-                                                         
+  void computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions);
 
 
+  ///The electron-ion table index in electron table.
   const int myTableIndex;
   const int Nelec;
   const int Nions;
 
-  RealType swpow;           ///< Power of space warp transformation.  Right now, r^{-swpow}.
-  Matrix<RealType> warpval; ///< Nelec x Nion matrix of F(|r_i-R_J|)
-  Matrix<PosType> gradval;  ///< Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
+  /// Power of space warp transformation.  Right now, r^{-swpow}.
+  RealType swpow;
+  /// Nelec x Nion matrix of F(|r_i-R_J|)
+  Matrix<RealType> warpval;
+  /// Nelec x Nion matrix of \nabla_i F(|r_i-R_J|)
+  Matrix<PosType> gradval;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/SpaceWarpTransformation.h
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.h
@@ -33,8 +33,8 @@ struct SpaceWarpTransformation : public QMCTraits
   SpaceWarpTransformation(ParticleSet& elns, ParticleSet& ions);
   ~SpaceWarpTransformation(){};
 
-  RealType f(RealType r, RealType a); 
-  RealType df(RealType r, RealType a); 
+  RealType f(RealType r); 
+  RealType df(RealType r); 
 
   void setPow(RealType swpow_in){swpow=swpow_in;};
   void computeSWTIntermediates(ParticleSet& P, ParticleSet& ions); //This computes the intermediate matrices required to build all 

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(SRCS test_bare_kinetic.cpp
          test_force.cpp
          test_force_ewald.cpp
          test_stress.cpp
+         test_spacewarp.cpp
          test_ecp.cpp
          test_hamiltonian_pool.cpp
          test_hamiltonian_factory.cpp
@@ -44,6 +45,12 @@ IF(QMC_CUDA)
       test_coulomb_CUDA.cpp 
 )
 ENDIF()
+
+SET(FILES_TO_COPY Na2.structure.xml)
+
+FOREACH(fname ${FILES_TO_COPY})
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${fname}" ${UTEST_DIR})
+ENDFOREACH()
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/simple.txt" ${UTEST_DIR})

--- a/src/QMCHamiltonians/tests/Na2.structure.xml
+++ b/src/QMCHamiltonians/tests/Na2.structure.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<qmcsystem>
+  <particleset name="ion0" size="2">
+    <group name="Na">
+      <parameter name="charge">1</parameter>
+      <parameter name="valence">1</parameter>
+      <parameter name="atomicnumber">11</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+  0.0000000000e+00  0.0000000000e+00  0.0000000000e+00
+  5.9999995664e+00  0.0000000000e+00  0.0000000000e+00
+</attrib>
+    <attrib name="ionid" datatype="stringArray">
+ Na Na 
+</attrib>
+  </particleset>
+  <particleset name="e" random="no">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+      <attrib name="position" datatype="posArray">
+    5.6362539350e-01  9.5600940368e-01 -1.1525504049e+00
+  </attrib>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+      <attrib name="position" datatype="posArray">
+      5.7820981934e+00 -1.0984181325e+00  1.1428020817e+00
+      </attrib>
+    </group>
+  </particleset>
+</qmcsystem>

--- a/src/QMCHamiltonians/tests/test_spacewarp.cpp
+++ b/src/QMCHamiltonians/tests/test_spacewarp.cpp
@@ -35,93 +35,93 @@ using std::string;
 
 namespace qmcplusplus
 {
-using RealType = QMCTraits::RealType; 
+using RealType = QMCTraits::RealType;
 TEST_CASE("SpaceWarp", "[hamiltonian]")
 {
-    Communicate* c = OHMMS::Controller;
+  Communicate* c = OHMMS::Controller;
 
-    Libxml2Document doc;
-    bool okay = doc.parse("Na2.structure.xml");
-    REQUIRE(okay);
-    xmlNodePtr root = doc.getRoot();
-    Tensor<int, 3> tmat;
-    tmat(0, 0) = 1;
-    tmat(1, 1) = 1;
-    tmat(2, 2) = 1;
+  Libxml2Document doc;
+  bool okay = doc.parse("Na2.structure.xml");
+  REQUIRE(okay);
+  xmlNodePtr root = doc.getRoot();
+  Tensor<int, 3> tmat;
+  tmat(0, 0) = 1;
+  tmat(1, 1) = 1;
+  tmat(2, 2) = 1;
 
-    ParticleSet ions;
-    XMLParticleParser parse_ions(ions, tmat);
-    OhmmsXPathObject particleset_ion("//particleset[@name='ion0']", doc.getXPathContext());
-    REQUIRE(particleset_ion.size() == 1);
-    parse_ions.put(particleset_ion[0]);
+  ParticleSet ions;
+  XMLParticleParser parse_ions(ions, tmat);
+  OhmmsXPathObject particleset_ion("//particleset[@name='ion0']", doc.getXPathContext());
+  REQUIRE(particleset_ion.size() == 1);
+  parse_ions.put(particleset_ion[0]);
 
-    REQUIRE(ions.groups() == 1);
-    REQUIRE(ions.R.size() == 2);
-    ions.update();
+  REQUIRE(ions.groups() == 1);
+  REQUIRE(ions.R.size() == 2);
+  ions.update();
 
-    ParticleSet elec;
-    XMLParticleParser parse_elec(elec, tmat);
-    OhmmsXPathObject particleset_elec("//particleset[@name='e']", doc.getXPathContext());
-    REQUIRE(particleset_elec.size() == 1);
-    parse_elec.put(particleset_elec[0]);
+  ParticleSet elec;
+  XMLParticleParser parse_elec(elec, tmat);
+  OhmmsXPathObject particleset_elec("//particleset[@name='e']", doc.getXPathContext());
+  REQUIRE(particleset_elec.size() == 1);
+  parse_elec.put(particleset_elec[0]);
 
-    REQUIRE(elec.groups() == 2);
-    REQUIRE(elec.R.size() == 2);
+  REQUIRE(elec.groups() == 2);
+  REQUIRE(elec.R.size() == 2);
 
-    elec.addTable(ions);
-    elec.update();  
-    
-    //Now build the wavefunction.  This will be needed to test \Nabla_i E_L and \Nabla_i logPsi contributions.  
-    //For now, just take them from a reference calculation.
-    
-    using Force_t = ParticleSet::ParticlePos_t;
-    Force_t dE_L;
-    Force_t el_contribution;
-    Force_t psi_contribution;
-    
-    dE_L.resize(elec.getTotalNum());
-    el_contribution.resize(ions.getTotalNum());
-    psi_contribution.resize(ions.getTotalNum());
+  elec.addTable(ions);
+  elec.update();
 
-    dE_L[0][0]=-0.0328339806050;
-    dE_L[0][1]=-0.0834441565340;
-    dE_L[0][2]= 0.0997813066140;
-    dE_L[1][0]=-0.0140597469190;
-    dE_L[1][1]= 0.0591827022730;
-    dE_L[1][2]=-0.0622852142310;
+  //Now build the wavefunction.  This will be needed to test \Nabla_i E_L and \Nabla_i logPsi contributions.
+  //For now, just take them from a reference calculation.
 
-    elec.G[0][0]= 0.4167938814700;
-    elec.G[0][1]= 0.2878426639600;
-    elec.G[0][2]=-0.3470187402100;
-    elec.G[1][0]=-0.2946265813200;
-    elec.G[1][1]=-0.3606166249000;
-    elec.G[1][2]= 0.3751881159300;
-  
-    SpaceWarpTransformation swt(elec,ions);
-    swt.setPow(3.0);
+  using Force_t = ParticleSet::ParticlePos_t;
+  Force_t dE_L;
+  Force_t el_contribution;
+  Force_t psi_contribution;
 
-    REQUIRE( swt.f(2.0) == Approx(0.125) );
-    REQUIRE( swt.df(2.0) == Approx(-0.1875) ); 
+  dE_L.resize(elec.getTotalNum());
+  el_contribution.resize(ions.getTotalNum());
+  psi_contribution.resize(ions.getTotalNum());
 
-    swt.setPow(4.0);
-    REQUIRE( swt.f(2.0) == Approx(0.0625));
-    REQUIRE( swt.df(2.0) == Approx(-0.125));
+  dE_L[0][0] = -0.0328339806050;
+  dE_L[0][1] = -0.0834441565340;
+  dE_L[0][2] = 0.0997813066140;
+  dE_L[1][0] = -0.0140597469190;
+  dE_L[1][1] = 0.0591827022730;
+  dE_L[1][2] = -0.0622852142310;
 
-    swt.computeSWT(elec, ions, dE_L, elec.G, el_contribution, psi_contribution);
-    app_log()<<"EL_Contribution:  "<<el_contribution<<std::endl;
-    app_log()<<"PSi_Contribution: "<<psi_contribution<<std::endl;
-    REQUIRE(el_contribution[0][0] == Approx(-0.0326934696861));
-    REQUIRE(el_contribution[0][1] == Approx(-0.0826080664130));
-    REQUIRE(el_contribution[0][2] == Approx( 0.0988243408507));
-    REQUIRE(el_contribution[1][0] == Approx(-0.0142002578379));
-    REQUIRE(el_contribution[1][1] == Approx( 0.0583466121520));
-    REQUIRE(el_contribution[1][2] == Approx(-0.0613282484677));
-   
-    REQUIRE(psi_contribution[0][0] == Approx( 0.4051467191368));
-    REQUIRE(psi_contribution[0][1] == Approx( 0.2757724717133));
-    REQUIRE(psi_contribution[0][2] == Approx(-0.3334287440127));
-    REQUIRE(psi_contribution[1][0] == Approx(-0.2829794189868));
-    REQUIRE(psi_contribution[1][1] == Approx(-0.3485464326533));
-    REQUIRE(psi_contribution[1][2] == Approx( 0.3615981197327));
+  elec.G[0][0] = 0.4167938814700;
+  elec.G[0][1] = 0.2878426639600;
+  elec.G[0][2] = -0.3470187402100;
+  elec.G[1][0] = -0.2946265813200;
+  elec.G[1][1] = -0.3606166249000;
+  elec.G[1][2] = 0.3751881159300;
+
+  SpaceWarpTransformation swt(elec, ions);
+  swt.setPow(3.0);
+
+  REQUIRE(swt.f(2.0) == Approx(0.125));
+  REQUIRE(swt.df(2.0) == Approx(-0.1875));
+
+  swt.setPow(4.0);
+  REQUIRE(swt.f(2.0) == Approx(0.0625));
+  REQUIRE(swt.df(2.0) == Approx(-0.125));
+
+  swt.computeSWT(elec, ions, dE_L, elec.G, el_contribution, psi_contribution);
+  app_log() << "EL_Contribution:  " << el_contribution << std::endl;
+  app_log() << "PSi_Contribution: " << psi_contribution << std::endl;
+  REQUIRE(el_contribution[0][0] == Approx(-0.0326934696861));
+  REQUIRE(el_contribution[0][1] == Approx(-0.0826080664130));
+  REQUIRE(el_contribution[0][2] == Approx(0.0988243408507));
+  REQUIRE(el_contribution[1][0] == Approx(-0.0142002578379));
+  REQUIRE(el_contribution[1][1] == Approx(0.0583466121520));
+  REQUIRE(el_contribution[1][2] == Approx(-0.0613282484677));
+
+  REQUIRE(psi_contribution[0][0] == Approx(0.4051467191368));
+  REQUIRE(psi_contribution[0][1] == Approx(0.2757724717133));
+  REQUIRE(psi_contribution[0][2] == Approx(-0.3334287440127));
+  REQUIRE(psi_contribution[1][0] == Approx(-0.2829794189868));
+  REQUIRE(psi_contribution[1][1] == Approx(-0.3485464326533));
+  REQUIRE(psi_contribution[1][2] == Approx(0.3615981197327));
 }
 } //namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_spacewarp.cpp
+++ b/src/QMCHamiltonians/tests/test_spacewarp.cpp
@@ -1,0 +1,127 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/ParticleSetPool.h"
+#include "ParticleIO/XMLParticleIO.h"
+#include "QMCHamiltonians/SpaceWarpTransformation.h"
+//#include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+//#include "QMCHamiltonians/ForceChiesaPBCAA.h"
+//#include "QMCHamiltonians/ForceCeperley.h"
+//#include "QMCHamiltonians/CoulombPotential.h"
+//#include "QMCHamiltonians/CoulombPBCAA.h"
+//#include "QMCHamiltonians/CoulombPBCAB.h"
+//#include "QMCWaveFunctions/TrialWaveFunction.h"
+//#include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
+//#include "QMCWaveFunctions/Fermion/SlaterDet.h"
+
+#include <stdio.h>
+#include <string>
+
+using std::string;
+
+namespace qmcplusplus
+{
+using RealType = QMCTraits::RealType; 
+TEST_CASE("SpaceWarp", "[hamiltonian]")
+{
+    Communicate* c = OHMMS::Controller;
+
+    Libxml2Document doc;
+    bool okay = doc.parse("Na2.structure.xml");
+    REQUIRE(okay);
+    xmlNodePtr root = doc.getRoot();
+    Tensor<int, 3> tmat;
+    tmat(0, 0) = 1;
+    tmat(1, 1) = 1;
+    tmat(2, 2) = 1;
+
+    ParticleSet ions;
+    XMLParticleParser parse_ions(ions, tmat);
+    OhmmsXPathObject particleset_ion("//particleset[@name='ion0']", doc.getXPathContext());
+    REQUIRE(particleset_ion.size() == 1);
+    parse_ions.put(particleset_ion[0]);
+
+    REQUIRE(ions.groups() == 1);
+    REQUIRE(ions.R.size() == 2);
+    ions.update();
+
+    ParticleSet elec;
+    XMLParticleParser parse_elec(elec, tmat);
+    OhmmsXPathObject particleset_elec("//particleset[@name='e']", doc.getXPathContext());
+    REQUIRE(particleset_elec.size() == 1);
+    parse_elec.put(particleset_elec[0]);
+
+    REQUIRE(elec.groups() == 2);
+    REQUIRE(elec.R.size() == 2);
+
+    elec.addTable(ions);
+    elec.update();  
+    
+    //Now build the wavefunction.  This will be needed to test \Nabla_i E_L and \Nabla_i logPsi contributions.  
+    //For now, just take them from a reference calculation.
+    
+    using Force_t = ParticleSet::ParticlePos_t;
+    Force_t dE_L;
+    Force_t el_contribution;
+    Force_t psi_contribution;
+    
+    dE_L.resize(elec.getTotalNum());
+    el_contribution.resize(ions.getTotalNum());
+    psi_contribution.resize(ions.getTotalNum());
+
+    dE_L[0][0]=-0.0328339806050;
+    dE_L[0][1]=-0.0834441565340;
+    dE_L[0][2]= 0.0997813066140;
+    dE_L[1][0]=-0.0140597469190;
+    dE_L[1][1]= 0.0591827022730;
+    dE_L[1][2]=-0.0622852142310;
+
+    elec.G[0][0]= 0.4167938814700;
+    elec.G[0][1]= 0.2878426639600;
+    elec.G[0][2]=-0.3470187402100;
+    elec.G[1][0]=-0.2946265813200;
+    elec.G[1][1]=-0.3606166249000;
+    elec.G[1][2]= 0.3751881159300;
+  
+    SpaceWarpTransformation swt(elec,ions);
+    swt.setPow(3.0);
+
+    REQUIRE( swt.f(2.0) == Approx(0.125) );
+    REQUIRE( swt.df(2.0) == Approx(-0.1875) ); 
+
+    swt.setPow(4.0);
+    REQUIRE( swt.f(2.0) == Approx(0.0625));
+    REQUIRE( swt.df(2.0) == Approx(-0.125));
+
+    swt.computeSWT(elec, ions, dE_L, elec.G, el_contribution, psi_contribution);
+    app_log()<<"EL_Contribution:  "<<el_contribution<<std::endl;
+    app_log()<<"PSi_Contribution: "<<psi_contribution<<std::endl;
+    REQUIRE(el_contribution[0][0] == Approx(-0.0326934696861));
+    REQUIRE(el_contribution[0][1] == Approx(-0.0826080664130));
+    REQUIRE(el_contribution[0][2] == Approx( 0.0988243408507));
+    REQUIRE(el_contribution[1][0] == Approx(-0.0142002578379));
+    REQUIRE(el_contribution[1][1] == Approx( 0.0583466121520));
+    REQUIRE(el_contribution[1][2] == Approx(-0.0613282484677));
+   
+    REQUIRE(psi_contribution[0][0] == Approx( 0.4051467191368));
+    REQUIRE(psi_contribution[0][1] == Approx( 0.2757724717133));
+    REQUIRE(psi_contribution[0][2] == Approx(-0.3334287440127));
+    REQUIRE(psi_contribution[1][0] == Approx(-0.2829794189868));
+    REQUIRE(psi_contribution[1][1] == Approx(-0.3485464326533));
+    REQUIRE(psi_contribution[1][2] == Approx( 0.3615981197327));
+}
+} //namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

This implements a preliminary reference version of the space-warp transformation for ZVZB force estimators, given in https://doi.org/10.1063/1.3516208.  Currently, Grad_i(E_L) w.r.t. electron coordinates is handled through finite differences, but replacement with analytic derivatives should reasonably occur within the current infrastructure.  

## What type(s) of changes does this code introduce?

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Local intel Xeon server.
## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed.  
- No. Documentation has been added (if appropriate)
