### PR TITLE
Update docker images for CI

### DIFF
--- a/config/docker/dependencies/ubuntu/clang-latest/Dockerfile
+++ b/config/docker/dependencies/ubuntu/clang-latest/Dockerfile
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
                     rsync \
                     wget \
                     software-properties-common \
+                    vim \
                     -y
 
 # add the latest clang development

--- a/config/docker/dependencies/ubuntu/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu/openmpi/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
                     git \
                     libopenmpi-dev \
                     libhdf5-openmpi-dev \
+                    libhdf5-serial-dev \
                     hdf5-tools \
                     libfftw3-dev \
                     libopenblas-openmp-dev \
@@ -27,6 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&\
                     rsync \
                     wget \
                     software-properties-common \
+                    vim \
                     -y
 
 # Python packages for tests

--- a/docs/running_docker.rst
+++ b/docs/running_docker.rst
@@ -44,7 +44,7 @@ Running Docker Containers
 
       docker run -it williamfgc/qmcpack-ci:ubuntu20-openmpi /bin/bash
 
-   The above will run the container in interactive mode dropping the default `user` to `/home/user` using the `bash` shell.
+   The above will run the container in interactive mode dropping the default `user` to `/home/user` using the `bash` shell. If `sudo` access is needed (e.g. install a package `sudo apt-get install emacs`) the password for the default `user` is also `user`.
 
    **Run an image (for Development)** `docker run` has a few extra options that can be used to run QMCPACK: 
 


### PR DESCRIPTION
## Proposed changes

Add vim and serial hdf5 dev in docker images (already published in DockerHub) used for GitHub Actions CI.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Other (please describe): Docker containers

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, CI will pull these containers

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
