### PR TITLE
Output linear matrices

### DIFF
--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(QMCDRIVERS
   WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
   WFOpt/QMCFixedSampleLinearOptimize.cpp
   WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+  WFOpt/OutputMatrix.cpp
   Optimizers/DescentEngine.cpp
   Optimizers/HybridEngine.cpp
   WFOpt/QMCCostFunctionBase.cpp

--- a/src/QMCDrivers/WFOpt/OutputMatrix.cpp
+++ b/src/QMCDrivers/WFOpt/OutputMatrix.cpp
@@ -27,7 +27,7 @@ void OutputMatrix::init_file(const std::string& root_name, const std::string& na
   // Assume that the root_name has the series suffix (".s000").
   // Remove the series suffix to get the project id
   std::string fname = root_name.substr(0, namelen - 5) + "." + name + ".s000.scalar.dat";
-  app_log() << "Output file: " << fname << std::endl;
+  app_log() << "Output matrix file: " << fname << std::endl;
 
   output_file_.open(fname);
   output_file_ << "# Index ";

--- a/src/QMCDrivers/WFOpt/OutputMatrix.cpp
+++ b/src/QMCDrivers/WFOpt/OutputMatrix.cpp
@@ -1,0 +1,60 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file OutputMatrix.cpp
+ * @brief Output the Hamiltonian and overlap matrices from linear method
+ */
+
+#include "QMCDrivers/WFOpt/OutputMatrix.h"
+
+
+namespace qmcplusplus
+{
+OutputMatrix::OutputMatrix() : index_(0) {}
+
+void OutputMatrix::init_file(const std::string& root_name, const std::string& name, int N)
+{
+  int namelen = root_name.length();
+  // Assume that the root_name has the series suffix (".s000").
+  // Remove the series suffix to get the project id
+  std::string fname = root_name.substr(0, namelen - 5) + "." + name + ".s000.scalar.dat";
+  app_log() << "Output file: " << fname << std::endl;
+
+  output_file_.open(fname);
+  output_file_ << "# Index ";
+  for (int i = 0; i < N; i++)
+  {
+    for (int j = 0; j < N; j++)
+    {
+      std::string index_name = name + "_" + std::to_string(i) + "_" + std::to_string(j);
+      output_file_ << index_name << " ";
+    }
+  }
+  output_file_ << std::endl;
+}
+
+void OutputMatrix::output(Matrix<RealType>& mat)
+{
+  output_file_ << index_ << " ";
+  for (int i = 0; i < mat.rows(); i++)
+  {
+    for (int j = 0; j < mat.cols(); j++)
+    {
+      output_file_ << mat(i, j) << " ";
+    }
+  }
+  output_file_ << std::endl;
+  index_++;
+}
+
+
+} // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/OutputMatrix.h
+++ b/src/QMCDrivers/WFOpt/OutputMatrix.h
@@ -1,0 +1,48 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file OutputMatrix.h
+ * @brief Output the Hamiltonian and overlap matrices from linear method
+ */
+#ifndef QMCPLUSPLUS_OUTPUT_MATRIX_H
+#define QMCPLUSPLUS_OUTPUT_MATRIX_H
+
+#include <ostream>
+#include <string>
+#include "Configuration.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+
+
+namespace qmcplusplus
+{
+class OutputMatrix
+{
+public:
+  using RealType = QMCTraits::RealType;
+
+  ///Constructor.
+  OutputMatrix();
+
+  /// Open a text-formatted scalar.dat file and print the header line
+  void init_file(const std::string& root_name, const std::string& name, int N);
+
+  /// Print matrix to text-formatted scalar.dat file
+  void output(Matrix<RealType>& mat);
+
+private:
+
+  int index_;
+
+  std::ofstream output_file_;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -1290,8 +1290,10 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare to use the middle shift's update as the guiding function for a new sample
-  for (int i = 0; i < numParams; i++)
-    optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
+  if (!do_output_matrices_) {
+    for (int i = 0; i < numParams; i++)
+      optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
+  }
 
   RealType largestChange(0);
   int max_element = 0;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -91,7 +91,8 @@ QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration
       previous_optimizer_type_(OptimizerType::NONE),
       current_optimizer_type_(OptimizerType::NONE),
       do_output_matrices_(false),
-      output_matrices_initialized_(false)
+      output_matrices_initialized_(false),
+      freeze_parameters_(false)
 {
   IsQMCDriver = false;
   //set the optimization flag
@@ -197,12 +198,12 @@ QMCFixedSampleLinearOptimize::RealType QMCFixedSampleLinearOptimize::Func(RealTy
 
 bool QMCFixedSampleLinearOptimize::run()
 {
-
-  if (do_output_matrices_ && !output_matrices_initialized_) {
+  if (do_output_matrices_ && !output_matrices_initialized_)
+  {
     numParams = optTarget->getNumParams();
-    int N = numParams + 1;
-    output_overlap_.init_file(get_root_name(),"ovl",N);
-    output_hamiltonian_.init_file(get_root_name(),"ham",N);
+    int N     = numParams + 1;
+    output_overlap_.init_file(get_root_name(), "ovl", N);
+    output_hamiltonian_.init_file(get_root_name(), "ham", N);
     output_matrices_initialized_ = true;
   }
 #ifdef HAVE_LMY_ENGINE
@@ -466,16 +467,33 @@ bool QMCFixedSampleLinearOptimize::put(xmlNodePtr q)
   std::string vmcMove("pbyp");
   std::string ReportToH5("no");
   std::string OutputMatrices("no");
+  std::string FreezeParameters("no");
   OhmmsAttributeSet oAttrib;
   oAttrib.add(useGPU, "gpu");
   oAttrib.add(vmcMove, "move");
   oAttrib.add(ReportToH5, "hdf5");
-  oAttrib.add(OutputMatrices, "output_matrices");
+
+  m_param.add(OutputMatrices, "output_matrices", "string");
+  m_param.add(FreezeParameters, "freeze_parameters", "string");
 
   oAttrib.put(q);
   m_param.put(q);
 
   do_output_matrices_ = (OutputMatrices != "no");
+  freeze_parameters_  = (FreezeParameters != "no");
+
+  // Use freeze_parameters with output_matrices to generate multiple lines in the output with
+  // the same parameters so statistics can be computed in post-processing.
+
+  if (freeze_parameters_)
+  {
+    app_log() << std::endl;
+    app_warning() << "  The option 'freeze_parameters' is enabled.  Variational parameters will not be updated.  This "
+                     "run will not perform variational parameter optimization!"
+                  << std::endl;
+    app_log() << std::endl;
+  }
+
 
   doHybrid = false;
 
@@ -834,7 +852,8 @@ void QMCFixedSampleLinearOptimize::solveShiftsWithoutLMYEngine(const std::vector
   optTarget->fillOverlapHamiltonianMatrices(hamMat, ovlMat);
 
   // Output Hamiltonian and Overlap matrices
-  if (do_output_matrices_) {
+  if (do_output_matrices_)
+  {
     output_overlap_.output(ovlMat);
     output_hamiltonian_.output(hamMat);
   }
@@ -1247,7 +1266,8 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   optTarget->fillOverlapHamiltonianMatrices(hamMat, ovlMat);
   invMat.copy(ovlMat);
 
-  if (do_output_matrices_) {
+  if (do_output_matrices_)
+  {
     output_overlap_.output(ovlMat);
     output_hamiltonian_.output(hamMat);
   }
@@ -1290,7 +1310,8 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare to use the middle shift's update as the guiding function for a new sample
-  if (!do_output_matrices_) {
+  if (!freeze_parameters_)
+  {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
   }

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -40,10 +40,7 @@ class QMCFixedSampleLinearOptimize : public QMCLinearOptimize, private NRCOptimi
 {
 public:
   ///Constructor.
-  QMCFixedSampleLinearOptimize(MCWalkerConfiguration& w,
-                               TrialWaveFunction& psi,
-                               QMCHamiltonian& h,
-                               Communicate* comm);
+  QMCFixedSampleLinearOptimize(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
 
   ///Destructor
   ~QMCFixedSampleLinearOptimize();
@@ -198,6 +195,9 @@ private:
 
   OutputMatrix output_hamiltonian_;
   OutputMatrix output_overlap_;
+
+  // Freeze variational parameters.  Do not update them during each step.
+  bool freeze_parameters_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -25,6 +25,7 @@
 #endif
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "QMCDrivers/Optimizers/HybridEngine.h"
+#include "QMCDrivers/WFOpt/OutputMatrix.h"
 
 namespace qmcplusplus
 {
@@ -188,6 +189,15 @@ private:
 
   //whether to use hybrid method
   bool doHybrid;
+
+  // Output Hamiltonian and overlap matrices
+  bool do_output_matrices_;
+
+  // Flag to open the files on first pass and print header line
+  bool output_matrices_initialized_;
+
+  OutputMatrix output_hamiltonian_;
+  OutputMatrix output_overlap_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -101,7 +101,8 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(MCWalke
       previous_optimizer_type_(OptimizerType::NONE),
       current_optimizer_type_(OptimizerType::NONE),
       do_output_matrices_(false),
-      output_matrices_initialized_(false)
+      output_matrices_initialized_(false),
+      freeze_parameters_(false)
 
 {
   //set the optimization flag
@@ -207,11 +208,12 @@ QMCFixedSampleLinearOptimizeBatched::RealType QMCFixedSampleLinearOptimizeBatche
 
 bool QMCFixedSampleLinearOptimizeBatched::run()
 {
-  if (do_output_matrices_ && !output_matrices_initialized_) {
+  if (do_output_matrices_ && !output_matrices_initialized_)
+  {
     numParams = optTarget->getNumParams();
-    int N = numParams + 1;
-    output_overlap_.init_file(get_root_name(),"ovl",N);
-    output_hamiltonian_.init_file(get_root_name(),"ham",N);
+    int N     = numParams + 1;
+    output_overlap_.init_file(get_root_name(), "ovl", N);
+    output_hamiltonian_.init_file(get_root_name(), "ham", N);
     output_matrices_initialized_ = true;
   }
 
@@ -466,16 +468,33 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
   std::string vmcMove("pbyp");
   std::string ReportToH5("no");
   std::string OutputMatrices("no");
+  std::string FreezeParameters("no");
   OhmmsAttributeSet oAttrib;
   oAttrib.add(useGPU, "gpu");
   oAttrib.add(vmcMove, "move");
   oAttrib.add(ReportToH5, "hdf5");
-  oAttrib.add(OutputMatrices, "output_matrices");
+
+  m_param.add(OutputMatrices, "output_matrices", "string");
+  m_param.add(FreezeParameters, "freeze_parameters", "string");
 
   oAttrib.put(q);
   m_param.put(q);
 
   do_output_matrices_ = (OutputMatrices != "no");
+  freeze_parameters_  = (FreezeParameters != "no");
+
+  // Use freeze_parameters with output_matrices to generate multiple lines in the output with
+  // the same parameters so statistics can be computed in post-processing.
+
+  if (freeze_parameters_)
+  {
+    app_log() << std::endl;
+    app_warning() << "  The option 'freeze_parameters' is enabled.  Variational parameters will not be updated.  This "
+                     "run will not perform variational parameter optimization!"
+                  << std::endl;
+    app_log() << std::endl;
+  }
+
 
   doHybrid = false;
 
@@ -496,7 +515,6 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
       adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
                               qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
   QMCDriverNew::startup(q, awc);
-
 }
 
 bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
@@ -1251,7 +1269,8 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   optTarget->fillOverlapHamiltonianMatrices(hamMat, ovlMat);
   invMat.copy(ovlMat);
 
-  if (do_output_matrices_) {
+  if (do_output_matrices_)
+  {
     output_overlap_.output(ovlMat);
     output_hamiltonian_.output(hamMat);
   }
@@ -1294,7 +1313,8 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare to use the middle shift's update as the guiding function for a new sample
-  if (!do_output_matrices_) {
+  if (!freeze_parameters_)
+  {
     for (int i = 0; i < numParams; i++)
       optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
   }

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -1294,8 +1294,10 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   optTarget->setneedGrads(false);
 
   // prepare to use the middle shift's update as the guiding function for a new sample
-  for (int i = 0; i < numParams; i++)
-    optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
+  if (!do_output_matrices_) {
+    for (int i = 0; i < numParams; i++)
+      optTarget->Params(i) = currentParameters.at(i) + parameterDirections.at(i + 1);
+  }
 
   RealType largestChange(0);
   int max_element = 0;

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -209,6 +209,9 @@ private:
 
   OutputMatrix output_hamiltonian_;
   OutputMatrix output_overlap_;
+
+  // Freeze variational parameters.  Do not update them during each step.
+  bool freeze_parameters_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -26,6 +26,7 @@
 #endif
 #include "QMCDrivers/Optimizers/DescentEngine.h"
 #include "QMCDrivers/Optimizers/HybridEngine.h"
+#include "QMCDrivers/WFOpt/OutputMatrix.h"
 
 namespace qmcplusplus
 {
@@ -199,6 +200,15 @@ private:
 
   //whether to use hybrid method
   bool doHybrid;
+
+  // Output Hamiltonian and overlap matrices
+  bool do_output_matrices_;
+
+  // Flag to open the files on first pass and print header line
+  bool output_matrices_initialized_;
+
+  OutputMatrix output_hamiltonian_;
+  OutputMatrix output_overlap_;
 };
 } // namespace qmcplusplus
 #endif


### PR DESCRIPTION
## Proposed changes

Output linear method matrices (overlap and Hamiltonian) in scalar.dat format.
They can be processed with qmca and check_scalars.py, and compared between the batched and non-batched versions of the code.
A separate option (`freeze_parameters`) disables updating the parameters so the output can be used for statistics.

Enable by adding the parameters `output_matrices` and `freeze_parameters` to the qmc block
```
   <qmc method="linear_batch" move="pbyp" checkpoint="-1">
      <parameter name="output_matrices">yes</parameter>
      <parameter name="freeze_parameters">yes</parameter>

```



## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
