### PR TITLE
Nexus: Add Tref (initial tilematrix) argument to optimal_tilematrix

### DIFF
--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -538,7 +538,7 @@ def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None
     axinv  = inv(axes)
     cube   = volume**(1./3)*identity(dim)
     if Tref is None:
-        Tref   = array(around(dot(cube,axinv)),dtype=int)
+        Tref = array(around(dot(cube,axinv)),dtype=int)
     else:
         Tref = np.asarray(Tref)
     #end if

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -520,7 +520,7 @@ class MaskFilter(DevBase):
 mask_filter = MaskFilter()
             
 
-def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None,nc=5):
+def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None,nc=5,Tref=None):
     if mask is not None:
         mask_filter.set(mask)
         filter = mask_filter
@@ -537,7 +537,11 @@ def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None
     volume = abs(det(axes))*volfac
     axinv  = inv(axes)
     cube   = volume**(1./3)*identity(dim)
-    Tref   = array(around(dot(cube,axinv)),dtype=int)
+    if Tref is None:
+        Tref   = array(around(dot(cube,axinv)),dtype=int)
+    else:
+        Tref = np.asarray(Tref)
+    #end if
     # calculate and store all tiling matrix variations
     if dn not in opt_tm_matrices:
         mats = []
@@ -719,6 +723,8 @@ def optimal_tilematrix(axes,volfac,dn=1,tol=1e-3,filter=trivial_filter,mask=None
         s = -1
     elif len(other)>0:
         cells = other
+    else:
+        cells = []
     #end if
     skew_min = 1e99
     if len(cells)>0:


### PR DESCRIPTION

## Proposed changes

This PR allows the user to supply an initial guess for the optimal tiling matrix. In some cases, this will allow the user to reach better tilings without the need to increase the search space through the `dn` argument.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No. All nxs-test cases pass.

## What systems has this change been tested on?

Desktop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
