### PR TITLE
Nexus: fix tests on Summit

### DIFF
--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -1591,6 +1591,10 @@ def qmcpack_simulation():
 
 
 def observables():
+    nunit('import')
+
+    nunit('defined_attribute_base')
+
     nunit_all()
 #end def observables
 
@@ -1619,8 +1623,6 @@ def qmc_fit():
 
 
 def qdens():
-    nunit('density')
-
     nunit_all()
 #end def qdens
 

--- a/nexus/lib/observables.py
+++ b/nexus/lib/observables.py
@@ -8,8 +8,18 @@ from copy import deepcopy
 
 # Non-standard Python imports
 import numpy as np
-import matplotlib.pyplot as plt
-import h5py
+
+from developer import unavailable # Nexus unavailable module guard
+try:
+    import matplotlib.pyplot as plt
+except:
+    plt = unavailable('matplotlib','pyplot')
+#end try
+try:
+    import h5py
+except:
+    h5py = unavailable('h5py')
+#end try
 
 # Nexus imports
 import memory

--- a/nexus/lib/testing.py
+++ b/nexus/lib/testing.py
@@ -223,9 +223,27 @@ def print_diff(o1,o2,atol=def_atol,rtol=def_rtol,int_as_float=False,text=False,b
 #end def print_diff
 
 
+# check for value equality and if different, print the difference
+def check_value_eq(v1,v2,**kwargs):
+    same = value_eq(v1,v2,**kwargs)
+    if not same and global_data['verbose']:
+        print('\nValues differ, please see below for details')
+        hline = '========== {} =========='
+        print()
+        print(hline.format('left value'))
+        print(v1)
+        print()
+        print(hline.format('right value'))
+        print(v2)
+        print()
+    #end if
+    return same
+#end def check_value_eq
+
+
 # check for object equality and if different, print the difference
-def check_object_eq(o1,o2):
-    same = object_eq(o1,o2)
+def check_object_eq(o1,o2,**kwargs):
+    same = object_eq(o1,o2,**kwargs)
     if not same and global_data['verbose']:
         print('\nObjects differ, please see below for details')
         print_diff(o1,o2)

--- a/nexus/tests/unit/test_qdens.py
+++ b/nexus/tests/unit/test_qdens.py
@@ -1,153 +1,161 @@
 
+import versions
 import testing
-from testing import execute,text_eq
+from testing import execute,text_eq,check_value_eq
 
 
+if versions.h5py_available:
+    def test_density():
+        import os
 
-def test_density():
-    import os
+        tpath = testing.setup_unit_test_output_directory('qdens','test_density')
 
-    tpath = testing.setup_unit_test_output_directory('qdens','test_density')
+        exe = testing.executable_path('qdens')
 
-    exe = testing.executable_path('qdens')
+        qa_files_path = testing.unit_test_file_path('qmcpack_analyzer','diamond_gamma/dmc')
+        command = 'rsync -a {} {}'.format(qa_files_path,tpath)
+        out,err,rc = execute(command)
+        assert(rc==0)
+        dmc_path = os.path.join(tpath,'dmc')
+        dmc_infile = os.path.join(dmc_path,'dmc.in.xml')
+        assert(os.path.exists(dmc_infile))
 
-    qa_files_path = testing.unit_test_file_path('qmcpack_analyzer','diamond_gamma/dmc')
-    command = 'rsync -a {} {}'.format(qa_files_path,tpath)
-    out,err,rc = execute(command)
-    assert(rc==0)
-    dmc_path = os.path.join(tpath,'dmc')
-    dmc_infile = os.path.join(dmc_path,'dmc.in.xml')
-    assert(os.path.exists(dmc_infile))
-
-    files_bef = '''
-dmc.err     dmc.s000.scalar.dat  dmc.s001.stat.h5     dmc.s003.scalar.dat
-dmc.in.xml  dmc.s000.stat.h5     dmc.s002.scalar.dat  dmc.s003.stat.h5
-dmc.out     dmc.s001.scalar.dat  dmc.s002.stat.h5
-    '''.split()
-
-    assert(set(os.listdir(dmc_path))==set(files_bef))
-
-    command = '{0} -v -e 4 -f xsf -i {1}/dmc.in.xml {1}/*stat.h5'.format(exe,dmc_path)
-
-    out,err,rc = execute(command)
-
-    files_aft = '''
-        dmc.err                           dmc.s001.stat.h5
-        dmc.in.xml                        dmc.s002.scalar.dat
-        dmc.out                           dmc.s002.SpinDensity_d-err.xsf
-        dmc.s000.scalar.dat               dmc.s002.SpinDensity_d+err.xsf
-        dmc.s000.SpinDensity_d-err.xsf    dmc.s002.SpinDensity_d.xsf
-        dmc.s000.SpinDensity_d+err.xsf    dmc.s002.SpinDensity_u-d-err.xsf
-        dmc.s000.SpinDensity_d.xsf        dmc.s002.SpinDensity_u-d+err.xsf
-        dmc.s000.SpinDensity_u-d-err.xsf  dmc.s002.SpinDensity_u+d-err.xsf
-        dmc.s000.SpinDensity_u-d+err.xsf  dmc.s002.SpinDensity_u+d+err.xsf
-        dmc.s000.SpinDensity_u+d-err.xsf  dmc.s002.SpinDensity_u-d.xsf
-        dmc.s000.SpinDensity_u+d+err.xsf  dmc.s002.SpinDensity_u+d.xsf
-        dmc.s000.SpinDensity_u-d.xsf      dmc.s002.SpinDensity_u-err.xsf
-        dmc.s000.SpinDensity_u+d.xsf      dmc.s002.SpinDensity_u+err.xsf
-        dmc.s000.SpinDensity_u-err.xsf    dmc.s002.SpinDensity_u.xsf
-        dmc.s000.SpinDensity_u+err.xsf    dmc.s002.stat.h5
-        dmc.s000.SpinDensity_u.xsf        dmc.s003.scalar.dat
-        dmc.s000.stat.h5                  dmc.s003.SpinDensity_d-err.xsf
-        dmc.s001.scalar.dat               dmc.s003.SpinDensity_d+err.xsf
-        dmc.s001.SpinDensity_d-err.xsf    dmc.s003.SpinDensity_d.xsf
-        dmc.s001.SpinDensity_d+err.xsf    dmc.s003.SpinDensity_u-d-err.xsf
-        dmc.s001.SpinDensity_d.xsf        dmc.s003.SpinDensity_u-d+err.xsf
-        dmc.s001.SpinDensity_u-d-err.xsf  dmc.s003.SpinDensity_u+d-err.xsf
-        dmc.s001.SpinDensity_u-d+err.xsf  dmc.s003.SpinDensity_u+d+err.xsf
-        dmc.s001.SpinDensity_u+d-err.xsf  dmc.s003.SpinDensity_u-d.xsf
-        dmc.s001.SpinDensity_u+d+err.xsf  dmc.s003.SpinDensity_u+d.xsf
-        dmc.s001.SpinDensity_u-d.xsf      dmc.s003.SpinDensity_u-err.xsf
-        dmc.s001.SpinDensity_u+d.xsf      dmc.s003.SpinDensity_u+err.xsf
-        dmc.s001.SpinDensity_u-err.xsf    dmc.s003.SpinDensity_u.xsf
-        dmc.s001.SpinDensity_u+err.xsf    dmc.s003.stat.h5
-        dmc.s001.SpinDensity_u.xsf
+        files_bef = '''
+    dmc.err     dmc.s000.scalar.dat  dmc.s001.stat.h5     dmc.s003.scalar.dat
+    dmc.in.xml  dmc.s000.stat.h5     dmc.s002.scalar.dat  dmc.s003.stat.h5
+    dmc.out     dmc.s001.scalar.dat  dmc.s002.stat.h5
         '''.split()
 
-    assert(set(os.listdir(dmc_path))==set(files_aft))
+        assert(check_value_eq(set(os.listdir(dmc_path)),set(files_bef)))
 
-    tot_file = os.path.join(dmc_path,'dmc.s003.SpinDensity_u+d.xsf')
-    pol_file = os.path.join(dmc_path,'dmc.s003.SpinDensity_u-d.xsf')
+        command = '{0} -v -e 4 -f xsf -i {1}/dmc.in.xml {1}/*stat.h5'.format(exe,dmc_path)
 
-    tot = open(tot_file,'r').read()
-    pol = open(pol_file,'r').read()
+        out,err,rc = execute(command)
 
-    tot_ref = '''
-         CRYSTAL
-         PRIMVEC 
-             1.78500000   1.78500000   0.00000000
-            -0.00000000   1.78500000   1.78500000
-             1.78500000  -0.00000000   1.78500000
-         PRIMCOORD 
-           2 1
-             6   0.00000000   0.00000000   0.00000000
-             6   0.89250000   0.89250000   0.89250000
-         BEGIN_BLOCK_DATAGRID_3D
-           density
-           BEGIN_DATAGRID_3D_density
-             4 4 4
-             0.59500000   0.59500000   0.59500000
-             1.78500000   1.78500000   0.00000000
-            -0.00000000   1.78500000   1.78500000
-             1.78500000  -0.00000000   1.78500000
-               0.73126076   0.62407496   0.51676366   0.73126076
-               0.62575089   0.19225114   0.18686389   0.62575089
-               0.51847569   0.18457799   0.42203355   0.51847569
-               0.73126076   0.62407496   0.51676366   0.73126076
-               0.62659840   0.19325900   0.18422995   0.62659840
-               0.19219866   0.04873728   0.13184395   0.19219866
-               0.18474638   0.13013188   0.10227670   0.18474638
-               0.62659840   0.19325900   0.18422995   0.62659840
-               0.51793019   0.18615766   0.41806405   0.51793019
-               0.18425005   0.13092538   0.10088238   0.18425005
-               0.41967003   0.10133434   0.14471118   0.41967003
-               0.51793019   0.18615766   0.41806405   0.51793019
-               0.73126076   0.62407496   0.51676366   0.73126076
-               0.62575089   0.19225114   0.18686389   0.62575089
-               0.51847569   0.18457799   0.42203355   0.51847569
-               0.73126076   0.62407496   0.51676366   0.73126076
-           END_DATAGRID_3D_density
-         END_BLOCK_DATAGRID_3D
-        '''
+        print(80*'=')
+        print(out)
+        print(80*'=')
+        print(err)
+        print(80*'=')
 
-    pol_ref = '''
-         CRYSTAL
-         PRIMVEC 
-             1.78500000   1.78500000   0.00000000
-            -0.00000000   1.78500000   1.78500000
-             1.78500000  -0.00000000   1.78500000
-         PRIMCOORD 
-           2 1
-             6   0.00000000   0.00000000   0.00000000
-             6   0.89250000   0.89250000   0.89250000
-         BEGIN_BLOCK_DATAGRID_3D
-           density
-           BEGIN_DATAGRID_3D_density
-             4 4 4
-             0.59500000   0.59500000   0.59500000
-             1.78500000   1.78500000   0.00000000
-            -0.00000000   1.78500000   1.78500000
-             1.78500000  -0.00000000   1.78500000
-               0.00106753   0.00015792  -0.00122859   0.00106753
-              -0.00003402   0.00018762  -0.00051347  -0.00003402
-               0.00154254   0.00067654   0.00073434   0.00154254
-               0.00106753   0.00015792  -0.00122859   0.00106753
-               0.00263956   0.00079744  -0.00118289   0.00263956
-              -0.00039348  -0.00026396  -0.00069392  -0.00039348
-               0.00087929   0.00000719   0.00113934   0.00087929
-               0.00263956   0.00079744  -0.00118289   0.00263956
-              -0.00013655  -0.00041508  -0.00235212  -0.00013655
-               0.00003805  -0.00025962  -0.00133495   0.00003805
-               0.00040692   0.00051699  -0.00198263   0.00040692
-              -0.00013655  -0.00041508  -0.00235212  -0.00013655
-               0.00106753   0.00015792  -0.00122859   0.00106753
-              -0.00003402   0.00018762  -0.00051347  -0.00003402
-               0.00154254   0.00067654   0.00073434   0.00154254
-               0.00106753   0.00015792  -0.00122859   0.00106753
-           END_DATAGRID_3D_density
-         END_BLOCK_DATAGRID_3D
-        '''
+        files_aft = '''
+            dmc.err                           dmc.s001.stat.h5
+            dmc.in.xml                        dmc.s002.scalar.dat
+            dmc.out                           dmc.s002.SpinDensity_d-err.xsf
+            dmc.s000.scalar.dat               dmc.s002.SpinDensity_d+err.xsf
+            dmc.s000.SpinDensity_d-err.xsf    dmc.s002.SpinDensity_d.xsf
+            dmc.s000.SpinDensity_d+err.xsf    dmc.s002.SpinDensity_u-d-err.xsf
+            dmc.s000.SpinDensity_d.xsf        dmc.s002.SpinDensity_u-d+err.xsf
+            dmc.s000.SpinDensity_u-d-err.xsf  dmc.s002.SpinDensity_u+d-err.xsf
+            dmc.s000.SpinDensity_u-d+err.xsf  dmc.s002.SpinDensity_u+d+err.xsf
+            dmc.s000.SpinDensity_u+d-err.xsf  dmc.s002.SpinDensity_u-d.xsf
+            dmc.s000.SpinDensity_u+d+err.xsf  dmc.s002.SpinDensity_u+d.xsf
+            dmc.s000.SpinDensity_u-d.xsf      dmc.s002.SpinDensity_u-err.xsf
+            dmc.s000.SpinDensity_u+d.xsf      dmc.s002.SpinDensity_u+err.xsf
+            dmc.s000.SpinDensity_u-err.xsf    dmc.s002.SpinDensity_u.xsf
+            dmc.s000.SpinDensity_u+err.xsf    dmc.s002.stat.h5
+            dmc.s000.SpinDensity_u.xsf        dmc.s003.scalar.dat
+            dmc.s000.stat.h5                  dmc.s003.SpinDensity_d-err.xsf
+            dmc.s001.scalar.dat               dmc.s003.SpinDensity_d+err.xsf
+            dmc.s001.SpinDensity_d-err.xsf    dmc.s003.SpinDensity_d.xsf
+            dmc.s001.SpinDensity_d+err.xsf    dmc.s003.SpinDensity_u-d-err.xsf
+            dmc.s001.SpinDensity_d.xsf        dmc.s003.SpinDensity_u-d+err.xsf
+            dmc.s001.SpinDensity_u-d-err.xsf  dmc.s003.SpinDensity_u+d-err.xsf
+            dmc.s001.SpinDensity_u-d+err.xsf  dmc.s003.SpinDensity_u+d+err.xsf
+            dmc.s001.SpinDensity_u+d-err.xsf  dmc.s003.SpinDensity_u-d.xsf
+            dmc.s001.SpinDensity_u+d+err.xsf  dmc.s003.SpinDensity_u+d.xsf
+            dmc.s001.SpinDensity_u-d.xsf      dmc.s003.SpinDensity_u-err.xsf
+            dmc.s001.SpinDensity_u+d.xsf      dmc.s003.SpinDensity_u+err.xsf
+            dmc.s001.SpinDensity_u-err.xsf    dmc.s003.SpinDensity_u.xsf
+            dmc.s001.SpinDensity_u+err.xsf    dmc.s003.stat.h5
+            dmc.s001.SpinDensity_u.xsf
+            '''.split()
 
-    assert(text_eq(tot,tot_ref,atol=1e-7))
-    assert(text_eq(pol,pol_ref,atol=1e-7))
-#end def test_density
+        assert(check_value_eq(set(os.listdir(dmc_path)),set(files_aft)))
+
+        tot_file = os.path.join(dmc_path,'dmc.s003.SpinDensity_u+d.xsf')
+        pol_file = os.path.join(dmc_path,'dmc.s003.SpinDensity_u-d.xsf')
+
+        tot = open(tot_file,'r').read()
+        pol = open(pol_file,'r').read()
+
+        tot_ref = '''
+             CRYSTAL
+             PRIMVEC 
+                 1.78500000   1.78500000   0.00000000
+                -0.00000000   1.78500000   1.78500000
+                 1.78500000  -0.00000000   1.78500000
+             PRIMCOORD 
+               2 1
+                 6   0.00000000   0.00000000   0.00000000
+                 6   0.89250000   0.89250000   0.89250000
+             BEGIN_BLOCK_DATAGRID_3D
+               density
+               BEGIN_DATAGRID_3D_density
+                 4 4 4
+                 0.59500000   0.59500000   0.59500000
+                 1.78500000   1.78500000   0.00000000
+                -0.00000000   1.78500000   1.78500000
+                 1.78500000  -0.00000000   1.78500000
+                   0.73126076   0.62407496   0.51676366   0.73126076
+                   0.62575089   0.19225114   0.18686389   0.62575089
+                   0.51847569   0.18457799   0.42203355   0.51847569
+                   0.73126076   0.62407496   0.51676366   0.73126076
+                   0.62659840   0.19325900   0.18422995   0.62659840
+                   0.19219866   0.04873728   0.13184395   0.19219866
+                   0.18474638   0.13013188   0.10227670   0.18474638
+                   0.62659840   0.19325900   0.18422995   0.62659840
+                   0.51793019   0.18615766   0.41806405   0.51793019
+                   0.18425005   0.13092538   0.10088238   0.18425005
+                   0.41967003   0.10133434   0.14471118   0.41967003
+                   0.51793019   0.18615766   0.41806405   0.51793019
+                   0.73126076   0.62407496   0.51676366   0.73126076
+                   0.62575089   0.19225114   0.18686389   0.62575089
+                   0.51847569   0.18457799   0.42203355   0.51847569
+                   0.73126076   0.62407496   0.51676366   0.73126076
+               END_DATAGRID_3D_density
+             END_BLOCK_DATAGRID_3D
+            '''
+
+        pol_ref = '''
+             CRYSTAL
+             PRIMVEC 
+                 1.78500000   1.78500000   0.00000000
+                -0.00000000   1.78500000   1.78500000
+                 1.78500000  -0.00000000   1.78500000
+             PRIMCOORD 
+               2 1
+                 6   0.00000000   0.00000000   0.00000000
+                 6   0.89250000   0.89250000   0.89250000
+             BEGIN_BLOCK_DATAGRID_3D
+               density
+               BEGIN_DATAGRID_3D_density
+                 4 4 4
+                 0.59500000   0.59500000   0.59500000
+                 1.78500000   1.78500000   0.00000000
+                -0.00000000   1.78500000   1.78500000
+                 1.78500000  -0.00000000   1.78500000
+                   0.00106753   0.00015792  -0.00122859   0.00106753
+                  -0.00003402   0.00018762  -0.00051347  -0.00003402
+                   0.00154254   0.00067654   0.00073434   0.00154254
+                   0.00106753   0.00015792  -0.00122859   0.00106753
+                   0.00263956   0.00079744  -0.00118289   0.00263956
+                  -0.00039348  -0.00026396  -0.00069392  -0.00039348
+                   0.00087929   0.00000719   0.00113934   0.00087929
+                   0.00263956   0.00079744  -0.00118289   0.00263956
+                  -0.00013655  -0.00041508  -0.00235212  -0.00013655
+                   0.00003805  -0.00025962  -0.00133495   0.00003805
+                   0.00040692   0.00051699  -0.00198263   0.00040692
+                  -0.00013655  -0.00041508  -0.00235212  -0.00013655
+                   0.00106753   0.00015792  -0.00122859   0.00106753
+                  -0.00003402   0.00018762  -0.00051347  -0.00003402
+                   0.00154254   0.00067654   0.00073434   0.00154254
+                   0.00106753   0.00015792  -0.00122859   0.00106753
+               END_DATAGRID_3D_density
+             END_BLOCK_DATAGRID_3D
+            '''
+
+        assert(text_eq(tot,tot_ref,atol=1e-7))
+        assert(text_eq(pol,pol_ref,atol=1e-7))
+    #end def test_density
+#end if

--- a/nexus/tests/unit/test_rmg_input.py
+++ b/nexus/tests/unit/test_rmg_input.py
@@ -1264,6 +1264,7 @@ def test_generate():
                                        dtype=float),
             ),
         )
-    assert(check_object_eq(gr,gr_ref))
+
+    assert(check_object_eq(gr,gr_ref,atol=1e-12))
 
 #end def test_generate


### PR DESCRIPTION
## Proposed changes

Fix failing tests on Summit.  Most of these are due to lack of guards for optional modules.  The test failure in #2958 was due to lack of an absolute tolerance on comparisons of near zero (+- machine epsilon) floating point values.

This PR addresses #2958.

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Summit

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

