### PR TITLE
Split J2OrbitalSoA and fix unit test

### DIFF
--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(JASTROW_SRCS
   Jastrow/RadialJastrowBuilder.cpp
   Jastrow/CountingJastrowBuilder.cpp
   Jastrow/RPAJastrow.cpp
+  Jastrow/J2OrbitalSoA.cpp
   LatticeGaussianProduct.cpp
   LatticeGaussianProductBuilder.cpp
   Fermion/SPOSetProxy.cpp

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -1,0 +1,517 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
+//                    Amrita Mathuriya, amrita.mathuriya@intel.com, Intel Corp.
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
+//////////////////////////////////////////////////////////////////////////////////////
+// -*- C++ -*-
+
+
+#include "J2OrbitalSoA.h"
+#include "CPU/SIMD/algorithm.hpp"
+#include "BsplineFunctor.h"
+#include "PadeFunctors.h"
+#include "UserFunctor.h"
+
+namespace qmcplusplus
+{
+template<typename FT>
+void J2OrbitalSoA<FT>::checkInVariables(opt_variables_type& active)
+{
+  myVars.clear();
+  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  while (it != it_end)
+  {
+    (*it).second->checkInVariables(active);
+    (*it).second->checkInVariables(myVars);
+    ++it;
+  }
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::checkOutVariables(const opt_variables_type& active)
+{
+  myVars.getIndex(active);
+  Optimizable = myVars.is_optimizable();
+  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  while (it != it_end)
+  {
+    (*it).second->checkOutVariables(active);
+    ++it;
+  }
+  if (dPsi)
+    dPsi->checkOutVariables(active);
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::resetParameters(const opt_variables_type& active)
+{
+  if (!Optimizable)
+    return;
+  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  while (it != it_end)
+  {
+    (*it).second->resetParameters(active);
+    ++it;
+  }
+  if (dPsi)
+    dPsi->resetParameters(active);
+  for (int i = 0; i < myVars.size(); ++i)
+  {
+    int ii = myVars.Index[i];
+    if (ii >= 0)
+      myVars[i] = active[ii];
+  }
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::reportStatus(std::ostream& os)
+{
+  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  while (it != it_end)
+  {
+    (*it).second->myVars.print(os);
+    ++it;
+  }
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios)
+{
+  for (int k = 0; k < ratios.size(); ++k)
+    ratios[k] = std::exp(Uat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTable(my_table_ID_).getDistRow(k)));
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::registerData(ParticleSet& P, WFBufferType& buf)
+{
+  if (Bytes_in_WFBuffer == 0)
+  {
+    Bytes_in_WFBuffer = buf.current();
+    buf.add(Uat.begin(), Uat.end());
+    buf.add(dUat.data(), dUat.end());
+    buf.add(d2Uat.begin(), d2Uat.end());
+    Bytes_in_WFBuffer = buf.current() - Bytes_in_WFBuffer;
+    // free local space
+    Uat.free();
+    dUat.free();
+    d2Uat.free();
+  }
+  else
+  {
+    buf.forward(Bytes_in_WFBuffer);
+  }
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
+{
+  Uat.attachReference(buf.lendReference<valT>(N), N);
+  dUat.attachReference(N, N_padded, buf.lendReference<valT>(N_padded * OHMMS_DIM));
+  d2Uat.attachReference(buf.lendReference<valT>(N), N);
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::updateBuffer(ParticleSet& P,
+                                                                       WFBufferType& buf,
+                                                                       bool fromscratch)
+{
+  evaluateGL(P, P.G, P.L, false);
+  buf.forward(Bytes_in_WFBuffer);
+  return LogValue;
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::valT J2OrbitalSoA<FT>::computeU(const ParticleSet& P, int iat, const DistRow& dist)
+{
+  valT curUat(0);
+  const int igt = P.GroupID[iat] * NumGroups;
+  for (int jg = 0; jg < NumGroups; ++jg)
+  {
+    const FuncType& f2(*F[igt + jg]);
+    int iStart = P.first(jg);
+    int iEnd   = P.last(jg);
+    curUat += f2.evaluateV(iat, iStart, iEnd, dist.data(), DistCompressed.data());
+  }
+  return curUat;
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::posT J2OrbitalSoA<FT>::accumulateG(const valT* restrict du, const DisplRow& displ) const
+{
+  posT grad;
+  for (int idim = 0; idim < OHMMS_DIM; ++idim)
+  {
+    const valT* restrict dX = displ.data(idim);
+    valT s                  = valT();
+
+#pragma omp simd reduction(+ : s) aligned(du, dX : QMC_SIMD_ALIGNMENT)
+    for (int jat = 0; jat < N; ++jat)
+      s += du[jat] * dX[jat];
+    grad[idim] = s;
+  }
+  return grad;
+}
+
+template<typename FT>
+J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p, int tid)
+    : WaveFunctionComponent("J2OrbitalSoA", obj_name), my_table_ID_(p.addTable(p)), j2_ke_corr_helper(p, F)
+{
+  if (myName.empty())
+    throw std::runtime_error("J2OrbitalSoA object name cannot be empty!");
+  init(p);
+  KEcorr = 0.0;
+}
+
+template<typename FT>
+J2OrbitalSoA<FT>::~J2OrbitalSoA()
+{
+  auto it = J2Unique.begin();
+  while (it != J2Unique.end())
+  {
+    delete ((*it).second);
+    ++it;
+  }
+} //need to clean up J2Unique
+
+template<typename FT>
+void J2OrbitalSoA<FT>::init(ParticleSet& p)
+{
+  N         = p.getTotalNum();
+  N_padded  = getAlignedSize<valT>(N);
+  NumGroups = p.groups();
+
+  Uat.resize(N);
+  dUat.resize(N);
+  d2Uat.resize(N);
+  cur_u.resize(N);
+  cur_du.resize(N);
+  cur_d2u.resize(N);
+  old_u.resize(N);
+  old_du.resize(N);
+  old_d2u.resize(N);
+  F.resize(NumGroups * NumGroups, nullptr);
+  DistCompressed.resize(N);
+  DistIndice.resize(N);
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
+{
+  if (ia == ib)
+  {
+    if (ia == 0) //first time, assign everything
+    {
+      int ij = 0;
+      for (int ig = 0; ig < NumGroups; ++ig)
+        for (int jg = 0; jg < NumGroups; ++jg, ++ij)
+          if (F[ij] == nullptr)
+            F[ij] = j;
+    }
+    else
+      F[ia * NumGroups + ib] = j;
+  }
+  else
+  {
+    // a very special case, 1 particle of each type (e.g. 1 up + 1 down)
+    // uu/dd/etc. was prevented by the builder
+    if (N == NumGroups)
+      for (int ig = 0; ig < NumGroups; ++ig)
+        F[ig * NumGroups + ig] = j;
+    // generic case
+    F[ia * NumGroups + ib] = j;
+    F[ib * NumGroups + ia] = j;
+  }
+  std::stringstream aname;
+  aname << ia << ib;
+  J2Unique[aname.str()] = j;
+}
+
+template<typename FT>
+WaveFunctionComponentPtr J2OrbitalSoA<FT>::makeClone(ParticleSet& tqp) const
+{
+  J2OrbitalSoA<FT>* j2copy = new J2OrbitalSoA<FT>(myName, tqp, -1);
+  if (dPsi)
+    j2copy->dPsi = dPsi->makeClone(tqp);
+  std::map<const FT*, FT*> fcmap;
+  for (int ig = 0; ig < NumGroups; ++ig)
+    for (int jg = ig; jg < NumGroups; ++jg)
+    {
+      int ij = ig * NumGroups + jg;
+      if (F[ij] == 0)
+        continue;
+      typename std::map<const FT*, FT*>::iterator fit = fcmap.find(F[ij]);
+      if (fit == fcmap.end())
+      {
+        FT* fc = new FT(*F[ij]);
+        j2copy->addFunc(ig, jg, fc);
+        //if (dPsi) (j2copy->dPsi)->addFunc(aname.str(),ig,jg,fc);
+        fcmap[F[ij]] = fc;
+      }
+    }
+  j2copy->KEcorr      = KEcorr;
+  j2copy->Optimizable = Optimizable;
+  return j2copy;
+}
+
+/** intenal function to compute \f$\sum_j u(r_j), du/dr, d2u/dr2\f$
+ * @param P particleset
+ * @param iat particle index
+ * @param dist starting distance
+ * @param u starting value
+ * @param du starting first deriv
+ * @param d2u starting second deriv
+ */
+template<typename FT>
+void J2OrbitalSoA<FT>::computeU3(const ParticleSet& P,
+                                 int iat,
+                                 const DistRow& dist,
+                                 RealType* restrict u,
+                                 RealType* restrict du,
+                                 RealType* restrict d2u,
+                                 bool triangle)
+{
+  const int jelmax = triangle ? iat : N;
+  constexpr valT czero(0);
+  std::fill_n(u, jelmax, czero);
+  std::fill_n(du, jelmax, czero);
+  std::fill_n(d2u, jelmax, czero);
+
+  const int igt = P.GroupID[iat] * NumGroups;
+  for (int jg = 0; jg < NumGroups; ++jg)
+  {
+    const FuncType& f2(*F[igt + jg]);
+    int iStart = P.first(jg);
+    int iEnd   = std::min(jelmax, P.last(jg));
+    f2.evaluateVGL(iat, iStart, iEnd, dist.data(), u, du, d2u, DistCompressed.data(), DistIndice.data());
+  }
+  //u[iat]=czero;
+  //du[iat]=czero;
+  //d2u[iat]=czero;
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratio(ParticleSet& P, int iat)
+{
+  //only ratio, ready to compute it again
+  UpdateMode = ORB_PBYP_RATIO;
+  cur_Uat    = computeU(P, iat, P.getDistTable(my_table_ID_).getTempDists());
+  return std::exp(static_cast<PsiValueType>(Uat[iat] - cur_Uat));
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
+{
+  const auto& d_table = P.getDistTable(my_table_ID_);
+  const auto& dist    = d_table.getTempDists();
+
+  for (int ig = 0; ig < NumGroups; ++ig)
+  {
+    const int igt = ig * NumGroups;
+    valT sumU(0);
+    for (int jg = 0; jg < NumGroups; ++jg)
+    {
+      const FuncType& f2(*F[igt + jg]);
+      int iStart = P.first(jg);
+      int iEnd   = P.last(jg);
+      sumU += f2.evaluateV(-1, iStart, iEnd, dist.data(), DistCompressed.data());
+    }
+
+    for (int i = P.first(ig); i < P.last(ig); ++i)
+    {
+      // remove self-interaction
+      const valT Uself = F[igt + ig]->evaluate(dist[i]);
+      ratios[i]        = std::exp(Uat[i] + Uself - sumU);
+    }
+  }
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::GradType J2OrbitalSoA<FT>::evalGrad(ParticleSet& P, int iat)
+{
+  return GradType(dUat[iat]);
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+{
+  UpdateMode = ORB_PBYP_PARTIAL;
+
+  computeU3(P, iat, P.getDistTable(my_table_ID_).getTempDists(), cur_u.data(), cur_du.data(), cur_d2u.data());
+  cur_Uat = simd::accumulate_n(cur_u.data(), N, valT());
+  DiffVal = Uat[iat] - cur_Uat;
+  grad_iat += accumulateG(cur_du.data(), P.getDistTable(my_table_ID_).getTempDispls());
+  return std::exp(static_cast<PsiValueType>(DiffVal));
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
+{
+  // get the old u, du, d2u
+  const auto& d_table = P.getDistTable(my_table_ID_);
+  computeU3(P, iat, d_table.getOldDists(), old_u.data(), old_du.data(), old_d2u.data());
+  if (UpdateMode == ORB_PBYP_RATIO)
+  { //ratio-only during the move; need to compute derivatives
+    const auto& dist = d_table.getTempDists();
+    computeU3(P, iat, dist, cur_u.data(), cur_du.data(), cur_d2u.data());
+  }
+
+  valT cur_d2Uat(0);
+  const auto& new_dr    = d_table.getTempDispls();
+  const auto& old_dr    = d_table.getOldDispls();
+  constexpr valT lapfac = OHMMS_DIM - RealType(1);
+#pragma omp simd reduction(+ : cur_d2Uat)
+  for (int jat = 0; jat < N; jat++)
+  {
+    const valT du   = cur_u[jat] - old_u[jat];
+    const valT newl = cur_d2u[jat] + lapfac * cur_du[jat];
+    const valT dl   = old_d2u[jat] + lapfac * old_du[jat] - newl;
+    Uat[jat] += du;
+    d2Uat[jat] += dl;
+    cur_d2Uat -= newl;
+  }
+  posT cur_dUat;
+  for (int idim = 0; idim < OHMMS_DIM; ++idim)
+  {
+    const valT* restrict new_dX    = new_dr.data(idim);
+    const valT* restrict old_dX    = old_dr.data(idim);
+    const valT* restrict cur_du_pt = cur_du.data();
+    const valT* restrict old_du_pt = old_du.data();
+    valT* restrict save_g          = dUat.data(idim);
+    valT cur_g                     = cur_dUat[idim];
+#pragma omp simd reduction(+ : cur_g) aligned(old_dX, new_dX, save_g, cur_du_pt, old_du_pt : QMC_SIMD_ALIGNMENT)
+    for (int jat = 0; jat < N; jat++)
+    {
+      const valT newg = cur_du_pt[jat] * new_dX[jat];
+      const valT dg   = newg - old_du_pt[jat] * old_dX[jat];
+      save_g[jat] -= dg;
+      cur_g += newg;
+    }
+    cur_dUat[idim] = cur_g;
+  }
+  LogValue += Uat[iat] - cur_Uat;
+  Uat[iat]   = cur_Uat;
+  dUat(iat)  = cur_dUat;
+  d2Uat[iat] = cur_d2Uat;
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::recompute(const ParticleSet& P)
+{
+  const auto& d_table = P.getDistTable(my_table_ID_);
+  for (int ig = 0; ig < NumGroups; ++ig)
+  {
+    for (int iat = P.first(ig), last = P.last(ig); iat < last; ++iat)
+    {
+      computeU3(P, iat, d_table.getDistRow(iat), cur_u.data(), cur_du.data(), cur_d2u.data(), true);
+      Uat[iat] = simd::accumulate_n(cur_u.data(), iat, valT());
+      posT grad;
+      valT lap(0);
+      const valT* restrict u   = cur_u.data();
+      const valT* restrict du  = cur_du.data();
+      const valT* restrict d2u = cur_d2u.data();
+      const auto& displ        = d_table.getDisplRow(iat);
+      constexpr valT lapfac    = OHMMS_DIM - RealType(1);
+#pragma omp simd reduction(+ : lap) aligned(du, d2u : QMC_SIMD_ALIGNMENT)
+      for (int jat = 0; jat < iat; ++jat)
+        lap += d2u[jat] + lapfac * du[jat];
+      for (int idim = 0; idim < OHMMS_DIM; ++idim)
+      {
+        const valT* restrict dX = displ.data(idim);
+        valT s                  = valT();
+#pragma omp simd reduction(+ : s) aligned(du, dX : QMC_SIMD_ALIGNMENT)
+        for (int jat = 0; jat < iat; ++jat)
+          s += du[jat] * dX[jat];
+        grad[idim] = s;
+      }
+      dUat(iat)  = grad;
+      d2Uat[iat] = -lap;
+// add the contribution from the upper triangle
+#pragma omp simd aligned(u, du, d2u : QMC_SIMD_ALIGNMENT)
+      for (int jat = 0; jat < iat; jat++)
+      {
+        Uat[jat] += u[jat];
+        d2Uat[jat] -= d2u[jat] + lapfac * du[jat];
+      }
+      for (int idim = 0; idim < OHMMS_DIM; ++idim)
+      {
+        valT* restrict save_g   = dUat.data(idim);
+        const valT* restrict dX = displ.data(idim);
+#pragma omp simd aligned(save_g, du, dX : QMC_SIMD_ALIGNMENT)
+        for (int jat = 0; jat < iat; jat++)
+          save_g[jat] -= du[jat] * dX[jat];
+      }
+    }
+  }
+}
+
+template<typename FT>
+typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(const ParticleSet& P,
+                                                                      ParticleSet::ParticleGradient_t& G,
+                                                                      ParticleSet::ParticleLaplacian_t& L)
+{
+  return evaluateGL(P, G, L, true);
+}
+
+template<typename FT>
+WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(const ParticleSet& P,
+                                                                 ParticleSet::ParticleGradient_t& G,
+                                                                 ParticleSet::ParticleLaplacian_t& L,
+                                                                 bool fromscratch)
+{
+  if (fromscratch)
+    recompute(P);
+  LogValue = valT(0);
+  for (int iat = 0; iat < N; ++iat)
+  {
+    LogValue += Uat[iat];
+    G[iat] += dUat[iat];
+    L[iat] += d2Uat[iat];
+  }
+
+  return LogValue = -LogValue * 0.5;
+}
+
+template<typename FT>
+void J2OrbitalSoA<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
+{
+  LogValue = 0.0;
+  const DistanceTableData& d_ee(P.getDistTable(my_table_ID_));
+  valT dudr, d2udr2;
+
+  Tensor<valT, DIM> ident;
+  grad_grad_psi = 0.0;
+  ident.diagonal(1.0);
+
+  for (int i = 1; i < N; ++i)
+  {
+    const auto& dist  = d_ee.getDistRow(i);
+    const auto& displ = d_ee.getDisplRow(i);
+    auto ig           = P.GroupID[i];
+    const int igt     = ig * NumGroups;
+    for (int j = 0; j < i; ++j)
+    {
+      auto r    = dist[j];
+      auto rinv = 1.0 / r;
+      auto dr   = displ[j];
+      auto jg   = P.GroupID[j];
+      auto uij  = F[igt + jg]->evaluate(r, dudr, d2udr2);
+      LogValue -= uij;
+      auto hess = rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
+      grad_grad_psi[i] -= hess;
+      grad_grad_psi[j] -= hess;
+    }
+  }
+}
+
+template class J2OrbitalSoA<BsplineFunctor<QMCTraits::RealType>>;
+template class J2OrbitalSoA<PadeFunctor<QMCTraits::RealType>>;
+template class J2OrbitalSoA<UserFunctor<QMCTraits::RealType>>;
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -196,6 +196,8 @@ void J2OrbitalSoA<FT>::init(ParticleSet& p)
 template<typename FT>
 void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
 {
+  assert(ia < NumGroups);
+  assert(ib < NumGroups);
   if (ia == ib)
   {
     if (ia == 0) //first time, assign everything

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -25,7 +25,7 @@ template<typename FT>
 void J2OrbitalSoA<FT>::checkInVariables(opt_variables_type& active)
 {
   myVars.clear();
-  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  auto it(J2Unique.begin()), it_end(J2Unique.end());
   while (it != it_end)
   {
     (*it).second->checkInVariables(active);
@@ -39,7 +39,7 @@ void J2OrbitalSoA<FT>::checkOutVariables(const opt_variables_type& active)
 {
   myVars.getIndex(active);
   Optimizable = myVars.is_optimizable();
-  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  auto it(J2Unique.begin()), it_end(J2Unique.end());
   while (it != it_end)
   {
     (*it).second->checkOutVariables(active);
@@ -54,7 +54,7 @@ void J2OrbitalSoA<FT>::resetParameters(const opt_variables_type& active)
 {
   if (!Optimizable)
     return;
-  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  auto it(J2Unique.begin()), it_end(J2Unique.end());
   while (it != it_end)
   {
     (*it).second->resetParameters(active);
@@ -73,7 +73,7 @@ void J2OrbitalSoA<FT>::resetParameters(const opt_variables_type& active)
 template<typename FT>
 void J2OrbitalSoA<FT>::reportStatus(std::ostream& os)
 {
-  typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
+  auto it(J2Unique.begin()), it_end(J2Unique.end());
   while (it != it_end)
   {
     (*it).second->myVars.print(os);
@@ -170,15 +170,7 @@ J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p, int 
 }
 
 template<typename FT>
-J2OrbitalSoA<FT>::~J2OrbitalSoA()
-{
-  auto it = J2Unique.begin();
-  while (it != J2Unique.end())
-  {
-    delete ((*it).second);
-    ++it;
-  }
-} //need to clean up J2Unique
+J2OrbitalSoA<FT>::~J2OrbitalSoA() = default;
 
 template<typename FT>
 void J2OrbitalSoA<FT>::init(ParticleSet& p)
@@ -230,7 +222,7 @@ void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
   }
   std::stringstream aname;
   aname << ia << ib;
-  J2Unique[aname.str()] = j;
+  J2Unique[aname.str()] = std::unique_ptr<FT>(j);
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -160,7 +160,7 @@ typename J2OrbitalSoA<FT>::posT J2OrbitalSoA<FT>::accumulateG(const valT* restri
 }
 
 template<typename FT>
-J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p, int tid)
+J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p)
     : WaveFunctionComponent("J2OrbitalSoA", obj_name), my_table_ID_(p.addTable(p)), j2_ke_corr_helper(p, F)
 {
   if (myName.empty())
@@ -228,7 +228,7 @@ void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
 template<typename FT>
 WaveFunctionComponentPtr J2OrbitalSoA<FT>::makeClone(ParticleSet& tqp) const
 {
-  J2OrbitalSoA<FT>* j2copy = new J2OrbitalSoA<FT>(myName, tqp, -1);
+  J2OrbitalSoA<FT>* j2copy = new J2OrbitalSoA<FT>(myName, tqp);
   if (dPsi)
     j2copy->dPsi = dPsi->makeClone(tqp);
   std::map<const FT*, FT*> fcmap;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -122,10 +122,6 @@ public:
   using DisplRow        = DistanceTableData::DisplRow;
   using gContainer_type = VectorSoaContainer<valT, OHMMS_DIM>;
 
-  // Ye: leaving this public is bad but currently used by unit tests.
-  ///Container for \f$F[ig*NumGroups+jg]\f$.
-  std::vector<FT*> F;
-
 protected:
   ///number of particles
   size_t N;
@@ -149,7 +145,9 @@ protected:
   aligned_vector<valT> DistCompressed;
   aligned_vector<int> DistIndice;
   ///Uniquue J2 set for cleanup
-  std::map<std::string, FT*> J2Unique;
+  std::map<std::string, std::unique_ptr<FT>> J2Unique;
+  ///Container for \f$F[ig*NumGroups+jg]\f$. treat every pointer as a reference.
+  std::vector<FT*> F;
   /// e-e table ID
   const int my_table_ID_;
   // helper for compute J2 Chiesa KE correction
@@ -237,6 +235,8 @@ public:
   inline RealType ChiesaKEcorrection() { return KEcorr = j2_ke_corr_helper.computeKEcorr(); }
 
   inline RealType KECorrection() { return KEcorr; }
+
+  const std::vector<FT*>& getPairFunctions() const { return F; }
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -154,7 +154,7 @@ protected:
   J2KECorrection<RealType, FT> j2_ke_corr_helper;
 
 public:
-  J2OrbitalSoA(const std::string& obj_name, ParticleSet& p, int tid);
+  J2OrbitalSoA(const std::string& obj_name, ParticleSet& p);
   J2OrbitalSoA(const J2OrbitalSoA& rhs) = delete;
   ~J2OrbitalSoA();
 

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -24,7 +24,6 @@
 #include "Particle/DistanceTableData.h"
 #include "LongRange/StructFact.h"
 #include "CPU/SIMD/aligned_allocator.hpp"
-#include "CPU/SIMD/algorithm.hpp"
 
 namespace qmcplusplus
 {
@@ -170,72 +169,25 @@ public:
   /** check in an optimizable parameter
    * @param o a super set of optimizable variables
    */
-  void checkInVariables(opt_variables_type& active)
-  {
-    myVars.clear();
-    typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
-    while (it != it_end)
-    {
-      (*it).second->checkInVariables(active);
-      (*it).second->checkInVariables(myVars);
-      ++it;
-    }
-  }
+  void checkInVariables(opt_variables_type& active);
 
   /** check out optimizable variables
    */
-  void checkOutVariables(const opt_variables_type& active)
-  {
-    myVars.getIndex(active);
-    Optimizable = myVars.is_optimizable();
-    typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
-    while (it != it_end)
-    {
-      (*it).second->checkOutVariables(active);
-      ++it;
-    }
-    if (dPsi)
-      dPsi->checkOutVariables(active);
-  }
+  void checkOutVariables(const opt_variables_type& active);
 
   ///reset the value of all the unique Two-Body Jastrow functions
-  void resetParameters(const opt_variables_type& active)
-  {
-    if (!Optimizable)
-      return;
-    typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
-    while (it != it_end)
-    {
-      (*it).second->resetParameters(active);
-      ++it;
-    }
-    if (dPsi)
-      dPsi->resetParameters(active);
-    for (int i = 0; i < myVars.size(); ++i)
-    {
-      int ii = myVars.Index[i];
-      if (ii >= 0)
-        myVars[i] = active[ii];
-    }
-  }
+  void resetParameters(const opt_variables_type& active);
 
-
-  void finalizeOptimization() { KEcorr = j2_ke_corr_helper.computeKEcorr(); }
+  inline void finalizeOptimization() { KEcorr = j2_ke_corr_helper.computeKEcorr(); }
 
   /** print the state, e.g., optimizables */
-  void reportStatus(std::ostream& os)
-  {
-    typename std::map<std::string, FT*>::iterator it(J2Unique.begin()), it_end(J2Unique.end());
-    while (it != it_end)
-    {
-      (*it).second->myVars.print(os);
-      ++it;
-    }
-  }
+  void reportStatus(std::ostream& os);
 
   WaveFunctionComponentPtr makeClone(ParticleSet& tqp) const;
 
-  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L);
+  LogValueType evaluateLog(const ParticleSet& P,
+                           ParticleSet::ParticleGradient_t& G,
+                           ParticleSet::ParticleLaplacian_t& L);
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi);
 
@@ -243,12 +195,7 @@ public:
   void recompute(const ParticleSet& P);
 
   PsiValueType ratio(ParticleSet& P, int iat);
-  void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios)
-  {
-    for (int k = 0; k < ratios.size(); ++k)
-      ratios[k] =
-          std::exp(Uat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTable(my_table_ID_).getDistRow(k)));
-  }
+  void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios);
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios);
 
   GradType evalGrad(ParticleSet& P, int iat);
@@ -265,437 +212,32 @@ public:
                           ParticleSet::ParticleLaplacian_t& L,
                           bool fromscratch = false);
 
-  inline void registerData(ParticleSet& P, WFBufferType& buf)
-  {
-    if (Bytes_in_WFBuffer == 0)
-    {
-      Bytes_in_WFBuffer = buf.current();
-      buf.add(Uat.begin(), Uat.end());
-      buf.add(dUat.data(), dUat.end());
-      buf.add(d2Uat.begin(), d2Uat.end());
-      Bytes_in_WFBuffer = buf.current() - Bytes_in_WFBuffer;
-      // free local space
-      Uat.free();
-      dUat.free();
-      d2Uat.free();
-    }
-    else
-    {
-      buf.forward(Bytes_in_WFBuffer);
-    }
-  }
+  void registerData(ParticleSet& P, WFBufferType& buf);
 
-  inline void copyFromBuffer(ParticleSet& P, WFBufferType& buf)
-  {
-    Uat.attachReference(buf.lendReference<valT>(N), N);
-    dUat.attachReference(N, N_padded, buf.lendReference<valT>(N_padded * OHMMS_DIM));
-    d2Uat.attachReference(buf.lendReference<valT>(N), N);
-  }
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf);
 
-  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
-  {
-    evaluateGL(P, P.G, P.L, false);
-    buf.forward(Bytes_in_WFBuffer);
-    return LogValue;
-  }
+  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false);
 
   /*@{ internal compute engines*/
-  inline valT computeU(const ParticleSet& P, int iat, const DistRow& dist)
-  {
-    valT curUat(0);
-    const int igt = P.GroupID[iat] * NumGroups;
-    for (int jg = 0; jg < NumGroups; ++jg)
-    {
-      const FuncType& f2(*F[igt + jg]);
-      int iStart = P.first(jg);
-      int iEnd   = P.last(jg);
-      curUat += f2.evaluateV(iat, iStart, iEnd, dist.data(), DistCompressed.data());
-    }
-    return curUat;
-  }
+  valT computeU(const ParticleSet& P, int iat, const DistRow& dist);
 
-  inline void computeU3(const ParticleSet& P,
-                        int iat,
-                        const DistRow& dist,
-                        RealType* restrict u,
-                        RealType* restrict du,
-                        RealType* restrict d2u,
-                        bool triangle = false);
+  void computeU3(const ParticleSet& P,
+                 int iat,
+                 const DistRow& dist,
+                 RealType* restrict u,
+                 RealType* restrict du,
+                 RealType* restrict d2u,
+                 bool triangle = false);
 
   /** compute gradient
    */
-  inline posT accumulateG(const valT* restrict du, const DisplRow& displ) const
-  {
-    posT grad;
-    for (int idim = 0; idim < OHMMS_DIM; ++idim)
-    {
-      const valT* restrict dX = displ.data(idim);
-      valT s                  = valT();
-
-#pragma omp simd reduction(+ : s) aligned(du, dX: QMC_SIMD_ALIGNMENT)
-      for (int jat = 0; jat < N; ++jat)
-        s += du[jat] * dX[jat];
-      grad[idim] = s;
-    }
-    return grad;
-  }
+  posT accumulateG(const valT* restrict du, const DisplRow& displ) const;
   /**@} */
 
-  RealType ChiesaKEcorrection() { return KEcorr = j2_ke_corr_helper.computeKEcorr(); }
+  inline RealType ChiesaKEcorrection() { return KEcorr = j2_ke_corr_helper.computeKEcorr(); }
 
-  RealType KECorrection() { return KEcorr; }
+  inline RealType KECorrection() { return KEcorr; }
 };
-
-template<typename FT>
-J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p, int tid)
-    : WaveFunctionComponent("J2OrbitalSoA", obj_name), my_table_ID_(p.addTable(p)), j2_ke_corr_helper(p, F)
-{
-  if (myName.empty())
-    throw std::runtime_error("J2OrbitalSoA object name cannot be empty!");
-  init(p);
-  KEcorr = 0.0;
-}
-
-template<typename FT>
-J2OrbitalSoA<FT>::~J2OrbitalSoA()
-{
-  auto it = J2Unique.begin();
-  while (it != J2Unique.end())
-  {
-    delete ((*it).second);
-    ++it;
-  }
-} //need to clean up J2Unique
-
-template<typename FT>
-void J2OrbitalSoA<FT>::init(ParticleSet& p)
-{
-  N         = p.getTotalNum();
-  N_padded  = getAlignedSize<valT>(N);
-  NumGroups = p.groups();
-
-  Uat.resize(N);
-  dUat.resize(N);
-  d2Uat.resize(N);
-  cur_u.resize(N);
-  cur_du.resize(N);
-  cur_d2u.resize(N);
-  old_u.resize(N);
-  old_du.resize(N);
-  old_d2u.resize(N);
-  F.resize(NumGroups * NumGroups, nullptr);
-  DistCompressed.resize(N);
-  DistIndice.resize(N);
-}
-
-template<typename FT>
-void J2OrbitalSoA<FT>::addFunc(int ia, int ib, FT* j)
-{
-  if (ia == ib)
-  {
-    if (ia == 0) //first time, assign everything
-    {
-      int ij = 0;
-      for (int ig = 0; ig < NumGroups; ++ig)
-        for (int jg = 0; jg < NumGroups; ++jg, ++ij)
-          if (F[ij] == nullptr)
-            F[ij] = j;
-    }
-    else
-      F[ia * NumGroups + ib] = j;
-  }
-  else
-  {
-    // a very special case, 1 particle of each type (e.g. 1 up + 1 down)
-    // uu/dd/etc. was prevented by the builder
-    if (N == NumGroups)
-      for (int ig = 0; ig < NumGroups; ++ig)
-        F[ig * NumGroups + ig] = j;
-    // generic case
-    F[ia * NumGroups + ib] = j;
-    F[ib * NumGroups + ia] = j;
-  }
-  std::stringstream aname;
-  aname << ia << ib;
-  J2Unique[aname.str()] = j;
-}
-
-template<typename FT>
-WaveFunctionComponentPtr J2OrbitalSoA<FT>::makeClone(ParticleSet& tqp) const
-{
-  J2OrbitalSoA<FT>* j2copy = new J2OrbitalSoA<FT>(myName, tqp, -1);
-  if (dPsi)
-    j2copy->dPsi = dPsi->makeClone(tqp);
-  std::map<const FT*, FT*> fcmap;
-  for (int ig = 0; ig < NumGroups; ++ig)
-    for (int jg = ig; jg < NumGroups; ++jg)
-    {
-      int ij = ig * NumGroups + jg;
-      if (F[ij] == 0)
-        continue;
-      typename std::map<const FT*, FT*>::iterator fit = fcmap.find(F[ij]);
-      if (fit == fcmap.end())
-      {
-        FT* fc = new FT(*F[ij]);
-        j2copy->addFunc(ig, jg, fc);
-        //if (dPsi) (j2copy->dPsi)->addFunc(aname.str(),ig,jg,fc);
-        fcmap[F[ij]] = fc;
-      }
-    }
-  j2copy->KEcorr      = KEcorr;
-  j2copy->Optimizable = Optimizable;
-  return j2copy;
-}
-
-/** intenal function to compute \f$\sum_j u(r_j), du/dr, d2u/dr2\f$
- * @param P particleset
- * @param iat particle index
- * @param dist starting distance
- * @param u starting value
- * @param du starting first deriv
- * @param d2u starting second deriv
- */
-template<typename FT>
-inline void J2OrbitalSoA<FT>::computeU3(const ParticleSet& P,
-                                        int iat,
-                                        const DistRow& dist,
-                                        RealType* restrict u,
-                                        RealType* restrict du,
-                                        RealType* restrict d2u,
-                                        bool triangle)
-{
-  const int jelmax = triangle ? iat : N;
-  constexpr valT czero(0);
-  std::fill_n(u, jelmax, czero);
-  std::fill_n(du, jelmax, czero);
-  std::fill_n(d2u, jelmax, czero);
-
-  const int igt = P.GroupID[iat] * NumGroups;
-  for (int jg = 0; jg < NumGroups; ++jg)
-  {
-    const FuncType& f2(*F[igt + jg]);
-    int iStart = P.first(jg);
-    int iEnd   = std::min(jelmax, P.last(jg));
-    f2.evaluateVGL(iat, iStart, iEnd, dist.data(), u, du, d2u, DistCompressed.data(), DistIndice.data());
-  }
-  //u[iat]=czero;
-  //du[iat]=czero;
-  //d2u[iat]=czero;
-}
-
-template<typename FT>
-typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratio(ParticleSet& P, int iat)
-{
-  //only ratio, ready to compute it again
-  UpdateMode = ORB_PBYP_RATIO;
-  cur_Uat    = computeU(P, iat, P.getDistTable(my_table_ID_).getTempDists());
-  return std::exp(static_cast<PsiValueType>(Uat[iat] - cur_Uat));
-}
-
-template<typename FT>
-inline void J2OrbitalSoA<FT>::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
-{
-  const auto& d_table = P.getDistTable(my_table_ID_);
-  const auto& dist    = d_table.getTempDists();
-
-  for (int ig = 0; ig < NumGroups; ++ig)
-  {
-    const int igt = ig * NumGroups;
-    valT sumU(0);
-    for (int jg = 0; jg < NumGroups; ++jg)
-    {
-      const FuncType& f2(*F[igt + jg]);
-      int iStart = P.first(jg);
-      int iEnd   = P.last(jg);
-      sumU += f2.evaluateV(-1, iStart, iEnd, dist.data(), DistCompressed.data());
-    }
-
-    for (int i = P.first(ig); i < P.last(ig); ++i)
-    {
-      // remove self-interaction
-      const valT Uself = F[igt + ig]->evaluate(dist[i]);
-      ratios[i]        = std::exp(Uat[i] + Uself - sumU);
-    }
-  }
-}
-
-template<typename FT>
-typename J2OrbitalSoA<FT>::GradType J2OrbitalSoA<FT>::evalGrad(ParticleSet& P, int iat)
-{
-  return GradType(dUat[iat]);
-}
-
-template<typename FT>
-typename J2OrbitalSoA<FT>::PsiValueType J2OrbitalSoA<FT>::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
-{
-  UpdateMode = ORB_PBYP_PARTIAL;
-
-  computeU3(P, iat, P.getDistTable(my_table_ID_).getTempDists(), cur_u.data(), cur_du.data(), cur_d2u.data());
-  cur_Uat = simd::accumulate_n(cur_u.data(), N, valT());
-  DiffVal = Uat[iat] - cur_Uat;
-  grad_iat += accumulateG(cur_du.data(), P.getDistTable(my_table_ID_).getTempDispls());
-  return std::exp(static_cast<PsiValueType>(DiffVal));
-}
-
-template<typename FT>
-void J2OrbitalSoA<FT>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
-{
-  // get the old u, du, d2u
-  const auto& d_table = P.getDistTable(my_table_ID_);
-  computeU3(P, iat, d_table.getOldDists(), old_u.data(), old_du.data(), old_d2u.data());
-  if (UpdateMode == ORB_PBYP_RATIO)
-  { //ratio-only during the move; need to compute derivatives
-    const auto& dist = d_table.getTempDists();
-    computeU3(P, iat, dist, cur_u.data(), cur_du.data(), cur_d2u.data());
-  }
-
-  valT cur_d2Uat(0);
-  const auto& new_dr    = d_table.getTempDispls();
-  const auto& old_dr    = d_table.getOldDispls();
-  constexpr valT lapfac = OHMMS_DIM - RealType(1);
-#pragma omp simd reduction(+ : cur_d2Uat)
-  for (int jat = 0; jat < N; jat++)
-  {
-    const valT du   = cur_u[jat] - old_u[jat];
-    const valT newl = cur_d2u[jat] + lapfac * cur_du[jat];
-    const valT dl   = old_d2u[jat] + lapfac * old_du[jat] - newl;
-    Uat[jat] += du;
-    d2Uat[jat] += dl;
-    cur_d2Uat -= newl;
-  }
-  posT cur_dUat;
-  for (int idim = 0; idim < OHMMS_DIM; ++idim)
-  {
-    const valT* restrict new_dX    = new_dr.data(idim);
-    const valT* restrict old_dX    = old_dr.data(idim);
-    const valT* restrict cur_du_pt = cur_du.data();
-    const valT* restrict old_du_pt = old_du.data();
-    valT* restrict save_g          = dUat.data(idim);
-    valT cur_g                     = cur_dUat[idim];
-#pragma omp simd reduction(+ : cur_g) aligned(old_dX, new_dX, save_g, cur_du_pt, old_du_pt: QMC_SIMD_ALIGNMENT)
-    for (int jat = 0; jat < N; jat++)
-    {
-      const valT newg = cur_du_pt[jat] * new_dX[jat];
-      const valT dg   = newg - old_du_pt[jat] * old_dX[jat];
-      save_g[jat] -= dg;
-      cur_g += newg;
-    }
-    cur_dUat[idim] = cur_g;
-  }
-  LogValue += Uat[iat] - cur_Uat;
-  Uat[iat]   = cur_Uat;
-  dUat(iat)  = cur_dUat;
-  d2Uat[iat] = cur_d2Uat;
-}
-
-template<typename FT>
-void J2OrbitalSoA<FT>::recompute(const ParticleSet& P)
-{
-  const auto& d_table = P.getDistTable(my_table_ID_);
-  for (int ig = 0; ig < NumGroups; ++ig)
-  {
-    for (int iat = P.first(ig), last = P.last(ig); iat < last; ++iat)
-    {
-      computeU3(P, iat, d_table.getDistRow(iat), cur_u.data(), cur_du.data(), cur_d2u.data(), true);
-      Uat[iat] = simd::accumulate_n(cur_u.data(), iat, valT());
-      posT grad;
-      valT lap(0);
-      const valT* restrict u   = cur_u.data();
-      const valT* restrict du  = cur_du.data();
-      const valT* restrict d2u = cur_d2u.data();
-      const auto& displ        = d_table.getDisplRow(iat);
-      constexpr valT lapfac    = OHMMS_DIM - RealType(1);
-#pragma omp simd reduction(+ : lap) aligned(du, d2u: QMC_SIMD_ALIGNMENT)
-      for (int jat = 0; jat < iat; ++jat)
-        lap += d2u[jat] + lapfac * du[jat];
-      for (int idim = 0; idim < OHMMS_DIM; ++idim)
-      {
-        const valT* restrict dX = displ.data(idim);
-        valT s                  = valT();
-#pragma omp simd reduction(+ : s) aligned(du, dX: QMC_SIMD_ALIGNMENT)
-        for (int jat = 0; jat < iat; ++jat)
-          s += du[jat] * dX[jat];
-        grad[idim] = s;
-      }
-      dUat(iat)  = grad;
-      d2Uat[iat] = -lap;
-// add the contribution from the upper triangle
-#pragma omp simd aligned(u, du, d2u: QMC_SIMD_ALIGNMENT)
-      for (int jat = 0; jat < iat; jat++)
-      {
-        Uat[jat] += u[jat];
-        d2Uat[jat] -= d2u[jat] + lapfac * du[jat];
-      }
-      for (int idim = 0; idim < OHMMS_DIM; ++idim)
-      {
-        valT* restrict save_g   = dUat.data(idim);
-        const valT* restrict dX = displ.data(idim);
-#pragma omp simd aligned(save_g, du, dX: QMC_SIMD_ALIGNMENT)
-        for (int jat = 0; jat < iat; jat++)
-          save_g[jat] -= du[jat] * dX[jat];
-      }
-    }
-  }
-}
-
-template<typename FT>
-typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::evaluateLog(const ParticleSet& P,
-                                                                      ParticleSet::ParticleGradient_t& G,
-                                                                      ParticleSet::ParticleLaplacian_t& L)
-{
-  return evaluateGL(P, G, L, true);
-}
-
-template<typename FT>
-WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(const ParticleSet& P,
-                                                                 ParticleSet::ParticleGradient_t& G,
-                                                                 ParticleSet::ParticleLaplacian_t& L,
-                                                                 bool fromscratch)
-{
-  if (fromscratch)
-    recompute(P);
-  LogValue = valT(0);
-  for (int iat = 0; iat < N; ++iat)
-  {
-    LogValue += Uat[iat];
-    G[iat] += dUat[iat];
-    L[iat] += d2Uat[iat];
-  }
-
-  return LogValue = -LogValue * 0.5;
-}
-
-template<typename FT>
-void J2OrbitalSoA<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
-{
-  LogValue = 0.0;
-  const DistanceTableData& d_ee(P.getDistTable(my_table_ID_));
-  valT dudr, d2udr2;
-
-  Tensor<valT, DIM> ident;
-  grad_grad_psi = 0.0;
-  ident.diagonal(1.0);
-
-  for (int i = 1; i < N; ++i)
-  {
-    const auto& dist  = d_ee.getDistRow(i);
-    const auto& displ = d_ee.getDisplRow(i);
-    auto ig           = P.GroupID[i];
-    const int igt     = ig * NumGroups;
-    for (int j = 0; j < i; ++j)
-    {
-      auto r    = dist[j];
-      auto rinv = 1.0 / r;
-      auto dr   = displ[j];
-      auto jg   = P.GroupID[j];
-      auto uij  = F[igt + jg]->evaluate(r, dudr, d2udr2);
-      LogValue -= uij;
-      auto hess = rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
-      grad_grad_psi[i] -= hess;
-      grad_grad_psi[j] -= hess;
-    }
-  }
-}
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -31,8 +31,8 @@
 
 namespace qmcplusplus
 {
-RPAJastrow::RPAJastrow(ParticleSet& target, bool is_manager)
-    : WaveFunctionComponent("RPAJastrow"), IsManager(is_manager), targetPtcl(target)
+RPAJastrow::RPAJastrow(ParticleSet& target)
+    : WaveFunctionComponent("RPAJastrow"), targetPtcl(target)
 {
   Optimizable = true;
 }
@@ -190,7 +190,7 @@ void RPAJastrow::makeShortRange()
   nfunc = new FuncType;
   SRA   = new ShortRangePartAdapter<RealType>(myHandler);
   SRA->setRmax(Rcut);
-  J2OrbitalSoA<BsplineFunctor<RealType>>* j2 = new J2OrbitalSoA<BsplineFunctor<RealType>>("RPA", targetPtcl, IsManager);
+  J2OrbitalSoA<BsplineFunctor<RealType>>* j2 = new J2OrbitalSoA<BsplineFunctor<RealType>>("RPA", targetPtcl);
   size_t nparam                              = 12;  // number of Bspline parameters
   size_t npts                                = 100; // number of 1D grid points for basis functions
   RealType cusp                              = SRA->df(0);
@@ -338,7 +338,7 @@ WaveFunctionComponent* RPAJastrow::makeClone(ParticleSet& tpq) const
                                          tpq);
   }
 
-  RPAJastrow* myClone = new RPAJastrow(tpq, IsManager);
+  RPAJastrow* myClone = new RPAJastrow(tpq);
   myClone->Rcut       = Rcut;
   myClone->Kc         = Kc;
   myClone->setHandler(tempHandler);

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.h
@@ -35,7 +35,7 @@ struct RPAJastrow : public WaveFunctionComponent
   typedef BsplineFunctor<RealType> FuncType;
   typedef LinearGrid<RealType> GridType;
 
-  RPAJastrow(ParticleSet& target, bool is_manager);
+  RPAJastrow(ParticleSet& target);
 
   ~RPAJastrow();
 
@@ -88,7 +88,6 @@ struct RPAJastrow : public WaveFunctionComponent
   WaveFunctionComponent* makeClone(ParticleSet& tqp) const;
 
 private:
-  bool IsManager;
   bool IgnoreSpin;
   bool DropLongRange;
   bool DropShortRange;

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -156,8 +156,7 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ2(xmlNodePtr cur)
   XMLAttrString input_name(cur, "name");
   std::string j2name = input_name.empty() ? "J2_" + Jastfunction : input_name;
   SpeciesSet& species(targetPtcl.getSpeciesSet());
-  int taskid = is_manager() ? getGroupID() : -1;
-  auto* J2   = new J2OrbitalType(j2name, targetPtcl, taskid);
+  auto* J2   = new J2OrbitalType(j2name, targetPtcl);
   auto* dJ2  = new DiffJ2OrbitalType(targetPtcl);
 
   std::string init_mode("0");
@@ -324,7 +323,7 @@ void RadialJastrowBuilder::computeJ2uk(const std::vector<RadFuncType*>& functors
 template<>
 WaveFunctionComponent* RadialJastrowBuilder::createJ2<RPAFunctor>(xmlNodePtr cur)
 {
-  RPAJastrow* rpajastrow = new RPAJastrow(targetPtcl, is_manager());
+  RPAJastrow* rpajastrow = new RPAJastrow(targetPtcl);
   rpajastrow->put(cur);
   return rpajastrow;
 }

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -264,7 +264,7 @@ WaveFunctionComponent* RadialJastrowBuilder::createJ2(xmlNodePtr cur)
 
   // Ye: actually don't know what uk.dat is used for
   if (targetPtcl.Lattice.SuperCellEnum)
-    computeJ2uk(J2->F);
+    computeJ2uk(J2->getPairFunctions());
 
   return J2;
 }

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
@@ -152,8 +152,8 @@ public:
 
   //TwoBodyJastrowOrbitalBspline(ParticleSet& pset, bool is_master) :
   //  TwoBodyJastrowOrbital<BsplineFunctor<WaveFunctionComponent::RealType> > (pset, is_master),
-  TwoBodyJastrowOrbitalBspline(const std::string& obj_name, ParticleSet& pset, int tid)
-      : J2OrbitalSoA<FT>(obj_name, pset, tid),
+  TwoBodyJastrowOrbitalBspline(const std::string& obj_name, ParticleSet& pset)
+      : J2OrbitalSoA<FT>(obj_name, pset),
         PtclRef(pset),
         L(obj_name + "L"),
         Linv(obj_name + "Linv"),

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -173,7 +173,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
                      {11.40, 0, 0, 0}};
 
 
-  BsplineFunctor<RealType>* bf = j2->F[0];
+  BsplineFunctor<RealType>* bf = j2->getPairFunctions()[0];
 
   for (int i = 0; i < N; i++)
   {

--- a/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
@@ -112,8 +112,7 @@ TEST_CASE("RPA Jastrow", "[wavefunction]")
   root = doc.getRoot();
 
   xmlNodePtr jas_node = xmlFirstElementChild(root);
-  bool is_manager=false;
-  auto jas = std::make_unique<RPAJastrow>(elec_, is_manager);
+  auto jas = std::make_unique<RPAJastrow>(elec_);
   jas->put(root);
 
   // update all distance tables

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -24,16 +24,11 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   auto qp = std::make_unique<ParticleSet>();
-  std::vector<int> agroup(1);
-  agroup[0] = 2;
+  std::vector<int> agroup(2, 1);
   qp->setName("e");
   qp->create(agroup);
-  qp->R[0][0] = 1.0;
-  qp->R[0][1] = 2.0;
-  qp->R[0][2] = 3.0;
-  qp->R[1][0] = 0.0;
-  qp->R[1][1] = 1.1;
-  qp->R[1][2] = 2.2;
+  qp->R[0] = {1.0, 2.0, 3.0};
+  qp->R[1] = {0.0, 1.1, 2.2};
 
   SpeciesSet& tspecies       = qp->getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");


### PR DESCRIPTION
## Proposed changes

Split J2OrbitalSoA in to header and cpp files.
Fix breakage from last night. https://cdash.qmcpack.org/CDash/testDetails.php?test=13317843&build=209109
The bug existed before but triggered on legacy CUDA build.

## What type(s) of changes does this code introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'