### PR TITLE
revamp wavefunction restart logic in AFQMC

### DIFF
--- a/src/AFQMC/Drivers/DriverFactory.cpp
+++ b/src/AFQMC/Drivers/DriverFactory.cpp
@@ -201,8 +201,6 @@ bool DriverFactory::executeAFQMCDriver(std::string title, int m_series, xmlNodeP
   int nnodes_propg = std::max(1, get_parameter<int>(PropFac, prop_name, "nnodes", 1));
   int nnodes_wfn   = std::max(1, get_parameter<int>(WfnFac, wfn_name, "nnodes", 1));
   RealType cutvn   = get_parameter<RealType>(PropFac, prop_name, "cutoff", 1e-6);
-  // Wavefunction and Hamiltonian Operations already stored in restart file.
-  std::string wfn_restart = get_parameter<std::string>(WfnFac, wfn_name, "restart_file", "");
 
   // setup task groups
   auto& TGprop = TGHandler.getTG(nnodes_propg);
@@ -218,7 +216,7 @@ bool DriverFactory::executeAFQMCDriver(std::string title, int m_series, xmlNodeP
   WalkerSet& wset          = WSetFac.getWalkerSet(TGHandler.getTG(1), wset_name, rng);
   WALKER_TYPES walker_type = wset.getWalkerType();
 
-  if (not WfnFac.is_constructed(wfn_name) && wfn_restart == "")
+  if (not WfnFac.is_constructed(wfn_name))
   {
     // hamiltonian
     Hamiltonian& ham0 = HamFac.getHamiltonian(gTG, ham_name);

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -120,6 +120,8 @@ void propg_fac_shared(boost::mpi3::communicator& world)
     // Create unique restart filename to avoid issues with running tests in parallel
     // through ctest.
     std::string restart_file = create_test_hdf(UTEST_WFN, UTEST_HAMIL);
+    app_log() << " propg_fac_shared destroy restart_file " << restart_file << "\n";
+    if (!remove_file(restart_file)) APP_ABORT("failed to remove restart_file");
     std::string wfn_xml      = "<Wavefunction name=\"wfn0\" info=\"info0\"> \
       <parameter name=\"filetype\">ascii</parameter> \
       <parameter name=\"filename\">" +
@@ -293,6 +295,8 @@ void propg_fac_distributed(boost::mpi3::communicator& world, int ngrp)
     REQUIRE(okay);
 
     std::string restart_file = create_test_hdf(UTEST_WFN, UTEST_HAMIL);
+    app_log() << " propg_fac_distributed destroy restart_file " << restart_file << "\n";
+    if (!remove_file(restart_file)) APP_ABORT("failed to remove restart_file");
     std::string wfn_xml      = "<Wavefunction name=\"wfn0\" info=\"info0\"> \
       <parameter name=\"filetype\">ascii</parameter> \
       <parameter name=\"filename\">" +

--- a/src/AFQMC/Utilities/test_utils.hpp
+++ b/src/AFQMC/Utilities/test_utils.hpp
@@ -139,6 +139,23 @@ inline std::string create_test_hdf(const std::string& wfn_file, const std::strin
   return wfn_base + "_" + ham_base + ".h5";
 }
 
+inline bool remove_file(const std::string& file_name)
+{
+  bool success=false;
+  std::ifstream ifile;
+  ifile.open(file_name);
+  if (ifile)
+  {
+    if (std::remove(file_name.c_str()) == 0)
+    {
+      success = true;
+    }
+  } else { // no file to remove
+    success = true;
+  }
+  return success;
+}
+
 inline bool check_hamil_wfn_for_utest(const std::string& test_name, std::string& wfn_file, std::string& hamil_file)
 {
   if (not file_exists(wfn_file) || not file_exists(hamil_file))

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -254,6 +254,8 @@ Wavefunction WavefunctionFactory::fromASCII(TaskGroup_& TGprop,
     hdf_archive dump(TGwfn.Global());
     if (restart_file != "")
     {
+      app_error() << " no restart fromASCII; use getHamOps not getHamiltonianOperations\n";
+      APP_ABORT("");
       if (TGwfn.Global().root())
       {
         if (!dump.create(restart_file, H5F_ACC_EXCL))

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.h
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.h
@@ -161,7 +161,7 @@ protected:
                         Hamiltonian& h,
                         RealType cutvn,
                         int targetNW);
-  HamiltonianOperations getHamOps(hdf_archive& restart,
+  HamiltonianOperations getHamOps(const std::string& restart_file,
                                   WALKER_TYPES type,
                                   int NMO,
                                   int NAEA,

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.h
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.h
@@ -161,8 +161,7 @@ protected:
                         Hamiltonian& h,
                         RealType cutvn,
                         int targetNW);
-  HamiltonianOperations getHamOps(bool read,
-                                  hdf_archive& dump,
+  HamiltonianOperations getHamOps(hdf_archive& restart,
                                   WALKER_TYPES type,
                                   int NMO,
                                   int NAEA,

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -129,6 +129,8 @@ void wfn_fac(boost::mpi3::communicator& world)
     okay = doc3.parseFromString(wlk_xml_block);
     REQUIRE(okay);
     std::string restart_file = create_test_hdf(UTEST_WFN, UTEST_HAMIL);
+    app_log() << " wfn_fac destroy restart_file " << restart_file << "\n";
+    if (!remove_file(restart_file)) APP_ABORT("failed to remove restart_file");
     std::string wfn_xml      = "<Wavefunction name=\"wfn0\" info=\"info0\"> \
       <parameter name=\"filetype\">ascii</parameter> \
       <parameter name=\"filename\">" +
@@ -466,6 +468,8 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     REQUIRE(okay);
 
     std::string restart_file = create_test_hdf(UTEST_WFN, UTEST_HAMIL);
+    app_log() << " wfn_fac_distributed destroy restart_file " << restart_file << "\n";
+    if (!remove_file(restart_file)) APP_ABORT("failed to remove restart_file");
     std::string wfn_xml      = "<Wavefunction name=\"wfn0\" info=\"info0\"> \
       <parameter name=\"filetype\">ascii</parameter> \
       <parameter name=\"filename\">" +


### PR DESCRIPTION
## Proposed changes

Concentrate wavefunction restart logic in `WavefunctionFactory::getHamOps`.
Allow user to restart without changing the input file as discussed in #2872

Once this PR is merged, issue #2851 should be fully addressed.

`WavefunctionFactory::fromASCII` is poised for deprecation, so I put an abort when that code path hits restart.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Fedora 32, E5-2620 v2, gcc 10.2.1, intel 19.1.2

## Checklist
- Yes This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
