### PR TITLE
Clang CUDA AFQMC workaround device_allocator by defining uninitialized_copy at the allocator level

### DIFF
--- a/src/AFQMC/Memory/device_pointers.hpp
+++ b/src/AFQMC/Memory/device_pointers.hpp
@@ -420,17 +420,20 @@ struct device_allocator
   bool operator==(device_allocator const& other) const { return true; }
   bool operator!=(device_allocator const& other) const { return false; }
   template<class U, class... Args>
-  void construct(U p, Args&&... args)
-  {}
-  //{
-  //    ::new((void*)p) U(std::forward<Args>(args)...);
-  //  }
+  void construct(U p, Args&&... args){
+    static_assert( std::is_trivially_copy_constructible<value_type>{}, "!"); // ::new((void*)p) U(std::forward<Args>(args)...);
+  }
   template<class U>
-  void destroy(U p)
-  {}
-  //  {
-  //    p->~U();
-  //  }
+  void destroy(U p){
+		static_assert( std::is_trivially_destructible<value_type>{}, "!"); // p->~U();
+  }
+  template<class InputIt, class ForwardIt>
+  ForwardIt alloc_uninitialized_copy(InputIt first, InputIt last, ForwardIt d_first){
+		static_assert( std::is_trivially_copy_constructible<value_type>{}, "!");
+		static_assert( std::is_trivially_destructible<value_type>{}, "!");
+		std::advance( d_first , std::distance(first, last) );
+		return d_first;
+  }
 };
 
 struct memory_resource


### PR DESCRIPTION
## Proposed changes

solve problems in Jenkins

https://jenkins-ci.cels.anl.gov/job/QMCPACK-CI-Clang10-AFQMC-CUDA/347/label=compute002.mcs.anl.gov,type=Real-Mixed-enable-CUDA/console

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Lassen, clang 10, cuda

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
