### PR TITLE
Expand multi walker shared resource to ParticleSet and Hamiltonian

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -26,6 +26,8 @@
 
 namespace qmcplusplus
 {
+class ResourceCollection;
+
 /** @ingroup nnlist
  * @brief Abstract class to manage pair data between two ParticleSets.
  *
@@ -262,6 +264,15 @@ public:
    * change in the indices N.
    */
   void resize(int npairs, int nw) { N_walkers = nw; }
+
+  /// initialize a shared resource and hand it to a collection
+  virtual void createResource(ResourceCollection& collection) {}
+
+  /// acquire a shared resource from a collection
+  virtual void acquireResource(ResourceCollection& collection) {}
+
+  /// return a shared resource to a collection
+  virtual void releaseResource(ResourceCollection& collection) {}
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -90,12 +90,18 @@ protected:
   int old_prepared_elec_id;
 
   ///name of the table
-  std::string Name;
+  const std::string name_;
 
 public:
   ///constructor using source and target ParticleSet
   DistanceTableData(const ParticleSet& source, const ParticleSet& target)
-      : Origin(&source), N_sources(0), N_targets(0), N_walkers(0), need_full_table_(false), old_prepared_elec_id(-1)
+      : Origin(&source),
+        N_sources(0),
+        N_targets(0),
+        N_walkers(0),
+        need_full_table_(false),
+        old_prepared_elec_id(-1),
+        name_(source.getName() + "_" + target.getName())
   {}
 
   ///virutal destructor
@@ -108,10 +114,7 @@ public:
   inline void setFullTableNeeds(bool is_needed) { need_full_table_ = is_needed; }
 
   ///return the name of table
-  inline const std::string& getName() const { return Name; }
-
-  ///set the name of table
-  inline void setName(const std::string& tname) { Name = tname; }
+  inline const std::string& getName() const { return name_; }
 
   ///returns the reference the origin particleset
   const ParticleSet& origin() const { return *Origin; }

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -269,7 +269,7 @@ public:
   void resize(int npairs, int nw) { N_walkers = nw; }
 
   /// initialize a shared resource and hand it to a collection
-  virtual void createResource(ResourceCollection& collection) {}
+  virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
   virtual void acquireResource(ResourceCollection& collection) {}

--- a/src/Particle/DynamicCoordinates.h
+++ b/src/Particle/DynamicCoordinates.h
@@ -22,6 +22,8 @@
 
 namespace qmcplusplus
 {
+class ResourceCollection;
+
 /** enumerator for DynamicCoordinates kinds
  */
 enum class DynamicCoordinateKind
@@ -56,10 +58,10 @@ public:
    */
   virtual void resize(size_t n) = 0;
   /// return the number of particles
-  virtual size_t size() const   = 0;
+  virtual size_t size() const = 0;
 
   /// overwrite the positions of all the particles.
-  virtual void setAllParticlePos(const ParticlePos_t& R)         = 0;
+  virtual void setAllParticlePos(const ParticlePos_t& R) = 0;
   /// overwrite the position of one the particle.
   virtual void setOneParticlePos(const PosType& pos, size_t iat) = 0;
   /** copy the active positions of particles with a uniform id in all the walkers to a single internal buffer.
@@ -68,8 +70,8 @@ public:
    *  @param new_positions proposed positions
    */
   virtual void mw_copyActivePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
-                                           size_t iat,
-                                           const std::vector<PosType>& new_positions) const
+                                size_t iat,
+                                const std::vector<PosType>& new_positions) const
   {
     assert(this == &coords_list.getLeader());
   }
@@ -88,10 +90,19 @@ public:
   /// all particle position accessor
   virtual const PosVectorSoa& getAllParticlePos() const = 0;
   /// one particle position accessor
-  virtual PosType getOneParticlePos(size_t iat) const   = 0;
+  virtual PosType getOneParticlePos(size_t iat) const = 0;
 
   /// secure internal data consistency after p-by-p moves
   virtual void donePbyP() {}
+
+  /// initialize a shared resource and hand it to a collection
+  virtual void createResource(ResourceCollection& collection) {}
+
+  /// acquire a shared resource from a collection
+  virtual void acquireResource(ResourceCollection& collection) {}
+
+  /// return a shared resource to a collection
+  virtual void releaseResource(ResourceCollection& collection) {}
 
 protected:
   /// type of dynamic coordinates

--- a/src/Particle/DynamicCoordinates.h
+++ b/src/Particle/DynamicCoordinates.h
@@ -96,7 +96,7 @@ public:
   virtual void donePbyP() {}
 
   /// initialize a shared resource and hand it to a collection
-  virtual void createResource(ResourceCollection& collection) {}
+  virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
   virtual void acquireResource(ResourceCollection& collection) {}

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -907,11 +907,26 @@ int ParticleSet::addPropertyHistory(int leng)
 //     }
 
 
-void ParticleSet::createResource(ResourceCollection& collection) {}
+void ParticleSet::createResource(ResourceCollection& collection)
+{
+  coordinates_->createResource(collection);
+  for (int i = 0; i < DistTables.size(); i++)
+    DistTables[i]->createResource(collection);
+}
 
-void ParticleSet::acquireResource(ResourceCollection& collection) {}
+void ParticleSet::acquireResource(ResourceCollection& collection)
+{
+  coordinates_->acquireResource(collection);
+  for (int i = 0; i < DistTables.size(); i++)
+    DistTables[i]->acquireResource(collection);
+}
 
-void ParticleSet::releaseResource(ResourceCollection& collection) {}
+void ParticleSet::releaseResource(ResourceCollection& collection)
+{
+  coordinates_->releaseResource(collection);
+  for (int i = 0; i < DistTables.size(); i++)
+    DistTables[i]->releaseResource(collection);
+}
 
 RefVectorWithLeader<DistanceTableData> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                      int id)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -906,6 +906,13 @@ int ParticleSet::addPropertyHistory(int leng)
 //       }
 //     }
 
+
+void ParticleSet::createResource(ResourceCollection& collection) {}
+
+void ParticleSet::acquireResource(ResourceCollection& collection) {}
+
+void ParticleSet::releaseResource(ResourceCollection& collection) {}
+
 RefVectorWithLeader<DistanceTableData> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                      int id)
 {

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -907,7 +907,7 @@ int ParticleSet::addPropertyHistory(int leng)
 //     }
 
 
-void ParticleSet::createResource(ResourceCollection& collection)
+void ParticleSet::createResource(ResourceCollection& collection) const
 {
   coordinates_->createResource(collection);
   for (int i = 0; i < DistTables.size(); i++)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -640,7 +640,7 @@ public:
   inline int getNumDistTables() const { return DistTables.size(); }
 
   /// initialize a shared resource and hand it to a collection
-  void createResource(ResourceCollection& collection);
+  void createResource(ResourceCollection& collection) const;
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -34,7 +34,7 @@ namespace qmcplusplus
 {
 ///forward declaration of DistanceTableData
 class DistanceTableData;
-
+class ResourceCollection;
 class StructFact;
 
 /** Specialized paritlce class for atomistic simulations
@@ -638,6 +638,17 @@ public:
   }
 
   inline int getNumDistTables() const { return DistTables.size(); }
+
+  /// initialize a shared resource and hand it to a collection
+  void createResource(ResourceCollection& collection);
+  /** acquire external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
+  void acquireResource(ResourceCollection& collection);
+  /** release external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
+  void releaseResource(ResourceCollection& collection);
 
   static RefVectorWithLeader<DistanceTableData> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                  int id);

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -181,7 +181,7 @@ public:
 
   const auto& getFusedNewPosBuffer() const { return mw_mem_->mw_new_pos; }
 
-  void createResource(ResourceCollection& collection) override
+  void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<MultiWalkerMem>());
     app_log() << "    Multi walker shared memory resource created in RealSpacePositionsOMPTarget. Index "

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -20,6 +20,7 @@
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "ParticleSet.h"
+#include "ResourceCollection.h"
 
 namespace qmcplusplus
 {
@@ -83,19 +84,29 @@ public:
   }
 
   void mw_copyActivePos(const RefVectorWithLeader<DynamicCoordinates>& coords_list,
-                                   size_t iat,
-                                   const std::vector<PosType>& new_positions) const override
+                        size_t iat,
+                        const std::vector<PosType>& new_positions) const override
   {
     assert(this == &coords_list.getLeader());
     auto& coords_leader = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
-    const auto nw       = coords_list.size();
+    // make this class unit tests friendly without the need of setup resources.
+    if (!coords_leader.mw_mem_)
+    {
+      app_warning()
+          << "RealSpacePositionsOMPTarget: This message should not be seen in production (performance bug) runs but "
+             "only unit tests (expected)."
+          << std::endl;
+      coords_leader.mw_mem_ = std::make_unique<MultiWalkerMem>();
+    }
+    const auto nw = coords_list.size();
 
-    coords_leader.mw_new_pos.resize(nw);
+    auto& mw_new_pos = coords_leader.mw_mem_->mw_new_pos;
+    mw_new_pos.resize(nw);
 
     for (int iw = 0; iw < nw; iw++)
-      coords_leader.mw_new_pos(iw) = new_positions[iw];
+      mw_new_pos(iw) = new_positions[iw];
 
-    auto* mw_pos_ptr = coords_leader.mw_new_pos.data();
+    auto* mw_pos_ptr = mw_new_pos.data();
     PRAGMA_OFFLOAD("omp target update to(mw_pos_ptr[:QMCTraits::DIM * mw_new_pos.capacity()])")
 
     coords_leader.is_nw_new_pos_prepared = true;
@@ -107,8 +118,10 @@ public:
                             const std::vector<bool>& isAccepted) const override
   {
     assert(this == &coords_list.getLeader());
-    auto& coords_leader = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
-    const size_t nw     = coords_list.size();
+    auto& coords_leader        = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
+    auto& mw_new_pos           = coords_leader.mw_mem_->mw_new_pos;
+    auto& nw_accept_index_ptrs = coords_leader.mw_mem_->nw_accept_index_ptrs;
+    const size_t nw            = coords_list.size();
 
     if (!is_nw_new_pos_prepared)
     {
@@ -118,10 +131,9 @@ public:
 
     coords_leader.is_nw_new_pos_prepared = false;
 
-    coords_leader.nw_accept_index_ptrs.resize((sizeof(int) + sizeof(RealType*)) * nw);
-    auto* RSoA_ptr_array = reinterpret_cast<RealType**>(coords_leader.nw_accept_index_ptrs.data());
-    auto* id_array =
-        reinterpret_cast<int*>(coords_leader.nw_accept_index_ptrs.data() + sizeof(RealType*) * coords_list.size());
+    nw_accept_index_ptrs.resize((sizeof(int) + sizeof(RealType*)) * nw);
+    auto* RSoA_ptr_array = reinterpret_cast<RealType**>(nw_accept_index_ptrs.data());
+    auto* id_array       = reinterpret_cast<int*>(nw_accept_index_ptrs.data() + sizeof(RealType*) * coords_list.size());
 
     size_t num_accepted = 0;
     for (int iw = 0; iw < nw; iw++)
@@ -136,7 +148,7 @@ public:
       }
 
     //offload to GPU
-    auto* restrict w_accept_buffer_ptr = coords_leader.nw_accept_index_ptrs.data();
+    auto* restrict w_accept_buffer_ptr = nw_accept_index_ptrs.data();
     auto* restrict mw_pos_ptr          = mw_new_pos.data();
     const size_t rsoa_stride           = RSoA.capacity();
     const size_t mw_pos_stride         = mw_new_pos.capacity();
@@ -167,17 +179,46 @@ public:
 
   const RealType* getDevicePtr() const { return RSoA.device_data(); }
 
-  const auto& getFusedNewPosBuffer() const { return mw_new_pos; }
+  const auto& getFusedNewPosBuffer() const { return mw_mem_->mw_new_pos; }
+
+  void createResource(ResourceCollection& collection) override
+  {
+    auto resource_index = collection.addResource(std::make_unique<MultiWalkerMem>());
+    app_log() << "    Multi walker shared memory resource created in RealSpacePositionsOMPTarget. Index "
+              << resource_index << std::endl;
+  }
+
+  void acquireResource(ResourceCollection& collection) override
+  {
+    auto res_ptr = dynamic_cast<MultiWalkerMem*>(collection.lendResource().release());
+    if (!res_ptr)
+      throw std::runtime_error("RealSpacePositionsOMPTarget::acquireResource dynamic_cast failed");
+    mw_mem_.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
 
 private:
   ///particle positions in SoA layout
   VectorSoaContainer<RealType, QMCTraits::DIM, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> RSoA;
 
-  ///one particle new/old positions in SoA layout
-  VectorSoaContainer<RealType, QMCTraits::DIM, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> mw_new_pos;
+  ///multi walker shared memory buffer
+  struct MultiWalkerMem : public Resource
+  {
+    ///one particle new/old positions in SoA layout
+    VectorSoaContainer<RealType, QMCTraits::DIM, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> mw_new_pos;
 
-  /// accept list
-  Vector<char, OMPallocator<char, PinnedAlignedAllocator<char>>> nw_accept_index_ptrs;
+    /// accept list
+    Vector<char, OMPallocator<char, PinnedAlignedAllocator<char>>> nw_accept_index_ptrs;
+
+    MultiWalkerMem() : Resource("MultiWalkerMem") {}
+
+    MultiWalkerMem(const MultiWalkerMem&) : MultiWalkerMem() {}
+
+    Resource* makeClone() const override { return new MultiWalkerMem(*this); }
+  };
+
+  std::unique_ptr<MultiWalkerMem> mw_mem_;
 
   ///host view of RSoA
   PosVectorSoa RSoA_hostview;

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -65,18 +65,14 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   SoaDistanceTableAAOMPTarget(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
         DistanceTableData(target, target),
-        offload_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::offload_") +
-                                                      target.getName() + "_" + target.getName(),
-                                                  timer_level_fine)),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::evaluate_") +
-                                                       target.getName() + "_" + target.getName(),
+        offload_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::offload_") + name_, timer_level_fine)),
+        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::evaluate_") + name_,
                                                    timer_level_fine)),
-        move_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::move_") + target.getName() +
-                                                   "_" + target.getName(),
-                                               timer_level_fine)),
-        update_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::update_") +
-                                                     target.getName() + "_" + target.getName(),
-                                                 timer_level_fine))
+        move_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::move_") + name_, timer_level_fine)),
+        update_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::update_") + name_, timer_level_fine))
 
   {
     auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&target.getCoordinates());
@@ -127,8 +123,8 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   void createResource(ResourceCollection& collection) override
   {
     auto resource_index = collection.addResource(std::make_unique<DTAAMultiWalkerMem>());
-    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableAAOMPTarget. Index "
-              << resource_index << std::endl;
+    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableAAOMPTarget " << name_
+              << ". Index " << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -120,7 +120,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   const DistRow& getOldDists() const override { return old_r_; }
   const DisplRow& getOldDispls() const override { return old_dr_; }
 
-  void createResource(ResourceCollection& collection) override
+  void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<DTAAMultiWalkerMem>());
     app_log() << "    Multi walker shared memory resource created in SoaDistanceTableAAOMPTarget " << name_

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -18,6 +18,7 @@
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"
+#include "ResourceCollection.h"
 
 namespace qmcplusplus
 {
@@ -44,10 +45,22 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   DistRow temp_r_mem_;
   DisplRow temp_dr_mem_;
 
-  ///dist displ
-  Vector<RealType, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> nw_new_old_dist_displ_;
+  ///multi walker shared memory buffer
+  struct DTAAMultiWalkerMem : public Resource
+  {
+    ///dist displ
+    Vector<RealType, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> nw_new_old_dist_displ;
 
-  Vector<const RealType*, OMPallocator<const RealType*, PinnedAlignedAllocator<const RealType*>>> rsoa_dev_list_;
+    Vector<const RealType*, OMPallocator<const RealType*, PinnedAlignedAllocator<const RealType*>>> rsoa_dev_list;
+
+    DTAAMultiWalkerMem() : Resource("DTAAMultiWalkerMem") {}
+
+    DTAAMultiWalkerMem(const DTAAMultiWalkerMem&) : DTAAMultiWalkerMem() {}
+
+    Resource* makeClone() const override { return new DTAAMultiWalkerMem(*this); }
+  };
+
+  std::unique_ptr<DTAAMultiWalkerMem> mw_mem_;
 
   SoaDistanceTableAAOMPTarget(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
@@ -111,6 +124,23 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   const DistRow& getOldDists() const override { return old_r_; }
   const DisplRow& getOldDispls() const override { return old_dr_; }
 
+  void createResource(ResourceCollection& collection) override
+  {
+    auto resource_index = collection.addResource(std::make_unique<DTAAMultiWalkerMem>());
+    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableAAOMPTarget. Index "
+              << resource_index << std::endl;
+  }
+
+  void acquireResource(ResourceCollection& collection) override
+  {
+    auto res_ptr = dynamic_cast<DTAAMultiWalkerMem*>(collection.lendResource().release());
+    if (!res_ptr)
+      throw std::runtime_error("SoaDistanceTableAAOMPTarget::acquireResource dynamic_cast failed");
+    mw_mem_.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+
   inline void evaluate(ParticleSet& P) override
   {
     ScopedTimer local_timer(evaluate_timer_);
@@ -154,29 +184,43 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
                bool prepare_old    = true) const override
   {
     assert(this == &dt_list.getLeader());
-    auto& dt_leader   = dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>();
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>();
+    // make this class unit tests friendly without the need of setup resources.
+    if (!dt_leader.mw_mem_)
+    {
+      app_warning()
+          << "SoaDistanceTableAAOMPTarget: This message should not be seen in production (performance bug) runs but "
+             "only unit tests (expected)."
+          << std::endl;
+      dt_leader.mw_mem_ = std::make_unique<DTAAMultiWalkerMem>();
+    }
+    auto& mw_mem      = *dt_leader.mw_mem_;
     auto& pset_leader = p_list.getLeader();
+
     ScopedTimer local_timer(move_timer_);
     const size_t nw          = dt_list.size();
     const size_t stride_size = Ntargets_padded * (D + 1);
-    dt_leader.nw_new_old_dist_displ_.resize(nw * 2 * stride_size);
-    dt_leader.rsoa_dev_list_.resize(nw);
+
+    auto& nw_new_old_dist_displ = mw_mem.nw_new_old_dist_displ;
+    auto& rsoa_dev_list         = mw_mem.rsoa_dev_list;
+    nw_new_old_dist_displ.resize(nw * 2 * stride_size);
+    rsoa_dev_list.resize(nw);
 
     for (int iw = 0; iw < nw; iw++)
     {
       auto& dt                = dt_list.getCastedElement<SoaDistanceTableAAOMPTarget>(iw);
       dt.old_prepared_elec_id = prepare_old ? iat : -1;
-      dt.temp_r_.attachReference(dt_leader.nw_new_old_dist_displ_.data() + stride_size * iw, Ntargets_padded);
+      dt.temp_r_.attachReference(nw_new_old_dist_displ.data() + stride_size * iw, Ntargets_padded);
       dt.temp_dr_.attachReference(N_targets, Ntargets_padded,
-                                  dt_leader.nw_new_old_dist_displ_.data() + stride_size * iw + Ntargets_padded);
+                                  nw_new_old_dist_displ.data() + stride_size * iw + Ntargets_padded);
       if (prepare_old)
       {
-        dt.old_r_.attachReference(dt_leader.nw_new_old_dist_displ_.data() + stride_size * (iw + nw), Ntargets_padded);
+        dt.old_r_.attachReference(nw_new_old_dist_displ.data() + stride_size * (iw + nw), Ntargets_padded);
         dt.old_dr_.attachReference(N_targets, Ntargets_padded,
-                                   dt_leader.nw_new_old_dist_displ_.data() + stride_size * (iw + nw) + Ntargets_padded);
+                                   nw_new_old_dist_displ.data() + stride_size * (iw + nw) + Ntargets_padded);
       }
-      auto& coordinates_soa        = static_cast<const RealSpacePositionsOMPTarget&>(p_list[iw].getCoordinates());
-      dt_leader.rsoa_dev_list_[iw] = coordinates_soa.getDevicePtr();
+      auto& coordinates_soa = static_cast<const RealSpacePositionsOMPTarget&>(p_list[iw].getCoordinates());
+      rsoa_dev_list[iw]     = coordinates_soa.getDevicePtr();
     }
 
     const int ChunkSizePerTeam = 256;
@@ -187,16 +231,16 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     const auto activePtcl_local = pset_leader.activePtcl;
     const auto N_sources_local  = N_targets;
     const auto N_sources_padded = Ntargets_padded;
-    auto* rsoa_dev_list_ptr     = dt_leader.rsoa_dev_list_.data();
-    auto* r_dr_ptr              = dt_leader.nw_new_old_dist_displ_.data();
+    auto* rsoa_dev_list_ptr     = rsoa_dev_list.data();
+    auto* r_dr_ptr              = nw_new_old_dist_displ.data();
     auto* new_pos_ptr           = coordinates_leader.getFusedNewPosBuffer().data();
     const size_t new_pos_stride = coordinates_leader.getFusedNewPosBuffer().capacity();
 
     {
       ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(nw * num_teams) \
-                        map(always, to: rsoa_dev_list_ptr[:rsoa_dev_list_.size()]) \
-                        map(always, from: r_dr_ptr[:nw_new_old_dist_displ_.size()])")
+                        map(always, to: rsoa_dev_list_ptr[:rsoa_dev_list.size()]) \
+                        map(always, from: r_dr_ptr[:nw_new_old_dist_displ.size()])")
       for (int iw = 0; iw < nw; ++iw)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -59,21 +59,16 @@ public:
   SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.Lattice),
         DistanceTableData(source, target),
-        offload_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") +
-                                                      target.getName() + "_" + source.getName(),
-                                                  timer_level_fine)),
-        copy_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::copy_") + target.getName() +
-                                                   "_" + source.getName(),
-                                               timer_level_fine)),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") +
-                                                       target.getName() + "_" + source.getName(),
+        offload_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") + name_, timer_level_fine)),
+        copy_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::copy_") + name_, timer_level_fine)),
+        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") + name_,
                                                    timer_level_fine)),
-        move_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::move_") + target.getName() +
-                                                   "_" + source.getName(),
-                                               timer_level_fine)),
-        update_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::update_") +
-                                                     target.getName() + "_" + source.getName(),
-                                                 timer_level_fine))
+        move_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::move_") + name_, timer_level_fine)),
+        update_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::update_") + name_, timer_level_fine))
 
   {
     auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&source.getCoordinates());
@@ -118,8 +113,8 @@ public:
   void createResource(ResourceCollection& collection) override
   {
     auto resource_index = collection.addResource(std::make_unique<DTABMultiWalkerMem>());
-    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableABOMPTarget. Index "
-              << resource_index << std::endl;
+    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableABOMPTarget " << name_
+              << ". Index " << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -17,6 +17,7 @@
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"
+#include "ResourceCollection.h"
 
 namespace qmcplusplus
 {
@@ -30,16 +31,29 @@ private:
   template<typename DT>
   using OffloadPinnedVector = Vector<DT, OMPallocator<DT, PinnedAlignedAllocator<DT>>>;
 
-  ///accelerator output array for multiple walkers, N_targets x N_sources_padded x (D+1) (distances, displacements)
-  OffloadPinnedVector<RealType> offload_output;
-  ///accelerator input array for a list of target particle positions, N_targets x D
-  OffloadPinnedVector<RealType> target_pos;
-  ///accelerator input buffer for multiple data set
-  OffloadPinnedVector<char> offload_input;
   ///accelerator output buffer for r and dr
   OffloadPinnedVector<RealType> r_dr_memorypool_;
-  ///target particle id
-  std::vector<int> particle_id;
+  ///accelerator input array for a list of target particle positions, N_targets x D
+  OffloadPinnedVector<T> target_pos;
+
+  ///multi walker shared memory buffer
+  struct DTABMultiWalkerMem : public Resource
+  {
+    ///accelerator output array for multiple walkers, N_targets x N_sources_padded x (D+1) (distances, displacements)
+    OffloadPinnedVector<T> offload_output;
+    ///accelerator input buffer for multiple data set
+    OffloadPinnedVector<char> offload_input;
+    ///target particle id
+    std::vector<int> particle_id;
+
+    DTABMultiWalkerMem() : Resource("DTABMultiWalkerMem") {}
+
+    DTABMultiWalkerMem(const DTABMultiWalkerMem&) : DTABMultiWalkerMem() {}
+
+    Resource* makeClone() const override { return new DTABMultiWalkerMem(*this); }
+  };
+
+  std::unique_ptr<DTABMultiWalkerMem> mw_mem_;
 
 public:
   SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
@@ -101,6 +115,23 @@ public:
 
   ~SoaDistanceTableABOMPTarget() { PRAGMA_OFFLOAD("omp target exit data map(delete : this[:1])") }
 
+  void createResource(ResourceCollection& collection) override
+  {
+    auto resource_index = collection.addResource(std::make_unique<DTABMultiWalkerMem>());
+    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableABOMPTarget. Index "
+              << resource_index << std::endl;
+  }
+
+  void acquireResource(ResourceCollection& collection) override
+  {
+    auto res_ptr = dynamic_cast<DTABMultiWalkerMem*>(collection.lendResource().release());
+    if (!res_ptr)
+      throw std::runtime_error("SoaDistanceTableABOMPTarget::acquireResource dynamic_cast failed");
+    mw_mem_.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+
   /** evaluate the full table */
   inline void evaluate(ParticleSet& P) override
   {
@@ -158,6 +189,17 @@ public:
                           const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
     assert(this == &dt_list.getLeader());
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
+    // make this class unit tests friendly without the need of setup resources.
+    if (!dt_leader.mw_mem_)
+    {
+      app_warning()
+          << "SoaDistanceTableABOMPTarget: This message should not be seen in production (performance bug) runs but "
+             "only unit tests (expected)."
+          << std::endl;
+      dt_leader.mw_mem_ = std::make_unique<DTABMultiWalkerMem>();
+    }
+
     ScopedTimer local_timer(evaluate_timer_);
     mw_evaluate_fuse_transfer(dt_list, p_list);
   }
@@ -169,8 +211,10 @@ public:
   inline void mw_evaluate_transfer_inplace(const RefVectorWithLeader<DistanceTableData>& dt_list,
                                            const RefVectorWithLeader<ParticleSet>& p_list) const
   {
-    auto& dt_leader      = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
-    const size_t nw      = dt_list.size();
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
+    const size_t nw = dt_list.size();
+    auto& mw_mem    = *dt_leader.mw_mem_;
+
     size_t count_targets = 0;
     for (ParticleSet& p : p_list)
       count_targets += p.getTotalNum();
@@ -180,7 +224,7 @@ public:
     constexpr size_t realtype_size = sizeof(RealType);
     constexpr size_t int_size      = sizeof(int);
     constexpr size_t ptr_size      = sizeof(RealType*);
-    auto& offload_input            = dt_leader.offload_input;
+    auto& offload_input            = mw_mem.offload_input;
     offload_input.resize(total_targets * D * realtype_size + total_targets * int_size +
                          (nw + total_targets) * ptr_size);
     auto target_positions = reinterpret_cast<RealType*>(offload_input.data());
@@ -191,8 +235,6 @@ public:
                                                     total_targets * int_size + nw * ptr_size);
 
     const int N_sources_padded = getAlignedSize<T>(N_sources);
-    auto& offload_output       = dt_leader.offload_output;
-    offload_output.resize(total_targets * N_sources_padded * (D + 1));
 
     count_targets = 0;
     for (size_t iw = 0; iw < nw; iw++)
@@ -272,8 +314,10 @@ public:
   void mw_evaluate_fuse_transfer(const RefVectorWithLeader<DistanceTableData>& dt_list,
                                  const RefVectorWithLeader<ParticleSet>& p_list) const
   {
-    auto& dt_leader      = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
-    const size_t nw      = dt_list.size();
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
+    const size_t nw = dt_list.size();
+    auto& mw_mem    = *dt_leader.mw_mem_;
+
     size_t count_targets = 0;
     for (ParticleSet& p : p_list)
       count_targets += p.getTotalNum();
@@ -283,18 +327,18 @@ public:
     const size_t realtype_size = sizeof(RealType);
     const size_t int_size      = sizeof(int);
     const size_t ptr_size      = sizeof(RealType*);
-    auto& offload_input        = dt_leader.offload_input;
+    auto& offload_input        = mw_mem.offload_input;
     offload_input.resize(total_targets * D * realtype_size + total_targets * int_size + nw * ptr_size);
     auto target_positions = reinterpret_cast<RealType*>(offload_input.data());
     auto walker_id_ptr    = reinterpret_cast<int*>(offload_input.data() + total_targets * D * realtype_size);
     auto source_ptrs      = reinterpret_cast<RealType**>(offload_input.data() + total_targets * D * realtype_size +
                                                     total_targets * int_size);
 
-    auto& particle_id = dt_leader.particle_id;
+    auto& particle_id = mw_mem.particle_id;
     particle_id.resize(total_targets);
 
     const int N_sources_padded = getAlignedSize<T>(N_sources);
-    auto& offload_output       = dt_leader.offload_output;
+    auto& offload_output       = mw_mem.offload_output;
     offload_output.resize(total_targets * N_sources_padded * (D + 1));
 
     count_targets = 0;

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -110,7 +110,7 @@ public:
 
   ~SoaDistanceTableABOMPTarget() { PRAGMA_OFFLOAD("omp target exit data map(delete : this[:1])") }
 
-  void createResource(ResourceCollection& collection) override
+  void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<DTABMultiWalkerMem>());
     app_log() << "    Multi walker shared memory resource created in SoaDistanceTableABOMPTarget " << name_

--- a/src/Particle/createDistanceTableAA.cpp
+++ b/src/Particle/createDistanceTableAA.cpp
@@ -92,14 +92,7 @@ DistanceTableData* createDistanceTableAA(ParticleSet& s, std::ostream& descripti
     dt = new SoaDistanceTableAA<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>(s);
   }
 
-
-  //set dt properties
-  std::ostringstream p;
-  p << s.getName() << "_" << s.getName();
-  dt->setName(p.str()); //assign the table name
-
   description << o.str() << std::endl;
-
   return dt;
 }
 

--- a/src/Particle/createDistanceTableAAOMPTarget.cpp
+++ b/src/Particle/createDistanceTableAAOMPTarget.cpp
@@ -92,14 +92,7 @@ DistanceTableData* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& 
     dt = new SoaDistanceTableAAOMPTarget<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>(s);
   }
 
-
-  //set dt properties
-  std::ostringstream p;
-  p << s.getName() << "_" << s.getName();
-  dt->setName(p.str()); //assign the table name
-
   description << o.str() << std::endl;
-
   return dt;
 }
 

--- a/src/Particle/createDistanceTableAB.cpp
+++ b/src/Particle/createDistanceTableAB.cpp
@@ -94,13 +94,7 @@ DistanceTableData* createDistanceTableAB(const ParticleSet& s, ParticleSet& t, s
     dt = new SoaDistanceTableAB<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>(s, t);
   }
 
-  //set dt properties
-  std::ostringstream p;
-  p << s.getName() << "_" << t.getName();
-  dt->setName(p.str()); //assign the table name
-
   description << o.str() << std::endl;
-
   return dt;
 }
 

--- a/src/Particle/createDistanceTableABOMPTarget.cpp
+++ b/src/Particle/createDistanceTableABOMPTarget.cpp
@@ -93,13 +93,7 @@ DistanceTableData* createDistanceTableABOMPTarget(const ParticleSet& s, Particle
     dt = new SoaDistanceTableABOMPTarget<RealType, DIM, SUPERCELL_OPEN + SOA_OFFSET>(s, t);
   }
 
-  //set dt properties
-  std::ostringstream p;
-  p << s.getName() << "_" << t.getName();
-  dt->setName(p.str()); //assign the table name
-
   description << o.str() << std::endl;
-
   return dt;
 }
 

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -13,7 +13,7 @@
 namespace qmcplusplus
 {
 Crowd::Crowd(EstimatorManagerNew& emb,
-             const FatWalkerResourceCollection& fatwalker_res,
+             const DriverWalkerResourceCollection& fatwalker_res,
              const MultiWalkerDispatchers& dispatchers)
     : dispatchers_(dispatchers), fatwalker_resource_collection_(fatwalker_res), estimator_manager_crowd_(emb)
 {}

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -13,9 +13,9 @@
 namespace qmcplusplus
 {
 Crowd::Crowd(EstimatorManagerNew& emb,
-             const DriverWalkerResourceCollection& fatwalker_res,
+             const DriverWalkerResourceCollection& driverwalker_res,
              const MultiWalkerDispatchers& dispatchers)
-    : dispatchers_(dispatchers), fatwalker_resource_collection_(fatwalker_res), estimator_manager_crowd_(emb)
+    : dispatchers_(dispatchers), driverwalker_resource_collection_(driverwalker_res), estimator_manager_crowd_(emb)
 {}
 
 Crowd::~Crowd() = default;

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -9,12 +9,13 @@
 
 #include "Crowd.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
-#include "ResourceCollection.h"
 
 namespace qmcplusplus
 {
-Crowd::Crowd(EstimatorManagerNew& emb, const MultiWalkerDispatchers& dispatchers)
-    : dispatchers_(dispatchers), estimator_manager_crowd_(emb)
+Crowd::Crowd(EstimatorManagerNew& emb,
+             const FatWalkerResourceCollection& fatwalker_res,
+             const MultiWalkerDispatchers& dispatchers)
+    : dispatchers_(dispatchers), fatwalker_resource_collection_(fatwalker_res), estimator_manager_crowd_(emb)
 {}
 
 Crowd::~Crowd() = default;
@@ -55,40 +56,6 @@ void Crowd::setRNGForHamiltonian(RandomGenerator_t& rng)
 {
   for (QMCHamiltonian& ham : walker_hamiltonians_)
     ham.setRandomGenerator(&rng);
-}
-
-void Crowd::initializeResources(const ResourceCollection& twf_resource)
-{
-  if (!twfs_shared_resource_)
-    twfs_shared_resource_ = std::make_unique<ResourceCollection>(twf_resource);
-}
-
-void Crowd::lendResources(size_t receiver)
-{
-  if (walker_twfs_.size() > 0)
-  {
-    if (twfs_shared_resource_->is_lent())
-      throw std::runtime_error("Crowd::lendResources resources are out already!");
-    if (receiver >= walker_twfs_.size())
-      throw std::runtime_error("Crowd::takebackResources receiver out of bound!");
-    twfs_shared_resource_->lock();
-    twfs_shared_resource_->rewind();
-    walker_twfs_[receiver].get().acquireResource(*twfs_shared_resource_);
-  }
-}
-
-void Crowd::takebackResources(size_t receiver)
-{
-  if (walker_twfs_.size() > 0)
-  {
-    if (!twfs_shared_resource_->is_lent())
-      throw std::runtime_error("Crowd::takebackResources resources was not lent out!");
-    if (receiver >= walker_twfs_.size())
-      throw std::runtime_error("Crowd::takebackResources receiver out of bound!");
-    twfs_shared_resource_->rewind();
-    walker_twfs_[receiver].get().releaseResource(*twfs_shared_resource_);
-    twfs_shared_resource_->unlock();
-  }
 }
 
 void Crowd::startBlock(int num_steps)

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -16,7 +16,7 @@
 #include "Estimators/EstimatorManagerCrowd.h"
 #include "RandomGenerator.h"
 #include "MultiWalkerDispatchers.h"
-#include "FatWalkerTypes.h"
+#include "DriverWalkerTypes.h"
 
 namespace qmcplusplus
 {
@@ -43,7 +43,7 @@ public:
   /** This is the data structure for walkers within a crowd
    */
   Crowd(EstimatorManagerNew& emb,
-        const FatWalkerResourceCollection& fatwalker_res,
+        const DriverWalkerResourceCollection& fatwalker_res,
         const MultiWalkerDispatchers& dispatchers);
 
   ~Crowd();
@@ -93,7 +93,7 @@ public:
 
   const EstimatorManagerCrowd& get_estimator_manager_crowd() const { return estimator_manager_crowd_; }
 
-  FatWalkerResourceCollection& getSharedResource() { return fatwalker_resource_collection_; }
+  DriverWalkerResourceCollection& getSharedResource() { return fatwalker_resource_collection_; }
 
   int size() const { return mcp_walkers_.size(); }
 
@@ -119,7 +119,7 @@ private:
   RefVector<QMCHamiltonian> walker_hamiltonians_;
   /** }@ */
 
-  FatWalkerResourceCollection fatwalker_resource_collection_;
+  DriverWalkerResourceCollection fatwalker_resource_collection_;
 
   EstimatorManagerCrowd estimator_manager_crowd_;
 

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -43,7 +43,7 @@ public:
   /** This is the data structure for walkers within a crowd
    */
   Crowd(EstimatorManagerNew& emb,
-        const DriverWalkerResourceCollection& fatwalker_res,
+        const DriverWalkerResourceCollection& driverwalker_res,
         const MultiWalkerDispatchers& dispatchers);
 
   ~Crowd();
@@ -93,7 +93,7 @@ public:
 
   const EstimatorManagerCrowd& get_estimator_manager_crowd() const { return estimator_manager_crowd_; }
 
-  DriverWalkerResourceCollection& getSharedResource() { return fatwalker_resource_collection_; }
+  DriverWalkerResourceCollection& getSharedResource() { return driverwalker_resource_collection_; }
 
   int size() const { return mcp_walkers_.size(); }
 
@@ -119,7 +119,7 @@ private:
   RefVector<QMCHamiltonian> walker_hamiltonians_;
   /** }@ */
 
-  DriverWalkerResourceCollection fatwalker_resource_collection_;
+  DriverWalkerResourceCollection driverwalker_resource_collection_;
 
   EstimatorManagerCrowd estimator_manager_crowd_;
 

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -16,6 +16,7 @@
 #include "Estimators/EstimatorManagerCrowd.h"
 #include "RandomGenerator.h"
 #include "MultiWalkerDispatchers.h"
+#include "FatWalkerTypes.h"
 
 namespace qmcplusplus
 {
@@ -41,7 +42,9 @@ public:
   using FullPrecRealType = QMCTraits::FullPrecRealType;
   /** This is the data structure for walkers within a crowd
    */
-  Crowd(EstimatorManagerNew& emb, const MultiWalkerDispatchers& dispatchers);
+  Crowd(EstimatorManagerNew& emb,
+        const FatWalkerResourceCollection& fatwalker_res,
+        const MultiWalkerDispatchers& dispatchers);
 
   ~Crowd();
   /** Because so many vectors allocate them upfront.
@@ -76,18 +79,6 @@ public:
 
   void setRNGForHamiltonian(RandomGenerator_t& rng);
 
-  /** initialize crowd-owned resources shared by walkers in the crowd
-   */
-  void initializeResources(const ResourceCollection& twf_resource);
-  /** lend crowd-owned resources to the crowd leader walker
-   * Note: use RAII CrowdResourceLock whenever possible
-   */
-  void lendResources(size_t receiver);
-  /** take back crowd-owned resources from the crowd leader walker
-   * Note: use RAII CrowdResourceLock whenever possible
-   */
-  void takebackResources(size_t receiver);
-
   auto beginWalkers() { return mcp_walkers_.begin(); }
   auto endWalkers() { return mcp_walkers_.end(); }
   auto beginTrialWaveFunctions() { return walker_twfs_.begin(); }
@@ -102,7 +93,7 @@ public:
 
   const EstimatorManagerCrowd& get_estimator_manager_crowd() const { return estimator_manager_crowd_; }
 
-  ResourceCollection& getTWFSharedResource() { return *twfs_shared_resource_; }
+  FatWalkerResourceCollection& getSharedResource() { return fatwalker_resource_collection_; }
 
   int size() const { return mcp_walkers_.size(); }
 
@@ -128,9 +119,9 @@ private:
   RefVector<QMCHamiltonian> walker_hamiltonians_;
   /** }@ */
 
-  EstimatorManagerCrowd estimator_manager_crowd_;
+  FatWalkerResourceCollection fatwalker_resource_collection_;
 
-  std::unique_ptr<ResourceCollection> twfs_shared_resource_;
+  EstimatorManagerCrowd estimator_manager_crowd_;
 
   /** @name Step State
    * 
@@ -141,26 +132,6 @@ private:
   unsigned long n_accept_          = 0;
   unsigned long n_nonlocal_accept_ = 0;
   /** @} */
-};
-
-/** Lock for a crowd lending and taking back shared resource to its consumer objects.
- */
-class CrowdResourceLock
-{
-public:
-  CrowdResourceLock(Crowd& locked_crowd, size_t receiver = 0) : locked_crowd_(locked_crowd), receiver_(receiver)
-  {
-    locked_crowd_.lendResources(receiver_);
-  }
-
-  ~CrowdResourceLock() { locked_crowd_.takebackResources(receiver_); }
-
-  CrowdResourceLock(const CrowdResourceLock&) = delete;
-  CrowdResourceLock(CrowdResourceLock&&)      = delete;
-
-private:
-  Crowd& locked_crowd_;
-  const size_t receiver_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -74,7 +74,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     int nnode_crossing(0);
     auto& walkers = crowd.get_walkers();
-    FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+    DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
                                               crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
     const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
     const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
@@ -290,7 +290,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     for (int iw = 0; iw < walkers.size(); ++iw)
     {
-      FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[iw],
+      DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[iw],
                                                  crowd.get_walker_twfs()[iw], crowd.get_walker_hamiltonians()[iw]);
       walker_non_local_moves_accepted[iw] = walker_hamiltonians[iw].makeNonLocalMoves(walker_elecs[iw]);
 
@@ -305,7 +305,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     if (moved_nonlocal_walkers.size())
     {
-      FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+      DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
                                                  crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
 
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -22,7 +22,6 @@
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Utilities/RunTimeManager.h"
 #include "Utilities/ProgressReportEngine.h"
-#include "ResourceCollection.h"
 #include "QMCDrivers/DMC/WalkerControl.h"
 #include "QMCDrivers/SFNBranch.h"
 #include "MemoryUsage.h"
@@ -71,11 +70,12 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   {
-    CrowdResourceLock pbyp_lock(crowd);
     assert(QMCDriverNew::checkLogAndGL(crowd));
 
     int nnode_crossing(0);
     auto& walkers = crowd.get_walkers();
+    FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+                                              crowd.get_walker_twfs()[0]);
     const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
     const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
     const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
@@ -290,7 +290,8 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     for (int iw = 0; iw < walkers.size(); ++iw)
     {
-      CrowdResourceLock pbyp_lock(crowd, iw);
+      FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[iw],
+                                                 crowd.get_walker_twfs()[iw]);
       walker_non_local_moves_accepted[iw] = walker_hamiltonians[iw].makeNonLocalMoves(walker_elecs[iw]);
 
       if (walker_non_local_moves_accepted[iw] > 0)
@@ -304,7 +305,8 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     if (moved_nonlocal_walkers.size())
     {
-      ResourceCollectionLock<TrialWaveFunction> resource_lock(crowd.getTWFSharedResource(), crowd.get_walker_twfs()[0]);
+      FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+                                                 crowd.get_walker_twfs()[0]);
 
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);
       assert(QMCDriverNew::checkLogAndGL(crowd));
@@ -361,8 +363,7 @@ void DMCBatched::process(xmlNodePtr node)
     branch_engine_ = std::make_unique<SFNBranch>(qmcdriver_input_.get_tau(), population_.get_num_global_walkers());
     branch_engine_->put(node);
 
-    walker_controller_ =
-        std::make_unique<WalkerControl>(myComm, dispatchers_, Random, dmcdriver_input_.get_reconfiguration());
+    walker_controller_ = std::make_unique<WalkerControl>(myComm, Random, dmcdriver_input_.get_reconfiguration());
     walker_controller_->setMinMax(population_.get_num_global_walkers(), 0);
     walker_controller_->start();
     walker_controller_->put(node);
@@ -447,8 +448,9 @@ bool DMCBatched::run()
       }
 
       {
-        int iter                 = block * qmcdriver_input_.get_max_steps() + step;
-        const int population_now = walker_controller_->branch(iter, population_, iter == 0);
+        int iter = block * qmcdriver_input_.get_max_steps() + step;
+        const int population_now =
+            walker_controller_->branch(iter, population_, dispatchers_, golden_resource_, iter == 0);
         branch_engine_->updateParamAfterPopControl(population_now, walker_controller_->get_ensemble_property(),
                                                    population_.get_num_particles());
         walker_controller_->setTrialEnergy(branch_engine_->getEtrial());

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -75,7 +75,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     int nnode_crossing(0);
     auto& walkers = crowd.get_walkers();
     FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                              crowd.get_walker_twfs()[0]);
+                                              crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
     const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
     const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
     const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
@@ -291,7 +291,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     for (int iw = 0; iw < walkers.size(); ++iw)
     {
       FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[iw],
-                                                 crowd.get_walker_twfs()[iw]);
+                                                 crowd.get_walker_twfs()[iw], crowd.get_walker_hamiltonians()[iw]);
       walker_non_local_moves_accepted[iw] = walker_hamiltonians[iw].makeNonLocalMoves(walker_elecs[iw]);
 
       if (walker_non_local_moves_accepted[iw] > 0)
@@ -306,7 +306,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     if (moved_nonlocal_walkers.size())
     {
       FatWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                                 crowd.get_walker_twfs()[0]);
+                                                 crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
 
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);
       assert(QMCDriverNew::checkLogAndGL(crowd));

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -27,7 +27,7 @@
 #include "type_traits/template_types.hpp"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "MultiWalkerDispatchers.h"
-#include "FatWalkerTypes.h"
+#include "DriverWalkerTypes.h"
 
 namespace qmcplusplus
 {
@@ -156,7 +156,7 @@ void WalkerControl::writeDMCdat(int iter, const std::vector<FullPrecRealType>& c
 int WalkerControl::branch(int iter,
                           MCPopulation& pop,
                           const MultiWalkerDispatchers& dispatchers,
-                          FatWalkerResourceCollection& fatwalker_res,
+                          DriverWalkerResourceCollection& fatwalker_res,
                           bool do_not_branch)
 {
   if (debug_disable_branching_)
@@ -256,7 +256,7 @@ int WalkerControl::branch(int iter,
     const auto wf_list_no_leader =
         convertUPtrToRefVectorSubset(pop.get_twfs(), untouched_walkers, num_walkers - untouched_walkers);
 
-    FatWalkerResourceCollection_PsetTWF_Lock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
+    DriverWalkerResourceCollection_PsetTWF_Lock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
     // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
 
     const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -156,7 +156,7 @@ void WalkerControl::writeDMCdat(int iter, const std::vector<FullPrecRealType>& c
 int WalkerControl::branch(int iter,
                           MCPopulation& pop,
                           const MultiWalkerDispatchers& dispatchers,
-                          DriverWalkerResourceCollection& fatwalker_res,
+                          DriverWalkerResourceCollection& driverwalker_res,
                           bool do_not_branch)
 {
   if (debug_disable_branching_)
@@ -256,7 +256,7 @@ int WalkerControl::branch(int iter,
     const auto wf_list_no_leader =
         convertUPtrToRefVectorSubset(pop.get_twfs(), untouched_walkers, num_walkers - untouched_walkers);
 
-    DriverWalkerResourceCollection_PsetTWF_Lock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
+    DriverWalkerResourceCollection_PsetTWF_Lock pbyp_lock(driverwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
     // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
 
     const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -256,7 +256,7 @@ int WalkerControl::branch(int iter,
     const auto wf_list_no_leader =
         convertUPtrToRefVectorSubset(pop.get_twfs(), untouched_walkers, num_walkers - untouched_walkers);
 
-    FatWalkerResourceCollectionLock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
+    FatWalkerResourceCollection_PsetTWF_Lock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
     // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
 
     const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -14,6 +14,7 @@
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
+
 #include <cassert>
 #include <stdexcept>
 #include <numeric>
@@ -25,7 +26,8 @@
 #include "OhmmsData/ParameterSet.h"
 #include "type_traits/template_types.hpp"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
-#include "ResourceCollection.h"
+#include "MultiWalkerDispatchers.h"
+#include "FatWalkerTypes.h"
 
 namespace qmcplusplus
 {
@@ -54,10 +56,7 @@ TimerNameList_t<WC_Timers> WalkerControlTimerNames = {{WC_branch, "WalkerControl
                                                       {WC_send, "WalkerControl::send"},
                                                       {WC_recv, "WalkerControl::recv"}};
 
-WalkerControl::WalkerControl(Communicate* c,
-                             const MultiWalkerDispatchers& dispatchers,
-                             RandomGenerator_t& rng,
-                             bool use_fixed_pop)
+WalkerControl::WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop)
     : MPIObjectBase(c),
       rng_(rng),
       use_fixed_pop_(use_fixed_pop),
@@ -70,8 +69,7 @@ WalkerControl::WalkerControl(Communicate* c,
       SwapMode(0),
       use_nonblocking_(true),
       debug_disable_branching_(false),
-      saved_num_walkers_sent_(0),
-      dispatchers_(dispatchers)
+      saved_num_walkers_sent_(0)
 {
   num_per_node_.resize(num_ranks_);
   fair_offset_.resize(num_ranks_ + 1);
@@ -155,7 +153,11 @@ void WalkerControl::writeDMCdat(int iter, const std::vector<FullPrecRealType>& c
   }
 }
 
-int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
+int WalkerControl::branch(int iter,
+                          MCPopulation& pop,
+                          const MultiWalkerDispatchers& dispatchers,
+                          FatWalkerResourceCollection& fatwalker_res,
+                          bool do_not_branch)
 {
   if (debug_disable_branching_)
     do_not_branch = true;
@@ -254,15 +256,15 @@ int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
     const auto wf_list_no_leader =
         convertUPtrToRefVectorSubset(pop.get_twfs(), untouched_walkers, num_walkers - untouched_walkers);
 
-    ResourceCollectionLock<TrialWaveFunction> resource_lock(pop.get_golden_twf().getResource(), pop.get_golden_twf());
+    FatWalkerResourceCollectionLock pbyp_lock(fatwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
     // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
 
     const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);
-    dispatchers_.ps_dispatcher_.flex_loadWalker(p_list, w_list_no_leader, true);
-    dispatchers_.ps_dispatcher_.flex_update(p_list, true);
+    dispatchers.ps_dispatcher_.flex_loadWalker(p_list, w_list_no_leader, true);
+    dispatchers.ps_dispatcher_.flex_update(p_list, true);
 
     const RefVectorWithLeader<TrialWaveFunction> wf_list(pop.get_golden_twf(), wf_list_no_leader);
-    dispatchers_.twf_dispatcher_.flex_evaluateLog(wf_list, p_list);
+    dispatchers.twf_dispatcher_.flex_evaluateLog(wf_list, p_list);
   }
 
   const int current_num_global_walkers = std::accumulate(num_per_node_.begin(), num_per_node_.end(), 0);

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -30,7 +30,7 @@
 namespace qmcplusplus
 {
 class MultiWalkerDispatchers;
-struct FatWalkerResourceCollection;
+struct DriverWalkerResourceCollection;
 
 /** Class for controlling the walkers for DMC simulations.
  * w and w/o MPI. Fixed and dynamic population in one place.
@@ -73,7 +73,7 @@ public:
   int branch(int iter,
              MCPopulation& pop,
              const MultiWalkerDispatchers& dispatchers,
-             FatWalkerResourceCollection& fatwalker_res,
+             DriverWalkerResourceCollection& fatwalker_res,
              bool do_not_branch);
 
   bool put(xmlNodePtr cur);

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -73,7 +73,7 @@ public:
   int branch(int iter,
              MCPopulation& pop,
              const MultiWalkerDispatchers& dispatchers,
-             DriverWalkerResourceCollection& fatwalker_res,
+             DriverWalkerResourceCollection& driverwalker_res,
              bool do_not_branch);
 
   bool put(xmlNodePtr cur);

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -29,6 +29,9 @@
 
 namespace qmcplusplus
 {
+class MultiWalkerDispatchers;
+struct FatWalkerResourceCollection;
+
 /** Class for controlling the walkers for DMC simulations.
  * w and w/o MPI. Fixed and dynamic population in one place.
  */
@@ -48,10 +51,7 @@ public:
    *
    * Set the SwapMode to zero so that instantiation can be done
    */
-  WalkerControl(Communicate* c,
-                const MultiWalkerDispatchers& dispatchers,
-                RandomGenerator_t& rng,
-                bool use_fixed_pop = false);
+  WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop = false);
 
   /** empty destructor to clean up the derived classes */
   ~WalkerControl();
@@ -70,7 +70,11 @@ public:
    *
    *  \return global population
    */
-  int branch(int iter, MCPopulation& pop, bool do_not_branch);
+  int branch(int iter,
+             MCPopulation& pop,
+             const MultiWalkerDispatchers& dispatchers,
+             FatWalkerResourceCollection& fatwalker_res,
+             bool do_not_branch);
 
   bool put(xmlNodePtr cur);
 
@@ -178,8 +182,6 @@ private:
   TimerList_t my_timers_;
   ///Number of walkers sent during the exchange
   IndexType saved_num_walkers_sent_;
-
-  const MultiWalkerDispatchers& dispatchers_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/DriverWalkerTypes.h
+++ b/src/QMCDrivers/DriverWalkerTypes.h
@@ -10,13 +10,24 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef QMCPLUSPLUS_FATWALKERTYPES_H
-#define QMCPLUSPLUS_FATWALKERTYPES_H
+/**
+ * @file
+ * Driver level walker (DriverWalker) related data structures.
+ * Unlike MCWalkerConfiguration which only holds electron positions and weights.
+ * Driver level walker includes all the per-walker data structures which depends on the type of driver
+ */
+
+#ifndef QMCPLUSPLUS_DRIVERWALKERTYPES_H
+#define QMCPLUSPLUS_DRIVERWALKERTYPES_H
 
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
 {
+
+/** DriverWalker multi walker resource collections
+ * It currently supports VMC and DMC only
+ */
 struct DriverWalkerResourceCollection
 {
   ResourceCollection pset_res;
@@ -26,11 +37,14 @@ struct DriverWalkerResourceCollection
   DriverWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction"), ham_res("Hamiltonian") {}
 };
 
+/** DriverWalkerResourceCollection locks
+ * Helper class for acquiring and releasing multi walker resources
+ */
 class DriverWalkerResourceCollectionLock
 {
 public:
-  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
-      : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf), ham_res_lock_(fatwalker_res.ham_res, ham)
+  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& driverwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
+      : pset_res_lock_(driverwalker_res.pset_res, pset), twf_res_lock_(driverwalker_res.twf_res, twf), ham_res_lock_(driverwalker_res.ham_res, ham)
   {}
 
 private:
@@ -39,11 +53,15 @@ private:
   ResourceCollectionLock<QMCHamiltonian> ham_res_lock_;
 };
 
+/** DriverWalkerResourceCollection locks
+ * Helper class for acquiring and releasing multi walker resources.
+ * Only ParticleSet and TrialWaveFunction resources are engaged.
+ */
 class DriverWalkerResourceCollection_PsetTWF_Lock
 {
 public:
-  DriverWalkerResourceCollection_PsetTWF_Lock(DriverWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
-      : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf)
+  DriverWalkerResourceCollection_PsetTWF_Lock(DriverWalkerResourceCollection& driverwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
+      : pset_res_lock_(driverwalker_res.pset_res, pset), twf_res_lock_(driverwalker_res.twf_res, twf)
   {}
 
 private:

--- a/src/QMCDrivers/DriverWalkerTypes.h
+++ b/src/QMCDrivers/DriverWalkerTypes.h
@@ -17,19 +17,19 @@
 
 namespace qmcplusplus
 {
-struct FatWalkerResourceCollection
+struct DriverWalkerResourceCollection
 {
   ResourceCollection pset_res;
   ResourceCollection twf_res;
   ResourceCollection ham_res;
 
-  FatWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction"), ham_res("Hamiltonian") {}
+  DriverWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction"), ham_res("Hamiltonian") {}
 };
 
-class FatWalkerResourceCollectionLock
+class DriverWalkerResourceCollectionLock
 {
 public:
-  FatWalkerResourceCollectionLock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
+  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
       : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf), ham_res_lock_(fatwalker_res.ham_res, ham)
   {}
 
@@ -39,10 +39,10 @@ private:
   ResourceCollectionLock<QMCHamiltonian> ham_res_lock_;
 };
 
-class FatWalkerResourceCollection_PsetTWF_Lock
+class DriverWalkerResourceCollection_PsetTWF_Lock
 {
 public:
-  FatWalkerResourceCollection_PsetTWF_Lock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
+  DriverWalkerResourceCollection_PsetTWF_Lock(DriverWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
       : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf)
   {}
 

--- a/src/QMCDrivers/FatWalkerTypes.h
+++ b/src/QMCDrivers/FatWalkerTypes.h
@@ -21,14 +21,28 @@ struct FatWalkerResourceCollection
 {
   ResourceCollection pset_res;
   ResourceCollection twf_res;
+  ResourceCollection ham_res;
 
-  FatWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction") {}
+  FatWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction"), ham_res("Hamiltonian") {}
 };
 
 class FatWalkerResourceCollectionLock
 {
 public:
-  FatWalkerResourceCollectionLock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
+  FatWalkerResourceCollectionLock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
+      : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf), ham_res_lock_(fatwalker_res.ham_res, ham)
+  {}
+
+private:
+  ResourceCollectionLock<ParticleSet> pset_res_lock_;
+  ResourceCollectionLock<TrialWaveFunction> twf_res_lock_;
+  ResourceCollectionLock<QMCHamiltonian> ham_res_lock_;
+};
+
+class FatWalkerResourceCollection_PsetTWF_Lock
+{
+public:
+  FatWalkerResourceCollection_PsetTWF_Lock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
       : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf)
   {}
 

--- a/src/QMCDrivers/FatWalkerTypes.h
+++ b/src/QMCDrivers/FatWalkerTypes.h
@@ -1,0 +1,40 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_FATWALKERTYPES_H
+#define QMCPLUSPLUS_FATWALKERTYPES_H
+
+#include <ResourceCollection.h>
+
+namespace qmcplusplus
+{
+struct FatWalkerResourceCollection
+{
+  ResourceCollection pset_res;
+  ResourceCollection twf_res;
+
+  FatWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction") {}
+};
+
+class FatWalkerResourceCollectionLock
+{
+public:
+  FatWalkerResourceCollectionLock(FatWalkerResourceCollection& fatwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
+      : pset_res_lock_(fatwalker_res.pset_res, pset), twf_res_lock_(fatwalker_res.twf_res, twf)
+  {}
+
+private:
+  ResourceCollectionLock<ParticleSet> pset_res_lock_;
+  ResourceCollectionLock<TrialWaveFunction> twf_res_lock_;
+};
+} // namespace qmcplusplus
+#endif

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -150,7 +150,6 @@ public:
     auto walker_index = 0;
     for (int i = 0; i < walker_consumers.size(); ++i)
     {
-      walker_consumers[i]->initializeResources(trial_wf_->getResource());
       walker_consumers[i]->clearWalkers();
       for (int j = 0; j < walkers_per_crowd[i]; ++j)
       {

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -334,7 +334,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
 
   auto& walkers = crowd.get_walkers();
-  FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
                                             crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -158,6 +158,7 @@ void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts aw
     app_log() << "Creating multi walker shared resources" << std::endl;
     population_.get_golden_electrons()->createResource(golden_resource_.pset_res);
     population_.get_golden_twf().createResource(golden_resource_.twf_res);
+    population_.get_golden_hamiltonian().createResource(golden_resource_.ham_res);
     app_log() << "Multi walker shared resources creation completed" << std::endl;
   }
 
@@ -334,7 +335,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
 
   auto& walkers = crowd.get_walkers();
   FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                            crowd.get_walker_twfs()[0]);
+                                            crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -135,15 +135,15 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
 void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc)
 {
   if (driver_scope_profiler_.isActive())
-    app_log() << "  Profiler data collection is enabled in this driver scope." << std::endl;
+    app_summary() << "  Profiler data collection is enabled in this driver scope." << std::endl;
   if (!dispatchers_.are_walkers_batched())
-    app_log() << "  Batched operations are serialized over walkers." << std::endl;
+    app_summary() << "  Batched operations are serialized over walkers." << std::endl;
 
-  app_log() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
-            << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl
-            << "                               num_crowds = " << awc.walkers_per_crowd.size() << std::endl
-            << "                    on rank 0, walkers_per_crowd = " << awc.walkers_per_crowd << std::endl
-            << std::endl;
+  app_summary() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
+                << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl
+                << "                               num_crowds = " << awc.walkers_per_crowd.size() << std::endl
+                << "                    on rank 0, walkers_per_crowd = " << awc.walkers_per_crowd << std::endl
+                << std::endl;
 
   // set num_global_walkers explicitly and then make local walkers.
   population_.set_num_global_walkers(awc.global_walkers);
@@ -153,12 +153,20 @@ void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts aw
 
   estimator_manager_->put(population_.get_golden_hamiltonian(), *population_.get_golden_electrons(), cur);
 
+  if (dispatchers_.are_walkers_batched())
+  {
+    app_log() << "Creating multi walker shared resources" << std::endl;
+    population_.get_golden_electrons()->createResource(golden_resource_.pset_res);
+    population_.get_golden_twf().createResource(golden_resource_.twf_res);
+    app_log() << "Multi walker shared resources creation completed" << std::endl;
+  }
+
   crowds_.resize(awc.walkers_per_crowd.size());
 
   // at this point we can finally construct the Crowd objects.
   for (int i = 0; i < crowds_.size(); ++i)
   {
-    crowds_[i].reset(new Crowd(*estimator_manager_, dispatchers_));
+    crowds_[i].reset(new Crowd(*estimator_manager_, golden_resource_, dispatchers_));
   }
 
   //now give walkers references to their walkers
@@ -319,13 +327,14 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   if (crowd.size() == 0)
     return;
 
-  CrowdResourceLock crowd_res_lock(crowd);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
   auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
 
   auto& walkers = crowd.get_walkers();
+  FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+                                            crowd.get_walker_twfs()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -39,7 +39,7 @@
 #include "QMCDrivers/ContextForSteps.h"
 #include "OhmmsApp/ProjectData.h"
 #include "MultiWalkerDispatchers.h"
-#include "FatWalkerTypes.h"
+#include "DriverWalkerTypes.h"
 
 class Communicate;
 
@@ -363,7 +363,7 @@ protected:
    * per crowd resources are copied from this gold instance
    * it should be activated when dispatchers don't serialize walkers
    */
-  struct FatWalkerResourceCollection golden_resource_;
+  struct DriverWalkerResourceCollection golden_resource_;
 
   /// multi walker dispatchers
   const MultiWalkerDispatchers dispatchers_;

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -39,6 +39,7 @@
 #include "QMCDrivers/ContextForSteps.h"
 #include "OhmmsApp/ProjectData.h"
 #include "MultiWalkerDispatchers.h"
+#include "FatWalkerTypes.h"
 
 class Communicate;
 
@@ -352,9 +353,17 @@ protected:
   ///root of all the output files
   std::string root_name_;
 
-
-  ///the entire (or on node) walker population
+  /** the entire (on node) walker population
+   * it serves VMCBatch and DMCBatch right now but will be polymorphic
+   */
   MCPopulation population_;
+
+  /** the golden multi walker shared resource
+   * serves ParticleSet TrialWaveFunction right now but actually should be based on MCPopulation.
+   * per crowd resources are copied from this gold instance
+   * it should be activated when dispatchers don't serialize walkers
+   */
+  struct FatWalkerResourceCollection golden_resource_;
 
   /// multi walker dispatchers
   const MultiWalkerDispatchers dispatchers_;

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -266,41 +266,41 @@ QMCUpdateBase::RealType QMCUpdateBase::getNodeCorrection(const ParticleSet::Part
 
 bool QMCUpdateBase::checkLogAndGL(ParticleSet& pset, TrialWaveFunction& twf)
 {
-  bool success         = true;
+  bool success = true;
   TrialWaveFunction::LogValueType log_value{twf.getLogPsi(), twf.getPhase()};
-  ParticleSet::ParticleGradient_t G_saved = twf.G;
+  ParticleSet::ParticleGradient_t G_saved  = twf.G;
   ParticleSet::ParticleLaplacian_t L_saved = twf.L;
 
   pset.update();
   twf.evaluateLog(pset);
 
   const RealType threshold = 100 * std::numeric_limits<float>::epsilon();
-    auto& ref_G = twf.G;
-    auto& ref_L = twf.L;
-    TrialWaveFunction::LogValueType ref_log{twf.getLogPsi(), twf.getPhase()};
-    if (std::abs(std::exp(log_value) - std::exp(ref_log)) > std::abs(std::exp(ref_log)) * threshold)
+  auto& ref_G              = twf.G;
+  auto& ref_L              = twf.L;
+  TrialWaveFunction::LogValueType ref_log{twf.getLogPsi(), twf.getPhase()};
+  if (std::abs(std::exp(log_value) - std::exp(ref_log)) > std::abs(std::exp(ref_log)) * threshold)
+  {
+    success = false;
+    std::cout << "Logpsi " << log_value << " ref " << ref_log << std::endl;
+  }
+  for (int iel = 0; iel < ref_G.size(); iel++)
+  {
+    auto grad_diff = ref_G[iel] - G_saved[iel];
+    if (std::sqrt(std::abs(dot(grad_diff, grad_diff))) > std::sqrt(std::abs(dot(ref_G[iel], ref_G[iel]))) * threshold)
     {
       success = false;
-      std::cout << "Logpsi " << log_value << " ref " << ref_log << std::endl;
+      std::cout << "Grad[" << iel << "] ref = " << ref_G[iel] << " wrong = " << G_saved[iel] << " Delta " << grad_diff
+                << std::endl;
     }
-    for (int iel = 0; iel < ref_G.size(); iel++)
+    auto lap_diff = ref_L[iel] - L_saved[iel];
+    if (std::abs(lap_diff) > std::abs(ref_L[iel]) * threshold)
     {
-      auto grad_diff = ref_G[iel] - G_saved[iel];
-      if (std::sqrt(std::abs(dot(grad_diff, grad_diff))) > std::sqrt(std::abs(dot(ref_G[iel], ref_G[iel]))) * threshold)
-      {
-        success = false;
-        std::cout << "Grad[" << iel << "] ref = " << ref_G[iel] << " wrong = " << G_saved[iel]
-                  << " Delta " << grad_diff << std::endl;
-      }
-      auto lap_diff = ref_L[iel] - L_saved[iel];
-      if (std::abs(lap_diff) > std::abs(ref_L[iel]) * threshold)
-      {
-        // very hard to check mixed precision case, only print, no error out
-        success = !std::is_same<RealType, FullPrecRealType>::value;
-        std::cout << "lap[" << iel << "] ref = " << ref_L[iel] << " wrong = " << L_saved[iel]
-                  << " Delta " << lap_diff << std::endl;
-      }
+      // very hard to check mixed precision case, only print, no error out
+      success = !std::is_same<RealType, FullPrecRealType>::value;
+      std::cout << "lap[" << iel << "] ref = " << ref_L[iel] << " wrong = " << L_saved[iel] << " Delta " << lap_diff
+                << std::endl;
     }
+  }
   return success;
 }
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -40,6 +40,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
                                 ContextForSteps& step_context,
                                 bool recompute)
 {
+  if (crowd.size() == 0) return;
   assert(QMCDriverNew::checkLogAndGL(crowd));
 
   auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -46,7 +46,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   auto& walkers        = crowd.get_walkers();
-  FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
                                             crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -47,7 +47,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   auto& walkers        = crowd.get_walkers();
   FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                            crowd.get_walker_twfs()[0]);
+                                            crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -46,6 +46,8 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   auto& walkers        = crowd.get_walkers();
+  FatWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
+                                            crowd.get_walker_twfs()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
 
@@ -208,7 +210,7 @@ void VMCBatched::runVMCStep(int crowd_id,
                             std::vector<std::unique_ptr<Crowd>>& crowds)
 {
   Crowd& crowd = *(crowds[crowd_id]);
-  CrowdResourceLock crowd_res_lock(crowd);
+
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
 
   int max_steps = sft.qmcdrv_input.get_max_steps();
@@ -288,7 +290,6 @@ bool VMCBatched::run()
   auto runWarmupStep = [](int crowd_id, StateForThread& sft, DriverTimers& timers,
                           UPtrVector<ContextForSteps>& context_for_steps, UPtrVector<Crowd>& crowds) {
     Crowd& crowd = *(crowds[crowd_id]);
-    CrowdResourceLock crowd_res_lock(crowd);
     advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], false);
   };
 

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -40,7 +40,7 @@ public:
   UPtrVector<TrialWaveFunction> twfs;
   UPtrVector<QMCHamiltonian> hams;
   std::vector<TinyVector<double, 3>> tpos;
-  DriverWalkerResourceCollection fatwalker_resource_collection_;
+  DriverWalkerResourceCollection driverwalker_resource_collection_;
   const MultiWalkerDispatchers dispatchers_;
 
 public:
@@ -49,7 +49,7 @@ public:
     FakeEstimator* fake_est = new FakeEstimator;
     em.add(fake_est, "fake");
 
-    crowd_ptr    = std::make_unique<Crowd>(em, fatwalker_resource_collection_, dispatchers_);
+    crowd_ptr    = std::make_unique<Crowd>(em, driverwalker_resource_collection_, dispatchers_);
     Crowd& crowd = *crowd_ptr;
     // To match the minimal particle set
     int num_particles = 2;
@@ -96,8 +96,8 @@ TEST_CASE("Crowd integration", "[drivers]")
   // The above was required behavior for crowd at one point.
   // TODO: determine whether it still is, I don't think so.
   const MultiWalkerDispatchers dispatchers(true);
-  DriverWalkerResourceCollection fatwalker_resource_collection_;
-  Crowd crowd(em, fatwalker_resource_collection_, dispatchers);
+  DriverWalkerResourceCollection driverwalker_resource_collection_;
+  Crowd crowd(em, driverwalker_resource_collection_, dispatchers);
 }
 
 TEST_CASE("Crowd::loadWalkers", "[particle]")

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -40,7 +40,7 @@ public:
   UPtrVector<TrialWaveFunction> twfs;
   UPtrVector<QMCHamiltonian> hams;
   std::vector<TinyVector<double, 3>> tpos;
-  FatWalkerResourceCollection fatwalker_resource_collection_;
+  DriverWalkerResourceCollection fatwalker_resource_collection_;
   const MultiWalkerDispatchers dispatchers_;
 
 public:
@@ -96,7 +96,7 @@ TEST_CASE("Crowd integration", "[drivers]")
   // The above was required behavior for crowd at one point.
   // TODO: determine whether it still is, I don't think so.
   const MultiWalkerDispatchers dispatchers(true);
-  FatWalkerResourceCollection fatwalker_resource_collection_;
+  DriverWalkerResourceCollection fatwalker_resource_collection_;
   Crowd crowd(em, fatwalker_resource_collection_, dispatchers);
 }
 

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -40,6 +40,7 @@ public:
   UPtrVector<TrialWaveFunction> twfs;
   UPtrVector<QMCHamiltonian> hams;
   std::vector<TinyVector<double, 3>> tpos;
+  FatWalkerResourceCollection fatwalker_resource_collection_;
   const MultiWalkerDispatchers dispatchers_;
 
 public:
@@ -48,7 +49,7 @@ public:
     FakeEstimator* fake_est = new FakeEstimator;
     em.add(fake_est, "fake");
 
-    crowd_ptr    = std::make_unique<Crowd>(em, dispatchers_);
+    crowd_ptr    = std::make_unique<Crowd>(em, fatwalker_resource_collection_, dispatchers_);
     Crowd& crowd = *crowd_ptr;
     // To match the minimal particle set
     int num_particles = 2;
@@ -95,7 +96,8 @@ TEST_CASE("Crowd integration", "[drivers]")
   // The above was required behavior for crowd at one point.
   // TODO: determine whether it still is, I don't think so.
   const MultiWalkerDispatchers dispatchers(true);
-  Crowd crowd(em, dispatchers);
+  FatWalkerResourceCollection fatwalker_resource_collection_;
+  Crowd crowd(em, fatwalker_resource_collection_, dispatchers);
 }
 
 TEST_CASE("Crowd::loadWalkers", "[particle]")

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -30,6 +30,24 @@ NonLocalECPComponent::~NonLocalECPComponent()
     delete VP;
 }
 
+void NonLocalECPComponent::createResource(ResourceCollection& collection) const
+{
+  if (VP)
+    VP->createResource(collection);
+}
+
+void NonLocalECPComponent::acquireResource(ResourceCollection& collection)
+{
+  if (VP)
+    VP->acquireResource(collection);
+}
+
+void NonLocalECPComponent::releaseResource(ResourceCollection& collection)
+{
+  if (VP)
+    VP->releaseResource(collection);
+}
+
 NonLocalECPComponent* NonLocalECPComponent::makeClone(const ParticleSet& qp)
 {
   NonLocalECPComponent* myclone = new NonLocalECPComponent(*this);

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -115,6 +115,18 @@ public:
   ///destructor
   ~NonLocalECPComponent();
 
+  /** initialize a shared resource and hand it to a collection
+   */
+  void createResource(ResourceCollection& collection) const;
+
+  /** acquire a shared resource from a collection
+   */
+  void acquireResource(ResourceCollection& collection);
+
+  /** return a shared resource to a collection
+   */
+  void releaseResource(ResourceCollection& collection);
+
   NonLocalECPComponent* makeClone(const ParticleSet& qp);
 
   ///add a new Non Local component

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -569,6 +569,27 @@ void NonLocalECPotential::addComponent(int groupID, std::unique_ptr<NonLocalECPC
   PPset[groupID] = std::move(ppot);
 }
 
+void NonLocalECPotential::createResource(ResourceCollection& collection) const
+{
+  for (int ig = 0; ig < PPset.size(); ++ig)
+    if (PPset[ig])
+      PPset[ig]->createResource(collection);
+}
+
+void NonLocalECPotential::acquireResource(ResourceCollection& collection)
+{
+  for (int ig = 0; ig < PPset.size(); ++ig)
+    if (PPset[ig])
+      PPset[ig]->acquireResource(collection);
+}
+
+void NonLocalECPotential::releaseResource(ResourceCollection& collection)
+{
+  for (int ig = 0; ig < PPset.size(); ++ig)
+    if (PPset[ig])
+      PPset[ig]->releaseResource(collection);
+}
+
 OperatorBase* NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   NonLocalECPotential* myclone = new NonLocalECPotential(IonConfig, qp, psi, ComputeForces, use_DLA);

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -90,6 +90,18 @@ public:
     return true;
   }
 
+  /** initialize a shared resource and hand it to a collection
+   */
+  void createResource(ResourceCollection& collection) const override;
+
+  /** acquire a shared resource from a collection
+   */
+  void acquireResource(ResourceCollection& collection) override;
+
+  /** return a shared resource to a collection
+   */
+  void releaseResource(ResourceCollection& collection) override;
+
   OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   void addComponent(int groupID, std::unique_ptr<NonLocalECPComponent>&& pp);

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -44,6 +44,7 @@ class MCWalkerConfiguration;
 class DistanceTableData;
 class TrialWaveFunction;
 class QMCHamiltonian;
+class ResourceCollection;
 
 struct NonLocalData : public QMCTraits
 {
@@ -322,6 +323,18 @@ struct OperatorBase : public QMCTraits
 
   /** write about the class */
   virtual bool get(std::ostream& os) const = 0;
+
+  /** initialize a shared resource and hand it to a collection
+   */
+  virtual void createResource(ResourceCollection& collection) const {}
+
+  /** acquire a shared resource from a collection
+   */
+  virtual void acquireResource(ResourceCollection& collection) {}
+
+  /** return a shared resource to a collection
+   */
+  virtual void releaseResource(ResourceCollection& collection) {}
 
   virtual OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -548,8 +548,8 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
   auto& ham_leader = ham_list.getLeader();
   ScopedTimer local_timer(ham_leader.ham_timer_);
   for (QMCHamiltonian& ham : ham_list)
-  for (int iw = 0; iw < ham_list.size(); iw++)
-    ham.LocalEnergy = 0.0;
+    for (int iw = 0; iw < ham_list.size(); iw++)
+      ham.LocalEnergy = 0.0;
 
   const int num_ham_operators = ham_leader.H.size();
   for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
@@ -943,6 +943,24 @@ std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<
       num_accepts[iw] = ham_list[iw].nlpp_ptr->makeNonLocalMovesPbyP(p_list[iw]);
   }
   return num_accepts;
+}
+
+void QMCHamiltonian::createResource(ResourceCollection& collection) const
+{
+  for (int i = 0; i < H.size(); ++i)
+    H[i]->createResource(collection);
+}
+
+void QMCHamiltonian::acquireResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < H.size(); ++i)
+    H[i]->acquireResource(collection);
+}
+
+void QMCHamiltonian::releaseResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < H.size(); ++i)
+    H[i]->releaseResource(collection);
 }
 
 QMCHamiltonian* QMCHamiltonian::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -548,8 +548,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
   auto& ham_leader = ham_list.getLeader();
   ScopedTimer local_timer(ham_leader.ham_timer_);
   for (QMCHamiltonian& ham : ham_list)
-    for (int iw = 0; iw < ham_list.size(); iw++)
-      ham.LocalEnergy = 0.0;
+    ham.LocalEnergy = 0.0;
 
   const int num_ham_operators = ham_leader.H.size();
   for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -385,6 +385,18 @@ public:
   static void updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
   static void updateKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
 
+
+  /// initialize a shared resource and hand it to a collection
+  void createResource(ResourceCollection& collection) const;
+  /** acquire external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
+  void acquireResource(ResourceCollection& collection);
+  /** release external resource
+   * Note: use RAII ResourceCollectionLock whenever possible
+   */
+  void releaseResource(ResourceCollection& collection);
+
   /** return a clone */
   QMCHamiltonian* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -139,7 +139,7 @@ public:
         mygH(in.mygH)
   {}
 
-  void createResource(ResourceCollection& collection) override
+  void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>());
     app_log() << "    Multi walker shared memory resource created in SplineC2COMPTarget. Index " << resource_index

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -143,7 +143,7 @@ public:
         mygH(in.mygH)
   {}
 
-  void createResource(ResourceCollection& collection) override
+  void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
     app_log() << "    Multi walker shared memory resource created in SplineC2ROMPTarget. Index " << resource_index

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -143,7 +143,6 @@ public:
         mygH(in.mygH)
   {}
 
-
   void createResource(ResourceCollection& collection) override
   {
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -702,7 +702,7 @@ DiracDeterminant<DU_TYPE>* DiracDeterminant<DU_TYPE>::makeCopy(std::shared_ptr<S
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::createResource(ResourceCollection& collection)
+void DiracDeterminant<DU_TYPE>::createResource(ResourceCollection& collection) const
 {
   Phi->createResource(collection);
 }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -171,7 +171,7 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
-  void createResource(ResourceCollection& collection) override;
+  void createResource(ResourceCollection& collection) const override;
   void acquireResource(ResourceCollection& collection) override;
   void releaseResource(ResourceCollection& collection) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -921,7 +921,7 @@ DiracDeterminantBatched<DET_ENGINE_TYPE>* DiracDeterminantBatched<DET_ENGINE_TYP
 }
 
 template<typename DET_ENGINE_TYPE>
-void DiracDeterminantBatched<DET_ENGINE_TYPE>::createResource(ResourceCollection& collection)
+void DiracDeterminantBatched<DET_ENGINE_TYPE>::createResource(ResourceCollection& collection) const
 {
   auto resource_index = collection.addResource(std::make_unique<DiracDeterminantBatchedMultiWalkerResource>());
   app_log() << "    Shared resource created in DiracDeterminantBatched. Index " << resource_index << std::endl;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -194,7 +194,7 @@ public:
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
-  void createResource(ResourceCollection& collection) override;
+  void createResource(ResourceCollection& collection) const override;
   void acquireResource(ResourceCollection& collection) override;
   void releaseResource(ResourceCollection& collection) override;
 

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -329,7 +329,7 @@ public:
     psiMinv.resize(norb, getAlignedSize<T>(norb));
   }
 
-  void createResource(ResourceCollection& collection)
+  void createResource(ResourceCollection& collection) const
   {
     auto resource_index = collection.addResource(std::make_unique<CUDALinearAlgebraHandles>());
     app_log() << "    Shared resource created in MatrixDelayedUpdateCUDA. Index " << resource_index << std::endl;

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -92,7 +92,7 @@ public:
    */
   inline void resize(int norb, int delay) { psiMinv.resize(norb, getAlignedSize<T>(norb)); }
 
-  void createResource(ResourceCollection& collection) {}
+  void createResource(ResourceCollection& collection) const {}
   void acquireResource(ResourceCollection& collection) {}
   void releaseResource(ResourceCollection& collection) {}
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -208,7 +208,7 @@ void SlaterDet::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
   }
 }
 
-void SlaterDet::createResource(ResourceCollection& collection)
+void SlaterDet::createResource(ResourceCollection& collection) const
 {
   for (int i = 0; i < Dets.size(); ++i)
     Dets[i]->createResource(collection);

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -93,7 +93,7 @@ public:
 
   virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override;
 
-  void createResource(ResourceCollection& collection) override;
+  void createResource(ResourceCollection& collection) const override;
 
   void acquireResource(ResourceCollection& collection) override;
 

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -406,7 +406,7 @@ public:
 
   /** initialize a shared resource and hand it to collection
    */
-  virtual void createResource(ResourceCollection& collection) {}
+  virtual void createResource(ResourceCollection& collection) const {}
 
   /** acquire a shared resource from collection
    */

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -53,8 +53,6 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, boo
 {
   if (suffixes.size() != TIMER_SKIP)
     throw std::runtime_error("TrialWaveFunction::TrialWaveFunction mismatched timer enums and suffixes");
-  if (create_local_resource)
-    twf_resource_ = std::make_unique<ResourceCollection>("TrialWaveFunction");
 
   for (auto& suffix : suffixes)
   {
@@ -89,8 +87,6 @@ void TrialWaveFunction::stopOptimization()
  */
 void TrialWaveFunction::addComponent(WaveFunctionComponent* aterm)
 {
-  if (twf_resource_)
-    aterm->createResource(*twf_resource_);
   Z.push_back(aterm);
 
   std::string aname = aterm->ClassName;
@@ -151,7 +147,7 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
   // TrialWaveFunction now also holds G and L to move forward but they need to be copied to P.G and P.L
   // to be compatiable with legacy use pattern.
   const int num_particles = p_leader.getTotalNum();
-  auto initGandL    = [num_particles, czero](TrialWaveFunction& twf, ParticleSet::ParticleGradient_t& grad,
+  auto initGandL          = [num_particles, czero](TrialWaveFunction& twf, ParticleSet::ParticleGradient_t& grad,
                                           ParticleSet::ParticleLaplacian_t& lapl) {
     grad.resize(num_particles);
     lapl.resize(num_particles);
@@ -1165,6 +1161,12 @@ void TrialWaveFunction::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value
     for (int j = 0; j < t.size(); ++j)
       ratios[j] *= t[j];
   }
+}
+
+void TrialWaveFunction::createResource(ResourceCollection& collection)
+{
+  for (int i = 0; i < Z.size(); ++i)
+    Z[i]->createResource(collection);
 }
 
 void TrialWaveFunction::acquireResource(ResourceCollection& collection)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1163,7 +1163,7 @@ void TrialWaveFunction::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value
   }
 }
 
-void TrialWaveFunction::createResource(ResourceCollection& collection)
+void TrialWaveFunction::createResource(ResourceCollection& collection) const
 {
   for (int i = 0; i < Z.size(); ++i)
     Z[i]->createResource(collection);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -396,6 +396,8 @@ public:
    *  See WaveFunctionComponent::updateBuffer for more detail */
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
+  /// initialize a shared resource and hand it to a collection
+  void createResource(ResourceCollection& collection);
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
@@ -452,19 +454,11 @@ public:
 
   bool use_tasking() const { return use_tasking_; }
 
-  ResourceCollection& getResource() { return *twf_resource_; }
-  const ResourceCollection& getResource() const { return *twf_resource_; }
-
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
 
   ///getName is in the way
   const std::string myName;
-
-  /** a collection of shared resource used by TWF
-   * created for the gold object of TWF not clones.
-   */
-  std::unique_ptr<ResourceCollection> twf_resource_;
 
   ///starting index of the buffer
   size_t BufferCursor;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -397,7 +397,7 @@ public:
   void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
   /// initialize a shared resource and hand it to a collection
-  void createResource(ResourceCollection& collection);
+  void createResource(ResourceCollection& collection) const;
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -435,15 +435,15 @@ struct WaveFunctionComponent : public QMCTraits
    */
   virtual void copyFromBuffer(ParticleSet& P, WFBufferType& buf) = 0;
 
-  /** initialize a shared resource and hand it to collection
+  /** initialize a shared resource and hand it to a collection
    */
   virtual void createResource(ResourceCollection& collection) {}
 
-  /** acquire a shared resource from collection
+  /** acquire a shared resource from a collection
    */
   virtual void acquireResource(ResourceCollection& collection) {}
 
-  /** return a shared resource to collection
+  /** return a shared resource to a collection
    */
   virtual void releaseResource(ResourceCollection& collection) {}
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -437,7 +437,7 @@ struct WaveFunctionComponent : public QMCTraits
 
   /** initialize a shared resource and hand it to a collection
    */
-  virtual void createResource(ResourceCollection& collection) {}
+  virtual void createResource(ResourceCollection& collection) const {}
 
   /** acquire a shared resource from a collection
    */


### PR DESCRIPTION
## Proposed changes
This PR expands multi walker shared resource beyond TrialWaveFunction to cover ParticleSet and QMCHamiltonian
```
struct FatWalkerResourceCollection
{
  ResourceCollection pset_res;
  ResourceCollection twf_res;
  ResourceCollection ham_res;
}
```
The gold shared resources now are created in the driver. The driver level design is largely complete.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'