### PR TITLE
Add status badges in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+[![License](https://img.shields.io/badge/License-UIUC/NCSA-blue.svg)](https://opensource.org/licenses/NCSA)
+[![Documentation Status](https://readthedocs.org/projects/qmcpack/badge/?version=develop)](https://qmcpack.readthedocs.io/en/develop/?badge=develop)
+
+[![GitHub release](https://img.shields.io/github/release/QMCPACK/qmcpack/all.svg)](https://github.com/QMCPACK/qmcpack/releases)
+[![Spack Version](https://img.shields.io/spack/v/qmcpack.svg)](https://spack.readthedocs.io/en/latest/package_list.html#qmcpack)
+
+[![GitHub Actions CI](https://github.com/QMCPACK/qmcpack/actions/workflows/ci-github-actions.yaml/badge.svg)](https://github.com/QMCPACK/qmcpack/actions/workflows/ci-github-actions.yaml)
+[![codecov-deterministic](https://codecov.io/gh/QMCPACK/qmcpack/branch/develop/graph/badge.svg?token=35D0u6GlBm)](https://codecov.io/gh/QMCPACK/qmcpack)
+
 # Getting and building QMCPACK
 
  Obtain the latest release from https://github.com/QMCPACK/qmcpack/releases or clone the development source from

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -5,6 +5,7 @@ comment: off
 
 # Ignore testing directory itself
 ignore:
+  - "external_codes"
   - "tests"
 
 # Fixes report prefix paths from CI dynamic coverage action


### PR DESCRIPTION
Add status badges in Readme for the `develop` branch statuses of GitHub releases and CI actions, Spack, Codecov, Readthedocs, License
Filter out external codes in coverage

Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
It just adds badges to Readme to have statuses, and GitHub and third-party links in one place.
Filters our external code from codecov coverage report.

## What type(s) of changes does this code introduce?

- Other (please describe): simple standard badges

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must be tested on GitHub markdown parser 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted (N/A)
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
