### PR TITLE
One Body Jastrow evaluateDerivatives test

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ set(JASTROW_SRC
     test_kspace_jastrow.cpp
     test_pade_jastrow.cpp
     test_short_range_cusp_jastrow.cpp
+    test_DiffOneBodyJastrowOrbital.cpp
     test_DiffTwoBodyJastrowOrbital.cpp)
 set(DETERMINANT_SRC
     FakeSPO.cpp

--- a/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
@@ -4,9 +4,9 @@
 //
 // Copyright (c) 2021 QMCPACK developers.
 //
-// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+// File developed by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Pittsburgh
 //
-// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+// File created by: Shiv Upadhyay, shivnupadhyay@gmail.com, University of Pittsburgh
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "catch.hpp"
@@ -21,8 +21,7 @@ namespace qmcplusplus
 {
 TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
 {
-  Communicate* c;
-  c              = OHMMS::Controller;
+  Communicate* c = OHMMS::Controller;
   auto ions_uptr = std::make_unique<ParticleSet>();
   auto elec_uptr = std::make_unique<ParticleSet>();
   ParticleSet& ions_(*ions_uptr);
@@ -101,9 +100,10 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   twf_component_list[0]->evaluateDerivatives(elec_, active, dlogpsi, dhpsioverpsi);
 
   // Numbers not validated
-  std::vector<ValueType> expected_dlogpsi = {-0.9336294487, -1.0196051794, 0.0, 0.0};
+  std::vector<ValueType> expected_dlogpsi      = {-0.9336294487, -1.0196051794, 0.0, 0.0};
   std::vector<ValueType> expected_dhpsioverpsi = {-1.1596433096, 0.7595492539, 0.0, 0.0};
-  for (int i = 0 ; i < nparam; i++){
+  for (int i = 0; i < nparam; i++)
+  {
     CHECK(dlogpsi[i] == ValueApprox(expected_dlogpsi[i]));
     CHECK(dhpsioverpsi[i] == ValueApprox(expected_dhpsioverpsi[i]));
   }

--- a/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
@@ -28,7 +28,7 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   ParticleSet& elec_(*elec_uptr);
 
   ions_.setName("ion0");
-  ions_.create({1, 1});
+  ions_.create(1);
   ions_.R[0]                 = {0.0, 0.0, 0.0};
   SpeciesSet& ispecies       = ions_.getSpeciesSet();
   int HIdx                   = ispecies.addSpecies("H");
@@ -57,10 +57,10 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   ptcl.addParticleSet(std::move(ions_uptr));
 
 
+  ions_.update();
   elec_.addTable(elec_);
   elec_.addTable(ions_);
   elec_.update();
-  ions_.update();
 
   const char* jasxml = "<wavefunction name=\"psi0\" target=\"e\"> \
   <jastrow name=\"J1\" type=\"One-Body\" function=\"Bspline\" print=\"yes\" source=\"ion0\"> \

--- a/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiffOneBodyJastrowOrbital.cpp
@@ -1,0 +1,111 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "Particle/ParticleSetPool.h"
+#include "QMCWaveFunctions/Jastrow/DiffOneBodyJastrowOrbital.h"
+#include "QMCWaveFunctions/Jastrow/J1OrbitalSoA.h"
+#include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
+
+namespace qmcplusplus
+{
+TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
+{
+  Communicate* c;
+  c              = OHMMS::Controller;
+  auto ions_uptr = std::make_unique<ParticleSet>();
+  auto elec_uptr = std::make_unique<ParticleSet>();
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
+
+  ions_.setName("ion0");
+  ions_.create({1, 1});
+  ions_.R[0]                 = {0.0, 0.0, 0.0};
+  SpeciesSet& ispecies       = ions_.getSpeciesSet();
+  int HIdx                   = ispecies.addSpecies("H");
+  int ichargeIdx             = ispecies.addAttribute("charge");
+  ispecies(ichargeIdx, HIdx) = 1.0;
+
+  elec_.setName("e");
+  elec_.create({1, 1});
+  elec_.R[0] = {0.5, 0.5, 0.5};
+  elec_.R[1] = {-0.5, -0.5, -0.5};
+
+  SpeciesSet& tspecies       = elec_.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int downIdx                = tspecies.addSpecies("d");
+  int massIdx                = tspecies.addAttribute("mass");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  tspecies(massIdx, upIdx)   = 1.0;
+  tspecies(massIdx, downIdx) = 1.0;
+  tspecies(chargeIdx, upIdx) = -1.0;
+  tspecies(massIdx, downIdx) = -1.0;
+  // Necessary to set mass
+  elec_.resetGroups();
+
+  ParticleSetPool ptcl = ParticleSetPool(c);
+  ptcl.addParticleSet(std::move(elec_uptr));
+  ptcl.addParticleSet(std::move(ions_uptr));
+
+
+  elec_.addTable(elec_);
+  elec_.addTable(ions_);
+  elec_.update();
+  ions_.update();
+
+  const char* jasxml = "<wavefunction name=\"psi0\" target=\"e\"> \
+  <jastrow name=\"J1\" type=\"One-Body\" function=\"Bspline\" print=\"yes\" source=\"ion0\"> \
+    <correlation elementType=\"H\" cusp=\"0.0\" size=\"2\" rcut=\"5.0\"> \
+      <coefficients id=\"J1H\" type=\"Array\"> 0.5 0.1 </coefficients> \
+    </correlation> \
+  </jastrow> \
+</wavefunction> \
+";
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(jasxml);
+  REQUIRE(okay);
+
+  xmlNodePtr jas1 = doc.getRoot();
+
+  // update all distance tables
+  elec_.update();
+  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  wf_factory.put(jas1);
+  auto& twf(*wf_factory.getTWF());
+  twf.setMassTerm(elec_);
+  twf.evaluateLog(elec_);
+  twf.prepareGroup(elec_, 0);
+
+  auto twf_component_list = twf.getOrbitals();
+
+  opt_variables_type active;
+  twf.checkInVariables(active);
+
+  int nparam = active.size_of_active();
+  REQUIRE(nparam == 4);
+
+  using ValueType = QMCTraits::ValueType;
+  std::vector<ValueType> dlogpsi(nparam);
+  std::vector<ValueType> dhpsioverpsi(nparam);
+  //twf.evaluateDerivatives(elec_, active, dlogpsi, dhpsioverpsi);
+  twf_component_list[0]->evaluateDerivatives(elec_, active, dlogpsi, dhpsioverpsi);
+
+  // Numbers not validated
+  std::vector<ValueType> expected_dlogpsi = {-0.9336294487, -1.0196051794, 0.0, 0.0};
+  std::vector<ValueType> expected_dhpsioverpsi = {-1.1596433096, 0.7595492539, 0.0, 0.0};
+  for (int i = 0 ; i < nparam; i++){
+    CHECK(dlogpsi[i] == ValueApprox(expected_dlogpsi[i]));
+    CHECK(dhpsioverpsi[i] == ValueApprox(expected_dhpsioverpsi[i]));
+  }
+}
+} // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
This PR extends the testing to cover the evaluate Derivatives for One Body Jastrow factors.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ryzen workstation (5900X)
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
