### PR TITLE
[CMake] Cleanup compiler detection and change version handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################################
 # CMake version and policies
 ######################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 3.14.0)
+cmake_minimum_required(VERSION 3.14.0)
 
 # CMP0074: CMake find_package will use <PackageName>_ROOT CMake variable
 # and environment variable in search path.
@@ -356,54 +356,49 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
     ENDIF()
   ENDIF()
 
-  #------------------------------------
-  # Identify the compiler -- This serves only to deal with case where only C or CXX is set, refactor? 
-  #------------------------------------
-  IF ( CMAKE_C_COMPILER_WORKS OR CMAKE_C_COMPILER_WORKS )
-    IF( (CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR ( CMAKE_C_COMPILER_ID MATCHES "GNU") )
-      SET( COMPILER GNU )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "XL") OR ( CMAKE_C_COMPILER_ID MATCHES "XL") )
-      SET( COMPILER IBM )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM") OR (CMAKE_C_COMPILER_ID MATCHES "IntelLLVM") )
-      SET( COMPILER Clang )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "Intel") OR (CMAKE_C_COMPILER_ID MATCHES "Intel") )
-      SET( COMPILER Intel )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "PGI") OR (CMAKE_C_COMPILER_ID MATCHES "PGI") )
-      SET( COMPILER PGI )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "NVHPC") OR (CMAKE_C_COMPILER_ID MATCHES "NVHPC") )
-      SET( COMPILER PGI )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "Cray") OR (CMAKE_C_COMPILER_ID MATCHES "Cray") )
-      SET( COMPILER Cray )
-    ELSEIF( (CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_C_COMPILER_ID MATCHES "Clang") )
-      SET( COMPILER Clang )
-    ELSE()
-        SET(USING_DEFAULT TRUE)
-        MESSAGE("${CMAKE_C_COMPILER_ID}")
-        MESSAGE(WARNING "Unknown C/C++ compiler, default flags will be used")
-    ENDIF()
-  ELSE()
-    MESSAGE(WARNING "No compiler identified")
-  ENDIF()
-  MESSAGE(STATUS "Compiler: ${COMPILER}")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(COMPILER GNU)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "XL")
+    set(COMPILER IBM)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+    set(COMPILER Clang)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+    set(COMPILER Intel)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
+    set(COMPILER PGI)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Cray")
+    set(COMPILER Cray)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(COMPILER Clang)
+  else()
+      message("${CMAKE_CXX_COMPILER_ID}")
+      message(WARNING "Unknown C/C++ compiler ${CMAKE_CXX_COMPILER_ID}, default flags will be used")
+  endif()
+  message(STATUS "Compiler identified by QMCPACK as : ${COMPILER}")
 
   #------------------------------------
   # Include compiler-specific cmake file
   #------------------------------------
-  IF( ${COMPILER} MATCHES "IBM" )
-    INCLUDE(${PROJECT_CMAKE}/IBMCompilers.cmake)
-  ELSEIF( ${COMPILER} MATCHES "Intel" )
-    INCLUDE(${PROJECT_CMAKE}/IntelCompilers.cmake)
-  ELSEIF( ${COMPILER} MATCHES "GNU" )
-    INCLUDE(${PROJECT_CMAKE}/GNUCompilers.cmake)
-  ELSEIF( ${COMPILER} MATCHES "Clang" )
-    INCLUDE(${PROJECT_CMAKE}/ClangCompilers.cmake)
-  ELSEIF( ${COMPILER} MATCHES "PGI" )
-    INCLUDE(${PROJECT_CMAKE}/PGICompilers.cmake)
-  ELSE()
-    MESSAGE(WARNING "No default file for compiler (${COMPILER})")
-  ENDIF()
+  if(COMPILER MATCHES "IBM")
+    include(${PROJECT_CMAKE}/IBMCompilers.cmake)
+  elseif(COMPILER MATCHES "Intel")
+    include(${PROJECT_CMAKE}/IntelCompilers.cmake)
+  elseif(COMPILER MATCHES "GNU")
+    include(${PROJECT_CMAKE}/GNUCompilers.cmake)
+  elseif(COMPILER MATCHES "Clang")
+    include(${PROJECT_CMAKE}/ClangCompilers.cmake)
+  elseif(COMPILER MATCHES "PGI")
+    include(${PROJECT_CMAKE}/PGICompilers.cmake)
+  else()
+    message(WARNING "No default file for compiler (${COMPILER})")
+  endif()
 
 ENDIF(CMAKE_TOOLCHAIN_FILE)
+
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL CMAKE_C_COMPILER_ID)
+  message(FATAL_ERROR "Mixing C and C++ compilers from different vendors is not permitted. Current "
+                      "C compiler is ${CMAKE_C_COMPILER_ID} but C++ compiler is ${CMAKE_CXX_COMPILER_ID}.")
+endif()
 
 ###############################################
 # Set C++ minimum standard and run basic checks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
       message("${CMAKE_CXX_COMPILER_ID}")
       message(WARNING "Unknown C/C++ compiler ${CMAKE_CXX_COMPILER_ID}, default flags will be used")
   endif()
-  message(STATUS "Compiler identified by QMCPACK as : ${COMPILER}")
+  message(STATUS "C++ Compiler is identified by QMCPACK as : ${COMPILER}")
 
   #------------------------------------
   # Include compiler-specific cmake file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,9 @@ include(CMakeDependentOption)
 ######################################################################
 # QMCPACK
 ######################################################################
-PROJECT(qmcpack)
-
-SET(QMCPACK_VERSION_MAJOR 3)
-SET(QMCPACK_VERSION_MINOR 11)
-SET(QMCPACK_VERSION_PATCH 9)
-SET(QMCPACK_VERSION "${QMCPACK_VERSION_MAJOR}.${QMCPACK_VERSION_MINOR}.${QMCPACK_VERSION_PATCH}")
+project(qmcpack
+        VERSION 3.11.9
+        LANGUAGES C CXX)
 
 ######################################################
 # Directory where customize cmake files reside

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -9,13 +9,13 @@
 #define QMCPLUSPLUS_CONFIGURATION_H
 
 /* define the major version */
-#define QMCPACK_VERSION_MAJOR  @QMCPACK_VERSION_MAJOR@
+#define QMCPACK_VERSION_MAJOR  @qmcpack_VERSION_MAJOR@
 
 /* define the minor version */
-#define QMCPACK_VERSION_MINOR  @QMCPACK_VERSION_MINOR@
+#define QMCPACK_VERSION_MINOR  @qmcpack_VERSION_MINOR@
 
 /* define the patch version */
-#define QMCPACK_VERSION_PATCH  @QMCPACK_VERSION_PATCH@
+#define QMCPACK_VERSION_PATCH  @qmcpack_VERSION_PATCH@
 
 /* define the release version */
 #cmakedefine QMCPACK_RELEASE  @QMCAPCK_RELEASE@

--- a/src/qmcpack.settings
+++ b/src/qmcpack.settings
@@ -1,5 +1,5 @@
 #qmcpack variables
-QMCPACK_VERSION    = @QMCPACK_VERSION@
+QMCPACK_VERSION    = @qmcpack_VERSION@
 # See qmcpack --version for the most up-to-date information about the
 # most recent git commit
 


### PR DESCRIPTION
## Proposed changes
1. explicit list C and CXX in project language
2. identify compiler collection by CMAKE_CXX_COMPILER_ID only. The C one is ignored.
3. Error out if CMAKE_CXX_COMPILER_ID and CMAKE_C_COMPILER_ID don't match.
4. Use CMake project() to handle QMCPACK version.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'