### PR TITLE
Move recompute out of walker control and add TWF::mw_recompute

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -813,9 +813,15 @@ void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
                                 const RefVector<Walker_t>& walkers,
                                 bool pbyp)
 {
+  auto loadWalkerConfig = [](ParticleSet& pset, Walker_t& awalker)
+  {
+    pset.R     = awalker.R;
+    pset.spins = awalker.spins;
+    pset.coordinates_->setAllParticlePos(pset.R);
+  };
 #pragma omp parallel for
   for (int iw = 0; iw < psets.size(); ++iw)
-    psets[iw].loadWalker(walkers[iw], pbyp);
+    loadWalkerConfig(psets[iw], walkers[iw]);
 }
 
 void ParticleSet::saveWalker(Walker_t& awalker)

--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -113,6 +113,8 @@ public:
   FullPrecRealType Multiplicity;
   /// mark true if this walker is being sent.
   bool SendInProgress;
+  /// if true, this walker is either copied or tranferred from another MPI rank.
+  bool wasTouched = true;
 
   /** The configuration vector (3N-dimensional vector to store
      the positions of all the particles for a single walker)*/

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -79,10 +79,19 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                   crowd.get_walker_hamiltonians());
 
-    ps_dispatcher.flex_loadWalker(walker_elecs, crowd.get_walkers(), true);
+    ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
     ps_dispatcher.flex_update(walker_elecs, true);
-    const std::vector<bool> recompute_all(walker_twfs.size(), true);
-    twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_all);
+    std::vector<bool> recompute_mask;
+    recompute_mask.reserve(walkers.size());
+    for (MCPWalker& awalker : walkers)
+      if (awalker.wasTouched)
+      {
+        recompute_mask.push_back(true);
+        awalker.wasTouched = false;
+      }
+      else
+        recompute_mask.push_back(false);
+    twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
 
     const int num_walkers = crowd.size();
 

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -73,25 +73,28 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     int nnode_crossing(0);
     auto& walkers = crowd.get_walkers();
     DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                              crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
+                                                 crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
     const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
     const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
     const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                   crowd.get_walker_hamiltonians());
 
-    ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
-    ps_dispatcher.flex_update(walker_elecs, true);
-    std::vector<bool> recompute_mask;
-    recompute_mask.reserve(walkers.size());
-    for (MCPWalker& awalker : walkers)
-      if (awalker.wasTouched)
-      {
-        recompute_mask.push_back(true);
-        awalker.wasTouched = false;
-      }
-      else
-        recompute_mask.push_back(false);
-    twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
+    {
+      ScopedTimer recompute_timer(dmc_timers.step_begin_recompute_timer);
+      ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
+      ps_dispatcher.flex_update(walker_elecs, true);
+      std::vector<bool> recompute_mask;
+      recompute_mask.reserve(walkers.size());
+      for (MCPWalker& awalker : walkers)
+        if (awalker.wasTouched)
+        {
+          recompute_mask.push_back(true);
+          awalker.wasTouched = false;
+        }
+        else
+          recompute_mask.push_back(false);
+      twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
+    }
 
     const int num_walkers = crowd.size();
 
@@ -304,7 +307,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     for (int iw = 0; iw < walkers.size(); ++iw)
     {
       DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[iw],
-                                                 crowd.get_walker_twfs()[iw], crowd.get_walker_hamiltonians()[iw]);
+                                                    crowd.get_walker_twfs()[iw], crowd.get_walker_hamiltonians()[iw]);
       walker_non_local_moves_accepted[iw] = walker_hamiltonians[iw].makeNonLocalMoves(walker_elecs[iw]);
 
       if (walker_non_local_moves_accepted[iw] > 0)
@@ -319,7 +322,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     if (moved_nonlocal_walkers.size())
     {
       DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                                 crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
+                                                    crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
 
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);
       assert(QMCDriverNew::checkLogAndGL(crowd));
@@ -461,9 +464,8 @@ bool DMCBatched::run()
       }
 
       {
-        int iter = block * qmcdriver_input_.get_max_steps() + step;
-        const int population_now =
-            walker_controller_->branch(iter, population_, iter == 0);
+        int iter                 = block * qmcdriver_input_.get_max_steps() + step;
+        const int population_now = walker_controller_->branch(iter, population_, iter == 0);
         branch_engine_->updateParamAfterPopControl(population_now, walker_controller_->get_ensemble_property(),
                                                    population_.get_num_particles());
         walker_controller_->setTrialEnergy(branch_engine_->getEtrial());

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -81,7 +81,8 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     ps_dispatcher.flex_loadWalker(walker_elecs, crowd.get_walkers(), true);
     ps_dispatcher.flex_update(walker_elecs, true);
-    twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);
+    const std::vector<bool> recompute_all(walker_twfs.size(), true);
+    twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_all);
 
     const int num_walkers = crowd.size();
 

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -66,7 +66,10 @@ public:
   {
   public:
     NewTimer& tmove_timer;
-    DMCTimers(const std::string& prefix) : tmove_timer(*timer_manager.createTimer(prefix + "Tmove", timer_level_medium))
+    NewTimer& step_begin_recompute_timer;
+    DMCTimers(const std::string& prefix)
+        : tmove_timer(*timer_manager.createTimer(prefix + "Tmove", timer_level_medium)),
+          step_begin_recompute_timer(*timer_manager.createTimer(prefix + "Step_begin_recompute", timer_level_medium))
     {}
   };
 

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -22,12 +22,9 @@
 
 #include "WalkerControl.h"
 #include "QMCDrivers/WalkerProperties.h"
-#include "Particle/HDFWalkerIO.h"
 #include "OhmmsData/ParameterSet.h"
 #include "type_traits/template_types.hpp"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
-#include "MultiWalkerDispatchers.h"
-#include "DriverWalkerTypes.h"
 
 namespace qmcplusplus
 {
@@ -153,11 +150,7 @@ void WalkerControl::writeDMCdat(int iter, const std::vector<FullPrecRealType>& c
   }
 }
 
-int WalkerControl::branch(int iter,
-                          MCPopulation& pop,
-                          const MultiWalkerDispatchers& dispatchers,
-                          DriverWalkerResourceCollection& driverwalker_res,
-                          bool do_not_branch)
+int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
 {
   if (debug_disable_branching_)
     do_not_branch = true;
@@ -241,30 +234,6 @@ int WalkerControl::branch(int iter,
         num_copies--;
       }
     }
-  }
-
-  if (walkers.size() - untouched_walkers > 0)
-  {
-    ScopedTimer recomputing_timer(my_timers_[WC_recomputing]);
-
-    const size_t num_walkers = walkers.size();
-    // recomputed received and duplicated walkers, the first untouched_walkers walkers doesn't need to be updated.
-    const auto w_list_no_leader =
-        convertUPtrToRefVectorSubset(pop.get_walkers(), untouched_walkers, num_walkers - untouched_walkers);
-    const auto p_list_no_leader =
-        convertUPtrToRefVectorSubset(pop.get_elec_particle_sets(), untouched_walkers, num_walkers - untouched_walkers);
-    const auto wf_list_no_leader =
-        convertUPtrToRefVectorSubset(pop.get_twfs(), untouched_walkers, num_walkers - untouched_walkers);
-
-    DriverWalkerResourceCollection_PsetTWF_Lock pbyp_lock(driverwalker_res, *pop.get_golden_electrons(), pop.get_golden_twf());
-    // a defensive update may not be necessary due to loadWalker above. however, load walker needs to be batched.
-
-    const RefVectorWithLeader<ParticleSet> p_list(*pop.get_golden_electrons(), p_list_no_leader);
-    dispatchers.ps_dispatcher_.flex_loadWalker(p_list, w_list_no_leader, true);
-    dispatchers.ps_dispatcher_.flex_update(p_list, true);
-
-    const RefVectorWithLeader<TrialWaveFunction> wf_list(pop.get_golden_twf(), wf_list_no_leader);
-    dispatchers.twf_dispatcher_.flex_evaluateLog(wf_list, p_list);
   }
 
   const int current_num_global_walkers = std::accumulate(num_per_rank_.begin(), num_per_rank_.end(), 0);

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -252,6 +252,12 @@ int WalkerControl::branch(int iter, MCPopulation& pop, bool do_not_branch)
       walker->Multiplicity = 1.0;
     }
 
+  for (int iw = 0; iw < untouched_walkers; iw++)
+    pop.get_walkers()[iw]->wasTouched = false;
+
+  for (int iw = untouched_walkers; iw < pop.get_num_local_walkers(); iw++)
+    pop.get_walkers()[iw]->wasTouched = true;
+
   return pop.get_num_global_walkers();
 }
 

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -20,12 +20,10 @@
 
 #include "Configuration.h"
 #include "Particle/MCWalkerConfiguration.h"
-#include "QMCDrivers/WalkerElementsRef.h"
 #include "QMCDrivers/MCPopulation.h"
 #include "Message/MPIObjectBase.h"
 #include "Message/CommOperators.h"
 #include "Utilities/RandomGenerator.h"
-#include "MultiWalkerDispatchers.h"
 
 namespace qmcplusplus
 {
@@ -33,9 +31,6 @@ namespace testing
 {
 class UnifiedDriverWalkerControlMPITest;
 }
-
-class MultiWalkerDispatchers;
-struct DriverWalkerResourceCollection;
 
 /** Class for controlling the walkers for DMC simulations.
  * w and w/o MPI. Fixed and dynamic population in one place.
@@ -75,11 +70,7 @@ public:
    *
    *  \return global population
    */
-  int branch(int iter,
-             MCPopulation& pop,
-             const MultiWalkerDispatchers& dispatchers,
-             DriverWalkerResourceCollection& driverwalker_res,
-             bool do_not_branch);
+  int branch(int iter, MCPopulation& pop, bool do_not_branch);
 
   bool put(xmlNodePtr cur);
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -361,6 +361,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
     walker.ReleasedNodeAge    = 0;
     walker.ReleasedNodeWeight = 0;
     walker.Weight             = 1;
+    walker.wasTouched         = false;
   };
   for (int iw = 0; iw < crowd.size(); ++iw)
     doesDoinTheseLastMatter(walkers[iw]);

--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -99,7 +99,7 @@ void AGPDeterminant::reportStatus(std::ostream& os)
  *contribution of the determinant to G(radient) and L(aplacian)
  *for local energy calculations.
  */
-AGPDeterminant::LogValueType AGPDeterminant::evaluateLog(ParticleSet& P,
+AGPDeterminant::LogValueType AGPDeterminant::evaluateLog(const ParticleSet& P,
                                                          ParticleSet::ParticleGradient_t& G,
                                                          ParticleSet::ParticleLaplacian_t& L)
 {
@@ -109,7 +109,7 @@ AGPDeterminant::LogValueType AGPDeterminant::evaluateLog(ParticleSet& P,
   return LogValue;
 }
 
-void AGPDeterminant::evaluateLogAndStore(ParticleSet& P)
+void AGPDeterminant::evaluateLogAndStore(const ParticleSet& P)
 {
   //GeminalBasis->evaluate(P);
   GeminalBasis->evaluateForWalkerMove(P); //@@

--- a/src/QMCWaveFunctions/AGPDeterminant.h
+++ b/src/QMCWaveFunctions/AGPDeterminant.h
@@ -90,7 +90,7 @@ public:
    *contribution of the determinant to G(radient) and L(aplacian)
    *for local energy calculations.
    */
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const;
 
@@ -174,7 +174,7 @@ public:
   ParticleSet::ParticleGradient_t myG, myG_temp;
   ParticleSet::ParticleLaplacian_t myL, myL_temp;
 
-  void evaluateLogAndStore(ParticleSet& P);
+  void evaluateLogAndStore(const ParticleSet& P);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/ConstantOrbital.h
+++ b/src/QMCWaveFunctions/ConstantOrbital.h
@@ -29,7 +29,7 @@ public:
 
   ConstantOrbital() : WaveFunctionComponent("ConstantOrbital"), FakeGradRatio(1.0) {}
 
-  virtual LogValueType evaluateLog(ParticleSet& P,
+  virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L) override
   {

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -61,7 +61,7 @@ bool ExampleHeComponent::put(xmlNodePtr cur)
   return true;
 }
 
-ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(ParticleSet& P,
+ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(const ParticleSet& P,
                                                                  ParticleSet::ParticleGradient_t& G,
                                                                  ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -42,7 +42,7 @@ public:
 
   void reportStatus(std::ostream& os) override {}
 
-  LogValueType evaluateLog(ParticleSet& P,
+  LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -269,7 +269,7 @@ void DiracDeterminant<DU_TYPE>::completeUpdates()
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::updateAfterSweep(ParticleSet& P,
+void DiracDeterminant<DU_TYPE>::updateAfterSweep(const ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& G,
                                                  ParticleSet::ParticleLaplacian_t& L)
 {
@@ -329,7 +329,7 @@ void DiracDeterminant<DU_TYPE>::registerData(ParticleSet& P, WFBufferType& buf)
 
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::evaluateGL(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
     ParticleSet::ParticleLaplacian_t& L,
     bool fromscratch)
@@ -635,7 +635,7 @@ typename DiracDeterminant<DU_TYPE>::GradType DiracDeterminant<DU_TYPE>::evalGrad
  */
 template<typename DU_TYPE>
 typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::evaluateLog(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
     ParticleSet::ParticleLaplacian_t& L)
 {
@@ -662,7 +662,7 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::eval
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::recompute(ParticleSet& P)
+void DiracDeterminant<DU_TYPE>::recompute(const ParticleSet& P)
 {
   {
     ScopedTimer local_timer(SPOVGLTimer);
@@ -675,9 +675,7 @@ void DiracDeterminant<DU_TYPE>::recompute(ParticleSet& P)
     LogValue      = convertValueToLog(det);
   }
   else
-  {
     invertPsiM(psiM_temp, psiM);
-  }
 
   // invRow becomes invalid after updating the inverse matrix
   invRow_id = -1;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -74,7 +74,7 @@ public:
 
   void registerData(ParticleSet& P, WFBufferType& buf) override;
 
-  void updateAfterSweep(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  void updateAfterSweep(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override;
 
@@ -152,7 +152,7 @@ public:
   void restore(int iat) override;
 
   ///evaluate log of a determinant for a particle set
-  LogValueType evaluateLog(ParticleSet& P,
+  LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 
@@ -162,9 +162,9 @@ public:
   //                    const std::vector<ParticleSet::ParticleGradient_t*>& G_list,
   //                    const std::vector<ParticleSet::ParticleLaplacian_t*>& L_list) override;
 
-  void recompute(ParticleSet& P) override;
+  void recompute(const ParticleSet& P) override;
 
-  LogValueType evaluateGL(ParticleSet& P,
+  LogValueType evaluateGL(const ParticleSet& P,
                           ParticleSet::ParticleGradient_t& G,
                           ParticleSet::ParticleLaplacian_t& L,
                           bool fromscratch) override;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -833,7 +833,8 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evaluateLog(
     const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) const
 {
   assert(this == &wfc_list.getLeader());
-  mw_recompute(wfc_list, p_list);
+  const std::vector<bool> recompute_all(wfc_list.size(), true);
+  mw_recompute(wfc_list, p_list, recompute_all);
 
   for (int iw = 0; iw < wfc_list.size(); iw++)
   {
@@ -858,7 +859,8 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::recompute(const ParticleSet& P)
 
 template<typename DET_ENGINE_TYPE>
 void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                            const RefVectorWithLeader<ParticleSet>& p_list) const
+                                                            const RefVectorWithLeader<ParticleSet>& p_list,
+                                                            const std::vector<bool>& recompute) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE_TYPE>>();
   const auto nw    = wfc_list.size();

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -377,7 +377,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::computeGL(ParticleSet::ParticleGr
 
 template<typename DET_ENGINE_TYPE>
 typename DiracDeterminantBatched<DET_ENGINE_TYPE>::LogValueType DiracDeterminantBatched<DET_ENGINE_TYPE>::evaluateGL(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
     ParticleSet::ParticleLaplacian_t& L,
     bool fromscratch)
@@ -816,7 +816,7 @@ typename DiracDeterminantBatched<DET_ENGINE_TYPE>::GradType DiracDeterminantBatc
  */
 template<typename DET_ENGINE_TYPE>
 typename DiracDeterminantBatched<DET_ENGINE_TYPE>::LogValueType DiracDeterminantBatched<DET_ENGINE_TYPE>::evaluateLog(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
     ParticleSet::ParticleLaplacian_t& L)
 {
@@ -843,7 +843,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evaluateLog(
 }
 
 template<typename DET_ENGINE_TYPE>
-void DiracDeterminantBatched<DET_ENGINE_TYPE>::recompute(ParticleSet& P)
+void DiracDeterminantBatched<DET_ENGINE_TYPE>::recompute(const ParticleSet& P)
 {
   {
     ScopedTimer spo_timer(SPOVGLTimer);
@@ -858,7 +858,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::recompute(ParticleSet& P)
 
 template<typename DET_ENGINE_TYPE>
 void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                            const RefVectorWithLeader<ParticleSet>& p_list)
+                                                            const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE_TYPE>>();
   const auto nw    = wfc_list.size();

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -170,7 +170,7 @@ public:
   /** evaluate log of a determinant for a particle set
    * This is the most defensive call. The psiM, dpsiM, d2psiM should be up-to-date on both device and host sides.
    */
-  LogValueType evaluateLog(ParticleSet& P,
+  LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 
@@ -179,9 +179,9 @@ public:
                       const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                       const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) const override;
 
-  void recompute(ParticleSet& P) override;
+  void recompute(const ParticleSet& P) override;
 
-  LogValueType evaluateGL(ParticleSet& P,
+  LogValueType evaluateGL(const ParticleSet& P,
                           ParticleSet::ParticleGradient_t& G,
                           ParticleSet::ParticleLaplacian_t& L,
                           bool fromscratch) override;
@@ -256,8 +256,8 @@ private:
   static void mw_invertPsiM(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                             const RefVector<const ValueMatrix_t>& logdetT_list);
 
-  static void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                           const RefVectorWithLeader<ParticleSet>& p_list);
+  void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                    const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   // make this class unit tests friendly without the need of setup resources.
   void guardMultiWalkerRes()

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -257,7 +257,8 @@ private:
                             const RefVector<const ValueMatrix_t>& logdetT_list);
 
   void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                    const RefVectorWithLeader<ParticleSet>& p_list) const override;
+                    const RefVectorWithLeader<ParticleSet>& p_list,
+                    const std::vector<bool>& recompute) const override;
 
   // make this class unit tests friendly without the need of setup resources.
   void guardMultiWalkerRes()

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -155,7 +155,7 @@ public:
     return nullptr;
   }
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::evaluateLog is illegal!");
     return 0;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -485,7 +485,7 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
  *for local energy calculations.
  */
 DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluateLog(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& G,
     ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -129,7 +129,7 @@ public:
    */
   void restore(int iat);
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   /** cloning function
    * @param tqp target particleset

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -378,7 +378,7 @@ void MultiDiracDeterminant::evaluateGrads(ParticleSet& P, int iat)
   }
 }
 
-void MultiDiracDeterminant::evaluateAllForPtclMove(ParticleSet& P, int iat)
+void MultiDiracDeterminant::evaluateAllForPtclMove(const ParticleSet& P, int iat)
 {
   UpdateMode = ORB_PBYP_ALL;
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -102,7 +102,7 @@ void out1(int n, std::string str = "NULL") {}
 //{ std::cout <<"MDD: " <<str <<"  " <<n << std::endl; std::cout.flush(); }
 
 
-void MultiDiracDeterminant::evaluateForWalkerMove(ParticleSet& P, bool fromScratch)
+void MultiDiracDeterminant::evaluateForWalkerMove(const ParticleSet& P, bool fromScratch)
 {
   evalWTimer.start();
   if (fromScratch)

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -220,13 +220,13 @@ public:
     return PsiValueType();
   }
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
     return 0.0;
   }
 
-  ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  ValueType evaluate(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     APP_ABORT("  MultiDiracDeterminant: This should not be called. \n");
     return ValueType();
@@ -386,9 +386,9 @@ public:
   void evaluateDetsForPtclMove(ParticleSet& P, int iat);
   void evaluateDetsAndGradsForPtclMove(ParticleSet& P, int iat);
   void evaluateGrads(ParticleSet& P, int iat);
-  void evaluateAllForPtclMove(ParticleSet& P, int iat);
+  void evaluateAllForPtclMove(const ParticleSet& P, int iat);
   // full evaluation of all the structures from scratch, used in evaluateLog for example
-  void evaluateForWalkerMove(ParticleSet& P, bool fromScratch = true);
+  void evaluateForWalkerMove(const ParticleSet& P, bool fromScratch = true);
 
   ///total number of particles
   int NP;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -147,7 +147,7 @@ void MultiSlaterDeterminant::resize(int n1, int n2)
   }
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P,
+WaveFunctionComponent::ValueType MultiSlaterDeterminant::evaluate(const ParticleSet& P,
                                                                   ParticleSet::ParticleGradient_t& G,
                                                                   ParticleSet::ParticleLaplacian_t& L)
 {
@@ -205,7 +205,7 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminant::evaluate(ParticleSet& P
   return psi;
 }
 
-WaveFunctionComponent::LogValueType MultiSlaterDeterminant::evaluateLog(ParticleSet& P,
+WaveFunctionComponent::LogValueType MultiSlaterDeterminant::evaluateLog(const ParticleSet& P,
                                                                         ParticleSet::ParticleGradient_t& G,
                                                                         ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.h
@@ -85,10 +85,9 @@ public:
   ///set BF pointers
   virtual void setBF(BackflowTransformation* BFTrans) {}
 
-  virtual ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  virtual ValueType evaluate(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  virtual LogValueType evaluateLog(ParticleSet& P //const DistanceTableData* dtable,
-                                   ,
+  virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L);
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -162,7 +162,7 @@ void MultiSlaterDeterminantFast::testMSD(ParticleSet& P, int iat)
  * Miguel's note: can this change over time??? I don't know yet
  */
 WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate_vgl_impl(
-    ParticleSet& P,
+    const ParticleSet& P,
     ParticleSet::ParticleGradient_t& g_tmp,
     ParticleSet::ParticleLaplacian_t& l_tmp)
 {
@@ -206,7 +206,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate_vgl_imp
   return psi;
 }
 
-WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate(ParticleSet& P,
+WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate(const ParticleSet& P,
                                                                          ParticleSet::ParticleGradient_t& G,
                                                                          ParticleSet::ParticleLaplacian_t& L)
 {
@@ -223,7 +223,7 @@ WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evaluate(Particl
   return psiCurrent;
 }
 
-WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::evaluateLog(ParticleSet& P,
+WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::evaluateLog(const ParticleSet& P,
                                                                             ParticleSet::ParticleGradient_t& G,
                                                                             ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -97,13 +97,13 @@ public:
       Dets[id]->setBF(bf);
   }
 
-  PsiValueType evaluate_vgl_impl(ParticleSet& P,
+  PsiValueType evaluate_vgl_impl(const ParticleSet& P,
                                  ParticleSet::ParticleGradient_t& g_tmp,
                                  ParticleSet::ParticleLaplacian_t& l_tmp);
 
-  PsiValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  PsiValueType evaluate(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  LogValueType evaluateLog(ParticleSet& P,
+  LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L) override;
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -105,7 +105,7 @@ void MultiSlaterDeterminantWithBackflow::resize(int n1, int n2)
   }
 }
 
-WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::evaluate(ParticleSet& P,
+WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::evaluate(const ParticleSet& P,
                                                                               ParticleSet::ParticleGradient_t& G,
                                                                               ParticleSet::ParticleLaplacian_t& L)
 {
@@ -166,7 +166,7 @@ WaveFunctionComponent::ValueType MultiSlaterDeterminantWithBackflow::evaluate(Pa
   return psi;
 }
 
-WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::evaluateLog(ParticleSet& P,
+WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::evaluateLog(const ParticleSet& P,
                                                                                     ParticleSet::ParticleGradient_t& G,
                                                                                     ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.h
@@ -55,10 +55,9 @@ public:
       dets_dn[i]->setBF(bf);
   }
 
-  ValueType evaluate(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  ValueType evaluate(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
-  LogValueType evaluateLog(ParticleSet& P //const DistanceTableData* dtable,
-                           ,
+  LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient_t& G,
                            ParticleSet::ParticleLaplacian_t& L);
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -179,12 +179,13 @@ void SlaterDet::recompute(const ParticleSet& P)
 }
 
 void SlaterDet::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                             const RefVectorWithLeader<ParticleSet>& p_list) const
+                             const RefVectorWithLeader<ParticleSet>& p_list,
+                             const std::vector<bool>& recompute) const
 {
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
-    Dets[i]->mw_recompute(Det_list, p_list);
+    Dets[i]->mw_recompute(Det_list, p_list, recompute);
   }
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -112,7 +112,7 @@ void SlaterDet::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& r
     Dets[i]->evaluateRatiosAlltoOne(P, ratios);
 }
 
-SlaterDet::LogValueType SlaterDet::evaluateLog(ParticleSet& P,
+SlaterDet::LogValueType SlaterDet::evaluateLog(const ParticleSet& P,
                                                ParticleSet::ParticleGradient_t& G,
                                                ParticleSet::ParticleLaplacian_t& L)
 {
@@ -141,7 +141,7 @@ void SlaterDet::mw_evaluateLog(const RefVectorWithLeader<WaveFunctionComponent>&
   }
 }
 
-SlaterDet::LogValueType SlaterDet::evaluateGL(ParticleSet& P,
+SlaterDet::LogValueType SlaterDet::evaluateGL(const ParticleSet& P,
                                               ParticleSet::ParticleGradient_t& G,
                                               ParticleSet::ParticleLaplacian_t& L,
                                               bool from_scratch)
@@ -172,10 +172,20 @@ void SlaterDet::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& 
   }
 }
 
-void SlaterDet::recompute(ParticleSet& P)
+void SlaterDet::recompute(const ParticleSet& P)
 {
   for (int i = 0; i < Dets.size(); ++i)
     Dets[i]->recompute(P);
+}
+
+void SlaterDet::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                             const RefVectorWithLeader<ParticleSet>& p_list) const
+{
+  for (int i = 0; i < Dets.size(); ++i)
+  {
+    const auto Det_list(extract_DetRef_list(wfc_list, i));
+    Dets[i]->mw_recompute(Det_list, p_list);
+  }
 }
 
 void SlaterDet::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -60,7 +60,7 @@ public:
 
   void reportStatus(std::ostream& os) override;
 
-  virtual LogValueType evaluateLog(ParticleSet& P,
+  virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L) override;
 
@@ -69,7 +69,7 @@ public:
                               const RefVector<ParticleSet::ParticleGradient_t>& G_list,
                               const RefVector<ParticleSet::ParticleLaplacian_t>& L_list) const override;
 
-  virtual LogValueType evaluateGL(ParticleSet& P,
+  virtual LogValueType evaluateGL(const ParticleSet& P,
                                   ParticleSet::ParticleGradient_t& G,
                                   ParticleSet::ParticleLaplacian_t& L,
                                   bool fromscratch) override;
@@ -80,7 +80,10 @@ public:
                              const RefVector<ParticleSet::ParticleLaplacian_t>& L_list,
                              bool fromscratch) const override;
 
-  virtual void recompute(ParticleSet& P) override;
+  virtual void recompute(const ParticleSet& P) override;
+
+  virtual void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   virtual void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -83,7 +83,8 @@ public:
   virtual void recompute(const ParticleSet& P) override;
 
   virtual void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                            const RefVectorWithLeader<ParticleSet>& p_list) const override;
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            const std::vector<bool>& recompute) const override;
 
   virtual void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 

--- a/src/QMCWaveFunctions/Jastrow/CountingGaussian.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingGaussian.h
@@ -645,7 +645,7 @@ public:
     }
   }
 
-  void evaluate_print(std::ostream& os, ParticleSet& P)
+  void evaluate_print(std::ostream& os, const ParticleSet& P)
   {
     // calculate all intermediates and values for electrons in a particle set
     std::vector<PosType> r_vec;

--- a/src/QMCWaveFunctions/Jastrow/CountingGaussianRegion.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingGaussianRegion.h
@@ -234,7 +234,7 @@ public:
   }
 
   // evaluate using the log of the counting basis
-  void evaluate(ParticleSet& P)
+  void evaluate(const ParticleSet& P)
   {
     // clear arrays
     std::fill(val.begin(), val.end(), 0);
@@ -286,7 +286,7 @@ public:
     }
   }
 
-  void evaluate_print(std::ostream& os, ParticleSet& P)
+  void evaluate_print(std::ostream& os, const ParticleSet& P)
   {
     for (auto it = C.begin(); it != C.end(); ++it)
       (*it)->evaluate_print(os, P);
@@ -307,7 +307,7 @@ public:
   }
 
 
-  void evaluateTemp(ParticleSet& P, int iat)
+  void evaluateTemp(const ParticleSet& P, int iat)
   {
     // clear arrays
     std::fill(val_t.begin(), val_t.end(), 0);
@@ -357,7 +357,7 @@ public:
     }
   }
 
-  void evaluateTemp_print(std::ostream& os, ParticleSet& P)
+  void evaluateTemp_print(std::ostream& os, const ParticleSet& P)
   {
     os << "CountingGaussianRegion::evaluateTemp_print" << std::endl;
     os << "val_t: ";

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -209,7 +209,7 @@ public:
   }
 
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     evaluateExponents(P);
     for (int i = 0; i < num_els; ++i)
@@ -222,13 +222,13 @@ public:
   }
 
 
-  void recompute(ParticleSet& P)
+  void recompute(const ParticleSet& P)
   {
     evaluateExponents(P);
     LogValue = Jval;
   }
 
-  void evaluateExponents(ParticleSet& P)
+  void evaluateExponents(const ParticleSet& P)
   {
     // evaluate counting regions
     C->evaluate(P);
@@ -274,7 +274,7 @@ public:
   }
 
 
-  void evaluateExponents_print(std::ostream& os, ParticleSet& P)
+  void evaluateExponents_print(std::ostream& os, const ParticleSet& P)
   {
     // print counting regions
     C->evaluate_print(app_log(), P);

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -109,7 +109,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     F[source_type] = afunc;
   }
 
-  void recompute(ParticleSet& P)
+  void recompute(const ParticleSet& P)
   {
     const DistanceTableData& d_ie(P.getDistTable(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
@@ -120,7 +120,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     }
   }
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     return evaluateGL(P, G, L, true);
   }
@@ -216,7 +216,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       ratios[i] = std::exp(Vat[i] - curAt);
   }
 
-  inline LogValueType evaluateGL(ParticleSet& P,
+  inline LogValueType evaluateGL(const ParticleSet& P,
                                  ParticleSet::ParticleGradient_t& G,
                                  ParticleSet::ParticleLaplacian_t& L,
                                  bool fromscratch = false)
@@ -258,7 +258,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
    * @param iat the moving particle
    * @param dist starting address of the distances of the ions wrt the iat-th particle
    */
-  inline void computeU3(ParticleSet& P, int iat, const DistRow& dist)
+  inline void computeU3(const ParticleSet& P, int iat, const DistRow& dist)
   {
     if (NumGroups > 0)
     { //ions are grouped

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -235,12 +235,12 @@ public:
 
   WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const;
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi);
 
   /** recompute internal data assuming distance table is fully ready */
-  void recompute(ParticleSet& P);
+  void recompute(const ParticleSet& P);
 
   PsiValueType ratio(ParticleSet& P, int iat);
   void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios)
@@ -260,7 +260,7 @@ public:
 
   /** compute G and L after the sweep
    */
-  LogValueType evaluateGL(ParticleSet& P,
+  LogValueType evaluateGL(const ParticleSet& P,
                           ParticleSet::ParticleGradient_t& G,
                           ParticleSet::ParticleLaplacian_t& L,
                           bool fromscratch = false);
@@ -595,7 +595,7 @@ void J2OrbitalSoA<FT>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 }
 
 template<typename FT>
-void J2OrbitalSoA<FT>::recompute(ParticleSet& P)
+void J2OrbitalSoA<FT>::recompute(const ParticleSet& P)
 {
   const auto& d_table = P.getDistTable(my_table_ID_);
   for (int ig = 0; ig < NumGroups; ++ig)
@@ -645,7 +645,7 @@ void J2OrbitalSoA<FT>::recompute(ParticleSet& P)
 }
 
 template<typename FT>
-typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(ParticleSet& P,
+typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(const ParticleSet& P,
                                                                       ParticleSet::ParticleGradient_t& G,
                                                                       ParticleSet::ParticleLaplacian_t& L)
 {
@@ -653,7 +653,7 @@ typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(ParticleSe
 }
 
 template<typename FT>
-WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(ParticleSet& P,
+WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(const ParticleSet& P,
                                                                  ParticleSet::ParticleGradient_t& G,
                                                                  ParticleSet::ParticleLaplacian_t& L,
                                                                  bool fromscratch)

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -382,7 +382,7 @@ public:
     }
   }
 
-  void build_compact_list(ParticleSet& P)
+  void build_compact_list(const ParticleSet& P)
   {
     const auto& eI_dists  = P.getDistTable(ei_Table_ID_).getDistances();
     const auto& eI_displs = P.getDistTable(ei_Table_ID_).getDisplacements();
@@ -406,7 +406,7 @@ public:
           }
   }
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
   {
     return evaluateGL(P, G, L, true);
   }
@@ -567,7 +567,7 @@ public:
     }
   }
 
-  inline void recompute(ParticleSet& P)
+  inline void recompute(const ParticleSet& P)
   {
     const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
     const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
@@ -846,7 +846,7 @@ public:
     build_compact_list(P);
   }
 
-  LogValueType evaluateGL(ParticleSet& P,
+  LogValueType evaluateGL(const ParticleSet& P,
                           ParticleSet::ParticleGradient_t& G,
                           ParticleSet::ParticleLaplacian_t& L,
                           bool fromscratch = false)

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -232,7 +232,7 @@ void RPAJastrow::reportStatus(std::ostream& os)
     Psi[i]->reportStatus(os);
 }
 
-RPAJastrow::LogValueType RPAJastrow::evaluateLog(ParticleSet& P,
+RPAJastrow::LogValueType RPAJastrow::evaluateLog(const ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& G,
                                                  ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -69,7 +69,7 @@ struct RPAJastrow : public WaveFunctionComponent
     */
   void resetParameters(const opt_variables_type& active);
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   PsiValueType ratio(ParticleSet& P, int iat);
   GradType evalGrad(ParticleSet& P, int iat);

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -361,7 +361,7 @@ void kSpaceJastrow::setCoefficients(std::vector<RealType>& oneBodyCoefs, std::ve
 //                  Evaluation functions                     //
 ///////////////////////////////////////////////////////////////
 
-kSpaceJastrow::LogValueType kSpaceJastrow::evaluateLog(ParticleSet& P,
+kSpaceJastrow::LogValueType kSpaceJastrow::evaluateLog(const ParticleSet& P,
                                                        ParticleSet::ParticleGradient_t& G,
                                                        ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -161,7 +161,7 @@ public:
   void resetParameters(const opt_variables_type& active);
   void reportStatus(std::ostream& os);
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   PsiValueType ratio(ParticleSet& P, int iat);
 

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -57,7 +57,7 @@ void LatticeGaussianProduct::reportStatus(std::ostream& os) {}
      *such that \f[ G[i]+={\bf \nabla}_i J({\bf R}) \f]
      *and \f[ L[i]+=\nabla^2_i J({\bf R}). \f]
      */
-LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(ParticleSet& P,
+LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(const ParticleSet& P,
                                                                          ParticleSet::ParticleGradient_t& G,
                                                                          ParticleSet::ParticleLaplacian_t& L)
 {
@@ -139,7 +139,7 @@ void LatticeGaussianProduct::acceptMove(ParticleSet& P, int iat, bool safe_to_de
   d2U[iat] = curLap;
 }
 
-void LatticeGaussianProduct::evaluateLogAndStore(ParticleSet& P,
+void LatticeGaussianProduct::evaluateLogAndStore(const ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& dG,
                                                  ParticleSet::ParticleLaplacian_t& dL)
 {

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.h
@@ -62,7 +62,7 @@ public:
    */
   void resetParameters(const opt_variables_type& active);
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
 
   PsiValueType ratio(ParticleSet& P, int iat);
 
@@ -83,7 +83,7 @@ public:
 
   WaveFunctionComponent* makeClone(ParticleSet& tqp) const;
 
-  void evaluateLogAndStore(ParticleSet& P, ParticleSet::ParticleGradient_t& dG, ParticleSet::ParticleLaplacian_t& dL);
+  void evaluateLogAndStore(const ParticleSet& P, ParticleSet::ParticleGradient_t& dG, ParticleSet::ParticleLaplacian_t& dL);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -38,7 +38,7 @@ public:
     coeff[2] = 3.0;
   }
 
-  virtual LogValueType evaluateLog(ParticleSet& P,
+  virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L)
   {

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -29,6 +29,19 @@ void TWFdispatcher::flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction
       wf_list[iw].evaluateLog(p_list[iw]);
 }
 
+void TWFdispatcher::flex_recompute(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                   const std::vector<bool>& recompute) const
+{
+  assert(wf_list.size() == p_list.size());
+  if (use_batch_)
+    TrialWaveFunction::mw_recompute(wf_list, p_list, recompute);
+  else
+    for (size_t iw = 0; iw < wf_list.size(); iw++)
+      if (recompute[iw])
+        wf_list[iw].recompute(p_list[iw]);
+}
+
 void TWFdispatcher::flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                    int iat,

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -35,6 +35,10 @@ public:
   void flex_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                         const RefVectorWithLeader<ParticleSet>& p_list) const;
 
+  void flex_recompute(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                      const RefVectorWithLeader<ParticleSet>& p_list,
+                      const std::vector<bool>& recompute) const;
+
   void flex_calcRatio(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                       const RefVectorWithLeader<ParticleSet>& p_list,
                       int iat,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -186,7 +186,7 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
   }
 }
 
-void TrialWaveFunction::recompute(ParticleSet& P)
+void TrialWaveFunction::recompute(const ParticleSet& P)
 {
   ScopedTimer local_timer(TWF_timers_[RECOMPUTE_TIMER]);
   for (int i = 0; i < Z.size(); ++i)
@@ -196,6 +196,23 @@ void TrialWaveFunction::recompute(ParticleSet& P)
   }
 }
 
+void TrialWaveFunction::mw_recompute(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                     const RefVectorWithLeader<ParticleSet>& p_list,
+                                     const std::vector<bool>& recompute)
+{
+  auto& wf_leader = wf_list.getLeader();
+  auto& p_leader  = p_list.getLeader();
+  ScopedTimer local_timer(wf_leader.TWF_timers_[RECOMPUTE_TIMER]);
+
+  auto& wavefunction_components = wf_leader.Z;
+  const int num_wfc             = wf_leader.Z.size();
+  for (int i = 0; i < num_wfc; ++i)
+  {
+    ScopedTimer z_timer(wf_leader.WFC_timers_[RECOMPUTE_TIMER + TIMER_SKIP * i]);
+    const auto wfc_list(extractWFCRefList(wf_list, i));
+    wavefunction_components[i]->mw_recompute(wfc_list, p_list, recompute);
+  }
+}
 
 TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, bool recomputeall)
 {

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -151,7 +151,12 @@ public:
                              const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** recompute the value of the orbitals which require critical accuracy */
-  void recompute(ParticleSet& P);
+  void recompute(const ParticleSet& P);
+
+  /** batched version of recompute*/
+  static void mw_recompute(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list,
+                           const std::vector<bool>& recompute);
 
   /** evaluate the log value of a many-body wave function
    * @param P input configuration containing N particles

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -49,6 +49,23 @@ void WaveFunctionComponent::mw_evaluateLog(const RefVectorWithLeader<WaveFunctio
     wfc_list[iw].evaluateLog(p_list[iw], G_list[iw], L_list[iw]);
 }
 
+void WaveFunctionComponent::recompute(const ParticleSet& P)
+{
+  ParticleSet::ParticleGradient_t temp_G(P.getTotalNum());
+  ParticleSet::ParticleLaplacian_t temp_L(P.getTotalNum());
+
+  evaluateLog(P, temp_G, temp_L);
+}
+
+void WaveFunctionComponent::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                         const RefVectorWithLeader<ParticleSet>& p_list) const
+{
+  assert(this == &wfc_list.getLeader());
+#pragma omp parallel for
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    wfc_list[iw].recompute(p_list[iw]);
+}
+
 void WaveFunctionComponent::mw_prepareGroup(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                             const RefVectorWithLeader<ParticleSet>& p_list,
                                             int ig) const
@@ -123,7 +140,7 @@ void WaveFunctionComponent::mw_completeUpdates(const RefVectorWithLeader<WaveFun
     wfc_list[iw].completeUpdates();
 }
 
-WaveFunctionComponent::LogValueType WaveFunctionComponent::evaluateGL(ParticleSet& P,
+WaveFunctionComponent::LogValueType WaveFunctionComponent::evaluateGL(const ParticleSet& P,
                                                                       ParticleSet::ParticleGradient_t& G,
                                                                       ParticleSet::ParticleLaplacian_t& L,
                                                                       bool fromscratch)

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -58,12 +58,14 @@ void WaveFunctionComponent::recompute(const ParticleSet& P)
 }
 
 void WaveFunctionComponent::mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                         const RefVectorWithLeader<ParticleSet>& p_list) const
+                                         const RefVectorWithLeader<ParticleSet>& p_list,
+                                         const std::vector<bool>& recompute) const
 {
   assert(this == &wfc_list.getLeader());
 #pragma omp parallel for
   for (int iw = 0; iw < wfc_list.size(); iw++)
-    wfc_list[iw].recompute(p_list[iw]);
+    if (recompute[iw])
+      wfc_list[iw].recompute(p_list[iw]);
 }
 
 void WaveFunctionComponent::mw_prepareGroup(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -180,7 +180,7 @@ struct WaveFunctionComponent : public QMCTraits
    * Mainly for walker-by-walker move. The initial stage of particle-by-particle
    * move also uses this.
    */
-  virtual LogValueType evaluateLog(ParticleSet& P,
+  virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,
                                    ParticleSet::ParticleLaplacian_t& L) = 0;
 
@@ -199,7 +199,10 @@ struct WaveFunctionComponent : public QMCTraits
   /** recompute the value of the WaveFunctionComponents which require critical accuracy.
    * needed for Slater Determinants but not needed for most types of WaveFunctionComponents
    */
-  virtual void recompute(ParticleSet& P) {}
+  virtual void recompute(const ParticleSet& P);
+
+  virtual void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list) const;
 
   // virtual void evaluateHessian(ParticleSet& P, IndexType iat, HessType& grad_grad_psi)
   // {
@@ -383,7 +386,7 @@ struct WaveFunctionComponent : public QMCTraits
    * @param fromscratch if true, all the internal data are recomputed from scratch
    * @return log(psi)
    */
-  virtual LogValueType evaluateGL(ParticleSet& P,
+  virtual LogValueType evaluateGL(const ParticleSet& P,
                                   ParticleSet::ParticleGradient_t& G,
                                   ParticleSet::ParticleLaplacian_t& L,
                                   bool fromscratch);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -202,7 +202,8 @@ struct WaveFunctionComponent : public QMCTraits
   virtual void recompute(const ParticleSet& P);
 
   virtual void mw_recompute(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                            const RefVectorWithLeader<ParticleSet>& p_list) const;
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            const std::vector<bool>& recompute) const;
 
   // virtual void evaluateHessian(ParticleSet& P, IndexType iat, HessType& grad_grad_psi)
   // {


### PR DESCRIPTION
## Proposed changes
In DMCBatch, a copied walker or transferred walker needs some recomputing. This was done previously in WalkerControl but it has too many side effects.
For this reason, those operations are moved to the beginning of a DMC p-by-p move section.

I went through the recompute() routine and added mw_recompute().
evaluateLog = recompute + evaluateGL.
This decomposition serves well with minimal duplicated code.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'