### PR TITLE
Add MSD evaluateRatios and mark Fast tag as deleted

### DIFF
--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -327,7 +327,7 @@ attributes:
   +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
   | ``format``:math:`^r`        | text         | xml/table             | table                  | Select file format                               |
   +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
-  | ``algorithm``:math:`^o`     | text         | batched/default       | default                | Choose NLPP algorithm                            |
+  | ``algorithm``:math:`^o`     | text         | batched/non-batched   | depends                | Choose NLPP algorithm                            |
   +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
   | ``DLA``:math:`^o`           | text         | yes/no                | no                     | Use determinant localization approximation       |
   +-----------------------------+--------------+-----------------------+------------------------+--------------------------------------------------+
@@ -359,14 +359,17 @@ Additional information:
    These elements specify individual file names and formats (both the
    FSAtom XML and CASINO tabular data formats are supported).
 
--  **algorithm** The default algorithm evaluates the ratios of
+-  **algorithm** The default value is ``batched`` when OpenMP offload
+   is enabled and``non-batched`` otherwise.
+   The ``non-batched`` algorithm evaluates the ratios of
    wavefunction components together for each quadrature point and then
-   one point after another. The batched algorithm evaluates the ratios
+   one point after another. The ``batched`` algorithm evaluates the ratios
    of quadrature points together for each wavefunction component and
    then one component after another. Internally, it uses
    ``VirtualParticleSet`` for quadrature points. Hybrid orbital
    representation has an extra optimization enabled when using the
-   batched algorithm.
+   batched algorithm. When OpenMP offload build is enabled, the default
+   value is ``batched``. Otherwise, ``non-batched`` is the default.
 
 -  **DLA** Determinant localization approximation
    (DLA) :cite:`Zen2019DLA` uses only the fermionic part of

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -62,24 +62,28 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
     soPot.resize(ng);
     L2Pot.resize(ng);
   }
-  std::string ecpFormat("table");
-  std::string NLPP_algo(omp_get_nested() ? "batched" : "default");
-#ifdef ENABLE_OFFLOAD
-  NLPP_algo = "batched"; // set "batched" as the default
-#endif
-  std::string use_DLA("no");
-  std::string pbc("yes");
-  std::string forces("no");
-  std::string physicalSO("no");
+  std::string ecpFormat;
+  std::string NLPP_algo;
+  std::string use_DLA;
+  std::string pbc;
+  std::string forces;
+  std::string physicalSO;
 
   OhmmsAttributeSet pAttrib;
-  pAttrib.add(ecpFormat, "format");
-  pAttrib.add(NLPP_algo, "algorithm");
-  pAttrib.add(use_DLA, "DLA");
-  pAttrib.add(pbc, "pbc");
-  pAttrib.add(forces, "forces");
-  pAttrib.add(physicalSO, "physicalSO");
+  pAttrib.add(ecpFormat, "format", {"table", "xml"});
+  pAttrib.add(NLPP_algo, "algorithm", {"", "batched", "non-batched"});
+  pAttrib.add(use_DLA, "DLA", {"no", "yes"});
+  pAttrib.add(pbc, "pbc", {"yes", "no"});
+  pAttrib.add(forces, "forces", {"no", "yes"});
+  pAttrib.add(physicalSO, "physicalSO", {"no", "yes"});
   pAttrib.put(cur);
+
+  if (NLPP_algo.empty())
+#ifdef ENABLE_OFFLOAD
+    NLPP_algo = "batched";
+#else
+    NLPP_algo = omp_get_nested() ? "batched" : "non-batched";
+#endif
 
   bool doForces = (forces == "yes") || (forces == "true");
   if (use_DLA == "yes")

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -39,9 +39,7 @@ SET(HAM_SRCS test_bare_kinetic.cpp
 IF(QMC_CUDA)
   SET(COULOMB_SRCS ${COULOMB_SRCS} test_coulomb_CUDA.cpp)
 ELSE()
-  IF(NOT ENABLE_OFFLOAD)
-    SET(FORCE_SRCS ${FORCE_SRCS} test_ion_derivs.cpp)
-  ENDIF()
+  SET(FORCE_SRCS ${FORCE_SRCS} test_ion_derivs.cpp)
 ENDIF()
 
 EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory "${UTEST_DIR}")

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
          <pairpot type=\"coulomb\" name=\"ElecElec\" source=\"e\" target=\"e\"/> \
          <pairpot type=\"coulomb\" name=\"IonIon\" source=\"ion0\" target=\"ion0\"/> \
-         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\"> \
+         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\" algorithm=\"non-batched\"> \
            <pseudo elementType=\"C\" href=\"C.ccECP.xml\"/> \
            <pseudo elementType=\"N\" href=\"N.ccECP.xml\"/> \
          </pairpot> \
@@ -307,7 +307,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
          <pairpot type=\"coulomb\" name=\"ElecElec\" source=\"e\" target=\"e\"/> \
          <pairpot type=\"coulomb\" name=\"IonIon\" source=\"ion0\" target=\"ion0\"/> \
-         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\"> \
+         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\" algorithm=\"non-batched\"> \
            <pseudo elementType=\"C\" href=\"C.ccECP.xml\"/> \
            <pseudo elementType=\"N\" href=\"N.ccECP.xml\"/> \
          </pairpot> \
@@ -492,7 +492,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
          <pairpot type=\"coulomb\" name=\"ElecElec\" source=\"e\" target=\"e\"/> \
          <pairpot type=\"coulomb\" name=\"IonIon\" source=\"ion0\" target=\"ion0\"/> \
-         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\"> \
+         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\" algorithm=\"non-batched\"> \
            <pseudo elementType=\"C\" href=\"C.ccECP.xml\"/> \
            <pseudo elementType=\"N\" href=\"N.ccECP.xml\"/> \
          </pairpot> \
@@ -647,7 +647,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
          <pairpot type=\"coulomb\" name=\"ElecElec\" source=\"e\" target=\"e\"/> \
          <pairpot type=\"coulomb\" name=\"IonIon\" source=\"ion0\" target=\"ion0\"/> \
-         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\"> \
+         <pairpot name=\"PseudoPot\" type=\"pseudo\" source=\"ion0\" wavefunction=\"psi0\" format=\"xml\" algorithm=\"non-batched\"> \
            <pseudo elementType=\"C\" href=\"C.ccECP.xml\"/> \
            <pseudo elementType=\"N\" href=\"N.ccECP.xml\"/> \
          </pairpot> \

--- a/src/QMCTools/ppconvert/src/ParserClass.h
+++ b/src/QMCTools/ppconvert/src/ParserClass.h
@@ -60,7 +60,7 @@ public:
   bool NextLine();
   void SavePos();
   void RestorePos();
-  inline void Reset();
+  void Reset();
 
   MemParserClass()
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -637,7 +637,7 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateRatiosAlltoOne(ParticleSet& P,
     Phi->evaluateValue(P, -1, psiV_host_view);
   }
   for (int i = 0; i < psiMinv.rows(); i++)
-    ratios[FirstIndex+i] = simd::dot(psiMinv[i], psiV.data(), NumOrbitals);
+    ratios[FirstIndex + i] = simd::dot(psiMinv[i], psiV.data(), NumOrbitals);
 }
 
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -636,8 +636,8 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateRatiosAlltoOne(ParticleSet& P,
     ScopedTimer local_timer(SPOVTimer);
     Phi->evaluateValue(P, -1, psiV_host_view);
   }
-  //FIXME due to padding in psiMinv
-  MatrixOperators::product(psiMinv, psiV.data(), &ratios[FirstIndex]);
+  for (int i = 0; i < psiMinv.rows(); i++)
+    ratios[FirstIndex+i] = simd::dot(psiMinv[i], psiV.data(), NumOrbitals);
 }
 
 
@@ -664,7 +664,7 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
   {
     resizeScratchObjectsForIonDerivs();
     Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
-    // psiMinv.cols() can be different from NumOrbitals
+    // psiMinv columns have padding but grad_source_psiM ones don't
     for (int i = 0; i < psiMinv.rows(); i++)
       g += simd::dot(psiMinv[i], grad_source_psiM[i], NumOrbitals);
   }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -664,8 +664,9 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
   {
     resizeScratchObjectsForIonDerivs();
     Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
-    // FIXME due padding of psiMinv
-    g = simd::dot(psiMinv.data(), grad_source_psiM.data(), psiMinv.size());
+    // psiMinv.cols() can be different from NumOrbitals
+    for (int i = 0; i < psiMinv.rows(); i++)
+      g += simd::dot(psiMinv[i], grad_source_psiM[i], NumOrbitals);
   }
 
   return g;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -212,7 +212,12 @@ public:
   /// return  for testing
   auto& getPsiMinv() const { return psiMinv; }
 
-  /// inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$, actual memory owned by det_engine_
+  /** inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$ memory view
+   * Actual memory is owned by det_engine_
+   * Only NumOrbitals x NumOrbitals subblock has meaningful data
+   * The number of rows is equal to NumOrbitals
+   * The number of columns in each row is padded to a multiple of QMC_SIMD_ALIGNMENT
+   */
   ValueMatrix_t psiMinv;
 
   /// memory for psiM, dpsiM and d2psiM. [5][norb*norb]

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -189,14 +189,14 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios(int ref,
 #endif
 }
 
-void MultiDiracDeterminant::evaluateDetsForPtclMove(ParticleSet& P, int iat)
+void MultiDiracDeterminant::evaluateDetsForPtclMove(const ParticleSet& P, int iat, int refPtcl)
 {
   UpdateMode = ORB_PBYP_RATIO;
   RatioTimer.start();
   evalOrbTimer.start();
   Phi->evaluateValue(P, iat, psiV);
   evalOrbTimer.stop();
-  WorkingIndex = iat - FirstIndex;
+  WorkingIndex = (refPtcl < 0 ? iat : refPtcl) - FirstIndex;
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::iterator it(ciConfigList->begin());
@@ -245,7 +245,7 @@ void MultiDiracDeterminant::evaluateDetsForPtclMove(ParticleSet& P, int iat)
   RatioTimer.stop();
 }
 
-void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(ParticleSet& P, int iat)
+void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(const ParticleSet& P, int iat)
 {
   UpdateMode = ORB_PBYP_PARTIAL;
   evalOrb1Timer.start();

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -197,7 +197,7 @@ void MultiDiracDeterminant::evaluateDetsForPtclMove(const ParticleSet& P, int ia
   Phi->evaluateValue(P, iat, psiV);
   evalOrbTimer.stop();
   const int WorkingIndex = (refPtcl < 0 ? iat : refPtcl) - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::iterator it(ciConfigList->begin());
@@ -253,7 +253,7 @@ void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(const ParticleSet& P
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
   evalOrb1Timer.stop();
   const int WorkingIndex = iat - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::iterator it(ciConfigList->begin());
@@ -330,7 +330,7 @@ void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(const ParticleSet& P
 void MultiDiracDeterminant::evaluateGrads(ParticleSet& P, int iat)
 {
   const int WorkingIndex = iat - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
 
   const auto& confgList = *ciConfigList;
   auto it               = confgList[0].occup.begin(); //just to avoid using the type
@@ -386,7 +386,7 @@ void MultiDiracDeterminant::evaluateAllForPtclMove(const ParticleSet& P, int iat
   UpdateMode = ORB_PBYP_ALL;
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
   const int WorkingIndex = iat - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::const_iterator it(ciConfigList->begin());

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -196,7 +196,8 @@ void MultiDiracDeterminant::evaluateDetsForPtclMove(const ParticleSet& P, int ia
   evalOrbTimer.start();
   Phi->evaluateValue(P, iat, psiV);
   evalOrbTimer.stop();
-  WorkingIndex = (refPtcl < 0 ? iat : refPtcl) - FirstIndex;
+  const int WorkingIndex = (refPtcl < 0 ? iat : refPtcl) - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::iterator it(ciConfigList->begin());
@@ -251,7 +252,8 @@ void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(const ParticleSet& P
   evalOrb1Timer.start();
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
   evalOrb1Timer.stop();
-  WorkingIndex = iat - FirstIndex;
+  const int WorkingIndex = iat - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::iterator it(ciConfigList->begin());
@@ -327,7 +329,8 @@ void MultiDiracDeterminant::evaluateDetsAndGradsForPtclMove(const ParticleSet& P
 
 void MultiDiracDeterminant::evaluateGrads(ParticleSet& P, int iat)
 {
-  WorkingIndex = iat - FirstIndex;
+  const int WorkingIndex = iat - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
 
   const auto& confgList = *ciConfigList;
   auto it               = confgList[0].occup.begin(); //just to avoid using the type
@@ -382,7 +385,8 @@ void MultiDiracDeterminant::evaluateAllForPtclMove(const ParticleSet& P, int iat
 {
   UpdateMode = ORB_PBYP_ALL;
   Phi->evaluateVGL(P, iat, psiV, dpsiV, d2psiV);
-  WorkingIndex = iat - FirstIndex;
+  const int WorkingIndex = iat - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
   if (NumPtcls == 1)
   {
     std::vector<ci_configuration2>::const_iterator it(ciConfigList->begin());

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -238,7 +238,7 @@ void MultiDiracDeterminant::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 void MultiDiracDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
   const int WorkingIndex = iat - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   switch (UpdateMode)
   {
   case ORB_PBYP_RATIO:
@@ -279,7 +279,7 @@ void MultiDiracDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_del
 void MultiDiracDeterminant::restore(int iat)
 {
   const int WorkingIndex = iat - FirstIndex;
-  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
+  assert(WorkingIndex >= 0 && WorkingIndex < LastIndex - FirstIndex);
   psiMinv_temp = psiMinv;
   for (int i = 0; i < NumOrbitals; i++)
     TpsiM(i, WorkingIndex) = psiM(WorkingIndex, i);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -237,7 +237,8 @@ void MultiDiracDeterminant::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 */
 void MultiDiracDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
-  WorkingIndex = iat - FirstIndex;
+  const int WorkingIndex = iat - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
   switch (UpdateMode)
   {
   case ORB_PBYP_RATIO:
@@ -277,7 +278,8 @@ void MultiDiracDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_del
 */
 void MultiDiracDeterminant::restore(int iat)
 {
-  WorkingIndex = iat - FirstIndex;
+  const int WorkingIndex = iat - FirstIndex;
+  assert(WorkingIndex>=0 && WorkingIndex < LastIndex-FirstIndex);
   psiMinv_temp = psiMinv;
   for (int i = 0; i < NumOrbitals; i++)
     TpsiM(i, WorkingIndex) = psiM(WorkingIndex, i);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -383,9 +383,19 @@ public:
 
   void setDetInfo(int ref, std::vector<ci_configuration2>* list);
 
-  void evaluateDetsForPtclMove(ParticleSet& P, int iat);
-  void evaluateDetsAndGradsForPtclMove(ParticleSet& P, int iat);
+  /** evaluate the value of all the unique determinants with one electron moved. Used by the table method
+   *@param P particle set which provides the positions
+   *@param iat the index of the moved electron
+   *@param refPtcl if given, the id of the reference particle in virtual moves
+   */
+  void evaluateDetsForPtclMove(const ParticleSet& P, int iat, int refPtcl = -1);
+
+  /// evaluate the value and gradients of all the unique determinants with one electron moved. Used by the table method
+  void evaluateDetsAndGradsForPtclMove(const ParticleSet& P, int iat);
+
+  /// evaluate the gradients of all the unique determinants with one electron moved. Used by the table method
   void evaluateGrads(ParticleSet& P, int iat);
+
   void evaluateAllForPtclMove(const ParticleSet& P, int iat);
   // full evaluation of all the structures from scratch, used in evaluateLog for example
   void evaluateForWalkerMove(const ParticleSet& P, bool fromScratch = true);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -410,8 +410,6 @@ public:
   int FirstIndex;
   ///index of the last particle with respect to the particle set
   int LastIndex;
-  ///index of the particle (or row)
-  int WorkingIndex;
   ///a set of single-particle orbitals used to fill in the  values of the matrix
   std::unique_ptr<SPOSet> Phi;
   /// number of determinants handled by this object

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.h
@@ -118,6 +118,8 @@ public:
   PsiValueType ratio_impl(ParticleSet& P, int iat);
   PsiValueType ratio_impl_no_precompute(ParticleSet& P, int iat);
 
+  void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override;
+
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
     // the base class routine may probably work, just never tested.

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -216,19 +216,9 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         spoAttrib.add(spoNames[0], "spo_up");
         spoAttrib.add(spoNames[1], "spo_dn");
       }
-      spoAttrib.add(fastAlg, "Fast", {"", "yes", "no"}, TagStatus::DEPRECATED);
-      spoAttrib.add(msd_algorithm, "algorithm", {"", "precomputed_table_method", "table_method", "all_determinants"});
+      spoAttrib.add(fastAlg, "Fast", {"", "yes", "no"}, TagStatus::DELETED);
+      spoAttrib.add(msd_algorithm, "algorithm", {"precomputed_table_method", "table_method", "all_determinants"});
       spoAttrib.put(cur);
-
-      if (msd_algorithm.empty())
-      {
-        if (fastAlg.empty())
-          msd_algorithm = "precomputed_table_method";
-        else if (fastAlg == "yes")
-          msd_algorithm = "table_method";
-        else
-          msd_algorithm = "all_determinants";
-      }
 
       //new format
       std::vector<std::unique_ptr<SPOSet>> spo_clones;

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -60,7 +60,7 @@ SET(SPOSET_SRC test_spo_collection_input_spline.cpp test_spo_collection_input_LC
 SET(JASTROW_SRC test_bspline_jastrow.cpp test_counting_jastrow.cpp test_polynomial_eeI_jastrow.cpp
                 test_rpa_jastrow.cpp test_user_jastrow.cpp test_kspace_jastrow.cpp test_pade_jastrow.cpp
                 test_short_range_cusp_jastrow.cpp test_DiffTwoBodyJastrowOrbital.cpp)
-SET(DETERMINANT_SRC FakeSPO.cpp makeRngSpdMatrix.cpp test_DiracDeterminantBatched.cpp test_dirac_det.cpp
+SET(DETERMINANT_SRC FakeSPO.cpp makeRngSpdMatrix.cpp test_DiracDeterminantBatched.cpp test_DiracDeterminantBatched.cpp
                     test_multi_dirac_determinant.cpp test_dirac_matrix.cpp
                     test_multi_slater_determinant.cpp)
 

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -83,20 +83,16 @@ void FakeSPO::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; }
 
 void FakeSPO::evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi)
 {
-  if (OrbitalSetSize == 3)
-  {
-    for (int i = 0; i < 3; i++)
-    {
-      psi[i] = a(iat, i);
-    }
-  }
-  else if (OrbitalSetSize == 4)
-  {
-    for (int i = 0; i < 4; i++)
-    {
-      psi[i] = a2(iat, i);
-    }
-  }
+  if (iat < 0)
+    for (int i = 0; i < psi.size(); i++)
+      psi[i] = 1.2 * i - i*i;
+  else
+    if (OrbitalSetSize == 3)
+      for (int i = 0; i < 3; i++)
+        psi[i] = a(iat, i);
+    else if (OrbitalSetSize == 4)
+      for (int i = 0; i < 4; i++)
+        psi[i] = a2(iat, i);
 }
 
 void FakeSPO::evaluateVGL(const ParticleSet& P, int iat, ValueVector_t& psi, GradVector_t& dpsi, ValueVector_t& d2psi)

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -36,6 +36,7 @@ namespace qmcplusplus
 using RealType     = QMCTraits::RealType;
 using ValueType    = QMCTraits::ValueType;
 using ComplexType  = QMCTraits::ComplexType;
+using PosType      = QMCTraits::PosType;
 using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
 using PsiValueType = QMCTraits::QTFull::ValueType;
 
@@ -93,7 +94,6 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
 
   check_matrix(ddb.psiM, b);
 
-
   ParticleSet::GradType grad;
   PsiValueType det_ratio  = ddb.ratioGrad(elec, 0, grad);
   PsiValueType det_ratio1 = 0.178276269185;
@@ -112,6 +112,43 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
   b(2, 2) = 0.9105960265;
 
   check_matrix(ddb.psiM, b);
+
+  // set virtutal particle position
+  PosType newpos(0.3, 0.2, 0.5);
+
+  elec.makeVirtualMoves(newpos);
+  std::vector<ValueType> ratios(elec.getTotalNum());
+  ddb.evaluateRatiosAlltoOne(elec, ratios);
+
+  CHECK(std::real(ratios[0]) == Approx(1.2070809985));
+  CHECK(std::real(ratios[1]) == Approx(0.2498726439));
+  CHECK(std::real(ratios[2]) == Approx(-1.3145695364));
+
+  elec.makeMove(0, newpos - elec.R[0]);
+  PsiValueType ratio_0 = ddb.ratio(elec, 0);
+  elec.rejectMove(0);
+
+  CHECK(std::real(ratio_0) == Approx(-0.5343861437));
+
+  VirtualParticleSet VP(elec, 2);
+  std::vector<PosType> newpos2(2);
+  std::vector<ValueType> ratios2(2);
+  newpos2[0] = newpos - elec.R[1];
+  newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
+  VP.makeMoves(1, elec.R[1], newpos2);
+  ddb.evaluateRatios(VP, ratios);
+
+  CHECK(std::real(ratios[0]) == Approx(0.4880285278));
+  CHECK(std::real(ratios[1]) == Approx(0.9308456444));
+
+  //test acceptMove
+  elec.makeMove(1, newpos - elec.R[1]);
+  PsiValueType ratio_1 = ddb.ratio(elec, 1);
+  ddb.acceptMove(elec, 1);
+  elec.acceptMove(1);
+
+  CHECK(std::real(ratio_1) == Approx(0.9308456444));
+  CHECK(std::real(ddb.LogValue) == Approx(1.9891064655));
 }
 
 //#define DUMP_INFO

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -136,10 +136,10 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
   VP.makeMoves(1, elec.R[1], newpos2);
-  ddb.evaluateRatios(VP, ratios);
+  ddb.evaluateRatios(VP, ratios2);
 
-  CHECK(std::real(ratios[0]) == Approx(0.4880285278));
-  CHECK(std::real(ratios[1]) == Approx(0.9308456444));
+  CHECK(std::real(ratios2[0]) == Approx(0.4880285278));
+  CHECK(std::real(ratios2[1]) == Approx(0.9308456444));
 
   //test acceptMove
   elec.makeMove(1, newpos - elec.R[1]);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -35,6 +35,7 @@ namespace qmcplusplus
 {
 using RealType     = QMCTraits::RealType;
 using ValueType    = QMCTraits::ValueType;
+using PosType      = QMCTraits::PosType;
 using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
 using PsiValueType = QMCTraits::QTFull::ValueType;
 
@@ -114,6 +115,43 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
   b(2, 2) = 0.9105960265;
 
   check_matrix(ddb.psiMinv, b);
+
+  // set virtutal particle position
+  PosType newpos(0.3, 0.2, 0.5);
+
+  elec.makeVirtualMoves(newpos);
+  std::vector<ValueType> ratios(elec.getTotalNum());
+  ddb.evaluateRatiosAlltoOne(elec, ratios);
+
+  CHECK(std::real(ratios[0]) == Approx(1.2070809985));
+  CHECK(std::real(ratios[1]) == Approx(0.2498726439));
+  CHECK(std::real(ratios[2]) == Approx(-1.3145695364));
+
+  elec.makeMove(0, newpos - elec.R[0]);
+  PsiValueType ratio_0 = ddb.ratio(elec, 0);
+  elec.rejectMove(0);
+
+  CHECK(std::real(ratio_0) == Approx(-0.5343861437));
+
+  VirtualParticleSet VP(elec, 2);
+  std::vector<PosType> newpos2(2);
+  std::vector<ValueType> ratios2(2);
+  newpos2[0] = newpos - elec.R[1];
+  newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
+  VP.makeMoves(1, elec.R[1], newpos2);
+  ddb.evaluateRatios(VP, ratios);
+
+  CHECK(std::real(ratios[0]) == Approx(0.4880285278));
+  CHECK(std::real(ratios[1]) == Approx(0.9308456444));
+
+  //test acceptMove
+  elec.makeMove(1, newpos - elec.R[1]);
+  PsiValueType ratio_1 = ddb.ratio(elec, 1);
+  ddb.acceptMove(elec, 1);
+  elec.acceptMove(1);
+
+  CHECK(std::real(ratio_1) == Approx(0.9308456444));
+  CHECK(std::real(ddb.LogValue) == Approx(1.9891064655));
 }
 
 //#define DUMP_INFO

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -139,10 +139,10 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
   VP.makeMoves(1, elec.R[1], newpos2);
-  ddb.evaluateRatios(VP, ratios);
+  ddb.evaluateRatios(VP, ratios2);
 
-  CHECK(std::real(ratios[0]) == Approx(0.4880285278));
-  CHECK(std::real(ratios[1]) == Approx(0.9308456444));
+  CHECK(std::real(ratios2[0]) == Approx(0.4880285278));
+  CHECK(std::real(ratios2[1]) == Approx(0.9308456444));
 
   //test acceptMove
   elec.makeMove(1, newpos - elec.R[1]);

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -237,10 +237,10 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
   VP.makeMoves(1, elec_.R[1], newpos2);
-  j2->evaluateRatios(VP, ratios);
+  j2->evaluateRatios(VP, ratios2);
 
-  REQUIRE(std::real(ratios[0]) == Approx(0.9871985577));
-  REQUIRE(std::real(ratios[1]) == Approx(0.9989268241));
+  REQUIRE(std::real(ratios2[0]) == Approx(0.9871985577));
+  REQUIRE(std::real(ratios2[1]) == Approx(0.9989268241));
 
   //test acceptMove
   elec_.makeMove(1, newpos - elec_.R[1]);

--- a/tests/solids/diamondC_1x1x1-Gaussian_pp_MSD/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1-Gaussian_pp_MSD/CMakeLists.txt
@@ -104,7 +104,7 @@ ENDIF()
                     det_short_vmc_dmc
                     det_short_vmc_dmc.in.xml
                     1 1
-                    ${SUCCESS_STATUS_OFFLOAD}
+                    TRUE
                     0 det_diamondC_1x1x1-Gaussian_pp_MSD_SHORT_VMC_SCALARS #VMC
                     1 det_diamondC_1x1x1-Gaussian_pp_MSD_SHORT_DMC_SCALARS #DMC
                     )

--- a/tests/solids/diamondC_2x1x1-Gaussian_pp_MSD/CMakeLists.txt
+++ b/tests/solids/diamondC_2x1x1-Gaussian_pp_MSD/CMakeLists.txt
@@ -119,7 +119,7 @@ ENDIF()
                     det_short_vmc_dmc
                     det_short_vmc_dmc.in.xml
                     1 1
-                    ${SUCCESS_STATUS_OFFLOAD}
+                    TRUE
                     0 det_diamondC_2x1x1-Gaussian_pp_MSD_SHORT_VMC_SCALARS #VMC
                     1 det_diamondC_2x1x1-Gaussian_pp_MSD_SHORT_DMC_SCALARS #DMC
                     )


### PR DESCRIPTION
## Proposed changes
1. Implement batched NLPP in MSD.
2. mark "Fast" tag as deleted
3. NLPP input tag changes. Input value "default" is removed. No input given actually means default. Add "non-batched" to explicitly call the non-batched code path.

## What type(s) of changes does this code introduce?
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?
- Yes. but I don't think algorithm="default" is actually used anywhere but development only

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'