### PR TITLE
Update to libopenblas-openmp in Dockerfile and CI container

### DIFF
--- a/config/docker/dependencies/ubuntu/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu/openmpi/Dockerfile
@@ -20,7 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
                     libhdf5-openmpi-dev \
                     hdf5-tools \
                     libfftw3-dev \
-                    libopenblas-dev \
+                    libopenblas-openmp-dev \
                     libxml2-dev \
                     sudo \
                     curl \


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Migrate from `libopenblas-dev` to `libopenblas-openmp-dev` in Dockerfile and container used for CI (already pushed) with QMCPACK dependencies.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests) : new container dependency

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Docker container running on Ubuntu 20.04, CI must pass with new updated container.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
