### PR TITLE
Cleanup license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-Important Notice for qmcpack developers and end-users:
-
-i) The original programs developed by Jeongnim Kim and her collaborators
-are distributed under UIUC/NCSA Open Source License (below). 
-
-ii) Some packages/features are not available under open source license and require
-separate license agreements with the authors. Contact the responsible authors.
-
-iii) autoconf/automake scripts are distributed under GPL (see COPYING).
-
-iv) The sources derived from any package distributed under GPL contain
-explicit acknowledgments of the original works and are distributed under GPL.
-
--------------
 		  University of Illinois/NCSA Open Source License
 
 Copyright (c) 2003, University of Illinois Board of Trustees.

--- a/nexus/LICENSE
+++ b/nexus/LICENSE
@@ -1,13 +1,4 @@
 
-Notice:
-
-Development work on Nexus was initiated by Jaron T. Krogel at UIUC in 2012.
-
-This software is distributed under the UIUC/NCSA Open Source License (below).
-
------------------------------------------------------------------------------
-
-
 		  University of Illinois/NCSA Open Source License
 
 Copyright (c) 2012, University of Illinois Board of Trustees.


### PR DESCRIPTION
## Proposed changes

Remove the historical and confusing disclaimers about code covered by licenses other than the main UIUC/NCSA one. We have gone through the repository and removed or replaced historical sources thought to be covered by other licenses.

This PR does not attempt to update the main license. However I'll note that the developed by text  is certainly not current and the URL given is no longer valid. We'll have to consult about how to amend it in future. 

Added after initial PR: based on discussion below, removed the development history text from the NEXUS license file as well.

## What type(s) of changes does this code introduce?

- Bugfix
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. Docs only.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
