### PR TITLE
Converging AFQMC unit test file check

### DIFF
--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -61,12 +61,7 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
 {
   using pointer = typename Allocator::pointer;
 
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("reduced_density_matrix", UTEST_WFN, UTEST_HAMIL))
   {
     timer_manager.set_timer_threshold(timer_level_coarse);
     setup_timers(AFQMCTimers, AFQMCTimerNames, timer_level_coarse);

--- a/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
+++ b/src/AFQMC/HamiltonianOperations/tests/test_hamiltonian_operations.cpp
@@ -64,12 +64,7 @@ void ham_ops_basic_serial(boost::mpi3::communicator& world)
 {
   using pointer = device_ptr<ComplexType>;
 
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("ham_ops_basic_serial", UTEST_WFN, UTEST_HAMIL))
   {
     // Global Task Group
     afqmc::GlobalTaskGroup gTG(world);

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -64,12 +64,7 @@ using namespace afqmc;
 
 void propg_fac_shared(boost::mpi3::communicator& world)
 {
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("propg_fac_shared", UTEST_WFN, UTEST_HAMIL))
   {
     timer_manager.set_timer_threshold(timer_level_coarse);
     setup_timers(AFQMCTimers, AFQMCTimerNames, timer_level_coarse);
@@ -241,12 +236,7 @@ void propg_fac_shared(boost::mpi3::communicator& world)
 
 void propg_fac_distributed(boost::mpi3::communicator& world, int ngrp)
 {
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("propg_fac_distributed", UTEST_WFN, UTEST_HAMIL))
   {
     timer_manager.set_timer_threshold(timer_level_coarse);
     setup_timers(AFQMCTimers, AFQMCTimerNames, timer_level_coarse);

--- a/src/AFQMC/Utilities/test_utils.hpp
+++ b/src/AFQMC/Utilities/test_utils.hpp
@@ -16,6 +16,7 @@
 
 #include <complex>
 #include "hdf/hdf_archive.h"
+#include "Utils.hpp"
 
 namespace qmcplusplus
 {
@@ -125,7 +126,7 @@ TEST_DATA<T> read_test_results_from_hdf(std::string fileName, std::string wfn_ty
 }
 
 // Create a fake output hdf5 filename for unit tests.
-inline std::string create_test_hdf(std::string& wfn_file, std::string& hamil_file)
+inline std::string create_test_hdf(const std::string& wfn_file, const std::string& hamil_file)
 {
   std::size_t startw   = wfn_file.find_last_of("\\/");
   std::size_t endw     = wfn_file.find_last_of(".");
@@ -138,6 +139,18 @@ inline std::string create_test_hdf(std::string& wfn_file, std::string& hamil_fil
   return wfn_base + "_" + ham_base + ".h5";
 }
 
+inline bool check_hamil_wfn_for_utest(const std::string& test_name, std::string& wfn_file, std::string& hamil_file)
+{
+  if (not file_exists(wfn_file) || not file_exists(hamil_file))
+  {
+    app_log() << " Skipping '" << test_name << "' test. Hamiltonian or wavefunction file not found." << std::endl;
+    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat." << std::endl;
+    //throw std::runtime_error("Failed to read testing needed h5 files.");
+    return false;
+  }
+  else
+    return true;
+}
 
 } // namespace afqmc
 } // namespace qmcplusplus

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -68,12 +68,7 @@ void test_read_phmsd(boost::mpi3::communicator& world)
 {
   using pointer = device_ptr<ComplexType>;
 
-  if (not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping read_phmsd. Wavefunction file not found. \n";
-    app_log() << " Run unit test with --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("test_read_phmsd", UTEST_WFN, UTEST_HAMIL))
   {
     // Global Task Group
     GlobalTaskGroup gTG(world);
@@ -191,12 +186,7 @@ void test_phmsd(boost::mpi3::communicator& world)
 {
   using pointer = device_ptr<ComplexType>;
 
-  if (not file_exists(UTEST_WFN) || not file_exists(UTEST_HAMIL))
-  {
-    app_log() << " Skipping read_phmsd. Wavefunction and/or Hamiltonian file not found. \n";
-    app_log() << " Run unit test with --wfn /path/to/wfn.h5 and --hamil /path/to/hamil.h5.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("read_phmsd", UTEST_WFN, UTEST_HAMIL))
   {
     // Global Task Group
     GlobalTaskGroup gTG(world);

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -65,12 +65,7 @@ void wfn_fac(boost::mpi3::communicator& world)
 {
   using pointer = device_ptr<ComplexType>;
 
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("wfn_fac", UTEST_WFN, UTEST_HAMIL))
   {
     // Global Task Group
     GlobalTaskGroup gTG(world);
@@ -406,12 +401,7 @@ void wfn_fac(boost::mpi3::communicator& world)
 template<class Allocator>
 void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
 {
-  if (not file_exists(UTEST_HAMIL) || not file_exists(UTEST_WFN))
-  {
-    app_log() << " Skipping ham_ops_basic_serial. Hamiltonian or wavefunction file not found. \n";
-    app_log() << " Run unit test with --hamil /path/to/hamil.h5 and --wfn /path/to/wfn.dat.\n";
-  }
-  else
+  if (check_hamil_wfn_for_utest("wfn_fac_distributed", UTEST_WFN, UTEST_HAMIL))
   {
     // Global Task Group
     GlobalTaskGroup gTG(world);


### PR DESCRIPTION
## Proposed changes
I noticed that AFQMC unit tests skip runs and report pass if h5 files for hamiltonian and wf are not found. I think this goes against the purpose of unit test. Now I converged all the file checks to a single routine and I would like to eventually throw error if files are not found. So far I cannot do this change because test deterministic-unit_test_afqmc_phmsd fails with missing files.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'