### PR TITLE
Drop WF buffers used in batched drivers

### DIFF
--- a/src/Particle/MCSample.h
+++ b/src/Particle/MCSample.h
@@ -36,6 +36,9 @@ struct MCSample
   ParticleSet::ParticleLaplacian_t L;
   ParticleSet::RealType LogPsi, Sign, PE, KE;
 
+  inline MCSample(const ParticleSet& pset) : R(pset.R), spins(pset.spins) { }
+
+  /// deprecated. Beyond w.R and w.spins, others are used perhaps somewhere but intended not to.
   inline MCSample(const Walker_t& w) : R(w.R), spins(w.spins), G(w.G), L(w.L)
   {
     LogPsi = w.Properties(WP::LOGPSI);

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -16,7 +16,6 @@ void Crowd::clearWalkers()
 {
   // We're clearing the refs to the objects not the referred to objects.
   mcp_walkers_.clear();
-  mcp_wfbuffers_.clear();
   walker_elecs_.clear();
   walker_twfs_.clear();
   walker_hamiltonians_.clear();
@@ -34,7 +33,6 @@ void Crowd::reserve(int crowd_size)
 void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& twf, QMCHamiltonian& hamiltonian)
 {
   mcp_walkers_.push_back(walker);
-  mcp_wfbuffers_.push_back(walker.DataSet);
   walker_elecs_.push_back(elecs);
   walker_twfs_.push_back(twf);
   walker_hamiltonians_.push_back(hamiltonian);

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -34,7 +34,6 @@ class Crowd
 {
 public:
   using MCPWalker        = MCPopulation::MCPWalker;
-  using WFBuffer         = MCPopulation::WFBuffer;
   using GradType         = QMCTraits::GradType;
   using RealType         = QMCTraits::RealType;
   using FullPrecRealType = QMCTraits::FullPrecRealType;
@@ -86,7 +85,6 @@ public:
   std::vector<std::reference_wrapper<TrialWaveFunction>>& get_walker_twfs() { return walker_twfs_; }
   std::vector<std::reference_wrapper<QMCHamiltonian>>& get_walker_hamiltonians() { return walker_hamiltonians_; }
 
-  RefVector<WFBuffer>& get_mcp_wfbuffers() { return mcp_wfbuffers_; }
   const EstimatorManagerCrowd& get_estimator_manager_crowd() const { return estimator_manager_crowd_; }
   int size() const { return mcp_walkers_.size(); }
 
@@ -104,7 +102,6 @@ private:
    * @{
    */
   RefVector<MCPWalker> mcp_walkers_;
-  RefVector<WFBuffer> mcp_wfbuffers_;
   RefVector<ParticleSet> walker_elecs_;
   RefVector<TrialWaveFunction> walker_twfs_;
   RefVector<QMCHamiltonian> walker_hamiltonians_;

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -92,25 +92,10 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
                                 ContextForSteps& step_context,
                                 bool recompute)
 {
-  timers.buffer_timer.start();
-  // We copy positions from the walkers to elec particles sets for all the crowds walkers
-  // we might have received a few updates over the wire (from MPI)
-  // ** None of the per walker objects have referential integrity step to step **
-  crowd.loadWalkers();
-
   int nnode_crossing(0);
   auto& walker_twfs  = crowd.get_walker_twfs();
   auto& walkers      = crowd.get_walkers();
   auto& walker_elecs = crowd.get_walker_elecs();
-
-  // Note this resets the identities of all the walker TWFs
-  auto copyTWFFromBuffer = [](TrialWaveFunction& twf, ParticleSet& pset, MCPWalker& walker) {
-    twf.copyFromBuffer(pset, walker.DataSet);
-  };
-  for (int iw = 0; iw < crowd.size(); ++iw)
-    copyTWFFromBuffer(walker_twfs[iw], walker_elecs[iw], walkers[iw]);
-
-  timers.buffer_timer.stop();
 
   const int num_walkers = crowd.size();
   //This generates an entire steps worth of deltas.
@@ -280,13 +265,11 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
   //To use the flex interfaces we have to build RefVectors for walker that moved and walkers that didn't
 
   auto& walker_hamiltonians  = crowd.get_walker_hamiltonians();
-  auto& walker_mcp_wfbuffers = crowd.get_mcp_wfbuffers();
 
   DMCPerWalkerRefRefs per_walker_ref_refs{walkers,
                                           walker_twfs,
                                           walker_hamiltonians,
                                           walker_elecs,
-                                          walker_mcp_wfbuffers,
                                           old_walker_energies,
                                           new_walker_energies,
                                           rr_proposed,
@@ -295,8 +278,8 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
   MovedStalled these = buildMovedStalled(did_walker_move, per_walker_ref_refs);
 
-  handleMovedWalkers(these.moved, sft, timers);
-  handleStalledWalkers(these.stalled, sft);
+  handleMovedWalkers(these.moved, sft, timers, recompute);
+  handleStalledWalkers(these.stalled, sft, recompute);
 
   dmc_timers.tmove_timer.start();
   std::vector<int> walker_non_local_moves_accepted(
@@ -327,11 +310,9 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
         moved_nonlocal.walker_twfs.push_back(walker_twfs[iw]);
         moved_nonlocal.walker_elecs.push_back(walker_elecs[iw]);
         moved_nonlocal.walker_hamiltonians.push_back(walker_hamiltonians[iw]);
-        moved_nonlocal.walker_mcp_wfbuffers.push_back(walker_mcp_wfbuffers[iw]);
       }
     }
-    TrialWaveFunction::flex_updateBuffer(moved_nonlocal.walker_twfs, moved_nonlocal.walker_elecs,
-                                         moved_nonlocal.walker_mcp_wfbuffers);
+    TrialWaveFunction::flex_evaluateGL(moved_nonlocal.walker_twfs, moved_nonlocal.walker_elecs, false);
     ParticleSet::flex_saveWalker(moved_nonlocal.walker_elecs, moved_nonlocal.walkers);
   }
 
@@ -361,7 +342,6 @@ DMCBatched::MovedStalled DMCBatched::buildMovedStalled(const std::vector<int>& d
       these.moved.walker_twfs.push_back(refs.walker_twfs[iw]);
       these.moved.walker_hamiltonians.push_back(refs.walker_hamiltonians[iw]);
       these.moved.walker_elecs.push_back(refs.walker_elecs[iw]);
-      these.moved.walker_mcp_wfbuffers.push_back(refs.walker_mcp_wfbuffers[iw]);
       these.moved.old_energies.push_back(refs.old_energies[iw]);
       these.moved.new_energies.push_back(refs.new_energies[iw]);
       these.moved.rr_proposed.push_back(refs.rr_proposed[iw]);
@@ -375,7 +355,6 @@ DMCBatched::MovedStalled DMCBatched::buildMovedStalled(const std::vector<int>& d
       these.stalled.walker_twfs.push_back(refs.walker_twfs[iw]);
       these.stalled.walker_hamiltonians.push_back(refs.walker_hamiltonians[iw]);
       these.stalled.walker_elecs.push_back(refs.walker_elecs[iw]);
-      these.stalled.walker_mcp_wfbuffers.push_back(refs.walker_mcp_wfbuffers[iw]);
       these.stalled.old_energies.push_back(refs.old_energies[iw]);
       these.stalled.new_energies.push_back(refs.new_energies[iw]);
       these.stalled.rr_proposed.push_back(refs.rr_proposed[iw]);
@@ -386,12 +365,12 @@ DMCBatched::MovedStalled DMCBatched::buildMovedStalled(const std::vector<int>& d
   return these;
 }
 
-void DMCBatched::handleMovedWalkers(DMCPerWalkerRefs& moved, const StateForThread& sft, DriverTimers& timers)
+void DMCBatched::handleMovedWalkers(DMCPerWalkerRefs& moved, const StateForThread& sft, DriverTimers& timers, bool recompute)
 {
   if (moved.walkers.size() > 0)
   {
     timers.buffer_timer.start();
-    TrialWaveFunction::flex_updateBuffer(moved.walker_twfs, moved.walker_elecs, moved.walker_mcp_wfbuffers);
+    TrialWaveFunction::flex_evaluateGL(moved.walker_twfs, moved.walker_elecs, recompute);
     std::for_each(moved.walkers.begin(), moved.walkers.end(), [](MCPWalker& walker) { walker.Age = 0; });
     ParticleSet::flex_saveWalker(moved.walker_elecs, moved.walkers);
     timers.buffer_timer.stop();
@@ -432,12 +411,12 @@ void DMCBatched::handleMovedWalkers(DMCPerWalkerRefs& moved, const StateForThrea
   }
 }
 
-void DMCBatched::handleStalledWalkers(DMCPerWalkerRefs& stalled, const StateForThread& sft)
+void DMCBatched::handleStalledWalkers(DMCPerWalkerRefs& stalled, const StateForThread& sft, bool recompute)
 {
   for (int iw = 0; iw < stalled.walkers.size(); ++iw)
   {
     std::cout << "A walker has stalled.\n";
-    TrialWaveFunction::flex_updateBuffer(stalled.walker_twfs, stalled.walker_elecs, stalled.walker_mcp_wfbuffers);
+    TrialWaveFunction::flex_evaluateGL(stalled.walker_twfs, stalled.walker_elecs, recompute);
     std::for_each(stalled.walkers.begin(), stalled.walkers.end(), [](MCPWalker& walker) { walker.Age = 0; });
     ParticleSet::flex_saveWalker(stalled.walker_elecs, stalled.walkers);
 

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -143,7 +143,6 @@ private:
     RefVector<TrialWaveFunction> walker_twfs;
     RefVector<QMCHamiltonian> walker_hamiltonians;
     RefVector<ParticleSet> walker_elecs;
-    RefVector<WFBuffer> walker_mcp_wfbuffers;
     RefVector<FullPrecRealType> old_energies;
     RefVector<FullPrecRealType> new_energies;
     RefVector<RealType> rr_proposed;
@@ -155,7 +154,6 @@ private:
       walker_twfs.reserve(nwalkers);
       walker_hamiltonians.reserve(nwalkers);
       walker_elecs.reserve(nwalkers);
-      walker_mcp_wfbuffers.reserve(nwalkers);
       old_energies.reserve(nwalkers);
       new_energies.reserve(nwalkers);
       rr_proposed.reserve(nwalkers);
@@ -172,7 +170,6 @@ private:
     RefVector<TrialWaveFunction>& walker_twfs;
     RefVector<QMCHamiltonian>& walker_hamiltonians;
     RefVector<ParticleSet>& walker_elecs;
-    RefVector<WFBuffer>& walker_mcp_wfbuffers;
     std::vector<FullPrecRealType>& old_energies;
     std::vector<FullPrecRealType>& new_energies;
     std::vector<RealType>& rr_proposed;
@@ -195,8 +192,8 @@ private:
 
   static MovedStalled buildMovedStalled(const std::vector<int>& did_walker_move, const DMCPerWalkerRefRefs& refs);
 
-  static void handleMovedWalkers(DMCPerWalkerRefs& moved, const StateForThread& sft, DriverTimers& timers);
-  static void handleStalledWalkers(DMCPerWalkerRefs& stalled, const StateForThread& sft);
+  static void handleMovedWalkers(DMCPerWalkerRefs& moved, const StateForThread& sft, DriverTimers& timers, bool recompute);
+  static void handleStalledWalkers(DMCPerWalkerRefs& stalled, const StateForThread& sft, bool recompute);
   // struct DMCTimers
   // {
   //   NewTimer& dmc_movePbyP;

--- a/src/QMCDrivers/DMC/WalkerControlMPI.cpp
+++ b/src/QMCDrivers/DMC/WalkerControlMPI.cpp
@@ -565,11 +565,6 @@ int WalkerControlMPI::swapWalkersSimple(MCPopulation& pop,
       // \todo narrow these down to a minimum and manage to reason out the state of a valid fat walker.
       this_pset.saveWalker(this_walker);
       this_walker.updateBuffer();
-      TrialWaveFunction& this_twf = message.walker_elements.twf;
-#ifndef NDEBUG
-      this_twf.evaluateLog(this_pset);
-#endif
-      this_twf.updateBuffer(this_pset, this_walker.DataSet);
       send_requests.emplace_back(myComm->comm.isend_n(message.walker_elements.walker.DataSet.data(),
                                                       message.walker_elements.walker.DataSet.size(),
                                                       message.target_rank));
@@ -620,9 +615,7 @@ int WalkerControlMPI::swapWalkersSimple(MCPopulation& pop,
           // Jastrow evaluations in evaluateLog.
           this_pset.update();
           TrialWaveFunction& this_twf = recv_message_list[im].walker_elements.twf;
-          this_twf.copyFromBuffer(this_pset, this_walker.DataSet);          
           this_twf.evaluateLog(this_pset);
-          this_twf.updateBuffer(this_pset, this_walker.DataSet);
           recv_completed[im] = 1;
         }
       }

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -207,11 +207,9 @@ WalkerElementsRef MCPopulation::spawnWalker()
     //walkers_.back()->Properties = elec_particle_set_->Properties;
 
     walker_elec_particle_sets_.emplace_back(std::make_unique<ParticleSet>(*elec_particle_set_));
-    walker_trial_wavefunctions_.push_back(UPtr<TrialWaveFunction>{});
-    walker_trial_wavefunctions_.back().reset(trial_wf_->makeClone(*(walker_elec_particle_sets_.back())));
-    walker_hamiltonians_.push_back(UPtr<QMCHamiltonian>{});
-    walker_hamiltonians_.back().reset(
-        hamiltonian_->makeClone(*(walker_elec_particle_sets_.back()), *(walker_trial_wavefunctions_.back())));
+    walker_trial_wavefunctions_.emplace_back(trial_wf_->makeClone(*walker_elec_particle_sets_.back()));
+    walker_hamiltonians_.emplace_back(
+        hamiltonian_->makeClone(*walker_elec_particle_sets_.back(), *walker_trial_wavefunctions_.back()));
     walkers_.back()->Multiplicity = 1.0;
     walkers_.back()->Weight       = 1.0;
   }

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -65,12 +65,6 @@ MCPopulation::~MCPopulation()
     saveWalkerConfigurations();
 }
 
-/** we could also search for walker_ptr
- */
-void MCPopulation::allocateWalkerStuffInplace(int walker_index)
-{
-}
-
 void MCPopulation::createWalkers(IndexType num_walkers, RealType reserve)
 {
   IndexType num_walkers_plus_reserve = static_cast<IndexType>(num_walkers * reserve);
@@ -91,6 +85,8 @@ void MCPopulation::createWalkers(IndexType num_walkers, RealType reserve)
     walker_ptr->R     = elec_particle_set_->R;
     walker_ptr->spins = elec_particle_set_->spins;
     walker_ptr->Properties = elec_particle_set_->Properties;
+    walker_ptr->registerData();
+    walker_ptr->DataSet.allocate();
   };
 
   walker_weights_.resize(num_walkers_plus_reserve, 1.0);
@@ -199,6 +195,8 @@ WalkerElementsRef MCPopulation::spawnWalker()
                   << " outside of reserves, this ideally should never happend." << std::endl;
     MCPWalker last_walker = *(walkers_.back());
     walkers_.push_back(std::make_unique<MCPWalker>(last_walker));
+    walkers_.back()->registerData();
+    walkers_.back()->DataSet.allocate();
 
     // There is no value in doing this here because its going to be wiped out
     // When we load from the receive buffer. It also won't necessarily be correct

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -116,8 +116,6 @@ public:
   WalkerElementsRef spawnWalker();
   void killWalker(MCPWalker&);
   void killLastWalker();
-  void createWalkerInplace(UPtr<MCPWalker>& walker_ptr);
-  void allocateWalkerStuffInplace(int walker_index);
   /** }@ */
 
   /** Creates walkers with a clone of the golden electron particle set and golden trial wavefunction

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -191,11 +191,13 @@ public:
   const UPtrVector<MCPWalker>& get_walkers() const { return walkers_; }
   const UPtrVector<MCPWalker>& get_dead_walkers() const { return dead_walkers_; }
 
-  UPtrVector<QMCHamiltonian>& get_hamiltonians() { return walker_hamiltonians_; }
-  UPtrVector<QMCHamiltonian>& get_dead_hamiltonians() { return dead_walker_hamiltonians_; }
+  UPtrVector<ParticleSet>& get_elec_particle_sets() { return walker_elec_particle_sets_; }
 
   UPtrVector<TrialWaveFunction>& get_twfs() { return walker_trial_wavefunctions_; }
   UPtrVector<TrialWaveFunction>& get_dead_twfs() { return dead_walker_trial_wavefunctions_; }
+
+  UPtrVector<QMCHamiltonian>& get_hamiltonians() { return walker_hamiltonians_; }
+  UPtrVector<QMCHamiltonian>& get_dead_hamiltonians() { return dead_walker_hamiltonians_; }
 
   /** Non threadsafe access to walkers and their elements
    *  

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -64,10 +64,8 @@ private:
   ///1/Mass per particle
   std::vector<RealType> ptcl_inv_mass_;
   size_t size_dataset_;
-  // could be
-  // std::shared_ptr<TrialWaveFunction> trial_wf_;
-  // std::shared_ptr<ParticleSet> elec_particle_set_;
-  // std::shared_ptr<QMCHamiltonian> hamiltonian_;
+  // walker weights
+  std::vector<QMCTraits::FullPrecRealType> walker_weights_;
 
   // This is necessary MCPopulation is constructed in a simple call scope in QMCDriverFactory from the legacy MCWalkerConfiguration
   // MCPopulation should have QMCMain scope eventually and the driver will just have a reference to it.
@@ -122,18 +120,12 @@ public:
   void allocateWalkerStuffInplace(int walker_index);
   /** }@ */
 
-  void createWalkers();
   /** Creates walkers with a clone of the golden electron particle set and golden trial wavefunction
    *
    *  \param[in] num_walkers number of living walkers in initial population
    *  \param[in] reserve multiple above that to reserve >=1.0
    */
   void createWalkers(IndexType num_walkers, RealType reserve = 1.0);
-  void createWalkers(int num_crowds_,
-                     int num_walkers_per_crowd_,
-                     IndexType num_walkers,
-                     const ParticleAttrib<TinyVector<QMCTraits::RealType, 3>>& pos);
-
 
   /** distributes walkers and their "cloned" elements to the elements of a vector
    *  of unique_ptr to "walker_consumers". 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -376,31 +376,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   for (ParticleSet& pset : walker_elecs)
     pset.update();
 
-  // We reuse the DataSet.
-  auto cleanDataSet = [](MCPWalker& walker, ParticleSet& pset, TrialWaveFunction& twf) {
-    if (walker.DataSet.size())
-    {
-      // These appear to be uneeded and harmful.
-      //walker.DataSet.zero();
-      //walker.DataSet.rewind();
-    }
-    else
-    {
-      walker.registerData();
-      twf.registerData(pset, walker.DataSet);
-      walker.DataSet.allocate();
-    }
-  };
-  for (int iw = 0; iw < crowd.size(); ++iw)
-    cleanDataSet(walkers[iw], walker_elecs[iw], walker_twfs[iw]);
-
-  auto copyFrom = [](TrialWaveFunction& twf, ParticleSet& pset, WFBuffer& wfb) { twf.copyFromBuffer(pset, wfb); };
-  for (int iw = 0; iw < crowd.size(); ++iw)
-    copyFrom(walker_twfs[iw], walker_elecs[iw], mcp_buffers[iw]);
-
   TrialWaveFunction::flex_evaluateLog(walker_twfs, walker_elecs);
-
-  TrialWaveFunction::flex_updateBuffer(crowd.get_walker_twfs(), crowd.get_walker_elecs(), crowd.get_mcp_wfbuffers());
 
   // For consistency this should be in ParticleSet as a flex call, but I think its a problem
   // in the algorithm logic and should be removed.

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -368,7 +368,6 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
 
   auto& walker_twfs         = crowd.get_walker_twfs();
-  auto& mcp_buffers         = crowd.get_mcp_wfbuffers();
   auto& walker_elecs        = crowd.get_walker_elecs();
   auto& walkers             = crowd.get_walkers();
   auto& walker_hamiltonians = crowd.get_walker_hamiltonians();

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -320,8 +320,8 @@ bool VMCBatched::run()
 
       if (collect_samples_)
       {
-        auto& walkers = population_.get_walkers();
-        for (auto& walker : walkers)
+        const auto& elec_psets = population_.get_elec_particle_sets();
+        for (const auto& walker : elec_psets)
         {
           samples_.appendSample(MCSample(*walker));
         }

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -40,7 +40,6 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
                                 ContextForSteps& step_context,
                                 bool recompute)
 {
-  timers.buffer_timer.start();
   crowd.loadWalkers();
 
   // Consider favoring lambda followed by for over walkers
@@ -48,12 +47,6 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   auto& walker_twfs      = crowd.get_walker_twfs();
   auto& walkers          = crowd.get_walkers();
   auto& walker_elecs     = crowd.get_walker_elecs();
-  auto copyTWFFromBuffer = [](TrialWaveFunction& twf, ParticleSet& pset, MCPWalker& walker) {
-    twf.copyFromBuffer(pset, walker.DataSet);
-  };
-  for (int iw = 0; iw < crowd.size(); ++iw)
-    copyTWFFromBuffer(walker_twfs[iw], walker_elecs[iw], walkers[iw]);
-  timers.buffer_timer.stop();
 
   timers.movepbyp_timer.start();
   const int num_walkers = crowd.size();
@@ -174,8 +167,6 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   timers.movepbyp_timer.stop();
 
   timers.buffer_timer.start();
-  TrialWaveFunction::flex_updateBuffer(crowd.get_walker_twfs(), crowd.get_walker_elecs(), crowd.get_mcp_wfbuffers());
-
   auto saveElecPosAndGLToWalkers = [](ParticleSet& pset, ParticleSet::Walker_t& walker) { pset.saveWalker(walker); };
   for (int iw = 0; iw < crowd.size(); ++iw)
     saveElecPosAndGLToWalkers(walker_elecs[iw], walkers[iw]);

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -394,9 +394,9 @@ void WalkerControlBase::onRankSpawn(MCPopulation& pop, PopulationAdjustment& adj
     {
       WalkerElementsRef walker_elements = pop.spawnWalker();
       walker_elements.walker            = adjust.good_walkers[iw].walker;
-      walker_elements.twf.copyFromBuffer(walker_elements.pset, walker_elements.walker.DataSet);
+      walker_elements.pset.loadWalker(walker_elements.walker, true);
+      walker_elements.pset.update();
       walker_elements.twf.evaluateLog(walker_elements.pset);
-      walker_elements.twf.updateBuffer(walker_elements.pset, walker_elements.walker.DataSet);
 
       // IF these are really unique ID's they should be UUID's or something
       // old algorithm seems to reuse them in a way that I'm not sure avoids

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -808,8 +808,11 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
     const auto g_list(TrialWaveFunction::extractGRefList(wf_list));
     const auto l_list(TrialWaveFunction::extractLRefList(wf_list));
 
+    const int num_particles = p_list[0].get().getTotalNum();
     for (TrialWaveFunction& wfs : wf_list)
     {
+      wfs.G.resize(num_particles);
+      wfs.L.resize(num_particles);
       wfs.G          = czero;
       wfs.L          = czero;
       wfs.LogValue   = czero;

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -795,8 +795,7 @@ TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bo
   PhaseValue = std::imag(logpsi);
   return logpsi;
 }
-/* flexible batched version of evaluateGL.
-   */
+
 void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_list,
                                         const RefVector<ParticleSet>& p_list,
                                         bool fromscratch)
@@ -809,10 +808,12 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
     const auto g_list(TrialWaveFunction::extractGRefList(wf_list));
     const auto l_list(TrialWaveFunction::extractLRefList(wf_list));
 
-    for (int iw = 0; iw < wf_list.size(); iw++)
+    for (TrialWaveFunction& wfs : wf_list)
     {
-      p_list[iw].get().G = czero; // Ye: remove when all the WFC uses WF.G/L
-      p_list[iw].get().L = czero; // Ye: remove when all the WFC uses WF.G/L
+      wfs.G          = czero;
+      wfs.L          = czero;
+      wfs.LogValue   = czero;
+      wfs.PhaseValue = czero;
     }
 
     auto& wavefunction_components = wf_list[0].get().Z;
@@ -825,8 +826,8 @@ void TrialWaveFunction::flex_evaluateGL(const RefVector<TrialWaveFunction>& wf_l
       wavefunction_components[i]->mw_evaluateGL(wfc_list, p_list, g_list, l_list, fromscratch);
       for (int iw = 0; iw < wf_list.size(); iw++)
       {
-        wf_list[iw].get().LogValue   = std::real(wfc_list[iw].get().LogValue);
-        wf_list[iw].get().PhaseValue = std::imag(wfc_list[iw].get().LogValue);
+        wf_list[iw].get().LogValue   += std::real(wfc_list[iw].get().LogValue);
+        wf_list[iw].get().PhaseValue += std::imag(wfc_list[iw].get().LogValue);
       }
     }
     auto copyToP = [](ParticleSet& pset, TrialWaveFunction& twf) {


### PR DESCRIPTION
## Proposed changes
Using a buffer to fuse data transfer is efficient but error prone. This PR removes almost all buffer operations in batched drivers leveraging #2848.
1. This PR also reduced interaction with the list of lightweight walkers owned by MCPopulation. The eventual goal is to get them removed. the list of lightweight walkers is only intended to used outside drivers or carry data between drivers not inside drivers.
2. Restore the recompute capability for determinants.
3. DMC without MPI is fixed as tests reporting pass. Consider the test check was not made tight. It can be buggy. With MPI still getting bad memory access.

Since the buffer motion is cleaned up, the walker exchange part is my next target.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'