### PR TITLE
Manage crowd shared resource

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ INCLUDE_DIRECTORIES("${qmcpack_SOURCE_DIR}/external_codes/boost_multi")
     Utilities/RunTimeManager.cpp
     Utilities/ProgressReportEngine.cpp
     Utilities/unit_conversion.cpp
+    Utilities/ResourceCollection.cpp
     OhmmsApp/ProjectData.cpp
     OhmmsApp/RandomNumberControl.cpp
     Numerics/OptimizableFunctorBase.cpp
@@ -152,6 +153,7 @@ IF(USE_OBJECT_TARGET)
 ELSE(USE_OBJECT_TARGET)
   ADD_LIBRARY(qmcutil ${UTILITIES})
 ENDIF(USE_OBJECT_TARGET)
+  TARGET_INCLUDE_DIRECTORIES(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Utilities")
   TARGET_LINK_LIBRARIES(qmcutil PUBLIC message containers qmcio)
   TARGET_LINK_LIBRARIES(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
 

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -62,26 +62,30 @@ void Crowd::initializeResources(const ResourceCollection& twf_resource)
     twfs_shared_resource_ = std::make_unique<ResourceCollection>(twf_resource);
 }
 
-void Crowd::lendResources()
+void Crowd::lendResources(size_t receiver)
 {
   if (walker_twfs_.size() > 0)
   {
     if (twfs_shared_resource_->is_lent())
       throw std::runtime_error("Crowd::lendResources resources are out already!");
+    if (receiver >= walker_twfs_.size())
+      throw std::runtime_error("Crowd::takebackResources receiver out of bound!");
     twfs_shared_resource_->lock();
     twfs_shared_resource_->rewind();
-    walker_twfs_[0].get().acquireResource(*twfs_shared_resource_);
+    walker_twfs_[receiver].get().acquireResource(*twfs_shared_resource_);
   }
 }
 
-void Crowd::takebackResources()
+void Crowd::takebackResources(size_t receiver)
 {
   if (walker_twfs_.size() > 0)
   {
     if (!twfs_shared_resource_->is_lent())
       throw std::runtime_error("Crowd::takebackResources resources was not lent out!");
+    if (receiver >= walker_twfs_.size())
+      throw std::runtime_error("Crowd::takebackResources receiver out of bound!");
     twfs_shared_resource_->rewind();
-    walker_twfs_[0].get().releaseResource(*twfs_shared_resource_);
+    walker_twfs_[receiver].get().releaseResource(*twfs_shared_resource_);
     twfs_shared_resource_->unlock();
   }
 }

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -59,7 +59,7 @@ void Crowd::setRNGForHamiltonian(RandomGenerator_t& rng)
 void Crowd::initializeResources(const ResourceCollection& twf_resource)
 {
   if (!twfs_shared_resource_)
-   twfs_shared_resource_ = std::make_unique<ResourceCollection>(twf_resource);
+    twfs_shared_resource_ = std::make_unique<ResourceCollection>(twf_resource);
 }
 
 void Crowd::lendResources()
@@ -69,6 +69,7 @@ void Crowd::lendResources()
     if (is_shared_resource_lent)
       throw std::runtime_error("Crowd::lendResources resources are out already!");
     is_shared_resource_lent = true;
+    twfs_shared_resource_->rewind();
     walker_twfs_[0].get().acquireResource(*twfs_shared_resource_);
   }
 }
@@ -80,6 +81,7 @@ void Crowd::takebackResources()
     if (!is_shared_resource_lent)
       throw std::runtime_error("Crowd::takebackResources resources was not lent out!");
     is_shared_resource_lent = false;
+    twfs_shared_resource_->rewind();
     walker_twfs_[0].get().releaseResource(*twfs_shared_resource_);
   }
 }

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -14,7 +14,7 @@
 namespace qmcplusplus
 {
 
-Crowd::Crowd(EstimatorManagerNew& emb) : is_shared_resource_lent(false), estimator_manager_crowd_(emb) {}
+Crowd::Crowd(EstimatorManagerNew& emb) : estimator_manager_crowd_(emb) {}
 
 Crowd::~Crowd() = default;
 
@@ -66,9 +66,9 @@ void Crowd::lendResources()
 {
   if (walker_twfs_.size() > 0)
   {
-    if (is_shared_resource_lent)
+    if (twfs_shared_resource_->is_lent())
       throw std::runtime_error("Crowd::lendResources resources are out already!");
-    is_shared_resource_lent = true;
+    twfs_shared_resource_->lock();
     twfs_shared_resource_->rewind();
     walker_twfs_[0].get().acquireResource(*twfs_shared_resource_);
   }
@@ -78,11 +78,11 @@ void Crowd::takebackResources()
 {
   if (walker_twfs_.size() > 0)
   {
-    if (!is_shared_resource_lent)
+    if (!twfs_shared_resource_->is_lent())
       throw std::runtime_error("Crowd::takebackResources resources was not lent out!");
-    is_shared_resource_lent = false;
     twfs_shared_resource_->rewind();
     walker_twfs_[0].get().releaseResource(*twfs_shared_resource_);
+    twfs_shared_resource_->unlock();
   }
 }
 

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -76,8 +76,16 @@ public:
 
   void setRNGForHamiltonian(RandomGenerator_t& rng);
 
+  /** initialize crowd-owned resources shared by walkers in the crowd
+   */
   void initializeResources(const ResourceCollection& twf_resource);
+  /** lend crowd-owned resources to the crowd leader walker
+   * Note: use RAII CrowdResourceLock whenever possible
+   */
   void lendResources();
+  /** take back crowd-owned resources from the crowd leader walker
+   * Note: use RAII CrowdResourceLock whenever possible
+   */
   void takebackResources();
 
   auto beginWalkers() { return mcp_walkers_.begin(); }
@@ -103,8 +111,6 @@ public:
   unsigned long get_reject() { return n_reject_; }
 
 private:
-  // true if shared_resources are lent out
-  bool is_shared_resource_lent;
   /** @name Walker Vectors
    *
    *  A single index into these ordered lists constitutes a complete 
@@ -132,6 +138,8 @@ private:
   /** @} */
 };
 
+/** Lock for a crowd lending and taking back shared resource to its consumer objects.
+ */
 class CrowdResourceLock
 {
 public:
@@ -141,6 +149,10 @@ public:
   }
 
   ~CrowdResourceLock() { locked_crowd_.takebackResources(); }
+
+  CrowdResourceLock(const CrowdResourceLock&) = delete;
+  CrowdResourceLock(CrowdResourceLock&&) = delete;
+
 private:
   Crowd& locked_crowd_;
 };

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -82,11 +82,11 @@ public:
   /** lend crowd-owned resources to the crowd leader walker
    * Note: use RAII CrowdResourceLock whenever possible
    */
-  void lendResources();
+  void lendResources(size_t receiver);
   /** take back crowd-owned resources from the crowd leader walker
    * Note: use RAII CrowdResourceLock whenever possible
    */
-  void takebackResources();
+  void takebackResources(size_t receiver);
 
   auto beginWalkers() { return mcp_walkers_.begin(); }
   auto endWalkers() { return mcp_walkers_.end(); }
@@ -143,18 +143,19 @@ private:
 class CrowdResourceLock
 {
 public:
-  CrowdResourceLock(Crowd& locked_crowd) : locked_crowd_(locked_crowd)
+  CrowdResourceLock(Crowd& locked_crowd, size_t receiver = 0) : locked_crowd_(locked_crowd), receiver_(receiver)
   {
-    locked_crowd_.lendResources();
+    locked_crowd_.lendResources(receiver_);
   }
 
-  ~CrowdResourceLock() { locked_crowd_.takebackResources(); }
+  ~CrowdResourceLock() { locked_crowd_.takebackResources(receiver_); }
 
   CrowdResourceLock(const CrowdResourceLock&) = delete;
   CrowdResourceLock(CrowdResourceLock&&) = delete;
 
 private:
   Crowd& locked_crowd_;
+  const size_t receiver_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -421,8 +421,11 @@ void DMCBatched::runDMCStep(int crowd_id,
                             UPtrVector<Crowd>& crowds)
 {
   Crowd& crowd = *(crowds[crowd_id]);
+
   if (crowd.size() == 0)
     return;
+
+  CrowdResourceLock crowd_res_lock(crowd);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
 
   int max_steps  = sft.qmcdrv_input.get_max_steps();

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -142,6 +142,8 @@ private:
 
   ///random number generator
   RandomGenerator_t& rng_;
+  /// TWF resource collection
+  std::unique_ptr<ResourceCollection> twfs_shared_resource_;
   ///if true, use fixed population
   bool use_fixed_pop_;
   ///minimum number of walkers

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -22,6 +22,7 @@
 #include "ParticleBase/ParticleAttrib.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "Particle/Walker.h"
+#include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCDrivers/WalkerElementsRef.h"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "Utilities/FairDivide.h"
@@ -36,7 +37,6 @@ namespace qmcplusplus
 {
 
 // forward declaration
-class TrialWaveFunction;
 class QMCHamiltonian;
 class MCPopulation
 {
@@ -151,6 +151,7 @@ public:
     auto walker_index = 0;
     for (int i = 0; i < walker_consumers.size(); ++i)
     {
+      walker_consumers[i]->initializeResources(trial_wf_->getResource());
       for (int j = 0; j < walkers_per_crowd[i]; ++j)
       {
         walker_consumers[i]->addWalker(*walkers_[walker_index], *walker_elec_particle_sets_[walker_index],

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -190,6 +190,8 @@ public:
   const ParticleSet& get_ions() const { return ions_; }
   const ParticleSet* get_golden_electrons() const { return elec_particle_set_; }
   ParticleSet* get_golden_electrons() { return elec_particle_set_; }
+  const TrialWaveFunction& get_golden_twf() const { return *trial_wf_; }
+
   void set_num_global_walkers(IndexType num_global_walkers) { num_global_walkers_ = num_global_walkers; }
   void set_num_local_walkers(IndexType num_local_walkers) { num_local_walkers_ = num_local_walkers; }
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -320,6 +320,8 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
                                         UPtrVector<ContextForSteps>& context_for_steps)
 {
   Crowd& crowd = *(crowds[crowd_id]);
+  CrowdResourceLock crowd_res_lock(crowd);
+
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
 
   auto& walker_twfs         = crowd.get_walker_twfs();

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -220,6 +220,7 @@ void VMCBatched::runVMCStep(int crowd_id,
                             std::vector<std::unique_ptr<Crowd>>& crowds)
 {
   Crowd& crowd = *(crowds[crowd_id]);
+  CrowdResourceLock crowd_res_lock(crowd);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
 
   int max_steps = sft.qmcdrv_input.get_max_steps();
@@ -296,6 +297,7 @@ bool VMCBatched::run()
   auto runWarmupStep = [](int crowd_id, StateForThread& sft, DriverTimers& timers,
                           UPtrVector<ContextForSteps>& context_for_steps, UPtrVector<Crowd>& crowds) {
     Crowd& crowd = *(crowds[crowd_id]);
+    CrowdResourceLock crowd_res_lock(crowd);
     advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], false);
   };
 

--- a/src/QMCDrivers/tests/WalkerConsumer.h
+++ b/src/QMCDrivers/tests/WalkerConsumer.h
@@ -18,6 +18,9 @@
 
 namespace qmcplusplus
 {
+
+class ResourceCollection;
+
 namespace testing
 {
 /** mock class to avoid testing dependency between Crowd and MCPopulation
@@ -31,6 +34,8 @@ public:
   std::vector<std::reference_wrapper<ParticleSet>> walker_elecs_;
   std::vector<std::reference_wrapper<TrialWaveFunction>> walker_twfs_;
   std::vector<std::reference_wrapper<QMCHamiltonian>> walker_hamiltonians_;
+
+  void initializeResources(const ResourceCollection& twf_resource) {}
 
   void addWalker(Walker<QMCTraits, PtclOnLatticeTraits>& walker,
                  ParticleSet& elecs,

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -133,6 +133,54 @@ public:
     }
   }
 
+  virtual void mw_evaluate_notranspose(const RefVector<SPOSet>& spo_list,
+                                       const RefVector<ParticleSet>& P_list,
+                                       int first,
+                                       int last,
+                                       const RefVector<ValueMatrix_t>& logdet_list,
+                                       const RefVector<GradMatrix_t>& dlogdet_list,
+                                       const RefVector<ValueMatrix_t>& d2logdet_list) override
+  {
+    typedef ValueMatrix_t::value_type value_type;
+    typedef GradMatrix_t::value_type grad_type;
+
+    const size_t nw = spo_list.size();
+    std::vector<ValueVector_t> mw_psi_v;
+    std::vector<GradVector_t> mw_dpsi_v;
+    std::vector<ValueVector_t> mw_d2psi_v;
+    RefVector<ValueVector_t> psi_v_list;
+    RefVector<GradVector_t> dpsi_v_list;
+    RefVector<ValueVector_t> d2psi_v_list;
+    mw_psi_v.reserve(nw);
+    mw_dpsi_v.reserve(nw);
+    mw_d2psi_v.reserve(nw);
+    psi_v_list.reserve(nw);
+    dpsi_v_list.reserve(nw);
+    d2psi_v_list.reserve(nw);
+
+    for (int iat = first, i = 0; iat < last; ++iat, ++i)
+    {
+      mw_psi_v.clear();
+      mw_dpsi_v.clear();
+      mw_d2psi_v.clear();
+      psi_v_list.clear();
+      dpsi_v_list.clear();
+      d2psi_v_list.clear();
+
+      for (int iw = 0; iw < nw; iw++)
+      {
+        mw_psi_v.push_back(ValueVector_t(logdet_list[iw].get()[i], OrbitalSetSize));
+        mw_dpsi_v.push_back(GradVector_t(dlogdet_list[iw].get()[i], OrbitalSetSize));
+        mw_d2psi_v.push_back(ValueVector_t(d2logdet_list[iw].get()[i], OrbitalSetSize));
+        psi_v_list.push_back(mw_psi_v[iw]);
+        dpsi_v_list.push_back(mw_dpsi_v[iw]);
+        d2psi_v_list.push_back(mw_d2psi_v[iw]);
+      }
+
+      mw_evaluateVGL(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);
+    }
+  }
+
   virtual void evaluate_notranspose(const ParticleSet& P,
                                     int first,
                                     int last,

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -169,12 +169,12 @@ public:
 
       for (int iw = 0; iw < nw; iw++)
       {
-        mw_psi_v.push_back(ValueVector_t(logdet_list[iw].get()[i], OrbitalSetSize));
-        mw_dpsi_v.push_back(GradVector_t(dlogdet_list[iw].get()[i], OrbitalSetSize));
-        mw_d2psi_v.push_back(ValueVector_t(d2logdet_list[iw].get()[i], OrbitalSetSize));
-        psi_v_list.push_back(mw_psi_v[iw]);
-        dpsi_v_list.push_back(mw_dpsi_v[iw]);
-        d2psi_v_list.push_back(mw_d2psi_v[iw]);
+        mw_psi_v.emplace_back(logdet_list[iw].get()[i], OrbitalSetSize);
+        mw_dpsi_v.emplace_back(dlogdet_list[iw].get()[i], OrbitalSetSize);
+        mw_d2psi_v.emplace_back(d2logdet_list[iw].get()[i], OrbitalSetSize);
+        psi_v_list.push_back(mw_psi_v.back());
+        dpsi_v_list.push_back(mw_dpsi_v.back());
+        d2psi_v_list.push_back(mw_d2psi_v.back());
       }
 
       mw_evaluateVGL(spo_list, P_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -99,6 +99,10 @@ public:
   using WaveFunctionComponent::registerData;
   using WaveFunctionComponent::updateBuffer;
 
+  using WaveFunctionComponent::createResource;
+  using WaveFunctionComponent::acquireResource;
+  using WaveFunctionComponent::releaseResource;
+
   using WaveFunctionComponent::acceptMove;
   using WaveFunctionComponent::completeUpdates;
   using WaveFunctionComponent::evalGrad;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -390,29 +390,13 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evaluateGL(const RefVector<Wav
   else
   {
     const auto nw = WFC_list.size();
-    {
-      ScopedTimer d2h(&D2HTimer);
-
-      RefVector<DET_ENGINE_TYPE> engine_list;
-      engine_list.reserve(nw);
-
-      for (int iw = 0; iw < nw; iw++)
-      {
-        auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
-        engine_list.push_back(det.det_engine_);
-        auto& my_psiM_vgl  = det.psiM_vgl;
-        auto* psiM_vgl_ptr = my_psiM_vgl.data();
-        PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4]) nowait")
-      }
-
-      det_engine_.mw_transferAinv_D2H(engine_list);
-
-      PRAGMA_OFFLOAD("omp taskwait")
-    }
+    RefVector<DET_ENGINE_TYPE> engine_list;
+    engine_list.reserve(nw);
 
     if (UpdateMode == ORB_PBYP_RATIO)
-    { //need to compute dpsiM and d2psiM. Do not touch psiM!
+    { //need to compute dpsiM and d2psiM. psiMinv is not touched!
       ScopedTimer spo_timer(&SPOVGLTimer);
+
       RefVector<SPOSet> phi_list;
       RefVector<ValueMatrix_t> psiM_temp_list;
       RefVector<GradMatrix_t> dpsiM_list;
@@ -425,6 +409,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evaluateGL(const RefVector<Wav
       for (int iw = 0; iw < nw; iw++)
       {
         auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
+        engine_list.push_back(det.det_engine_);
         phi_list.push_back(*det.Phi);
         psiM_temp_list.push_back(det.psiM_temp);
         dpsiM_list.push_back(det.dpsiM);
@@ -432,9 +417,27 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evaluateGL(const RefVector<Wav
       }
 
       Phi->mw_evaluate_notranspose(phi_list, P_list, FirstIndex, LastIndex, psiM_temp_list, dpsiM_list, d2psiM_list);
+      det_engine_.mw_transferAinv_D2H(engine_list);
       //FIXME maybe need the same transfer as recompute
     }
-    for (int iw = 0; iw < WFC_list.size(); iw++)
+    else
+    { // transfer dpsiM, d2psiM, psiMinv to host
+      ScopedTimer d2h(&D2HTimer);
+
+      for (int iw = 0; iw < nw; iw++)
+      {
+        auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
+        engine_list.push_back(det.det_engine_);
+        auto& my_psiM_vgl  = det.psiM_vgl;
+        auto* psiM_vgl_ptr = my_psiM_vgl.data();
+        PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4]) nowait")
+      }
+
+      det_engine_.mw_transferAinv_D2H(engine_list);
+      PRAGMA_OFFLOAD("omp taskwait")
+    }
+
+    for (int iw = 0; iw < nw; iw++)
     {
       auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
       det.computeGL(G_list[iw], L_list[iw]);
@@ -826,7 +829,6 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVector<Wave
                                                             const RefVector<ParticleSet>& P_list)
 {
   const auto nw = WFC_list.size();
-  /*
   {
     ScopedTimer spo_timer(&SPOVGLTimer);
 
@@ -850,7 +852,6 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVector<Wave
 
     Phi->mw_evaluate_notranspose(phi_list, P_list, FirstIndex, LastIndex, psiM_temp_list, dpsiM_list, d2psiM_list);
   }
-  */
 
   RefVector<const ValueMatrix_t> psiM_temp_list;
   psiM_temp_list.reserve(nw);
@@ -858,14 +859,12 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVector<Wave
   for (int iw = 0; iw < nw; iw++)
   {
     auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
-    det.Phi->evaluate_notranspose(P_list[iw], FirstIndex, LastIndex, det.psiM_temp, det.dpsiM, det.d2psiM);
     auto* psiM_vgl_ptr = det.psiM_vgl.data();
-    PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[psiM_vgl.capacity():psiM_vgl.capacity()*4])")
-    //det.invertPsiM(det.psiM_temp);
+    PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[psiM_vgl.capacity():psiM_vgl.capacity()*4]) nowait")
     psiM_temp_list.push_back(det.psiM_temp);
   }
-
   mw_invertPsiM(WFC_list, psiM_temp_list);
+  PRAGMA_OFFLOAD("omp taskwait")
 }
 
 template<typename DET_ENGINE_TYPE>

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -77,11 +77,20 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_invertPsiM(const RefVector<Wav
     }
   }
   else
+  {
+    RefVector<DET_ENGINE_TYPE> engine_list;
+    RefVector<LogValueType> log_value_list;
+    engine_list.reserve(nw);
+
     for (int iw = 0; iw < nw; iw++)
     {
-      auto& diracdet = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
-      diracdet.det_engine_.invert_transpose(logdetT_list[iw], diracdet.LogValue);
+      auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
+      engine_list.push_back(det.det_engine_);
+      log_value_list.push_back(det.LogValue);
     }
+
+    det_engine_.mw_invert_transpose(engine_list, logdetT_list, log_value_list);
+  }
 }
 
 ///reset the size: with the number of particles and number of orbtials
@@ -858,7 +867,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVector<Wave
 
   for (int iw = 0; iw < nw; iw++)
   {
-    auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
+    auto& det          = static_cast<DiracDeterminantBatched<DET_ENGINE_TYPE>&>(WFC_list[iw].get());
     auto* psiM_vgl_ptr = det.psiM_vgl.data();
     PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[psiM_vgl.capacity():psiM_vgl.capacity()*4]) nowait")
     psiM_temp_list.push_back(det.psiM_temp);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -788,6 +788,24 @@ DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYP
   return dclone;
 }
 
+template<typename DET_ENGINE_TYPE>
+void DiracDeterminantBatched<DET_ENGINE_TYPE>::createResource(ResourceCollection& collection)
+{
+  det_engine_.createResource(collection);
+}
+
+template<typename DET_ENGINE_TYPE>
+void DiracDeterminantBatched<DET_ENGINE_TYPE>::acquireResource(ResourceCollection& collection)
+{
+  det_engine_.acquireResource(collection);
+}
+
+template<typename DET_ENGINE_TYPE>
+void DiracDeterminantBatched<DET_ENGINE_TYPE>::releaseResource(ResourceCollection& collection)
+{
+  det_engine_.releaseResource(collection);
+}
+
 template class DiracDeterminantBatched<>;
 #if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
 template class DiracDeterminantBatched<MatrixDelayedUpdateCUDA<QMCTraits::ValueType, QMCTraits::QTFull::ValueType>>;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -145,14 +145,14 @@ public:
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 
-/*
   void mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
                       const RefVector<ParticleSet>& P_list,
                       const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                       const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) override;
-*/
 
   void recompute(ParticleSet& P) override;
+
+  void mw_recompute(const RefVector<WaveFunctionComponent>& WFC_list, const RefVector<ParticleSet>& P_list);
 
   LogValueType evaluateGL(ParticleSet& P,
                           ParticleSet::ParticleGradient_t& G,
@@ -164,7 +164,6 @@ public:
                      const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                      const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
                      bool fromscratch) override;
-
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
@@ -234,8 +233,10 @@ private:
   /// compute G adn L assuming psiMinv, dpsiM, d2psiM are ready for use
   void computeGL(ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) const;
 
-  /// invert psiM or its copies
+  /// invert logdetT(psiM), result is in the engine.
   void invertPsiM(const ValueMatrix_t& logdetT);
+  void mw_invertPsiM(const RefVector<WaveFunctionComponent>& WFC_list,
+                     const RefVector<const ValueMatrix_t>& logdetT_list);
 
   /// Resize all temporary arrays required for force computation.
   void resizeScratchObjectsForIonDerivs();

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -145,11 +145,12 @@ public:
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 
-  //Ye: TODO, good performance needs batched SPO evaluation.
-  //void mw_evaluateLog(const std::vector<WaveFunctionComponent*>& WFC_list,
-  //                    const std::vector<ParticleSet*>& P_list,
-  //                    const std::vector<ParticleSet::ParticleGradient_t*>& G_list,
-  //                    const std::vector<ParticleSet::ParticleLaplacian_t*>& L_list) override;
+/*
+  void mw_evaluateLog(const RefVector<WaveFunctionComponent>& WFC_list,
+                      const RefVector<ParticleSet>& P_list,
+                      const RefVector<ParticleSet::ParticleGradient_t>& G_list,
+                      const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) override;
+*/
 
   void recompute(ParticleSet& P) override;
 
@@ -186,7 +187,7 @@ public:
   auto& getPsiMinv() const { return psiMinv; }
 
   /// inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$, actual memory owned by det_engine_
-  OffloadPinnedValueMatrix_t psiMinv;
+  ValueMatrix_t psiMinv;
 
   /// memory for psiM, dpsiM and d2psiM. [5][norb*norb]
   OffloadVGLVector_t psiM_vgl;
@@ -230,8 +231,11 @@ public:
   std::vector<GradType> grad_new_local;
 
 private:
+  /// compute G adn L assuming psiMinv, dpsiM, d2psiM are ready for use
+  void computeGL(ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) const;
+
   /// invert psiM or its copies
-  void invertPsiM(const ValueMatrix_t& logdetT, OffloadPinnedValueMatrix_t& invMat);
+  void invertPsiM(const ValueMatrix_t& logdetT);
 
   /// Resize all temporary arrays required for force computation.
   void resizeScratchObjectsForIonDerivs();

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -167,6 +167,10 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
+  void createResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection) override;
+  void releaseResource(ResourceCollection& collection) override;
+
   /** cloning function
    * @param tqp target particleset
    * @param spo spo set

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -24,6 +24,8 @@
 #include "CUDA/cuBLAS_missing_functions.hpp"
 #include "QMCWaveFunctions/detail/CUDA/matrix_update_helper.hpp"
 #include "CUDA/CUDAallocator.hpp"
+#include "ResourceCollection.h"
+
 
 namespace qmcplusplus
 {
@@ -388,6 +390,10 @@ public:
     psiMinv.resize(norb, getAlignedSize<T>(norb));
     psiMinv_dev_ptr = getOffloadDevicePtr(psiMinv.data());
   }
+
+  void createResource(ResourceCollection& collection) {}
+  void acquireResource(ResourceCollection& collection) {}
+  void releaseResource(ResourceCollection& collection) {}
 
   inline OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -392,8 +392,6 @@ public:
 
   MatrixDelayedUpdateCUDA(const MatrixDelayedUpdateCUDA&) = delete;
 
-  ~MatrixDelayedUpdateCUDA() {}
-
   /** resize the internal storage
    * @param norb number of electrons/orbitals
    * @param delay, maximum delay 0<delay<=norb
@@ -441,7 +439,7 @@ public:
   template<typename TREAL>
   inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)
   {
-    // this is to make unit tests friendly without the need of setup resources.
+    // make this class unit tests friendly without the need of setup resources.
     if (!cuda_handles_)
       cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
 
@@ -459,7 +457,7 @@ public:
                                   const RefVector<const Matrix<T>>& logdetT_list,
                                   const RefVector<std::complex<TREAL>>& LogValues)
   {
-    // this is to make unit tests friendly without the need of setup resources.
+    // make this class unit tests friendly without the need of setup resources.
     if (!cuda_handles_)
       cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
 

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -29,7 +29,6 @@
 
 namespace qmcplusplus
 {
-
 struct CUDALinearAlgebraHandles : public Resource
 {
   // CUDA specific variables
@@ -43,8 +42,7 @@ struct CUDALinearAlgebraHandles : public Resource
     cublasErrorCheck(cublasSetStream(h_cublas, hstream), "cublasSetStream failed!");
   }
 
-  CUDALinearAlgebraHandles(const CUDALinearAlgebraHandles&) : CUDALinearAlgebraHandles()
-  { }
+  CUDALinearAlgebraHandles(const CUDALinearAlgebraHandles&) : CUDALinearAlgebraHandles() {}
 
   ~CUDALinearAlgebraHandles()
   {
@@ -52,10 +50,7 @@ struct CUDALinearAlgebraHandles : public Resource
     cudaErrorCheck(cudaStreamDestroy(hstream), "cudaStreamDestroy failed!");
   }
 
-  Resource* makeClone() const override
-  {
-    return new CUDALinearAlgebraHandles(*this);
-  }
+  Resource* makeClone() const override { return new CUDALinearAlgebraHandles(*this); }
 };
 
 /** implements dirac matrix delayed update using OpenMP offload and CUDA.
@@ -160,7 +155,10 @@ class MatrixDelayedUpdateCUDA
   // index in the resource collection when created.
   int resource_index;
 
-  inline void waitStream() { cudaErrorCheck(cudaStreamSynchronize(cuda_handles_->hstream), "cudaStreamSynchronize failed!"); }
+  inline void waitStream()
+  {
+    cudaErrorCheck(cudaStreamSynchronize(cuda_handles_->hstream), "cudaStreamSynchronize failed!");
+  }
   // ensure no previous delay left
   inline void guard_no_delay() const
   {
@@ -302,14 +300,14 @@ class MatrixDelayedUpdateCUDA
     //BLAS::gemv('T', norb, delay_count, cone, U_gpu.data(), norb, invRow.data(), 1, czero, p_gpu.data(), 1);
     //BLAS::gemv('N', delay_count, delay_count, -cone, Binv.data(), lda_Binv, p.data(), 1, czero, Binv[delay_count], 1);
     //BLAS::gemv('N', norb, delay_count, cone, V.data(), norb, Binv[delay_count], 1, cone, invRow.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cone_dev_ptr, U_mw_ptr, norb,
-                                            invRow_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cone_dev_ptr, U_mw_ptr,
+                                            norb, invRow_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', delay_count, delay_count, cminusone_dev_ptr, Binv_mw_ptr,
-                                            lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvRow_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', delay_count, delay_count, cminusone_dev_ptr,
+                                            Binv_mw_ptr, lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', norb, delay_count, cone_dev_ptr, V_mw_ptr, norb,
-                                            BinvRow_mw_ptr, 1, cone_dev_ptr, invRow_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', norb, delay_count, cone_dev_ptr, V_mw_ptr,
+                                            norb, BinvRow_mw_ptr, 1, cone_dev_ptr, invRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
     // mark row prepared
     invRow_id = rowchanged;
@@ -372,29 +370,29 @@ class MatrixDelayedUpdateCUDA
       T* ratio_inv_mw   = reinterpret_cast<T*>(updateRow_buffer_H2D_dev_ptr + sizeof(T*) * n_accepted * 8);
 
       // invoke the Fahy's variant of Sherman-Morrison update.
-      cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, norb, cone_dev_ptr, Ainv_mw_ptr, lda, phiV_mw_ptr, 1,
-                                              czero_dev_ptr, temp_mw_ptr, 1, n_accepted),
+      cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, norb, cone_dev_ptr, Ainv_mw_ptr, lda,
+                                              phiV_mw_ptr, 1, czero_dev_ptr, temp_mw_ptr, 1, n_accepted),
                      "cuBLAS_MFs::gemv_batched failed!");
 
-      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(cuda_handles_->hstream, rowchanged, norb, Ainv_mw_ptr, lda, temp_mw_ptr,
-                                                   rcopy_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, dpsiM_mw_out, d2psiM_mw_out,
-                                                   n_accepted),
+      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(cuda_handles_->hstream, rowchanged, norb, Ainv_mw_ptr, lda,
+                                                   temp_mw_ptr, rcopy_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, dpsiM_mw_out,
+                                                   d2psiM_mw_out, n_accepted),
                      "CUDA::copyAinvRow_saveGL_cuda failed!");
 
 
-      cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1, temp_mw_ptr, 1,
-                                             Ainv_mw_ptr, lda, n_accepted),
+      cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1,
+                                             temp_mw_ptr, 1, Ainv_mw_ptr, lda, n_accepted),
                      "cuBLAS_MFs::ger_batched failed!");
     }
   }
 
 public:
   /// default constructor
-  MatrixDelayedUpdateCUDA() : invRow_id(-1), delay_count(0), resource_index(-1) { }
+  MatrixDelayedUpdateCUDA() : invRow_id(-1), delay_count(0), resource_index(-1) {}
 
   MatrixDelayedUpdateCUDA(const MatrixDelayedUpdateCUDA&) = delete;
 
-  ~MatrixDelayedUpdateCUDA() { }
+  ~MatrixDelayedUpdateCUDA() {}
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals
@@ -424,7 +422,7 @@ public:
     auto res_ptr = dynamic_cast<CUDALinearAlgebraHandles*>(collection.lendResource(resource_index).release());
     if (!res_ptr)
       throw std::runtime_error("MatrixDelayedUpdateCUDA::acquireResource dynamic_cast failed");
-   cuda_handles_.reset(res_ptr);
+    cuda_handles_.reset(res_ptr);
   }
 
   void releaseResource(ResourceCollection& collection)
@@ -448,11 +446,35 @@ public:
       cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
 
     guard_no_delay();
+
     auto& Ainv = psiMinv;
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
     detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
     T* Ainv_ptr = Ainv.data();
     PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
+  }
+
+  template<typename TREAL>
+  inline void mw_invert_transpose(const RefVector<This_t>& engines,
+                                  const RefVector<const Matrix<T>>& logdetT_list,
+                                  const RefVector<std::complex<TREAL>>& LogValues)
+  {
+    // this is to make unit tests friendly without the need of setup resources.
+    if (!cuda_handles_)
+      cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
+
+    guard_no_delay();
+
+    // FIXME use cublas batched inverse.
+    for (int iw = 0; iw < engines.size(); iw++)
+    {
+      auto& Ainv = engines[iw].get().psiMinv;
+      Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
+      detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
+      T* Ainv_ptr = Ainv.data();
+      PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
+    }
+    PRAGMA_OFFLOAD("omp taskwait")
   }
 
   // prepare invRow and compute the old gradients.
@@ -487,7 +509,8 @@ public:
     const T** dpsiM_row_ptr = reinterpret_cast<const T**>(evalGrad_buffer_H2D_dev_ptr) + nw;
 
     const int norb = psiMinv.rows();
-    cudaErrorCheck(CUDA::calcGradients_cuda(cuda_handles_->hstream, norb, invRow_ptr, dpsiM_row_ptr, grads_value_dev_ptr, nw),
+    cudaErrorCheck(CUDA::calcGradients_cuda(cuda_handles_->hstream, norb, invRow_ptr, dpsiM_row_ptr,
+                                            grads_value_dev_ptr, nw),
                    "CUDA::calcGradients_cuda failed!");
     cudaErrorCheck(cudaMemcpyAsync(grads_value_v.data(), grads_value_dev_ptr, grads_value_v.size() * sizeof(T),
                                    cudaMemcpyDeviceToHost, cuda_handles_->hstream),
@@ -624,26 +647,28 @@ public:
     // handle accepted walkers
     // the new Binv is [[X Y] [Z y]]
     //BLAS::gemv('T', norb, delay_count + 1, cminusone, V.data(), norb, psiV.data(), 1, czero, p.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cminusone_dev_ptr, V_mw_ptr, norb,
-                                            phiV_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, n_accepted),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cminusone_dev_ptr, V_mw_ptr,
+                                            norb, phiV_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // Y
     //BLAS::gemv('T', delay_count, delay_count, y, Binv.data(), lda_Binv, p.data(), 1, czero, Binv.data() + delay_count,
     //           lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr, Binv_mw_ptr,
-                                            lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvCol_mw_ptr, lda_Binv, n_accepted),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr,
+                                            Binv_mw_ptr, lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvCol_mw_ptr, lda_Binv,
+                                            n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // X
     //BLAS::ger(delay_count, delay_count, cone, Binv[delay_count], 1, Binv.data() + delay_count, lda_Binv,
     //          Binv.data(), lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, delay_count, delay_count, cone_dev_ptr, BinvRow_mw_ptr, 1,
-                                           BinvCol_mw_ptr, lda_Binv, Binv_mw_ptr, lda_Binv, n_accepted),
+    cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, delay_count, delay_count, cone_dev_ptr,
+                                           BinvRow_mw_ptr, 1, BinvCol_mw_ptr, lda_Binv, Binv_mw_ptr, lda_Binv,
+                                           n_accepted),
                    "cuBLAS_MFs::ger_batched failed!");
     // y and Z
-    cudaErrorCheck(CUDA::add_delay_list_save_y_VGL_batched(cuda_handles_->hstream, delay_list_mw_ptr, rowchanged, delay_count,
-                                                           Binv_mw_ptr, lda_Binv, ratio_inv_mw_ptr, phiV_mw_ptr,
-                                                           dpsiM_mw_in, d2psiM_mw_in, U_row_mw_ptr, dpsiM_mw_out,
-                                                           d2psiM_mw_out, norb, n_accepted, nw),
+    cudaErrorCheck(CUDA::add_delay_list_save_y_VGL_batched(cuda_handles_->hstream, delay_list_mw_ptr, rowchanged,
+                                                           delay_count, Binv_mw_ptr, lda_Binv, ratio_inv_mw_ptr,
+                                                           phiV_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, U_row_mw_ptr,
+                                                           dpsiM_mw_out, d2psiM_mw_out, norb, n_accepted, nw),
                    "CUDA::add_delay_list_save_y_VGL_batched failed!");
     delay_count++;
     // update Ainv when maximal delay is reached
@@ -702,16 +727,20 @@ public:
     {
       const int lda_Binv = Binv_gpu.cols();
       constexpr T cone(1), czero(0), cminusone(-1);
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb, &cone,
-                                            U_mw_ptr, norb, Ainv_mw_ptr, lda, &czero, tempMat_mw_ptr, lda_Binv, nw),
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb,
+                                            &cone, U_mw_ptr, norb, Ainv_mw_ptr, lda, &czero, tempMat_mw_ptr, lda_Binv,
+                                            nw),
                        "cuBLAS::gemm_batched failed!");
-      cudaErrorCheck(CUDA::applyW_batched(cuda_handles_->hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr, lda_Binv, nw),
+      cudaErrorCheck(CUDA::applyW_batched(cuda_handles_->hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr,
+                                          lda_Binv, nw),
                      "CUDA::applyW_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count, delay_count, &cone,
-                                            V_mw_ptr, norb, Binv_mw_ptr, lda_Binv, &czero, U_mw_ptr, norb, nw),
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count,
+                                            delay_count, &cone, V_mw_ptr, norb, Binv_mw_ptr, lda_Binv, &czero, U_mw_ptr,
+                                            norb, nw),
                        "cuBLAS::gemm_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count, &cminusone,
-                                            U_mw_ptr, norb, tempMat_mw_ptr, lda_Binv, &cone, Ainv_mw_ptr, lda, nw),
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count,
+                                            &cminusone, U_mw_ptr, norb, tempMat_mw_ptr, lda_Binv, &cone, Ainv_mw_ptr,
+                                            lda, nw),
                        "cuBLAS::gemm_batched failed!");
     }
     delay_count = 0;

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -29,6 +29,35 @@
 
 namespace qmcplusplus
 {
+
+struct CUDALinearAlgebraHandles : public Resource
+{
+  // CUDA specific variables
+  cudaStream_t hstream;
+  cublasHandle_t h_cublas;
+
+  CUDALinearAlgebraHandles() : Resource("MatrixDelayedUpdateCUDA")
+  {
+    cudaErrorCheck(cudaStreamCreate(&hstream), "cudaStreamCreate failed!");
+    cublasErrorCheck(cublasCreate(&h_cublas), "cublasCreate failed!");
+    cublasErrorCheck(cublasSetStream(h_cublas, hstream), "cublasSetStream failed!");
+  }
+
+  CUDALinearAlgebraHandles(const CUDALinearAlgebraHandles&) : CUDALinearAlgebraHandles()
+  { }
+
+  ~CUDALinearAlgebraHandles()
+  {
+    cublasErrorCheck(cublasDestroy(h_cublas), "cublasDestroy failed!");
+    cudaErrorCheck(cudaStreamDestroy(hstream), "cudaStreamDestroy failed!");
+  }
+
+  Resource* makeClone() const override
+  {
+    return new CUDALinearAlgebraHandles(*this);
+  }
+};
+
 /** implements dirac matrix delayed update using OpenMP offload and CUDA.
  * It is used as DET_ENGINE_TYPE in DiracDeterminantBatched.
  * @tparam T base precision for most computation
@@ -126,11 +155,12 @@ class MatrixDelayedUpdateCUDA
   /// current number of delays, increase one for each acceptance, reset to 0 after updating Ainv
   int delay_count;
 
-  // CUDA specific variables
-  cudaStream_t hstream;
-  cublasHandle_t h_cublas;
+  // CUDA stream, cublas handle object
+  std::unique_ptr<CUDALinearAlgebraHandles> cuda_handles_;
+  // index in the resource collection when created.
+  int resource_index;
 
-  inline void waitStream() { cudaErrorCheck(cudaStreamSynchronize(hstream), "cudaStreamSynchronize failed!"); }
+  inline void waitStream() { cudaErrorCheck(cudaStreamSynchronize(cuda_handles_->hstream), "cudaStreamSynchronize failed!"); }
   // ensure no previous delay left
   inline void guard_no_delay() const
   {
@@ -253,7 +283,7 @@ class MatrixDelayedUpdateCUDA
     }
 
     cudaErrorCheck(cudaMemcpyAsync(prepare_inv_row_buffer_H2D_dev_ptr, prepare_inv_row_buffer_H2D.data(),
-                                   prepare_inv_row_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
+                                   prepare_inv_row_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
                    "cudaMemcpyAsync prepare_inv_row_buffer_H2D failed!");
 
     T** oldRow_mw_ptr  = reinterpret_cast<T**>(prepare_inv_row_buffer_H2D_dev_ptr);
@@ -266,19 +296,19 @@ class MatrixDelayedUpdateCUDA
 
     // save Ainv[rowchanged] to invRow
     //std::copy_n(Ainv[rowchanged], norb, invRow.data());
-    cudaErrorCheck(cuBLAS_MFs::copy_batched(hstream, norb, oldRow_mw_ptr, 1, invRow_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::copy_batched(cuda_handles_->hstream, norb, oldRow_mw_ptr, 1, invRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::copy_batched failed!");
     // multiply V (NxK) Binv(KxK) U(KxN) invRow right to the left
     //BLAS::gemv('T', norb, delay_count, cone, U_gpu.data(), norb, invRow.data(), 1, czero, p_gpu.data(), 1);
     //BLAS::gemv('N', delay_count, delay_count, -cone, Binv.data(), lda_Binv, p.data(), 1, czero, Binv[delay_count], 1);
     //BLAS::gemv('N', norb, delay_count, cone, V.data(), norb, Binv[delay_count], 1, cone, invRow.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, delay_count, cone_dev_ptr, U_mw_ptr, norb,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cone_dev_ptr, U_mw_ptr, norb,
                                             invRow_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'N', delay_count, delay_count, cminusone_dev_ptr, Binv_mw_ptr,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', delay_count, delay_count, cminusone_dev_ptr, Binv_mw_ptr,
                                             lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'N', norb, delay_count, cone_dev_ptr, V_mw_ptr, norb,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', norb, delay_count, cone_dev_ptr, V_mw_ptr, norb,
                                             BinvRow_mw_ptr, 1, cone_dev_ptr, invRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
     // mark row prepared
@@ -327,7 +357,7 @@ class MatrixDelayedUpdateCUDA
     resize_fill_constant_arrays(n_accepted);
 
     cudaErrorCheck(cudaMemcpyAsync(updateRow_buffer_H2D_dev_ptr, updateRow_buffer_H2D.data(),
-                                   updateRow_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
+                                   updateRow_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
                    "cudaMemcpyAsync updateRow_buffer_H2D failed!");
 
     {
@@ -342,17 +372,17 @@ class MatrixDelayedUpdateCUDA
       T* ratio_inv_mw   = reinterpret_cast<T*>(updateRow_buffer_H2D_dev_ptr + sizeof(T*) * n_accepted * 8);
 
       // invoke the Fahy's variant of Sherman-Morrison update.
-      cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, norb, cone_dev_ptr, Ainv_mw_ptr, lda, phiV_mw_ptr, 1,
+      cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, norb, cone_dev_ptr, Ainv_mw_ptr, lda, phiV_mw_ptr, 1,
                                               czero_dev_ptr, temp_mw_ptr, 1, n_accepted),
                      "cuBLAS_MFs::gemv_batched failed!");
 
-      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(hstream, rowchanged, norb, Ainv_mw_ptr, lda, temp_mw_ptr,
+      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(cuda_handles_->hstream, rowchanged, norb, Ainv_mw_ptr, lda, temp_mw_ptr,
                                                    rcopy_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, dpsiM_mw_out, d2psiM_mw_out,
                                                    n_accepted),
                      "CUDA::copyAinvRow_saveGL_cuda failed!");
 
 
-      cudaErrorCheck(cuBLAS_MFs::ger_batched(hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1, temp_mw_ptr, 1,
+      cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1, temp_mw_ptr, 1,
                                              Ainv_mw_ptr, lda, n_accepted),
                      "cuBLAS_MFs::ger_batched failed!");
     }
@@ -360,18 +390,11 @@ class MatrixDelayedUpdateCUDA
 
 public:
   /// default constructor
-  MatrixDelayedUpdateCUDA() : invRow_id(-1), delay_count(0)
-  {
-    cudaErrorCheck(cudaStreamCreate(&hstream), "cudaStreamCreate failed!");
-    cublasErrorCheck(cublasCreate(&h_cublas), "cublasCreate failed!");
-    cublasErrorCheck(cublasSetStream(h_cublas, hstream), "cublasSetStream failed!");
-  }
+  MatrixDelayedUpdateCUDA() : invRow_id(-1), delay_count(0), resource_index(-1) { }
 
-  ~MatrixDelayedUpdateCUDA()
-  {
-    cublasErrorCheck(cublasDestroy(h_cublas), "cublasDestroy failed!");
-    cudaErrorCheck(cudaStreamDestroy(hstream), "cudaStreamDestroy failed!");
-  }
+  MatrixDelayedUpdateCUDA(const MatrixDelayedUpdateCUDA&) = delete;
+
+  ~MatrixDelayedUpdateCUDA() { }
 
   /** resize the internal storage
    * @param norb number of electrons/orbitals
@@ -391,9 +414,23 @@ public:
     psiMinv_dev_ptr = getOffloadDevicePtr(psiMinv.data());
   }
 
-  void createResource(ResourceCollection& collection) {}
-  void acquireResource(ResourceCollection& collection) {}
-  void releaseResource(ResourceCollection& collection) {}
+  void createResource(ResourceCollection& collection)
+  {
+    resource_index = collection.addResource(std::make_unique<CUDALinearAlgebraHandles>());
+  }
+
+  void acquireResource(ResourceCollection& collection)
+  {
+    auto res_ptr = dynamic_cast<CUDALinearAlgebraHandles*>(collection.lendResource(resource_index).release());
+    if (!res_ptr)
+      throw std::runtime_error("MatrixDelayedUpdateCUDA::acquireResource dynamic_cast failed");
+   cuda_handles_.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection)
+  {
+    collection.takebackResource(resource_index, std::move(cuda_handles_));
+  }
 
   inline OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
@@ -406,6 +443,10 @@ public:
   template<typename TREAL, typename OMPALLOC>
   inline void invert_transpose(const Matrix<T>& logdetT, Matrix<T, OMPALLOC>& Ainv, std::complex<TREAL>& LogValue)
   {
+    // this is to make unit tests friendly without the need of setup resources.
+    if (!cuda_handles_)
+      cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
+
     guard_no_delay();
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
     detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
@@ -436,7 +477,7 @@ public:
     }
 
     cudaErrorCheck(cudaMemcpyAsync(evalGrad_buffer_H2D_dev_ptr, evalGrad_buffer_H2D.data(), evalGrad_buffer_H2D.size(),
-                                   cudaMemcpyHostToDevice, hstream),
+                                   cudaMemcpyHostToDevice, cuda_handles_->hstream),
                    "cudaMemcpyAsync evalGrad_buffer_H2D failed!");
 
     resizeGradsArray(nw, GT::Size);
@@ -445,10 +486,10 @@ public:
     const T** dpsiM_row_ptr = reinterpret_cast<const T**>(evalGrad_buffer_H2D_dev_ptr) + nw;
 
     const int norb = psiMinv.rows();
-    cudaErrorCheck(CUDA::calcGradients_cuda(hstream, norb, invRow_ptr, dpsiM_row_ptr, grads_value_dev_ptr, nw),
+    cudaErrorCheck(CUDA::calcGradients_cuda(cuda_handles_->hstream, norb, invRow_ptr, dpsiM_row_ptr, grads_value_dev_ptr, nw),
                    "CUDA::calcGradients_cuda failed!");
     cudaErrorCheck(cudaMemcpyAsync(grads_value_v.data(), grads_value_dev_ptr, grads_value_v.size() * sizeof(T),
-                                   cudaMemcpyDeviceToHost, hstream),
+                                   cudaMemcpyDeviceToHost, cuda_handles_->hstream),
                    "cudaMemcpyAsync grads_value_v failed!");
     waitStream();
 
@@ -556,7 +597,7 @@ public:
     }
 
     cudaErrorCheck(cudaMemcpyAsync(accept_rejectRow_buffer_H2D_dev_ptr, accept_rejectRow_buffer_H2D.data(),
-                                   accept_rejectRow_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
+                                   accept_rejectRow_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
                    "cudaMemcpyAsync prepare_inv_row_buffer_H2D failed!");
 
     T** invRow_mw_ptr       = reinterpret_cast<T**>(accept_rejectRow_buffer_H2D_dev_ptr);
@@ -576,28 +617,28 @@ public:
     T* ratio_inv_mw_ptr     = reinterpret_cast<T*>(accept_rejectRow_buffer_H2D_dev_ptr + sizeof(T*) * nw * 14);
 
     //std::copy_n(Ainv[rowchanged], norb, V[delay_count]);
-    cudaErrorCheck(cuBLAS_MFs::copy_batched(hstream, norb, invRow_mw_ptr, 1, V_row_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::copy_batched(cuda_handles_->hstream, norb, invRow_mw_ptr, 1, V_row_mw_ptr, 1, nw),
                    "cuBLAS_MFs::copy_batched failed!");
     // handle accepted walkers
     // the new Binv is [[X Y] [Z y]]
     //BLAS::gemv('T', norb, delay_count + 1, cminusone, V.data(), norb, psiV.data(), 1, czero, p.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, delay_count, cminusone_dev_ptr, V_mw_ptr, norb,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cminusone_dev_ptr, V_mw_ptr, norb,
                                             phiV_mw_ptr, 1, czero_dev_ptr, p_mw_ptr, 1, n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // Y
     //BLAS::gemv('T', delay_count, delay_count, y, Binv.data(), lda_Binv, p.data(), 1, czero, Binv.data() + delay_count,
     //           lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr, Binv_mw_ptr,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr, Binv_mw_ptr,
                                             lda_Binv, p_mw_ptr, 1, czero_dev_ptr, BinvCol_mw_ptr, lda_Binv, n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // X
     //BLAS::ger(delay_count, delay_count, cone, Binv[delay_count], 1, Binv.data() + delay_count, lda_Binv,
     //          Binv.data(), lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::ger_batched(hstream, delay_count, delay_count, cone_dev_ptr, BinvRow_mw_ptr, 1,
+    cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, delay_count, delay_count, cone_dev_ptr, BinvRow_mw_ptr, 1,
                                            BinvCol_mw_ptr, lda_Binv, Binv_mw_ptr, lda_Binv, n_accepted),
                    "cuBLAS_MFs::ger_batched failed!");
     // y and Z
-    cudaErrorCheck(CUDA::add_delay_list_save_y_VGL_batched(hstream, delay_list_mw_ptr, rowchanged, delay_count,
+    cudaErrorCheck(CUDA::add_delay_list_save_y_VGL_batched(cuda_handles_->hstream, delay_list_mw_ptr, rowchanged, delay_count,
                                                            Binv_mw_ptr, lda_Binv, ratio_inv_mw_ptr, phiV_mw_ptr,
                                                            dpsiM_mw_in, d2psiM_mw_in, U_row_mw_ptr, dpsiM_mw_out,
                                                            d2psiM_mw_out, norb, n_accepted, nw),
@@ -635,7 +676,7 @@ public:
     }
 
     cudaErrorCheck(cudaMemcpyAsync(updateInv_buffer_H2D_dev_ptr, updateInv_buffer_H2D.data(),
-                                   updateInv_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
+                                   updateInv_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
                    "cudaMemcpyAsync updateInv_buffer_H2D failed!");
 
     T** U_mw_ptr            = reinterpret_cast<T**>(updateInv_buffer_H2D_dev_ptr);
@@ -659,15 +700,15 @@ public:
     {
       const int lda_Binv = Binv_gpu.cols();
       constexpr T cone(1), czero(0), cminusone(-1);
-      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb, &cone,
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb, &cone,
                                             U_mw_ptr, norb, Ainv_mw_ptr, lda, &czero, tempMat_mw_ptr, lda_Binv, nw),
                        "cuBLAS::gemm_batched failed!");
-      cudaErrorCheck(CUDA::applyW_batched(hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr, lda_Binv, nw),
+      cudaErrorCheck(CUDA::applyW_batched(cuda_handles_->hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr, lda_Binv, nw),
                      "CUDA::applyW_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count, delay_count, &cone,
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count, delay_count, &cone,
                                             V_mw_ptr, norb, Binv_mw_ptr, lda_Binv, &czero, U_mw_ptr, norb, nw),
                        "cuBLAS::gemm_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count, &cminusone,
+      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count, &cminusone,
                                             U_mw_ptr, norb, tempMat_mw_ptr, lda_Binv, &cone, Ainv_mw_ptr, lda, nw),
                        "cuBLAS::gemm_batched failed!");
     }
@@ -739,7 +780,7 @@ public:
 
     for (This_t& engine : engines)
       cudaErrorCheck(cudaMemcpyAsync(engine.psiMinv.data(), engine.psiMinv_dev_ptr, engine.psiMinv.size() * sizeof(T),
-                                     cudaMemcpyDeviceToHost, hstream),
+                                     cudaMemcpyDeviceToHost, cuda_handles_->hstream),
                      "cudaMemcpyAsync Ainv failed!");
     waitStream();
   }

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -440,14 +440,15 @@ public:
    * @param logdetT orbital value matrix
    * @param Ainv inverse matrix
    */
-  template<typename TREAL, typename OMPALLOC>
-  inline void invert_transpose(const Matrix<T>& logdetT, Matrix<T, OMPALLOC>& Ainv, std::complex<TREAL>& LogValue)
+  template<typename TREAL>
+  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)
   {
     // this is to make unit tests friendly without the need of setup resources.
     if (!cuda_handles_)
       cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
 
     guard_no_delay();
+    auto& Ainv = psiMinv;
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
     detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
     T* Ainv_ptr = Ainv.data();
@@ -497,10 +498,11 @@ public:
       grad_now[iw] = {grads_value_v[iw][0], grads_value_v[iw][1], grads_value_v[iw][2]};
   }
 
-  template<typename VVT, typename RATIOT, typename OMPALLOC>
-  void updateRow(Matrix<T, OMPALLOC>& Ainv, int rowchanged, const VVT& phiV, RATIOT c_ratio_in)
+  template<typename VVT, typename RATIOT>
+  void updateRow(int rowchanged, const VVT& phiV, RATIOT c_ratio_in)
   {
     guard_no_delay();
+    auto& Ainv = psiMinv;
     // update the inverse matrix
     constexpr T cone(1), czero(0);
     const int norb = Ainv.rows();

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -436,9 +436,9 @@ public:
 
   inline T* getRow_psiMinv_offload(int row_id) { return psiMinv_dev_ptr + row_id * psiMinv.cols(); }
 
-  /** compute the inverse of the transpose of matrix A
+  /** compute the inverse of the transpose of matrix logdetT, result is in psiMinv
    * @param logdetT orbital value matrix
-   * @param Ainv inverse matrix
+   * @param LogValue log(det(logdetT))
    */
   template<typename TREAL>
   inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -112,9 +112,9 @@ public:
 
   inline T* getRow_psiMinv_offload(int row_id) { return psiMinv_dev_ptr + row_id * psiMinv.cols(); }
 
-  /** compute the inverse of the transpose of matrix A
+  /** compute the inverse of the transpose of matrix logdetT, result is in psiMinv
    * @param logdetT orbital value matrix
-   * @param Ainv inverse matrix
+   * @param LogValue log(det(logdetT))
    */
   template<typename TREAL>
   inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -18,8 +18,9 @@
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
-#include "Platforms/OMPTarget/ompBLAS.hpp"
-#include "Platforms/OMPTarget/ompReduction.hpp"
+#include "OMPTarget/ompBLAS.hpp"
+#include "OMPTarget/ompReduction.hpp"
+#include "ResourceCollection.h"
 
 
 namespace qmcplusplus
@@ -102,6 +103,10 @@ public:
     psiMinv.resize(norb, getAlignedSize<T>(norb));
     psiMinv_dev_ptr = getOffloadDevicePtr(psiMinv.data());
   }
+
+  void createResource(ResourceCollection& collection) {}
+  void acquireResource(ResourceCollection& collection) {}
+  void releaseResource(ResourceCollection& collection) {}
 
   OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -116,9 +116,10 @@ public:
    * @param logdetT orbital value matrix
    * @param Ainv inverse matrix
    */
-  template<typename TREAL, typename OMPALLOC>
-  inline void invert_transpose(const Matrix<T>& logdetT, Matrix<T, OMPALLOC>& Ainv, std::complex<TREAL>& LogValue)
+  template<typename TREAL>
+  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)
   {
+    auto& Ainv = psiMinv;
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
     detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
     T* Ainv_ptr = Ainv.data();
@@ -170,9 +171,10 @@ public:
       grad_now[iw] = {grads_value_v[iw][0], grads_value_v[iw][1], grads_value_v[iw][2]};
   }
 
-  template<typename VVT, typename RATIOT, typename OMPALLOC>
-  inline void updateRow(Matrix<T, OMPALLOC>& Ainv, int rowchanged, const VVT& phiV, RATIOT c_ratio_in)
+  template<typename VVT, typename RATIOT>
+  inline void updateRow(int rowchanged, const VVT& phiV, RATIOT c_ratio_in)
   {
+    auto& Ainv = psiMinv;
     // update the inverse matrix
     constexpr T cone(1);
     constexpr T czero(0);

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -208,6 +208,24 @@ void SlaterDet::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   }
 }
 
+void SlaterDet::createResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Dets.size(); ++i)
+    Dets[i]->createResource(collection);
+}
+
+void SlaterDet::acquireResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Dets.size(); ++i)
+    Dets[i]->acquireResource(collection);
+}
+
+void SlaterDet::releaseResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Dets.size(); ++i)
+    Dets[i]->releaseResource(collection);
+}
+
 void SlaterDet::registerData(ParticleSet& P, WFBufferType& buf)
 {
   DEBUG_PSIBUFFER(" SlaterDet::registerData ", buf.current());

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -95,6 +95,12 @@ public:
 
   virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override;
 
+  void createResource(ResourceCollection& collection) override;
+
+  void acquireResource(ResourceCollection& collection) override;
+
+  void releaseResource(ResourceCollection& collection) override;
+
   virtual inline void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override
   {
     return Dets[getDetID(VP.refPtcl)]->evaluateRatios(VP, ratios);

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -108,6 +108,19 @@ void SPOSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMa
   APP_ABORT("Need specialization of SPOSet::evaluateThirdDeriv(). \n");
 }
 
+void SPOSet::mw_evaluate_notranspose(const RefVector<SPOSet>& spo_list,
+                                     const RefVector<ParticleSet>& P_list,
+                                     int first,
+                                     int last,
+                                     const RefVector<ValueMatrix_t>& logdet_list,
+                                     const RefVector<GradMatrix_t>& dlogdet_list,
+                                     const RefVector<ValueMatrix_t>& d2logdet_list)
+{
+#pragma omp parallel for
+  for (int iw = 0; iw < spo_list.size(); iw++)
+    spo_list[iw].get().evaluate_notranspose(P_list[iw], first, last, logdet_list[iw], dlogdet_list[iw], d2logdet_list[iw]);
+}
+
 void SPOSet::evaluate_notranspose(const ParticleSet& P,
                                   int first,
                                   int last,

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -325,6 +325,14 @@ public:
                                     GradMatrix_t& dlogdet,
                                     ValueMatrix_t& d2logdet) = 0;
 
+  virtual void mw_evaluate_notranspose(const RefVector<SPOSet>& spo_list,
+                                       const RefVector<ParticleSet>& P_list,
+                                       int first,
+                                       int last,
+                                       const RefVector<ValueMatrix_t>& logdet_list,
+                                       const RefVector<GradMatrix_t>& dlogdet_list,
+                                       const RefVector<ValueMatrix_t>& d2logdet_list);
+
   /** evaluate the values, gradients and hessians of this single-particle orbital for [first,last) particles
    * @param P current ParticleSet
    * @param first starting index of the particles

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -41,7 +41,6 @@ static const std::vector<std::string> suffixes{"V", "VGL", "accept", "NLratio", 
 
 TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, bool create_local_resource)
     : myName(aname),
-      twf_resource_(std::make_unique<ResourceCollection>("TrialWaveFunction")),
       BufferCursor(0),
       BufferCursor_scalar(0),
       PhaseValue(0.0),
@@ -50,6 +49,9 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, boo
       OneOverM(1.0),
       use_tasking_(tasking)
 {
+  if (create_local_resource)
+    twf_resource_ = std::make_unique<ResourceCollection>("TrialWaveFunction");
+
   for (auto& suffix : suffixes)
   {
     std::string timer_name = "WaveFunction:" + myName + "::" + suffix;

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include "TrialWaveFunction.h"
+#include "ResourceCollection.h"
 #include "Utilities/IteratorUtility.h"
 #include "Concurrency/Info.hpp"
 
@@ -38,8 +39,9 @@ typedef enum
 
 static const std::vector<std::string> suffixes{"V", "VGL", "accept", "NLratio", "recompute", "buffer", "derivs"};
 
-TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking)
+TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, bool create_local_resource)
     : myName(aname),
+      twf_resource_(std::make_unique<ResourceCollection>("TrialWaveFunction")),
       BufferCursor(0),
       BufferCursor_scalar(0),
       PhaseValue(0.0),
@@ -81,6 +83,8 @@ void TrialWaveFunction::stopOptimization()
  */
 void TrialWaveFunction::addComponent(WaveFunctionComponent* aterm)
 {
+  if (twf_resource_)
+    aterm->createResource(*twf_resource_);
   Z.push_back(aterm);
 
   std::string aname = aterm->ClassName;
@@ -1150,7 +1154,7 @@ void TrialWaveFunction::reset() {}
 
 TrialWaveFunction* TrialWaveFunction::makeClone(ParticleSet& tqp) const
 {
-  TrialWaveFunction* myclone   = new TrialWaveFunction(myName, use_tasking_);
+  TrialWaveFunction* myclone   = new TrialWaveFunction(myName, use_tasking_, false);
   myclone->BufferCursor        = BufferCursor;
   myclone->BufferCursor_scalar = BufferCursor_scalar;
   for (int i = 0; i < Z.size(); ++i)
@@ -1272,6 +1276,18 @@ void TrialWaveFunction::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value
     for (int j = 0; j < t.size(); ++j)
       ratios[j] *= t[j];
   }
+}
+
+void TrialWaveFunction::acquireResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Z.size(); ++i)
+    Z[i]->acquireResource(collection);
+}
+
+void TrialWaveFunction::releaseResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Z.size(); ++i)
+    Z[i]->releaseResource(collection);
 }
 
 RefVector<WaveFunctionComponent> TrialWaveFunction::extractWFCRefList(const RefVector<TrialWaveFunction>& wf_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -407,8 +407,13 @@ public:
                            const RefVector<ParticleSet>& P_list,
                            const RefVector<WFBufferType>& buf_list) const;
 
+  /** acquire external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
   void acquireResource(ResourceCollection& collection);
-
+  /** release external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
   void releaseResource(ResourceCollection& collection);
 
   RealType KECorrection() const;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -407,9 +407,9 @@ public:
                            const RefVector<ParticleSet>& P_list,
                            const RefVector<WFBufferType>& buf_list) const;
 
-void acquireResource(ResourceCollection& collection);
+  void acquireResource(ResourceCollection& collection);
 
-void releaseResource(ResourceCollection& collection);
+  void releaseResource(ResourceCollection& collection);
 
   RealType KECorrection() const;
 
@@ -457,6 +457,8 @@ void releaseResource(ResourceCollection& collection);
   const std::string& getName() const { return myName; }
 
   bool use_tasking() const { return use_tasking_; }
+
+  const ResourceCollection& getResource() const { return *twf_resource_; }
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -97,7 +97,7 @@ public:
   ///differential laplacians
   ParticleSet::ParticleLaplacian_t L;
 
-  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false);
+  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false, bool create_local_resource = true);
 
   // delete copy constructor
   TrialWaveFunction(const TrialWaveFunction&) = delete;
@@ -120,7 +120,6 @@ public:
 
   /** add a WaveFunctionComponent
    * @param aterm a WaveFunctionComponent pointer
-   * @param aname a name to the added WaveFunctionComponent object for printing
    */
   void addComponent(WaveFunctionComponent* aterm);
 
@@ -408,6 +407,10 @@ public:
                            const RefVector<ParticleSet>& P_list,
                            const RefVector<WFBufferType>& buf_list) const;
 
+void acquireResource(ResourceCollection& collection);
+
+void releaseResource(ResourceCollection& collection);
+
   RealType KECorrection() const;
 
   void evaluateDerivatives(ParticleSet& P,
@@ -460,6 +463,11 @@ private:
 
   ///getName is in the way
   const std::string myName;
+
+  /** a collection of shared resource used by TWF
+   * created for the gold object of TWF not clones.
+   */
+  std::unique_ptr<ResourceCollection> twf_resource_;
 
   ///starting index of the buffer
   size_t BufferCursor;

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -45,10 +45,10 @@ struct NLjob
 };
 #endif
 
-///forward declaration of WaveFunctionComponent
+///forward declaration
 struct WaveFunctionComponent;
-///forward declaration of DiffWaveFunctionComponent
 struct DiffWaveFunctionComponent;
+class ResourceCollection;
 
 typedef WaveFunctionComponent* WaveFunctionComponentPtr;
 typedef DiffWaveFunctionComponent* DiffWaveFunctionComponentPtr;
@@ -472,6 +472,18 @@ struct WaveFunctionComponent : public QMCTraits
     for (int iw = 0; iw < wfc_list.size(); iw++)
       wfc_list[iw].get().copyFromBuffer(p_list[iw], buf_list[iw]);
   }
+
+  /** initialize a shared resource and hand it to collection
+   */
+  virtual void createResource(ResourceCollection& collection) {}
+
+  /** acquire a shared resource from collection
+   */
+  virtual void acquireResource(ResourceCollection& collection) {}
+
+  /** return a shared resource to collection
+   */
+  virtual void releaseResource(ResourceCollection& collection) {}
 
   /** make clone
    * @param tqp target Quantum ParticleSet

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -26,6 +26,8 @@ public:
 
 private:
   const std::string name_;
+  int index_in_collection_ = -1;
+  friend class ResourceCollection;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -1,0 +1,31 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RESOURCE_H
+#define QMCPLUSPLUS_RESOURCE_H
+
+#include <string>
+
+namespace qmcplusplus
+{
+class Resource
+{
+public:
+  Resource(const std::string& name) : name_(name) {}
+  virtual ~Resource()                 = default;
+  virtual Resource* makeClone() const = 0;
+  const std::string& getName() const { return name_; }
+
+private:
+  const std::string name_;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -10,32 +10,47 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "ResourceCollection.h"
+#include <iostream>
 
 namespace qmcplusplus
 {
-ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
+ResourceCollection::ResourceCollection(const std::string& name) : name_(name), cursor_index_(0) {}
 
-ResourceCollection::ResourceCollection(const ResourceCollection& ref) : name_(ref.getName())
+ResourceCollection::ResourceCollection(const ResourceCollection& ref) : name_(ref.getName()), cursor_index_(0)
 {
-  for (auto& res : collection)
+  for (auto& res : ref.collection_)
     addResource(std::unique_ptr<Resource>(res->makeClone()));
 }
 
-void ResourceCollection::printResources() {}
+void ResourceCollection::printResources() const
+{
+  std::cout << "list resources in " << getName() << std::endl;
+  std::cout << "-------------------------------" << std::endl;
+  for (int i = 0; i < collection_.size(); i++)
+    std::cout << "resource " << i << "    name: " << collection_[i]->getName()
+              << "    address: " << collection_[i].get() << std::endl;
+  std::cout << "-------------------------------" << std::endl << std::endl;
+}
 
 size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
 {
-  size_t id = collection.size();
-  collection.emplace_back(std::move(res));
+  size_t id = collection_.size();
+  collection_.emplace_back(std::move(res));
   return id;
 }
 
-std::unique_ptr<Resource> ResourceCollection::lendResource(int index) { return std::move(collection[index]); }
-
-void ResourceCollection::takebackResource(int index, std::unique_ptr<Resource>&& res)
+std::unique_ptr<Resource> ResourceCollection::lendResource()
 {
-  //add checks for index
-  collection[index] = std::move(res);
+  if (cursor_index_ >= collection_.size())
+    throw std::runtime_error("ResourceCollection::lendResource no more resource to lend. Bug in the code.");
+  return std::move(collection_[cursor_index_++]);
+}
+
+void ResourceCollection::takebackResource(std::unique_ptr<Resource>&& res)
+{
+  if (cursor_index_ >= collection_.size())
+    throw std::runtime_error("ResourceCollection::takebackResource cannot take back resources more than owned. Bug in the code.");
+  collection_[cursor_index_++] = std::move(res);
 }
 
 } // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -15,6 +15,12 @@ namespace qmcplusplus
 {
 ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
 
+ResourceCollection::ResourceCollection(const ResourceCollection& ref) : name_(ref.getName())
+{
+  for (auto& res : collection)
+    addResource(std::unique_ptr<Resource>(res->makeClone()));
+}
+
 void ResourceCollection::printResources() {}
 
 size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -34,22 +34,27 @@ void ResourceCollection::printResources() const
 
 size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
 {
-  size_t id = collection_.size();
+  size_t index = collection_.size();
+  res->index_in_collection_ = index;
   collection_.emplace_back(std::move(res));
-  return id;
+  return index;
 }
 
 std::unique_ptr<Resource> ResourceCollection::lendResource()
 {
   if (cursor_index_ >= collection_.size())
-    throw std::runtime_error("ResourceCollection::lendResource no more resource to lend. Bug in the code.");
+    throw std::runtime_error("ResourceCollection::lendResource BUG no more resource to lend.");
+  if (cursor_index_ != collection_[cursor_index_]->index_in_collection_)
+    throw std::runtime_error("ResourceCollection::lendResource BUG mismatched cursor index and recorded index in the resource.");
   return std::move(collection_[cursor_index_++]);
 }
 
 void ResourceCollection::takebackResource(std::unique_ptr<Resource>&& res)
 {
   if (cursor_index_ >= collection_.size())
-    throw std::runtime_error("ResourceCollection::takebackResource cannot take back resources more than owned. Bug in the code.");
+    throw std::runtime_error("ResourceCollection::takebackResource BUG cannot take back resources more than owned.");
+  if (cursor_index_ != res->index_in_collection_)
+    throw std::runtime_error("ResourceCollection::takebackResource BUG mismatched cursor index and recorded index in the resource.");
   collection_[cursor_index_++] = std::move(res);
 }
 

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "ResourceCollection.h"
+
+namespace qmcplusplus
+{
+ResourceCollection::ResourceCollection(const std::string& name) : name_(name) {}
+
+void ResourceCollection::printResources() {}
+
+size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
+{
+  size_t id = collection.size();
+  collection.emplace_back(std::move(res));
+  return id;
+}
+
+std::unique_ptr<Resource> ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
+
+void ResourceCollection::takebackResource(size_t id, std::unique_ptr<Resource>&& res)
+{
+  collection[id] = std::move(res);
+}
+
+} // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -24,11 +24,12 @@ size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
   return id;
 }
 
-std::unique_ptr<Resource> ResourceCollection::lendResource(size_t id) { return std::move(collection[id]); }
+std::unique_ptr<Resource> ResourceCollection::lendResource(int index) { return std::move(collection[index]); }
 
-void ResourceCollection::takebackResource(size_t id, std::unique_ptr<Resource>&& res)
+void ResourceCollection::takebackResource(int index, std::unique_ptr<Resource>&& res)
 {
-  collection[id] = std::move(res);
+  //add checks for index
+  collection[index] = std::move(res);
 }
 
 } // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -1,0 +1,39 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RESOURCECOLLECTION_H
+#define QMCPLUSPLUS_RESOURCECOLLECTION_H
+
+#include <string>
+#include <memory>
+#include <cstddef>
+#include <vector>
+#include "Resource.h"
+
+namespace qmcplusplus
+{
+class ResourceCollection
+{
+public:
+  ResourceCollection(const std::string& name);
+  const std::string& getName() const { return name_; }
+  void printResources();
+
+  size_t addResource(std::unique_ptr<Resource>&& res);
+  std::unique_ptr<Resource> lendResource(size_t id);
+  void takebackResource(size_t i, std::unique_ptr<Resource>&& res);
+
+private:
+  const std::string name_;
+  std::vector<std::unique_ptr<Resource>> collection;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -26,15 +26,18 @@ public:
   ResourceCollection(const std::string& name);
   ResourceCollection(const ResourceCollection&);
   const std::string& getName() const { return name_; }
-  void printResources();
+  size_t size() const { return collection_.size(); }
+  void printResources() const;
 
   size_t addResource(std::unique_ptr<Resource>&& res);
-  std::unique_ptr<Resource> lendResource(int index);
-  void takebackResource(int index, std::unique_ptr<Resource>&& res);
+  void rewind() { cursor_index_ = 0; }
+  std::unique_ptr<Resource> lendResource();
+  void takebackResource(std::unique_ptr<Resource>&& res);
 
 private:
   const std::string name_;
-  std::vector<std::unique_ptr<Resource>> collection;
+  size_t cursor_index_;
+  std::vector<std::unique_ptr<Resource>> collection_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -28,8 +28,8 @@ public:
   void printResources();
 
   size_t addResource(std::unique_ptr<Resource>&& res);
-  std::unique_ptr<Resource> lendResource(size_t id);
-  void takebackResource(size_t i, std::unique_ptr<Resource>&& res);
+  std::unique_ptr<Resource> lendResource(int index);
+  void takebackResource(int index, std::unique_ptr<Resource>&& res);
 
 private:
   const std::string name_;

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -24,6 +24,7 @@ class ResourceCollection
 {
 public:
   ResourceCollection(const std::string& name);
+  ResourceCollection(const ResourceCollection&);
   const std::string& getName() const { return name_; }
   void printResources();
 

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 ADD_EXECUTABLE(${UTEST_EXE} test_rng.cpp test_parser.cpp test_timer.cpp test_runtime_manager.cpp
                             test_prime_set.cpp test_partition.cpp test_pooled_memory.cpp
+                            test_ResourceCollection.cpp
                             test_infostream.cpp test_output_manager.cpp test_StdRandom.cpp)
 TARGET_LINK_LIBRARIES(${UTEST_EXE} catch_main qmcutil)
 

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -60,7 +60,7 @@ public:
 
 private:
   std::unique_ptr<MemoryResource> external_memory_handle;
-  size_t resource_index = -1;
+  int resource_index = -1;
 };
 
 TEST_CASE("ResourceCollection", "[utilities]")

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -40,12 +40,12 @@ public:
   {
     external_memory_handle = std::make_unique<MemoryResource>("test_res");
     external_memory_handle->data.resize(5);
-    resource_index = collection.addResource(std::move(external_memory_handle));
+    collection.addResource(std::move(external_memory_handle));
   }
 
   void acquireResource(ResourceCollection& collection)
   {
-    auto res_ptr = dynamic_cast<MemoryResource*>(collection.lendResource(resource_index).release());
+    auto res_ptr = dynamic_cast<MemoryResource*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("WFCResourceConsumer::acquireResource dynamic_cast failed");
     external_memory_handle.reset(res_ptr);
@@ -53,14 +53,13 @@ public:
 
   void releaseResource(ResourceCollection& collection)
   {
-    collection.takebackResource(resource_index, std::move(external_memory_handle));
+    collection.takebackResource(std::move(external_memory_handle));
   }
 
   MemoryResource* getPtr() const { return external_memory_handle.get(); }
 
 private:
   std::unique_ptr<MemoryResource> external_memory_handle;
-  int resource_index = -1;
 };
 
 TEST_CASE("ResourceCollection", "[utilities]")
@@ -76,6 +75,7 @@ TEST_CASE("ResourceCollection", "[utilities]")
   REQUIRE(wfc.getPtr() != nullptr);
   REQUIRE(wfc.getPtr()->data.size() == 5);
 
+  res_collection.rewind();
   wfc.releaseResource(res_collection);
   REQUIRE(wfc.getPtr() == nullptr);
 }

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+#include "ResourceCollection.h"
+
+namespace qmcplusplus
+{
+class MemoryResource : public Resource
+{
+public:
+  MemoryResource(const std::string& name) : Resource(name) {}
+
+  MemoryResource* makeClone() const override { return new MemoryResource(*this); }
+
+  std::vector<int> data;
+};
+
+TEST_CASE("Resource", "[utilities]")
+{
+  auto mem_res = std::make_unique<MemoryResource>("test_res");
+  mem_res->data.resize(5);
+
+  std::unique_ptr<MemoryResource> res_copy(mem_res->makeClone());
+  REQUIRE(res_copy->data.size() == 5);
+}
+
+class WFCResourceConsumer
+{
+public:
+  void createResource(ResourceCollection& collection)
+  {
+    external_memory_handle = std::make_unique<MemoryResource>("test_res");
+    external_memory_handle->data.resize(5);
+    resource_index = collection.addResource(std::move(external_memory_handle));
+  }
+
+  void acquireResource(ResourceCollection& collection)
+  {
+    auto res_ptr = dynamic_cast<MemoryResource*>(collection.lendResource(resource_index).release());
+    if (!res_ptr)
+      throw std::runtime_error("WFCResourceConsumer::acquireResource dynamic_cast failed");
+    external_memory_handle.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection)
+  {
+    collection.takebackResource(resource_index, std::move(external_memory_handle));
+  }
+
+  MemoryResource* getPtr() const { return external_memory_handle.get(); }
+
+private:
+  std::unique_ptr<MemoryResource> external_memory_handle;
+  size_t resource_index = -1;
+};
+
+TEST_CASE("ResourceCollection", "[utilities]")
+{
+  ResourceCollection res_collection("abc");
+  WFCResourceConsumer wfc;
+  REQUIRE(wfc.getPtr() == nullptr);
+
+  wfc.createResource(res_collection);
+  REQUIRE(wfc.getPtr() == nullptr);
+
+  wfc.acquireResource(res_collection);
+  REQUIRE(wfc.getPtr() != nullptr);
+  REQUIRE(wfc.getPtr()->data.size() == 5);
+
+  wfc.releaseResource(res_collection);
+  REQUIRE(wfc.getPtr() == nullptr);
+}
+
+} // namespace qmcplusplus

--- a/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1_pp/CMakeLists.txt
@@ -109,6 +109,16 @@ IF(NOT QMC_CUDA)
                     1 DIAMOND2_DMC_SCALARS # DMC
                     )
 
+  #4 batches of 16 walkers in one rank, batched slater det
+  QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch_dmcbatch-4b_sdbatch_jas
+                    "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
+                    qmc_short_sdbatch_vmcbatch_dmcbatch
+                    qmc_short_sdbatch_vmcbatch_dmcbatch.in.xml
+                    1 4
+                    TRUE
+                    1 DIAMOND2_DMC_SCALARS # DMC
+                    )
+
   # 4 batches of 16 walkers over 4 ranks
   QMC_RUN_AND_CHECK(short-diamondC_2x1x1_pp-vmcbatch_dmcbatch_4r_sdj
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
@@ -614,7 +624,7 @@ IF(NOT QMC_CUDA)
                     1 DET_DIAMOND2_VMC_BATCH_MWALKERS2_SCALARS # VMC cycle 2
                     )
 
-  QMC_RUN_AND_CHECK(deterministic-diamondC_2x1x1_pp-sdbatch-vmcbatch-mwalkers_sdj
+  QMC_RUN_AND_CHECK(deterministic-diamondC_2x1x1_pp-vmcbatch-mwalkers_sdbatch_jas
                     "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_2x1x1_pp"
                     det_qmc_short_sdbatch_vmcbatch_mwalkers
                     det_qmc_short_sdbatch_vmcbatch_mwalkers.in.xml

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_dmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_dmcbatch.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="qmc_short_vmcbatch_dmcbatch" series="0">
+   <project id="qmc_short_sdbatch_vmcbatch_dmcbatch" series="0">
       <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
    </project>
    <qmcsystem>
@@ -41,7 +41,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant batch="no">
+            <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>


### PR DESCRIPTION
## Proposed changes
Add Resource and ResourceCollection for managing shared resource of a set of walkers (crowd/population).
They are unit tested.
introduce CUDALinearAlgebraHandles resource to MatrixDelayedUpdateCUDA. No more create one per walker.

Also add more mw_ routines specialization in DiracDeterminantBatched and spline SPO.
Ready for connecting batched matrix inversion.

Address #2874 VMCBatched is ready.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- Yes. DMC batch is broken but fixed by a follow-up PR. better to review separately.

## What systems has this change been tested on?
Epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'