### PR TITLE
Increase LiH 1x1x1 equilibration

### DIFF
--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb-drift.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma-drift.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x_hybridrep.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x_hybridrep.xml
@@ -85,7 +85,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  1000 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  400 </parameter>
+    <parameter name="warmupSteps">  100 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
@@ -35,7 +35,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    256 </parameter>
     <parameter name="substeps">  1 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  1 </parameter>
     <parameter name="blocks">  1 </parameter>
     <parameter name="timestep">  1.0 </parameter>
@@ -46,7 +46,7 @@
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="targetwalkers"> 256 </parameter>
     <parameter name="reconfiguration">   no </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="timestep">  0.001 </parameter>
     <parameter name="steps">   100 </parameter>
     <parameter name="blocks">  400 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/md_cc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/md_cc_vmc_LiH-gamma.xml
@@ -99,7 +99,7 @@ H
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  100 </parameter>
     <parameter name="timestep">  1.0 </parameter>

--- a/tests/solids/LiH_solid_1x1x1_pp/md_rc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/md_rc_vmc_LiH-gamma.xml
@@ -99,7 +99,7 @@ H
     <estimator name="LocalEnergy" hdf5="no"/>
     <parameter name="walkers">    16 </parameter>
     <parameter name="substeps">  5 </parameter>
-    <parameter name="warmupSteps">  100 </parameter>
+    <parameter name="warmupSteps">  400 </parameter>
     <parameter name="steps">  100 </parameter>
     <parameter name="blocks">  100 </parameter>
     <parameter name="timestep">  1.0 </parameter>


### PR DESCRIPTION
## Proposed changes

Increase equilibration from 100 to 400 steps to hopefully reduce sporadic many-sigma failures seen in converter tests. Increased error bars may also be needed in a later PR. Tests are significantly longer than equilibration time so runtime impact should be negligible.

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
