### PR TITLE
Fix pwscf analyzer when eigenvalues touch

### DIFF
--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -288,6 +288,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
                     for j in range(i+1,i_occ):
                         seigs+=lines[j]
                     #end for
+                    seigs = seigs.replace('-',' -') # For cases where the eigenvalues "touch", e.g. -144.9938-144.9938 -84.3023
                     seigs = seigs.strip()
                     eigs = array(seigs.split(),dtype=float)
 


### PR DESCRIPTION


## Proposed changes

Small change to pwscf_analyzer. QE can print touching eigenvalues, e.g., `-144.9938-144.9938`, which then prevents the bands from being stored.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

ORNL CADES

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
