### PR TITLE
Change timer usage as references instead of pointers

### DIFF
--- a/src/AFQMC/Drivers/AFQMCDriver.cpp
+++ b/src/AFQMC/Drivers/AFQMCDriver.cpp
@@ -41,18 +41,18 @@ bool AFQMCDriver::run(WalkerSet& wset)
 
       if ((step_tot + 1) % nStabilize == 0)
       {
-        AFQMCTimers[ortho_timer]->start();
+        AFQMCTimers[ortho_timer].get().start();
         wfn0.Orthogonalize(wset, !prop0.free_propagation());
-        AFQMCTimers[ortho_timer]->stop();
+        AFQMCTimers[ortho_timer].get().stop();
       }
 
       if (total_time < weight_reset_period && !prop0.free_propagation())
         wset.resetWeights();
 
       {
-        AFQMCTimers[popcont_timer]->start();
+        AFQMCTimers[popcont_timer].get().start();
         wset.popControl(curData);
-        AFQMCTimers[popcont_timer]->stop();
+        AFQMCTimers[popcont_timer].get().stop();
         estim0.accumulate_step(wset, curData);
       }
 

--- a/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
+++ b/src/AFQMC/Estimators/BackPropagatedEstimator.hpp
@@ -181,7 +181,7 @@ public:
       return;
     }
 
-    AFQMCTimers[back_propagate_timer]->start();
+    AFQMCTimers[back_propagate_timer].get().start();
     int nrow(NMO * ((walker_type == NONCOLLINEAR) ? 2 : 1));
     int ncol(NAEA + ((walker_type == CLOSED) ? 0 : NAEB));
     int nx((walker_type == COLLINEAR) ? 2 : 1);
@@ -246,7 +246,7 @@ public:
       iblock++;
       accumulated_in_last_block = true;
     }
-    AFQMCTimers[back_propagate_timer]->stop();
+    AFQMCTimers[back_propagate_timer].get().stop();
   }
 
   void tags(std::ofstream& out)
@@ -260,8 +260,8 @@ public:
     // I doubt we will ever collect a billion blocks of data.
     if (writer)
     {
-      out << std::setprecision(5) << AFQMCTimers[back_propagate_timer]->get_total() << " ";
-      AFQMCTimers[back_propagate_timer]->reset();
+      out << std::setprecision(5) << AFQMCTimers[back_propagate_timer].get().get_total() << " ";
+      AFQMCTimers[back_propagate_timer].get().reset();
     }
     if (accumulated_in_last_block)
     {

--- a/src/AFQMC/Estimators/BasicEstimator.h
+++ b/src/AFQMC/Estimators/BasicEstimator.h
@@ -56,19 +56,19 @@ public:
 
     if (timers)
     {
-      AFQMCTimers[block_timer]->reset();
-      AFQMCTimers[pseudo_energy_timer]->reset();
-      AFQMCTimers[vHS_timer]->reset();
-      AFQMCTimers[vbias_timer]->reset();
-      AFQMCTimers[G_for_vbias_timer]->reset();
-      AFQMCTimers[propagate_timer]->reset();
-      AFQMCTimers[E_comm_overhead_timer]->reset();
-      AFQMCTimers[vHS_comm_overhead_timer]->reset();
-      AFQMCTimers[assemble_X_timer]->reset();
-      AFQMCTimers[popcont_timer]->reset();
-      AFQMCTimers[ortho_timer]->reset();
-      AFQMCTimers[setup_timer]->reset();
-      AFQMCTimers[extra_timer]->reset();
+      AFQMCTimers[block_timer].get().reset();
+      AFQMCTimers[pseudo_energy_timer].get().reset();
+      AFQMCTimers[vHS_timer].get().reset();
+      AFQMCTimers[vbias_timer].get().reset();
+      AFQMCTimers[G_for_vbias_timer].get().reset();
+      AFQMCTimers[propagate_timer].get().reset();
+      AFQMCTimers[E_comm_overhead_timer].get().reset();
+      AFQMCTimers[vHS_comm_overhead_timer].get().reset();
+      AFQMCTimers[assemble_X_timer].get().reset();
+      AFQMCTimers[popcont_timer].get().reset();
+      AFQMCTimers[ortho_timer].get().reset();
+      AFQMCTimers[setup_timer].get().reset();
+      AFQMCTimers[extra_timer].get().reset();
     }
 
     enume          = 0.0;
@@ -88,7 +88,7 @@ public:
     nwalk_max      = 0;
 
     // first block will always be off, move to Driver if problematic
-    AFQMCTimers[block_timer]->start();
+    AFQMCTimers[block_timer].get().start();
   }
 
   ~BasicEstimator() {}
@@ -190,37 +190,37 @@ public:
 
   void print_timers(std::ofstream& out)
   {
-    AFQMCTimers[block_timer]->stop();
+    AFQMCTimers[block_timer].get().stop();
 
     if (writer)
     {
       if (timers)
-        out << std::setprecision(5) << AFQMCTimers[pseudo_energy_timer]->get_total() << " "
-            << AFQMCTimers[vHS_timer]->get_total() << " " << AFQMCTimers[vbias_timer]->get_total() << " "
-            << AFQMCTimers[G_for_vbias_timer]->get_total() << " " << AFQMCTimers[propagate_timer]->get_total() << " "
-            << AFQMCTimers[E_comm_overhead_timer]->get_total() << " "
-            << AFQMCTimers[vHS_comm_overhead_timer]->get_total() << " " << AFQMCTimers[assemble_X_timer]->get_total()
-            << " " << AFQMCTimers[popcont_timer]->get_total() << " " << AFQMCTimers[ortho_timer]->get_total() << " "
-            << AFQMCTimers[setup_timer]->get_total() << " " << AFQMCTimers[extra_timer]->get_total() << " "
-            << AFQMCTimers[block_timer]->get_total() << " " << std::setprecision(16);
+        out << std::setprecision(5) << AFQMCTimers[pseudo_energy_timer].get().get_total() << " "
+            << AFQMCTimers[vHS_timer].get().get_total() << " " << AFQMCTimers[vbias_timer].get().get_total() << " "
+            << AFQMCTimers[G_for_vbias_timer].get().get_total() << " " << AFQMCTimers[propagate_timer].get().get_total() << " "
+            << AFQMCTimers[E_comm_overhead_timer].get().get_total() << " "
+            << AFQMCTimers[vHS_comm_overhead_timer].get().get_total() << " " << AFQMCTimers[assemble_X_timer].get().get_total()
+            << " " << AFQMCTimers[popcont_timer].get().get_total() << " " << AFQMCTimers[ortho_timer].get().get_total() << " "
+            << AFQMCTimers[setup_timer].get().get_total() << " " << AFQMCTimers[extra_timer].get().get_total() << " "
+            << AFQMCTimers[block_timer].get().get_total() << " " << std::setprecision(16);
     }
     if (timers)
     {
-      AFQMCTimers[block_timer]->reset();
-      AFQMCTimers[pseudo_energy_timer]->reset();
-      AFQMCTimers[vHS_timer]->reset();
-      AFQMCTimers[vbias_timer]->reset();
-      AFQMCTimers[G_for_vbias_timer]->reset();
-      AFQMCTimers[propagate_timer]->reset();
-      AFQMCTimers[E_comm_overhead_timer]->reset();
-      AFQMCTimers[vHS_comm_overhead_timer]->reset();
-      AFQMCTimers[popcont_timer]->reset();
-      AFQMCTimers[assemble_X_timer]->reset();
-      AFQMCTimers[ortho_timer]->reset();
-      AFQMCTimers[setup_timer]->reset();
-      AFQMCTimers[extra_timer]->reset();
+      AFQMCTimers[block_timer].get().reset();
+      AFQMCTimers[pseudo_energy_timer].get().reset();
+      AFQMCTimers[vHS_timer].get().reset();
+      AFQMCTimers[vbias_timer].get().reset();
+      AFQMCTimers[G_for_vbias_timer].get().reset();
+      AFQMCTimers[propagate_timer].get().reset();
+      AFQMCTimers[E_comm_overhead_timer].get().reset();
+      AFQMCTimers[vHS_comm_overhead_timer].get().reset();
+      AFQMCTimers[popcont_timer].get().reset();
+      AFQMCTimers[assemble_X_timer].get().reset();
+      AFQMCTimers[ortho_timer].get().reset();
+      AFQMCTimers[setup_timer].get().reset();
+      AFQMCTimers[extra_timer].get().reset();
     }
-    AFQMCTimers[block_timer]->start();
+    AFQMCTimers[block_timer].get().start();
   }
 
   double getEloc() { return data[0] / data[1]; }

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -56,7 +56,7 @@ public:
 
   void accumulate_block(WalkerSet& wset)
   {
-    AFQMCTimers[energy_timer].get().start();
+    ScopedTimer local_timer(AFQMCTimers[energy_timer]);
     size_t nwalk = wset.size();
     if (eloc.size(0) != nwalk || eloc.size(1) != 3)
       eloc.reextent({nwalk, 3});
@@ -99,7 +99,6 @@ public:
       }
       TG.TG_heads().all_reduce_in_place_n(data.begin(), data.size(), std::plus<>());
     }
-    AFQMCTimers[energy_timer].get().stop();
   }
 
   void tags(std::ofstream& out)

--- a/src/AFQMC/Estimators/EnergyEstimator.h
+++ b/src/AFQMC/Estimators/EnergyEstimator.h
@@ -56,7 +56,7 @@ public:
 
   void accumulate_block(WalkerSet& wset)
   {
-    AFQMCTimers[energy_timer]->start();
+    AFQMCTimers[energy_timer].get().start();
     size_t nwalk = wset.size();
     if (eloc.size(0) != nwalk || eloc.size(1) != 3)
       eloc.reextent({nwalk, 3});
@@ -99,7 +99,7 @@ public:
       }
       TG.TG_heads().all_reduce_in_place_n(data.begin(), data.size(), std::plus<>());
     }
-    AFQMCTimers[energy_timer]->stop();
+    AFQMCTimers[energy_timer].get().stop();
   }
 
   void tags(std::ofstream& out)
@@ -124,12 +124,12 @@ public:
     {
       int n = wset.get_global_target_population();
       out << data[0].real() / n << " " << data[0].imag() / n << " " << data[1].real() / n << " " << data[1].imag() / n
-          << " " << AFQMCTimers[energy_timer]->get_total() << " ";
+          << " " << AFQMCTimers[energy_timer].get().get_total() << " ";
       if (energy_components)
       {
         out << data[2].real() / n << " " << data[3].real() / n << " " << data[4].real() / n << " ";
       }
-      AFQMCTimers[energy_timer]->reset();
+      AFQMCTimers[energy_timer].get().reset();
     }
   }
 

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.icc
@@ -35,7 +35,7 @@ namespace afqmc
 template<class WlkSet>
 void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealType dt)
 {
-  AFQMCTimers[setup_timer]->start();
+  AFQMCTimers[setup_timer].get().start();
   auto walker_type = wset.getWalkerType();
   int npol         = (walker_type == NONCOLLINEAR) ? 2 : 1;
   int nsteps       = nsteps_;
@@ -79,7 +79,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
   // if timestep changed, recalculate one body propagator
   if (std::abs(dt - old_dt) > 1e-6)
     generateP1(dt, walker_type);
-  AFQMCTimers[setup_timer]->stop();
+  AFQMCTimers[setup_timer].get().stop();
 
   StaticMatrix vHS(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
 
@@ -88,7 +88,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     StaticSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
+    AFQMCTimers[G_for_vbias_timer].get().start();
 #if defined(MIXED_PRECISION)
     {
       int Gak0, GakN;
@@ -101,13 +101,13 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
 #else
     wfn.MixedDensityMatrix_for_vbias(wset, G);
 #endif
-    AFQMCTimers[G_for_vbias_timer]->stop();
+    AFQMCTimers[G_for_vbias_timer].get().stop();
     //std::cout<<" G: " <<ma::dot(G(G.extension(0),0),G(G.extension(0),0)) <<std::endl;
 
     StaticSPMatrix vbias({long(localnCV), long(nwalk)},
                          buffer_manager.get_generator().template get_allocator<SPComplexType>());
     // 2. Calculate vbias for initial configuration
-    AFQMCTimers[vbias_timer]->start();
+    AFQMCTimers[vbias_timer].get().start();
     if (free_projection)
     {
       fill_n(vbias.origin(), localnCV * nwalk, SPComplexType(0.0, 0.0));
@@ -116,13 +116,13 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     {
       wfn.vbias(G, vbias, sqrtdt);
     }
-    AFQMCTimers[vbias_timer]->stop();
+    AFQMCTimers[vbias_timer].get().stop();
     //std::cout<<" vbias: " <<ma::sum(vbias) <<std::endl;
 
     StaticSPMatrix X({long(localnCV), long(nwalk * nsteps)},
                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
     // 3. Assemble X(nCV,nsteps,nwalk)
-    AFQMCTimers[assemble_X_timer]->start();
+    AFQMCTimers[assemble_X_timer].get().start();
     assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
     if (TG.TG_local().size() > 1)
     {
@@ -130,7 +130,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
       TG.TG_local().all_reduce_in_place_n(to_address(hybrid_weight.origin()), hybrid_weight.num_elements(),
                                           std::plus<>());
     }
-    AFQMCTimers[assemble_X_timer]->stop();
+    AFQMCTimers[assemble_X_timer].get().stop();
     // Store sqrtdt*X in wset if back propagating
     int bp_step = wset.getBPPos(), bp_max = wset.NumBackProp();
     if (bp_step >= 0 && bp_step < bp_max)
@@ -158,7 +158,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     //std::cout<<" X: " <<ma::sum(X) <<std::endl;
 
     // 4. Calculate vHS(M*M,nsteps,nwalk)/vHS(nsteps,nwalk,M*M)
-    AFQMCTimers[vHS_timer]->start();
+    AFQMCTimers[vHS_timer].get().start();
 #if defined(MIXED_PRECISION)
     // is this clever or dirsty? seems to work well and saves memory!
     SPCMatrix_ref vsp(sp_pointer(make_device_ptr(vHS.origin())), vhs_ext);
@@ -170,7 +170,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
 #else
     wfn.vHS(X, vHS, sqrtdt);
 #endif
-    AFQMCTimers[vHS_timer]->stop();
+    AFQMCTimers[vHS_timer].get().stop();
     //std::cout<<" Pg vHS: " <<TG.Global().rank() <<" " <<ma::sum(vHS) <<"\n" <<std::endl;
   }
 
@@ -195,7 +195,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
   for (int ni = 0; ni < nsteps_; ni++)
   {
     // 5. Propagate walkers
-    AFQMCTimers[propagate_timer]->start();
+    AFQMCTimers[propagate_timer].get().start();
     if (nbatched_propagation != 0)
     {
       apply_propagators_batched('N', wset, ni, vHS3D);
@@ -204,12 +204,12 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
     {
       apply_propagators('N', wset, ni, tk0, tkN, ntasks_total_serial, vHS3D);
     }
-    AFQMCTimers[propagate_timer]->stop();
+    AFQMCTimers[propagate_timer].get().stop();
     //std::cout<<" propg wfn " <<std::endl; //: "
     //std::cout<<ma::sum(*wset[0].SlaterMatrix(Alpha)) <<" " <<ma::sum(*wset[0].SlaterMatrix(Beta)) <<std::endl;
 
     // 6. Calculate local energy/overlap
-    AFQMCTimers[pseudo_energy_timer]->start();
+    AFQMCTimers[pseudo_energy_timer].get().start();
     if (hybrid)
     {
       wfn.Overlap(wset, new_overlaps);
@@ -219,11 +219,11 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
       wfn.Energy(wset, new_energies, new_overlaps);
     }
     TG.local_barrier();
-    AFQMCTimers[pseudo_energy_timer]->stop();
+    AFQMCTimers[pseudo_energy_timer].get().stop();
     //std::cout<<" pseudo energy " <<std::endl;
 
     // 7. update weights/energy/etc, apply constrains/bounds/etc
-    AFQMCTimers[extra_timer]->start();
+    AFQMCTimers[extra_timer].get().start();
     if (TG.TG_local().root())
     {
       if (free_projection)
@@ -248,7 +248,7 @@ void AFQMCBasePropagator::step(int nsteps_, WlkSet& wset, RealType Eshift, RealT
         wset.advanceHistoryPos();
     }
     TG.local_barrier();
-    AFQMCTimers[extra_timer]->stop();
+    AFQMCTimers[extra_timer].get().stop();
     //std::cout<<" update: " <<hybrid_weight[0][0]  <<" " <<MFfactor[0][0] <<std::endl <<std::endl;
   }
 }

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.icc
@@ -37,7 +37,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
 {
   using std::copy_n;
   using std::fill_n;
-  AFQMCTimers[setup_timer]->start();
+  AFQMCTimers[setup_timer].get().start();
   const ComplexType one(1.), zero(0.);
   auto walker_type      = wset.getWalkerType();
   int nsteps            = size_t(nsteps_);
@@ -81,7 +81,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   if (std::abs(dt - old_dt) > 1e-6)
     generateP1(dt, walker_type);
   TG.local_barrier();
-  AFQMCTimers[setup_timer]->stop();
+  AFQMCTimers[setup_timer].get().stop();
 
   StaticMatrix vHS_buff(vhs_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
   SPCMatrix_ref vHS(sp_pointer(make_device_ptr(vHS_buff.origin())), vhs_ext);
@@ -89,7 +89,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     StaticSPMatrix G(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
+    AFQMCTimers[G_for_vbias_timer].get().start();
 #if defined(MIXED_PRECISION)
     { // control scope of Gc
       int Gak0, GakN;
@@ -103,7 +103,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
 #else
     wfn.MixedDensityMatrix_for_vbias(wset, G);
 #endif
-    AFQMCTimers[G_for_vbias_timer]->stop();
+    AFQMCTimers[G_for_vbias_timer].get().stop();
 
     StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
     StaticSPMatrix X({long(nCV), long(nwalk * nsteps)},
@@ -134,7 +134,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     for (int k = 0; k < nnodes; ++k)
     {
       // 2. bcast G (and X) to TG
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       if (k == node_number)
       {
         int i0, iN, Gak0, GakN;
@@ -148,19 +148,19 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       core_comm.broadcast_n(to_address(Gwork.origin()) + G0, GN - G0, k);
       core_comm.broadcast_n(to_address(X.origin()) + X0, XN - X0, k);
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
       // calculate vHS contribution from this node
       // 4a. Calculate vbias for initial configuration
-      AFQMCTimers[vbias_timer]->start();
+      AFQMCTimers[vbias_timer].get().start();
       wfn.vbias(Gwork, vbias, sqrtdt);
-      AFQMCTimers[vbias_timer]->stop();
+      AFQMCTimers[vbias_timer].get().stop();
 
       // all_reduce vbias
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       core_comm.all_reduce_in_place_n(to_address(vbias.origin()) + vb0, vbN - vb0, std::plus<>());
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
       // 4b. Assemble X(nCV,nsteps,nwalk)
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor[1], hybrid_weight[1], false);
@@ -173,16 +173,16 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       }
 
       // 4c. Calculate vHS(M*M,nsteps,nwalk)
-      AFQMCTimers[vHS_timer]->start();
+      AFQMCTimers[vHS_timer].get().start();
       wfn.vHS(X, vHSwork, sqrtdt);
       TG.local_barrier();
-      AFQMCTimers[vHS_timer]->stop();
+      AFQMCTimers[vHS_timer].get().stop();
 
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       core_comm.reduce_n(to_address(vHSwork.origin()) + vak0, vakN - vak0, to_address(vHS.origin()) + vak0,
                          std::plus<>(), k);
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
     }
   }
 
@@ -216,7 +216,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
   for (int ni = 0; ni < nsteps_; ni++)
   {
     // 5. Propagate walkers
-    AFQMCTimers[propagate_timer]->start();
+    AFQMCTimers[propagate_timer].get().start();
     if (nbatched_propagation != 0)
     {
       apply_propagators_batched('N', wset, ni, vHS3D);
@@ -225,10 +225,10 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
     {
       apply_propagators('N', wset, ni, tk0, tkN, ntasks_total_serial, vHS3D);
     }
-    AFQMCTimers[propagate_timer]->stop();
+    AFQMCTimers[propagate_timer].get().stop();
 
     // 6. Calculate local energy/overlap
-    AFQMCTimers[pseudo_energy_timer]->start();
+    AFQMCTimers[pseudo_energy_timer].get().start();
     if (hybrid)
     {
       wfn.Overlap(wset, new_overlaps);
@@ -238,10 +238,10 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       wfn.Energy(wset, new_energies, new_overlaps);
     }
     TG.local_barrier();
-    AFQMCTimers[pseudo_energy_timer]->stop();
+    AFQMCTimers[pseudo_energy_timer].get().stop();
 
     // 7. update weights/energy/etc, apply constrains/bounds/etc
-    AFQMCTimers[extra_timer]->start();
+    AFQMCTimers[extra_timer].get().start();
     if (TG.TG_local().root())
     {
       if (free_projection)
@@ -260,7 +260,7 @@ void AFQMCDistributedPropagator::step(int nsteps_, WlkSet& wset, RealType Eshift
       }
     }
     TG.local_barrier();
-    AFQMCTimers[extra_timer]->stop();
+    AFQMCTimers[extra_timer].get().stop();
   }
 }
 

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.icc
@@ -41,7 +41,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   using ma::axpy;
   using std::copy_n;
   using std::fill_n;
-  AFQMCTimers[setup_timer]->start();
+  AFQMCTimers[setup_timer].get().start();
   const SPComplexType one(1.), zero(0.);
   auto walker_type        = wset.getWalkerType();
   int nsteps              = nsteps_;
@@ -99,7 +99,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
 
     // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
+    AFQMCTimers[G_for_vbias_timer].get().start();
 #if defined(MIXED_PRECISION)
     { // control scope of Gc
       int Gak0, GakN;
@@ -112,7 +112,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
 #else
     wfn.MixedDensityMatrix_for_vbias(wset, Gwork);
 #endif
-    AFQMCTimers[G_for_vbias_timer]->stop();
+    AFQMCTimers[G_for_vbias_timer].get().stop();
 
 
     StaticSPMatrix Grecv(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
@@ -178,14 +178,14 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     }
 
     TG.local_barrier();
-    AFQMCTimers[setup_timer]->stop();
+    AFQMCTimers[setup_timer].get().stop();
 
     MPI_Status st;
 
     for (int k = 0; k < nnodes; ++k)
     {
       // 2. wait for communication of previous step
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       if (k > 0)
       {
         MPI_Wait(&req_Grecv, &st);
@@ -200,23 +200,23 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
         MPI_Start(&req_Gsend);
         MPI_Start(&req_Grecv);
       }
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
       // calculate vHS contribution from this node
       // 4a. Calculate vbias for initial configuration
-      AFQMCTimers[vbias_timer]->start();
+      AFQMCTimers[vbias_timer].get().start();
       wfn.vbias(Gwork, vbias, sqrtdt);
-      AFQMCTimers[vbias_timer]->stop();
+      AFQMCTimers[vbias_timer].get().stop();
 
       // 4b. Assemble X(nCV,nsteps,nwalk)
-      AFQMCTimers[assemble_X_timer]->start();
+      AFQMCTimers[assemble_X_timer].get().start();
       int q = (node_number + k) % nnodes;
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
       copy_n(make_device_ptr(MFfactor.origin()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[q].origin()));
       copy_n(make_device_ptr(hybrid_weight.origin()), hybrid_weight.num_elements(),
              make_device_ptr(globalhybrid_weight[q].origin()));
       TG.local_barrier();
-      AFQMCTimers[assemble_X_timer]->stop();
+      AFQMCTimers[assemble_X_timer].get().stop();
       if (bp_step >= 0 && bp_step < bp_max)
       {
         // receive X
@@ -236,12 +236,12 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       }
 
       // 4c. Calculate vHS(M*M,nsteps,nwalk)
-      AFQMCTimers[vHS_timer]->start();
+      AFQMCTimers[vHS_timer].get().start();
       wfn.vHS(X, vHS, sqrtdt);
       TG.local_barrier();
-      AFQMCTimers[vHS_timer]->stop();
+      AFQMCTimers[vHS_timer].get().stop();
 
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       // 5. receive v
       if (k > 0)
       {
@@ -257,11 +257,11 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       MPI_Start(&req_vsend);
       MPI_Start(&req_vrecv);
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
     }
 
     // after the wait, vrecv ( and by extention vHS3D ) has the final vHS for the local walkers
-    AFQMCTimers[vHS_comm_overhead_timer]->start();
+    AFQMCTimers[vHS_comm_overhead_timer].get().start();
     MPI_Wait(&req_vrecv, &st);
     MPI_Wait(&req_vsend, &st);
     MPI_Wait(&req_X2recv, &st);
@@ -315,7 +315,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
            make_device_ptr(hybrid_weight.origin()));
 
     TG.local_barrier();
-    AFQMCTimers[vHS_comm_overhead_timer]->stop();
+    AFQMCTimers[vHS_comm_overhead_timer].get().stop();
   }
 
 #if defined(MIXED_PRECISION)
@@ -348,7 +348,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   for (int ni = 0; ni < nsteps_; ni++)
   {
     // 5. Propagate walkers
-    AFQMCTimers[propagate_timer]->start();
+    AFQMCTimers[propagate_timer].get().start();
     if (nbatched_propagation != 0)
     {
       apply_propagators_batched('N', wset, ni, vHS3D);
@@ -357,10 +357,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     {
       apply_propagators('N', wset, ni, tk0, tkN, ntasks_total_serial, vHS3D);
     }
-    AFQMCTimers[propagate_timer]->stop();
+    AFQMCTimers[propagate_timer].get().stop();
 
     // 6. Calculate local energy/overlap
-    AFQMCTimers[pseudo_energy_timer]->start();
+    AFQMCTimers[pseudo_energy_timer].get().start();
     if (hybrid)
     {
       wfn.Overlap(wset, new_overlaps);
@@ -370,10 +370,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       wfn.Energy(wset, new_energies, new_overlaps);
     }
     TG.local_barrier();
-    AFQMCTimers[pseudo_energy_timer]->stop();
+    AFQMCTimers[pseudo_energy_timer].get().stop();
 
     // 7. update weights/energy/etc, apply constrains/bounds/etc
-    AFQMCTimers[extra_timer]->start();
+    AFQMCTimers[extra_timer].get().start();
     if (TG.TG_local().root())
     {
       if (free_projection)
@@ -396,7 +396,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
         wset.advanceHistoryPos();
     }
     TG.local_barrier();
-    AFQMCTimers[extra_timer]->stop();
+    AFQMCTimers[extra_timer].get().stop();
   }
 }
 
@@ -411,7 +411,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   using ma::axpy;
   using std::copy_n;
   using std::fill_n;
-  AFQMCTimers[setup_timer]->start();
+  AFQMCTimers[setup_timer].get().start();
   const SPComplexType one(1.), zero(0.);
   auto walker_type        = wset.getWalkerType();
   int nsteps              = nsteps_;
@@ -474,7 +474,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     std::tie(Gak0, GakN) = FairDivideBoundary(TG.getLocalTGRank(), int(Gstore.num_elements()), TG.getNCoresPerTG());
 
     // 1. Calculate Green function for all (local) walkers
-    AFQMCTimers[G_for_vbias_timer]->start();
+    AFQMCTimers[G_for_vbias_timer].get().start();
 #if defined(MIXED_PRECISION)
     {
       StaticMatrix Gstore_(G_ext, buffer_manager.get_generator().template get_allocator<ComplexType>());
@@ -485,7 +485,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     wfn.MixedDensityMatrix_for_vbias(wset, Gstore);
 #endif
     TG.local_barrier();
-    AFQMCTimers[G_for_vbias_timer]->stop();
+    AFQMCTimers[G_for_vbias_timer].get().stop();
 
     StaticSPMatrix Gwork(G_ext, buffer_manager.get_generator().template get_allocator<SPComplexType>());
     StaticSPMatrix vbias({long(localnCV), long(nwalk)},
@@ -545,14 +545,14 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     }
 
     TG.local_barrier();
-    AFQMCTimers[setup_timer]->stop();
+    AFQMCTimers[setup_timer].get().stop();
 
     MPI_Status st;
 
     for (int k = 0; k < nnodes; ++k)
     {
       // 2. bcast G
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       if (k == node_number)
         copy_n(make_device_ptr(Gstore.origin()) + Gak0, GakN - Gak0, make_device_ptr(Gwork.origin()) + Gak0);
 #ifdef BUILD_AFQMC_WITH_NCCL
@@ -572,22 +572,22 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       TG.TG_Cores().broadcast_n(to_address(Gwork.origin()) + Gak0, GakN - Gak0, k);
 #endif
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
       // calculate vHS contribution from this node
       // 3a. Calculate vbias for initial configuration
-      AFQMCTimers[vbias_timer]->start();
+      AFQMCTimers[vbias_timer].get().start();
       wfn.vbias(Gwork, vbias, sqrtdt);
-      AFQMCTimers[vbias_timer]->stop();
+      AFQMCTimers[vbias_timer].get().stop();
 
       // 3b. Assemble X(nCV,nsteps,nwalk)
-      AFQMCTimers[assemble_X_timer]->start();
+      AFQMCTimers[assemble_X_timer].get().start();
       assemble_X(nsteps, nwalk, sqrtdt, X, vbias, MFfactor, hybrid_weight);
       copy_n(make_device_ptr(MFfactor.origin()), MFfactor.num_elements(), make_device_ptr(globalMFfactor[k].origin()));
       copy_n(make_device_ptr(hybrid_weight.origin()), hybrid_weight.num_elements(),
              make_device_ptr(globalhybrid_weight[k].origin()));
       TG.local_barrier();
-      AFQMCTimers[assemble_X_timer]->stop();
+      AFQMCTimers[assemble_X_timer].get().stop();
       if (bp_step >= 0 && bp_step < bp_max)
       {
         APP_ABORT("Finish");
@@ -602,12 +602,12 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       }
 
       // 3c. Calculate vHS(M*M,nsteps,nwalk)
-      AFQMCTimers[vHS_timer]->start();
+      AFQMCTimers[vHS_timer].get().start();
       wfn.vHS(X, vHS, sqrtdt);
       TG.local_barrier();
-      AFQMCTimers[vHS_timer]->stop();
+      AFQMCTimers[vHS_timer].get().stop();
 
-      AFQMCTimers[vHS_comm_overhead_timer]->start();
+      AFQMCTimers[vHS_comm_overhead_timer].get().start();
       // 4. Reduce vHS
 #ifdef BUILD_AFQMC_WITH_NCCL
 #ifdef ENABLE_CUDA
@@ -628,11 +628,11 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
 #endif
 
       TG.local_barrier();
-      AFQMCTimers[vHS_comm_overhead_timer]->stop();
+      AFQMCTimers[vHS_comm_overhead_timer].get().stop();
     }
 
     // after the wait, vrecv ( and by extention vHS3D ) has the final vHS for the local walkers
-    AFQMCTimers[vHS_comm_overhead_timer]->start();
+    AFQMCTimers[vHS_comm_overhead_timer].get().start();
 
     // store fields in walker
     if (bp_step >= 0 && bp_step < bp_max)
@@ -688,7 +688,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     copy_n(make_device_ptr(globalhybrid_weight[node_number].origin()), hybrid_weight.num_elements(),
            make_device_ptr(hybrid_weight.origin()));
 
-    AFQMCTimers[vHS_comm_overhead_timer]->stop();
+    AFQMCTimers[vHS_comm_overhead_timer].get().stop();
   } // scope controlling lifetime of temporary arrays
 
 #if defined(MIXED_PRECISION)
@@ -719,7 +719,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
   for (int ni = 0; ni < nsteps_; ni++)
   {
     // 5. Propagate walkers
-    AFQMCTimers[propagate_timer]->start();
+    AFQMCTimers[propagate_timer].get().start();
     if (nbatched_propagation != 0)
     {
       apply_propagators_batched('N', wset, ni, vHS3D);
@@ -728,10 +728,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
     {
       apply_propagators('N', wset, ni, tk0, tkN, ntasks_total_serial, vHS3D);
     }
-    AFQMCTimers[propagate_timer]->stop();
+    AFQMCTimers[propagate_timer].get().stop();
 
     // 6. Calculate local energy/overlap
-    AFQMCTimers[pseudo_energy_timer]->start();
+    AFQMCTimers[pseudo_energy_timer].get().start();
     if (hybrid)
     {
       wfn.Overlap(wset, new_overlaps);
@@ -741,10 +741,10 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
       wfn.Energy(wset, new_energies, new_overlaps);
     }
     TG.local_barrier();
-    AFQMCTimers[pseudo_energy_timer]->stop();
+    AFQMCTimers[pseudo_energy_timer].get().stop();
 
     // 7. update weights/energy/etc, apply constrains/bounds/etc
-    AFQMCTimers[extra_timer]->start();
+    AFQMCTimers[extra_timer].get().start();
     if (TG.TG_local().root())
     {
       if (free_projection)
@@ -767,7 +767,7 @@ void AFQMCDistributedPropagatorDistCV::step_collective(int nsteps_, WlkSet& wset
         wset.advanceHistoryPos();
     }
     TG.local_barrier();
-    AFQMCTimers[extra_timer]->stop();
+    AFQMCTimers[extra_timer].get().stop();
   }
 }
 

--- a/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
+++ b/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.icc
@@ -39,7 +39,7 @@ namespace afqmc
 template<class WlkSet>
 void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType Eshift, RealType dt)
 {
-  AFQMCTimers[setup_timer]->start();
+  AFQMCTimers[setup_timer].get().start();
   const ComplexType one(1.), zero(0.);
   auto walker_type      = wset.getWalkerType();
   int nsteps            = nsteps_;
@@ -191,21 +191,21 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   fill_n(vsend.origin() + vak0, (vakN - vak0), zero);
 
   TG.local_barrier();
-  AFQMCTimers[setup_timer]->stop();
+  AFQMCTimers[setup_timer].get().stop();
 
   MPI_Status st;
 
   // 1. Calculate Green function for all (local) walkers
-  AFQMCTimers[G_for_vbias_timer]->start();
+  AFQMCTimers[G_for_vbias_timer].get().start();
   wfn.MixedDensityMatrix_for_vbias(wset, Gwork);
   ma::copy(Gwork.sliced(Gak0, GakN), Gsend.sliced(Gak0, GakN));
   TG.local_barrier();
-  AFQMCTimers[G_for_vbias_timer]->stop();
+  AFQMCTimers[G_for_vbias_timer].get().stop();
 
   for (int k = 0; k < nnodes; ++k)
   {
     // 2. wait for communication of previous step
-    AFQMCTimers[vHS_comm_overhead_timer]->start();
+    AFQMCTimers[vHS_comm_overhead_timer].get().start();
     if (k > 0)
     {
       MPI_Wait(&req_Grecv, &st);
@@ -221,13 +221,13 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       MPI_Start(&req_Gsend);
       MPI_Start(&req_Grecv);
     }
-    AFQMCTimers[vHS_comm_overhead_timer]->stop();
+    AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
     // calculate vHS contribution from this node
     // 4a. Calculate vbias for initial configuration
-    AFQMCTimers[vbias_timer]->start();
+    AFQMCTimers[vbias_timer].get().start();
     wfn.vbias(Gwork, vbias, sqrtdt);
-    AFQMCTimers[vbias_timer]->stop();
+    AFQMCTimers[vbias_timer].get().stop();
 
     // 4b. Assemble X(nCV,nsteps,nwalk)
     int q = (node_number + k) % nnodes;
@@ -236,12 +236,12 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     assemble_X(nsteps, nwalk, sqrtdt, X, vbias, mf_, hw_);
 
     // 4c. Calculate vHS(M*M,nsteps,nwalk)
-    AFQMCTimers[vHS_timer]->start();
+    AFQMCTimers[vHS_timer].get().start();
     wfn.vHS(X, vHS, sqrtdt);
     TG.local_barrier();
-    AFQMCTimers[vHS_timer]->stop();
+    AFQMCTimers[vHS_timer].get().stop();
 
-    AFQMCTimers[vHS_comm_overhead_timer]->start();
+    AFQMCTimers[vHS_comm_overhead_timer].get().start();
     // 5. receive v
     if (k > 0)
     {
@@ -264,11 +264,11 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     MPI_Start(&req_vsend);
     MPI_Start(&req_vrecv);
     TG.local_barrier();
-    AFQMCTimers[vHS_comm_overhead_timer]->stop();
+    AFQMCTimers[vHS_comm_overhead_timer].get().stop();
   }
 
   // after the wait, vrecv has the final vHS for the local walkers
-  AFQMCTimers[vHS_comm_overhead_timer]->start();
+  AFQMCTimers[vHS_comm_overhead_timer].get().start();
   MPI_Wait(&req_vrecv, &st);
   MPI_Wait(&req_vsend, &st);
   copy_n(vrecv.origin() + vak0, vakN - vak0, vHS.origin() + vak0);
@@ -281,7 +281,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
     TG.TG().all_reduce_in_place_n(to_address(hybrid_weight.origin()), hybrid_weight.num_elements(), std::plus<>());
   }
   TG.local_barrier();
-  AFQMCTimers[vHS_comm_overhead_timer]->stop();
+  AFQMCTimers[vHS_comm_overhead_timer].get().stop();
 
   // From here on is similar to Shared
   int nx = 1;
@@ -304,7 +304,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
   for (int ni = 0; ni < nsteps_; ni++)
   {
     // 5. Propagate walkers
-    AFQMCTimers[propagate_timer]->start();
+    AFQMCTimers[propagate_timer].get().start();
     if (nbatched_propagation != 0)
     {
       if (wset.getNBackProp() > 0)
@@ -327,10 +327,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
         apply_propagators(wset, ni, tk0, tkN, ntasks_total_serial, vHS3D);
       }
     }
-    AFQMCTimers[propagate_timer]->stop();
+    AFQMCTimers[propagate_timer].get().stop();
 
     // 6. Calculate local energy/overlap
-    AFQMCTimers[pseudo_energy_timer]->start();
+    AFQMCTimers[pseudo_energy_timer].get().start();
     if (hybrid)
     {
       wfn.Overlap(wset, new_overlaps);
@@ -340,10 +340,10 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       wfn.Energy(wset, new_energies, new_overlaps);
     }
     TG.local_barrier();
-    AFQMCTimers[pseudo_energy_timer]->stop();
+    AFQMCTimers[pseudo_energy_timer].get().stop();
 
     // 7. update weights/energy/etc, apply constrains/bounds/etc
-    AFQMCTimers[extra_timer]->start();
+    AFQMCTimers[extra_timer].get().start();
     if (TG.TG_local().root())
     {
       if (free_projection)
@@ -362,7 +362,7 @@ void AFQMCDistributedPropagatorDistCV::step(int nsteps_, WlkSet& wset, RealType 
       }
     }
     TG.local_barrier();
-    AFQMCTimers[extra_timer]->stop();
+    AFQMCTimers[extra_timer].get().stop();
   }
 }
 

--- a/src/AFQMC/Walkers/WalkerSetBase.icc
+++ b/src/AFQMC/Walkers/WalkerSetBase.icc
@@ -282,7 +282,7 @@ void WalkerSetBase<Alloc, Ptr>::resize(int n)
 template<class Alloc, typename Ptr>
 void WalkerSetBase<Alloc, Ptr>::popControl(std::vector<ComplexType>& curData)
 {
-  Timers[Branching_t]->start();
+  Timers[Branching_t].get().start();
   ComplexType minus = ComplexType(-1.0, 0.0);
 
   curData.resize(7);
@@ -330,12 +330,12 @@ void WalkerSetBase<Alloc, Ptr>::popControl(std::vector<ComplexType>& curData)
     APP_ABORT(" Error: Distributed comb not implemented yet. \n\n\n");
     //afqmc::DistCombBranching(*this,rng_heads,nwalk_counts_old);
   }
-  Timers[Branching_t]->stop();
+  Timers[Branching_t].get().stop();
 
-  Timers[LoadBalance_t]->start();
+  Timers[LoadBalance_t].get().start();
   // load balance after population control events
   loadBalance(Wexcess);
-  Timers[LoadBalance_t]->stop();
+  Timers[LoadBalance_t].get().stop();
 
   if (tot_num_walkers != targetN_per_TG)
     APP_ABORT(" Error: tot_num_walkers != targetN_per_TG");
@@ -373,10 +373,10 @@ void WalkerSetBase<Alloc, Ptr>::benchmark(std::string& blist, int maxnW, int del
         {
           if (TG.TG_heads().rank() == 0)
           {
-            //            Timer.start("M1");
+            //            Timer.get().start("M1");
             MPI_Isend(Cbuff.data(), 2 * Cbuff.size(), MPI_DOUBLE, 1, 999, &(TG.TG_heads()), &req);
             MPI_Wait(&req, &st);
-            //            Timer.stop("M1");
+            //            Timer.get().stop("M1");
           }
           else
           {

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -90,7 +90,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
   inline void evaluate(ParticleSet& P)
   {
-    ScopedTimer local_timer(&evaluate_timer_);
+    ScopedTimer local_timer(evaluate_timer_);
     constexpr T BigR = std::numeric_limits<T>::max();
     for (int iat = 0; iat < N_targets; ++iat)
     {
@@ -103,7 +103,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old)
   {
-    ScopedTimer local_timer(&move_timer_);
+    ScopedTimer local_timer(move_timer_);
     DTD_BConds<T, D, SC>::computeDistances(rnew, P.getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_, 0,
                                            N_targets, P.activePtcl);
     // set up old_r_ and old_dr_ for moves may get accepted.
@@ -163,7 +163,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
    */
   inline void update(IndexType iat, bool partial_update)
   {
-    ScopedTimer local_timer(&update_timer_);
+    ScopedTimer local_timer(update_timer_);
     //update by a cache line
     const int nupdate = getAlignedSize<T>(iat);
     //copy row

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -116,7 +116,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
   inline void evaluate(ParticleSet& P) override
   {
-    ScopedTimer local_timer(&evaluate_timer_);
+    ScopedTimer local_timer(evaluate_timer_);
 
     constexpr T BigR = std::numeric_limits<T>::max();
     for (int iat = 0; iat < N_targets; ++iat)
@@ -130,7 +130,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
-    ScopedTimer local_timer(&move_timer_);
+    ScopedTimer local_timer(move_timer_);
 
     temp_r_.attachReference(temp_r_mem_.data(), temp_r_mem_.size());
     temp_dr_.attachReference(temp_dr_mem_.size(), temp_dr_mem_.capacity(), temp_dr_mem_.data());
@@ -168,7 +168,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     assert(this == &dt_list.getLeader());
     auto& dt_leader   = dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>();
     auto& pset_leader = p_list.getLeader();
-    ScopedTimer local_timer(&move_timer_);
+    ScopedTimer local_timer(move_timer_);
     const size_t nw          = dt_list.size();
     const size_t stride_size = Ntargets_padded * (D + 1);
     dt_leader.nw_new_old_dist_displ_.resize(nw * 2 * stride_size);
@@ -201,7 +201,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     const size_t new_pos_stride = coordinates_leader.getFusedNewPosBuffer().capacity();
 
     {
-      ScopedTimer offload(&offload_timer_);
+      ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(nw * num_teams) \
                         map(always, to: rsoa_dev_list_ptr[:rsoa_dev_list_.size()]) \
                         map(always, from: r_dr_ptr[:nw_new_old_dist_displ_.size()])")
@@ -246,7 +246,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
     if (prepare_old)
     {
-      ScopedTimer local(&copy_old_timer_);
+      ScopedTimer local(copy_old_timer_);
       for (int iw = 0; iw < dt_list.size(); iw++)
       {
         auto& dt = dt_list.getCastedElement<SoaDistanceTableAAOMPTarget>(iw);
@@ -301,7 +301,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
    */
   inline void update(IndexType iat, bool partial_update) override
   {
-    ScopedTimer local_timer(&update_timer_);
+    ScopedTimer local_timer(update_timer_);
 
     //update by a cache line
     const int nupdate = getAlignedSize<T>(iat);

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -69,7 +69,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   /** evaluate the full table */
   inline void evaluate(ParticleSet& P)
   {
-    ScopedTimer local_timer(&evaluate_timer_);
+    ScopedTimer local_timer(evaluate_timer_);
 #pragma omp parallel
     {
       int first, last;
@@ -85,7 +85,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old)
   {
-    ScopedTimer local_timer(&move_timer_);
+    ScopedTimer local_timer(move_timer_);
     DTD_BConds<T, D, SC>::computeDistances(rnew, Origin->getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_,
                                            0, N_sources);
     // If the full table is not ready all the time, overwrite the current value.
@@ -98,7 +98,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   ///update the stripe for jat-th particle
   inline void update(IndexType iat, bool partial_update)
   {
-    ScopedTimer local_timer(&update_timer_);
+    ScopedTimer local_timer(update_timer_);
     std::copy_n(temp_r_.data(), N_sources, distances_[iat].data());
     for (int idim = 0; idim < D; ++idim)
       std::copy_n(temp_dr_.data(idim), N_sources, displacements_[iat].data(idim));

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -104,7 +104,7 @@ public:
   /** evaluate the full table */
   inline void evaluate(ParticleSet& P)
   {
-    ScopedTimer local_timer(&evaluate_timer_);
+    ScopedTimer local_timer(evaluate_timer_);
     // be aware of the sign of Displacement
     const int N_targets_local  = N_targets;
     const int N_sources_local  = N_sources;
@@ -124,7 +124,7 @@ public:
     const int num_teams        = (N_sources + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
     {
-      ScopedTimer offload(&offload_timer_);
+      ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(N_targets*num_teams) \
                         map(to: source_pos_ptr[:N_sources_padded*D]) \
                         map(always, to: target_pos_ptr[:N_targets*D]) \
@@ -158,7 +158,7 @@ public:
                           const RefVectorWithLeader<ParticleSet>& p_list) const
   {
     assert(this == &dt_list.getLeader());
-    ScopedTimer local_timer(&evaluate_timer_);
+    ScopedTimer local_timer(evaluate_timer_);
     mw_evaluate_fuse_transfer(dt_list, p_list);
   }
 
@@ -223,7 +223,7 @@ public:
     const int N_sources_local = N_sources;
 
     {
-      ScopedTimer offload(&dt_leader.offload_timer_);
+      ScopedTimer offload(dt_leader.offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(total_targets*num_teams) \
                         map(always, to: input_ptr[:offload_input.size()]) \
                         nowait depend(out: total_targets)")
@@ -253,7 +253,7 @@ public:
     }
 
     {
-      ScopedTimer copy(&dt_leader.copy_timer_);
+      ScopedTimer copy(dt_leader.copy_timer_);
       for (size_t iw = 0; iw < nw; iw++)
       {
         auto& dt       = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
@@ -327,7 +327,7 @@ public:
     const int N_sources_local = N_sources;
 
     {
-      ScopedTimer offload(&dt_leader.offload_timer_);
+      ScopedTimer offload(dt_leader.offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(total_targets*num_teams) \
                         map(always, to: input_ptr[:offload_input.size()]) \
                         map(always, from: r_dr_ptr[:offload_output.size()])")
@@ -356,7 +356,7 @@ public:
     }
 
     {
-      ScopedTimer copy(&dt_leader.copy_timer_);
+      ScopedTimer copy(dt_leader.copy_timer_);
       for (size_t iat = 0; iat < total_targets; iat++)
       {
         const int wid = walker_id_ptr[iat];
@@ -373,7 +373,7 @@ public:
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old)
   {
-    ScopedTimer local_timer(&move_timer_);
+    ScopedTimer local_timer(move_timer_);
     DTD_BConds<T, D, SC>::computeDistances(rnew, Origin->getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_,
                                            0, N_sources);
     // If the full table is not ready all the time, overwrite the current value.
@@ -386,7 +386,7 @@ public:
   ///update the stripe for jat-th particle
   inline void update(IndexType iat, bool partial_update)
   {
-    ScopedTimer local_timer(&update_timer_);
+    ScopedTimer local_timer(update_timer_);
     std::copy_n(temp_r_.data(), N_sources, distances_[iat].data());
     for (int idim = 0; idim < D; ++idim)
       std::copy_n(temp_dr_.data(idim), N_sources, displacements_[iat].data(idim));

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -169,7 +169,7 @@ bool QMCMain::execute()
   if (simulationType == "afqmc")
   {
     NewTimer* t2 = timer_manager.createTimer("Total", timer_level_coarse);
-    ScopedTimer t2_scope(t2);
+    ScopedTimer t2_scope(*t2);
     app_log() << std::endl
               << "/*************************************************\n"
               << " ********  This is an AFQMC calculation   ********\n"

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -105,7 +105,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     std::vector<RealType> rr_accepted(num_walkers, 0.0);
 
     {
-      ScopedTimer pbyp_local_timer(&(timers.movepbyp_timer));
+      ScopedTimer pbyp_local_timer(timers.movepbyp_timer);
       for (int ig = 0; ig < step_context.get_num_groups(); ++ig)
       {
         RealType tauovermass = sft.qmcdrv_input.get_tau() * sft.population.get_ptclgrp_inv_mass()[ig];
@@ -230,13 +230,13 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     }
 
     { // collect GL for KE.
-      ScopedTimer buffer_local(&timers.buffer_timer);
+      ScopedTimer buffer_local(timers.buffer_timer);
       TrialWaveFunction::flex_evaluateGL(walker_twfs, walker_elecs, recompute);
       ParticleSet::flex_saveWalker(walker_elecs, walkers);
     }
 
     { // hamiltonian
-      ScopedTimer ham_local(&timers.hamiltonian_timer);
+      ScopedTimer ham_local(timers.hamiltonian_timer);
 
       std::vector<QMCHamiltonian::FullPrecRealType> new_energies(
           QMCHamiltonian::flex_evaluateWithToperator(walker_hamiltonians, walker_elecs));
@@ -260,7 +260,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     }
 
     { // estimator collectables
-      ScopedTimer collectable_local(&timers.collectables_timer);
+      ScopedTimer collectable_local(timers.collectables_timer);
 
       // evaluate non-physical hamiltonian elements
       for (int iw = 0; iw < walkers.size(); ++iw)
@@ -273,7 +273,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
   }
 
   { // T-moves
-    ScopedTimer tmove_timer(&dmc_timers.tmove_timer);
+    ScopedTimer tmove_timer(dmc_timers.tmove_timer);
 
     auto& walkers = crowd.get_walkers();
     const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
@@ -396,7 +396,7 @@ bool DMCBatched::run()
   RunTimeControl<> runtimeControl(run_time_manager, MaxCPUSecs);
 
   { // walker initialization
-    ScopedTimer local_timer(&(timers_.init_walkers_timer));
+    ScopedTimer local_timer(timers_.init_walkers_timer);
     ParallelExecutor<> section_start_task;
     section_start_task(crowds_.size(), initialLogEvaluation, std::ref(crowds_), std::ref(step_contexts_));
   }
@@ -428,7 +428,7 @@ bool DMCBatched::run()
 
     for (int step = 0; step < qmcdriver_input_.get_max_steps(); ++step)
     {
-      ScopedTimer local_timer(&(timers_.run_steps_timer));
+      ScopedTimer local_timer(timers_.run_steps_timer);
       dmc_state.step = step;
       crowd_task(crowds_.size(), runDMCStep, dmc_state, timers_, dmc_timers_, std::ref(step_contexts_),
                  std::ref(crowds_));

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -53,11 +53,12 @@ DMCUpdatePbyPWithRejectionFast::~DMCUpdatePbyPWithRejectionFast() {}
 
 void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool recompute)
 {
-  myTimers[DMC_buffer]->start();
   Walker_t::WFBuffer_t& w_buffer(thisWalker.DataSet);
-  W.loadWalker(thisWalker, true);
-  Psi.copyFromBuffer(W, w_buffer);
-  myTimers[DMC_buffer]->stop();
+  {
+    ScopedTimer local_timer(myTimers[DMC_buffer]);
+    W.loadWalker(thisWalker, true);
+    Psi.copyFromBuffer(W, w_buffer);
+  }
   //create a 3N-Dimensional Gaussian with variance=1
   makeGaussRandomWithEngine(deltaR, RandomGen);
   int nAcceptTemp(0);
@@ -68,83 +69,88 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
   RealType gf_acc      = 1.0;
-  myTimers[DMC_movePbyP]->start();
-  for (int ig = 0; ig < W.groups(); ++ig) //loop over species
   {
-    RealType tauovermass = Tau * MassInvS[ig];
-    RealType oneover2tau = 0.5 / (tauovermass);
-    RealType sqrttau     = std::sqrt(tauovermass);
-    Psi.prepareGroup(W, ig);
-    for (int iat = W.first(ig); iat < W.last(ig); ++iat)
+    ScopedTimer local_timer(myTimers[DMC_movePbyP]);
+    for (int ig = 0; ig < W.groups(); ++ig) //loop over species
     {
-      //get the displacement
-      GradType grad_iat = Psi.evalGrad(W, iat);
-      PosType dr;
-      DriftModifier->getDrift(tauovermass, grad_iat, dr);
-      dr += sqrttau * deltaR[iat];
-      bool is_valid = W.makeMoveAndCheck(iat, dr);
-      RealType rr   = tauovermass * dot(deltaR[iat], deltaR[iat]);
-      rr_proposed += rr;
-      if (!is_valid || rr > m_r2max)
+      RealType tauovermass = Tau * MassInvS[ig];
+      RealType oneover2tau = 0.5 / (tauovermass);
+      RealType sqrttau     = std::sqrt(tauovermass);
+      Psi.prepareGroup(W, ig);
+      for (int iat = W.first(ig); iat < W.last(ig); ++iat)
       {
-        ++nRejectTemp;
-        continue;
-      }
-      ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
-      //node is crossed reject the move
-      if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
-      {
-        ++nRejectTemp;
-        ++nNodeCrossing;
-        W.rejectMove(iat);
-        Psi.rejectMove(iat);
-      }
-      else
-      {
-        FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
-        //Use the force of the particle iat
+        //get the displacement
+        GradType grad_iat = Psi.evalGrad(W, iat);
+        PosType dr;
         DriftModifier->getDrift(tauovermass, grad_iat, dr);
-        dr                     = W.R[iat] - W.activePos - dr;
-        FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
-        RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
-        if (RandomGen() < prob)
-        {
-          ++nAcceptTemp;
-          Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
-          rr_accepted += rr;
-          gf_acc *= prob; //accumulate the ratio
-        }
-        else
+        dr += sqrttau * deltaR[iat];
+        bool is_valid = W.makeMoveAndCheck(iat, dr);
+        RealType rr   = tauovermass * dot(deltaR[iat], deltaR[iat]);
+        rr_proposed += rr;
+        if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
+          continue;
+        }
+        ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
+        //node is crossed reject the move
+        if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
+        {
+          ++nRejectTemp;
+          ++nNodeCrossing;
           W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        else
+        {
+          FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
+          //Use the force of the particle iat
+          DriftModifier->getDrift(tauovermass, grad_iat, dr);
+          dr                     = W.R[iat] - W.activePos - dr;
+          FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
+          RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
+          if (RandomGen() < prob)
+          {
+            ++nAcceptTemp;
+            Psi.acceptMove(W, iat, true);
+            W.acceptMove(iat, true);
+            rr_accepted += rr;
+            gf_acc *= prob; //accumulate the ratio
+          }
+          else
+          {
+            ++nRejectTemp;
+            W.rejectMove(iat);
+            Psi.rejectMove(iat);
+          }
+        }
       }
     }
+    Psi.completeUpdates();
+    W.donePbyP();
   }
-  Psi.completeUpdates();
-  W.donePbyP();
-  myTimers[DMC_movePbyP]->stop();
 
   if (nAcceptTemp > 0)
   {
     //need to overwrite the walker properties
-    myTimers[DMC_buffer]->start();
-    thisWalker.Age  = 0;
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, recompute);
-    W.saveWalker(thisWalker);
-    myTimers[DMC_buffer]->stop();
-    myTimers[DMC_hamiltonian]->start();
-    enew = H.evaluateWithToperator(W);
-    myTimers[DMC_hamiltonian]->stop();
+    RealType logpsi(0);
+    {
+      ScopedTimer local_timer(myTimers[DMC_buffer]);
+      thisWalker.Age = 0;
+      logpsi         = Psi.updateBuffer(W, w_buffer, recompute);
+      W.saveWalker(thisWalker);
+    }
+    {
+      ScopedTimer local_timer(myTimers[DMC_hamiltonian]);
+      enew = H.evaluateWithToperator(W);
+    }
     thisWalker.resetProperty(logpsi, Psi.getPhase(), enew, rr_accepted, rr_proposed, 1.0);
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
-    myTimers[DMC_collectables]->start();
-    H.auxHevaluate(W, thisWalker);
-    H.saveProperty(thisWalker.getPropertyBase());
-    myTimers[DMC_collectables]->stop();
+    {
+      ScopedTimer local_timer(myTimers[DMC_collectables]);
+      H.auxHevaluate(W, thisWalker);
+      H.saveProperty(thisWalker.getPropertyBase());
+    }
   }
   else
   {
@@ -165,19 +171,20 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
 #if !defined(REMOVE_TRACEMANAGER)
   Traces->buffer_sample(W.current_step);
 #endif
-  myTimers[DMC_tmoves]->start();
-  const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
-  if (NonLocalMoveAcceptedTemp > 0)
   {
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
-    // debugging lines
-    //W.update(true);
-    //RealType logpsi2 = Psi.evaluateLog(W);
-    //if(logpsi!=logpsi2) std::cout << " logpsi " << logpsi << " logps2i " << logpsi2 << " diff " << logpsi2-logpsi << std::endl;
-    W.saveWalker(thisWalker);
-    NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    ScopedTimer local_timer(myTimers[DMC_tmoves]);
+    const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
+    if (NonLocalMoveAcceptedTemp > 0)
+    {
+      RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
+      // debugging lines
+      //W.update(true);
+      //RealType logpsi2 = Psi.evaluateLog(W);
+      //if(logpsi!=logpsi2) std::cout << " logpsi " << logpsi << " logps2i " << logpsi2 << " diff " << logpsi2-logpsi << std::endl;
+      W.saveWalker(thisWalker);
+      NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    }
   }
-  myTimers[DMC_tmoves]->stop();
   nAccept += nAcceptTemp;
   nReject += nRejectTemp;
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
@@ -47,11 +47,12 @@ DMCUpdatePbyPL2::~DMCUpdatePbyPL2() {}
 
 void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
 {
-  myTimers[DMC_buffer]->start();
   Walker_t::WFBuffer_t& w_buffer(thisWalker.DataSet);
-  W.loadWalker(thisWalker, true);
-  Psi.copyFromBuffer(W, w_buffer);
-  myTimers[DMC_buffer]->stop();
+  {
+    ScopedTimer local_timer(myTimers[DMC_buffer]);
+    W.loadWalker(thisWalker, true);
+    Psi.copyFromBuffer(W, w_buffer);
+  }
   //create a 3N-Dimensional Gaussian with variance=1
   makeGaussRandomWithEngine(deltaR, RandomGen);
   int nAcceptTemp(0);
@@ -67,140 +68,145 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
   mPosType K;
   mTensorType D;
   mTensorType Dchol;
-  PosType Ktmp,drtmp;
+  PosType Ktmp, drtmp;
   TensorType Dtmp;
   bool L2_proj = H.has_L2();
-  if(L2_proj)
+  if (L2_proj)
   {
     Ktmp = 0.0;
     Dtmp = 0.0;
-    for(int d=0;d<DIM;d++)
-      Dtmp(d,d) = 1.0;
+    for (int d = 0; d < DIM; d++)
+      Dtmp(d, d) = 1.0;
   }
-  myTimers[DMC_movePbyP]->start();
-  for (int ig = 0; ig < W.groups(); ++ig) //loop over species
   {
-    RealType tauovermass = Tau * MassInvS[ig];
-    RealType oneover2tau = 0.5 / (tauovermass);
-    RealType sqrttau     = std::sqrt(tauovermass);
-    RealType rr;
-    for (int iat = W.first(ig); iat < W.last(ig); ++iat)
+    ScopedTimer local_timer(myTimers[DMC_movePbyP]);
+    for (int ig = 0; ig < W.groups(); ++ig) //loop over species
     {
-      //W.setActive(iat);
-      //get the displacement
-      GradType grad_iat = Psi.evalGrad(W, iat);
-      mPosType dr;
-      mPosType dr_diff = deltaR[iat];
-      if(!L2_proj) // normal projector
+      RealType tauovermass = Tau * MassInvS[ig];
+      RealType oneover2tau = 0.5 / (tauovermass);
+      RealType sqrttau     = std::sqrt(tauovermass);
+      RealType rr;
+      for (int iat = W.first(ig); iat < W.last(ig); ++iat)
       {
-        getScaledDrift(tauovermass, grad_iat, dr);
-        dr += sqrttau * dr_diff;
-        rr = tauovermass * dot(dr_diff, dr_diff);
-        rr_proposed += rr;
-        if (rr > m_r2max)
+        //W.setActive(iat);
+        //get the displacement
+        GradType grad_iat = Psi.evalGrad(W, iat);
+        mPosType dr;
+        mPosType dr_diff = deltaR[iat];
+        if (!L2_proj) // normal projector
+        {
+          getScaledDrift(tauovermass, grad_iat, dr);
+          dr += sqrttau * dr_diff;
+          rr = tauovermass * dot(dr_diff, dr_diff);
+          rr_proposed += rr;
+          if (rr > m_r2max)
+          {
+            ++nRejectTemp;
+            continue;
+          }
+          if (!W.makeMoveAndCheck(iat, dr))
+            continue;
+        }
+        else // projector including L2 potential
+        {
+          // do a fake move (zero distance)
+          // this ensures the temporary distance data is correct
+          // will need to remove this later, but requires reimplementation of computeL2DK
+          dr = 0.0;
+          if (!W.makeMoveAndCheck(iat, dr))
+            continue;
+
+          H.computeL2DK(W, iat, Dtmp, Ktmp);
+          D = Dtmp; // upcast for mixed precision
+          K = Ktmp;
+          getScaledDriftL2(tauovermass, grad_iat, D, K, dr);
+
+          W.rejectMove(iat);
+          rr = tauovermass * dot(dr_diff, dr_diff);
+          rr_proposed += rr;
+          if (rr > m_r2max)
+          {
+            ++nRejectTemp;
+            continue;
+          }
+
+          // move with just drift to update distance tables
+          if (!W.makeMoveAndCheck(iat, dr))
+            continue;
+
+          // compute diffusion step
+          H.computeL2D(W, iat, Dtmp);
+          D       = Dtmp; // upcast for mixed precision
+          Dchol   = cholesky(D);
+          dr_diff = dot(Dchol, dr_diff);
+          dr += sqrttau * dr_diff;
+
+          // reverse the intermediate drift move
+          W.rejectMove(iat);
+          // move with drift and diffusion together
+          if (!W.makeMoveAndCheck(iat, dr))
+            continue;
+        }
+        ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
+        //node is crossed reject the move
+        if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
         {
           ++nRejectTemp;
-          continue;
-        }
-        if (!W.makeMoveAndCheck(iat, dr))
-          continue;
-      }
-      else // projector including L2 potential
-      {
-        // do a fake move (zero distance)
-        // this ensures the temporary distance data is correct 
-        // will need to remove this later, but requires reimplementation of computeL2DK
-        dr = 0.0;
-        if (!W.makeMoveAndCheck(iat, dr))
-          continue;
-
-        H.computeL2DK(W,iat,Dtmp,Ktmp);
-        D = Dtmp; // upcast for mixed precision
-        K = Ktmp;
-        getScaledDriftL2(tauovermass,grad_iat,D,K,dr);
-
-        W.rejectMove(iat);
-        rr = tauovermass * dot(dr_diff, dr_diff);
-        rr_proposed += rr;
-        if (rr > m_r2max)
-        {
-          ++nRejectTemp;
-          continue;
-        }
-
-        // move with just drift to update distance tables
-        if (!W.makeMoveAndCheck(iat, dr))
-          continue;
-
-        // compute diffusion step 
-        H.computeL2D(W,iat,Dtmp);
-        D = Dtmp; // upcast for mixed precision
-        Dchol = cholesky(D);
-        dr_diff = dot(Dchol,dr_diff);
-        dr += sqrttau * dr_diff;
-
-        // reverse the intermediate drift move
-        W.rejectMove(iat);
-        // move with drift and diffusion together
-        if (!W.makeMoveAndCheck(iat, dr))
-          continue;
-      }
-      ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
-      //node is crossed reject the move
-      if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
-      {
-        ++nRejectTemp;
-        ++nNodeCrossing;
-        W.rejectMove(iat);
-        Psi.rejectMove(iat);
-      }
-      else
-      {
-        FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
-        //Use the force of the particle iat
-        DriftModifier->getDrift(tauovermass, grad_iat, drtmp);
-        dr = drtmp; // upcast for mixed precision
-        dr                     = W.R[iat] - W.activePos - dr;
-        FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
-        RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
-        if (RandomGen() < prob)
-        {
-          ++nAcceptTemp;
-          Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
-          rr_accepted += rr;
-          gf_acc *= prob; //accumulate the ratio
-        }
-        else
-        {
-          ++nRejectTemp;
+          ++nNodeCrossing;
           W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        else
+        {
+          FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
+          //Use the force of the particle iat
+          DriftModifier->getDrift(tauovermass, grad_iat, drtmp);
+          dr                     = drtmp; // upcast for mixed precision
+          dr                     = W.R[iat] - W.activePos - dr;
+          FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
+          RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
+          if (RandomGen() < prob)
+          {
+            ++nAcceptTemp;
+            Psi.acceptMove(W, iat, true);
+            W.acceptMove(iat, true);
+            rr_accepted += rr;
+            gf_acc *= prob; //accumulate the ratio
+          }
+          else
+          {
+            ++nRejectTemp;
+            W.rejectMove(iat);
+            Psi.rejectMove(iat);
+          }
+        }
       }
     }
+    Psi.completeUpdates();
+    W.donePbyP();
   }
-  Psi.completeUpdates();
-  W.donePbyP();
-  myTimers[DMC_movePbyP]->stop();
 
   if (nAcceptTemp > 0)
   {
     //need to overwrite the walker properties
-    myTimers[DMC_buffer]->start();
-    thisWalker.Age  = 0;
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, recompute);
-    W.saveWalker(thisWalker);
-    myTimers[DMC_buffer]->stop();
-    myTimers[DMC_hamiltonian]->start();
-    enew = H.evaluateWithToperator(W);
-    myTimers[DMC_hamiltonian]->stop();
+    RealType logpsi(0);
+    {
+      ScopedTimer local_timer(myTimers[DMC_buffer]);
+      thisWalker.Age = 0;
+      logpsi         = Psi.updateBuffer(W, w_buffer, recompute);
+      W.saveWalker(thisWalker);
+    }
+    {
+      ScopedTimer local_timer(myTimers[DMC_hamiltonian]);
+      enew = H.evaluateWithToperator(W);
+    }
     thisWalker.resetProperty(logpsi, Psi.getPhase(), enew, rr_accepted, rr_proposed, 1.0);
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
-    myTimers[DMC_collectables]->start();
-    H.auxHevaluate(W, thisWalker);
-    H.saveProperty(thisWalker.getPropertyBase());
-    myTimers[DMC_collectables]->stop();
+    {
+      ScopedTimer local_timer(myTimers[DMC_collectables]);
+      H.auxHevaluate(W, thisWalker);
+      H.saveProperty(thisWalker.getPropertyBase());
+    }
   }
   else
   {
@@ -221,15 +227,16 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
 #if !defined(REMOVE_TRACEMANAGER)
   Traces->buffer_sample(W.current_step);
 #endif
-  myTimers[DMC_tmoves]->start();
-  const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
-  if (NonLocalMoveAcceptedTemp > 0)
   {
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
-    W.saveWalker(thisWalker);
-    NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    ScopedTimer local_timer(myTimers[DMC_tmoves]);
+    const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
+    if (NonLocalMoveAcceptedTemp > 0)
+    {
+      RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
+      W.saveWalker(thisWalker);
+      NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    }
   }
-  myTimers[DMC_tmoves]->stop();
   nAccept += nAcceptTemp;
   nReject += nRejectTemp;
 

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -50,11 +50,12 @@ SODMCUpdatePbyPWithRejectionFast::~SODMCUpdatePbyPWithRejectionFast() {}
 
 void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool recompute)
 {
-  myTimers[SODMC_buffer]->start();
   Walker_t::WFBuffer_t& w_buffer(thisWalker.DataSet);
-  W.loadWalker(thisWalker, true);
-  Psi.copyFromBuffer(W, w_buffer);
-  myTimers[SODMC_buffer]->stop();
+  {
+    ScopedTimer local_timer(myTimers[SODMC_buffer]);
+    W.loadWalker(thisWalker, true);
+    Psi.copyFromBuffer(W, w_buffer);
+  }
   //create a 3N-Dimensional Gaussian with variance=1
   makeGaussRandomWithEngine(deltaR, RandomGen);
   makeGaussRandomWithEngine(deltaS, RandomGen);
@@ -66,90 +67,95 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
   RealType gf_acc      = 1.0;
-  myTimers[SODMC_movePbyP]->start();
-  for (int ig = 0; ig < W.groups(); ++ig) //loop over species
   {
-    RealType tauovermass = Tau * MassInvS[ig];
-    RealType oneover2tau = 0.5 / (tauovermass);
-    RealType sqrttau     = std::sqrt(tauovermass);
-    for (int iat = W.first(ig); iat < W.last(ig); ++iat)
+    ScopedTimer local_timer(myTimers[SODMC_movePbyP]);
+    for (int ig = 0; ig < W.groups(); ++ig) //loop over species
     {
-      //get the displacement
-      ComplexType spingrad_iat;
-      GradType grad_iat = Psi.evalGradWithSpin(W, iat, spingrad_iat);
-      PosType dr;
-      ParticleSet::Scalar_t ds;
-      DriftModifier->getDrift(tauovermass, grad_iat, dr);
-      DriftModifier->getDrift(tauovermass / spinMass, spingrad_iat, ds);
-      dr += sqrttau * deltaR[iat];
-      ds += std::sqrt(tauovermass / spinMass) * deltaS[iat];
-      bool is_valid = W.makeMoveAndCheckWithSpin(iat, dr, ds);
-      RealType rr   = tauovermass * dot(deltaR[iat], deltaR[iat]);
-      rr_proposed += rr;
-      if (!is_valid || rr > m_r2max)
+      RealType tauovermass = Tau * MassInvS[ig];
+      RealType oneover2tau = 0.5 / (tauovermass);
+      RealType sqrttau     = std::sqrt(tauovermass);
+      for (int iat = W.first(ig); iat < W.last(ig); ++iat)
       {
-        ++nRejectTemp;
-        continue;
-      }
-      ValueType ratio = Psi.calcRatioGradWithSpin(W, iat, grad_iat, spingrad_iat);
-      //node is crossed reject the move
-      if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
-      {
-        ++nRejectTemp;
-        ++nNodeCrossing;
-        W.rejectMove(iat);
-        Psi.rejectMove(iat);
-      }
-      else
-      {
-        FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
-        logGf += -0.5 * deltaS[iat] * deltaS[iat];
-        //Use the force of the particle iat
+        //get the displacement
+        ComplexType spingrad_iat;
+        GradType grad_iat = Psi.evalGradWithSpin(W, iat, spingrad_iat);
+        PosType dr;
+        ParticleSet::Scalar_t ds;
         DriftModifier->getDrift(tauovermass, grad_iat, dr);
         DriftModifier->getDrift(tauovermass / spinMass, spingrad_iat, ds);
-        dr                     = W.R[iat] - W.activePos - dr;
-        ds                     = W.spins[iat] - W.activeSpinVal - ds;
-        FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
-        logGb += -spinMass * oneover2tau * ds * ds;
-        RealType prob = std::norm(ratio) * std::exp(logGb - logGf);
-        if (RandomGen() < prob)
-        {
-          ++nAcceptTemp;
-          Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
-          rr_accepted += rr;
-          gf_acc *= prob; //accumulate the ratio
-        }
-        else
+        dr += sqrttau * deltaR[iat];
+        ds += std::sqrt(tauovermass / spinMass) * deltaS[iat];
+        bool is_valid = W.makeMoveAndCheckWithSpin(iat, dr, ds);
+        RealType rr   = tauovermass * dot(deltaR[iat], deltaR[iat]);
+        rr_proposed += rr;
+        if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
+          continue;
+        }
+        ValueType ratio = Psi.calcRatioGradWithSpin(W, iat, grad_iat, spingrad_iat);
+        //node is crossed reject the move
+        if (branchEngine->phaseChanged(Psi.getPhaseDiff()))
+        {
+          ++nRejectTemp;
+          ++nNodeCrossing;
           W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        else
+        {
+          FullPrecRealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
+          logGf += -0.5 * deltaS[iat] * deltaS[iat];
+          //Use the force of the particle iat
+          DriftModifier->getDrift(tauovermass, grad_iat, dr);
+          DriftModifier->getDrift(tauovermass / spinMass, spingrad_iat, ds);
+          dr                     = W.R[iat] - W.activePos - dr;
+          ds                     = W.spins[iat] - W.activeSpinVal - ds;
+          FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
+          logGb += -spinMass * oneover2tau * ds * ds;
+          RealType prob = std::norm(ratio) * std::exp(logGb - logGf);
+          if (RandomGen() < prob)
+          {
+            ++nAcceptTemp;
+            Psi.acceptMove(W, iat, true);
+            W.acceptMove(iat, true);
+            rr_accepted += rr;
+            gf_acc *= prob; //accumulate the ratio
+          }
+          else
+          {
+            ++nRejectTemp;
+            W.rejectMove(iat);
+            Psi.rejectMove(iat);
+          }
+        }
       }
     }
+    Psi.completeUpdates();
+    W.donePbyP();
   }
-  Psi.completeUpdates();
-  W.donePbyP();
-  myTimers[SODMC_movePbyP]->stop();
 
   if (nAcceptTemp > 0)
   {
     //need to overwrite the walker properties
-    myTimers[SODMC_buffer]->start();
-    thisWalker.Age  = 0;
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, recompute);
-    W.saveWalker(thisWalker);
-    myTimers[SODMC_buffer]->stop();
-    myTimers[SODMC_hamiltonian]->start();
-    enew = H.evaluateWithToperator(W);
-    myTimers[SODMC_hamiltonian]->stop();
+    RealType logpsi(0);
+    {
+      ScopedTimer local_timer(myTimers[SODMC_buffer]);
+      thisWalker.Age = 0;
+      logpsi         = Psi.updateBuffer(W, w_buffer, recompute);
+      W.saveWalker(thisWalker);
+    }
+    {
+      ScopedTimer local_timer(myTimers[SODMC_hamiltonian]);
+      enew = H.evaluateWithToperator(W);
+    }
     thisWalker.resetProperty(logpsi, Psi.getPhase(), enew, rr_accepted, rr_proposed, 1.0);
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
-    myTimers[SODMC_collectables]->start();
-    H.auxHevaluate(W, thisWalker);
-    H.saveProperty(thisWalker.getPropertyBase());
-    myTimers[SODMC_collectables]->stop();
+    {
+      ScopedTimer local_timer(myTimers[SODMC_collectables]);
+      H.auxHevaluate(W, thisWalker);
+      H.saveProperty(thisWalker.getPropertyBase());
+    }
   }
   else
   {
@@ -170,15 +176,16 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
 #if !defined(REMOVE_TRACEMANAGER)
   Traces->buffer_sample(W.current_step);
 #endif
-  myTimers[SODMC_tmoves]->start();
-  const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
-  if (NonLocalMoveAcceptedTemp > 0)
   {
-    RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
-    W.saveWalker(thisWalker);
-    NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    ScopedTimer local_timer(myTimers[SODMC_tmoves]);
+    const int NonLocalMoveAcceptedTemp = H.makeNonLocalMoves(W);
+    if (NonLocalMoveAcceptedTemp > 0)
+    {
+      RealType logpsi = Psi.updateBuffer(W, w_buffer, false);
+      W.saveWalker(thisWalker);
+      NonLocalMoveAccepted += NonLocalMoveAcceptedTemp;
+    }
   }
-  myTimers[SODMC_tmoves]->stop();
   nAccept += nAcceptTemp;
   nReject += nRejectTemp;
 

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -57,7 +57,7 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
       Psi(psi),
       H(h),
       wOut(0),
-      driver_scope_timer_(timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
+      driver_scope_timer_(*timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(enable_profiling)
 {
   ResetRandom  = false;

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -58,7 +58,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       estimator_manager_(nullptr),
       wOut(0),
       timers_(timer_prefix),
-      driver_scope_timer_(timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
+      driver_scope_timer_(*timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(qmcdriver_input_.get_scoped_profiling()),
       project_data_(project_data),
       setNonLocalMoveHandler_(snlm_handler)
@@ -249,7 +249,7 @@ void QMCDriverNew::makeLocalWalkers(IndexType nwalkers,
                                     RealType reserve,
                                     const ParticleAttrib<TinyVector<QMCTraits::RealType, 3>>& positions)
 {
-  ScopedTimer local_timer(&(timers_.create_walkers_timer));
+  ScopedTimer local_timer(timers_.create_walkers_timer);
   // ensure nwalkers local walkers in population_
   if (population_.get_walkers().size() == 0)
   {

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -280,7 +280,7 @@ bool VMCBatched::run()
   RunTimeControl<> runtimeControl(run_time_manager, MaxCPUSecs);
 
   { // walker initialization
-    ScopedTimer local_timer(&(timers_.init_walkers_timer));
+    ScopedTimer local_timer(timers_.init_walkers_timer);
     ParallelExecutor<> section_start_task;
     section_start_task(crowds_.size(), initialLogEvaluation, std::ref(crowds_), std::ref(step_contexts_));
   }
@@ -296,7 +296,7 @@ bool VMCBatched::run()
 
   for (int step = 0; step < qmcdriver_input_.get_warmup_steps(); ++step)
   {
-    ScopedTimer local_timer(&(timers_.run_steps_timer));
+    ScopedTimer local_timer(timers_.run_steps_timer);
     crowd_task(crowds_.size(), runWarmupStep, vmc_state, std::ref(timers_), std::ref(step_contexts_),
                std::ref(crowds_));
   }
@@ -318,7 +318,7 @@ bool VMCBatched::run()
       crowd->startBlock(qmcdriver_input_.get_max_steps());
     for (int step = 0; step < qmcdriver_input_.get_max_steps(); ++step)
     {
-      ScopedTimer local_timer(&(timers_.run_steps_timer));
+      ScopedTimer local_timer(timers_.run_steps_timer);
       vmc_state.step = step;
       crowd_task(crowds_.size(), runVMCStep, vmc_state, timers_, std::ref(step_contexts_), std::ref(crowds_));
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -244,7 +244,7 @@ void compute_batch_parameters(int sample_size, int batch_size, int& num_batches,
 /** evaluate everything before optimization */
 void QMCCostFunctionBatched::checkConfigurations()
 {
-  ScopedTimer tmp_timer(&check_config_timer_);
+  ScopedTimer tmp_timer(check_config_timer_);
 
   RealType et_tot = 0.0;
   RealType e2_tot = 0.0;
@@ -494,7 +494,7 @@ void QMCCostFunctionBatched::resetPsi(bool final_reset)
 
 QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(bool needGrad)
 {
-  ScopedTimer tmp_timer(&corr_sampling_timer_);
+  ScopedTimer tmp_timer(corr_sampling_timer_);
 
   {
     //    synchronize the random number generator with the node
@@ -722,7 +722,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::fillOverlapHamiltonianMatrices(Matrix<Return_rt>& Left,
                                                                                          Matrix<Return_rt>& Right)
 {
-  ScopedTimer tmp_timer(&fill_timer_);
+  ScopedTimer tmp_timer(fill_timer_);
 
   RealType b1, b2;
   if (GEVType == "H2")

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp
@@ -78,7 +78,7 @@ void QMCLinearOptimize::start()
 {
   {
     //generate samples
-    ScopedTimer local(&generate_samples_timer_);
+    ScopedTimer local(generate_samples_timer_);
     generateSamples();
     //store active number of walkers
     NumOfVMCWalkers = W.getActiveWalkers();
@@ -92,7 +92,7 @@ void QMCLinearOptimize::start()
   app_log() << "   Reading configurations from h5FileRoot " << h5FileRoot << std::endl;
   {
     //get configuration from the previous run
-    ScopedTimer local(&initialize_timer_);
+    ScopedTimer local(initialize_timer_);
     Timer t2;
     optTarget->getConfigurations(h5FileRoot);
     optTarget->setRng(vmcEngine->getRng());
@@ -121,7 +121,7 @@ void QMCLinearOptimize::engine_start(cqmc::engine::LMYEngine<ValueType>* EngineO
 
   {
     //generate samples
-    ScopedTimer local(&generate_samples_timer_);
+    ScopedTimer local(generate_samples_timer_);
     generateSamples();
     //store active number of walkers
     NumOfVMCWalkers = W.getActiveWalkers();
@@ -136,7 +136,7 @@ void QMCLinearOptimize::engine_start(cqmc::engine::LMYEngine<ValueType>* EngineO
   app_log() << "     Reading configurations from h5FileRoot " << h5FileRoot << std::endl;
   {
     // get configuration from the previous run
-    ScopedTimer local(&initialize_timer_);
+    ScopedTimer local(initialize_timer_);
     Timer t2;
     optTarget->getConfigurations(h5FileRoot);
     optTarget->setRng(vmcEngine->getRng());

--- a/src/QMCHamiltonians/EwaldRef.h
+++ b/src/QMCHamiltonians/EwaldRef.h
@@ -373,7 +373,7 @@ real_t ewaldSum(const RealVec& r, const RealMat& a, real_t tol = 1e-10)
 real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, real_t tol = 1e-10)
 {
   // Timer for EwaldRef
-  ScopedTimer totalEwaldTimer(timer_manager.createTimer("EwaldRef"));
+  ScopedTimer totalEwaldTimer(*timer_manager.createTimer("EwaldRef"));
 
   // Number of particles
   const size_t N = R.size();
@@ -383,7 +383,7 @@ real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, re
 
   {
     // Sum Madelung contributions
-    ScopedTimer totalMadelungTimer(timer_manager.createTimer("MadelungSum"));
+    ScopedTimer totalMadelungTimer(*timer_manager.createTimer("MadelungSum"));
     // Maximum self-interaction charge product
     real_t qqmax = 0.0;
     for (size_t i = 0; i < N; ++i)
@@ -399,7 +399,7 @@ real_t ewaldEnergy(const RealMat& a, const PosArray& R, const ChargeArray& Q, re
 
   {
     // Sum the interaction terms for all particle pairs
-    ScopedTimer EwaldSumTimer(timer_manager.createTimer("EwaldSum"));
+    ScopedTimer EwaldSumTimer(*timer_manager.createTimer("EwaldSum"));
 
     int_t Npairs = (N * (N - 1)) / 2;
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -37,7 +37,7 @@ QMCHamiltonian::QMCHamiltonian(const std::string& aname)
       myName(aname),
       nlpp_ptr(nullptr),
       l2_ptr(nullptr),
-      ham_timer_(timer_manager.createTimer("Hamiltonian:" + aname, timer_level_medium))
+      ham_timer_(*timer_manager.createTimer("Hamiltonian:" + aname, timer_level_medium))
 #if !defined(REMOVE_TRACEMANAGER)
       ,
       streaming_position(false),
@@ -97,7 +97,7 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
     h->myName = aname;
     H.push_back(h);
     std::string tname = "Hamiltonian:" + aname;
-    my_timers_.push_back(timer_manager.createTimer(tname, timer_level_fine));
+    my_timers_.push_back(*timer_manager.createTimer(tname, timer_level_fine));
   }
   else
   {

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -427,9 +427,9 @@ private:
   ///vector of Hamiltonians
   std::vector<OperatorBase*> auxH;
   /// Total timer for H evaluation
-  NewTimer* ham_timer_;
+  NewTimer& ham_timer_;
   /// timers for H components
-  std::vector<NewTimer*> my_timers_;
+  TimerList_t my_timers_;
   ///types of component operators
   std::map<std::string, std::string> operator_types;
   ///data

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -253,7 +253,7 @@ void SplineC2COMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   const size_t first_spo_local   = first_spo;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*nVP) \
                 map(always, to: psiinv_ptr[0:psiinv_pos_copy.size()]) \
                 map(always, from: ratios_private_ptr[0:NumTeams*nVP])")
@@ -371,7 +371,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
   const size_t first_spo_local   = first_spo;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*mw_nVP) \
                 map(always, to: buffer_H2D_ptr[0:det_ratios_buffer_H2D.size()]) \
                 map(always, from: ratios_private_ptr[0:NumTeams*mw_nVP])")
@@ -526,7 +526,7 @@ void SplineC2COMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   const size_t first_spo_local   = first_spo;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(NumTeams) \
                 map(always, from: results_scratch_ptr[0:orb_size*5])")
     for (int team_id = 0; team_id < NumTeams; team_id++)
@@ -598,7 +598,7 @@ void SplineC2COMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   const size_t first_spo_local   = first_spo;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*num_pos) \
                     map(always, to: pos_copy_ptr[0:num_pos*6]) \
                     map(always, from: results_scratch_ptr[0:orb_size*num_pos*5])")
@@ -747,7 +747,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   const size_t phi_vgl_stride    = phi_vgl_v.capacity();
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*num_pos) \
                     map(always, to: buffer_H2D_ptr[:buffer_H2D.size()]) \
                     map(always, from: rg_private_ptr[0:rg_private.size()])")

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -258,7 +258,7 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
     const int nComplexBands_local  = nComplexBands;
 
     {
-      ScopedTimer offload(&offload_timer_);
+      ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute num_teams(NumTeams) \
                   map(always, from: psi_ptr[0:orb_size])")
       for (int team_id = 0; team_id < NumTeams; team_id++)
@@ -334,7 +334,7 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   const int nComplexBands_local  = nComplexBands;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*nVP) \
                 map(always, to: psiinv_ptr[0:psiinv_pos_copy.size()]) \
                 map(always, from: ratios_private_ptr[0:NumTeams*nVP])")
@@ -455,7 +455,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
   const int nComplexBands_local  = nComplexBands;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*mw_nVP) \
                 map(always, to: buffer_H2D_ptr[0:det_ratios_buffer_H2D.size()]) \
                 map(always, from: ratios_private_ptr[0:NumTeams*mw_nVP])")
@@ -669,7 +669,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   const int nComplexBands_local  = nComplexBands;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(NumTeams) \
                 map(always, from: results_scratch_ptr[0:orb_size*5])")
     for (int team_id = 0; team_id < NumTeams; team_id++)
@@ -742,7 +742,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   const int nComplexBands_local  = nComplexBands;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*num_pos) \
                     map(always, to: pos_copy_ptr[0:num_pos*6]) \
                     map(always, from: results_scratch_ptr[0:orb_size*num_pos*5])")
@@ -892,7 +892,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   const int nComplexBands_local  = nComplexBands;
 
   {
-    ScopedTimer offload(&offload_timer_);
+    ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*num_pos) \
                     map(always, to: buffer_H2D_ptr[:buffer_H2D.size()]) \
                     map(always, from: rg_private_ptr[0:rg_private.size()])")

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -129,7 +129,7 @@ SPOSet* EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   std::string useGPU = "no";
 #endif
   std::string GPUsharing = "no";
-  ScopedTimer spo_timer_scope(timer_manager.createTimer("einspline::CreateSPOSetFromXML", timer_level_medium));
+  ScopedTimer spo_timer_scope(*timer_manager.createTimer("einspline::CreateSPOSetFromXML", timer_level_medium));
 
   {
     OhmmsAttributeSet a;

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
@@ -49,7 +49,7 @@ SPOSet* EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   std::string spo_prec("double");
   std::string truncate("no");
   std::string hybrid_rep("no");
-  ScopedTimer spo_timer_scope(timer_manager.createTimer("einspline::CreateSpinorSetFromXML", timer_level_medium));
+  ScopedTimer spo_timer_scope(*timer_manager.createTimer("einspline::CreateSpinorSetFromXML", timer_level_medium));
 
   {
     OhmmsAttributeSet a;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -60,7 +60,7 @@ void DiracDeterminant<DU_TYPE>::set(int first, int nel, int delay)
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::invertPsiM(const ValueMatrix_t& logdetT, ValueMatrix_t& invMat)
 {
-  ScopedTimer local_timer(&InverseTimer);
+  ScopedTimer local_timer(InverseTimer);
   updateEng.invert_transpose(logdetT, invMat, LogValue);
 }
 
@@ -95,7 +95,7 @@ void DiracDeterminant<DU_TYPE>::resize(int nel, int morb)
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad(ParticleSet& P, int iat)
 {
-  ScopedTimer local_timer(&RatioTimer);
+  ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
   invRow_id = WorkingIndex;
@@ -111,7 +111,7 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
                                                                                          ComplexType& spingrad)
 {
   Phi->evaluate_spin(P, iat, psiV, dspin_psiV);
-  ScopedTimer local_timer(&RatioTimer);
+  ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
   invRow_id = WorkingIndex;
@@ -129,7 +129,7 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
                                                                                       GradType& grad_iat)
 {
   {
-    ScopedTimer local_timer(&SPOVGLTimer);
+    ScopedTimer local_timer(SPOVGLTimer);
     Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
   }
   return ratioGrad_compute(iat, grad_iat);
@@ -139,7 +139,7 @@ template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::ratioGrad_compute(int iat,
                                                                                               GradType& grad_iat)
 {
-  ScopedTimer local_timer(&RatioTimer);
+  ScopedTimer local_timer(RatioTimer);
 
   UpdateMode             = ORB_PBYP_PARTIAL;
   const int WorkingIndex = iat - FirstIndex;
@@ -166,13 +166,13 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
                                                                                               ComplexType& spingrad_iat)
 {
   {
-    ScopedTimer local_timer(&SPOVGLTimer);
+    ScopedTimer local_timer(SPOVGLTimer);
     Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
     Phi->evaluate_spin(P, iat, psiV, dspin_psiV);
   }
 
   {
-    ScopedTimer local_timer(&RatioTimer);
+    ScopedTimer local_timer(RatioTimer);
     UpdateMode             = ORB_PBYP_PARTIAL;
     const int WorkingIndex = iat - FirstIndex;
     assert(WorkingIndex >= 0);
@@ -203,7 +203,7 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
                                              std::vector<GradType>& grad_new) const
 {
   {
-    ScopedTimer local_timer(&SPOVGLTimer);
+    ScopedTimer local_timer(SPOVGLTimer);
     RefVectorWithLeader<SPOSet> phi_list(*Phi);
     phi_list.reserve(wfc_list.size());
     RefVector<ValueVector_t> psi_v_list;
@@ -235,7 +235,7 @@ void DiracDeterminant<DU_TYPE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunct
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
-  ScopedTimer local_timer(&UpdateTimer);
+  ScopedTimer local_timer(UpdateTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
   LogValue += convertValueToLog(curRatio);
@@ -263,7 +263,7 @@ void DiracDeterminant<DU_TYPE>::restore(int iat)
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::completeUpdates()
 {
-  ScopedTimer local_timer(&UpdateTimer);
+  ScopedTimer local_timer(UpdateTimer);
   // invRow becomes invalid after updating the inverse matrix
   invRow_id = -1;
   updateEng.updateInvMat(psiM);
@@ -276,7 +276,7 @@ void DiracDeterminant<DU_TYPE>::updateAfterSweep(ParticleSet& P,
 {
   if (UpdateMode == ORB_PBYP_RATIO)
   { //need to compute dpsiM and d2psiM. Do not touch psiM!
-    ScopedTimer local_timer(&SPOVGLTimer);
+    ScopedTimer local_timer(SPOVGLTimer);
     Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
   }
 
@@ -349,7 +349,7 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::upda
 {
   evaluateGL(P, P.G, P.L, fromscratch);
   {
-    ScopedTimer local_timer(&BufferTimer);
+    ScopedTimer local_timer(BufferTimer);
     buf.forward(Bytes_in_WFBuffer);
     buf.put(LogValue);
   }
@@ -359,7 +359,7 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::upda
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 {
-  ScopedTimer local_timer(&BufferTimer);
+  ScopedTimer local_timer(BufferTimer);
   psiM.attachReference(buf.lendReference<ValueType>(psiM.size()));
   dpsiM.attachReference(buf.lendReference<GradType>(dpsiM.size()));
   d2psiM.attachReference(buf.lendReference<ValueType>(d2psiM.size()));
@@ -380,11 +380,11 @@ typename DiracDeterminant<DU_TYPE>::PsiValueType DiracDeterminant<DU_TYPE>::rati
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
   {
-    ScopedTimer local_timer(&SPOVTimer);
+    ScopedTimer local_timer(SPOVTimer);
     Phi->evaluateValue(P, iat, psiV);
   }
   {
-    ScopedTimer local_timer(&RatioTimer);
+    ScopedTimer local_timer(RatioTimer);
     // This is an optimization.
     // check invRow_id against WorkingIndex to see if getInvRow() has been called
     // This is intended to save redundant compuation in TM1 and TM3
@@ -402,13 +402,13 @@ template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios)
 {
   {
-    ScopedTimer local_timer(&RatioTimer);
+    ScopedTimer local_timer(RatioTimer);
     const int WorkingIndex = VP.refPtcl - FirstIndex;
     assert(WorkingIndex >= 0);
     std::copy_n(psiM[WorkingIndex], invRow.size(), invRow.data());
   }
   {
-    ScopedTimer local_timer(&SPOVTimer);
+    ScopedTimer local_timer(SPOVTimer);
     Phi->evaluateDetRatios(VP, psiV, invRow, ratios);
   }
 }
@@ -428,7 +428,7 @@ void DiracDeterminant<DU_TYPE>::mw_evaluateRatios(const RefVectorWithLeader<Wave
   invRow_ptr_list.reserve(nw);
 
   {
-    ScopedTimer local_timer(&RatioTimer);
+    ScopedTimer local_timer(RatioTimer);
     for (size_t iw = 0; iw < nw; iw++)
     {
       auto& det = wfc_list.getCastedElement<DiracDeterminant<DU_TYPE>>(iw);
@@ -446,7 +446,7 @@ void DiracDeterminant<DU_TYPE>::mw_evaluateRatios(const RefVectorWithLeader<Wave
   }
 
   {
-    ScopedTimer local_timer(&SPOVTimer);
+    ScopedTimer local_timer(SPOVTimer);
     // Phi->isOMPoffload() requires device invRow pointers for mw_evaluateDetRatios.
     // evaluateDetRatios only requires host invRow pointers.
     if (Phi->isOMPoffload())
@@ -463,7 +463,7 @@ void DiracDeterminant<DU_TYPE>::mw_evaluateRatios(const RefVectorWithLeader<Wave
 template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
 {
-  ScopedTimer local_timer(&SPOVTimer);
+  ScopedTimer local_timer(SPOVTimer);
   Phi->evaluateValue(P, -1, psiV);
   MatrixOperators::product(psiM, psiV.data(), &ratios[FirstIndex]);
 }
@@ -666,7 +666,7 @@ template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::recompute(ParticleSet& P)
 {
   {
-    ScopedTimer local_timer(&SPOVGLTimer);
+    ScopedTimer local_timer(SPOVGLTimer);
     Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
   }
   if (NumPtcls == 1)

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -215,7 +215,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate(Particl
                                                                          ParticleSet::ParticleGradient_t& G,
                                                                          ParticleSet::ParticleLaplacian_t& L)
 {
-  ScopedTimer local_timer(&EvaluateTimer);
+  ScopedTimer local_timer(EvaluateTimer);
   Dets[0]->evaluateForWalkerMove(P);
   Dets[1]->evaluateForWalkerMove(P);
 
@@ -303,7 +303,7 @@ WaveFunctionComponent::GradType MultiSlaterDeterminantFast::evalGrad(ParticleSet
     APP_ABORT("Fast MSD+BF: evalGrad not implemented. \n");
   }
 
-  ScopedTimer local_timer(&EvalGradTimer);
+  ScopedTimer local_timer(EvalGradTimer);
 
   GradType grad_iat;
   PsiValueType psi;
@@ -323,7 +323,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratioGrad(Partic
     APP_ABORT("Fast MSD+BF: ratioGrad not implemented. \n");
   }
 
-  ScopedTimer local_timer(&RatioGradTimer);
+  ScopedTimer local_timer(RatioGradTimer);
   UpdateMode = ORB_PBYP_PARTIAL;
 
   GradType dummy;
@@ -386,7 +386,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::ratio(ParticleSe
     APP_ABORT("Fast MSD+BF: ratio not implemented. \n");
   }
 
-  ScopedTimer local_timer(&RatioTimer);
+  ScopedTimer local_timer(RatioTimer);
   UpdateMode = ORB_PBYP_RATIO;
 
   PsiValueType psiNew;
@@ -408,7 +408,7 @@ void MultiSlaterDeterminantFast::acceptMove(ParticleSet& P, int iat, bool safe_t
     APP_ABORT("Fast MSD+BF: acceptMove not implemented. \n");
   }
 
-  ScopedTimer local_timer(&AccRejTimer);
+  ScopedTimer local_timer(AccRejTimer);
   // update psiCurrent,myG_temp,myL_temp
   psiCurrent *= curRatio;
   curRatio = 1.0;
@@ -423,7 +423,7 @@ void MultiSlaterDeterminantFast::restore(int iat)
     APP_ABORT("Fast MSD+BF: restore not implemented. \n");
   }
 
-  ScopedTimer local_timer(&AccRejTimer);
+  ScopedTimer local_timer(AccRejTimer);
   Dets[getDetID(iat)]->restore(iat);
   curRatio = 1.0;
 }
@@ -446,7 +446,7 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::updateBuffer(Par
                                                                              WFBufferType& buf,
                                                                              bool fromscratch)
 {
-  ScopedTimer local_timer(&UpdateTimer);
+  ScopedTimer local_timer(UpdateTimer);
 
   Dets[0]->updateBuffer(P, buf, fromscratch);
   Dets[1]->updateBuffer(P, buf, fromscratch);
@@ -883,7 +883,7 @@ void MultiSlaterDeterminantFast::prepareGroup(ParticleSet& P, int ig)
   // C_otherDs(1, :) stores C x D_up x D_pos
   // C_otherDs(2, :) stores C x D_up x D_dn
 
-  ScopedTimer local_timer(&PrepareGroupTimer);
+  ScopedTimer local_timer(PrepareGroupTimer);
   C_otherDs[ig].resize(Dets[ig]->NumDets);
   std::fill(C_otherDs[ig].begin(), C_otherDs[ig].end(), ValueType(0));
   for (size_t i = 0; i < C->size(); i++)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -59,7 +59,7 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, boo
   for (auto& suffix : suffixes)
   {
     std::string timer_name = "WaveFunction:" + myName + "::" + suffix;
-    TWF_timers_.push_back(timer_manager.createTimer(timer_name, timer_level_medium));
+    TWF_timers_.push_back(*timer_manager.createTimer(timer_name, timer_level_medium));
   }
 }
 
@@ -101,7 +101,7 @@ void TrialWaveFunction::addComponent(WaveFunctionComponent* aterm)
     app_log() << "  Added a fermionic WaveFunctionComponent " << aname << std::endl;
 
   for (auto& suffix : suffixes)
-    WFC_timers_.push_back(timer_manager.createTimer(aname + "::" + suffix));
+    WFC_timers_.push_back(*timer_manager.createTimer(aname + "::" + suffix));
 }
 
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -493,9 +493,9 @@ private:
   std::vector<WaveFunctionComponent*> Z;
 
   /// timers at TrialWaveFunction function call level
-  std::vector<NewTimer*> TWF_timers_;
+  TimerList_t TWF_timers_;
   /// timers at WaveFunctionComponent function call level
-  std::vector<NewTimer*> WFC_timers_;
+  TimerList_t WFC_timers_;
   std::vector<RealType> myTwist;
 
   /** @{

--- a/src/QMCWaveFunctions/TrialWaveFunction_CUDA.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction_CUDA.cpp
@@ -41,9 +41,8 @@ void TrialWaveFunction::recompute(MCWalkerConfiguration& W, bool firstTime)
 {
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->recompute(W, firstTime);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -100,9 +99,8 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 0; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->ratio(W, iat, psi_ratios, newG);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -121,9 +119,8 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->ratio(W, iat, psi_ratios, newG, newL);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -142,9 +139,8 @@ void TrialWaveFunction::calcRatio(MCWalkerConfiguration& W,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->calcRatio(W, iat, psi_ratios, newG, newL);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -158,14 +154,12 @@ void TrialWaveFunction::addRatio(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = 1; i < Z.size() - 1; i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->addRatio(W, iat, k, psi_ratios, newG, newL);
-    WFC_timers_[ii]->stop();
   }
   gpu::synchronize();
-  WFC_timers_[1 + TIMER_SKIP * (Z.size() - 1)]->start();
+  ScopedTimer local_timer(WFC_timers_[1 + TIMER_SKIP * (Z.size() - 1)]);
   Z[Z.size() - 1]->addRatio(W, iat, k, psi_ratios, newG, newL);
-  WFC_timers_[1 + TIMER_SKIP * (Z.size() - 1)]->stop();
 }
 
 void TrialWaveFunction::det_lookahead(MCWalkerConfiguration& W,
@@ -179,9 +173,8 @@ void TrialWaveFunction::det_lookahead(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->det_lookahead(W, psi_ratios, grad, lapl, iat, k, kd, nw);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -220,9 +213,8 @@ void TrialWaveFunction::ratio(std::vector<Walker_t*>& walkers,
   }
   for (int i = 0, ii = 1; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->ratio(walkers, iatList, rNew, psi_ratios, newG, newL);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -232,9 +224,8 @@ void TrialWaveFunction::ratio(MCWalkerConfiguration& W, int iat, std::vector<Val
     psi_ratios[iw] = 1.0;
   for (int i = 0, ii = V_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->ratio(W, iat, psi_ratios);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -246,9 +237,8 @@ void TrialWaveFunction::update(MCWalkerConfiguration* W,
 {
   for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->update(W, walkers, iat, acc, k);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -256,9 +246,8 @@ void TrialWaveFunction::update(const std::vector<Walker_t*>& walkers, const std:
 {
   for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->update(walkers, iatList);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -273,9 +262,8 @@ void TrialWaveFunction::gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, 
     }
   for (int i = 0, ii = VGL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     Z[i]->gradLapl(W, grads, lapl);
-    WFC_timers_[ii]->stop();
   }
   for (int iw = 0; iw < W.WalkerList.size(); iw++)
     for (int ptcl = 0; ptcl < grads.cols(); ptcl++)
@@ -295,13 +283,12 @@ void TrialWaveFunction::NLratios(MCWalkerConfiguration& W,
     psi_ratios[i] = 1.0;
   for (int i = 0, ii = NL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-      if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
-          (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
-      {
-        WFC_timers_[ii]->start();
-        Z[i]->NLratios(W, jobList, quadPoints, psi_ratios);
-        WFC_timers_[ii]->stop();
-      }
+    if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
+        (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
+    {
+      ScopedTimer local_timer(WFC_timers_[ii]);
+      Z[i]->NLratios(W, jobList, quadPoints, psi_ratios);
+    }
   }
 }
 
@@ -316,13 +303,12 @@ void TrialWaveFunction::NLratios(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = NL_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-      if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
-          (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
-      {
-        WFC_timers_[ii]->start();
-        Z[i]->NLratios(W, Rlist, ElecList, NumCoreElecs, QuadPosList, RatioList, numQuadPoints);
-        WFC_timers_[ii]->stop();
-      }
+    if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
+        (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
+    {
+      ScopedTimer local_timer(WFC_timers_[ii]);
+      Z[i]->NLratios(W, Rlist, ElecList, NumCoreElecs, QuadPosList, RatioList, numQuadPoints);
+    }
   }
 }
 
@@ -332,10 +318,9 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W, std::vector<R
     logpsi_opt[iw] = RealType();
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     if (Z[i]->Optimizable)
       Z[i]->addLog(W, logpsi_opt);
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -356,7 +341,7 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W,
   // First, sum optimizable part, using fixedG and fixedL as temporaries
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     if (Z[i]->Optimizable)
     {
       Z[i]->addLog(W, logpsi_opt);
@@ -379,7 +364,6 @@ void TrialWaveFunction::evaluateDeltaLog(MCWalkerConfiguration& W,
       Z[i]->addLog(W, logpsi_fixed);
       Z[i]->gradLapl(W, fixedG, fixedL);
     }
-    WFC_timers_[ii]->stop();
   }
   // Add on the fixed part to the total laplacian and gradient
   for (int iw = 0; iw < W.WalkerList.size(); iw++)
@@ -402,13 +386,12 @@ void TrialWaveFunction::evaluateOptimizableLog(MCWalkerConfiguration& W,
   // Sum optimizable part of log Psi
   for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     if (Z[i]->Optimizable)
     {
       Z[i]->addLog(W, logpsi_opt);
       Z[i]->gradLapl(W, optG, optL);
     }
-    WFC_timers_[ii]->stop();
   }
 }
 
@@ -420,10 +403,9 @@ void TrialWaveFunction::evaluateDerivatives(MCWalkerConfiguration& W,
 {
   for (int i = 0, ii = DERIVS_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
   {
-    WFC_timers_[ii]->start();
+    ScopedTimer local_timer(WFC_timers_[ii]);
     if (Z[i]->Optimizable)
       Z[i]->evaluateDerivatives(W, optvars, dlogpsi, dhpsioverpsi);
-    WFC_timers_[ii]->stop();
   }
 }
 } // namespace qmcplusplus

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -241,20 +241,23 @@ template<class TIMER = NewTimer>
 class ScopeGuard
 {
 public:
-  ScopeGuard(TIMER* t) : timer(t)
+  ScopeGuard(TIMER& t) : timer(t)
   {
-    if (timer)
-      timer->start();
+    timer.start();
   }
+
+  ScopeGuard(const ScopeGuard&) = delete;
+  ScopeGuard& operator=(const ScopeGuard&) = delete;
+  ScopeGuard(ScopeGuard&&) = default;
+  ScopeGuard& operator=(ScopeGuard&&) = default;
 
   ~ScopeGuard()
   {
-    if (timer)
-      timer->stop();
+    timer.stop();
   }
 
 private:
-  TIMER* timer;
+  TIMER& timer;
 };
 
 using ScopedTimer     = ScopeGuard<NewTimer>;

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -144,7 +144,7 @@ extern TimerManager<NewTimer> timer_manager;
 // Helpers to make it easier to define a set of timers
 // See tests/test_timer.cpp for an example
 
-typedef std::vector<NewTimer*> TimerList_t;
+using TimerList_t = std::vector<std::reference_wrapper<NewTimer>>;
 
 template<class T>
 struct TimerIDName_t
@@ -157,14 +157,14 @@ template<class T>
 using TimerNameList_t = std::vector<TimerIDName_t<T>>;
 
 template<class T, class TIMER>
-void setup_timers(std::vector<TIMER*>& timers,
+void setup_timers(std::vector<std::reference_wrapper<TIMER>>& timers,
                   TimerNameList_t<T> timer_list,
                   timer_levels timer_level     = timer_level_fine,
                   TimerManager<TIMER>* manager = &timer_manager)
 {
-  timers.resize(timer_list.size());
+  timers.reserve(timer_list.size());
   for (int i = 0; i < timer_list.size(); i++)
-    timers[timer_list[i].id] = manager->createTimer(timer_list[i].name, timer_level);
+    timers.push_back(*manager->createTimer(timer_list[i].name, timer_level));
 }
 
 } // namespace qmcplusplus

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -54,7 +54,7 @@ TEST_CASE("test_timer_scoped", "[utilities]")
   FakeTimerManager tm;
   FakeTimer* t1 = tm.createTimer("timer1", timer_level_coarse);
   {
-    ScopedFakeTimer st(t1);
+    ScopedFakeTimer st(*t1);
   }
 #if ENABLE_TIMERS
   REQUIRE(t1->get_total() == Approx(1.0));
@@ -65,7 +65,7 @@ TEST_CASE("test_timer_scoped", "[utilities]")
   const std::string prefix_str("Prefix::");
   FakeTimer& t2(*(tm.createTimer(prefix_str + "timer2", timer_level_coarse)));
   {
-    ScopedFakeTimer st(&t2);
+    ScopedFakeTimer st(t2);
   }
 #if ENABLE_TIMERS
   REQUIRE(t1->get_total() == Approx(1.0));
@@ -385,16 +385,16 @@ TEST_CASE("test setup timers", "[utilities]")
 {
   FakeTimerManager tm;
   // Create  a list of timers and initialize it
-  std::vector<FakeTimer*> Timers;
+  std::vector<std::reference_wrapper<FakeTimer>>  Timers;
   setup_timers(Timers, TestTimerNames, timer_level_coarse, &tm);
 
   FakeCPUClock::fake_cpu_clock_increment = 1.0;
-  Timers[MyTimer1]->start();
-  Timers[MyTimer1]->stop();
+  Timers[MyTimer1].get().start();
+  Timers[MyTimer1].get().stop();
 
 #ifdef ENABLE_TIMERS
-  REQUIRE(Timers[MyTimer1]->get_total() == Approx(1.0));
-  REQUIRE(Timers[MyTimer1]->get_num_calls() == 1);
+  REQUIRE(Timers[MyTimer1].get().get_total() == Approx(1.0));
+  REQUIRE(Timers[MyTimer1].get().get_num_calls() == 1);
 #endif
 }
 


### PR DESCRIPTION
## Proposed changes
This PR reduces the use of pointers in timers. Timers returned by TimerManager::createTimer are actually a reference and will be changed to reference. It was left as a pointer because of the need for a vector of pointers. Now actually we can use reference_wrapper to hold a vector of reference, so it is better to reduce the use of pointers.
ScopeTimer constructor is also changed to take reference instead of pointers.

Time start/stop in real-space are changed by sed + clang-format with a bit manual tweaks.
```
1,$s/\([^/]*\)->start();/{ ScopedTimer local_timer(\1);/
1,$s/\([^/]*\)->stop();/}/
```
AFQMC still uses start/stop instead of ScopedTimer until pending problems are fixed.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'