### PR TITLE
Fix two body Jastrow optimizstion with inactive variables

### DIFF
--- a/src/Optimize/VariableSet.cpp
+++ b/src/Optimize/VariableSet.cpp
@@ -237,10 +237,11 @@ void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader) c
 {
   std::string pad_str = std::string(leftPadSpaces, ' ');
   int max_name_len    = 0;
-  max_name_len =
-      std::max_element(NameAndValue.begin(), NameAndValue.end(),
-                       [](const pair_type& e1, const pair_type& e2) { return e1.first.length() < e2.first.length(); })
-          ->first.length();
+  if (NameAndValue.size() > 0)
+    max_name_len =
+        std::max_element(NameAndValue.begin(), NameAndValue.end(), [](const pair_type& e1, const pair_type& e2) {
+          return e1.first.length() < e2.first.length();
+        })->first.length();
 
   int max_value_len     = 28; // 6 for the precision and 7 for minus sign, leading value, period, and exponent.
   int max_type_len      = 1;

--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -42,7 +42,7 @@ class DiffTwoBodyJastrowOrbital : public DiffWaveFunctionComponent
   std::vector<FT*> F;
   /// e-e table ID
   const int my_table_ID_;
-  ///offset for the optimizable variables
+  /// Map indices from subcomponent variables to component variables
   std::vector<std::pair<int, int>> OffSet;
   Vector<RealType> dLogPsi;
   std::vector<GradVectorType*> gradLogPsi;
@@ -65,9 +65,9 @@ public:
   }
 
   // Accessors for unit testing
-  std::pair<int, int> getOffset(int index) { return OffSet.at(index); }
+  std::pair<int, int> getComponentOffset(int index) { return OffSet.at(index); }
 
-  opt_variables_type& getVars() { return myVars; }
+  opt_variables_type& getComponentVars() { return myVars; }
 
 
   void addFunc(int ia, int ib, FT* j)
@@ -129,6 +129,9 @@ public:
       myVars.insertFrom((*it).second->myVars);
       ++it;
     }
+    // Remove inactive variables so the mappings are correct
+    myVars.removeInactive();
+
     myVars.getIndex(active);
     NumVars = myVars.size();
 

--- a/src/QMCWaveFunctions/tests/test_DiffTwoBodyJastrowOrbital.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiffTwoBodyJastrowOrbital.cpp
@@ -9,14 +9,12 @@
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
-
 #include "catch.hpp"
 
 #include "QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h"
 
 namespace qmcplusplus
 {
-
 // Mock radial function to use in DiffTwoBodyJastrowOrbital
 class FakeJastrow
 {
@@ -27,9 +25,15 @@ public:
 
   using RealType = QMCTraits::RealType;
 
-  bool evaluateDerivatives(RealType r, std::vector<TinyVector<RealType, 3>>& derivs) { return true; }
+  bool evaluateDerivatives(RealType r, std::vector<TinyVector<RealType, 3>>& derivs)
+  {
+    derivs = derivs_;
+    return true;
+  }
 
   void resetParameters(const opt_variables_type& active) {}
+
+  std::vector<TinyVector<RealType, 3>> derivs_;
 };
 
 TEST_CASE("DiffTwoBodyJastrowOrbital simple", "[wavefunction]")
@@ -69,10 +73,20 @@ ParticleSet get_two_species_particleset()
   std::vector<int> ud{2, 2};
   elec.setName("e");
   elec.create(ud);
+
+  elec.R[0] = {1.0, 0.0, 0.0};
+  elec.R[1] = {1.1, 1.0, 0.1};
+  elec.R[2] = {0.9, 0.8, 1.0};
+  elec.R[3] = {0.9, 0.5, 1.1};
+
   SpeciesSet& tspecies = elec.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
   int downIdx          = tspecies.addSpecies("d");
   elec.resetGroups();
+
+  elec.addTable(elec);
+  elec.update();
+
   return elec;
 }
 
@@ -108,7 +122,7 @@ TEST_CASE("DiffTwoBodyJastrowOrbital two variables", "[wavefunction]")
   //j2a.myVars.print(std::cout,0,true);
   //j2b.myVars.print(std::cout,0,true);
   //global_active.print(std::cout,0,true);
-  //jorb.getVars().print(std::cout,0,true);
+  //jorb.getComponentVars().print(std::cout,0,true);
 
   CHECK(global_active.size_of_active() == 2);
 
@@ -119,19 +133,19 @@ TEST_CASE("DiffTwoBodyJastrowOrbital two variables", "[wavefunction]")
   // F[3] is (1,1) b-b (by default uses the same function as a-a)
 
   // Index into global_active
-  auto o1 = jorb.getOffset(0);
+  auto o1 = jorb.getComponentOffset(0);
   CHECK(o1.first == 0);
   CHECK(o1.second == 1);
 
-  auto o2 = jorb.getOffset(1);
+  auto o2 = jorb.getComponentOffset(1);
   CHECK(o2.first == 1);
   CHECK(o2.second == 2);
 
-  auto o3 = jorb.getOffset(2);
+  auto o3 = jorb.getComponentOffset(2);
   CHECK(o3.first == 1);
   CHECK(o3.second == 2);
 
-  auto o4 = jorb.getOffset(3);
+  auto o4 = jorb.getComponentOffset(3);
   CHECK(o4.first == 0);
   CHECK(o4.second == 1);
 }
@@ -168,20 +182,109 @@ TEST_CASE("DiffTwoBodyJastrowOrbital variables fail", "[wavefunction]")
 
   CHECK(global_active.size_of_active() == 1);
   // Not optimizing the parameter in this Jastrow factor, indicated by first index is -1
-  auto o1 = jorb.getOffset(0);
+  auto o1 = jorb.getComponentOffset(0);
   CHECK(o1.first == -1);
 
   // Offset into set of active variables (global_active)
-  auto o2 = jorb.getOffset(1);
+  auto o2 = jorb.getComponentOffset(1);
   CHECK(o2.first == 0);
   CHECK(o2.second == 1);
 
-  auto o3 = jorb.getOffset(2);
+  auto o3 = jorb.getComponentOffset(2);
   CHECK(o3.first == 0);
   CHECK(o3.second == 1);
 
-  auto o4 = jorb.getOffset(3);
+  auto o4 = jorb.getComponentOffset(3);
   CHECK(o4.first == -1);
+
+  using ValueType = QMCTraits::ValueType;
+
+  // Check derivative indexing
+  int num_vars = 1;
+  j2b.derivs_.resize(num_vars);
+  // Elements are d/dp_i u(r), d/dp_i du/dr,  d/dp_i d2u/dr2
+  j2b.derivs_[0] = {0.5, 1.3, 2.4};
+  std::vector<ValueType> dlogpsi(num_vars);
+  jorb.evaluateDerivativesWF(elec, global_active, dlogpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(-2.0)); // 4 * derivs_[0][0]
+
+  std::vector<ValueType> dlogpsi2(num_vars);
+  std::vector<ValueType> dhpsioverpsi(num_vars);
+
+  jorb.evaluateDerivatives(elec, global_active, dlogpsi2, dhpsioverpsi);
+  CHECK(dlogpsi2[0] == ValueApprox(-2.0));
+}
+
+// Other variational parameters in the wavefunction (e.g. one-body Jastrow)
+
+TEST_CASE("DiffTwoBodyJastrowOrbital other variables", "[wavefunction]")
+{
+  ParticleSet elec = get_two_species_particleset();
+
+  DiffTwoBodyJastrowOrbital<FakeJastrow> jorb(elec);
+
+  FakeJastrow j2a;
+  j2a.myVars.insert("opt1", 1.0);
+  j2a.name = "j2a";
+  // update num_active_vars
+  j2a.myVars.resetIndex();
+  jorb.addFunc(0, 0, &j2a);
+
+  FakeJastrow j2b;
+  j2b.myVars.insert("opt2", 2.0);
+  j2b.name = "j2b";
+  // update num_active_vars
+  j2b.myVars.resetIndex();
+  jorb.addFunc(0, 1, &j2b);
+
+  opt_variables_type global_active;
+  // This is a parameter from another part of the wavefunction
+  global_active.insert("other_opt", 1.0);
+  global_active.insertFrom(j2b.myVars);
+  global_active.resetIndex();
+
+
+  jorb.checkOutVariables(global_active);
+
+  //global_active.print(std::cout,0,true);
+  //jorb.getComponentVars().print(std::cout,0,true);
+
+  CHECK(global_active.size_of_active() == 2);
+  // Not optimizing the parameter in this Jastrow factor, indicated by first index is -1
+  auto o1 = jorb.getComponentOffset(0);
+  CHECK(o1.first < 0);
+
+  // Offset into set of active variables (global_active)
+  auto o2 = jorb.getComponentOffset(1);
+  CHECK(o2.first == 0);
+  CHECK(o2.second == 1);
+
+  auto o3 = jorb.getComponentOffset(2);
+  CHECK(o3.first == 0);
+  CHECK(o3.second == 1);
+
+  auto o4 = jorb.getComponentOffset(3);
+  CHECK(o4.first < 0);
+
+
+  using ValueType = QMCTraits::ValueType;
+
+  // Check derivative indexing
+  int num_vars = 1;
+  j2b.derivs_.resize(num_vars);
+  // Elements are d/dp_i u(r), d/dp_i du/dr,  d/dp_i d2u/dr2
+  j2b.derivs_[0] = {0.5, 1.3, 2.4};
+  std::vector<ValueType> dlogpsi(num_vars);
+  jorb.evaluateDerivativesWF(elec, global_active, dlogpsi);
+
+  CHECK(dlogpsi[1] == ValueApprox(-2.0)); // 4 * derivs_[0][0]
+
+  std::vector<ValueType> dlogpsi2(num_vars);
+  std::vector<ValueType> dhpsioverpsi(num_vars);
+
+  jorb.evaluateDerivatives(elec, global_active, dlogpsi2, dhpsioverpsi);
+  CHECK(dlogpsi2[1] == ValueApprox(-2.0));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_DiffTwoBodyJastrowOrbital.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiffTwoBodyJastrowOrbital.cpp
@@ -271,7 +271,7 @@ TEST_CASE("DiffTwoBodyJastrowOrbital other variables", "[wavefunction]")
   using ValueType = QMCTraits::ValueType;
 
   // Check derivative indexing
-  int num_vars = 1;
+  int num_vars = 2;
   j2b.derivs_.resize(num_vars);
   // Elements are d/dp_i u(r), d/dp_i du/dr,  d/dp_i d2u/dr2
   j2b.derivs_[0] = {0.5, 1.3, 2.4};


### PR DESCRIPTION
Remove inactive variables from myVars in order to construct correct mappings from sub-component variables to component variables, and from component variables to global variables (active).

Fixes #2814.  I believe this change also renders the change in #3040 moot.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
Desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
