### PR TITLE
Remove dataset.value attribute on PyscfToQmcpack_Spline.py

### DIFF
--- a/src/QMCTools/PyscfToQmcpack_Spline.py
+++ b/src/QMCTools/PyscfToQmcpack_Spline.py
@@ -295,12 +295,12 @@ class PwscfH5:
 
   def val(self,loc):
     """ get value array of an arbitrary entry at location 'loc' """
-    return self.fp[loc].value
+    return self.fp[loc][()]
 
   def get(self,name):
     """ get value array of a known entry """
     loc   = self.locations[name]
-    return self.fp[loc].value
+    return self.fp[loc][()]
 
   # =======================================================================
   # Advance Read Methods i.e. more specific to QMCPACK 3.0.0
@@ -324,11 +324,11 @@ class PwscfH5:
   # access specific eigenvalue or eigenvector
   def psig(self,ikpt=0,ispin=0,istate=0):
     psig_loc = self.state_path(ikpt,ispin,istate)+'psi_g'
-    return self.fp[psig_loc].value
+    return self.fp[psig_loc][()]
 
   def psir(self,ikpt=0,ispin=0,istate=0):
     psir_loc = self.state_path(ikpt,ispin,istate)+'psi_r'
-    return self.fp[psir_loc].value
+    return self.fp[psir_loc][()]
 
   def eigenvalues(self):
     """ return all eigenvalues, shape=(nkpt,nspin,nstate) """
@@ -395,16 +395,16 @@ class PwscfH5:
     nspin= self.get('nspin')
     for ikpt in range(nkpt):
       k_grp = self.fp[self.kpoint_path(ikpt)]
-      rkvec = k_grp['reduced_k'].value
+      rkvec = k_grp['reduced_k'][()]
       for ispin in range(nspin):
         spin_loc = self.spin_path(ikpt,ispin)
         sp_grp   = self.fp[spin_loc]
-        nstate   = sp_grp['number_of_states'].value[0]
-        evals    = sp_grp['eigenvalues'].value
+        nstate   = sp_grp['number_of_states'][(0)]
+        evals    = sp_grp['eigenvalues'][()]
         for istate in range(nstate):
           st_loc = self.state_path(ikpt,ispin,istate)
           st_grp = self.fp[st_loc]
-          evector= st_grp['psi_g'].value # shape (ngvec,2) (real,complex)
+          evector= st_grp['psi_g'][()] # shape (ngvec,2) (real,complex)
           entry  = {'ikpt':ikpt,'ispin':ispin,'istate':istate,
             'reduced_k':rkvec,'evalue':evals[istate],'evector':evector}
           data.append(entry)
@@ -665,19 +665,19 @@ class InputXml:
 
   def particleset_from_hdf5(self,h5_handle):
     atom_grp = h5_handle.get('atoms')
-    nspec = atom_grp.get('number_of_species').value[0]
-    species_ids = atom_grp.get('species_ids').value
-    positions = atom_grp.get('positions').value
+    nspec = atom_grp.get('number_of_species')[(0)]
+    species_ids = atom_grp.get('species_ids')[()]
+    positions = atom_grp.get('positions')[()]
 
-    natom_total = atom_grp.get('number_of_atoms').value[0]
+    natom_total = atom_grp.get('number_of_atoms')[(0)]
     # Get the name of the atoms
     groups = []
     for ispec in range(nspec):
       # turn h5 group into dictionary (i.e. h5ls -d)
       sp_grp         = atom_grp.get('species_%d'%ispec)
-      name           = sp_grp.get('name').value[0]
-      valence_charge = sp_grp.get('valence_charge').value[0]
-      atomic_number  = sp_grp.get('atomic_number').value[0]
+      name           = sp_grp.get('name')[(0)]
+      valence_charge = sp_grp.get('valence_charge')[(0)]
+      atomic_number  = sp_grp.get('atomic_number')[(0)]
 
       # locate particles of this species
       atom_idx = np.where(species_ids==ispec)
@@ -703,7 +703,7 @@ class InputXml:
     groups.append(pos_node)
 
     ionid_node = etree.Element('attrib',{'name':'ionid','datatype':'stringArray'})
-    ionid_node.text = self.arr2text(np.array([atom_grp.get('species_{}/name'.format(id_)).value[0]  for id_ in species_ids]))
+    ionid_node.text = self.arr2text(np.array([atom_grp.get('species_{}/name'.format(id_))[(0)]  for id_ in species_ids]))
 
     groups.append(ionid_node)
 
@@ -718,7 +718,7 @@ class InputXml:
     pset_node = etree.Element('particleset',{'name':'e','random':"yes", 'randomsrc':'ion0'})
 
     # size = number of electron up and down
-    elec_alpha_beta = h5_handle.get('electrons/number_of_electrons').value
+    elec_alpha_beta = h5_handle.get('electrons/number_of_electrons')[()]
     l_name = ("u","d")
     for name, electron in zip(l_name,elec_alpha_beta):
       groupe_node = etree.Element('group',{'name':"{}".format(name),'size':"{}".format(electron)})
@@ -741,7 +741,7 @@ class InputXml:
     determinantset_node.append(basisset_node)
 
     atom_grp = h5_handle.get('electrons')
-    alpha, beta = atom_grp.get('number_of_electrons').value
+    alpha, beta = atom_grp.get('number_of_electrons')[()]
 
     # Slaterdet,imamt
     slaterdet_node = etree.fromstring('''
@@ -774,8 +774,8 @@ class InputXml:
 
     # Species_id
     atom_grp = h5_handle.get('atoms')
-    species_ids = atom_grp.get('species_ids').value
-    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_)).value[0].decode()  for id_ in species_ids))
+    species_ids = atom_grp.get('species_ids')[()]
+    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_))[(0)].decode()  for id_ in species_ids))
 
     jastrow_node =   etree.Element('jastrow', {'name':"J1", 'type':"One-Body", "function":"Bspline", "print":"yes", "source":"ion0"})
 
@@ -791,8 +791,8 @@ class InputXml:
   def hamiltonian(self,h5_handle, cell):
 
     atom_grp = h5_handle.get('atoms')
-    species_ids = atom_grp.get('species_ids').value
-    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_)).value[0].decode()  for id_ in species_ids))
+    species_ids = atom_grp.get('species_ids')[()]
+    list_atom = sorted(set(atom_grp.get('species_{}/name'.format(id_))[(0)].decode()  for id_ in species_ids))
 
     if cell.has_ecp():
       hamiltonian_node = etree.fromstring('''


### PR DESCRIPTION
## Proposed changes

Close #2956 

Removed dataset.value attribute in PyscfToQmcpack_Spline.py. This is no longer available since h5py 3.0.0.
  
## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
