### PR TITLE
Fix parallel walker creation in batched drivers

### DIFF
--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -65,15 +65,15 @@ public:
   inline void setTrialEnergy(FullPrecRealType et) { trial_energy_ = et; }
 
   /** reset to accumulate data */
-  virtual void reset();
+  void reset();
 
   /** unified: perform branch and swap walkers as required 
    *
    *  \return global population
    */
-  virtual FullPrecRealType branch(int iter, MCPopulation& pop, bool do_not_branch);
+  FullPrecRealType branch(int iter, MCPopulation& pop, bool do_not_branch);
 
-  virtual FullPrecRealType getFeedBackParameter(int ngen, FullPrecRealType tau)
+  FullPrecRealType getFeedBackParameter(int ngen, FullPrecRealType tau)
   {
     return 1.0 / (static_cast<FullPrecRealType>(ngen) * tau);
   }

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -86,6 +86,7 @@ void MCPopulation::createWalkers(IndexType num_walkers, RealType reserve)
 
   outputManager.pause();
 
+  //this part is time consuming, it must be threaded and calls should be thread-safe.
 #pragma omp parallel for
   for (size_t iw = 0; iw < num_walkers_plus_reserve; iw++)
   {
@@ -103,6 +104,7 @@ void MCPopulation::createWalkers(IndexType num_walkers, RealType reserve)
     }
 
     walker_elec_particle_sets_[iw] = std::make_unique<ParticleSet>(*elec_particle_set_);
+#pragma omp critical
     walker_trial_wavefunctions_[iw].reset(trial_wf_->makeClone(*walker_elec_particle_sets_[iw]));
     walker_hamiltonians_[iw].reset(
         hamiltonian_->makeClone(*walker_elec_particle_sets_[iw], *walker_trial_wavefunctions_[iw]));

--- a/src/Utilities/TimerManager.cpp
+++ b/src/Utilities/TimerManager.cpp
@@ -66,8 +66,8 @@ template<class TIMER>
 TIMER* TimerManager<TIMER>::createTimer(const std::string& myname, timer_levels mytimer)
 {
   TIMER* t = nullptr;
-#pragma omp critical
   {
+    const std::lock_guard<std::mutex> lock(timer_list_lock_);
     TimerList.push_back(std::make_unique<TIMER>(myname, this, mytimer));
     t = TimerList.back().get();
     initializeTimer(*t);

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <string>
+#include <mutex>
 #include <map>
 #include "NewTimer.h"
 #include "config.h"
@@ -45,6 +46,8 @@ class TimerManager
 private:
   /// All the timers created by this manager
   std::vector<std::unique_ptr<TIMER>> TimerList;
+  /// mutex for TimerList
+  std::mutex timer_list_lock_;
   /// The stack of nested active timers
   std::vector<TIMER*> CurrentTimerStack;
   /// The threshold for active timers


### PR DESCRIPTION
## Proposed changes
1. protect TWF::makeClone call under "omp critical". offload classes makeClone should be thread-safe but it is not the case. Not fully understand the issue. Put a workaround now.
2. "omp critical" cannot be nested use mutex in timer manager.
3. fix clang warning

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'