### PR TITLE
Use macro if defined(SWITCH) rather than if SWITCH.

### DIFF
--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -414,7 +414,7 @@ private:
       set_buffer(N);
       CMatrix_ref R( Buff.origin(), {dN,NMO*NMO});
       CVector_ref R1D( Buff.origin(), {dN*NMO*NMO});
-#if ENABLE_CUDA
+#if defined(ENABLE_CUDA)
       if(Grot.size() < R.num_elements()) 
         Grot = stdCVector(iextensions<1u>(R.num_elements()));
 #endif
@@ -428,7 +428,7 @@ private:
         // use ger later
         ma::product( Gw.sliced(i0,iN), ma::T(Gw), R );
 
-#if ENABLE_CUDA
+#if defined(ENABLE_CUDA)
         using std::copy_n;
         copy_n(R.origin(),R.num_elements(),Grot.origin());
         ma::axpy( Xw[iw], Grot, DMWork[iw].sliced(i0*NMO*NMO,iN*NMO*NMO) );

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization.hpp
@@ -262,7 +262,7 @@ public:
       for (int J = I + 1; J < npol * NMO; J++)
       {
         // This is really cutoff dependent!!!
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         if (std::abs(P1[I][J] - ma::conj(P1[J][I])) * 2.0 > 1e-5)
         {
 #else
@@ -342,7 +342,7 @@ public:
     size_t cnt(0);
     if (addEJ)
     {
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += 2 * nwalk * local_nCV;
 #else
       if (not getKr)
@@ -361,7 +361,7 @@ public:
       Knr = nwalk;
       Knc = local_nCV;
       cnt = 0;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKr)
       {
         assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
@@ -380,7 +380,7 @@ public:
         Krptr = to_address(SM_TMats.origin());
         cnt += nwalk * local_nCV;
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
@@ -653,7 +653,7 @@ public:
           }
         }
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         size_t i0, iN;
@@ -710,7 +710,7 @@ public:
     size_t cnt(0);
     if (addEJ)
     {
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += 2 * nwalk * local_nCV;
 #else
       if (not getKr)
@@ -729,7 +729,7 @@ public:
       Knr = nwalk;
       Knc = local_nCV;
       cnt = 0;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKr)
       {
         assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
@@ -748,7 +748,7 @@ public:
         Krptr = to_address(SM_TMats.origin());
         cnt += nwalk * local_nCV;
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
@@ -1079,7 +1079,7 @@ public:
           }
         }
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         size_t i0, iN;

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorization_batched.hpp
@@ -414,7 +414,7 @@ public:
       for (int J = I + 1; J < npol * NMO; J++)
       {
         // This is really cutoff dependent!!!
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         if (std::abs(P1[I][J] - ma::conj(P1[J][I])) * 2.0 > 1e-5)
         {
 #else
@@ -821,7 +821,7 @@ public:
       size_t mem_needs(nwalk*nkpts*nkpts*nspin*nocca_max*nmo_max);
       size_t cnt(0);  
       if(addEJ) { 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         mem_needs += 2*nwalk*local_nCV;
 #else
         if(not getKr) mem_needs += nwalk*local_nCV;
@@ -837,7 +837,7 @@ public:
         Knr=nwalk;
         Knc=local_nCV;
         cnt=0;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         if(getKr) {
           assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
           assert(KEright->stride(0) == KEright->size(1));
@@ -853,7 +853,7 @@ public:
           Krptr = BTMats.origin();
           cnt += nwalk*local_nCV;
         }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         if(getKl) {
           assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
           assert(KEleft->stride(0) == KEleft->size(1));
@@ -1222,7 +1222,7 @@ public:
 
     // "rotate" X
     //  XIJ = 0.5*a*(Xn+ -i*Xn-), XJI = 0.5*a*(Xn+ +i*Xn-)
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     StaticMatrix Xdev(X.extensions(), device_buffer_manager.get_generator().template get_allocator<SPComplexType>());
     copy_n_cast(make_device_ptr(X.origin()), X.num_elements(), Xdev.origin());
 #else

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization.hpp
@@ -219,7 +219,7 @@ public:
     size_t cnt(0);
     if (addEJ)
     {
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += nwalk * local_nCV;
 #else
       if (not getKl)
@@ -229,7 +229,7 @@ public:
     if (addEXX)
     {
       mem_needs += nwalk * nel[0] * nel[0] * local_nCV;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += nwalk * nel[0] * NMO;
 #else
       if (nspin == 2)
@@ -250,7 +250,7 @@ public:
         assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
         assert(KEright->stride(0) == KEright->size(1));
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
@@ -305,7 +305,7 @@ public:
       {
         size_t cnt_(cnt);
         SPComplexType* ptr(nullptr);
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         ptr = to_address(SM_TMats.origin()) + cnt_;
         cnt_ += nwalk * nel[ispin] * NMO;
         for (int n = 0; n < nwalk; ++n)
@@ -388,7 +388,7 @@ public:
         if (n % TG.TG_local().size() == TG.TG_local().rank())
           E[n][2] += 0.5 * static_cast<ComplexType>(scl * scl * ma::dot(Kl[n], Kl[n]));
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         long i0, iN;

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched.hpp
@@ -215,7 +215,7 @@ public:
     size_t cnt(0);
     if (addEJ)
     {
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += nwalk * local_nCV;
 #else
       if (not getKl)
@@ -225,7 +225,7 @@ public:
     if (addEXX)
     {
       mem_needs += nwalk * nel[0] * nel[0] * local_nCV;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs += nwalk * nel[0] * NMO;
 #else
       if (nspin == 2)
@@ -246,7 +246,7 @@ public:
         assert(KEright->size(0) == nwalk && KEright->size(1) == local_nCV);
         assert(KEright->stride(0) == KEright->size(1));
       }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
       {
         assert(KEleft->size(0) == nwalk && KEleft->size(1) == local_nCV);
@@ -299,7 +299,7 @@ public:
       {
         size_t cnt_(cnt);
         sp_pointer ptr(nullptr);
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         ptr = TBuff.origin() + cnt_;
         cnt_ += nwalk * nel[ispin] * NMO;
         for (int n = 0; n < nwalk; ++n)
@@ -366,7 +366,7 @@ public:
       SPRealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
       for (int n = 0; n < nwalk; ++n)
         E[n][2] += 0.5 * static_cast<ComplexType>(scl * scl * ma::dot(Kl[n], Kl[n]));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       if (getKl)
         copy_n_cast(Klptr, KEleft->num_elements(), make_device_ptr(KEleft->origin()));
 #endif
@@ -390,7 +390,7 @@ public:
   {
     assert(Likn.size(1) == X.size(0));
     assert(Likn.size(0) == v.size(0));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     size_t mem_needs = X.num_elements() + v.num_elements();
     set_buffer(mem_needs);
     SpCVector_ref vsp(TBuff.origin(), v.extensions());
@@ -412,7 +412,7 @@ public:
     assert(Likn.size(1) == X.size(0));
     assert(Likn.size(0) == v.size(0));
     assert(X.size(1) == v.size(1));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     size_t mem_needs = X.num_elements() + v.num_elements();
     set_buffer(mem_needs);
     SpCMatrix_ref vsp(TBuff.origin(), v.extensions());
@@ -437,7 +437,7 @@ public:
       assert(Lakn.size(0) == G.size(0));
       assert(Lakn.size(1) == v.size(0));
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
       SpCVector_ref vsp(TBuff.origin(), v.extensions());
@@ -459,7 +459,7 @@ public:
       assert(Likn.size(0) == G.size(0));
       assert(Likn.size(1) == v.size(0));
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
       SpCVector_ref vsp(TBuff.origin(), v.extensions());
@@ -490,7 +490,7 @@ public:
       assert(Lakn.size(1) == v.size(0));
       assert(G.size(1) == v.size(1));
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
       SpCMatrix_ref vsp(TBuff.origin(), v.extensions());
@@ -513,7 +513,7 @@ public:
       assert(Likn.size(1) == v.size(0));
       assert(G.size(1) == v.size(1));
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       size_t mem_needs = G.num_elements() + v.num_elements();
       set_buffer(mem_needs);
       SpCMatrix_ref vsp(TBuff.origin(), v.extensions());

--- a/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
+++ b/src/AFQMC/HamiltonianOperations/Real3IndexFactorization_batched_v2.hpp
@@ -293,7 +293,7 @@ public:
       SPRealType scl = (walker_type == CLOSED ? 2.0 : 1.0);
 
       long mem_needs(0);
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       mem_needs = nwalk * nel[0] * NMO;
 #else
       if (nspin > 1)
@@ -305,7 +305,7 @@ public:
       for (int ispin = 0, is0 = 0; ispin < nspin; ispin++)
       {
         sp_pointer ptr(nullptr);
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         ptr = T1.origin();
         for (int n = 0; n < nwalk; ++n)
           copy_n_cast(make_device_ptr(Gc[n].origin()) + is0, nel[ispin] * NMO, ptr + n * nel[ispin] * NMO);
@@ -573,7 +573,7 @@ public:
 
     // can you find out how much memory is available on the buffer?
     long LBytes = max_memory_MB * 1024L * 1024L / long(sizeof(SPComplexType));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     LBytes -= long((3 * nspin + 1) * nwalk * NMO * NMO); // G, Fp, Fm and Gt
 #else
     LBytes -= long((1 + nspin) * nwalk * NMO * NMO); //  G and Gt
@@ -583,7 +583,7 @@ public:
     int nwmax = std::min(std::max(1, Bytes), nwalk);
     assert(nwmax >= 1 && nwmax <= nwmax);
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     StaticMatrix Fp_({nwalk, nspin * NMO * NMO},
                      buffer_manager.get_generator().template get_allocator<SPComplexType>());
     StaticMatrix Fm_({nwalk, nspin * NMO * NMO},
@@ -604,7 +604,7 @@ public:
     Carray.reserve(nwalk);
 
     long gsz(0);
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     gsz = nspin * nwmax * NMO * NMO;
 #else
     if (nspin > 1)
@@ -619,7 +619,7 @@ public:
 
       sp_pointer ptr(nullptr);
       // transpose/cast G
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       ptr = GBuff.origin();
       for (int ispin = 0, is0 = 0, ip = 0; ispin < nspin; ispin++, is0 += NMO * NMO)
         for (int n = 0; n < nw; ++n, ip += NMO * NMO)
@@ -778,7 +778,7 @@ public:
       nw0 += nw;
     }
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     copy_n_cast(Fp_.origin(), Fp_.num_elements(), make_device_ptr(Fp.origin()));
     copy_n_cast(Fm_.origin(), Fm_.num_elements(), make_device_ptr(Fm.origin()));
 #endif

--- a/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensor.hpp
@@ -208,7 +208,7 @@ public:
     if (addEJ and getKr)
       assert(Kr->size(0) == nwalk && Kr->size(1) == SpvnT[k].size(0));
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     size_t mem_needs = Gc.num_elements();
     set_buffer(mem_needs);
     boost::multi::array_ref<SPComplexType, 2> Gsp(to_address(SM_TMats.origin()), Gc.extensions());
@@ -269,7 +269,7 @@ public:
       for (int wi = 0; wi < Gc.size(1); wi++)
         E[wi][2] = 0.5 * scl * static_cast<ComplexType>(ma::dot(v_(v_.extension(0), wi), v_(v_.extension(0), wi)));
     }
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
 #endif
   }
 

--- a/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
@@ -204,7 +204,7 @@ SparseTensor<T1, T2> loadSparseTensor(hdf_archive& dump,
     //std::vector<SpCType_shm_csr_matrix> SpvnT;
     using matrix_view = typename T2_shm_csr_matrix::template matrix_view<int>;
     std::vector<matrix_view> SpvnTview;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
     auto PsiTsp(csr::shm::CSRvector_to_single_precision<PsiT_Matrix_t<SPComplexType>>(PsiT));
 #else
     auto& PsiTsp(PsiT);

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -211,7 +211,7 @@ public:
       {
         H1[i][j] += hij[i][j] + vn0[i][j];
         H1[j][i] += hij[j][i] + vn0[j][i];
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
         if (std::abs(H1[i][j] - ma::conj(H1[j][i])) > 1e-5)
         {
 #else

--- a/src/AFQMC/HamiltonianOperations/sparse_matrix_energy.hpp
+++ b/src/AFQMC/HamiltonianOperations/sparse_matrix_energy.hpp
@@ -63,7 +63,7 @@ inline void calculate_energy(EMat&& locV, const MatA& Gc, MatB&& Gcloc, const Sp
 
   for (int i = 0, iend = Gc.size(0); i < iend; i++)
     for (int n = 0; n < nwalk; n++)
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       locV[n][1] += static_cast<Type>(Gc[i][n] * Gcloc[i][n]);
 #else
       locV[n][1] += Gc[i][n] * Gcloc[i][n];
@@ -114,7 +114,7 @@ inline void calculate_energy(EMat&& locV, const MatA& Gc, MatB&& Gcloc, const Sp
   int r0 = Vakbl.local_origin()[0];
   for (int i = 0, iend = Gcloc.size(0); i < iend; i++)
     for (int n = 0; n < nwalk; n++)
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       locV[n][1] += static_cast<Type>(Gc[i + r0][n] * Gcloc[i][n]);
 #else
       locV[n][1] += Gc[i + r0][n] * Gcloc[i][n];

--- a/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/FactorizedSparseHamiltonian.cpp
@@ -240,7 +240,7 @@ HamiltonianOperations FactorizedSparseHamiltonian::getHamiltonianOperations(bool
   if (type == COLLINEAR)
     assert(PsiT.size() % 2 == 0);
 
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
   auto PsiTsp(csr::shm::CSRvector_to_single_precision<PsiT_Matrix_t<SPComplexType>>(PsiT));
 #else
   auto& PsiTsp(PsiT);

--- a/src/AFQMC/Hamiltonians/Hamiltonian_Utilities.hpp
+++ b/src/AFQMC/Hamiltonians/Hamiltonian_Utilities.hpp
@@ -137,7 +137,7 @@ inline int getSpinSector(const int NMO, const IndexType& i, const IndexType& j)
 
 inline IndexType Index2Col(const int NMO, const IndexType i)
 {
-#if AFQMC_DEBUG
+#if defined(AFQMC_DEBUG)
 // assert( ((i<NMO)&&(j<NMO)) || ((i>NMO)&&(j>NMO))   )
 #endif
   return (i < NMO) ? (i) : (i - NMO);

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
 {
 namespace afqmc
 {
-#if QMC_COMPLEX
+#if defined(QMC_COMPLEX)
 HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations(bool pureSD,
                                                                         bool addCoulomb,
                                                                         WALKER_TYPES type,
@@ -627,7 +627,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].origin()),
                                                          {nmo_per_kp[K], nmo_per_kp[QK] * nchol_per_kp[Q]});
           using ma::H;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
           boost::multi::array<SPComplexType, 2> v1_({nmo_per_kp[K], nmo_per_kp[K]});
           ma::product(SPComplexType(-0.5), Likn, H(Likn), SPComplexType(0.0), v1_);
           boost::multi::array<ComplexType, 2> v2_(v1_);
@@ -651,7 +651,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
           boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.origin()),
                                                        {nmo_per_kp[K], nmo_per_kp[QK] * nchol_per_kp[Qm]});
           using ma::H;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
           boost::multi::array<SPComplexType, 2> v1_({nmo_per_kp[K], nmo_per_kp[K]});
           ma::product(SPComplexType(-0.5), L_, H(L_), SPComplexType(0.0), v1_);
           boost::multi::array<ComplexType, 2> v2_(v1_);
@@ -1415,7 +1415,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
           boost::multi::array_ref<SPComplexType, 2> Likn(to_address(LQKikn[Q][K].origin()),
                                                          {nmo_max, nmo_max * nchol_max});
           using ma::H;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
           boost::multi::array<SPComplexType, 2> v1_({nmo_max, nmo_max});
           ma::product(SPComplexType(-0.5), Likn, H(Likn), SPComplexType(0.0), v1_);
           using std::copy_n;
@@ -1438,7 +1438,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
                 buff3D[i][k][n] = ma::conj(Lkin[k][i][n]);
           boost::multi::array_ref<SPComplexType, 2> L_(to_address(buff3D.origin()), {nmo_max, nmo_max * nchol_max});
           using ma::H;
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
           boost::multi::array<SPComplexType, 2> v1_({nmo_max, nmo_max});
           ma::product(SPComplexType(-0.5), L_, H(L_), SPComplexType(0.0), v1_);
           boost::multi::array<ComplexType, 2> v2_(v1_);

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -253,7 +253,7 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     if (TG.Node().root())
     {
       copy_n_cast(v0_.origin(), NMO * NMO, to_address(v0.origin()));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       // MAM: Since Muv gets large, might have problems with the check for hermicity below
       // fixing here
       for (int i = 0; i < NMO; i++)
@@ -304,7 +304,7 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
     if (TG.Node().root())
     {
       copy_n_cast(v0_.origin(), NMO * NMO, to_address(v0.origin()));
-#if MIXED_PRECISION
+#if defined(MIXED_PRECISION)
       // MAM: Since Muv gets large, might have problems with the check for hermicity below
       // fixing here
       for (int i = 0; i < NMO; i++)

--- a/src/Sandbox/einspline_spo.cpp
+++ b/src/Sandbox/einspline_spo.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
   //use the global generator
 
   bool ionode=(mycomm->rank() == 0);
-#if USE_NIO
+#if defined(USE_NIO)
   int na=1; int nb=1; int nc=1;
   int nx=37,ny=37,nz=37;
 #else

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -39,7 +39,7 @@ TEST_CASE("test_timer_stack", "[utilities]")
   //  changes will persist from test to test.
   FakeTimerManager tm;
   FakeTimer* t1 = tm.createTimer("timer1", timer_level_coarse);
-#if ENABLE_TIMERS
+#if defined(ENABLE_TIMERS)
 #ifdef USE_STACK_TIMERS
   t1->start();
   REQUIRE(tm.current_timer() == t1);
@@ -56,7 +56,7 @@ TEST_CASE("test_timer_scoped", "[utilities]")
   {
     ScopedFakeTimer st(*t1);
   }
-#if ENABLE_TIMERS
+#if defined(ENABLE_TIMERS)
   REQUIRE(t1->get_total() == Approx(1.0));
   REQUIRE(t1->get_num_calls() == 1);
 #endif
@@ -67,7 +67,7 @@ TEST_CASE("test_timer_scoped", "[utilities]")
   {
     ScopedFakeTimer st(t2);
   }
-#if ENABLE_TIMERS
+#if defined(ENABLE_TIMERS)
   REQUIRE(t1->get_total() == Approx(1.0));
   REQUIRE(t1->get_num_calls() == 1);
 #endif

--- a/src/config/stdlib/math.hpp
+++ b/src/config/stdlib/math.hpp
@@ -24,7 +24,7 @@ namespace qmcplusplus
 {
 
 /// sincos function wrapper
-#if __APPLE__
+#if defined(__APPLE__)
 
 inline void sincos(double a, double* s, double* c)
 {


### PR DESCRIPTION
## Proposed changes
With out this fix, passing `-DQMC_COMPLEX=1` or `-DQMC_COMPLEX=ON`  to cmake behaves differently.
fixes #3036

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'