### PR TITLE
Split flex_ APIs in ParticleSet

### DIFF
--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(PARTICLE
   InitMolecularSystem.cpp
   ParticleSetPool.cpp
   ParticleSet.cpp
+  PSdispatcher.cpp
   VirtualParticleSet.cpp
   ParticleSet.BC.cpp
   DynamicCoordinatesBuilder.cpp

--- a/src/Particle/PSdispatcher.cpp
+++ b/src/Particle/PSdispatcher.cpp
@@ -1,0 +1,76 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020 QMCPACK developers.
+//
+// File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Luke Shulenburger, lshulen@sandia.gov, Sandia National Laboratories
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "PSdispatcher.h"
+
+namespace qmcplusplus
+{
+PSdispatcher::PSdispatcher(bool use_batch) : use_batch_(use_batch) {}
+
+void PSdispatcher::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK) const
+{
+  if (use_batch_)
+    ParticleSet::mw_update(p_list, skipSK);
+  else
+    for (ParticleSet& pset : p_list)
+      pset.update(skipSK);
+}
+
+void PSdispatcher::flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
+                                int iat,
+                                const std::vector<SingleParticlePos_t>& displs) const
+{
+  if (use_batch_)
+    ParticleSet::mw_makeMove(p_list, iat, displs);
+  else
+    for (size_t iw = 0; iw < p_list.size(); iw++)
+      p_list[iw].makeMove(iat, displs[iw]);
+}
+
+void PSdispatcher::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
+                                         int iat,
+                                         const std::vector<bool>& isAccepted,
+                                         bool forward_mode) const
+{
+  if (use_batch_)
+    ParticleSet::mw_accept_rejectMove(p_list, iat, isAccepted, forward_mode);
+  else
+    for (size_t iw = 0; iw < p_list.size(); iw++)
+      p_list[iw].accept_rejectMove(iat, isAccepted[iw], forward_mode);
+}
+
+void PSdispatcher::flex_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list) const
+{
+  if (use_batch_)
+    ParticleSet::mw_donePbyP(p_list);
+  else
+    for (ParticleSet& pset : p_list)
+      pset.donePbyP();
+}
+
+void PSdispatcher::flex_saveWalker(const RefVectorWithLeader<ParticleSet>& p_list, const RefVector<Walker_t>& walkers) const
+{
+  if (use_batch_)
+    ParticleSet::mw_saveWalker(p_list, walkers);
+  else
+    for (size_t iw = 0; iw < p_list.size(); iw++)
+      p_list[iw].saveWalker(walkers[iw]);
+}
+
+} // namespace qmcplusplus

--- a/src/Particle/PSdispatcher.cpp
+++ b/src/Particle/PSdispatcher.cpp
@@ -2,18 +2,11 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
-// File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
-//                    Luke Shulenburger, lshulen@sandia.gov, Sandia National Laboratories
-//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
-//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
-//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
-//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
-//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
-//                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
-// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/Particle/PSdispatcher.cpp
+++ b/src/Particle/PSdispatcher.cpp
@@ -16,6 +16,17 @@ namespace qmcplusplus
 {
 PSdispatcher::PSdispatcher(bool use_batch) : use_batch_(use_batch) {}
 
+void PSdispatcher::flex_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
+                                   const RefVector<Walker_t>& walkers,
+                                   bool pbyp) const
+{
+  if (use_batch_)
+    ParticleSet::mw_loadWalker(p_list, walkers, pbyp);
+  else
+    for (size_t iw = 0; iw < p_list.size(); iw++)
+      p_list[iw].loadWalker(walkers[iw], pbyp);
+}
+
 void PSdispatcher::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK) const
 {
   if (use_batch_)
@@ -26,8 +37,8 @@ void PSdispatcher::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, b
 }
 
 void PSdispatcher::flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                int iat,
-                                const std::vector<SingleParticlePos_t>& displs) const
+                                 int iat,
+                                 const std::vector<SingleParticlePos_t>& displs) const
 {
   if (use_batch_)
     ParticleSet::mw_makeMove(p_list, iat, displs);
@@ -37,9 +48,9 @@ void PSdispatcher::flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
 }
 
 void PSdispatcher::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                         int iat,
-                                         const std::vector<bool>& isAccepted,
-                                         bool forward_mode) const
+                                          int iat,
+                                          const std::vector<bool>& isAccepted,
+                                          bool forward_mode) const
 {
   if (use_batch_)
     ParticleSet::mw_accept_rejectMove(p_list, iat, isAccepted, forward_mode);
@@ -57,7 +68,8 @@ void PSdispatcher::flex_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
       pset.donePbyP();
 }
 
-void PSdispatcher::flex_saveWalker(const RefVectorWithLeader<ParticleSet>& p_list, const RefVector<Walker_t>& walkers) const
+void PSdispatcher::flex_saveWalker(const RefVectorWithLeader<ParticleSet>& p_list,
+                                   const RefVector<Walker_t>& walkers) const
 {
   if (use_batch_)
     ParticleSet::mw_saveWalker(p_list, walkers);

--- a/src/Particle/PSdispatcher.h
+++ b/src/Particle/PSdispatcher.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_PSDISPATCH_H
+#define QMCPLUSPLUS_PSDISPATCH_H
+
+#include "ParticleSet.h"
+
+namespace qmcplusplus
+{
+
+/** Wrappers for dispatching to ParticleSet single walker APIs or mw_ APIs.
+ * This should be only used by QMC drivers.
+ * member function names must match mw_ APIs in TrialWaveFunction
+ */
+class PSdispatcher
+{
+public:
+  using Walker_t = ParticleSet::Walker_t;
+  using SingleParticlePos_t = ParticleSet::SingleParticlePos_t;
+
+  PSdispatcher(bool use_batch);
+
+  void flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false) const;
+
+  void flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
+                            int iat,
+                            const std::vector<SingleParticlePos_t>& displs) const;
+
+  void flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
+                                     int iat,
+                                     const std::vector<bool>& isAccepted,
+                                     bool forward_mode = true) const;
+
+  void flex_saveWalker(const RefVectorWithLeader<ParticleSet>& p_list, const RefVector<Walker_t>& walkers) const;
+
+  void flex_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list) const;
+
+private:
+  bool use_batch_;
+};
+} // namespace qmcplusplus
+
+#endif

--- a/src/Particle/PSdispatcher.h
+++ b/src/Particle/PSdispatcher.h
@@ -17,7 +17,6 @@
 
 namespace qmcplusplus
 {
-
 /** Wrappers for dispatching to ParticleSet single walker APIs or mw_ APIs.
  * This should be only used by QMC drivers.
  * member function names must match mw_ APIs in TrialWaveFunction
@@ -25,21 +24,25 @@ namespace qmcplusplus
 class PSdispatcher
 {
 public:
-  using Walker_t = ParticleSet::Walker_t;
+  using Walker_t            = ParticleSet::Walker_t;
   using SingleParticlePos_t = ParticleSet::SingleParticlePos_t;
 
   PSdispatcher(bool use_batch);
 
+  void flex_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
+                       const RefVector<Walker_t>& walkers,
+                       bool pbyp) const;
+
   void flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false) const;
 
   void flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                            int iat,
-                            const std::vector<SingleParticlePos_t>& displs) const;
+                     int iat,
+                     const std::vector<SingleParticlePos_t>& displs) const;
 
   void flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                     int iat,
-                                     const std::vector<bool>& isAccepted,
-                                     bool forward_mode = true) const;
+                              int iat,
+                              const std::vector<bool>& isAccepted,
+                              bool forward_mode = true) const;
 
   void flex_saveWalker(const RefVectorWithLeader<ParticleSet>& p_list, const RefVector<Walker_t>& walkers) const;
 

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -399,25 +399,25 @@ void ParticleSet::update(bool skipSK)
 
 void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK)
 {
-    auto& p_leader = p_list.getLeader();
-    ScopedTimer update_scope(p_leader.myTimers[PS_update]);
+  auto& p_leader = p_list.getLeader();
+  ScopedTimer update_scope(p_leader.myTimers[PS_update]);
 
-    for (ParticleSet& pset : p_list)
-      pset.setCoordinates(pset.R);
+  for (ParticleSet& pset : p_list)
+    pset.setCoordinates(pset.R);
 
-    auto& dts = p_leader.DistTables;
-    for (int i = 0; i < dts.size(); ++i)
-    {
-      const auto dt_list(extractDTRefList(p_list, i));
-      dts[i]->mw_evaluate(dt_list, p_list);
-    }
+  auto& dts = p_leader.DistTables;
+  for (int i = 0; i < dts.size(); ++i)
+  {
+    const auto dt_list(extractDTRefList(p_list, i));
+    dts[i]->mw_evaluate(dt_list, p_list);
+  }
 
-    if (!skipSK && p_leader.SK)
-    {
+  if (!skipSK && p_leader.SK)
+  {
 #pragma omp parallel for
-      for (int iw = 0; iw < p_list.size(); iw++)
-        p_list[iw].SK->UpdateAllPart(p_list[iw]);
-    }
+    for (int iw = 0; iw < p_list.size(); iw++)
+      p_list[iw].SK->UpdateAllPart(p_list[iw]);
+  }
 }
 
 void ParticleSet::makeMove(Index_t iat, const SingleParticlePos_t& displ, bool maybe_accept)
@@ -435,20 +435,20 @@ void ParticleSet::makeMoveWithSpin(Index_t iat, const SingleParticlePos_t& displ
 }
 
 void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                Index_t iat,
-                                const std::vector<SingleParticlePos_t>& displs)
+                              Index_t iat,
+                              const std::vector<SingleParticlePos_t>& displs)
 {
-    std::vector<SingleParticlePos_t> new_positions;
-    new_positions.reserve(displs.size());
+  std::vector<SingleParticlePos_t> new_positions;
+  new_positions.reserve(displs.size());
 
-    for (int iw = 0; iw < p_list.size(); iw++)
-    {
-      p_list[iw].activePtcl = iat;
-      p_list[iw].activePos  = p_list[iw].R[iat] + displs[iw];
-      new_positions.push_back(p_list[iw].activePos);
-    }
+  for (int iw = 0; iw < p_list.size(); iw++)
+  {
+    p_list[iw].activePtcl = iat;
+    p_list[iw].activePos  = p_list[iw].R[iat] + displs[iw];
+    new_positions.push_back(p_list[iw].activePos);
+  }
 
-    mw_computeNewPosDistTablesAndSK(p_list, iat, new_positions);
+  mw_computeNewPosDistTablesAndSK(p_list, iat, new_positions);
 }
 
 bool ParticleSet::makeMoveAndCheck(Index_t iat, const SingleParticlePos_t& displ)
@@ -729,31 +729,31 @@ void ParticleSet::rejectMoveForwardMode(Index_t iat)
 }
 
 void ParticleSet::mw_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                         Index_t iat,
-                                         const std::vector<bool>& isAccepted,
-                                         bool forward_mode)
+                                       Index_t iat,
+                                       const std::vector<bool>& isAccepted,
+                                       bool forward_mode)
 {
-    ParticleSet& leader = p_list.getLeader();
-    ScopedTimer update_scope(leader.myTimers[PS_accept]);
+  ParticleSet& leader = p_list.getLeader();
+  ScopedTimer update_scope(leader.myTimers[PS_accept]);
 
-    const auto coords_list(extractCoordsRefList(p_list));
-    std::vector<SingleParticlePos_t> new_positions;
-    new_positions.reserve(p_list.size());
-    for (const ParticleSet& pset : p_list)
-      new_positions.push_back(pset.activePos);
-    leader.coordinates_->mw_acceptParticlePos(coords_list, iat, new_positions, isAccepted);
+  const auto coords_list(extractCoordsRefList(p_list));
+  std::vector<SingleParticlePos_t> new_positions;
+  new_positions.reserve(p_list.size());
+  for (const ParticleSet& pset : p_list)
+    new_positions.push_back(pset.activePos);
+  leader.coordinates_->mw_acceptParticlePos(coords_list, iat, new_positions, isAccepted);
 
 #pragma omp parallel for
-    for (int iw = 0; iw < p_list.size(); iw++)
-    {
-      if (isAccepted[iw])
-        p_list[iw].acceptMove_impl(iat, forward_mode);
-      else if (forward_mode)
-        p_list[iw].rejectMoveForwardMode(iat);
-      else
-        p_list[iw].rejectMove(iat);
-      assert(p_list[iw].R[iat] == p_list[iw].coordinates_->getAllParticlePos()[iat]);
-    }
+  for (int iw = 0; iw < p_list.size(); iw++)
+  {
+    if (isAccepted[iw])
+      p_list[iw].acceptMove_impl(iat, forward_mode);
+    else if (forward_mode)
+      p_list[iw].rejectMoveForwardMode(iat);
+    else
+      p_list[iw].rejectMove(iat);
+    assert(p_list[iw].R[iat] == p_list[iw].coordinates_->getAllParticlePos()[iat]);
+  }
 }
 
 void ParticleSet::donePbyP()
@@ -769,8 +769,8 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
 {
 // Leaving bare omp pragma here. It can potentially be improved with cleaner abstraction.
 #pragma omp parallel for
-    for (int iw = 0; iw < p_list.size(); iw++)
-      p_list[iw].donePbyP();
+  for (int iw = 0; iw < p_list.size(); iw++)
+    p_list[iw].donePbyP();
 }
 
 void ParticleSet::makeVirtualMoves(const SingleParticlePos_t& newpos)
@@ -804,6 +804,15 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
   }
 
   activePtcl = -1;
+}
+
+void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
+                                const RefVector<Walker_t>& walkers,
+                                bool pbyp)
+{
+#pragma omp parallel for
+  for (int iw = 0; iw < psets.size(); ++iw)
+    psets[iw].loadWalker(walkers[iw], pbyp);
 }
 
 void ParticleSet::saveWalker(Walker_t& awalker)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -397,10 +397,8 @@ void ParticleSet::update(bool skipSK)
   activePtcl = -1;
 }
 
-void ParticleSet::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK)
+void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK)
 {
-  if (p_list.size() > 1)
-  {
     auto& p_leader = p_list.getLeader();
     ScopedTimer update_scope(p_leader.myTimers[PS_update]);
 
@@ -420,9 +418,6 @@ void ParticleSet::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bo
       for (int iw = 0; iw < p_list.size(); iw++)
         p_list[iw].SK->UpdateAllPart(p_list[iw]);
     }
-  }
-  else if (p_list.size() == 1)
-    p_list[0].update(skipSK);
 }
 
 void ParticleSet::makeMove(Index_t iat, const SingleParticlePos_t& displ, bool maybe_accept)
@@ -439,12 +434,10 @@ void ParticleSet::makeMoveWithSpin(Index_t iat, const SingleParticlePos_t& displ
   activeSpinVal += sdispl;
 }
 
-void ParticleSet::flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
+void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                 Index_t iat,
                                 const std::vector<SingleParticlePos_t>& displs)
 {
-  if (p_list.size() > 1)
-  {
     std::vector<SingleParticlePos_t> new_positions;
     new_positions.reserve(displs.size());
 
@@ -456,9 +449,6 @@ void ParticleSet::flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
     }
 
     mw_computeNewPosDistTablesAndSK(p_list, iat, new_positions);
-  }
-  else if (p_list.size() == 1)
-    p_list[0].makeMove(iat, displs[0]);
 }
 
 bool ParticleSet::makeMoveAndCheck(Index_t iat, const SingleParticlePos_t& displ)
@@ -738,13 +728,11 @@ void ParticleSet::rejectMoveForwardMode(Index_t iat)
   activePtcl = -1;
 }
 
-void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
+void ParticleSet::mw_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                          Index_t iat,
                                          const std::vector<bool>& isAccepted,
                                          bool forward_mode)
 {
-  if (p_list.size() > 1)
-  {
     ParticleSet& leader = p_list.getLeader();
     ScopedTimer update_scope(leader.myTimers[PS_accept]);
 
@@ -766,9 +754,6 @@ void ParticleSet::flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>&
         p_list[iw].rejectMove(iat);
       assert(p_list[iw].R[iat] == p_list[iw].coordinates_->getAllParticlePos()[iat]);
     }
-  }
-  else if (p_list.size() == 1)
-    p_list[0].accept_rejectMove(iat, isAccepted[0], forward_mode);
 }
 
 void ParticleSet::donePbyP()
@@ -780,17 +765,12 @@ void ParticleSet::donePbyP()
   activePtcl = -1;
 }
 
-void ParticleSet::flex_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
+void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
 {
-  if (p_list.size() > 1)
-  {
 // Leaving bare omp pragma here. It can potentially be improved with cleaner abstraction.
 #pragma omp parallel for
     for (int iw = 0; iw < p_list.size(); iw++)
       p_list[iw].donePbyP();
-  }
-  else if (p_list.size() == 1)
-    p_list[0].donePbyP();
 }
 
 void ParticleSet::makeVirtualMoves(const SingleParticlePos_t& newpos)
@@ -834,24 +814,12 @@ void ParticleSet::saveWalker(Walker_t& awalker)
   awalker.G = G;
   awalker.L = L;
 #endif
-  //PAOps<RealType,OHMMS_DIM>::copy(G,awalker.Drift);
-  //if (SK)
-  //  SK->UpdateAllPart(*this);
-  //awalker.DataSet.rewind();
 }
 
-void ParticleSet::flex_saveWalker(const RefVectorWithLeader<ParticleSet>& psets, const RefVector<Walker_t>& walkers)
+void ParticleSet::mw_saveWalker(const RefVectorWithLeader<ParticleSet>& psets, const RefVector<Walker_t>& walkers)
 {
-  int num_sets    = psets.size();
-  auto saveWalker = [](ParticleSet& pset, Walker_t& walker) {
-    walker.R = pset.R;
-#if !defined(SOA_MEMORY_OPTIMIZED)
-    walker.G = pset.G;
-    walker.L = pset.L;
-#endif
-  };
-  for (int iw = 0; iw < num_sets; ++iw)
-    saveWalker(psets[iw], walkers[iw]);
+  for (int iw = 0; iw < psets.size(); ++iw)
+    psets[iw].saveWalker(walkers[iw]);
 }
 
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -297,8 +297,8 @@ public:
 
   /// batched version of makeMove
   static void mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                            int iat,
-                            const std::vector<SingleParticlePos_t>& displs);
+                          int iat,
+                          const std::vector<SingleParticlePos_t>& displs);
 
   /** move the iat-th particle to activePos
    * @param iat the index of the particle to be moved
@@ -383,9 +383,9 @@ public:
   void rejectMove(Index_t iat);
   /// batched version of acceptMove and rejectMove fused
   static void mw_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
-                                     Index_t iat,
-                                     const std::vector<bool>& isAccepted,
-                                     bool forward_mode = true);
+                                   Index_t iat,
+                                   const std::vector<bool>& isAccepted,
+                                   bool forward_mode = true);
 
   void initPropertyList();
   inline int addProperty(const std::string& pname) { return PropertyList.add(pname.c_str()); }
@@ -417,6 +417,10 @@ public:
    * PbyP requires the distance tables and Sk with awalker.R
    */
   void loadWalker(Walker_t& awalker, bool pbyp);
+  /** batched version of loadWalker */
+  static void mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
+                            const RefVector<Walker_t>& walkers,
+                            bool pbyp);
 
   /** save this to awalker
    *

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -243,7 +243,7 @@ public:
   void update(bool skipSK = false);
 
   /// batched version of update
-  static void flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false);
+  static void mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false);
 
   /** create Structure Factor with PBCs
    */
@@ -296,7 +296,7 @@ public:
   void makeMoveWithSpin(Index_t iat, const SingleParticlePos_t& displ, const Scalar_t& sdispl);
 
   /// batched version of makeMove
-  static void flex_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
+  static void mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
                             int iat,
                             const std::vector<SingleParticlePos_t>& displs);
 
@@ -382,7 +382,7 @@ public:
    */
   void rejectMove(Index_t iat);
   /// batched version of acceptMove and rejectMove fused
-  static void flex_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
+  static void mw_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p_list,
                                      Index_t iat,
                                      const std::vector<bool>& isAccepted,
                                      bool forward_mode = true);
@@ -429,7 +429,7 @@ public:
    *
    *  just the R, G, and L
    */
-  static void flex_saveWalker(const RefVectorWithLeader<ParticleSet>& psets, const RefVector<Walker_t>& walkers);
+  static void mw_saveWalker(const RefVectorWithLeader<ParticleSet>& psets, const RefVector<Walker_t>& walkers);
 
   /** update structure factor and unmark activePtcl
    *
@@ -440,7 +440,7 @@ public:
    */
   void donePbyP();
   /// batched version of donePbyP
-  static void flex_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list);
+  static void mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list);
 
   ///return the address of the values of Hamiltonian terms
   inline FullPrecRealType* restrict getPropertyBase() { return Properties.data(); }

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -56,36 +56,30 @@ void VirtualParticleSet::makeMoves(int jel,
   update();
 }
 
-void VirtualParticleSet::flex_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
+void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
                                         const RefVector<const std::vector<PosType>>& deltaV_list,
                                         const RefVector<const NLPPJob<RealType>>& joblist,
                                         bool sphere)
 {
-  if (vp_list.size() > 1)
+  RefVectorWithLeader<ParticleSet> p_list(vp_list.getLeader());
+  p_list.reserve(vp_list.size());
+
+  for (int iw = 0; iw < vp_list.size(); iw++)
   {
-    RefVectorWithLeader<ParticleSet> p_list(vp_list.getLeader());
-    p_list.reserve(vp_list.size());
+    VirtualParticleSet& vp(vp_list[iw]);
+    const std::vector<PosType>& deltaV(deltaV_list[iw]);
+    const NLPPJob<RealType>& job(joblist[iw]);
 
-    for (int iw = 0; iw < vp_list.size(); iw++)
-    {
-      VirtualParticleSet& vp(vp_list[iw]);
-      const std::vector<PosType>& deltaV(deltaV_list[iw]);
-      const NLPPJob<RealType>& job(joblist[iw]);
-
-      vp.onSphere      = sphere;
-      vp.refPtcl       = job.electron_id;
-      vp.refSourcePtcl = job.ion_id;
-      assert(vp.R.size() == deltaV.size());
-      for (size_t ivp = 0; ivp < vp.R.size(); ivp++)
-        vp.R[ivp] = job.elec_pos + deltaV[ivp];
-      p_list.push_back(vp);
-    }
-
-    flex_update(p_list);
+    vp.onSphere      = sphere;
+    vp.refPtcl       = job.electron_id;
+    vp.refSourcePtcl = job.ion_id;
+    assert(vp.R.size() == deltaV.size());
+    for (size_t ivp = 0; ivp < vp.R.size(); ivp++)
+      vp.R[ivp] = job.elec_pos + deltaV[ivp];
+    p_list.push_back(vp);
   }
-  else if (vp_list.size() == 1)
-    vp_list[0].makeMoves(joblist[0].get().electron_id, joblist[0].get().electron_id, deltaV_list[0].get(), sphere,
-                         joblist[0].get().ion_id);
+
+  mw_update(p_list);
 }
 
 } // namespace qmcplusplus

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -65,7 +65,7 @@ public:
                  bool sphere = false,
                  int iat     = -1);
 
-  static void flex_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
+  static void mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
                              const RefVector<const std::vector<PosType>>& deltaV_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              bool sphere);

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -67,6 +67,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
                                 ContextForSteps& step_context,
                                 bool recompute)
 {
+  auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   {
@@ -156,7 +157,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
           for (int i = 0; i < rr.size(); ++i)
             assert(std::isfinite(rr[i]));
 #endif
-          ParticleSet::flex_makeMove(walker_elecs, iat, drifts);
+          ps_dispatcher.flex_makeMove(walker_elecs, iat, drifts);
 
           twf_dispatcher.flex_calcRatioGrad(walker_twfs, walker_elecs, iat, ratios, grads_new);
 
@@ -218,18 +219,18 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
           twf_dispatcher.flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
 
-          ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted);
+          ps_dispatcher.flex_accept_rejectMove(walker_elecs, iat, isAccepted);
         }
       }
 
       twf_dispatcher.flex_completeUpdates(walker_twfs);
-      ParticleSet::flex_donePbyP(walker_elecs);
+      ps_dispatcher.flex_donePbyP(walker_elecs);
     }
 
     { // collect GL for KE.
       ScopedTimer buffer_local(timers.buffer_timer);
       twf_dispatcher.flex_evaluateGL(walker_twfs, walker_elecs, recompute);
-      ParticleSet::flex_saveWalker(walker_elecs, walkers);
+      ps_dispatcher.flex_saveWalker(walker_elecs, walkers);
     }
 
     { // hamiltonian
@@ -307,7 +308,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);
       assert(QMCDriverNew::checkLogAndGL(crowd));
-      ParticleSet::flex_saveWalker(moved_nonlocal_walker_elecs, moved_nonlocal_walkers);
+      ps_dispatcher.flex_saveWalker(moved_nonlocal_walker_elecs, moved_nonlocal_walkers);
     }
   }
 }

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -257,7 +257,7 @@ int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
     // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
 
     const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);
-    ParticleSet::flex_update(p_list, true);
+    dispatchers_.ps_dispatcher_.flex_update(p_list, true);
 
     const RefVectorWithLeader<TrialWaveFunction> wf_list(pop.get_golden_twf(), wf_list_no_leader);
     dispatchers_.twf_dispatcher_.flex_evaluateLog(wf_list, p_list);

--- a/src/QMCDrivers/MultiWalkerDispatchers.h
+++ b/src/QMCDrivers/MultiWalkerDispatchers.h
@@ -27,11 +27,15 @@ class MultiWalkerDispatchers
 {
 public:
 
-  MultiWalkerDispatchers(bool use_batch) : ps_dispatcher_(use_batch), twf_dispatcher_(use_batch), ham_dispatcher_(use_batch) {}
+  MultiWalkerDispatchers(bool use_batch) : ps_dispatcher_(use_batch), twf_dispatcher_(use_batch), ham_dispatcher_(use_batch), use_batch_(use_batch) {}
+
+  const bool are_walkers_batched() const { return use_batch_; }
 
   const PSdispatcher ps_dispatcher_;
   const TWFdispatcher twf_dispatcher_;
   const Hdispatcher ham_dispatcher_;
+private:
+  const bool use_batch_;
 };
 }
 #endif

--- a/src/QMCDrivers/MultiWalkerDispatchers.h
+++ b/src/QMCDrivers/MultiWalkerDispatchers.h
@@ -5,12 +5,15 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 
 #ifndef QMCPLUSPLUS_MWDISPATCHERS_H
 #define QMCPLUSPLUS_MWDISPATCHERS_H
 
+#include <PSdispatcher.h>
 #include <TWFdispatcher.h>
 #include <Hdispatcher.h>
 
@@ -24,8 +27,9 @@ class MultiWalkerDispatchers
 {
 public:
 
-  MultiWalkerDispatchers(bool use_batch) : twf_dispatcher_(use_batch), ham_dispatcher_(use_batch) {}
+  MultiWalkerDispatchers(bool use_batch) : ps_dispatcher_(use_batch), twf_dispatcher_(use_batch), ham_dispatcher_(use_batch) {}
 
+  const PSdispatcher ps_dispatcher_;
   const TWFdispatcher twf_dispatcher_;
   const Hdispatcher ham_dispatcher_;
 };

--- a/src/QMCDrivers/MultiWalkerDispatchers.h
+++ b/src/QMCDrivers/MultiWalkerDispatchers.h
@@ -29,7 +29,7 @@ public:
 
   MultiWalkerDispatchers(bool use_batch) : ps_dispatcher_(use_batch), twf_dispatcher_(use_batch), ham_dispatcher_(use_batch), use_batch_(use_batch) {}
 
-  const bool are_walkers_batched() const { return use_batch_; }
+  bool are_walkers_batched() const { return use_batch_; }
 
   const PSdispatcher ps_dispatcher_;
   const TWFdispatcher twf_dispatcher_;

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -33,6 +33,9 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
 {
   // ParameterSet has an dependency on the lifetime of the backing xmlNodePtr
   // so its better it not live long
+
+  std::string serialize_walkers;
+
   ParameterSet parameter_set;
   parameter_set.add(RollBackBlocks_, "rewind");
   parameter_set.add(store_config_period_, "storeconfigs");
@@ -50,6 +53,7 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   parameter_set.add(warmup_steps_, "warmupsteps");
   parameter_set.add(warmup_steps_, "warmup_steps");
   parameter_set.add(num_crowds_, "crowds");
+  parameter_set.add(serialize_walkers, "crowd_serialize_walkers", {"no", "yes"});
   parameter_set.add(walkers_per_rank_, "walkers_per_rank");
   parameter_set.add(total_walkers_, "total_walkers");
   parameter_set.add(steps_between_samples_, "stepsbetweensamples");
@@ -113,6 +117,8 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
       tcur = tcur->next;
     }
   }
+
+  crowd_serialize_walkers_ = serialize_walkers == "yes";
 
   if (check_point_period_.period < 1)
     check_point_period_.period = max_blocks_;

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -39,7 +39,6 @@ public:
 protected:
 
   bool scoped_profiling_ = false;
-
   /** @ingroup Input Parameters for QMCDriver base class
    *  @{
    *  All input determined variables should be here
@@ -47,6 +46,9 @@ protected:
    *  Do not write out blocks of gets for variables like this
    *  there will be code generation snippets soon in utils
    */
+
+  /// if true, batched operations are serialized over walkers
+  bool crowd_serialize_walkers_ = false;
 
   /// number of blocks to be rolled back
   int RollBackBlocks_ = 0;
@@ -126,6 +128,7 @@ public:
   const std::string& get_qmc_method() const { return qmc_method_; }
   const std::string& get_update_mode() const { return update_mode_; }
   bool get_scoped_profiling() const { return scoped_profiling_; }
+  bool are_walkers_serialized() const { return crowd_serialize_walkers_; }
 
   const std::string get_drift_modifier() const { return drift_modifier_; }
   RealType get_drift_modifier_unr_a() const { return drift_modifier_unr_a_; }

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -316,6 +316,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
 
   CrowdResourceLock crowd_res_lock(crowd);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
+  auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
 
@@ -326,7 +327,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
                                                                 crowd.get_walker_hamiltonians());
 
   crowd.loadWalkers();
-  ParticleSet::flex_update(walker_elecs);
+  ps_dispatcher.flex_update(walker_elecs);
   twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);
 
   // For consistency this should be in ParticleSet as a flex call, but I think its a problem
@@ -509,6 +510,7 @@ void QMCDriverNew::endBlock()
 bool QMCDriverNew::checkLogAndGL(Crowd& crowd)
 {
   bool success         = true;
+  auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
 
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
@@ -526,7 +528,7 @@ bool QMCDriverNew::checkLogAndGL(Crowd& crowd)
     Ls.push_back(walker_twfs[iw].L);
   }
 
-  ParticleSet::flex_update(walker_elecs);
+  ps_dispatcher.flex_update(walker_elecs);
   twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);
 
   const RealType threshold = 100 * std::numeric_limits<float>::epsilon();

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -135,9 +135,9 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
 void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc)
 {
   if (driver_scope_profiler_.isActive())
-    app_log() << " Profiler data collection is enabled in this driver scope." << std::endl;
+    app_log() << "  Profiler data collection is enabled in this driver scope." << std::endl;
   if (!dispatchers_.are_walkers_batched())
-    app_log() << " Batched operations are serialized over walkers." << std::endl;
+    app_log() << "  Batched operations are serialized over walkers." << std::endl;
 
   app_log() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
             << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -51,7 +51,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       qmcdriver_input_(std::move(input)),
       QMCType(QMC_driver_type),
       population_(std::move(population)),
-      dispatchers_(true),
+      dispatchers_(!qmcdriver_input_.are_walkers_serialized()),
       estimator_manager_(nullptr),
       wOut(0),
       timers_(timer_prefix),
@@ -134,6 +134,11 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
  */
 void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc)
 {
+  if (driver_scope_profiler_.isActive())
+    app_log() << " Profiler data collection is enabled in this driver scope." << std::endl;
+  if (!dispatchers_.are_walkers_batched())
+    app_log() << " Batched operations are serialized over walkers." << std::endl;
+
   app_log() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
             << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl
             << "                               num_crowds = " << awc.walkers_per_crowd.size() << std::endl

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -42,6 +42,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
 {
   assert(QMCDriverNew::checkLogAndGL(crowd));
 
+  auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   auto& walkers        = crowd.get_walkers();
@@ -107,7 +108,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
                          [sqrttau](const PosType& delta_r) { return sqrttau * delta_r; });
         }
 
-        ParticleSet::flex_makeMove(walker_elecs, iat, drifts);
+        ps_dispatcher.flex_makeMove(walker_elecs, iat, drifts);
 
         // This is inelegant
         if (use_drift)
@@ -150,13 +151,13 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
 
         twf_dispatcher.flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
 
-        ParticleSet::flex_accept_rejectMove(walker_elecs, iat, isAccepted);
+        ps_dispatcher.flex_accept_rejectMove(walker_elecs, iat, isAccepted);
       }
     }
     twf_dispatcher.flex_completeUpdates(walker_twfs);
   }
 
-  ParticleSet::flex_donePbyP(walker_elecs);
+  ps_dispatcher.flex_donePbyP(walker_elecs);
   timers.movepbyp_timer.stop();
 
   timers.buffer_timer.start();

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -344,7 +344,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       }
 
       // Compute distance tables.
-      ParticleSet::flex_update(p_list, true);
+      ParticleSet::mw_update(p_list, true);
 
       // Log psi and prepare for difference the log psi
       opt_data.zero_log_psi();
@@ -559,7 +559,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
       }
 
       // Update distance tables, etc for the loaded sample positions
-      ParticleSet::flex_update(p_list, true);
+      ParticleSet::mw_update(p_list, true);
 
       // Evaluate difference in log psi
 

--- a/src/QMCHamiltonians/Hdispatcher.cpp
+++ b/src/QMCHamiltonians/Hdispatcher.cpp
@@ -5,6 +5,8 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/QMCHamiltonians/Hdispatcher.h
+++ b/src/QMCHamiltonians/Hdispatcher.h
@@ -5,6 +5,8 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -217,7 +217,7 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
         psiratios_list.push_back(component.psiratio);
       }
 
-      ecp_component_leader.VP->flex_makeMoves(vp_list, deltaV_list, joblist, true);
+      VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
 
       if (use_DLA)
         TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -547,8 +547,9 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
 {
   auto& ham_leader = ham_list.getLeader();
   ScopedTimer local_timer(ham_leader.ham_timer_);
+  for (QMCHamiltonian& ham : ham_list)
   for (int iw = 0; iw < ham_list.size(); iw++)
-    ham_list[iw].LocalEnergy = 0.0;
+    ham.LocalEnergy = 0.0;
 
   const int num_ham_operators = ham_leader.H.size();
   for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
@@ -777,8 +778,8 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
 {
-  for (int iw = 0; iw < ham_list.size(); iw++)
-    ham_list[iw].LocalEnergy = 0.0;
+  for (QMCHamiltonian& ham : ham_list)
+    ham.LocalEnergy = 0.0;
 
   auto& ham_leader            = ham_list.getLeader();
   const int num_ham_operators = ham_leader.H.size();

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -665,7 +665,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
     app_warning() << "SplineC2COMPTarget : This message should not be seen in production (performance bug) runs but "
                      "only unit tests (expected)."
                   << std::endl;
-    phi_leader.mw_mem_ = std::make_unique<OffloadMultiWalkerMem<ST, ComplexT>>();
+    phi_leader.mw_mem_ = std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>();
   }
   auto& mw_mem             = *phi_leader.mw_mem_;
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -26,7 +26,7 @@
 #include "Platforms/PinnedAllocator.h"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
-#include "OffloadMultiWalkerMem.h"
+#include "SplineOMPTargetMultiWalkerMem.h"
 
 namespace qmcplusplus
 {
@@ -82,7 +82,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  std::unique_ptr<OffloadMultiWalkerMem<ST, ComplexT>> mw_mem_;
+  std::unique_ptr<SplineOMPTargetMultiWalkerMem<ST, ComplexT>> mw_mem_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<ComplexT, OffloadPinnedAllocator<ComplexT>> ratios_private;
@@ -141,14 +141,14 @@ public:
 
   void createResource(ResourceCollection& collection) override
   {
-    auto resource_index = collection.addResource(std::make_unique<OffloadMultiWalkerMem<ST, ComplexT>>());
+    auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>());
     app_log() << "    Multi walker shared memory resource created in SplineC2COMPTarget. Index " << resource_index
               << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override
   {
-    auto res_ptr = dynamic_cast<OffloadMultiWalkerMem<ST, ComplexT>*>(collection.lendResource().release());
+    auto res_ptr = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, ComplexT>*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SplineC2COMPTarget::acquireResource dynamic_cast failed");
     mw_mem_.reset(res_ptr);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -808,7 +808,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
     app_warning() << "SplineC2ROMPTarget : This message should not be seen in production (performance bug) runs but "
                      "only unit tests (expected)."
                   << std::endl;
-    phi_leader.mw_mem_ = std::make_unique<OffloadMultiWalkerMem<ST, TT>>();
+    phi_leader.mw_mem_ = std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>();
   }
   auto& mw_mem             = *phi_leader.mw_mem_;
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -26,7 +26,7 @@
 #include "Platforms/PinnedAllocator.h"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
-#include "OffloadMultiWalkerMem.h"
+#include "SplineOMPTargetMultiWalkerMem.h"
 
 namespace qmcplusplus
 {
@@ -84,7 +84,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  std::unique_ptr<OffloadMultiWalkerMem<ST, TT>> mw_mem_;
+  std::unique_ptr<SplineOMPTargetMultiWalkerMem<ST, TT>> mw_mem_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<TT, OffloadPinnedAllocator<TT>> ratios_private;
@@ -146,14 +146,14 @@ public:
 
   void createResource(ResourceCollection& collection) override
   {
-    auto resource_index = collection.addResource(std::make_unique<OffloadMultiWalkerMem<ST, TT>>());
+    auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
     app_log() << "    Multi walker shared memory resource created in SplineC2ROMPTarget. Index " << resource_index
               << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override
   {
-    auto res_ptr = dynamic_cast<OffloadMultiWalkerMem<ST, TT>*>(collection.lendResource().release());
+    auto res_ptr = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, TT>*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SplineC2ROMPTarget::acquireResource dynamic_cast failed");
     mw_mem_.reset(res_ptr);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineOMPTargetMultiWalkerMem.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineOMPTargetMultiWalkerMem.h
@@ -21,7 +21,7 @@ namespace qmcplusplus
 {
 
 template<typename ST, typename TT>
-struct OffloadMultiWalkerMem: public Resource
+struct SplineOMPTargetMultiWalkerMem: public Resource
 {
   template<typename DT>
   using OffloadPinnedAllocator = OMPallocator<DT, PinnedAlignedAllocator<DT>>;
@@ -41,11 +41,11 @@ struct OffloadMultiWalkerMem: public Resource
   ///multi purpose H2D buffer for mw_evaluateDetRatios
   Vector<char, OffloadPinnedAllocator<char>> det_ratios_buffer_H2D;
 
-  OffloadMultiWalkerMem() : Resource("OffloadMultiWalkerMem") {}
+  SplineOMPTargetMultiWalkerMem() : Resource("SplineOMPTargetMultiWalkerMem") {}
 
-  OffloadMultiWalkerMem(const OffloadMultiWalkerMem&) : OffloadMultiWalkerMem() {}
+  SplineOMPTargetMultiWalkerMem(const SplineOMPTargetMultiWalkerMem&) : SplineOMPTargetMultiWalkerMem() {}
 
-  Resource* makeClone() const override { return new OffloadMultiWalkerMem(*this); }
+  Resource* makeClone() const override { return new SplineOMPTargetMultiWalkerMem(*this); }
 };
 }
 #endif

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -5,6 +5,8 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -117,8 +117,8 @@ void TWFdispatcher::flex_completeUpdates(const RefVectorWithLeader<TrialWaveFunc
   if (use_batch_)
     TrialWaveFunction::mw_completeUpdates(wf_list);
   else
-    for (size_t iw = 0; iw < wf_list.size(); iw++)
-      wf_list[iw].completeUpdates();
+    for (TrialWaveFunction& wf : wf_list)
+      wf.completeUpdates();
 }
 
 void TWFdispatcher::flex_evaluateGL(const RefVectorWithLeader<TrialWaveFunction>& wf_list,

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -5,6 +5,8 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -215,7 +215,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   RefVectorWithLeader<ParticleSet> p_ref_list(elec_, {elec_, elec_clone});
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
-  elec_.flex_update(p_ref_list);
+  ParticleSet::mw_update(p_ref_list);
   TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
 #if defined(QMC_COMPLEX)
   REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -238,7 +238,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   RefVectorWithLeader<ParticleSet> p_ref_list(elec_, {elec_, elec_clone});
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
-  elec_.flex_update(p_ref_list);
+  ParticleSet::mw_update(p_ref_list);
   TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
   std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " "
             << WF_list[0]->getPhase() << std::endl;
@@ -381,7 +381,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
           LogComplexApprox(std::complex<RealType>(-8.013162503965223, 6.283185307179586)));
 #endif
 
-  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id, isAccepted, false);
+  ParticleSet::mw_accept_rejectMove(p_ref_list, moved_elec_id, isAccepted, false);
 
   const int moved_elec_id_next = 1;
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
@@ -424,7 +424,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   std::vector<PosType> displ(2);
   displ[0] = displ[1] = {0.1, 0.2, 0.3};
 
-  ParticleSet::flex_makeMove(p_ref_list, moved_elec_id_next, displ);
+  ParticleSet::mw_makeMove(p_ref_list, moved_elec_id_next, displ);
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id_next, ratios, grad_new);
   std::cout << "ratioGrad next electron " << std::setprecision(14) << grad_new[0][0] << " " << grad_new[0][1] << " "
             << grad_new[0][2] << " " << grad_new[1][0] << " " << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
@@ -448,7 +448,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   isAccepted[1] = false;
   TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id_next, isAccepted, true);
 
-  ParticleSet::flex_accept_rejectMove(p_ref_list, moved_elec_id_next, isAccepted, false);
+  ParticleSet::mw_accept_rejectMove(p_ref_list, moved_elec_id_next, isAccepted, false);
   TrialWaveFunction::mw_completeUpdates(wf_ref_list);
   TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
 

--- a/src/Utilities/ScopedProfiler.h
+++ b/src/Utilities/ScopedProfiler.h
@@ -17,9 +17,9 @@ namespace qmcplusplus
 class ScopedProfiler
 {
 public:
-  ScopedProfiler(bool active) : isActive(active)
+  ScopedProfiler(bool active) : active_(active)
   {
-    if (isActive)
+    if (active_)
     {
 #ifdef ENABLE_CUDA
       cudaErrorCheck(cudaProfilerStart(), "cudaProfilerStart failed!");
@@ -32,7 +32,7 @@ public:
 
   ~ScopedProfiler()
   {
-    if (isActive)
+    if (active_)
     {
 #ifdef ENABLE_CUDA
       cudaErrorCheck(cudaProfilerStop(), "cudaProfilerStop failed!");
@@ -42,8 +42,10 @@ public:
 #endif
     }
   }
+
+  const bool isActive() const { return active_; }
 private:
-  const bool isActive;
+  const bool active_;
 };
 }
 #endif

--- a/src/Utilities/ScopedProfiler.h
+++ b/src/Utilities/ScopedProfiler.h
@@ -43,7 +43,7 @@ public:
     }
   }
 
-  const bool isActive() const { return active_; }
+  bool isActive() const { return active_; }
 private:
   const bool active_;
 };


### PR DESCRIPTION
## Proposed changes

1, Split flex_ APIs in ParticleSet to PSdispatcher.h
2. Introduce "crowd_serialize_walkers" driver input tag to force flex_ API loop over single walker calls. default no. It covers all the flex_ calls to ParticleSet, TrialWaveFunction and QMCHamiltonian.

In batched driver
1. crowd_serialize_walkers=no default case
batched_driver -> dispatcher::flex_update -> ParticleSet::mw_update (mw_ API fails back to serial internally if no specialization exists)
2. crowd_serialize_walkers=yes. This is intended for CPU only runs to bypass any overhead or CPU unfriendly implementation in batched code paths.
batched_driver -> dispatcher::flex_update -> loop over ParticleSet::update

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'