### PR TITLE
Add DTModes which represents switches used in distance tables.

### DIFF
--- a/src/Particle/DTModes.h
+++ b/src/Particle/DTModes.h
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_DTMODES_H
+#define QMCPLUSPLUS_DTMODES_H
+
+#include <cstdint>
+
+namespace qmcplusplus
+{
+enum class DTModes : uint_fast8_t
+{
+  ALL_OFF = 0x0,
+  /** whether full table needs to be ready at anytime or not
+   * Optimization can be implemented during forward PbyP move when the full table is not needed all the time.
+   * DT consumers should know if full table is needed or not and request via addTable.
+   */
+  NEED_FULL_TABLE_ANYTIME   = 0x1,
+  NO_NEED_TEMP_DATA_ON_HOST = 0x2
+};
+
+constexpr bool operator&(DTModes x, DTModes y)
+{
+  return static_cast<uint_fast8_t>(x) & static_cast<uint_fast8_t>(y) != 0x0;
+}
+
+constexpr DTModes operator|(DTModes x, DTModes y)
+{
+  return static_cast<DTModes>(static_cast<uint_fast8_t>(x) | static_cast<uint_fast8_t>(y));
+}
+
+inline constexpr DTModes operator~(DTModes x) { return static_cast<DTModes>(~static_cast<uint_fast8_t>(x)); }
+
+inline DTModes& operator|=(DTModes& x, DTModes y)
+{
+  x = x | y;
+  return x;
+}
+} // namespace qmcplusplus
+#endif

--- a/src/Particle/DTModes.h
+++ b/src/Particle/DTModes.h
@@ -25,12 +25,12 @@ enum class DTModes : uint_fast8_t
    * DT consumers should know if full table is needed or not and request via addTable.
    */
   NEED_FULL_TABLE_ANYTIME   = 0x1,
-  NO_NEED_TEMP_DATA_ON_HOST = 0x2
+  NEED_TEMP_DATA_ON_HOST = 0x2
 };
 
 constexpr bool operator&(DTModes x, DTModes y)
 {
-  return static_cast<uint_fast8_t>(x) & static_cast<uint_fast8_t>(y) != 0x0;
+  return (static_cast<uint_fast8_t>(x) & static_cast<uint_fast8_t>(y)) != 0x0;
 }
 
 constexpr DTModes operator|(DTModes x, DTModes y)
@@ -38,7 +38,7 @@ constexpr DTModes operator|(DTModes x, DTModes y)
   return static_cast<DTModes>(static_cast<uint_fast8_t>(x) | static_cast<uint_fast8_t>(y));
 }
 
-inline constexpr DTModes operator~(DTModes x) { return static_cast<DTModes>(~static_cast<uint_fast8_t>(x)); }
+constexpr DTModes operator~(DTModes x) { return static_cast<DTModes>(~static_cast<uint_fast8_t>(x)); }
 
 inline DTModes& operator|=(DTModes& x, DTModes y)
 {

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -17,12 +17,13 @@
 #define QMCPLUSPLUS_DISTANCETABLEDATAIMPL_H
 
 #include "Particle/ParticleSet.h"
+#include <limits>
+#include <bitset>
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "CPU/SIMD/aligned_allocator.hpp"
 #include "OhmmsSoA/VectorSoaContainer.h"
-#include <limits>
-#include <bitset>
+#include "DTModes.h"
 
 namespace qmcplusplus
 {
@@ -77,11 +78,8 @@ protected:
   DisplRow temp_dr_;
   /*@}*/
 
-  /** whether full table needs to be ready at anytime or not
-   * Optimization can be implemented during forward PbyP move when the full table is not needed all the time.
-   * DT consumers should know if full table is needed or not and request via addTable.
-   */
-  bool need_full_table_;
+  ///operation modes defined by DTModes
+  DTModes modes_;
 
   /** set to particle id after move() with prepare_old = true. -1 means not prepared.
    * It is intended only for safety checks, not for codepath selection.
@@ -97,7 +95,7 @@ public:
       : Origin(&source),
         N_sources(source.getTotalNum()),
         N_targets(target.getTotalNum()),
-        need_full_table_(false),
+        modes_(DTModes::ALL_OFF),
         old_prepared_elec_id(-1),
         name_(source.getName() + "_" + target.getName())
   {}
@@ -105,11 +103,11 @@ public:
   ///virutal destructor
   virtual ~DistanceTableData() = default;
 
-  ///get need_full_table_
-  inline bool getFullTableNeeds() const { return need_full_table_; }
+  ///get modes
+  inline DTModes getModes() const { return modes_; }
 
-  ///set need_full_table_
-  inline void setFullTableNeeds(bool is_needed) { need_full_table_ = is_needed; }
+  ///set modes
+  inline void setModes(DTModes modes) { modes_ = modes; }
 
   ///return the name of table
   inline const std::string& getName() const { return name_; }

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -18,7 +18,6 @@
 
 #include "Particle/ParticleSet.h"
 #include <limits>
-#include <bitset>
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "CPU/SIMD/aligned_allocator.hpp"

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -108,7 +108,7 @@ ParticleSet::ParticleSet(const ParticleSet& p)
   Collectables        = p.Collectables;
   //construct the distance tables with the same order
   for (int i = 0; i < p.DistTables.size(); ++i)
-    addTable(p.DistTables[i]->origin(), p.DistTables[i]->getFullTableNeeds());
+    addTable(p.DistTables[i]->origin(), p.DistTables[i]->getModes());
   if (p.SK)
   {
     LRBox = p.LRBox;                             //copy LRBox
@@ -356,7 +356,7 @@ void ParticleSet::reset() { app_log() << "<<<< going to set properties >>>> " <<
 ///read the particleset
 bool ParticleSet::put(xmlNodePtr cur) { return true; }
 
-int ParticleSet::addTable(const ParticleSet& psrc, bool need_full_table)
+int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
 {
   if (myName == "none" || psrc.getName() == "none")
     APP_ABORT("ParticleSet::addTable needs proper names for both source and target particle sets.");
@@ -382,7 +382,7 @@ int ParticleSet::addTable(const ParticleSet& psrc, bool need_full_table)
     app_debug() << "  ... ParticleSet::addTable Reuse Table #" << tid << " " << DistTables[tid]->getName() << std::endl;
   }
 
-  DistTables[tid]->setFullTableNeeds(DistTables[tid]->getFullTableNeeds() || need_full_table);
+  DistTables[tid]->setModes(DistTables[tid]->getModes() | modes);
 
   app_log().flush();
   return tid;
@@ -802,7 +802,7 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
   {
     // in certain cases, full tables must be ready
     for (int i = 0; i < DistTables.size(); i++)
-      if (DistTables[i]->getFullTableNeeds())
+      if (DistTables[i]->getModes() & DTModes::NEED_FULL_TABLE_ANYTIME)
         DistTables[i]->evaluate(*this);
     //computed so that other objects can use them, e.g., kSpaceJastrow
     if (SK && SK->DoUpdate)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -29,6 +29,7 @@
 #include "Utilities/TimerManager.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
 #include "type_traits/template_types.hpp"
+#include "DTModes.h"
 
 namespace qmcplusplus
 {
@@ -225,11 +226,11 @@ public:
 
   /** add a distance table
    * @param psrc source particle set
-   * @param need_full_table if true, DT is fully computed in loadWalker() and maintained up-to-date during p-by-p moving
+   * @param modes bitmask DistanceTableData::DTModes
    *
    * if this->myName == psrc.getName(), AA type. Otherwise, AB type.
    */
-  int addTable(const ParticleSet& psrc, bool need_full_table = false);
+  int addTable(const ParticleSet& psrc, DTModes modes = DTModes::ALL_OFF);
 
   /** get a distance table by table_ID
    */

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -88,7 +88,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
                                            0, N_sources);
     // If the full table is not ready all the time, overwrite the current value.
     // If this step is missing, DT values can be undefined in case a move is rejected.
-    if (!need_full_table_ && prepare_old)
+    if (!(modes_ & DTModes::NEED_FULL_TABLE_ANYTIME) && prepare_old)
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], Origin->getCoordinates().getAllParticlePos(),
                                              distances_[iat].data(), displacements_[iat], 0, N_sources);
   }

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -355,7 +355,7 @@ public:
                                            0, N_sources);
     // If the full table is not ready all the time, overwrite the current value.
     // If this step is missing, DT values can be undefined in case a move is rejected.
-    if (!need_full_table_ && prepare_old)
+    if (!(modes_ & DTModes::NEED_FULL_TABLE_ANYTIME) && prepare_old)
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], Origin->getCoordinates().getAllParticlePos(),
                                              distances_[iat].data(), displacements_[iat], 0, N_sources);
   }

--- a/src/Particle/tests/CMakeLists.txt
+++ b/src/Particle/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UTEST_EXE test_${SRC_DIR})
 set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 add_executable(${UTEST_EXE} test_particle.cpp test_distance_table.cpp test_walker.cpp test_particle_pool.cpp
-                            test_sample_stack.cpp)
+                            test_sample_stack.cpp test_DTModes.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle Math::scalar_vector_functions)
 if(USE_OBJECT_TARGET)
   target_link_libraries(${UTEST_EXE} qmcutil containers platform_omptarget)

--- a/src/Particle/tests/test_DTModes.cpp
+++ b/src/Particle/tests/test_DTModes.cpp
@@ -1,0 +1,29 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2020  QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "DTModes.h"
+
+namespace qmcplusplus
+{
+TEST_CASE("DTModes", "[particle]")
+{
+  DTModes modes;
+
+  modes = DTModes::NEED_FULL_TABLE_ANYTIME | ~DTModes::NEED_TEMP_DATA_ON_HOST;
+
+  CHECK(modes & DTModes::NEED_FULL_TABLE_ANYTIME);
+  CHECK(!(modes & DTModes::NEED_TEMP_DATA_ON_HOST));
+}
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -114,7 +114,7 @@ public:
   JeeIOrbitalSoA(const std::string& obj_name, const ParticleSet& ions, ParticleSet& elecs, bool is_master = false)
       : WaveFunctionComponent("JeeIOrbitalSoA", obj_name),
         ee_Table_ID_(elecs.addTable(elecs)),
-        ei_Table_ID_(elecs.addTable(ions, true)),
+        ei_Table_ID_(elecs.addTable(ions, DTModes::NEED_FULL_TABLE_ANYTIME)),
         Ions(ions),
         NumVars(0)
   {

--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 {
 template<class COT, typename ORBT>
 SoaLocalizedBasisSet<COT, ORBT>::SoaLocalizedBasisSet(ParticleSet& ions, ParticleSet& els)
-    : ions_(ions), myTableIndex(els.addTable(ions, true)), SuperTwist(0.0)
+    : ions_(ions), myTableIndex(els.addTable(ions, DTModes::NEED_FULL_TABLE_ANYTIME)), SuperTwist(0.0)
 {
   NumCenters = ions.getTotalNum();
   NumTargets = els.getTotalNum();


### PR DESCRIPTION
## Proposed changes
DTModes records operations switches required by distance table consumers.
Use strongly typed enum.
Intended to avoid unnecessary D2H transfer when offloading Jastrow factors.
The avail 'modes' are not final. Will adjust as the implementation goes.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
