### PR TITLE
Fix legacy CUDA DMC breakage

### DIFF
--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -206,7 +206,13 @@ public:
     //static_cast<Matrix<FullPrecRealType>>(Properties) = 0.0;
   }
 
+#if defined(QMC_CUDA)
+  //some member variables in CUDA build cannot be and should not be copied
+  //use default copy constructor to skip actual data copy
+  Walker(const Walker& a) = default;
+#else
   Walker(const Walker& a) : Properties(1, WP::NUMPROPERTIES, 1, WP::MAXPROPERTIES) { makeCopy(a); }
+#endif
 
   inline int addPropertyHistory(int leng)
   {

--- a/src/QMCDrivers/DMC/DMCFactoryNew.cpp
+++ b/src/QMCDrivers/DMC/DMCFactoryNew.cpp
@@ -20,6 +20,10 @@ QMCDriverInterface* DMCFactoryNew::create(MCPopulation&& pop,
                                           QMCHamiltonian& h,
                                           Communicate* comm)
 {
+#if defined(QMC_CUDA)
+  comm->barrier_and_abort("DMC batched driver is not supported by legacy CUDA builds.");
+#endif
+
   QMCDriverInput qmcdriver_input(qmc_counter_);
   qmcdriver_input.readXML(input_node_);
   DMCDriverInput dmcdriver_input;

--- a/src/QMCDrivers/VMC/VMCFactoryNew.cpp
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.cpp
@@ -26,6 +26,10 @@ QMCDriverInterface* VMCFactoryNew::create(MCPopulation&& pop,
                                           SampleStack& samples,
                                           Communicate* comm)
 {
+
+#if defined(QMC_CUDA)
+  comm->barrier_and_abort("VMC batched driver is not supported by legacy CUDA builds.");
+#endif
   QMCDriverInput qmcdriver_input(qmc_counter_);
   qmcdriver_input.readXML(input_node_);
   VMCDriverInput vmcdriver_input;

--- a/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
@@ -17,7 +17,7 @@
                     TRUE
                     0 DIAMOND2_SCALARS # VMC
                     )
-
+IF(NOT QMC_CUDA)
   # 16 batches of 1 walker each
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -56,7 +56,7 @@
                     TRUE
                     0 DIAMOND2_SCALARS # VMC
                     )
-
+ENDIF()
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-delayed_update-vmc_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
                     qmc_short
@@ -98,6 +98,7 @@
                     )
 
 
+IF(NOT QMC_CUDA)
   #16 batches of 16 walkers in one rank
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch_dmcbatch_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -117,6 +118,7 @@
                     TRUE
                     1 DIAMOND2_DMC_SCALARS # DMC
                     )
+ENDIF()
 
   LIST(APPEND DIAMOND2_DMC_SCALARS "totenergy" "-21.844975 0.00779")
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-dmc-reconf_sdj


### PR DESCRIPTION
## Proposed changes
Fix breakage #2855 and protect inaccessible code pathes which their tests skipped.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'