### PR TITLE
Not print accelerator in QMC_CUDA build

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -86,7 +86,7 @@ QMCMain::QMCMain(Communicate* c)
       << "\n  MPI group ID              = " << myComm->getGroupID()
       << "\n  Number of ranks in group  = " << myComm->size()
       << "\n  MPI ranks per node        = " << NodeComm.size()
-#if defined(ENABLE_OFFLOAD) || defined(ENABLE_CUDA) || defined(QMC_CUDA) || defined(ENABLE_ROCM)
+#if defined(ENABLE_OFFLOAD) || defined(ENABLE_CUDA) || defined(ENABLE_ROCM)
       << "\n  Accelerators per node     = " << num_accelerators
 #endif
       << std::endl;


### PR DESCRIPTION
## Proposed changes
In QMC_CUDA case, the GPU to MPI rank assignment is handled differently from all the rest cases. So Just don't print in this place. The same info has been printed before this line.

```
Rank =    0  Free Memory = 268400 MB
1 MPI ranks on node(s) sulfur.ornl.gov with 1 appropriate CUDA devices.
<- Rank 0 will use CUDA device #0 (Tesla V100-PCIE-16GB)
Rank 0: relative rank number = 0, number of devices = 1
Assigned device numbers: 0
Default MAX_GPU_SPLINE_SIZE_MB is 81920 MB.
  Input file(s): det_qmc_short_vmc_dmc.in.xml 

=====================================================
                    QMCPACK 3.10.9
```

Closes #3008

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'