### PR TITLE
Fix race conditions in CUDA kernels causing incorrect energies

### DIFF
--- a/src/QMCHamiltonians/CudaCoulomb.cu
+++ b/src/QMCHamiltonians/CudaCoulomb.cu
@@ -284,6 +284,7 @@ __global__ void coulomb_AA_PBC_kernel(TR** R,
     for (int i = 0; i < 3; i++)
       if ((3 * b + i) * BS + tid < 3 * N)
         r1[0][i * BS + tid] = myR[(3 * b + i) * BS + tid];
+    __syncthreads();
     int ptcl1 = b * BS + tid;
     if (ptcl1 < N)
     {
@@ -308,12 +309,14 @@ __global__ void coulomb_AA_PBC_kernel(TR** R,
   }
   // Avoid double-counting on the diagonal blocks
   mysum *= 0.5;
+  __syncthreads();
   // Now do off-diagonal blocks
   for (int b1 = 0; b1 < NB; b1++)
   {
     for (int i = 0; i < 3; i++)
       if ((3 * b1 + i) * BS + tid < 3 * N)
         r1[0][i * BS + tid] = myR[(3 * b1 + i) * BS + tid];
+    __syncthreads();
     int ptcl1 = b1 * BS + tid;
     if (ptcl1 < N)
     {
@@ -322,6 +325,7 @@ __global__ void coulomb_AA_PBC_kernel(TR** R,
         for (int i = 0; i < 3; i++)
           if ((3 * b2 + i) * BS + tid < 3 * N)
             r2[0][i * BS + tid] = myR[(3 * b2 + i) * BS + tid];
+        __syncthreads();
         int end = ((b2 + 1) * BS < N) ? BS : (N - b2 * BS);
         for (int j = 0; j < end; j++)
         {
@@ -368,6 +372,7 @@ __global__ void coulomb_AA_kernel(T** R, int N, T* sum)
     for (int i = 0; i < 3; i++)
       if ((3 * b + i) * BS + tid < 3 * N)
         r1[0][i * BS + tid] = myR[(3 * b + i) * BS + tid];
+    __syncthreads();
     int ptcl1 = b * BS + tid;
     if (ptcl1 < N)
     {
@@ -388,12 +393,14 @@ __global__ void coulomb_AA_kernel(T** R, int N, T* sum)
   }
   // Avoid double-counting on the diagonal blocks
   mysum *= 0.5;
+  __syncthreads();
   // Now do off-diagonal blocks
   for (int b1 = 0; b1 < NB; b1++)
   {
     for (int i = 0; i < 3; i++)
       if ((3 * b1 + i) * BS + tid < 3 * N)
         r1[0][i * BS + tid] = myR[(3 * b1 + i) * BS + tid];
+    __syncthreads();
     int ptcl1 = b1 * BS + tid;
     if (ptcl1 < N)
     {
@@ -402,6 +409,7 @@ __global__ void coulomb_AA_kernel(T** R, int N, T* sum)
         for (int i = 0; i < 3; i++)
           if ((3 * b2 + i) * BS + tid < 3 * N)
             r2[0][i * BS + tid] = myR[(3 * b2 + i) * BS + tid];
+        __syncthreads();
         int end = ((b2 + 1) * BS < N) ? BS : (N - b2 * BS);
         for (int j = 0; j < end; j++)
         {
@@ -544,6 +552,7 @@ __global__ void MPC_SR_kernel(T** R, int N, T* lattice, T* latticeInv, T* sum)
   }
   // Avoid double-counting on the diagonal blocks
   mysum *= 0.5;
+  __syncthreads();
   // Now do off-diagonal blocks
   for (int b1 = 0; b1 < NB; b1++)
   {
@@ -559,6 +568,7 @@ __global__ void MPC_SR_kernel(T** R, int N, T* lattice, T* latticeInv, T* sum)
         for (int i = 0; i < 3; i++)
           if ((3 * b2 + i) * BS + tid < 3 * N)
             r2[0][i * BS + tid] = myR[(3 * b2 + i) * BS + tid];
+        __syncthreads();
         int end = ((b2 + 1) * BS < N) ? BS : (N - b2 * BS);
         for (int j = 0; j < end; j++)
         {
@@ -1074,6 +1084,7 @@ __global__ void eval_rhok_kernel(T** R, int numr, T* kpoints, int numk, T** rhok
         if ((i + 3 * rBlock) * BS + tid < 3 * numr)
           r[0][BS * i + tid] = myR[(i + 3 * rBlock) * BS + tid];
       int end = ((rBlock + 1) * BS < numr) ? BS : (numr - rBlock * BS);
+      __syncthreads();
       for (int j = 0; j < end; j++)
       {
         T phase = (k[tid][0] * r[j][0] + k[tid][1] * r[j][1] + k[tid][2] * r[j][2]);
@@ -1122,6 +1133,7 @@ __global__ void eval_rhok_kernel(TR** R, int first, int last, T* kpoints, int nu
       for (int i = 0; i < 3; i++)
         if ((i + 3 * rBlock) * BS + tid < 3 * numr)
           r[0][BS * i + tid] = myR[3 * first + (i + 3 * rBlock) * BS + tid];
+      __syncthreads();
       int end = ((rBlock + 1) * BS < numr) ? BS : (numr - rBlock * BS);
       for (int j = 0; j < end; j++)
       {
@@ -1234,18 +1246,19 @@ __global__ void vk_sum_kernel2(T** rhok1, T** rhok2, T* vk, int numk, T* sum)
     myrhok1 = rhok1[blockIdx.x];
     myrhok2 = rhok2[blockIdx.x];
   }
-  __syncthreads();
   // Used to do coalesced global loads
   __shared__ T rhok_s1[2 * BS], rhok_s2[2 * BS];
   int NB  = numk / BS + ((numk % BS) ? 1 : 0);
   T mysum = 0.0f;
   for (int b = 0; b < NB; b++)
   {
+    __syncthreads();
     if (2 * b * BS + tid < 2 * numk)
     {
       rhok_s1[tid] = myrhok1[2 * b * BS + tid];
       rhok_s2[tid] = myrhok2[2 * b * BS + tid];
     }
+    __syncthreads();
     if ((2 * b + 1) * BS + tid < 2 * numk)
     {
       rhok_s1[BS + tid] = myrhok1[(2 * b + 1) * BS + tid];
@@ -1313,18 +1326,19 @@ __global__ void vk_sum_kernel2(T** rhok1, T* rhok2, T* vk, int numk, T* sum)
   __shared__ T* myrhok1;
   if (tid == 0)
     myrhok1 = rhok1[blockIdx.x];
-  __syncthreads();
   // Used to do coalesced global loads
   __shared__ T rhok_s1[2 * BS], rhok_s2[2 * BS];
   int NB  = numk / BS + ((numk % BS) ? 1 : 0);
   T mysum = 0.0f;
   for (int b = 0; b < NB; b++)
   {
+    __syncthreads();
     if (2 * b * BS + tid < 2 * numk)
     {
       rhok_s1[tid] = myrhok1[2 * b * BS + tid];
       rhok_s2[tid] = rhok2[2 * b * BS + tid];
     }
+    __syncthreads();
     if ((2 * b + 1) * BS + tid < 2 * numk)
     {
       rhok_s1[BS + tid] = myrhok1[(2 * b + 1) * BS + tid];

--- a/src/QMCHamiltonians/NLPP.cu
+++ b/src/QMCHamiltonians/NLPP.cu
@@ -312,6 +312,7 @@ __global__ void find_core_electrons_PBC_kernel(T** R,
         disp[tid][1] = r[tid][1] - i[ion][1];
         disp[tid][2] = r[tid][2] - i[ion][2];
         dist[tid]    = min_dist<T>(disp[tid][0], disp[tid][1], disp[tid][2], L, Linv);
+        __syncthreads();
         for (int elec = 0; elec < elecEnd; elec++)
         {
           __syncthreads();

--- a/src/QMCWaveFunctions/detail/CUDA_legacy/determinant_update.cu
+++ b/src/QMCWaveFunctions/detail/CUDA_legacy/determinant_update.cu
@@ -1412,6 +1412,7 @@ __global__ void calc_ratio_grad_lapl(T** Ainv_list,
   // ratio to make it w.r.t. new position
   if (tid < 4)
     ratio_prod[(tid + 1) * BS1] /= ratio_prod[0];
+  __syncthreads();  
   if (tid < 5)
     ratio_grad_lapl[5 * blockIdx.x + tid] = ratio_prod[tid * BS1];
 }


### PR DESCRIPTION
## Proposed changes

Fix reported bugs by Andrea Zen / Dario Alfe where the legacy CUDA code will give clearly wrong energies for certain calculations. The symptom is a total energy as well as several subcomponents of the total energy that vary significantly with walker count. This problem was initially discovered via non-sensical DMC results, but the problems also occur in VMC.

Bugs are traced to handful of potential race conditions in the kernels associated with Coulomb energy evaluation. These bugs are present in Volta generation and more recent GPUs due to their independent thread scheduling. Our regular testing for e.g. carbon diamond did not identify them.

A side effect of these fixes is that the legacy CUDA code now appears to be completely deterministic.

Despite the extra syncthreads calls, running the performance tests showed no change in runtime within measurement error.

I do not have a small reproducer for the problems.

Thanks to @jefflarkin for reminders of CUDA tools (cuda-memcheck) that helped track these problems down efficiently.

The racecheck tool still issues a warning in find_core_electrons_PBC_kernel in NLPP.cu . It looks to be a false warning but needs more study. Otherwise the code is clean of races in VMC for the standard spline+j1+j2 inputs that I tried. 

The initcheck tool flags a couple of uninitialized memory references associated with determinant setup and update. 

![energies](https://user-images.githubusercontent.com/13683814/107271001-9fa43e80-6a19-11eb-9c6a-3bc7d469c49b.png)

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen: AMD Rome + NVIDIA V100 32GB. LLVM dev + CUDA 11.2.0

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No, only CUDA changes. We have not reformatted the CUDA. Code added or changed in the PR has been clang-formatted.
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)

( Created the PR from within vscode, hence initial draft. )