### PR TITLE
Enhance TimerManager and fix a missing timer stop() call in VMCbatched driver

### DIFF
--- a/src/Concurrency/ParallelExecutorOPENMP.hpp
+++ b/src/Concurrency/ParallelExecutorOPENMP.hpp
@@ -54,7 +54,7 @@ void ParallelExecutor<Executor::OPENMP>::operator()(int num_tasks, F&& f, Args&&
         ++nested_throw_count;
       else
       {
-        app_warning() << re.what();
+        app_error() << re.what() << std::flush;
         ++throw_count;
       }
     }

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -178,6 +178,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   for (int iw = 0; iw < log_values.size(); iw++)
     std::cout << "Logpsi walker[" << iw<< "] " << log_values[iw] << " ref " << TrialWaveFunction::LogValueType{crowd.get_walker_twfs()[iw].get().getLogPsi(), crowd.get_walker_twfs()[iw].get().getPhase()} << std::endl;
 #endif
+  timers.buffer_timer.stop();
   timers.hamiltonian_timer.start();
   auto& walker_hamiltonians = crowd.get_walker_hamiltonians();
   std::vector<QMCHamiltonian::FullPrecRealType> local_energies(

--- a/src/Utilities/NewTimer.cpp
+++ b/src/Utilities/NewTimer.cpp
@@ -57,9 +57,6 @@ void TimerType<CLOCK>::start()
     {
       if (manager)
       {
-        if (this == manager->current_timer())
-          std::cerr << "Timer loop: " << name << std::endl;
-
         // compute current_stack_key
         TimerType* parent = manager->current_timer();
         if (parent)
@@ -103,26 +100,22 @@ void TimerType<CLOCK>::stop()
       if (omp_get_ancestor_thread_num(level) != 0)
         is_true_master = false;
     if (is_true_master)
-#endif
     {
       double elapsed = CLOCK()() - start_time;
       total_time += elapsed;
       num_calls++;
 
-#ifdef USE_STACK_TIMERS
       per_stack_total_time[current_stack_key] += elapsed;
       per_stack_num_calls[current_stack_key] += 1;
 
       if (manager)
-      {
-        if (this != manager->current_timer())
-          std::cerr << "Timer stack pop not matching push! "
-                    << "Expect \"" << name << "\" but \"" << manager->current_timer()->name << "\" on the top."
-                    << std::endl;
-        manager->pop_timer();
-      }
-#endif
+        manager->pop_timer(this);
     }
+#else
+    double elapsed = CLOCK()() - start_time;
+    total_time += elapsed;
+    num_calls++;
+#endif
   }
 }
 #endif

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -84,7 +84,7 @@ void TimerManager<TIMER>::push_timer(TIMER* t)
     std::cerr << "Timer " << t->get_name()
               << " instance is already at the top of the stack. "
                  "start() is being called again. This often happens when stop() is not paired properly with start(). "
-              << "ScopedTimer uses RAII and managers timer start/stop much safer." << std::endl;
+              << "ScopedTimer uses RAII and manages timer start/stop more safely." << std::endl;
     throw std::runtime_error("TimerManager push_timer error!");
   }
   else
@@ -103,7 +103,8 @@ void TimerManager<TIMER>::pop_timer(TIMER* t)
   else if (t != stack_top)
   {
     std::cerr << "Timer stack pop not matching push! "
-              << "Expect \"" << t->get_name() << "\" but \"" << stack_top->get_name() << "\" on the top." << std::endl;
+              << "Expecting \"" << t->get_name() << "\" but \"" << stack_top->get_name() << "\" is on the top."
+              << std::endl;
     throw std::runtime_error("TimerManager pop_timer error!");
   }
   else

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -92,7 +92,9 @@ void TimerManager<TIMER>::push_timer(TIMER* t)
   // current_timer() can be nullptr when the stack was empty.
   if (t == current_timer())
   {
-    std::cerr << "Timer loop: " << t->get_name() << std::endl;
+    std::cerr << "Timer " << t->get_name() << " instance is already at the top of the stack. "
+                 "start() is being called again. This often happens when stop() is not paired properly with start(). "
+              << "ScopedTimer uses RAII and managers timer start/stop much safer." << std::endl;
     throwErrorMessageOnceAndPrintOnlyAfter("TimerManager push_timer error!");
   }
   else

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -92,7 +92,8 @@ void TimerManager<TIMER>::push_timer(TIMER* t)
   // current_timer() can be nullptr when the stack was empty.
   if (t == current_timer())
   {
-    std::cerr << "Timer " << t->get_name() << " instance is already at the top of the stack. "
+    std::cerr << "Timer " << t->get_name()
+              << " instance is already at the top of the stack. "
                  "start() is being called again. This often happens when stop() is not paired properly with start(). "
               << "ScopedTimer uses RAII and managers timer start/stop much safer." << std::endl;
     throwErrorMessageOnceAndPrintOnlyAfter("TimerManager push_timer error!");
@@ -113,8 +114,7 @@ void TimerManager<TIMER>::pop_timer(TIMER* t)
   else if (t != stack_top)
   {
     std::cerr << "Timer stack pop not matching push! "
-              << "Expect \"" << t->get_name() << "\" but \"" << stack_top->get_name() << "\" on the top."
-              << std::endl;
+              << "Expect \"" << t->get_name() << "\" but \"" << stack_top->get_name() << "\" on the top." << std::endl;
     throwErrorMessageOnceAndPrintOnlyAfter("TimerManager pop_timer error!");
   }
   else

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <algorithm>
 #include <array>
+#include <stdexcept>
 #include <libxml/xmlwriter.h>
 #include "Configuration.h"
 #include "Message/OpenMP.h"
@@ -62,18 +63,6 @@ void TimerManager<TIMER>::initializeTimer(TIMER& t)
 }
 
 template<class TIMER>
-void TimerManager<TIMER>::throwErrorMessageOnceAndPrintOnlyAfter(const std::string& msg)
-{
-  if (stop_throw_already_in_bad_state)
-    std::cerr << msg << std::flush;
-  else
-  {
-    stop_throw_already_in_bad_state = true;
-    throw std::runtime_error(msg);
-  }
-}
-
-template<class TIMER>
 TIMER* TimerManager<TIMER>::createTimer(const std::string& myname, timer_levels mytimer)
 {
   TIMER* t = nullptr;
@@ -96,7 +85,7 @@ void TimerManager<TIMER>::push_timer(TIMER* t)
               << " instance is already at the top of the stack. "
                  "start() is being called again. This often happens when stop() is not paired properly with start(). "
               << "ScopedTimer uses RAII and managers timer start/stop much safer." << std::endl;
-    throwErrorMessageOnceAndPrintOnlyAfter("TimerManager push_timer error!");
+    throw std::runtime_error("TimerManager push_timer error!");
   }
   else
     CurrentTimerStack.push_back(t);
@@ -109,13 +98,13 @@ void TimerManager<TIMER>::pop_timer(TIMER* t)
   if (stack_top == nullptr)
   {
     std::cerr << "Timer stack pop failed on an empty stack! Requested \"" << t->get_name() << "\"." << std::endl;
-    throwErrorMessageOnceAndPrintOnlyAfter("TimerManager pop_timer error!");
+    throw std::runtime_error("TimerManager pop_timer error!");
   }
   else if (t != stack_top)
   {
     std::cerr << "Timer stack pop not matching push! "
               << "Expect \"" << t->get_name() << "\" but \"" << stack_top->get_name() << "\" on the top." << std::endl;
-    throwErrorMessageOnceAndPrintOnlyAfter("TimerManager pop_timer error!");
+    throw std::runtime_error("TimerManager pop_timer error!");
   }
   else
     CurrentTimerStack.pop_back();

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -72,7 +72,11 @@ public:
   __itt_domain* task_domain;
 #endif
 
-  TimerManager() : timer_threshold(timer_level_coarse), max_timer_id(1), max_timers_exceeded(false), stop_throw_already_in_bad_state(false)
+  TimerManager()
+      : timer_threshold(timer_level_coarse),
+        max_timer_id(1),
+        max_timers_exceeded(false),
+        stop_throw_already_in_bad_state(false)
   {
 #ifdef USE_VTUNE_TASKS
     task_domain = __itt_domain_create("QMCPACK");

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -57,11 +57,7 @@ private:
   std::map<timer_id_t, std::string> timer_id_name;
   /// name to timer id mapping
   std::map<std::string, timer_id_t> timer_name_to_id;
-  /// if true, the manager is in bad state and should not throw
-  bool stop_throw_already_in_bad_state;
 
-  /// After the first call to this function, all the calls will print error only without throw
-  void throwErrorMessageOnceAndPrintOnlyAfter(const std::string& msg);
   void initializeTimer(TIMER& t);
 
   void print_flat(Communicate* comm);
@@ -75,8 +71,7 @@ public:
   TimerManager()
       : timer_threshold(timer_level_coarse),
         max_timer_id(1),
-        max_timers_exceeded(false),
-        stop_throw_already_in_bad_state(false)
+        max_timers_exceeded(false)
   {
 #ifdef USE_VTUNE_TASKS
     task_domain = __itt_domain_create("QMCPACK");

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -333,14 +333,13 @@ TEST_CASE("test stack exceeded message")
     FakeTimer* t = tm.createTimer(name.str());
     timer_list.push_back(t);
   }
+
   for (int i = 0; i < StackKey::max_level + 1; i++)
-  {
     timer_list[i]->start();
-  }
-  for (int i = 0; i < StackKey::max_level + 1; i++)
-  {
+
+  for (int i = StackKey::max_level; i >= 0; i--)
     timer_list[i]->stop();
-  }
+
   REQUIRE(timer_max_level_exceeded == true);
 
   //tm.print_stack(NULL);


### PR DESCRIPTION
## Proposed changes

1. Some error traps in NewTimer class are moved to TimerManager. Now if an error was detected, the code will stop instead of just print an error. Usually an error in the timer indicates pathological call flow, it is better to do a hard stop. Because exception can be thrown via TimerManager::pop_timer() called by ScopedTimer destructor, it is better to print the full error message right away instead of via runtime_error object which may get lost due to destructors being implicitly noexcept by default.
2. A bug was fixed in timer unit test.
3. The fix to unpaired timer call is trivial.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'