### PR TITLE
Explicit two modes of distance table operations

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -2083,7 +2083,7 @@ Distance tables
 
 Distance tables store distances between particles. There are symmetric
 (AA) tables for distance between like particles (electron-electron or
-ion-ion) and asymmetric (BA) tables for distance between unlike
+ion-ion) and asymmetric (AB) tables for distance between unlike
 particles (electron-ion)
 
 The ``Distances`` and ``Displacements`` members contain the data. The

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -204,9 +204,8 @@ public:
 
   /** fill the distance table by the pair relations for the old particle position. Used in forward mode when a move is reject
    * @param iat the particle with an accepted move
-   * @param partial_update If true, rows after iat will not be updated. If false, upon accept a move, the full table should be up-to-date
    */
-  virtual void updateForOldPos(IndexType jat) {};
+  virtual void updateForOldPosPartial(IndexType jat){};
 
   /** build a compact list of a neighbor for the iat source
    * @param iat source particle id

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -82,13 +82,18 @@ protected:
    */
   bool need_full_table_;
 
+  /** set to particle id after move() with prepare_old = true. -1 means not prepared.
+   * It is intended only for safety checks, not for codepath selection.
+   */
+  int old_prepared_elec_id;
+
   ///name of the table
   std::string Name;
 
 public:
   ///constructor using source and target ParticleSet
   DistanceTableData(const ParticleSet& source, const ParticleSet& target)
-      : Origin(&source), N_sources(0), N_targets(0), N_walkers(0), need_full_table_(false)
+      : Origin(&source), N_sources(0), N_targets(0), N_walkers(0), need_full_table_(false), old_prepared_elec_id(-1)
   {}
 
   ///virutal destructor
@@ -191,11 +196,17 @@ public:
       dt_list[iw].move(p_list[iw], rnew_list[iw], iat, prepare_old);
   }
 
-  /** update the distance table by the pair relations if a move is accepted
+  /** update the distance table by the pair relations from the temporal position. Used when a move is accepted
+   * @param iat the particle with an accepted move
+   * @param partial_update If true (forward mode), rows after iat will not be updated. If false (regular mode), upon accept a move, the full table should be up-to-date
+   */
+  virtual void update(IndexType jat, bool partial_update = false) = 0;
+
+  /** fill the distance table by the pair relations for the old particle position. Used in forward mode when a move is reject
    * @param iat the particle with an accepted move
    * @param partial_update If true, rows after iat will not be updated. If false, upon accept a move, the full table should be up-to-date
    */
-  virtual void update(IndexType jat, bool partial_update = false) = 0;
+  virtual void updateForOldPos(IndexType jat) {};
 
   /** build a compact list of a neighbor for the iat source
    * @param iat source particle id

--- a/src/Particle/DynamicCoordinates.h
+++ b/src/Particle/DynamicCoordinates.h
@@ -51,29 +51,50 @@ public:
 
   virtual std::unique_ptr<DynamicCoordinates> makeClone() = 0;
 
+  /** resize internal storages based on the number of particles
+   *  @param n the number of particles
+   */
   virtual void resize(size_t n) = 0;
-  virtual size_t size()         = 0;
+  /// return the number of particles
+  virtual size_t size() const   = 0;
 
+  /// overwrite the positions of all the particles.
   virtual void setAllParticlePos(const ParticlePos_t& R)         = 0;
+  /// overwrite the position of one the particle.
   virtual void setOneParticlePos(const PosType& pos, size_t iat) = 0;
-  virtual void mw_copyActiveOldParticlePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
+  /** copy the active positions of particles with a uniform id in all the walkers to a single internal buffer.
+   *  @param coords_list a batch of DynamicCoordinates
+   *  @param iat paricle id, uniform across coords_list
+   *  @param new_positions proposed positions
+   */
+  virtual void mw_copyActivePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
                                            size_t iat,
                                            const std::vector<PosType>& new_positions) const
   {
     assert(this == &coords_list.getLeader());
   }
 
+  /** overwrite the positions of particles with a uniform id in all the walkers upon acceptance.
+   *  @param coords_list a batch of DynamicCoordinates
+   *  @param iat paricle id, uniform across coords_list
+   *  @param new_positions proposed positions
+   *  @param isAccepted accept/reject info
+   */
   virtual void mw_acceptParticlePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
                                     size_t iat,
                                     const std::vector<PosType>& new_positions,
                                     const std::vector<bool>& isAccepted) const = 0;
 
+  /// all particle position accessor
   virtual const PosVectorSoa& getAllParticlePos() const = 0;
+  /// one particle position accessor
   virtual PosType getOneParticlePos(size_t iat) const   = 0;
 
+  /// secure internal data consistency after p-by-p moves
   virtual void donePbyP() {}
 
 protected:
+  /// type of dynamic coordinates
   const DynamicCoordinateKind variable_kind_;
 };
 } // namespace qmcplusplus

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -715,6 +715,15 @@ void ParticleSet::rejectMove(Index_t iat)
   activePtcl = -1;
 }
 
+void ParticleSet::rejectMoveForwardMode(Index_t iat)
+{
+  assert(iat == activePtcl);
+  //Update distance-table
+  for (int i = 0, n = DistTables.size(); i < n; i++)
+    DistTables[i]->updateForOldPos(iat);
+  activePtcl = -1;
+}
+
 void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                          Index_t iat,
                                          const std::vector<bool>& isAccepted,
@@ -737,6 +746,8 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
     {
       if (isAccepted[iw])
         p_list[iw].acceptMove_impl(iat, partial_table_update);
+      else if (partial_table_update)
+        p_list[iw].rejectMoveForwardMode(iat);
       else
         p_list[iw].rejectMove(iat);
       assert(p_list[iw].R[iat] == p_list[iw].coordinates_->getAllParticlePos()[iat]);
@@ -746,6 +757,8 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
   {
     if (isAccepted[0])
       p_list[0].acceptMove(iat, partial_table_update);
+    else if (partial_table_update)
+      p_list[0].rejectMoveForwardMode(iat);
     else
       p_list[0].rejectMove(iat);
   }

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -512,7 +512,7 @@ void ParticleSet::mw_computeNewPosDistTablesAndSK(const RefVectorWithLeader<Part
   {
     ScopedTimer copy_scope(p_leader.myTimers[PS_mw_copy]);
     const auto coords_list(extractCoordsRefList(p_list));
-    p_leader.coordinates_->mw_copyActiveOldParticlePos(coords_list, iat, new_positions);
+    p_leader.coordinates_->mw_copyActivePos(coords_list, iat, new_positions);
   }
 
   {

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -734,7 +734,7 @@ void ParticleSet::rejectMoveForwardMode(Index_t iat)
   assert(iat == activePtcl);
   //Update distance-table
   for (int i = 0, n = DistTables.size(); i < n; i++)
-    DistTables[i]->updateForOldPos(iat);
+    DistTables[i]->updateForOldPosPartial(iat);
   activePtcl = -1;
 }
 

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -675,13 +675,13 @@ bool ParticleSet::makeMoveAllParticlesWithDrift(const Walker_t& awalker,
  * When the activePtcl is equal to iat, overwrite the position and update the
  * content of the distance tables.
  */
-void ParticleSet::acceptMove_impl(Index_t iat, bool partial_table_update)
+void ParticleSet::acceptMove_impl(Index_t iat, bool forward_mode)
 {
   if (iat == activePtcl)
   {
     //Update position + distance-table
     for (int i = 0, n = DistTables.size(); i < n; i++)
-      DistTables[i]->update(iat, partial_table_update);
+      DistTables[i]->update(iat, forward_mode);
 
     //Do not change SK: 2007-05-18
     if (SK && SK->DoUpdate)
@@ -699,11 +699,25 @@ void ParticleSet::acceptMove_impl(Index_t iat, bool partial_table_update)
   }
 }
 
-void ParticleSet::acceptMove(Index_t iat, bool partial_table_update)
+void ParticleSet::acceptMove(Index_t iat)
 {
   ScopedTimer update_scope(myTimers[PS_accept]);
   coordinates_->setOneParticlePos(activePos, iat);
-  acceptMove_impl(iat, partial_table_update);
+  acceptMove_impl(iat, false);
+}
+
+void ParticleSet::accept_rejectMove(Index_t iat, bool accepted, bool forward_mode)
+{
+  if (accepted)
+  {
+    ScopedTimer update_scope(myTimers[PS_accept]);
+    coordinates_->setOneParticlePos(activePos, iat);
+    acceptMove_impl(iat, false);
+  }
+  else if (forward_mode)
+    rejectMoveForwardMode(iat);
+  else
+    rejectMove(iat);
 }
 
 void ParticleSet::rejectMove(Index_t iat)
@@ -727,7 +741,7 @@ void ParticleSet::rejectMoveForwardMode(Index_t iat)
 void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                          Index_t iat,
                                          const std::vector<bool>& isAccepted,
-                                         bool partial_table_update)
+                                         bool forward_mode)
 {
   if (p_list.size() > 1)
   {
@@ -745,8 +759,8 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
     for (int iw = 0; iw < p_list.size(); iw++)
     {
       if (isAccepted[iw])
-        p_list[iw].acceptMove_impl(iat, partial_table_update);
-      else if (partial_table_update)
+        p_list[iw].acceptMove_impl(iat, forward_mode);
+      else if (forward_mode)
         p_list[iw].rejectMoveForwardMode(iat);
       else
         p_list[iw].rejectMove(iat);
@@ -754,14 +768,7 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
     }
   }
   else if (p_list.size() == 1)
-  {
-    if (isAccepted[0])
-      p_list[0].acceptMove(iat, partial_table_update);
-    else if (partial_table_update)
-      p_list[0].rejectMoveForwardMode(iat);
-    else
-      p_list[0].rejectMove(iat);
-  }
+    p_list[0].accept_rejectMove(iat, isAccepted[0], forward_mode);
 }
 
 void ParticleSet::donePbyP()

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -712,7 +712,7 @@ void ParticleSet::accept_rejectMove(Index_t iat, bool accepted, bool forward_mod
   {
     ScopedTimer update_scope(myTimers[PS_accept]);
     coordinates_->setOneParticlePos(activePos, iat);
-    acceptMove_impl(iat, false);
+    acceptMove_impl(iat, forward_mode);
   }
   else if (forward_mode)
     rejectMoveForwardMode(iat);

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -365,7 +365,7 @@ public:
    */
   void acceptMove(Index_t iat);
 
-  void accept_rejectMove(Index_t iat, bool accepted, bool forward_mode = false);
+  void accept_rejectMove(Index_t iat, bool accepted, bool forward_mode = true);
   /** reject a proposed move in regular mode
    * @param iat the electron whose proposed move gets rejected.
    */
@@ -374,7 +374,7 @@ public:
   static void flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                      Index_t iat,
                                      const std::vector<bool>& isAccepted,
-                                     bool forward_mode = false);
+                                     bool forward_mode = true);
 
   void initPropertyList();
   inline int addProperty(const std::string& pname) { return PropertyList.add(pname.c_str()); }

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -355,15 +355,17 @@ public:
    *@param iat the index of the particle whose position and other attributes to be updated
    *@param forward if true, moves of particles are proposed and accepted in order.
    *
-   * partial_table_update = true case is an optimization by skipping the DT update to >iat rows.
+   * forward_mode = true case is an optimization by skipping the DT update to >iat rows.
    * It works only if the move of each particle is proposed once and in order.
    * Once the particle sweep is done, all the distance tables are up-to-date.
    * This can be used during p-by-p moves.
    *
-   * partial_table_update = false case is the safe route. Uppon accept a move, all the distance tables are up-to-date.
+   * forward_mode = false case is the safe route. Uppon accept a move, all the distance tables are up-to-date.
    * This can be used on moves proposed on randomly selected electrons.
    */
-  void acceptMove(Index_t iat, bool partial_table_update = false);
+  void acceptMove(Index_t iat);
+
+  void accept_rejectMove(Index_t iat, bool accepted, bool forward_mode = false);
   /** reject a proposed move in regular mode
    * @param iat the electron whose proposed move gets rejected.
    */
@@ -372,7 +374,7 @@ public:
   static void flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                      Index_t iat,
                                      const std::vector<bool>& isAccepted,
-                                     bool partial_table_update = false);
+                                     bool forward_mode = false);
 
   void initPropertyList();
   inline int addProperty(const std::string& pname) { return PropertyList.add(pname.c_str()); }
@@ -675,7 +677,7 @@ protected:
                                               const std::vector<SingleParticlePos_t>& new_positions,
                                               bool maybe_accept = true);
   /// actual implemenation of acceptMove
-  void acceptMove_impl(Index_t iat, bool partial_table_update);
+  void acceptMove_impl(Index_t iat, bool forward_mode);
 
   /** reject a proposed move in forward mode
    * @param iat the electron whose proposed move gets rejected.

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -364,7 +364,7 @@ public:
    * This can be used on moves proposed on randomly selected electrons.
    */
   void acceptMove(Index_t iat, bool partial_table_update = false);
-  /** reject the move
+  /** reject a proposed move in regular mode
    * @param iat the electron whose proposed move gets rejected.
    */
   void rejectMove(Index_t iat);
@@ -676,6 +676,11 @@ protected:
                                               bool maybe_accept = true);
   /// actual implemenation of acceptMove
   void acceptMove_impl(Index_t iat, bool partial_table_update);
+
+  /** reject a proposed move in forward mode
+   * @param iat the electron whose proposed move gets rejected.
+   */
+  void rejectMoveForwardMode(Index_t iat);
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/RealSpacePositions.h
+++ b/src/Particle/RealSpacePositions.h
@@ -34,7 +34,7 @@ public:
   std::unique_ptr<DynamicCoordinates> makeClone() override { return std::make_unique<RealSpacePositions>(*this); }
 
   void resize(size_t n) override { RSoA.resize(n); }
-  size_t size() override { return RSoA.size(); }
+  size_t size() const override { return RSoA.size(); }
 
   void setAllParticlePos(const ParticlePos_t& R) override
   {

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -52,7 +52,7 @@ public:
     }
   }
 
-  size_t size() override { return RSoA_hostview.size(); }
+  size_t size() const override { return RSoA_hostview.size(); }
 
   void setAllParticlePos(const ParticlePos_t& R) override
   {
@@ -82,7 +82,7 @@ public:
     */
   }
 
-  void mw_copyActiveOldParticlePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
+  void mw_copyActivePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
                                    size_t iat,
                                    const std::vector<PosType>& new_positions) const override
   {
@@ -112,7 +112,7 @@ public:
 
     if (!is_nw_new_pos_prepared)
     {
-      mw_copyActiveOldParticlePos(coords_list, iat, new_positions);
+      mw_copyActivePos(coords_list, iat, new_positions);
       app_warning() << "This message only appear in unit tests. Report a bug if seen in production code." << std::endl;
     }
 
@@ -182,7 +182,7 @@ private:
   ///host view of RSoA
   PosVectorSoa RSoA_hostview;
 
-  ///if true, host position has been changed while device copy not updated.
+  ///if true, host position has been changed while the device copy has not been updated.
   bool is_host_position_changed_;
 
   ///if true, mw_new_pos has been updated with active positions.

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -55,9 +55,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
         offload_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::offload_") +
                                                       target.getName() + "_" + target.getName(),
                                                   timer_level_fine)),
-        copy_old_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::copy_old_") +
-                                                       target.getName() + "_" + target.getName(),
-                                                   timer_level_fine)),
         evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::evaluate_") +
                                                        target.getName() + "_" + target.getName(),
                                                    timer_level_fine)),
@@ -316,8 +313,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 private:
   /// timer for offload portion
   NewTimer& offload_timer_;
-  /// timer for copy portion
-  NewTimer& copy_old_timer_;
   /// timer for evaluate()
   NewTimer& evaluate_timer_;
   /// timer for move()

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -67,7 +67,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   SoaDistanceTableAB(const SoaDistanceTableAB&) = delete;
 
   /** evaluate the full table */
-  inline void evaluate(ParticleSet& P)
+  inline void evaluate(ParticleSet& P) override
   {
     ScopedTimer local_timer(evaluate_timer_);
 #pragma omp parallel
@@ -83,20 +83,20 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   }
 
   ///evaluate the temporary pair relations
-  inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old)
+  inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {
     ScopedTimer local_timer(move_timer_);
     DTD_BConds<T, D, SC>::computeDistances(rnew, Origin->getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_,
                                            0, N_sources);
     // If the full table is not ready all the time, overwrite the current value.
     // If this step is missing, DT values can be undefined in case a move is rejected.
-    if (!need_full_table_)
+    if (!need_full_table_ && prepare_old)
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], Origin->getCoordinates().getAllParticlePos(),
                                              distances_[iat].data(), displacements_[iat], 0, N_sources);
   }
 
   ///update the stripe for jat-th particle
-  inline void update(IndexType iat, bool partial_update)
+  inline void update(IndexType iat, bool partial_update) override
   {
     ScopedTimer local_timer(update_timer_);
     std::copy_n(temp_r_.data(), N_sources, distances_[iat].data());
@@ -108,7 +108,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
                        RealType rcut,
                        int* restrict jid,
                        RealType* restrict dist,
-                       PosType* restrict displ) const
+                       PosType* restrict displ) const override
   {
     constexpr T cminus(-1);
     size_t nn = 0;
@@ -126,7 +126,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
     return nn;
   }
 
-  int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const
+  int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
@@ -50,7 +50,6 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
 
   //Now we compute sumratio and more importantly, ratioij.
   computeSumRatio(logpsi, avgNorm, RatioIJ, sumratio);
-                   // myTimers[1]->start();
   for (int iter = 0; iter < nSubSteps; ++iter)
   {
     makeGaussRandomWithEngine(deltaR, RandomGen);
@@ -71,14 +70,15 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
           for (int ipsi = 0; ipsi < nPsi; ipsi++)
             prob += ratio[ipsi] / sumratio[ipsi];
 
+          bool is_accepted = false;
           if (RandomGen() < prob)
           {
-            stucked = false;
+            is_accepted = true;
+            stucked     = false;
             ++nAccept;
             for (int ipsi = 0; ipsi < nPsi; ipsi++)
               Psi1[ipsi]->acceptMove(W, iat, true);
 
-            W.acceptMove(iat, true);
             //Now we update ratioIJ.
             updateRatioMatrix(ratio, RatioIJ);
             computeSumRatio(RatioIJ, sumratio);
@@ -86,10 +86,11 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
           else
           {
             ++nReject;
-            W.rejectMove(iat);
             for (int ipsi = 0; ipsi < nPsi; ipsi++)
               Psi1[ipsi]->rejectMove(iat);
           }
+
+          W.accept_rejectMove(iat, is_accepted, true);
         }
         else //reject illegal moves
           ++nReject;
@@ -102,8 +103,6 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
     for (int ipsi = 0; ipsi < nPsi; ipsi++)
       Psi1[ipsi]->completeUpdates();
   }
-  //  myTimers[1]->stop();
-  //  myTimers[2]->start();
 
   W.donePbyP();
 
@@ -131,10 +130,10 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
   {
     //Now reload the G and L associated with ipsi into the walker and particle set.
     //This is required for correct calculation of kinetic energy.
-    thisWalker.G                                = *G1[ipsi];
-    thisWalker.L                                = *L1[ipsi];
-    W.L                                         = thisWalker.L;
-    W.G                                         = thisWalker.G;
+    thisWalker.G                                    = *G1[ipsi];
+    thisWalker.L                                    = *L1[ipsi];
+    W.L                                             = thisWalker.L;
+    W.G                                             = thisWalker.G;
     thisWalker.Properties(ipsi, WP::LOCALENERGY)    = H1[ipsi]->evaluate(W);
     thisWalker.Properties(ipsi, WP::LOGPSI)         = logpsi[ipsi];
     thisWalker.Properties(ipsi, WP::SIGN)           = Psi1[ipsi]->getPhase();

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
@@ -90,7 +90,7 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
               Psi1[ipsi]->rejectMove(iat);
           }
 
-          W.accept_rejectMove(iat, is_accepted, true);
+          W.accept_rejectMove(iat, is_accepted);
         }
         else //reject illegal moves
           ++nReject;

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -217,7 +217,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
           TrialWaveFunction::flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
 
-          ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted, true);
+          ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted);
         }
       }
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -90,7 +90,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
         if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           continue;
         }
         ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -99,7 +99,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
         {
           ++nRejectTemp;
           ++nNodeCrossing;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           Psi.rejectMove(iat);
         }
         else
@@ -124,7 +124,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
             ++nRejectTemp;
             Psi.rejectMove(iat);
           }
-          W.accept_rejectMove(iat, is_accepted, true);
+          W.accept_rejectMove(iat, is_accepted);
         }
       }
     }

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -90,6 +90,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
         if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
+          W.accept_rejectMove(iat, false, true);
           continue;
         }
         ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -98,7 +99,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
         {
           ++nRejectTemp;
           ++nNodeCrossing;
-          W.rejectMove(iat);
+          W.accept_rejectMove(iat, false, true);
           Psi.rejectMove(iat);
         }
         else
@@ -109,20 +110,21 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
           dr                     = W.R[iat] - W.activePos - dr;
           FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
           RealType prob          = std::norm(ratio) * std::exp(logGb - logGf);
+          bool is_accepted       = false;
           if (RandomGen() < prob)
           {
+            is_accepted = true;
             ++nAcceptTemp;
             Psi.acceptMove(W, iat, true);
-            W.acceptMove(iat, true);
             rr_accepted += rr;
             gf_acc *= prob; //accumulate the ratio
           }
           else
           {
             ++nRejectTemp;
-            W.rejectMove(iat);
             Psi.rejectMove(iat);
           }
+          W.accept_rejectMove(iat, is_accepted, true);
         }
       }
     }

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
@@ -102,12 +102,12 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
           if (rr > m_r2max)
           {
             ++nRejectTemp;
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
           if (!W.makeMoveAndCheck(iat, dr))
           {
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
         }
@@ -119,7 +119,7 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
           dr = 0.0;
           if (!W.makeMoveAndCheck(iat, dr))
           {
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
 
@@ -128,20 +128,20 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
           K = Ktmp;
           getScaledDriftL2(tauovermass, grad_iat, D, K, dr);
 
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           rr = tauovermass * dot(dr_diff, dr_diff);
           rr_proposed += rr;
           if (rr > m_r2max)
           {
             ++nRejectTemp;
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
 
           // move with just drift to update distance tables
           if (!W.makeMoveAndCheck(iat, dr))
           {
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
 
@@ -153,11 +153,11 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
           dr += sqrttau * dr_diff;
 
           // reverse the intermediate drift move
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           // move with drift and diffusion together
           if (!W.makeMoveAndCheck(iat, dr))
           {
-            W.accept_rejectMove(iat, false, true);
+            W.accept_rejectMove(iat, false);
             continue;
           }
         }
@@ -167,7 +167,7 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
         {
           ++nRejectTemp;
           ++nNodeCrossing;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           Psi.rejectMove(iat);
         }
         else
@@ -195,7 +195,7 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
             ++nRejectTemp;
             Psi.rejectMove(iat);
           }
-          W.accept_rejectMove(iat, is_accepted, true);
+          W.accept_rejectMove(iat, is_accepted);
         }
       }
     }

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -91,7 +91,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
         if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           continue;
         }
         ValueType ratio = Psi.calcRatioGradWithSpin(W, iat, grad_iat, spingrad_iat);
@@ -100,7 +100,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
         {
           ++nRejectTemp;
           ++nNodeCrossing;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           Psi.rejectMove(iat);
         }
         else
@@ -131,7 +131,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
             ++nRejectTemp;
             Psi.rejectMove(iat);
           }
-          W.accept_rejectMove(iat, is_accepted, true);
+          W.accept_rejectMove(iat, is_accepted);
         }
       }
     }

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -91,6 +91,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
         if (!is_valid || rr > m_r2max)
         {
           ++nRejectTemp;
+          W.accept_rejectMove(iat, false, true);
           continue;
         }
         ValueType ratio = Psi.calcRatioGradWithSpin(W, iat, grad_iat, spingrad_iat);
@@ -99,7 +100,7 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
         {
           ++nRejectTemp;
           ++nNodeCrossing;
-          W.rejectMove(iat);
+          W.accept_rejectMove(iat, false, true);
           Psi.rejectMove(iat);
         }
         else
@@ -113,21 +114,24 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
           ds                     = W.spins[iat] - W.activeSpinVal - ds;
           FullPrecRealType logGb = -oneover2tau * dot(dr, dr);
           logGb += -spinMass * oneover2tau * ds * ds;
-          RealType prob = std::norm(ratio) * std::exp(logGb - logGf);
+          RealType prob    = std::norm(ratio) * std::exp(logGb - logGf);
+          bool is_accepted = false;
+
           if (RandomGen() < prob)
           {
+            is_accepted = true;
+
             ++nAcceptTemp;
             Psi.acceptMove(W, iat, true);
-            W.acceptMove(iat, true);
             rr_accepted += rr;
             gf_acc *= prob; //accumulate the ratio
           }
           else
           {
             ++nRejectTemp;
-            W.rejectMove(iat);
             Psi.rejectMove(iat);
           }
+          W.accept_rejectMove(iat, is_accepted, true);
         }
       }
     }

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -159,6 +159,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
       if (!is_valid || rr > m_r2max)
       {
         ++nRejectTemp;
+        W.accept_rejectMove(iat, false, true);
         continue;
       }
       ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -167,7 +168,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
       {
         ++nRejectTemp;
         ++nNodeCrossing;
-        W.rejectMove(iat);
+        W.accept_rejectMove(iat, false, true);
         Psi.rejectMove(iat);
       }
       else
@@ -175,23 +176,24 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
         RealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
         //Use the force of the particle iat
         DriftModifier->getDrift(tauovermass, grad_iat, dr);
-        dr             = W.R[iat] - W.activePos - dr;
-        RealType logGb = -oneover2tau * dot(dr, dr);
-        RealType prob  = std::norm(ratio) * std::exp(logGb - logGf);
+        dr               = W.R[iat] - W.activePos - dr;
+        RealType logGb   = -oneover2tau * dot(dr, dr);
+        RealType prob    = std::norm(ratio) * std::exp(logGb - logGf);
+        bool is_accepted = false;
         if (RandomGen() < prob)
         {
+          is_accepted = true;
           ++nAcceptTemp;
           Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
           rr_accepted += rr;
           gf_acc *= prob; //accumulate the ratio
         }
         else
         {
           ++nRejectTemp;
-          W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        W.accept_rejectMove(iat, is_accepted, true);
       }
     }
   }
@@ -288,6 +290,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
       if (!is_valid || rr > m_r2max)
       {
         ++nRejectTemp;
+        W.accept_rejectMove(iat, false, true);
         continue;
       }
       ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -296,7 +299,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
       {
         ++nRejectTemp;
         ++nNodeCrossing;
-        W.rejectMove(iat);
+        W.accept_rejectMove(iat, false, true);
         Psi.rejectMove(iat);
       }
       else
@@ -304,23 +307,24 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
         RealType logGf = -0.5 * dot(deltaR[iat], deltaR[iat]);
         //Use the force of the particle iat
         DriftModifier->getDrift(tauovermass, grad_iat, dr);
-        dr             = W.R[iat] - W.activePos - dr;
-        RealType logGb = -oneover2tau * dot(dr, dr);
-        RealType prob  = std::norm(ratio) * std::exp(logGb - logGf);
+        dr               = W.R[iat] - W.activePos - dr;
+        RealType logGb   = -oneover2tau * dot(dr, dr);
+        RealType prob    = std::norm(ratio) * std::exp(logGb - logGf);
+        bool is_accepted = false;
         if (RandomGen() < prob)
         {
+          is_accepted = true;
           ++nAcceptTemp;
           Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
           rr_accepted += rr;
           gf_acc *= prob; //accumulate the ratio
         }
         else
         {
           ++nRejectTemp;
-          W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        W.accept_rejectMove(iat, is_accepted, true);
       }
     }
   }

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -159,7 +159,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
       if (!is_valid || rr > m_r2max)
       {
         ++nRejectTemp;
-        W.accept_rejectMove(iat, false, true);
+        W.accept_rejectMove(iat, false);
         continue;
       }
       ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -168,7 +168,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
       {
         ++nRejectTemp;
         ++nNodeCrossing;
-        W.accept_rejectMove(iat, false, true);
+        W.accept_rejectMove(iat, false);
         Psi.rejectMove(iat);
       }
       else
@@ -193,7 +193,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
           ++nRejectTemp;
           Psi.rejectMove(iat);
         }
-        W.accept_rejectMove(iat, is_accepted, true);
+        W.accept_rejectMove(iat, is_accepted);
       }
     }
   }
@@ -290,7 +290,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
       if (!is_valid || rr > m_r2max)
       {
         ++nRejectTemp;
-        W.accept_rejectMove(iat, false, true);
+        W.accept_rejectMove(iat, false);
         continue;
       }
       ValueType ratio = Psi.calcRatioGrad(W, iat, grad_iat);
@@ -299,7 +299,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
       {
         ++nRejectTemp;
         ++nNodeCrossing;
-        W.accept_rejectMove(iat, false, true);
+        W.accept_rejectMove(iat, false);
         Psi.rejectMove(iat);
       }
       else
@@ -324,7 +324,7 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
           ++nRejectTemp;
           Psi.rejectMove(iat);
         }
-        W.accept_rejectMove(iat, is_accepted, true);
+        W.accept_rejectMove(iat, is_accepted);
       }
     }
   }

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
@@ -80,7 +80,7 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         if (!W.makeMoveAndCheckWithSpin(iat, dr, ds))
         {
           ++nReject;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           continue;
         }
         RealType prob(0);
@@ -119,7 +119,7 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
           ++nReject;
           Psi.rejectMove(iat);
         }
-        W.accept_rejectMove(iat, is_accepted, true);
+        W.accept_rejectMove(iat, is_accepted);
       }
     }
     Psi.completeUpdates();

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
@@ -80,6 +80,7 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         if (!W.makeMoveAndCheckWithSpin(iat, dr, ds))
         {
           ++nReject;
+          W.accept_rejectMove(iat, false, true);
           continue;
         }
         RealType prob(0);
@@ -104,19 +105,21 @@ void SOVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         {
           prob = std::norm(Psi.calcRatio(W, iat));
         }
+
+        bool is_accepted = false;
         if (prob >= std::numeric_limits<RealType>::epsilon() && RandomGen() < prob)
         {
-          moved = true;
+          is_accepted = true;
+          moved       = true;
           ++nAccept;
           Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
         }
         else
         {
           ++nReject;
-          W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        W.accept_rejectMove(iat, is_accepted, true);
       }
     }
     Psi.completeUpdates();

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -156,7 +156,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
 
         TrialWaveFunction::flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
 
-        ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted, true);
+        ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted);
       }
     }
     TrialWaveFunction::flex_completeUpdates(walker_twfs);

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -75,7 +75,7 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         if (!W.makeMoveAndCheck(iat, dr))
         {
           ++nReject;
-          W.accept_rejectMove(iat, false, true);
+          W.accept_rejectMove(iat, false);
           continue;
         }
 
@@ -106,7 +106,7 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
           ++nReject;
           Psi.rejectMove(iat);
         }
-        W.accept_rejectMove(iat, is_accepted, true);
+        W.accept_rejectMove(iat, is_accepted);
       }
     }
     Psi.completeUpdates();

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -75,6 +75,7 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         if (!W.makeMoveAndCheck(iat, dr))
         {
           ++nReject;
+          W.accept_rejectMove(iat, false, true);
           continue;
         }
 
@@ -92,19 +93,20 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
         else
           prob = std::norm(Psi.calcRatio(W, iat));
 
+        bool is_accepted = false;
         if (prob >= std::numeric_limits<RealType>::epsilon() && RandomGen() < prob)
         {
-          moved = true;
+          is_accepted = true;
+          moved       = true;
           ++nAccept;
           Psi.acceptMove(W, iat, true);
-          W.acceptMove(iat, true);
         }
         else
         {
           ++nReject;
-          W.rejectMove(iat);
           Psi.rejectMove(iat);
         }
+        W.accept_rejectMove(iat, is_accepted, true);
       }
     }
     Psi.completeUpdates();

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -381,7 +381,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
           LogComplexApprox(std::complex<RealType>(-8.013162503965223, 6.283185307179586)));
 #endif
 
-  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id, isAccepted);
+  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id, isAccepted, false);
 
   const int moved_elec_id_next = 1;
   psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
@@ -448,7 +448,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   isAccepted[1] = false;
   TrialWaveFunction::flex_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id_next, isAccepted, true);
 
-  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id_next, isAccepted);
+  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id_next, isAccepted, false);
   TrialWaveFunction::flex_completeUpdates(wf_ref_list);
   TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, false);
 


### PR DESCRIPTION
## Proposed changes
1. Clean up the accept/reject single particle move logic. Two modes regular and forward mode documented in PartcleSet.h
2. Full documentation for DynamicCoordinates class.

## What type(s) of changes does this code introduce?
- Refactoring with api changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'