### PR TITLE
Remove ratioGradAsync

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -111,10 +111,8 @@ public:
   using WaveFunctionComponent::mw_completeUpdates;
   using WaveFunctionComponent::mw_evalGrad;
   using WaveFunctionComponent::mw_ratioGrad;
-  using WaveFunctionComponent::mw_ratioGradAsync;
   using WaveFunctionComponent::ratio;
   using WaveFunctionComponent::ratioGrad;
-  using WaveFunctionComponent::ratioGradAsync;
   using WaveFunctionComponent::restore;
 
   using WaveFunctionComponent::evalGradSource;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -90,10 +90,6 @@ PsiValueType SlaterDet::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
   return Dets[getDetID(iat)]->ratioGrad(P, iat, grad_iat);
 }
-void SlaterDet::ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat)
-{
-  Dets[getDetID(iat)]->ratioGradAsync(P, iat, ratio, grad_iat);
-}
 
 PsiValueType SlaterDet::ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad_iat)
 {
@@ -108,16 +104,6 @@ void SlaterDet::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& w
 {
   const int det_id = getDetID(iat);
   Dets[det_id]->mw_ratioGrad(extract_DetRef_list(wfc_list, det_id), p_list, iat, ratios, grad_now);
-}
-
-void SlaterDet::mw_ratioGradAsync(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                  const RefVectorWithLeader<ParticleSet>& p_list,
-                                  int iat,
-                                  std::vector<PsiValueType>& ratios,
-                                  std::vector<GradType>& grad_now) const
-{
-  const int det_id = getDetID(iat);
-  Dets[det_id]->mw_ratioGradAsync(extract_DetRef_list(wfc_list, det_id), p_list, iat, ratios, grad_now);
 }
 
 void SlaterDet::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -114,7 +114,6 @@ public:
   }
 
   virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
-  virtual void ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat) override;
 
   virtual PsiValueType ratioGradWithSpin(ParticleSet& P,
                                          int iat,
@@ -126,12 +125,6 @@ public:
                             int iat,
                             std::vector<PsiValueType>& ratios,
                             std::vector<GradType>& grad_now) const override;
-
-  void mw_ratioGradAsync(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                         const RefVectorWithLeader<ParticleSet>& p_list,
-                         int iat,
-                         std::vector<PsiValueType>& ratios,
-                         std::vector<GradType>& grad_now) const override;
 
   virtual GradType evalGrad(ParticleSet& P, int iat) override { return Dets[getDetID(iat)]->evalGrad(P, iat); }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -166,21 +166,24 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
     ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
-    auto accumulateLogAndPhase = [](TrialWaveFunction& twf, WaveFunctionComponent& wfc) {
-      twf.LogValue += std::real(wfc.LogValue);
-      twf.PhaseValue += std::imag(wfc.LogValue);
-    };
-    for (int iw = 0; iw < wf_list.size(); iw++)
-      accumulateLogAndPhase(wf_list[iw], wfc_list[iw]);
   }
-  auto copyToP = [](ParticleSet& pset, TrialWaveFunction& twf) {
+
+  for (int iw = 0; iw < wf_list.size(); iw++)
+  {
+    ParticleSet& pset      = p_list[iw];
+    TrialWaveFunction& twf = wf_list[iw];
+
+    for (int i = 0; i < num_wfc; ++i)
+    {
+      twf.LogValue += std::real(twf.Z[i]->LogValue);
+      twf.PhaseValue += std::imag(twf.Z[i]->LogValue);
+    }
+
+    // Ye: temporal workaround to have P.G/L always defined.
+    // remove when KineticEnergy use WF.G/L instead of P.G/L
     pset.G = twf.G;
     pset.L = twf.L;
-  };
-  // Copy TWF::G/L to ParticleSet::G/L
-  // remove when KineticEnergy use WF.G/L instead of P.G/L
-  for (int iw = 0; iw < wf_list.size(); iw++)
-    copyToP(p_list[iw], wf_list[iw]);
+  }
 }
 
 void TrialWaveFunction::recompute(ParticleSet& P)
@@ -829,20 +832,24 @@ void TrialWaveFunction::mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunctio
     ScopedTimer z_timer(wf_leader.WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evaluateGL(wfc_list, p_list, g_list, l_list, fromscratch);
-    for (int iw = 0; iw < wf_list.size(); iw++)
-    {
-      wf_list[iw].LogValue += std::real(wfc_list[iw].LogValue);
-      wf_list[iw].PhaseValue += std::imag(wfc_list[iw].LogValue);
-    }
   }
-  auto copyToP = [](ParticleSet& pset, TrialWaveFunction& twf) {
+
+  for (int iw = 0; iw < wf_list.size(); iw++)
+  {
+    ParticleSet& pset      = p_list[iw];
+    TrialWaveFunction& twf = wf_list[iw];
+
+    for (int i = 0; i < num_wfc; ++i)
+    {
+      twf.LogValue += std::real(twf.Z[i]->LogValue);
+      twf.PhaseValue += std::imag(twf.Z[i]->LogValue);
+    }
+
+    // Ye: temporal workaround to have P.G/L always defined.
+    // remove when KineticEnergy use WF.G/L instead of P.G/L
     pset.G = twf.G;
     pset.L = twf.L;
-  };
-  // Ye: temporal workaround to have P.G/L always defined.
-  // remove when KineticEnergy use WF.G/L instead of P.G/L
-  for (int iw = 0; iw < wf_list.size(); iw++)
-    copyToP(p_list[iw], wf_list[iw]);
+  }
 }
 
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -111,9 +111,9 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateLog(ParticleSet& P)
   P.G = 0.0;
   P.L = 0.0;
   LogValueType logpsi(0.0);
-  for (int i = 0, ii = RECOMPUTE_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
 #ifndef NDEBUG
     // Best way I've found yet to quickly see if WFC made it over the wire successfully
     auto subterm = Z[i]->evaluateLog(P, P.G, P.L);
@@ -161,9 +161,9 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
 
   auto& wavefunction_components = wf_leader.Z;
   const int num_wfc             = wf_leader.Z.size();
-  for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; ++i)
   {
-    ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
     auto accumulateLogAndPhase = [](TrialWaveFunction& twf, WaveFunctionComponent& wfc) {
@@ -186,12 +186,10 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
 void TrialWaveFunction::recompute(ParticleSet& P)
 {
   ScopedTimer local_timer(TWF_timers_[RECOMPUTE_TIMER]);
-  std::vector<WaveFunctionComponent*>::iterator it(Z.begin());
-  std::vector<WaveFunctionComponent*>::iterator it_end(Z.end());
-  for (int ii = RECOMPUTE_TIMER; it != it_end; ++it, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
-    (*it)->recompute(P);
+    ScopedTimer z_timer(WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
+    Z[i]->recompute(P);
   }
 }
 
@@ -202,14 +200,11 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
   P.G = 0.0;
   P.L = 0.0;
   LogValueType logpsi(0.0);
-  std::vector<WaveFunctionComponent*>::iterator it(Z.begin());
-  std::vector<WaveFunctionComponent*>::iterator it_end(Z.end());
-  int ii = RECOMPUTE_TIMER;
-  for (; it != it_end; ++it, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
-    if ((*it)->Optimizable)
-      logpsi += (*it)->evaluateLog(P, P.G, P.L);
+    ScopedTimer z_timer(WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
+    if (Z[i]->Optimizable)
+      logpsi += Z[i]->evaluateLog(P, P.G, P.L);
   }
   LogValue   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
@@ -222,14 +217,11 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
     ParticleSet::ParticleGradient_t dummyG(P.G);
     ParticleSet::ParticleLaplacian_t dummyL(P.L);
 
-    it     = Z.begin();
-    it_end = Z.end();
-
-    for (; it != it_end; ++it)
+    for (int i = 0; i < Z.size(); ++i)
     {
-      if (!(*it)->Optimizable)
-        (*it)->evaluateLog(P, dummyG,
-                           dummyL); //update orbitals if its not flagged optimizable, AND recomputeall is true
+      //update orbitals if its not flagged optimizable, AND recomputeall is true
+      if (!Z[i]->Optimizable)
+        Z[i]->evaluateLog(P, dummyG, dummyL);
     }
   }
   return LogValue;
@@ -248,16 +240,14 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
   fixedG = 0.0;
   LogValueType logpsi_fixed(0.0);
   LogValueType logpsi_opt(0.0);
-  std::vector<WaveFunctionComponent*>::iterator it(Z.begin());
-  std::vector<WaveFunctionComponent*>::iterator it_end(Z.end());
-  int ii = RECOMPUTE_TIMER;
-  for (; it != it_end; ++it, ii += TIMER_SKIP)
+
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
-    if ((*it)->Optimizable)
-      logpsi_opt += (*it)->evaluateLog(P, P.G, P.L);
+    ScopedTimer z_timer(WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
+    if (Z[i]->Optimizable)
+      logpsi_opt += Z[i]->evaluateLog(P, P.G, P.L);
     else
-      logpsi_fixed += (*it)->evaluateLog(P, fixedG, fixedL);
+      logpsi_fixed += Z[i]->evaluateLog(P, fixedG, fixedL);
   }
   P.G += fixedG;
   P.L += fixedL;
@@ -294,9 +284,9 @@ void TrialWaveFunction::mw_evaluateDeltaLogSetup(const RefVectorWithLeader<Trial
     initGandL(wf_list[iw], g_list[iw], l_list[iw]);
   auto& wavefunction_components = wf_leader.Z;
   const int num_wfc             = wf_leader.Z.size();
-  for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; ++i)
   {
-    ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     if (wavefunction_components[i]->Optimizable)
     {
@@ -357,10 +347,10 @@ void TrialWaveFunction::mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveF
   const int num_wfc             = wf_leader.Z.size();
 
   // Loop over the wavefunction components
-  for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; ++i)
     if (wavefunction_components[i]->Optimizable)
     {
-      ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+      ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
       for (int iw = 0; iw < wf_list.size(); iw++)
@@ -381,10 +371,10 @@ void TrialWaveFunction::mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveF
   // Call mw_evaluateLog for the wavefunction components that were skipped previously.
   // Ignore logPsi, G and L.
   if (recompute)
-    for (int i = 0, ii = RECOMPUTE_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+    for (int i = 0; i < num_wfc; ++i)
       if (!wavefunction_components[i]->Optimizable)
       {
-        ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+        ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
         const auto wfc_list(extractWFCRefList(wf_list, i));
         wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, dummyG_list, dummyL_list);
       }
@@ -429,11 +419,11 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatio(ParticleSet& P, int ia
 {
   ScopedTimer local_timer(TWF_timers_[V_TIMER]);
   PsiValueType r(1.0);
-  for (int i = 0, ii = V_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); i++)
     if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
         (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
     {
-      ScopedTimer z_timer(WFC_timers_[ii]);
+      ScopedTimer z_timer(WFC_timers_[V_TIMER + TIMER_SKIP * i]);
       r *= Z[i]->ratio(P, iat);
     }
   return static_cast<ValueType>(r);
@@ -455,12 +445,12 @@ void TrialWaveFunction::mw_calcRatio(const RefVectorWithLeader<TrialWaveFunction
   auto& wavefunction_components = wf_leader.Z;
 
   std::vector<PsiValueType> ratios_z(num_wf);
-  for (int i = 0, ii = V_TIMER; i < num_wfc; i++, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; i++)
   {
     if (ct == ComputeType::ALL || (wavefunction_components[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
         (!wavefunction_components[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
     {
-      ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+      ScopedTimer z_timer(wf_leader.WFC_timers_[V_TIMER + TIMER_SKIP * i]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_calcRatio(wfc_list, p_list, iat, ratios_z);
       for (int iw = 0; iw < wf_list.size(); iw++)
@@ -486,9 +476,9 @@ void TrialWaveFunction::mw_prepareGroup(const RefVectorWithLeader<TrialWaveFunct
   const int num_wfc             = wf_leader.Z.size();
   auto& wavefunction_components = wf_leader.Z;
 
-  for (int i = 0, ii = PREPAREGROUP_TIMER; i < num_wfc; i++, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; i++)
   {
-    ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer z_timer(wf_leader.WFC_timers_[PREPAREGROUP_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_prepareGroup(wfc_list, p_list, ig);
   }
@@ -498,9 +488,9 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGrad(ParticleSet& P, int iat)
 {
   ScopedTimer local_timer(TWF_timers_[VGL_TIMER]);
   GradType grad_iat;
-  for (int i = 0, ii = VGL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     grad_iat += Z[i]->evalGrad(P, iat);
   }
   return grad_iat;
@@ -511,9 +501,9 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, 
   ScopedTimer local_timer(TWF_timers_[VGL_TIMER]);
   GradType grad_iat;
   spingrad = 0;
-  for (int i = 0, ii = VGL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     grad_iat += Z[i]->evalGradWithSpin(P, iat, spingrad);
   }
   return grad_iat;
@@ -535,9 +525,9 @@ void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>
   auto& wavefunction_components = wf_leader.Z;
 
   std::vector<GradType> grad_now_z(num_wf);
-  for (int i = 0, ii = VGL_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; ++i)
   {
-    ScopedTimer localtimer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer localtimer(wf_leader.WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evalGrad(wfc_list, p_list, iat, grad_now_z);
     for (int iw = 0; iw < wf_list.size(); iw++)
@@ -584,7 +574,7 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGrad(ParticleSet& P, in
   {
     std::vector<GradType> grad_components(Z.size(), GradType(0.0));
     std::vector<PsiValueType> ratio_components(Z.size(), 0.0);
-    #pragma omp taskloop default(shared)
+#pragma omp taskloop default(shared)
     for (int i = 0; i < Z.size(); ++i)
     {
       ScopedTimer z_timer(WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
@@ -617,9 +607,9 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGradWithSpin(ParticleSe
   grad_iat     = 0.0;
   spingrad_iat = 0.0;
   PsiValueType r(1.0);
-  for (int i = 0, ii = VGL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
     r *= Z[i]->ratioGradWithSpin(P, iat, grad_iat, spingrad_iat);
   }
 
@@ -649,7 +639,7 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
   {
     std::vector<std::vector<PsiValueType>> ratios_components(num_wfc, std::vector<PsiValueType>(wf_list.size()));
     std::vector<std::vector<GradType>> grads_components(num_wfc, std::vector<GradType>(wf_list.size()));
-    #pragma omp taskloop default(shared)
+#pragma omp taskloop default(shared)
     for (int i = 0; i < num_wfc; ++i)
     {
       ScopedTimer z_timer(wf_leader.WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
@@ -667,9 +657,9 @@ void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunc
   else
   {
     std::vector<PsiValueType> ratios_z(wf_list.size());
-    for (int i = 0, ii = VGL_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+    for (int i = 0; i < num_wfc; ++i)
     {
-      ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+      ScopedTimer z_timer(wf_leader.WFC_timers_[VGL_TIMER + TIMER_SKIP * i]);
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_ratioGrad(wfc_list, p_list, iat, ratios_z, grad_new);
       for (int iw = 0; iw < wf_list.size(); iw++)
@@ -716,7 +706,7 @@ void TrialWaveFunction::rejectMove(int iat)
 void TrialWaveFunction::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
   ScopedTimer local_timer(TWF_timers_[ACCEPT_TIMER]);
-  #pragma omp taskloop default(shared) if(use_tasking_)
+#pragma omp taskloop default(shared) if (use_tasking_)
   for (int i = 0; i < Z.size(); i++)
   {
     ScopedTimer z_timer(WFC_timers_[ACCEPT_TIMER + TIMER_SKIP * i]);
@@ -747,7 +737,7 @@ void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWave
       wf_list[iw].PhaseValue = 0;
     }
 
-  #pragma omp taskloop default(shared) if(wf_leader.use_tasking_)
+#pragma omp taskloop default(shared) if (wf_leader.use_tasking_)
   for (int i = 0; i < num_wfc; i++)
   {
     ScopedTimer z_timer(wf_leader.WFC_timers_[ACCEPT_TIMER + TIMER_SKIP * i]);
@@ -765,9 +755,9 @@ void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWave
 void TrialWaveFunction::completeUpdates()
 {
   ScopedTimer local_timer(TWF_timers_[ACCEPT_TIMER]);
-  for (int i = 0, ii = ACCEPT_TIMER; i < Z.size(); i++, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); i++)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[ACCEPT_TIMER + TIMER_SKIP * i]);
     Z[i]->completeUpdates();
   }
 }
@@ -779,9 +769,9 @@ void TrialWaveFunction::mw_completeUpdates(const RefVectorWithLeader<TrialWaveFu
   const int num_wfc             = wf_leader.Z.size();
   auto& wavefunction_components = wf_leader.Z;
 
-  for (int i = 0, ii = ACCEPT_TIMER; i < num_wfc; i++, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; i++)
   {
-    ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer z_timer(wf_leader.WFC_timers_[ACCEPT_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_completeUpdates(wfc_list);
   }
@@ -793,9 +783,9 @@ TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bo
   P.G = 0.0;
   P.L = 0.0;
   LogValueType logpsi(0.0);
-  for (int i = 0, ii = BUFFER_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     logpsi += Z[i]->evaluateGL(P, P.G, P.L, fromscratch);
   }
 
@@ -834,9 +824,9 @@ void TrialWaveFunction::mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunctio
   auto& wavefunction_components = wf_leader.Z;
   const int num_wfc             = wf_leader.Z.size();
 
-  for (int i = 0, ii = BUFFER_TIMER; i < num_wfc; ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < num_wfc; ++i)
   {
-    ScopedTimer z_timer(wf_leader.WFC_timers_[ii]);
+    ScopedTimer z_timer(wf_leader.WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     const auto wfc_list(extractWFCRefList(wf_list, i));
     wavefunction_components[i]->mw_evaluateGL(wfc_list, p_list, g_list, l_list, fromscratch);
     for (int iw = 0; iw < wf_list.size(); iw++)
@@ -904,9 +894,9 @@ void TrialWaveFunction::registerData(ParticleSet& P, WFBufferType& buf)
   //save the current position
   BufferCursor        = buf.current();
   BufferCursor_scalar = buf.current_scalar();
-  for (int i = 0, ii = BUFFER_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     Z[i]->registerData(P, buf);
   }
   buf.add(PhaseValue);
@@ -935,9 +925,9 @@ TrialWaveFunction::RealType TrialWaveFunction::updateBuffer(ParticleSet& P, WFBu
   P.L = 0.0;
   buf.rewind(BufferCursor, BufferCursor_scalar);
   LogValueType logpsi(0.0);
-  for (int i = 0, ii = BUFFER_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     logpsi += Z[i]->updateBuffer(P, buf, fromscratch);
   }
 
@@ -958,9 +948,9 @@ void TrialWaveFunction::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 {
   ScopedTimer local_timer(TWF_timers_[BUFFER_TIMER]);
   buf.rewind(BufferCursor, BufferCursor_scalar);
-  for (int i = 0, ii = BUFFER_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer z_timer(WFC_timers_[ii]);
+    ScopedTimer z_timer(WFC_timers_[BUFFER_TIMER + TIMER_SKIP * i]);
     Z[i]->copyFromBuffer(P, buf);
   }
   //get the gradients and laplacians from the buffer
@@ -975,11 +965,11 @@ void TrialWaveFunction::evaluateRatios(const VirtualParticleSet& VP, std::vector
   assert(VP.getTotalNum() == ratios.size());
   std::vector<ValueType> t(ratios.size());
   std::fill(ratios.begin(), ratios.end(), 1.0);
-  for (int i = 0, ii = NL_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
     if (ct == ComputeType::ALL || (Z[i]->is_fermionic && ct == ComputeType::FERMIONIC) ||
         (!Z[i]->is_fermionic && ct == ComputeType::NONFERMIONIC))
     {
-      ScopedTimer z_timer(WFC_timers_[ii]);
+      ScopedTimer z_timer(WFC_timers_[NL_TIMER + TIMER_SKIP * i]);
       Z[i]->evaluateRatios(VP, t);
       for (int j = 0; j < ratios.size(); ++j)
         ratios[j] *= t[j];
@@ -1159,9 +1149,9 @@ void TrialWaveFunction::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<Value
   ScopedTimer local_timer(TWF_timers_[V_TIMER]);
   std::fill(ratios.begin(), ratios.end(), 1.0);
   std::vector<ValueType> t(ratios.size());
-  for (int i = 0, ii = V_TIMER; i < Z.size(); ++i, ii += TIMER_SKIP)
+  for (int i = 0; i < Z.size(); ++i)
   {
-    ScopedTimer local_timer(WFC_timers_[ii]);
+    ScopedTimer local_timer(WFC_timers_[V_TIMER + TIMER_SKIP * i]);
     Z[i]->evaluateRatiosAlltoOne(P, t);
     for (int j = 0; j < t.size(); ++j)
       ratios[j] *= t[j];

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -88,12 +88,6 @@ PsiValueType WaveFunctionComponent::ratioGrad(ParticleSet& P, int iat, GradType&
   return ValueType();
 }
 
-void WaveFunctionComponent::ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat)
-{
-#pragma omp task default(none) firstprivate(iat) shared(P, ratio, grad_iat)
-  ratio = ratioGrad(P, iat, grad_iat);
-}
-
 void WaveFunctionComponent::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list,
                                          int iat,
@@ -104,19 +98,6 @@ void WaveFunctionComponent::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionC
 #pragma omp parallel for
   for (int iw = 0; iw < wfc_list.size(); iw++)
     ratios[iw] = wfc_list[iw].ratioGrad(p_list[iw], iat, grad_new[iw]);
-}
-
-void WaveFunctionComponent::mw_ratioGradAsync(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                              const RefVectorWithLeader<ParticleSet>& p_list,
-                                              int iat,
-                                              std::vector<PsiValueType>& ratios,
-                                              std::vector<GradType>& grad_new) const
-{
-  assert(this == &wfc_list.getLeader());
-#if !defined(__INTEL_COMPILER)
-#pragma omp task default(none) firstprivate(wfc_list, p_list, iat) shared(ratios, grad_new)
-#endif
-  mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new);
 }
 
 void WaveFunctionComponent::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -295,8 +295,6 @@ struct WaveFunctionComponent : public QMCTraits
    */
   virtual PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
 
-  virtual void ratioGradAsync(ParticleSet& P, int iat, PsiValueType& ratio, GradType& grad_iat);
-
   /** evaluate the ratio of the new to old WaveFunctionComponent value and the new spin gradient
    * Default implementation assumes that WaveFunctionComponent does not explicitly depend on Spin.
    * @param P the active ParticleSet
@@ -321,12 +319,6 @@ struct WaveFunctionComponent : public QMCTraits
                             int iat,
                             std::vector<PsiValueType>& ratios,
                             std::vector<GradType>& grad_new) const;
-
-  virtual void mw_ratioGradAsync(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                 const RefVectorWithLeader<ParticleSet>& p_list,
-                                 int iat,
-                                 std::vector<PsiValueType>& ratios,
-                                 std::vector<GradType>& grad_new) const;
 
   /** a move for iat-th particle is accepted. Update the current content.
    * @param P target ParticleSet

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -42,26 +42,15 @@ WaveFunctionPool::~WaveFunctionPool()
 
 bool WaveFunctionPool::put(xmlNodePtr cur)
 {
-  std::string id("psi0"), target("e"), role("extra"), tasking("no");
+  std::string id("psi0"), target("e"), role("extra"), tasking;
   OhmmsAttributeSet pAttrib;
   pAttrib.add(id, "id");
   pAttrib.add(id, "name");
   pAttrib.add(target, "target");
   pAttrib.add(target, "ref");
-  pAttrib.add(tasking, "tasking");
+  pAttrib.add(tasking, "tasking", {"no", "yes"});
   pAttrib.add(role, "role");
   pAttrib.put(cur);
-
-  if (tasking != "yes" && tasking != "no")
-    myComm->barrier_and_abort("Incorrect input value of 'tasking' attribute. It can only be 'yes' or 'no'.");
-
-#if defined(__INTEL_COMPILER)
-  if (tasking == "yes")
-  {
-    tasking = "no";
-    app_warning() << "Asynchronous tasking has to be turned off on builds using Intel compilers." << std::endl;
-  }
-#endif
 
   ParticleSet* qp = ptcl_pool_.getParticleSet(target);
 


### PR DESCRIPTION
## Proposed changes
1. Use taskloop instead of task+taskwait. Keep the code simple
2. Write canonical loop in TWF. timer index is computed in-place instead of using the loop.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora, Epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'