### PR TITLE
Update XL build recipe.

### DIFF
--- a/config/build_olcf_summit_XL.sh
+++ b/config/build_olcf_summit_XL.sh
@@ -31,7 +31,7 @@ source_folder=..
 for name in offload_real_MP offload_real # offload_cplx offload_cplx_MP
 do
 
-CMAKE_FLAGS="-D CMAKE_BUILD_TYPE=$TYPE -D ENABLE_CUDA=1 -D CUDA_ARCH=sm_70 -D ENABLE_MASS=1 -D MASS_ROOT=/sw/summit/xl/16.1.1-5/xlmass/9.1.1 -D MPIEXEC_EXECUTABLE=`which jsrun` -D MPIEXEC_NUMPROC_FLAG='-n' -D MPIEXEC_PREFLAGS='-c;16;-g;1;-b;packed:16;--smpiargs=off'"
+CMAKE_FLAGS="-D CMAKE_BUILD_TYPE=$TYPE -D ENABLE_CUDA=1 -D CUDA_ARCH=sm_70 -D CUDA_HOST_COMPILER=/sw/summit/gcc/6.4.0/bin/gcc -D ENABLE_MASS=1 -D MASS_ROOT=/sw/summit/xl/16.1.1-5/xlmass/9.1.1 -D MPIEXEC_EXECUTABLE=`which jsrun` -D MPIEXEC_NUMPROC_FLAG='-n' -D MPIEXEC_PREFLAGS='-c;16;-g;1;-b;packed:16;--smpiargs=off'"
 
 if [[ $name == *"cplx"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -D QMC_COMPLEX=1"

--- a/src/Platforms/CUDA/CUDATypeMapping.hpp
+++ b/src/Platforms/CUDA/CUDATypeMapping.hpp
@@ -9,8 +9,11 @@
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
+
 #ifndef QMCPLUSPLUS_CUDA_TYPE_MAPPING_HPP
 #define QMCPLUSPLUS_CUDA_TYPE_MAPPING_HPP
+
+#include <type_traits>
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
## Proposed changes
Recent changes use more C++14 on the CUDA side and I have difficulty to teach the host compiler of nvcc using newer C++ so switch nvcc host compiler from XL to gcc when XL is used on Summit.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Sunmit

## Checklist
- Yes/No. This PR is up to date with current the current state of 'develop'