### PR TITLE
Fix direct memory leaks in deterministic-unit_test_hamiltonian_force

### DIFF
--- a/src/Numerics/OneDimCubicSpline.h
+++ b/src/Numerics/OneDimCubicSpline.h
@@ -180,10 +180,11 @@ public:
   //  base_type(rhs), m_Y2(rhs.m_Y2)
   //  { }
 
-  OneDimCubicSpline(const grid_type* gt = 0) : base_type(gt) {}
+  OneDimCubicSpline(std::unique_ptr<grid_type> gt = std::unique_ptr<grid_type>()) : base_type(std::move(gt)) {}
 
   template<class VV>
-  OneDimCubicSpline(const grid_type* gt, const VV& nv) : base_type(gt), first_deriv(0.0), last_deriv(0.0)
+  OneDimCubicSpline(std::unique_ptr<grid_type> gt, const VV& nv)
+      : base_type(std::move(gt)), first_deriv(0.0), last_deriv(0.0)
   {
     m_Y.resize(nv.size());
     m_Y2.resize(nv.size());

--- a/src/Numerics/OneDimGridBase.h
+++ b/src/Numerics/OneDimGridBase.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include "OhmmsPETE/OhmmsVector.h"
 #include "Numerics/GridTraits.h"
 #include "einspline/bspline_base.h"
@@ -51,7 +52,7 @@ struct OneDimGridBase
 
   inline OneDimGridBase() : num_points(0) {}
 
-  virtual OneDimGridBase<T, CT>* makeClone() const = 0;
+  virtual std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const = 0;
 
   virtual ~OneDimGridBase() = default;
 
@@ -140,7 +141,7 @@ struct LinearGrid : public OneDimGridBase<T, CT>
   using OneDimGridBase<T, CT>::DeltaInv;
   using OneDimGridBase<T, CT>::X;
 
-  OneDimGridBase<T, CT>* makeClone() const { return new LinearGrid<T, CT>(*this); }
+  std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const { return std::make_unique<LinearGrid<T, CT>>(*this); }
 
   inline int locate(T r) const { return static_cast<int>((static_cast<double>(r) - X[0]) * DeltaInv); }
 
@@ -191,7 +192,7 @@ struct LogGrid : public OneDimGridBase<T, CT>
   // T Delta;
   T OneOverLogDelta;
 
-  OneDimGridBase<T, CT>* makeClone() const { return new LogGrid<T, CT>(*this); }
+  std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const { return std::make_unique<LogGrid<T, CT>>(*this); }
 
   inline int locate(T r) const { return static_cast<int>(std::log(r / X[0]) * OneOverLogDelta); }
 
@@ -237,7 +238,7 @@ struct LogGridZero : public OneDimGridBase<T, CT>
   T OneOverA;
   T OneOverB;
 
-  OneDimGridBase<T, CT>* makeClone() const { return new LogGridZero<T, CT>(*this); }
+  std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const { return std::make_unique<LogGridZero<T, CT>>(*this); }
 
   inline int locate(T r) const { return static_cast<int>(std::log(r * OneOverB + 1.0) * OneOverA); }
 
@@ -285,7 +286,7 @@ struct NumericalGrid : public OneDimGridBase<T, CT>
     assign(nv.begin(), nv.end());
   }
 
-  OneDimGridBase<T, CT>* makeClone() const { return new NumericalGrid<T, CT>(*this); }
+  std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const { return std::make_unique<NumericalGrid<T, CT>>(*this); }
 
 
   template<class IT>

--- a/src/Numerics/OneDimGridFactory.cpp
+++ b/src/Numerics/OneDimGridFactory.cpp
@@ -106,7 +106,8 @@ OneDimGridFactory::RealType OneDimGridFactory::setSmoothCutoff(GridType* agrid, 
   if (cur != NULL)
   {
     const XMLAttrString rc(cur, "rc");
-    if (!rc.empty()) rcut = std::stod(rc);
+    if (!rc.empty())
+      rcut = std::stod(rc);
   }
   if (rcut > rmax)
   //set it to 0.99

--- a/src/Numerics/OneDimGridFunctor.h
+++ b/src/Numerics/OneDimGridFunctor.h
@@ -60,9 +60,9 @@ struct OneDimGridFunctor
   {
     if (a.m_grid)
       m_grid = a.m_grid->makeClone();
-    Y           = a.Y;
-    dY          = a.dY;
-    d2Y         = a.d2Y;
+    Y   = a.Y;
+    dY  = a.dY;
+    d2Y = a.d2Y;
     m_Y.resize(a.m_Y.size());
     m_Y      = a.m_Y;
     NumNodes = a.NumNodes;

--- a/src/Numerics/OneDimGridFunctor.h
+++ b/src/Numerics/OneDimGridFunctor.h
@@ -50,7 +50,7 @@ struct OneDimGridFunctor
   /** constructor
    *@param gt a radial grid. The pointer is treated as a reference
    */
-  OneDimGridFunctor(const grid_type* gt = 0) : m_grid(gt ? gt->makeClone() : nullptr)
+  OneDimGridFunctor(std::unique_ptr<grid_type> gt = std::unique_ptr<grid_type>()) : m_grid(std::move(gt))
   {
     if (m_grid)
       resize(m_grid->size());
@@ -59,7 +59,7 @@ struct OneDimGridFunctor
   OneDimGridFunctor(const OneDimGridFunctor& a)
   {
     if (a.m_grid)
-      m_grid.reset(a.m_grid->makeClone());
+      m_grid = a.m_grid->makeClone();
     Y           = a.Y;
     dY          = a.dY;
     d2Y         = a.d2Y;

--- a/src/Numerics/OneDimQuinticSpline.h
+++ b/src/Numerics/OneDimQuinticSpline.h
@@ -54,10 +54,11 @@ public:
   value_type last_deriv;
   value_type ConstValue;
 
-  OneDimQuinticSpline(const grid_type* gt = 0) : base_type(gt) {}
+  OneDimQuinticSpline(std::unique_ptr<grid_type> gt = std::unique_ptr<grid_type>()) : base_type(std::move(gt)) {}
 
   template<class VV>
-  OneDimQuinticSpline(const grid_type* gt, const VV& nv) : base_type(gt), first_deriv(0.0), last_deriv(0.0)
+  OneDimQuinticSpline(std::unique_ptr<grid_type> gt, const VV& nv)
+      : base_type(std::move(gt)), first_deriv(0.0), last_deriv(0.0)
   {
     int n = nv.size();
     m_Y.resize(nv.size());

--- a/src/Numerics/tests/test_grid_functor.cpp
+++ b/src/Numerics/tests/test_grid_functor.cpp
@@ -28,7 +28,7 @@ namespace qmcplusplus
 TEST_CASE("double_1d_grid_functor", "[numerics]")
 {
   LinearGrid<double> grid;
-  OneDimGridFunctor<double> f(&grid);
+  OneDimGridFunctor<double> f(grid.makeClone());
 
   grid.set(0.0, 1.0, 3);
 

--- a/src/Numerics/tests/test_one_dim_cubic_spline.cpp
+++ b/src/Numerics/tests/test_one_dim_cubic_spline.cpp
@@ -117,10 +117,10 @@ TEST_CASE("one_dim_cubic_spline_1", "[numerics]")
   const int n               = 3;
   std::vector<double> yvals = {1.0, 2.0, 1.5};
 
-  LinearGrid<double> grid;
-  grid.set(0.0, 2.0, n);
+  auto grid = std::make_unique<LinearGrid<double>>();
+  grid->set(0.0, 2.0, n);
 
-  OneDimCubicSpline<double> cubic_spline(&grid, yvals);
+  OneDimCubicSpline<double> cubic_spline(std::move(grid), yvals);
 
   int imin = 0;
   int imax = 3 - 1;

--- a/src/Numerics/tests/test_transform.cpp
+++ b/src/Numerics/tests/test_transform.cpp
@@ -38,9 +38,9 @@ TEST_CASE("transform2gridfunctor", "[numerics]")
   typedef OneDimGridBase<double> GridType;
   typedef OneDimQuinticSpline<double> OutputType;
 
-  GridType* agrid = new LogGrid<double>;
+  auto agrid = std::make_unique<LogGrid<double>>();
   agrid->set(0.1, 10, 10);
-  OutputType output(agrid);
+  OutputType output(std::move(agrid));
   Input input;
   Transform2GridFunctor<Input, OutputType> transform(input, output);
   double rmin = 0.1;
@@ -51,6 +51,5 @@ TEST_CASE("transform2gridfunctor", "[numerics]")
   REQUIRE(output.splint(0.15) == Approx(0.0225));
   REQUIRE(output.splint(7.0) == Approx(49.0));
   REQUIRE(output.splint(10) == Approx(100.0));
-  delete agrid;
 }
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/LRCoulombSingleton.cpp
+++ b/src/Particle/LongRange/LRCoulombSingleton.cpp
@@ -187,7 +187,7 @@ std::unique_ptr<OneDimCubicSpline<T>> createSpline4RbyVs_temp(LRHandlerBase* aLR
   }
   v[0]      = 2.0 * v[1] - v[2];
   v[ng - 1] = 0.0;
-  auto V0   = std::make_unique<func_type>(agrid, v);
+  auto V0   = std::make_unique<func_type>(agrid->makeClone(), v);
   T deriv   = (v[1] - v[0]) / ((*agrid)[1] - (*agrid)[0]);
   V0->spline(0, deriv, ng - 1, 0.0);
   return V0;
@@ -224,7 +224,7 @@ std::unique_ptr<OneDimCubicSpline<T>> createSpline4RbyVsDeriv_temp(LRHandlerBase
   }
   v[0]      = 2.0 * v[1] - v[2];
   v[ng - 1] = 0.0;
-  auto dV0  = std::make_unique<func_type>(agrid, v);
+  auto dV0  = std::make_unique<func_type>(agrid->makeClone(), v);
   T deriv   = (v[1] - v[0]) / ((*agrid)[1] - (*agrid)[0]);
   dV0->spline(0, deriv, ng - 1, 0.0);
   return dV0;

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -462,8 +462,8 @@ void CoulombPBCAB::add(int groupID, std::unique_ptr<RadFunctorType>&& ppot)
     //by construction, v has to go to zero at the boundary
     v[ng - 2]             = 0.0;
     v[ng - 1]             = 0.0;
-    auto rfunc            = std::make_unique<RadFunctorType>(myGrid.get(), v);
     RealType deriv        = (v[1] - v[0]) / ((*myGrid)[1] - (*myGrid)[0]);
+    auto rfunc            = std::make_unique<RadFunctorType>(myGrid->makeClone(), v);
     rfunc->spline(0, deriv, ng - 1, 0.0);
     for (int iat = 0; iat < NptclA; iat++)
     {
@@ -503,8 +503,8 @@ void CoulombPBCAB::add(int groupID, std::unique_ptr<RadFunctorType>&& ppot)
     dv[ng - 2] = 0;
     dv[ng - 1] = 0;
 
-    auto ffunc  = std::make_unique<RadFunctorType>(myGrid.get(), v);
-    auto fdfunc = std::make_unique<RadFunctorType>(myGrid.get(), dv);
+    auto ffunc  = std::make_unique<RadFunctorType>(myGrid->makeClone(), v);
+    auto fdfunc = std::make_unique<RadFunctorType>(myGrid->makeClone(), dv);
 
     RealType fderiv = (dv[1] - dv[0]) / ((*myGrid)[1] - (*myGrid)[0]);
 

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -460,10 +460,10 @@ void CoulombPBCAB::add(int groupID, std::unique_ptr<RadFunctorType>&& ppot)
     }
     v[0] = 2.0 * v[1] - v[2];
     //by construction, v has to go to zero at the boundary
-    v[ng - 2]             = 0.0;
-    v[ng - 1]             = 0.0;
-    RealType deriv        = (v[1] - v[0]) / ((*myGrid)[1] - (*myGrid)[0]);
-    auto rfunc            = std::make_unique<RadFunctorType>(myGrid->makeClone(), v);
+    v[ng - 2]      = 0.0;
+    v[ng - 1]      = 0.0;
+    RealType deriv = (v[1] - v[0]) / ((*myGrid)[1] - (*myGrid)[0]);
+    auto rfunc     = std::make_unique<RadFunctorType>(myGrid->makeClone(), v);
     rfunc->spline(0, deriv, ng - 1, 0.0);
     for (int iat = 0; iat < NptclA; iat++)
     {

--- a/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
@@ -22,8 +22,8 @@ namespace qmcplusplus
 void ECPComponentBuilder::addSemiLocal(xmlNodePtr cur)
 {
   std::unique_ptr<mGridType> grid_semilocal;
-  RealType rmax             = pp_nonloc->Rmax;
-  cur                       = cur->children;
+  RealType rmax = pp_nonloc->Rmax;
+  cur           = cur->children;
   while (cur != NULL)
   {
     std::string cname((const char*)cur->name);
@@ -112,7 +112,8 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
 
   std::string vFormat("V");
   const XMLAttrString v_str(cur, "format");
-  if (!v_str.empty()) vFormat = v_str;
+  if (!v_str.empty())
+    vFormat = v_str;
 
   int vPowerCorrection = 1;
   if (vFormat == "r*V")

--- a/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
@@ -21,7 +21,7 @@ namespace qmcplusplus
 {
 void ECPComponentBuilder::addSemiLocal(xmlNodePtr cur)
 {
-  mGridType* grid_semilocal = 0;
+  std::unique_ptr<mGridType> grid_semilocal;
   RealType rmax             = pp_nonloc->Rmax;
   cur                       = cur->children;
   while (cur != NULL)
@@ -43,7 +43,7 @@ void ECPComponentBuilder::addSemiLocal(xmlNodePtr cur)
         std::string cname1((const char*)cur1->name);
         if (cname1 == "basisGroup")
         {
-          pp_nonloc->add(l, createVrWithBasisGroup(cur1, grid_semilocal));
+          pp_nonloc->add(l, createVrWithBasisGroup(cur1, grid_semilocal.get()));
         }
         //else if(cname1 == "data")
         //{
@@ -78,12 +78,12 @@ ECPComponentBuilder::RadialPotentialType* ECPComponentBuilder::createVrWithBasis
   app_log() << "  calculated cutoff for " << eps << " = " << rout << std::endl;
   int ng = agrid->size();
   //all ways reset grid. Ye Luo
-  GridType* agrid_new;
+  std::unique_ptr<GridType> agrid_new;
   //if(agrid->GridTag != LINEAR_1DGRID)// || rout > agrid->rmax())
   {
     RealType ri = 0.0;
     RealType rf = std::max(rout, agrid->rmax());
-    agrid_new   = new LinearGrid<RealType>;
+    agrid_new   = std::make_unique<LinearGrid<RealType>>();
     agrid_new->set(ri, rf, ng);
     app_log() << "  Reset the grid for SemiLocal component to a LinearGrid. " << std::endl;
   }
@@ -93,7 +93,7 @@ ECPComponentBuilder::RadialPotentialType* ECPComponentBuilder::createVrWithBasis
     v[ig] = a.f((*agrid_new)[ig]);
   }
   v[ng - 1]                = 0.0;
-  RadialPotentialType* app = new RadialPotentialType(agrid_new, v);
+  RadialPotentialType* app = new RadialPotentialType(std::move(agrid_new), v);
   app->spline();
   return app;
 }
@@ -125,8 +125,8 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
     app_log() << "  Local pseudopotential format = V" << std::endl;
   }
   typedef GaussianTimesRN<RealType> InFuncType;
-  GridType* grid_local      = 0;
-  mGridType* grid_local_inp = 0;
+  std::unique_ptr<GridType> grid_local;
+  std::unique_ptr<mGridType> grid_local_inp;
   InFuncType vr;
   bool bareCoulomb = true;
   cur              = cur->children;
@@ -144,22 +144,22 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
     }
     else if (cname == "data")
     {
-      pp_loc = std::unique_ptr<RadialPotentialType>(createVrWithData(cur, grid_local_inp, vPowerCorrection));
+      pp_loc = std::unique_ptr<RadialPotentialType>(createVrWithData(cur, grid_local_inp.get(), vPowerCorrection));
       app_log() << "  Local pseduopotential in a <data/>" << std::endl;
       return;
     }
     cur = cur->next;
   }
-  if (grid_local_inp == 0)
+  if (grid_local_inp == nullptr)
   {
-    if (grid_global == 0)
+    if (grid_global == nullptr)
       myComm->barrier_and_abort("ECPComponentBuilder::buildLocal Missing grid information. ");
-    grid_local = new LinearGrid<RealType>;
+    grid_local = std::make_unique<LinearGrid<RealType>>();
     grid_local->set(grid_global->rmin(), grid_global->rmax(), grid_global->size());
   }
   else
   {
-    grid_local = new LinearGrid<RealType>;
+    grid_local = std::make_unique<LinearGrid<RealType>>();
     grid_local->set(grid_local_inp->rmin(), grid_local_inp->rmax(), grid_local_inp->size());
   }
   if (grid_local->GridTag == CUSTOM_1DGRID)
@@ -174,7 +174,7 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
       v.resize(3);
       for (int ig = 0; ig < 3; ig++)
         v[ig] = 1.0;
-      pp_loc = std::make_unique<RadialPotentialType>(grid_local, v);
+      pp_loc = std::make_unique<RadialPotentialType>(std::move(grid_local), v);
       pp_loc->spline(0, 0.0, 2, 0.0);
     }
     else
@@ -207,13 +207,13 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
       }
       v[0]      = 2.0 * v[1] - v[2];
       v[ng - 1] = 1.0;
-      pp_loc    = std::make_unique<RadialPotentialType>(grid_local, v);
+      pp_loc    = std::make_unique<RadialPotentialType>(std::move(grid_local), v);
       pp_loc->spline(); //use the fixed conditions
     }
   }
 }
 
-ECPComponentBuilder::mGridType* ECPComponentBuilder::createGrid(xmlNodePtr cur, bool useLinear)
+std::unique_ptr<ECPComponentBuilder::mGridType> ECPComponentBuilder::createGrid(xmlNodePtr cur, bool useLinear)
 {
   mRealType ri     = 1e-6;
   mRealType rf     = 100.0;
@@ -237,10 +237,10 @@ ECPComponentBuilder::mGridType* ECPComponentBuilder::createGrid(xmlNodePtr cur, 
   radAttrib.add(ascale, "scale");
   radAttrib.add(astep, "step");
   radAttrib.put(cur);
-  std::map<std::string, mGridType*>::iterator git(grid_inp.find(gridID));
+  auto git = grid_inp.find(gridID);
   if (git != grid_inp.end())
   {
-    return (*git).second; //use the same grid
+    return (*git).second->makeClone(); //use the same grid
   }
   //overwrite the grid type to linear starting at 0.0
   if (useLinear)
@@ -248,13 +248,13 @@ ECPComponentBuilder::mGridType* ECPComponentBuilder::createGrid(xmlNodePtr cur, 
     gridType = "linear";
     ri       = 0.0;
   }
-  mGridType* agrid = 0;
+  std::unique_ptr<mGridType> agrid;
   if (gridType == "log")
   {
     if (ascale > 0.0)
     {
       app_log() << "   Log grid scale=" << ascale << " step=" << astep << " npts=" << npts << std::endl;
-      agrid = new LogGridZero<mRealType>;
+      agrid = std::make_unique<LogGridZero<mRealType>>();
       agrid->set(astep, ascale, npts);
     }
     else
@@ -263,13 +263,13 @@ ECPComponentBuilder::mGridType* ECPComponentBuilder::createGrid(xmlNodePtr cur, 
       {
         ri = std::numeric_limits<mRealType>::epsilon();
       }
-      agrid = new LogGrid<mRealType>;
+      agrid = std::make_unique<LogGrid<mRealType>>();
       agrid->set(ri, rf, npts);
     }
   }
   else if (gridType == "linear")
   {
-    agrid = new LinearGrid<mRealType>;
+    agrid = std::make_unique<LinearGrid<mRealType>>();
     if (astep > 0.0)
     {
       npts = static_cast<int>((rf - ri) / astep) + 1;
@@ -288,7 +288,7 @@ ECPComponentBuilder::mGridType* ECPComponentBuilder::createGrid(xmlNodePtr cur, 
       {
         std::vector<double> gIn(npts);
         putContent(gIn, cur1);
-        agrid = new NumericalGrid<mRealType>(gIn);
+        agrid = std::make_unique<NumericalGrid<mRealType>>(gIn);
         app_log() << "   Numerical grid npts = " << gIn.size() << std::endl;
       }
       cur1 = cur1->next;
@@ -302,7 +302,7 @@ ECPComponentBuilder::RadialPotentialType* ECPComponentBuilder::createVrWithData(
                                                                                 mGridType* agrid,
                                                                                 int rCorrection)
 {
-  return 0;
+  return nullptr;
   //  RealType rcIn = agrid->rmax();
   //  //use the maximum value of the grid
   //  if(RcutMax<0) RcutMax=rcIn;

--- a/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
@@ -303,7 +303,7 @@ void ECPComponentBuilder::buildSO(const std::vector<int>& angList,
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
   //this is a new grid
   mRealType d                 = 1e-4;
-  LinearGrid<RealType>* agrid = new LinearGrid<RealType>;
+  auto agrid                  = std::make_unique<LinearGrid<RealType>>();
   // If the global grid is already linear, do not interpolate the data
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
@@ -335,7 +335,7 @@ void ECPComponentBuilder::buildSO(const std::vector<int>& angList,
     for (int i = 0; i < ngIn; i++)
       newPin[i] = Vprefactor * vp[i];
 
-    OneDimCubicSpline<mRealType> infunc(grid_global, newPin);
+    OneDimCubicSpline<mRealType> infunc(grid_global->makeClone(), newPin);
     infunc.spline(0, 0.0, ngIn - 1, 0.0);
     for (int i = 1; i < ng - 1; i++)
     {
@@ -344,7 +344,7 @@ void ECPComponentBuilder::buildSO(const std::vector<int>& angList,
     }
     newP[0]                  = newP[1];
     newP[ng - 1]             = 0.0;
-    RadialPotentialType* app = new RadialPotentialType(agrid, newP);
+    RadialPotentialType* app = new RadialPotentialType(agrid->makeClone(), newP);
     app->spline();
     pp_so->add(angList[l], app);
   }
@@ -398,7 +398,7 @@ bool ECPComponentBuilder::parseCasino(const std::string& fname, xmlNodePtr cur)
   aParser.skiplines(fin, 1); //R(i) in atomic units
   aParser.getValues(fin, temp.begin(), temp.end());
   //create a global grid of numerical type
-  grid_global = new NumericalGrid<mRealType>(temp);
+  grid_global = std::make_unique<NumericalGrid<mRealType>>(temp);
   Matrix<mRealType> vnn(Lmax + 1, npts);
   for (int l = 0; l <= Lmax; l++)
   {
@@ -461,7 +461,7 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
   //this is a new grid
   mRealType d                 = 1e-4;
-  LinearGrid<RealType>* agrid = new LinearGrid<RealType>;
+  auto agrid                  = std::make_unique<LinearGrid<RealType>>();
   // If the global grid is already linear, do not interpolate the data
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
@@ -508,7 +508,7 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
     int ll                          = angList[l];
     for (int i = 0; i < ngIn; i++)
       newPin[i] = Vprefactor * (vp[i] - vpLoc[i]);
-    OneDimCubicSpline<mRealType> infunc(grid_global, newPin);
+    OneDimCubicSpline<mRealType> infunc(grid_global->makeClone(), newPin);
     infunc.spline(0, 0.0, ngIn - 1, 0.0);
     for (int i = 1; i < ng - 1; i++)
     {
@@ -517,7 +517,7 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
     }
     newP[0]                  = newP[1];
     newP[ng - 1]             = 0.0;
-    RadialPotentialType* app = new RadialPotentialType(agrid, newP);
+    auto app                 = new RadialPotentialType(agrid->makeClone(), newP);
     app->spline();
     pp_nonloc->add(angList[l], app);
   }
@@ -542,13 +542,13 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
     for (int i = 0; i < ngIn; i++)
       newPin[i] = vfac * vpLoc[i];
     double dy0 = (newPin[1] - newPin[0]) / ((*grid_global)[1] - (*grid_global)[0]);
-    OneDimCubicSpline<mRealType> infunc(grid_global, newPin);
+    OneDimCubicSpline<mRealType> infunc(grid_global->makeClone(), newPin);
     infunc.spline(0, dy0, ngIn - 1, 0.0);
     int m                          = grid_global->size();
     double loc_max                 = grid_global->r(m - 1);
     int nloc                       = (int)std::floor(loc_max / d);
     loc_max                        = (nloc - 1) * d;
-    LinearGrid<RealType>* grid_loc = new LinearGrid<RealType>;
+    auto grid_loc                  = std::make_unique<LinearGrid<RealType>>();
     grid_loc->set(0.0, loc_max, nloc);
     app_log() << "   Making L=" << Llocal << " a local potential with a radial cutoff of " << loc_max << std::endl;
     std::vector<RealType> newPloc(nloc);
@@ -559,7 +559,7 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
     }
     newPloc[0]        = 0.0;
     newPloc[nloc - 1] = 1.0;
-    pp_loc            = std::make_unique<RadialPotentialType>(grid_loc, newPloc);
+    pp_loc            = std::make_unique<RadialPotentialType>(std::move(grid_loc), newPloc);
     pp_loc->spline(0, dy0, nloc - 1, 0.0);
     // for (double r=0.0; r<3.50001; r+=0.001)
     //   fprintf (stderr, "%10.5f %10.5f\n", r, pp_loc->splint(r));

--- a/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
@@ -302,8 +302,8 @@ void ECPComponentBuilder::buildSO(const std::vector<int>& angList,
   const int max_points = 100000;
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
   //this is a new grid
-  mRealType d                 = 1e-4;
-  auto agrid                  = std::make_unique<LinearGrid<RealType>>();
+  mRealType d = 1e-4;
+  auto agrid  = std::make_unique<LinearGrid<RealType>>();
   // If the global grid is already linear, do not interpolate the data
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
@@ -460,8 +460,8 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
 #endif
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
   //this is a new grid
-  mRealType d                 = 1e-4;
-  auto agrid                  = std::make_unique<LinearGrid<RealType>>();
+  mRealType d = 1e-4;
+  auto agrid  = std::make_unique<LinearGrid<RealType>>();
   // If the global grid is already linear, do not interpolate the data
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
@@ -515,9 +515,9 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
       mRealType r = d * i;
       newP[i]     = infunc.splint(r) / r;
     }
-    newP[0]                  = newP[1];
-    newP[ng - 1]             = 0.0;
-    auto app                 = new RadialPotentialType(agrid->makeClone(), newP);
+    newP[0]      = newP[1];
+    newP[ng - 1] = 0.0;
+    auto app     = new RadialPotentialType(agrid->makeClone(), newP);
     app->spline();
     pp_nonloc->add(angList[l], app);
   }
@@ -544,11 +544,11 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
     double dy0 = (newPin[1] - newPin[0]) / ((*grid_global)[1] - (*grid_global)[0]);
     OneDimCubicSpline<mRealType> infunc(grid_global->makeClone(), newPin);
     infunc.spline(0, dy0, ngIn - 1, 0.0);
-    int m                          = grid_global->size();
-    double loc_max                 = grid_global->r(m - 1);
-    int nloc                       = (int)std::floor(loc_max / d);
-    loc_max                        = (nloc - 1) * d;
-    auto grid_loc                  = std::make_unique<LinearGrid<RealType>>();
+    int m          = grid_global->size();
+    double loc_max = grid_global->r(m - 1);
+    int nloc       = (int)std::floor(loc_max / d);
+    loc_max        = (nloc - 1) * d;
+    auto grid_loc  = std::make_unique<LinearGrid<RealType>>();
     grid_loc->set(0.0, loc_max, nloc);
     app_log() << "   Making L=" << Llocal << " a local potential with a radial cutoff of " << loc_max << std::endl;
     std::vector<RealType> newPloc(nloc);

--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -36,8 +36,7 @@ ECPComponentBuilder::ECPComponentBuilder(const std::string& aname, Communicate* 
       AtomicNumber(0),
       Zeff(0),
       RcutMax(-1),
-      Species(aname),
-      grid_global(0)
+      Species(aname)
 {
   angMon["s"] = 0;
   angMon["p"] = 1;

--- a/src/QMCHamiltonians/ECPComponentBuilder.h
+++ b/src/QMCHamiltonians/ECPComponentBuilder.h
@@ -40,8 +40,8 @@ struct ECPComponentBuilder : public MPIObjectBase, public QMCTraits
   RealType Zeff;
   RealType RcutMax;
   std::string Species;
-  mGridType* grid_global;
-  std::map<std::string, mGridType*> grid_inp;
+  std::unique_ptr<mGridType> grid_global;
+  std::map<std::string, std::unique_ptr<mGridType>> grid_inp;
   std::unique_ptr<RadialPotentialType> pp_loc;
   std::unique_ptr<NonLocalECPComponent> pp_nonloc;
   std::unique_ptr<SOECPComponent> pp_so; //Spin-orbit potential component.
@@ -72,7 +72,7 @@ struct ECPComponentBuilder : public MPIObjectBase, public QMCTraits
   //  7          50         11
   void SetQuadratureRule(int rule);
 
-  mGridType* createGrid(xmlNodePtr cur, bool useLinear = false);
+  std::unique_ptr<mGridType> createGrid(xmlNodePtr cur, bool useLinear = false);
   RadialPotentialType* createVrWithBasisGroup(xmlNodePtr cur, mGridType* agrid);
   RadialPotentialType* createVrWithData(xmlNodePtr cur, mGridType* agrid, int rCorrection = 0);
 

--- a/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
@@ -91,8 +91,8 @@ void ECPComponentBuilder::buildL2(xmlNodePtr cur)
   RealType rmax        = rcut;
   const int max_points = 100000;
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
-  auto grid                  = std::make_unique<LinearGrid<RealType>>();
-  RealType d                 = 1e-4;
+  auto grid  = std::make_unique<LinearGrid<RealType>>();
+  RealType d = 1e-4;
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
   {

--- a/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
@@ -91,7 +91,7 @@ void ECPComponentBuilder::buildL2(xmlNodePtr cur)
   RealType rmax        = rcut;
   const int max_points = 100000;
   app_log() << "   Creating a Linear Grid Rmax=" << rmax << std::endl;
-  LinearGrid<RealType>* grid = new LinearGrid<RealType>;
+  auto grid                  = std::make_unique<LinearGrid<RealType>>();
   RealType d                 = 1e-4;
   int ng;
   if (grid_global->getGridTag() == LINEAR_1DGRID)
@@ -121,7 +121,7 @@ void ECPComponentBuilder::buildL2(xmlNodePtr cur)
   std::vector<RealType> new_vL2in(ngIn);
   for (int i = 0; i < ngIn; i++)
     new_vL2in[i] = Vprefactor * vL2in[i];
-  OneDimCubicSpline<mRealType> infunc(grid_global, new_vL2in);
+  OneDimCubicSpline<mRealType> infunc(grid_global->makeClone(), new_vL2in);
   infunc.spline(0, 0.0, ngIn - 1, 0.0);
   for (int i = 1; i < ng - 1; i++)
   {
@@ -130,7 +130,7 @@ void ECPComponentBuilder::buildL2(xmlNodePtr cur)
   }
   new_vL2[0]               = new_vL2[1];
   new_vL2[ng - 1]          = 0.0;
-  RadialPotentialType* vL2 = new RadialPotentialType(grid, new_vL2);
+  RadialPotentialType* vL2 = new RadialPotentialType(std::move(grid), new_vL2);
   vL2->spline();
 
   // save the splined L2 potential

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -367,7 +367,7 @@ void ECPotentialBuilder::useSimpleTableFormat()
         int ng          = npoints - 1;
         RealType rf     = 5.0;
         ng              = static_cast<int>(rf * 100) + 1; //use 1e-2 resolution
-        GridType* agrid = new LinearGrid<RealType>;
+        auto agrid      = std::make_unique<LinearGrid<RealType>>();
         agrid->set(0, rf, ng);
         std::vector<RealType> pp_temp(ng);
         pp_temp[0] = 0.0;
@@ -377,7 +377,7 @@ void ECPotentialBuilder::useSimpleTableFormat()
           pp_temp[j] = r * zinv * inFunc.splint(r);
         }
         pp_temp[ng - 1] = 1.0;
-        auto app        = std::make_unique<RadialPotentialType>(agrid, pp_temp);
+        auto app        = std::make_unique<RadialPotentialType>(std::move(agrid), pp_temp);
         app->spline();
         localPot[ig] = std::move(app);
         app_log() << "    LocalECP l=" << angmom << std::endl;
@@ -390,7 +390,7 @@ void ECPotentialBuilder::useSimpleTableFormat()
         if (!mynnloc)
           mynnloc = std::make_unique<NonLocalECPComponent>();
         RealType rf     = inFunc.rmax();
-        GridType* agrid = new LinearGrid<RealType>;
+        auto agrid      = std::make_unique<LinearGrid<RealType>>();
         int ng          = static_cast<int>(rf * 100) + 1;
         agrid->set(0.0, rf, ng);
         app_log() << "    NonLocalECP l=" << angmom << " rmax = " << rf << std::endl;
@@ -402,7 +402,7 @@ void ECPotentialBuilder::useSimpleTableFormat()
         {
           pp_temp[j] = inFunc.splint((*agrid)[j]);
         }
-        RadialPotentialType* app = new RadialPotentialType(agrid, pp_temp);
+        auto app = new RadialPotentialType(std::move(agrid), pp_temp);
         app->spline();
         mynnloc->add(angmom, app);
         lmax = std::max(lmax, angmom);

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -363,11 +363,11 @@ void ECPotentialBuilder::useSimpleTableFormat()
       if (angmom < 0)
       //local potential, input is rescale by -r/z
       {
-        RealType zinv   = -1.0 / Species(icharge, ig);
-        int ng          = npoints - 1;
-        RealType rf     = 5.0;
-        ng              = static_cast<int>(rf * 100) + 1; //use 1e-2 resolution
-        auto agrid      = std::make_unique<LinearGrid<RealType>>();
+        RealType zinv = -1.0 / Species(icharge, ig);
+        int ng        = npoints - 1;
+        RealType rf   = 5.0;
+        ng            = static_cast<int>(rf * 100) + 1; //use 1e-2 resolution
+        auto agrid    = std::make_unique<LinearGrid<RealType>>();
         agrid->set(0, rf, ng);
         std::vector<RealType> pp_temp(ng);
         pp_temp[0] = 0.0;
@@ -389,9 +389,9 @@ void ECPotentialBuilder::useSimpleTableFormat()
         hasNonLocalPot = true; //will create NonLocalECPotential
         if (!mynnloc)
           mynnloc = std::make_unique<NonLocalECPComponent>();
-        RealType rf     = inFunc.rmax();
-        auto agrid      = std::make_unique<LinearGrid<RealType>>();
-        int ng          = static_cast<int>(rf * 100) + 1;
+        RealType rf = inFunc.rmax();
+        auto agrid  = std::make_unique<LinearGrid<RealType>>();
+        int ng      = static_cast<int>(rf * 100) + 1;
         agrid->set(0.0, rf, ng);
         app_log() << "    NonLocalECP l=" << angmom << " rmax = " << rf << std::endl;
         app_log() << "      Linear grid=[0," << rf << "] npts=" << ng << std::endl;

--- a/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
@@ -77,8 +77,8 @@ void applyCuspCorrection(const Matrix<CuspCorrectionParameters>& info,
     for (int mo_idx = 0; mo_idx < orbital_set_size; mo_idx++)
     {
       computeRadialPhiBar(&targetPtcl, &sourcePtcl, mo_idx, ic, &phi, xgrid, rad_orb, info(ic, mo_idx));
-      OneDimQuinticSpline<RealType> radial_spline(radial_grid.get(), rad_orb);
       RealType yprime_i = (rad_orb[1] - rad_orb[0]) / (radial_grid->r(1) - radial_grid->r(0));
+      OneDimQuinticSpline<RealType> radial_spline(radial_grid->makeClone(), rad_orb);
       radial_spline.spline(0, yprime_i, rad_orb.size() - 1, 0.0);
       cot->addSpline(mo_idx, radial_spline);
 

--- a/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
@@ -63,7 +63,7 @@ struct A2NTransformer : TransformerBase<T>
   void convert(grid_type& agrid, FnOut& multiset, int ispline, int order)
   {
     typedef OneDimQuinticSpline<OHMMS_PRECISION_FULL> spline_type;
-    spline_type radorb(&agrid);
+    spline_type radorb(agrid.makeClone());
     Transform2GridFunctor<FnIn, spline_type> transform(*m_ref, radorb);
     transform.generate(agrid.rmin(), agrid.rmax(), agrid.size());
     multiset.add_spline(ispline, radorb);

--- a/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_multiquintic_spline.cpp
@@ -62,11 +62,11 @@ TEST_CASE("MultiQuinticSpline", "[wavefunction][LCAO]")
   auto agrid = std::make_unique<LogGrid<double>>();
   agrid->set(.1, 1.0, 5);
 
-  OneDimQuinticSpline<double> spline1(agrid.get());
+  OneDimQuinticSpline<double> spline1(agrid->makeClone());
   spline1.set(data);
   spline1.spline();
 
-  OneDimQuinticSpline<double> spline2(agrid.get());
+  OneDimQuinticSpline<double> spline2(agrid->makeClone());
   spline2.set(data2);
   spline2.spline();
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This fixes most direct leaks found in deterministic-unit_test_hamiltonian_force by clang address sanitizer.

I didn't fix the leak in src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp:343 since @williamfgc already has a branch that changes the return type from a raw pointer to a unique_ptr. 

This is part of #3083.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- n/a. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- n/a. Documentation has been added (if appropriate)
