### PR TITLE
Change base class of linear optimizer to QMCDriverNew

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -12,8 +12,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef QMCPLUSPLUS_COSTFUNCTION_H
-#define QMCPLUSPLUS_COSTFUNCTION_H
+#ifndef QMCPLUSPLUS_COSTFUNCTION_BATCHED_H
+#define QMCPLUSPLUS_COSTFUNCTION_BATCHED_H
 
 #include "QMCDrivers/WFOpt/QMCCostFunctionBase.h"
 #include "QMCDrivers/CloneManager.h"

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -1176,7 +1176,6 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
 
   // set the number samples to be initial one
   optTarget->setNumSamples(init_num_samp);
-  nTargetSamples = init_num_samp;
 
   //app_log() << "block first second third end " << block_first << block_second << block_third << endl;
   // return whether the cost function's report counter is positive

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -51,16 +51,16 @@ public:
                                       Communicate* comm);
 
   ///Destructor
-  ~QMCFixedSampleLinearOptimizeBatched();
+  virtual ~QMCFixedSampleLinearOptimizeBatched();
 
   ///Run the Optimization algorithm.
-  bool run();
+  bool run() override;
   ///preprocess xml node
-  bool put(xmlNodePtr cur);
+  void process(xmlNodePtr cur) override;
   ///process xml node value (parameters for both VMC and OPT) for the actual optimization
   bool processOptXML(xmlNodePtr cur, const std::string& vmcMove, bool reportH5, bool useGPU);
 
-  RealType Func(RealType dl);
+  RealType Func(RealType dl) override;
 
 private:
   inline bool ValidCostFunction(bool valid)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -51,7 +51,7 @@ public:
                                       Communicate* comm);
 
   ///Destructor
-  virtual ~QMCFixedSampleLinearOptimizeBatched();
+  ~QMCFixedSampleLinearOptimizeBatched();
 
   ///Run the Optimization algorithm.
   bool run() override;

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
@@ -129,12 +129,12 @@ void QMCLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<ValueType>* 
   // reset the root name
   optTarget->setRootName(get_root_name());
   optTarget->setWaveFunctionNode(wfNode);
-  app_log() << "     Reading configurations from h5FileRoot " << h5FileRoot << std::endl;
+  app_log() << "     Reading configurations from h5FileRoot " << std::endl;
 
   // get configuration from the previous run
   Timer t1;
   initialize_timer_.start();
-  optTarget->getConfigurations(h5FileRoot);
+  optTarget->getConfigurations("");
   optTarget->setRng(vmcEngine->getRng());
   optTarget->engine_checkConfigurations(EngineObj, descentEngineObj,
                                         MinMethod); // computes derivative ratios and pass into engine

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.cpp
@@ -20,6 +20,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
 #include "QMCDrivers/WFOpt/QMCCostFunction.h"
+#include "QMCDrivers/WFOpt/QMCCostFunctionBatched.h"
 #include "QMCHamiltonians/HamiltonianPool.h"
 #include "CPU/Blasf.h"
 #include "Numerics/MatrixOperators.h"
@@ -40,26 +41,30 @@ QMCLinearOptimizeBatched::QMCLinearOptimizeBatched(MCWalkerConfiguration& w,
                                                    SampleStack& samples,
                                                    Communicate* comm,
                                                    const std::string& QMC_driver_type)
-    : QMCDriver(w, psi, h, comm, QMC_driver_type),
+    : QMCDriverNew(std::move(qmcdriver_input),
+                   std::move(population),
+                   psi,
+                   h,
+                   "QMCLinearOptimizeBatched::",
+                   comm,
+                   "QMCLinearOptimizeBatched"),
       PartID(0),
       NumParts(1),
       wfNode(NULL),
       optNode(NULL),
       param_tol(1e-4),
-      qmcdriver_input_(qmcdriver_input),
       vmcdriver_input_(vmcdriver_input),
-      population_(std::move(population)),
       samples_(samples),
       generate_samples_timer_(
           *timer_manager.createTimer("QMCLinearOptimizeBatched::GenerateSamples", timer_level_medium)),
       initialize_timer_(*timer_manager.createTimer("QMCLinearOptimizeBatched::Initialize", timer_level_medium)),
       eigenvalue_timer_(*timer_manager.createTimer("QMCLinearOptimizeBatched::Eigenvalue", timer_level_medium)),
       line_min_timer_(*timer_manager.createTimer("QMCLinearOptimizeBatched::Line_Minimization", timer_level_medium)),
-      cost_function_timer_(*timer_manager.createTimer("QMCLinearOptimizeBatched::CostFunction", timer_level_medium))
+      cost_function_timer_(*timer_manager.createTimer("QMCLinearOptimizeBatched::CostFunction", timer_level_medium)),
+      W(w)
 {
-  IsQMCDriver = false;
   //     //set the optimization flag
-  qmc_driver_mode.set(QMC_OPTIMIZE, 1);
+  qmc_driver_mode_.set(QMC_OPTIMIZE, 1);
   //read to use vmc output (just in case)
   m_param.add(param_tol, "alloweddifference", "double");
   //Set parameters for line minimization:
@@ -83,17 +88,16 @@ void QMCLinearOptimizeBatched::start()
   generateSamples();
   generate_samples_timer_.stop();
   //store active number of walkers
-  NumOfVMCWalkers = W.getActiveWalkers();
   app_log() << "<opt stage=\"setup\">" << std::endl;
   app_log() << "  <log>" << std::endl;
   //reset the rootname
-  optTarget->setRootName(RootName);
+  optTarget->setRootName(get_root_name());
   optTarget->setWaveFunctionNode(wfNode);
-  app_log() << "   Reading configurations from h5FileRoot " << h5FileRoot << std::endl;
+  app_log() << "   Reading configurations from h5FileRoot " << std::endl;
   //get configuration from the previous run
   Timer t1;
   initialize_timer_.start();
-  optTarget->getConfigurations(h5FileRoot);
+  optTarget->getConfigurations("");
   optTarget->setRng(vmcEngine->getRng());
   optTarget->checkConfigurations();
   initialize_timer_.stop();
@@ -123,7 +127,7 @@ void QMCLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<ValueType>* 
   app_log() << "  <log>" << std::endl;
 
   // reset the root name
-  optTarget->setRootName(RootName);
+  optTarget->setRootName(get_root_name());
   optTarget->setWaveFunctionNode(wfNode);
   app_log() << "     Reading configurations from h5FileRoot " << h5FileRoot << std::endl;
 
@@ -146,7 +150,6 @@ void QMCLinearOptimizeBatched::engine_start(cqmc::engine::LMYEngine<ValueType>* 
 
 void QMCLinearOptimizeBatched::finish()
 {
-  MyCounter++;
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
   app_log() << "  </log>" << std::endl;
 
@@ -154,14 +157,6 @@ void QMCLinearOptimizeBatched::finish()
     optTarget->reportParametersH5();
   optTarget->reportParameters();
 
-
-  int nw_removed = W.getActiveWalkers() - NumOfVMCWalkers;
-  app_log() << "   Restore the number of walkers to " << NumOfVMCWalkers << ", removing " << nw_removed << " walkers."
-            << std::endl;
-  if (nw_removed > 0)
-    W.destroyWalkers(nw_removed);
-  else
-    W.createWalkers(-nw_removed);
   app_log() << "</opt>" << std::endl;
   app_log() << "</optimization-report>" << std::endl;
 }
@@ -169,18 +164,17 @@ void QMCLinearOptimizeBatched::finish()
 void QMCLinearOptimizeBatched::generateSamples()
 {
   app_log() << "<optimization-report>" << std::endl;
-  app_log() << "<vmc stage=\"main\" blocks=\"" << nBlocks << "\">" << std::endl;
   t1.restart();
   //     W.reset();
-  branchEngine->flush(0);
-  branchEngine->reset();
+  branch_engine_->flush(0);
+  branch_engine_->reset();
   samples_.resetSampleCount();
   population_.set_variational_parameters(optTarget->getOptVariables());
 
   vmcEngine->run();
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
   app_log() << "</vmc>" << std::endl;
-  h5FileRoot = RootName;
+  h5_file_root_ = get_root_name();
 }
 
 QMCLinearOptimizeBatched::RealType QMCLinearOptimizeBatched::getLowestEigenvector(Matrix<RealType>& A,
@@ -602,62 +596,6 @@ void QMCLinearOptimizeBatched::orthoScale(std::vector<RealType>& dP, Matrix<Real
   //     rescale = 1.0/(1.0-rescale);
   //     app_log()<<rescale<< std::endl;
   //     for (int i=0; i<dP.size(); i++) dP[i] *= rescale;
-}
-
-/** Parses the xml input file for parameter definitions for the wavefunction optimization.
-* @param q current xmlNode
-* @return true if successful
-*/
-bool QMCLinearOptimizeBatched::put(xmlNodePtr q)
-{
-  std::string useGPU("no");
-  std::string vmcMove("pbyp");
-  OhmmsAttributeSet oAttrib;
-  oAttrib.add(useGPU, "gpu");
-  oAttrib.add(vmcMove, "move");
-  oAttrib.put(q);
-  optNode        = q;
-  xmlNodePtr cur = optNode->children;
-  int pid        = OHMMS::Controller->rank();
-  while (cur != NULL)
-  {
-    std::string cname((const char*)(cur->name));
-    if (cname == "mcwalkerset")
-    {
-      mcwalkerNodePtr.push_back(cur);
-    }
-    cur = cur->next;
-  }
-  //no walkers exist, add 10
-  if (W.getActiveWalkers() == 0)
-    addWalkers(omp_get_max_threads());
-  NumOfVMCWalkers = W.getActiveWalkers();
-  bool success    = true;
-  //allways reset optTarget
-  optTarget = std::make_unique<QMCCostFunction>(W, Psi, H, myComm);
-  optTarget->setStream(&app_log());
-  success = optTarget->put(q);
-
-  //create VMC engine
-  if (vmcEngine == 0)
-  {
-    QMCDriverInput qmcdriver_input_copy = qmcdriver_input_;
-    VMCDriverInput vmcdriver_input_copy = vmcdriver_input_;
-    vmcEngine =
-        std::make_unique<VMCBatched>(std::move(qmcdriver_input_copy), std::move(vmcdriver_input_copy),
-                                     MCPopulation(myComm->size(), myComm->rank(), population_.getWalkerConfigsRef(),
-                                                  population_.get_golden_electrons(), &Psi, &H)
-
-                                         ,
-                                     Psi, H, samples_, myComm);
-
-    vmcEngine->setUpdateMode(vmcMove[0] == 'p');
-    vmcEngine->setStatus(RootName, h5FileRoot, AppendRun);
-    vmcEngine->process(optNode);
-  }
-  vmcEngine->enable_sample_collection();
-
-  return success;
 }
 
 bool QMCLinearOptimizeBatched::fitMappedStabilizers(std::vector<std::pair<RealType, RealType>>& mappedStabilizers,

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
@@ -173,6 +173,7 @@ public:
   ///common operation to start optimization, used by the derived classes
   void start();
 #ifdef HAVE_LMY_ENGINE
+  using ValueType = QMCTraits::ValueType;
   void engine_start(cqmc::engine::LMYEngine<ValueType>* EngineObj,
                     DescentEngine& descentEngineObj,
                     std::string MinMethod);

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
@@ -21,7 +21,7 @@
 #define QMCPLUSPLUS_QMCLINEAROPTIMIZATION_BATCHED_H
 
 #include <memory>
-#include "QMCDrivers/QMCDriver.h"
+#include "QMCDrivers/QMCDriverNew.h"
 #include "QMCDrivers/QMCDriverInput.h"
 #include "QMCDrivers/VMC/VMCDriverInput.h"
 #include "QMCDrivers/VMC/VMCBatched.h"
@@ -49,7 +49,7 @@ class HamiltonianPool;
  * generated from VMC.
  */
 
-class QMCLinearOptimizeBatched : public QMCDriver
+class QMCLinearOptimizeBatched : public QMCDriverNew
 {
 public:
   ///Constructor.
@@ -67,9 +67,8 @@ public:
   virtual ~QMCLinearOptimizeBatched() = default;
 
   ///Run the Optimization algorithm.
-  virtual bool run() = 0;
-  ///process xml node
-  virtual bool put(xmlNodePtr cur);
+  virtual bool run() override = 0;
+
   ///add a configuration file to the list of files
   void addConfiguration(const std::string& a);
   void setWaveFunctionNode(xmlNodePtr cur) { wfNode = cur; }
@@ -190,18 +189,22 @@ public:
   RealType getNonLinearRescale(std::vector<RealType>& dP, Matrix<RealType>& S);
   void generateSamples();
 
-  QMCDriverInput qmcdriver_input_;
   VMCDriverInput vmcdriver_input_;
-  MCPopulation population_;
   SampleStack& samples_;
 
-  virtual QMCRunType getRunType() { return QMCRunType::LINEAR_OPTIMIZE; }
+  virtual QMCRunType getRunType() override { return QMCRunType::LINEAR_OPTIMIZE; }
   NewTimer& generate_samples_timer_;
   NewTimer& initialize_timer_;
   NewTimer& eigenvalue_timer_;
   NewTimer& line_min_timer_;
   NewTimer& cost_function_timer_;
   Timer t1;
+
+  ParameterSet m_param;
+
+  // Need to keep this around, unfortunately, since QMCCostFunctionBatched uses QMCCostFunctionBase,
+  // which still takes an MCWalkerConfiguration in the constructor.
+  MCWalkerConfiguration& W;
 };
 } // namespace qmcplusplus
 #endif

--- a/tests/molecules/He_ae/CMakeLists.txt
+++ b/tests/molecules/He_ae/CMakeLists.txt
@@ -26,6 +26,8 @@ ELSE()
 
   # Test batched version of optimizer
 
+ LIST(APPEND He_batch_VMC_SCALARS "totenergy" "-2.2273099 0.000001")
+
   SIMPLE_RUN_AND_CHECK(
     deterministic-He_ae-opt-batch
     "${CMAKE_SOURCE_DIR}/tests/molecules/He_ae"
@@ -40,7 +42,7 @@ ELSE()
                     det_He_opt_batch.xml
                     1 1
                     TRUE
-                    2 He_VMC_SCALARS # VMC
+                    2 He_batch_VMC_SCALARS # VMC
                     )
 
 ENDIF()


### PR DESCRIPTION
## Proposed changes

The counterpart to #2700 for the linear optimizer.   Mostly changing names and moving a few things around to match QMCDriverNew.

Two changes that are not among the above
- `QMCLinearOptimizeBatched::put` was removed (rather than rename to process).  It is not called, and confusingly duplicates code in `QMCFixedSampleLinearOptimizeBatched`.
- Rng handling in the QMCDriverNew destructor.   The previous code leads to a segfault (null Rng pointer) when VMC follows an optimizer run.   See the comment for more details.


The test deterministic-He_ae-opt_vmc-batch-1-1-totenergy fails.  I think the value just needs to be updated, but I need to look into it more.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
