### PR TITLE
Switching from copy_directory to file(COPY ...) changed behavior

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -19,7 +19,7 @@ INCLUDE("${PROJECT_SOURCE_DIR}/CMake/test_labels.cmake")
 
 # Function to copy a directory
 FUNCTION( COPY_DIRECTORY SRC_DIR DST_DIR )
-    file(COPY ${SRC_DIR} DESTINATION ${DST_DIR})
+    EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E copy_directory "${SRC_DIR}" "${DST_DIR}" )
 ENDFUNCTION()
 
 # Create symlinks for a list of files.


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

In #3096, I tried to use `file(COPY ...)` to avoid an additional call to `EXECUTE_PROCESS`, but that changed behavior. I don't see anything in the documentation to get the same behavior as `copy_directory` without using `GLOB`. Instead of making things more complicated, this reverts that line to what it was previously.

Fixes #3101

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Build related changes

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'