### PR TITLE
Improve and fix PySCF tests

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -47,7 +47,7 @@ FUNCTION( COPY_DIRECTORY_USING_SYMLINK_LIMITED SRC_DIR DST_DIR ${ARGN})
         "${SRC_DIR}/*.ccECP.xml"
         "${SRC_DIR}/*.py" "${SRC_DIR}/*.sh" "${SRC_DIR}/*.restart.xml"
         "${SRC_DIR}/Li.xml" "${SRC_DIR}/H.xml" "${SRC_DIR}/*.L2_test.xml" "${SRC_DIR}/*.opt_L2.xml"
-        "${SRC_DIR}/*.wfnoj.xml" "${SRC_DIR}/*.wfj.xml" "${SRC_DIR}/*.wfs*.xml"
+        "${SRC_DIR}/*.wfnoj.xml" "${SRC_DIR}/*.wfj*.xml" "${SRC_DIR}/*.wfs*.xml"
         "${SRC_DIR}/*.wfn*.xml" "${SRC_DIR}/*.cuspInfo.xml" "${SRC_DIR}/*.H*.xml"
         "${SRC_DIR}/*.structure.xml" "${SRC_DIR}/*ptcl.xml")
     FOREACH(F IN LISTS FILE_FOLDER_NAMES)

--- a/examples/solids/pyscf-inputs/diamondC_1x1x1_pp_Bspline.py
+++ b/examples/solids/pyscf-inputs/diamondC_1x1x1_pp_Bspline.py
@@ -55,7 +55,7 @@ mf.exxdiv = 'ewald'
 mf.with_df = mydf
 
 e_scf=mf.kernel()
-
+assert mf.converged
 
 ener = open('e_scf','w')
 ener.write('%s\n' % (e_scf))

--- a/examples/solids/pyscf-inputs/diamondC_1x1x1_pp_LCAO.py
+++ b/examples/solids/pyscf-inputs/diamondC_1x1x1_pp_LCAO.py
@@ -54,7 +54,7 @@ mf.exxdiv = 'ewald'
 mf.with_df = mydf
 
 e_scf=mf.kernel()
-
+assert mf.converged
 
 ener = open('e_scf','w')
 ener.write('%s\n' % (e_scf))

--- a/src/QMCTools/PyscfToQmcpack_Spline.py
+++ b/src/QMCTools/PyscfToQmcpack_Spline.py
@@ -122,7 +122,7 @@ def pyscf2qmcpackspline(cell,mf,title="Default", kpts=[], kmesh=[],  sp_twist=[]
   root.extend(a)
 
   doc.write(xml_fname,pretty_print=True)
-
+  print ('Wavefunction successfully saved to QMCPACK HDF5 spline format')
 
 
 
@@ -253,7 +253,7 @@ def generate_pwscf_h5(cell,gvecs,eig_df,h5_fname):
 
   # transfer version info. !!!! hard code for now
   new.create_dataset('application/code',data=[np.string_('PySCF')])
-  new.create_dataset('application/version',data=[np.string_('1.6.2')])
+  new.create_dataset('application/version',data=[np.string_('1.7.5')])
   new.create_dataset('format',data=[np.string_('ES-HDF')])
   new.create_dataset('version',data=[2,1,0])
   new.close()

--- a/tests/pyscf/CMakeLists.txt
+++ b/tests/pyscf/CMakeLists.txt
@@ -9,6 +9,8 @@
   RUN_PYSCF_TEST(pyscf-diamond_1x1x1_pp_LCAO ${CMAKE_SOURCE_DIR}/examples/solids/pyscf-inputs
                  diamondC_1x1x1_pp_LCAO PYSCF_TEST_NAME )
 
+  SET_TESTS_PROPERTIES( ${PYSCF_TEST_NAME} PROPERTIES PASS_REGULAR_EXPRESSION "successfully saved to QMCPACK HDF5" )
+
   SOFTLINK_H5( ${PYSCF_TEST_NAME} diamondC_1x1x1_pp-vmc_gaussian_sdj-1-16 C_Diamond C_Diamond.h5 LAST_TEST_NAME )
 
   # LCAO and Bspline test should use the same references.
@@ -40,6 +42,8 @@
             
   RUN_PYSCF_TEST(pyscf-diamond_1x1x1_pp_Bspline ${CMAKE_SOURCE_DIR}/examples/solids/pyscf-inputs
                  diamondC_1x1x1_pp_Bspline PYSCF_TEST_NAME )
+
+  SET_TESTS_PROPERTIES( ${PYSCF_TEST_NAME} PROPERTIES PASS_REGULAR_EXPRESSION "successfully saved to QMCPACK HDF5" )
 
   SOFTLINK_H5( ${PYSCF_TEST_NAME} diamondC_1x1x1_pp-vmc_gaussian-bspline_sdj-1-16 C_Diamond C_Diamond-Bspline.h5 LAST_TEST_NAME )
 


### PR DESCRIPTION
## Proposed changes

Periodic PySCF runs check SCF convergence + check for text indicating our custom HDF5 files were created.

Fix a missing wfj copy that broke the bspline test.

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Nitrogen, ~nightly configuration.

(When running ctest interactively I need to set OMP_NUM_THREADS=1 presumably due to threading issues with OpenBLAS or PySCF causing a bad SCF. The nightlies currently run OK.)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
