### PR TITLE
remove global namespaces blitz and std

### DIFF
--- a/src/QMCTools/ppconvert/src/NLPPClass.cc
+++ b/src/QMCTools/ppconvert/src/NLPPClass.cc
@@ -27,7 +27,7 @@ void
 ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer, 
 					bool writeVl)
 {
-  string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
+  std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a logarithmic grid:
   // r(i) = a*(exp(b*i) - 1)
   const int numPoints = 2001;
@@ -53,15 +53,15 @@ ChannelPotentialClass::WriteChannelLog (XMLWriterClass &writer,
   writer.WriteAttribute("step", step, true);
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
-  vector<double> data;
+  std::vector<double> data;
   for (int i=0; i<numPoints; i++) {
     double r  = scale * (expm1(step*i));
     if (writeVl) {
-      double rmin = min (r, Vl.grid.End());
+      double rmin = std::min (r, Vl.grid.End());
       data.push_back(Vlr(rmin));
     }
     else {
-      r = min (r, ul.grid.End());
+      r = std::min (r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -77,7 +77,7 @@ void
 ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer, 
 					   double dr, double rmax, bool writeVl)
 {
-  string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
+  std::string channels[] = {"s", "p", "d", "f", "g", "h", "i", "j"};
   // Use a linear grid
   // r(i) = dr * i
   const int numPoints = (int)round(rmax/dr) + 1;
@@ -100,18 +100,18 @@ ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
   writer.WriteAttribute("rf", dr*(double)(numPoints-1));
   writer.WriteAttribute("npts", numPoints);
   writer.EndElement(); // "grid"
-  vector<double> data;
+  std::vector<double> data;
   for (int i=0; i<numPoints; i++) {
     double r  = dr*(double)i;
     if (writeVl) {
-      r = min (r, ul.grid.End());
+      r = std::min (r, ul.grid.End());
       if (r < Vl.grid.Start())
   	data.push_back(0.0);
       else
   	data.push_back(Vlr(r));
     }
     else {
-      r = min (r, ul.grid.End());
+      r = std::min (r, ul.grid.End());
       data.push_back(ul(r));
     }
   }
@@ -125,15 +125,15 @@ ChannelPotentialClass::WriteChannelLinear (XMLWriterClass &writer,
 void
 PseudoClass::SetupMaps()
 {
-  UnitToHartreeMap[string("hartree")] = 1.0;
-  UnitToHartreeMap[string("hartrees")] = 1.0;
-  UnitToHartreeMap[string("Hartrees")] = 1.0;
-  UnitToHartreeMap[string("rydberg")] = 0.5;
-  UnitToHartreeMap[string("ev")]      = 0.03674932595264097934;
+  UnitToHartreeMap[std::string("hartree")] = 1.0;
+  UnitToHartreeMap[std::string("hartrees")] = 1.0;
+  UnitToHartreeMap[std::string("Hartrees")] = 1.0;
+  UnitToHartreeMap[std::string("rydberg")] = 0.5;
+  UnitToHartreeMap[std::string("ev")]      = 0.03674932595264097934;
   
-  UnitToBohrMap[string("bohr")]     = 1.0;
-  UnitToBohrMap[string("atomic")]   = 1.0;
-  UnitToBohrMap[string("angstrom")] = 1.8897261;
+  UnitToBohrMap[std::string("bohr")]     = 1.0;
+  UnitToBohrMap[std::string("atomic")]   = 1.0;
+  UnitToBohrMap[std::string("angstrom")] = 1.8897261;
 
   XCMap[XC_LDA] ="LDA" ; XCRevMap["LDA"] =XC_LDA;  XCRevMap["lda"] =XC_LDA;
   XCMap[XC_GGA] ="GGA" ; XCRevMap["GGA"] =XC_GGA;  XCRevMap["gga"] =XC_LDA;
@@ -325,7 +325,7 @@ PseudoClass::SetupMaps()
 }
 
 void
-PseudoClass::WriteFPMD(string fname)
+PseudoClass::WriteFPMD(std::string fname)
 {
   const int numPoints = 2000;
   const double dr = 0.005;
@@ -392,7 +392,7 @@ PseudoClass::WriteFPMD(string fname)
     writer.WriteAttribute("size", numPoints);
     
     writer.StartElement("radial_potential");
-    vector<double> vl(numPoints);
+    std::vector<double> vl(numPoints);
     for (int ir=0; ir<numPoints; ir++) {
       double r = (double)ir*dr;
       vl[ir] = (ir==0) ? pot.Vl(0.0) : pot.Vlr(r)/r;
@@ -402,7 +402,7 @@ PseudoClass::WriteFPMD(string fname)
 
     if (pot.HasProjector && pot.l != LocalChannel) {
       writer.StartElement("radial_function");
-      vector<double> ul(numPoints);
+      std::vector<double> ul(numPoints);
       for (int ir=0; ir<numPoints; ir++) {
 	double r = (ir==0) ? 1.0e-8 : (double)ir*dr;
 	ul[ir] = pot.ul(r)/r;
@@ -423,14 +423,14 @@ PseudoClass::WriteFPMD(string fname)
 }
 
 void
-PseudoClass::WriteCASINO(string fname)
+PseudoClass::WriteCASINO(std::string fname)
 {
   const int numPoints = 10001;
   const double rMax = 10.0;
 
   FILE *fout = fopen (fname.c_str(), "w");
   if (!fout) {
-    cerr << "Error trying to write " << fname << ".\n";
+    std::cerr << "Error trying to write " << fname << ".\n";
     abort();
   }
 
@@ -455,7 +455,7 @@ PseudoClass::WriteCASINO(string fname)
     ChannelPotentialClass &pot = (l < ChannelPotentials.size()) ?
       ChannelPotentials[l] : ChannelPotentials[LocalChannel];
     if (l < ChannelPotentials.size() && l != pot.l) {
-      cerr << "Channel mismatch in WriteCASINO.\n";
+      std::cerr << "Channel mismatch in WriteCASINO.\n";
       abort();
     }
     fprintf (fout, "r*potential (L=%d) in Ry\n",
@@ -470,7 +470,7 @@ PseudoClass::WriteCASINO(string fname)
 }
 
 void
-PseudoClass::WriteXML(string fname)
+PseudoClass::WriteXML(std::string fname)
 {
 //   int rc;
 //   xmlTextWriterPtr writer = xmlNewTextWriterFilename (fname.c_str(), 0);
@@ -485,8 +485,8 @@ PseudoClass::WriteXML(string fname)
 //   xmlFreeTextWriter(writer);
   for (int l=0; l<ChannelPotentials.size(); l++)
     if (!ChannelPotentials[l].HasProjector) {
-      cerr << "Missing projector for l=" << l 
-	   << ".  Aborting." << endl;
+      std::cerr << "Missing projector for l=" << l 
+	   << ".  Aborting." << std::endl;
       exit(1);
     }
   XMLWriterClass writer;
@@ -527,7 +527,7 @@ PseudoClass::WriteXML(string fname)
     writer.EndElement(); // "grid"
   }
   else {
-    rmax = min (10.0, PotentialGrid.End());
+    rmax = std::min (10.0, PotentialGrid.End());
     int numPoints = (int)round(rmax/grid_delta) + 1;
     writer.StartElement("grid");
     writer.WriteAttribute("type", "linear");
@@ -570,7 +570,7 @@ PseudoClass::WriteXML(string fname)
 
 
 void
-PseudoClass::Write4Block (FILE *fout, vector<double>& data, int indent)
+PseudoClass::Write4Block (FILE *fout, std::vector<double>& data, int indent)
 {
   int N = data.size();
   for (int i=0; i<N/4; i++) {
@@ -587,12 +587,12 @@ PseudoClass::Write4Block (FILE *fout, vector<double>& data, int indent)
 
 
 void
-PseudoClass::WriteUPF (string fileName)
+PseudoClass::WriteUPF (std::string fileName)
 {
-  cerr << "LocalChannel = " << LocalChannel << endl;
+  std::cerr << "LocalChannel = " << LocalChannel << std::endl;
   FILE *fout = fopen (fileName.c_str(), "w");
   if (fout == NULL) {
-    cerr << "Error writing UPF file " << fileName << endl;
+    std::cerr << "Error writing UPF file " << fileName << std::endl;
     return;
   }
 
@@ -604,7 +604,7 @@ PseudoClass::WriteUPF (string fileName)
   // Get date
   time_t now = time(NULL);
   struct tm &ltime = *(localtime (&now));
-  stringstream date;
+  std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
@@ -624,7 +624,7 @@ PseudoClass::WriteUPF (string fileName)
 	   ZToSymbolMap[AtomicNumber].c_str());
   fprintf (fout, "  NC                  Norm - Conserving pseudopotential\n");
   fprintf (fout, "   F                  Nonlinear Core Correction\n");
-  string F_EX, F_CORR, F_XC_GRAD, F_CORR_GRAD;
+  std::string F_EX, F_CORR, F_XC_GRAD, F_CORR_GRAD;
   F_EX = "SLA";
   F_CORR = "PW";
   F_XC_GRAD = "PBE";
@@ -657,7 +657,7 @@ PseudoClass::WriteUPF (string fileName)
   Write4Block (fout, PotentialGrid.Points());
   fprintf (fout, "  </PP_R>\n");
   fprintf (fout, "  <PP_RAB>\n");
-  vector<double> dr(N);
+  std::vector<double> dr(N);
   for (int i=1; i<(N-1); i++)
     dr[i] = 0.5*(PotentialGrid[i+1]-PotentialGrid[i-1]);
   dr[0]   = 2.0*dr[ 1 ]-dr[ 2 ];
@@ -669,7 +669,7 @@ PseudoClass::WriteUPF (string fileName)
 
   // Write PP_LOCAL section
   fprintf (fout, "<PP_LOCAL>\n");
-  vector<double> vloc(N);
+  std::vector<double> vloc(N);
   for (int i=0; i<N; i++)
     vloc[i] = 2.0*ChannelPotentials[LocalChannel].Vl(i); // /PotentialGrid[i];
   //vloc[0] = 2.0*ChannelPotentials[LocalChannel].Vl(1.0e-7)/1.0e-7;
@@ -681,7 +681,7 @@ PseudoClass::WriteUPF (string fileName)
   int betaNum = 1;
   for (int l=0; l<ChannelPotentials.size(); l++)
     if (l != LocalChannel) {
-      vector<double> beta(N);
+      std::vector<double> beta(N);
       for (int i=0; i<N; i++) {
 	double Vloc = ChannelPotentials[LocalChannel].Vlr(i);
 	double Vl   = ChannelPotentials[l].Vlr(i);
@@ -750,7 +750,7 @@ PseudoClass::WriteUPF (string fileName)
     ChannelPotentialClass &pot = ChannelPotentials[l];
     fprintf (fout, "%d%s    %d  %6.4f          Wavefunction\n",
 	     pot.n_principal, ChannelMap[l].c_str(), l, pot.Occupation);
-    vector<double> u(N);
+    std::vector<double> u(N);
     for (int i=0; i<N; i++)
       u[i] = pot.ul(i);
     Write4Block (fout, u);
@@ -759,7 +759,7 @@ PseudoClass::WriteUPF (string fileName)
 
   // Write PP_RHOATOM section
   fprintf (fout, "<PP_RHOATOM>\n");
-  vector<double> rho_at(N);
+  std::vector<double> rho_at(N);
   for (int i=0; i<N; i++) {
     if (RhoAtom.Initialized)
       rho_at[i] = RhoAtom(i)*PotentialGrid[i]*PotentialGrid[i];
@@ -782,7 +782,7 @@ PseudoClass::WriteUPF (string fileName)
 
 
 void
-PseudoClass::WriteFHI (string fileName)
+PseudoClass::WriteFHI (std::string fileName)
 {
   const double amesh =  1.013084867359809;
   const int numPoints = 1118;
@@ -795,7 +795,7 @@ PseudoClass::WriteFHI (string fileName)
 	   ZToSymbolMap[AtomicNumber].c_str());
   time_t now = time(NULL);
   struct tm &ltime = *(localtime (&now));
-  stringstream date;
+  std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
@@ -842,7 +842,7 @@ PseudoClass::WriteFHI (string fileName)
 
 
 void
-PseudoClass::WriteABINIT (string fileName)
+PseudoClass::WriteABINIT (std::string fileName)
 {
   if (fileName == "") 
     fileName = ZToSymbolMap[AtomicNumber] + ".psp";
@@ -852,7 +852,7 @@ PseudoClass::WriteABINIT (string fileName)
 
   time_t now = time(NULL);
   struct tm &ltime = *(localtime (&now));
-  stringstream date;
+  std::stringstream date;
   int year = ltime.tm_year % 100;
   int mon  = ltime.tm_mon + 1;
   int day  = ltime.tm_mday;
@@ -983,17 +983,17 @@ PseudoClass::WriteASCII()
 }
 
 bool
-PseudoClass::ReadBFD_PP (string fileName)
+PseudoClass::ReadBFD_PP (std::string fileName)
 {
   MemParserClass parser;
   assert(parser.OpenFile (fileName));
   
   assert (parser.FindToken ("Element Symbol:"));
-  string symbol;
+  std::string symbol;
   assert (parser.ReadWord(symbol));
   AtomicNumber = SymbolToZMap[symbol];
-  cerr << "Reading element " << symbol 
-       << ", which has Z=" << AtomicNumber << endl;
+  std::cerr << "Reading element " << symbol 
+       << ", which has Z=" << AtomicNumber << std::endl;
   int numProtons, numProjectors;
   assert (parser.FindToken ("Number of replaced protons:"));
   assert (parser.ReadInt (numProtons));
@@ -1021,7 +1021,7 @@ PseudoClass::ReadBFD_PP (string fileName)
   assert (parser.ReadDouble(exp2));
 
   // Create local channel spline
-  vector<double> gridPoints, Vlocal, Vlocalr;
+  std::vector<double> gridPoints, Vlocal, Vlocalr;
   FILE *fout = fopen ("Vlocal.dat", "w");
   for (double r=1.0e-8; r<150.0; r+=0.01) {
     gridPoints.push_back (r);
@@ -1060,7 +1060,7 @@ PseudoClass::ReadBFD_PP (string fileName)
     assert (parser.ReadInt(channel));
     assert (channel == l);
     assert (parser.FindToken("|"));
-    vector<double> Vl(gridPoints.size()), Vlr(gridPoints.size());
+    std::vector<double> Vl(gridPoints.size()), Vlr(gridPoints.size());
     for (int i=0; i<gridPoints.size(); i++) {
       double r = gridPoints[i];
       Vl[i]  =  Vlocal[i] +   c0*exp(-exp0*r*r);
@@ -1080,14 +1080,14 @@ PseudoClass::ReadBFD_PP (string fileName)
 
 
 bool
-PseudoClass::ReadFHI_PP (string fileName)
+PseudoClass::ReadFHI_PP (std::string fileName)
 {
   MemParserClass parser;
   if (!parser.OpenFile (fileName)) {
-    cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
+    std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
-  string temp;
+  std::string temp;
   // Read top comment line
   assert (parser.ReadLine(temp));
   double atomCharge;
@@ -1109,8 +1109,8 @@ PseudoClass::ReadFHI_PP (string fileName)
   double chrg;
   assert (parser.ReadDouble(chrg));
   if(fabs(chrg-PseudoCharge) > 1.0e-10) {
-    cerr << "PseudoCharge = " << PseudoCharge << endl;
-    cerr << "chrg = " << chrg << endl;
+    std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
+    std::cerr << "chrg = " << chrg << std::endl;
   }
 
   // Read number of channels and resize
@@ -1128,7 +1128,7 @@ PseudoClass::ReadFHI_PP (string fileName)
     double a_ratio;
     assert (parser.ReadInt(numPoints));
     assert (parser.ReadDouble(a_ratio));
-    vector<double> points(numPoints), ul(numPoints), Vl(numPoints), 
+    std::vector<double> points(numPoints), ul(numPoints), Vl(numPoints), 
       Vlr(numPoints);
     for (int m=0; m<numPoints; m++) {
       int mtest;
@@ -1183,19 +1183,19 @@ public:
 };
 
 bool
-PseudoClass::ReadUPF_PP (string fileName)
+PseudoClass::ReadUPF_PP (std::string fileName)
 {
   MemParserClass parser;
   if (!parser.OpenFile (fileName)) {
-    cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
+    std::cerr << "Could not open file \"" << fileName << "\".  Exitting.\n";
     exit(-1);
   }
-  string temp;
+  std::string temp;
 
   assert(parser.FindToken("<PP_HEADER>")); assert(parser.NextLine());
   // Skip version number
   assert(parser.NextLine());
-  string element, ppType, coreCorrection;  
+  std::string element, ppType, coreCorrection;  
   assert(parser.ReadWord(element));  assert(parser.NextLine());
   assert(SymbolToZMap.find(element) != SymbolToZMap.end());
   AtomicNumber = SymbolToZMap[element];
@@ -1203,7 +1203,7 @@ PseudoClass::ReadUPF_PP (string fileName)
   
   assert(parser.ReadWord(ppType));
   if (ppType != "NC") {
-    cerr << "Psuedopotential type \"" << ppType 
+    std::cerr << "Psuedopotential type \"" << ppType 
 	 << "\" is not norm-conserving.\n";
     abort();
   }
@@ -1213,7 +1213,7 @@ PseudoClass::ReadUPF_PP (string fileName)
       coreCorrection != "false" && coreCorrection != "False" &&
       coreCorrection != ".F." && coreCorrection != ".f" &&
       coreCorrection != "FALSE") {
-    cerr << "It appears that a nonlinear core correction was used.  Cannot convert PP.\n";
+    std::cerr << "It appears that a nonlinear core correction was used.  Cannot convert PP.\n";
     abort();
   }
 
@@ -1250,7 +1250,7 @@ PseudoClass::ReadUPF_PP (string fileName)
   
   assert(parser.FindToken("<PP_MESH>"));
   assert(parser.FindToken("<PP_R>"));
-  vector<double> r(numPoints), dr(numPoints);
+  std::vector<double> r(numPoints), dr(numPoints);
   for (int i=0; i<numPoints; i++) 
     assert(parser.ReadDouble(r[i]));
   assert(parser.FindToken("</PP_R>"));
@@ -1264,7 +1264,7 @@ PseudoClass::ReadUPF_PP (string fileName)
   assert(parser.FindToken("</PP_MESH>"));
 	 
   assert(parser.FindToken("<PP_LOCAL>"));
-  vector<double> Vlocal(numPoints);
+  std::vector<double> Vlocal(numPoints);
   for (int i=0; i<numPoints; i++) {
     assert(parser.ReadDouble(Vlocal[i]));
     Vlocal[i] *= 0.5;
@@ -1290,7 +1290,7 @@ PseudoClass::ReadUPF_PP (string fileName)
     int npt;
     assert (parser.ReadInt(npt));
 
-    vector<double> beta(numPoints);
+    std::vector<double> beta(numPoints);
     for (int ir=0; ir<numPoints; ir++) 
       assert(parser.ReadDouble(beta[ir]));
     assert (parser.FindToken("</PP_BETA>"));
@@ -1304,7 +1304,7 @@ PseudoClass::ReadUPF_PP (string fileName)
   LocalChannel = llocal;
   //  fprintf (stderr, "First channel without a projector=%d\n", llocal);
   ChannelPotentials[llocal].Vl.Init(PotentialGrid, Vlocal);
-  vector<double> Vlocal_r(numPoints);
+  std::vector<double> Vlocal_r(numPoints);
   for (int ir=0; ir<numPoints; ir++)
     Vlocal_r[ir] = r[ir]*Vlocal[ir];
   ChannelPotentials[llocal].Vlr.Init(PotentialGrid, Vlocal_r);
@@ -1314,7 +1314,7 @@ PseudoClass::ReadUPF_PP (string fileName)
     assert (parser.FindToken("PP_PSWFC"));
     assert (parser.NextLine());
     for (int iwf=0; iwf<numWF; iwf++) {
-      string NL;
+      std::string NL;
       assert (parser.ReadWord(NL));
       int l;
       assert (parser.ReadInt(l));
@@ -1328,7 +1328,7 @@ PseudoClass::ReadUPF_PP (string fileName)
       if (l != llocal) {
 	assert (lmap.find(l) != lmap.end());
 	KBprojector &proj = projectors[lmap[l]];
-	vector<double> Vl(numPoints), Vlr(numPoints);
+	std::vector<double> Vl(numPoints), Vlr(numPoints);
 	for (int ir=0; ir<numPoints; ir++) {
 	  Vl[ir]  = Vlocal[ir];
 	  if (wf[ir] != 0.0) 
@@ -1461,23 +1461,23 @@ PseudoClass::ReadUPF_PP (string fileName)
 }
 
 bool
-PseudoClass::ReadGAMESS_PP (string fileName)
+PseudoClass::ReadGAMESS_PP (std::string fileName)
 {
   MemParserClass parser;
   assert (parser.OpenFile (fileName));
 
-  string psp_name, psp_type;
+  std::string psp_name, psp_type;
   assert (parser.ReadWord(psp_name));
   assert (parser.ReadWord(psp_type));
   // izcore is the number of core electrons removed
   // Find atomic number.
-  string symbol;
+  std::string symbol;
   int i=0;
   while ((i<psp_name.size()) && (psp_name[i] != '-')) {
     symbol = symbol + psp_name[i];
     i++;
   }
-  cerr << "Atomic symbol = " << symbol << endl;
+  std::cerr << "Atomic symbol = " << symbol << std::endl;
   int Z = SymbolToZMap[symbol];
   AtomicNumber = Z;
   int izcore, lmax;
@@ -1490,7 +1490,7 @@ PseudoClass::ReadGAMESS_PP (string fileName)
   ChannelPotentials.resize(lmax+1);
 
   // Setup the potential grid
-  vector<double> rPoints;
+  std::vector<double> rPoints;
   if (WriteLogGrid) {
     const int numPoints = 2001;
     double end = 150.0;
@@ -1505,10 +1505,10 @@ PseudoClass::ReadGAMESS_PP (string fileName)
   }
   PotentialGrid.Init(rPoints);
   int N = rPoints.size();
-  vector<double> Vlocal(N), Vl(N);
-  vector<double> Vlocal_r(N), Vl_r(N);
-  cerr << "PseudoCharge = " << PseudoCharge << endl;
-  cerr << "lmax = " << lmax << endl;
+  std::vector<double> Vlocal(N), Vl(N);
+  std::vector<double> Vlocal_r(N), Vl_r(N);
+  std::cerr << "PseudoCharge = " << PseudoCharge << std::endl;
+  std::cerr << "lmax = " << lmax << std::endl;
 
   for (int index=0; index<=lmax; index++) {
     // lmax is first, followed by 0, 1, etc.
@@ -1516,8 +1516,8 @@ PseudoClass::ReadGAMESS_PP (string fileName)
     int ngpot;
     assert (parser.ReadInt (ngpot));
     assert (parser.FindToken("\n"));
-    vector<double> coefs(ngpot), exponents(ngpot);
-    vector<int> powers(ngpot);
+    std::vector<double> coefs(ngpot), exponents(ngpot);
+    std::vector<int> powers(ngpot);
     
     // The local channel is given first
     for (int i=0; i<ngpot; i++) {
@@ -1581,15 +1581,15 @@ PseudoClass::ReadGAMESS_PP (string fileName)
     ChannelPotentials[l].Cutoff = rPoints[ir];
 
 
-  cerr << "Finished reading GAMESS pseudopotential.\n";
+  std::cerr << "Finished reading GAMESS pseudopotential.\n";
   return true;
 }
 
 bool
-ReadInt (string &s, int &n)
+ReadInt (std::string &s, int &n)
 {
   int pos=0;
-  string sint;
+  std::string sint;
   while (s[pos] >= '0' && s[pos] <= '9') 
     sint.push_back(s[pos++]);
   s.erase(0,pos);
@@ -1598,10 +1598,10 @@ ReadInt (string &s, int &n)
 }
 
 bool
-ReadDouble (string &s, double &x)
+ReadDouble (std::string &s, double &x)
 {
   int pos=0;
-  string sd;
+  std::string sd;
   while ((s[pos] >= '0' && s[pos] <= '9') || s[pos]=='.') 
     sd.push_back(s[pos++]);
   s.erase(0,pos);
@@ -1610,7 +1610,7 @@ ReadDouble (string &s, double &x)
 }
 
 
-Config::Config(string s)
+Config::Config(std::string s)
 {
   ChannelRevMap['s'] = 0;
   ChannelRevMap['p'] = 1;
@@ -1635,7 +1635,7 @@ Config::Config(string s)
 
 
 bool 
-PseudoClass::ReadCASINO_PP (string fileName)
+PseudoClass::ReadCASINO_PP (std::string fileName)
 {
   MemParserClass parser;
   parser.OpenFile (fileName);
@@ -1645,17 +1645,17 @@ PseudoClass::ReadCASINO_PP (string fileName)
   assert (parser.ReadDouble (PseudoCharge));
   assert (parser.FindToken("(rydberg/hartree/ev):"));
   assert (parser.ReadWord(EnergyUnit));
-  cerr << "EnergyUnit = " << EnergyUnit << endl;
+  std::cerr << "EnergyUnit = " << EnergyUnit << std::endl;
   assert (parser.FindToken("(0=s,1=p,2=d..)"));
   assert (parser.ReadInt (LocalChannel));
   assert (parser.FindToken("grid points"));
   int numGridPoints;
   assert (parser.ReadInt(numGridPoints));
-  vector<double> gridPoints(numGridPoints), Vl(numGridPoints), 
+  std::vector<double> gridPoints(numGridPoints), Vl(numGridPoints), 
     Vlr(numGridPoints);
   assert (parser.FindToken ("in"));
   assert (parser.ReadWord(LengthUnit));
-  cerr << "LengthUnit = " << LengthUnit << endl;
+  std::cerr << "LengthUnit = " << LengthUnit << std::endl;
   assert (parser.FindToken("\n"));
   //  assert (parser.FindToken("atomic units"));
   for (int i=0; i<numGridPoints; i++) {
@@ -1684,14 +1684,14 @@ PseudoClass::ReadCASINO_PP (string fileName)
       ChannelPotentials[l].l = l;
     }
   }
-  cerr << "Found " << (l+1) << " l-channel potentials.\n";
+  std::cerr << "Found " << (l+1) << " l-channel potentials.\n";
 
   // Now read the summary file to get core radii
   if (!parser.OpenFile ("summary.txt")) {
-    cerr << "Could not find summary.txt file.  Aborting.\n";
+    std::cerr << "Could not find summary.txt file.  Aborting.\n";
     abort();
   }
-  string summaryUnits;
+  std::string summaryUnits;
   assert (parser.FindToken("Units:"));
   assert (parser.ReadWord (summaryUnits));
   assert (parser.FindToken("core radii"));
@@ -1718,7 +1718,7 @@ PseudoClass::ReadCASINO_PP (string fileName)
 
   // Find ground state occupations
   assert (parser.FindToken ("Eigenvalues of the"));
-  string GSconfig;
+  std::string GSconfig;
   parser.ReadWord (GSconfig);
   Config c(GSconfig);
   for (int is=0; is<c.size(); is++)
@@ -1750,17 +1750,17 @@ PseudoClass::ReadCASINO_PP (string fileName)
   assert (parser.FindToken ("Pseudo HF"));
   assert (parser.FindToken ("\n"));
   assert (parser.FindToken ("\n"));
-  string channel;
+  std::string channel;
   parser.ReadWord (channel);
   while ((channel=="s") || (channel=="p") || (channel=="d") || 
 	 (channel=="f") || (channel=="g")) {
     int l = ChannelRevMap[channel];
-    string tmp;
+    std::string tmp;
     parser.ReadWord (tmp);
     assert (parser.ReadDouble (ChannelPotentials[l].Eigenvalue));
     ChannelPotentials[l].Eigenvalue *= UnitToHartreeMap[summaryUnits];
-    cerr << "Eigenvalue for " << channel << "-channel = " 
-	 << ChannelPotentials[l].Eigenvalue << endl;
+    std::cerr << "Eigenvalue for " << channel << "-channel = " 
+	 << ChannelPotentials[l].Eigenvalue << std::endl;
     parser.ReadLine (tmp);
     parser.ReadWord (channel);
   }
@@ -1769,7 +1769,7 @@ PseudoClass::ReadCASINO_PP (string fileName)
   assert (parser.FindToken ("="));
   assert (parser.ReadDouble (TotalEnergy));
   TotalEnergy *= UnitToHartreeMap[summaryUnits];
-  cerr << "Total energy = " << TotalEnergy << endl;
+  std::cerr << "Total energy = " << TotalEnergy << std::endl;
 
 //   for (int i=0; i<=l; i++)
 //     ChannelPotentials[i].Cutoff = rloc;
@@ -1781,7 +1781,7 @@ PseudoClass::ReadCASINO_PP (string fileName)
 /// Note:  the pseudopotentials must be read before the wave
 /// functions.  
 bool
-PseudoClass::ReadCASINO_WF (string fileName, int l)
+PseudoClass::ReadCASINO_WF (std::string fileName, int l)
 {
   // Make sure that l is not too high
   assert (l < ChannelPotentials.size());
@@ -1818,7 +1818,7 @@ PseudoClass::ReadCASINO_WF (string fileName, int l)
     assert (parser.ReadInt(n));
     assert (parser.ReadInt(thisl));
     if (thisl == l) {
-      vector<double> ul(numPoints);
+      std::vector<double> ul(numPoints);
       for (int i=0; i<numPoints; i++)
 	assert (parser.ReadDouble(ul[i]));
       ChannelPotentials[l].ul.Init(PotentialGrid, ul);
@@ -1828,8 +1828,8 @@ PseudoClass::ReadCASINO_WF (string fileName, int l)
     }
   }
   if (!orbFound) {
-    cerr << "Could not file orbital with l=" << l 
-	 << " in file ""filename""" << endl; 
+    std::cerr << "Could not file orbital with l=" << l 
+	 << " in file ""filename""" << std::endl; 
     exit(1);
   }
   return true;
@@ -1855,7 +1855,7 @@ PseudoClass::HaveProjectors()
 int main(int argc, char **argv)
 {
   // Create list of acceptable command-line parameters
-  list<ParamClass> argList;
+  std::list<ParamClass> argList;
   // input formats
   argList.push_back(ParamClass("fhi_pot",   true));
   argList.push_back(ParamClass("casino_pot", true));
@@ -1886,7 +1886,7 @@ int main(int argc, char **argv)
   CommandLineParserClass parser(argList);
   bool success = parser.Parse(argc, argv);
   if (!success || parser.NumFiles()!=0) {
-    cerr << "Usage:  ppconvert  options\n"
+    std::cerr << "Usage:  ppconvert  options\n"
          << "  Options include:    \n"
          << "     Input formats:   \n"
          << "   --casino_pot fname \n"
@@ -1920,7 +1920,7 @@ int main(int argc, char **argv)
   }
 
 
-  string xmlFile, tmFile;
+  std::string xmlFile, tmFile;
   // Read the PP file
   PseudoClass nlpp;
 
@@ -1944,7 +1944,7 @@ int main(int argc, char **argv)
   else if (parser.Found ("gamess_pot"))
     nlpp.ReadGAMESS_PP (parser.GetArg("gamess_pot"));
   else {
-    cerr << "Need to specify a potential file with --casino_pot "
+    std::cerr << "Need to specify a potential file with --casino_pot "
 	 << "or --bfd_pot or --fhi_pot or --upf_pot or --gamess_pot.\n";
     exit(1);
   }
@@ -1958,7 +1958,7 @@ int main(int argc, char **argv)
       else if (parser.Found("casino_us"))
 	nlpp.ReadCASINO_WF(parser.GetArg("casino_us"), 0);
       else {
-	cerr << "Please specify the s-channel projector with either "
+	std::cerr << "Please specify the s-channel projector with either "
 	     << " --s_ref or --casino_us.\n";
 	// exit(-1);
       }
@@ -1969,7 +1969,7 @@ int main(int argc, char **argv)
       else if (parser.Found("casino_up"))
 	nlpp.ReadCASINO_WF(parser.GetArg("casino_up"), 1);
       else {
-	cerr << "Please specify the p-channel projector with either "
+	std::cerr << "Please specify the p-channel projector with either "
 	     << " --p_ref or --casino_up.\n";
 	// exit(-1);
       }
@@ -1980,7 +1980,7 @@ int main(int argc, char **argv)
       else if(parser.Found("casino_ud"))
 	nlpp.ReadCASINO_WF(parser.GetArg("casino_ud"), 2);
       else {
-	cerr << "Please specify the d-channel projector with either "
+	std::cerr << "Please specify the d-channel projector with either "
 	     << " --d_ref or --casino_ud.\n";
 	// exit(-1);
       }
@@ -1991,7 +1991,7 @@ int main(int argc, char **argv)
       else if(parser.Found("casino_uf"))
 	nlpp.ReadCASINO_WF(parser.GetArg("casino_uf"), 3);
       else {
-	cerr << "Please specify the f-channel projector with either "
+	std::cerr << "Please specify the f-channel projector with either "
 	     << " --f_ref or --casino_uf.\n";
 	// exit(-1);
       }
@@ -2002,7 +2002,7 @@ int main(int argc, char **argv)
       else if(parser.Found("casino_ug"))
 	nlpp.ReadCASINO_WF(parser.GetArg("casino_ug"), 4);
       else {
-	cerr << "Please specify the g-channel projector with either "
+	std::cerr << "Please specify the g-channel projector with either "
 	     << " --g_ref or --casino_ug.\n";
 	// exit(-1);
       }
@@ -2040,7 +2040,7 @@ int main(int argc, char **argv)
 
 #include "common/IO.h"
 
-Array<double,1> vector2Array(vector<double> &vec)
+Array<double,1> vector2Array(std::vector<double> &vec)
 {
   blitz::Array<double,1> array(vec.size());
   for (int i=0; i<vec.size(); i++)
@@ -2051,31 +2051,31 @@ Array<double,1> vector2Array(vector<double> &vec)
 
 
 bool
-PseudoClass::GetNextState (string &state, int &n, int &l, double &occ)
+PseudoClass::GetNextState (std::string &state, int &n, int &l, double &occ)
 {
   if (state.length() <= 0)
     return false;
 
   if ((state[0]<'1') || (state[0] > '9')) {
-    cerr << "Error parsing reference state.\n";
+    std::cerr << "Error parsing reference state.\n";
     abort();
   }
   n = state[0] - '0';
-  string channel = state.substr (1,1);
+  std::string channel = state.substr (1,1);
   if ((channel != "s") && (channel != "p") &&
       (channel != "d") && (channel != "f") && (channel != "g")) {
-    cerr << "Unrecognized angular momentum channel in reference state.\n";
+    std::cerr << "Unrecognized angular momentum channel in reference state.\n";
     abort();
   }
   l = ChannelRevMap[channel];
   // cerr << "n=" << n << "  l=" << l << endl;
   if (state[2] != '(') {
-    cerr << "Error parsing occupancy in reference state.\n";
+    std::cerr << "Error parsing occupancy in reference state.\n";
     abort();
   }
   state.erase(0,3);
   
-  string occString;
+  std::string occString;
   while ((state.length() > 0) && (state[0] != ')')) {
     occString.append (state.substr(0,1));
     state.erase(0,1);
@@ -2084,7 +2084,7 @@ PseudoClass::GetNextState (string &state, int &n, int &l, double &occ)
   const char *occStr = occString.c_str();
   occ = strtod (occStr, &endptr);
   if (state[0] != ')') {
-    cerr << "Expected a ')' in parsing reference state.\n";
+    std::cerr << "Expected a ')' in parsing reference state.\n";
     abort();
   }
   state.erase(0,1);
@@ -2095,13 +2095,13 @@ PseudoClass::GetNextState (string &state, int &n, int &l, double &occ)
 
 #include "common/DFTAtom.h"
 void
-PseudoClass::CalcProjector(string refstate, int lchannel)
+PseudoClass::CalcProjector(std::string refstate, int lchannel)
 {
   DFTAtom atom;
-  string saveState = refstate;
+  std::string saveState = refstate;
   // Temp storage for refstate;
-  vector<double> occList;
-  vector<int> nList, lList;
+  std::vector<double> occList;
+  std::vector<int> nList, lList;
   bool done = false;
   int n, l;
   double occ;
@@ -2137,11 +2137,11 @@ PseudoClass::CalcProjector(string refstate, int lchannel)
   atom.SetBarePot (this);
   // Solve atom
   atom.NewMix = DensityMix;
-  cerr << "Solving atom for reference state " << saveState << ":\n";
+  std::cerr << "Solving atom for reference state " << saveState << ":\n";
   atom.Solve();
   
   // Now, initialize the channel u functions
-  vector<double> ul(PotentialGrid.NumPoints()),
+  std::vector<double> ul(PotentialGrid.NumPoints()),
     rhoAtom(PotentialGrid.NumPoints());
   for (int i=0; i<ul.size(); i++) {
     double r = PotentialGrid[i];

--- a/src/QMCTools/ppconvert/src/NLPPClass.h
+++ b/src/QMCTools/ppconvert/src/NLPPClass.h
@@ -86,7 +86,7 @@ private:
   std::map<std::string, XCType> XCRevMap;
   std::map<int, std::string> ChannelMap;
   std::map<std::string, int> ChannelRevMap;
-  std::map<int, string> ZToSymbolMap;
+  std::map<int, std::string> ZToSymbolMap;
   std::map<int, double> ZToMassMap;
   std::map<std::string, int> SymbolToZMap;
   void SetupMaps();

--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -20,12 +20,18 @@
 #include "blitz/array.h"
 #include "blitz/tinyvec-et.h"
 
-using namespace blitz;
 typedef double scalar;
 
 // #define NDIM 3
 
-using namespace blitz;
+template<class T, std::size_t N> using TinyVector = typename blitz::TinyVector<T, N>;
+
+template<class T, std::size_t N1, std::size_t N2> using TinyMatrix = typename blitz::TinyMatrix<T, N1, N2>;
+
+template<class T, std::size_t D> using Array = typename blitz::Array<T, D>;
+
+using Range = blitz::Range;
+
 typedef TinyVector<scalar, 1> Vec1;
 typedef TinyVector<scalar, 2> Vec2;
 typedef TinyVector<scalar, 3> Vec3;

--- a/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
+++ b/src/QMCTools/ppconvert/src/common/CubicSplineCommon.h
@@ -67,9 +67,9 @@ public:
     EndDeriv   = endderiv;
     if (NewGrid->NumPoints != NewYs.rows())
     {
-      cerr << "Size mismatch in CubicSplineCommon.\n";
-      cerr << "Grid Points = " << NewGrid->NumPoints << std::endl;
-      cerr << "Y points    = " << NewYs.rows() << std::endl;
+      std::cerr << "Size mismatch in CubicSplineCommon.\n";
+      std::cerr << "Grid Points = " << NewGrid->NumPoints << std::endl;
+      std::cerr << "Y points    = " << NewYs.rows() << std::endl;
       exit(1);
     }
     grid      = NewGrid;
@@ -320,9 +320,9 @@ public:
 
     if (NewGrid->NumPoints != NewYs.rows())
     {
-      cerr << "Size mismatch in CubicSplineCommon.\n";
-      cerr << "Grid Points = " << NewGrid->NumPoints << std::endl;
-      cerr << "Y points    = " << NewYs.rows() << std::endl;
+      std::cerr << "Size mismatch in CubicSplineCommon.\n";
+      std::cerr << "Grid Points = " << NewGrid->NumPoints << std::endl;
+      std::cerr << "Y points    = " << NewYs.rows() << std::endl;
       exit(1);
     }
 
@@ -348,7 +348,7 @@ public:
 
     if (NewGrid->NumPoints != NewYs.rows())
     {
-      cerr << "Size mismatch in CubicSplineCommon.\n";
+      std::cerr << "Size mismatch in CubicSplineCommon.\n";
       exit(1);
     }
 

--- a/src/QMCTools/ppconvert/src/common/DFTAtom.cc
+++ b/src/QMCTools/ppconvert/src/common/DFTAtom.cc
@@ -172,7 +172,7 @@ DFTAtom::SolveIter()
   double maxDiff = 0.0;
   for (int i=0; i<RadialWFs.size(); i++) {
     RadialWFs(i).Solve();
-    maxDiff = max(fabs(OldEnergies(i)-RadialWFs(i).Energy), maxDiff);
+    maxDiff = std::max(fabs(OldEnergies(i)-RadialWFs(i).Energy), maxDiff);
     OldEnergies(i) = RadialWFs(i).Energy;
     // fprintf (stderr, "Energy(%d) = %1.16f\n", i, RadialWFs(i).Energy);
   }

--- a/src/QMCTools/ppconvert/src/common/Fitting.cc
+++ b/src/QMCTools/ppconvert/src/common/Fitting.cc
@@ -45,7 +45,7 @@ void LinFitLU (Array<double,1> &y, Array<double,1> &sigma,    // inputs
   int M = F.cols();
 
   if (y.rows() != F.rows()) {
-    cerr << "Differernt number of rows in basis functions that in data "
+    std::cerr << "Differernt number of rows in basis functions that in data "
 	 << "points in LinFit.  Exitting.\n";
     abort();
   }
@@ -101,7 +101,7 @@ void LinFitSVD (Array<double,1> &y, Array<double,1> &sigma,  // inputs
   int M = F.cols();
 
   if (y.rows() != F.rows()) {
-    cerr << "Differernt number of rows in basis functions that in data "
+    std::cerr << "Differernt number of rows in basis functions that in data "
 	 << "points in LinFit.  Exitting.\n";
     abort();
   }
@@ -130,7 +130,7 @@ void LinFitSVD (Array<double,1> &y, Array<double,1> &sigma,  // inputs
   // Zero out near-singular values
   double Smax=S(0);
   for (int i=1; i<S.size(); i++)
-    Smax = max (S(i),Smax);
+    Smax = std::max (S(i),Smax);
   Array<double,1> Sinv(S.size());
   for (int i=0; i<S.size(); i++)
     Sinv(i) = (S(i) < (tolerance*Smax)) ? 0.0 : (1.0/S(i));
@@ -165,7 +165,7 @@ LinFitSVD (Array<double,1> &y, Array<double,1> &sigma,  // inputs
   int M = F.cols(); // Number of basis functions
 
   if (y.rows() != F.rows()) {
-    cerr << "Different number of rows in basis functions that in data "
+    std::cerr << "Different number of rows in basis functions that in data "
 	 << "points in LinFit.  Exitting.\n";
     abort();
   }
@@ -221,7 +221,7 @@ LinFitSVD (Array<double,1> &y, Array<double,1> &sigma,  // inputs
   // Zero out near-singular values
   double Smax=S(0);
   for (int i=1; i<S.size(); i++)
-    Smax = max (S(i),Smax);
+    Smax = std::max (S(i),Smax);
   for (int i=0; i<S.size(); i++)
     Sinv(i) = (S(i) < (tolerance*Smax)) ? 0.0 : (1.0/S(i));
   

--- a/src/QMCTools/ppconvert/src/common/Grid.h
+++ b/src/QMCTools/ppconvert/src/common/Grid.h
@@ -65,6 +65,7 @@ public:
   virtual int ReverseMap(double r)             = 0;
   virtual void Write(IOSectionClass& out)      = 0;
   virtual void Read(IOSectionClass& inSection) = 0;
+  virtual ~Grid(){}
 };
 
 

--- a/src/QMCTools/ppconvert/src/common/Grid.h
+++ b/src/QMCTools/ppconvert/src/common/Grid.h
@@ -18,8 +18,10 @@
 #define GRID_H
 
 #include "IO.h"
-using namespace IO;
+
 #include "Blitz.h"
+
+using IO::IOSectionClass;
 
 //Ken's Grid Class
 
@@ -162,7 +164,7 @@ public:
           lo = i;
         done = (hi - lo) < 2;
       }
-      return min(lo, NumPoints - 2);
+      return std::min(lo, NumPoints - 2);
     }
   }
 

--- a/src/QMCTools/ppconvert/src/common/IO.cc
+++ b/src/QMCTools/ppconvert/src/common/IO.cc
@@ -23,15 +23,15 @@ namespace IO
 
   void SetVerbose (bool verb) {
     if (verb)
-      verr.rdbuf(cerr.rdbuf());
+      verr.rdbuf(std::cerr.rdbuf());
   }
 
   /// In the file name format name.extn, returns the extension.
   /// Actually returns everything after the trailing.
-  string Extension (string fileName)
+  std::string Extension (std::string fileName)
   {
-    string extn;
-    stack<char> bwExtn;
+    std::string extn;
+    std::stack<char> bwExtn;
     int pos = fileName.length()-1;
     while ((pos >= 0) && fileName[pos]!='.') {
       bwExtn.push(fileName[pos]);
@@ -55,10 +55,10 @@ namespace IO
   /// .h5:            HDF5
   /// .xml:           XML
   /// .anything_else  ASCII
-  IOTreeClass *ReadTree (string fileName, string myName, IOTreeClass *parent)
+  IOTreeClass *ReadTree (std::string fileName, std::string myName, IOTreeClass *parent)
   {
     IOTreeClass *newTree;
-    string extn = Extension (fileName);
+    std::string extn = Extension (fileName);
     newTree = new IOTreeASCIIClass;
     
     newTree->FileName = fileName;
@@ -71,10 +71,10 @@ namespace IO
     }
   }
   
-  IOTreeClass *NewTree (string fileName, string myName, IOTreeClass *parent)
+  IOTreeClass *NewTree (std::string fileName, std::string myName, IOTreeClass *parent)
   {
     IOTreeClass *newTree;
-    string extn = Extension (fileName);
+    std::string extn = Extension (fileName);
     newTree = new IOTreeASCIIClass;
     
     bool success = newTree->NewFile (fileName, myName, parent);
@@ -87,7 +87,7 @@ namespace IO
   }
 
   bool 
-  IOSectionClass::OpenFile (string fileName)
+  IOSectionClass::OpenFile (std::string fileName)
   {
     CurrentSection = ReadTree (fileName, "Root", NULL);
     if (CurrentSection == NULL)
@@ -97,7 +97,7 @@ namespace IO
   }
 
   bool 
-  IOSectionClass::NewFile (string fileName)
+  IOSectionClass::NewFile (std::string fileName)
   {
     CurrentSection = NewTree (fileName, "Root", NULL);
     if (CurrentSection == NULL)
@@ -128,7 +128,7 @@ namespace IO
   }
 
 
-  bool IOSectionClass::OpenSection (string name, int num)
+  bool IOSectionClass::OpenSection (std::string name, int num)
   {
     IOTreeClass *newSection;
     bool success;
@@ -143,7 +143,7 @@ namespace IO
   IOSectionClass::OpenSection (int num)
   {
     IOTreeClass *newSection;
-    list<IOTreeClass*>::iterator Iter=CurrentSection->SectionList.begin();
+    std::list<IOTreeClass*>::iterator Iter=CurrentSection->SectionList.begin();
     int i = 0;
     while ((i<num) && 
 	   (Iter != CurrentSection->SectionList.end())){
@@ -160,7 +160,7 @@ namespace IO
 
 
   bool 
-  IOSectionClass::IncludeSection (string name, string fileName)
+  IOSectionClass::IncludeSection (std::string name, std::string fileName)
   {
     IOTreeClass *newSection;
     newSection = ReadTree (fileName, name, CurrentSection);
@@ -174,7 +174,7 @@ namespace IO
 
   ///Don't think this pushes to back of list like it should nor does newfile
   bool 
-  IOSectionClass::NewSection (string name, string fileName)
+  IOSectionClass::NewSection (std::string name, std::string fileName)
   {
     IOTreeClass *newSection;
     newSection = NewTree (fileName, name, CurrentSection);
@@ -196,7 +196,7 @@ namespace IO
   }
 
 
-  string
+  std::string
   IOSectionClass::GetFileName()
   {
     IOTreeClass *tree = CurrentSection;

--- a/src/QMCTools/ppconvert/src/common/IOASCII.cc
+++ b/src/QMCTools/ppconvert/src/common/IOASCII.cc
@@ -27,11 +27,11 @@ namespace IO {
   inline void ASCIIPrintIndent(int num)
   {
     for (int counter=0;counter<num*2;counter++)
-      cout<<' ';
+      std::cout<<' ';
   }
 
   /// Simply prints 3*num spaces
-  inline void ASCIIPrintIndent(int num,ofstream &outFile)
+  inline void ASCIIPrintIndent(int num,std::ofstream &outFile)
   {
     for (int counter=0;counter<num*2;counter++)
       outFile<<' ';
@@ -43,14 +43,14 @@ namespace IO {
   void IOTreeASCIIClass::PrintTree(int indentNum)
   {
     ASCIIPrintIndent(indentNum);
-    cout<<"Section: "<<Name<<endl;
-    list<IOVarBase*>::iterator varIter=VarList.begin();
+    std::cout<<"Section: "<<Name<<std::endl;
+    std::list<IOVarBase*>::iterator varIter=VarList.begin();
     while (varIter!=VarList.end()){
       ASCIIPrintIndent(indentNum+1);
-      cout<<"Variable: "<<(*varIter)->GetName()<<" "<<endl;
+      std::cout<<"Variable: "<<(*varIter)->GetName()<<" "<<std::endl;
       varIter++;
     }
-    list<IOTreeClass*>::iterator secIter=SectionList.begin();
+    std::list<IOTreeClass*>::iterator secIter=SectionList.begin();
     while (secIter!=SectionList.end()){
       //    cout<<"Section: "<<(*secIter)->Name<<endl;
       (*secIter)->PrintTree(indentNum+1);
@@ -125,7 +125,7 @@ namespace IO {
   /// Valid tokens are special characters: "(){}[]<>,", quoted strings,
   /// words, or numbers.  White space is not significant, except in
   /// separating tokens.
-  void Tokenize(blitz::Array<char,1> buffer, list<TokenClass>& tokenList)
+  void Tokenize(blitz::Array<char,1> buffer, std::list<TokenClass>& tokenList)
   {
     int pos=0;
     int lineNum=1;
@@ -176,10 +176,10 @@ namespace IO {
       else if (buffer(pos)=='\0')
 	break;
       else {
-	cerr<<"There was a token we do not recognize in line "<<lineNum<<endl;
-	cerr <<"The rest of the file is as follows:\n";
+	std::cerr<<"There was a token we do not recognize in line "<<lineNum<<std::endl;
+	std::cerr <<"The rest of the file is as follows:\n";
 	while (pos<buffer.size()) {
-	  cerr << (int)buffer(pos);
+	  std::cerr << (int)buffer(pos);
 	  pos++;
 	}
 	exit(1);
@@ -203,11 +203,11 @@ namespace IO {
 
   /// Reads a file into a character array, removing C and C++ style
   /// comments. 
-  bool IOTreeASCIIClass::ReadWithoutComments(string fileName,
+  bool IOTreeASCIIClass::ReadWithoutComments(std::string fileName,
 					     blitz::Array<char,1> 
 					     &buffer)
   {
-    ifstream infile;
+    std::ifstream infile;
     infile.open(fileName.c_str());
     if (!infile.is_open()) 
       return false;
@@ -224,7 +224,7 @@ namespace IO {
     buffer.resize(counter);
     counter=-1;
     infile.close();
-    ifstream infile2;
+    std::ifstream infile2;
     infile2.open(fileName.c_str());
     while (!infile2.eof()){
       counter++;
@@ -282,20 +282,20 @@ namespace IO {
 
   /// If isError is true, then we print out an error message giving the
   /// line number and the string passed to us in ErrorStr.
-  inline void ReadAbort (bool isError, int lineNumber, string ErrorStr)
+  inline void ReadAbort (bool isError, int lineNumber, std::string ErrorStr)
   {
     if (isError) {
-      cerr << "Error in input file at line number " << lineNumber 
+      std::cerr << "Error in input file at line number " << lineNumber 
 	   << ":\n";
-      cerr << ErrorStr;
+      std::cerr << ErrorStr;
       exit(1);
     }
   }
 
   /// Removes all double quotes from the input string and return it.
-  string StripQuote(string str)
+  std::string StripQuote(std::string str)
   {
-    string newString;
+    std::string newString;
     int i=0;
     assert (str[0] == '\"');
     assert (str[str.length()-1] == '\"');
@@ -312,7 +312,7 @@ namespace IO {
   /// Looks at the string passed to it and returns the corresponding
   /// enumerated type.  If the type is not recognized, it returns
   /// INVALID.  
-  IODataType GetType (string typeString)
+  IODataType GetType (std::string typeString)
   {
     if (typeString=="double")
       return DOUBLE_TYPE;
@@ -350,7 +350,7 @@ namespace IO {
 
   /// Takes a token and reads its value into a string, aborting if there
   /// is a problem.
-  void ReadAtomicVar(TokenClass token,string &d)
+  void ReadAtomicVar(TokenClass token,std::string &d)
   {
 
     ReadAbort (token.Str[0] != '\"', token.LineNumber, 
@@ -375,17 +375,17 @@ namespace IO {
 
   /// Takes a token and reads its value into a bool, aborting if there
   /// is a problem.
-  void ReadAtomicVar(TokenClass token, complex<double> &a)
+  void ReadAtomicVar(TokenClass token, std::complex<double> &a)
   {
-    cerr << "Reading complex not yet implemented.";
+    std::cerr << "Reading complex not yet implemented.";
   }
 
   /// This template function reads a 1-D array from a token list into
   /// the array.  The syntax requires an opening '[' the a
   /// comma-separated list of values, then a closing ']'.
   template <class T>
-  void ReadArrayData(list<TokenClass>::iterator &iter,
-		     list<TokenClass> &tokenList,
+  void ReadArrayData(std::list<TokenClass>::iterator &iter,
+		     std::list<TokenClass> &tokenList,
 		     blitz::Array<T,1> valArray)
   {
     ReadAbort(iter->Str != "[", iter->LineNumber, "Expected [ not found\n");
@@ -412,8 +412,8 @@ namespace IO {
   /// read row-ordered, i.e. the first index changes fastests as we read
   /// in the values.
   template <class T>
-  void ReadArrayData(list<TokenClass>::iterator &iter,
-		     list<TokenClass> &tokenList,
+  void ReadArrayData(std::list<TokenClass>::iterator &iter,
+		     std::list<TokenClass> &tokenList,
 		     blitz::Array<T,2> valArray)
   {
     ReadAbort(iter->Str != "[", iter->LineNumber, "Expected [ not found\n");
@@ -443,8 +443,8 @@ namespace IO {
   /// read row-ordered, i.e. the first index changes fastests as we read
   /// in the values.
   template <class T>
-  void ReadArrayData(list<TokenClass>::iterator &iter,
-		     list<TokenClass> &tokenList,
+  void ReadArrayData(std::list<TokenClass>::iterator &iter,
+		     std::list<TokenClass> &tokenList,
 		     blitz::Array<T,3> valArray)
   {
     ReadAbort(iter->Str != "[", iter->LineNumber, "Expected [ not found\n");
@@ -476,8 +476,8 @@ namespace IO {
   /// read row-ordered, i.e. the first index changes fastests as we read
   /// in the values.
   template <class T>
-  void ReadArrayData(list<TokenClass>::iterator &iter,
-		     list<TokenClass> &tokenList,
+  void ReadArrayData(std::list<TokenClass>::iterator &iter,
+		     std::list<TokenClass> &tokenList,
 		     blitz::Array<T,4> valArray)
   {
     ReadAbort(iter->Str != "[", iter->LineNumber, "Expected [ not found\n");
@@ -505,7 +505,7 @@ namespace IO {
   }
 
 
-  IOVarBase *NewASCIIVar (string name, IODataType newType, int ndim,
+  IOVarBase *NewASCIIVar (std::string name, IODataType newType, int ndim,
 			  blitz::Array<int,1> dims)
   {
     if (ndim == 0) {
@@ -514,11 +514,11 @@ namespace IO {
       else if (newType == INT_TYPE)
 	return new IOVarASCII<int,0>(name);
       else if (newType == STRING_TYPE)
-	return new IOVarASCII<string,0>(name);
+	return new IOVarASCII<std::string,0>(name);
       else if (newType == BOOL_TYPE)
 	return new IOVarASCII<bool,0>(name);
       else if (newType == COMPLEX_TYPE)
-	return new IOVarASCII<complex<double>,0>(name);
+	return new IOVarASCII<std::complex<double>,0>(name);
     }
     else if (ndim == 1) {
       if (newType == DOUBLE_TYPE) {
@@ -532,7 +532,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == STRING_TYPE) {
-	IOVarASCII<string,1> *newVar = new IOVarASCII<string,1>(name);
+	IOVarASCII<std::string,1> *newVar = new IOVarASCII<std::string,1>(name);
 	newVar->ArrayValue.resize(dims(0));
 	return newVar;
       }
@@ -542,7 +542,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == COMPLEX_TYPE) {
-	IOVarASCII<complex<double>,1> *newVar = new IOVarASCII<complex<double>,1>(name);
+	IOVarASCII<std::complex<double>,1> *newVar = new IOVarASCII<std::complex<double>,1>(name);
 	newVar->ArrayValue.resize(dims(0));
 	return newVar;
       }
@@ -559,7 +559,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == STRING_TYPE) {
-	IOVarASCII<string,2> *newVar = new IOVarASCII<string,2>(name);
+	IOVarASCII<std::string,2> *newVar = new IOVarASCII<std::string,2>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1));
 	return newVar;
       }
@@ -569,7 +569,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == COMPLEX_TYPE) {
-	IOVarASCII<complex<double>,2> *newVar = new IOVarASCII<complex<double>,2>(name);
+	IOVarASCII<std::complex<double>,2> *newVar = new IOVarASCII<std::complex<double>,2>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1));
 	return newVar;
       }
@@ -586,7 +586,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == STRING_TYPE) {
-	IOVarASCII<string,3> *newVar = new IOVarASCII<string,3>(name);
+	IOVarASCII<std::string,3> *newVar = new IOVarASCII<std::string,3>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1), dims(2));
 	return newVar;
       }
@@ -596,7 +596,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == COMPLEX_TYPE) {
-	IOVarASCII<complex<double>,3> *newVar = new IOVarASCII<complex<double>,3>(name);
+	IOVarASCII<std::complex<double>,3> *newVar = new IOVarASCII<std::complex<double>,3>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1), dims(2));
 	return newVar;
       }
@@ -613,7 +613,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == STRING_TYPE) {
-	IOVarASCII<string,4> *newVar = new IOVarASCII<string,4>(name);
+	IOVarASCII<std::string,4> *newVar = new IOVarASCII<std::string,4>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1), dims(2), dims(3));
 	return newVar;
       }
@@ -623,7 +623,7 @@ namespace IO {
 	return newVar;
       }
       else if (newType == COMPLEX_TYPE) {
-	IOVarASCII<complex<double>,4> *newVar = new IOVarASCII<complex<double>,4>(name);
+	IOVarASCII<std::complex<double>,4> *newVar = new IOVarASCII<std::complex<double>,4>(name);
 	newVar->ArrayValue.resize(dims(0), dims(1), dims(2), dims(3));
 	return newVar;
       }
@@ -638,8 +638,8 @@ namespace IO {
   /// Reads an array from a list of tokens, starting at the token
   /// pointed to by iter.  It places the array into the newVar object.
   /// It expects to begin reading after the word "Array".
-  IOVarBase * ReadArray(list<TokenClass>::iterator &iter,
-			list<TokenClass> &tokenList)
+  IOVarBase * ReadArray(std::list<TokenClass>::iterator &iter,
+			std::list<TokenClass> &tokenList)
   {
     ReadAbort(iter->Str != "<", iter->LineNumber, "Expected < not found\n");
     iter++;
@@ -657,7 +657,7 @@ namespace IO {
   
     blitz::Array<int,1> dimSize(numDim);
   
-    string myName=iter->Str;
+    std::string myName=iter->Str;
 
     iter++;
     ReadAbort(iter->Str != "(", iter->LineNumber, "Expected ( not found\n");
@@ -685,11 +685,11 @@ namespace IO {
       else if (myType == INT_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<int,1> *)   newVar)->ArrayValue);
       else if (myType == STRING_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<string,1> *)newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::string,1> *)newVar)->ArrayValue);
       else if (myType == BOOL_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<bool,1> *)  newVar)->ArrayValue);
       else if (myType == COMPLEX_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<complex<double>,1> *)  newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::complex<double>,1> *)  newVar)->ArrayValue);
     }
     if (numDim == 2) {
       if (myType == DOUBLE_TYPE)
@@ -697,11 +697,11 @@ namespace IO {
       else if (myType == INT_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<int,2> *)   newVar)->ArrayValue);
       else if (myType == STRING_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<string,2> *)newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::string,2> *)newVar)->ArrayValue);
       else if (myType == BOOL_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<bool,2> *)  newVar)->ArrayValue);
       else if (myType == COMPLEX_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<complex<double>,2> *) newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::complex<double>,2> *) newVar)->ArrayValue);
     }
     if (numDim == 3) {
       if (myType == DOUBLE_TYPE)
@@ -709,11 +709,11 @@ namespace IO {
       else if (myType == INT_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<int,3> *)   newVar)->ArrayValue);
       else if (myType == STRING_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<string,3> *)newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::string,3> *)newVar)->ArrayValue);
       else if (myType == BOOL_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<bool,3> *)  newVar)->ArrayValue);
       else if (myType == COMPLEX_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<complex<double>,3> *)  newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::complex<double>,3> *)  newVar)->ArrayValue);
     }
     if (numDim == 4) {
       if (myType == DOUBLE_TYPE)
@@ -721,11 +721,11 @@ namespace IO {
       else if (myType == INT_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<int,4> *)   newVar)->ArrayValue);
       else if (myType == STRING_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<string,4> *)newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::string,4> *)newVar)->ArrayValue);
       else if (myType == BOOL_TYPE)
 	ReadArrayData(iter, tokenList, ((IOVarASCII<bool,4> *)  newVar)->ArrayValue);
       else if (myType == COMPLEX_TYPE)
-	ReadArrayData(iter, tokenList, ((IOVarASCII<complex<double>,4> *)  newVar)->ArrayValue);
+	ReadArrayData(iter, tokenList, ((IOVarASCII<std::complex<double>,4> *)  newVar)->ArrayValue);
     }
     return (newVar);
   }
@@ -736,8 +736,8 @@ namespace IO {
   /// creates a new VarASCIIClass object and puts the appropriate value
   /// in that object.  It recognizes any of the atomic types or arrays
   /// of theose atomic types.
-  IOVarBase* ReadASCIIVar (list<TokenClass>::iterator &iter,
-			       list<TokenClass> &tokenList)
+  IOVarBase* ReadASCIIVar (std::list<TokenClass>::iterator &iter,
+			       std::list<TokenClass> &tokenList)
   {
     IOVarBase *newVar;
     IODataType myType=GetType(iter->Str);
@@ -749,7 +749,7 @@ namespace IO {
     }
     else {
       iter++;
-      string myName=iter->Str;
+      std::string myName=iter->Str;
 
       iter++;
       ReadAbort(iter->Str!="=",iter->LineNumber,"Expected equals sign\n");
@@ -765,11 +765,11 @@ namespace IO {
       else if (myType == INT_TYPE)
 	ReadAtomicVar (valToken, ((IOVarASCII<int,0> *)newVar)->Value);
       else if (myType == STRING_TYPE)
-	ReadAtomicVar (valToken, ((IOVarASCII<string,0> *)newVar)->Value);
+	ReadAtomicVar (valToken, ((IOVarASCII<std::string,0> *)newVar)->Value);
       else if (myType == BOOL_TYPE)
 	ReadAtomicVar (valToken, ((IOVarASCII<bool,0> *)newVar)->Value);
       else if (myType == COMPLEX_TYPE)
-	ReadAtomicVar (valToken, ((IOVarASCII<complex<double>,0> *)newVar)->Value);
+	ReadAtomicVar (valToken, ((IOVarASCII<std::complex<double>,0> *)newVar)->Value);
     }
     return(newVar);
   }
@@ -782,9 +782,9 @@ namespace IO {
   /// buffer runs out.  Calls itself recursively as necessary, builing
   /// up a tree of sections and variables.
   bool IOTreeASCIIClass::ReadSection (IOTreeClass *parent,
-				      string myName,
-				      list<TokenClass>::iterator &iter,
-				      list<TokenClass> &tokenList,
+				      std::string myName,
+				      std::list<TokenClass>::iterator &iter,
+				      std::list<TokenClass> &tokenList,
 				      bool wantEndBrace)
   {
     Parent = parent;
@@ -795,13 +795,13 @@ namespace IO {
 	iter++;
 	ReadAbort(iter->Str != "(", iter->LineNumber, "Expected ( not found\n");
 	iter++;
-	string newName = iter->Str;
+	std::string newName = iter->Str;
 	iter++;
 	// Check for included section
 	if (iter->Str == ",") {
 	  // Get filename
 	  iter++;
-	  string fileName = StripQuote(iter->Str);
+	  std::string fileName = StripQuote(iter->Str);
 	  iter++;
 	  ReadAbort (iter->Str!=")", iter->LineNumber, "Expected ) not found\n");
 	  iter++;
@@ -829,7 +829,7 @@ namespace IO {
       }
     }
     if ((iter==tokenList.end()) && wantEndBrace) {
-      cerr << "Unexpected end of file before } \n";
+      std::cerr << "Unexpected end of file before } \n";
       exit (1);
     }
 	    
@@ -838,7 +838,7 @@ namespace IO {
     return (true);
   }
 
-  IOTreeClass* IOTreeASCIIClass::NewSection(string name)
+  IOTreeClass* IOTreeASCIIClass::NewSection(std::string name)
   {
     IOTreeClass* tempSection=new IOTreeASCIIClass();
     tempSection->Name=name;
@@ -860,8 +860,8 @@ namespace IO {
 
 
 
-  bool IOTreeASCIIClass::NewFile (string fileName,
-				  string mySectionName,
+  bool IOTreeASCIIClass::NewFile (std::string fileName,
+				  std::string mySectionName,
 				  IOTreeClass *parent)
   {
     FileName=fileName;
@@ -876,31 +876,31 @@ namespace IO {
   /// the parent of this section.  It reads the file into a buffer,
   /// converts it to a list of tokens, then parses the tokens,
   /// constructing a tree of sections containing variables lists.  
-  bool IOTreeASCIIClass::OpenFile(string fileName, string myName, 
+  bool IOTreeASCIIClass::OpenFile(std::string fileName, std::string myName, 
 				  IOTreeClass *parent)
   {
     blitz::Array<char,1> buffer;
     bool success = ReadWithoutComments(fileName,buffer);
     if (!success)
       return false;
-    list<TokenClass> tokenList;
+    std::list<TokenClass> tokenList;
     Tokenize(buffer,tokenList);
-    list<TokenClass>::iterator iter=tokenList.begin();
+    std::list<TokenClass>::iterator iter=tokenList.begin();
     ReadSection(parent,myName,iter,tokenList, false);
     return true;
   }
 
 
 
-  void IOTreeASCIIClass::WriteSection(ofstream &outFile,int indentNum)
+  void IOTreeASCIIClass::WriteSection(std::ofstream &outFile,int indentNum)
   {
-    list<IOVarBase*>::iterator varIter=VarList.begin();
+    std::list<IOVarBase*>::iterator varIter=VarList.begin();
     while (varIter!=VarList.end()){
       ASCIIPrintIndent(indentNum,outFile);
       (*varIter)->Print(outFile);    
       varIter++;
     }
-    list<IOTreeClass*>::iterator secIter=SectionList.begin();
+    std::list<IOTreeClass*>::iterator secIter=SectionList.begin();
     while (secIter!=SectionList.end()){
       if ((*secIter)->FileName==""){
 	ASCIIPrintIndent(indentNum,outFile);
@@ -914,7 +914,7 @@ namespace IO {
       else {
 	ASCIIPrintIndent(indentNum,outFile);
 	outFile<<"Section ("<<(*secIter)->Name<<", \"";
-	outFile<<(*secIter)->FileName<<"\");"<<endl;
+	outFile<<(*secIter)->FileName<<"\");"<<std::endl;
 	(*secIter)->FlushFile();
       }
       secIter++;
@@ -925,13 +925,13 @@ namespace IO {
 
   void IOTreeASCIIClass::FlushFile()
   {
-    ofstream outfile;
+    std::ofstream outfile;
     if ((FileName!="") && IsModified){
       outfile.open(FileName.c_str());
       WriteSection(outfile,0);
     }
 
-    list<IOTreeClass*>::iterator iter = SectionList.begin();
+    std::list<IOTreeClass*>::iterator iter = SectionList.begin();
     while (iter != SectionList.end()) {
       (*iter)->FlushFile();
       iter++;
@@ -971,7 +971,7 @@ namespace IO {
   void
   IOVarASCII<double,0>::Resize(int n)
   {
-    cerr << "Cannot resize atomic variable.\n";
+    std::cerr << "Cannot resize atomic variable.\n";
     abort();
   }
 
@@ -990,30 +990,30 @@ namespace IO {
   void
   IOVarASCII<int,0>::Resize(int n)
   {
-    cerr << "Cannot resize atomic variable.\n";
+    std::cerr << "Cannot resize atomic variable.\n";
     abort();
   }
 
   int 
-  IOVarASCII<string,0>::GetRank()
+  IOVarASCII<std::string,0>::GetRank()
   { return 0; }
   IODataType 
-  IOVarASCII<string,0>::GetType()
+  IOVarASCII<std::string,0>::GetType()
   { return STRING_TYPE; }
   IOFileType 
-  IOVarASCII<string,0>::GetFileType()
+  IOVarASCII<std::string,0>::GetFileType()
   { return ASCII_TYPE; }
   int
-  IOVarASCII<string,0>::GetExtent(int i)
+  IOVarASCII<std::string,0>::GetExtent(int i)
   { return 1; }
   void
-  IOVarASCII<string,0>::Resize(int n)
+  IOVarASCII<std::string,0>::Resize(int n)
   {
-    cerr << "Cannot resize atomic variable.\n";
+    std::cerr << "Cannot resize atomic variable.\n";
     abort();
   }
   bool
-  IOVarASCII<string,0>::VarRead (string &val) 
+  IOVarASCII<std::string,0>::VarRead (std::string &val) 
   { 
     val = Value; 
     return true; 
@@ -1034,26 +1034,26 @@ namespace IO {
   void
   IOVarASCII<bool,0>::Resize(int n)
   {
-    cerr << "Cannot resize atomic variable.\n";
+    std::cerr << "Cannot resize atomic variable.\n";
     abort();
   }
 
   int 
-  IOVarASCII<complex<double>,0>::GetRank()
+  IOVarASCII<std::complex<double>,0>::GetRank()
   { return 0; }
   IODataType 
-  IOVarASCII<complex<double>,0>::GetType()
+  IOVarASCII<std::complex<double>,0>::GetType()
   { return COMPLEX_TYPE; }
   IOFileType 
-  IOVarASCII<complex<double>,0>::GetFileType()
+  IOVarASCII<std::complex<double>,0>::GetFileType()
   { return ASCII_TYPE; }
   int
-  IOVarASCII<complex<double>,0>::GetExtent(int i)
+  IOVarASCII<std::complex<double>,0>::GetExtent(int i)
   { return 1; }
   void
-  IOVarASCII<complex<double>,0>::Resize(int n)
+  IOVarASCII<std::complex<double>,0>::Resize(int n)
   {
-    cerr << "Cannot resize atomic variable.\n";
+    std::cerr << "Cannot resize atomic variable.\n";
     abort();
   }
 

--- a/src/QMCTools/ppconvert/src/common/IOASCII.h
+++ b/src/QMCTools/ppconvert/src/common/IOASCII.h
@@ -62,7 +62,7 @@ class IOTreeASCIIClass : public IOTreeClass
                    bool wantEndBrace);
 
 public:
-  void WriteSection(ofstream& outFile, int indent);
+  void WriteSection(std::ofstream& outFile, int indent);
   IOFileType GetFileType();
   /// Print an indented tree of section variable names.
   void PrintTree(int level);

--- a/src/QMCTools/ppconvert/src/common/IOVar.h
+++ b/src/QMCTools/ppconvert/src/common/IOVar.h
@@ -19,6 +19,8 @@
 
 #include "IOVarASCII.h"
 
+#include "Blitz.h"
+
 namespace IO
 {
 template<typename T>
@@ -29,7 +31,7 @@ bool IOVarBase::Read(T& val)
     IOVarASCII<T, 0>* newVar = dynamic_cast<IOVarASCII<T, 0>*>(this);
     if (newVar == NULL)
     {
-      cerr << "Error in dynamic cast to IOVarASCII.\n";
+      std::cerr << "Error in dynamic cast to IOVarASCII.\n";
       abort();
     }
     return newVar->VarRead(val);
@@ -49,7 +51,7 @@ bool IOVarBase::Read(TinyVector<T, LEN>& val)
     IOVarASCII<T, 1>* newVar = dynamic_cast<IOVarASCII<T, 1>*>(this);
     if (newVar == NULL)
     {
-      cerr << "Error in dynamic cast to IOVarASCII.\n";
+      std::cerr << "Error in dynamic cast to IOVarASCII.\n";
       abort();
     }
     Array<T, 1> aVal;
@@ -78,7 +80,7 @@ bool IOVarBase::Read(blitz::Array<T, RANK>& val)
     IOVarASCII<T, RANK>* newVar = dynamic_cast<IOVarASCII<T, RANK>*>(this);
     if (newVar == NULL)
     {
-      cerr << "Error in dynamic cast to IOVarASCII.\n";
+      std::cerr << "Error in dynamic cast to IOVarASCII.\n";
       abort();
     }
     return newVar->VarRead(val);
@@ -130,7 +132,7 @@ bool IOVarBase::Read(blitz::Array<T, RANK>& val,
     IOVarASCII<T, varRank>* newVar = dynamic_cast<IOVarASCII<T, varRank>*>(this);
     if (newVar == NULL)
     {
-      cerr << "Error in dynamic cast to IOVarHDF5.\n";
+      std::cerr << "Error in dynamic cast to IOVarHDF5.\n";
       abort();
     }
     return newVar->Slice(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10).VarRead(val);
@@ -177,7 +179,7 @@ bool IOVarBase::Write(const blitz::Array<T, RANK>& val,
     IOVarASCII<T, varRank>* newVar = dynamic_cast<IOVarASCII<T, varRank>*>(this);
     if (newVar == NULL)
     {
-      cerr << "Error in dynamic cast to IOVarASCII.\n";
+      std::cerr << "Error in dynamic cast to IOVarASCII.\n";
       abort();
     }
     return newVar->Slice(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10).VarWrite(val);

--- a/src/QMCTools/ppconvert/src/common/IOVarASCII.h
+++ b/src/QMCTools/ppconvert/src/common/IOVarASCII.h
@@ -22,7 +22,6 @@
 
 namespace IO
 {
-using namespace blitz;
 template<typename T, int RANK>
 class IOVarASCII;
 
@@ -96,7 +95,7 @@ public:
   IODataType GetType();
   IOFileType GetFileType();
 
-  void Print(ofstream& out);
+  void Print(std::ofstream& out);
 
   int GetExtent(int dim);
   void Resize(int n);
@@ -113,7 +112,7 @@ public:
            typename T8,
            typename T9,
            typename T10>
-  bool VarRead(typename SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
+  bool VarRead(typename blitz::SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
                T0 s0,
                T1 s1,
                T2 s2,
@@ -138,7 +137,7 @@ public:
            typename T8,
            typename T9,
            typename T10>
-  bool VarWrite(const typename SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
+  bool VarWrite(const typename blitz::SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
                 T0 s0,
                 T1 s1,
                 T2 s2,
@@ -366,7 +365,7 @@ template<typename T0,
          typename T9,
          typename T10>
 inline bool IOVarASCII<T, RANK>::VarRead(
-    typename SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
+    typename blitz::SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
     T0 s0,
     T1 s1,
     T2 s2,
@@ -410,7 +409,7 @@ template<typename T0,
          typename T9,
          typename T10>
 inline bool IOVarASCII<T, RANK>::VarWrite(
-    const typename SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
+    const typename blitz::SliceInfo<T, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::T_slice& val,
     T0 s0,
     T1 s1,
     T2 s2,
@@ -450,7 +449,7 @@ typename ASCIISliceMaker<T, RANK, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::
 }
 
 template<class T, int RANK>
-void IOVarASCII<T, RANK>::Print(ofstream& out)
+void IOVarASCII<T, RANK>::Print(std::ofstream& out)
 {
   T a;
   if (GetRank() == 0)

--- a/src/QMCTools/ppconvert/src/common/IOVarBase.h
+++ b/src/QMCTools/ppconvert/src/common/IOVarBase.h
@@ -20,10 +20,10 @@
 #include "blitz/array.h"
 #include <iostream>
 
+#include "Blitz.h"
 
 namespace IO
 {
-using namespace blitz;
 typedef enum
 {
   DOUBLE_TYPE,
@@ -60,7 +60,7 @@ public:
 class IOVarBase
 {
 private:
-  nilArraySection n0;
+  blitz::nilArraySection n0;
 
 protected:
   std::string Name;

--- a/src/QMCTools/ppconvert/src/common/MatrixOps.cc
+++ b/src/QMCTools/ppconvert/src/common/MatrixOps.cc
@@ -51,8 +51,8 @@ F77_DGESVD (char *JOBU, char* JOBVT, int *M, int *N,
 
 extern "C" void 
 F77_ZGESVD (char *JOBU, char* JOBVT, int *M, int *N,
-	    complex<double> *A, int *LDA, double *S, complex<double> *U,
-	    int *LDU, complex<double> *VT, int *LDVT, complex<double> *work,
+	    std::complex<double> *A, int *LDA, double *S, std::complex<double> *U,
+	    int *LDU, std::complex<double> *VT, int *LDVT, std::complex<double> *work,
 	    int *LWORK, double *work2, int *INFO);
 
 
@@ -64,7 +64,7 @@ F77_DPOTRF(char *UPLO, int *n, double A[], int *lda, int *info);
 
 
 extern "C" void 
-F77_ZGETRF(int *m, int *n, complex<double> A[], 
+F77_ZGETRF(int *m, int *n, std::complex<double> A[], 
 	   int *lda, int ipiv[], int *info);
 
 extern "C" void 
@@ -72,8 +72,8 @@ F77_DGETRI (int *N, double A[], int *lda, int ipiv[], double work[],
 	    int *lwork, int *info);
 
 extern "C" void 
-F77_ZGETRI (int *N, complex<double> A[], int *lda, int ipiv[], 
-	    complex<double> work[], int *lwork, int *info);
+F77_ZGETRI (int *N, std::complex<double> A[], int *lda, int ipiv[], 
+	    std::complex<double> work[], int *lwork, int *info);
 
 extern "C" void 
 F77_DGEMM (char *transA, char *transB, int *m, int *n, int *k,
@@ -82,8 +82,8 @@ F77_DGEMM (char *transA, char *transB, int *m, int *n, int *k,
 
 extern "C" void 
 F77_ZGEMM (char *transA, char *transB, int *m, int *n, int *k,
-	   complex<double> *alpha, const complex<double> *A, int *lda, const complex<double> *B, 
-	   int *ldb, complex<double> *beta,  complex<double> *C, int *ldc);
+	   std::complex<double> *alpha, const std::complex<double> *A, int *lda, const std::complex<double> *B, 
+	   int *ldb, std::complex<double> *beta,  std::complex<double> *C, int *ldc);
 
 extern "C" void 
 F77_DSYEVR (char *JobType, char *Range, char *UpperLower, 
@@ -99,14 +99,14 @@ F77_DSYEVR (char *JobType, char *Range, char *UpperLower,
 
 extern "C" void 
 F77_ZHEEVR (char *JobType, char *Range, char *UpperLower, 
-	    int *N, complex<double> *Amat, int *LDA,
+	    int *N, std::complex<double> *Amat, int *LDA,
 	    double *VL, double *VU,
 	    int *IL, int *IU, 
 	    double *AbsTolerance, int *M,
 	    double *EigVals, 
-	    complex<double> *EigVecs, int *LDEigVecs, 
+	    std::complex<double> *EigVecs, int *LDEigVecs, 
 	    int *ISuppZ,
-	    complex<double> *Work, int *Lwork, 
+	    std::complex<double> *Work, int *Lwork, 
 	    double *Rwork, int *LRwork,
 	    int *IWorkSpace, int *LIwork,
 	    int *Info);
@@ -125,16 +125,16 @@ const Array<double,2> operator*(const Array<double,2> &A,
   char transB = 'T';
   double alpha = 1.0;
   double beta = 0.0;
-  GeneralArrayStorage<2> colMajor;
-  colMajor.ordering() = firstDim, secondDim;
+  blitz::GeneralArrayStorage<2> colMajor;
+  colMajor.ordering() = blitz::firstDim, blitz::secondDim;
   Array<double,2> C(m,n,colMajor);
   F77_DGEMM (&transA, &transB, &m, &n, &k, &alpha, A.data(), &k, 
 	     B.data(), &n, &beta, C.data(), &m);
   return C;
 }
 
-const Array<complex<double>,2> operator*(const Array<complex<double>,2> &A,
-					 const Array<complex<double>,2> &B)
+const Array<std::complex<double>,2> operator*(const Array<std::complex<double>,2> &A,
+					 const Array<std::complex<double>,2> &B)
 {
   int m = A.rows();
   int n = B.cols();
@@ -144,11 +144,11 @@ const Array<complex<double>,2> operator*(const Array<complex<double>,2> &A,
   // thinks is transposed.
   char transA = 'T';
   char transB = 'T';
-  complex<double> alpha(1.0, 0.0);
-  complex<double> beta(0.0, 0.0);
-  GeneralArrayStorage<2> colMajor;
-  colMajor.ordering() = firstDim, secondDim;
-  Array<complex<double>,2> C(m,n,colMajor);
+  std::complex<double> alpha(1.0, 0.0);
+  std::complex<double> beta(0.0, 0.0);
+  blitz::GeneralArrayStorage<2> colMajor;
+  colMajor.ordering() = blitz::firstDim, blitz::secondDim;
+  Array<std::complex<double>,2> C(m,n,colMajor);
   F77_ZGEMM (&transA, &transB, &m, &n, &k, &alpha, A.data(), &k, 
 	     B.data(), &n, &beta, C.data(), &m);
   return C;
@@ -168,8 +168,8 @@ void MatMult (const Array<double,2> &A, const Array<double,2> &B,
   char transB = 'T';
   double alpha = 1.0;
   double beta = 0.0;
-  GeneralArrayStorage<2> colMajor;
-  colMajor.ordering() = firstDim, secondDim;
+  blitz::GeneralArrayStorage<2> colMajor;
+  colMajor.ordering() = blitz::firstDim, blitz::secondDim;
   F77_DGEMM (&transA, &transB, &m, &n, &k, &alpha, A.data(), &k, 
 	     B.data(), &n, &beta, C.data(), &m);
 }
@@ -226,8 +226,8 @@ LinearLeastSquares(Array<double,2> &A, Array<double,1> &x,
 	    &ldwork,&info);
 
 }
-void MatMult (const Array<complex<double>,2> &A, const Array<complex<double>,2> &B,
-	      Array<complex<double>,2> &C)
+void MatMult (const Array<std::complex<double>,2> &A, const Array<std::complex<double>,2> &B,
+	      Array<std::complex<double>,2> &C)
 {
   int m = A.rows();
   int n = B.cols();
@@ -237,10 +237,10 @@ void MatMult (const Array<complex<double>,2> &A, const Array<complex<double>,2> 
   // thinks is transposed.
   char transA = 'T';
   char transB = 'T';
-  complex<double> alpha = 1.0;
-  complex<double> beta = 0.0;
-  GeneralArrayStorage<2> colMajor;
-  colMajor.ordering() = firstDim, secondDim;
+  std::complex<double> alpha = 1.0;
+  std::complex<double> beta = 0.0;
+  blitz::GeneralArrayStorage<2> colMajor;
+  colMajor.ordering() = blitz::firstDim, blitz::secondDim;
   F77_ZGEMM (&transA, &transB, &m, &n, &k, &alpha, A.data(), &k, 
 	     B.data(), &n, &beta, C.data(), &m);
   Transpose(C);
@@ -277,8 +277,8 @@ double Determinant (const Array<double,2> &A)
   }
 }
 
-complex<double> 
-Determinant (const Array<complex<double>,2> &A)
+std::complex<double> 
+Determinant (const Array<std::complex<double>,2> &A)
 {
   int m = A.rows();
   int n = A.cols();
@@ -289,13 +289,13 @@ Determinant (const Array<complex<double>,2> &A)
   if (A.rows() == 2) 
     return (A(0,0)*A(1,1)-A(0,1)*A(1,0));
   else {
-    Array<complex<double>,2> LU(m,m);
+    Array<std::complex<double>,2> LU(m,m);
     Array<int,1> ipiv(m);
     int info;
     LU = A;
     // Do LU factorization
     F77_ZGETRF (&m, &n, LU.data(), &m, ipiv.data(), &info);
-    complex<double> det = 1.0;
+    std::complex<double> det = 1.0;
     int numPerm = 0;
     for (int i=0; i<m; i++) {
       det *= LU(i,i);
@@ -351,8 +351,8 @@ double GJInverse (Array<double,2> &A)
 	    }
 	  }
 	  else if (ipiv[k] > 0) {
-	    cerr << "GJInverse: Singular matrix!\n";
-	    cerr << "A = " << A << endl;
+	    std::cerr << "GJInverse: Singular matrix!\n";
+	    std::cerr << "A = " << A << std::endl;
 	    abort();
 	  }
 	}
@@ -360,13 +360,13 @@ double GJInverse (Array<double,2> &A)
     
     if (irow != icol) 
       for (int l=0; l<n; l++) 
-	swap (A(irow,l), A(icol,l));
+	std::swap (A(irow,l), A(icol,l));
     
     rowIndex[i] = irow;
     colIndex[i] = icol;
     if (A(icol,icol) == 0.0) { 
-      cerr << "GJInverse: Singular matrix!\n";
-      cerr << "A = " << A << endl;
+      std::cerr << "GJInverse: Singular matrix!\n";
+      std::cerr << "A = " << A << std::endl;
       abort();
     }
     det *= A(icol,icol);
@@ -386,7 +386,7 @@ double GJInverse (Array<double,2> &A)
   for (int l=n-1; l>=0; l--) {
     if (rowIndex[l] != colIndex[l]) {
       for (int k=0; k<n ; k++)
-	swap (A(k,rowIndex[l]),A(k, colIndex[l]));
+	std::swap (A(k,rowIndex[l]),A(k, colIndex[l]));
       det *= -1.0;
     }
   }
@@ -497,10 +497,10 @@ void SVdecomp (Array<double,2> &A,
   int N = A.cols();
   Array<double,2> Atrans(M,N);
   // U will be Utrans after lapack call
-  U.resize(min(M,N),M);
-  V.resize(N,min(M,N));
+  U.resize(std::min(M,N),M);
+  V.resize(N,std::min(M,N));
   
-  S.resize(min(N,M));
+  S.resize(std::min(N,M));
   Atrans = A;
 
   // Transpose U for FORTRAN ordering
@@ -509,8 +509,8 @@ void SVdecomp (Array<double,2> &A,
   char JOBVT = 'S'; // return min (M,N) columns of V
   int LDA = M;
   int LDU = M;
-  int LDVT = min(M,N);
-  int LWORK = 10 * max(3*min(M,N)+max(M,N),5*min(M,N));
+  int LDVT = std::min(M,N);
+  int LWORK = 10 * std::max(3*std::min(M,N)+std::max(M,N),5*std::min(M,N));
   Array<double,1> WORK(LWORK);
   int INFO;
 
@@ -524,17 +524,17 @@ void SVdecomp (Array<double,2> &A,
 }
 
 
-void SVdecomp (Array<complex<double>,2> &A, Array<complex<double>,2> &U, 
-	       Array<double,1> &S, Array<complex<double>,2> &V)
+void SVdecomp (Array<std::complex<double>,2> &A, Array<std::complex<double>,2> &U, 
+	       Array<double,1> &S, Array<std::complex<double>,2> &V)
 {
   int M = A.rows();
   int N = A.cols();
-  Array<complex<double>,2> Atrans(M,N);
+  Array<std::complex<double>,2> Atrans(M,N);
   // U will be Utrans after lapack call
-  U.resize(min(M,N),M);
-  V.resize(N,min(M,N));
+  U.resize(std::min(M,N),M);
+  V.resize(N,std::min(M,N));
   
-  S.resize(min(N,M));
+  S.resize(std::min(N,M));
   Atrans = A;
 
   // Transpose U for FORTRAN ordering
@@ -543,10 +543,10 @@ void SVdecomp (Array<complex<double>,2> &A, Array<complex<double>,2> &U,
   char JOBVT = 'S'; // return min (M,N) columns of V
   int LDA = M;
   int LDU = M;
-  int LDVT = min(M,N);
-  int LWORK = 10 * max(3*min(M,N)+max(M,N),5*min(M,N));
-  Array<complex<double>,1> WORK(LWORK);
-  Array<double,1> WORK2(5*min(M,N));
+  int LDVT = std::min(M,N);
+  int LWORK = 10 * std::max(3*std::min(M,N)+std::max(M,N),5*std::min(M,N));
+  Array<std::complex<double>,1> WORK(LWORK);
+  Array<double,1> WORK2(5*std::min(M,N));
   int INFO;
 
   F77_ZGESVD (&JOBU, &JOBVT, &M, &N, Atrans.data(), &LDA,
@@ -559,15 +559,15 @@ void SVdecomp (Array<complex<double>,2> &A, Array<complex<double>,2> &U,
 }
 
 
-void PolarOrthogonalize (Array<complex<double>,2> &A)
+void PolarOrthogonalize (Array<std::complex<double>,2> &A)
 {
   int M = A.rows();
   int N = A.cols();
   if (M != N) {
-    cerr << "Error:  nonsquare matrix in PolarOrthogonalize. Aborting.\n";
+    std::cerr << "Error:  nonsquare matrix in PolarOrthogonalize. Aborting.\n";
     abort();
   }
-  Array<complex<double>,2> U, V;
+  Array<std::complex<double>,2> U, V;
   Array<double,1> S;
 
   SVdecomp (A, U, S, V);
@@ -596,7 +596,7 @@ void LUdecomp (Array<double,2> &A, Array<int,1> &perm,
     for (int j=0; j<n; j++)
       if (fabs(A(i,j)) > big) big = fabs(A(i,j));
     if (big == 0.0) {
-      cerr << "Singularity in LUdecomp.\n";
+      std::cerr << "Singularity in LUdecomp.\n";
       abort();
     }
     vv(i) = 1.0/big;
@@ -740,7 +740,7 @@ void SymmEigenPairs (const Array<scalar,2> &A, int NumPairs,
 	       &Info);
 
    if (Info !=0) 
-     cerr << "Lapack error in DSYEVR: " << Info << endl;
+     std::cerr << "Lapack error in DSYEVR: " << Info << std::endl;
 
    // Now copy over output of Vectors and Vals
    Vals.resize(NumPairs);
@@ -765,16 +765,16 @@ void SymmEigenPairs (const Array<scalar,2> &A, int NumPairs,
 
 
 
-void SymmEigenPairs (const Array<complex<double>,2> &A, int NumPairs,
+void SymmEigenPairs (const Array<std::complex<double>,2> &A, int NumPairs,
 		     Array<scalar,1> &Vals,
-		     Array<complex<double>,2> &Vectors)
+		     Array<std::complex<double>,2> &Vectors)
 {
   char JobType = 'V';    // Find eigenvectors and eignevalues
   char Range   = 'I';    // Find eigenpairs in a range of indices
   char UpperLower = 'U'; // Use upper triagle of A
 
   int N   = A.rows();
-  complex<double> *Amat = new complex<double>[N*N];
+  std::complex<double> *Amat = new std::complex<double>[N*N];
   int LDA = N;
   double VL = 0.0;
   double VU = 0.0;
@@ -783,7 +783,7 @@ void SymmEigenPairs (const Array<complex<double>,2> &A, int NumPairs,
   double AbsTolerance = 0.0;
   int NumComputed;
   double *EigVals = new double[N];
-  complex<double> *EigVecs = new complex<double>[N*NumPairs];
+  std::complex<double> *EigVecs = new std::complex<double>[N*NumPairs];
   int LDEigVecs = N;
   int *ISuppZ = new int[2*NumPairs];
   int Info;
@@ -792,7 +792,7 @@ void SymmEigenPairs (const Array<complex<double>,2> &A, int NumPairs,
   int Lwork = -1;
   int LIwork = -1;
   int LRwork = -1;
-  complex<double> WorkSize;
+  std::complex<double> WorkSize;
   double RWorkSize;
   int IWorkSize;
   
@@ -809,7 +809,7 @@ void SymmEigenPairs (const Array<complex<double>,2> &A, int NumPairs,
    Lwork = (int) floor(WorkSize.real()+0.5);
    LIwork = IWorkSize;
    LRwork = (int) floor (RWorkSize+0.5);
-   complex<double> *WorkSpace = new complex<double>[Lwork];
+   std::complex<double> *WorkSpace = new std::complex<double>[Lwork];
    double * RWorkSpace = new double[LRwork];
    int *IWorkSpace = new int[LIwork];
    
@@ -910,9 +910,9 @@ DetCofactorsWorksize(int N)
 
 /// This function returns the determinant of A and replaces A with its
 /// cofactors.
-complex<double>
-ComplexDetCofactors (Array<complex<double>,2> &A, 
-		     Array<complex<double>,1> &work)
+std::complex<double>
+ComplexDetCofactors (Array<std::complex<double>,2> &A, 
+		     Array<std::complex<double>,1> &work)
 {
   const int maxN = 2000;
   int ipiv[maxN];
@@ -932,7 +932,7 @@ ComplexDetCofactors (Array<complex<double>,2> &A,
   int info;
   // Do LU factorization
   F77_ZGETRF (&N, &M, A.data(), &N, ipiv, &info);
-  complex<double> det = 1.0;
+  std::complex<double> det = 1.0;
   int numPerm = 0;
   for (int i=0; i<N; i++) {
     det *= A(i,i);
@@ -954,8 +954,8 @@ ComplexDetCofactors (Array<complex<double>,2> &A,
 int 
 ComplexDetCofactorsWorksize(int N)
 {
-  complex<double> work;
-  complex<double> dummy;
+  std::complex<double> work;
+  std::complex<double> dummy;
   int info;
   int ipiv;
   int lwork = -1;

--- a/src/QMCTools/ppconvert/src/common/MatrixOps.h
+++ b/src/QMCTools/ppconvert/src/common/MatrixOps.h
@@ -57,7 +57,7 @@ void MatMult(const Array<std::complex<double>, 2>& A,
              Array<std::complex<double>, 2>& C);
 
 double Determinant(const Array<double, 2>& A);
-complex<double> Determinant(const Array<std::complex<double>, 2>& A);
+std::complex<double> Determinant(const Array<std::complex<double>, 2>& A);
 
 /// This function returns the determinant of A and replaces A with its
 /// cofactors.
@@ -68,7 +68,7 @@ int DetCofactorsWorksize(int N);
 
 
 /// Complex versions of the functions above
-complex<double> ComplexDetCofactors(Array<std::complex<double>, 2>& A, Array<std::complex<double>, 1>& work);
+std::complex<double> ComplexDetCofactors(Array<std::complex<double>, 2>& A, Array<std::complex<double>, 1>& work);
 int ComplexDetCofactorsWorksize(int N);
 
 double GJInverse(Array<double, 2>& A);
@@ -110,7 +110,7 @@ inline void Transpose(Array<double, 2>& A)
   {
     for (int i = 0; i < m; i++)
       for (int j = i + 1; j < m; j++)
-        swap(A(i, j), A(j, i));
+        std::swap(A(i, j), A(j, i));
   }
 }
 
@@ -124,7 +124,7 @@ inline void Transpose(Array<std::complex<double>, 2>& A)
   {
     for (int i = 0; i < m; i++)
       for (int j = i + 1; j < m; j++)
-        swap(A(i, j), A(j, i));
+        std::swap(A(i, j), A(j, i));
   }
 }
 

--- a/src/QMCTools/ppconvert/src/common/NLPP.cc
+++ b/src/QMCTools/ppconvert/src/common/NLPP.cc
@@ -70,7 +70,7 @@ NLPPClass::Read(IOSectionClass &in)
     int l;
     assert (in.ReadVar("l", l));
     if (l > numChannels) {
-      cerr << "Skipped channels in NLPPClass read.\n";
+      std::cerr << "Skipped channels in NLPPClass read.\n";
       abort();
     }
     Vl[l].Read(in, PotentialGrid);
@@ -222,8 +222,8 @@ ChannelPotential::SetupProjector (double G_max, double G_FFT)
   ProjectorNorm = 1.0/sqrt(norm);
   Job = EKB;
   E_KB = norm/integrator.Integrate(0.0, grid.End, 1.0e-12);
-  cerr << "l = " << l << "  Norm is " << norm 
-       << "  E_KB is " << E_KB << "  R0 = " << R0 << endl;
+  std::cerr << "l = " << l << "  Norm is " << norm 
+       << "  E_KB is " << E_KB << "  R0 = " << R0 << std::endl;
   
   // Compute zeta(r)
   Array<double,1> zeta(grid.NumPoints);
@@ -320,8 +320,8 @@ ChannelPotential::SetupProjector (double G_max, double G_FFT)
   double norm2 = integrator.Integrate(0.0, grid.End, 1.0e-8);
   double error = integrator.Integrate( R0, grid.End, 1.0e-8);
   if (error > 1.0e-16)
-    cerr << "Fractional error in real-space projection = "
-	 << (error / norm2) << endl;
+    std::cerr << "Fractional error in real-space projection = "
+	 << (error / norm2) << std::endl;
 }
 
 

--- a/src/QMCTools/ppconvert/src/common/NLPP.h
+++ b/src/QMCTools/ppconvert/src/common/NLPP.h
@@ -22,7 +22,6 @@
 #include "CubicSplineCommon.h"
 #include <vector>
 using namespace IO;
-using namespace blitz;
 
 class ChannelPotential
 {

--- a/src/QMCTools/ppconvert/src/common/NonlinearFit.h
+++ b/src/QMCTools/ppconvert/src/common/NonlinearFit.h
@@ -19,8 +19,6 @@
 #include "blitz/array.h"
 #include "MatrixOps.h"
 
-using namespace blitz;
-
 // Template class for fitting a function with M nonlinear parameters.
 template<int M, typename ModelType>
 class NonlinearFitClass

--- a/src/QMCTools/ppconvert/src/common/OptimizedBreakup.h
+++ b/src/QMCTools/ppconvert/src/common/OptimizedBreakup.h
@@ -19,8 +19,6 @@
 
 #include "blitz/array.h"
 
-using namespace blitz;
-
 class BasisClass
 {
 public:

--- a/src/QMCTools/ppconvert/src/common/Potential.cc
+++ b/src/QMCTools/ppconvert/src/common/Potential.cc
@@ -17,7 +17,7 @@
 
 Potential* ReadPotential (IOSectionClass &in)
 {
-  string type;
+  std::string type;
   Potential *pot;
   assert (in.ReadVar ("Type", type));
   if (type == "Coulomb")
@@ -31,7 +31,7 @@ Potential* ReadPotential (IOSectionClass &in)
   else if (type == "NLPP")
     pot = new NLPPClass;
   else {
-    cerr << "Unrecognize potential type \"" << type << "\".  Exitting.\n";
+    std::cerr << "Unrecognize potential type \"" << type << "\".  Exitting.\n";
     exit(1);
   }
   pot->Read(in);

--- a/src/QMCTools/ppconvert/src/common/RadialWF.cc
+++ b/src/QMCTools/ppconvert/src/common/RadialWF.cc
@@ -325,13 +325,13 @@ RadialWF::Solve(double tolerance)
   Normalize();
   NumNodes = CountNodes();
   if (NumNodes != TotalNodes) {
-    cerr << "Node number error!  We have " << NumNodes 
+    std::cerr << "Node number error!  We have " << NumNodes 
 	 << " nodes and want " << TotalNodes << ".\n";
 //     IOSectionClass out;
 //     out.NewFile ("BadWF.h5");
 //     out.WriteVar ("u", u.Data());
 //     out.CloseFile();
-    cerr << "Energy = " << Energy << endl;
+    std::cerr << "Energy = " << Energy << std::endl;
   }
   //out.CloseFile();
 }
@@ -436,7 +436,7 @@ RadialWF::Read (IOSectionClass &in)
 {
   bool succ;
   if (u.grid == NULL) {
-    cerr << "Grid not set prior to calling RadialWF::Read.\n";
+    std::cerr << "Grid not set prior to calling RadialWF::Read.\n";
     exit(1);
   }
   in.ReadVar ("u", u.Data());


### PR DESCRIPTION
## Proposed changes

Remove the use of global namespace in source of ppconvert (`using namespace blitz / std; `).
This will help refactor the code.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
