### PR TITLE
Use multi walker memory shared resource in determinant update engines and remove 1 walker code path in NLPP

### DIFF
--- a/src/Platforms/OMPTarget/OMPallocator.hpp
+++ b/src/Platforms/OMPTarget/OMPallocator.hpp
@@ -11,8 +11,8 @@
 // -*- C++ -*-
 /** @file OMPallocator.hpp
  */
-#ifndef QMCPLUSPLUS_OPENMP_ALLOCATOR_H
-#define QMCPLUSPLUS_OPENMP_ALLOCATOR_H
+#ifndef QMCPLUSPLUS_OMPTARGET_ALLOCATOR_H
+#define QMCPLUSPLUS_OMPTARGET_ALLOCATOR_H
 
 #include <memory>
 #include <type_traits>

--- a/src/Platforms/OMPTarget/OffloadAlignedAllocators.hpp
+++ b/src/Platforms/OMPTarget/OffloadAlignedAllocators.hpp
@@ -1,0 +1,28 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2011 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_OMPTARGET_ALIGNED_ALLOCATOR_H
+#define QMCPLUSPLUS_OMPTARGET_ALIGNED_ALLOCATOR_H
+
+#include <CPU/SIMD/aligned_allocator.hpp>
+#include "OMPallocator.hpp"
+#include "PinnedAllocator.h"
+
+namespace qmcplusplus
+{
+  template<typename T>
+  using OffloadAllocator = OMPallocator<T, aligned_allocator<T>>;
+  template<typename T>
+  using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
+} // namespace qmcplusplus
+
+#endif

--- a/src/Platforms/OMPTarget/OffloadAlignedAllocators.hpp
+++ b/src/Platforms/OMPTarget/OffloadAlignedAllocators.hpp
@@ -19,10 +19,10 @@
 
 namespace qmcplusplus
 {
-  template<typename T>
-  using OffloadAllocator = OMPallocator<T, aligned_allocator<T>>;
-  template<typename T>
-  using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
+template<typename T>
+using OffloadAllocator = OMPallocator<T, aligned_allocator<T>>;
+template<typename T>
+using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
 } // namespace qmcplusplus
 
 #endif

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -72,7 +72,6 @@ private:
   std::vector<RealType> ptclgrp_inv_mass_;
   ///1/Mass per particle
   std::vector<RealType> ptcl_inv_mass_;
-  size_t size_dataset_;
 
   // This is necessary MCPopulation is constructed in a simple call scope in QMCDriverFactory from the legacy MCWalkerConfiguration
   // MCPopulation should have QMCMain scope eventually and the driver will just have a reference to it.

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -139,11 +139,11 @@ void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts aw
 
   if (dispatchers_.are_walkers_batched())
   {
-    app_log() << "Creating multi walker shared resources" << std::endl;
+    app_debug() << "Creating multi walker shared resources" << std::endl;
     population_.get_golden_electrons()->createResource(golden_resource_.pset_res);
     population_.get_golden_twf().createResource(golden_resource_.twf_res);
     population_.get_golden_hamiltonian().createResource(golden_resource_.ham_res);
-    app_log() << "Multi walker shared resources creation completed" << std::endl;
+    app_debug() << "Multi walker shared resources creation completed" << std::endl;
   }
 
   crowds_.resize(awc.walkers_per_crowd.size());

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -190,84 +190,77 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
                                           ResourceCollection& collection,
                                           bool use_DLA)
 {
-  if (ecp_component_list.size() > 1)
+  auto& ecp_component_leader = ecp_component_list.getLeader();
+  if (ecp_component_leader.VP)
   {
-    auto& ecp_component_leader = ecp_component_list.getLeader();
-    if (ecp_component_leader.VP)
-    {
-      // Compute ratios with VP
-      RefVectorWithLeader<VirtualParticleSet> vp_list(*ecp_component_leader.VP);
-      RefVector<const VirtualParticleSet> const_vp_list;
-      RefVector<const std::vector<PosType>> deltaV_list;
-      RefVector<std::vector<ValueType>> psiratios_list;
-      vp_list.reserve(ecp_component_list.size());
-      const_vp_list.reserve(ecp_component_list.size());
-      deltaV_list.reserve(ecp_component_list.size());
-      psiratios_list.reserve(ecp_component_list.size());
+    // Compute ratios with VP
+    RefVectorWithLeader<VirtualParticleSet> vp_list(*ecp_component_leader.VP);
+    RefVector<const VirtualParticleSet> const_vp_list;
+    RefVector<const std::vector<PosType>> deltaV_list;
+    RefVector<std::vector<ValueType>> psiratios_list;
+    vp_list.reserve(ecp_component_list.size());
+    const_vp_list.reserve(ecp_component_list.size());
+    deltaV_list.reserve(ecp_component_list.size());
+    psiratios_list.reserve(ecp_component_list.size());
 
-      for (size_t i = 0; i < ecp_component_list.size(); i++)
-      {
-        NonLocalECPComponent& component(ecp_component_list[i]);
-        const NLPPJob<RealType>& job = joblist[i];
-
-        component.buildQuadraturePointDeltaPositions(job.ion_elec_dist, job.ion_elec_displ, component.deltaV);
-
-        vp_list.push_back(*component.VP);
-        const_vp_list.push_back(*component.VP);
-        deltaV_list.push_back(component.deltaV);
-        psiratios_list.push_back(component.psiratio);
-      }
-
-      auto vp_to_p_list = VirtualParticleSet::RefVectorWithLeaderParticleSet(vp_list);
-      ResourceCollectionTeamLock<ParticleSet> vp_res_lock(collection, vp_to_p_list);
-
-      VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
-
-      if (use_DLA)
-        TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,
-                                             TrialWaveFunction::ComputeType::FERMIONIC);
-      else
-        TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list);
-    }
-    else
-    {
-      // Compute ratios without VP. This is working but very slow code path.
-#pragma omp parallel for
-      for (size_t i = 0; i < p_list.size(); i++)
-      {
-        NonLocalECPComponent& component(ecp_component_list[i]);
-        auto* VP = component.VP;
-        ParticleSet& W(p_list[i]);
-        TrialWaveFunction& psi(psi_list[i]);
-        const NLPPJob<RealType>& job = joblist[i];
-
-        component.buildQuadraturePointDeltaPositions(job.ion_elec_dist, job.ion_elec_displ, component.deltaV);
-
-        // Compute ratio of wave functions
-        for (int j = 0; j < component.getNknot(); j++)
-        {
-          W.makeMove(job.electron_id, component.deltaV[j], false);
-          if (use_DLA)
-            component.psiratio[j] = psi.calcRatio(W, job.electron_id, TrialWaveFunction::ComputeType::FERMIONIC);
-          else
-            component.psiratio[j] = psi.calcRatio(W, job.electron_id);
-          W.rejectMove(job.electron_id);
-          psi.resetPhaseDiff();
-        }
-      }
-    }
-
-    for (size_t i = 0; i < p_list.size(); i++)
+    for (size_t i = 0; i < ecp_component_list.size(); i++)
     {
       NonLocalECPComponent& component(ecp_component_list[i]);
       const NLPPJob<RealType>& job = joblist[i];
-      pairpots[i]                  = component.calculateProjector(job.ion_elec_dist, job.ion_elec_displ);
+
+      component.buildQuadraturePointDeltaPositions(job.ion_elec_dist, job.ion_elec_displ, component.deltaV);
+
+      vp_list.push_back(*component.VP);
+      const_vp_list.push_back(*component.VP);
+      deltaV_list.push_back(component.deltaV);
+      psiratios_list.push_back(component.psiratio);
+    }
+
+    auto vp_to_p_list = VirtualParticleSet::RefVectorWithLeaderParticleSet(vp_list);
+    ResourceCollectionTeamLock<ParticleSet> vp_res_lock(collection, vp_to_p_list);
+
+    VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
+
+    if (use_DLA)
+      TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,
+                                           TrialWaveFunction::ComputeType::FERMIONIC);
+    else
+      TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list);
+  }
+  else
+  {
+    // Compute ratios without VP. This is working but very slow code path.
+#pragma omp parallel for
+    for (size_t i = 0; i < p_list.size(); i++)
+    {
+      NonLocalECPComponent& component(ecp_component_list[i]);
+      auto* VP = component.VP;
+      ParticleSet& W(p_list[i]);
+      TrialWaveFunction& psi(psi_list[i]);
+      const NLPPJob<RealType>& job = joblist[i];
+
+      component.buildQuadraturePointDeltaPositions(job.ion_elec_dist, job.ion_elec_displ, component.deltaV);
+
+      // Compute ratio of wave functions
+      for (int j = 0; j < component.getNknot(); j++)
+      {
+        W.makeMove(job.electron_id, component.deltaV[j], false);
+        if (use_DLA)
+          component.psiratio[j] = psi.calcRatio(W, job.electron_id, TrialWaveFunction::ComputeType::FERMIONIC);
+        else
+          component.psiratio[j] = psi.calcRatio(W, job.electron_id);
+        W.rejectMove(job.electron_id);
+        psi.resetPhaseDiff();
+      }
     }
   }
-  else if (ecp_component_list.size() == 1)
-    pairpots[0] =
-        ecp_component_list[0].evaluateOne(p_list[0], joblist[0].get().ion_id, psi_list[0], joblist[0].get().electron_id,
-                                          joblist[0].get().ion_elec_dist, joblist[0].get().ion_elec_displ, use_DLA);
+
+  for (size_t i = 0; i < p_list.size(); i++)
+  {
+    NonLocalECPComponent& component(ecp_component_list[i]);
+    const NLPPJob<RealType>& job = joblist[i];
+    pairpots[i]                  = component.calculateProjector(job.ion_elec_dist, job.ion_elec_displ);
+  }
 }
 
 NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(ParticleSet& W,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -61,7 +61,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_invertPsiM(const RefVectorWith
   ScopedTimer inverse_timer(wfc_leader.InverseTimer);
   const auto nw = wfc_list.size();
 
-  RefVector<DET_ENGINE_TYPE> engine_list;
+  RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
   RefVector<LogValueType> log_value_list;
   engine_list.reserve(nw);
 
@@ -72,7 +72,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_invertPsiM(const RefVectorWith
     log_value_list.push_back(det.LogValue);
   }
 
-  wfc_leader.det_engine_.mw_invert_transpose(engine_list, logdetT_list, log_value_list);
+  DET_ENGINE_TYPE::mw_invert_transpose(engine_list, logdetT_list, log_value_list);
 }
 
 ///reset the size: with the number of particles and number of orbtials
@@ -126,7 +126,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evalGrad(const RefVectorWithLe
 
   const int nw = wfc_list.size();
   std::vector<const ValueType*> dpsiM_row_list(nw, nullptr);
-  RefVector<DET_ENGINE_TYPE> engine_list;
+  RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
   engine_list.reserve(nw);
 
   const int WorkingIndex = iat - FirstIndex;
@@ -137,7 +137,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_evalGrad(const RefVectorWithLe
     engine_list.push_back(det.det_engine_);
   }
 
-  wfc_leader.det_engine_.mw_evalGrad(engine_list, dpsiM_row_list, WorkingIndex, grad_now);
+  DET_ENGINE_TYPE::mw_evalGrad(engine_list, dpsiM_row_list, WorkingIndex, grad_now);
 
 #ifndef NDEBUG
   for (int iw = 0; iw < nw; iw++)
@@ -188,7 +188,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_ratioGrad(const RefVectorWithL
     ScopedTimer local_timer(SPOVGLTimer);
     RefVectorWithLeader<SPOSet> phi_list(*Phi);
     phi_list.reserve(wfc_list.size());
-    RefVector<DET_ENGINE_TYPE> engine_list;
+    RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
 
     const int WorkingIndex = iat - FirstIndex;
@@ -200,7 +200,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_ratioGrad(const RefVectorWithL
     }
 
     auto psiMinv_row_dev_ptr_list =
-        wfc_leader.det_engine_.mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(NumOrbitals * wfc_list.size());
     ratios_local.resize(wfc_list.size());
@@ -266,7 +266,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_accept_rejectMove(
       count++;
   const int n_accepted = count;
 
-  RefVector<DET_ENGINE_TYPE> engine_list;
+  RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
   engine_list.reserve(nw);
   std::vector<ValueType*> psiM_g_dev_ptr_list(n_accepted, nullptr);
   std::vector<ValueType*> psiM_l_dev_ptr_list(n_accepted, nullptr);
@@ -293,11 +293,11 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_accept_rejectMove(
     PRAGMA_OFFLOAD("omp target update to(phi_vgl_v_ptr[:phi_vgl_v.capacity()*5])")
   }
 
-  wfc_leader.det_engine_.mw_accept_rejectRow(engine_list, WorkingIndex, psiM_g_dev_ptr_list, psiM_l_dev_ptr_list,
+  DET_ENGINE_TYPE::mw_accept_rejectRow(engine_list, WorkingIndex, psiM_g_dev_ptr_list, psiM_l_dev_ptr_list,
                                              isAccepted, phi_vgl_v.device_data(), phi_vgl_v.capacity(), ratios_local);
 
   if (!safe_to_delay)
-    wfc_leader.det_engine_.mw_updateInvMat(engine_list);
+    DET_ENGINE_TYPE::mw_updateInvMat(engine_list);
 }
 
 /** move was rejected. copy the real container to the temporary to move on
@@ -328,7 +328,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_completeUpdates(
   assert(this == &wfc_list.getLeader());
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE_TYPE>>();
   const auto nw    = wfc_list.size();
-  RefVector<DET_ENGINE_TYPE> engine_list;
+  RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
   engine_list.reserve(nw);
   for (int iw = 0; iw < nw; iw++)
   {
@@ -338,14 +338,14 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_completeUpdates(
 
   {
     ScopedTimer update(UpdateTimer);
-    wfc_leader.det_engine_.mw_updateInvMat(engine_list);
+    DET_ENGINE_TYPE::mw_updateInvMat(engine_list);
   }
 
   { // transfer dpsiM, d2psiM, psiMinv to host
     ScopedTimer d2h(D2HTimer);
 
     // this call also completes all the device copying of dpsiM, d2psiM before the target update
-    wfc_leader.det_engine_.mw_transferAinv_D2H(engine_list);
+    DET_ENGINE_TYPE::mw_transferAinv_D2H(engine_list);
 
     if (UpdateMode == ORB_PBYP_PARTIAL)
     {
@@ -545,7 +545,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_calcRatio(const RefVectorWithL
     ScopedTimer local_timer(SPOVTimer);
     RefVectorWithLeader<SPOSet> phi_list(*Phi);
     phi_list.reserve(wfc_list.size());
-    RefVector<DET_ENGINE_TYPE> engine_list;
+    RefVectorWithLeader<DET_ENGINE_TYPE> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
 
     const int WorkingIndex = iat - FirstIndex;
@@ -557,7 +557,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_calcRatio(const RefVectorWithL
     }
 
     auto psiMinv_row_dev_ptr_list =
-        wfc_leader.det_engine_.mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
+        DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(NumOrbitals * wfc_list.size());
     ratios_local.resize(wfc_list.size());

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -199,8 +199,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_ratioGrad(const RefVectorWithL
       engine_list.push_back(det.det_engine_);
     }
 
-    auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
+    auto psiMinv_row_dev_ptr_list = DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(NumOrbitals * wfc_list.size());
     ratios_local.resize(wfc_list.size());
@@ -293,8 +292,8 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_accept_rejectMove(
     PRAGMA_OFFLOAD("omp target update to(phi_vgl_v_ptr[:phi_vgl_v.capacity()*5])")
   }
 
-  DET_ENGINE_TYPE::mw_accept_rejectRow(engine_list, WorkingIndex, psiM_g_dev_ptr_list, psiM_l_dev_ptr_list,
-                                             isAccepted, phi_vgl_v.device_data(), phi_vgl_v.capacity(), ratios_local);
+  DET_ENGINE_TYPE::mw_accept_rejectRow(engine_list, WorkingIndex, psiM_g_dev_ptr_list, psiM_l_dev_ptr_list, isAccepted,
+                                       phi_vgl_v.device_data(), phi_vgl_v.capacity(), ratios_local);
 
   if (!safe_to_delay)
     DET_ENGINE_TYPE::mw_updateInvMat(engine_list);
@@ -556,8 +555,7 @@ void DiracDeterminantBatched<DET_ENGINE_TYPE>::mw_calcRatio(const RefVectorWithL
       engine_list.push_back(det.det_engine_);
     }
 
-    auto psiMinv_row_dev_ptr_list =
-        DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
+    auto psiMinv_row_dev_ptr_list = DET_ENGINE_TYPE::mw_getInvRow(engine_list, WorkingIndex, !Phi->isOMPoffload());
 
     phi_vgl_v.resize(NumOrbitals * wfc_list.size());
     ratios_local.resize(wfc_list.size());

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -12,9 +12,7 @@
 #ifndef QMCPLUSPLUS_MATRIX_DELAYED_UPDATE_CUDA_H
 #define QMCPLUSPLUS_MATRIX_DELAYED_UPDATE_CUDA_H
 
-#include "CPU/SIMD/aligned_allocator.hpp"
-#include "Platforms/PinnedAllocator.h"
-#include "OMPTarget/OMPallocator.hpp"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
@@ -53,6 +51,43 @@ struct CUDALinearAlgebraHandles : public Resource
   Resource* makeClone() const override { return new CUDALinearAlgebraHandles(*this); }
 };
 
+template<typename T>
+struct MatrixDelayedUpdateCUDAMultiWalkerMem : public Resource
+{
+  using OffloadValueVector_t       = Vector<T, OffloadAllocator<T>>;
+  using OffloadPinnedValueVector_t = Vector<T, OffloadPinnedAllocator<T>>;
+  using OffloadPinnedValueMatrix_t = Matrix<T, OffloadPinnedAllocator<T>>;
+
+  // constant array value T(1)
+  OffloadValueVector_t cone_vec;
+  // constant array value T(-1)
+  OffloadValueVector_t cminusone_vec;
+  // constant array value T(0)
+  OffloadValueVector_t czero_vec;
+  // multi walker of grads for transfer needs.
+  OffloadPinnedValueMatrix_t grads_value_v;
+  // mw_updateRow pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> updateRow_buffer_H2D;
+  // mw_prepareInvRow pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> prepare_inv_row_buffer_H2D;
+  // mw_accept_rejectRow pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> accept_rejectRow_buffer_H2D;
+  // mw_updateInv pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> updateInv_buffer_H2D;
+  // mw_evalGrad pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> evalGrad_buffer_H2D;
+  /// scratch space for rank-1 update
+  OffloadValueVector_t mw_temp;
+  // scratch space for keeping one row of Ainv
+  OffloadValueVector_t mw_rcopy;
+
+  MatrixDelayedUpdateCUDAMultiWalkerMem() : Resource("MatrixDelayedUpdateCUDAMultiWalkerMem") {}
+
+  MatrixDelayedUpdateCUDAMultiWalkerMem(const MatrixDelayedUpdateCUDAMultiWalkerMem&) : MatrixDelayedUpdateCUDAMultiWalkerMem() {}
+
+  Resource* makeClone() const override { return new MatrixDelayedUpdateCUDAMultiWalkerMem(*this); }
+};
+
 /** implements dirac matrix delayed update using OpenMP offload and CUDA.
  * It is used as DET_ENGINE_TYPE in DiracDeterminantBatched.
  * @tparam T base precision for most computation
@@ -63,10 +98,6 @@ class MatrixDelayedUpdateCUDA
 {
   using This_t = MatrixDelayedUpdateCUDA<T, T_FP>;
 
-  template<typename DT>
-  using OffloadAllocator = OMPallocator<DT, aligned_allocator<DT>>;
-  template<typename DT>
-  using OffloadPinnedAllocator     = OMPallocator<DT, PinnedAlignedAllocator<DT>>;
   using OffloadValueVector_t       = Vector<T, OffloadAllocator<T>>;
   using OffloadPinnedValueVector_t = Vector<T, OffloadPinnedAllocator<T>>;
   using OffloadPinnedValueMatrix_t = Matrix<T, OffloadPinnedAllocator<T>>;
@@ -87,24 +118,6 @@ class MatrixDelayedUpdateCUDA
   int invRow_id;
   // scratch space for keeping one row of Ainv
   OffloadValueVector_t rcopy;
-  // constant array value T(1)
-  OffloadValueVector_t cone_vec;
-  // constant array value T(-1)
-  OffloadValueVector_t cminusone_vec;
-  // constant array value T(0)
-  OffloadValueVector_t czero_vec;
-  // multi walker of grads for transfer needs.
-  OffloadPinnedValueMatrix_t grads_value_v;
-  // mw_updateRow pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> updateRow_buffer_H2D;
-  // mw_prepareInvRow pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> prepare_inv_row_buffer_H2D;
-  // mw_accept_rejectRow pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> accept_rejectRow_buffer_H2D;
-  // mw_updateInv pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> updateInv_buffer_H2D;
-  // mw_evalGrad pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> evalGrad_buffer_H2D;
 
   using DeviceValueMatrix_t = Matrix<T, CUDAAllocator<T>>;
   using DeviceValueVector_t = Vector<T, CUDAAllocator<T>>;
@@ -125,11 +138,14 @@ class MatrixDelayedUpdateCUDA
 
   // CUDA stream, cublas handle object
   std::unique_ptr<CUDALinearAlgebraHandles> cuda_handles_;
+  // multi walker memory buffers
+  std::unique_ptr<MatrixDelayedUpdateCUDAMultiWalkerMem<T>> mw_mem_;
 
   inline void waitStream()
   {
     cudaErrorCheck(cudaStreamSynchronize(cuda_handles_->hstream), "cudaStreamSynchronize failed!");
   }
+
   // ensure no previous delay left
   inline void guard_no_delay() const
   {
@@ -142,22 +158,22 @@ class MatrixDelayedUpdateCUDA
 
   void resize_fill_constant_arrays(size_t nw)
   {
-    if (cone_vec.size() < nw)
+    if (mw_mem_->cone_vec.size() < nw)
     {
       // cone
-      cone_vec.resize(nw);
-      std::fill_n(cone_vec.data(), nw, T(1));
-      T* cone_ptr = cone_vec.data();
+      mw_mem_->cone_vec.resize(nw);
+      std::fill_n(mw_mem_->cone_vec.data(), nw, T(1));
+      T* cone_ptr = mw_mem_->cone_vec.data();
       PRAGMA_OFFLOAD("omp target update to(cone_ptr[:nw])")
       // cminusone
-      cminusone_vec.resize(nw);
-      std::fill_n(cminusone_vec.data(), nw, T(-1));
-      T* cminusone_ptr = cminusone_vec.data();
+      mw_mem_->cminusone_vec.resize(nw);
+      std::fill_n(mw_mem_->cminusone_vec.data(), nw, T(-1));
+      T* cminusone_ptr = mw_mem_->cminusone_vec.data();
       PRAGMA_OFFLOAD("omp target update to(cminusone_ptr[:nw])")
       // czero
-      czero_vec.resize(nw);
-      std::fill_n(czero_vec.data(), nw, T(0));
-      T* czero_ptr = czero_vec.data();
+      mw_mem_->czero_vec.resize(nw);
+      std::fill_n(mw_mem_->czero_vec.data(), nw, T(0));
+      T* czero_ptr = mw_mem_->czero_vec.data();
       PRAGMA_OFFLOAD("omp target update to(czero_ptr[:nw])")
     }
   }
@@ -165,10 +181,10 @@ class MatrixDelayedUpdateCUDA
   void resize_updateRow_scratch_arrays(int norb, size_t nw)
   {
     size_t total_size = norb * nw;
-    if (temp.size() < total_size)
+    if (mw_mem_->mw_temp.size() < total_size)
     {
-      temp.resize(total_size);
-      rcopy.resize(total_size);
+      mw_mem_->mw_temp.resize(total_size);
+      mw_mem_->mw_rcopy.resize(total_size);
     }
   }
 
@@ -176,19 +192,27 @@ class MatrixDelayedUpdateCUDA
    * @param Ainv inverse matrix
    * @param rowchanged the row id corresponding to the proposed electron
    */
-  void mw_prepareInvRow(const RefVector<This_t>& engines, const int rowchanged)
+  static void mw_prepareInvRow(const RefVectorWithLeader<This_t>& engines, const int rowchanged)
   {
-    const int norb = psiMinv.rows();
+    auto& engine_leader = engines.getLeader();
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    auto& h_cublas = engine_leader.cuda_handles_->h_cublas;
+    auto& cminusone_vec = engine_leader.mw_mem_->cminusone_vec;
+    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
+    auto& prepare_inv_row_buffer_H2D = engine_leader.mw_mem_->prepare_inv_row_buffer_H2D;
+    const int norb = engine_leader.psiMinv.rows();
     const int nw   = engines.size();
+    int& delay_count = engine_leader.delay_count;
     prepare_inv_row_buffer_H2D.resize(sizeof(T*) * 7 * nw);
-    resize_fill_constant_arrays(nw);
+    engine_leader.resize_fill_constant_arrays(nw);
 
-    const int lda_Binv = Binv_gpu.cols();
+    const int lda_Binv = engine_leader.Binv_gpu.cols();
     Matrix<T*> ptr_buffer(reinterpret_cast<T**>(prepare_inv_row_buffer_H2D.data()), 7, nw);
     for (int iw = 0; iw < nw; iw++)
     {
       This_t& engine    = engines[iw];
-      ptr_buffer[0][iw] = engine.psiMinv.device_data() + rowchanged * psiMinv.cols();
+      ptr_buffer[0][iw] = engine.psiMinv.device_data() + rowchanged * engine.psiMinv.cols();
       ptr_buffer[1][iw] = engine.invRow.device_data();
       ptr_buffer[2][iw] = engine.U_gpu.data();
       ptr_buffer[3][iw] = engine.p_gpu.data();
@@ -198,7 +222,7 @@ class MatrixDelayedUpdateCUDA
     }
 
     cudaErrorCheck(cudaMemcpyAsync(prepare_inv_row_buffer_H2D.device_data(), prepare_inv_row_buffer_H2D.data(),
-                                   prepare_inv_row_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
+                                   prepare_inv_row_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync prepare_inv_row_buffer_H2D failed!");
 
     T** oldRow_mw_ptr  = reinterpret_cast<T**>(prepare_inv_row_buffer_H2D.device_data());
@@ -211,28 +235,28 @@ class MatrixDelayedUpdateCUDA
 
     // save Ainv[rowchanged] to invRow
     //std::copy_n(Ainv[rowchanged], norb, invRow.data());
-    cudaErrorCheck(cuBLAS_MFs::copy_batched(cuda_handles_->hstream, norb, oldRow_mw_ptr, 1, invRow_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::copy_batched(hstream, norb, oldRow_mw_ptr, 1, invRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::copy_batched failed!");
     // multiply V (NxK) Binv(KxK) U(KxN) invRow right to the left
     //BLAS::gemv('T', norb, delay_count, cone, U_gpu.data(), norb, invRow.data(), 1, czero, p_gpu.data(), 1);
     //BLAS::gemv('N', delay_count, delay_count, -cone, Binv.data(), lda_Binv, p.data(), 1, czero, Binv[delay_count], 1);
     //BLAS::gemv('N', norb, delay_count, cone, V.data(), norb, Binv[delay_count], 1, cone, invRow.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cone_vec.device_data(),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, delay_count, cone_vec.device_data(),
                                             U_mw_ptr, norb, invRow_mw_ptr, 1, czero_vec.device_data(), p_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', delay_count, delay_count,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'N', delay_count, delay_count,
                                             cminusone_vec.device_data(), Binv_mw_ptr, lda_Binv, p_mw_ptr, 1,
                                             czero_vec.device_data(), BinvRow_mw_ptr, 1, nw),
                    "cuBLAS_MFs::gemv_batched failed!");
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'N', norb, delay_count, cone_vec.device_data(),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'N', norb, delay_count, cone_vec.device_data(),
                                             V_mw_ptr, norb, BinvRow_mw_ptr, 1, cone_vec.device_data(), invRow_mw_ptr, 1,
                                             nw),
                    "cuBLAS_MFs::gemv_batched failed!");
     // mark row prepared
-    invRow_id = rowchanged;
+    engine_leader.invRow_id = rowchanged;
   }
 
-  void mw_updateRow(const RefVector<This_t>& engines,
+  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines,
                     const int rowchanged,
                     const std::vector<T*>& psiM_g_list,
                     const std::vector<T*>& psiM_l_list,
@@ -241,15 +265,23 @@ class MatrixDelayedUpdateCUDA
                     const size_t phi_vgl_stride,
                     const std::vector<T>& ratios)
   {
-    guard_no_delay();
+    auto& engine_leader = engines.getLeader();
+    engine_leader.guard_no_delay();
 
     const size_t n_accepted = psiM_g_list.size();
     if (n_accepted == 0)
       return;
 
-    const int norb = psiMinv.rows();
-    const int lda  = psiMinv.cols();
-    resize_updateRow_scratch_arrays(norb, n_accepted);
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    auto& updateRow_buffer_H2D = engine_leader.mw_mem_->updateRow_buffer_H2D;
+    auto& cminusone_vec = engine_leader.mw_mem_->cminusone_vec;
+    auto& mw_temp = engine_leader.mw_mem_->mw_temp;
+    auto& mw_rcopy = engine_leader.mw_mem_->mw_rcopy;
+    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
+    const int norb = engine_leader.psiMinv.rows();
+    const int lda  = engine_leader.psiMinv.cols();
+    engine_leader.resize_updateRow_scratch_arrays(norb, n_accepted);
     updateRow_buffer_H2D.resize((sizeof(T*) * 8 + sizeof(T)) * n_accepted);
 
     // to handle T** of Ainv, psi_v, temp, rcopy
@@ -258,10 +290,10 @@ class MatrixDelayedUpdateCUDA
     for (int iw = 0, count = 0; iw < isAccepted.size(); iw++)
       if (isAccepted[iw])
       {
-        ptr_buffer[0][count] = engines[iw].get().psiMinv.device_data();
+        ptr_buffer[0][count] = engines[iw].psiMinv.device_data();
         ptr_buffer[1][count] = const_cast<T*>(phi_vgl_v_dev_ptr + norb * iw);
-        ptr_buffer[2][count] = temp.device_data() + norb * count;
-        ptr_buffer[3][count] = rcopy.device_data() + norb * count;
+        ptr_buffer[2][count] = mw_temp.device_data() + norb * count;
+        ptr_buffer[3][count] = mw_rcopy.device_data() + norb * count;
         ptr_buffer[4][count] = psiM_g_list[count];
         ptr_buffer[5][count] = psiM_l_list[count];
         ptr_buffer[6][count] = const_cast<T*>(phi_vgl_v_dev_ptr + phi_vgl_stride + norb * 3 * iw);
@@ -272,10 +304,10 @@ class MatrixDelayedUpdateCUDA
       }
 
     // update the inverse matrix
-    resize_fill_constant_arrays(n_accepted);
+    engine_leader.resize_fill_constant_arrays(n_accepted);
 
     cudaErrorCheck(cudaMemcpyAsync(updateRow_buffer_H2D.device_data(), updateRow_buffer_H2D.data(),
-                                   updateRow_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
+                                   updateRow_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync updateRow_buffer_H2D failed!");
 
     {
@@ -290,18 +322,18 @@ class MatrixDelayedUpdateCUDA
       T* ratio_inv_mw   = reinterpret_cast<T*>(updateRow_buffer_H2D.device_data() + sizeof(T*) * n_accepted * 8);
 
       // invoke the Fahy's variant of Sherman-Morrison update.
-      cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, norb, cone_vec.device_data(),
+      cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, norb, cone_vec.device_data(),
                                               Ainv_mw_ptr, lda, phiV_mw_ptr, 1, czero_vec.device_data(), temp_mw_ptr, 1,
                                               n_accepted),
                      "cuBLAS_MFs::gemv_batched failed!");
 
-      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(cuda_handles_->hstream, rowchanged, norb, Ainv_mw_ptr, lda,
+      cudaErrorCheck(CUDA::copyAinvRow_saveGL_cuda(hstream, rowchanged, norb, Ainv_mw_ptr, lda,
                                                    temp_mw_ptr, rcopy_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, dpsiM_mw_out,
                                                    d2psiM_mw_out, n_accepted),
                      "CUDA::copyAinvRow_saveGL_cuda failed!");
 
 
-      cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1,
+      cudaErrorCheck(cuBLAS_MFs::ger_batched(hstream, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1,
                                              temp_mw_ptr, 1, Ainv_mw_ptr, lda, n_accepted),
                      "cuBLAS_MFs::ger_batched failed!");
     }
@@ -331,18 +363,28 @@ public:
 
   void createResource(ResourceCollection& collection) const
   {
-    auto resource_index = collection.addResource(std::make_unique<CUDALinearAlgebraHandles>());
+    collection.addResource(std::make_unique<CUDALinearAlgebraHandles>());
+    collection.addResource(std::make_unique<MatrixDelayedUpdateCUDAMultiWalkerMem<T>>());
   }
 
   void acquireResource(ResourceCollection& collection)
   {
     auto res_ptr = dynamic_cast<CUDALinearAlgebraHandles*>(collection.lendResource().release());
     if (!res_ptr)
-      throw std::runtime_error("MatrixDelayedUpdateCUDA::acquireResource dynamic_cast failed");
+      throw std::runtime_error("MatrixDelayedUpdateCUDA::acquireResource dynamic_cast CUDALinearAlgebraHandles failed");
     cuda_handles_.reset(res_ptr);
+
+    auto res2_ptr = dynamic_cast<MatrixDelayedUpdateCUDAMultiWalkerMem<T>*>(collection.lendResource().release());
+    if (!res2_ptr)
+      throw std::runtime_error("MatrixDelayedUpdateCUDA::acquireResource dynamic_cast MatrixDelayedUpdateCUDAMultiWalkerMem failed");
+    mw_mem_.reset(res2_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) { collection.takebackResource(std::move(cuda_handles_)); }
+  void releaseResource(ResourceCollection& collection)
+  {
+    collection.takebackResource(std::move(cuda_handles_));
+    collection.takebackResource(std::move(mw_mem_));
+  }
 
   inline OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
@@ -369,27 +411,35 @@ public:
   }
 
   template<typename TREAL>
-  inline void mw_invert_transpose(const RefVector<This_t>& engines,
+  static void mw_invert_transpose(const RefVectorWithLeader<This_t>& engines,
                                   const RefVector<const Matrix<T>>& logdetT_list,
                                   const RefVector<std::complex<TREAL>>& LogValues)
   {
+    auto& engine_leader = engines.getLeader();
     // make this class unit tests friendly without the need of setup resources.
-    if (!cuda_handles_)
+    if (!engine_leader.cuda_handles_)
     {
       app_warning() << "MatrixDelayedUpdateCUDA : This message should not be seen in production (performance bug) runs "
                        "but only unit tests (expected)."
                     << std::endl;
-      cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
+      engine_leader.cuda_handles_ = std::make_unique<CUDALinearAlgebraHandles>();
+    }
+    if (!engine_leader.mw_mem_)
+    {
+      app_warning() << "MatrixDelayedUpdateCUDA : This message should not be seen in production (performance bug) runs "
+                       "but only unit tests (expected)."
+                    << std::endl;
+      engine_leader.mw_mem_ = std::make_unique<MatrixDelayedUpdateCUDAMultiWalkerMem<T>>();
     }
 
-    guard_no_delay();
+    engine_leader.guard_no_delay();
 
     // FIXME use cublas batched inverse.
     for (int iw = 0; iw < engines.size(); iw++)
     {
-      auto& Ainv = engines[iw].get().psiMinv;
+      auto& Ainv = engines[iw].psiMinv;
       Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-      detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
+      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
       T* Ainv_ptr = Ainv.data();
       PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
     }
@@ -398,28 +448,33 @@ public:
 
   // prepare invRow and compute the old gradients.
   template<typename GT>
-  void mw_evalGrad(const RefVector<This_t>& engines,
+  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines,
                    const std::vector<const T*>& dpsiM_row_list,
                    const int rowchanged,
                    std::vector<GT>& grad_now)
   {
-    if (!isSM1())
+    auto& engine_leader = engines.getLeader();
+    if (!engine_leader.isSM1())
       mw_prepareInvRow(engines, rowchanged);
+
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    auto& evalGrad_buffer_H2D = engine_leader.mw_mem_->evalGrad_buffer_H2D;
+    auto& grads_value_v = engine_leader.mw_mem_->grads_value_v;
 
     const int nw = engines.size();
     evalGrad_buffer_H2D.resize(sizeof(T*) * 2 * nw);
     Matrix<const T*> ptr_buffer(reinterpret_cast<const T**>(evalGrad_buffer_H2D.data()), 2, nw);
     for (int iw = 0; iw < nw; iw++)
     {
-      if (isSM1())
-        ptr_buffer[0][iw] = engines[iw].get().psiMinv.device_data() + rowchanged * psiMinv.cols();
+      if (engine_leader.isSM1())
+        ptr_buffer[0][iw] = engines[iw].psiMinv.device_data() + rowchanged * engine_leader.psiMinv.cols();
       else
-        ptr_buffer[0][iw] = engines[iw].get().invRow.device_data();
+        ptr_buffer[0][iw] = engines[iw].invRow.device_data();
       ptr_buffer[1][iw] = dpsiM_row_list[iw];
     }
 
     cudaErrorCheck(cudaMemcpyAsync(evalGrad_buffer_H2D.device_data(), evalGrad_buffer_H2D.data(),
-                                   evalGrad_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
+                                   evalGrad_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync evalGrad_buffer_H2D failed!");
 
     if (grads_value_v.rows() != nw || grads_value_v.cols() != GT::Size)
@@ -428,14 +483,14 @@ public:
     const T** invRow_ptr    = reinterpret_cast<const T**>(evalGrad_buffer_H2D.device_data());
     const T** dpsiM_row_ptr = reinterpret_cast<const T**>(evalGrad_buffer_H2D.device_data()) + nw;
 
-    const int norb = psiMinv.rows();
-    cudaErrorCheck(CUDA::calcGradients_cuda(cuda_handles_->hstream, norb, invRow_ptr, dpsiM_row_ptr,
+    const int norb = engine_leader.psiMinv.rows();
+    cudaErrorCheck(CUDA::calcGradients_cuda(hstream, norb, invRow_ptr, dpsiM_row_ptr,
                                             grads_value_v.device_data(), nw),
                    "CUDA::calcGradients_cuda failed!");
     cudaErrorCheck(cudaMemcpyAsync(grads_value_v.data(), grads_value_v.device_data(), grads_value_v.size() * sizeof(T),
-                                   cudaMemcpyDeviceToHost, cuda_handles_->hstream),
+                                   cudaMemcpyDeviceToHost, hstream),
                    "cudaMemcpyAsync grads_value_v failed!");
-    waitStream();
+    engine_leader.waitStream();
 
     for (int iw = 0; iw < nw; iw++)
       grad_now[iw] = {grads_value_v[iw][0], grads_value_v[iw][1], grads_value_v[iw][2]};
@@ -450,7 +505,8 @@ public:
     constexpr T cone(1), czero(0);
     const int norb = Ainv.rows();
     const int lda  = Ainv.cols();
-    resize_updateRow_scratch_arrays(norb, 1);
+    temp.resize(norb);
+    rcopy.resize(norb);
     // invoke the Fahy's variant of Sherman-Morrison update.
     int dummy_handle  = 0;
     int success       = 0;
@@ -475,7 +531,7 @@ public:
     }
   }
 
-  void mw_accept_rejectRow(const RefVector<This_t>& engines,
+  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines,
                            const int rowchanged,
                            const std::vector<T*>& psiM_g_list,
                            const std::vector<T*>& psiM_l_list,
@@ -484,23 +540,30 @@ public:
                            const size_t phi_vgl_stride,
                            const std::vector<T>& ratios)
   {
+    auto& engine_leader = engines.getLeader();
     // invRow consumed, mark invRow_id unset
-    invRow_id = -1;
+    engine_leader.invRow_id = -1;
 
-    if (isSM1())
+    if (engine_leader.isSM1())
     {
       mw_updateRow(engines, rowchanged, psiM_g_list, psiM_l_list, isAccepted, phi_vgl_v_dev_ptr, phi_vgl_stride,
                    ratios);
       return;
     }
 
-    const int lda_Binv   = Binv_gpu.cols();
-    const int norb       = psiMinv.rows();
-    const int lda        = psiMinv.cols();
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    auto& cminusone_vec = engine_leader.mw_mem_->cminusone_vec;
+    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
+    auto& accept_rejectRow_buffer_H2D = engine_leader.mw_mem_->accept_rejectRow_buffer_H2D;
+    int& delay_count = engine_leader.delay_count;
+    const int lda_Binv   = engine_leader.Binv_gpu.cols();
+    const int norb       = engine_leader.psiMinv.rows();
+    const int lda        = engine_leader.psiMinv.cols();
     const int nw         = engines.size();
     const int n_accepted = psiM_g_list.size();
     accept_rejectRow_buffer_H2D.resize((sizeof(T*) * 14 + sizeof(T)) * nw);
-    resize_fill_constant_arrays(nw);
+    engine_leader.resize_fill_constant_arrays(nw);
 
     Matrix<T*> ptr_buffer(reinterpret_cast<T**>(accept_rejectRow_buffer_H2D.data()), 14, nw);
     T* c_ratio_inv = reinterpret_cast<T*>(accept_rejectRow_buffer_H2D.data() + sizeof(T*) * 14 * nw);
@@ -542,7 +605,7 @@ public:
     }
 
     cudaErrorCheck(cudaMemcpyAsync(accept_rejectRow_buffer_H2D.device_data(), accept_rejectRow_buffer_H2D.data(),
-                                   accept_rejectRow_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
+                                   accept_rejectRow_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync prepare_inv_row_buffer_H2D failed!");
 
     T** invRow_mw_ptr       = reinterpret_cast<T**>(accept_rejectRow_buffer_H2D.device_data());
@@ -562,31 +625,31 @@ public:
     T* ratio_inv_mw_ptr     = reinterpret_cast<T*>(accept_rejectRow_buffer_H2D.device_data() + sizeof(T*) * nw * 14);
 
     //std::copy_n(Ainv[rowchanged], norb, V[delay_count]);
-    cudaErrorCheck(cuBLAS_MFs::copy_batched(cuda_handles_->hstream, norb, invRow_mw_ptr, 1, V_row_mw_ptr, 1, nw),
+    cudaErrorCheck(cuBLAS_MFs::copy_batched(hstream, norb, invRow_mw_ptr, 1, V_row_mw_ptr, 1, nw),
                    "cuBLAS_MFs::copy_batched failed!");
     // handle accepted walkers
     // the new Binv is [[X Y] [Z sigma]]
     //BLAS::gemv('T', norb, delay_count + 1, cminusone, V.data(), norb, psiV.data(), 1, czero, p.data(), 1);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', norb, delay_count, cminusone_vec.device_data(),
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', norb, delay_count, cminusone_vec.device_data(),
                                             V_mw_ptr, norb, phiV_mw_ptr, 1, czero_vec.device_data(), p_mw_ptr, 1,
                                             n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // Y
     //BLAS::gemv('T', delay_count, delay_count, sigma, Binv.data(), lda_Binv, p.data(), 1, czero, Binv.data() + delay_count,
     //           lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::gemv_batched(cuda_handles_->hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr,
+    cudaErrorCheck(cuBLAS_MFs::gemv_batched(hstream, 'T', delay_count, delay_count, ratio_inv_mw_ptr,
                                             Binv_mw_ptr, lda_Binv, p_mw_ptr, 1, czero_vec.device_data(), BinvCol_mw_ptr,
                                             lda_Binv, n_accepted),
                    "cuBLAS_MFs::gemv_batched failed!");
     // X
     //BLAS::ger(delay_count, delay_count, cone, Binv[delay_count], 1, Binv.data() + delay_count, lda_Binv,
     //          Binv.data(), lda_Binv);
-    cudaErrorCheck(cuBLAS_MFs::ger_batched(cuda_handles_->hstream, delay_count, delay_count, cone_vec.device_data(),
+    cudaErrorCheck(cuBLAS_MFs::ger_batched(hstream, delay_count, delay_count, cone_vec.device_data(),
                                            BinvRow_mw_ptr, 1, BinvCol_mw_ptr, lda_Binv, Binv_mw_ptr, lda_Binv,
                                            n_accepted),
                    "cuBLAS_MFs::ger_batched failed!");
     // sigma and Z
-    cudaErrorCheck(CUDA::add_delay_list_save_sigma_VGL_batched(cuda_handles_->hstream, delay_list_mw_ptr, rowchanged,
+    cudaErrorCheck(CUDA::add_delay_list_save_sigma_VGL_batched(hstream, delay_list_mw_ptr, rowchanged,
                                                                delay_count, Binv_mw_ptr, lda_Binv, ratio_inv_mw_ptr,
                                                                phiV_mw_ptr, dpsiM_mw_in, d2psiM_mw_in, U_row_mw_ptr,
                                                                dpsiM_mw_out, d2psiM_mw_out, norb, n_accepted, nw),
@@ -600,16 +663,24 @@ public:
   /** update the full Ainv and reset delay_count
    * @param Ainv inverse matrix
    */
-  void mw_updateInvMat(const RefVector<This_t>& engines)
+  static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines)
   {
+    auto& engine_leader = engines.getLeader();
+    int& delay_count = engine_leader.delay_count;
     if (delay_count == 0)
       return;
     // update the inverse matrix
-    const int norb = psiMinv.rows();
-    const int lda  = psiMinv.cols();
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    auto& h_cublas = engine_leader.cuda_handles_->h_cublas;
+    auto& cminusone_vec = engine_leader.mw_mem_->cminusone_vec;
+    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
+    auto& updateInv_buffer_H2D = engine_leader.mw_mem_->updateInv_buffer_H2D;
+    const int norb = engine_leader.psiMinv.rows();
+    const int lda  = engine_leader.psiMinv.cols();
     const int nw   = engines.size();
     updateInv_buffer_H2D.resize(sizeof(T*) * 6 * nw);
-    resize_fill_constant_arrays(nw);
+    engine_leader.resize_fill_constant_arrays(nw);
 
     Matrix<T*> ptr_buffer(reinterpret_cast<T**>(updateInv_buffer_H2D.data()), 6, nw);
     for (int iw = 0; iw < nw; iw++)
@@ -624,7 +695,7 @@ public:
     }
 
     cudaErrorCheck(cudaMemcpyAsync(updateInv_buffer_H2D.device_data(), updateInv_buffer_H2D.data(),
-                                   updateInv_buffer_H2D.size(), cudaMemcpyHostToDevice, cuda_handles_->hstream),
+                                   updateInv_buffer_H2D.size(), cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync updateInv_buffer_H2D failed!");
 
     T** U_mw_ptr            = reinterpret_cast<T**>(updateInv_buffer_H2D.device_data());
@@ -646,20 +717,20 @@ public:
     else
 */
     {
-      const int lda_Binv = Binv_gpu.cols();
+      const int lda_Binv = engine_leader.Binv_gpu.cols();
       constexpr T cone(1), czero(0), cminusone(-1);
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb,
+      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, delay_count, norb, norb,
                                             &cone, U_mw_ptr, norb, Ainv_mw_ptr, lda, &czero, tempMat_mw_ptr, lda_Binv,
                                             nw),
                        "cuBLAS::gemm_batched failed!");
-      cudaErrorCheck(CUDA::applyW_batched(cuda_handles_->hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr,
+      cudaErrorCheck(CUDA::applyW_batched(hstream, delay_list_mw_ptr, delay_count, tempMat_mw_ptr,
                                           lda_Binv, nw),
                      "CUDA::applyW_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count,
+      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, delay_count,
                                             delay_count, &cone, V_mw_ptr, norb, Binv_mw_ptr, lda_Binv, &czero, U_mw_ptr,
                                             norb, nw),
                        "cuBLAS::gemm_batched failed!");
-      cublasErrorCheck(cuBLAS::gemm_batched(cuda_handles_->h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count,
+      cublasErrorCheck(cuBLAS::gemm_batched(h_cublas, CUBLAS_OP_N, CUBLAS_OP_N, norb, norb, delay_count,
                                             &cminusone, U_mw_ptr, norb, tempMat_mw_ptr, lda_Binv, &cone, Ainv_mw_ptr,
                                             lda, nw),
                        "cuBLAS::gemm_batched failed!");
@@ -683,17 +754,19 @@ public:
   /** return invRow host or device pointers based on on_host request
    * prepare invRow if not already.
    */
-  std::vector<const T*> mw_getInvRow(const RefVector<This_t>& engines, const int row_id, bool on_host)
+  static std::vector<const T*> mw_getInvRow(const RefVectorWithLeader<This_t>& engines, const int row_id, bool on_host)
   {
-    if (isSM1())
-      waitStream();
-    else if (invRow_id != row_id)
+    auto& engine_leader = engines.getLeader();
+    if (engine_leader.isSM1())
+      engine_leader.waitStream();
+    else if (engine_leader.invRow_id != row_id)
     {
       // this can be skipped if mw_evalGrad gets called already.
       mw_prepareInvRow(engines, row_id);
-      waitStream();
+      engine_leader.waitStream();
     }
 
+    const size_t ncols = engines.getLeader().psiMinv.cols();
     const size_t nw = engines.size();
     std::vector<const T*> row_ptr_list;
     row_ptr_list.reserve(nw);
@@ -701,16 +774,16 @@ public:
     {
       // copy values to host and return host pointer
       for (This_t& engine : engines)
-        if (isSM1())
+        if (engine_leader.isSM1())
         {
           auto* ptr = engine.psiMinv.data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[row_id * psiMinv.cols():psiMinv.cols()])")
-          row_ptr_list.push_back(ptr + row_id * psiMinv.cols());
+          PRAGMA_OFFLOAD("omp target update from(ptr[row_id * ncols : ncols])")
+          row_ptr_list.push_back(ptr + row_id * ncols);
         }
         else
         {
           auto* ptr = engine.invRow.data();
-          PRAGMA_OFFLOAD("omp target update from(ptr[:invRow.size()])")
+          PRAGMA_OFFLOAD("omp target update from(ptr[:engine.invRow.size()])")
           row_ptr_list.push_back(ptr);
         }
     }
@@ -718,23 +791,25 @@ public:
     {
       // return device pointer
       for (This_t& engine : engines)
-        if (isSM1())
-          row_ptr_list.push_back(engine.psiMinv.device_data() + row_id * psiMinv.cols());
+        if (engine_leader.isSM1())
+          row_ptr_list.push_back(engine.psiMinv.device_data() + row_id * ncols);
         else
           row_ptr_list.push_back(engine.invRow.device_data());
     }
     return row_ptr_list;
   }
 
-  inline void mw_transferAinv_D2H(const RefVector<This_t>& engines)
+  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines)
   {
-    guard_no_delay();
+    auto& engine_leader = engines.getLeader();
+    auto& hstream = engine_leader.cuda_handles_->hstream;
+    engine_leader.guard_no_delay();
 
     for (This_t& engine : engines)
       cudaErrorCheck(cudaMemcpyAsync(engine.psiMinv.data(), engine.psiMinv.device_data(),
-                                     engine.psiMinv.size() * sizeof(T), cudaMemcpyDeviceToHost, cuda_handles_->hstream),
+                                     engine.psiMinv.size() * sizeof(T), cudaMemcpyDeviceToHost, hstream),
                      "cudaMemcpyAsync Ainv failed!");
-    waitStream();
+    engine_leader.waitStream();
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -180,16 +180,6 @@ class MatrixDelayedUpdateCUDA
     }
   }
 
-  void resize_updateRow_scratch_arrays(int norb, size_t nw)
-  {
-    size_t total_size = norb * nw;
-    if (mw_mem_->mw_temp.size() < total_size)
-    {
-      mw_mem_->mw_temp.resize(total_size);
-      mw_mem_->mw_rcopy.resize(total_size);
-    }
-  }
-
   /** compute the row of up-to-date Ainv
    * @param Ainv inverse matrix
    * @param rowchanged the row id corresponding to the proposed electron
@@ -275,14 +265,14 @@ class MatrixDelayedUpdateCUDA
 
     auto& hstream              = engine_leader.cuda_handles_->hstream;
     auto& updateRow_buffer_H2D = engine_leader.mw_mem_->updateRow_buffer_H2D;
-    auto& cminusone_vec        = engine_leader.mw_mem_->cminusone_vec;
     auto& mw_temp              = engine_leader.mw_mem_->mw_temp;
     auto& mw_rcopy             = engine_leader.mw_mem_->mw_rcopy;
     auto& cone_vec             = engine_leader.mw_mem_->cone_vec;
     auto& czero_vec            = engine_leader.mw_mem_->czero_vec;
     const int norb             = engine_leader.psiMinv.rows();
     const int lda              = engine_leader.psiMinv.cols();
-    engine_leader.resize_updateRow_scratch_arrays(norb, n_accepted);
+    mw_temp.resize(norb * n_accepted);
+    mw_rcopy.resize(norb * n_accepted);
     updateRow_buffer_H2D.resize((sizeof(T*) * 8 + sizeof(T)) * n_accepted);
 
     // to handle T** of Ainv, psi_v, temp, rcopy
@@ -670,9 +660,6 @@ public:
     // update the inverse matrix
     auto& hstream              = engine_leader.cuda_handles_->hstream;
     auto& h_cublas             = engine_leader.cuda_handles_->h_cublas;
-    auto& cminusone_vec        = engine_leader.mw_mem_->cminusone_vec;
-    auto& cone_vec             = engine_leader.mw_mem_->cone_vec;
-    auto& czero_vec            = engine_leader.mw_mem_->czero_vec;
     auto& updateInv_buffer_H2D = engine_leader.mw_mem_->updateInv_buffer_H2D;
     const int norb             = engine_leader.psiMinv.rows();
     const int lda              = engine_leader.psiMinv.cols();

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -23,7 +23,6 @@
 
 namespace qmcplusplus
 {
-
 template<typename T>
 struct MatrixUpdateOMPTargetMultiWalkerMem : public Resource
 {
@@ -46,7 +45,9 @@ struct MatrixUpdateOMPTargetMultiWalkerMem : public Resource
 
   MatrixUpdateOMPTargetMultiWalkerMem() : Resource("MatrixUpdateOMPTargetMultiWalkerMem") {}
 
-  MatrixUpdateOMPTargetMultiWalkerMem(const MatrixUpdateOMPTargetMultiWalkerMem&) : MatrixUpdateOMPTargetMultiWalkerMem() {}
+  MatrixUpdateOMPTargetMultiWalkerMem(const MatrixUpdateOMPTargetMultiWalkerMem&)
+      : MatrixUpdateOMPTargetMultiWalkerMem()
+  {}
 
   Resource* makeClone() const override { return new MatrixUpdateOMPTargetMultiWalkerMem(*this); }
 };
@@ -118,14 +119,12 @@ public:
   {
     auto res_ptr = dynamic_cast<MatrixUpdateOMPTargetMultiWalkerMem<T>*>(collection.lendResource().release());
     if (!res_ptr)
-      throw std::runtime_error("MatrixUpdateOMPTarget::acquireResource dynamic_cast MatrixUpdateOMPTargetMultiWalkerMem failed");
+      throw std::runtime_error(
+          "MatrixUpdateOMPTarget::acquireResource dynamic_cast MatrixUpdateOMPTargetMultiWalkerMem failed");
     mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection)
-  {
-    collection.takebackResource(std::move(mw_mem_));
-  }
+  void releaseResource(ResourceCollection& collection) { collection.takebackResource(std::move(mw_mem_)); }
 
   OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
@@ -178,7 +177,7 @@ public:
                           std::vector<GT>& grad_now)
   {
     auto& engine_leader = engines.getLeader();
-    auto& buffer_H2D = engine_leader.mw_mem_->buffer_H2D;
+    auto& buffer_H2D    = engine_leader.mw_mem_->buffer_H2D;
     auto& grads_value_v = engine_leader.mw_mem_->grads_value_v;
 
     const int norb = engine_leader.psiMinv.rows();
@@ -269,14 +268,14 @@ public:
       return;
 
     auto& engine_leader = engines.getLeader();
-    auto& buffer_H2D = engine_leader.mw_mem_->buffer_H2D;
+    auto& buffer_H2D    = engine_leader.mw_mem_->buffer_H2D;
     auto& grads_value_v = engine_leader.mw_mem_->grads_value_v;
-    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
-    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
-    auto& mw_temp = engine_leader.mw_mem_->mw_temp;
-    auto& mw_rcopy = engine_leader.mw_mem_->mw_rcopy;
-    const int norb          = engine_leader.psiMinv.rows();
-    const int lda           = engine_leader.psiMinv.cols();
+    auto& cone_vec      = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec     = engine_leader.mw_mem_->czero_vec;
+    auto& mw_temp       = engine_leader.mw_mem_->mw_temp;
+    auto& mw_rcopy      = engine_leader.mw_mem_->mw_rcopy;
+    const int norb      = engine_leader.psiMinv.rows();
+    const int lda       = engine_leader.psiMinv.cols();
 
     engine_leader.resize_scratch_arrays(norb, n_accepted);
 
@@ -376,7 +375,7 @@ public:
 
   std::vector<const T*> static mw_getInvRow(const RefVectorWithLeader<This_t>& engines, const int row_id, bool on_host)
   {
-    const size_t nw = engines.size();
+    const size_t nw    = engines.size();
     const size_t ncols = engines.getLeader().psiMinv.cols();
     std::vector<const T*> row_ptr_list;
     row_ptr_list.reserve(nw);

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -12,9 +12,7 @@
 #ifndef QMCPLUSPLUS_MATRIX_UPDATE_OMPTARGET_H
 #define QMCPLUSPLUS_MATRIX_UPDATE_OMPTARGET_H
 
-#include "CPU/SIMD/aligned_allocator.hpp"
-#include "Platforms/PinnedAllocator.h"
-#include "OMPTarget/OMPallocator.hpp"
+#include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "QMCWaveFunctions/Fermion/DiracMatrix.h"
@@ -25,6 +23,34 @@
 
 namespace qmcplusplus
 {
+
+template<typename T>
+struct MatrixUpdateOMPTargetMultiWalkerMem : public Resource
+{
+  using OffloadValueVector_t       = Vector<T, OffloadAllocator<T>>;
+  using OffloadPinnedValueVector_t = Vector<T, OffloadPinnedAllocator<T>>;
+  using OffloadPinnedValueMatrix_t = Matrix<T, OffloadPinnedAllocator<T>>;
+
+  // constant array value T(1)
+  OffloadValueVector_t cone_vec;
+  // constant array value T(0)
+  OffloadValueVector_t czero_vec;
+  // multi walker of grads for transfer needs.
+  OffloadPinnedValueMatrix_t grads_value_v;
+  // pointer buffer
+  Vector<char, OffloadPinnedAllocator<char>> buffer_H2D;
+  /// scratch space for rank-1 update
+  OffloadValueVector_t mw_temp;
+  // scratch space for keeping one row of Ainv
+  OffloadValueVector_t mw_rcopy;
+
+  MatrixUpdateOMPTargetMultiWalkerMem() : Resource("MatrixUpdateOMPTargetMultiWalkerMem") {}
+
+  MatrixUpdateOMPTargetMultiWalkerMem(const MatrixUpdateOMPTargetMultiWalkerMem&) : MatrixUpdateOMPTargetMultiWalkerMem() {}
+
+  Resource* makeClone() const override { return new MatrixUpdateOMPTargetMultiWalkerMem(*this); }
+};
+
 /** Implements dirac matrix update using OpenMP offload.
  * It is used as DET_ENGINE_TYPE in DiracDeterminantBatched.
  * @tparam T base precision for most computation
@@ -35,10 +61,6 @@ class MatrixUpdateOMPTarget
 {
   using This_t = MatrixUpdateOMPTarget<T, T_FP>;
 
-  template<typename DT>
-  using OffloadAllocator = OMPallocator<DT, aligned_allocator<DT>>;
-  template<typename DT>
-  using OffloadPinnedAllocator     = OMPallocator<DT, PinnedAlignedAllocator<DT>>;
   using OffloadValueVector_t       = Vector<T, OffloadAllocator<T>>;
   using OffloadPinnedValueVector_t = Vector<T, OffloadPinnedAllocator<T>>;
   using OffloadPinnedValueMatrix_t = Matrix<T, OffloadPinnedAllocator<T>>;
@@ -51,26 +73,21 @@ class MatrixUpdateOMPTarget
   OffloadValueVector_t temp;
   // scratch space for keeping one row of Ainv
   OffloadValueVector_t rcopy;
-  // constant array value T(1)
-  OffloadValueVector_t cone_vec;
-  // constant array value T(0)
-  OffloadValueVector_t czero_vec;
-  // multi walker of grads for transfer needs.
-  OffloadPinnedValueMatrix_t grads_value_v;
-  // pointer buffer
-  Vector<char, OffloadPinnedAllocator<char>> buffer_H2D;
+
+  // multi walker memory buffers
+  std::unique_ptr<MatrixUpdateOMPTargetMultiWalkerMem<T>> mw_mem_;
 
   void resize_fill_constant_arrays(size_t nw)
   {
-    if (cone_vec.size() < nw)
+    if (mw_mem_->cone_vec.size() < nw)
     {
-      cone_vec.resize(nw);
-      czero_vec.resize(nw);
-      std::fill_n(cone_vec.data(), nw, T(1));
-      std::fill_n(czero_vec.data(), nw, T(0));
-      T* cone_ptr = cone_vec.data();
+      mw_mem_->cone_vec.resize(nw);
+      mw_mem_->czero_vec.resize(nw);
+      std::fill_n(mw_mem_->cone_vec.data(), nw, T(1));
+      std::fill_n(mw_mem_->czero_vec.data(), nw, T(0));
+      T* cone_ptr = mw_mem_->cone_vec.data();
       PRAGMA_OFFLOAD("omp target update to(cone_ptr[:nw])")
-      T* czero_ptr = czero_vec.data();
+      T* czero_ptr = mw_mem_->czero_vec.data();
       PRAGMA_OFFLOAD("omp target update to(czero_ptr[:nw])")
     }
   }
@@ -78,10 +95,10 @@ class MatrixUpdateOMPTarget
   void resize_scratch_arrays(int norb, size_t nw)
   {
     size_t total_size = norb * nw;
-    if (temp.size() < total_size)
+    if (mw_mem_->mw_temp.size() < total_size)
     {
-      temp.resize(total_size);
-      rcopy.resize(total_size);
+      mw_mem_->mw_temp.resize(total_size);
+      mw_mem_->mw_rcopy.resize(total_size);
     }
   }
 
@@ -92,9 +109,23 @@ public:
    */
   inline void resize(int norb, int delay) { psiMinv.resize(norb, getAlignedSize<T>(norb)); }
 
-  void createResource(ResourceCollection& collection) const {}
-  void acquireResource(ResourceCollection& collection) {}
-  void releaseResource(ResourceCollection& collection) {}
+  void createResource(ResourceCollection& collection) const
+  {
+    collection.addResource(std::make_unique<MatrixUpdateOMPTargetMultiWalkerMem<T>>());
+  }
+
+  void acquireResource(ResourceCollection& collection)
+  {
+    auto res_ptr = dynamic_cast<MatrixUpdateOMPTargetMultiWalkerMem<T>*>(collection.lendResource().release());
+    if (!res_ptr)
+      throw std::runtime_error("MatrixUpdateOMPTarget::acquireResource dynamic_cast MatrixUpdateOMPTargetMultiWalkerMem failed");
+    mw_mem_.reset(res_ptr);
+  }
+
+  void releaseResource(ResourceCollection& collection)
+  {
+    collection.takebackResource(std::move(mw_mem_));
+  }
 
   OffloadPinnedValueMatrix_t& get_psiMinv() { return psiMinv; }
 
@@ -115,15 +146,25 @@ public:
   }
 
   template<typename TREAL>
-  inline void mw_invert_transpose(const RefVector<This_t>& engines,
+  static void mw_invert_transpose(const RefVectorWithLeader<This_t>& engines,
                                   const RefVector<const Matrix<T>>& logdetT_list,
                                   const RefVector<std::complex<TREAL>>& LogValues)
   {
+    auto& engine_leader = engines.getLeader();
+    // make this class unit tests friendly without the need of setup resources.
+    if (!engine_leader.mw_mem_)
+    {
+      app_warning() << "MatrixUpdateOMPTarget : This message should not be seen in production (performance bug) runs "
+                       "but only unit tests (expected)."
+                    << std::endl;
+      engine_leader.mw_mem_ = std::make_unique<MatrixUpdateOMPTargetMultiWalkerMem<T>>();
+    }
+
     for (int iw = 0; iw < engines.size(); iw++)
     {
-      auto& Ainv = engines[iw].get().psiMinv;
+      auto& Ainv = engines[iw].psiMinv;
       Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-      detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
+      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
       T* Ainv_ptr = Ainv.data();
       PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
     }
@@ -131,18 +172,22 @@ public:
   }
 
   template<typename GT>
-  inline void mw_evalGrad(const RefVector<This_t>& engines,
+  static void mw_evalGrad(const RefVectorWithLeader<This_t>& engines,
                           const std::vector<const T*>& dpsiM_row_list,
                           int rowchanged,
                           std::vector<GT>& grad_now)
   {
-    const int norb = psiMinv.rows();
+    auto& engine_leader = engines.getLeader();
+    auto& buffer_H2D = engine_leader.mw_mem_->buffer_H2D;
+    auto& grads_value_v = engine_leader.mw_mem_->grads_value_v;
+
+    const int norb = engine_leader.psiMinv.rows();
     const int nw   = engines.size();
     buffer_H2D.resize(sizeof(T*) * 2 * nw);
     Matrix<const T*> ptr_buffer(reinterpret_cast<const T**>(buffer_H2D.data()), 2, nw);
     for (int iw = 0; iw < nw; iw++)
     {
-      ptr_buffer[0][iw] = engines[iw].get().psiMinv.device_data() + rowchanged * psiMinv.cols();
+      ptr_buffer[0][iw] = engines[iw].psiMinv.device_data() + rowchanged * engine_leader.psiMinv.cols();
       ptr_buffer[1][iw] = dpsiM_row_list[iw];
     }
 
@@ -184,7 +229,8 @@ public:
     constexpr T czero(0);
     const int norb = Ainv.rows();
     const int lda  = Ainv.cols();
-    resize_scratch_arrays(norb, 1);
+    temp.resize(norb);
+    rcopy.resize(norb);
     // invoke the Fahy's variant of Sherman-Morrison update.
     int dummy_handle  = 0;
     int success       = 0;
@@ -209,7 +255,7 @@ public:
     }
   }
 
-  inline void mw_updateRow(const RefVector<This_t>& engines,
+  static void mw_updateRow(const RefVectorWithLeader<This_t>& engines,
                            int rowchanged,
                            const std::vector<T*>& psiM_g_list,
                            const std::vector<T*>& psiM_l_list,
@@ -218,13 +264,21 @@ public:
                            const size_t phi_vgl_stride,
                            const std::vector<T>& ratios)
   {
-    const int norb          = psiMinv.rows();
-    const int lda           = psiMinv.cols();
     const size_t n_accepted = psiM_g_list.size();
     if (n_accepted == 0)
       return;
 
-    resize_scratch_arrays(norb, n_accepted);
+    auto& engine_leader = engines.getLeader();
+    auto& buffer_H2D = engine_leader.mw_mem_->buffer_H2D;
+    auto& grads_value_v = engine_leader.mw_mem_->grads_value_v;
+    auto& cone_vec = engine_leader.mw_mem_->cone_vec;
+    auto& czero_vec = engine_leader.mw_mem_->czero_vec;
+    auto& mw_temp = engine_leader.mw_mem_->mw_temp;
+    auto& mw_rcopy = engine_leader.mw_mem_->mw_rcopy;
+    const int norb          = engine_leader.psiMinv.rows();
+    const int lda           = engine_leader.psiMinv.cols();
+
+    engine_leader.resize_scratch_arrays(norb, n_accepted);
 
     // to handle T** of Ainv, psi_v, temp, rcopy
     buffer_H2D.resize((sizeof(T*) * 8 + sizeof(T)) * n_accepted);
@@ -233,10 +287,10 @@ public:
     for (int iw = 0, count = 0; iw < isAccepted.size(); iw++)
       if (isAccepted[iw])
       {
-        ptr_buffer[0][count] = engines[iw].get().psiMinv.device_data();
+        ptr_buffer[0][count] = engines[iw].psiMinv.device_data();
         ptr_buffer[1][count] = const_cast<T*>(phi_vgl_v_dev_ptr + norb * iw);
-        ptr_buffer[2][count] = temp.device_data() + norb * count;
-        ptr_buffer[3][count] = rcopy.device_data() + norb * count;
+        ptr_buffer[2][count] = mw_temp.device_data() + norb * count;
+        ptr_buffer[3][count] = mw_rcopy.device_data() + norb * count;
         ptr_buffer[4][count] = psiM_g_list[count];
         ptr_buffer[5][count] = psiM_l_list[count];
         ptr_buffer[6][count] = const_cast<T*>(phi_vgl_v_dev_ptr + phi_vgl_stride + norb * 3 * iw);
@@ -252,7 +306,7 @@ public:
     int dummy_handle     = 0;
     int success          = 0;
     auto* buffer_H2D_ptr = buffer_H2D.data();
-    resize_fill_constant_arrays(n_accepted);
+    engine_leader.resize_fill_constant_arrays(n_accepted);
     T* cone_ptr  = cone_vec.data();
     T* czero_ptr = czero_vec.data();
     PRAGMA_OFFLOAD("omp target data \
@@ -303,7 +357,7 @@ public:
     }
   }
 
-  inline void mw_accept_rejectRow(const RefVector<This_t>& engines,
+  static void mw_accept_rejectRow(const RefVectorWithLeader<This_t>& engines,
                                   const int rowchanged,
                                   const std::vector<T*>& psiM_g_list,
                                   const std::vector<T*>& psiM_l_list,
@@ -318,36 +372,33 @@ public:
   /** update the full Ainv and reset delay_count
    * @param Ainv inverse matrix
    */
-  inline void mw_updateInvMat(const RefVector<This_t>& engines) {}
+  inline static void mw_updateInvMat(const RefVectorWithLeader<This_t>& engines) {}
 
-  std::vector<const T*> mw_getInvRow(const RefVector<This_t>& engines, const int row_id, bool on_host) const
+  std::vector<const T*> static mw_getInvRow(const RefVectorWithLeader<This_t>& engines, const int row_id, bool on_host)
   {
     const size_t nw = engines.size();
+    const size_t ncols = engines.getLeader().psiMinv.cols();
     std::vector<const T*> row_ptr_list;
     row_ptr_list.reserve(nw);
     if (on_host)
-    {
       for (This_t& engine : engines)
       {
         auto* ptr = engine.psiMinv.data();
-        PRAGMA_OFFLOAD("omp target update from(ptr[row_id * psiMinv.cols():psiMinv.cols()])")
-        row_ptr_list.push_back(ptr + row_id * psiMinv.cols());
+        PRAGMA_OFFLOAD("omp target update from(ptr[row_id * ncols : ncols])")
+        row_ptr_list.push_back(ptr + row_id * ncols);
       }
-    }
     else
-    {
       for (This_t& engine : engines)
-        row_ptr_list.push_back(engine.psiMinv.device_data() + row_id * psiMinv.cols());
-    }
+        row_ptr_list.push_back(engine.psiMinv.device_data() + row_id * ncols);
     return row_ptr_list;
   }
 
-  void mw_transferAinv_D2H(const RefVector<This_t>& engines)
+  static void mw_transferAinv_D2H(const RefVectorWithLeader<This_t>& engines)
   {
     for (This_t& engine : engines)
     {
       auto* ptr = engine.psiMinv.data();
-      PRAGMA_OFFLOAD("omp target update from(ptr[:psiMinv.size()])")
+      PRAGMA_OFFLOAD("omp target update from(ptr[:engine.psiMinv.size()])")
     }
   }
 };

--- a/src/Utilities/ResourceCollection.cpp
+++ b/src/Utilities/ResourceCollection.cpp
@@ -38,8 +38,8 @@ size_t ResourceCollection::addResource(std::unique_ptr<Resource>&& res, bool nop
   size_t index              = collection_.size();
   res->index_in_collection_ = index;
   if (!noprint)
-    app_log() << "Multi walker shared resource \"" << res->getName() << "\" created in resource collection \"" << name_
-              << "\" index " << index << std::endl;
+    app_debug_stream() << "Multi walker shared resource \"" << res->getName() << "\" created in resource collection \""
+                << name_ << "\" index " << index << std::endl;
   collection_.emplace_back(std::move(res));
   return index;
 }


### PR DESCRIPTION
## Proposed changes

1. Move multi walker memory to shared resource to stop increasing memory consumption over time.
2. Remove the 1 walker code path under NonLocalECPComponent::mw_evaluateOne(). An oversight from previous refactoring. The massive change shown here is caused by formatting.

## What type(s) of changes does this code introduce?
- Bugfix
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'