### PR TITLE
Mark most LRHandler evaluate functions const and clean up its usage in Coulomb

### DIFF
--- a/src/Particle/LongRange/EwaldHandler.cpp
+++ b/src/Particle/LongRange/EwaldHandler.cpp
@@ -106,7 +106,7 @@ void EwaldHandler::fillFk(KContainer& KList)
   app_log().flush();
 }
 
-EwaldHandler::mRealType EwaldHandler::evaluate_vlr_k(mRealType k)
+EwaldHandler::mRealType EwaldHandler::evaluate_vlr_k(mRealType k) const
 {
   mRealType uk = 0.0;
   if (SuperCellEnum == SUPERCELL_SLAB)
@@ -133,7 +133,7 @@ EwaldHandler::mRealType EwaldHandler::evaluate_vlr_k(mRealType k)
 
   EwaldHandler::mRealType EwaldHandler::evaluate_slab(pRealType z, const std::vector<int>& kshell,
                                                       const pComplexType* restrict eikr_i,
-                                                      const pComplexType* restrict eikr_j)
+                                                      const pComplexType* restrict eikr_j) const
   {
     mRealType zp = z * Sigma;
     mRealType vk = -SlabFunc0(z, zp);

--- a/src/Particle/LongRange/EwaldHandler.h
+++ b/src/Particle/LongRange/EwaldHandler.h
@@ -68,7 +68,7 @@ public:
    */
   EwaldHandler(const EwaldHandler& aLR, ParticleSet& ref);
 
-  LRHandlerBase* makeClone(ParticleSet& ref) override { return new EwaldHandler(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new EwaldHandler(*this, ref); }
 
   void initBreakup(ParticleSet& ref) override;
 
@@ -76,7 +76,7 @@ public:
 
   void resetTargetParticleSet(ParticleSet& ref) override {}
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) override { return erfc(r * Sigma) * rinv; }
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override { return erfc(r * Sigma) * rinv; }
 
   /** evaluate the contribution from the long-range part for for spline
    */

--- a/src/Particle/LongRange/EwaldHandler.h
+++ b/src/Particle/LongRange/EwaldHandler.h
@@ -80,20 +80,20 @@ public:
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) override { return -erf(r * Sigma) / r; }
+  inline mRealType evaluateLR(mRealType r) const override { return -erf(r * Sigma) / r; }
 
-  inline mRealType evaluateSR_k0() override { return 0.0; }
+  inline mRealType evaluateSR_k0() const override { return 0.0; }
 
-  inline mRealType evaluateLR_r0() override { return 2.0 * Sigma / std::sqrt(M_PI) + PreFactors[3]; }
+  inline mRealType evaluateLR_r0() const override { return 2.0 * Sigma / std::sqrt(M_PI) + PreFactors[3]; }
 
   /**  evaluate the first derivative of the short range part at r
    *
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) override { return 0.0; }
+  inline mRealType srDf(mRealType r, mRealType rinv) const override { return 0.0; }
 
-  mRealType evaluate_vlr_k(mRealType k) override;
+  mRealType evaluate_vlr_k(mRealType k) const override;
 
   void fillFk(KContainer& KList);
 
@@ -102,7 +102,7 @@ public:
   mRealType evaluate_slab(pRealType z,
                           const std::vector<int>& kshell,
                           const pComplexType* restrict rk1,
-                          const pComplexType* restrict rk2) override;
+                          const pComplexType* restrict rk2) const override;
 
   /** evaluate k=0 term at z
    * @param z distance in the slab direction
@@ -111,7 +111,7 @@ public:
    *
    * Here \f$ X=\frac{2\pi}{A}\f$ and \f$ Y=\frac{2\sqrt{\pi}}{A*Simga}\f$
    */
-  inline mRealType SlabFunc0(mRealType z, mRealType zp)
+  inline mRealType SlabFunc0(mRealType z, mRealType zp) const
   {
     return PreFactors[0] * z * erf(zp) + PreFactors[1] * std::exp(-zp * zp);
   }
@@ -121,7 +121,7 @@ public:
    * @param z distance in the slab direction
    * @param zp z*Sigma
    */
-  inline mRealType SlabFuncK(int ks, mRealType z, mRealType zp)
+  inline mRealType SlabFuncK(int ks, mRealType z, mRealType zp) const
   {
     mRealType expkz = std::exp(kMag[ks] * z);
     mRealType kz0   = PreFactors[2] * kMag[ks]; //could save this

--- a/src/Particle/LongRange/EwaldHandler3D.cpp
+++ b/src/Particle/LongRange/EwaldHandler3D.cpp
@@ -79,7 +79,7 @@ void EwaldHandler3D::fillFk(KContainer& KList)
   app_log().flush();
 }
 
-EwaldHandler3D::mRealType EwaldHandler3D::evaluate_vlr_k(mRealType k)
+EwaldHandler3D::mRealType EwaldHandler3D::evaluate_vlr_k(mRealType k) const
 {
   mRealType kgauss = 1.0 / (4 * Sigma * Sigma);
   mRealType knorm  = 4 * M_PI / Volume;

--- a/src/Particle/LongRange/EwaldHandler3D.h
+++ b/src/Particle/LongRange/EwaldHandler3D.h
@@ -125,7 +125,8 @@ public:
   }
 
   //This returns the stress derivative of Fk, except for the explicit volume dependence.  The explicit volume dependence is factored away into V.
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag) const override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k,
+                                                            pRealType kmag) const override
   {
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
 
@@ -144,7 +145,8 @@ public:
   }
 
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag) const override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r,
+                                                            pRealType rmag) const override
   {
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
 

--- a/src/Particle/LongRange/EwaldHandler3D.h
+++ b/src/Particle/LongRange/EwaldHandler3D.h
@@ -55,7 +55,7 @@ public:
    */
   EwaldHandler3D(const EwaldHandler3D& aLR, ParticleSet& ref);
 
-  LRHandlerBase* makeClone(ParticleSet& ref) override { return new EwaldHandler3D(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new EwaldHandler3D(*this, ref); }
 
   void initBreakup(ParticleSet& ref) override;
 
@@ -63,7 +63,7 @@ public:
 
   void resetTargetParticleSet(ParticleSet& ref) override {}
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) override { return erfc(r * Sigma) * rinv; }
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override { return erfc(r * Sigma) * rinv; }
 
   /** evaluate the contribution from the long-range part for for spline
    */

--- a/src/Particle/LongRange/EwaldHandler3D.h
+++ b/src/Particle/LongRange/EwaldHandler3D.h
@@ -67,24 +67,24 @@ public:
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) override { return erf(r * Sigma) / r; }
+  inline mRealType evaluateLR(mRealType r) const override { return erf(r * Sigma) / r; }
 
-  inline mRealType evaluateSR_k0() override
+  inline mRealType evaluateSR_k0() const override
   {
     mRealType v0 = M_PI / Sigma / Sigma / Volume;
     return v0;
   }
 
-  mRealType evaluate_vlr_k(mRealType k) override;
+  mRealType evaluate_vlr_k(mRealType k) const override;
 
-  mRealType evaluateLR_r0() override { return 2.0 * Sigma / std::sqrt(M_PI); }
+  mRealType evaluateLR_r0() const override { return 2.0 * Sigma / std::sqrt(M_PI); }
 
   /**  evaluate the first derivative of the short range part at r
    *
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) override
+  inline mRealType srDf(mRealType r, mRealType rinv) const override
   {
     return -2.0 * Sigma * std::exp(-Sigma * Sigma * r * r) / (std::sqrt(M_PI) * r) - erfc(Sigma * r) * rinv * rinv;
   }
@@ -93,7 +93,7 @@ public:
    *
    * @param r  radius
    */
-  inline mRealType lrDf(mRealType r) override
+  inline mRealType lrDf(mRealType r) const override
   {
     mRealType rinv = 1.0 / r;
     return 2.0 * Sigma * std::exp(-Sigma * Sigma * r * r) / (std::sqrt(M_PI) * r) - erf(Sigma * r) * rinv * rinv;
@@ -113,6 +113,7 @@ public:
         Fkgstrain[ki++] = uk;
     }
   }
+
   void filldFk_dk(KContainer& KList)
   {
     dFk_dstrain.resize(KList.kpts_cart.size());
@@ -124,7 +125,7 @@ public:
   }
 
   //This returns the stress derivative of Fk, except for the explicit volume dependence.  The explicit volume dependence is factored away into V.
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag) override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag) const override
   {
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
 
@@ -143,7 +144,7 @@ public:
   }
 
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag) override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag) const override
   {
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
 
@@ -160,7 +161,7 @@ public:
     return deriv_tensor;
   }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() const override
   {
     mRealType v0 = -M_PI / Sigma / Sigma / Volume;
     SymTensor<mRealType, OHMMS_DIM> stress;
@@ -170,16 +171,16 @@ public:
     return stress;
   }
 
-  inline mRealType evaluateLR_r0_dstrain(int i, int j) { return 0.0; }
+  inline mRealType evaluateLR_r0_dstrain(int i, int j) const { return 0.0; }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() const override
   {
     SymTensor<mRealType, OHMMS_DIM> stress;
     return stress;
   }
 
 private:
-  inline mRealType evalYkgstrain(mRealType k)
+  inline mRealType evalYkgstrain(mRealType k) const
   {
     mRealType norm  = 4.0 * M_PI / Volume;
     mRealType denom = 4.0 * Sigma * Sigma;
@@ -187,7 +188,7 @@ private:
     return norm * std::exp(-k2 / denom) / k2;
   }
 
-  inline mRealType evaldYkgstrain(mRealType k)
+  inline mRealType evaldYkgstrain(mRealType k) const
   {
     mRealType norm   = 4.0 * M_PI / Volume;
     mRealType denom  = 4.0 * Sigma * Sigma;

--- a/src/Particle/LongRange/LPQHIBasis.cpp
+++ b/src/Particle/LongRange/LPQHIBasis.cpp
@@ -76,7 +76,7 @@ void LPQHIBasis::set_rc(mRealType rc)
 //}
 
 
-LPQHIBasis::mRealType LPQHIBasis::hintr2(int n)
+LPQHIBasis::mRealType LPQHIBasis::hintr2(int n) const
 {
   int j                 = n / 3;
   int alpha             = n - 3 * j;
@@ -136,7 +136,7 @@ LPQHIBasis::mRealType LPQHIBasis::hintr2(int n)
 }
 
 
-LPQHIBasis::mRealType LPQHIBasis::c(int m, mRealType k)
+LPQHIBasis::mRealType LPQHIBasis::c(int m, mRealType k) const
 {
   int i         = m / 3;
   int alpha     = m - 3 * i;
@@ -168,7 +168,7 @@ LPQHIBasis::mRealType LPQHIBasis::c(int m, mRealType k)
 }
 
 
-inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eplus(int i, mRealType k, int n)
+inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eplus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   if (n == 0)
@@ -188,7 +188,7 @@ inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eplus(int i, mRealType k,
 }
 
 
-inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eminus(int i, mRealType k, int n)
+inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eminus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   if (n == 0)
@@ -208,7 +208,7 @@ inline std::complex<LPQHIBasis::mRealType> LPQHIBasis::Eminus(int i, mRealType k
 }
 
 
-inline LPQHIBasis::mRealType LPQHIBasis::Dplus(int i, mRealType k, int n)
+inline LPQHIBasis::mRealType LPQHIBasis::Dplus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> Z1 = Eplus(i, k, n + 1);
   std::complex<mRealType> Z2 = Eplus(i, k, n);
@@ -216,7 +216,7 @@ inline LPQHIBasis::mRealType LPQHIBasis::Dplus(int i, mRealType k, int n)
 }
 
 
-inline LPQHIBasis::mRealType LPQHIBasis::Dminus(int i, mRealType k, int n)
+inline LPQHIBasis::mRealType LPQHIBasis::Dminus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> Z1 = Eminus(i, k, n + 1);
   std::complex<mRealType> Z2 = Eminus(i, k, n);

--- a/src/Particle/LongRange/LPQHIBasis.h
+++ b/src/Particle/LongRange/LPQHIBasis.h
@@ -37,10 +37,10 @@ private:
   std::vector<mRealType> tvec; //Coefficients
 
   //Helper functions for computing FT of basis functions (used in c(n,k))
-  inline std::complex<mRealType> Eplus(int i, mRealType k, int n);
-  inline std::complex<mRealType> Eminus(int i, mRealType k, int n);
-  inline mRealType Dplus(int i, mRealType k, int n);
-  inline mRealType Dminus(int i, mRealType k, int n);
+  inline std::complex<mRealType> Eplus(int i, mRealType k, int n) const;
+  inline std::complex<mRealType> Eminus(int i, mRealType k, int n) const;
+  inline mRealType Dplus(int i, mRealType k, int n) const;
+  inline mRealType Dminus(int i, mRealType k, int n) const;
 
 public:
   LPQHIBasis(const LPQHIBasis& b, ParticleLayout_t& ref)
@@ -64,6 +64,7 @@ public:
   //inline int NumBasisElem() const {return 3*NumKnots;}
   void set_NumKnots(int n); // n >= 2 required
   void set_rc(mRealType rc);
+
   inline mRealType h(int n, mRealType r) const
   {
     int i        = n / 3;
@@ -86,6 +87,7 @@ public:
       return Sa[0] + x * (Sa[1] + x * (Sa[2] + x * (Sa[3] + x * (Sa[4] + x * Sa[5]))));
     }
   }
+
   inline mRealType dh_dr(int n, mRealType r) const
   {
     int i        = n / 3;
@@ -135,8 +137,8 @@ public:
   //      }
   //    }
 
-  mRealType hintr2(int n);
-  mRealType c(int n, mRealType k);
+  mRealType hintr2(int n) const;
+  mRealType c(int n, mRealType k) const;
   //Constructor...fill S matrix...call correct base-class constructor
   LPQHIBasis(ParticleLayout_t& ref) : LRBasis(ref), NumKnots(0), delta(0.0)
   {

--- a/src/Particle/LongRange/LPQHIBasis.h
+++ b/src/Particle/LongRange/LPQHIBasis.h
@@ -63,9 +63,9 @@ public:
   inline mRealType get_delta() const { return delta; }
   //inline int NumBasisElem() const {return 3*NumKnots;}
   void set_NumKnots(int n); // n >= 2 required
-  void set_rc(mRealType rc);
+  void set_rc(mRealType rc) override;
 
-  inline mRealType h(int n, mRealType r) const
+  inline mRealType h(int n, mRealType r) const override
   {
     int i        = n / 3;
     int alpha    = n - 3 * i;
@@ -88,7 +88,7 @@ public:
     }
   }
 
-  inline mRealType dh_dr(int n, mRealType r) const
+  inline mRealType dh_dr(int n, mRealType r) const override
   {
     int i        = n / 3;
     int alpha    = n - 3 * i;
@@ -137,8 +137,9 @@ public:
   //      }
   //    }
 
-  mRealType hintr2(int n) const;
-  mRealType c(int n, mRealType k) const;
+  mRealType hintr2(int n) const override;
+  mRealType c(int n, mRealType k) const override;
+
   //Constructor...fill S matrix...call correct base-class constructor
   LPQHIBasis(ParticleLayout_t& ref) : LRBasis(ref), NumKnots(0), delta(0.0)
   {

--- a/src/Particle/LongRange/LPQHISRCoulombBasis.cpp
+++ b/src/Particle/LongRange/LPQHISRCoulombBasis.cpp
@@ -75,7 +75,7 @@ void LPQHISRCoulombBasis::set_rc(mRealType rc)
 //}
 
 
-LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::hintr2(int n)
+LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::hintr2(int n) const
 {
   int j             = n / 3;
   int alpha         = n - 3 * j;
@@ -95,7 +95,7 @@ LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::hintr2(int n)
 }
 
 
-LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::c(int m, mRealType k)
+LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::c(int m, mRealType k) const
 {
   int i         = m / 3;
   int alpha     = m - 3 * i;
@@ -127,7 +127,7 @@ LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::c(int m, mRealType k)
 }
 
 
-inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus(int i, mRealType k, int n)
+inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   if (n == 0)
@@ -147,7 +147,7 @@ inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus(i
 }
 
 
-inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus(int i, mRealType k, int n)
+inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   if (n == 0)
@@ -167,20 +167,20 @@ inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus(
 }
 
 
-inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dplus(int i, mRealType k, int n)
+inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dplus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> Z1 = Eplus(i, k, n);
   return 4.0 * M_PI / (k * Lattice.Volume) * (Z1.imag());
 }
 
 
-inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dminus(int i, mRealType k, int n)
+inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dminus(int i, mRealType k, int n) const
 {
   std::complex<mRealType> Z1 = Eminus(i, k, n);
   return -4.0 * M_PI / (k * Lattice.Volume) * (Z1.imag());
 }
 
-LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::dc_dk(int m, mRealType k)
+LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::dc_dk(int m, mRealType k) const
 {
   int i         = m / 3;
   int alpha     = m - 3 * i;
@@ -211,7 +211,7 @@ LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::dc_dk(int m, mRealType k)
   return std::pow(delta, alpha) * (sum);
 }
 
-inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus_dG(int i, mRealType k, int n)
+inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus_dG(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   mRealType ri   = i * delta;
@@ -220,17 +220,13 @@ inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eplus_d
   std::complex<mRealType> eigr(cos(k * ri), sin(k * ri));
 
   if (n == 0)
-  {
     return Eplus(i, k, n) * (eye * ri - kinv) + delta * kinv * eigr * eigd;
-  }
   else
-  {
     return -kinv * Eplus(i, k, n) -
         eye * kinv * (eye * (ri + delta) * eigd * eigr - (n / mRealType(delta)) * Eplus_dG(i, k, n - 1));
-  }
 }
 
-inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus_dG(int i, mRealType k, int n)
+inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus_dG(int i, mRealType k, int n) const
 {
   std::complex<mRealType> eye(0.0, 1.0);
   mRealType ri   = i * delta;
@@ -245,15 +241,13 @@ inline std::complex<LPQHISRCoulombBasis::mRealType> LPQHISRCoulombBasis::Eminus_
     return Eminus(i, k, n) * (eye * ri - kinv) - delta * kinv * eigr * eigd;
   }
   else
-  {
     return -kinv * Eminus(i, k, n) -
         eye * kinv *
         (mRealType(pow(-1.0, n)) * eye * (ri - delta) * eigd * eigr - (n / mRealType(delta)) * Eminus_dG(i, k, n - 1));
-  }
 }
 
 
-inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dplus_dG(int i, mRealType k, int n)
+inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dplus_dG(int i, mRealType k, int n) const
 {
   mRealType kinv             = 1.0 / mRealType(k);
   std::complex<mRealType> Z1 = Eplus_dG(i, k, n);
@@ -262,7 +256,7 @@ inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dplus_dG(int i, mReal
 }
 
 
-inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dminus_dG(int i, mRealType k, int n)
+inline LPQHISRCoulombBasis::mRealType LPQHISRCoulombBasis::Dminus_dG(int i, mRealType k, int n) const
 {
   mRealType kinv             = 1.0 / mRealType(k);
   std::complex<mRealType> Z1 = Eminus_dG(i, k, n);

--- a/src/Particle/LongRange/LPQHISRCoulombBasis.h
+++ b/src/Particle/LongRange/LPQHISRCoulombBasis.h
@@ -69,8 +69,8 @@ public:
   inline mRealType get_delta() const { return delta; }
   //inline int NumBasisElem() const {return 3*NumKnots;}
   void set_NumKnots(int n); // n >= 2 required
-  void set_rc(mRealType rc);
-  inline mRealType h(int n, mRealType r) const
+  void set_rc(mRealType rc) override;
+  inline mRealType h(int n, mRealType r) const override
   {
     int i          = n / 3;
     int alpha      = n - 3 * i;
@@ -95,6 +95,7 @@ public:
           (Sa[0] + x * (Sa[1] + x * (Sa[2] + x * (Sa[3] + x * (Sa[4] + x * Sa[5])))));
     }
   }
+
   inline mRealType rh(int n, mRealType r) const
   {
     int i        = n / 3;
@@ -119,7 +120,7 @@ public:
     }
   }
 
-  inline mRealType dh_dr(int n, mRealType r) const
+  inline mRealType dh_dr(int n, mRealType r) const override
   {
     int i        = n / 3;
     int alpha    = n - 3 * i;
@@ -186,9 +187,10 @@ public:
   //      }
   //    }
 
-  mRealType hintr2(int n) const;
-  mRealType c(int n, mRealType k) const;
-  mRealType dc_dk(int n, mRealType k) const;
+  mRealType hintr2(int n) const override;
+  mRealType c(int n, mRealType k) const override;
+  mRealType dc_dk(int n, mRealType k) const override;
+
   //Constructor...fill S matrix...call correct base-class constructor
   LPQHISRCoulombBasis(ParticleLayout_t& ref) : LRBasis(ref), NumKnots(0), delta(0.0)
   {

--- a/src/Particle/LongRange/LPQHISRCoulombBasis.h
+++ b/src/Particle/LongRange/LPQHISRCoulombBasis.h
@@ -38,14 +38,14 @@ private:
   std::vector<mRealType> tvec; //Coefficients
 
   //Helper functions for computing FT of basis functions (used in c(n,k))
-  inline std::complex<mRealType> Eplus(int i, mRealType k, int n);
-  inline std::complex<mRealType> Eminus(int i, mRealType k, int n);
-  inline std::complex<mRealType> Eplus_dG(int i, mRealType k, int n);
-  inline std::complex<mRealType> Eminus_dG(int i, mRealType k, int n);
-  inline mRealType Dplus(int i, mRealType k, int n);
-  inline mRealType Dminus(int i, mRealType k, int n);
-  inline mRealType Dplus_dG(int i, mRealType k, int n);
-  inline mRealType Dminus_dG(int i, mRealType k, int n);
+  inline std::complex<mRealType> Eplus(int i, mRealType k, int n) const;
+  inline std::complex<mRealType> Eminus(int i, mRealType k, int n) const;
+  inline std::complex<mRealType> Eplus_dG(int i, mRealType k, int n) const;
+  inline std::complex<mRealType> Eminus_dG(int i, mRealType k, int n) const;
+  inline mRealType Dplus(int i, mRealType k, int n) const;
+  inline mRealType Dminus(int i, mRealType k, int n) const;
+  inline mRealType Dplus_dG(int i, mRealType k, int n) const;
+  inline mRealType Dminus_dG(int i, mRealType k, int n) const;
 
 
 public:
@@ -186,9 +186,9 @@ public:
   //      }
   //    }
 
-  mRealType hintr2(int n);
-  mRealType c(int n, mRealType k);
-  mRealType dc_dk(int n, mRealType k);
+  mRealType hintr2(int n) const;
+  mRealType c(int n, mRealType k) const;
+  mRealType dc_dk(int n, mRealType k) const;
   //Constructor...fill S matrix...call correct base-class constructor
   LPQHISRCoulombBasis(ParticleLayout_t& ref) : LRBasis(ref), NumKnots(0), delta(0.0)
   {

--- a/src/Particle/LongRange/LRBasis.h
+++ b/src/Particle/LongRange/LRBasis.h
@@ -51,18 +51,18 @@ public:
   { /*Do nothing*/
   }
 
-  virtual ~LRBasis() {}
+  virtual ~LRBasis() = default;
 
   inline int NumBasisElem() const { return BasisSize; }
 
   //Real-space basis function + integral: override these
   virtual mRealType h(int n, mRealType r) const = 0;
-  virtual mRealType hintr2(int n)               = 0;
+  virtual mRealType hintr2(int n) const         = 0;
   virtual mRealType dh_dr(int n, mRealType r) const { return 0.0; };
   //k-space basis function: override this
-  virtual mRealType c(int m, mRealType k) = 0;
+  virtual mRealType c(int m, mRealType k) const = 0;
   //k-space basis function k space derivative.
-  virtual mRealType dc_dk(int m, mRealType k) { return 0.0; };
+  virtual mRealType dc_dk(int m, mRealType k) const { return 0.0; };
 
   //
   // df(m,r) is included for legacy reasons.  Please use dh_dr
@@ -83,7 +83,7 @@ public:
  * 
  */
 
-  inline mRealType f(mRealType r, std::vector<mRealType>& coefs)
+  inline mRealType f(mRealType r, const std::vector<mRealType>& coefs) const
   {
     mRealType f = 0.0;
     //RealType df = myFunc.df(r, rinv);
@@ -101,7 +101,7 @@ public:
  * 
  */
 
-  inline mRealType df_dr(mRealType r, std::vector<mRealType>& coefs)
+  inline mRealType df_dr(mRealType r, const std::vector<mRealType>& coefs) const
   {
     mRealType df = 0.0;
     //RealType df = myFunc.df(r, rinv);
@@ -120,7 +120,7 @@ public:
  */
 
 
-  inline mRealType fk(mRealType k, std::vector<mRealType> coefs)
+  inline mRealType fk(mRealType k, const std::vector<mRealType> coefs) const
   {
     mRealType fk = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -137,7 +137,7 @@ public:
  * 
  */
 
-  inline mRealType dfk_dk(mRealType k, std::vector<mRealType> coefs)
+  inline mRealType dfk_dk(mRealType k, const std::vector<mRealType> coefs) const
   {
     mRealType dfk = 0.0;
     for (int n = 0; n < coefs.size(); n++)

--- a/src/Particle/LongRange/LRBasis.h
+++ b/src/Particle/LongRange/LRBasis.h
@@ -147,10 +147,10 @@ public:
 
   //May need extra functionality when resetting rc. Override this.
   virtual void set_rc(mRealType rc) = 0;
-  inline mRealType get_rc() { return m_rc; }
-  inline mRealType get_CellVolume() { return Lattice.Volume; }
-  inline ParticleLayout_t& get_Lattice() { return Lattice; }
+  inline mRealType get_rc() const { return m_rc; }
+  inline mRealType get_CellVolume() const { return Lattice.Volume; }
   inline void set_Lattice(ParticleLayout_t& ref) { Lattice = ref; }
+  inline ParticleLayout_t& get_Lattice() const { return Lattice; }
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/LRBreakup.h
+++ b/src/Particle/LongRange/LRBreakup.h
@@ -132,8 +132,7 @@ struct LRBreakup
     int LWORK  = 10 * std::max(3 * std::min(N, M) + std::max(M, N), 5 * std::min(M, N));
     std::vector<mRealType> WORK(LWORK);
     int INFO;
-    LAPACK::gesvd(JOBU, JOBVT, M, N, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
-                  INFO);
+    LAPACK::gesvd(JOBU, JOBVT, M, N, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
     assert(INFO == 0);
     int ur = U.rows();
     int uc = U.cols();
@@ -258,8 +257,7 @@ struct LRBreakup
     int LWORK  = 10 * std::max(3 * std::min(N, M) + std::max(M, N), 5 * std::min(M, N));
     std::vector<mRealType> WORK(LWORK);
     int INFO;
-    LAPACK::gesvd(JOBU, JOBVT, M, N, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
-                  INFO);
+    LAPACK::gesvd(JOBU, JOBVT, M, N, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
     assert(INFO == 0);
     int ur = U.rows();
     int uc = U.cols();
@@ -508,8 +506,7 @@ typename LRBreakup<BreakupBasis>::mRealType LRBreakup<BreakupBasis>::DoBreakup(m
   int LWORK  = 10 * std::max(3 * std::min(n, m) + std::max(m, n), 5 * std::min(m, n));
   std::vector<mRealType> WORK(LWORK);
   int INFO;
-  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
-                INFO);
+  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
   assert(INFO == 0);
   int ur = U.rows();
   int uc = U.cols();
@@ -678,8 +675,7 @@ typename LRBreakup<BreakupBasis>::mRealType LRBreakup<BreakupBasis>::DoGradBreak
   int LWORK  = 10 * std::max(3 * std::min(n, m) + std::max(m, n), 5 * std::min(m, n));
   std::vector<mRealType> WORK(LWORK);
   int INFO;
-  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
-                INFO);
+  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
   assert(INFO == 0);
   int ur = U.rows();
   int uc = U.cols();
@@ -848,8 +844,7 @@ typename LRBreakup<BreakupBasis>::mRealType LRBreakup<BreakupBasis>::DoStrainBre
   int LWORK  = 10 * std::max(3 * std::min(n, m) + std::max(m, n), 5 * std::min(m, n));
   std::vector<mRealType> WORK(LWORK);
   int INFO;
-  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
-                INFO);
+  LAPACK::gesvd(JOBU, JOBVT, m, n, Atrans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
   assert(INFO == 0);
   int ur = U.rows();
   int uc = U.cols();
@@ -1090,16 +1085,15 @@ void LRBreakup<BreakupBasis>::DoAllBreakup(mRealType* chisqrlist,
   int LWORK  = 10 * std::max(3 * std::min(n, m) + std::max(m, n), 5 * std::min(m, n));
   std::vector<mRealType> WORK(LWORK);
   int INFO;
-  LAPACK::gesvd(JOBU, JOBVT, m, n, A_trans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK,
+  LAPACK::gesvd(JOBU, JOBVT, m, n, A_trans.data(), LDA, &S[0], U.data(), LDU, V.data(), LDVT, &WORK[0], LWORK, INFO);
+  assert(INFO == 0);
+
+  LAPACK::gesvd(JOBU, JOBVT, m, n, Af_trans.data(), LDA, &Sf[0], Uf.data(), LDU, Vf.data(), LDVT, &WORK[0], LWORK,
                 INFO);
   assert(INFO == 0);
 
-  LAPACK::gesvd(JOBU, JOBVT, m, n, Af_trans.data(), LDA, &Sf[0], Uf.data(), LDU, Vf.data(), LDVT, &WORK[0],
-                LWORK, INFO);
-  assert(INFO == 0);
-
-  LAPACK::gesvd(JOBU, JOBVT, m, n, As_trans.data(), LDA, &Ss[0], Us.data(), LDU, Vs.data(), LDVT, &WORK[0],
-                LWORK, INFO);
+  LAPACK::gesvd(JOBU, JOBVT, m, n, As_trans.data(), LDA, &Ss[0], Us.data(), LDU, Vs.data(), LDVT, &WORK[0], LWORK,
+                INFO);
   assert(INFO == 0);
 
   int ur = U.rows();

--- a/src/Particle/LongRange/LRCoulombSingleton.cpp
+++ b/src/Particle/LongRange/LRCoulombSingleton.cpp
@@ -47,7 +47,7 @@ struct CoulombFunctor
   inline CoulombFunctor() {}
   void reset(ParticleSet& ref) { NormFactor = 4.0 * M_PI / ref.LRBox.Volume; }
   void reset(ParticleSet& ref, T rs) { NormFactor = 4.0 * M_PI / ref.LRBox.Volume; }
-  inline T operator()(T r, T rinv) { return rinv; }
+  inline T operator()(T r, T rinv) const { return rinv; }
   inline T df(T r) { return -1.0 / (r * r); }
   inline T df2(T r) { return 2.0 / (r * r * r); }
   inline T Vk(T k) { return NormFactor / (k * k); }
@@ -71,7 +71,7 @@ struct CoulombFunctor
   inline CoulombFunctor() {}
   void reset(ParticleSet& ref) { NormFactor = 2.0 * M_PI / ref.LRBox.Volume; }
   void reset(ParticleSet& ref, T rs) { NormFactor = 2.0 * M_PI / ref.LRBox.Volume; }
-  inline T operator()(T r, T rinv) { return rinv; }
+  inline T operator()(T r, T rinv) const { return rinv; }
   inline T df(T r) { return -1.0 / (r * r); }
   inline T df2(T r) { return 2 / (r * r * r); }
   inline T Fk(T k, T rc) { return NormFactor / k * std::cos(k * rc); }
@@ -81,31 +81,6 @@ struct CoulombFunctor
   inline T integrate_r2(T r) const { return 0.5 * r * r; }
 };
 #endif
-
-template<class T = double>
-struct PseudoCoulombFunctor
-{
-  //typedef OneDimCubicSpline<T> RadialFunctorType;
-  typedef OneDimLinearSpline<T> RadialFunctorType;
-  RadialFunctorType& radFunc;
-  T NormFactor;
-  inline PseudoCoulombFunctor(RadialFunctorType& rfunc) : radFunc(rfunc) {}
-  void reset(ParticleSet& ref) { NormFactor = 4.0 * M_PI / ref.LRBox.Volume; }
-  inline T operator()(T r, T rinv) { return radFunc.splint(r); }
-  inline T df(T r)
-  {
-    T du, d2u;
-    radFunc.splint(r, du, d2u);
-    return du;
-  }
-  inline T Fk(T k, T rc) { return NormFactor / (k * k) * std::cos(k * rc); }
-  inline T Xk(T k, T rc) { return -NormFactor / (k * k) * std::cos(k * rc); }
-  inline T integrate_r2(T r) const
-  {
-    //fix this to return the integration
-    return 0.5 * r * r;
-  }
-};
 
 
 std::unique_ptr<LRCoulombSingleton::LRHandlerType> LRCoulombSingleton::getHandler(ParticleSet& ref)

--- a/src/Particle/LongRange/LRCoulombSingleton.cpp
+++ b/src/Particle/LongRange/LRCoulombSingleton.cpp
@@ -48,18 +48,13 @@ struct CoulombFunctor
   void reset(ParticleSet& ref) { NormFactor = 4.0 * M_PI / ref.LRBox.Volume; }
   void reset(ParticleSet& ref, T rs) { NormFactor = 4.0 * M_PI / ref.LRBox.Volume; }
   inline T operator()(T r, T rinv) const { return rinv; }
-  inline T df(T r) { return -1.0 / (r * r); }
-  inline T df2(T r) { return 2.0 / (r * r * r); }
-  inline T Vk(T k) { return NormFactor / (k * k); }
+  inline T df(T r) const { return -1.0 / (r * r); }
+  inline T Vk(T k) const { return NormFactor / (k * k); }
 
-  inline T Xk_dk(T k) { return 0.0; }
-  inline T Fk(T k, T rc) { return NormFactor / (k * k) * std::cos(k * rc); }
-  inline T Xk(T k, T rc) { return -NormFactor / (k * k) * std::cos(k * rc); }
+  inline T Fk(T k, T rc) const { return NormFactor / (k * k) * std::cos(k * rc); }
+  inline T Xk(T k, T rc) const { return -NormFactor / (k * k) * std::cos(k * rc); }
 
-  inline T dVk_dk(T k) { return -2 * NormFactor / k / k / k; }
-  inline T dFk_dk(T k, T rc) { return -NormFactor / k / k * (2.0 / k * std::cos(k * rc) + rc * std::sin(k * rc)); }
-
-  inline T dXk_dk(T k, T rc) { return NormFactor / k / k * (2.0 / k * std::cos(k * rc) + rc * std::sin(k * rc)); }
+  inline T dVk_dk(T k) const { return -2 * NormFactor / k / k / k; }
 
   inline T integrate_r2(T r) const { return 0.5 * r * r; }
 };
@@ -72,10 +67,9 @@ struct CoulombFunctor
   void reset(ParticleSet& ref) { NormFactor = 2.0 * M_PI / ref.LRBox.Volume; }
   void reset(ParticleSet& ref, T rs) { NormFactor = 2.0 * M_PI / ref.LRBox.Volume; }
   inline T operator()(T r, T rinv) const { return rinv; }
-  inline T df(T r) { return -1.0 / (r * r); }
-  inline T df2(T r) { return 2 / (r * r * r); }
-  inline T Fk(T k, T rc) { return NormFactor / k * std::cos(k * rc); }
-  inline T Xk(T k, T rc) { return -NormFactor / k * std::cos(k * rc); }
+  inline T df(T r) const { return -1.0 / (r * r); }
+  inline T Fk(T k, T rc) const { return NormFactor / k * std::cos(k * rc); }
+  inline T Xk(T k, T rc) const { return -NormFactor / k * std::cos(k * rc); }
 
 
   inline T integrate_r2(T r) const { return 0.5 * r * r; }

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -55,7 +55,7 @@ struct LRHandlerBase
   ///Coefficient for strain fit.
   std::vector<mRealType> gstraincoefs;
 
-  virtual mRealType evaluate_vlr_k(mRealType k) = 0;
+  virtual mRealType evaluate_vlr_k(mRealType k) const = 0;
 
 
   //constructor
@@ -91,7 +91,7 @@ struct LRHandlerBase
     return vk;
   }
 
-  inline mRealType evaluate_w_sk(const std::vector<int>& kshell, const pRealType* restrict sk)
+  inline mRealType evaluate_w_sk(const std::vector<int>& kshell, const pRealType* restrict sk) const
   {
     mRealType vk = 0.0;
     for (int ks = 0, ki = 0; ks < MaxKshell; ks++)
@@ -125,7 +125,7 @@ struct LRHandlerBase
   virtual mRealType evaluate_slab(pRealType z,
                                   const std::vector<int>& kshell,
                                   const pComplexType* restrict eikr_i,
-                                  const pComplexType* restrict eikr_j)
+                                  const pComplexType* restrict eikr_j) const
   {
     return 0.0;
   }
@@ -181,7 +181,7 @@ struct LRHandlerBase
                            const ParticleSet& B,
                            int specB,
                            std::vector<pRealType>& Zat,
-                           std::vector<TinyVector<pRealType, OHMMS_DIM>>& grad1)
+                           std::vector<TinyVector<pRealType, OHMMS_DIM>>& grad1) const
   {
 #if !defined(USE_REAL_STRUCT_FACTOR)
     const Matrix<pComplexType>& e2ikrA = A.SK->eikr;
@@ -219,7 +219,7 @@ struct LRHandlerBase
                                                         const pRealType* rhokA_r,
                                                         const pRealType* rhokA_i,
                                                         const pRealType* rhokB_r,
-                                                        const pRealType* rhokB_i)
+                                                        const pRealType* rhokB_i) const
   {
     SymTensor<pRealType, OHMMS_DIM> stress;
     for (int ki = 0; ki < dFk_dstrain.size(); ki++)
@@ -233,7 +233,7 @@ struct LRHandlerBase
   ///FIX_PRECISION
   inline SymTensor<pRealType, OHMMS_DIM> evaluateStress(const std::vector<int>& kshell,
                                                         const pComplexType* rhokA,
-                                                        const pComplexType* rhokB)
+                                                        const pComplexType* rhokB) const
   {
     SymTensor<pRealType, OHMMS_DIM> stress;
     for (int ki = 0; ki < dFk_dstrain.size(); ki++)
@@ -245,20 +245,20 @@ struct LRHandlerBase
 
   /** evaluate \f$ v_{s}(k=0) = \frac{4\pi}{V}\int_0^{r_c} r^2 v_s(r) dr \f$
    */
-  virtual mRealType evaluateSR_k0() { return 0.0; }
+  virtual mRealType evaluateSR_k0() const { return 0.0; }
   /** evaluate \f$ v_s(r=0) \f$ for the self-interaction term
    */
-  virtual mRealType evaluateLR_r0() { return 0.0; }
+  virtual mRealType evaluateLR_r0() const { return 0.0; }
 
   ///These functions return the strain derivatives of all corresponding quantities
   /// in total energy.  See documentation (forthcoming).
-  virtual SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() { return 0; };
-  virtual SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() { return 0; };
-  virtual SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag)
+  virtual SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() const { return 0; };
+  virtual SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() const { return 0; };
+  virtual SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag) const
   {
     return 0;
   };
-  virtual SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag)
+  virtual SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag) const
   {
     return 0;
   };
@@ -268,10 +268,10 @@ struct LRHandlerBase
   virtual void resetTargetParticleSet(ParticleSet& ref)   = 0;
 
   virtual mRealType evaluate(mRealType r, mRealType rinv) const = 0;
-  virtual mRealType evaluateLR(mRealType r)                     = 0;
-  virtual mRealType srDf(mRealType r, mRealType rinv)           = 0;
+  virtual mRealType evaluateLR(mRealType r) const               = 0;
+  virtual mRealType srDf(mRealType r, mRealType rinv) const     = 0;
 
-  virtual mRealType lrDf(mRealType r)
+  virtual mRealType lrDf(mRealType r) const
   {
     APP_ABORT("Error: lrDf(r) is not implemented in " + ClassName + "\n");
     return 0.0;
@@ -325,10 +325,10 @@ struct DummyLRHandler : public LRHandlerBase
     }
   }
 
-  mRealType evaluate_vlr_k(mRealType k) override { return 0.0; }
+  mRealType evaluate_vlr_k(mRealType k) const override { return 0.0; }
   mRealType evaluate(mRealType r, mRealType rinv) const override { return 0.0; }
-  mRealType evaluateLR(mRealType r) override { return 0.0; }
-  mRealType srDf(mRealType r, mRealType rinv) override { return 0.0; }
+  mRealType evaluateLR(mRealType r) const override { return 0.0; }
+  mRealType srDf(mRealType r, mRealType rinv) const override { return 0.0; }
   void Breakup(ParticleSet& ref, mRealType rs_in) override {}
   void resetTargetParticleSet(ParticleSet& ref) override {}
   virtual LRHandlerBase* makeClone(ParticleSet& ref) const override { return new DummyLRHandler<Func>(LR_kc); }

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -78,7 +78,7 @@ struct LRHandlerBase
    */
   inline mRealType evaluate(const std::vector<int>& kshell,
                             const pComplexType* restrict rk1,
-                            const pComplexType* restrict rk2)
+                            const pComplexType* restrict rk2) const
   {
     mRealType vk = 0.0;
     for (int ks = 0, ki = 0; ks < MaxKshell; ks++)
@@ -108,7 +108,7 @@ struct LRHandlerBase
                             const pRealType* restrict rk1_r,
                             const pRealType* restrict rk1_i,
                             const pRealType* restrict rk2_r,
-                            const pRealType* restrict rk2_i)
+                            const pRealType* restrict rk2_i) const
   {
     mRealType vk = 0.0;
     for (int ks = 0, ki = 0; ks < MaxKshell; ks++)
@@ -130,7 +130,7 @@ struct LRHandlerBase
     return 0.0;
   }
 
-  inline mRealType evaluate(const std::vector<int>& kshell, int iat, const pComplexType* restrict rk2, ParticleSet& P)
+  inline mRealType evaluate(const std::vector<int>& kshell, int iat, const pComplexType* restrict rk2, ParticleSet& P) const
   {
     mRealType vk = 0.0;
 #if !defined(USE_REAL_STRUCT_FACTOR)
@@ -152,7 +152,7 @@ struct LRHandlerBase
                             int iat,
                             const pRealType* restrict rk2_r,
                             const pRealType* restrict rk2_i,
-                            ParticleSet& P)
+                            ParticleSet& P) const
   {
     mRealType vk = 0.0;
 #if defined(USE_REAL_STRUCT_FACTOR)
@@ -267,9 +267,9 @@ struct LRHandlerBase
   virtual void Breakup(ParticleSet& ref, mRealType rs_in) = 0;
   virtual void resetTargetParticleSet(ParticleSet& ref)   = 0;
 
-  virtual mRealType evaluate(mRealType r, mRealType rinv) = 0;
-  virtual mRealType evaluateLR(mRealType r)               = 0;
-  virtual mRealType srDf(mRealType r, mRealType rinv)     = 0;
+  virtual mRealType evaluate(mRealType r, mRealType rinv) const = 0;
+  virtual mRealType evaluateLR(mRealType r)                     = 0;
+  virtual mRealType srDf(mRealType r, mRealType rinv)           = 0;
 
   virtual mRealType lrDf(mRealType r)
   {
@@ -278,7 +278,7 @@ struct LRHandlerBase
   };
 
   /** make clone */
-  virtual LRHandlerBase* makeClone(ParticleSet& ref) = 0;
+  virtual LRHandlerBase* makeClone(ParticleSet& ref) const = 0;
 
 protected:
   std::string ClassName;
@@ -326,12 +326,12 @@ struct DummyLRHandler : public LRHandlerBase
   }
 
   mRealType evaluate_vlr_k(mRealType k) override { return 0.0; }
-  mRealType evaluate(mRealType r, mRealType rinv) override { return 0.0; }
+  mRealType evaluate(mRealType r, mRealType rinv) const override { return 0.0; }
   mRealType evaluateLR(mRealType r) override { return 0.0; }
   mRealType srDf(mRealType r, mRealType rinv) override { return 0.0; }
   void Breakup(ParticleSet& ref, mRealType rs_in) override {}
   void resetTargetParticleSet(ParticleSet& ref) override {}
-  virtual LRHandlerBase* makeClone(ParticleSet& ref) override { return new DummyLRHandler<Func>(LR_kc); }
+  virtual LRHandlerBase* makeClone(ParticleSet& ref) const override { return new DummyLRHandler<Func>(LR_kc); }
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -62,7 +62,7 @@ struct LRHandlerBase
   explicit LRHandlerBase(mRealType kc) : MaxKshell(0), LR_kc(kc), LR_rc(0), ClassName("LRHandlerBase") {}
 
   // virtual destructor
-  virtual ~LRHandlerBase() {}
+  virtual ~LRHandlerBase() = default;
 
   //return r cutoff
   inline mRealType get_rc() const { return LR_rc; }

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -130,7 +130,10 @@ struct LRHandlerBase
     return 0.0;
   }
 
-  inline mRealType evaluate(const std::vector<int>& kshell, int iat, const pComplexType* restrict rk2, ParticleSet& P) const
+  inline mRealType evaluate(const std::vector<int>& kshell,
+                            int iat,
+                            const pComplexType* restrict rk2,
+                            ParticleSet& P) const
   {
     mRealType vk = 0.0;
 #if !defined(USE_REAL_STRUCT_FACTOR)

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -77,7 +77,7 @@ public:
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.LRBox)
   {}
 
-  LRHandlerBase* makeClone(ParticleSet& ref)
+  LRHandlerBase* makeClone(ParticleSet& ref) const
   {
     LRHandlerSRCoulomb* tmp = new LRHandlerSRCoulomb<Func, BreakupBasis>(*this, ref);
     //    tmp->makeSplines(1001);
@@ -110,7 +110,7 @@ public:
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv)
+  inline mRealType evaluate(mRealType r, mRealType rinv) const
   {
     //Right now LRHandlerSRCoulomb is the force only handler.  This is why the gcoefs are used for evaluate.
     mRealType v = Basis.f(r, gcoefs);

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -169,7 +169,7 @@ public:
   }
 
   //This returns the stress derivative of Fk, except for the explicit volume dependence.  The explicit volume dependence is factored away into V.
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<mRealType, OHMMS_DIM> k, mRealType kmag) const override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<pRealType, OHMMS_DIM> k, pRealType kmag) const override
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
@@ -185,7 +185,7 @@ public:
   }
 
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<mRealType, OHMMS_DIM> r, mRealType rmag) const override
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<pRealType, OHMMS_DIM> r, pRealType rmag) const override
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -77,14 +77,14 @@ public:
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.LRBox)
   {}
 
-  LRHandlerBase* makeClone(ParticleSet& ref) const
+  LRHandlerBase* makeClone(ParticleSet& ref) const override
   {
     LRHandlerSRCoulomb* tmp = new LRHandlerSRCoulomb<Func, BreakupBasis>(*this, ref);
     //    tmp->makeSplines(1001);
     return tmp;
   }
 
-  void initBreakup(ParticleSet& ref)
+  void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.LRBox, 1);
     //    fillYk(ref.SK->KLists);
@@ -94,7 +94,7 @@ public:
     LR_rc = Basis.get_rc();
   }
 
-  void Breakup(ParticleSet& ref, mRealType rs_ext)
+  void Breakup(ParticleSet& ref, mRealType rs_ext) override
   {
     rs = rs_ext;
     myFunc.reset(ref, rs);
@@ -106,25 +106,25 @@ public:
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) { myFunc.reset(ref); }
+  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) const
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     //Right now LRHandlerSRCoulomb is the force only handler.  This is why the gcoefs are used for evaluate.
     mRealType v = Basis.f(r, gcoefs);
     return v;
   }
 
-  inline mRealType evaluate_vlr_k(mRealType k) const { return evalYk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const override { return evalYk(k); }
 
   /**  evaluate the first derivative of the short range part at r
    *
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) const
+  inline mRealType srDf(mRealType r, mRealType rinv) const override
   {
     mRealType df = Basis.df_dr(r, gcoefs);
     return df;
@@ -137,21 +137,21 @@ public:
     return df;
   }
 
-  inline mRealType lrDf(mRealType r) const
+  inline mRealType lrDf(mRealType r) const override
   {
     mRealType lr = myFunc.df(r) - srDf(r, 1.0 / r);
     return lr;
   }
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) const
+  inline mRealType evaluateLR(mRealType r) const override
   {
     mRealType v = 0.0;
     v           = myFunc(r, 1.0 / r) - evaluate(r, 1.0 / r);
     return v;
   }
 
-  inline mRealType evaluateSR_k0() const
+  inline mRealType evaluateSR_k0() const override
   {
     mRealType v0 = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -160,7 +160,7 @@ public:
   }
 
 
-  inline mRealType evaluateLR_r0() const
+  inline mRealType evaluateLR_r0() const override
   {
     //this is because the constraint v(r)=sigma(r) as r-->0.
     // so v(r)-sigma(r)="0".  Divergence prevents me from coding this.
@@ -169,7 +169,7 @@ public:
   }
 
   //This returns the stress derivative of Fk, except for the explicit volume dependence.  The explicit volume dependence is factored away into V.
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<mRealType, OHMMS_DIM> k, mRealType kmag) const
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<mRealType, OHMMS_DIM> k, mRealType kmag) const override
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
@@ -185,7 +185,7 @@ public:
   }
 
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<mRealType, OHMMS_DIM> r, mRealType rmag) const
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<mRealType, OHMMS_DIM> r, mRealType rmag) const override
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
@@ -200,7 +200,7 @@ public:
     return deriv_tensor;
   }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() const
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() const override
   {
     APP_ABORT("Stresses not supported yet\n");
     mRealType v0   = 0.0;
@@ -224,7 +224,7 @@ public:
     return 0.0; //Basis.f(0,dcoefs(i,j));
   }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() const
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() const override
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> stress;

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -117,41 +117,41 @@ public:
     return v;
   }
 
-  inline mRealType evaluate_vlr_k(mRealType k) { return evalYk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const { return evalYk(k); }
 
   /**  evaluate the first derivative of the short range part at r
    *
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv)
+  inline mRealType srDf(mRealType r, mRealType rinv) const
   {
     mRealType df = Basis.df_dr(r, gcoefs);
     return df;
   }
 
-  inline mRealType srDf_strain(mRealType r, mRealType rinv)
+  inline mRealType srDf_strain(mRealType r, mRealType rinv) const
   {
     APP_ABORT("Stresses not supported yet\n");
     mRealType df = Basis.df_dr(r, gstraincoefs);
     return df;
   }
 
-  inline mRealType lrDf(mRealType r)
+  inline mRealType lrDf(mRealType r) const
   {
     mRealType lr = myFunc.df(r) - srDf(r, 1.0 / r);
     return lr;
   }
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r)
+  inline mRealType evaluateLR(mRealType r) const
   {
     mRealType v = 0.0;
     v           = myFunc(r, 1.0 / r) - evaluate(r, 1.0 / r);
     return v;
   }
 
-  inline mRealType evaluateSR_k0()
+  inline mRealType evaluateSR_k0() const
   {
     mRealType v0 = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -160,7 +160,7 @@ public:
   }
 
 
-  inline mRealType evaluateLR_r0()
+  inline mRealType evaluateLR_r0() const
   {
     //this is because the constraint v(r)=sigma(r) as r-->0.
     // so v(r)-sigma(r)="0".  Divergence prevents me from coding this.
@@ -169,7 +169,7 @@ public:
   }
 
   //This returns the stress derivative of Fk, except for the explicit volume dependence.  The explicit volume dependence is factored away into V.
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<mRealType, OHMMS_DIM> k, mRealType kmag)
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_dstrain(TinyVector<mRealType, OHMMS_DIM> k, mRealType kmag) const
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
@@ -185,7 +185,7 @@ public:
   }
 
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<mRealType, OHMMS_DIM> r, mRealType rmag)
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_dstrain(TinyVector<mRealType, OHMMS_DIM> r, mRealType rmag) const
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> deriv_tensor = 0;
@@ -200,7 +200,7 @@ public:
     return deriv_tensor;
   }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain()
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateSR_k0_dstrain() const
   {
     APP_ABORT("Stresses not supported yet\n");
     mRealType v0   = 0.0;
@@ -217,14 +217,14 @@ public:
     return stress;
   }
 
-  inline mRealType evaluateLR_r0_dstrain(int i, int j)
+  inline mRealType evaluateLR_r0_dstrain(int i, int j) const
   {
     APP_ABORT("Stresses not supported yet\n");
     //the t derivative for the relevant basis elements are all zero because of constraints.
     return 0.0; //Basis.f(0,dcoefs(i,j));
   }
 
-  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain()
+  inline SymTensor<mRealType, OHMMS_DIM> evaluateLR_r0_dstrain() const
   {
     APP_ABORT("Stresses not supported yet\n");
     SymTensor<mRealType, OHMMS_DIM> stress;
@@ -232,7 +232,7 @@ public:
   }
 
 private:
-  inline mRealType evalYk(mRealType k)
+  inline mRealType evalYk(mRealType k) const
   {
     //FatK = 4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());
     mRealType FatK = myFunc.Vk(k) - Basis.fk(k, coefs);
@@ -240,14 +240,14 @@ private:
     //    FatK -= coefs[n]*Basis.c(n,k);
     return FatK;
   }
-  inline mRealType evalYkg(mRealType k)
+  inline mRealType evalYkg(mRealType k) const
   {
     mRealType FatK = myFunc.Vk(k) - Basis.fk(k, gcoefs);
     //for(int n=0; n<Basis.NumBasisElem(); n++)
     //   FatK -= gcoefs[n]*Basis.c(n,k);
     return FatK;
   }
-  inline mRealType evalYkgstrain(mRealType k)
+  inline mRealType evalYkgstrain(mRealType k) const
   {
     APP_ABORT("Stresses not supported yet\n");
     mRealType FatK = myFunc.Vk(k) - Basis.fk(k, gstraincoefs);
@@ -256,7 +256,7 @@ private:
     return FatK;
   }
 
-  inline mRealType evaldYkgstrain(mRealType k)
+  inline mRealType evaldYkgstrain(mRealType k) const
   {
     APP_ABORT("Stresses not supported yet\n");
     mRealType dFk_dk = myFunc.dVk_dk(k) - Basis.dfk_dk(k, gstraincoefs);

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -115,7 +115,7 @@ public:
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv)
+  inline mRealType srDf(mRealType r, mRealType rinv) const
   {
     APP_ABORT("LRHandlerTemp::srDF not implemented (missing gcoefs)");
     mRealType df = 0.0;
@@ -128,12 +128,12 @@ public:
     return df;
   }
 
-  inline mRealType evaluate_vlr_k(mRealType k) { return evalFk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const { return evalFk(k); }
 
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r)
+  inline mRealType evaluateLR(mRealType r) const
   {
     mRealType v = 0.0;
     if (r >= LR_rc)
@@ -142,9 +142,10 @@ public:
       v += coefs[n] * Basis.h(n, r);
     return v;
   }
+
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType lrDf(mRealType r)
+  inline mRealType lrDf(mRealType r) const
   {
     APP_ABORT("LRHandlerTemp::lrDF not implemented (missing gcoefs)");
     mRealType dv = 0.0;
@@ -160,7 +161,7 @@ public:
   }
 
 
-  inline mRealType evaluateSR_k0()
+  inline mRealType evaluateSR_k0() const
   {
     mRealType v0 = myFunc.integrate_r2(Basis.get_rc());
     for (int n = 0; n < coefs.size(); n++)
@@ -168,7 +169,7 @@ public:
     return v0 * 2.0 * TWOPI / Basis.get_CellVolume();
   }
 
-  inline mRealType evaluateLR_r0()
+  inline mRealType evaluateLR_r0() const
   {
     mRealType v0 = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -177,7 +178,7 @@ public:
   }
 
 private:
-  inline mRealType evalFk(mRealType k)
+  inline mRealType evalFk(mRealType k) const
   {
     //FatK = 4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());
     mRealType FatK = myFunc.Fk(k, Basis.get_rc());
@@ -185,7 +186,7 @@ private:
       FatK += coefs[n] * Basis.c(n, k);
     return FatK;
   }
-  inline mRealType evalXk(mRealType k)
+  inline mRealType evalXk(mRealType k) const
   {
     //RealType FatK;
     //FatK = -4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -76,16 +76,16 @@ public:
     fillFk(ref.SK->KLists);
   }
 
-  LRHandlerBase* makeClone(ParticleSet& ref) const { return new LRHandlerTemp<Func, BreakupBasis>(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new LRHandlerTemp<Func, BreakupBasis>(*this, ref); }
 
-  void initBreakup(ParticleSet& ref)
+  void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.LRBox, 1);
     fillFk(ref.SK->KLists);
     LR_rc = Basis.get_rc();
   }
 
-  void Breakup(ParticleSet& ref, mRealType rs_ext)
+  void Breakup(ParticleSet& ref, mRealType rs_ext) override
   {
     //ref.LRBox.Volume=ref.getTotalNum()*4.0*M_PI/3.0*rs*rs*rs;
     rs = rs_ext;
@@ -95,11 +95,11 @@ public:
     LR_rc = Basis.get_rc();
   }
 
-  void resetTargetParticleSet(ParticleSet& ref) { myFunc.reset(ref); }
+  void resetTargetParticleSet(ParticleSet& ref) override { myFunc.reset(ref); }
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) const
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;
     if (r >= LR_rc)
@@ -115,7 +115,7 @@ public:
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) const
+  inline mRealType srDf(mRealType r, mRealType rinv) const override
   {
     APP_ABORT("LRHandlerTemp::srDF not implemented (missing gcoefs)");
     mRealType df = 0.0;
@@ -128,12 +128,12 @@ public:
     return df;
   }
 
-  inline mRealType evaluate_vlr_k(mRealType k) const { return evalFk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const override { return evalFk(k); }
 
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) const
+  inline mRealType evaluateLR(mRealType r) const override
   {
     mRealType v = 0.0;
     if (r >= LR_rc)
@@ -145,7 +145,7 @@ public:
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType lrDf(mRealType r) const
+  inline mRealType lrDf(mRealType r) const override
   {
     APP_ABORT("LRHandlerTemp::lrDF not implemented (missing gcoefs)");
     mRealType dv = 0.0;
@@ -161,7 +161,7 @@ public:
   }
 
 
-  inline mRealType evaluateSR_k0() const
+  inline mRealType evaluateSR_k0() const override
   {
     mRealType v0 = myFunc.integrate_r2(Basis.get_rc());
     for (int n = 0; n < coefs.size(); n++)
@@ -169,7 +169,7 @@ public:
     return v0 * 2.0 * TWOPI / Basis.get_CellVolume();
   }
 
-  inline mRealType evaluateLR_r0() const
+  inline mRealType evaluateLR_r0() const override
   {
     mRealType v0 = 0.0;
     for (int n = 0; n < coefs.size(); n++)

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -76,7 +76,7 @@ public:
     fillFk(ref.SK->KLists);
   }
 
-  LRHandlerBase* makeClone(ParticleSet& ref) { return new LRHandlerTemp<Func, BreakupBasis>(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const { return new LRHandlerTemp<Func, BreakupBasis>(*this, ref); }
 
   void initBreakup(ParticleSet& ref)
   {
@@ -99,7 +99,7 @@ public:
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv)
+  inline mRealType evaluate(mRealType r, mRealType rinv) const
   {
     mRealType v = 0.0;
     if (r >= LR_rc)

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -113,7 +113,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) override
+  inline mRealType srDf(mRealType r, mRealType rinv) const override
   {
     mRealType df = 0.0;
     //mRealType df = myFunc.df(r, rinv);
@@ -125,7 +125,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) override
+  inline mRealType evaluateLR(mRealType r) const override
   {
     mRealType vk = 0.0;
     return vk;
@@ -158,10 +158,10 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     return vk;
   }
 
-  inline mRealType evaluate_vlr_k(mRealType k) override { return evalFk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const override { return evalFk(k); }
 
 private:
-  inline mRealType evalFk(mRealType k)
+  inline mRealType evalFk(mRealType k) const
   {
     //FatK = 4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());
     mRealType FatK = myFunc.Fk(k, Basis.get_rc());
@@ -170,7 +170,7 @@ private:
     return FatK;
   }
 
-  inline mRealType evalXk(mRealType k)
+  inline mRealType evalXk(mRealType k) const
   {
     //mRealType FatK;
     //FatK = -4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -74,7 +74,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     fillFk(ref.SK->KLists);
   }
 
-  LRHandlerBase* makeClone(ParticleSet& ref) override
+  LRHandlerBase* makeClone(ParticleSet& ref) const override
   {
     return new LRRPABFeeHandlerTemp<Func, BreakupBasis>(*this, ref);
   }
@@ -100,7 +100,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) override
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -141,7 +141,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
    */
   inline mRealType evaluate(const std::vector<int>& kshell,
                             const pComplexType* restrict rk1,
-                            const pComplexType* restrict rk2)
+                            const pComplexType* restrict rk2) const
   {
     mRealType vk = 0.0;
     for (int ks = 0, ki = 0; ks < MaxKshell; ks++)

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -112,7 +112,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
    * @param r  radius
    * @param rinv 1/r
    */
-  inline mRealType srDf(mRealType r, mRealType rinv) override
+  inline mRealType srDf(mRealType r, mRealType rinv) const override
   {
     mRealType df = 0.0;
     //mRealType df = myFunc.df(r, rinv);
@@ -123,7 +123,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline mRealType evaluateLR(mRealType r) override
+  inline mRealType evaluateLR(mRealType r) const override
   {
     mRealType vk = 0.0;
     return vk;
@@ -157,10 +157,10 @@ struct LRRPAHandlerTemp : public LRHandlerBase
   }
 
   // use what is put in fillFk. Multiplies evalFk by -1
-  inline mRealType evaluate_vlr_k(mRealType k) override { return -1.0 * evalFk(k); }
+  inline mRealType evaluate_vlr_k(mRealType k) const override { return -1.0 * evalFk(k); }
 
 private:
-  inline mRealType evalFk(mRealType k)
+  inline mRealType evalFk(mRealType k) const
   {
     //FatK = 4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());
     mRealType FatK = myFunc.Fk(k, Basis.get_rc());
@@ -169,7 +169,7 @@ private:
     return FatK;
   }
 
-  inline mRealType evalXk(mRealType k)
+  inline mRealType evalXk(mRealType k) const
   {
     //mRealType FatK;
     //FatK = -4.0*M_PI/(Basis.get_CellVolume()*k*k)* std::cos(k*Basis.get_rc());

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -73,7 +73,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
     fillFk(ref.SK->KLists);
   }
 
-  LRHandlerBase* makeClone(ParticleSet& ref) override { return new LRRPAHandlerTemp<Func, BreakupBasis>(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new LRRPAHandlerTemp<Func, BreakupBasis>(*this, ref); }
 
   void initBreakup(ParticleSet& ref) override
   {
@@ -99,7 +99,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
 
   void resetTargetParticleSet(ParticleSet& ref, mRealType rs) { myFunc.reset(ref, rs); }
 
-  inline mRealType evaluate(mRealType r, mRealType rinv) override
+  inline mRealType evaluate(mRealType r, mRealType rinv) const override
   {
     mRealType v = 0.0;
     for (int n = 0; n < coefs.size(); n++)
@@ -139,7 +139,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
    */
   inline mRealType evaluate(const std::vector<int>& kshell,
                             const pComplexType* restrict rk1,
-                            const pComplexType* restrict rk2)
+                            const pComplexType* restrict rk2) const
   {
     mRealType vk = 0.0;
     for (int ks = 0, ki = 0; ks < MaxKshell; ks++)

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -73,7 +73,10 @@ struct LRRPAHandlerTemp : public LRHandlerBase
     fillFk(ref.SK->KLists);
   }
 
-  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new LRRPAHandlerTemp<Func, BreakupBasis>(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override
+  {
+    return new LRRPAHandlerTemp<Func, BreakupBasis>(*this, ref);
+  }
 
   void initBreakup(ParticleSet& ref) override
   {

--- a/src/Particle/LongRange/TwoDEwaldHandler.h
+++ b/src/Particle/LongRange/TwoDEwaldHandler.h
@@ -52,30 +52,30 @@ public:
    */
   TwoDEwaldHandler(const TwoDEwaldHandler& aLR, ParticleSet& ref);
 
-  LRHandlerBase* makeClone(ParticleSet& ref) { return new TwoDEwaldHandler(*this, ref); }
+  LRHandlerBase* makeClone(ParticleSet& ref) const override { return new TwoDEwaldHandler(*this, ref); }
 
-  void initBreakup(ParticleSet& ref);
+  void initBreakup(ParticleSet& ref) override;
 
-  void Breakup(ParticleSet& ref, RealType rs_in) { initBreakup(ref); }
+  void Breakup(ParticleSet& ref, RealType rs_in) override { initBreakup(ref); }
 
-  void resetTargetParticleSet(ParticleSet& ref) {}
+  void resetTargetParticleSet(ParticleSet& ref) override {}
 
-  inline RealType evaluate(RealType r, RealType rinv) { return erfc(r * Sigma) * rinv; }
+  inline RealType evaluate(RealType r, RealType rinv) const override { return erfc(r * Sigma) * rinv; }
 
   /** evaluate the contribution from the long-range part for for spline
    */
-  inline RealType evaluateLR(RealType r) { return -erf(r * Sigma) / r; }
+  inline RealType evaluateLR(RealType r) const override { return -erf(r * Sigma) / r; }
 
-  inline RealType evaluateSR_k0() { return 2.0 * std::sqrt(M_PI) / (Sigma * Volume); }
+  inline RealType evaluateSR_k0() const override { return 2.0 * std::sqrt(M_PI) / (Sigma * Volume); }
 
-  inline RealType evaluateLR_r0() { return 2.0 * Sigma / std::sqrt(M_PI); }
+  inline RealType evaluateLR_r0() const override { return 2.0 * Sigma / std::sqrt(M_PI); }
 
   /**  evaluate the first derivative of the short range part at r
    *
    * @param r  radius
    * @param rinv 1/r
    */
-  inline RealType srDf(RealType r, RealType rinv) { return 0.0; }
+  inline RealType srDf(RealType r, RealType rinv) const override { return 0.0; }
 
   void fillFk(KContainer& KList);
 };

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -24,11 +24,11 @@ struct EslerCoulomb3D_ForSRCOUL
 { // stripped down version of LRCoulombSingleton::CoulombFunctor for 3D
   double norm;
   inline double operator()(double r, double rinv) const { return rinv; }
-  inline double Vk(double k) { return 1. / (k * k); }
-  inline double dVk_dk(double k) { return -2 * norm / (k * k * k); }
+  inline double Vk(double k) const { return 1. / (k * k); }
+  inline double dVk_dk(double k) const { return -2 * norm / (k * k * k); }
   void reset(ParticleSet& ref) { norm = 4.0 * M_PI / ref.LRBox.Volume; }
   void reset(ParticleSet& ref, double rs) { reset(ref); } // ignore rs
-  inline double df(double r) { return -1. / (r * r); }
+  inline double df(double r) const { return -1. / (r * r); }
 };
 
 /** evalaute bare Coulomb in 3D

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -23,7 +23,7 @@ using mRealType = LRHandlerBase::mRealType;
 struct EslerCoulomb3D_ForSRCOUL
 { // stripped down version of LRCoulombSingleton::CoulombFunctor for 3D
   double norm;
-  inline double operator()(double r, double rinv) { return rinv; }
+  inline double operator()(double r, double rinv) const { return rinv; }
   inline double Vk(double k) { return 1. / (k * k); }
   inline double dVk_dk(double k) { return -2 * norm / (k * k * k); }
   void reset(ParticleSet& ref) { norm = 4.0 * M_PI / ref.LRBox.Volume; }

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -25,10 +25,10 @@ struct EslerCoulomb3D
   double norm;
   inline double operator()(double r, double rinv) const { return rinv; }
   void reset(ParticleSet& ref) { norm = 4.0 * M_PI / ref.LRBox.Volume; }
-  inline double Xk(double k, double rc) { return -norm / (k * k) * std::cos(k * rc); }
-  inline double Fk(double k, double rc) { return -Xk(k, rc); }
+  inline double Xk(double k, double rc) const { return -norm / (k * k) * std::cos(k * rc); }
+  inline double Fk(double k, double rc) const { return -Xk(k, rc); }
   inline double integrate_r2(double r) const { return 0.5 * r * r; }
-  inline double df(double r) { return 0; }                // ignore derivatives for now
+  inline double df(double r) const { return 0; }                // ignore derivatives for now
   void reset(ParticleSet& ref, double rs) { reset(ref); } // ignore rs
 };
 

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -23,7 +23,7 @@ using mRealType = LRHandlerBase::mRealType;
 struct EslerCoulomb3D
 { // stripped down version of LRCoulombSingleton::CoulombFunctor for 3D
   double norm;
-  inline double operator()(double r, double rinv) { return rinv; }
+  inline double operator()(double r, double rinv) const { return rinv; }
   void reset(ParticleSet& ref) { norm = 4.0 * M_PI / ref.LRBox.Volume; }
   inline double Xk(double k, double rc) { return -norm / (k * k) * std::cos(k * rc); }
   inline double Fk(double k, double rc) { return -Xk(k, rc); }

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -504,12 +504,8 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
   return res;
 }
 
-
 std::unique_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  std::unique_ptr<CoulombPBCAA> myClone = is_active
-      ? std::make_unique<CoulombPBCAA>(qp, is_active, ComputeForces)
-      : std::make_unique<CoulombPBCAA>(*this); //nothing needs to be re-evaluated
-  return myClone;
+  return std::make_unique<CoulombPBCAA>(*this);
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -24,8 +24,6 @@ namespace qmcplusplus
 {
 CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
     : ForceBase(ref, ref),
-      myGrid(0),
-      myGridforce(0),
       is_active(active),
       FirstTime(true),
       myConst(0.0),
@@ -303,14 +301,14 @@ void CoulombPBCAA::initBreakup(ParticleSet& P)
   myRcut  = AA->get_rc(); //Basis.get_rc();
 
   if (rVs == nullptr)
-    rVs = LRCoulombSingleton::createSpline4RbyVs(AA.get(), myRcut, myGrid);
+    rVs = LRCoulombSingleton::createSpline4RbyVs(AA.get(), myRcut);
 
   if (ComputeForces)
   {
     dAA = LRCoulombSingleton::getDerivHandler(P);
     if (rVsforce == nullptr)
     {
-      rVsforce = LRCoulombSingleton::createSpline4RbyVs(dAA.get(), myRcut, myGridforce);
+      rVsforce = LRCoulombSingleton::createSpline4RbyVs(dAA.get(), myRcut);
     }
   }
 }

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -44,11 +44,9 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
 
   // energy-optimized
   std::shared_ptr<LRHandlerType> AA;
-  GridType* myGrid;
   std::shared_ptr<RadFunctorType> rVs;
   // force-optimized
   std::shared_ptr<LRHandlerType> dAA;
-  GridType* myGridforce;
   std::shared_ptr<RadFunctorType> rVsforce;
 
   bool is_active;

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -36,17 +36,13 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
   typedef LRCoulombSingleton::RadFunctorType RadFunctorType;
   typedef LRHandlerType::mRealType mRealType;
 
-  // using shared_ptr on AA, dAA is a compromise
-  // When ion-ion is_active = false, makeClone calls the copy constructor.
-  // AA, dAA are shared between clones.
-  // When elec-elec is_active = true, makeClone calls the constructor
-  // AA, dAA are not shared between clones and behave more like unique_ptr
-
-  // energy-optimized
+  /// energy-optimized long range handle
   std::shared_ptr<LRHandlerType> AA;
+  /// energy-optimized short range pair potential
   std::shared_ptr<RadFunctorType> rVs;
-  // force-optimized
+  /// force-optimized long range handle
   std::shared_ptr<LRHandlerType> dAA;
+  /// force-optimized short range pair potential
   std::shared_ptr<RadFunctorType> rVsforce;
 
   bool is_active;

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -62,12 +62,7 @@ void CoulombPBCAA_CUDA::initBreakup(ParticleSet& P, bool cloning)
 
 std::unique_ptr<OperatorBase> CoulombPBCAA_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  std::unique_ptr<CoulombPBCAA_CUDA> myclone = is_active
-      ? std::make_unique<CoulombPBCAA_CUDA>(qp, is_active, true)
-      : std::make_unique<CoulombPBCAA_CUDA>(*this); //nothing needs to be re-evaluated
-
-  myclone->SRSpline = SRSpline;
-  return myclone;
+  return std::make_unique<CoulombPBCAA_CUDA>(*this);
 }
 
 void CoulombPBCAA_CUDA::setupLongRangeGPU(ParticleSet& P)

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -45,43 +45,7 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
 
 std::unique_ptr<OperatorBase> CoulombPBCAB::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  std::unique_ptr<CoulombPBCAB> myclone = std::make_unique<CoulombPBCAB>(PtclA, qp, ComputeForces);
-
-  myclone->FirstForceIndex = FirstForceIndex;
-  for (int ig = 0; ig < Vspec.size(); ++ig)
-  {
-    if (Vspec[ig])
-    {
-      auto apot = std::unique_ptr<RadFunctorType>{Vspec[ig]->makeClone()};
-      for (int iat = 0; iat < PtclA.getTotalNum(); ++iat)
-      {
-        if (PtclA.GroupID[iat] == ig)
-          myclone->Vat[iat] = apot.get();
-      }
-      myclone->Vspec[ig] = std::move(apot);
-    }
-  }
-  //If forces exist, force arrays will have been allocated.  Iterate over one
-  //such array to clone.
-  for (int ig = 0; ig < fVspec.size(); ig++)
-  {
-    if (fVspec[ig])
-    {
-      auto apot  = std::unique_ptr<RadFunctorType>{fVspec[ig]->makeClone()};
-      auto dapot = std::unique_ptr<RadFunctorType>{fdVspec[ig]->makeClone()};
-      for (int iat = 0; iat < PtclA.getTotalNum(); ++iat)
-      {
-        if (PtclA.GroupID[iat] == ig)
-        {
-          myclone->fVat[iat]  = apot.get();
-          myclone->fdVat[iat] = dapot.get();
-        }
-      }
-      myclone->fVspec[ig]  = std::move(apot);
-      myclone->fdVspec[ig] = std::move(dapot);
-    }
-  }
-  return myclone;
+  return std::make_unique<CoulombPBCAB>(*this);
 }
 
 CoulombPBCAB::~CoulombPBCAB() = default;

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -42,9 +42,9 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///source particle set
   ParticleSet& PtclA;
   ///long-range Handler
-  std::unique_ptr<LRHandlerType> AB;
+  std::shared_ptr<LRHandlerType> AB;
   ///long-range derivative handler
-  std::unique_ptr<LRHandlerType> dAB;
+  std::shared_ptr<LRHandlerType> dAB;
   ///locator of the distance table
   const int myTableIndex;
   ///number of species of A particle set
@@ -62,11 +62,11 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///radial grid
   std::shared_ptr<GridType> myGrid;
   ///Always mave a radial functor for the bare coulomb
-  std::unique_ptr<RadFunctorType> V0;
+  std::shared_ptr<RadFunctorType> V0;
   ///Radial functor for bare coulomb, optimized for forces
-  std::unique_ptr<RadFunctorType> fV0;
+  std::shared_ptr<RadFunctorType> fV0;
   ///Radial functor for derivative of bare coulomb, optimized for forces
-  std::unique_ptr<RadFunctorType> dfV0;
+  std::shared_ptr<RadFunctorType> dfV0;
   /// Flag for whether to compute forces or not
   bool ComputeForces;
   int MaxGridPoints;
@@ -86,14 +86,14 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///Short-range potential for each ion
   std::vector<RadFunctorType*> Vat;
   ///Short-range potential for each species
-  std::vector<std::unique_ptr<RadFunctorType>> Vspec;
+  std::vector<std::shared_ptr<RadFunctorType>> Vspec;
   ///Short-range potential (r*V) and potential derivative d/dr(rV) derivative for each ion
   ///Required for force evaluations.
   std::vector<RadFunctorType*> fVat;
   std::vector<RadFunctorType*> fdVat;
   ////Short-range potential (r*V) and potential derivative d/dr(rV) derivative for each species
-  std::vector<std::unique_ptr<RadFunctorType>> fVspec;
-  std::vector<std::unique_ptr<RadFunctorType>> fdVspec;
+  std::vector<std::shared_ptr<RadFunctorType>> fVspec;
+  std::vector<std::shared_ptr<RadFunctorType>> fdVspec;
   /*@{
    * @brief temporary data for pbyp evaluation
    */

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -60,7 +60,7 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///cutoff radius of the short-range part
   RealType myRcut;
   ///radial grid
-  GridType* myGrid;
+  std::shared_ptr<GridType> myGrid;
   ///Always mave a radial functor for the bare coulomb
   std::unique_ptr<RadFunctorType> V0;
   ///Radial functor for bare coulomb, optimized for forces
@@ -118,8 +118,10 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   Array<TraceReal, 1> Ve_const;
   Array<TraceReal, 1> Vi_const;
 #endif
-  ParticleSet& Peln;
   ParticleSet& Pion;
+  // FIXME: Coulomb class is walker agnositic, it should not record a particular electron particle set.
+  // kept for the trace manager.
+  ParticleSet& Peln;
 
   CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeForces = false);
 
@@ -169,7 +171,7 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   ///Computes the long-range contribution to the coulomb energy and forces.
   Return_t evalLRwithForces(ParticleSet& P);
   ///Evaluates madelung and background contributions to total energy.
-  Return_t evalConsts(bool report = true);
+  Return_t evalConsts(const ParticleSet& P, bool report = true);
   ///Adds a local pseudopotential channel "ppot" to all source species of type "groupID".
   void add(int groupID, std::unique_ptr<RadFunctorType>&& ppot);
 

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -233,27 +233,7 @@ void CoulombPBCAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
 
 std::unique_ptr<OperatorBase> CoulombPBCAB_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
-  std::unique_ptr<CoulombPBCAB_CUDA> myclone = std::make_unique<CoulombPBCAB_CUDA>(PtclA, qp, true);
-  if (myGrid)
-  {
-    myclone->myGrid = new GridType(*myGrid);
-  }
-  for (int ig = 0; ig < Vspec.size(); ++ig)
-  {
-    if (Vspec[ig])
-    {
-      auto apot = std::unique_ptr<RadFunctorType>{Vspec[ig]->makeClone()};
-      for (int iat = 0; iat < PtclA.getTotalNum(); ++iat)
-      {
-        if (PtclA.GroupID[iat] == ig)
-          myclone->Vat[iat] = apot.get();
-      }
-      myclone->Vspec[ig] = std::move(apot);
-    }
-    myclone->V0Spline      = V0Spline;
-    myclone->SRSplines[ig] = SRSplines[ig];
-  }
-  return myclone;
+  return std::make_unique<CoulombPBCAB_CUDA>(*this);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
   CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(0.0));
 
   double val = cab.evaluate(elec);
@@ -161,7 +161,7 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
   CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(0.0));
 
   double val = cab.evaluate(elec);

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(2 * 0.0506238028)); // not validated
 
   double val_ei = cab.evaluate(elec);
@@ -170,7 +170,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   CoulombPBCAB cab(ions, elec);
 
   // Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(0.0267892759 * 4)); // not validated
 
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(0.0523598776 * 2)); //not validated
 
   double val_ei = cab.evaluate(elec);
@@ -179,7 +179,7 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   CoulombPBCAB cab(ions, elec);
 
   // Background charge term
-  double consts = cab.evalConsts();
+  double consts = cab.evalConsts(elec);
   REQUIRE(consts == Approx(0.0277076538 * 4)); //not validated
 
 

--- a/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
+++ b/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
@@ -71,7 +71,7 @@ struct YukawaBreakup
     //return 1.0 / OneOverSqrtRs - 0.5 * r;
   }
 
-  inline T df(T r)
+  inline T df(T r) const
   {
     if (r < std::numeric_limits<T>::epsilon())
       return -0.5 + r * OneOverSqrtRs / 3.0;
@@ -82,11 +82,10 @@ struct YukawaBreakup
       return -Rs * rinv * rinv * (1.0 - exponential) + exponential * rinv * SqrtRs;
     }
   }
-  inline T df2(T r) { APP_ABORT("Need to implement df2 in YukawaBreakup"); }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T coskr    = std::cos(k * rc);
     T sinkr    = std::sin(k * rc);
@@ -96,18 +95,18 @@ struct YukawaBreakup
          std::exp(-rc * OneOverSqrtRs) * (coskr - OneOverSqrtRs * sinkr * oneOverK) / (k * k + 1.0 / Rs));
   }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
   /** return RPA value at |k|
     * @param kk |k|^2
     */
-  inline T Uk(T kk) { return NormFactor * Rs / kk; }
+  inline T Uk(T kk) const { return NormFactor * Rs / kk; }
 
   /** return d u(k)/d rs
     *
     * Implement a correct one
     */
-  inline T derivUk(T kk) { return NormFactor / kk; }
+  inline T derivUk(T kk) const { return NormFactor / kk; }
 };
 
 template<class T = double>
@@ -144,11 +143,11 @@ struct DerivRPABreakup
 
   inline T operator()(T r, T rinv) const { return 0.0; }
 
-  inline T df(T r) { return 0.0; }
+  inline T df(T r) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T y = 0.5 * k / Kf;
     T Sy;
@@ -166,17 +165,17 @@ struct DerivRPABreakup
           (std::pow(1.0 / (Sy * Sy) + 12.0 / (k * k * k * k * Rs * Rs * Rs), 0.5))));
   }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
   /** return RPA value at |k|
   * @param kk |k|^2
   */
-  inline T Uk(T kk) { return NormFactor * Rs / kk; }
+  inline T Uk(T kk) const { return NormFactor * Rs / kk; }
 
   /** return d u(k)/d rs
   *
   * Implement a correct one
   */
-  inline T derivUk(T kk) { return 0.0; }
+  inline T derivUk(T kk) const { return 0.0; }
 };
 
 
@@ -214,11 +213,11 @@ struct RPABreakup
 
   inline T operator()(T r, T rinv) const { return 0.0; }
 
-  inline T df(T r) { return 0.0; }
+  inline T df(T r) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T y = 0.5 * k / Kf;
     T Sy;
@@ -234,18 +233,18 @@ struct RPABreakup
     return NormFactor * (0.5 * (-1.0 / Sy + std::pow(1.0 / (Sy * Sy) + 12.0 / (k * k * k * k * Rs * Rs * Rs), 0.5)));
   }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
   /** return RPA value at |k|
   * @param kk |k|^2
   */
-  inline T Uk(T kk) { return NormFactor * Rs / kk; }
+  inline T Uk(T kk) const { return NormFactor * Rs / kk; }
 
   /** return d u(k)/d rs
   *
   * Implement a correct one
     */
-  inline T derivUk(T kk) { return 0.0; }
+  inline T derivUk(T kk) const { return 0.0; }
 };
 
 
@@ -302,7 +301,7 @@ struct DerivYukawaBreakup
   }
 
   /** need d(df(r)/d(rs))/dr */
-  inline T df(T r)
+  inline T df(T r) const
   {
     if (r < std::numeric_limits<T>::epsilon())
       return -0.5 * OneOverRs * (1.0 - r * OneOverSqrtRs);
@@ -311,14 +310,13 @@ struct DerivYukawaBreakup
       return -0.5 * OneOverRs * std::exp(-r * OneOverSqrtRs);
     }
   }
-  inline T df2(T r) { APP_ABORT("Need to implement df2 in DerivYukawaBreakup"); }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
   /** integral from kc to infinity */
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T Rc       = rc;
     T coskr    = std::cos(k * Rc);
@@ -364,11 +362,11 @@ struct EPRPABreakup
 
   inline T operator()(T r, T rinv) const { return 0.0; }
 
-  inline T df(T r) { return 0.0; }
+  inline T df(T r) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T y = 0.5 * k / Kf;
     T Sy;
@@ -384,19 +382,20 @@ struct EPRPABreakup
     return -0.5 * NormFactor * val * std::pow(1.0 / (Sy * Sy) + val, -0.5);
   }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
   /** return RPA value at |k|
   * @param kk |k|^2
    */
-  inline T Uk(T kk) { return NormFactor * Rs / kk; }
+  inline T Uk(T kk) const { return NormFactor * Rs / kk; }
 
   /** return d u(k)/d rs
   *
   * Implement a correct one
    */
-  inline T derivUk(T kk) { return 0.0; }
+  inline T derivUk(T kk) const { return 0.0; }
 };
+
 template<class T = double>
 struct derivEPRPABreakup
 {
@@ -429,11 +428,11 @@ struct derivEPRPABreakup
 
   inline T operator()(T r, T rinv) const { return 0.0; }
 
-  inline T df(T r) { return 0.0; }
+  inline T df(T r) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T y = 0.5 * k / Kf;
     T Sy;
@@ -449,18 +448,18 @@ struct derivEPRPABreakup
     T uk  = val * std::pow(1.0 / (Sy * Sy) + val, -0.5);
     return -0.5 * NormFactor * (uk / Rs) * (1.0 - 0.5 * val / (1.0 / (Sy * Sy) + val));
   }
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
   /** return RPA value at |k|
   * @param kk |k|^2
    */
-  inline T Uk(T kk) { return NormFactor * Rs / kk; }
+  inline T Uk(T kk) const { return NormFactor * Rs / kk; }
 
   /** return d u(k)/d rs
          *
          * Implement a correct one
    */
-  inline T derivUk(T kk) { return 0.0; }
+  inline T derivUk(T kk) const { return 0.0; }
 };
 
 template<typename T>
@@ -545,11 +544,11 @@ struct RPABFeeBreakup
 
   inline T operator()(T r, T rinv) const { return 0.0; }
 
-  inline T df(T r) { return 0.0; }
+  inline T df(T r) const { return 0.0; }
 
-  inline T Fk(T k, T rc) { return -Xk(k, rc); }
+  inline T Fk(T k, T rc) const { return -Xk(k, rc); }
 
-  inline T Xk(T k, T rc)
+  inline T Xk(T k, T rc) const
   {
     T u    = urpa(k) * volume / nelec;
     T eq   = k * k * hbs2m;
@@ -593,20 +592,20 @@ struct RPABFeeBreakup
     return yq / volume;
   }
 
-  inline T integrate_r2(T rc) { return 0.0; }
+  inline T integrate_r2(T rc) const { return 0.0; }
 
   /** return RPA value at |k|
   * @param kk |k|^2
   */
-  inline T Uk(T kk) { return 0.0; }
+  inline T Uk(T kk) const { return 0.0; }
 
   /** return d u(k)/d rs
   *
   * Implement a correct one
     */
-  inline T derivUk(T kk) { return 0.0; }
+  inline T derivUk(T kk) const { return 0.0; }
 
-  T urpa(T q)
+  T urpa(T q) const
   {
     T a = 0.0, vkbare;
     if (q > 0.0)
@@ -618,7 +617,7 @@ struct RPABFeeBreakup
   }
 
   // mmorales: taken from bopimc (originally by M Holzmann)
-  T Dlindhard(T q, T w)
+  T Dlindhard(T q, T w) const
   {
     T xd1, xd2, small = 0.00000001, xdummy, rq1, rq2;
     T res = 0.0;
@@ -678,7 +677,7 @@ struct RPABFeeBreakup
   }
 
   // mmorales: taken from bopimc (originally by M Holzmann)
-  T Dlindhardp(T q, T w)
+  T Dlindhardp(T q, T w) const
   {
     T xd1, xd2, small = 0.00000001, xdummy, rq1, rq2;
     T res = 0.0;

--- a/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
+++ b/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
  * A Func for LRHandlerTemp.  Four member functions have to be provided
  *
  * - reset(T volume) : reset the normalization factor
- * - operator() (T r, T rinv) : return a value of the original function e.g., 1.0/r
+ * - operator() (T r, T rinv) const : return a value of the original function e.g., 1.0/r
  * - Fk(T k, T rc)
  * - Xk(T k, T rc)
  *
@@ -61,7 +61,7 @@ struct YukawaBreakup
   }
 
 
-  inline T operator()(T r, T rinv)
+  inline T operator()(T r, T rinv) const
   {
     if (r < std::numeric_limits<T>::epsilon())
       return SqrtRs - 0.5 * r;
@@ -142,7 +142,7 @@ struct DerivRPABreakup
   }
 
 
-  inline T operator()(T r, T rinv) { return 0.0; }
+  inline T operator()(T r, T rinv) const { return 0.0; }
 
   inline T df(T r) { return 0.0; }
 
@@ -212,7 +212,7 @@ struct RPABreakup
   }
 
 
-  inline T operator()(T r, T rinv) { return 0.0; }
+  inline T operator()(T r, T rinv) const { return 0.0; }
 
   inline T df(T r) { return 0.0; }
 
@@ -291,7 +291,7 @@ struct DerivYukawaBreakup
   }
 
   /** need the df(r)/d(rs) */
-  inline T operator()(T r, T rinv)
+  inline T operator()(T r, T rinv) const
   {
     if (r < std::numeric_limits<T>::epsilon())
       return 0.5 * OneOverSqrtRs * (1.0 - r * OneOverSqrtRs);
@@ -362,7 +362,7 @@ struct EPRPABreakup
   }
 
 
-  inline T operator()(T r, T rinv) { return 0.0; }
+  inline T operator()(T r, T rinv) const { return 0.0; }
 
   inline T df(T r) { return 0.0; }
 
@@ -427,7 +427,7 @@ struct derivEPRPABreakup
   }
 
 
-  inline T operator()(T r, T rinv) { return 0.0; }
+  inline T operator()(T r, T rinv) const { return 0.0; }
 
   inline T df(T r) { return 0.0; }
 
@@ -543,7 +543,7 @@ struct RPABFeeBreakup
   }
 
 
-  inline T operator()(T r, T rinv) { return 0.0; }
+  inline T operator()(T r, T rinv) const { return 0.0; }
 
   inline T df(T r) { return 0.0; }
 


### PR DESCRIPTION
Review after merging #3235

## Proposed changes
Before this PR, shared_ptr are used for long range handler and short range pair functions in Coulomb PBC AA class. In fact when particle sets are active, the shared_ptr is used as unique_ptr. The AB class use unique_ptr.

In this PR, all the evaluation functions of  long range handler and short range pair functions are defined const (thread-safe).
So a shared copy of long range handler and short range pair function can be used among all the walkers safely. Both makeClone functions become calling compiler generated copy constructor.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'