### PR TITLE
Replace deprecated OpenMP get nested call

### DIFF
--- a/src/Message/OpenMP.h
+++ b/src/Message/OpenMP.h
@@ -27,7 +27,7 @@ inline omp_int_t omp_get_max_threads() { return 1; }
 inline omp_int_t omp_get_num_threads() { return 1; }
 inline omp_int_t omp_get_level() { return 0; }
 inline omp_int_t omp_get_ancestor_thread_num(int level) { return 0; }
-inline bool omp_get_nested() { return false; }
+inline int omp_get_max_active_levels() { return 1; }
 #endif
 
 /// get the number of threads at the next parallel level

--- a/src/Message/OpenMP.h
+++ b/src/Message/OpenMP.h
@@ -27,7 +27,6 @@ inline omp_int_t omp_get_max_threads() { return 1; }
 inline omp_int_t omp_get_num_threads() { return 1; }
 inline omp_int_t omp_get_level() { return 0; }
 inline omp_int_t omp_get_ancestor_thread_num(int level) { return 0; }
-inline int omp_get_max_active_levels() { return 1; }
 #endif
 
 /// get the number of threads at the next parallel level

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -82,7 +82,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
 #ifdef ENABLE_OFFLOAD
     NLPP_algo = "batched";
 #else
-    NLPP_algo = (omp_get_max_active_levels() > 1) ? "batched" : "non-batched";
+    NLPP_algo = "non-batched";
 #endif
 
   bool doForces = (forces == "yes") || (forces == "true");

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -82,7 +82,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
 #ifdef ENABLE_OFFLOAD
     NLPP_algo = "batched";
 #else
-    NLPP_algo = omp_get_nested() ? "batched" : "non-batched";
+    NLPP_algo = (omp_get_max_active_levels() > 1) ? "batched" : "non-batched";
 #endif
 
   bool doForces = (forces == "yes") || (forces == "true");


### PR DESCRIPTION
## Proposed changes

omp_get_nested is deprecated in OpenMP >=5.0. Implementations now create warnings. Use the recommended replacement call which has been present since at least 3.0.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen, llvm12.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
