### PR TITLE
Fix AFQMC clang unused function warning

### DIFF
--- a/src/AFQMC/Numerics/detail/CPU/lapack_cpu.hpp
+++ b/src/AFQMC/Numerics/detail/CPU/lapack_cpu.hpp
@@ -38,7 +38,7 @@
 
 namespace ma
 {
-inline static void gesvd(char jobu,
+inline void gesvd(char jobu,
                          char jobvt,
                          int m,
                          int n,
@@ -57,7 +57,7 @@ inline static void gesvd(char jobu,
   //sgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, info);
 }
 
-inline static void gesvd(char jobu,
+inline void gesvd(char jobu,
                          char jobvt,
                          int m,
                          int n,
@@ -76,7 +76,7 @@ inline static void gesvd(char jobu,
   //dgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, info);
 }
 
-inline static void gesvd(char jobu,
+inline void gesvd(char jobu,
                          char jobvt,
                          int m,
                          int n,
@@ -96,7 +96,7 @@ inline static void gesvd(char jobu,
   //cgesvd(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, info);
 }
 
-inline static void gesvd(char jobu,
+inline void gesvd(char jobu,
                          char jobvt,
                          int m,
                          int n,
@@ -117,7 +117,7 @@ inline static void gesvd(char jobu,
 }
 
 template<typename T>
-inline static void gesvd_bufferSize(const int m, const int n, T* a, int& lwork)
+inline void gesvd_bufferSize(const int m, const int n, T* a, int& lwork)
 {
   T work, S;
   int status;
@@ -127,7 +127,7 @@ inline static void gesvd_bufferSize(const int m, const int n, T* a, int& lwork)
 }
 
 template<typename T>
-inline static void gesvd_bufferSize(const int m, const int n, std::complex<T>* a, int& lwork)
+inline void gesvd_bufferSize(const int m, const int n, std::complex<T>* a, int& lwork)
 {
   std::complex<T> work;
   T rwork;
@@ -137,7 +137,7 @@ inline static void gesvd_bufferSize(const int m, const int n, std::complex<T>* a
   lwork = int(real(work));
 }
 
-inline static void geev(char* jobvl,
+inline void geev(char* jobvl,
                         char* jobvr,
                         int* n,
                         double* a,
@@ -155,7 +155,7 @@ inline static void geev(char* jobvl,
   dgeev(jobvl, jobvr, n, a, lda, alphar, alphai, vl, ldvl, vr, ldvr, work, lwork, info);
 }
 
-inline static void geev(char* jobvl,
+inline void geev(char* jobvl,
                         char* jobvr,
                         int* n,
                         float* a,
@@ -173,7 +173,7 @@ inline static void geev(char* jobvl,
   sgeev(jobvl, jobvr, n, a, lda, alphar, alphai, vl, ldvl, vr, ldvr, work, lwork, info);
 }
 
-inline static void ggev(char* jobvl,
+inline void ggev(char* jobvl,
                         char* jobvr,
                         int* n,
                         double* a,
@@ -194,7 +194,7 @@ inline static void ggev(char* jobvl,
   dggev(jobvl, jobvr, n, a, lda, b, ldb, alphar, alphai, beta, vl, ldvl, vr, ldvr, work, lwork, info);
 }
 
-inline static void ggev(char* jobvl,
+inline void ggev(char* jobvl,
                         char* jobvr,
                         int* n,
                         float* a,
@@ -215,7 +215,7 @@ inline static void ggev(char* jobvl,
   sggev(jobvl, jobvr, n, a, lda, b, ldb, alphar, alphai, beta, vl, ldvl, vr, ldvr, work, lwork, info);
 }
 
-inline static void hevr(char& JOBZ,
+inline void hevr(char& JOBZ,
                         char& RANGE,
                         char& UPLO,
                         int& N,
@@ -256,7 +256,7 @@ inline static void hevr(char& JOBZ,
   }
 }
 
-inline static void hevr(char& JOBZ,
+inline void hevr(char& JOBZ,
                         char& RANGE,
                         char& UPLO,
                         int& N,
@@ -297,7 +297,7 @@ inline static void hevr(char& JOBZ,
   }
 }
 
-inline static void hevr(char& JOBZ,
+inline void hevr(char& JOBZ,
                         char& RANGE,
                         char& UPLO,
                         int& N,
@@ -338,7 +338,7 @@ inline static void hevr(char& JOBZ,
   }
 }
 
-inline static void hevr(char& JOBZ,
+inline void hevr(char& JOBZ,
                         char& RANGE,
                         char& UPLO,
                         int& N,
@@ -379,7 +379,7 @@ inline static void hevr(char& JOBZ,
   }
 }
 
-inline static void gvx(int ITYPE,
+inline void gvx(int ITYPE,
                        char& JOBZ,
                        char& RANGE,
                        char& UPLO,
@@ -417,7 +417,7 @@ inline static void gvx(int ITYPE,
   }
 }
 
-inline static void gvx(int ITYPE,
+inline void gvx(int ITYPE,
                        char& JOBZ,
                        char& RANGE,
                        char& UPLO,
@@ -455,7 +455,7 @@ inline static void gvx(int ITYPE,
   }
 }
 
-inline static void gvx(int ITYPE,
+inline void gvx(int ITYPE,
                        char& JOBZ,
                        char& RANGE,
                        char& UPLO,
@@ -493,7 +493,7 @@ inline static void gvx(int ITYPE,
   }
 }
 
-inline static void gvx(int ITYPE,
+inline void gvx(int ITYPE,
                        char& JOBZ,
                        char& RANGE,
                        char& UPLO,
@@ -531,28 +531,28 @@ inline static void gvx(int ITYPE,
   }
 }
 
-inline static void getrf_bufferSize(const int n, const int m, float* a, const int lda, int& lwork) { lwork = 0; }
-inline static void getrf_bufferSize(const int n, const int m, double* a, const int lda, int& lwork) { lwork = 0; }
-inline static void getrf_bufferSize(const int n, const int m, std::complex<float>* a, const int lda, int& lwork)
+inline void getrf_bufferSize(const int n, const int m, float* a, const int lda, int& lwork) { lwork = 0; }
+inline void getrf_bufferSize(const int n, const int m, double* a, const int lda, int& lwork) { lwork = 0; }
+inline void getrf_bufferSize(const int n, const int m, std::complex<float>* a, const int lda, int& lwork)
 {
   lwork = 0;
 }
-inline static void getrf_bufferSize(const int n, const int m, std::complex<double>* a, const int lda, int& lwork)
+inline void getrf_bufferSize(const int n, const int m, std::complex<double>* a, const int lda, int& lwork)
 {
   lwork = 0;
 }
 
-void static getrf(const int& n, const int& m, double* a, const int& n0, int* piv, int& st, double* work = nullptr)
+inline void getrf(const int& n, const int& m, double* a, const int& n0, int* piv, int& st, double* work = nullptr)
 {
   dgetrf(n, m, a, n0, piv, st);
 }
 
-void static getrf(const int& n, const int& m, float* a, const int& n0, int* piv, int& st, float* work = nullptr)
+inline void getrf(const int& n, const int& m, float* a, const int& n0, int* piv, int& st, float* work = nullptr)
 {
   sgetrf(n, m, a, n0, piv, st);
 }
 
-void static getrf(const int& n,
+inline void getrf(const int& n,
                   const int& m,
                   std::complex<double>* a,
                   const int& n0,
@@ -563,7 +563,7 @@ void static getrf(const int& n,
   zgetrf(n, m, a, n0, piv, st);
 }
 
-void static getrf(const int& n,
+inline void getrf(const int& n,
                   const int& m,
                   std::complex<float>* a,
                   const int& n0,
@@ -574,31 +574,31 @@ void static getrf(const int& n,
   cgetrf(n, m, a, n0, piv, st);
 }
 
-inline static void getrfBatched(const int n, float** a, int lda, int* piv, int* info, int batchSize)
+inline void getrfBatched(const int n, float** a, int lda, int* piv, int* info, int batchSize)
 {
   for (int i = 0; i < batchSize; i++)
     getrf(n, n, a[i], lda, piv + i * n, *(info + i));
 }
 
-inline static void getrfBatched(const int n, double** a, int lda, int* piv, int* info, int batchSize)
+inline void getrfBatched(const int n, double** a, int lda, int* piv, int* info, int batchSize)
 {
   for (int i = 0; i < batchSize; i++)
     getrf(n, n, a[i], lda, piv + i * n, *(info + i));
 }
 
-inline static void getrfBatched(const int n, std::complex<double>** a, int lda, int* piv, int* info, int batchSize)
+inline void getrfBatched(const int n, std::complex<double>** a, int lda, int* piv, int* info, int batchSize)
 {
   for (int i = 0; i < batchSize; i++)
     getrf(n, n, a[i], lda, piv + i * n, *(info + i));
 }
 
-inline static void getrfBatched(const int n, std::complex<float>** a, int lda, int* piv, int* info, int batchSize)
+inline void getrfBatched(const int n, std::complex<float>** a, int lda, int* piv, int* info, int batchSize)
 {
   for (int i = 0; i < batchSize; i++)
     getrf(n, n, a[i], lda, piv + i * n, *(info + i));
 }
 
-inline static void getri_bufferSize(int n, float const* a, int lda, int& lwork)
+inline void getri_bufferSize(int n, float const* a, int lda, int& lwork)
 {
   float work;
   int status;
@@ -607,7 +607,7 @@ inline static void getri_bufferSize(int n, float const* a, int lda, int& lwork)
   lwork = int(work);
 }
 
-inline static void getri_bufferSize(int n, double const* a, int lda, int& lwork)
+inline void getri_bufferSize(int n, double const* a, int lda, int& lwork)
 {
   double work;
   int status;
@@ -616,7 +616,7 @@ inline static void getri_bufferSize(int n, double const* a, int lda, int& lwork)
   lwork = int(work);
 }
 
-inline static void getri_bufferSize(int n, std::complex<float> const* a, int lda, int& lwork)
+inline void getri_bufferSize(int n, std::complex<float> const* a, int lda, int& lwork)
 {
   std::complex<float> work;
   int status;
@@ -625,7 +625,7 @@ inline static void getri_bufferSize(int n, std::complex<float> const* a, int lda
   lwork = int(real(work));
 }
 
-inline static void getri_bufferSize(int n, std::complex<double> const* a, int lda, int& lwork)
+inline void getri_bufferSize(int n, std::complex<double> const* a, int lda, int& lwork)
 {
   std::complex<double> work;
   int status;
@@ -635,12 +635,12 @@ inline static void getri_bufferSize(int n, std::complex<double> const* a, int ld
 }
 
 
-void static getri(int n, float* restrict a, int n0, int const* restrict piv, float* restrict work, int n1, int& status)
+inline void getri(int n, float* restrict a, int n0, int const* restrict piv, float* restrict work, int n1, int& status)
 {
   sgetri(n, a, n0, piv, work, n1, status);
 }
 
-void static getri(int n,
+inline void getri(int n,
                   double* restrict a,
                   int n0,
                   int const* restrict piv,
@@ -651,7 +651,7 @@ void static getri(int n,
   dgetri(n, a, n0, piv, work, n1, status);
 }
 
-void static getri(int n,
+inline void getri(int n,
                   std::complex<float>* restrict a,
                   int n0,
                   int const* restrict piv,
@@ -662,7 +662,7 @@ void static getri(int n,
   cgetri(n, a, n0, piv, work, n1, status);
 }
 
-void static getri(int n,
+inline void getri(int n,
                   std::complex<double>* restrict a,
                   int n0,
                   int const* restrict piv,
@@ -674,7 +674,7 @@ void static getri(int n,
 }
 
 template<typename T>
-inline static void getriBatched(int n, T** a, int lda, int* piv, T** ainv, int ldc, int* info, int batchSize)
+inline void getriBatched(int n, T** a, int lda, int* piv, T** ainv, int ldc, int* info, int batchSize)
 {
   for (int i = 0; i < batchSize; i++)
   {
@@ -684,7 +684,7 @@ inline static void getriBatched(int n, T** a, int lda, int* piv, T** ainv, int l
   }
 }
 
-void static geqrf(int M,
+inline void geqrf(int M,
                   int N,
                   std::complex<double>* A,
                   const int LDA,
@@ -701,7 +701,7 @@ void static geqrf(int M,
 #endif
 }
 
-void static geqrf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+inline void geqrf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -711,7 +711,7 @@ void static geqrf(int M, int N, double* A, const int LDA, double* TAU, double* W
 #endif
 }
 
-void static geqrf(int M,
+inline void geqrf(int M,
                   int N,
                   std::complex<float>* A,
                   const int LDA,
@@ -728,7 +728,7 @@ void static geqrf(int M,
 #endif
 }
 
-void static geqrf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+inline void geqrf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -739,7 +739,7 @@ void static geqrf(int M, int N, float* A, const int LDA, float* TAU, float* WORK
 }
 
 template<typename T>
-static void geqrf_bufferSize(int m, int n, T* a, int lda, int& lwork)
+inline void geqrf_bufferSize(int m, int n, T* a, int lda, int& lwork)
 {
   typename std::decay<T>::type work;
   int status;
@@ -748,7 +748,7 @@ static void geqrf_bufferSize(int m, int n, T* a, int lda, int& lwork)
   lwork = int(real(work));
 }
 
-void static gelqf(int M,
+inline void gelqf(int M,
                   int N,
                   std::complex<double>* A,
                   const int LDA,
@@ -765,7 +765,7 @@ void static gelqf(int M,
 #endif
 }
 
-void static gelqf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+inline void gelqf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -775,7 +775,7 @@ void static gelqf(int M, int N, double* A, const int LDA, double* TAU, double* W
 #endif
 }
 
-void static gelqf(int M,
+inline void gelqf(int M,
                   int N,
                   std::complex<float>* A,
                   const int LDA,
@@ -792,7 +792,7 @@ void static gelqf(int M,
 #endif
 }
 
-void static gelqf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+inline void gelqf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -803,7 +803,7 @@ void static gelqf(int M, int N, float* A, const int LDA, float* TAU, float* WORK
 }
 
 template<typename T>
-static void gelqf_bufferSize(int m, int n, T* a, int lda, int& lwork)
+inline void gelqf_bufferSize(int m, int n, T* a, int lda, int& lwork)
 {
   typename std::decay<T>::type work;
   int status;
@@ -812,7 +812,7 @@ static void gelqf_bufferSize(int m, int n, T* a, int lda, int& lwork)
   lwork = int(real(work));
 }
 
-void static gqr(int M,
+inline void gqr(int M,
                 int N,
                 int K,
                 std::complex<double>* A,
@@ -830,7 +830,7 @@ void static gqr(int M,
 #endif
 }
 
-void static gqr(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+inline void gqr(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -840,7 +840,7 @@ void static gqr(int M, int N, int K, double* A, const int LDA, double* TAU, doub
 #endif
 }
 
-void static gqr(int M,
+inline void gqr(int M,
                 int N,
                 int K,
                 std::complex<float>* A,
@@ -858,7 +858,7 @@ void static gqr(int M,
 #endif
 }
 
-void static gqr(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+inline void gqr(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -869,7 +869,7 @@ void static gqr(int M, int N, int K, float* A, const int LDA, float* TAU, float*
 }
 
 template<typename T>
-static void gqr_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
+inline void gqr_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
 {
   typename std::decay<T>::type work;
   int status;
@@ -878,7 +878,7 @@ static void gqr_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
   lwork = int(real(work));
 }
 
-void static glq(int M,
+inline void glq(int M,
                 int N,
                 int K,
                 std::complex<double>* A,
@@ -896,7 +896,7 @@ void static glq(int M,
 #endif
 }
 
-void static glq(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+inline void glq(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -906,7 +906,7 @@ void static glq(int M, int N, int K, double* A, const int LDA, double* TAU, doub
 #endif
 }
 
-void static glq(int M,
+inline void glq(int M,
                 int N,
                 int K,
                 std::complex<float>* A,
@@ -924,7 +924,7 @@ void static glq(int M,
 #endif
 }
 
-void static glq(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int const LWORK, int& INFO)
+inline void glq(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int const LWORK, int& INFO)
 {
 #ifdef __NO_QR__
   INFO    = 0;
@@ -935,7 +935,7 @@ void static glq(int M, int N, int K, float* A, const int LDA, float* TAU, float*
 }
 
 template<typename T>
-static void glq_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
+inline void glq_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
 {
   typename std::decay<T>::type work;
   int status;
@@ -945,7 +945,7 @@ static void glq_bufferSize(int m, int n, int k, T* a, int lda, int& lwork)
 }
 
 template<typename T1, typename T2>
-inline static void matinvBatched(int n, T1* const* a, int lda, T2** ainv, int lda_inv, int* info, int batchSize)
+inline void matinvBatched(int n, T1* const* a, int lda, T2** ainv, int lda_inv, int* info, int batchSize)
 {
   std::vector<int> piv(n);
   int lwork(-1);

--- a/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/rotate.hpp
@@ -484,7 +484,7 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
     APP_ABORT(" Error: kN > NMO in halfRotateCholeskyMatrix. \n");
 
   // map from [0:2*NMO) to [0:NMO) in collinear case
-  int k0_alpha, k0_beta, kN_alpha = 0, kN_beta = 0;
+  int k0_alpha = 0, k0_beta = 0, kN_alpha = 0, kN_beta = 0;
   if (k0 >= 0)
   {
     k0_alpha = std::min(k0, NMO);
@@ -494,10 +494,6 @@ void halfRotateCholeskyMatrix(WALKER_TYPES type,
       k0_beta = std::max(k0, NMO) - NMO;
       kN_beta = std::max(kN, NMO) - NMO;
     }
-  }
-  else
-  {
-    k0_alpha = k0_beta = kN_alpha = kN_beta = 0;
   }
 
   int ak0, ak1;

--- a/src/Platforms/CPU/BLAS.hpp
+++ b/src/Platforms/CPU/BLAS.hpp
@@ -88,11 +88,13 @@ namespace BLAS
     zaxpy(n, x, a, incx, b, incy);
   }
 
+  inline static float norm2(int n, const float* a, int incx = 1) { return snrm2(n, a, incx); }
+
+  inline static float norm2(int n, const std::complex<float>* a, int incx = 1) { return scnrm2(n, a, incx); }
+
   inline static double norm2(int n, const double* a, int incx = 1) { return dnrm2(n, a, incx); }
 
   inline static double norm2(int n, const std::complex<double>* a, int incx = 1) { return dznrm2(n, a, incx); }
-
-  inline static float norm2(int n, const float* a, int incx = 1) { return snrm2(n, a, incx); }
 
   inline static void scal(int n, float alpha, float* x, int incx = 1) { sscal(n, alpha, x, incx); }
 
@@ -112,10 +114,6 @@ namespace BLAS
 
   inline static void scal(int n, float alpha, std::complex<float>* x, int incx = 1) { csscal(n, alpha, x, incx); }
 
-  //inline static
-  //void gemv(char trans, int n, int m, const double* amat, const double* x, double* y) {
-  //  dgemv(trans, n, m, done, amat, n, x, INCX, dzero, y, INCY);
-  //}
   inline static void gemv(int n, int m, const double* restrict amat, const double* restrict x, double* restrict y)
   {
     dgemv(NOTRANS, m, n, done, amat, m, x, INCX, dzero, y, INCY);
@@ -232,190 +230,6 @@ namespace BLAS
     cgemv(trans_in, n, m, alpha, amat, lda, x, incx, beta, y, incy);
   }
 
-#if defined(HAVE_MKL)
-  inline static void gemv(char trans_in,
-                          int n,
-                          int m,
-                          const std::complex<double>& alpha,
-                          const double* restrict amat,
-                          int lda,
-                          const std::complex<double>* restrict x,
-                          int incx,
-                          const std::complex<double>& beta,
-                          std::complex<double>* y,
-                          int incy)
-  {
-    dzgemv(trans_in, n, m, alpha, amat, lda, x, incx, beta, y, incy);
-  }
-
-  inline static void gemv(char trans_in,
-                          int n,
-                          int m,
-                          const std::complex<float>& alpha,
-                          const float* restrict amat,
-                          int lda,
-                          const std::complex<float>* restrict x,
-                          int incx,
-                          const std::complex<float>& beta,
-                          std::complex<float>* y,
-                          int incy)
-  {
-    scgemv(trans_in, n, m, alpha, amat, lda, x, incx, beta, y, incy);
-  }
-
-  inline static void gemm_batch(const CBLAS_LAYOUT Layout,
-                                const CBLAS_TRANSPOSE* transa_array,
-                                const CBLAS_TRANSPOSE* transb_array,
-                                const int* m_array,
-                                const int* n_array,
-                                const int* k_array,
-                                const float* alpha_array,
-                                const void** a_array,
-                                const int* lda_array,
-                                const void** b_array,
-                                const int* ldb_array,
-                                const void* beta_array,
-                                void** c_array,
-                                const int* ldc_array,
-                                const int group_count,
-                                const int* group_size)
-  {
-    cblas_sgemm_batch(Layout, transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array,
-                      b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size);
-  }
-
-  inline static void gemm_batch(const CBLAS_LAYOUT Layout,
-                                const CBLAS_TRANSPOSE* transa_array,
-                                const CBLAS_TRANSPOSE* transb_array,
-                                const int* m_array,
-                                const int* n_array,
-                                const int* k_array,
-                                const double* alpha_array,
-                                const void** a_array,
-                                const int* lda_array,
-                                const void** b_array,
-                                const int* ldb_array,
-                                const void* beta_array,
-                                void** c_array,
-                                const int* ldc_array,
-                                const int group_count,
-                                const int* group_size)
-  {
-    cblas_dgemm_batch(Layout, transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array,
-                      b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size);
-  }
-
-  inline static void gemm_batch(const CBLAS_LAYOUT Layout,
-                                const CBLAS_TRANSPOSE* transa_array,
-                                const CBLAS_TRANSPOSE* transb_array,
-                                const int* m_array,
-                                const int* n_array,
-                                const int* k_array,
-                                const std::complex<float>* alpha_array,
-                                const void** a_array,
-                                const int* lda_array,
-                                const void** b_array,
-                                const int* ldb_array,
-                                const void* beta_array,
-                                void** c_array,
-                                const int* ldc_array,
-                                const int group_count,
-                                const int* group_size)
-  {
-    cblas_cgemm_batch(Layout, transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array,
-                      b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size);
-  }
-
-  inline static void gemm_batch(const CBLAS_LAYOUT Layout,
-                                const CBLAS_TRANSPOSE* transa_array,
-                                const CBLAS_TRANSPOSE* transb_array,
-                                const int* m_array,
-                                const int* n_array,
-                                const int* k_array,
-                                const std::complex<double>* alpha_array,
-                                const void** a_array,
-                                const int* lda_array,
-                                const void** b_array,
-                                const int* ldb_array,
-                                const void* beta_array,
-                                void** c_array,
-                                const int* ldc_array,
-                                const int group_count,
-                                const int* group_size)
-  {
-    cblas_zgemm_batch(Layout, transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array,
-                      b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size);
-  }
-#endif
-
-  template<typename T>
-  inline static void gemmStridedBatched(char Atrans,
-                                        char Btrans,
-                                        int M,
-                                        int N,
-                                        int K,
-                                        T alpha,
-                                        const T* A,
-                                        int lda,
-                                        int strideA,
-                                        const T* restrict B,
-                                        int ldb,
-                                        int strideB,
-                                        T beta,
-                                        T* restrict C,
-                                        int ldc,
-                                        int strideC,
-                                        int batchSize)
-  {
-#ifdef HAVE_MKL
-    // MKL has batched gemm, but with pointer interface. Translate here
-    std::vector<const void*> Aptrs(batchSize);
-    std::vector<const void*> Bptrs(batchSize);
-    std::vector<const void*> Cptrs(batchSize);
-
-    for (int i = 0; i < batchSize; i++)
-    {
-      Aptrs[i] = static_cast<const void*>(A + i * strideA);
-      Bptrs[i] = static_cast<const void*>(B + i * strideB);
-      Cptrs[i] = static_cast<const void*>(C + i * strideC);
-    }
-
-    // Expect arrays of size group_count.
-    // This is 1 in strided case, so passing pointers to everything
-    gemm_batch(CblasColMajor, &Atrans, &Btrans, &M, &N, &K, &alpha, Aptrs.data(), &lda, Bptrs.data(), &ldb, &beta,
-               Cptrs.data(), &ldc, 1, &batchSize);
-#else
-    // No batched gemm, :-( gemm loop
-    for (int i = 0; i < batchSize; i++)
-      gemm(Atrans, Btrans, M, N, K, alpha, A + i * strideA, lda, B + i * strideB, ldb, beta, C + i * strideC, ldc);
-#endif
-  }
-
-  template<typename T>
-  inline static void gemmBatched(char Atrans,
-                                 char Btrans,
-                                 int M,
-                                 int N,
-                                 int K,
-                                 T alpha,
-                                 T const** A,
-                                 int lda,
-                                 T const** B,
-                                 int ldb,
-                                 T beta,
-                                 T** C,
-                                 int ldc,
-                                 int batchSize)
-  {
-#ifdef HAVE_MKL
-    gemm_batch(CblasColMajor, &Atrans, &Btrans, &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc, 1, &batchSize);
-#else
-    // No batched gemm, :-( gemm loop
-    for (int i = 0; i < batchSize; i++)
-      gemm(Atrans, Btrans, M, N, K, alpha, A[i], lda, B[i], ldb, beta, C[i], ldc);
-#endif
-  }
-
   inline static void gemm(char Atrans,
                           char Btrans,
                           int M,
@@ -483,77 +297,6 @@ namespace BLAS
   {
     cgemm(Atrans, Btrans, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
   }
-
-
-  //   inline static
-  //   void symv(char uplo, int n, const double alpha, double* a, int lda,
-  //             double* x, const int incx, const double beta, double* y,
-  //             const int incy) {
-  //     dsymv(&uplo,&n,&alpha,a,&lda,x,&incx,&beta,y,&incy);
-  //   }
-
-  //   inline static
-  //   void symv(char uplo, int n, const std::complex<double> alpha,
-  //             std::complex<double>* a, int lda, std::complex<double>* x, const int incx,
-  //             const std::complex<double> beta, std::complex<double>* y, const int incy) {
-  //     zsymv(&uplo,&n,&alpha,a,&lda,x,&incx,&beta,y,&incy);
-  //   }
-
-  //   inline static
-  //   void symv(const char uplo, int n, const float alpha, float* a, int lda,
-  //             float* x, const int incx, const float beta, float* y,
-  //             const int incy) {
-  //     ssymv(&uplo,&n,&alpha,a,&lda,x,&incx,&beta,y,&incy);
-  //   }
-
-  //   inline static
-  //   void symv(const char uplo, int n, const std::complex<float> alpha,
-  //             std::complex<float>* a, int lda, std::complex<float>* x, const int incx,
-  //             const std::complex<float> beta, std::complex<float>* y, const int incy) {
-  //     csymv(&uplo,&n,&alpha,a,&lda,x,&incx,&beta,y,&incy);
-  //   }
-
-  //   inline static
-  //   void symv(int n, double alpha, double* a, double* x, double* y) {
-  //     dsymv(&UPLO,&n,&alpha,a,&n,x,&INCX,&dzero,y,&INCY);
-  //   }
-
-  //   inline static
-  //   void symv(int n, const double* a, const double* x, double* y) {
-  //     dsymv(&UPLO,&n,&done,a,&n,x,&INCX,&dzero,y,&INCY);
-  //   }
-
-  //   inline static
-  //   void symv(int n, float alpha, float* a, float* x, float* y) {
-  //     ssymv(&UPLO,&n,&alpha,a,&n,x,&INCX,&szero,y,&INCY);
-  //   }
-
-  //   inline static
-  //   void symv(int n, float* a, float* x, float* y) {
-  //     ssymv(&UPLO,&n,&sone,a,&n,x,&INCX,&szero,y,&INCY);
-  //   }
-
-  //   inline static void
-  //   symv(int n, std::complex<double> alpha, std::complex<double>* a, std::complex<double>* x,
-  //        std::complex<double>* y) {
-  //     zsymv(&UPLO,&n,&alpha,a,&n,x,&INCX,&zzero,y,&INCY);
-  //   }
-
-  //   inline static
-  //   void symv(int n, std::complex<double>* a, std::complex<double>* x, std::complex<double>* y) {
-  //     zsymv(&UPLO,&n,&zone,a,&n,x,&INCX,&zzero,y,&INCY);
-  //   }
-
-  //   inline static void
-  //   symv(int n, std::complex<float> alpha, std::complex<float>* a, std::complex<float>* x,
-  //        std::complex<float>* y) {
-  //     csymv(&UPLO,&n,&alpha,a,&n,x,&INCX,&czero,y,&INCY);
-  //   }
-
-  //   inline static
-  //   void symv(int n, std::complex<float>* a, std::complex<float>* x, std::complex<float>* y) {
-  //     csymv(&UPLO,&n,&cone,a,&n,x,&INCX,&czero,y,&INCY);
-  //   }
 
   template<typename T>
   inline static T dot(int n, const T* restrict a, const T* restrict b)

--- a/src/Platforms/CPU/Blasf.h
+++ b/src/Platforms/CPU/Blasf.h
@@ -26,6 +26,7 @@
 #define zaxpy zaxpy_
 #define dnrm2 dnrm2_
 #define snrm2 snrm2_
+#define scnrm2 scnrm2_
 #define dznrm2 dznrm2_
 #define dsymv dsymv_
 #define ssymv ssymv_
@@ -107,29 +108,13 @@
 #define dpotrf dpotrf_
 #define zpotrf zpotrf_
 
-#if defined(HAVE_MKL)
-#define dzgemv dzgemv_
-#define scgemv scgemv_
-#define dzgemm dzgemm_
-#define scgemm scgemm_
-typedef enum
-{
-  CblasRowMajor = 101,
-  CblasColMajor = 102
-} CBLAS_LAYOUT;
-typedef enum
-{
-  CblasNoTrans   = 111,
-  CblasTrans     = 112,
-  CblasConjTrans = 113
-} CBLAS_TRANSPOSE;
-#endif
-
 #endif
 
 // declaring Fortran interfaces
 extern "C"
 {
+  void saxpy(const int& n, const float& da, const float* dx, const int& incx, float* dy, const int& incy);
+
   void caxpy(const int& n,
              const std::complex<float>& da,
              const std::complex<float>* dx,
@@ -139,8 +124,6 @@ extern "C"
 
   void daxpy(const int& n, const double& da, const double* dx, const int& incx, double* dy, const int& incy);
 
-  void saxpy(const int& n, const float& da, const float* dx, const int& incx, float* dy, const int& incy);
-
   void zaxpy(const int& n,
              const std::complex<double>& da,
              const std::complex<double>* dx,
@@ -149,18 +132,18 @@ extern "C"
              const int& incy);
 
 
-  double dnrm2(const int& n, const double* dx, const int& incx);
   float snrm2(const int& n, const float* dx, const int& incx);
+  float scnrm2(const int& n, const std::complex<float>* dx, const int& incx);
+  double dnrm2(const int& n, const double* dx, const int& incx);
   double dznrm2(const int& n, const std::complex<double>* dx, const int& incx);
 
 
-  double dscal(const int& n, const double&, double* x, const int&);
-  double sscal(const int& n, const float&, float* x, const int&);
-
-  double cscal(const int& n, const std::complex<float>&, std::complex<float>* x, const int&);
-  double zscal(const int& n, const std::complex<double>&, std::complex<double>* x, const int&);
-  double zdscal(const int& n, const double&, std::complex<double>* x, const int&);
-  double csscal(const int& n, const float&, std::complex<float>* x, const int&);
+  void sscal(const int& n, const float&, float* x, const int&);
+  void cscal(const int& n, const std::complex<float>&, std::complex<float>* x, const int&);
+  void dscal(const int& n, const double&, double* x, const int&);
+  void zscal(const int& n, const std::complex<double>&, std::complex<double>* x, const int&);
+  void csscal(const int& n, const float&, std::complex<float>* x, const int&);
+  void zdscal(const int& n, const double&, std::complex<double>* x, const int&);
 
   void dsymv(const char& uplo,
              const int& n,
@@ -339,130 +322,6 @@ extern "C"
              const std::complex<float>& beta,
              std::complex<float>* cv,
              const int& incy);
-
-#if defined(HAVE_MKL)
-
-  void dzgemm(const char&,
-              const char&,
-              const int&,
-              const int&,
-              const int&,
-              const std::complex<double>&,
-              const double*,
-              const int&,
-              const std::complex<double>*,
-              const int&,
-              const std::complex<double>&,
-              std::complex<double>*,
-              const int&);
-
-  void scgemm(const char&,
-              const char&,
-              const int&,
-              const int&,
-              const int&,
-              const std::complex<float>&,
-              const float*,
-              const int&,
-              const std::complex<float>*,
-              const int&,
-              const std::complex<float>&,
-              std::complex<float>*,
-              const int&);
-
-  void dzgemv(const char& trans,
-              const int& nr,
-              const int& nc,
-              const std::complex<double>& alpha,
-              const double* amat,
-              const int& lda,
-              const std::complex<double>* bv,
-              const int& incx,
-              const std::complex<double>& beta,
-              std::complex<double>* cv,
-              const int& incy);
-
-  void scgemv(const char& trans,
-              const int& nr,
-              const int& nc,
-              const std::complex<float>& alpha,
-              const float* amat,
-              const int& lda,
-              const std::complex<float>* bv,
-              const int& incx,
-              const std::complex<float>& beta,
-              std::complex<float>* cv,
-              const int& incy);
-
-  void cblas_sgemm_batch(const CBLAS_LAYOUT Layout,
-                         const CBLAS_TRANSPOSE* transa_array,
-                         const CBLAS_TRANSPOSE* transb_array,
-                         const int* m_array,
-                         const int* n_array,
-                         const int* k_array,
-                         const void* alpha_array,
-                         const void** a_array,
-                         const int* lda_array,
-                         const void** b_array,
-                         const int* ldb_array,
-                         const void* beta_array,
-                         void** c_array,
-                         const int* ldc_array,
-                         const int group_count,
-                         const int* group_size);
-
-  void cblas_cgemm_batch(const CBLAS_LAYOUT Layout,
-                         const CBLAS_TRANSPOSE* transa_array,
-                         const CBLAS_TRANSPOSE* transb_array,
-                         const int* m_array,
-                         const int* n_array,
-                         const int* k_array,
-                         const void* alpha_array,
-                         const void** a_array,
-                         const int* lda_array,
-                         const void** b_array,
-                         const int* ldb_array,
-                         const void* beta_array,
-                         void** c_array,
-                         const int* ldc_array,
-                         const int group_count,
-                         const int* group_size);
-
-  void cblas_dgemm_batch(const CBLAS_LAYOUT Layout,
-                         const CBLAS_TRANSPOSE* transa_array,
-                         const CBLAS_TRANSPOSE* transb_array,
-                         const int* m_array,
-                         const int* n_array,
-                         const int* k_array,
-                         const void* alpha_array,
-                         const void** a_array,
-                         const int* lda_array,
-                         const void** b_array,
-                         const int* ldb_array,
-                         const void* beta_array,
-                         void** c_array,
-                         const int* ldc_array,
-                         const int group_count,
-                         const int* group_size);
-
-  void cblas_zgemm_batch(const CBLAS_LAYOUT Layout,
-                         const CBLAS_TRANSPOSE* transa_array,
-                         const CBLAS_TRANSPOSE* transb_array,
-                         const int* m_array,
-                         const int* n_array,
-                         const int* k_array,
-                         const void* alpha_array,
-                         const void** a_array,
-                         const int* lda_array,
-                         const void** b_array,
-                         const int* ldb_array,
-                         const void* beta_array,
-                         void** c_array,
-                         const int* ldc_array,
-                         const int group_count,
-                         const int* group_size);
-
-#endif
 
   void dsyrk(const char&,
              const char&,


### PR DESCRIPTION
## Proposed changes
Reduce Clang warning and remove MKL bits in BLAS.hpp, Blas.f because AFQMC doesn't use these header files.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'