### PR TITLE
Hack for correct VMC timer ordering

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -566,6 +566,8 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml,
   NumOfVMCWalkers = W.getActiveWalkers();
 
 
+  // Hack to correctly order timer with object lifetime scope
+  vmcEngine.reset(nullptr);
   // create VMC engine
   // if (vmcEngine == 0)
   // {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -566,7 +566,7 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml,
   NumOfVMCWalkers = W.getActiveWalkers();
 
 
-  // Hack to correctly order timer with object lifetime scope
+  // Destroy old object to stop timer to correctly order timer with object lifetime scope
   vmcEngine.reset(nullptr);
   // create VMC engine
   // if (vmcEngine == 0)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -556,6 +556,8 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
   NumOfVMCWalkers = W.getActiveWalkers();
 
 
+  // Hack to correctly order timer with object lifetime scope
+  vmcEngine.reset(nullptr);
   // create VMC engine
   // if (vmcEngine == 0)
   // {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -556,7 +556,7 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
   NumOfVMCWalkers = W.getActiveWalkers();
 
 
-  // Hack to correctly order timer with object lifetime scope
+  // Destroy old object to stop timer to correctly order timer with object lifetime scope
   vmcEngine.reset(nullptr);
   // create VMC engine
   // if (vmcEngine == 0)


### PR DESCRIPTION
The VMC timers for these objects have the same scope as the object lifetime (that is - timer starts in the constructor, and stops in the destructor).
The call to make_unique creates the new object first, and then deletes the old object.  This causes an incorrect ordering in the timers. (The new timer starts before the old timer stops.)

This results in an error message - "Timer stack pop not matching push". The printed timer results also show VMC nested under VMC.

The fix is to force the old object to destroyed before the new object is created.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
