### PR TITLE
Use update call for inactive particleset only in CoulombPBCAA

### DIFF
--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -85,6 +85,7 @@ private:
     {
       auto& dt = dt_list.getCastedElement<SoaDistanceTableABOMPTarget>(iw);
       count_targets += dt.targets();
+      dt.r_dr_memorypool_.free();
     }
 
     const int N_sources        = dt_leader.N_sources;

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -48,6 +48,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
   }
   if (!is_active)
   {
+    ref.update();
     update_source(ref);
 
     ewaldref::RealMat A;
@@ -314,8 +315,6 @@ void CoulombPBCAA::initBreakup(ParticleSet& P)
       rVsforce = LRCoulombSingleton::createSpline4RbyVs(dAA.get(), myRcut, myGridforce);
     }
   }
-
-  P.update();
 }
 
 


### PR DESCRIPTION
## Proposed changes
1. Calling particleset update() in the constructor of CoulombPBCAA only make sense for inactive particles (ions).
2. In SoaDistanceTableABOMPTarget, actively free single walker memory before multi walker shared buffer is resized to avoid keep the memory twice.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'