### PR TITLE
stop block_timer at blocks end

### DIFF
--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -89,7 +89,7 @@ bool AFQMCDriver::run(WalkerSet& wset)
     // resize stack pointers to match maximum buffer use
     update_memory_managers();
   }
-  AFQMCTimers[block_timer].stop();
+  AFQMCTimers[block_timer]->stop();
 
   if (nCheckpoint > 0)
     checkpoint(wset, iBlock, step_tot);

--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -33,6 +33,7 @@ bool AFQMCDriver::run(WalkerSet& wset)
   int step_tot      = step0, iBlock;
   for (iBlock = block0; iBlock < nBlock; ++iBlock)
   {
+    AFQMCTimers[block_timer]->start();
     for (int iStep = 0; iStep < nStep; ++iStep, ++step_tot)
     {
       // propagate nSubstep
@@ -84,12 +85,12 @@ bool AFQMCDriver::run(WalkerSet& wset)
     // quantities that are measured once per block
     estim0.accumulate_block(wset);
 
+    AFQMCTimers[block_timer]->stop();
     estim0.print(iBlock + 1, total_time, Eshift, wset);
 
     // resize stack pointers to match maximum buffer use
     update_memory_managers();
   }
-  AFQMCTimers[block_timer]->stop();
 
   if (nCheckpoint > 0)
     checkpoint(wset, iBlock, step_tot);

--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -89,6 +89,7 @@ bool AFQMCDriver::run(WalkerSet& wset)
     // resize stack pointers to match maximum buffer use
     update_memory_managers();
   }
+  AFQMCTimers[block_timer].stop();
 
   if (nCheckpoint > 0)
     checkpoint(wset, iBlock, step_tot);

--- a/src/AFQMC/Estimators/BasicEstimator.h
+++ b/src/AFQMC/Estimators/BasicEstimator.h
@@ -86,9 +86,6 @@ public:
     ncalls_substep = 0;
     nwalk_min      = 1000000;
     nwalk_max      = 0;
-
-    // first block will always be off, move to Driver if problematic
-    AFQMCTimers[block_timer]->start();
   }
 
   ~BasicEstimator() {}
@@ -190,8 +187,6 @@ public:
 
   void print_timers(std::ofstream& out)
   {
-    AFQMCTimers[block_timer]->stop();
-
     if (writer)
     {
       if (timers)
@@ -220,7 +215,6 @@ public:
       AFQMCTimers[setup_timer]->reset();
       AFQMCTimers[extra_timer]->reset();
     }
-    AFQMCTimers[block_timer]->start();
   }
 
   double getEloc() { return data[0] / data[1]; }


### PR DESCRIPTION
## Proposed changes

Stop AFQMC block timer at the end of the simulation.

block_timer is stopped in `BasicEstimator::print_timers` right before it prints to output, then started right after print.
This leaves the block_timer running after the last block.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Fedora 32, E5-2620 v2, gcc 10.2.1, intel 19.1.2

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
