### PR TITLE
Copy ccECP in CMake

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -37,13 +37,14 @@ FUNCTION( COPY_DIRECTORY_USING_SYMLINK SRC_DIR DST_DIR )
     ENDFOREACH()
 ENDFUNCTION()
 
-# Copy selected files only. h5, NLPP, wavefunction, structure and the used one input file are copied.
+# Copy selected files only. h5, pseudopotentials, wavefunction, structure and the used one input file are copied.
 FUNCTION( COPY_DIRECTORY_USING_SYMLINK_LIMITED SRC_DIR DST_DIR ${ARGN})
     FILE(MAKE_DIRECTORY "${DST_DIR}")
     # Find all the files but not subdirectories
     FILE(GLOB FILE_FOLDER_NAMES LIST_DIRECTORIES TRUE
         "${SRC_DIR}/qmc_ref" "${SRC_DIR}/qmc-ref" "${SRC_DIR}/*.h5"
         "${SRC_DIR}/*.opt.xml" "${SRC_DIR}/*.ncpp.xml" "${SRC_DIR}/*.BFD.xml"
+        "${SRC_DIR}/*.ccECP.xml"
         "${SRC_DIR}/*.py" "${SRC_DIR}/*.sh" "${SRC_DIR}/*.restart.xml"
         "${SRC_DIR}/Li.xml" "${SRC_DIR}/H.xml" "${SRC_DIR}/*.L2_test.xml" "${SRC_DIR}/*.opt_L2.xml"
         "${SRC_DIR}/*.wfnoj.xml" "${SRC_DIR}/*.wfj.xml" "${SRC_DIR}/*.wfs*.xml"

--- a/docs/integration_tests.rst
+++ b/docs/integration_tests.rst
@@ -33,7 +33,7 @@ COPY_DIRECTORY_USING_SYMLINK_LIMITED function in Cmake/macros.cmake.
 ::
 
   qmc-ref/qmc_ref for reference data folder.
-  *.opt.xml/*.ncpp.xml/*.BFD.xml for pseudo-potential files.
+  *.opt.xml/*.ncpp.xml/*.BFD.xml/*.ccECP.xml for pseudo-potential files.
   *.py/*.sh for result checking helper scripts.
   *.wfj.xml/*.wfnoj.xml/*.wfs.xml for standalone wavefunction input files.
   *.structure.xml/*.ptcl.xml for standalone structure/particleset input files.


### PR DESCRIPTION
## Proposed changes

Al.ccECP.xml was not being copied, breaking Al periodic Gaussian tests. e.g. https://cdash.qmcpack.org/CDash/testDetails.php?test=11358261&build=172864 . Trivial bug introduced with mid-December cmake macro update for selective file copies.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Fix based on cdash error log.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
