### PR TITLE
Request full ion-electron table ready at loadWalker for LCAO

### DIFF
--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
@@ -73,7 +73,7 @@ struct SoaLocalizedBasisSet : public SoaBasisSetBase<ORBT>
    * @param els electronic system
    */
   SoaLocalizedBasisSet(ParticleSet& ions, ParticleSet& els)
-      : ions_(ions), myTableIndex(els.addTable(ions)), SuperTwist(0.0)
+      : ions_(ions), myTableIndex(els.addTable(ions, true)), SuperTwist(0.0)
   {
     NumCenters = ions.getTotalNum();
     NumTargets = els.getTotalNum();


### PR DESCRIPTION
## Proposed changes
Request full ion-electron table ready at loadWalker for LCAO to fix spin-orbit case.

Without spin-orbit, evalGrad doesn't recompute SPO but read from stored values.
With spin-orbit, such values are recomputed. When LCAO is used, the old electron-ion pair distances are required.
For this reason, request full ion-electron table ready at loadWalker.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen-box

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'