### PR TITLE
Fewer catch_main

### DIFF
--- a/src/Message/CMakeLists.txt
+++ b/src/Message/CMakeLists.txt
@@ -22,10 +22,7 @@ endif()
 
 add_library(catch_main catch_main.cpp)
 target_include_directories(catch_main PUBLIC "${PROJECT_SOURCE_DIR}/external_codes/catch")
-# This plus using the definition of the catch_benchmark_main as INTERFACE target
-# would allow just building catch main once for benchmarking and mpi enabled testing
-# But it causes a segv on power9 with clang12 and on alcf-gnu-mkl18
-# target_compile_definitions(catch_main PRIVATE "CATCH_CONFIG_ENABLE_BENCHMARKING")
+target_compile_definitions(catch_main PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
 target_link_libraries(catch_main message)
 if(HAVE_MPI)
   target_compile_definitions(catch_main PRIVATE "CATCH_MAIN_HAVE_MPI")
@@ -33,15 +30,3 @@ endif()
 
 add_library(catch_main_no_mpi catch_main.cpp)
 target_include_directories(catch_main_no_mpi PUBLIC "${PROJECT_SOURCE_DIR}/external_codes/catch")
-
-# add_library(catch_benchmark_main INTERFACE)
-# target_compile_definitions(catch_benchmark_main INTERFACE "CATCH_CONFIG_ENABLE_BENCHMARKING")
-# target_link_libraries(catch_benchmark_main INTERFACE catch_main)
-
-add_library(catch_benchmark_main catch_main.cpp)
-target_compile_definitions(catch_benchmark_main PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
-target_link_libraries(catch_benchmark_main message)
-if(HAVE_MPI)
-  target_compile_definitions(catch_benchmark_main PRIVATE "CATCH_MAIN_HAVE_MPI")
-endif()
-target_include_directories(catch_benchmark_main PUBLIC "${PROJECT_SOURCE_DIR}/external_codes/catch")

--- a/src/Message/CMakeLists.txt
+++ b/src/Message/CMakeLists.txt
@@ -17,12 +17,7 @@ target_link_libraries(message PUBLIC platform_host)
 
 if(HAVE_MPI)
   target_link_libraries(message PUBLIC MPI::MPI_CXX Boost::boost)
-  set_property(
-    TARGET message
-    APPEND
-    PROPERTY INCLUDE_DIRECTORIES "${qmcpack_SOURCE_DIR}/external_codes/mpi_wrapper")
-  set_property(TARGET message APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                                              "${qmcpack_SOURCE_DIR}/external_codes/mpi_wrapper")
+  target_include_directories(message PUBLIC ${qmcpack_SOURCE_DIR}/external_codes/mpi_wrapper)
 endif()
 
 add_library(catch_main catch_main.cpp)
@@ -30,23 +25,23 @@ target_include_directories(catch_main PUBLIC "${PROJECT_SOURCE_DIR}/external_cod
 # This plus using the definition of the catch_benchmark_main as INTERFACE target
 # would allow just building catch main once for benchmarking and mpi enabled testing
 # But it causes a segv on power9 with clang12 and on alcf-gnu-mkl18
-# TARGET_COMPILE_DEFINITIONS(catch_main PRIVATE "CATCH_CONFIG_ENABLE_BENCHMARKING")
+# target_compile_definitions(catch_main PRIVATE "CATCH_CONFIG_ENABLE_BENCHMARKING")
 target_link_libraries(catch_main message)
 if(HAVE_MPI)
-  set_property(TARGET catch_main APPEND PROPERTY COMPILE_DEFINITIONS "CATCH_MAIN_HAVE_MPI")
+  target_compile_definitions(catch_main PRIVATE "CATCH_MAIN_HAVE_MPI")
 endif()
 
 add_library(catch_main_no_mpi catch_main.cpp)
 target_include_directories(catch_main_no_mpi PUBLIC "${PROJECT_SOURCE_DIR}/external_codes/catch")
 
-# ADD_LIBRARY(catch_benchmark_main INTERFACE)
-# SET_TARGET_PROPERTIES(catch_benchmark_main PROPERTIES INTERFACE_COMPILE_DEFINITIONS "CATCH_CONFIG_ENABLE_BENCHMARKING")
-# TARGET_LINK_LIBRARIES(catch_benchmark_main INTERFACE catch_main)
+# add_library(catch_benchmark_main INTERFACE)
+# target_compile_definitions(catch_benchmark_main INTERFACE "CATCH_CONFIG_ENABLE_BENCHMARKING")
+# target_link_libraries(catch_benchmark_main INTERFACE catch_main)
 
 add_library(catch_benchmark_main catch_main.cpp)
 target_compile_definitions(catch_benchmark_main PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
 target_link_libraries(catch_benchmark_main message)
 if(HAVE_MPI)
-  set_property(TARGET catch_benchmark_main APPEND PROPERTY COMPILE_DEFINITIONS "CATCH_MAIN_HAVE_MPI")
+  target_compile_definitions(catch_benchmark_main PRIVATE "CATCH_MAIN_HAVE_MPI")
 endif()
 target_include_directories(catch_benchmark_main PUBLIC "${PROJECT_SOURCE_DIR}/external_codes/catch")

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -154,7 +154,7 @@ if(ENABLE_CUDA AND BUILD_MICRO_BENCHMARKS)
   set(UTEST_NAME deterministic-unit_${UTEST_EXE})
   set(BENCHMARK_SRC makeRngSpdMatrix.cpp benchmark_DiracMatrixComputeCUDA.cpp)
   add_executable(${UTEST_EXE} ${BENCHMARK_SRC})
-  target_link_libraries(${UTEST_EXE} catch_benchmark_main qmcwfs Math::BLAS_LAPACK Math::scalar_vector_functions
+  target_link_libraries(${UTEST_EXE} catch_main qmcwfs Math::BLAS_LAPACK Math::scalar_vector_functions
                         utilities_for_test)
   if(USE_OBJECT_TARGET)
     target_link_libraries(${UTEST_EXE} qmcutil qmcparticle containers platform_omptarget)


### PR DESCRIPTION
## Proposed changes
Compiling catch_main is slow. So better to keep fewer catch_main variants.
catch_benchmark_main is removed as catch_main turns on benchmark by default.

Overall compilation time change is noticeable but it becomes more friendly to partial build.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'