### PR TITLE
Add include limits C++ header

### DIFF
--- a/external_codes/catch/complex_approx.hpp
+++ b/external_codes/catch/complex_approx.hpp
@@ -2,6 +2,7 @@
 #define CATCH_COMPLEX_APPROX
 
 #include <complex>
+#include <limits>
 
 // Copy and modify the Approx class to handle complex numbers
 

--- a/external_codes/catch/log_complex_approx.hpp
+++ b/external_codes/catch/log_complex_approx.hpp
@@ -3,6 +3,7 @@
 
 #include <complex>
 #include <cmath>
+#include <limits>
 
 // Copy and modify the ComplexApprox class to handle complex numbers for log(complex)
 


### PR DESCRIPTION
## Proposed changes
As `std::numeric_limits<T>` is used, `<limits>` header file should be included.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'