### PR TITLE
Restore previous arguments to flex_update

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -344,7 +344,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       }
 
       // Compute distance tables.
-      ParticleSet::flex_update(p_list, true);
+      ParticleSet::flex_update(p_list);
 
       // Log psi and prepare for difference the log psi
       opt_data.zero_log_psi();


### PR DESCRIPTION
The default for the second argument, skipSK, is false.
Fixes #2959


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
