### PR TITLE
Adjust tolerance of deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars for mixed precision build

### DIFF
--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -1040,7 +1040,7 @@ ENDIF()
       "${CMAKE_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
       qmc_trace_scalars.in.xml
       1 1
-      check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1 --tol=1e-6
+      check_traces.py -p qmc_trace_scalars -s '0,1' -m 'vmc,dmc' --dmc_steps_exclude=1 --tol=2e-6
       )
    ELSE()     
     SIMPLE_RUN_AND_CHECK(


### PR DESCRIPTION
## Proposed changes

Close #3107 
Close #2765 

Deterministic-diamondC_1x1x1_pp-vmc-dmc-trace_scalars are failing in Sulfur and Ye-Ryzen-Box with ~ 1.2e-6 tolerance which is still acceptable for the mixed precision build. This PR is to adjust tolerance from 1.0e-6  to 2.0e-6 in order to cover the variations in the mixed precision build. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
