### PR TITLE
Stop cusparse(11.4) warning since CUDA 11.2.1.

### DIFF
--- a/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
+++ b/src/AFQMC/Numerics/detail/CUDA/sparse_cuda_gpu_ptr.hpp
@@ -29,6 +29,9 @@
 #if CUSPARSE_VER_MAJOR < 11
 #include "AFQMC/Numerics/detail/CUDA/cusparse_wrapper_deprecated.hpp"
 #endif
+#if CUSPARSE_VERSION >= 11400
+#define CUSPARSE_CSRMV_ALG1 CUSPARSE_SPMV_CSR_ALG1
+#endif
 
 #include "multi/array.hpp"
 


### PR DESCRIPTION
## Proposed changes
Warning removal.

## What type(s) of changes does this code introduce?
- Other (please describe):

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'