### PR TITLE
Introduce debug build GL check in non-batched drivers and fix two tests

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -196,16 +196,22 @@ public:
       dt_list[iw].move(p_list[iw], rnew_list[iw], iat, prepare_old);
   }
 
-  /** update the distance table by the pair relations from the temporal position. Used when a move is accepted
+  /** update the distance table by the pair relations from the temporal position.
+   *  Used when a move is accepted in regular mode
    * @param iat the particle with an accepted move
-   * @param partial_update If true (forward mode), rows after iat will not be updated. If false (regular mode), upon accept a move, the full table should be up-to-date
    */
-  virtual void update(IndexType jat, bool partial_update = false) = 0;
+  virtual void update(IndexType jat) = 0;
 
-  /** fill the distance table by the pair relations for the old particle position. Used in forward mode when a move is reject
+  /** fill partially the distance table by the pair relations from the temporary or old particle position.
+   *  Used in forward mode when a move is reject
    * @param iat the particle with an accepted move
+   * @param from_temp if true, copy from temp. if false, copy from old
    */
-  virtual void updateForOldPosPartial(IndexType jat){};
+  virtual void updatePartial(IndexType jat, bool from_temp)
+  {
+    if (from_temp)
+      update(jat);
+  }
 
   /** build a compact list of a neighbor for the iat source
    * @param iat source particle id

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -670,8 +670,11 @@ void ParticleSet::acceptMove_impl(Index_t iat, bool forward_mode)
   if (iat == activePtcl)
   {
     //Update position + distance-table
-    for (int i = 0, n = DistTables.size(); i < n; i++)
-      DistTables[i]->update(iat, forward_mode);
+    for (int i = 0; i < DistTables.size(); i++)
+      if (forward_mode)
+        DistTables[i]->updatePartial(iat, true);
+      else
+        DistTables[i]->update(iat);
 
     //Do not change SK: 2007-05-18
     if (SK && SK->DoUpdate)
@@ -723,8 +726,8 @@ void ParticleSet::rejectMoveForwardMode(Index_t iat)
 {
   assert(iat == activePtcl);
   //Update distance-table
-  for (int i = 0, n = DistTables.size(); i < n; i++)
-    DistTables[i]->updateForOldPosPartial(iat);
+  for (int i = 0; i < DistTables.size(); i++)
+    DistTables[i]->updatePartial(iat, false);
   activePtcl = -1;
 }
 

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -272,42 +272,43 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
    * only the [0,iat-1) columns need to save the new values.
    * The memory copy goes up to the padded size only for better performance.
    */
-  inline void update(IndexType iat, bool partial_update) override
+  inline void update(IndexType iat) override
   {
     ScopedTimer local_timer(update_timer_);
-
     //update by a cache line
     const int nupdate = getAlignedSize<T>(iat);
     //copy row
     std::copy_n(temp_r_.data(), nupdate, distances_[iat].data());
     for (int idim = 0; idim < D; ++idim)
       std::copy_n(temp_dr_.data(idim), nupdate, displacements_[iat].data(idim));
-    // This is an optimization to reduce update >iat rows during p-by-p forward move when no consumer needs full table.
-    if (need_full_table_ || !partial_update)
+    //copy column
+    for (size_t i = iat + 1; i < N_targets; ++i)
     {
-      //copy column
-      for (size_t i = iat + 1; i < N_targets; ++i)
-      {
-        distances_[i][iat]     = temp_r_[i];
-        displacements_[i](iat) = -temp_dr_[i];
-      }
+      distances_[i][iat]     = temp_r_[i];
+      displacements_[i](iat) = -temp_dr_[i];
     }
   }
 
-  void updateForOldPosPartial(IndexType jat) override
+  void updatePartial(IndexType jat, bool from_temp) override
   {
-    assert(old_prepared_elec_id == jat);
-    if (old_r_.data() == distances_[jat].data())
-      return;
-
     ScopedTimer local_timer(update_timer_);
-
     //update by a cache line
     const int nupdate = getAlignedSize<T>(jat);
-    //copy row
-    std::copy_n(old_r_.data(), nupdate, distances_[jat].data());
-    for (int idim = 0; idim < D; ++idim)
-      std::copy_n(old_dr_.data(idim), nupdate, displacements_[jat].data(idim));
+    if (from_temp)
+    {
+      //copy row
+      std::copy_n(temp_r_.data(), nupdate, distances_[jat].data());
+      for (int idim = 0; idim < D; ++idim)
+        std::copy_n(temp_dr_.data(idim), nupdate, displacements_[jat].data(idim));
+    }
+    else
+    {
+      assert(old_prepared_elec_id == jat);
+      //copy row
+      std::copy_n(old_r_.data(), nupdate, distances_[jat].data());
+      for (int idim = 0; idim < D; ++idim)
+        std::copy_n(old_dr_.data(idim), nupdate, displacements_[jat].data(idim));
+    }
   }
 
 private:

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -96,7 +96,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
   }
 
   ///update the stripe for jat-th particle
-  inline void update(IndexType iat, bool partial_update) override
+  inline void update(IndexType iat) override
   {
     ScopedTimer local_timer(update_timer_);
     std::copy_n(temp_r_.data(), N_sources, distances_[iat].data());

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -384,7 +384,7 @@ public:
   }
 
   ///update the stripe for jat-th particle
-  inline void update(IndexType iat, bool partial_update) override
+  inline void update(IndexType iat) override
   {
     ScopedTimer local_timer(update_timer_);
     std::copy_n(temp_r_.data(), N_sources, distances_[iat].data());

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -140,6 +140,7 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
       ScopedTimer local_timer(myTimers[DMC_buffer]);
       thisWalker.Age = 0;
       logpsi         = Psi.updateBuffer(W, w_buffer, recompute);
+      assert(checkLogAndGL(W, Psi));
       W.saveWalker(thisWalker);
     }
     {

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -264,6 +264,46 @@ QMCUpdateBase::RealType QMCUpdateBase::getNodeCorrection(const ParticleSet::Part
   return setScaledDriftPbyPandNodeCorr(Tau, MassInvP, g, gscaled);
 }
 
+bool QMCUpdateBase::checkLogAndGL(ParticleSet& pset, TrialWaveFunction& twf)
+{
+  bool success         = true;
+  TrialWaveFunction::LogValueType log_value{twf.getLogPsi(), twf.getPhase()};
+  ParticleSet::ParticleGradient_t G_saved = twf.G;
+  ParticleSet::ParticleLaplacian_t L_saved = twf.L;
+
+  pset.update();
+  twf.evaluateLog(pset);
+
+  const RealType threshold = 100 * std::numeric_limits<float>::epsilon();
+    auto& ref_G = twf.G;
+    auto& ref_L = twf.L;
+    TrialWaveFunction::LogValueType ref_log{twf.getLogPsi(), twf.getPhase()};
+    if (std::abs(std::exp(log_value) - std::exp(ref_log)) > std::abs(std::exp(ref_log)) * threshold)
+    {
+      success = false;
+      std::cout << "Logpsi " << log_value << " ref " << ref_log << std::endl;
+    }
+    for (int iel = 0; iel < ref_G.size(); iel++)
+    {
+      auto grad_diff = ref_G[iel] - G_saved[iel];
+      if (std::sqrt(std::abs(dot(grad_diff, grad_diff))) > std::sqrt(std::abs(dot(ref_G[iel], ref_G[iel]))) * threshold)
+      {
+        success = false;
+        std::cout << "Grad[" << iel << "] ref = " << ref_G[iel] << " wrong = " << G_saved[iel]
+                  << " Delta " << grad_diff << std::endl;
+      }
+      auto lap_diff = ref_L[iel] - L_saved[iel];
+      if (std::abs(lap_diff) > std::abs(ref_L[iel]) * threshold)
+      {
+        // very hard to check mixed precision case, only print, no error out
+        success = !std::is_same<RealType, FullPrecRealType>::value;
+        std::cout << "lap[" << iel << "] ref = " << ref_L[iel] << " wrong = " << L_saved[iel]
+                  << " Delta " << lap_diff << std::endl;
+      }
+    }
+  return success;
+}
+
 void QMCUpdateBase::setReleasedNodeMultiplicity(WalkerIter_t it, WalkerIter_t it_end)
 {
   for (; it != it_end; ++it)

--- a/src/QMCDrivers/QMCUpdateBase.h
+++ b/src/QMCDrivers/QMCUpdateBase.h
@@ -298,6 +298,9 @@ protected:
   ///copy constructor (disabled)
   QMCUpdateBase(const QMCUpdateBase&) = delete;
 
+  /// check logpsi and grad and lap against values computed from scratch
+  static bool checkLogAndGL(ParticleSet& pset, TrialWaveFunction& twf);
+
 private:
   ///set default parameters
   void setDefaults();

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -115,6 +115,7 @@ void VMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
   movepbyp_timer_.stop();
   buffer_timer_.start();
   RealType logpsi = Psi.updateBuffer(W, w_buffer, recompute);
+  assert(checkLogAndGL(W, Psi));
   W.saveWalker(thisWalker);
   buffer_timer_.stop();
   // end PbyP moves

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -42,7 +42,6 @@ public:
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L)
   {
-    APP_ABORT("LinearOrbital. evaluateLog");
     ValueType v = 0.0;
     for (int i = 0; i < P.R.size(); i++)
     {
@@ -69,7 +68,7 @@ public:
 
   virtual void registerData(ParticleSet& P, WFBufferType& buf) {}
 
-  virtual LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) { return 0.0; }
+  virtual LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) { return evaluateLog(P, P.G, P.L); }
 
   virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) {}
 };

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -943,6 +943,9 @@ TrialWaveFunction::RealType TrialWaveFunction::updateBuffer(ParticleSet& P, WFBu
     logpsi += Z[i]->updateBuffer(P, buf, fromscratch);
   }
 
+  G = P.G;
+  L = P.L;
+
   LogValue   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
   //printGL(P.G,P.L);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -204,6 +204,7 @@ UPtrVector<ParticleSet::ParticleLaplacian_t> create_particle_laplacian(int nelec
   return L_list;
 }
 
+#ifndef QMC_CUDA
 TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
 {
   using ValueType = QMCTraits::ValueType;
@@ -418,6 +419,7 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   RealType logpsi2b = psi2.evaluateDeltaLog(p_list[1], true);
   CHECK(logpsi2b == Approx(logpsi_variable_list2[1]));
 }
+#endif
 
 
 } // namespace qmcplusplus

--- a/tests/heg/heg_54_J2rpa/CMakeLists.txt
+++ b/tests/heg/heg_54_J2rpa/CMakeLists.txt
@@ -20,7 +20,7 @@ IF (NOT QMC_CUDA)
                     heg.rpa.rs5.xml
                     16 1
                     TRUE
-                    0 HEG54J2RPA_SCALARS
+                    1 HEG54J2RPA_SCALARS
                     )
 
 ELSE()


### PR DESCRIPTION
## Proposed changes
1. Add debug build checkLogAndGL assertion in non-batched code. Fortunately, caught nothing.
2. Move distance table partial update logic out of DT::update() to DT::updatePartial() more straight forward logic.
3. Fix https://cdash.qmcpack.org/CDash/testDetails.php?test=9533311&build=190366
4. Fix #2966 by bypassing a unit test not suitable for legacy CUDA. 

## What type(s) of changes does this code introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'