### PR TITLE
Nexus: Add h-channel to list of possible local channels in pseudopotential.

### DIFF
--- a/nexus/lib/pseudopotential.py
+++ b/nexus/lib/pseudopotential.py
@@ -1423,7 +1423,11 @@ class SemilocalPP(Pseudopotential):
         zval          = self.Zval
         creator       = 'Nexus'
         npots_down    = len(channels)
-        l_local       = 'spdfgi'.find(self.local)
+        l_local       = 'spdfghi'.find(self.local)
+        if l_local == -1:
+            self.error('Local channel, {}, not coded.'.format(self.local))
+        #end if
+
 
         rmin = 1e99
         rmax = -1e99


### PR DESCRIPTION

## Proposed changes

When writing pseudopotential to QMCPACK form, there is an issue if the local channel is _h_ -- namely, the _l_-value of the local channel (l_local) is set to -1 in this case. This PR resolves this. 

Note: The channels are now coded up to 'i'. Furthermore, I think the CASINO code also has the same issue. If so, I can fix this as well along with this PR.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
