### PR TITLE
Fix determinisitic opt test failures in offload

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -155,7 +155,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
           for (int i = 0; i < rr.size(); ++i)
             assert(std::isfinite(rr[i]));
 #endif
-          auto elecs = walker_elecs;
           ParticleSet::flex_makeMove(walker_elecs, iat, drifts);
 
           TrialWaveFunction::flex_calcRatioGrad(walker_twfs, walker_elecs, iat, ratios, grads_new);

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers.in.xml
@@ -42,7 +42,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant>
+            <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_mwalkers.in.xml
@@ -42,7 +42,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant>
+            <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
@@ -41,7 +41,7 @@
       </particleset>
       <wavefunction name="psi0" target="e">
          <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
-            <slaterdeterminant>
+            <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>
                </determinant>


### PR DESCRIPTION
## Proposed changes

1. @markdewing suggested this fix. Removing the 1 electron special case which has been covered by the generic case.
2. Add batch="no" to deterministic tests which have corresponding batch="yes" tests already.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'