### PR TITLE
Fix legacy CUDA unit test.

### DIFF
--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -227,7 +227,7 @@ TEST_CASE("Coulomb PBC A-A CUDA BCC H", "[hamiltonian][CUDA]")
   ions.updateLists_GPU();
 
 
-  CoulombPBCAA_CUDA caa(ions, true);
+  CoulombPBCAA_CUDA caa(ions, false);
 
   // Background charge term
   double consts = caa.evalConsts();


### PR DESCRIPTION
## Proposed changes
The unit test didn't mark Coulomb on ion inactive. Failure showed up in nightly.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'