### PR TITLE
No more macro for cuda type casting

### DIFF
--- a/src/Platforms/CUDA/CUDATypeMapping.hpp
+++ b/src/Platforms/CUDA/CUDATypeMapping.hpp
@@ -63,10 +63,9 @@ using CUDATypeMap =
                                          OnTypesEqual<T, const std::complex<float>*, const cuComplex*>,
                                          OnTypesEqual<T, const std::complex<float>**, const cuComplex**>,
                                          OnTypesEqual<T, const std::complex<double>**, const cuDoubleComplex**>,
+                                         OnTypesEqual<T, const std::complex<float>* const *, const cuComplex* const *>,
+                                         OnTypesEqual<T, const std::complex<double>* const *, const cuDoubleComplex* const *>,
                                          default_type<void>>::type;
-
-// There must be a way to make this a template function. but it's so easy as a macro.
-#define CUDATYPECAST(var) reinterpret_cast<CUDATypeMap<decltype(var)>>(var)
 
 template<typename T>
 CUDATypeMap<T> castCUDAType(T var)

--- a/src/Platforms/CUDA/CUDATypeMapping.hpp
+++ b/src/Platforms/CUDA/CUDATypeMapping.hpp
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #ifndef QMCPLUSPLUS_CUDA_TYPE_MAPPING_HPP
-#define QMCPLUSPLUS_CUBLAS_LU_HPP
+#define QMCPLUSPLUS_CUDA_TYPE_MAPPING_HPP
 
 namespace qmcplusplus
 {
@@ -46,7 +46,7 @@ struct default_type : std::true_type
 
 // This saves us writing specific overloads with reinterpret casts for different std::complex to cuComplex types.
 template<typename T>
-using TypesMapper =
+using CUDATypeMap =
     typename c14disjunction::disjunction<OnTypesEqual<T, float, float>,
                                          OnTypesEqual<T, double, double>,
                                          OnTypesEqual<T, float*, float*>,
@@ -66,7 +66,13 @@ using TypesMapper =
                                          default_type<void>>::type;
 
 // There must be a way to make this a template function. but it's so easy as a macro.
-#define CUDATYPECAST(var) reinterpret_cast<TypesMapper<decltype(var)>>(var)
+#define CUDATYPECAST(var) reinterpret_cast<CUDATypeMap<decltype(var)>>(var)
+
+template<typename T>
+CUDATypeMap<T> castCUDAType(T var)
+{
+  return reinterpret_cast<CUDATypeMap<T>>(var);
+}
 
 } // namespace qmcplusplus
 

--- a/src/Platforms/CUDA/cuBLAS.hpp
+++ b/src/Platforms/CUDA/cuBLAS.hpp
@@ -18,11 +18,16 @@
 #include <iostream>
 #include <string>
 #include <stdexcept>
+#include "CUDATypeMapping.hpp"
 
 #define cublasErrorCheck(ans, cause)                \
   {                                                 \
     cublasAssert((ans), cause, __FILE__, __LINE__); \
   }
+
+template<typename CT>
+using constPtrnonconstArr = std::add_pointer<typename std::remove_const<typename std::remove_pointer<CT>::type>::type>;
+
 /// prints cuBLAS error messages. Always use cublasErrorCheck macro.
 inline void cublasAssert(cublasStatus_t code, const std::string& cause, const char* file, int line, bool abort = true)
 {
@@ -110,8 +115,8 @@ inline cublasStatus_t gemm(cublasHandle_t& handle,
                            std::complex<float>* C,
                            int ldc)
 {
-  return cublasCgemm(handle, transa, transb, m, n, k, (const cuComplex*)alpha, (const cuComplex*)A, lda,
-                     (const cuComplex*)B, ldb, (const cuComplex*)beta, (cuComplex*)C, ldc);
+  return cublasCgemm(handle, transa, transb, m, n, k, castCUDAType(alpha), castCUDAType(A), lda,
+                     castCUDAType(B), ldb, castCUDAType(beta), castCUDAType(C), ldc);
 }
 
 inline cublasStatus_t gemm(cublasHandle_t& handle,
@@ -147,8 +152,8 @@ inline cublasStatus_t gemm(cublasHandle_t& handle,
                            std::complex<double>* C,
                            int ldc)
 {
-  return cublasZgemm(handle, transa, transb, m, n, k, (const cuDoubleComplex*)alpha, (const cuDoubleComplex*)A, lda,
-                     (const cuDoubleComplex*)B, ldb, (const cuDoubleComplex*)beta, (cuDoubleComplex*)C, ldc);
+  return cublasZgemm(handle, transa, transb, m, n, k, castCUDAType(alpha), castCUDAType(A), lda,
+                     castCUDAType(B), ldb, castCUDAType(beta), castCUDAType(C), ldc);
 }
 
 inline cublasStatus_t gemm_batched(cublasHandle_t& handle,
@@ -186,8 +191,11 @@ inline cublasStatus_t gemm_batched(cublasHandle_t& handle,
                                    int ldc,
                                    int batchCount)
 {
-  return cublasCgemmBatched(handle, transa, transb, m, n, k, (const cuComplex*)alpha, (const cuComplex**)A, lda,
-                            (const cuComplex**)B, ldb, (const cuComplex*)beta, (cuComplex**)C, ldc, batchCount);
+  auto non_const_A = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(A)>::type>::type>::type>(A);
+  auto non_const_B = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(B)>::type>::type>::type>(B);
+  auto non_const_C = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(C)>::type>::type>::type>(C);
+  return cublasCgemmBatched(handle, transa, transb, m, n, k, castCUDAType(alpha), castCUDAType(non_const_A), lda,
+                            castCUDAType(non_const_B), ldb, castCUDAType(beta), castCUDAType(non_const_C), ldc, batchCount);
 }
 
 inline cublasStatus_t gemm_batched(cublasHandle_t& handle,
@@ -225,8 +233,12 @@ inline cublasStatus_t gemm_batched(cublasHandle_t& handle,
                                    int ldc,
                                    int batchCount)
 {
-  return cublasZgemmBatched(handle, transa, transb, m, n, k, (const cuDoubleComplex*)alpha, (const cuDoubleComplex**)A,
-                            lda, (const cuDoubleComplex**)B, ldb, (const cuDoubleComplex*)beta, (cuDoubleComplex**)C,
+  auto non_const_A = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(A)>::type>::type>::type>(A);
+  auto non_const_B = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(B)>::type>::type>::type>(B);
+  auto non_const_C = const_cast<std::add_pointer<typename std::remove_const<typename std::remove_pointer<decltype(C)>::type>::type>::type>(C);
+
+  return cublasZgemmBatched(handle, transa, transb, m, n, k, castCUDAType(alpha), castCUDAType(non_const_A),
+                            lda, castCUDAType(non_const_B), ldb, castCUDAType(beta), castCUDAType(non_const_C),
                             ldc, batchCount);
 }
 
@@ -260,7 +272,7 @@ inline cublasStatus_t getrf_batched(cublasHandle_t& handle,
                                     int* infoArray,
                                     int batchSize)
 {
-  return cublasCgetrfBatched(handle, n, reinterpret_cast<cuComplex* const*>(A), lda, PivotArray, infoArray, batchSize);
+  return cublasCgetrfBatched(handle, n, castCUDAType(A), lda, PivotArray, infoArray, batchSize);
 }
 
 inline cublasStatus_t getrf_batched(cublasHandle_t& handle,
@@ -271,7 +283,7 @@ inline cublasStatus_t getrf_batched(cublasHandle_t& handle,
                                     int* infoArray,
                                     int batchSize)
 {
-  return cublasZgetrfBatched(handle, n, reinterpret_cast<cuDoubleComplex* const*>(A), lda, PivotArray, infoArray,
+  return cublasZgetrfBatched(handle, n, castCUDAType(A), lda, PivotArray, infoArray,
                              batchSize);
 }
 
@@ -311,8 +323,8 @@ inline cublasStatus_t getri_batched(cublasHandle_t& handle,
                                     int* infoArray,
                                     int batchSize)
 {
-  return cublasCgetriBatched(handle, n, reinterpret_cast<cuComplex* const*>(A), lda, PivotArray,
-                             reinterpret_cast<cuComplex* const*>(C), ldc, infoArray, batchSize);
+  return cublasCgetriBatched(handle, n, castCUDAType(A), lda, PivotArray,
+                             castCUDAType(C), ldc, infoArray, batchSize);
 }
 
 inline cublasStatus_t getri_batched(cublasHandle_t& handle,
@@ -325,8 +337,8 @@ inline cublasStatus_t getri_batched(cublasHandle_t& handle,
                                     int* infoArray,
                                     int batchSize)
 {
-  return cublasZgetriBatched(handle, n, reinterpret_cast<cuDoubleComplex* const*>(A), lda, PivotArray,
-                             reinterpret_cast<cuDoubleComplex* const*>(C), ldc, infoArray, batchSize);
+  return cublasZgetriBatched(handle, n, castCUDAType(A), lda, PivotArray,
+                             castCUDAType(C), ldc, infoArray, batchSize);
 }
 
 }; // namespace cuBLAS

--- a/src/QMCWaveFunctions/detail/CUDA/cuBLAS_LU.cu
+++ b/src/QMCWaveFunctions/detail/CUDA/cuBLAS_LU.cu
@@ -123,7 +123,7 @@ cudaError_t computeLogDet_batched_impl(cudaStream_t& hstream,
   dim3 dimBlock(COLBS);
   dim3 dimGrid(batch_size, num_col_blocks);
   computeLogDet_kernel<COLBS>
-      <<<dimGrid, dimBlock, 0, hstream>>>(n, lda, CUDATYPECAST(LU_mat), pivots, CUDATYPECAST(logdets));
+      <<<dimGrid, dimBlock, 0, hstream>>>(n, lda, castCUDAType(LU_mat), pivots, castCUDAType(logdets));
   return cudaPeekAtLastError();
 }
 

--- a/src/type_traits/type_manipulation.hpp
+++ b/src/type_traits/type_manipulation.hpp
@@ -1,0 +1,24 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_TYPE_MANIPULATIONS_H
+#define QMCPLUSPLUS_TYPE_MANIPULATIONS_H
+
+#include <type_traits>
+
+/** Type with the bottom const removed in types of X (const) * const *
+ */
+template<typename CT>
+struct BottomConstRemoved {
+  using type = typename std::add_pointer<typename std::remove_const<typename std::remove_pointer<CT>::type>::type>::type;
+};
+
+#endif


### PR DESCRIPTION
## Proposed changes

Replace macro for CUDATypeMapping with template function doing the same thing.
Plus some improvement of naming.
Use the `castCUDAType` function for all the cases this occurs in `cuBLAS.hpp`

Workaround lack of second const on array of const pointers in batched API of cuBLAS.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

This is WIP because it should be rebased on develop after #3122 has been merged.

- No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
