### PR TITLE
Make hdf5 io interfaces respect size_t and reduce NVHPC compiler warnings

### DIFF
--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -165,8 +165,12 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
       APP_ABORT("");
     }
     SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
-    hyperslab_proxy<SpRMatrix_ref, 2> hslab(L, std::array<int, 2>{NMO * NMO, global_ncvecs},
-                                            std::array<int, 2>{NMO * NMO, local_ncv}, std::array<int, 2>{0, nc0});
+    hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
+                                            std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
+                                                                  static_cast<size_t>(global_ncvecs)},
+                                            std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
+                                                                  static_cast<size_t>(local_ncv)},
+                                            std::array<size_t, 2>{0, static_cast<size_t>(nc0)});
     std::vector<int> shape;
     if (dump.getShape<boost::multi::array<RealType, 2>>("L", shape))
     {

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
@@ -162,8 +162,12 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
       APP_ABORT("");
     }
     SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
-    hyperslab_proxy<SpRMatrix_ref, 2> hslab(L, std::array<int, 2>{NMO * NMO, global_ncvecs},
-                                            std::array<int, 2>{NMO * NMO, local_ncv}, std::array<int, 2>{0, nc0});
+    hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
+                                            std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
+                                                                  static_cast<size_t>(global_ncvecs)},
+                                            std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),
+                                                                  static_cast<size_t>(local_ncv)},
+                                            std::array<size_t, 2>{0, static_cast<size_t>(nc0)});
     std::vector<int> shape;
     if (dump.getShape<boost::multi::array<RealType, 2>>("L", shape))
     {

--- a/src/AFQMC/Walkers/WalkerIO.hpp
+++ b/src/AFQMC/Walkers/WalkerIO.hpp
@@ -264,10 +264,10 @@ bool restartFromHDF5(WalkerSet& wset,
         int nw_ = std::min(ni + wlk_per_blk[bi], nWN) - std::max(ni, nW0);
         Data.reextent({nw_, wlk_nterms});
         hyperslab_proxy<boost::multi::array_ref<ComplexType, 2>, 2> hslab(Data,
-                                                                          std::array<int, 2>{wlk_per_blk[bi],
-                                                                                             wlk_nterms},
-                                                                          std::array<int, 2>{nw_, wlk_nterms},
-                                                                          std::array<int, 2>{w0, 0});
+                                                                          std::array<size_t, 2>{static_cast<size_t>(wlk_per_blk[bi]),
+                                                                                             static_cast<size_t>(wlk_nterms)},
+                                                                          std::array<size_t, 2>{static_cast<size_t>(nw_), static_cast<size_t>(wlk_nterms)},
+                                                                          std::array<size_t, 2>{static_cast<size_t>(w0), 0});
         read.read(hslab, std::string("walkers_") + std::to_string(bi));
         for (int n = 0; n < nw_; n++, nread++)
           wset.copyFromIO(Data[n], nread);

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -256,8 +256,9 @@ void test_hyperslab()
   }
   dump.push("WalkerSet");
 
-  hyperslab_proxy<Matrix, 2> hslab(Data, std::array<int, 2>{nwtot, nprop}, std::array<int, 2>{nwalk, nprop},
-                                   std::array<int, 2>{rank * nwalk, 0});
+  hyperslab_proxy<Matrix, 2> hslab(Data, std::array<size_t, 2>{static_cast<size_t>(nwtot), static_cast<size_t>(nprop)},
+                                   std::array<size_t, 2>{static_cast<size_t>(nwalk), static_cast<size_t>(nprop)},
+                                   std::array<size_t, 2>{static_cast<size_t>(rank * nwalk), 0});
   dump.write(hslab, "Walkers");
   dump.close();
   world.barrier();
@@ -273,8 +274,10 @@ void test_hyperslab()
 
     Matrix DataIn({nwalk, nprop});
 
-    hyperslab_proxy<Matrix, 2> hslab(DataIn, std::array<int, 2>{nwtot, nprop}, std::array<int, 2>{nwalk, nprop},
-                                     std::array<int, 2>{rank * nwalk, 0});
+    hyperslab_proxy<Matrix, 2> hslab(DataIn,
+                                     std::array<size_t, 2>{static_cast<size_t>(nwtot), static_cast<size_t>(nprop)},
+                                     std::array<size_t, 2>{static_cast<size_t>(nwalk), static_cast<size_t>(nprop)},
+                                     std::array<size_t, 2>{static_cast<size_t>(rank * nwalk), 0});
     read.read(hslab, "Walkers");
     read.close();
 
@@ -319,8 +322,12 @@ void test_double_hyperslab()
   dump.push("WalkerSet");
 
   //double_hyperslab_proxy<Matrix,2> hslab(Data,
-  hyperslab_proxy<Matrix, 2> hslab(Data, std::array<int, 2>{nwtot, nprop_to_safe},
-                                   std::array<int, 2>{nwalk, nprop_to_safe}, std::array<int, 2>{rank * nwalk, 0}); //,
+  hyperslab_proxy<Matrix, 2> hslab(Data,
+                                   std::array<size_t, 2>{static_cast<size_t>(nwtot),
+                                                         static_cast<size_t>(nprop_to_safe)},
+                                   std::array<size_t, 2>{static_cast<size_t>(nwalk),
+                                                         static_cast<size_t>(nprop_to_safe)},
+                                   std::array<size_t, 2>{static_cast<size_t>(rank * nwalk), 0}); //,
 
   //                                  std::array<int,2>{nwalk,nprop},
   //                                  std::array<int,2>{nwalk,nprop_to_safe},
@@ -342,8 +349,12 @@ void test_double_hyperslab()
     Matrix DataIn({nwalk, nprop_to_safe});
 
     //double_hyperslab_proxy<Matrix,2> hslab(DataIn,
-    hyperslab_proxy<Matrix, 2> hslab(DataIn, std::array<int, 2>{nwtot, nprop_to_safe},
-                                     std::array<int, 2>{nwalk, nprop_to_safe}, std::array<int, 2>{rank * nwalk, 0}); //,
+    hyperslab_proxy<Matrix, 2> hslab(DataIn,
+                                     std::array<size_t, 2>{static_cast<size_t>(nwtot),
+                                                           static_cast<size_t>(nprop_to_safe)},
+                                     std::array<size_t, 2>{static_cast<size_t>(nwalk),
+                                                           static_cast<size_t>(nprop_to_safe)},
+                                     std::array<size_t, 2>{static_cast<size_t>(rank * nwalk), 0}); //,
     //                                  std::array<int,2>{nwalk,nprop},
     //                                  std::array<int,2>{nwalk,nprop_to_safe},
     //                                  std::array<int,2>{0,0});

--- a/src/Numerics/OneDimCubicSpline.h
+++ b/src/Numerics/OneDimCubicSpline.h
@@ -231,7 +231,7 @@ public:
   //  m_grid->locate(r);
   //}
 
-  inline value_type splint(point_type r) const
+  inline value_type splint(point_type r) const override
   {
     if (r < r_min)
     {
@@ -255,7 +255,7 @@ public:
    *@param d2u return the 2nd derivative
    *@return the value of the function
   */
-  inline value_type splint(point_type r, value_type& du, value_type& d2u) const
+  inline value_type splint(point_type r, value_type& du, value_type& d2u) const override
   {
     if (r < r_min)
     //linear-extrapolation returns y[0]+y'*(r-r[0])
@@ -318,7 +318,7 @@ public:
    *and each object can have its own range of valid grid points.
    *r_min and r_max are used to specify the range.
    */
-  inline void spline(int imin, value_type yp1, int imax, value_type ypn)
+  inline void spline(int imin, value_type yp1, int imax, value_type ypn) override
   {
     first_deriv = yp1;
     last_deriv  = ypn;
@@ -333,7 +333,7 @@ public:
     //FirstAddress[2]=m_Y2.data()+imin;
   }
 
-  inline void spline() { spline(0, 0.0, m_grid->size() - 1, 0.0); }
+  inline void spline() override { spline(0, 0.0, m_grid->size() - 1, 0.0); }
 };
 
 

--- a/src/Numerics/OneDimGridFunctor.h
+++ b/src/Numerics/OneDimGridFunctor.h
@@ -202,9 +202,9 @@ struct OneDimGridFunctor
   //  ///DO NOTHING
   //}
 
-  virtual value_type splint(point_type r, value_type& du, value_type& d2u) { return 0.0; }
+  virtual value_type splint(point_type r, value_type& du, value_type& d2u) const { return 0.0; }
 
-  virtual value_type splint(point_type r) { return 0.0; }
+  virtual value_type splint(point_type r) const { return 0.0; }
 
   virtual void spline(int imin, value_type yp1, int imax, value_type ypn) {}
 
@@ -263,9 +263,9 @@ public:
 
   OneDimConstFunctor(grid_type* gt = 0) : base_type(gt), ConstValue(0.0) {}
 
-  inline value_type splint(point_type r) { return ConstValue; }
+  inline value_type splint(point_type r) const override { return ConstValue; }
 
-  inline value_type splint(point_type r, value_type& du, value_type& d2u)
+  inline value_type splint(point_type r, value_type& du, value_type& d2u) const override
   {
     du  = 0.0;
     d2u = 0.0;

--- a/src/Numerics/OneDimLinearSpline.h
+++ b/src/Numerics/OneDimLinearSpline.h
@@ -99,7 +99,7 @@ public:
    * Performance may be tunned: define USE_MEMORYSAVEMODE
    * to evaluate the coefficients instead of using aux. arrays
    */
-  inline value_type splint(point_type r)
+  inline value_type splint(point_type r) const override
   {
     if (r >= r_max)
       return ConstValue;
@@ -160,7 +160,7 @@ public:
    * @param d2u second derivative (assigned)
    * @return value obtained by cubic-spline
    */
-  inline value_type splint(point_type r, value_type& du, value_type& d2u)
+  inline value_type splint(point_type r, value_type& du, value_type& d2u) const override
   {
     std::cerr << "  OneDimLinearSpline cannot be used for derivates." << std::endl;
     return 0.0;

--- a/src/Numerics/OneDimQuinticSpline.h
+++ b/src/Numerics/OneDimQuinticSpline.h
@@ -156,7 +156,7 @@ private:
   }
 
 public:
-  inline value_type splint(point_type r) const
+  inline value_type splint(point_type r) const override
   {
     if (r < r_min)
     {
@@ -172,7 +172,7 @@ public:
   }
 
 
-  inline value_type splint(point_type r, value_type& du, value_type& d2u) const
+  inline value_type splint(point_type r, value_type& du, value_type& d2u) const override
   {
     if (r < r_min)
     {
@@ -202,7 +202,7 @@ public:
     return quinticInterpolateThirdDeriv(cL, m_Y[Loc], B[Loc], m_Y2[Loc], D[Loc], E[Loc], F[Loc], du, d2u, d3u);
   }
 
-  inline void spline(int imin, value_type yp1, int imax, value_type ypn)
+  inline void spline(int imin, value_type yp1, int imax, value_type ypn) override
   {
     first_deriv = yp1;
     last_deriv  = ypn;
@@ -224,7 +224,7 @@ public:
     ConstValue = m_Y[imax];
   }
 
-  inline void spline() { spline(0, 0.0, m_grid->size() - 1, 0.0); }
+  inline void spline() override { spline(0, 0.0, m_grid->size() - 1, 0.0); }
 };
 
 

--- a/src/OhmmsApp/RandomNumberControl.cpp
+++ b/src/OhmmsApp/RandomNumberControl.cpp
@@ -380,7 +380,11 @@ void RandomNumberControl::write(const std::string& fname, Communicate* comm)
 //Parallel read
 void RandomNumberControl::read_parallel(hdf_archive& hin, Communicate* comm)
 {
-  int nthreads = omp_get_max_threads();
+  // cast integer to size_t
+  const size_t nthreads = static_cast<size_t>(omp_get_max_threads());
+  const size_t comm_size = static_cast<size_t>(comm->size());
+  const size_t comm_rank = static_cast<size_t>(comm->rank());
+
   std::vector<uint_type> vt, mt;
   TinyVector<int, 3> shape_now(comm->size(), nthreads, Random.state_size()); //cur configuration
   TinyVector<int, 3> shape_hdf5(3, 0);                                       //configuration when file was written
@@ -404,9 +408,9 @@ void RandomNumberControl::read_parallel(hdf_archive& hin, Communicate* comm)
   vt.resize(nthreads * Random.state_size()); //buffer for children[ip]
   mt.resize(Random.state_size());            //buffer for single thread Random object of random nums
 
-  std::array<int, 2> shape{comm->size() * nthreads, Random.state_size()}; //global dims of children dataset
-  std::array<int, 2> counts{nthreads, Random.state_size()};               //local dimensions of dataset
-  std::array<int, 2> offsets{comm->rank() * nthreads, 0};                 //offsets for each process to read in
+  std::array<size_t, 2> shape{comm_size * nthreads, Random.state_size()}; //global dims of children dataset
+  std::array<size_t, 2> counts{nthreads, Random.state_size()};               //local dimensions of dataset
+  std::array<size_t, 2> offsets{comm_rank * nthreads, 0};                 //offsets for each process to read in
 
   hin.push("random"); //group that holds children[ip] random nums
   hyperslab_proxy<std::vector<uint_type>, 2> slab(vt, shape, counts, offsets);
@@ -433,7 +437,11 @@ void RandomNumberControl::read_parallel(hdf_archive& hin, Communicate* comm)
 //Parallel write
 void RandomNumberControl::write_parallel(hdf_archive& hout, Communicate* comm)
 {
-  int nthreads = omp_get_max_threads();
+  // cast integer to size_t
+  const size_t nthreads = static_cast<size_t>(omp_get_max_threads());
+  const size_t comm_size = static_cast<size_t>(comm->size());
+  const size_t comm_rank = static_cast<size_t>(comm->rank());
+
   std::vector<uint_type> vt, mt;
   TinyVector<int, 3> shape_hdf5(comm->size(), nthreads, Random.state_size()); //configuration at write time
   vt.reserve(nthreads * Random.state_size()); //buffer for random numbers from children[ip] of each thread
@@ -447,9 +455,9 @@ void RandomNumberControl::write_parallel(hdf_archive& hout, Communicate* comm)
   }
   Random.save(mt); //get nums for single random object (no threads)
 
-  std::array<int, 2> shape{comm->size() * nthreads, Random.state_size()}; //global dimensions
-  std::array<int, 2> counts{nthreads, Random.state_size()};               //local dimensions
-  std::array<int, 2> offsets{comm->rank() * nthreads, 0};                 //offset for the file write
+  std::array<size_t, 2> shape{comm_size * nthreads, Random.state_size()}; //global dimensions
+  std::array<size_t, 2> counts{nthreads, Random.state_size()};               //local dimensions
+  std::array<size_t, 2> offsets{comm_rank * nthreads, 0};                 //offset for the file write
 
   hout.push(hdf::main_state);
   hout.write(shape_hdf5, "nprocs_nthreads_statesize"); //save the shape of the data at write
@@ -471,11 +479,15 @@ void RandomNumberControl::write_parallel(hdf_archive& hout, Communicate* comm)
 //Scatter read
 void RandomNumberControl::read_rank_0(hdf_archive& hin, Communicate* comm)
 {
-  int nthreads = omp_get_max_threads();
+  // cast integer to size_t
+  const size_t nthreads = static_cast<size_t>(omp_get_max_threads());
+  const size_t comm_size = static_cast<size_t>(comm->size());
+  const size_t comm_rank = static_cast<size_t>(comm->rank());
+
   std::vector<uint_type> vt, vt_tot, mt, mt_tot;
-  TinyVector<int, 3> shape_now(comm->size(), nthreads, Random.state_size()); //current configuration
-  TinyVector<int, 3> shape_hdf5;                                             //configuration when hdf5 file was written
-  std::array<int, 2> shape{comm->size() * nthreads, Random.state_size()};    //dimensions of children dataset
+  TinyVector<size_t, 3> shape_now(comm_size, nthreads, Random.state_size()); //current configuration
+  TinyVector<size_t, 3> shape_hdf5;                                             //configuration when hdf5 file was written
+  std::array<size_t, 2> shape{comm_size * nthreads, Random.state_size()};    //dimensions of children dataset
 
   //grab configuration of threads/procs and Random.state_size() in hdf5 file
   if (comm->rank() == 0)
@@ -538,10 +550,14 @@ void RandomNumberControl::read_rank_0(hdf_archive& hin, Communicate* comm)
 //scatter write
 void RandomNumberControl::write_rank_0(hdf_archive& hout, Communicate* comm)
 {
-  int nthreads = omp_get_max_threads();
+  // cast integer to size_t
+  const size_t nthreads = static_cast<size_t>(omp_get_max_threads());
+  const size_t comm_size = static_cast<size_t>(comm->size());
+  const size_t comm_rank = static_cast<size_t>(comm->rank());
+
   std::vector<uint_type> vt, vt_tot, mt, mt_tot;
-  std::array<int, 2> shape{comm->size() * nthreads, Random.state_size()};     //dimensions of children dataset
-  TinyVector<int, 3> shape_hdf5(comm->size(), nthreads, Random.state_size()); //configuration at write time
+  std::array<size_t, 2> shape{comm_size * nthreads, Random.state_size()};     //dimensions of children dataset
+  TinyVector<size_t, 3> shape_hdf5(comm_size, nthreads, Random.state_size()); //configuration at write time
   vt.reserve(nthreads * Random.state_size()); //buffer for children[ip] (Random object of seeds for each thread)
   mt.reserve(Random.state_size()); //buffer for single Random object of seeds, one per proc regardless of thread num
 

--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -121,7 +121,7 @@ bool HDFWalkerInput_0_4::put(xmlNodePtr cur)
 
 bool HDFWalkerInput_0_4::read_hdf5(std::string h5name)
 {
-  int nw_in = 0;
+  size_t nw_in = 0;
 
   h5name.append(hdf::config_ext);
   hdf_archive hin(myComm, false); //everone reads this
@@ -149,7 +149,7 @@ bool HDFWalkerInput_0_4::read_hdf5(std::string h5name)
 
   typedef std::vector<QMCTraits::RealType> Buffer_t;
   Buffer_t posin;
-  std::array<int, 3> dims{nw_in, static_cast<int>(targetW.getTotalNum()), OHMMS_DIM};
+  std::array<size_t, 3> dims{nw_in, targetW.getTotalNum(), OHMMS_DIM};
   posin.resize(dims[0] * dims[1] * dims[2]);
   hin.readSlabReshaped(posin, dims, hdf::walkers);
 
@@ -157,7 +157,6 @@ bool HDFWalkerInput_0_4::read_hdf5(std::string h5name)
   hin.read(woffsets, "walker_partition");
 
   int np1 = myComm->size() + 1;
-  std::vector<int> counts(np1);
   if (woffsets.size() != np1)
   {
     woffsets.resize(myComm->size() + 1, 0);
@@ -198,7 +197,7 @@ bool HDFWalkerInput_0_4::read_hdf5(std::string h5name)
 
 bool HDFWalkerInput_0_4::read_hdf5_scatter(std::string h5name)
 {
-  int nw_in = 0;
+  size_t nw_in = 0;
   h5name.append(hdf::config_ext);
 
   if (myComm->rank() == 0)
@@ -236,7 +235,7 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(std::string h5name)
   std::vector<int> counts(myComm->size()), woffsets(np1, 0);
   FairDivideLow(nw_in, myComm->size(), woffsets);
 
-  int nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
+  size_t nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
 
   int nitems = targetW.getTotalNum() * OHMMS_DIM;
   for (int i = 0; i < woffsets.size(); ++i)
@@ -244,7 +243,7 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(std::string h5name)
   for (int i = 0; i < counts.size(); ++i)
     counts[i] = woffsets[i + 1] - woffsets[i];
 
-  std::array<int, 3> dims{nw_in, static_cast<int>(targetW.getTotalNum()), OHMMS_DIM};
+  std::array<size_t, 3> dims{nw_in, targetW.getTotalNum(), OHMMS_DIM};
   Buffer_t posin(nw_in * nitems), posout(counts[myComm->rank()]);
 
   if (myComm->rank() == 0)
@@ -270,7 +269,7 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(std::string h5name)
 
 bool HDFWalkerInput_0_4::read_phdf5(std::string h5name)
 {
-  int nw_in = 0;
+  size_t nw_in = 0;
   h5name.append(hdf::config_ext);
   std::vector<int> woffsets;
   int woffsets_size = 0;
@@ -328,7 +327,7 @@ bool HDFWalkerInput_0_4::read_phdf5(std::string h5name)
 
   typedef std::vector<QMCTraits::RealType> Buffer_t;
   Buffer_t posin;
-  std::array<int, 3> dims{nw_in, static_cast<int>(targetW.getTotalNum()), OHMMS_DIM};
+  std::array<size_t, 3> dims{nw_in, targetW.getTotalNum(), OHMMS_DIM};
 
   if (woffsets.size() != myComm->size() + 1)
   {
@@ -336,10 +335,10 @@ bool HDFWalkerInput_0_4::read_phdf5(std::string h5name)
     FairDivideLow(nw_in, myComm->size(), woffsets);
   }
 
-  int nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
+  size_t nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
 
-  std::array<int, 3> counts{nw_loc, static_cast<int>(targetW.getTotalNum()), OHMMS_DIM};
-  std::array<int, 3> offsets{woffsets[myComm->rank()], 0, 0};
+  std::array<size_t, 3> counts{nw_loc, targetW.getTotalNum(), OHMMS_DIM};
+  std::array<size_t, 3> offsets{static_cast<size_t>(woffsets[myComm->rank()]), 0, 0};
   posin.resize(nw_loc * dims[1] * dims[2]);
 
   hyperslab_proxy<Buffer_t, 3> slab(posin, dims, counts, offsets);

--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -134,15 +134,15 @@ void HDFWalkerOutput::write_configuration(MCWalkerConfiguration& W, hdf_archive&
   number_of_walkers = W.WalkerOffsets[myComm->size()];
   hout.write(number_of_walkers, hdf::num_walkers);
 
-  std::array<int, 3> gcounts{number_of_walkers, number_of_particles, OHMMS_DIM};
+  std::array<size_t, 3> gcounts{number_of_walkers, number_of_particles, OHMMS_DIM};
 
   if (hout.is_parallel())
   {
     { // write walker offset.
       // Though it is a small array, it needs to be written collectively in large scale runs.
-      std::array<int, 1> gcounts{myComm->size() + 1};
-      std::array<int, 1> counts{0};
-      std::array<int, 1> offsets{myComm->rank()};
+      std::array<size_t, 1> gcounts{static_cast<size_t>(myComm->size()) + 1};
+      std::array<size_t, 1> counts{0};
+      std::array<size_t, 1> offsets{static_cast<size_t>(myComm->rank())};
       std::vector<int> myWalkerOffset;
       if (myComm->size() - 1 == myComm->rank())
       {
@@ -159,8 +159,8 @@ void HDFWalkerOutput::write_configuration(MCWalkerConfiguration& W, hdf_archive&
       hout.write(slab, "walker_partition");
     }
     { // write walker configuration
-      std::array<int, 3> counts{static_cast<int>(W.getActiveWalkers()), number_of_particles, OHMMS_DIM};
-      std::array<int, 3> offsets{W.WalkerOffsets[myComm->rank()], 0, 0};
+      std::array<size_t, 3> counts{W.getActiveWalkers(), number_of_particles, OHMMS_DIM};
+      std::array<size_t, 3> offsets{static_cast<size_t>(W.WalkerOffsets[myComm->rank()]), 0, 0};
       hyperslab_proxy<BufferType, 3> slab(*RemoteData[0], gcounts, counts, offsets);
       hout.write(slab, hdf::walkers);
     }

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -35,9 +35,9 @@ class HDFWalkerOutput
    * When the number of walkers per state has changed, NumOfWalkers is used
    * to reallocate the hdf5 group.
    */
-  int number_of_walkers;
+  size_t number_of_walkers;
   /** number of particles */
-  int number_of_particles;
+  size_t number_of_particles;
   ///current number of backups
   int number_of_backups;
   ///current number of backups

--- a/src/Platforms/CPU/BLAS.hpp
+++ b/src/Platforms/CPU/BLAS.hpp
@@ -745,27 +745,27 @@ struct LAPACK
            IWORK, LIWORK, INFO);
   }
 
-  void static getrf(const int& n, const int& m, double* a, const int& n0, int* piv, int& st)
+  static void getrf(const int& n, const int& m, double* a, const int& n0, int* piv, int& st)
   {
     dgetrf(n, m, a, n0, piv, st);
   }
 
-  void static getrf(const int& n, const int& m, float* a, const int& n0, int* piv, int& st)
+  static void getrf(const int& n, const int& m, float* a, const int& n0, int* piv, int& st)
   {
     sgetrf(n, m, a, n0, piv, st);
   }
 
-  void static getrf(const int& n, const int& m, std::complex<double>* a, const int& n0, int* piv, int& st)
+  static void getrf(const int& n, const int& m, std::complex<double>* a, const int& n0, int* piv, int& st)
   {
     zgetrf(n, m, a, n0, piv, st);
   }
 
-  void static getrf(const int& n, const int& m, std::complex<float>* a, const int& n0, int* piv, int& st)
+  static void getrf(const int& n, const int& m, std::complex<float>* a, const int& n0, int* piv, int& st)
   {
     cgetrf(n, m, a, n0, piv, st);
   }
 
-  void static getri(int n,
+  static void getri(int n,
                     float* restrict a,
                     int n0,
                     int const* restrict piv,
@@ -776,7 +776,7 @@ struct LAPACK
     sgetri(n, a, n0, piv, work, n1, status);
   }
 
-  void static getri(int n,
+  static void getri(int n,
                     double* restrict a,
                     int n0,
                     int const* restrict piv,
@@ -787,7 +787,7 @@ struct LAPACK
     dgetri(n, a, n0, piv, work, n1, status);
   }
 
-  void static getri(int n,
+  static void getri(int n,
                     std::complex<float>* restrict a,
                     int n0,
                     int const* restrict piv,
@@ -798,7 +798,7 @@ struct LAPACK
     cgetri(n, a, n0, piv, work, n1, status);
   }
 
-  void static getri(int n,
+  static void getri(int n,
                     std::complex<double>* restrict a,
                     int n0,
                     int const* restrict piv,
@@ -809,7 +809,7 @@ struct LAPACK
     zgetri(n, a, n0, piv, work, n1, status);
   }
 
-  void static geqrf(int M,
+  static void geqrf(int M,
                     int N,
                     std::complex<double>* A,
                     const int LDA,
@@ -821,12 +821,12 @@ struct LAPACK
     zgeqrf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static geqrf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+  static void geqrf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
   {
     dgeqrf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static geqrf(int M,
+  static void geqrf(int M,
                     int N,
                     std::complex<float>* A,
                     const int LDA,
@@ -838,12 +838,12 @@ struct LAPACK
     cgeqrf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static geqrf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+  static void geqrf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
   {
     sgeqrf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gelqf(int M,
+  static void gelqf(int M,
                     int N,
                     std::complex<double>* A,
                     const int LDA,
@@ -855,12 +855,12 @@ struct LAPACK
     zgelqf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gelqf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+  static void gelqf(int M, int N, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
   {
     dgelqf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gelqf(int M,
+  static void gelqf(int M,
                     int N,
                     std::complex<float>* A,
                     const int LDA,
@@ -872,12 +872,12 @@ struct LAPACK
     cgelqf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gelqf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+  static void gelqf(int M, int N, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
   {
     sgelqf(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gqr(int M,
+  static void gqr(int M,
                   int N,
                   int K,
                   std::complex<double>* A,
@@ -890,12 +890,12 @@ struct LAPACK
     zungqr(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gqr(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+  static void gqr(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
   {
     dorgqr(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gqr(int M,
+  static void gqr(int M,
                   int N,
                   int K,
                   std::complex<float>* A,
@@ -908,12 +908,12 @@ struct LAPACK
     cungqr(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static gqr(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
+  static void gqr(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int LWORK, int& INFO)
   {
     sorgqr(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static glq(int M,
+  static void glq(int M,
                   int N,
                   int K,
                   std::complex<double>* A,
@@ -926,12 +926,12 @@ struct LAPACK
     zunglq(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static glq(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
+  static void glq(int M, int N, int K, double* A, const int LDA, double* TAU, double* WORK, int LWORK, int& INFO)
   {
     dorglq(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static glq(int M,
+  static void glq(int M,
                   int N,
                   int K,
                   std::complex<float>* A,
@@ -944,27 +944,27 @@ struct LAPACK
     cunglq(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static glq(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int const LWORK, int& INFO)
+  static void glq(int M, int N, int K, float* A, const int LDA, float* TAU, float* WORK, int const LWORK, int& INFO)
   {
     sorglq(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
-  void static potrf(const char& UPLO, const int& N, float* A, const int& LDA, int& INFO)
+  static void potrf(const char& UPLO, const int& N, float* A, const int& LDA, int& INFO)
   {
     spotrf(UPLO, N, A, LDA, INFO);
   }
 
-  void static potrf(const char& UPLO, const int& N, double* A, const int& LDA, int& INFO)
+  static void potrf(const char& UPLO, const int& N, double* A, const int& LDA, int& INFO)
   {
     dpotrf(UPLO, N, A, LDA, INFO);
   }
 
-  void static potrf(const char& UPLO, const int& N, std::complex<float>* A, const int& LDA, int& INFO)
+  static void potrf(const char& UPLO, const int& N, std::complex<float>* A, const int& LDA, int& INFO)
   {
     cpotrf(UPLO, N, A, LDA, INFO);
   }
 
-  void static potrf(const char& UPLO, const int& N, std::complex<double>* A, const int& LDA, int& INFO)
+  static void potrf(const char& UPLO, const int& N, std::complex<double>* A, const int& LDA, int& INFO)
   {
     zpotrf(UPLO, N, A, LDA, INFO);
   }

--- a/src/Platforms/CUDA/CUDAallocator.hpp
+++ b/src/Platforms/CUDA/CUDAallocator.hpp
@@ -119,7 +119,7 @@ bool operator!=(const CUDAAllocator<T1>&, const CUDAAllocator<T2>&)
 template<typename T>
 struct allocator_traits<CUDAAllocator<T>>
 {
-  const static bool is_host_accessible = false;
+  static const bool is_host_accessible = false;
   static void fill_n(T* ptr, size_t n, const T& value) { CUDAfill_n(ptr, n, value); }
 };
 

--- a/src/Platforms/allocator_traits.hpp
+++ b/src/Platforms/allocator_traits.hpp
@@ -22,7 +22,7 @@ namespace qmcplusplus
 template<class Allocator>
 struct allocator_traits
 {
-  const static bool is_host_accessible = true;
+  static const bool is_host_accessible = true;
   template<typename T>
   static void fill_n(T* ptr, size_t n, const T& value)
   {

--- a/src/Platforms/tests/OMPTarget/test_class_member.cpp
+++ b/src/Platforms/tests/OMPTarget/test_class_member.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 template<typename T>
 struct maptest
 {
-  const static size_t size = 6;
+  static const size_t size = 6;
   T data[size];
 
   PRAGMA_OFFLOAD("omp declare target")

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -129,22 +129,20 @@ void FakeSPO::evaluate_notranspose(const ParticleSet& P,
   if (OrbitalSetSize == 3)
   {
     for (int i = 0; i < 3; i++)
-    {
       for (int j = 0; j < 3; j++)
       {
         logdet(j, i) = a(i, j);
+        dlogdet[i][j] = gv[j] + GradType(i);
       }
-    }
   }
   else if (OrbitalSetSize == 4)
   {
     for (int i = 0; i < 4; i++)
-    {
       for (int j = 0; j < 4; j++)
       {
         logdet(j, i) = a2(i, j);
+        dlogdet[i][j] = gv[j] + GradType(i);
       }
-    }
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -334,18 +334,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
 
   check_matrix(ddc.psiMinv, a_update1);
 
-  try
-  {
-    grad = ddc.evalGrad(elec, 1);
-  }
-  catch (const std::exception& exc)
-  {
-    if (exc.what() == std::string("gradient of zero"))
-      std::cout << "caught expected std::exception from ddc.evalGrad : " << exc.what() << ". Caused by FakeSPO."
-                << std::endl;
-    else
-      throw exc;
-  }
+  grad = ddc.evalGrad(elec, 1);
 
   PsiValueType det_ratio2 = ddc.ratioGrad(elec, 1, grad);
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
@@ -365,18 +354,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   // update of Ainv in ddc is delayed
   ddc.acceptMove(elec, 1, true);
 
-  try
-  {
-    grad = ddc.evalGrad(elec, 2);
-  }
-  catch (const std::exception& exc)
-  {
-    if (exc.what() == std::string("gradient of zero"))
-      std::cout << "caught expected std::exception from ddc.evalGrad : " << exc.what() << ". Caused by FakeSPO."
-                << std::endl;
-    else
-      throw exc;
-  }
+  grad = ddc.evalGrad(elec, 2);
 
   PsiValueType det_ratio3 = ddc.ratioGrad(elec, 2, grad);
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),

--- a/src/QMCWaveFunctions/tests/test_dirac_det.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_det.cpp
@@ -332,18 +332,7 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   ddc.completeUpdates();
   check_matrix(a_update1, ddc.psiM);
 
-  try
-  {
-    grad = ddc.evalGrad(elec, 1);
-  }
-  catch (const std::exception& exc)
-  {
-    if (exc.what() == std::string("gradient of zero"))
-      std::cout << "caught expected std::exception from ddc.evalGrad : " << exc.what() << ". Caused by FakeSPO."
-                << std::endl;
-    else
-      throw exc;
-  }
+  grad = ddc.evalGrad(elec, 1);
 
   PsiValueType det_ratio2 = ddc.ratioGrad(elec, 1, grad);
   simd::transpose(a_update2.data(), a_update2.rows(), a_update2.cols(), scratchT.data(), scratchT.rows(),
@@ -363,18 +352,7 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   // update of Ainv in ddc is delayed
   ddc.acceptMove(elec, 1, true);
 
-  try
-  {
-    grad = ddc.evalGrad(elec, 2);
-  }
-  catch (const std::exception& exc)
-  {
-    if (exc.what() == std::string("gradient of zero"))
-      std::cout << "caught expected std::exception from ddc.evalGrad : " << exc.what() << ". Caused by FakeSPO."
-                << std::endl;
-    else
-      throw exc;
-  }
+  grad = ddc.evalGrad(elec, 2);
 
   PsiValueType det_ratio3 = ddc.ratioGrad(elec, 2, grad);
   simd::transpose(a_update3.data(), a_update3.rows(), a_update3.cols(), scratchT.data(), scratchT.rows(),

--- a/src/Utilities/BoostRandom.h
+++ b/src/Utilities/BoostRandom.h
@@ -151,7 +151,7 @@ public:
   //  g2 = v2*fac;
   //}
 
-  inline int state_size() const { return uni.engine().state_size; }
+  inline size_t state_size() const { return uni.engine().state_size; }
 
   inline void read(std::istream& rin) { rin >> uni.engine(); }
 

--- a/src/io/hdf/hdf_hyperslab.h
+++ b/src/io/hdf/hdf_hyperslab.h
@@ -69,16 +69,11 @@ struct hyperslab_proxy
                          const std::array<IT, RANK>& offsets_in)
       : ref_(a)
   {
+    static_assert(std::is_unsigned<IT>::value, "only accept unsigned integer types like size_t");
     for (int i = 0; i < slab_rank; ++i)
     {
-      if (dims_in[i] < 0)
-        throw std::runtime_error("Negative size detected in some dimensions of filespace input\n");
       file_space.dims[i] = static_cast<hsize_t>(dims_in[i]);
-      if (selected_in[i] < 0)
-        throw std::runtime_error("Negative size detected in some dimensions of selected space input\n");
       selected_space.dims[i] = static_cast<hsize_t>(selected_in[i]);
-      if (offsets_in[i] < 0)
-        throw std::runtime_error("Negative value detected in some dimensions of offset input\n");
       slab_offset[i] = static_cast<hsize_t>(offsets_in[i]);
     }
 

--- a/src/io/tests/hdf/test_hdf_hyperslab.cpp
+++ b/src/io/tests/hdf/test_hdf_hyperslab.cpp
@@ -79,13 +79,13 @@ TEST_CASE("hdf_read_partial", "[hdf]")
   Matrix<double> outbuffer3(1, 1);
   Matrix<double> outbuffer4;
 
-  std::array<int, 2> dims_unused;
+  std::array<size_t, 2> dims_unused;
   dims_unused[0] = 3;
   dims_unused[1] = 4;
-  std::array<int, 2> dims_local;
+  std::array<size_t, 2> dims_local;
   dims_local[0] = 1;
   dims_local[1] = 4;
-  std::array<int, 2> offsets;
+  std::array<size_t, 2> offsets;
   offsets[0] = 1;
   offsets[1] = 0;
 


### PR DESCRIPTION
## Proposed changes
Make io/hdf only accept size_t not int. Seems a nice thing to have.
PGI complains about "void static". Changed to "static void"
Make some suspicious virtual function overriding explicit.

Restart tests pass.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'