### PR TITLE
Split flex_ APIs in TWF

### DIFF
--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -13,7 +13,7 @@
 
 namespace qmcplusplus
 {
-Crowd::Crowd(EstimatorManagerNew& emb) : estimator_manager_crowd_(emb) {}
+Crowd::Crowd(EstimatorManagerNew& emb, const TWFdispatcher& twf_dispatcher) : twf_dispatcher_(twf_dispatcher), estimator_manager_crowd_(emb) {}
 
 Crowd::~Crowd() = default;
 

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -20,6 +20,7 @@ namespace qmcplusplus
 {
 // forward declaration
 class ResourceCollection;
+class TWFdispatcher;
 
 /** Driver synchronized step context
  * 
@@ -40,7 +41,7 @@ public:
   using FullPrecRealType = QMCTraits::FullPrecRealType;
   /** This is the data structure for walkers within a crowd
    */
-  Crowd(EstimatorManagerNew& emb);
+  Crowd(EstimatorManagerNew& emb, const TWFdispatcher& twf_dispatcher);
 
   ~Crowd();
   /** Because so many vectors allocate them upfront.
@@ -111,6 +112,8 @@ public:
   unsigned long get_nonlocal_accept() { return n_nonlocal_accept_; }
   unsigned long get_accept() { return n_accept_; }
   unsigned long get_reject() { return n_reject_; }
+
+  const TWFdispatcher& twf_dispatcher_;
 
 private:
   /** @name Walker Vectors

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -55,7 +55,10 @@ TimerNameList_t<WC_Timers> WalkerControlTimerNames = {{WC_branch, "WalkerControl
                                                       {WC_send, "WalkerControl::send"},
                                                       {WC_recv, "WalkerControl::recv"}};
 
-WalkerControl::WalkerControl(Communicate* c, const TWFdispatcher& twf_dispatcher, RandomGenerator_t& rng, bool use_fixed_pop)
+WalkerControl::WalkerControl(Communicate* c,
+                             const TWFdispatcher& twf_dispatcher,
+                             RandomGenerator_t& rng,
+                             bool use_fixed_pop)
     : MPIObjectBase(c),
       rng_(rng),
       use_fixed_pop_(use_fixed_pop),

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include "WalkerControl.h"
+#include "QMCWaveFunctions/TWFdispatcher.h"
 #include "QMCDrivers/WalkerProperties.h"
 #include "Particle/HDFWalkerIO.h"
 #include "OhmmsData/ParameterSet.h"
@@ -54,7 +55,7 @@ TimerNameList_t<WC_Timers> WalkerControlTimerNames = {{WC_branch, "WalkerControl
                                                       {WC_send, "WalkerControl::send"},
                                                       {WC_recv, "WalkerControl::recv"}};
 
-WalkerControl::WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop)
+WalkerControl::WalkerControl(Communicate* c, const TWFdispatcher& twf_dispatcher, RandomGenerator_t& rng, bool use_fixed_pop)
     : MPIObjectBase(c),
       rng_(rng),
       use_fixed_pop_(use_fixed_pop),
@@ -67,7 +68,8 @@ WalkerControl::WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fi
       SwapMode(0),
       use_nonblocking_(true),
       debug_disable_branching_(false),
-      saved_num_walkers_sent_(0)
+      saved_num_walkers_sent_(0),
+      twf_dispatcher_(twf_dispatcher)
 {
   num_per_node_.resize(num_ranks_);
   fair_offset_.resize(num_ranks_ + 1);
@@ -259,7 +261,7 @@ int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
     ParticleSet::flex_update(p_list);
 
     const RefVectorWithLeader<TrialWaveFunction> wf_list(pop.get_golden_twf(), wf_list_no_leader);
-    TrialWaveFunction::flex_evaluateLog(wf_list, p_list);
+    twf_dispatcher_.flex_evaluateLog(wf_list, p_list);
   }
 
   const int current_num_global_walkers = std::accumulate(num_per_node_.begin(), num_per_node_.end(), 0);

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -32,6 +32,9 @@
 
 namespace qmcplusplus
 {
+
+class TWFdispatcher;
+
 /** Class for controlling the walkers for DMC simulations.
  * w and w/o MPI. Fixed and dynamic population in one place.
  */
@@ -51,7 +54,7 @@ public:
    *
    * Set the SwapMode to zero so that instantiation can be done
    */
-  WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop = false);
+  WalkerControl(Communicate* c, const TWFdispatcher& twf_dispatcher, RandomGenerator_t& rng, bool use_fixed_pop = false);
 
   /** empty destructor to clean up the derived classes */
   ~WalkerControl();
@@ -180,6 +183,8 @@ private:
   TimerList_t my_timers_;
   ///Number of walkers sent during the exchange
   IndexType saved_num_walkers_sent_;
+
+  const TWFdispatcher& twf_dispatcher_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -32,7 +32,6 @@
 
 namespace qmcplusplus
 {
-
 class TWFdispatcher;
 
 /** Class for controlling the walkers for DMC simulations.
@@ -54,7 +53,10 @@ public:
    *
    * Set the SwapMode to zero so that instantiation can be done
    */
-  WalkerControl(Communicate* c, const TWFdispatcher& twf_dispatcher, RandomGenerator_t& rng, bool use_fixed_pop = false);
+  WalkerControl(Communicate* c,
+                const TWFdispatcher& twf_dispatcher,
+                RandomGenerator_t& rng,
+                bool use_fixed_pop = false);
 
   /** empty destructor to clean up the derived classes */
   ~WalkerControl();

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -366,7 +366,7 @@ protected:
   MCPopulation population_;
 
   /// TWF dispatcher
-  TWFdispatcher twf_dispatcher_;
+  const TWFdispatcher twf_dispatcher_;
 
   ///trial function
   TrialWaveFunction& Psi;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -32,6 +32,7 @@
 #include "Utilities/PooledData.h"
 #include "Utilities/TimerManager.h"
 #include "Utilities/ScopedProfiler.h"
+#include "QMCWaveFunctions/TWFdispatcher.h"
 #include "QMCDrivers/MCPopulation.h"
 #include "QMCDrivers/QMCDriverInterface.h"
 #include "QMCDrivers/GreenFunctionModifiers/DriftModifierBase.h"
@@ -363,6 +364,9 @@ protected:
 
   ///the entire (or on node) walker population
   MCPopulation population_;
+
+  /// TWF dispatcher
+  TWFdispatcher twf_dispatcher_;
 
   ///trial function
   TrialWaveFunction& Psi;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -349,7 +349,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       // Log psi and prepare for difference the log psi
       opt_data.zero_log_psi();
 
-      TrialWaveFunction::flex_evaluateDeltaLogSetup(wf_list, p_list, opt_data.get_log_psi_fixed(),
+      TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, opt_data.get_log_psi_fixed(),
                                                     opt_data.get_log_psi_opt(), ref_dLogPsi, ref_d2LogPsi);
 
       if (needGrads)
@@ -358,7 +358,7 @@ void QMCCostFunctionBatched::checkConfigurations()
         int nparam = optVars.size();
         RecordArray<Return_t> dlogpsi_array(nparam, curr_crowd_size);
         RecordArray<Return_t> dhpsioverpsi_array(nparam, curr_crowd_size);
-        TrialWaveFunction::flex_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array,
+        TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array,
                                                              dhpsioverpsi_array);
 
 
@@ -582,7 +582,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
           }
           opt_data.zero_log_psi();
 
-          TrialWaveFunction::flex_evaluateDeltaLog(wf_list, p_list, opt_data.get_log_psi_opt(), dummyG_list,
+          TrialWaveFunction::mw_evaluateDeltaLog(wf_list, p_list, opt_data.get_log_psi_opt(), dummyG_list,
                                                    dummyL_list, compute_all_from_scratch);
 
           Return_rt inv_n_samples = 1.0 / samples.getNumSamples();
@@ -609,7 +609,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
             RecordArray<Return_t> dlogpsi_array(nparam, curr_crowd_size);
             RecordArray<Return_t> dhpsioverpsi_array(nparam, curr_crowd_size);
 
-            TrialWaveFunction::flex_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array,
+            TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array,
                                                                  dhpsioverpsi_array);
 
 

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -15,6 +15,7 @@
 #include "Message/Communicate.h"
 #include "QMCDrivers/Crowd.h"
 #include "type_traits/template_types.hpp"
+#include "QMCWaveFunctions/TWFdispatcher.h"
 #include "Estimators/tests/FakeEstimator.h"
 #include "Estimators/EstimatorManagerNew.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
@@ -40,14 +41,15 @@ public:
   UPtrVector<TrialWaveFunction> twfs;
   UPtrVector<QMCHamiltonian> hams;
   std::vector<TinyVector<double, 3>> tpos;
+  const TWFdispatcher twf_dispatcher_;
 
 public:
-  CrowdWithWalkers(SetupPools& pools) : em(pools.comm)
+  CrowdWithWalkers(SetupPools& pools) : em(pools.comm), twf_dispatcher_(true)
   {
     FakeEstimator* fake_est = new FakeEstimator;
     em.add(fake_est, "fake");
 
-    crowd_ptr    = std::make_unique<Crowd>(em);
+    crowd_ptr    = std::make_unique<Crowd>(em, twf_dispatcher_);
     Crowd& crowd = *crowd_ptr;
     // To match the minimal particle set
     int num_particles = 2;
@@ -93,7 +95,8 @@ TEST_CASE("Crowd integration", "[drivers]")
   REQUIRE(fake_est2 == fake_est);
   // The above was required behavior for crowd at one point.
   // TODO: determine whether it still is, I don't think so.
-  Crowd crowd(em);
+  const TWFdispatcher twf_dispatcher(true);
+  Crowd crowd(em, twf_dispatcher);
 }
 
 TEST_CASE("Crowd::loadWalkers", "[particle]")

--- a/src/QMCDrivers/tests/test_SFNBranch.cpp
+++ b/src/QMCDrivers/tests/test_SFNBranch.cpp
@@ -19,7 +19,6 @@
 #include "Estimators/tests/FakeEstimator.h"
 #include "QMCDrivers/SFNBranch.h"
 #include "QMCDrivers/MCPopulation.h"
-#include "QMCDrivers/Crowd.h"
 #include "QMCDrivers/tests/ValidQMCInputSections.h"
 #include "QMCDrivers/tests/SetupPools.h"
 
@@ -65,10 +64,6 @@ public:
     createMyNode(sfnb, valid_dmc_input_sections[valid_dmc_input_dmc_batch_index]);
 
     sfnb.initParam(*pop_, 0, 0, false, false);
-
-    UPtrVector<Crowd> crowds;
-    crowds.emplace_back(std::make_unique<Crowd>(*emb_));
-    crowds.emplace_back(std::make_unique<Crowd>(*emb_));
 
     return sfnb;
   }

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -183,11 +183,11 @@ NonLocalECPComponent::RealType NonLocalECPComponent::calculateProjector(RealType
 }
 
 void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
-                                            const RefVectorWithLeader<ParticleSet>& p_list,
-                                            const RefVectorWithLeader<TrialWaveFunction>& psi_list,
-                                            const RefVector<const NLPPJob<RealType>>& joblist,
-                                            std::vector<RealType>& pairpots,
-                                            bool use_DLA)
+                                          const RefVectorWithLeader<ParticleSet>& p_list,
+                                          const RefVectorWithLeader<TrialWaveFunction>& psi_list,
+                                          const RefVector<const NLPPJob<RealType>>& joblist,
+                                          std::vector<RealType>& pairpots,
+                                          bool use_DLA)
 {
   if (ecp_component_list.size() > 1)
   {
@@ -221,7 +221,7 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
 
       if (use_DLA)
         TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,
-                                                 TrialWaveFunction::ComputeType::FERMIONIC);
+                                             TrialWaveFunction::ComputeType::FERMIONIC);
       else
         TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list);
     }

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -182,7 +182,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::calculateProjector(RealType
   return pairpot;
 }
 
-void NonLocalECPComponent::flex_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
+void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
                                             const RefVectorWithLeader<ParticleSet>& p_list,
                                             const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                                             const RefVector<const NLPPJob<RealType>>& joblist,
@@ -220,10 +220,10 @@ void NonLocalECPComponent::flex_evaluateOne(const RefVectorWithLeader<NonLocalEC
       ecp_component_leader.VP->flex_makeMoves(vp_list, deltaV_list, joblist, true);
 
       if (use_DLA)
-        psi_list.getLeader().flex_evaluateRatios(psi_list, const_vp_list, psiratios_list,
+        TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,
                                                  TrialWaveFunction::ComputeType::FERMIONIC);
       else
-        psi_list.getLeader().flex_evaluateRatios(psi_list, const_vp_list, psiratios_list);
+        TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list);
     }
     else
     {

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -173,7 +173,7 @@ public:
    * Note: ecp_component_list allows including different NLPP component for different walkers.
    * electrons in iel_list must be of the same group (spin)
    */
-  static void flex_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
+  static void mw_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
                                const RefVectorWithLeader<ParticleSet>& p_list,
                                const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                                const RefVector<const NLPPJob<RealType>>& joblist,

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -174,11 +174,11 @@ public:
    * electrons in iel_list must be of the same group (spin)
    */
   static void mw_evaluateOne(const RefVectorWithLeader<NonLocalECPComponent>& ecp_component_list,
-                               const RefVectorWithLeader<ParticleSet>& p_list,
-                               const RefVectorWithLeader<TrialWaveFunction>& psi_list,
-                               const RefVector<const NLPPJob<RealType>>& joblist,
-                               std::vector<RealType>& pairpots,
-                               bool use_DLA);
+                             const RefVectorWithLeader<ParticleSet>& p_list,
+                             const RefVectorWithLeader<TrialWaveFunction>& psi_list,
+                             const RefVector<const NLPPJob<RealType>>& joblist,
+                             std::vector<RealType>& pairpots,
+                             bool use_DLA);
 
   /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid
    * to total energy from ion "iat" and electron "iel".

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -310,7 +310,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       psi_list.clear();
       for (size_t iw = 0; iw < nw; iw++)
         psi_list.push_back(O_list.getCastedElement<NonLocalECPotential>(iw).Psi);
-      TrialWaveFunction::flex_prepareGroup(psi_list, p_list, ig);
+      TrialWaveFunction::mw_prepareGroup(psi_list, p_list, ig);
     }
 
     for (size_t jobid = 0; jobid < max_num_jobs[ig]; jobid++)
@@ -335,7 +335,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         }
       }
 
-      NonLocalECPComponent::flex_evaluateOne(ecp_component_list, pset_list, psi_list, batch_list, pairpots,
+      NonLocalECPComponent::mw_evaluateOne(ecp_component_list, pset_list, psi_list, batch_list, pairpots,
                                              O_leader.use_DLA);
 
       for (size_t j = 0; j < ecp_potential_list.size(); j++)

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -336,7 +336,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       }
 
       NonLocalECPComponent::mw_evaluateOne(ecp_component_list, pset_list, psi_list, batch_list, pairpots,
-                                             O_leader.use_DLA);
+                                           O_leader.use_DLA);
 
       for (size_t j = 0; j < ecp_potential_list.size(); j++)
       {

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
@@ -75,7 +75,7 @@ public:
                            ParticleSet& els,
                            TrialWaveFunction& psi,
                            bool usePBC,
-                           bool doForces = false,
+                           bool doForces   = false,
                            bool enable_DLA = false);
 
   OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -197,6 +197,7 @@ SET(FERMION_SRCS ${FERMION_SRCS}
   Fermion/MultiSlaterDeterminantWithBackflow.cpp
   SPOSetBuilderFactory.cpp
   TrialWaveFunction.cpp
+  TWFdispatcher.cpp
   WaveFunctionFactory.cpp
   )
 

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -1,0 +1,145 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "TWFdispatcher.h"
+#include "TrialWaveFunction.h"
+
+namespace qmcplusplus
+{
+
+TWFdispatcher::TWFdispatcher(bool use_batch) : use_batch_(use_batch) {}
+
+void TWFdispatcher::flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                         const RefVectorWithLeader<ParticleSet>& p_list) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_evaluateLog(wf_list, p_list);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].evaluateLog(p_list[iw]);
+}
+
+void TWFdispatcher::flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                       int iat,
+                                       std::vector<PsiValueType>& ratios,
+                                       ComputeType ct) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_calcRatio(wf_list, p_list, iat, ratios, ct);
+  else
+  {
+    const int num_wf = wf_list.size();
+    ratios.resize(num_wf);
+    for(size_t iw = 0; iw < num_wf; iw++)
+      ratios[iw] = wf_list[iw].calcRatio(p_list[iw], iat, ct);
+  }
+}
+
+void TWFdispatcher::flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                          const RefVectorWithLeader<ParticleSet>& p_list,
+                                          int ig) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_prepareGroup(wf_list, p_list, ig);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].prepareGroup(p_list[iw], ig);
+}
+
+void TWFdispatcher::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      int iat,
+                                      std::vector<GradType>& grad_now) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_evalGrad(wf_list, p_list, iat, grad_now);
+  else
+  {
+    const int num_wf = wf_list.size();
+    grad_now.resize(num_wf);
+    for(size_t iw = 0; iw < num_wf; iw++)
+      grad_now[iw] = wf_list[iw].evalGrad(p_list[iw], iat);
+  }
+}
+
+void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           int iat,
+                                           std::vector<PsiValueType>& ratios,
+                                           std::vector<GradType>& grad_new) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_calcRatioGrad(wf_list, p_list, iat, ratios, grad_new);
+  else
+  {
+    const int num_wf = wf_list.size();
+    ratios.resize(num_wf);
+    grad_new.resize(num_wf);
+    for(size_t iw = 0; iw < num_wf; iw++)
+      ratios[iw] = wf_list[iw].calcRatioGrad(p_list[iw], iat, grad_new[iw]);
+  }
+}
+
+void TWFdispatcher::flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                               const RefVectorWithLeader<ParticleSet>& p_list,
+                                               int iat,
+                                               const std::vector<bool>& isAccepted,
+                                               bool safe_to_delay) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_accept_rejectMove(wf_list, p_list, iat, isAccepted, safe_to_delay);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+      if (isAccepted[iw])
+        wf_list[iw].acceptMove(p_list[iw], iat, safe_to_delay);
+      else
+        wf_list[iw].rejectMove(iat);
+}
+
+void TWFdispatcher::flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_completeUpdates(wf_list);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].completeUpdates();
+}
+
+void TWFdispatcher::flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                        const RefVectorWithLeader<ParticleSet>& p_list,
+                                        bool fromscratch) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_evaluateGL(wf_list, p_list, fromscratch);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+  {
+    wf_list[iw].evaluateGL(p_list[iw], fromscratch);
+    // Ye: temporal workaround to have WF.G/L always defined.
+    // remove when KineticEnergy use WF.G/L instead of P.G/L
+    wf_list[iw].G = p_list[iw].G;
+    wf_list[iw].L = p_list[iw].L;
+  }
+}
+
+void TWFdispatcher::flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                            const RefVector<const VirtualParticleSet>& vp_list,
+                                            const RefVector<std::vector<ValueType>>& ratios_list,
+                                            ComputeType ct) const
+{
+  if (use_batch_)
+    TrialWaveFunction::mw_evaluateRatios(wf_list, vp_list, ratios_list, ct);
+  else
+    for(size_t iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].evaluateRatios(vp_list[iw], ratios_list[iw], ct);
+}
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -9,73 +9,78 @@
 
 
 #include "TWFdispatcher.h"
+#include <cassert>
 #include "TrialWaveFunction.h"
 
 namespace qmcplusplus
 {
-
 TWFdispatcher::TWFdispatcher(bool use_batch) : use_batch_(use_batch) {}
 
 void TWFdispatcher::flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                         const RefVectorWithLeader<ParticleSet>& p_list) const
+                                     const RefVectorWithLeader<ParticleSet>& p_list) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_evaluateLog(wf_list, p_list);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].evaluateLog(p_list[iw]);
 }
 
 void TWFdispatcher::flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                       int iat,
-                                       std::vector<PsiValueType>& ratios,
-                                       ComputeType ct) const
+                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                   int iat,
+                                   std::vector<PsiValueType>& ratios,
+                                   ComputeType ct) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_calcRatio(wf_list, p_list, iat, ratios, ct);
   else
   {
     const int num_wf = wf_list.size();
     ratios.resize(num_wf);
-    for(size_t iw = 0; iw < num_wf; iw++)
+    for (size_t iw = 0; iw < num_wf; iw++)
       ratios[iw] = wf_list[iw].calcRatio(p_list[iw], iat, ct);
   }
 }
 
 void TWFdispatcher::flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                          const RefVectorWithLeader<ParticleSet>& p_list,
-                                          int ig) const
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      int ig) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_prepareGroup(wf_list, p_list, ig);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].prepareGroup(p_list[iw], ig);
 }
 
 void TWFdispatcher::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                      const RefVectorWithLeader<ParticleSet>& p_list,
-                                      int iat,
-                                      std::vector<GradType>& grad_now) const
+                                  const RefVectorWithLeader<ParticleSet>& p_list,
+                                  int iat,
+                                  std::vector<GradType>& grad_now) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_evalGrad(wf_list, p_list, iat, grad_now);
   else
   {
     const int num_wf = wf_list.size();
     grad_now.resize(num_wf);
-    for(size_t iw = 0; iw < num_wf; iw++)
+    for (size_t iw = 0; iw < num_wf; iw++)
       grad_now[iw] = wf_list[iw].evalGrad(p_list[iw], iat);
   }
 }
 
 void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           int iat,
-                                           std::vector<PsiValueType>& ratios,
-                                           std::vector<GradType>& grad_new) const
+                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                       int iat,
+                                       std::vector<PsiValueType>& ratios,
+                                       std::vector<GradType>& grad_new) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_calcRatioGrad(wf_list, p_list, iat, ratios, grad_new);
   else
@@ -83,21 +88,22 @@ void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFuncti
     const int num_wf = wf_list.size();
     ratios.resize(num_wf);
     grad_new.resize(num_wf);
-    for(size_t iw = 0; iw < num_wf; iw++)
+    for (size_t iw = 0; iw < num_wf; iw++)
       ratios[iw] = wf_list[iw].calcRatioGrad(p_list[iw], iat, grad_new[iw]);
   }
 }
 
 void TWFdispatcher::flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                               const RefVectorWithLeader<ParticleSet>& p_list,
-                                               int iat,
-                                               const std::vector<bool>& isAccepted,
-                                               bool safe_to_delay) const
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           int iat,
+                                           const std::vector<bool>& isAccepted,
+                                           bool safe_to_delay) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_accept_rejectMove(wf_list, p_list, iat, isAccepted, safe_to_delay);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
       if (isAccepted[iw])
         wf_list[iw].acceptMove(p_list[iw], iat, safe_to_delay);
       else
@@ -109,36 +115,33 @@ void TWFdispatcher::flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunc
   if (use_batch_)
     TrialWaveFunction::mw_completeUpdates(wf_list);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].completeUpdates();
 }
 
 void TWFdispatcher::flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                        const RefVectorWithLeader<ParticleSet>& p_list,
-                                        bool fromscratch) const
+                                    const RefVectorWithLeader<ParticleSet>& p_list,
+                                    bool fromscratch) const
 {
+  assert(wf_list.size() == p_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_evaluateGL(wf_list, p_list, fromscratch);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
-  {
-    wf_list[iw].evaluateGL(p_list[iw], fromscratch);
-    // Ye: temporal workaround to have WF.G/L always defined.
-    // remove when KineticEnergy use WF.G/L instead of P.G/L
-    wf_list[iw].G = p_list[iw].G;
-    wf_list[iw].L = p_list[iw].L;
-  }
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
+      wf_list[iw].evaluateGL(p_list[iw], fromscratch);
 }
 
 void TWFdispatcher::flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                            const RefVector<const VirtualParticleSet>& vp_list,
-                                            const RefVector<std::vector<ValueType>>& ratios_list,
-                                            ComputeType ct) const
+                                        const RefVector<const VirtualParticleSet>& vp_list,
+                                        const RefVector<std::vector<ValueType>>& ratios_list,
+                                        ComputeType ct) const
 {
+  assert(wf_list.size() == vp_list.size());
+  assert(wf_list.size() == ratios_list.size());
   if (use_batch_)
     TrialWaveFunction::mw_evaluateRatios(wf_list, vp_list, ratios_list, ct);
   else
-    for(size_t iw = 0; iw < wf_list.size(); iw++)
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].evaluateRatios(vp_list[iw], ratios_list[iw], ct);
 }
 

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -1,0 +1,76 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_TWFDISPATCH_H
+#define QMCPLUSPLUS_TWFDISPATCH_H
+
+#include "TrialWaveFunction.h"
+
+namespace qmcplusplus
+{
+
+class TWFdispatcher
+{
+public:
+
+using PsiValueType = TrialWaveFunction::PsiValueType;
+using ComputeType = TrialWaveFunction::ComputeType;
+using ValueType = TrialWaveFunction::ValueType;
+using GradType = TrialWaveFunction::GradType;
+
+TWFdispatcher(bool use_batch);
+
+void flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                         const RefVectorWithLeader<ParticleSet>& p_list) const;
+
+void flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                       int iat,
+                                       std::vector<PsiValueType>& ratios,
+                                       ComputeType ct = ComputeType::ALL) const;
+
+void flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                          const RefVectorWithLeader<ParticleSet>& p_list,
+                                          int ig) const;
+
+void flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      int iat,
+                                      std::vector<GradType>& grad_now) const;
+
+void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                           const RefVectorWithLeader<ParticleSet>& p_list,
+                                           int iat,
+                                           std::vector<PsiValueType>& ratios,
+                                           std::vector<GradType>& grad_new) const;
+
+void flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                               const RefVectorWithLeader<ParticleSet>& p_list,
+                                               int iat,
+                                               const std::vector<bool>& isAccepted,
+                                               bool safe_to_delay) const;
+
+void flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list) const;
+
+void flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                        const RefVectorWithLeader<ParticleSet>& p_list,
+                                        bool fromscratch) const;
+
+void flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                            const RefVector<const VirtualParticleSet>& vp_list,
+                                            const RefVector<std::vector<ValueType>>& ratios_list,
+                                            ComputeType ct) const;
+
+private:
+bool use_batch_;
+};
+} // namespace qmcplusplus
+
+#endif

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -15,61 +15,59 @@
 
 namespace qmcplusplus
 {
-
 class TWFdispatcher
 {
 public:
+  using PsiValueType = TrialWaveFunction::PsiValueType;
+  using ComputeType  = TrialWaveFunction::ComputeType;
+  using ValueType    = TrialWaveFunction::ValueType;
+  using GradType     = TrialWaveFunction::GradType;
 
-using PsiValueType = TrialWaveFunction::PsiValueType;
-using ComputeType = TrialWaveFunction::ComputeType;
-using ValueType = TrialWaveFunction::ValueType;
-using GradType = TrialWaveFunction::GradType;
+  TWFdispatcher(bool use_batch);
 
-TWFdispatcher(bool use_batch);
+  void flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                        const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-void flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                         const RefVectorWithLeader<ParticleSet>& p_list) const;
+  void flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                      const RefVectorWithLeader<ParticleSet>& p_list,
+                      int iat,
+                      std::vector<PsiValueType>& ratios,
+                      ComputeType ct = ComputeType::ALL) const;
 
-void flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                       int iat,
-                                       std::vector<PsiValueType>& ratios,
-                                       ComputeType ct = ComputeType::ALL) const;
+  void flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                         const RefVectorWithLeader<ParticleSet>& p_list,
+                         int ig) const;
 
-void flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                          const RefVectorWithLeader<ParticleSet>& p_list,
-                                          int ig) const;
+  void flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                     const RefVectorWithLeader<ParticleSet>& p_list,
+                     int iat,
+                     std::vector<GradType>& grad_now) const;
 
-void flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                      const RefVectorWithLeader<ParticleSet>& p_list,
-                                      int iat,
-                                      std::vector<GradType>& grad_now) const;
+  void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list,
+                          int iat,
+                          std::vector<PsiValueType>& ratios,
+                          std::vector<GradType>& grad_new) const;
 
-void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list,
-                                           int iat,
-                                           std::vector<PsiValueType>& ratios,
-                                           std::vector<GradType>& grad_new) const;
+  void flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              int iat,
+                              const std::vector<bool>& isAccepted,
+                              bool safe_to_delay) const;
 
-void flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                               const RefVectorWithLeader<ParticleSet>& p_list,
-                                               int iat,
-                                               const std::vector<bool>& isAccepted,
-                                               bool safe_to_delay) const;
+  void flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list) const;
 
-void flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list) const;
+  void flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                       const RefVectorWithLeader<ParticleSet>& p_list,
+                       bool fromscratch) const;
 
-void flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                        const RefVectorWithLeader<ParticleSet>& p_list,
-                                        bool fromscratch) const;
-
-void flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                            const RefVector<const VirtualParticleSet>& vp_list,
-                                            const RefVector<std::vector<ValueType>>& ratios_list,
-                                            ComputeType ct) const;
+  void flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                           const RefVector<const VirtualParticleSet>& vp_list,
+                           const RefVector<std::vector<ValueType>>& ratios_list,
+                           ComputeType ct) const;
 
 private:
-bool use_batch_;
+  bool use_batch_;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -15,6 +15,11 @@
 
 namespace qmcplusplus
 {
+
+/** Wrappers on dispatching to TrialWaveFunction single walker APIs or mw_ APIs.
+ * This should be only used by QMC drivers.
+ * member function names must match mw_ APIs in TrialWaveFunction
+ */
 class TWFdispatcher
 {
 public:

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -136,11 +136,9 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateLog(ParticleSet& P)
   return LogValue;
 }
 
-void TrialWaveFunction::flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list)
 {
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     auto& p_leader  = p_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[RECOMPUTE_TIMER]);
@@ -184,9 +182,6 @@ void TrialWaveFunction::flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunc
     // remove when KineticEnergy use WF.G/L instead of P.G/L
     for (int iw = 0; iw < wf_list.size(); iw++)
       copyToP(p_list[iw], wf_list[iw]);
-  }
-  else if (wf_list.size() == 1)
-    wf_list[0].evaluateLog(p_list[0]);
 }
 
 void TrialWaveFunction::recompute(ParticleSet& P)
@@ -272,7 +267,7 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
 }
 
 
-void TrialWaveFunction::flex_evaluateDeltaLogSetup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateDeltaLogSetup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                                    std::vector<RealType>& logpsi_fixed_list,
                                                    std::vector<RealType>& logpsi_opt_list,
@@ -330,7 +325,7 @@ void TrialWaveFunction::flex_evaluateDeltaLogSetup(const RefVectorWithLeader<Tri
 }
 
 
-void TrialWaveFunction::flex_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                               const RefVectorWithLeader<ParticleSet>& p_list,
                                               std::vector<RealType>& logpsi_list,
                                               RefVector<ParticleSet::ParticleGradient_t>& dummyG_list,
@@ -445,7 +440,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatio(ParticleSet& P, int ia
   return static_cast<ValueType>(r);
 }
 
-void TrialWaveFunction::flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                        const RefVectorWithLeader<ParticleSet>& p_list,
                                        int iat,
                                        std::vector<PsiValueType>& ratios,
@@ -455,8 +450,6 @@ void TrialWaveFunction::flex_calcRatio(const RefVectorWithLeader<TrialWaveFuncti
   ratios.resize(num_wf);
   std::fill(ratios.begin(), ratios.end(), PsiValueType(1));
 
-  if (num_wf > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[V_TIMER]);
     const int num_wfc             = wf_leader.Z.size();
@@ -477,9 +470,6 @@ void TrialWaveFunction::flex_calcRatio(const RefVectorWithLeader<TrialWaveFuncti
     }
     for (int iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].PhaseDiff = std::imag(std::arg(ratios[iw]));
-  }
-  else if (wf_list.size() == 1)
-    ratios[0] = wf_list[0].calcRatio(p_list[0], iat);
 }
 
 void TrialWaveFunction::prepareGroup(ParticleSet& P, int ig)
@@ -488,12 +478,10 @@ void TrialWaveFunction::prepareGroup(ParticleSet& P, int ig)
     Z[i]->prepareGroup(P, ig);
 }
 
-void TrialWaveFunction::flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                           const RefVectorWithLeader<ParticleSet>& p_list,
                                           int ig)
 {
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[PREPAREGROUP_TIMER]);
     const int num_wfc             = wf_leader.Z.size();
@@ -505,9 +493,6 @@ void TrialWaveFunction::flex_prepareGroup(const RefVectorWithLeader<TrialWaveFun
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_prepareGroup(wfc_list, p_list, ig);
     }
-  }
-  else if (wf_list.size() == 1)
-    wf_list[0].prepareGroup(p_list[0], ig);
 }
 
 TrialWaveFunction::GradType TrialWaveFunction::evalGrad(ParticleSet& P, int iat)
@@ -535,7 +520,7 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, 
   return grad_iat;
 }
 
-void TrialWaveFunction::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                       const RefVectorWithLeader<ParticleSet>& p_list,
                                       int iat,
                                       std::vector<GradType>& grad_now)
@@ -544,8 +529,6 @@ void TrialWaveFunction::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunctio
   grad_now.resize(num_wf);
   std::fill(grad_now.begin(), grad_now.end(), GradType(0));
 
-  if (num_wf > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[VGL_TIMER]);
     // Right now mw_evalGrad can only be called through an concrete instance of a wavefunctioncomponent
@@ -561,9 +544,6 @@ void TrialWaveFunction::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunctio
       for (int iw = 0; iw < wf_list.size(); iw++)
         grad_now[iw] += grad_now_z[iw];
     }
-  }
-  else if (wf_list.size() == 1)
-    grad_now[0] = wf_list[0].evalGrad(p_list[0], iat);
 }
 
 
@@ -649,7 +629,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGradWithSpin(ParticleSe
   return static_cast<ValueType>(r);
 }
 
-void TrialWaveFunction::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                            const RefVectorWithLeader<ParticleSet>& p_list,
                                            int iat,
                                            std::vector<PsiValueType>& ratios,
@@ -661,8 +641,6 @@ void TrialWaveFunction::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFu
   ratios.resize(num_wf);
   std::fill(ratios.begin(), ratios.end(), PsiValueType(1));
 
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[VGL_TIMER]);
     const int num_wfc             = wf_leader.Z.size();
@@ -701,9 +679,6 @@ void TrialWaveFunction::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFu
     }
     for (int iw = 0; iw < wf_list.size(); iw++)
       wf_list[iw].PhaseDiff = std::imag(std::arg(ratios[iw]));
-  }
-  else if (wf_list.size() == 1)
-    ratios[0] = wf_list[0].calcRatioGrad(p_list[0], iat, grad_new[0]);
 }
 
 void TrialWaveFunction::printGL(ParticleSet::ParticleGradient_t& G,
@@ -754,14 +729,12 @@ void TrialWaveFunction::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
     LogValue += std::real(Z[i]->LogValue);
 }
 
-void TrialWaveFunction::flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                const RefVectorWithLeader<ParticleSet>& p_list,
                                                int iat,
                                                const std::vector<bool>& isAccepted,
                                                bool safe_to_delay)
 {
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[ACCEPT_TIMER]);
     const int num_wfc             = wf_leader.Z.size();
@@ -786,14 +759,6 @@ void TrialWaveFunction::flex_accept_rejectMove(const RefVectorWithLeader<TrialWa
           wf_list[iw].PhaseValue += std::imag(wfc_list[iw].LogValue);
         }
     }
-  }
-  else if (wf_list.size() == 1)
-  {
-    if (isAccepted[0])
-      wf_list[0].acceptMove(p_list[0], iat, safe_to_delay);
-    else
-      wf_list[0].rejectMove(iat);
-  }
 }
 
 void TrialWaveFunction::completeUpdates()
@@ -806,10 +771,8 @@ void TrialWaveFunction::completeUpdates()
   }
 }
 
-void TrialWaveFunction::flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list)
+void TrialWaveFunction::mw_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list)
 {
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[ACCEPT_TIMER]);
     const int num_wfc             = wf_leader.Z.size();
@@ -821,9 +784,6 @@ void TrialWaveFunction::flex_completeUpdates(const RefVectorWithLeader<TrialWave
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_completeUpdates(wfc_list);
     }
-  }
-  else if (wf_list.size() == 1)
-    wf_list[0].completeUpdates();
 }
 
 TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bool fromscratch)
@@ -843,12 +803,10 @@ TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bo
   return logpsi;
 }
 
-void TrialWaveFunction::flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                         const RefVectorWithLeader<ParticleSet>& p_list,
                                         bool fromscratch)
 {
-  if (wf_list.size() > 1)
-  {
     auto& p_leader  = p_list.getLeader();
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[BUFFER_TIMER]);
@@ -890,15 +848,6 @@ void TrialWaveFunction::flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunct
     // remove when KineticEnergy use WF.G/L instead of P.G/L
     for (int iw = 0; iw < wf_list.size(); iw++)
       copyToP(p_list[iw], wf_list[iw]);
-  }
-  else if (wf_list.size() == 1)
-  {
-    wf_list[0].evaluateGL(p_list[0], fromscratch);
-    // Ye: temporal workaround to have WF.G/L always defined.
-    // remove when KineticEnergy use WF.G/L instead of P.G/L
-    wf_list[0].G = p_list[0].G;
-    wf_list[0].L = p_list[0].L;
-  }
 }
 
 
@@ -1029,13 +978,11 @@ void TrialWaveFunction::evaluateRatios(const VirtualParticleSet& VP, std::vector
     }
 }
 
-void TrialWaveFunction::flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                             const RefVector<const VirtualParticleSet>& vp_list,
                                             const RefVector<std::vector<ValueType>>& ratios_list,
                                             ComputeType ct)
 {
-  if (wf_list.size() > 1)
-  {
     auto& wf_leader = wf_list.getLeader();
     ScopedTimer local_timer(wf_leader.TWF_timers_[NL_TIMER]);
     auto& wavefunction_components = wf_leader.Z;
@@ -1062,9 +1009,6 @@ void TrialWaveFunction::flex_evaluateRatios(const RefVectorWithLeader<TrialWaveF
             ratios[j] *= t[iw][j];
         }
       }
-  }
-  else if (wf_list.size() == 1)
-    wf_list[0].evaluateRatios(vp_list[0], ratios_list[0], ct);
 }
 
 void TrialWaveFunction::evaluateDerivRatios(VirtualParticleSet& VP,
@@ -1141,13 +1085,13 @@ void TrialWaveFunction::evaluateDerivatives(ParticleSet& P,
   }
 }
 
-void TrialWaveFunction::flex_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+void TrialWaveFunction::mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                           const RefVectorWithLeader<ParticleSet>& p_list,
                                                           const opt_variables_type& optvars,
                                                           RecordArray<ValueType>& dlogpsi,
                                                           RecordArray<ValueType>& dhpsioverpsi)
 {
-  int nparam = dlogpsi.nparam();
+  const int nparam = dlogpsi.nparam();
   for (int iw = 0; iw < wf_list.size(); iw++)
   {
     std::vector<ValueType> tmp_dlogpsi(nparam);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -54,10 +54,7 @@ namespace qmcplusplus
  * a batch of TrialWaveFunction objects in a lock-step fashion. These functions
  * are defined statically because they should not have access to a
  * concrete TWF object except through the passed RefVectorWithLeader<TWF>&.
- *
- * It dispatches to mw_ functions of WaveFunctionComponent or single walker functions
- * based on the number of objects WFC in the input. This accomidates openmp's implicit detection
- * of nested parallelism.
+ * It dispatches to mw_ functions of WaveFunctionComponent
  */
 class TrialWaveFunction
 {
@@ -368,20 +365,20 @@ public:
   void rejectMove(int iat);
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);
-  /* flexible batched version of acceptMove */
+  /* batched version of acceptMove */
   static void mw_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                    int iat,
                                    const std::vector<bool>& isAccepted,
                                    bool safe_to_delay = false);
   void completeUpdates();
-  /* flexible batched version of completeUpdates.  */
+  /* batched version of completeUpdates.  */
   static void mw_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list);
 
   /** compute gradients and laplacian of the TWF with respect to each particle.
    *  See WaveFunctionComponent::evaluateGL for more detail */
   LogValueType evaluateGL(ParticleSet& P, bool fromscratch);
-  /* flexible batched version of evaluateGL.
+  /* batched version of evaluateGL.
    */
   static void mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                             const RefVectorWithLeader<ParticleSet>& p_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -151,7 +151,7 @@ public:
 
   /** batched version of evaluateLog. gold reference */
   static void mw_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                               const RefVectorWithLeader<ParticleSet>& p_list);
+                             const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** recompute the value of the orbitals which require critical accuracy */
   void recompute(ParticleSet& P);
@@ -215,11 +215,11 @@ public:
    * and the external object adds the varying G and L and the fixed terms.
    */
   static void mw_evaluateDeltaLogSetup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                         const RefVectorWithLeader<ParticleSet>& p_list,
-                                         std::vector<RealType>& logpsi_fixed_list,
-                                         std::vector<RealType>& logpsi_opt_list,
-                                         RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
-                                         RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
+                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                       std::vector<RealType>& logpsi_fixed_list,
+                                       std::vector<RealType>& logpsi_opt_list,
+                                       RefVector<ParticleSet::ParticleGradient_t>& fixedG_list,
+                                       RefVector<ParticleSet::ParticleLaplacian_t>& fixedL_list);
 
   /** evaluate the log value for optimizable parts of a many-body wave function
    * @param wf_list vector of wavefunctions
@@ -245,11 +245,11 @@ public:
 
 
   static void mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                    const RefVectorWithLeader<ParticleSet>& p_list,
-                                    std::vector<RealType>& logpsi_list,
-                                    RefVector<ParticleSet::ParticleGradient_t>& dummyG_list,
-                                    RefVector<ParticleSet::ParticleLaplacian_t>& dummyL_list,
-                                    bool recompute = false);
+                                  const RefVectorWithLeader<ParticleSet>& p_list,
+                                  std::vector<RealType>& logpsi_list,
+                                  RefVector<ParticleSet::ParticleGradient_t>& dummyG_list,
+                                  RefVector<ParticleSet::ParticleLaplacian_t>& dummyL_list,
+                                  bool recompute = false);
 
 
   /** compute psi(R_new) / psi(R_current) ratio
@@ -263,10 +263,10 @@ public:
 
   /** batched version of calcRatio */
   static void mw_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                             const RefVectorWithLeader<ParticleSet>& p_list,
-                             int iat,
-                             std::vector<PsiValueType>& ratios,
-                             ComputeType ct = ComputeType::ALL);
+                           const RefVectorWithLeader<ParticleSet>& p_list,
+                           int iat,
+                           std::vector<PsiValueType>& ratios,
+                           ComputeType ct = ComputeType::ALL);
 
   /** compulte multiple ratios to handle non-local moves and other virtual moves
    */
@@ -275,9 +275,9 @@ public:
    * Note: unlike other mw_ static functions, *this is the batch leader instead of wf_list[0].
    */
   static void mw_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                  const RefVector<const VirtualParticleSet>& Vp_list,
-                                  const RefVector<std::vector<ValueType>>& ratios_list,
-                                  ComputeType ct = ComputeType::ALL);
+                                const RefVector<const VirtualParticleSet>& Vp_list,
+                                const RefVector<std::vector<ValueType>>& ratios_list,
+                                ComputeType ct = ComputeType::ALL);
 
   /** compute both ratios and deriatives of ratio with respect to the optimizables*/
   void evaluateDerivRatios(VirtualParticleSet& P,
@@ -323,10 +323,10 @@ public:
    *  all vector sizes must match
    */
   static void mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                 const RefVectorWithLeader<ParticleSet>& p_list,
-                                 int iat,
-                                 std::vector<PsiValueType>& ratios,
-                                 std::vector<GradType>& grad_new);
+                               const RefVectorWithLeader<ParticleSet>& p_list,
+                               int iat,
+                               std::vector<PsiValueType>& ratios,
+                               std::vector<GradType>& grad_new);
 
   /** Prepare internal data for updating WFC correspond to a particle group
    *  Particle groups usually correspond to determinants of different spins.
@@ -340,8 +340,8 @@ public:
    *  all vector sizes must match
    */
   static void mw_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                const RefVectorWithLeader<ParticleSet>& p_list,
-                                int ig);
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              int ig);
 
   GradType evalGrad(ParticleSet& P, int iat);
 
@@ -361,19 +361,19 @@ public:
     * to any TWF.
     */
   static void mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                            const RefVectorWithLeader<ParticleSet>& p_list,
-                            int iat,
-                            std::vector<GradType>& grad_now);
+                          const RefVectorWithLeader<ParticleSet>& p_list,
+                          int iat,
+                          std::vector<GradType>& grad_now);
 
   void rejectMove(int iat);
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);
   /* flexible batched version of acceptMove */
   static void mw_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                     const RefVectorWithLeader<ParticleSet>& p_list,
-                                     int iat,
-                                     const std::vector<bool>& isAccepted,
-                                     bool safe_to_delay = false);
+                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                   int iat,
+                                   const std::vector<bool>& isAccepted,
+                                   bool safe_to_delay = false);
   void completeUpdates();
   /* flexible batched version of completeUpdates.  */
   static void mw_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list);
@@ -384,8 +384,8 @@ public:
   /* flexible batched version of evaluateGL.
    */
   static void mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                              const RefVectorWithLeader<ParticleSet>& p_list,
-                              bool fromscratch);
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            bool fromscratch);
 
   /** register all the wavefunction components in buffer.
    *  See WaveFunctionComponent::registerData for more detail */
@@ -417,10 +417,10 @@ public:
                            bool project = false);
 
   static void mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                const RefVectorWithLeader<ParticleSet>& p_list,
-                                                const opt_variables_type& optvars,
-                                                RecordArray<ValueType>& dlogpsi,
-                                                RecordArray<ValueType>& dhpsioverpsi);
+                                              const RefVectorWithLeader<ParticleSet>& p_list,
+                                              const opt_variables_type& optvars,
+                                              RecordArray<ValueType>& dlogpsi,
+                                              RecordArray<ValueType>& dhpsioverpsi);
 
   void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, std::vector<ValueType>& dlogpsi);
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -50,7 +50,7 @@ namespace qmcplusplus
  *Each WaveFunctionComponent should provide proper evaluate functions
  *for the value, gradient and laplacian values.
  *
- * flex_ prefix is a function name signature indicating it is for handling
+ * mw_ prefix is a function name signature indicating it is for handling
  * a batch of TrialWaveFunction objects in a lock-step fashion. These functions
  * are defined statically because they should not have access to a
  * concrete TWF object except through the passed RefVectorWithLeader<TWF>&.
@@ -150,7 +150,7 @@ public:
   RealType evaluateLog(ParticleSet& P);
 
   /** batched version of evaluateLog. gold reference */
-  static void flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** recompute the value of the orbitals which require critical accuracy */
@@ -211,10 +211,10 @@ public:
    *
    * Parameters fixedG_list and fixedL_list save the terms coming from the components
    * that do not have optimizable parameters.
-   * It is expected that flex_evaluateDeltaLog(P,false) is called later
+   * It is expected that mw_evaluateDeltaLog(P,false) is called later
    * and the external object adds the varying G and L and the fixed terms.
    */
-  static void flex_evaluateDeltaLogSetup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateDeltaLogSetup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list,
                                          std::vector<RealType>& logpsi_fixed_list,
                                          std::vector<RealType>& logpsi_opt_list,
@@ -237,14 +237,14 @@ public:
    *   default value.  call evaluateLog only on optimizable orbitals.  OK if nonlocal pp's aren't used.
    *
    * To save time, logpsi, G, and L are only computed for orbitals that change over the course of the optimization.
-   * It is assumed that the fixed components are stored elsewhere.  See flex_evaluateDeltaLogSetup defined above.
+   * It is assumed that the fixed components are stored elsewhere.  See mw_evaluateDeltaLogSetup defined above.
    * Nonlocal pseudopotential evaluation requires temporary information like matrix inverses, so while
    * the logpsi, G, and L don't change, evaluateLog is called anyways to compute these auxiliary quantities from scratch.
    * logpsi, G, and L associated with these non-optimizable orbitals are discarded explicitly and with dummy variables.
    */
 
 
-  static void flex_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                     const RefVectorWithLeader<ParticleSet>& p_list,
                                     std::vector<RealType>& logpsi_list,
                                     RefVector<ParticleSet::ParticleGradient_t>& dummyG_list,
@@ -262,7 +262,7 @@ public:
   ValueType calcRatio(ParticleSet& P, int iat, ComputeType ct = ComputeType::ALL);
 
   /** batched version of calcRatio */
-  static void flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                              const RefVectorWithLeader<ParticleSet>& p_list,
                              int iat,
                              std::vector<PsiValueType>& ratios,
@@ -272,9 +272,9 @@ public:
    */
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios, ComputeType ct = ComputeType::ALL);
   /** batched version of evaluateRatios
-   * Note: unlike other flex_ static functions, *this is the batch leader instead of wf_list[0].
+   * Note: unlike other mw_ static functions, *this is the batch leader instead of wf_list[0].
    */
-  static void flex_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateRatios(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                   const RefVector<const VirtualParticleSet>& Vp_list,
                                   const RefVector<std::vector<ValueType>>& ratios_list,
                                   ComputeType ct = ComputeType::ALL);
@@ -322,7 +322,7 @@ public:
    *
    *  all vector sizes must match
    */
-  static void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                  const RefVectorWithLeader<ParticleSet>& p_list,
                                  int iat,
                                  std::vector<PsiValueType>& ratios,
@@ -339,7 +339,7 @@ public:
    *
    *  all vector sizes must match
    */
-  static void flex_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_prepareGroup(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                 const RefVectorWithLeader<ParticleSet>& p_list,
                                 int ig);
 
@@ -360,7 +360,7 @@ public:
     * This is static because it should have no direct access
     * to any TWF.
     */
-  static void flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                             const RefVectorWithLeader<ParticleSet>& p_list,
                             int iat,
                             std::vector<GradType>& grad_now);
@@ -369,21 +369,21 @@ public:
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);
   /* flexible batched version of acceptMove */
-  static void flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                      const RefVectorWithLeader<ParticleSet>& p_list,
                                      int iat,
                                      const std::vector<bool>& isAccepted,
                                      bool safe_to_delay = false);
   void completeUpdates();
   /* flexible batched version of completeUpdates.  */
-  static void flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list);
+  static void mw_completeUpdates(const RefVectorWithLeader<TrialWaveFunction>& wf_list);
 
   /** compute gradients and laplacian of the TWF with respect to each particle.
    *  See WaveFunctionComponent::evaluateGL for more detail */
   LogValueType evaluateGL(ParticleSet& P, bool fromscratch);
   /* flexible batched version of evaluateGL.
    */
-  static void flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               bool fromscratch);
 
@@ -416,7 +416,7 @@ public:
                            std::vector<ValueType>& dhpsioverpsi,
                            bool project = false);
 
-  static void flex_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+  static void mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                 const RefVectorWithLeader<ParticleSet>& p_list,
                                                 const opt_variables_type& optvars,
                                                 RecordArray<ValueType>& dlogpsi,

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -216,7 +216,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
   elec_.flex_update(p_ref_list);
-  psi.flex_evaluateLog(wf_ref_list, p_ref_list);
+  TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
 #if defined(QMC_COMPLEX)
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
           LogComplexApprox(std::complex<RealType>(0.4351202455204972, 6.665972664860828)));
@@ -238,7 +238,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
             << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
 
-  psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
+  TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
   REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
   REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
@@ -281,7 +281,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   p_ref_list[1].makeMove(moved_elec_id, delta);
 
   std::vector<PsiValueType> ratios(2);
-  psi.flex_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
+  TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
   std::cout << "calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(ratios[0] == ComplexApprox(PsiValueType(1, 0)));
@@ -304,7 +304,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
 
-  psi.flex_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
+  TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
 #if defined(QMC_COMPLEX)
   REQUIRE(ratios[0] == ComplexApprox(ValueType(1, 0)));
   REQUIRE(grad_new[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
@@ -326,7 +326,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   std::vector<bool> isAccepted(2, true);
-  psi.flex_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted);
+  TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted);
 #if defined(QMC_COMPLEX)
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
           LogComplexApprox(std::complex<RealType>(0.4351202455204972, 6.665972664860828)));
@@ -339,7 +339,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
           LogComplexApprox(std::complex<RealType>(-0.6365029797784554, 3.141592653589793)));
 #endif
 
-  psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
+  TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
   REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
   REQUIRE(grad_old[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -257,7 +257,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   auto fixedG_list     = convertUPtrToRefVector(fixedG_list_ptr);
   auto fixedL_list     = convertUPtrToRefVector(fixedL_list_ptr);
 
-  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
+  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list,
+                                              fixedL_list);
 
 
   // Evaluate old (single item) evaluateDeltaLog
@@ -321,7 +322,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   auto fixedG_list2     = convertUPtrToRefVector(fixedG_list2_ptr);
   auto fixedL_list2     = convertUPtrToRefVector(fixedL_list2_ptr);
 
-  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
+  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2,
+                                              fixedL_list2);
 
   // Evaluate old (single item) evaluateDeltaLog corresponding to the second wavefunction/particleset
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -152,7 +152,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   RecordArray<ValueType> dlogpsi_list(nparam, nentry);
   RecordArray<ValueType> dhpsi_over_psi_list(nparam, nentry);
 
-  psi.flex_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
+  TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
 
   CHECK(dlogpsi[0] == ValueApprox(dlogpsi_list.getValue(0, 0)));
   CHECK(dhpsioverpsi[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 0)));
@@ -171,7 +171,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   //  If a new one is needed, what is the easiest way to copy?
   wf_list.push_back(psi);
   p_list.push_back(elec2);
-  psi.flex_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
+  TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
 
   std::vector<ValueType> dlogpsi2(nparam);
   std::vector<ValueType> dhpsioverpsi2(nparam);
@@ -257,7 +257,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   auto fixedG_list     = convertUPtrToRefVector(fixedG_list_ptr);
   auto fixedL_list     = convertUPtrToRefVector(fixedL_list_ptr);
 
-  psi.flex_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
+  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list, fixedL_list);
 
 
   // Evaluate old (single item) evaluateDeltaLog
@@ -321,7 +321,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   auto fixedG_list2     = convertUPtrToRefVector(fixedG_list2_ptr);
   auto fixedL_list2     = convertUPtrToRefVector(fixedL_list2_ptr);
 
-  psi2.flex_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
+  TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list2, logpsi_opt_list2, fixedG_list2, fixedL_list2);
 
   // Evaluate old (single item) evaluateDeltaLog corresponding to the second wavefunction/particleset
 
@@ -391,7 +391,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   RefVector<ParticleSet::ParticleLaplacian_t> dummyL_list;
 
   std::vector<RealType> logpsi_variable_list(nentry);
-  TrialWaveFunction::flex_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list, dummyG_list, dummyL_list, false);
+  TrialWaveFunction::mw_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list, dummyG_list, dummyL_list, false);
 
   RealType logpsi1 = psi.evaluateDeltaLog(p_list[0], false);
   CHECK(logpsi1 == Approx(logpsi_variable_list[0]));
@@ -408,7 +408,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
 
   std::vector<RealType> logpsi_variable_list2(nentry);
 
-  TrialWaveFunction::flex_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list2, dummyG_list2, dummyL_list2, true);
+  TrialWaveFunction::mw_evaluateDeltaLog(wf_list, p_list, logpsi_variable_list2, dummyG_list2, dummyL_list2, true);
 
   RealType logpsi1b = psi.evaluateDeltaLog(p_list[0], true);
   CHECK(logpsi1b == Approx(logpsi_variable_list2[0]));

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -239,7 +239,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
   elec_.flex_update(p_ref_list);
-  psi.flex_evaluateLog(wf_ref_list, p_ref_list);
+  TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
   std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " "
             << WF_list[0]->getPhase() << std::endl;
   std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " "
@@ -265,7 +265,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
             << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
 
-  psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
+  TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
 #if defined(QMC_COMPLEX)
   REQUIRE(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653, 0.020838031926441)).epsilon(8e-5));
@@ -311,7 +311,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   p_ref_list[1].makeMove(moved_elec_id, delta);
 
   std::vector<PsiValueType> ratios(2);
-  psi.flex_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
+  TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
   std::cout << "mixed move calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
 
 #if defined(QMC_COMPLEX)
@@ -339,7 +339,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
 
-  psi.flex_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
+  TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
   std::cout << "flex_calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
             << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
             << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
@@ -364,7 +364,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 
   std::vector<bool> isAccepted(2, true);
-  psi.flex_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted, true);
+  TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted, true);
   std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi()
             << " " << WF_list[0]->getPhase() << std::endl;
   std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi()
@@ -384,7 +384,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id, isAccepted, false);
 
   const int moved_elec_id_next = 1;
-  psi.flex_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
+  TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
   std::cout << "evalGrad next electron " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " "
             << grad_old[0][2] << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
 #if defined(MIXED_PRECISION)
@@ -425,7 +425,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   displ[0] = displ[1] = {0.1, 0.2, 0.3};
 
   ParticleSet::flex_makeMove(p_ref_list, moved_elec_id_next, displ);
-  TrialWaveFunction::flex_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id_next, ratios, grad_new);
+  TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id_next, ratios, grad_new);
   std::cout << "ratioGrad next electron " << std::setprecision(14) << grad_new[0][0] << " " << grad_new[0][1] << " "
             << grad_new[0][2] << " " << grad_new[1][0] << " " << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
@@ -446,11 +446,11 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   isAccepted[0] = true;
   isAccepted[1] = false;
-  TrialWaveFunction::flex_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id_next, isAccepted, true);
+  TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id_next, isAccepted, true);
 
   ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id_next, isAccepted, false);
-  TrialWaveFunction::flex_completeUpdates(wf_ref_list);
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, false);
+  TrialWaveFunction::mw_completeUpdates(wf_ref_list);
+  TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
 
   std::cout << "invMat next electron " << std::setprecision(14) << det_up->getPsiMinv()[0][0] << " "
             << det_up->getPsiMinv()[0][1] << " " << det_up->getPsiMinv()[1][0] << " " << det_up->getPsiMinv()[1][1]
@@ -467,10 +467,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(det_up->getPsiMinv()[1][1] == Approx(45.51992500251).epsilon(1e-4));
 #endif
   std::vector<LogValueType> log_values(wf_ref_list.size());
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, false);
+  TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
   for (int iw = 0; iw < log_values.size(); iw++)
     log_values[iw] = {wf_ref_list[iw].getLogPsi(), wf_ref_list[iw].getPhase()};
-  TrialWaveFunction::flex_evaluateGL(wf_ref_list, p_ref_list, true);
+  TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, true);
   for (int iw = 0; iw < log_values.size(); iw++)
     REQUIRE(LogComplexApprox(log_values[iw]) == LogValueType{wf_ref_list[iw].getLogPsi(), wf_ref_list[iw].getPhase()});
 


### PR DESCRIPTION
## Proposed changes
When called from the driver, the flex API is doing dispatch to single walker or multi walker on per-call basis. It is often enter corner cases when the number of walker in a crowd drops to 1. This PR change
```C++
TrialWaveFunction::flex_evaluate()
{
  if(nw >1)
  { batched operation }
  else if (nw ==1)
  { single walker }
}
```
into

```C++
TrialWaveFunction::mw_evaluate()
{
  { batched operation }
}
```
and
```C++
TWFdispatcher::flex_evaluate()
{
  if (use_batch)
    TrialWaveFunction::mw_evaluate
  else
    loop over walker
    { single walker }
}
```
use_batch is selected per driver. Input control will be added once the ParticleSet flex_ APIs are updated.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'