### PR TITLE
Fix ubuntu installation in documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -681,8 +681,8 @@ production, a platform-optimized BLAS should be used.
 
 ::
 
-  apt-get cmake g++ openmpi-bin libopenmpi-dev libboost-dev
-  apt-get libatlas-base-dev liblapack-dev libhdf5-dev libxml2-dev fftw3-dev
+  sudo apt-get install cmake g++ openmpi-bin libopenmpi-dev libboost-dev
+  sudo apt-get install libatlas-base-dev liblapack-dev libhdf5-dev libxml2-dev fftw3-dev
   export CXX=mpiCC
   cd build
   cmake ..


### PR DESCRIPTION
## Proposed changes

Fix ubuntu installation in docs. Add missing `sudo` and `install` keywords.

## What type(s) of changes does this code introduce?

- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, personal laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Documentation has been added (if appropriate)
