### PR TITLE
Split hamiltonian unit test

### DIFF
--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -15,62 +15,65 @@
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
 
 SET(SRC_DIR hamiltonian)
-SET(UTEST_EXE test_${SRC_DIR})
-SET(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 SET(UTEST_DIR ${qmcpack_BINARY_DIR}/tests/hamiltonians)
-SET(UTEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp/pwscf.pwscf.h5)
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")
-MAYBE_SYMLINK(${UTEST_HDF_INPUT} ${UTEST_DIR}/pwscf.pwscf.h5)
 
-
-SET(SRCS test_bare_kinetic.cpp
-         test_coulomb_pbcAB.cpp
-         test_coulomb_pbcAB_ewald.cpp
-         test_coulomb_pbcAA.cpp
-         test_coulomb_pbcAA_ewald.cpp
-         test_force.cpp
-         test_force_ewald.cpp
-         test_stress.cpp
-         test_spacewarp.cpp
-         test_ecp.cpp
-         test_hamiltonian_pool.cpp
-         test_hamiltonian_factory.cpp
-         test_PairCorrEstimator.cpp
-         test_SkAllEstimator.cpp
-         test_QMCHamiltonian.cpp
-         test_ion_derivs.cpp
-         test_ObservableHelper.cpp
-         )
+SET(COULOMB_SRCS
+    test_coulomb_pbcAB.cpp
+    test_coulomb_pbcAB_ewald.cpp
+    test_coulomb_pbcAA.cpp
+    test_coulomb_pbcAA_ewald.cpp)
+SET(FORCE_SRCS
+    test_force.cpp
+    test_force_ewald.cpp
+    test_stress.cpp
+    test_spacewarp.cpp)
+SET(HAM_SRCS test_bare_kinetic.cpp
+    test_ecp.cpp
+    test_hamiltonian_pool.cpp
+    test_hamiltonian_factory.cpp
+    test_PairCorrEstimator.cpp
+    test_SkAllEstimator.cpp
+    test_QMCHamiltonian.cpp
+    test_ObservableHelper.cpp)
          
 IF(QMC_CUDA)
-  SET(SRCS ${SRCS}
-      test_coulomb_CUDA.cpp 
-)
+  SET(COULOMB_SRCS ${COULOMB_SRCS} test_coulomb_CUDA.cpp)
+ELSE()
+  SET(FORCE_SRCS ${FORCE_SRCS} test_ion_derivs.cpp)
 ENDIF()
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")
 
-foreach(fname Na2.structure.xml simple.txt)
-  file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/${fname} ${UTEST_DIR}/${fname} SYMBOLIC)
+SET(UTEST_HDF_INPUT ${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp/pwscf.pwscf.h5)
+MAYBE_SYMLINK(${UTEST_HDF_INPUT} ${UTEST_DIR}/pwscf.pwscf.h5)
+
+foreach(fname Na2.structure.xml simple.txt )
+  MAYBE_SYMLINK(${CMAKE_CURRENT_SOURCE_DIR}/${fname} ${UTEST_DIR}/${fname})
 endforeach()
 
 foreach(fname cn.wfnoj.xml cn.wfj.xml cn.msd-wfnoj.xml cn.msd-wfj.xml)
-  file(CREATE_LINK ${qmcpack_SOURCE_DIR}/src/QMCWaveFunctions/tests/${fname} ${UTEST_DIR}/${fname} SYMBOLIC)
+  MAYBE_SYMLINK(${qmcpack_SOURCE_DIR}/src/QMCWaveFunctions/tests/${fname} ${UTEST_DIR}/${fname})
 endforeach()
 
 foreach(fname C.BFD.xml Na.BFD.xml so_ecp_test.xml C.ccECP.xml N.ccECP.xml)
-  file(CREATE_LINK ${qmcpack_SOURCE_DIR}/tests/pseudopotentials_for_tests/${fname} ${UTEST_DIR}/${fname} SYMBOLIC)
+  MAYBE_SYMLINK(${qmcpack_SOURCE_DIR}/tests/pseudopotentials_for_tests/${fname} ${UTEST_DIR}/${fname})
 endforeach()
 
-ADD_EXECUTABLE(${UTEST_EXE} ${SRCS})
-TARGET_LINK_LIBRARIES(${UTEST_EXE} catch_main qmcham)
-IF(USE_OBJECT_TARGET)
-TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcwfs qmcparticle qmcutil containers platform_omptarget)
-ENDIF()
+foreach(CATEGORY coulomb force ham)
+  SET(UTEST_EXE test_${SRC_DIR}_${CATEGORY})
+  SET(UTEST_NAME deterministic-unit_${UTEST_EXE})
+  STRING(TOUPPER "${CATEGORY}_SRCS" SOURCE_FILE_VAR_NAME)
+  ADD_EXECUTABLE(${UTEST_EXE} ${${SOURCE_FILE_VAR_NAME}})
 
-ADD_UNIT_TEST(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
-SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
+  TARGET_LINK_LIBRARIES(${UTEST_EXE} catch_main qmcham)
+  IF(USE_OBJECT_TARGET)
+    TARGET_LINK_LIBRARIES(${UTEST_EXE} qmcwfs qmcparticle qmcutil containers platform_omptarget)
+  ENDIF()
 
-IF( "${ENABLE_SANITIZER}" STREQUAL "asan" ) 
-  SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS noasan)
-ENDIF()
+  ADD_UNIT_TEST(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+  SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
+
+  IF( "${ENABLE_SANITIZER}" STREQUAL "asan" )
+    SET_TESTS_PROPERTIES(${UTEST_NAME} PROPERTIES LABELS noasan)
+  ENDIF()
+endforeach()


### PR DESCRIPTION
## Proposed changes
Split it into coulomb, ham and force to speed up execution and results parsing.
Workaround texture limit https://cdash.qmcpack.org/CDash/testDetails.php?test=13317902&build=209114
This is caused by legacy CUDA not freeing texture and multiple runs of uni test cases exhausted the reserved pool.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'