### PR TITLE
Fix SlaterDetWithBackflow virtual function override mismatch

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.h
@@ -71,13 +71,13 @@ public:
   }
 
   ///set BF pointers
-  void setBF(BackflowTransformation* bf) { BFTrans = bf; }
+  void setBF(BackflowTransformation* bf) override { BFTrans = bf; }
 
   // in general, assume that P is the quasiparticle set
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& active,
                            std::vector<ValueType>& dlogpsi,
-                           std::vector<ValueType>& dhpsioverpsi);
+                           std::vector<ValueType>& dhpsioverpsi) override;
 
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& active,
@@ -92,44 +92,44 @@ public:
                            int offset,
                            Matrix<RealType>& dlogpsi,
                            Array<GradType, OHMMS_DIM>& dG,
-                           Matrix<RealType>& dL);
+                           Matrix<RealType>& dL) override;
 
   ///reset the size: with the number of particles and number of orbtials
   void resize(int nel, int morb);
 
-  void registerData(ParticleSet& P, WFBufferType& buf);
+  void registerData(ParticleSet& P, WFBufferType& buf) override;
 
-  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
+  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override;
 
-  void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override;
 
   /** return the ratio only for the  iat-th partcle move
    * @param P current configuration
    * @param iat the particle thas is being moved
    */
-  PsiValueType ratio(ParticleSet& P, int iat);
+  PsiValueType ratio(ParticleSet& P, int iat) override;
 
-  void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios);
+  void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 
-  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat);
-  GradType evalGrad(ParticleSet& P, int iat);
-  GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat);
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override;
+  GradType evalGrad(ParticleSet& P, int iat) override;
+  GradType evalGradSource(ParticleSet& P, ParticleSet& source, int iat) override;
 
   GradType evalGradSource(ParticleSet& P,
                           ParticleSet& source,
                           int iat,
                           TinyVector<ParticleSet::ParticleGradient_t, OHMMS_DIM>& grad_grad,
-                          TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad);
+                          TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad) override;
 
   /** move was accepted, update the real container
    */
-  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);
+  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override;
 
   /** move was rejected. copy the real container to the temporary to move on
    */
-  void restore(int iat);
+  void restore(int iat) override;
 
-  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) override;
 
   /** cloning function
    * @param tqp target particleset
@@ -138,7 +138,7 @@ public:
    * This interface is exposed only to SlaterDet and its derived classes
    * can overwrite to clone itself correctly.
    */
-  DiracDeterminantWithBackflow* makeCopy(std::shared_ptr<SPOSet>&& spo) const;
+  DiracDeterminantWithBackflow* makeCopy(std::shared_ptr<SPOSet>&& spo) const override;
 
   inline ValueType rcdot(TinyVector<RealType, OHMMS_DIM>& lhs, TinyVector<ValueType, OHMMS_DIM>& rhs)
   {

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -36,7 +36,7 @@ void SlaterDetWithBackflow::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<V
     Dets[i]->evaluateRatiosAlltoOne(P, ratios);
 }
 
-SlaterDetWithBackflow::LogValueType SlaterDetWithBackflow::evaluateLog(ParticleSet& P,
+SlaterDetWithBackflow::LogValueType SlaterDetWithBackflow::evaluateLog(const ParticleSet& P,
                                                                        ParticleSet::ParticleGradient_t& G,
                                                                        ParticleSet::ParticleLaplacian_t& L)
 {

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.h
@@ -37,14 +37,14 @@ public:
   ~SlaterDetWithBackflow();
 
   ///set BF pointers
-  void setBF(BackflowTransformation* bf)
+  void setBF(BackflowTransformation* bf) override
   {
     BFTrans = bf;
     for (int i = 0; i < Dets.size(); i++)
       Dets[i]->setBF(BFTrans);
   }
 
-  void checkInVariables(opt_variables_type& active)
+  void checkInVariables(opt_variables_type& active) override
   {
     //if(Optimizable) {
     if (BFTrans->isOptimizable())
@@ -55,7 +55,7 @@ public:
     }
   }
 
-  void checkOutVariables(const opt_variables_type& active)
+  void checkOutVariables(const opt_variables_type& active) override
   {
     //if(Optimizable) {
     if (BFTrans->isOptimizable())
@@ -67,7 +67,7 @@ public:
   }
 
   ///reset all the Dirac determinants, Optimizable is true
-  void resetParameters(const opt_variables_type& active)
+  void resetParameters(const opt_variables_type& active) override
   {
     //if(Optimizable) {
     if (BFTrans->isOptimizable())
@@ -78,13 +78,13 @@ public:
     }
   }
 
-  LogValueType evaluateLog(ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L) override;
 
-  void registerData(ParticleSet& P, WFBufferType& buf);
-  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
-  void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
+  void registerData(ParticleSet& P, WFBufferType& buf) override;
+  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override;
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override;
 
-  inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  inline PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
   {
     BFTrans->evaluatePbyPWithGrad(P, iat);
     //BFTrans->evaluate(P);
@@ -94,7 +94,7 @@ public:
     return psi;
   }
 
-  GradType evalGrad(ParticleSet& P, int iat)
+  GradType evalGrad(ParticleSet& P, int iat) override
   {
     QMCTraits::GradType g;
     for (int i = 0; i < Dets.size(); ++i)
@@ -102,7 +102,7 @@ public:
     return g;
   }
 
-  GradType evalGradSource(ParticleSet& P, ParticleSet& src, int iat)
+  GradType evalGradSource(ParticleSet& P, ParticleSet& src, int iat) override
   {
     APP_ABORT("Need to implement SlaterDetWithBackflow::evalGradSource() \n");
     return ValueType();
@@ -112,20 +112,20 @@ public:
                           ParticleSet& src,
                           int iat,
                           TinyVector<ParticleSet::ParticleGradient_t, OHMMS_DIM>& grad_grad,
-                          TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad)
+                          TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad) override
   {
     APP_ABORT("Need to implement SlaterDetWithBackflow::evalGradSource() \n");
     return GradType();
   }
 
-  inline void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false)
+  inline void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override
   {
     BFTrans->acceptMove(P, iat);
     for (int i = 0; i < Dets.size(); i++)
       Dets[i]->acceptMove(P, iat);
   }
 
-  inline void restore(int iat)
+  inline void restore(int iat) override
   {
     BFTrans->restore(iat);
     for (int i = 0; i < Dets.size(); i++)
@@ -133,7 +133,7 @@ public:
   }
 
 
-  inline PsiValueType ratio(ParticleSet& P, int iat)
+  inline PsiValueType ratio(ParticleSet& P, int iat) override
   {
     BFTrans->evaluatePbyP(P, iat);
     //BFTrans->evaluate(P);
@@ -143,16 +143,16 @@ public:
     return ratio;
   }
 
-  WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const;
+  WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const override;
 
-  SPOSetPtr getPhi(int i = 0) { return Dets[i]->getPhi(); }
+  SPOSetPtr getPhi(int i = 0) override { return Dets[i]->getPhi(); }
 
-  void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios);
+  void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override;
 
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& optvars,
                            std::vector<ValueType>& dlogpsi,
-                           std::vector<ValueType>& dhpsioverpsi);
+                           std::vector<ValueType>& dhpsioverpsi) override;
 
   void testDerivGL(ParticleSet& P);
 


### PR DESCRIPTION
## Proposed changes
Fix a breakage introduced in #3012
SlaterDetWithBackflow::evaluateLog has been corrected. All other changes are just adding override keyword to prevent future mistakes.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'