### PR TITLE
Update recipes for nightly tests

### DIFF
--- a/tests/test_automation/nightly_test_scripts/ornl_setup.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_setup.sh
@@ -73,13 +73,11 @@ EOF
 	mkdir /scratch/$USER/spack_build_stage
 
 	#Use system installed SSL. See https://spack.readthedocs.io/en/latest/getting_started.html#openssl
-
-# externals option does not work for spack 0c63c94103acae33c4f3adfe7b90d2ea1165ce46 2020-07-24	
 	cat >>$HOME/.spack/packages.yaml<<EOF
 packages:
     openssl:
         externals:
-        - spec: openssl@1.1.1c
+        - spec: openssl@1.1.1g
           prefix: /usr
           buildable: False
 EOF
@@ -107,20 +105,46 @@ EOF
 	rm -r -f /scratch/$USER/spack_build_stage
 	mkdir /scratch/$USER/spack_build_stage
 	#Use system installed SSL. See https://spack.readthedocs.io/en/latest/getting_started.html#openssl
+	#Use system RHEL gcc8 compiler for cmake to solve bootstrap problems
 	cat >>$HOME/.spack/packages.yaml<<EOF
 packages:
     openssl:
         externals:
-        - spec: openssl@1.1.1c
+        - spec: openssl@1.1.1g
           prefix: /usr
           buildable: False
 EOF
+# Workaround cmake bootstrap error with old versions/old spack compilers. e.g.
+# spack install cmake@3.13.2%gcc@8.3.0 failure but spack install cmake@3.13.2%gcc@8.3.1 OK (RHEL compiler)	
+        cat >>$HOME/.spack/packages.yaml<<EOF
+    cmake:
+        compiler: [gcc@8.3.1]
+EOF
+#    boost:
+#        compiler: [gcc@8.3.1]
+#    perl:
+#        compiler: [gcc@8.3.1]
 # Workaround linux-rhel8-cascadelake problem on sulfur for GCC in spack circa 202006
 #	cat >>$HOME/.spack/packages.yaml<<EOF
 #packages:
 #  all:
 #    target: [skylake_avx512]
 #EOF
+
+# Workaround build error of perl%gcc@installed_by_spack	. perl-data-dumper & perl are e.g. an LLVM build dep
+# dnf install perl-data-dumper if missing
+	cat >>$HOME/.spack/packages.yaml<<EOF
+    perl:
+        externals:
+        - spec: perl@5.26.3
+          prefix: /
+          buildable: False
+    perl-data-dumper:
+        externals:
+        - spec: perl-data-dumper@2.167.399
+          prefix: /
+          buildable: False
+EOF
 	cat >>$HOME/.spack/packages.yaml<<EOF
     all:
         target: [x86_64]
@@ -138,7 +162,8 @@ mkdir $HOME/apps
 fi
 
 cd $HOME/apps
-git clone https://github.com/spack/spack.git
+#DEBUG git clone --depth 1 https://github.com/spack/spack.git 
+git clone https://github.com/spack/spack.git 
 
 cd $HOME/apps/spack
 # For reproducibility, use a specific version of Spack
@@ -151,6 +176,17 @@ cd $HOME/apps/spack
 #
 #    * Relax architecture compatibility check
 #    * Add test coverage for the spack.abi module
+#cp -p var/spack/repos/builtin/packages/gcc/package.py var/spack/repos/builtin/packages/gcc/package.py_orig
+#git checkout 5f9de810ff14455ac6b433398b965d2cf6b4a70f -- var/spack/repos/builtin/packages/gcc/package.py
+#ls -l var/spack/repos/builtin/packages/gcc/package.py*
+
+#git checkout v0.16.0 #Works? FAIL 18 Nov.
+#git checkout e0ae60edc4ee7dafc5ab99d756d9c63624c281d5 # Works 1 Nov
+#git checkout a5faf7d27a3ef1afca28e5d2348130f580be898d # Works 20 Oct
+#git checkout 9eb87d1026819875dec8bb7fa00252576fd62006 # Works 23 Sep. 
+#git checkout v0.15.4 #works 13 Aug
+#git checkout v0.15.0 #works
+
 echo --- Git version and last log entry
 git log -1
 
@@ -162,14 +198,13 @@ export SPACK_ROOT=$HOME/apps/spack
 export PATH=$SPACK_ROOT/bin:$PATH
 . $SPACK_ROOT/share/spack/setup-env.sh
 
-# IMPORTANT: Install+Use a GCC toolset on Red Hat systems to use
-# recent compilers with better architecture support.
-# e.g. yum install gcc-toolset-9
-if [ -e /opt/rh/gcc-toolset-9/root/bin/gcc ]; then
-    echo --- Added gcc-toolset-9 to path for RHEL provided GCC9 compilers
-    export PATH=/opt/rh/gcc-toolset-9/root/bin/:$PATH
-fi
-
+## IMPORTANT: Install+Use a GCC toolset on Red Hat systems to use
+## recent compilers with better architecture support.
+## e.g. yum install gcc-toolset-9
+#if [ -e /opt/rh/gcc-toolset-9/root/bin/gcc ]; then
+#    echo --- Added gcc-toolset-9 to path for RHEL provided GCC9 compilers
+#    export PATH=/opt/rh/gcc-toolset-9/root/bin/:$PATH
+#fi
 
 echo --- Spack list
 spack find
@@ -184,25 +219,37 @@ module list
 echo --- End listings
 
 
-echo --- START env `date`
+echo --- START `date`
+echo --- diffutils iconv dependency workaround
+cp ${SPACK_ROOT}/var/spack/repos/builtin/packages/diffutils/package.py  ${SPACK_ROOT}/var/spack/repos/builtin/packages/diffutils/package.py_orig
+sed 's/.*depends_on.*iconv.*//g' ${SPACK_ROOT}/var/spack/repos/builtin/packages/diffutils/package.py_orig >  ${SPACK_ROOT}/var/spack/repos/builtin/packages/diffutils/package.py
+#echo --- Debug
+#spack install gcc@10.2.0
+#spack load gcc@10.2.0
+#spack compiler find
+#spack install cmake%gcc@10.2.0
+#spack load cmake%gcc@10.2.0
+#exit
+echo --- Convenience
+spack install git
 echo --- gcc@${gcc_vnew}
 spack install gcc@${gcc_vnew}
 echo --- load gcc@${gcc_vnew}
 spack load gcc@${gcc_vnew}
 module list
 spack compiler find
-echo --- Convenience
-spack install git%gcc@${gcc_vnew}
 echo --- gcc@${gcc_vnew} consumers
+spack install cmake@${cmake_vnew}
+spack install libxml2@${libxml2_v}%gcc@${gcc_vnew}
+#spack install boost@${boost_vnew}%gcc@${gcc_vnew}
+spack install boost@${boost_vnew}
 spack install python@${python_version}%gcc@${gcc_vnew} # Needed by libflame, good safety measure
 spack load python@${python_version}%gcc@${gcc_vnew}
-spack install libxml2@${libxml2_vnew}%gcc@${gcc_vnew}
-spack install cmake@${cmake_vnew}%gcc@${gcc_vnew}
-spack install boost@${boost_vnew}%gcc@${gcc_vnew}
-spack install openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_vnew}%gcc@${gcc_vnew}
+spack install openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_v}%gcc@${gcc_vnew}
 #spack HDF5 package requires fortran and hl (high level) support to be specifically enabled for use with QE
 spack install hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
 spack install fftw@${fftw_vnew}%gcc@${gcc_vnew} -mpi #Avoid MPI for simplicity
+#spack install perl%gcc@${gcc_vnew} # Kludge for broken deps
 spack unload python@${python_version}%gcc@${gcc_vnew}
 spack unload gcc@${gcc_vnew}
 echo --- gcc@${gcc_vold}
@@ -211,19 +258,23 @@ echo --- load gcc@${gcc_vold}
 spack load gcc@${gcc_vold}
 module list
 spack compiler find
-
+spack unload gcc@${gcc_vold}
 echo --- gcc@${gcc_vold} consumers
+#spack install cmake@${cmake_vold}%gcc@${gcc_vold}
+spack install cmake@${cmake_vold} # Some old cmakes do not bootstrap with old gcc
+spack install --no-checksum libxml2@${libxml2_v}%gcc@${gcc_vold}
+spack install boost@${boost_vold}%gcc@${gcc_vold}
+#spack install boost@${boost_vold}
 spack install python@${python_version}%gcc@${gcc_vold}
 spack load python@${python_version}%gcc@${gcc_vold}
-spack install --no-checksum libxml2@${libxml2_vold}%gcc@${gcc_vold}
-spack install cmake@${cmake_vold}%gcc@${gcc_vold}
-spack install boost@${boost_vold}%gcc@${gcc_vold}
-spack install openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_vold}%gcc@${gcc_vold}
+#spack install --no-checksum libxml2@${libxml2_v}%gcc@${gcc_vold}
+#spack install openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_v}%gcc@${gcc_vold}
+#spack install openmpi@${ompi_vold} ^libxml2@${libxml2_v}%gcc@${gcc_vold}
+spack install openmpi@${ompi_vold} ^libxml2@${libxml2_v}%gcc@${gcc_vold}
 #spack HDF5 package requires fortran and hl (high level) support to be specifically enabled for use with QE
 spack install hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
 spack install fftw@${fftw_vold}%gcc@${gcc_vold} -mpi #Avoid MPI for simplicity
 spack unload python@${python_version}%gcc@${gcc_vold}
-spack unload gcc@${gcc_vold}
 echo --- gcc@${gcc_vcuda}
 spack install gcc@${gcc_vcuda}
 spack load gcc@${gcc_vcuda}
@@ -246,11 +297,11 @@ spack install llvm@${llvm_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 spack load llvm@${llvm_vnew}
 spack compiler find
 spack unload llvm@${llvm_vnew}
-echo --- llvm@${llvm_vold}
-spack install llvm@${llvm_vold}%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
-spack load llvm@${llvm_vold}%gcc@$gcc_vold
-spack compiler find
-spack unload llvm@${llvm_vold}%gcc@$gcc_vold
+#echo --- llvm@${llvm_vold}
+#spack install --no-checksum llvm@${llvm_vold}%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+#spack load llvm@${llvm_vold}%gcc@$gcc_vold
+#spack compiler find
+#spack unload llvm@${llvm_vold}%gcc@$gcc_vold
 echo --- llvm@${llvm_vcuda}
 spack install llvm@${llvm_vcuda} ^python@${python_version}%gcc@${gcc_vnew}
 spack load llvm@${llvm_vcuda}
@@ -259,74 +310,81 @@ spack unload llvm@${llvm_vcuda}
 echo --- BLAS+LAPACK
 # Additional development required here due to only partial AMD Rome coverage and
 # spack support for optimized BLAS and LAPACK, problems building libflame etc.
-spack install blis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
-if [ "$ourplatform" == "AMD" ]; then
-    spack install amdblis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
-fi
+#spack install blis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
+#if [ "$ourplatform" == "AMD" ]; then
+#    spack install amdblis%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
+#fi
 
-# Spack has no amdlibflame package for LAPACK
-# libflame builds fail 20200326 with SHA-1 collisions
-#spack install libflame%gcc@${gcc_vnew} ^blis%gcc@${gcc_vnew} # Needs env python to work to build. Python is loaded above.
-spack install netlib-lapack%gcc@${gcc_vnew} # Netlib failback
-#spack install openblas%gcc@${gcc_vnew} # Historically crashed in Performance tests with large thread counts on AMD
+## Spack has no amdlibflame package for LAPACK
+## libflame builds fail 20200326 with SHA-1 collisions
+##spack install libflame%gcc@${gcc_vnew} ^blis%gcc@${gcc_vnew} # Needs env python to work to build. Python is loaded above.
+#spack install netlib-lapack%gcc@${gcc_vnew} # Netlib failback
+##spack install openblas%gcc@${gcc_vnew} # Historically crashed in Performance tests with large thread counts on AMD
+
+#spack install openblas%gcc@${gcc_vnew} threads=openmp
+#spack install openblas%gcc@${gcc_vold} threads=openmp
+spack install openblas threads=openmp
+
 echo --- Modules installed so far
 spack find
 echo --- Python setup for NEXUS `date`
 echo --- New python modules
 #spack install py-numpy^blis%gcc@${gcc_vnew} # will pull in libflame (problems 2020-03-27)
+spack load gcc@${gcc_vnew}
 spack load python@${python_version}%gcc@${gcc_vnew} 
 spack install py-numpy%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew} # Will pull in OpenBLAS
 spack install py-scipy%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
-#spack install py-mpi4py%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_vnew}%gcc@${gcc_vnew} 
+#spack install py-mpi4py%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^libxml2@${libxml2_v}%gcc@${gcc_vnew} 
 spack install py-setuptools%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 spack install py-mpi4py%gcc@${gcc_vnew} ^openmpi@${ompi_vnew}%gcc@${gcc_vnew} ^py-setuptools%gcc@${gcc_vnew}  ^python@${python_version}%gcc@${gcc_vnew}
 spack install py-h5py%gcc@${gcc_vnew}  -mpi ^python@${python_version}%gcc@${gcc_vnew} ^hdf5@${hdf5_vnew}%gcc@${gcc_vnew} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break 
 spack install py-pandas%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
-spack install py-lxml%gcc@${gcc_vnew}  ^python@${python_version}%gcc@${gcc_vnew}
+spack install py-lxml%gcc@${gcc_vnew}  
+spack install py-matplotlib%gcc@${gcc_vnew} ^python@${python_version}%gcc@${gcc_vnew}
 spack activate py-numpy%gcc@${gcc_vnew} 
 spack activate py-scipy%gcc@${gcc_vnew} 
 spack activate py-h5py%gcc@${gcc_vnew} 
 spack activate py-pandas%gcc@${gcc_vnew} 
-spack activate py-lxml%gcc@${gcc_vnew} 
+spack activate py-lxml%gcc@${gcc_vnew}
+spack activate py-matplotlib%gcc@${gcc_vnew}
 spack unload python@${python_version}%gcc@${gcc_vnew} 
+spack unload gcc@${gcc_vnew}
 echo --- Old python modules
+# Due to problems installing old versions with old compilers of at least scipy (20201223) we only install numpy.
+spack load gcc@${gcc_vold}
 spack load python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 1
-spack find
 spack install py-numpy%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} # Will pull in OpenBLAS
-echo --- Modules installed so far 2
-spack find
-spack install py-scipy%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 3
-spack find
-spack install py-setuptools%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 4
-spack find
-#BAD gives dupe python spack install py-mpi4py%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_vold}%gcc@${gcc_vold}
-spack install py-mpi4py%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^py-setuptools%gcc@${gcc_vold}  ^python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 5
-spack find
-spack install py-h5py%gcc@${gcc_vold}  -mpi ^python@${python_version}%gcc@${gcc_vold} ^hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
-echo --- Modules installed so far 6
-spack find
-spack install py-pandas%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 7
-spack find
-spack install py-lxml%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
-echo --- Modules installed so far 8
-spack find
+#SKIP#BADspack install py-scipy%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} # Will pull in py-pybind11 and cmake which won't bootstrap 20201223
+#SKIPspack install py-setuptools%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+#SKIP#BAD gives dupe python spack install py-mpi4py%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^libxml2@${libxml2_v}%gcc@${gcc_vold}
+#SKIPspack install py-mpi4py%gcc@${gcc_vold} ^openmpi@${ompi_vold}%gcc@${gcc_vold} ^py-setuptools%gcc@${gcc_vold}  ^python@${python_version}%gcc@${gcc_vold}
+#SKIPspack install py-h5py%gcc@${gcc_vold}  -mpi ^python@${python_version}%gcc@${gcc_vold} ^hdf5@${hdf5_vold}%gcc@${gcc_vold} +fortran +hl -mpi #Avoid MPI otherwise nompi build can break
+#SKIPspack install py-pandas%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+#SKIPspack install py-lxml%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
+#SKIPspack install py-matplotlib%gcc@${gcc_vold} ^python@${python_version}%gcc@${gcc_vold}
 spack activate py-numpy%gcc@${gcc_vold} 
-spack activate py-scipy%gcc@${gcc_vold} 
-spack activate py-h5py%gcc@${gcc_vold} 
-spack activate py-pandas%gcc@${gcc_vold} 
-spack activate py-lxml%gcc@${gcc_vold} 
+#SKIPspack activate py-scipy%gcc@${gcc_vold} 
+#SKIPspack activate py-h5py%gcc@${gcc_vold} 
+#SKIPspack activate py-pandas%gcc@${gcc_vold} 
+#SKIPspack activate py-lxml%gcc@${gcc_vold} 
+#SKIPspack activate py-matplotlib%gcc@${gcc_vold}
 spack unload python@${python_version}%gcc@${gcc_vold} 
-echo --- Remove build dependencies
-spack gc --yes-to-all
+spack unload gcc@${gcc_vold}
+#spack load git
+#DEBUG Disable cleanup based on guess there are hidden dependencies
+#DEBUGecho --- Remove build dependencies
+#DEBUGspack gc --yes-to-all
 echo --- PGI setup reminder
 echo "To configure the PGI compilers with one of the newly installed C++ libraries:"
 echo "spack load gcc@${gcc_vpgi} # For example"
 echo "cd /opt/pgi/linux86-64/19.10/bin"
 echo "sudo ./makelocalrc -x /opt/pgi/linux86-64/19.10/ -gcc `which gcc` -gpp `which g++` -g77 `which gfortran`"
 echo "gcc_vpgi is set to" ${gcc_vpgi}
+# sudo ./makelocalrc -x /opt/nvidia/hpc_sdk/Linux_x86_64/20.9/compilers/ -gcc `which gcc` -gpp `which g++` -g77 `which gfortran`
+
+# Bug avoidance 20200902
+if [ -e /usr/lib/aomp/bin/clang ]; then
+    echo --- AOMP Bug workaround
+    echo Change permissions back on AOMP Clang install detected, e.g. sudo chmod og+rx /usr/lib/aomp
+fi
 echo --- FINISH setup script `date`

--- a/tests/test_automation/nightly_test_scripts/ornl_update.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_update.sh
@@ -3,6 +3,8 @@
 # Update packages that track master
 # Currently only llvm
 # Intended to be run nightly/weekly etc.
+#
+# Implicitly assume that cuda version for llvm from spack is compatible with system installed driver
 
 echo --- Update Script START `date`
 
@@ -14,6 +16,6 @@ else
 fi
 
 spack uninstall -y llvm@master
-spack install llvm@master ^python@${python_version}%gcc@${gcc_vnew}
+spack install llvm@master +cuda cuda_arch=70 ^python@${python_version}%gcc@${gcc_vnew}
 
 echo --- Update Script END `date`

--- a/tests/test_automation/nightly_test_scripts/ornl_versions.sh
+++ b/tests/test_automation/nightly_test_scripts/ornl_versions.sh
@@ -2,45 +2,42 @@
 # Versions should be consistent with setup script
 #
 
-# AMD Zen2 (Rome) well supported from gcc 9.2+, llvm 10+
-
 # GCC
-# Zen2 optimziations are only in gcc 9.1+, with improved scheduling in 9.2+
 # Dates at https://gcc.gnu.org/releases.html
-gcc_vnew=10.2.0 # 2020-07-23
-gcc_vold=7.3.0 # 2018-01-25
+gcc_vnew=10.2.0 # Released 2020-07-23
+#gcc_vold=8.2.0  # Released 2018-07-26
+gcc_vold=8.3.0  # Released 2019-02-22 (8.2.0 results in too many install issues 20201202)
 
-#gcc_vcuda=8.2.1 #  For CUDA 10.2 compatibility  https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-gcc_vcuda=8.3.0 #  Use 8.3.0 instead since available in spack
-gcc_vintel=8.3.0 # Compiler for C++ library used by Intel compiler
-gcc_vpgi=8.3.0 # Use makelocalrc to configure PGI with this compiler
+gcc_vcuda=9.3.0  # Released 2020-03-12 9.x For CUDA 11.1 compatibility https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+gcc_vintel=8.3.0 # Released 2019-02-22 Compiler for C++ library used by Intel compiler
+gcc_vpgi=8.3.0   # Released 2019-02-22 Use makelocalrc to configure PGI with this compiler
 
 # LLVM 
-# Zen2 scheduling optimizations are only in LLVM 10+
 # Dates at http://releases.llvm.org/
-llvm_vnew=10.0.1 # 2020-08-06
-llvm_vold=6.0.1 # 2018-07-05
-llvm_vcuda=8.0.0 # For CUDA 10.2 compatibility https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+#llvm_vnew=11.0.0 # Released 2020-10-12
+llvm_vnew=10.0.1 # Released 2020-08-06
+#llvm_vold=7.0.1  # Released 2018-12-21 (disabled due to SPACK install issues 20201202)
+#llvm_vcuda=9.0.0 # Released 2019-09-19 9.0.0 For CUDA 11.1 compatibility https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+llvm_vcuda=9.0.1 # Released 2019-12-20 9.0.1 (because 9.0.0 will not install 20201203)
 
 # HDF5
 # Dates at https://portal.hdfgroup.org/display/support/Downloads
-#hdf5_vnew=1.12.0 # Released 2020-02-28 . Not supported by py-h5py 2.10.0, latest in spack on 20200604
-hdf5_vnew=1.10.5 # Releeased 2019-02-28
-hdf5_vold=1.8.19 # Released 2017-06-16
+#hdf5_vnew=1.12.0 # Released 2020-02-28 . Not supported by py-h5py 2.10.0, needs v3+
+hdf5_vnew=1.10.7  # Released 2020-09-15
+hdf5_vold=1.8.19  # Released 2017-06-16
 
 # CMake 
 # Dates at https://cmake.org/files/
-cmake_vnew=3.18.2 # Released 2020-08-20
-cmake_vold=3.12.1 # Released 2018-08-09
+cmake_vnew=3.19.2 # Released 2020-12-16
+cmake_vold=3.13.2 # Released 2018-12-13
 
 # OpenMPI
-# Dates at https://www.open-mpi.org/software/ompi/v4.0/
-ompi_vnew=4.0.4 # Released 2020-06-10
-ompi_vold=3.1.2 # Released 2018-08-22
+# Dates at https://www.open-mpi.org/software/ompi/v4.1/
+ompi_vnew=4.1.0 # Released 2020-12-18
+ompi_vold=3.1.6 # Released 2020-03-18
 
 # Libxml2
-libxml2_vnew=2.9.10 # Released 2019-10-30 See http://xmlsoft.org/sources/
-libxml2_vold=2.9.1 # Released 2013-04-19
+libxml2_v=2.9.10 # Released 2019-10-30 See http://xmlsoft.org/sources/
 
 # FFTW
 # Dates at http://www.fftw.org/release-notes.html
@@ -49,12 +46,10 @@ fftw_vold=3.3.4 # Released 2014-03-16
 
 # BOOST
 # Dates at https://www.boost.org/users/history/
-boost_vnew=1.74.0 # Released 2020-08-14
+boost_vnew=1.75.0 # Released 2020-12-11
 boost_vold=1.68.0 # Released 2018-08-09
-
 
 # Python
 # Use a single version to reduce dependencies
-# Can not use spack python default 3.7.x as of 20200831 due to hidden 3.8 requirement in LLVM master
-python_version=3.8.5
+python_version=3.8.6
 


### PR DESCRIPTION
## Proposed changes

Latest versions of nightly integration scripts for nitrogen+sulfur. Includes updated PySCF build. These are in use but a few problems remain. The gccnew route (gcc 10.2, all the python dependencies etc.) that is most used in testing is believed to be complete and fully functional.

Versions of installed packages are selected based on those that could be made to work while roughly following the two-year support rule. Several new workarounds are needed for new spack problems that prevent standard packages from building on these systems, e.g. perl (any compiler), python (gccold fails but gccnew is OK). The problems seem to mainly result from missing build and runtime dependencies in the spack packages resulting in unintended usage of system libraries that may not be suitable.

## What type(s) of changes does this code introduce?

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Two RHEL8 systems

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
