### PR TITLE
Two-body jastrow optimization bug fix : Set opt offset to be equal to first active variable

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -139,7 +139,13 @@ public:
         lapLogPsi[i]  = new ValueVectorType(NumPtcls);
       }
       OffSet.resize(F.size());
-      int varoffset = myVars.Index[0];
+      int varoffset = -1;
+      for (int i = 0; i < myVars.size(); i++)
+      {
+        varoffset = myVars.Index[i];
+        if (varoffset != -1)
+          break;
+      }
       for (int i = 0; i < F.size(); ++i)
       {
         if (F[i] && F[i]->myVars.Index.size())
@@ -172,7 +178,7 @@ public:
         continue;
       if (active.recompute(kk))
         recalculate = true;
-      rcsingles[k] = true;
+      rcsingles[kk] = true;
     }
     if (recalculate)
     {
@@ -181,9 +187,9 @@ public:
         int kk = myVars.where(k);
         if (kk < 0)
           continue;
-        if (rcsingles[k])
+        if (rcsingles[kk])
         {
-          dhpsioverpsi[kk] = -RealType(0.5) * ValueType(Sum(*lapLogPsi[k])) - ValueType(Dot(P.G, *gradLogPsi[k]));
+          dhpsioverpsi[kk] = -RealType(0.5) * ValueType(Sum(*lapLogPsi[kk])) - ValueType(Dot(P.G, *gradLogPsi[kk]));
         }
       }
     }
@@ -270,9 +276,9 @@ public:
         int kk = myVars.where(k);
         if (kk < 0)
           continue;
-        if (rcsingles[k])
+        if (rcsingles[kk])
         {
-          dlogpsi[kk] = dLogPsi[k];
+          dlogpsi[kk] = dLogPsi[kk];
         }
         //optVars.setDeriv(p,dLogPsi[ip],-0.5*Sum(*lapLogPsi[ip])-Dot(P.G,*gradLogPsi[ip]));
       }


### PR DESCRIPTION
Detailed disussion on issue #2814

## Proposed changes
The two body jastrow optimization would fail when the first optimizable parameters were not the first parameters (e.g. if the u-u terms were frozen). This implements @markdewing's suggestions from #2814, which fixes the offset variable to point at the correct set of parameters. 

Closes #2814 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Laptop Intel i7-7700HQ
Desktop Intel i7-2600S

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
