### PR TITLE
[WIP] Refactor raw pointers in QMCDrivers into shared_ptr to address leak

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -199,7 +199,7 @@ void QMCCostFunction::getConfigurations(const std::string& aroot)
       H_KE_Node[ip]->addOperator(hClones[ip]->getHamiltonian("Kinetic"), "Kinetic");
       if (includeNonlocalH != "no")
       {
-        OperatorBase* a = hClones[ip]->getHamiltonian(includeNonlocalH);
+        std::shared_ptr<OperatorBase> a = hClones[ip]->getHamiltonian(includeNonlocalH);
         if (a)
         {
           app_log() << " Found non-local Hamiltonian element named " << includeNonlocalH << std::endl;
@@ -268,8 +268,9 @@ void QMCCostFunction::checkConfigurations()
         HDerivRecords[ip]->resize(wRef.numSamples(), NumOptimizables);
       }
     }
-    OperatorBase* nlpp = (includeNonlocalH == "no") ? 0 : hClones[ip]->getHamiltonian(includeNonlocalH);
-    bool compute_nlpp  = useNLPPDeriv && nlpp;
+    std::shared_ptr<OperatorBase> nlpp =
+        (includeNonlocalH == "no") ? nullptr : hClones[ip]->getHamiltonian(includeNonlocalH);
+    bool compute_nlpp = useNLPPDeriv && nlpp;
     //set the optimization mode for the trial wavefunction
     psiClones[ip]->startOptimization();
     //    synchronize the random number generator with the node
@@ -394,8 +395,9 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
         //HDerivRecords[ip]->resize(wRef.numSamples(),NumOptimizables);
       }
     }
-    OperatorBase* nlpp = (includeNonlocalH == "no") ? 0 : hClones[ip]->getHamiltonian(includeNonlocalH.c_str());
-    bool compute_nlpp  = useNLPPDeriv && nlpp;
+    std::shared_ptr<OperatorBase> nlpp =
+        (includeNonlocalH == "no") ? nullptr : hClones[ip]->getHamiltonian(includeNonlocalH.c_str());
+    bool compute_nlpp = useNLPPDeriv && nlpp;
     //set the optimization mode for the trial wavefunction
     psiClones[ip]->startOptimization();
     //    synchronize the random number generator with the node

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -184,7 +184,7 @@ std::unique_ptr<QMCHamiltonian> QMCCostFunctionBatched::extractFixedHamiltonianC
   KE_Ham->addOperator(H.getHamiltonian("Kinetic"), "Kinetic");
   if (includeNonlocalH != "no")
   {
-    OperatorBase* a = H.getHamiltonian(includeNonlocalH);
+    std::shared_ptr<OperatorBase> a = H.getHamiltonian(includeNonlocalH);
     if (a)
     {
       app_log() << " Found non-local Hamiltonian element named " << includeNonlocalH << std::endl;
@@ -268,8 +268,8 @@ void QMCCostFunctionBatched::checkConfigurations()
       HDerivRecords_.resize(numSamples, NumOptimizables);
     }
   }
-  OperatorBase* nlpp = (includeNonlocalH == "no") ? 0 : H.getHamiltonian(includeNonlocalH);
-  bool compute_nlpp  = useNLPPDeriv && nlpp;
+  std::shared_ptr<OperatorBase> nlpp = (includeNonlocalH == "no") ? nullptr : H.getHamiltonian(includeNonlocalH);
+  bool compute_nlpp                  = useNLPPDeriv && nlpp;
   //set the optimization mode for the trial wavefunction
   Psi.startOptimization();
   //    synchronize the random number generator with the node
@@ -390,7 +390,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
           if (includeNonlocalH != "no")
           {
-            OperatorBase* nlpp = h_list[ib].getHamiltonian(includeNonlocalH);
+            std::shared_ptr<OperatorBase> nlpp = h_list[ib].getHamiltonian(includeNonlocalH);
             RecordsOnNode[is][ENERGY_FIXED] -= nlpp->Value;
           }
         }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionCUDA.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionCUDA.cpp
@@ -179,7 +179,7 @@ void QMCCostFunctionCUDA::getConfigurations(const std::string& aroot)
     {
       if (includeNonlocalH == "yes")
         includeNonlocalH = "NonLocalECP";
-      OperatorBase* a = H.getHamiltonian(includeNonlocalH);
+      std::shared_ptr<OperatorBase> a = H.getHamiltonian(includeNonlocalH);
       if (a)
       {
         H_KE.addOperator(a, includeNonlocalH);

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -83,7 +83,7 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
   FakeRandom rg;
 
   QMCHamiltonian h;
-  h.addOperator(new BareKineticEnergy<double>(elec), "Kinetic");
+  h.addOperator(std::make_shared<BareKineticEnergy<double>>(elec), "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
@@ -178,7 +178,7 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dm
   FakeRandom rg;
 
   QMCHamiltonian h;
-  h.addOperator(new BareKineticEnergy<double>(elec), "Kinetic");
+  h.addOperator(std::make_shared<BareKineticEnergy<double>>(elec), "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
   elec.resetWalkerProperty(); // get memory corruption w/o this

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -85,7 +85,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  BareKineticEnergy<double>* p_bke = new BareKineticEnergy<double>(elec);
+  std::shared_ptr<BareKineticEnergy<double>> p_bke = std::make_shared<BareKineticEnergy<double>>(elec);
   h.addOperator(p_bke, "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
@@ -125,7 +125,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
   REQUIRE(elec.R[1][2] == Approx(1.0));
 
   delete doc;
-  delete p_bke;
+  p_bke.reset();
 }
 
 TEST_CASE("SODMC", "[drivers][dmc]")
@@ -173,7 +173,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  BareKineticEnergy<double>* p_bke = new BareKineticEnergy<double>(elec);
+  std::shared_ptr<BareKineticEnergy<double>> p_bke = std::make_shared<BareKineticEnergy<double>>(elec);
   h.addOperator(p_bke, "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
@@ -213,6 +213,6 @@ TEST_CASE("SODMC", "[drivers][dmc]")
   REQUIRE(elec.spins[0] == Approx(-0.74465948215809097));
 
   delete doc;
-  delete p_bke;
+  p_bke.reset();
 }
 } // namespace qmcplusplus

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -83,7 +83,7 @@ TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  h.addOperator(new BareKineticEnergy<double>(elec), "Kinetic");
+  h.addOperator(std::make_shared<BareKineticEnergy<double>>(elec), "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
   elec.resetWalkerProperty(); // get memory corruption w/o this

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -85,7 +85,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  h.addOperator(new BareKineticEnergy<double>(elec), "Kinetic");
+  h.addOperator(std::make_shared<BareKineticEnergy<double>>(elec), "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
@@ -172,7 +172,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  h.addOperator(new BareKineticEnergy<double>(elec), "Kinetic");
+  h.addOperator(std::make_shared<BareKineticEnergy<double>>(elec), "Kinetic");
   h.addObservables(elec); // get double free error on 'h.Observables' w/o this
 
   elec.resetWalkerProperty(); // get memory corruption w/o this

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -40,15 +40,15 @@ ACForce::ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& ps
   delta = 1e-4;
 };
 
-OperatorBase* ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   APP_ABORT("ACForce::makeClone(ParticleSet&,TrialWaveFunction&) shouldn't be called");
   return nullptr;
 }
 
-OperatorBase* ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi_in, QMCHamiltonian& ham_in)
+std::shared_ptr<OperatorBase> ACForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi_in, QMCHamiltonian& ham_in)
 {
-  OperatorBase* myclone = new ACForce(ions, qp, psi_in, ham_in);
+  std::shared_ptr<OperatorBase> myclone = std::make_shared<ACForce>(ions, qp, psi_in, ham_in);
   return myclone;
 }
 
@@ -77,7 +77,7 @@ bool ACForce::put(xmlNodePtr cur)
 void ACForce::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& ham_in)
 {
   //The following line is modified
-  OperatorBase* myclone = makeClone(qp, psi, ham_in);
+  std::shared_ptr<OperatorBase> myclone = makeClone(qp, psi, ham_in);
   if (myclone)
     ham_in.addOperator(myclone, myName, UpdateMode[PHYSICAL]);
 }

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -39,9 +39,9 @@ struct ACForce : public OperatorBase
 
   /** Cloning **/
   //We don't actually use this makeClone method.  We just put an APP_ABORT here
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
   //Not derived from base class.  But we need it to properly set the Hamiltonian reference.
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& H);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& H);
 
   /** Initialization/assignment **/
   void resetTargetParticleSet(ParticleSet& P){};

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -461,7 +461,10 @@ struct BareKineticEnergy : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return new BareKineticEnergy(*this); }
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final
+  {
+    return std::make_shared<BareKineticEnergy>(*this);
+  }
 
 #ifdef QMC_CUDA
   ////////////////////////////////

--- a/src/QMCHamiltonians/ChiesaCorrection.cpp
+++ b/src/QMCHamiltonians/ChiesaCorrection.cpp
@@ -22,9 +22,9 @@ void ChiesaCorrection::resetTargetParticleSet(ParticleSet& P) {}
 bool ChiesaCorrection::put(xmlNodePtr cur) { return true; }
 
 
-OperatorBase* ChiesaCorrection::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> ChiesaCorrection::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return new ChiesaCorrection(qp, psi);
+  return std::make_shared<ChiesaCorrection>(qp, psi);
 }
 
 ChiesaCorrection::Return_t ChiesaCorrection::evaluate(ParticleSet& P) { return Value = psi_ref.KECorrection(); }

--- a/src/QMCHamiltonians/ChiesaCorrection.h
+++ b/src/QMCHamiltonians/ChiesaCorrection.h
@@ -44,7 +44,7 @@ public:
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -99,7 +99,10 @@ struct ConservedEnergy : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return new ConservedEnergy; }
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final
+  {
+    return std::make_shared<ConservedEnergy>();
+  }
 
 #ifdef QMC_CUDA
   ////////////////////////////////

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -509,11 +509,11 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
 }
 
 
-OperatorBase* CoulombPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   if (is_active)
-    return new CoulombPBCAA(qp, is_active, ComputeForces);
+    return std::make_shared<CoulombPBCAA>(qp, is_active, ComputeForces);
   else
-    return new CoulombPBCAA(*this); //nothing needs to be re-evaluated
+    return std::make_shared<CoulombPBCAA>(*this); //nothing needs to be re-evaluated
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -106,7 +106,7 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   void initBreakup(ParticleSet& P);
 

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -60,13 +60,12 @@ void CoulombPBCAA_CUDA::initBreakup(ParticleSet& P, bool cloning)
 #endif
 }
 
-OperatorBase* CoulombPBCAA_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPBCAA_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  CoulombPBCAA_CUDA* myclone;
-  if (is_active)
-    myclone = new CoulombPBCAA_CUDA(qp, is_active, true);
-  else
-    myclone = new CoulombPBCAA_CUDA(*this); //nothing needs to be re-evaluated
+  std::shared_ptr<CoulombPBCAA_CUDA> myclone = is_active
+      ? std::make_shared<CoulombPBCAA_CUDA>(qp, is_active, true)
+      : std::make_shared<CoulombPBCAA_CUDA>(*this); //nothing needs to be re-evaluated
+
   myclone->SRSpline = SRSpline;
   return myclone;
 }

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.h
@@ -50,7 +50,7 @@ struct CoulombPBCAA_CUDA : public CoulombPBCAA
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
   void initBreakup(ParticleSet& P, bool cloning);
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -47,9 +47,10 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
   app_log() << "  Number of k vectors " << AB->Fk.size() << std::endl;
 }
 
-OperatorBase* CoulombPBCAB::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPBCAB::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  CoulombPBCAB* myclone    = new CoulombPBCAB(PtclA, qp, ComputeForces);
+  std::shared_ptr<CoulombPBCAB> myclone = std::make_shared<CoulombPBCAB>(PtclA, qp, ComputeForces);
+
   myclone->FirstForceIndex = FirstForceIndex;
   if (myGrid)
     myclone->myGrid = new GridType(*myGrid);

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -155,7 +155,7 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   ///Creates the long-range handlers, then splines and stores it by particle and species for quick evaluation.
   void initBreakup(ParticleSet& P);

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -231,9 +231,9 @@ void CoulombPBCAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
 }
 
 
-OperatorBase* CoulombPBCAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPBCAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  CoulombPBCAB_CUDA* myclone = new CoulombPBCAB_CUDA(PtclA, qp, true);
+  std::shared_ptr<CoulombPBCAB_CUDA> myclone = std::make_shared<CoulombPBCAB_CUDA>(PtclA, qp, true);
   if (myGrid)
     myclone->myGrid = new GridType(*myGrid);
   for (int ig = 0; ig < Vspec.size(); ++ig)

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
@@ -63,7 +63,7 @@ struct CoulombPBCAB_CUDA : public CoulombPBCAB
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   CoulombPBCAB_CUDA(ParticleSet& ions, ParticleSet& elns, bool cloning = false);
 };

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -377,19 +377,20 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       setParticleSetF(plist, offset);
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override
   {
     if (is_AA)
     {
       if (is_active)
-        return new CoulombPotential(qp, true, ComputeForces);
+        return std::make_shared<CoulombPotential>(qp, true, ComputeForces);
       else
         // Ye Luo April 16th, 2015
         // avoid recomputing ion-ion DistanceTable when reusing ParticleSet
-        return new CoulombPotential(Pa, false, ComputeForces, true);
+        return std::make_shared<CoulombPotential>(Pa, false, ComputeForces, true);
     }
     else
-      return new CoulombPotential(Pa, qp, true);
+      return std::make_shared<CoulombPotential>(Pa, qp, true);
   }
 };
 

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -57,9 +57,9 @@ void HamiltonianFactory::addMPCPotential(xmlNodePtr cur, bool isphysical)
   renameProperty(a);
   isphysical = (physical == "yes" || physical == "true");
 #ifdef QMC_CUDA
-  MPC_CUDA* mpc = new MPC_CUDA(targetPtcl, cutoff);
+  std::shared_ptr<MPC_CUDA> mpc = std::make_shared<MPC_CUDA>(targetPtcl, cutoff);
 #else
-  MPC* mpc = new MPC(targetPtcl, cutoff);
+  std::shared_ptr<MPC> mpc = std::make_shared<MPC>(targetPtcl, cutoff);
 #endif
   targetH->addOperator(mpc, "MPC", isphysical);
 #else
@@ -112,20 +112,20 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
     bool quantum = (sourceInp == targetPtcl.getName());
 #ifdef QMC_CUDA
     if (applyPBC)
-      targetH->addOperator(new CoulombPBCAA_CUDA(*ptclA, quantum, doForces), title, physical);
+      targetH->addOperator(std::make_shared<CoulombPBCAA_CUDA>(*ptclA, quantum, doForces), title, physical);
     else
     {
       if (quantum)
-        targetH->addOperator(new CoulombPotentialAA_CUDA(*ptclA, true), title, physical);
+        targetH->addOperator(std::make_shared<CoulombPotentialAA_CUDA>(*ptclA, true), title, physical);
       else
-        targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum, doForces), title, physical);
+        targetH->addOperator(std::make_shared<CoulombPotential<Return_t>>(*ptclA, quantum, doForces), title, physical);
     }
 #else
     if (applyPBC)
-      targetH->addOperator(new CoulombPBCAA(*ptclA, quantum, doForces), title, physical);
+      targetH->addOperator(std::make_shared<CoulombPBCAA>(*ptclA, quantum, doForces), title, physical);
     else
     {
-      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, quantum, doForces), title, physical);
+      targetH->addOperator(std::make_shared<CoulombPotential<Return_t>>(*ptclA, quantum, doForces), title, physical);
     }
 #endif
   }
@@ -133,14 +133,14 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
   {
 #ifdef QMC_CUDA
     if (applyPBC)
-      targetH->addOperator(new CoulombPBCAB_CUDA(*ptclA, targetPtcl), title);
+      targetH->addOperator(std::make_shared<CoulombPBCAB_CUDA>(*ptclA, targetPtcl), title);
     else
-      targetH->addOperator(new CoulombPotentialAB_CUDA(*ptclA, targetPtcl), title);
+      targetH->addOperator(std::make_shared<CoulombPotentialAB_CUDA>(*ptclA, targetPtcl), title);
 #else
     if (applyPBC)
-      targetH->addOperator(new CoulombPBCAB(*ptclA, targetPtcl), title);
+      targetH->addOperator(std::make_shared<CoulombPBCAB>(*ptclA, targetPtcl), title);
     else
-      targetH->addOperator(new CoulombPotential<Return_t>(*ptclA, targetPtcl, true), title);
+      targetH->addOperator(std::make_shared<CoulombPotential<Return_t>>(*ptclA, targetPtcl, true), title);
 #endif
   }
 }
@@ -182,7 +182,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   //bool applyPBC= (PBCType && pbc=="yes");
   if (mode == "bare")
   {
-    BareForce* bareforce = new BareForce(*source, *target);
+    std::shared_ptr<BareForce> bareforce = std::make_shared<BareForce>(*source, *target);
     bareforce->put(cur);
     targetH->addOperator(bareforce, title, false);
   }
@@ -190,13 +190,13 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   {
     if (applyPBC == true)
     {
-      ForceChiesaPBCAA* force_chi = new ForceChiesaPBCAA(*source, *target, true);
+      std::shared_ptr<ForceChiesaPBCAA> force_chi = std::make_shared<ForceChiesaPBCAA>(*source, *target, true);
       force_chi->put(cur);
       targetH->addOperator(force_chi, title, false);
     }
     else
     {
-      ForceCeperley* force_cep = new ForceCeperley(*source, *target);
+      std::shared_ptr<ForceCeperley> force_cep = std::make_shared<ForceCeperley>(*source, *target);
       force_cep->put(cur);
       targetH->addOperator(force_cep, title, false);
     }
@@ -209,16 +209,14 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
     {
       APP_ABORT("Unknown psi \"" + PsiName + "\" for zero-variance force.");
     }
-    TrialWaveFunction& psi = *psi_it->second->getTWF();
-    ACForce* acforce       = new ACForce(*source, *target, psi, *targetH);
+    TrialWaveFunction& psi           = *psi_it->second->getTWF();
+    std::shared_ptr<ACForce> acforce = std::make_shared<ACForce>(*source, *target, psi, *targetH);
     acforce->put(cur);
     targetH->addOperator(acforce, title, false);
   }
   else
   {
     ERRORMSG("Failed to recognize Force mode " << mode);
-    //} else if(mode=="FD") {
-    //  targetH->addOperator(new ForceFiniteDiff(*source, *target), title, false);
   }
 #endif
 }

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
@@ -42,9 +42,9 @@ void CoulombPotentialAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Re
   }
 }
 
-OperatorBase* CoulombPotentialAA_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPotentialAA_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return new CoulombPotentialAA_CUDA(qp, true);
+  return std::make_shared<CoulombPotentialAA_CUDA>(qp, true);
 }
 
 
@@ -95,9 +95,9 @@ void CoulombPotentialAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Re
   }
 }
 
-OperatorBase* CoulombPotentialAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::unique_ptr<OperatorBase> CoulombPotentialAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return new CoulombPotentialAB_CUDA(Pa, qp);
+  return std::make_unique<CoulombPotentialAB_CUDA>(Pa, qp);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
@@ -95,9 +95,9 @@ void CoulombPotentialAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Re
   }
 }
 
-std::unique_ptr<OperatorBase> CoulombPotentialAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> CoulombPotentialAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return std::make_unique<CoulombPotentialAB_CUDA>(Pa, qp);
+  return std::make_shared<CoulombPotentialAB_CUDA>(Pa, qp);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.h
@@ -36,7 +36,7 @@ struct CoulombPotentialAA_CUDA : public CoulombPotential<OHMMS_PRECISION>
   gpu::host_vector<CUDA_PRECISION> SumHost;
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 
 /** CoulombPotential for ion-el
@@ -58,7 +58,7 @@ struct CoulombPotentialAB_CUDA : public CoulombPotential<OHMMS_PRECISION>
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.h
@@ -58,7 +58,7 @@ struct CoulombPotentialAB_CUDA : public CoulombPotential<OHMMS_PRECISION>
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
-  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -180,10 +180,10 @@ bool DensityEstimator::get(std::ostream& os) const
   return true;
 }
 
-OperatorBase* DensityEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> DensityEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   //default constructor is sufficient
-  return new DensityEstimator(*this);
+  return std::make_shared<DensityEstimator>(*this);
 }
 
 void DensityEstimator::resize()

--- a/src/QMCHamiltonians/DensityEstimator.h
+++ b/src/QMCHamiltonians/DensityEstimator.h
@@ -42,7 +42,7 @@ public:
   void setParticlePropertyList(PropertySetType& plist, int offset);
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   inline int getGridIndex(int i, int j, int k) const { return myIndex + k + NumGrids[2] * (j + NumGrids[1] * i); }
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -56,9 +56,9 @@ DensityMatrices1B::~DensityMatrices1B()
 }
 
 
-OperatorBase* DensityMatrices1B::makeClone(ParticleSet& P, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> DensityMatrices1B::makeClone(ParticleSet& P, TrialWaveFunction& psi)
 {
-  return new DensityMatrices1B(*this, P, psi);
+  return std::make_shared<DensityMatrices1B>(*this, P, psi);
 }
 
 

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -161,7 +161,7 @@ public:
   ~DensityMatrices1B();
 
   //standard interface
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
   bool put(xmlNodePtr cur);
   Return_t evaluate(ParticleSet& P);
 

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -102,9 +102,9 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
     if (IonConfig.Lattice.SuperCellEnum == SUPERCELL_OPEN || pbc == "no")
     {
 #ifdef QMC_CUDA
-      LocalECPotential_CUDA* apot = new LocalECPotential_CUDA(IonConfig, targetPtcl);
+      std::shared_ptr<LocalECPotential_CUDA> apot = std::make_shared<LocalECPotential_CUDA>(IonConfig, targetPtcl);
 #else
-      LocalECPotential* apot = new LocalECPotential(IonConfig, targetPtcl);
+      std::shared_ptr<LocalECPotential> apot = std::make_shared<LocalECPotential>(IonConfig, targetPtcl);
 #endif
       for (int i = 0; i < localPot.size(); i++)
         if (localPot[i])
@@ -116,9 +116,9 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
       if (doForces)
         app_log() << "  Will compute forces in CoulombPBCAB.\n" << std::endl;
 #ifdef QMC_CUDA
-      CoulombPBCAB_CUDA* apot = new CoulombPBCAB_CUDA(IonConfig, targetPtcl, doForces);
+      std::shared_ptr<CoulombPBCAB_CUDA> apot = std::make_shared<CoulombPBCAB_CUDA>(IonConfig, targetPtcl, doForces);
 #else
-      CoulombPBCAB* apot     = new CoulombPBCAB(IonConfig, targetPtcl, doForces);
+      std::shared_ptr<CoulombPBCAB> apot     = std::make_shared<CoulombPBCAB>(IonConfig, targetPtcl, doForces);
 #endif
       for (int i = 0; i < localPot.size(); i++)
       {
@@ -131,9 +131,12 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   if (hasNonLocalPot)
   {
 #ifdef QMC_CUDA
-    NonLocalECPotential_CUDA* apot = new NonLocalECPotential_CUDA(IonConfig, targetPtcl, targetPsi, usePBC, doForces, use_DLA == "yes");
+    std::shared_ptr<NonLocalECPotential_CUDA> apot =
+        std::make_shared<NonLocalECPotential_CUDA>(IonConfig, targetPtcl, targetPsi, usePBC, doForces,
+                                                   use_DLA == "yes");
 #else
-    NonLocalECPotential* apot = new NonLocalECPotential(IonConfig, targetPtcl, targetPsi, doForces, use_DLA == "yes");
+    std::shared_ptr<NonLocalECPotential> apot =
+        std::make_shared<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, doForces, use_DLA == "yes");
 #endif
     int nknot_max = 0;
     for (int i = 0; i < nonLocalPot.size(); i++)
@@ -165,9 +168,9 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
     else
       APP_ABORT("physicalSO must be set to yes/no. Unknown option given\n");
 
-    SOECPotential* apot = new SOECPotential(IonConfig, targetPtcl, targetPsi);
-    int nknot_max       = 0;
-    int sknot_max       = 0;
+    std::shared_ptr<SOECPotential> apot = std::make_shared<SOECPotential>(IonConfig, targetPtcl, targetPsi);
+    int nknot_max                       = 0;
+    int sknot_max                       = 0;
     for (int i = 0; i < soPot.size(); i++)
     {
       if (soPot[i])
@@ -188,7 +191,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
   }
   if (hasL2Pot)
   {
-    L2Potential* apot = new L2Potential(IonConfig, targetPtcl, targetPsi);
+    std::shared_ptr<L2Potential> apot = std::make_shared<L2Potential>(IonConfig, targetPtcl, targetPsi);
     for (int i = 0; i < L2Pot.size(); i++)
       if (L2Pot[i])
         apot->add(i, std::move(L2Pot[i]));
@@ -369,8 +372,8 @@ void ECPotentialBuilder::useSimpleTableFormat()
           RealType r((*agrid)[j]);
           pp_temp[j] = r * zinv * inFunc.splint(r);
         }
-        pp_temp[ng - 1]          = 1.0;
-        auto app = std::make_unique<RadialPotentialType>(agrid, pp_temp);
+        pp_temp[ng - 1] = 1.0;
+        auto app        = std::make_unique<RadialPotentialType>(agrid, pp_temp);
         app->spline();
         localPot[ig] = std::move(app);
         app_log() << "    LocalECP l=" << angmom << std::endl;
@@ -429,7 +432,7 @@ void ECPotentialBuilder::useSimpleTableFormat()
       }
       //cout << "Spherical grid : " << numsgridpts << " points" << std::endl;
       mynnloc->resize_warrays(numsgridpts, numnonloc, lmax);
-      nonLocalPot[ig]   = std::move(mynnloc);
+      nonLocalPot[ig] = std::move(mynnloc);
     }
   } //species
 }

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -529,12 +529,13 @@ void EnergyDensityEstimator::setParticlePropertyList(PropertySetType& plist, int
 }
 
 
-OperatorBase* EnergyDensityEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> EnergyDensityEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   bool write = omp_get_thread_num() == 0;
   if (write)
     app_log() << "EnergyDensityEstimator::makeClone" << std::endl;
-  EnergyDensityEstimator* edclone = new EnergyDensityEstimator(psetpool, defKE);
+
+  std::shared_ptr<EnergyDensityEstimator> edclone = std::make_shared<EnergyDensityEstimator>(psetpool, defKE);
   edclone->put(input_xml, qp);
   //int thread = omp_get_thread_num();
   //app_log()<<thread<<"make edclone"<< std::endl;

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -41,7 +41,7 @@ public:
   bool put(xmlNodePtr cur);
   bool put(xmlNodePtr cur, ParticleSet& P);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void write_description(std::ostream& os);
 

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -142,7 +142,10 @@ BareForce::BareForce(ParticleSet& ions, ParticleSet& elns) : ForceBase(ions, eln
 
 void BareForce::resetTargetParticleSet(ParticleSet& P) {}
 
-OperatorBase* BareForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return new BareForce(*this); }
+std::shared_ptr<OperatorBase> BareForce::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+{
+  return std::make_shared<BareForce>(*this);
+}
 
 void BareForce::addObservables(PropertySetType& plist, BufferType& collectables)
 {

--- a/src/QMCHamiltonians/ForceBase.h
+++ b/src/QMCHamiltonians/ForceBase.h
@@ -116,7 +116,7 @@ public:
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -141,7 +141,10 @@ bool ForceCeperley::put(xmlNodePtr cur)
   return true;
 }
 
-OperatorBase* ForceCeperley::makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return new ForceCeperley(*this); }
+std::shared_ptr<OperatorBase> ForceCeperley::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+{
+  return std::make_shared<ForceCeperley>(*this);
+}
 } // namespace qmcplusplus
 
 //  void ForceCeperley::addObservables(PropertySetType& plist) {

--- a/src/QMCHamiltonians/ForceCeperley.h
+++ b/src/QMCHamiltonians/ForceCeperley.h
@@ -31,9 +31,9 @@ private:
   const int d_ei_ID;
 
 public:
-  double Rcut;                    // parameter: radial distance within which estimator is used
-  int m_exp;                      // parameter: exponent in polynomial fit
-  int N_basis;                    // parameter: size of polynomial basis set
+  double Rcut;                   // parameter: radial distance within which estimator is used
+  int m_exp;                     // parameter: exponent in polynomial fit
+  int N_basis;                   // parameter: size of polynomial basis set
   Matrix<FullPrecRealType> Sinv; // terms in fitting polynomial
   Vector<FullPrecRealType> h;    // terms in fitting polynomial
   Vector<FullPrecRealType> c;    // polynomial coefficients
@@ -60,7 +60,7 @@ public:
   void evaluate_IonIon(ParticleSet::ParticlePos_t& forces) const;
 
   void setParticlePropertyList(PropertySetType& plist, int offset) { setParticleSetF(plist, offset); }
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   bool put(xmlNodePtr cur);
 

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -232,12 +232,12 @@ void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collec
   addObservablesF(plist);
 }
 
-OperatorBase* ForceChiesaPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> ForceChiesaPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  ForceChiesaPBCAA* tmp = new ForceChiesaPBCAA(PtclA, qp, false);
-  tmp->Rcut             = Rcut;    // parameter: radial distance within which estimator is used
-  tmp->m_exp            = m_exp;   // parameter: exponent in polynomial fit
-  tmp->N_basis          = N_basis; // parameter: size of polynomial basis set
+  std::shared_ptr<ForceChiesaPBCAA> tmp = std::make_shared<ForceChiesaPBCAA>(PtclA, qp, false);
+  tmp->Rcut                             = Rcut;    // parameter: radial distance within which estimator is used
+  tmp->m_exp                            = m_exp;   // parameter: exponent in polynomial fit
+  tmp->N_basis                          = N_basis; // parameter: size of polynomial basis set
   tmp->Sinv.resize(N_basis, N_basis);
   tmp->Sinv = Sinv; // terms in fitting polynomial
   tmp->h.resize(N_basis);

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.h
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.h
@@ -97,7 +97,7 @@ struct ForceChiesaPBCAA : public OperatorBase, public ForceBase
   void resetTargetParticleSet(ParticleSet& P);
 
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   bool put(xmlNodePtr cur);
 

--- a/src/QMCHamiltonians/ForwardWalking.cpp
+++ b/src/QMCHamiltonians/ForwardWalking.cpp
@@ -24,7 +24,6 @@
 
 namespace qmcplusplus
 {
-
 bool ForwardWalking::putSpecial(xmlNodePtr cur, QMCHamiltonian& h, ParticleSet& P)
 {
   using WP = WalkerProperties::Indexes;
@@ -79,7 +78,7 @@ bool ForwardWalking::putSpecial(xmlNodePtr cur, QMCHamiltonian& h, ParticleSet& 
         app_log() << " Hamiltonian Element " << tagName << " was found at " << Hindex << std::endl;
         int numT = blockSeries / blockFreq;
         nObservables += 1;
-        nValues      += numT;
+        nValues += numT;
         app_log() << "   " << numT << " values will be calculated every " << blockFreq << "*tau H^-1" << std::endl;
         std::vector<int> pms(3);
         pms[0] = blockFreq;
@@ -116,7 +115,7 @@ bool ForwardWalking::putSpecial(xmlNodePtr cur, QMCHamiltonian& h, ParticleSet& 
             Hindices.push_back(Hindex);
             int numT = blockSeries / blockFreq;
             nObservables += 1;
-            nValues      += numT;
+            nValues += numT;
             app_log() << "   " << numT << " values will be calculated every " << blockFreq << "*tau H^-1" << std::endl;
             std::vector<int> pms(3);
             pms[0] = blockFreq;
@@ -151,10 +150,10 @@ bool ForwardWalking::putSpecial(xmlNodePtr cur, QMCHamiltonian& h, ParticleSet& 
   return true;
 }
 
-OperatorBase* ForwardWalking::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> ForwardWalking::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   //nothing to worry, default copy constructor will do
-  return new ForwardWalking(*this);
+  return std::make_shared<ForwardWalking>(*this);
 }
 
 void ForwardWalking::addObservables(PropertySetType& plist)

--- a/src/QMCHamiltonians/ForwardWalking.h
+++ b/src/QMCHamiltonians/ForwardWalking.h
@@ -95,7 +95,7 @@ struct ForwardWalking : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void addObservables(PropertySetType& plist);
 

--- a/src/QMCHamiltonians/GridExternalPotential.cpp
+++ b/src/QMCHamiltonians/GridExternalPotential.cpp
@@ -97,9 +97,9 @@ bool GridExternalPotential::get(std::ostream& os) const
 }
 
 
-OperatorBase* GridExternalPotential::makeClone(ParticleSet& P, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> GridExternalPotential::makeClone(ParticleSet& P, TrialWaveFunction& psi)
 {
-  return new GridExternalPotential(*this);
+  return std::make_shared<GridExternalPotential>(*this);
 }
 
 

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -50,7 +50,7 @@ struct GridExternalPotential : public OperatorBase
   //standard interface functions
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
 
   //functions for physical (hamiltonian component) estimator
   Return_t evaluate(ParticleSet& P);

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -321,7 +321,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         if (PBCType) //only if perioidic
         {
 #ifdef QMC_CUDA
-          std::shared_ptr<SkEstimator_CUDA*> apot = std::make_shared<SkEstimator_CUDA>(targetPtcl);
+          std::shared_ptr<SkEstimator_CUDA> apot = std::make_shared<SkEstimator_CUDA>(targetPtcl);
 #else
           std::shared_ptr<SkEstimator> apot = std::make_shared<SkEstimator>(targetPtcl);
 #endif

--- a/src/QMCHamiltonians/HarmonicExternalPotential.cpp
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.cpp
@@ -54,9 +54,9 @@ bool HarmonicExternalPotential::get(std::ostream& os) const
 }
 
 
-OperatorBase* HarmonicExternalPotential::makeClone(ParticleSet& P, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> HarmonicExternalPotential::makeClone(ParticleSet& P, TrialWaveFunction& psi)
 {
-  return new HarmonicExternalPotential(*this);
+  return std::make_shared<HarmonicExternalPotential>(*this);
 }
 
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -48,7 +48,7 @@ struct HarmonicExternalPotential : public OperatorBase
   //standard interface functions
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
 
   //functions for physical (hamiltonian component) estimator
   Return_t evaluate(ParticleSet& P);

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -106,17 +106,17 @@ void L2Potential::evaluateDK(ParticleSet& P, int iel, TensorType& D, PosType& K)
     L2RadialPotential* ppot = PP[iat];
     if (ppot == nullptr)
       continue;
-    RealType r  = d_table.getTempDists()[iat];
+    RealType r = d_table.getTempDists()[iat];
     if (r < ppot->rcut)
     {
-      PosType  rv = -1*d_table.getTempDispls()[iat];
+      PosType rv   = -1 * d_table.getTempDispls()[iat];
       RealType vL2 = ppot->evaluate(r);
-      K += 2*rv*vL2;
+      K += 2 * rv * vL2;
       for (int i = 0; i < DIM; ++i)
-        D(i,i) += 2*vL2*r*r;
+        D(i, i) += 2 * vL2 * r * r;
       for (int i = 0; i < DIM; ++i)
         for (int j = 0; j < DIM; ++j)
-          D(i,j) -= 2*vL2*rv[i]*rv[j];
+          D(i, j) -= 2 * vL2 * rv[i] * rv[j];
     }
   }
 }
@@ -134,24 +134,24 @@ void L2Potential::evaluateD(ParticleSet& P, int iel, TensorType& D)
     L2RadialPotential* ppot = PP[iat];
     if (ppot == nullptr)
       continue;
-    RealType r  = d_table.getTempDists()[iat];
+    RealType r = d_table.getTempDists()[iat];
     if (r < ppot->rcut)
     {
-      PosType  rv = d_table.getTempDispls()[iat];
+      PosType rv   = d_table.getTempDispls()[iat];
       RealType vL2 = ppot->evaluate(r);
       for (int i = 0; i < DIM; ++i)
-        D(i,i) += 2*vL2*r*r;
+        D(i, i) += 2 * vL2 * r * r;
       for (int i = 0; i < DIM; ++i)
         for (int j = 0; j < DIM; ++j)
-          D(i,j) -= 2*vL2*rv[i]*rv[j];
+          D(i, j) -= 2 * vL2 * rv[i] * rv[j];
     }
   }
 }
 
 
-OperatorBase* L2Potential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> L2Potential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  L2Potential* myclone = new L2Potential(IonConfig, qp, psi);
+  std::shared_ptr<L2Potential> myclone = std::make_shared<L2Potential>(IonConfig, qp, psi);
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->add(ig, std::unique_ptr<L2RadialPotential>(PPset[ig]->makeClone()));

--- a/src/QMCHamiltonians/L2Potential.h
+++ b/src/QMCHamiltonians/L2Potential.h
@@ -86,7 +86,7 @@ struct L2Potential : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   /** Add a RadialPotentialType of a species
    * @param groupID index of the ion species

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -215,13 +215,13 @@ void LatticeDeviationEstimator::setObservables(PropertySetType& plist)
 
 void LatticeDeviationEstimator::resetTargetParticleSet(ParticleSet& P) {}
 
-OperatorBase* LatticeDeviationEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> LatticeDeviationEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   // default constructor does not work with threads
   //LatticeDeviationEstimator* myclone = new LatticeDeviationEstimator(*this);
-  LatticeDeviationEstimator* myclone = new LatticeDeviationEstimator(qp, spset, tgroup, sgroup);
+  std::shared_ptr<LatticeDeviationEstimator> myclone =
+      std::make_shared<LatticeDeviationEstimator>(qp, spset, tgroup, sgroup);
   myclone->put(input_xml);
-
   return myclone;
 }
 

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.h
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.h
@@ -58,8 +58,8 @@ public:
   //void addObservables(PropertySetType& plist, BufferType& collectables); // also used for multiple scalars
 
   // pure virtual functions require overrider
-  void resetTargetParticleSet(ParticleSet& P);                            // required
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi); // required
+  void resetTargetParticleSet(ParticleSet& P);                                            // required
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final; // required
 
 private:
   SpeciesSet& tspecies;       // species table of target particle set
@@ -74,7 +74,7 @@ private:
   xmlNodePtr input_xml;       // original xml
   // distance table ID
   const int myTableID_;
-};                            // LatticeDeviationEstimator
+}; // LatticeDeviationEstimator
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -217,9 +217,10 @@ LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
   return Value;
 }
 
-OperatorBase* LocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> LocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  LocalECPotential* myclone = new LocalECPotential(IonConfig, qp);
+  std::shared_ptr<LocalECPotential> myclone = std::make_shared<LocalECPotential>(IonConfig, qp);
+
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->add(ig, std::unique_ptr<RadialPotentialType>(PPset[ig]->makeClone()), gZeff[ig]);

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -91,7 +91,7 @@ struct LocalECPotential : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   /** Add a RadialPotentialType of a species
    * @param groupID index of the ion species

--- a/src/QMCHamiltonians/LocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/LocalECPotential_CUDA.cpp
@@ -123,9 +123,9 @@ void LocalECPotential_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Real
 }
 
 
-OperatorBase* LocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> LocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  LocalECPotential_CUDA* myclone = new LocalECPotential_CUDA(IonRef, qp);
+  std::shared_ptr<LocalECPotential_CUDA> myclone = std::make_shared<LocalECPotential_CUDA>(IonRef, qp);
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->add(ig, std::unique_ptr<RadialPotentialType>(PPset[ig]->makeClone()), gZeff[ig]);

--- a/src/QMCHamiltonians/LocalECPotential_CUDA.h
+++ b/src/QMCHamiltonians/LocalECPotential_CUDA.h
@@ -43,7 +43,7 @@ struct LocalECPotential_CUDA : public LocalECPotential
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   LocalECPotential_CUDA(ParticleSet& ions, ParticleSet& elns);
 };

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -323,10 +323,10 @@ void MPC::initBreakup()
   app_log() << "  === MPC interaction initialized === \n\n";
 }
 
-OperatorBase* MPC::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> MPC::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   // return new MPC(qp, Ecut);
-  MPC* newMPC = new MPC(*this);
+  std::shared_ptr<MPC> newMPC = std::make_shared<MPC>(*this);
   newMPC->resetTargetParticleSet(qp);
   return newMPC;
 }

--- a/src/QMCHamiltonians/MPC.h
+++ b/src/QMCHamiltonians/MPC.h
@@ -90,7 +90,7 @@ public:
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   void initBreakup();
 };

--- a/src/QMCHamiltonians/MPC_CUDA.cpp
+++ b/src/QMCHamiltonians/MPC_CUDA.cpp
@@ -52,10 +52,10 @@ void MPC_CUDA::initBreakup()
   //  app_log() << "    Finished copying MPC spline to GPU memory.\n";
 }
 
-OperatorBase* MPC_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> MPC_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   // return new MPC(qp, Ecut);
-  MPC_CUDA* newMPC = new MPC_CUDA(*this);
+  std::shared_ptr<MPC_CUDA> newMPC = std::make_shared<MPC_CUDA>(*this);
   newMPC->resetTargetParticleSet(qp);
   return newMPC;
 }
@@ -130,7 +130,7 @@ void MPC_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalE
 
   for (int iw = 0; iw < nw; iw++)
   {
-    double e                                                = esum[iw] + SumHost[iw] + Vconst;
+    double e                                                    = esum[iw] + SumHost[iw] + Vconst;
     walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = e;
     LocalEnergy[iw] += e;
   }

--- a/src/QMCHamiltonians/MPC_CUDA.h
+++ b/src/QMCHamiltonians/MPC_CUDA.h
@@ -41,7 +41,7 @@ protected:
 public:
   MPC_CUDA(ParticleSet& ref, double cutoff);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 };

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -72,7 +72,7 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
       const RealType* restrict phases_vPos_c = phases_vPos[s].data(0);
       const RealType* restrict phases_vPos_s = phases_vPos[s].data(1);
       RealType* restrict nofK_here           = nofK.data();
-#pragma omp simd aligned(nofK_here, phases_c, phases_s, phases_vPos_c, phases_vPos_s: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(nofK_here, phases_c, phases_s, phases_vPos_c, phases_vPos_s : QMC_SIMD_ALIGNMENT)
       for (int ik = 0; ik < nk; ++ik)
         nofK_here[ik] += (phases_c[ik] * phases_vPos_c[ik] - phases_s[ik] * phases_vPos_s[ik]) * ratio_c -
             (phases_s[ik] * phases_vPos_c[ik] + phases_c[ik] * phases_vPos_s[ik]) * ratio_s;
@@ -421,9 +421,9 @@ bool MomentumEstimator::putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootN
 
 bool MomentumEstimator::get(std::ostream& os) const { return true; }
 
-OperatorBase* MomentumEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> MomentumEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  MomentumEstimator* myclone = new MomentumEstimator(qp, psi);
+  std::shared_ptr<MomentumEstimator> myclone = std::make_shared<MomentumEstimator>(qp, psi);
   myclone->resize(kPoints, M);
   myclone->myIndex   = myIndex;
   myclone->norm_nofK = norm_nofK;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -33,7 +33,7 @@ public:
   bool putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootNode);
   bool put(xmlNodePtr cur) { return false; };
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
   void setRandomGenerator(RandomGenerator_t* rng);
   //resize the internal data by input k-point list
   void resize(const std::vector<PosType>& kin, const int Min);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -308,11 +308,11 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
                   << std::endl;
     O_leader.mw_res_ = std::make_unique<NonLocalECPotentialMultiWalkerResource>();
     for (int ig = 0; ig < O_leader.PPset.size(); ++ig)
-    if (O_leader.PPset[ig]->getVP())
-    {
-      O_leader.PPset[ig]->getVP()->createResource(O_leader.mw_res_->collection);
-      break;
-    }
+      if (O_leader.PPset[ig]->getVP())
+      {
+        O_leader.PPset[ig]->getVP()->createResource(O_leader.mw_res_->collection);
+        break;
+      }
   }
 
   auto pp_component = std::find_if(O_leader.PPset.begin(), O_leader.PPset.end(), [](auto& ptr) { return bool(ptr); });
@@ -621,9 +621,10 @@ void NonLocalECPotential::releaseResource(ResourceCollection& collection)
   collection.takebackResource(std::move(mw_res_));
 }
 
-OperatorBase* NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  NonLocalECPotential* myclone = new NonLocalECPotential(IonConfig, qp, psi, ComputeForces, use_DLA);
+  std::shared_ptr<NonLocalECPotential> myclone =
+      std::make_shared<NonLocalECPotential>(IonConfig, qp, psi, ComputeForces, use_DLA);
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->addComponent(ig, std::unique_ptr<NonLocalECPComponent>(PPset[ig]->makeClone(qp)));

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -105,7 +105,7 @@ public:
    */
   void releaseResource(ResourceCollection& collection) override;
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
   void addComponent(int groupID, std::unique_ptr<NonLocalECPComponent>&& pp);
 

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
@@ -49,9 +49,10 @@ NonLocalECPotential_CUDA::NonLocalECPotential_CUDA(ParticleSet& ions,
 }
 
 
-OperatorBase* NonLocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> NonLocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  NonLocalECPotential_CUDA* myclone = new NonLocalECPotential_CUDA(IonConfig, qp, psi, UsePBC, ComputeForces, use_DLA);
+  std::shared_ptr<NonLocalECPotential_CUDA> myclone =
+      std::make_shared<NonLocalECPotential_CUDA>(IonConfig, qp, psi, UsePBC, ComputeForces, use_DLA);
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->addComponent(ig, std::unique_ptr<NonLocalECPComponent>(PPset[ig]->makeClone(qp)));

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
@@ -78,7 +78,7 @@ public:
                            bool doForces   = false,
                            bool enable_DLA = false);
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
   void addEnergy(MCWalkerConfiguration& W,

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -159,7 +159,7 @@ bool OperatorBase::quantum_domain_valid(quantum_domains qdomain) { return qdomai
 
 void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
 {
-  OperatorBase* myclone = makeClone(qp, psi);
+  std::shared_ptr<OperatorBase> myclone = makeClone(qp, psi);
   if (myclone)
     targetH.addOperator(myclone, myName, UpdateMode[PHYSICAL]);
 }

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -32,6 +32,7 @@
 #endif
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
 #include <bitset>
+#include <memory> // std::unique_ptr
 
 namespace qmcplusplus
 {
@@ -336,7 +337,9 @@ struct OperatorBase : public QMCTraits
    */
   virtual void releaseResource(ResourceCollection& collection) {}
 
-  virtual OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
+  virtual std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
+
+  //virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& H);
 
   virtual void setRandomGenerator(RandomGenerator_t* rng)
   {

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -19,7 +19,8 @@
 
 namespace qmcplusplus
 {
-OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory) : psetpool(PSP), wf_factory_(factory)
+OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory)
+    : psetpool(PSP), wf_factory_(factory)
 {
   //keep the electron particle to get the cell later, if necessary
   Peln = &P;
@@ -29,11 +30,11 @@ OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, 
 }
 
 
-OperatorBase* OrbitalImages::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
+std::shared_ptr<OperatorBase> OrbitalImages::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
 {
   //cloning shouldn't strictly be necessary, but do it right just in case
-  OrbitalImages* clone = new OrbitalImages(*this);
-  clone->Peln          = &P;
+  std::shared_ptr<OrbitalImages> clone = std::make_shared<OrbitalImages>(*this);
+  clone->Peln                          = &P;
   for (int i = 0; i < sposets.size(); ++i)
   {
     clone->sposet_indices[i] = new std::vector<int>(*sposet_indices[i]);

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -221,7 +221,7 @@ public:
   ~OrbitalImages(){};
 
   //standard interface
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
 
   ///read xml input
   bool put(xmlNodePtr cur);

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -316,10 +316,10 @@ bool PairCorrEstimator::get(std::ostream& os) const
   return true;
 }
 
-OperatorBase* PairCorrEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> PairCorrEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   //default constructor is sufficient
-  return new PairCorrEstimator(*this);
+  return std::make_shared<PairCorrEstimator>(*this);
 }
 
 void PairCorrEstimator::resize(int nbins)

--- a/src/QMCHamiltonians/PairCorrEstimator.h
+++ b/src/QMCHamiltonians/PairCorrEstimator.h
@@ -47,7 +47,7 @@ public:
   void setParticlePropertyList(PropertySetType& plist, int offset);
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void set_norm_factor();
   void report();

--- a/src/QMCHamiltonians/Pressure.h
+++ b/src/QMCHamiltonians/Pressure.h
@@ -129,7 +129,10 @@ struct Pressure : public OperatorBase
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) { return new Pressure(qp); }
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final
+  {
+    return std::make_shared<Pressure>(qp);
+  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -79,10 +79,10 @@ bool QMCHamiltonian::get(std::ostream& os) const
  * @param aname name of h
  * @param physical if true, a physical operator
  */
-void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool physical)
+void QMCHamiltonian::addOperator(std::shared_ptr<OperatorBase> h, const std::string& aname, bool physical)
 {
   //change UpdateMode[PHYSICAL] of h so that cloning can be done correctly
-  h.UpdateMode[OperatorBase::PHYSICAL] = physical;
+  h->UpdateMode[OperatorBase::PHYSICAL] = physical;
   if (physical)
   {
     for (int i = 0; i < H.size(); ++i)
@@ -94,8 +94,8 @@ void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to H, physical Hamiltonian " << std::endl;
-    h.myName = aname;
-    H.push_back(&h);
+    h->myName = aname;
+    H.push_back(h);
     std::string tname = "Hamiltonian:" + aname;
     my_timers_.push_back(*timer_manager.createTimer(tname, timer_level_fine));
   }
@@ -111,8 +111,8 @@ void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to auxH " << std::endl;
-    h.myName = aname;
-    auxH.push_back(&h);
+    h->myName = aname;
+    auxH.push_back(h);
   }
 
   //assign save NLPP if found
@@ -120,7 +120,7 @@ void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool
   if (aname == "NonLocalECP")
   {
     if (nlpp_ptr == nullptr)
-      nlpp_ptr = dynamic_cast<NonLocalECPotential*>(&h);
+      nlpp_ptr = dynamic_cast<NonLocalECPotential*>(h.get());
     else
       APP_ABORT("QMCHamiltonian::addOperator nlpp_ptr is supposed to be null. Something went wrong!");
   }
@@ -130,7 +130,7 @@ void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool
   if (aname == "L2")
   {
     if (l2_ptr == nullptr)
-      l2_ptr = dynamic_cast<L2Potential*>(&h);
+      l2_ptr = dynamic_cast<L2Potential*>(h.get());
     else
       APP_ABORT("QMCHamiltonian::addOperator l2_ptr is supposed to be null. Something went wrong!");
   }
@@ -877,7 +877,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::getEnsembleAverage()
  *
  * If not found, return 0
  */
-OperatorBase* QMCHamiltonian::getHamiltonian(const std::string& aname)
+std::shared_ptr<OperatorBase> QMCHamiltonian::getHamiltonian(const std::string& aname)
 {
   for (int i = 0; i < H.size(); ++i)
     if (H[i]->myName == aname)

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -79,10 +79,10 @@ bool QMCHamiltonian::get(std::ostream& os) const
  * @param aname name of h
  * @param physical if true, a physical operator
  */
-void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool physical)
+void QMCHamiltonian::addOperator(OperatorBase& h, const std::string& aname, bool physical)
 {
   //change UpdateMode[PHYSICAL] of h so that cloning can be done correctly
-  h->UpdateMode[OperatorBase::PHYSICAL] = physical;
+  h.UpdateMode[OperatorBase::PHYSICAL] = physical;
   if (physical)
   {
     for (int i = 0; i < H.size(); ++i)
@@ -94,8 +94,8 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to H, physical Hamiltonian " << std::endl;
-    h->myName = aname;
-    H.push_back(h);
+    h.myName = aname;
+    H.push_back(&h);
     std::string tname = "Hamiltonian:" + aname;
     my_timers_.push_back(*timer_manager.createTimer(tname, timer_level_fine));
   }
@@ -111,8 +111,8 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to auxH " << std::endl;
-    h->myName = aname;
-    auxH.push_back(h);
+    h.myName = aname;
+    auxH.push_back(&h);
   }
 
   //assign save NLPP if found
@@ -120,7 +120,7 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
   if (aname == "NonLocalECP")
   {
     if (nlpp_ptr == nullptr)
-      nlpp_ptr = dynamic_cast<NonLocalECPotential*>(h);
+      nlpp_ptr = dynamic_cast<NonLocalECPotential*>(&h);
     else
       APP_ABORT("QMCHamiltonian::addOperator nlpp_ptr is supposed to be null. Something went wrong!");
   }
@@ -130,7 +130,7 @@ void QMCHamiltonian::addOperator(OperatorBase* h, const std::string& aname, bool
   if (aname == "L2")
   {
     if (l2_ptr == nullptr)
-      l2_ptr = dynamic_cast<L2Potential*>(h);
+      l2_ptr = dynamic_cast<L2Potential*>(&h);
     else
       APP_ABORT("QMCHamiltonian::addOperator l2_ptr is supposed to be null. Something went wrong!");
   }

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -66,7 +66,7 @@ public:
   ~QMCHamiltonian();
 
   ///add an operator
-  void addOperator(OperatorBase& h, const std::string& aname, bool physical = true);
+  void addOperator(std::shared_ptr<OperatorBase> h, const std::string& aname, bool physical = true);
 
   ///record the name-type pair of an operator
   void addOperatorType(const std::string& name, const std::string& type);
@@ -84,13 +84,13 @@ public:
    * @param aname name of a OperatorBase
    * @return 0 if aname is not found.
    */
-  OperatorBase* getHamiltonian(const std::string& aname);
+  std::shared_ptr<OperatorBase> getHamiltonian(const std::string& aname);
 
   /** return i-th OperatorBase
    * @param i index of the OperatorBase
    * @return H[i]
    */
-  OperatorBase* getHamiltonian(int i) { return H[i]; }
+  OperatorBase* getHamiltonian(int i) { return H[i].get(); }
 
 #if !defined(REMOVE_TRACEMANAGER)
   ///initialize trace data
@@ -430,13 +430,13 @@ private:
   ///getName is in the way
   const std::string myName;
   ///vector of Hamiltonians
-  std::vector<OperatorBase*> H;
+  std::vector<std::shared_ptr<OperatorBase>> H;
   ///pointer to NonLocalECP
   NonLocalECPotential* nlpp_ptr;
   ///pointer to L2Potential
   L2Potential* l2_ptr;
   ///vector of Hamiltonians
-  std::vector<OperatorBase*> auxH;
+  std::vector<std::shared_ptr<OperatorBase>> auxH;
   /// Total timer for H evaluation
   NewTimer& ham_timer_;
   /// timers for H components

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -66,7 +66,7 @@ public:
   ~QMCHamiltonian();
 
   ///add an operator
-  void addOperator(OperatorBase* h, const std::string& aname, bool physical = true);
+  void addOperator(OperatorBase& h, const std::string& aname, bool physical = true);
 
   ///record the name-type pair of an operator
   void addOperatorType(const std::string& name, const std::string& type);

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -62,9 +62,9 @@ SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
   return Value;
 }
 
-OperatorBase* SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  SOECPotential* myclone = new SOECPotential(IonConfig, qp, psi);
+  std::shared_ptr<SOECPotential> myclone = std::make_shared<SOECPotential>(IonConfig, qp, psi);
   for (int ig = 0; ig < PPset.size(); ++ig)
     if (PPset[ig])
       myclone->addComponent(ig, std::unique_ptr<SOECPComponent>(PPset[ig]->makeClone(qp)));

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -34,7 +34,7 @@ public:
     return true;
   }
 
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   void addComponent(int groupID, std::unique_ptr<SOECPComponent>&& pp);
 

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -341,11 +341,11 @@ bool SkAllEstimator::get(std::ostream& os) const
   return true;
 }
 
-OperatorBase* SkAllEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> SkAllEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  SkAllEstimator* myclone = new SkAllEstimator(*this);
-  myclone->hdf5_out       = hdf5_out;
-  myclone->myIndex        = myIndex;
+  std::shared_ptr<SkAllEstimator> myclone = std::make_shared<SkAllEstimator>(*this);
+  myclone->hdf5_out                       = hdf5_out;
+  myclone->myIndex                        = myIndex;
   return myclone;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SkAllEstimator.h
+++ b/src/QMCHamiltonians/SkAllEstimator.h
@@ -44,7 +44,7 @@ public:
   void setParticlePropertyList(PropertySetType& plist, int offset);
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
 protected:
   //  ParticleSet *sourcePtcl;

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -177,11 +177,11 @@ bool SkEstimator::put(xmlNodePtr cur)
 
 bool SkEstimator::get(std::ostream& os) const { return true; }
 
-OperatorBase* SkEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> SkEstimator::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  SkEstimator* myclone = new SkEstimator(*this);
-  myclone->hdf5_out    = hdf5_out;
-  myclone->myIndex     = myIndex;
+  std::shared_ptr<SkEstimator> myclone = std::make_shared<SkEstimator>(*this);
+  myclone->hdf5_out                    = hdf5_out;
+  myclone->myIndex                     = myIndex;
   return myclone;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SkEstimator.h
+++ b/src/QMCHamiltonians/SkEstimator.h
@@ -41,7 +41,7 @@ public:
   void setParticlePropertyList(PropertySetType& plist, int offset);
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
 protected:
   ParticleSet* sourcePtcl;

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -72,9 +72,9 @@ bool SkPot::put(xmlNodePtr cur)
 
 bool SkPot::get(std::ostream& os) const { return true; }
 
-OperatorBase* SkPot::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> SkPot::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  SkPot* myclone = new SkPot(*this);
+  std::shared_ptr<SkPot> myclone = std::make_shared<SkPot>(*this);
   myclone->FillFk();
   return myclone;
 }

--- a/src/QMCHamiltonians/SkPot.h
+++ b/src/QMCHamiltonians/SkPot.h
@@ -35,7 +35,7 @@ public:
 
   bool put(xmlNodePtr cur);
   bool get(std::ostream& os) const;
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
   inline void FillFk()
   {

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -116,9 +116,9 @@ SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
   return Value;
 }
 
-OperatorBase* SpeciesKineticEnergy::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> SpeciesKineticEnergy::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  return new SpeciesKineticEnergy(*this);
+  return std::make_shared<SpeciesKineticEnergy>(*this);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.h
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.h
@@ -35,8 +35,8 @@ public:
   Return_t evaluate(ParticleSet& P);
 
   // pure virtual functions require overrider
-  void resetTargetParticleSet(ParticleSet& P) {}                          // required
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi); // required
+  void resetTargetParticleSet(ParticleSet& P) {}                                          // required
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final; // required
 
   // allocate multiple columns in scalar.dat
   void addObservables(PropertySetType& plist, BufferType& collectables);

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -53,7 +53,10 @@ void SpinDensity::reset()
 }
 
 
-OperatorBase* SpinDensity::makeClone(ParticleSet& P, TrialWaveFunction& Psi) { return new SpinDensity(*this); }
+std::shared_ptr<OperatorBase> SpinDensity::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
+{
+  return std::make_shared<SpinDensity>(*this);
+}
 
 
 bool SpinDensity::put(xmlNodePtr cur)

--- a/src/QMCHamiltonians/SpinDensity.h
+++ b/src/QMCHamiltonians/SpinDensity.h
@@ -43,7 +43,7 @@ public:
   ~SpinDensity() {}
 
   //standard interface
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
   bool put(xmlNodePtr cur);
   Return_t evaluate(ParticleSet& P);
 

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -44,9 +44,9 @@ void StaticStructureFactor::reset()
 }
 
 
-OperatorBase* StaticStructureFactor::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
+std::shared_ptr<OperatorBase> StaticStructureFactor::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
 {
-  return new StaticStructureFactor(*this);
+  return std::make_shared<StaticStructureFactor>(*this);
 }
 
 

--- a/src/QMCHamiltonians/StaticStructureFactor.h
+++ b/src/QMCHamiltonians/StaticStructureFactor.h
@@ -37,7 +37,7 @@ public:
   ~StaticStructureFactor() {}
 
   //standard interface
-  OperatorBase* makeClone(ParticleSet& P, TrialWaveFunction& psi);
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;
   bool put(xmlNodePtr cur);
   Return_t evaluate(ParticleSet& P);
 

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -334,14 +334,14 @@ bool StressPBC::put(xmlNodePtr cur)
   return true;
 }
 
-OperatorBase* StressPBC::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::shared_ptr<OperatorBase> StressPBC::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  StressPBC* tmp       = new StressPBC(PtclA, qp, psi);
-  tmp->firstTimeStress = firstTimeStress;
-  tmp->stress_IonIon   = stress_IonIon;
-  tmp->stress_ee_const = stress_ee_const;
-  tmp->stress_eI_const = stress_eI_const;
-  tmp->addionion       = addionion;
+  std::shared_ptr<StressPBC> tmp = std::make_shared<StressPBC>(PtclA, qp, psi);
+  tmp->firstTimeStress           = firstTimeStress;
+  tmp->stress_IonIon             = stress_IonIon;
+  tmp->stress_ee_const           = stress_ee_const;
+  tmp->stress_eI_const           = stress_eI_const;
+  tmp->addionion                 = addionion;
   return tmp;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/StressPBC.h
+++ b/src/QMCHamiltonians/StressPBC.h
@@ -90,7 +90,7 @@ struct StressPBC : public OperatorBase, public ForceBase
   void resetTargetParticleSet(ParticleSet& P) override {}
 
   void setParticlePropertyList(PropertySetType& plist, int offset) override { setParticleSetStress(plist, offset); }
-  OperatorBase* makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
+  std::shared_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
   bool put(xmlNodePtr cur) override;
 
   bool get(std::ostream& os) const override

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -267,9 +267,9 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // copied.  Would be nice if there were a better way than inspection
   // to ensure all the members are copied/set up/tested.
 
-  OperatorBase* base_force2 = force.makeClone(elec, psi);
-  ForceChiesaPBCAA* force2  = dynamic_cast<ForceChiesaPBCAA*>(base_force2);
-  REQUIRE(force2 != NULL);
+  std::shared_ptr<OperatorBase> base_force2 = force.makeClone(elec, psi);
+  ForceChiesaPBCAA* force2                  = dynamic_cast<ForceChiesaPBCAA*>(base_force2.get());
+  REQUIRE(force2 != nullptr);
 
   check_force_copy(*force2, force);
 }

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -211,7 +211,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
   TrialWaveFunction psi;
-  std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi)));
+  std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).get()));
   clone->evaluate(elec);
   REQUIRE(clone->addionion == force.addionion);
   REQUIRE(clone->forces_IonIon[0][0] == Approx(-0.0228366));

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -211,7 +211,7 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
   TrialWaveFunction psi;
-  std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).get()));
+  std::shared_ptr<ForceChiesaPBCAA> clone = std::dynamic_pointer_cast<ForceChiesaPBCAA>(force.makeClone(elec, psi));
   clone->evaluate(elec);
   REQUIRE(clone->addionion == force.addionion);
   REQUIRE(clone->forces_IonIon[0][0] == Approx(-0.0228366));


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Refactor raw pointers in QMCDrivers into shared_ptr for RAII (automatic deallocation). 
Affects `OperatorBase`, `addOperator` and `makeclone`, `getHamiltonian` functions that retrieve/interact with `OperatorBase`
Raw pointers were creating a leak as part of #3083 identified tests
Tried `unique_ptr` first, but these pointers have shared ownership (some tests failed).
Must still use pointers due to runtime polymorphism.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix: addressing leak related to using raw pointers
- Refactoring (no functional changes, no api changes): internal API changed for `OperatorBase`

### Does this introduce a breaking change?

- Yes: internal API changed for `OperatorBase`, no external change

## What systems has this change been tested on?
Ubuntun 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
