### PR TITLE
Fix doxygen formulas 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ tests/solids/NiO_a4_e48_pp/NiO-fcc-supertwist111-supershift000-S1.h5
 
 # Visual Studio code settings
 .vscode/
+
+# Doxygen
+doxygen/output/
+doxygen/qmcpack_all.tag

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -69,10 +69,10 @@ struct LRHandlerBase
   //return k cutoff
   inline mRealType get_kc() const { return LR_kc; }
 
-  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k} \rho^2_{\bf k}\f$
+  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k}} \rho^2_{\bf k}\f$
    * @param kshell degeneracies of the vectors
-   * @param rk1 starting address of \f$\rho^1_{{\bf k}\f$
-   * @param rk2 starting address of \f$\rho^2_{{\bf k}\f$
+   * @param rk1 starting address of \f$\rho^1_{{\bf k}}\f$
+   * @param rk2 starting address of \f$\rho^2_{{\bf k}}\f$
    *
    * Valid for the strictly ordered k and \f$F_{k}\f$.
    */
@@ -169,11 +169,11 @@ struct LRHandlerBase
     return vk;
   }
 
-  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k} \rho^2_{\bf k}\f$
-   * and \f$\sum_k F_{k} \rho^1_{-{\bf k} \rho^2_{\bf k}\f$
+  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k}} \rho^2_{\bf k}\f$
+   * and \f$\sum_k F_{k} \rho^1_{-{\bf k}} \rho^2_{\bf k}\f$
    * @param kshell degeneracies of the vectors
-   * @param rk1 starting address of \f$\rho^1_{{\bf k}\f$
-   * @param rk2 starting address of \f$\rho^2_{{\bf k}\f$
+   * @param rk1 starting address of \f$\rho^1_{{\bf k}}\f$
+   * @param rk2 starting address of \f$\rho^2_{{\bf k}}\f$
    *
    * Valid for the strictly ordered k and \f$F_{k}\f$.
    */

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -132,10 +132,10 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     //       for(int n=0; n<coefs.size(); n++) v -= coefs[n]*Basis.h(n,r);
   }
 
-  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k} \rho^2_{\bf k}\f$
+  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k}} \rho^2_{\bf k}\f$
    * @param kshell degeneracies of the vectors
-   * @param rk1 starting address of \f$\rho^1_{{\bf k}\f$
-   * @param rk2 starting address of \f$\rho^2_{{\bf k}\f$
+   * @param rk1 starting address of \f$\rho^1_{{\bf k}}\f$
+   * @param rk2 starting address of \f$\rho^2_{{\bf k}}\f$
    *
    * Valid for the strictly ordered k and \f$F_{k}\f$.
    */

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -130,10 +130,10 @@ struct LRRPAHandlerTemp : public LRHandlerBase
     //       for(int n=0; n<coefs.size(); n++) v -= coefs[n]*Basis.h(n,r);
   }
 
-  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k} \rho^2_{\bf k}\f$
+  /** evaluate \f$\sum_k F_{k} \rho^1_{-{\bf k}} \rho^2_{\bf k}\f$
    * @param kshell degeneracies of the vectors
-   * @param rk1 starting address of \f$\rho^1_{{\bf k}\f$
-   * @param rk2 starting address of \f$\rho^2_{{\bf k}\f$
+   * @param rk1 starting address of \f$\rho^1_{{\bf k}}\f$
+   * @param rk2 starting address of \f$\rho^2_{{\bf k}}\f$
    *
    * Valid for the strictly ordered k and \f$F_{k}\f$.
    */

--- a/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/DiffWaveFunctionComponent.h
@@ -27,9 +27,9 @@ namespace qmcplusplus
  * @brief Base base class for derivatives of WaveFunctionComponent
  *
  * Derived classes implement the differentiate function which evaluates
- * - \f$\fraction{\partial \log\Psi}{\partial \alpha}\f$
- * - \f$\nabla \fraction{\partial \log\Psi}{\partial \alpha}\f$
- * - \f$\nabla^2 \fraction{\partial \log\Psi}{\partial \alpha}\f$
+ * - \f${\partial \log \Psi}/{\partial \alpha}\f$
+ * - \f$\nabla {\partial \log \Psi}/{\partial \alpha}\f$
+ * - \f$\nabla^2 {\partial \log \Psi}/{\partial \alpha}\f$
  * Each object handles one or more parameters during the optimiation.
  * The data type of refOrbital, std::vector<WaveFunctionComponent*> is intended for the cases
  * when a common variable is used by several WaveFunctionComponent class, e.g.,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -492,7 +492,7 @@ struct WaveFunctionComponent : public QMCTraits
     }
   }
 
-  /** Calculates the derivatives of \f$ \grad(\textrm{log}(\psif)) \f$ with respect to
+  /** Calculates the derivatives of \f$ \nabla \textnormal{log} \psi_f \f$ with respect to
       the optimizable parameters, and the dot product of this is then
       performed with the passed-in G_in gradient vector. This object is then
       returned as dgradlogpsi.


### PR DESCRIPTION
## Proposed changes

Minor PR to re-enable doxygen API documentation generation as it's currently broken due to latex symbols.

## What type(s) of changes does this code introduce?

- Bugfix
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
