### PR TITLE
Nexus: support grand-canonical twist averaging

### DIFF
--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -192,8 +192,17 @@ class PwscfAnalyzer(SimulationAnalyzer):
         try:
             fermi_energies = []
             for l in lines:
-                if l.find('Fermi energy')!=-1:
-                    fermi_energies.append( float( l.split('is')[1].split()[0] ) )
+                if l.find('Fermi energ')!=-1:
+                    toks = l.split()[::-1]
+                    assert toks[0] == 'ev'
+                    for tok in toks[1:]:
+                      try:
+                        ef1 = float(tok)
+                        fermi_energies.append(ef1)
+                      except ValueError:
+                        fermi_energies = fermi_energies[::-1]
+                      #end try
+                    #end for
                 #end if
             #end for
             if len(fermi_energies)==0:

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -201,6 +201,7 @@ class PwscfAnalyzer(SimulationAnalyzer):
                         fermi_energies.append(ef1)
                       except ValueError:
                         fermi_energies = fermi_energies[::-1]
+                        break
                       #end try
                     #end for
                 #end if

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -547,6 +547,38 @@ class Qmcpack(Simulation):
                         fobj.close()
                     #end if
                 #end for
+                grand_canonical_twist_average = 'nelecs_at_twist' in self
+                if grand_canonical_twist_average:
+                    for itwist, qi in enumerate(input.inputs):
+                        elecs = self.nelecs_at_twist[itwist]
+                        # step 1: resize particlesets
+                        nup = elecs[0]
+                        ndn = elecs[1]
+                        qi.get('u').set(size=nup)
+                        qi.get('d').set(size=ndn)
+                        # step 2: resize orbital sets
+                        sb = qi.get('sposet_builder')
+                        bb = sb.bspline  # hard-code for Bspline orbs
+                        assert itwist == bb.twistnum
+                        sposets = bb.sposets
+                        if len(sposets) == 1:  # RHF/ROHF
+                            norb = max(nup, ndn)
+                            sposets[list(sposets.keys())[0]].set(size=norb)
+                        else:  # UHF
+                            for spo in sposets:
+                                ispin = spo.get('spindataset')
+                                nelec = elecs[ispin]
+                                spo.set(size=nelec)
+                            #end for
+                        #end if
+                        # step 3: resize determinants
+                        dset = qi.get('determinantset')
+                        sdet = dset.slaterdeterminant  # hard-code single det
+                        for det, nelec in zip(sdet.determinants, elecs):
+                            det.set(size=nelec)
+                        #end for
+                    #end for
+                #end if
             #end if
         #end if
     #end def write_prep

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -566,26 +566,24 @@ class Qmcpack(Simulation):
                         ndn = elecs[1]
                         qi.get('u').set(size=nup)
                         qi.get('d').set(size=ndn)
-                        # step 2: resize orbital sets
+                        # step 2: resize determinants
+                        dset = qi.get('determinantset')
+                        sdet = dset.slaterdeterminant  # hard-code single det
+                        spo_size_map = {}
+                        for det, nelec in zip(sdet.determinants, elecs):
+                            spo_name = det.get('sposet')
+                            spo_size_map[spo_name] = nelec
+                            det.set(size=nelec)
+                        #end for
+                        # step 3: resize orbital sets
                         sb = qi.get('sposet_builder')
                         bb = sb.bspline  # hard-code for Bspline orbs
                         assert itwist == bb.twistnum
                         sposets = bb.sposets
-                        if len(sposets) == 1:  # RHF/ROHF
-                            norb = max(nup, ndn)
-                            sposets[list(sposets.keys())[0]].set(size=norb)
-                        else:  # UHF
-                            for spo in sposets:
-                                ispin = spo.get('spindataset')
-                                nelec = elecs[ispin]
-                                spo.set(size=nelec)
-                            #end for
-                        #end if
-                        # step 3: resize determinants
-                        dset = qi.get('determinantset')
-                        sdet = dset.slaterdeterminant  # hard-code single det
-                        for det, nelec in zip(sdet.determinants, elecs):
-                            det.set(size=nelec)
+                        for spo in sposets:
+                            if spo.name in spo_size_map:
+                                spo.set(size=spo_size_map[spo.name])
+                            #end if
                         #end for
                     #end for
                 #end if

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -570,7 +570,17 @@ class Qmcpack(Simulation):
                         dset = qi.get('determinantset')
                         sdet = dset.slaterdeterminant  # hard-code single det
                         spo_size_map = {}
-                        for det, nelec in zip(sdet.determinants, elecs):
+                        for det in sdet.determinants:
+                            nelec = None  # determine from group
+                            group = det.get('group')
+                            if group == 'u':
+                                nelec = nup
+                            elif group == 'd':
+                                nelec = ndn
+                            else:
+                                msg = 'need to count number of "%s"' % group
+                                self.error(msg)
+                            #end if
                             spo_name = det.get('sposet')
                             spo_size_map[spo_name] = nelec
                             det.set(size=nelec)

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -385,17 +385,24 @@ class Qmcpack(Simulation):
                 self.error('incorporating wavefunction from '+sim.__class__.__name__+' has not been implemented')
             #end if
         elif result_name=='gc_occupation':
+            from pwscf import Pwscf
             from qmcpack_converters import gcta_occupation
             if not isinstance(sim,Pw2qmcpack):
                 msg = 'grand-canonical occupation require Pw2qmcpack'
                 self.error(msg)
             #endif
             # step 1: extract Fermi energy for each spin from nscf
-            if len(sim.dependencies) != 1:
-                msg = 'need scf/nscf calculation for Fermi energy'
+            nscf = None
+            npwdep = 0
+            for dep in sim.dependencies:
+                if isinstance(dep.sim,Pwscf):
+                    nscf = dep.sim
+                    npwdep += 1
+            if npwdep != 1:
+                msg = 'need exactly 1 scf/nscf calculation for Fermi energy'
+                msg += '\n found %d' % npwdep
                 self.error(msg)
             #end if
-            nscf = sim.dependencies[1].sim
             na = nscf.load_analyzer_image()
             Ef_list = na.fermi_energies
             # step 2: analyze ESH5 file for states below Fermi energy

--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -407,7 +407,10 @@ class Qmcpack(Simulation):
             Ef_list = na.fermi_energies
             # step 2: analyze ESH5 file for states below Fermi energy
             pa = sim.load_analyzer_image()
-            pa.analyze(Ef_list=Ef_list)
+            if 'wfh5' not in pa:
+              pa.analyze(Ef_list=Ef_list)
+              sim.save_analyzer_image(pa)
+            #end if
             # step 3: count the number of up/dn electrons at each supertwist
             s1 = self.system.structure
             ntwist = len(s1.kpoints)

--- a/nexus/lib/qmcpack_converters.py
+++ b/nexus/lib/qmcpack_converters.py
@@ -185,24 +185,12 @@ def generate_pw2qmcpack_input(prefix='pwscf',outdir='pwscf_output',write_psir=Fa
 #end def generate_pw2qmcpack_input
 
 
-def import_nexus_module(module_name):
-    import importlib
-    return importlib.import_module(module_name)
-#end def import_nexus_module
-
-
 def read_eshdf_eig_data(filename, Ef_list):
     import numpy as np
     from numpy import array,pi
     from numpy.linalg import inv
     from unit_converter import convert
-    try:
-        hdfreader = import_nexus_module('hdfreader')
-        read_hdf = hdfreader.read_hdf
-        del hdfreader
-    except:
-        from hdfreader import read_hdf
-    #end try
+    from hdfreader import read_hdf
 
     def h5int(i):
         return array(i,dtype=int)[0]

--- a/nexus/lib/qmcpack_converters.py
+++ b/nexus/lib/qmcpack_converters.py
@@ -283,6 +283,27 @@ def read_eshdf_nofk_data(filename, Ef_list):
 #end def read_eshdf_nofk_data
 
 
+def gcta_occupation(wfh5, ntwist):
+  nspin = wfh5.nspins
+  nk = wfh5.nkpoints
+  nprim = nk//ntwist
+  assert nprim*ntwist == nk
+  nelecs_at_twist = []
+  for itwist in range(ntwist):
+    iks = range(itwist, nk, ntwist)
+    # calculate nelec for each spin
+    nelecs = []
+    for ispin in range(nspin):
+      nl = [len(wfh5.data[ik, ispin].eig) for ik in iks]
+      nup = sum(nl)
+      nelecs.append(nup)
+      if nspin == 1:
+        nelecs.append(nup)
+    nelecs_at_twist.append(nelecs)
+  return nelecs_at_twist
+#end gcta_occupation
+
+
 class Pw2qmcpackAnalyzer(SimulationAnalyzer):
     def __init__(self,arg0):
         if isinstance(arg0,Simulation):

--- a/nexus/lib/qmcpack_converters.py
+++ b/nexus/lib/qmcpack_converters.py
@@ -191,6 +191,7 @@ def read_eshdf_eig_data(filename, Ef_list):
     from numpy.linalg import inv
     from unit_converter import convert
     from hdfreader import read_hdf
+    from developer import error
 
     def h5int(i):
         return array(i,dtype=int)[0]
@@ -203,7 +204,7 @@ def read_eshdf_eig_data(filename, Ef_list):
     ns       = h5int(h.electrons.number_of_spins)
     if len(Ef_list) != ns:
       msg = 'Ef "%s" must have same length as nspin=%d' % (str(Ef_list), ns)
-      return msg
+      error(msg)
     data     = obj()
     for k in range(nk):
         kp = h.electrons['kpoint_'+str(k)]
@@ -274,11 +275,8 @@ class Pw2qmcpackAnalyzer(SimulationAnalyzer):
 
     def analyze(self, Ef_list=None):
       if Ef_list is not None:
-        res = read_eshdf_eig_data(self.h5file, Ef_list)
-        if type(res) is str:
-          self.error(res)
-        else:
-          self.wfh5 = res
+        self.wfh5 = read_eshdf_eig_data(self.h5file, Ef_list)
+      #end if
     #end def analyze
 
     def get_result(self,result_name):

--- a/nexus/lib/qmcpack_converters.py
+++ b/nexus/lib/qmcpack_converters.py
@@ -338,11 +338,13 @@ class Pw2qmcpack(Simulation):
     generic_identifier = 'pw2qmcpack'
     application = 'pw2qmcpack.x'
     application_properties = set(['serial'])
-    application_results    = set(['orbitals'])
+    application_results    = set(['orbitals','gc_occupation'])
 
     def check_result(self,result_name,sim):
         calculating_result = False
         if result_name=='orbitals':
+            calculating_result = True
+        elif result_name=='gc_occupation':
             calculating_result = True
         #end if        
         return calculating_result
@@ -367,6 +369,8 @@ class Pw2qmcpack(Simulation):
             result.h5file   = os.path.join(self.locdir,outdir,prefix+'.pwscf.h5')
             result.ptcl_xml = os.path.join(self.locdir,outdir,prefix+'.ptcl.xml')
             result.wfs_xml  = os.path.join(self.locdir,outdir,prefix+'.wfs.xml')
+        elif result_name=='gc_occupation':
+            pass  # defer to Qmcpack.incorporate_result
         else:
             self.error('ability to get result '+result_name+' has not been implemented')
         #end if        

--- a/nexus/lib/simulation.py
+++ b/nexus/lib/simulation.py
@@ -927,6 +927,11 @@ class Simulation(NexusCore):
     #end def load_analyzer_image
 
 
+    def save_analyzer_image(self,analyzer):
+        analyzer.save(os.path.join(self.imresdir,self.analyzer_image))
+    #end def save_analyzer_image
+
+
     def attempt_files(self):
         return (self.infile,self.outfile,self.errfile)
     #end def attempt_files


### PR DESCRIPTION
## Proposed changes

Enable nexus to setup grand-canonical twist average grid using DFT Fermi energy and KS eigenvalues.
Activated when an occupation dependency is give to `generate_qmcpack`, e.g. `(p2q, 'gc_occupation')`

Tested using the attached BCC Li example:
[bcc-li-n16.zip](https://github.com/QMCPACK/qmcpack/files/6424040/bcc-li-n16.zip)


## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Fedora 32, E5-2620 v2, gcc 10.2.1, intel 19.1.2

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
