### PR TITLE
Add evaluateGL apis to TWF

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -691,6 +691,15 @@ void ParticleSet::acceptMove(Index_t iat, bool partial_table_update)
   }
 }
 
+void ParticleSet::rejectMove(Index_t iat)
+{
+#ifndef NDEBUG
+  if (iat != activePtcl)
+    throw std::runtime_error("Bug detected by rejectMove! Request electron is not active!");
+#endif
+  activePtcl = -1;
+}
+
 void ParticleSet::flex_donePbyP(const RefVector<ParticleSet>& P_list)
 {
   if (P_list.size() > 1)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -371,8 +371,9 @@ public:
   }
 
   /** reject the move
+   * @param iat the electron whose proposed move gets rejected.
    */
-  void rejectMove(Index_t iat) { activePtcl = -1; }
+  void rejectMove(Index_t iat);
   /// batched version of rejectMove
   static void flex_rejectMove(const RefVector<ParticleSet>& P_list, Index_t iat)
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -337,18 +337,25 @@ void DiracDeterminant<DU_TYPE>::registerData(ParticleSet& P, WFBufferType& buf)
 }
 
 template<typename DU_TYPE>
+typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::evaluateGL(
+    ParticleSet& P,
+    ParticleSet::ParticleGradient_t& G,
+    ParticleSet::ParticleLaplacian_t& L,
+    bool fromscratch)
+{
+  if (fromscratch)
+    evaluateLog(P, G, L);
+  else
+    updateAfterSweep(P, G, L);
+  return LogValue;
+}
+
+template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::updateBuffer(ParticleSet& P,
                                                                                          WFBufferType& buf,
                                                                                          bool fromscratch)
 {
-  if (fromscratch)
-  {
-    LogValue = evaluateLog(P, P.G, P.L);
-  }
-  else
-  {
-    updateAfterSweep(P, P.G, P.L);
-  }
+  evaluateGL(P, P.G, P.L, fromscratch);
   BufferTimer.start();
   buf.forward(Bytes_in_WFBuffer);
   buf.put(LogValue);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -164,6 +164,11 @@ public:
 
   void recompute(ParticleSet& P) override;
 
+  LogValueType evaluateGL(ParticleSet& P,
+                          ParticleSet::ParticleGradient_t& G,
+                          ParticleSet::ParticleLaplacian_t& L,
+                          bool fromscratch) override;
+
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
   /** cloning function
@@ -183,7 +188,7 @@ public:
 #else
   ValueMatrix_t& getPsiMinv() { return psiM; }
 #endif
-  
+
   /// psiM(j,i) \f$= \psi_j({\bf r}_i)\f$
   ValueMatrix_t psiM_temp;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -89,7 +89,9 @@ public:
 
   // expose CPU interfaces
   using WaveFunctionComponent::evaluateDerivatives;
+  using WaveFunctionComponent::evaluateGL;
   using WaveFunctionComponent::evaluateLog;
+  using WaveFunctionComponent::mw_evaluateGL;
   using WaveFunctionComponent::mw_evaluateLog;
   using WaveFunctionComponent::recompute;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -331,6 +331,19 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::updateAfterSweep(ParticleSet& P,
     }
   }
 }
+template<typename DET_ENGINE_TYPE>
+typename DiracDeterminantBatched<DET_ENGINE_TYPE>::LogValueType DiracDeterminantBatched<DET_ENGINE_TYPE>::evaluateGL(
+    ParticleSet& P,
+    ParticleSet::ParticleGradient_t& G,
+    ParticleSet::ParticleLaplacian_t& L,
+    bool fromscratch)
+{
+  if (fromscratch)
+    evaluateLog(P, G, L);
+  else
+    updateAfterSweep(P, G, L);
+  return LogValue;
+}
 
 template<typename DET_ENGINE_TYPE>
 void DiracDeterminantBatched<DET_ENGINE_TYPE>::registerData(ParticleSet& P, WFBufferType& buf)
@@ -347,14 +360,7 @@ typename DiracDeterminantBatched<DET_ENGINE_TYPE>::LogValueType DiracDeterminant
     WFBufferType& buf,
     bool fromscratch)
 {
-  if (fromscratch)
-  {
-    LogValue = evaluateLog(P, P.G, P.L);
-  }
-  else
-  {
-    updateAfterSweep(P, P.G, P.L);
-  }
+  evaluateGL(P, P.G, P.L, fromscratch);
   BufferTimer.start();
   buf.put(psiMinv.first_address(), psiMinv.last_address());
   buf.put(dpsiM.first_address(), dpsiM.last_address());
@@ -744,7 +750,8 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::evaluateDerivatives(ParticleSet& 
 }
 
 template<typename DET_ENGINE_TYPE>
-DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYPE>::makeCopy(std::shared_ptr<SPOSet>&& spo) const
+DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYPE>::makeCopy(
+    std::shared_ptr<SPOSet>&& spo) const
 {
   DiracDeterminantBatched<DET_ENGINE_TYPE>* dclone = new DiracDeterminantBatched<DET_ENGINE_TYPE>(std::move(spo));
   dclone->set(FirstIndex, LastIndex - FirstIndex, ndelay);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -153,6 +153,11 @@ public:
 
   void recompute(ParticleSet& P) override;
 
+  LogValueType evaluateGL(ParticleSet& P,
+                          ParticleSet::ParticleGradient_t& G,
+                          ParticleSet::ParticleLaplacian_t& L,
+                          bool fromscratch) override;
+
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
   /** cloning function

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -155,6 +155,37 @@ void SlaterDet::mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
   }
 }
 
+SlaterDet::LogValueType SlaterDet::evaluateGL(ParticleSet& P,
+                                              ParticleSet::ParticleGradient_t& G,
+                                              ParticleSet::ParticleLaplacian_t& L,
+                                              bool from_scratch)
+{
+  LogValue = 0.0;
+  for (int i = 0; i < Dets.size(); ++i)
+    LogValue += Dets[i]->evaluateGL(P, G, L, from_scratch);
+  return LogValue;
+}
+
+void SlaterDet::mw_evaluateGL(const RefVector<WaveFunctionComponent>& WFC_list,
+                              const RefVector<ParticleSet>& P_list,
+                              const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
+                              bool fromscratch)
+{
+  constexpr LogValueType czero(0);
+
+  for (WaveFunctionComponent& wfc : WFC_list)
+    wfc.LogValue = czero;
+
+  for (int i = 0; i < Dets.size(); ++i)
+  {
+    const auto Det_list(extract_DetRef_list(WFC_list, i));
+    Dets[i]->mw_evaluateGL(Det_list, P_list, G_list, L_list, fromscratch);
+    for (int iw = 0; iw < WFC_list.size(); iw++)
+      WFC_list[iw].get().LogValue += Det_list[iw].get().LogValue;
+  }
+}
+
 void SlaterDet::recompute(ParticleSet& P)
 {
   for (int i = 0; i < Dets.size(); ++i)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -71,6 +71,17 @@ public:
                               const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                               const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) override;
 
+  virtual LogValueType evaluateGL(ParticleSet& P,
+                                  ParticleSet::ParticleGradient_t& G,
+                                  ParticleSet::ParticleLaplacian_t& L,
+                                  bool fromscratch) override;
+
+  virtual void mw_evaluateGL(const RefVector<WaveFunctionComponent>& WFC_list,
+                             const RefVector<ParticleSet>& P_list,
+                             const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                             const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
+                             bool fromscratch) override;
+
   virtual void recompute(ParticleSet& P) override;
 
   virtual void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -122,8 +122,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    evaluateGL(P, G, L, true);
-    return LogValue;
+    return evaluateGL(P, G, L, true);
   }
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
@@ -217,10 +216,10 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       ratios[i] = std::exp(Vat[i] - curAt);
   }
 
-  inline void evaluateGL(ParticleSet& P,
-                         ParticleSet::ParticleGradient_t& G,
-                         ParticleSet::ParticleLaplacian_t& L,
-                         bool fromscratch = false)
+  inline LogValueType evaluateGL(ParticleSet& P,
+                                 ParticleSet::ParticleGradient_t& G,
+                                 ParticleSet::ParticleLaplacian_t& L,
+                                 bool fromscratch = false)
   {
     if (fromscratch)
       recompute(P);
@@ -229,7 +228,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       G[iat] += Grad[iat];
     for (size_t iat = 0; iat < Nelec; ++iat)
       L[iat] -= Lap[iat];
-    LogValue = -simd::accumulate_n(Vat.data(), Nelec, valT());
+    return LogValue = -simd::accumulate_n(Vat.data(), Nelec, valT());
   }
 
   /** compute gradient and lap

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -260,10 +260,10 @@ public:
 
   /** compute G and L after the sweep
    */
-  void evaluateGL(ParticleSet& P,
-                  ParticleSet::ParticleGradient_t& G,
-                  ParticleSet::ParticleLaplacian_t& L,
-                  bool fromscratch = false);
+  LogValueType evaluateGL(ParticleSet& P,
+                          ParticleSet::ParticleGradient_t& G,
+                          ParticleSet::ParticleLaplacian_t& L,
+                          bool fromscratch = false);
 
   inline void registerData(ParticleSet& P, WFBufferType& buf)
   {
@@ -448,7 +448,7 @@ WaveFunctionComponentPtr J2OrbitalSoA<FT>::makeClone(ParticleSet& tqp) const
         fcmap[F[ij]] = fc;
       }
     }
-  j2copy->KEcorr = KEcorr;
+  j2copy->KEcorr      = KEcorr;
   j2copy->Optimizable = Optimizable;
   return j2copy;
 }
@@ -649,15 +649,14 @@ typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(ParticleSe
                                                                       ParticleSet::ParticleGradient_t& G,
                                                                       ParticleSet::ParticleLaplacian_t& L)
 {
-  evaluateGL(P, G, L, true);
-  return LogValue;
+  return evaluateGL(P, G, L, true);
 }
 
 template<typename FT>
-void J2OrbitalSoA<FT>::evaluateGL(ParticleSet& P,
-                                  ParticleSet::ParticleGradient_t& G,
-                                  ParticleSet::ParticleLaplacian_t& L,
-                                  bool fromscratch)
+WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(ParticleSet& P,
+                                                                 ParticleSet::ParticleGradient_t& G,
+                                                                 ParticleSet::ParticleLaplacian_t& L,
+                                                                 bool fromscratch)
 {
   if (fromscratch)
     recompute(P);
@@ -669,7 +668,7 @@ void J2OrbitalSoA<FT>::evaluateGL(ParticleSet& P,
     L[iat] += d2Uat[iat];
   }
 
-  LogValue = -LogValue * 0.5;
+  return LogValue = -LogValue * 0.5;
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -408,8 +408,7 @@ public:
 
   LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
-    evaluateGL(P, G, L, true);
-    return LogValue;
+    return evaluateGL(P, G, L, true);
   }
 
   PsiValueType ratio(ParticleSet& P, int iat)
@@ -847,10 +846,10 @@ public:
     build_compact_list(P);
   }
 
-  void evaluateGL(ParticleSet& P,
-                  ParticleSet::ParticleGradient_t& G,
-                  ParticleSet::ParticleLaplacian_t& L,
-                  bool fromscratch = false)
+  LogValueType evaluateGL(ParticleSet& P,
+                          ParticleSet::ParticleGradient_t& G,
+                          ParticleSet::ParticleLaplacian_t& L,
+                          bool fromscratch = false)
   {
     if (fromscratch)
       recompute(P);
@@ -862,7 +861,7 @@ public:
       L[iat] += d2Uat[iat];
     }
 
-    LogValue = -LogValue * 0.5;
+    return LogValue = -LogValue * 0.5;
   }
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -799,7 +799,6 @@ TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bo
    */
 void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_list,
                                         const RefVector<ParticleSet>& p_list,
-                                        std::vector<LogValueType>& log_values,
                                         bool fromscratch)
 {
   if (wf_list.size() > 1)
@@ -814,7 +813,6 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
     {
       p_list[iw].get().G = czero; // Ye: remove when all the WFC uses WF.G/L
       p_list[iw].get().L = czero; // Ye: remove when all the WFC uses WF.G/L
-      log_values[iw]     = LogValueType(0);
     }
 
     auto& wavefunction_components = wf_list[0].get().Z;
@@ -827,13 +825,9 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
       wavefunction_components[i]->mw_evaluateGL(wfc_list, p_list, g_list, l_list, fromscratch);
       for (int iw = 0; iw < wf_list.size(); iw++)
       {
-        log_values[iw] += wfc_list[iw].get().LogValue;
+        wf_list[iw].get().LogValue   = std::real(wfc_list[iw].get().LogValue);
+        wf_list[iw].get().PhaseValue = std::imag(wfc_list[iw].get().LogValue);
       }
-    }
-    for (int iw = 0; iw < wf_list.size(); iw++)
-    {
-      wf_list[iw].get().LogValue   = std::real(log_values[iw]);
-      wf_list[iw].get().PhaseValue = std::imag(log_values[iw]);
     }
     auto copyToP = [](ParticleSet& pset, TrialWaveFunction& twf) {
       pset.G = twf.G;
@@ -846,7 +840,7 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
   }
   else if (wf_list.size() == 1)
   {
-    log_values[0] = wf_list[0].get().evaluateGL(p_list[0], fromscratch);
+    wf_list[0].get().evaluateGL(p_list[0], fromscratch);
     // Ye: temporal workaround to have WF.G/L always defined.
     // remove when KineticEnergy use WF.G/L instead of P.G/L
     wf_list[0].get().G = p_list[0].get().G;

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -827,8 +827,7 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
       wavefunction_components[i]->mw_evaluateGL(wfc_list, p_list, g_list, l_list, fromscratch);
       for (int iw = 0; iw < wf_list.size(); iw++)
       {
-        wf_list[iw].get().LogValue += std::real(wfc_list[iw].get().LogValue);
-        wf_list[iw].get().PhaseValue += std::imag(wfc_list[iw].get().LogValue);
+        log_values[iw] += wfc_list[iw].get().LogValue;
       }
     }
     for (int iw = 0; iw < wf_list.size(); iw++)
@@ -847,7 +846,7 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
   }
   else if (wf_list.size() == 1)
   {
-    wf_list[0].get().evaluateGL(p_list[0], fromscratch);
+    log_values[0] = wf_list[0].get().evaluateGL(p_list[0], fromscratch);
     // Ye: temporal workaround to have WF.G/L always defined.
     // remove when KineticEnergy use WF.G/L instead of P.G/L
     wf_list[0].get().G = p_list[0].get().G;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -370,7 +370,6 @@ public:
    */
   static void flex_evaluateGL(const RefVector<TrialWaveFunction>& WF_list,
                               const RefVector<ParticleSet>& P_list,
-                              std::vector<LogValueType>& log_values,
                               bool fromscratch);
 
   /** register all the wavefunction components in buffer.

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -365,11 +365,13 @@ public:
 
   /** compute gradients and laplacian of the TWF with respect to each particle.
    *  See WaveFunctionComponent::evaluateGL for more detail */
-  RealType evaluateGL(ParticleSet& P);
+  LogValueType evaluateGL(ParticleSet& P, bool fromscratch);
   /* flexible batched version of evaluateGL.
-   * TODO: split the computation from updateBuffer to evaluateGL. Expected to be called by KE
    */
-  void flex_evaluateGL(const std::vector<TrialWaveFunction*>& WF_list, const std::vector<ParticleSet*>& P_list) const;
+  static void flex_evaluateGL(const RefVector<TrialWaveFunction>& WF_list,
+                              const RefVector<ParticleSet>& P_list,
+                              std::vector<LogValueType>& log_values,
+                              bool fromscratch);
 
   /** register all the wavefunction components in buffer.
    *  See WaveFunctionComponent::registerData for more detail */

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -318,7 +318,7 @@ public:
    */
   ValueType calcRatioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat);
 
-  /** batched version of ratioGrad 
+  /** batched version of ratioGrad
    *
    *  all vector sizes must match
    */
@@ -363,12 +363,20 @@ public:
   /* flexible batched version of completeUpdates.  */
   static void flex_completeUpdates(const RefVector<TrialWaveFunction>& WF_list);
 
+  /** compute gradients and laplacian of the TWF with respect to each particle.
+   *  See WaveFunctionComponent::evaluateGL for more detail */
+  RealType evaluateGL(ParticleSet& P);
+  /* flexible batched version of evaluateGL.
+   * TODO: split the computation from updateBuffer to evaluateGL. Expected to be called by KE
+   */
+  void flex_evaluateGL(const std::vector<TrialWaveFunction*>& WF_list, const std::vector<ParticleSet*>& P_list) const;
+
   /** register all the wavefunction components in buffer.
    *  See WaveFunctionComponent::registerData for more detail */
   void registerData(ParticleSet& P, WFBufferType& buf);
 
   /* flexible batched version of registerData.
-   * 
+   *
    * Ye: perhaps it doesn't need to be flexible but just operates on all the walkers
    * The strange mix of argument types reflect this being called from MCPopulation instead
    * of Crowd like most of the flex functions.
@@ -381,7 +389,7 @@ public:
    *  See WaveFunctionComponent::updateBuffer for more detail */
   RealType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
 
-  /* flexible batched version of updateBuffer. 
+  /* flexible batched version of updateBuffer.
    * Ye: perhaps it doesn't need to be flexible but just operates on all the walkers
    */
   static void flex_updateBuffer(const RefVector<TrialWaveFunction>& WF_list,
@@ -392,7 +400,7 @@ public:
   /** copy all the wavefunction components from buffer.
    *  See WaveFunctionComponent::updateBuffer for more detail */
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
-  /* flexible batched version of copyFromBuffer. 
+  /* flexible batched version of copyFromBuffer.
    * Ye: perhaps it doesn't need to be flexible but just operates on all the walkers
    */
   void flex_copyFromBuffer(const RefVector<TrialWaveFunction>& WF_list,
@@ -441,11 +449,6 @@ public:
   }
 
   RealType getReciprocalMass() { return OneOverM; }
-
-  /* flexible batched version of evaluateGL.
-   * TODO: split the computation from updateBuffer to evaluateGL. Expected to be called by KE
-   */
-  void flex_evaluateGL(const std::vector<TrialWaveFunction*>& WF_list, const std::vector<ParticleSet*>& P_list) const;
 
   const std::string& getName() const { return myName; }
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -135,12 +135,11 @@ void WaveFunctionComponent::mw_evaluateGL(const RefVector<WaveFunctionComponent>
                                           const RefVector<ParticleSet>& P_list,
                                           const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                                           const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
-                                          std::vector<LogValueType> log_values,
                                           bool from_scratch)
 {
 #pragma omp parallel for
   for (int iw = 0; iw < WFC_list.size(); iw++)
-    log_values[iw] = WFC_list[iw].get().evaluateGL(P_list[iw], G_list[iw], L_list[iw], from_scratch);
+    WFC_list[iw].get().evaluateGL(P_list[iw], G_list[iw], L_list[iw], from_scratch);
 }
 
 void WaveFunctionComponent::setDiffOrbital(DiffWaveFunctionComponentPtr d) { dPsi = d; }

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -135,11 +135,11 @@ void WaveFunctionComponent::mw_evaluateGL(const RefVector<WaveFunctionComponent>
                                           const RefVector<ParticleSet>& P_list,
                                           const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                                           const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
-                                          bool from_scratch)
+                                          bool fromscratch)
 {
 #pragma omp parallel for
   for (int iw = 0; iw < WFC_list.size(); iw++)
-    WFC_list[iw].get().evaluateGL(P_list[iw], G_list[iw], L_list[iw], from_scratch);
+    WFC_list[iw].get().evaluateGL(P_list[iw], G_list[iw], L_list[iw], fromscratch);
 }
 
 void WaveFunctionComponent::setDiffOrbital(DiffWaveFunctionComponentPtr d) { dPsi = d; }

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -374,7 +374,7 @@ struct WaveFunctionComponent : public QMCTraits
    * @param P particle set
    * @param G Gradients, \f$\nabla\ln\Psi\f$
    * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
-   * @param from_scratch if true, all the internal data are recomputed from scratch
+   * @param fromscratch if true, all the internal data are recomputed from scratch
    * @return log(psi)
    */
   virtual LogValueType evaluateGL(ParticleSet& P,
@@ -387,13 +387,13 @@ struct WaveFunctionComponent : public QMCTraits
    * @param P_list the list of ParticleSet pointers in a walker batch
    * @param G_list the list of Gradients pointers in a walker batch, \f$\nabla\ln\Psi\f$
    * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
-   * @param from_scratch if true, all the internal data are recomputed from scratch
+   * @param fromscratch if true, all the internal data are recomputed from scratch
    */
   virtual void mw_evaluateGL(const RefVector<WaveFunctionComponent>& WFC_list,
                              const RefVector<ParticleSet>& P_list,
                              const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
-                             bool from_scratch);
+                             bool fromscratch);
 
   /** For particle-by-particle move. Requests space in the buffer
    *  based on the data type sizes of the objects in this class.

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -189,17 +189,12 @@ struct WaveFunctionComponent : public QMCTraits
    * @param P_list the list of ParticleSet pointers in a walker batch
    * @param G_list the list of Gradients pointers in a walker batch, \f$\nabla\ln\Psi\f$
    * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
-   * @@param values the log WF values of walkers in a batch
+   * @param values the log WF values of walkers in a batch
    */
   virtual void mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
                               const RefVector<ParticleSet>& P_list,
                               const RefVector<ParticleSet::ParticleGradient_t>& G_list,
-                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw].get().evaluateLog(P_list[iw], G_list[iw], L_list[iw]);
-  }
+                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list);
 
   /** recompute the value of the WaveFunctionComponents which require critical accuracy.
    * needed for Slater Determinants but not needed for most types of WaveFunctionComponents
@@ -244,12 +239,7 @@ struct WaveFunctionComponent : public QMCTraits
   virtual void mw_evalGrad(const RefVector<WaveFunctionComponent>& WFC_list,
                            const RefVector<ParticleSet>& P_list,
                            int iat,
-                           std::vector<GradType>& grad_now)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      grad_now[iw] = WFC_list[iw].get().evalGrad(P_list[iw].get(), iat);
-  }
+                           std::vector<GradType>& grad_now);
 
   /** return the logarithmic gradient for the iat-th particle
    * of the source particleset
@@ -342,15 +332,7 @@ struct WaveFunctionComponent : public QMCTraits
                                     const RefVector<ParticleSet>& P_list,
                                     int iat,
                                     const std::vector<bool>& isAccepted,
-                                    bool safe_to_delay = false)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      if (isAccepted[iw])
-        WFC_list[iw].get().acceptMove(P_list[iw], iat, safe_to_delay);
-      else
-        WFC_list[iw].get().restore(iat);
-  }
+                                    bool safe_to_delay = false);
 
   /** complete all the delayed updates, must be called after each substep or step during pbyp move
    */
@@ -359,12 +341,7 @@ struct WaveFunctionComponent : public QMCTraits
   /** complete all the delayed updates for all the walkers in a batch
    * must be called after each substep or step during pbyp move
    */
-  virtual void mw_completeUpdates(const RefVector<WaveFunctionComponent>& WFC_list)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      WFC_list[iw].get().completeUpdates();
-  }
+  virtual void mw_completeUpdates(const RefVector<WaveFunctionComponent>& WFC_list);
 
   /** If a move for iat-th particle is rejected, restore to the content.
    * @param iat index of the particle whose new position was proposed
@@ -391,12 +368,34 @@ struct WaveFunctionComponent : public QMCTraits
   virtual void mw_calcRatio(const RefVector<WaveFunctionComponent>& WFC_list,
                             const RefVector<ParticleSet>& P_list,
                             int iat,
-                            std::vector<PsiValueType>& ratios)
-  {
-#pragma omp parallel for
-    for (int iw = 0; iw < WFC_list.size(); iw++)
-      ratios[iw] = WFC_list[iw].get().ratio(P_list[iw], iat);
-  }
+                            std::vector<PsiValueType>& ratios);
+
+  /** compute gradients and laplacian of the TWF with respect to each particle.
+   * @param P particle set
+   * @param G Gradients, \f$\nabla\ln\Psi\f$
+   * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
+   * @param from_scratch if true, all the internal data are recomputed from scratch
+   * @return log(psi)
+   */
+  virtual LogValueType evaluateGL(ParticleSet& P,
+                                  ParticleSet::ParticleGradient_t& G,
+                                  ParticleSet::ParticleLaplacian_t& L,
+                                  bool fromscratch);
+
+  /** evaluate gradients and laplacian of the same type WaveFunctionComponent of multiple walkers
+   * @param WFC_list the list of WaveFunctionComponent pointers of the same component in a walker batch
+   * @param P_list the list of ParticleSet pointers in a walker batch
+   * @param G_list the list of Gradients pointers in a walker batch, \f$\nabla\ln\Psi\f$
+   * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
+   * @param from_scratch if true, all the internal data are recomputed from scratch
+   * @param log_values values the log WF values of walkers in a batch
+   */
+  virtual void mw_evaluateGL(const RefVector<WaveFunctionComponent>& WFC_list,
+                             const RefVector<ParticleSet>& P_list,
+                             const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                             const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
+                             std::vector<LogValueType> log_values,
+                             bool from_scratch);
 
   /** For particle-by-particle move. Requests space in the buffer
    *  based on the data type sizes of the objects in this class.

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -388,13 +388,11 @@ struct WaveFunctionComponent : public QMCTraits
    * @param G_list the list of Gradients pointers in a walker batch, \f$\nabla\ln\Psi\f$
    * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
    * @param from_scratch if true, all the internal data are recomputed from scratch
-   * @param log_values values the log WF values of walkers in a batch
    */
   virtual void mw_evaluateGL(const RefVector<WaveFunctionComponent>& WFC_list,
                              const RefVector<ParticleSet>& P_list,
                              const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
-                             std::vector<LogValueType> log_values,
                              bool from_scratch);
 
   /** For particle-by-particle move. Requests space in the buffer

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -156,6 +156,20 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(logpsi == Approx(-5.932711221043984));
 #endif
 
+  auto logpsi_cplx = psi.evaluateGL(elec_, false);
+#if defined(QMC_COMPLEX)
+  REQUIRE(std::real(logpsi_cplx) == Approx(-4.546410485374186));
+#else
+  REQUIRE(std::real(logpsi_cplx) == Approx(-5.932711221043984));
+#endif
+
+  logpsi_cplx = psi.evaluateGL(elec_, true);
+#if defined(QMC_COMPLEX)
+  REQUIRE(std::real(logpsi_cplx) == Approx(-4.546410485374186));
+#else
+  REQUIRE(std::real(logpsi_cplx) == Approx(-5.932711221043984));
+#endif
+
   // make a TrialWaveFunction Clone
   TrialWaveFunction* psi_clone = psi.makeClone(elec_clone);
 
@@ -457,6 +471,13 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(det_up->getPsiMinv()[1][0] == Approx(-54.376457060136).epsilon(1e-4));
   REQUIRE(det_up->getPsiMinv()[1][1] == Approx(45.51992500251).epsilon(1e-4));
 #endif
+
+  std::vector<LogValueType> log_values(wf_ref_list.size());
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, false);
+  std::vector<LogValueType> log_values_fromscratch(wf_ref_list.size());
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, true);
+  for (int iw = 0; iw < log_values.size(); iw++)
+    REQUIRE(LogComplexApprox(log_values[iw]) == log_values_fromscratch[iw]);
 
   //FIXME more thinking and fix about ownership and schope are needed for exiting clean
   delete psi_clone;

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -424,6 +424,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 #endif
 
+  std::vector<LogValueType> log_values(wf_ref_list.size());
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, false);
   std::vector<PosType> displ(2);
   displ[0] = displ[1] = {0.1, 0.2, 0.3};
 
@@ -452,9 +454,14 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   TrialWaveFunction::flex_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id_next, isAccepted, true);
 
   elec_accept_list.clear();
+  RefVector<ParticleSet> elec_reject_list;
   for (int iw = 0; iw < isAccepted.size(); iw++)
-    elec_accept_list.push_back(p_ref_list[iw]);
+    if (isAccepted[iw])
+      elec_accept_list.push_back(p_ref_list[iw]);
+    else
+      elec_reject_list.push_back(p_ref_list[iw]);
   ParticleSet::flex_acceptMove(elec_accept_list, moved_elec_id_next);
+  ParticleSet::flex_rejectMove(elec_reject_list, moved_elec_id_next);
   TrialWaveFunction::flex_completeUpdates(wf_ref_list);
 
   std::cout << "invMat next electron " << std::setprecision(14) << det_up->getPsiMinv()[0][0] << " "
@@ -471,11 +478,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(det_up->getPsiMinv()[1][0] == Approx(-54.376457060136).epsilon(1e-4));
   REQUIRE(det_up->getPsiMinv()[1][1] == Approx(45.51992500251).epsilon(1e-4));
 #endif
-
-  std::vector<LogValueType> log_values(wf_ref_list.size());
+  //std::vector<LogValueType> log_values(wf_ref_list.size());
   TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, false);
   std::vector<LogValueType> log_values_fromscratch(wf_ref_list.size());
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, true);
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values_fromscratch, true);
   for (int iw = 0; iw < log_values.size(); iw++)
     REQUIRE(LogComplexApprox(log_values[iw]) == log_values_fromscratch[iw]);
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -424,8 +424,6 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 #endif
 
-  std::vector<LogValueType> log_values(wf_ref_list.size());
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, false);
   std::vector<PosType> displ(2);
   displ[0] = displ[1] = {0.1, 0.2, 0.3};
 
@@ -478,12 +476,13 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(det_up->getPsiMinv()[1][0] == Approx(-54.376457060136).epsilon(1e-4));
   REQUIRE(det_up->getPsiMinv()[1][1] == Approx(45.51992500251).epsilon(1e-4));
 #endif
-  //std::vector<LogValueType> log_values(wf_ref_list.size());
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values, false);
-  std::vector<LogValueType> log_values_fromscratch(wf_ref_list.size());
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, log_values_fromscratch, true);
+  std::vector<LogValueType> log_values(wf_ref_list.size());
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, false);
   for (int iw = 0; iw < log_values.size(); iw++)
-    REQUIRE(LogComplexApprox(log_values[iw]) == log_values_fromscratch[iw]);
+    log_values[iw] = {wf_ref_list[iw].get().getLogPsi(), wf_ref_list[iw].get().getPhase()};
+  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, true);
+  for (int iw = 0; iw < log_values.size(); iw++)
+    REQUIRE(LogComplexApprox(log_values[iw]) == LogValueType{wf_ref_list[iw].get().getLogPsi(), wf_ref_list[iw].get().getPhase()});
 
 #endif
 }

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -171,7 +171,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 
   // make a TrialWaveFunction Clone
-  TrialWaveFunction* psi_clone = psi.makeClone(elec_clone);
+  std::unique_ptr<TrialWaveFunction> psi_clone(psi.makeClone(elec_clone));
 
   elec_clone.update();
   double logpsi_clone = psi_clone->evaluateLog(elec_clone);
@@ -231,7 +231,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   std::vector<TrialWaveFunction*> WF_list(2, nullptr);
   WF_list[0] = &psi;
-  WF_list[1] = psi_clone;
+  WF_list[1] = psi_clone.get();
 
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
@@ -485,8 +485,6 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   for (int iw = 0; iw < log_values.size(); iw++)
     REQUIRE(LogComplexApprox(log_values[iw]) == log_values_fromscratch[iw]);
 
-  //FIXME more thinking and fix about ownership and schope are needed for exiting clean
-  delete psi_clone;
 #endif
 }
 


### PR DESCRIPTION
## Proposed changes
In order to clean up buffers, I need this new set of APIs to do the compute work used to be in updateBuffer.
Slow fallback is in-place to ensure correctness.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
