### PR TITLE
Fix two bugs in walker batched runs

### DIFF
--- a/src/Containers/OhmmsPETE/OhmmsMatrix.h
+++ b/src/Containers/OhmmsPETE/OhmmsMatrix.h
@@ -325,6 +325,29 @@ protected:
   Container_t X;
 };
 
+template<class T, class Alloc>
+bool operator==(const Matrix<T, Alloc>& lhs, const Matrix<T, Alloc>& rhs)
+{
+  static_assert(allocator_traits<Alloc>::is_host_accessible, "operator== requires host accessible Vector.");
+  if (lhs.size() == rhs.size())
+  {
+    for (int i = 0; i < rhs.size(); i++)
+      if (lhs(i) != rhs(i))
+        return false;
+    return true;
+  }
+  else
+    return false;
+}
+
+template<class T, class Alloc>
+bool operator!=(const Matrix<T, Alloc>& lhs, const Matrix<T, Alloc>& rhs)
+{
+  static_assert(allocator_traits<Alloc>::is_host_accessible, "operator== requires host accessible Vector.");
+  return !(lhs == rhs);
+}
+
+
 // I/O
 template<class T, typename Alloc>
 std::ostream& operator<<(std::ostream& out, const Matrix<T, Alloc>& rhs)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -739,6 +739,7 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
         p_list[iw].acceptMove_impl(iat, partial_table_update);
       else
         p_list[iw].rejectMove(iat);
+      assert(p_list[iw].R[iat] == p_list[iw].coordinates_->getAllParticlePos()[iat]);
     }
   }
   else if (p_list.size() == 1)


### PR DESCRIPTION
## Proposed changes
1. DMC batched driver was rejecting a move twice when fixed node sign change happens. This was caused by debug build assertions.
2. Batched determinant has a race when CUDA transfer has not been completed but OpenMP transfer was asked for. This was the root cause of unstable deterministic tests. Also debug build defensive assertion caught this. Additional assertions have been added.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'