### PR TITLE
Consistent use of covariant return type

### DIFF
--- a/src/Estimators/CSEnergyEstimator.cpp
+++ b/src/Estimators/CSEnergyEstimator.cpp
@@ -45,7 +45,7 @@ CSEnergyEstimator::CSEnergyEstimator(QMCHamiltonian& h, int hcopy)
   scalars_saved.resize(scalars.size());
 }
 
-ScalarEstimatorBase* CSEnergyEstimator::clone() { return new CSEnergyEstimator(*this); }
+CSEnergyEstimator* CSEnergyEstimator::clone() { return new CSEnergyEstimator(*this); }
 
 /**  add the local energy, variance and all the Hamiltonian components to the scalar record container
    *@param record storage of scalar records (name,value)

--- a/src/Estimators/CSEnergyEstimator.h
+++ b/src/Estimators/CSEnergyEstimator.h
@@ -82,7 +82,7 @@ struct CSEnergyEstimator : public ScalarEstimatorBase
    */
   void add2Record(RecordNamedProperty<RealType>& record) override;
   void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override;
-  ScalarEstimatorBase* clone() override;
+  CSEnergyEstimator* clone() override;
 
   void evaluateDiff();
 };

--- a/src/Estimators/LocalEnergyEstimator.cpp
+++ b/src/Estimators/LocalEnergyEstimator.cpp
@@ -25,7 +25,7 @@ LocalEnergyEstimator::LocalEnergyEstimator(QMCHamiltonian& h, bool use_hdf5) : U
   scalars_saved.resize(SizeOfHamiltonians + LE_MAX);
 }
 
-ScalarEstimatorBase* LocalEnergyEstimator::clone() { return new LocalEnergyEstimator(*this); }
+LocalEnergyEstimator* LocalEnergyEstimator::clone() { return new LocalEnergyEstimator(*this); }
 
 void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid)
 {

--- a/src/Estimators/LocalEnergyEstimator.h
+++ b/src/Estimators/LocalEnergyEstimator.h
@@ -75,7 +75,7 @@ public:
   }
   void add2Record(RecordListType& record) override;
   void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) override;
-  ScalarEstimatorBase* clone() override;
+  LocalEnergyEstimator* clone() override;
   /*@}*/
 
   inline void accumulate(const RefVector<MCPWalker>& walkers) override

--- a/src/Estimators/LocalEnergyOnlyEstimator.h
+++ b/src/Estimators/LocalEnergyOnlyEstimator.h
@@ -65,7 +65,7 @@ struct LocalEnergyOnlyEstimator : public ScalarEstimatorBase
     clear();
   }
 
-  ScalarEstimatorBase* clone() override { return new LocalEnergyOnlyEstimator(); }
+  LocalEnergyOnlyEstimator* clone() override { return new LocalEnergyOnlyEstimator(); }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Estimators/RMCLocalEnergyEstimator.cpp
+++ b/src/Estimators/RMCLocalEnergyEstimator.cpp
@@ -25,7 +25,7 @@ RMCLocalEnergyEstimator::RMCLocalEnergyEstimator(QMCHamiltonian& h, int nobs) : 
   scalars_saved.resize(2 * SizeOfHamiltonians + RMCSpecificTerms);
 }
 
-ScalarEstimatorBase* RMCLocalEnergyEstimator::clone() { return new RMCLocalEnergyEstimator(*this); }
+RMCLocalEnergyEstimator* RMCLocalEnergyEstimator::clone() { return new RMCLocalEnergyEstimator(*this); }
 
 /**  add the local energy, variance and all the Hamiltonian components to the scalar record container
  * @param record storage of scalar records (name,value)

--- a/src/Estimators/RMCLocalEnergyEstimator.h
+++ b/src/Estimators/RMCLocalEnergyEstimator.h
@@ -143,7 +143,7 @@ public:
 
   void add2Record(RecordListType& record) override;
   void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override {}
-  ScalarEstimatorBase* clone() override;
+  RMCLocalEnergyEstimator* clone() override;
   /*@}*/
 };
 } // namespace qmcplusplus

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -73,7 +73,7 @@ std::vector<int> SpinDensityNew::getSpeciesSize(SpeciesSet& species)
 
 size_t SpinDensityNew::getFullDataSize() { return species_.size() * derived_parameters_.npoints; }
 
-OperatorEstBase* SpinDensityNew::clone()
+SpinDensityNew* SpinDensityNew::clone()
 {
   std::cout << "SpinDensity clone called\n";
   return new SpinDensityNew(*this);

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -77,7 +77,7 @@ public:
 
   /** standard interface
    */
-  OperatorEstBase* clone() override;
+  SpinDensityNew* clone() override;
 
   /** accumulate 1 or more walkers of SpinDensity samples
    */

--- a/src/Estimators/tests/FakeEstimator.h
+++ b/src/Estimators/tests/FakeEstimator.h
@@ -25,7 +25,7 @@ class FakeEstimator : public ScalarEstimatorBase
 
   void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override {}
 
-  ScalarEstimatorBase* clone() override { return new FakeEstimator; }
+  FakeEstimator* clone() override { return new FakeEstimator; }
 };
 
 } // namespace qmcplusplus

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -34,8 +34,8 @@ public:
   void registerOperatorEstimator(hid_t gid) override {}
 
   void startBlock(int nsteps) override {}
-  
-  OperatorEstBase* clone() override { return new FakeOperatorEstimator(*this); }
+
+  FakeOperatorEstimator* clone() override { return new FakeOperatorEstimator(*this); }
 
   void set_walker_weights(QMCT::RealType weight) { walkers_weight_ = weight; }
 };

--- a/src/Estimators/tests/test_local_energy_est.cpp
+++ b/src/Estimators/tests/test_local_energy_est.cpp
@@ -48,7 +48,7 @@ TEST_CASE("LocalEnergy", "[estimators]")
   QMCHamiltonian H;
   LocalEnergyEstimator le_est(H, false);
 
-  std::unique_ptr<LocalEnergyEstimator> le_est2{dynamic_cast<LocalEnergyEstimator*>(le_est.clone())};
+  std::unique_ptr<LocalEnergyEstimator> le_est2{le_est.clone()};
   REQUIRE(le_est2 != nullptr);
   REQUIRE(le_est2.get() != &le_est);
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Consistently use covariant return types for the clone() member function in classes that inherit from ScalarEstimatorBase and OperatorEstBase.

This was found in #3190

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- n/a. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- n/a. Documentation has been added (if appropriate)
