### PR TITLE
Allow Coeff_0 for ground state CI coefficients

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -151,7 +151,8 @@ private:
 
     extVar=extVar+"_imag";
     if(!hin.readEntry(CIcoeff_imag, extVar))
-       app_log() << "Coeff_imag not found in h5. Set to zero." << std::endl;
+      if (ext_level != 0 || !hin.readEntry(CIcoeff_imag, "Coeff_imag"))
+        app_log() << "Coeff_imag not found in h5. Set to zero." << std::endl;
  
     for (size_t i = 0; i < n_dets; i++)
       ci_coeff[i] = VT(CIcoeff_real[i], CIcoeff_imag[i]);


### PR DESCRIPTION
Some converters use the "Coeff" tag for the ground state in the HDF5 file, and some use "Coeff_0".  Try "Coeff_0" first, and then try "Coeff" if reading the ground state.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
