### PR TITLE
Fixing slow matrix inversion unit tests.

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -132,7 +132,7 @@ public:
   /** Set the flag whether to compute forces or not.
    * @param val The boolean value for computing forces
    */ 
-  inline void setComputeForces(bool val){ComputeForces=val;}
+  inline void setComputeForces(bool val) override {ComputeForces=val;}
 protected:
   ///random number generator
   RandomGenerator_t* myRNG;

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
@@ -145,7 +145,7 @@ TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermio
 
 TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefunction][fermion]")
 {
-  int n = 256;
+  int n = 64;
   auto cuda_handles = std::make_unique<CUDALinearAlgebraHandles>();
 
   DiracMatrixComputeCUDA<std::complex<double>> dmcc(cuda_handles->hstream);;
@@ -199,7 +199,7 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
 
 TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunction][fermion]")
 {
-  int n = 256;
+  int n = 64;
   auto cuda_handles = std::make_unique<CUDALinearAlgebraHandles>();
 
   DiracMatrixComputeCUDA<double> dmcc(cuda_handles->hstream);;

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
@@ -108,7 +108,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
 
 TEST_CASE("DiracMatrixComputeOMPTarget_large_determinants_against_legacy", "[wavefunction][fermion]")
 {
-  int n = 1024;
+  int n = 64;
 
   DiracMatrixComputeOMPTarget<double> dmc_omp;
 


### PR DESCRIPTION
## Proposed changes

Yesterday I pushed abusively slow unit tests to develop.  This should be ~1000 times faster.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist
- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
