### PR TITLE
Address leak related to functor in JastrowBuilder

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -21,6 +21,7 @@
 #include "CPU/SIMD/algorithm.hpp"
 #include <map>
 #include <numeric>
+#include <memory>
 
 namespace qmcplusplus
 {
@@ -69,7 +70,7 @@ class JeeIOrbitalSoA : public WaveFunctionComponent
   ///container for the Jastrow functions
   Array<FT*, 3> F;
 
-  std::map<std::string, FT*> J3Unique;
+  std::map<std::string, std::unique_ptr<FT>> J3Unique;
   //YYYY
   std::map<FT*, int> J3UniqueIndex;
 
@@ -137,9 +138,9 @@ public:
           typename std::map<const FT*, FT*>::iterator fit = fcmap.find(F(iG, eG1, eG2));
           if (fit == fcmap.end())
           {
-            FT* fc = new FT(*F(iG, eG1, eG2));
+            std::unique_ptr<FT> fc = std::make_unique<FT>(*F(iG, eG1, eG2));
+            fcmap[F(iG, eG1, eG2)] = fc.get();
             eeIcopy->addFunc(iG, eG1, eG2, fc);
-            fcmap[F(iG, eG1, eG2)] = fc;
           }
         }
     // Ye: I don't like the following memory allocated by default.
@@ -196,16 +197,16 @@ public:
 
   void initUnique()
   {
-    typename std::map<std::string, FT*>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
+    typename std::map<std::string, std::unique_ptr<FT>>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
     du_dalpha.resize(J3Unique.size());
     dgrad_dalpha.resize(J3Unique.size());
     dhess_dalpha.resize(J3Unique.size());
     int ifunc = 0;
     while (it != it_end)
     {
-      J3UniqueIndex[it->second] = ifunc;
-      FT& functor               = *(it->second);
-      int numParams             = functor.getNumParameters();
+      J3UniqueIndex[it->second.get()] = ifunc;
+      FT& functor                     = *(it->second);
+      int numParams                   = functor.getNumParameters();
       du_dalpha[ifunc].resize(numParams);
       dgrad_dalpha[ifunc].resize(numParams);
       dhess_dalpha[ifunc].resize(numParams);
@@ -214,7 +215,7 @@ public:
     }
   }
 
-  void addFunc(int iSpecies, int eSpecies1, int eSpecies2, FT* j)
+  void addFunc(int iSpecies, int eSpecies1, int eSpecies2, std::unique_ptr<FT>& j)
   {
     if (eSpecies1 == eSpecies2)
     {
@@ -224,13 +225,13 @@ public:
           for (int eG2 = 0; eG2 < eGroups; eG2++)
           {
             if (F(iSpecies, eG1, eG2) == 0)
-              F(iSpecies, eG1, eG2) = j;
+              F(iSpecies, eG1, eG2) = j.get();
           }
     }
     else
     {
-      F(iSpecies, eSpecies1, eSpecies2) = j;
-      F(iSpecies, eSpecies2, eSpecies1) = j;
+      F(iSpecies, eSpecies1, eSpecies2) = j.get();
+      F(iSpecies, eSpecies2, eSpecies1) = j.get();
     }
     if (j)
     {
@@ -245,7 +246,7 @@ public:
     }
     std::stringstream aname;
     aname << iSpecies << "_" << eSpecies1 << "_" << eSpecies2;
-    J3Unique[aname.str()] = j;
+    J3Unique.emplace(aname.str(), std::move(j));
     initUnique();
   }
 
@@ -310,12 +311,11 @@ public:
   void checkInVariables(opt_variables_type& active)
   {
     myVars.clear();
-    typename std::map<std::string, FT*>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
-    while (it != it_end)
+
+    for (auto& ftPair : J3Unique)
     {
-      (*it).second->checkInVariables(active);
-      (*it).second->checkInVariables(myVars);
-      ++it;
+      ftPair.second->checkInVariables(active);
+      ftPair.second->checkInVariables(myVars);
     }
   }
 
@@ -324,13 +324,13 @@ public:
   void checkOutVariables(const opt_variables_type& active)
   {
     myVars.clear();
-    typename std::map<std::string, FT*>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
-    while (it != it_end)
+
+    for (auto& ftPair : J3Unique)
     {
-      (*it).second->myVars.getIndex(active);
-      myVars.insertFrom((*it).second->myVars);
-      ++it;
+      ftPair.second->myVars.getIndex(active);
+      myVars.insertFrom(ftPair.second->myVars);
     }
+
     myVars.getIndex(active);
     NumVars = myVars.size();
     if (NumVars)
@@ -358,11 +358,12 @@ public:
   {
     if (!Optimizable)
       return;
-    typename std::map<std::string, FT*>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
-    while (it != it_end)
+
+    for (auto& ftPair : J3Unique)
     {
-      (*it++).second->resetParameters(active);
+      ftPair.second->resetParameters(active);
     }
+
     for (int i = 0; i < myVars.size(); ++i)
     {
       int ii = myVars.Index[i];
@@ -374,11 +375,9 @@ public:
   /** print the state, e.g., optimizables */
   void reportStatus(std::ostream& os)
   {
-    typename std::map<std::string, FT*>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
-    while (it != it_end)
+    for (auto& ftPair : J3Unique)
     {
-      (*it).second->myVars.print(os);
-      ++it;
+      ftPair.second->myVars.print(os);
     }
   }
 
@@ -406,7 +405,9 @@ public:
           }
   }
 
-  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P,
+                           ParticleSet::ParticleGradient_t& G,
+                           ParticleSet::ParticleLaplacian_t& L)
   {
     return evaluateGL(P, G, L, true);
   }
@@ -501,7 +502,7 @@ public:
       valT* restrict save_g      = dUat.data(idim);
       const valT* restrict new_g = newdUk.data(idim);
       const valT* restrict old_g = olddUk.data(idim);
-#pragma omp simd aligned(save_g, new_g, old_g: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(save_g, new_g, old_g : QMC_SIMD_ALIGNMENT)
       for (int jel = 0; jel < Nelec; jel++)
         save_g[jel] += new_g[jel] - old_g[jel];
     }
@@ -591,7 +592,7 @@ public:
       {
         valT* restrict save_g      = dUat.data(idim);
         const valT* restrict new_g = newdUk.data(idim);
-#pragma omp simd aligned(save_g, new_g: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(save_g, new_g : QMC_SIMD_ALIGNMENT)
         for (int kel = 0; kel < jel; kel++)
           save_g[kel] += new_g[kel];
       }
@@ -691,7 +692,7 @@ public:
       valT* restrict jI = Disp_jI_Compressed.data(idim);
       valT* restrict kI = Disp_kI_Compressed.data(idim);
       valT dUj_x(0);
-#pragma omp simd aligned(gradF0, gradF1, gradF2, hessF11, jk, jI, kI: QMC_SIMD_ALIGNMENT) reduction(+ : dUj_x)
+#pragma omp simd aligned(gradF0, gradF1, gradF2, hessF11, jk, jI, kI : QMC_SIMD_ALIGNMENT) reduction(+ : dUj_x)
       for (int kel_index = 0; kel_index < kel_counter; kel_index++)
       {
         // recycle hessF11
@@ -708,7 +709,7 @@ public:
       valT* restrict jk0 = Disp_jk_Compressed.data(0);
       if (idim > 0)
       {
-#pragma omp simd aligned(jk, jk0: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(jk, jk0 : QMC_SIMD_ALIGNMENT)
         for (int kel_index = 0; kel_index < kel_counter; kel_index++)
           jk0[kel_index] += jk[kel_index];
       }
@@ -719,12 +720,12 @@ public:
     }
     valT sum(0);
     valT* restrict jk0 = Disp_jk_Compressed.data(0);
-#pragma omp simd aligned(jk0, hessF01: QMC_SIMD_ALIGNMENT) reduction(+ : sum)
+#pragma omp simd aligned(jk0, hessF01 : QMC_SIMD_ALIGNMENT) reduction(+ : sum)
     for (int kel_index = 0; kel_index < kel_counter; kel_index++)
       sum += hessF01[kel_index] * jk0[kel_index];
     d2Uj -= ctwo * sum;
 
-#pragma omp simd aligned(hessF00, hessF22, gradF0, gradF2, hessF02, hessF11: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(hessF00, hessF22, gradF0, gradF2, hessF02, hessF11 : QMC_SIMD_ALIGNMENT)
     for (int kel_index = 0; kel_index < kel_counter; kel_index++)
       hessF00[kel_index] = hessF00[kel_index] + hessF22[kel_index] + lapfac * (gradF0[kel_index] + gradF2[kel_index]) -
           ctwo * hessF02[kel_index] * hessF11[kel_index];

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -138,9 +138,9 @@ public:
           typename std::map<const FT*, FT*>::iterator fit = fcmap.find(F(iG, eG1, eG2));
           if (fit == fcmap.end())
           {
-            std::unique_ptr<FT> fc = std::make_unique<FT>(*F(iG, eG1, eG2));
+            auto fc                = std::make_unique<FT>(*F(iG, eG1, eG2));
             fcmap[F(iG, eG1, eG2)] = fc.get();
-            eeIcopy->addFunc(iG, eG1, eG2, fc);
+            eeIcopy->addFunc(iG, eG1, eG2, std::move(fc));
           }
         }
     // Ye: I don't like the following memory allocated by default.
@@ -197,25 +197,24 @@ public:
 
   void initUnique()
   {
-    typename std::map<std::string, std::unique_ptr<FT>>::iterator it(J3Unique.begin()), it_end(J3Unique.end());
     du_dalpha.resize(J3Unique.size());
     dgrad_dalpha.resize(J3Unique.size());
     dhess_dalpha.resize(J3Unique.size());
     int ifunc = 0;
-    while (it != it_end)
+
+    for (auto& j3UniquePair : J3Unique)
     {
-      J3UniqueIndex[it->second.get()] = ifunc;
-      FT& functor                     = *(it->second);
-      int numParams                   = functor.getNumParameters();
+      auto functorPtr           = j3UniquePair.second.get();
+      J3UniqueIndex[functorPtr] = ifunc;
+      const int numParams       = functorPtr->getNumParameters();
       du_dalpha[ifunc].resize(numParams);
       dgrad_dalpha[ifunc].resize(numParams);
       dhess_dalpha[ifunc].resize(numParams);
-      ++it;
       ifunc++;
     }
   }
 
-  void addFunc(int iSpecies, int eSpecies1, int eSpecies2, std::unique_ptr<FT>& j)
+  void addFunc(int iSpecies, int eSpecies1, int eSpecies2, std::unique_ptr<FT> j)
   {
     if (eSpecies1 == eSpecies2)
     {

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -133,9 +133,9 @@ public:
       for (int eG1 = 0; eG1 < eGroups; eG1++)
         for (int eG2 = 0; eG2 < eGroups; eG2++)
         {
-          if (F(iG, eG1, eG2) == 0)
+          if (F(iG, eG1, eG2) == nullptr)
             continue;
-          typename std::map<const FT*, FT*>::iterator fit = fcmap.find(F(iG, eG1, eG2));
+          auto fit = fcmap.find(F(iG, eG1, eG2));
           if (fit == fcmap.end())
           {
             auto fc                = std::make_unique<FT>(*F(iG, eG1, eG2));
@@ -359,9 +359,7 @@ public:
       return;
 
     for (auto& ftPair : J3Unique)
-    {
       ftPair.second->resetParameters(active);
-    }
 
     for (int i = 0; i < myVars.size(); ++i)
     {
@@ -375,9 +373,7 @@ public:
   void reportStatus(std::ostream& os)
   {
     for (auto& ftPair : J3Unique)
-    {
       ftPair.second->myVars.print(os);
-    }
   }
 
   void build_compact_list(const ParticleSet& P)

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -52,13 +52,13 @@ bool eeI_JastrowBuilder::putkids(xmlNodePtr kids, J3type& J3)
       rAttrib.add(eI_cusp, "icusp");
       rAttrib.put(kids);
       typedef typename J3type::FuncType FT;
-      std::unique_ptr<FT> functor = std::make_unique<FT>(ee_cusp, eI_cusp);
-      functor->iSpecies           = iSpecies;
-      functor->eSpecies1          = eSpecies1;
-      functor->eSpecies2          = eSpecies2;
-      int iNum                    = iSet.findSpecies(iSpecies);
-      int eNum1                   = eSet.findSpecies(eSpecies1);
-      int eNum2                   = eSet.findSpecies(eSpecies2);
+      auto functor       = std::make_unique<FT>(ee_cusp, eI_cusp);
+      functor->iSpecies  = iSpecies;
+      functor->eSpecies1 = eSpecies1;
+      functor->eSpecies2 = eSpecies2;
+      int iNum           = iSet.findSpecies(iSpecies);
+      int eNum1          = eSet.findSpecies(eSpecies1);
+      int eNum2          = eSet.findSpecies(eSpecies2);
       if (iNum == iSet.size())
       {
         APP_ABORT("ion species " + iSpecies + " requested for Jastrow " + jname + " does not exist in ParticleSet " +
@@ -106,7 +106,7 @@ bool eeI_JastrowBuilder::putkids(xmlNodePtr kids, J3type& J3)
       {
         APP_ABORT("  eeI Jastrow cutoff unspecified.  Cutoff must be given when using open boundary conditions");
       }
-      J3.addFunc(iNum, eNum1, eNum2, functor);
+      J3.addFunc(iNum, eNum1, eNum2, std::move(functor));
     }
     kids = kids->next;
   }

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -22,6 +22,13 @@
 
 namespace qmcplusplus
 {
+eeI_JastrowBuilder::eeI_JastrowBuilder(Communicate* comm, ParticleSet& target, ParticleSet& source)
+    : WaveFunctionComponentBuilder(comm, target), sourcePtcl(&source)
+{
+  ClassName = "eeI_JastroBuilder";
+}
+
+
 template<typename J3type>
 bool eeI_JastrowBuilder::putkids(xmlNodePtr kids, J3type& J3)
 {
@@ -45,13 +52,13 @@ bool eeI_JastrowBuilder::putkids(xmlNodePtr kids, J3type& J3)
       rAttrib.add(eI_cusp, "icusp");
       rAttrib.put(kids);
       typedef typename J3type::FuncType FT;
-      FT* functor        = new FT(ee_cusp, eI_cusp);
-      functor->iSpecies  = iSpecies;
-      functor->eSpecies1 = eSpecies1;
-      functor->eSpecies2 = eSpecies2;
-      int iNum           = iSet.findSpecies(iSpecies);
-      int eNum1          = eSet.findSpecies(eSpecies1);
-      int eNum2          = eSet.findSpecies(eSpecies2);
+      std::unique_ptr<FT> functor = std::make_unique<FT>(ee_cusp, eI_cusp);
+      functor->iSpecies           = iSpecies;
+      functor->eSpecies1          = eSpecies1;
+      functor->eSpecies2          = eSpecies2;
+      int iNum                    = iSet.findSpecies(iSpecies);
+      int eNum1                   = eSet.findSpecies(eSpecies1);
+      int eNum2                   = eSet.findSpecies(eSpecies2);
       if (iNum == iSet.size())
       {
         APP_ABORT("ion species " + iSpecies + " requested for Jastrow " + jname + " does not exist in ParticleSet " +

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.h
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.h
@@ -20,18 +20,16 @@ namespace qmcplusplus
 //forward declaration
 class ParticleSet;
 
-struct eeI_JastrowBuilder : public WaveFunctionComponentBuilder
+class eeI_JastrowBuilder : public WaveFunctionComponentBuilder
 {
+public:
   ParticleSet* sourcePtcl;
   // Two-body constructor
-  eeI_JastrowBuilder(Communicate *comm, ParticleSet& target, ParticleSet& source)
-      : WaveFunctionComponentBuilder(comm, target), sourcePtcl(&source)
-  {
-    ClassName = "eeI_JastrowBuilder";
-  }
+  eeI_JastrowBuilder(Communicate* comm, ParticleSet& target, ParticleSet& source);
 
   WaveFunctionComponent* buildComponent(xmlNodePtr cur) override;
 
+private:
   template<typename J3type>
   bool putkids(xmlNodePtr kids, J3type& J3);
 };


### PR DESCRIPTION
## Proposed changes

Replace raw pointer with `std::unique_ptr` in `J3Unique` container as it produced a leak caught by `asan/lsan`.
Make `eeI_JastrowBuilder` a class and move `putkids` to a private scope.
This is a minor PR only affecting `deterministic-unit_test_wavefunction_jastrow`. It doesn't reinstate the test as there a more direct leaks.

## What type(s) of changes does this code introduce?

- Bugfix: leak fix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04 , must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
