### PR TITLE
Fix evaluation of non-optimizable components in flex_evaluateDeltaLog.

### DIFF
--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -368,11 +368,13 @@ void TrialWaveFunction::flex_evaluateDeltaLog(const RefVector<TrialWaveFunction>
   for (int iw = 0; iw < wf_list.size(); iw++)
     copyToP(p_list[iw], wf_list[iw]);
 
-  // In cases where recompute is needed, ignore the logPsi contribution
-  // and ignore G and L.
+  // Recompute is usually used to prepare the wavefunction for NLPP derivatives.
+  // (e.g compute the matrix inverse for determinants)
+  // Call mw_evaluateLog for the wavefunction components that were skipped previously.
+  // Ignore logPsi, G and L.
   if (recompute)
     for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
-      if (wavefunction_components[i]->Optimizable)
+      if (!wavefunction_components[i]->Optimizable)
       {
         ScopedTimer z_timer(wf_list[0].get().WFC_timers_[ii]);
         const auto wfc_list(extractWFCRefList(wf_list, i));


### PR DESCRIPTION
If recompute is true (which it is for NLPP derivatives), need to call mw_evaluateLog to ensure the matrix inverses are computed
prior to the NLPP derivative computation.   This needs to done for wavefunction components that were *not* updated in the first part of the function.

The test case (NiO) that shows the problem has a determinant part with no variational parameters.

The cost function has two parts that compute the derivatives - the first one does setup and derivative computation (`checkConfigurations`).  The second one does correlated sampling (`correlatedSampling`), and only computes parts of the wavefunction that change (i.e that have optimizable variational parameters).
The problem doesn't manifest in `checkConfiguations` because evaluateLog is called on all wavefunction components.  The problem shows up in `correlatedSampling` because evaluateLog is not called on all components.  This logic fix ensures evaluateLog is called on all components in the NLPP case.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

laptop, desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
