### PR TITLE
Adjust recompute at the begining of a DMC step

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -178,6 +178,21 @@ public:
       dt_list[iw].evaluate(p_list[iw]);
   }
 
+  /** recompute multi walker internal data, recompute
+   * @param dt_list the distance table batch
+   * @param p_list the target particle set batch
+   * @param recompute if true, must recompute. Otherwise, implementation dependent.
+   */
+  virtual void mw_recompute(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            const std::vector<bool>& recompute) const
+  {
+#pragma omp parallel for
+    for (int iw = 0; iw < dt_list.size(); iw++)
+      if (recompute[iw])
+        dt_list[iw].evaluate(p_list[iw]);
+  }
+
   /** evaluate the temporary pair relations when a move is proposed
    * @param P the target particle set
    * @param rnew proposed new position

--- a/src/Particle/PSdispatcher.cpp
+++ b/src/Particle/PSdispatcher.cpp
@@ -18,13 +18,15 @@ PSdispatcher::PSdispatcher(bool use_batch) : use_batch_(use_batch) {}
 
 void PSdispatcher::flex_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
                                    const RefVector<Walker_t>& walkers,
+                                   const std::vector<bool>& recompute,
                                    bool pbyp) const
 {
   if (use_batch_)
-    ParticleSet::mw_loadWalker(p_list, walkers, pbyp);
+    ParticleSet::mw_loadWalker(p_list, walkers, recompute, pbyp);
   else
     for (size_t iw = 0; iw < p_list.size(); iw++)
-      p_list[iw].loadWalker(walkers[iw], pbyp);
+      if (recompute[iw])
+        p_list[iw].loadWalker(walkers[iw], pbyp);
 }
 
 void PSdispatcher::flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK) const

--- a/src/Particle/PSdispatcher.h
+++ b/src/Particle/PSdispatcher.h
@@ -31,6 +31,7 @@ public:
 
   void flex_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
                        const RefVector<Walker_t>& walkers,
+                       const std::vector<bool>& recompute,
                        bool pbyp) const;
 
   void flex_update(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false) const;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -46,6 +46,7 @@ enum PSetTimers
   PS_newpos,
   PS_donePbyP,
   PS_accept,
+  PS_loadWalker,
   PS_update,
   PS_dt_move,
   PS_mw_copy
@@ -56,6 +57,7 @@ static const TimerNameList_t<PSetTimers> generatePSetTimerNames(std::string& obj
   return {{PS_newpos, "ParticleSet:" + obj_name + "::computeNewPosDT"},
           {PS_donePbyP, "ParticleSet:" + obj_name + "::donePbyP"},
           {PS_accept, "ParticleSet:" + obj_name + "::acceptMove"},
+          {PS_loadWalker, "ParticleSet:" + obj_name + "::loadWalker"},
           {PS_update, "ParticleSet:" + obj_name + "::update"},
           {PS_dt_move, "ParticleSet:" + obj_name + "::dt_move"},
           {PS_mw_copy, "ParticleSet:" + obj_name + "::mw_copy"}};
@@ -786,6 +788,7 @@ void ParticleSet::makeVirtualMoves(const SingleParticlePos_t& newpos)
 
 void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
 {
+  ScopedTimer update_scope(myTimers[PS_loadWalker]);
   R     = awalker.R;
   spins = awalker.spins;
   coordinates_->setAllParticlePos(R);
@@ -795,8 +798,6 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
 #endif
   if (pbyp)
   {
-    ScopedTimer update_scope(myTimers[PS_update]);
-
     // in certain cases, full tables must be ready
     for (int i = 0; i < DistTables.size(); i++)
       if (DistTables[i]->getFullTableNeeds())
@@ -809,18 +810,40 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
   activePtcl = -1;
 }
 
-void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
+void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
                                 const RefVector<Walker_t>& walkers,
+                                const std::vector<bool>& recompute,
                                 bool pbyp)
 {
+  auto& p_leader = p_list.getLeader();
+  ScopedTimer load_scope(p_leader.myTimers[PS_loadWalker]);
+
   auto loadWalkerConfig = [](ParticleSet& pset, Walker_t& awalker) {
     pset.R     = awalker.R;
     pset.spins = awalker.spins;
     pset.coordinates_->setAllParticlePos(pset.R);
   };
 #pragma omp parallel for
-  for (int iw = 0; iw < psets.size(); ++iw)
-    loadWalkerConfig(psets[iw], walkers[iw]);
+  for (int iw = 0; iw < p_list.size(); ++iw)
+    if (recompute[iw])
+      loadWalkerConfig(p_list[iw], walkers[iw]);
+
+  if (pbyp)
+  {
+    auto& dts = p_leader.DistTables;
+    for (int i = 0; i < dts.size(); ++i)
+    {
+      const auto dt_list(extractDTRefList(p_list, i));
+      dts[i]->mw_recompute(dt_list, p_list, recompute);
+    }
+
+    if (p_leader.SK && p_leader.SK->DoUpdate)
+    {
+#pragma omp parallel for
+      for (int iw = 0; iw < p_list.size(); iw++)
+        p_list[iw].SK->UpdateAllPart(p_list[iw]);
+    }
+  }
 }
 
 void ParticleSet::saveWalker(Walker_t& awalker)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -418,8 +418,9 @@ public:
    */
   void loadWalker(Walker_t& awalker, bool pbyp);
   /** batched version of loadWalker */
-  static void mw_loadWalker(const RefVectorWithLeader<ParticleSet>& psets,
+  static void mw_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
                             const RefVector<Walker_t>& walkers,
+                            const std::vector<bool>& recompute,
                             bool pbyp);
 
   /** save this to awalker

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -642,12 +642,12 @@ public:
 
   /// initialize a shared resource and hand it to a collection
   void createResource(ResourceCollection& collection) const;
-  /** acquire external resource
-   * Note: use RAII ResourceCollectionLock whenever possible
+  /** acquire external resource and assocaite it with the list of ParticleSet
+   * Note: use RAII ResourceCollectionTeamLock whenever possible
    */
   static void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
   /** release external resource
-   * Note: use RAII ResourceCollectionLock whenever possible
+   * Note: use RAII ResourceCollectionTeamLock whenever possible
    */
   static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
 

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -156,7 +156,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   std::string role("none");
   std::string randomR("no");
   std::string randomsrc;
-  std::string useGPU("no");
+  std::string useGPU;
   OhmmsAttributeSet pAttrib;
   pAttrib.add(id, "id");
   pAttrib.add(id, "name");
@@ -165,7 +165,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   pAttrib.add(randomsrc, "randomsrc");
   pAttrib.add(randomsrc, "random_source");
 #if defined(ENABLE_OFFLOAD)
-  pAttrib.add(useGPU, "gpu");
+  pAttrib.add(useGPU, "gpu", {"yes", "no"});
 #endif
   pAttrib.put(cur);
   //backward compatibility
@@ -177,7 +177,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
     app_summary() << std::endl;
     app_summary() << " Particle Set" << std::endl;
     app_summary() << " ------------" << std::endl;
-    app_summary() << "  Name: " << id << "  Offload : " << useGPU << std::endl;
+    app_summary() << "  Name: " << id << "   Offload : " << useGPU << std::endl;
     app_summary() << std::endl;
 
     // select OpenMP offload implementation in ParticleSet.

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -339,6 +339,13 @@ public:
     }
   }
 
+  inline void mw_recompute(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list,
+                           const std::vector<bool>& recompute) const override
+  {
+    mw_evaluate(dt_list, p_list);
+  }
+
   ///evaluate the temporary pair relations
   inline void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old) override
   {

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -86,8 +86,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     {
       ScopedTimer recompute_timer(dmc_timers.step_begin_recompute_timer);
-      ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
-      ps_dispatcher.flex_update(walker_elecs, true);
       std::vector<bool> recompute_mask;
       recompute_mask.reserve(walkers.size());
       for (MCPWalker& awalker : walkers)
@@ -98,6 +96,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
         }
         else
           recompute_mask.push_back(false);
+      ps_dispatcher.flex_loadWalker(walker_elecs, walkers, recompute_mask, true);
       twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
     }
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -327,8 +327,9 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
 
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
 
-  ps_dispatcher.flex_loadWalker(walker_elecs, walkers, true);
-  ps_dispatcher.flex_update(walker_elecs);
+  std::vector<bool> recompute_mask(walkers.size(), true);
+  ps_dispatcher.flex_loadWalker(walker_elecs, walkers, recompute_mask, true);
+  ps_dispatcher.flex_donePbyP(walker_elecs);
   twf_dispatcher.flex_evaluateLog(walker_twfs, walker_elecs);
 
   // For consistency this should be in ParticleSet as a flex call, but I think its a problem

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -179,7 +179,7 @@ public:
                              const RefVectorWithLeader<TrialWaveFunction>& psi_list,
                              const RefVector<const NLPPJob<RealType>>& joblist,
                              std::vector<RealType>& pairpots,
-                                          ResourceCollection& collection,
+                             ResourceCollection& collection,
                              bool use_DLA);
 
   /** @brief Evaluate the nonlocal pp contribution via randomized quadrature grid

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -864,20 +864,27 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVectorWithL
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE_TYPE>>();
   const auto nw    = wfc_list.size();
-  {
-    ScopedTimer spo_timer(wfc_leader.SPOVGLTimer);
 
-    RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
-    RefVector<ValueMatrix_t> psiM_temp_list;
-    RefVector<GradMatrix_t> dpsiM_list;
-    RefVector<ValueMatrix_t> d2psiM_list;
-    phi_list.reserve(wfc_list.size());
-    psiM_temp_list.reserve(nw);
-    dpsiM_list.reserve(nw);
-    d2psiM_list.reserve(nw);
+  RefVectorWithLeader<WaveFunctionComponent> wfc_filtered_list(wfc_list.getLeader());
+  RefVectorWithLeader<ParticleSet> p_filtered_list(p_list.getLeader());
+  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  RefVector<ValueMatrix_t> psiM_temp_list;
+  RefVector<GradMatrix_t> dpsiM_list;
+  RefVector<ValueMatrix_t> d2psiM_list;
 
-    for (int iw = 0; iw < nw; iw++)
+  wfc_filtered_list.reserve(nw);
+  p_filtered_list.reserve(nw);
+  phi_list.reserve(nw);
+  psiM_temp_list.reserve(nw);
+  dpsiM_list.reserve(nw);
+  d2psiM_list.reserve(nw);
+
+  for (int iw = 0; iw < nw; iw++)
+    if (recompute[iw])
     {
+      wfc_filtered_list.push_back(wfc_list[iw]);
+      p_filtered_list.push_back(p_list[iw]);
+
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE_TYPE>>(iw);
       phi_list.push_back(*det.Phi);
       psiM_temp_list.push_back(det.psiM_temp);
@@ -885,23 +892,30 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_recompute(const RefVectorWithL
       d2psiM_list.push_back(det.d2psiM);
     }
 
-    wfc_leader.Phi->mw_evaluate_notranspose(phi_list, p_list, wfc_leader.FirstIndex, wfc_leader.LastIndex,
+  if (!wfc_filtered_list.size())
+    return;
+
+  {
+    ScopedTimer spo_timer(wfc_leader.SPOVGLTimer);
+    wfc_leader.Phi->mw_evaluate_notranspose(phi_list, p_filtered_list, wfc_leader.FirstIndex, wfc_leader.LastIndex,
                                             psiM_temp_list, dpsiM_list, d2psiM_list);
   }
 
-  RefVector<const ValueMatrix_t> psiM_temp_list;
-  psiM_temp_list.reserve(nw);
+  { // transfer dpsiM, d2psiM, psiMinv to device
+    ScopedTimer d2h(H2DTimer);
 
-  for (int iw = 0; iw < nw; iw++)
-  {
-    auto& det          = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE_TYPE>>(iw);
-    auto* psiM_vgl_ptr = det.psiM_vgl.data();
-    size_t stride      = wfc_leader.psiM_vgl.capacity();
-    PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[stride:stride*4]) nowait")
-    psiM_temp_list.push_back(det.psiM_temp);
+    RefVector<const ValueMatrix_t> const_psiM_temp_list;
+    for (int iw = 0; iw < wfc_filtered_list.size(); iw++)
+    {
+      auto& det          = wfc_filtered_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE_TYPE>>(iw);
+      auto* psiM_vgl_ptr = det.psiM_vgl.data();
+      size_t stride      = wfc_leader.psiM_vgl.capacity();
+      PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[stride:stride*4]) nowait")
+      const_psiM_temp_list.push_back(det.psiM_temp);
+    }
+    mw_invertPsiM(wfc_filtered_list, const_psiM_temp_list);
+    PRAGMA_OFFLOAD("omp taskwait")
   }
-  mw_invertPsiM(wfc_list, psiM_temp_list);
-  PRAGMA_OFFLOAD("omp taskwait")
 }
 
 template<typename DET_ENGINE_TYPE>

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -44,6 +44,8 @@ private:
   std::vector<std::unique_ptr<Resource>> collection_;
 };
 
+/** handles acquire/release resource by the consumer.
+ */
 template<class CONSUMER>
 class ResourceCollectionLock
 {
@@ -78,6 +80,8 @@ private:
 };
 
 
+/** handles acquire/release resource by the consumer (RefVectorWithLeader type).
+ */
 template<class CONSUMER>
 class ResourceCollectionTeamLock
 {


### PR DESCRIPTION
Review after #3015

## Proposed changes
1. Add recompute mask to loadWalker to reduce recompute impact.
2. Take advantage of mask in mw_recompute in DiracDeterminantBatch
3. turn on distance table offload by default.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server, Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'