### PR TITLE
Change ParticleSet resource management API

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -260,10 +260,14 @@ public:
   virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
-  virtual void acquireResource(ResourceCollection& collection) {}
+  virtual void acquireResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<DistanceTableData>& dt_list) const
+  {}
 
   /// return a shared resource to a collection
-  virtual void releaseResource(ResourceCollection& collection) {}
+  virtual void releaseResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<DistanceTableData>& dt_list) const
+  {}
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/DynamicCoordinates.h
+++ b/src/Particle/DynamicCoordinates.h
@@ -99,10 +99,14 @@ public:
   virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
-  virtual void acquireResource(ResourceCollection& collection) {}
+  virtual void acquireResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<DynamicCoordinates>& coords_list) const
+  {}
 
   /// return a shared resource to a collection
-  virtual void releaseResource(ResourceCollection& collection) {}
+  virtual void releaseResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<DynamicCoordinates>& coords_list) const
+  {}
 
 protected:
   /// type of dynamic coordinates

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -813,8 +813,7 @@ void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
                                 const RefVector<Walker_t>& walkers,
                                 bool pbyp)
 {
-  auto loadWalkerConfig = [](ParticleSet& pset, Walker_t& awalker)
-  {
+  auto loadWalkerConfig = [](ParticleSet& pset, Walker_t& awalker) {
     pset.R     = awalker.R;
     pset.spins = awalker.spins;
     pset.coordinates_->setAllParticlePos(pset.R);
@@ -923,18 +922,20 @@ void ParticleSet::createResource(ResourceCollection& collection) const
     DistTables[i]->createResource(collection);
 }
 
-void ParticleSet::acquireResource(ResourceCollection& collection)
+void ParticleSet::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list)
 {
-  coordinates_->acquireResource(collection);
-  for (int i = 0; i < DistTables.size(); i++)
-    DistTables[i]->acquireResource(collection);
+  auto& ps_leader = p_list.getLeader();
+  ps_leader.coordinates_->acquireResource(collection, extractCoordsRefList(p_list));
+  for (int i = 0; i < ps_leader.DistTables.size(); i++)
+    ps_leader.DistTables[i]->acquireResource(collection, extractDTRefList(p_list, i));
 }
 
-void ParticleSet::releaseResource(ResourceCollection& collection)
+void ParticleSet::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list)
 {
-  coordinates_->releaseResource(collection);
-  for (int i = 0; i < DistTables.size(); i++)
-    DistTables[i]->releaseResource(collection);
+  auto& ps_leader = p_list.getLeader();
+  ps_leader.coordinates_->releaseResource(collection, extractCoordsRefList(p_list));
+  for (int i = 0; i < ps_leader.DistTables.size(); i++)
+    ps_leader.DistTables[i]->releaseResource(collection, extractDTRefList(p_list, i));
 }
 
 RefVectorWithLeader<DistanceTableData> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -644,11 +644,11 @@ public:
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void acquireResource(ResourceCollection& collection);
+  static void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
   /** release external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void releaseResource(ResourceCollection& collection);
+  static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
 
   static RefVectorWithLeader<DistanceTableData> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                  int id);

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -31,8 +31,7 @@
 
 namespace qmcplusplus
 {
-ParticleSetPool::ParticleSetPool(Communicate* c, const char* aname)
-    : MPIObjectBase(c), TileMatrix(0)
+ParticleSetPool::ParticleSetPool(Communicate* c, const char* aname) : MPIObjectBase(c), TileMatrix(0)
 {
   TileMatrix.diagonal(1);
   ClassName = "ParticleSetPool";

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -184,8 +184,6 @@ public:
   void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<MultiWalkerMem>());
-    app_log() << "    Multi walker shared memory resource created in RealSpacePositionsOMPTarget. Index "
-              << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection,

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -188,15 +188,20 @@ public:
               << resource_index << std::endl;
   }
 
-  void acquireResource(ResourceCollection& collection) override
+  void acquireResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DynamicCoordinates>& coords_list) const override
   {
     auto res_ptr = dynamic_cast<MultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("RealSpacePositionsOMPTarget::acquireResource dynamic_cast failed");
-    mw_mem_.reset(res_ptr);
+    coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+  void releaseResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DynamicCoordinates>& coords_list) const override
+  {
+    collection.takebackResource(std::move(coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_));
+  }
 
 private:
   ///particle positions in SoA layout

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -121,8 +121,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<DTAAMultiWalkerMem>());
-    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableAAOMPTarget " << name_
-              << ". Index " << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection,

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -255,7 +255,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
             PRAGMA_OFFLOAD("omp parallel for")
             for (int iel = first; iel < last; iel++)
-              DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iw_ptr, dr_iw_ptr, N_sources_local,
+              DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iw_ptr, dr_iw_ptr, N_sources_padded,
                                                             iel, activePtcl_local);
           }
 
@@ -266,11 +266,11 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
             T pos[D];
             for (int idim = 0; idim < D; idim++)
-              pos[idim] = source_pos_ptr[idim * N_sources_local + iat];
+              pos[idim] = source_pos_ptr[idim * N_sources_padded + iat];
 
             PRAGMA_OFFLOAD("omp parallel for")
             for (int iel = first; iel < last; iel++)
-              DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iw_ptr, dr_iw_ptr, N_sources_local,
+              DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iw_ptr, dr_iw_ptr, N_sources_padded,
                                                             iel, iat);
             r_iw_ptr[iat] = std::numeric_limits<T>::max(); //assign a big number
           }

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -125,15 +125,20 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
               << ". Index " << resource_index << std::endl;
   }
 
-  void acquireResource(ResourceCollection& collection) override
+  void acquireResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTAAMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SoaDistanceTableAAOMPTarget::acquireResource dynamic_cast failed");
-    mw_mem_.reset(res_ptr);
+    dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>().mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+  void releaseResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+  {
+    collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>().mw_mem_));
+  }
 
   inline void evaluate(ParticleSet& P) override
   {

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -225,9 +225,6 @@ public:
     }
   }
 
-  /** It has two implementation mw_evaluate_transfer_inplace and mw_evaluate_fuse_transfer with different D2H memory transfer schemes.
-   * Eventually, there will be only one version wihtout any transfer and solve the dilemma.
-   */
   inline void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
                           const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
@@ -245,17 +242,7 @@ public:
     }
 
     ScopedTimer local_timer(evaluate_timer_);
-    mw_evaluate_fuse_transfer(dt_list, p_list);
-  }
 
-  /** this function implements mw_evaluate.
-   * After offloading the computation of distances and displacements, the result for all the walkers is transferred back together in one shot
-   * and then copied to per-walker data structure. Memory copy on the CPU is still costly and not beneficial for large problem size with a few walkers.
-   */
-  void mw_evaluate_fuse_transfer(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                                 const RefVectorWithLeader<ParticleSet>& p_list) const
-  {
-    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
     const size_t nw = dt_list.size();
     auto& mw_mem    = *dt_leader.mw_mem_;
     auto& mw_r_dr   = mw_mem.mw_r_dr;

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -111,8 +111,6 @@ public:
   void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<DTABMultiWalkerMem>());
-    app_log() << "    Multi walker shared memory resource created in SoaDistanceTableABOMPTarget " << name_
-              << ". Index " << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection,

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -115,15 +115,20 @@ public:
               << ". Index " << resource_index << std::endl;
   }
 
-  void acquireResource(ResourceCollection& collection) override
+  void acquireResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTABMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SoaDistanceTableABOMPTarget::acquireResource dynamic_cast failed");
-    mw_mem_.reset(res_ptr);
+    dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+  void releaseResource(ResourceCollection& collection,
+                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+  {
+    collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_));
+  }
 
   /** evaluate the full table */
   inline void evaluate(ParticleSet& P) override

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -40,11 +40,9 @@ private:
   struct DTABMultiWalkerMem : public Resource
   {
     ///accelerator output array for multiple walkers, N_targets x N_sources_padded x (D+1) (distances, displacements)
-    OffloadPinnedVector<T> offload_output;
+    OffloadPinnedVector<T> mw_r_dr;
     ///accelerator input buffer for multiple data set
     OffloadPinnedVector<char> offload_input;
-    ///target particle id
-    std::vector<int> particle_id;
 
     DTABMultiWalkerMem() : Resource("DTABMultiWalkerMem") {}
 
@@ -55,32 +53,11 @@ private:
 
   std::unique_ptr<DTABMultiWalkerMem> mw_mem_;
 
-public:
-  SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
-      : DTD_BConds<T, D, SC>(source.Lattice),
-        DistanceTableData(source, target),
-        offload_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") + name_, timer_level_fine)),
-        copy_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::copy_") + name_, timer_level_fine)),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") + name_,
-                                                   timer_level_fine)),
-        move_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::move_") + name_, timer_level_fine)),
-        update_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::update_") + name_, timer_level_fine))
-
-  {
-    auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&source.getCoordinates());
-    if (!coordinates_soa)
-      throw std::runtime_error("Source particle set doesn't have OpenMP offload. Contact developers!");
-    resize();
-    PRAGMA_OFFLOAD("omp target enter data map(to : this[:1])")
-  }
-
   void resize()
   {
     if (N_sources * N_targets == 0)
+      return;
+    if (distances_.size())
       return;
 
     // initialize memory containers and views
@@ -96,9 +73,68 @@ public:
       displacements_[i].attachReference(N_sources, N_sources_padded,
                                         r_dr_memorypool_.data() + i * stride_size + N_sources_padded);
     }
+  }
+
+  static void associateResource(const RefVectorWithLeader<DistanceTableData>& dt_list)
+  {
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
+
+    // initialize memory containers and views
+    size_t count_targets = 0;
+    for (size_t iw = 0; iw < dt_list.size(); iw++)
+    {
+      auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
+      count_targets += dt.targets();
+    }
+
+    const int N_sources        = dt_leader.N_sources;
+    const int N_sources_padded = getAlignedSize<T>(dt_leader.N_sources);
+    const int stride_size      = N_sources_padded * (D + 1);
+    const size_t total_targets = count_targets;
+    auto& mw_r_dr              = dt_leader.mw_mem_->mw_r_dr;
+    mw_r_dr.resize(total_targets * stride_size);
+
+    count_targets = 0;
+    for (size_t iw = 0; iw < dt_list.size(); iw++)
+    {
+      auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
+      assert(N_sources == dt.N_sources);
+
+      dt.distances_.resize(dt.targets());
+      dt.displacements_.resize(dt.targets());
+
+      for (int i = 0; i < dt.targets(); ++i)
+      {
+        dt.distances_[i].attachReference(mw_r_dr.data() + (i + count_targets) * stride_size, N_sources);
+        dt.displacements_[i].attachReference(N_sources, N_sources_padded,
+                                          mw_r_dr.data() + (i + count_targets) * stride_size + N_sources_padded);
+      }
+      count_targets += dt.targets();
+    }
+  }
+
+public:
+  SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
+      : DTD_BConds<T, D, SC>(source.Lattice),
+        DistanceTableData(source, target),
+        offload_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") + name_, timer_level_fine)),
+        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") + name_,
+                                                   timer_level_fine)),
+        move_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::move_") + name_, timer_level_fine)),
+        update_timer_(
+            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::update_") + name_, timer_level_fine))
+
+  {
+    auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&source.getCoordinates());
+    if (!coordinates_soa)
+      throw std::runtime_error("Source particle set doesn't have OpenMP offload. Contact developers!");
+    PRAGMA_OFFLOAD("omp target enter data map(to : this[:1])")
 
     // The padding of temp_r_ and temp_dr_ is necessary for the memory copy in the update function
     // temp_r_ is padded explicitly while temp_dr_ is padded internally
+    const int N_sources_padded = getAlignedSize<T>(N_sources);
     temp_r_.resize(N_sources_padded);
     temp_dr_.resize(N_sources);
   }
@@ -119,18 +155,28 @@ public:
     auto res_ptr = dynamic_cast<DTABMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SoaDistanceTableABOMPTarget::acquireResource dynamic_cast failed");
-    dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_.reset(res_ptr);
+    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
+    dt_leader.mw_mem_.reset(res_ptr);
+    associateResource(dt_list);
   }
 
   void releaseResource(ResourceCollection& collection,
                        const RefVectorWithLeader<DistanceTableData>& dt_list) const override
   {
     collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_));
+    for (size_t iw = 0; iw < dt_list.size(); iw++)
+    {
+      auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
+      dt.distances_.clear();
+      dt.displacements_.clear();
+    }
   }
 
   /** evaluate the full table */
   inline void evaluate(ParticleSet& P) override
   {
+    resize();
+
     ScopedTimer local_timer(evaluate_timer_);
     // be aware of the sign of Displacement
     const int N_targets_local  = N_targets;
@@ -144,18 +190,20 @@ public:
 
     auto* target_pos_ptr = target_pos.data();
     auto* source_pos_ptr = Origin->getCoordinates().getAllParticlePos().data();
-    auto* r_dr_ptr       = r_dr_memorypool_.data();
+    auto* r_dr_ptr       = distances_[0].data();
+    assert(distances_[0].data() + N_sources_padded == displacements_[0].data());
 
     // To maximize thread usage, the loop over electrons is chunked. Each chunk is sent to an OpenMP offload thread team.
     const int ChunkSizePerTeam = 256;
     const int num_teams        = (N_sources + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
+    const size_t stride_size   = N_sources_padded * (D + 1);
 
     {
       ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(N_targets*num_teams) \
                         map(to: source_pos_ptr[:N_sources_padded*D]) \
                         map(always, to: target_pos_ptr[:N_targets*D]) \
-                        map(always, from: r_dr_ptr[:r_dr_memorypool_.size()])")
+                        map(always, from: r_dr_ptr[:N_targets*stride_size])")
       for (int iat = 0; iat < N_targets_local; ++iat)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {
@@ -166,7 +214,6 @@ public:
           for (int idim = 0; idim < D; idim++)
             pos[idim] = target_pos_ptr[iat * D + idim];
 
-          const size_t stride_size = N_sources_padded * (D + 1);
           auto* r_iat_ptr          = r_dr_ptr + iat * stride_size;
           auto* dr_iat_ptr         = r_iat_ptr + N_sources_padded;
 
@@ -194,113 +241,11 @@ public:
              "only unit tests (expected)."
           << std::endl;
       dt_leader.mw_mem_ = std::make_unique<DTABMultiWalkerMem>();
+      associateResource(dt_list);
     }
 
     ScopedTimer local_timer(evaluate_timer_);
     mw_evaluate_fuse_transfer(dt_list, p_list);
-  }
-
-  /** this function implements mw_evaluate.
-   * After offloading the computation of distances and displacements, the per-walker result is transferred back walker by walker in place.
-   * The runtime overhead is very high for small problem size with many walkers.
-   */
-  inline void mw_evaluate_transfer_inplace(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                                           const RefVectorWithLeader<ParticleSet>& p_list) const
-  {
-    auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
-    const size_t nw = dt_list.size();
-    auto& mw_mem    = *dt_leader.mw_mem_;
-
-    size_t count_targets = 0;
-    for (ParticleSet& p : p_list)
-      count_targets += p.getTotalNum();
-    const size_t total_targets = count_targets;
-
-    // This is horrible optimization putting different data types in a single buffer but allows a single H2D transfer
-    constexpr size_t realtype_size = sizeof(RealType);
-    constexpr size_t int_size      = sizeof(int);
-    constexpr size_t ptr_size      = sizeof(RealType*);
-    auto& offload_input            = mw_mem.offload_input;
-    offload_input.resize(total_targets * D * realtype_size + total_targets * int_size +
-                         (nw + total_targets) * ptr_size);
-    auto target_positions = reinterpret_cast<RealType*>(offload_input.data());
-    auto walker_id_ptr    = reinterpret_cast<int*>(offload_input.data() + total_targets * D * realtype_size);
-    auto source_ptrs      = reinterpret_cast<RealType**>(offload_input.data() + total_targets * D * realtype_size +
-                                                    total_targets * int_size);
-    auto output_ptrs      = reinterpret_cast<RealType**>(offload_input.data() + total_targets * D * realtype_size +
-                                                    total_targets * int_size + nw * ptr_size);
-
-    const int N_sources_padded = getAlignedSize<T>(N_sources);
-
-    count_targets = 0;
-    for (size_t iw = 0; iw < nw; iw++)
-    {
-      auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
-      ParticleSet& pset(p_list[iw]);
-
-      assert(N_sources == dt.N_sources);
-
-      auto& RSoA_OMPTarget = static_cast<const RealSpacePositionsOMPTarget&>(dt.Origin->getCoordinates());
-      source_ptrs[iw]      = const_cast<RealType*>(RSoA_OMPTarget.getDevicePtr());
-
-      for (size_t iat = 0; iat < pset.getTotalNum(); ++iat, ++count_targets)
-      {
-        for (size_t idim = 0; idim < D; idim++)
-          target_positions[count_targets * D + idim] = pset.R[iat][idim];
-
-        walker_id_ptr[count_targets] = iw;
-        output_ptrs[count_targets]   = dt.r_dr_memorypool_.device_data() + iat * N_sources_padded * (D + 1);
-      }
-    }
-
-    // To maximize thread usage, the loop over electrons is chunked. Each chunk is sent to an OpenMP offload thread team.
-    const int ChunkSizePerTeam = 256;
-    const int num_teams        = (N_sources + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
-
-    auto* input_ptr           = offload_input.data();
-    const int N_sources_local = N_sources;
-
-    {
-      ScopedTimer offload(dt_leader.offload_timer_);
-      PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(total_targets*num_teams) \
-                        map(always, to: input_ptr[:offload_input.size()]) \
-                        nowait depend(out: total_targets)")
-      for (int iat = 0; iat < total_targets; ++iat)
-        for (int team_id = 0; team_id < num_teams; team_id++)
-        {
-          auto* target_pos_ptr = reinterpret_cast<RealType*>(input_ptr);
-          const int walker_id  = reinterpret_cast<int*>(input_ptr + total_targets * D * realtype_size)[iat];
-          auto* source_pos_ptr = reinterpret_cast<RealType**>(input_ptr + total_targets * D * realtype_size +
-                                                              total_targets * int_size)[walker_id];
-          auto* r_iat_ptr      = reinterpret_cast<RealType**>(input_ptr + total_targets * D * realtype_size +
-                                                         total_targets * int_size + nw * ptr_size)[iat];
-          auto* dr_iat_ptr     = r_iat_ptr + N_sources_padded;
-
-          const int first = ChunkSizePerTeam * team_id;
-          const int last  = (first + ChunkSizePerTeam) > N_sources_local ? N_sources_local : first + ChunkSizePerTeam;
-
-          T pos[D];
-          for (int idim = 0; idim < D; idim++)
-            pos[idim] = target_pos_ptr[iat * D + idim];
-
-          PRAGMA_OFFLOAD("omp parallel for")
-          for (int iel = first; iel < last; iel++)
-            DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iat_ptr, dr_iat_ptr, N_sources_padded,
-                                                          iel);
-        }
-    }
-
-    {
-      ScopedTimer copy(dt_leader.copy_timer_);
-      for (size_t iw = 0; iw < nw; iw++)
-      {
-        auto& dt       = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
-        auto* pool_ptr = dt.r_dr_memorypool_.data();
-        PRAGMA_OFFLOAD(
-            "omp target update from(pool_ptr[:dt.r_dr_memorypool_.size()]) nowait depend(inout : total_targets)")
-      }
-      PRAGMA_OFFLOAD("omp taskwait")
-    }
   }
 
   /** this function implements mw_evaluate.
@@ -313,11 +258,30 @@ public:
     auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
     const size_t nw = dt_list.size();
     auto& mw_mem    = *dt_leader.mw_mem_;
+    auto& mw_r_dr   = mw_mem.mw_r_dr;
 
     size_t count_targets = 0;
     for (ParticleSet& p : p_list)
       count_targets += p.getTotalNum();
     const size_t total_targets = count_targets;
+
+    const int N_sources_padded = getAlignedSize<T>(N_sources);
+    const int stride_size      = N_sources_padded * (D + 1);
+
+#ifndef NDEBUG
+    count_targets = 0;
+    for (size_t iw = 0; iw < dt_list.size(); iw++)
+    {
+      auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
+
+      for (int i = 0; i < dt.targets(); ++i)
+      {
+        assert(dt.distances_[i].data() == mw_r_dr.data() + (i + count_targets) * stride_size);
+        assert(dt.displacements_[i].data() == mw_r_dr.data() + (i + count_targets) * stride_size + N_sources_padded);
+      }
+      count_targets += dt.targets();
+    }
+#endif
 
     // This is horrible optimization putting different data types in a single buffer but allows a single H2D transfer
     const size_t realtype_size = sizeof(RealType);
@@ -330,19 +294,13 @@ public:
     auto source_ptrs      = reinterpret_cast<RealType**>(offload_input.data() + total_targets * D * realtype_size +
                                                     total_targets * int_size);
 
-    auto& particle_id = mw_mem.particle_id;
-    particle_id.resize(total_targets);
-
-    const int N_sources_padded = getAlignedSize<T>(N_sources);
-    auto& offload_output       = mw_mem.offload_output;
-    offload_output.resize(total_targets * N_sources_padded * (D + 1));
-
     count_targets = 0;
     for (size_t iw = 0; iw < nw; iw++)
     {
       auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
       ParticleSet& pset(p_list[iw]);
 
+      assert(dt.targets() == pset.getTotalNum());
       assert(N_sources == dt.N_sources);
 
       auto& RSoA_OMPTarget = static_cast<const RealSpacePositionsOMPTarget&>(dt.Origin->getCoordinates());
@@ -350,11 +308,9 @@ public:
 
       for (size_t iat = 0; iat < pset.getTotalNum(); ++iat, ++count_targets)
       {
+        walker_id_ptr[count_targets] = iw;
         for (size_t idim = 0; idim < D; idim++)
           target_positions[count_targets * D + idim] = pset.R[iat][idim];
-
-        walker_id_ptr[count_targets] = iw;
-        particle_id[count_targets]   = iat;
       }
     }
 
@@ -362,7 +318,7 @@ public:
     const int ChunkSizePerTeam = 256;
     const int num_teams        = (N_sources + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
-    auto* r_dr_ptr            = offload_output.data();
+    auto* r_dr_ptr            = mw_r_dr.data();
     auto* input_ptr           = offload_input.data();
     const int N_sources_local = N_sources;
 
@@ -370,7 +326,7 @@ public:
       ScopedTimer offload(dt_leader.offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(total_targets*num_teams) \
                         map(always, to: input_ptr[:offload_input.size()]) \
-                        map(always, from: r_dr_ptr[:offload_output.size()])")
+                        map(always, from: r_dr_ptr[:mw_r_dr.size()])")
       for (int iat = 0; iat < total_targets; ++iat)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {
@@ -393,20 +349,6 @@ public:
             DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iat_ptr, dr_iat_ptr, N_sources_padded,
                                                           iel);
         }
-    }
-
-    {
-      ScopedTimer copy(dt_leader.copy_timer_);
-      for (size_t iat = 0; iat < total_targets; iat++)
-      {
-        const int wid = walker_id_ptr[iat];
-        const int pid = particle_id[iat];
-        auto& dt      = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(wid);
-        assert(N_sources_padded == dt.displacements_[pid].capacity());
-        auto offset = offload_output.data() + iat * N_sources_padded * (D + 1);
-        std::copy_n(offset, N_sources_padded, dt.distances_[pid].data());
-        std::copy_n(offset + N_sources_padded, N_sources_padded * D, dt.displacements_[pid].data());
-      }
     }
   }
 
@@ -507,8 +449,6 @@ public:
 private:
   /// timer for offload portion
   NewTimer& offload_timer_;
-  /// timer for copy portion
-  NewTimer& copy_timer_;
   /// timer for evaluate()
   NewTimer& evaluate_timer_;
   /// timer for move()

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -66,9 +66,19 @@ public:
                  int iat     = -1);
 
   static void mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
-                             const RefVector<const std::vector<PosType>>& deltaV_list,
-                             const RefVector<const NLPPJob<RealType>>& joblist,
-                             bool sphere);
+                           const RefVector<const std::vector<PosType>>& deltaV_list,
+                           const RefVector<const NLPPJob<RealType>>& joblist,
+                           bool sphere);
+
+  static RefVectorWithLeader<ParticleSet> RefVectorWithLeaderParticleSet(
+      const RefVectorWithLeader<VirtualParticleSet>& vp_list)
+  {
+    RefVectorWithLeader<ParticleSet> ref_list(vp_list.getLeader());
+    ref_list.reserve(ref_list.size());
+    for (VirtualParticleSet& vp : vp_list)
+      ref_list.push_back(vp);
+    return ref_list;
+  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -46,12 +46,6 @@ void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& 
   walker_hamiltonians_.push_back(hamiltonian);
 };
 
-void Crowd::loadWalkers()
-{
-  for (int i = 0; i < mcp_walkers_.size(); ++i)
-    walker_elecs_[i].get().loadWalker(mcp_walkers_[i], true);
-}
-
 void Crowd::setRNGForHamiltonian(RandomGenerator_t& rng)
 {
   for (QMCHamiltonian& ham : walker_hamiltonians_)

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -59,8 +59,6 @@ public:
   EstimatorManagerCrowd& get_estimator_manager_crowd() { return estimator_manager_crowd_; }
   void addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& twf, QMCHamiltonian& hamiltonian);
 
-  void loadWalkers();
-
   /** Clears all walker vectors
    *
    *  Unless you are _redistributing_ walkers to crowds don't

--- a/src/QMCDrivers/DriverWalkerTypes.h
+++ b/src/QMCDrivers/DriverWalkerTypes.h
@@ -24,7 +24,6 @@
 
 namespace qmcplusplus
 {
-
 /** DriverWalker multi walker resource collections
  * It currently supports VMC and DMC only
  */
@@ -43,30 +42,15 @@ struct DriverWalkerResourceCollection
 class DriverWalkerResourceCollectionLock
 {
 public:
-  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& driverwalker_res, ParticleSet& pset, TrialWaveFunction& twf, QMCHamiltonian& ham)
-      : pset_res_lock_(driverwalker_res.pset_res, pset), twf_res_lock_(driverwalker_res.twf_res, twf), ham_res_lock_(driverwalker_res.ham_res, ham)
+  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& driverwalker_res,
+                                     TrialWaveFunction& twf,
+                                     QMCHamiltonian& ham)
+      : twf_res_lock_(driverwalker_res.twf_res, twf), ham_res_lock_(driverwalker_res.ham_res, ham)
   {}
 
 private:
-  ResourceCollectionLock<ParticleSet> pset_res_lock_;
   ResourceCollectionLock<TrialWaveFunction> twf_res_lock_;
   ResourceCollectionLock<QMCHamiltonian> ham_res_lock_;
-};
-
-/** DriverWalkerResourceCollection locks
- * Helper class for acquiring and releasing multi walker resources.
- * Only ParticleSet and TrialWaveFunction resources are engaged.
- */
-class DriverWalkerResourceCollection_PsetTWF_Lock
-{
-public:
-  DriverWalkerResourceCollection_PsetTWF_Lock(DriverWalkerResourceCollection& driverwalker_res, ParticleSet& pset, TrialWaveFunction& twf)
-      : pset_res_lock_(driverwalker_res.pset_res, pset), twf_res_lock_(driverwalker_res.twf_res, twf)
-  {}
-
-private:
-  ResourceCollectionLock<ParticleSet> pset_res_lock_;
-  ResourceCollectionLock<TrialWaveFunction> twf_res_lock_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -318,13 +318,14 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
 
   auto& walkers = crowd.get_walkers();
-  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                            crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
+  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
+                                               crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                 crowd.get_walker_hamiltonians());
 
+  ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
   crowd.loadWalkers();
   ps_dispatcher.flex_update(walker_elecs);
   twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -326,7 +326,8 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
                                                                 crowd.get_walker_hamiltonians());
 
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
-  crowd.loadWalkers();
+
+  ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
   ps_dispatcher.flex_update(walker_elecs);
   twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -40,17 +40,20 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
                                 ContextForSteps& step_context,
                                 bool recompute)
 {
-  if (crowd.size() == 0) return;
+  if (crowd.size() == 0)
+    return;
   assert(QMCDriverNew::checkLogAndGL(crowd));
 
   auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
   auto& walkers        = crowd.get_walkers();
-  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_elecs()[0],
-                                            crowd.get_walker_twfs()[0], crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
+
+  ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
+  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
+                                               crowd.get_walker_hamiltonians()[0]);
 
   timers.movepbyp_timer.start();
   const int num_walkers = crowd.size();

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -42,8 +42,6 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
 {
   if (crowd.size() == 0)
     return;
-  assert(QMCDriverNew::checkLogAndGL(crowd));
-
   auto& ps_dispatcher  = crowd.dispatchers_.ps_dispatcher_;
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
@@ -54,6 +52,8 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
   DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
                                                crowd.get_walker_hamiltonians()[0]);
+
+  assert(QMCDriverNew::checkLogAndGL(crowd));
 
   timers.movepbyp_timer.start();
   const int num_walkers = crowd.size();

--- a/src/QMCDrivers/tests/test_Crowd.cpp
+++ b/src/QMCDrivers/tests/test_Crowd.cpp
@@ -86,27 +86,6 @@ TEST_CASE("Crowd integration", "[drivers]")
   Crowd crowd(em, driverwalker_resource_collection_, dispatchers);
 }
 
-TEST_CASE("Crowd::loadWalkers", "[particle]")
-{
-  using namespace testing;
-  SetupPools pools;
-
-  CrowdWithWalkers crowd_with_walkers(pools);
-  Crowd& crowd = crowd_with_walkers.get_crowd();
-
-  std::vector<std::pair<int, int>> particle_group_indexes{{0, 1}, {1, 2}};
-
-  RandomGenerator_t random_gen;
-
-  crowd.loadWalkers();
-
-  auto checkParticleSetPos = [&crowd_with_walkers](int iw) {
-    REQUIRE(crowd_with_walkers.psets[iw]->R[0] == crowd_with_walkers.tpos[iw]);
-  };
-  for (int i = 0; i < crowd.size(); ++i)
-    checkParticleSetPos(i);
-}
-
 TEST_CASE("Crowd redistribute walkers")
 {
   using namespace testing;

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -218,7 +218,8 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
         psiratios_list.push_back(component.psiratio);
       }
 
-      ResourceCollectionLock<VirtualParticleSet> vp_res_lock(collection, *ecp_component_leader.VP);
+      auto vp_to_p_list = VirtualParticleSet::RefVectorWithLeaderParticleSet(vp_list);
+      ResourceCollectionTeamLock<ParticleSet> vp_res_lock(collection, vp_to_p_list);
 
       VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -30,24 +30,6 @@ NonLocalECPComponent::~NonLocalECPComponent()
     delete VP;
 }
 
-void NonLocalECPComponent::createResource(ResourceCollection& collection) const
-{
-  if (VP)
-    VP->createResource(collection);
-}
-
-void NonLocalECPComponent::acquireResource(ResourceCollection& collection)
-{
-  if (VP)
-    VP->acquireResource(collection);
-}
-
-void NonLocalECPComponent::releaseResource(ResourceCollection& collection)
-{
-  if (VP)
-    VP->releaseResource(collection);
-}
-
 NonLocalECPComponent* NonLocalECPComponent::makeClone(const ParticleSet& qp)
 {
   NonLocalECPComponent* myclone = new NonLocalECPComponent(*this);
@@ -205,6 +187,7 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
                                           const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                                           const RefVector<const NLPPJob<RealType>>& joblist,
                                           std::vector<RealType>& pairpots,
+                                          ResourceCollection& collection,
                                           bool use_DLA)
 {
   if (ecp_component_list.size() > 1)
@@ -234,6 +217,8 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
         deltaV_list.push_back(component.deltaV);
         psiratios_list.push_back(component.psiratio);
       }
+
+      ResourceCollectionLock<VirtualParticleSet> vp_res_lock(collection, *ecp_component_leader.VP);
 
       VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -17,12 +17,13 @@
 #ifndef QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
 #define QMCPLUSPLUS_NONLOCAL_ECPOTENTIAL_COMPONENT_H
 #include "QMCHamiltonians/OperatorBase.h"
-#include "QMCHamiltonians/NLPPJob.h"
-#include "QMCWaveFunctions/TrialWaveFunction.h"
+#include <ResourceCollection.h>
+#include <TrialWaveFunction.h>
 #include "Numerics/OneDimGridBase.h"
 #include "Numerics/OneDimGridFunctor.h"
 #include "Numerics/OneDimLinearSpline.h"
 #include "Numerics/OneDimCubicSpline.h"
+#include "NLPPJob.h"
 
 namespace qmcplusplus
 {
@@ -115,18 +116,6 @@ public:
   ///destructor
   ~NonLocalECPComponent();
 
-  /** initialize a shared resource and hand it to a collection
-   */
-  void createResource(ResourceCollection& collection) const;
-
-  /** acquire a shared resource from a collection
-   */
-  void acquireResource(ResourceCollection& collection);
-
-  /** return a shared resource to a collection
-   */
-  void releaseResource(ResourceCollection& collection);
-
   NonLocalECPComponent* makeClone(const ParticleSet& qp);
 
   ///add a new Non Local component
@@ -190,6 +179,7 @@ public:
                              const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
+                                          ResourceCollection& collection,
                              bool use_DLA);
 
   /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid
@@ -258,6 +248,7 @@ public:
   inline int getNknot() const { return nknot; }
   inline void setLmax(int Lmax) { lmax = Lmax; }
   inline int getLmax() const { return lmax; }
+  const VirtualParticleSet* getVP() const { return VP; };
 
   // copy sgridxyz_m to rrotsgrid_m without rotation. For testing only.
   friend void copyGridUnrotatedForTest(NonLocalECPComponent& nlpp);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -74,6 +74,8 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
   }
 }
 
+NonLocalECPotential::~NonLocalECPotential() = default;
+
 #if !defined(REMOVE_TRACEMANAGER)
 void NonLocalECPotential::contribute_particle_quantities() { request.contribute_array(myName); }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -14,14 +14,24 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Particle/DistanceTableData.h"
 #include "NonLocalECPotential.h"
-#include "QMCHamiltonians/NonLocalECPComponent.h"
-#include "QMCHamiltonians/NLPPJob.h"
-#include "Utilities/IteratorUtility.h"
+#include <DistanceTableData.h>
+#include <IteratorUtility.h>
+#include <ResourceCollection.h>
+#include "NonLocalECPComponent.h"
+#include "NLPPJob.h"
 
 namespace qmcplusplus
 {
+struct NonLocalECPotentialMultiWalkerResource : public Resource
+{
+  NonLocalECPotentialMultiWalkerResource() : Resource("NonLocalECPotential"), collection("NLPPcollection") {}
+
+  Resource* makeClone() const override { return new NonLocalECPotentialMultiWalkerResource(*this); }
+
+  ResourceCollection collection;
+};
+
 void NonLocalECPotential::resetTargetParticleSet(ParticleSet& P) {}
 
 /** constructor
@@ -288,6 +298,21 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     O.Value = 0.0;
   }
 
+  // make this class unit tests friendly without the need of setup resources.
+  if (!O_leader.mw_res_)
+  {
+    app_warning() << "NonLocalECPotential: This message should not be seen in production (performance bug) runs "
+                     "but only unit tests (expected)."
+                  << std::endl;
+    O_leader.mw_res_ = std::make_unique<NonLocalECPotentialMultiWalkerResource>();
+    for (int ig = 0; ig < O_leader.PPset.size(); ++ig)
+    if (O_leader.PPset[ig]->getVP())
+    {
+      O_leader.PPset[ig]->getVP()->createResource(O_leader.mw_res_->collection);
+      break;
+    }
+  }
+
   auto pp_component = std::find_if(O_leader.PPset.begin(), O_leader.PPset.end(), [](auto& ptr) { return bool(ptr); });
   assert(pp_component != std::end(O_leader.PPset));
 
@@ -336,7 +361,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       }
 
       NonLocalECPComponent::mw_evaluateOne(ecp_component_list, pset_list, psi_list, batch_list, pairpots,
-                                           O_leader.use_DLA);
+                                           O_leader.mw_res_->collection, O_leader.use_DLA);
 
       for (size_t j = 0; j < ecp_potential_list.size(); j++)
       {
@@ -571,23 +596,29 @@ void NonLocalECPotential::addComponent(int groupID, std::unique_ptr<NonLocalECPC
 
 void NonLocalECPotential::createResource(ResourceCollection& collection) const
 {
+  auto new_res = std::make_unique<NonLocalECPotentialMultiWalkerResource>();
   for (int ig = 0; ig < PPset.size(); ++ig)
-    if (PPset[ig])
-      PPset[ig]->createResource(collection);
+    if (PPset[ig]->getVP())
+    {
+      PPset[ig]->getVP()->createResource(new_res->collection);
+      break;
+    }
+  auto resource_index = collection.addResource(std::move(new_res));
+  app_log() << "    Multi walker shared memory resource created in NonLocalECPotential. Index " << resource_index
+            << std::endl;
 }
 
 void NonLocalECPotential::acquireResource(ResourceCollection& collection)
 {
-  for (int ig = 0; ig < PPset.size(); ++ig)
-    if (PPset[ig])
-      PPset[ig]->acquireResource(collection);
+  auto res_ptr = dynamic_cast<NonLocalECPotentialMultiWalkerResource*>(collection.lendResource().release());
+  if (!res_ptr)
+    throw std::runtime_error("NonLocalECPotential::acquireResource dynamic_cast failed");
+  mw_res_.reset(res_ptr);
 }
 
 void NonLocalECPotential::releaseResource(ResourceCollection& collection)
 {
-  for (int ig = 0; ig < PPset.size(); ++ig)
-    if (PPset[ig])
-      PPset[ig]->releaseResource(collection);
+  collection.takebackResource(std::move(mw_res_));
 }
 
 OperatorBase* NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -604,8 +604,6 @@ void NonLocalECPotential::createResource(ResourceCollection& collection) const
       break;
     }
   auto resource_index = collection.addResource(std::move(new_res));
-  app_log() << "    Multi walker shared memory resource created in NonLocalECPotential. Index " << resource_index
-            << std::endl;
 }
 
 void NonLocalECPotential::acquireResource(ResourceCollection& collection)

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -26,6 +26,8 @@ namespace qmcplusplus
 template<typename T>
 struct NLPPJob;
 
+struct NonLocalECPotentialMultiWalkerResource;
+
 /** @ingroup hamiltonian
  * \brief Evaluate the semi local potentials
  */
@@ -161,6 +163,8 @@ private:
 #endif
   ///NLPP job list of ion-electron pairs by spin group
   std::vector<std::vector<NLPPJob<RealType>>> nlpp_jobs;
+  /// mult walker shared resource
+  std::unique_ptr<NonLocalECPotentialMultiWalkerResource> mw_res_;
 
   /** the actual implementation, used by evaluate and evaluateWithToperator
    * @param P particle set

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -35,6 +35,7 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
 {
 public:
   NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool computeForces, bool enable_DLA);
+  ~NonLocalECPotential();
 
   void resetTargetParticleSet(ParticleSet& P) override;
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -142,8 +142,6 @@ public:
   void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>());
-    app_log() << "    Multi walker shared memory resource created in SplineC2COMPTarget. Index " << resource_index
-              << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -146,8 +146,6 @@ public:
   void createResource(ResourceCollection& collection) const override
   {
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
-    app_log() << "    Multi walker shared memory resource created in SplineC2ROMPTarget. Index " << resource_index
-              << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection) override

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -926,7 +926,6 @@ template<typename DET_ENGINE_TYPE>
 void DiracDeterminantBatched<DET_ENGINE_TYPE>::createResource(ResourceCollection& collection) const
 {
   auto resource_index = collection.addResource(std::make_unique<DiracDeterminantBatchedMultiWalkerResource>());
-  app_log() << "    Shared resource created in DiracDeterminantBatched. Index " << resource_index << std::endl;
   Phi->createResource(collection);
   det_engine_.createResource(collection);
 }

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -332,7 +332,6 @@ public:
   void createResource(ResourceCollection& collection) const
   {
     auto resource_index = collection.addResource(std::make_unique<CUDALinearAlgebraHandles>());
-    app_log() << "    Shared resource created in MatrixDelayedUpdateCUDA. Index " << resource_index << std::endl;
   }
 
   void acquireResource(ResourceCollection& collection)

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -11,6 +11,7 @@
 
 #include "ResourceCollection.h"
 #include <iostream>
+#include <Host/OutputManager.h>
 
 namespace qmcplusplus
 {
@@ -19,7 +20,7 @@ ResourceCollection::ResourceCollection(const std::string& name) : name_(name), c
 ResourceCollection::ResourceCollection(const ResourceCollection& ref) : name_(ref.getName()), cursor_index_(0)
 {
   for (auto& res : ref.collection_)
-    addResource(std::unique_ptr<Resource>(res->makeClone()));
+    addResource(std::unique_ptr<Resource>(res->makeClone()), true);
 }
 
 void ResourceCollection::printResources() const
@@ -32,10 +33,13 @@ void ResourceCollection::printResources() const
   std::cout << "-------------------------------" << std::endl << std::endl;
 }
 
-size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res)
+size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res, bool noprint)
 {
-  size_t index = collection_.size();
+  size_t index              = collection_.size();
   res->index_in_collection_ = index;
+  if (!noprint)
+    app_log() << "Multi walker shared resource \"" << res->getName() << "\" created in resource collection \"" << name_
+              << "\" index " << index << std::endl;
   collection_.emplace_back(std::move(res));
   return index;
 }
@@ -45,7 +49,8 @@ std::unique_ptr<Resource> ResourceCollection::lendResource()
   if (cursor_index_ >= collection_.size())
     throw std::runtime_error("ResourceCollection::lendResource BUG no more resource to lend.");
   if (cursor_index_ != collection_[cursor_index_]->index_in_collection_)
-    throw std::runtime_error("ResourceCollection::lendResource BUG mismatched cursor index and recorded index in the resource.");
+    throw std::runtime_error(
+        "ResourceCollection::lendResource BUG mismatched cursor index and recorded index in the resource.");
   return std::move(collection_[cursor_index_++]);
 }
 
@@ -54,7 +59,8 @@ void ResourceCollection::takebackResource(std::unique_ptr<Resource>&& res)
   if (cursor_index_ >= collection_.size())
     throw std::runtime_error("ResourceCollection::takebackResource BUG cannot take back resources more than owned.");
   if (cursor_index_ != res->index_in_collection_)
-    throw std::runtime_error("ResourceCollection::takebackResource BUG mismatched cursor index and recorded index in the resource.");
+    throw std::runtime_error(
+        "ResourceCollection::takebackResource BUG mismatched cursor index and recorded index in the resource.");
   collection_[cursor_index_++] = std::move(res);
 }
 

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -30,7 +30,7 @@ public:
   size_t size() const { return collection_.size(); }
   void printResources() const;
 
-  size_t addResource(std::unique_ptr<Resource>&& res);
+  size_t addResource(std::unique_ptr<Resource>&& res, bool noprint = false);
   std::unique_ptr<Resource> lendResource();
   void takebackResource(std::unique_ptr<Resource>&& res);
 

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <vector>
 #include "Resource.h"
+#include "type_traits/RefVectorWithLeader.h"
 
 namespace qmcplusplus
 {
@@ -72,6 +73,42 @@ public:
 private:
   ResourceCollection& resource;
   CONSUMER& consumer;
+  const size_t cursor_begin_;
+  const bool active;
+};
+
+
+template<class CONSUMER>
+class ResourceCollectionTeamLock
+{
+public:
+  ResourceCollectionTeamLock(ResourceCollection& res_ref,
+                             const RefVectorWithLeader<CONSUMER>& consumer_ref,
+                             size_t cursor = 0)
+      : resource(res_ref), consumer(consumer_ref), cursor_begin_(cursor), active(!res_ref.empty())
+  {
+    if (active)
+    {
+      resource.rewind(cursor_begin_);
+      consumer.getLeader().acquireResource(resource, consumer);
+    }
+  }
+
+  ~ResourceCollectionTeamLock()
+  {
+    if (active)
+    {
+      resource.rewind(cursor_begin_);
+      consumer.getLeader().releaseResource(resource, consumer);
+    }
+  }
+
+  ResourceCollectionTeamLock(const ResourceCollectionTeamLock&) = delete;
+  ResourceCollectionTeamLock(ResourceCollectionTeamLock&&)      = delete;
+
+private:
+  ResourceCollection& resource;
+  const RefVectorWithLeader<CONSUMER>& consumer;
   const size_t cursor_begin_;
   const bool active;
 };


### PR DESCRIPTION
## Proposed changes
multi walker shared resources are assigned not to the leader of a crowd but a crowd with a leader. Memory views are set up and clean up when such assignment/release happens. This allows the distance table offload better optimized. 

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server, summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
