### PR TITLE
Resolve misaligned address in CUDA

### DIFF
--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -108,7 +108,7 @@ private:
       {
         dt.distances_[i].attachReference(mw_r_dr.data() + (i + count_targets) * stride_size, N_sources);
         dt.displacements_[i].attachReference(N_sources, N_sources_padded,
-                                          mw_r_dr.data() + (i + count_targets) * stride_size + N_sources_padded);
+                                             mw_r_dr.data() + (i + count_targets) * stride_size + N_sources_padded);
       }
       count_targets += dt.targets();
     }
@@ -215,8 +215,8 @@ public:
           for (int idim = 0; idim < D; idim++)
             pos[idim] = target_pos_ptr[iat * D + idim];
 
-          auto* r_iat_ptr          = r_dr_ptr + iat * stride_size;
-          auto* dr_iat_ptr         = r_iat_ptr + N_sources_padded;
+          auto* r_iat_ptr  = r_dr_ptr + iat * stride_size;
+          auto* dr_iat_ptr = r_iat_ptr + N_sources_padded;
 
           PRAGMA_OFFLOAD("omp parallel for")
           for (int iel = first; iel < last; iel++)
@@ -277,10 +277,10 @@ public:
     const size_t ptr_size      = sizeof(RealType*);
     auto& offload_input        = mw_mem.offload_input;
     offload_input.resize(total_targets * D * realtype_size + total_targets * int_size + nw * ptr_size);
-    auto target_positions = reinterpret_cast<RealType*>(offload_input.data());
-    auto walker_id_ptr    = reinterpret_cast<int*>(offload_input.data() + total_targets * D * realtype_size);
-    auto source_ptrs      = reinterpret_cast<RealType**>(offload_input.data() + total_targets * D * realtype_size +
-                                                    total_targets * int_size);
+    auto source_ptrs      = reinterpret_cast<RealType**>(offload_input.data());
+    auto target_positions = reinterpret_cast<RealType*>(offload_input.data() + ptr_size * nw);
+    auto walker_id_ptr =
+        reinterpret_cast<int*>(offload_input.data() + ptr_size * nw + total_targets * D * realtype_size);
 
     count_targets = 0;
     for (size_t iw = 0; iw < nw; iw++)
@@ -318,10 +318,10 @@ public:
       for (int iat = 0; iat < total_targets; ++iat)
         for (int team_id = 0; team_id < num_teams; team_id++)
         {
-          auto* target_pos_ptr = reinterpret_cast<RealType*>(input_ptr);
-          const int walker_id  = reinterpret_cast<int*>(input_ptr + total_targets * D * realtype_size)[iat];
-          auto* source_pos_ptr = reinterpret_cast<RealType**>(input_ptr + total_targets * D * realtype_size +
-                                                              total_targets * int_size)[walker_id];
+          auto* target_pos_ptr = reinterpret_cast<RealType*>(input_ptr + ptr_size * nw);
+          const int walker_id =
+              reinterpret_cast<int*>(input_ptr + ptr_size * nw + total_targets * D * realtype_size)[iat];
+          auto* source_pos_ptr = reinterpret_cast<RealType**>(input_ptr)[walker_id];
           auto* r_iat_ptr      = r_dr_ptr + iat * N_sources_padded * (D + 1);
           auto* dr_iat_ptr     = r_dr_ptr + iat * N_sources_padded * (D + 1) + N_sources_padded;
 


### PR DESCRIPTION
## Proposed changes
The CUDA error shows up when there is odd number of electrons with full precision real build code.

When using a fused memory buffer for transferring data, it is necessary to fill larger objects than smaller ones. pointers 64 bit before RealType 64 bit or 32 bit before int 32bit.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted