### PR TITLE
Reduce clang warning -Wunused-but-set-variable

### DIFF
--- a/src/Estimators/LocalEnergyEstimator.cpp
+++ b/src/Estimators/LocalEnergyEstimator.cpp
@@ -56,9 +56,9 @@ void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5
 void LocalEnergyEstimator::add2Record(RecordListType& record)
 {
   FirstIndex = record.size();
-  int dumy   = record.add("LocalEnergy");
-  dumy       = record.add("LocalEnergy_sq");
-  dumy       = record.add("LocalPotential");
+  record.add("LocalEnergy");
+  record.add("LocalEnergy_sq");
+  record.add("LocalPotential");
   for (int i = 0; i < SizeOfHamiltonians; ++i)
     record.add(refH.getObservableName(i));
   LastIndex = record.size();

--- a/src/QMCApp/tests/test_project_data.cpp
+++ b/src/QMCApp/tests/test_project_data.cpp
@@ -54,9 +54,6 @@ TEST_CASE("ProjectData", "[ohmmsapp]")
 
 TEST_CASE("ProjectData::put no series", "[ohmmsapp]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ProjectData proj("test");
 
   const char* xml_input = "<project id='test1'></project>";
@@ -72,9 +69,6 @@ TEST_CASE("ProjectData::put no series", "[ohmmsapp]")
 
 TEST_CASE("ProjectData::put with series", "[ohmmsapp]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ProjectData proj("test");
 
   const char* xml_input = "<project id='test1' series='1'></project>";

--- a/src/QMCApp/tests/test_rng_control.cpp
+++ b/src/QMCApp/tests/test_rng_control.cpp
@@ -27,9 +27,6 @@ namespace qmcplusplus
 {
 TEST_CASE("RandomNumberControl make_seeds", "[ohmmsapp]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   RandomNumberControl::make_seeds();
 
   REQUIRE(RandomNumberControl::Children.size() > 0);
@@ -37,9 +34,6 @@ TEST_CASE("RandomNumberControl make_seeds", "[ohmmsapp]")
 
 TEST_CASE("RandomNumberControl no random in xml", "[ohmmsapp]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   const char* xml_input = "<tmp></tmp>";
 
   Libxml2Document doc;

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -68,7 +68,6 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
   FullPrecRealType enew(eold);
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
-  RealType gf_acc      = 1.0;
   {
     ScopedTimer local_timer(myTimers[DMC_movePbyP]);
     for (int ig = 0; ig < W.groups(); ++ig) //loop over species
@@ -117,7 +116,6 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
             ++nAcceptTemp;
             Psi.acceptMove(W, iat, true);
             rr_accepted += rr;
-            gf_acc *= prob; //accumulate the ratio
           }
           else
           {
@@ -168,7 +166,6 @@ void DMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool re
     thisWalker.Weight = wtmp;
     ++nAllRejected;
     enew   = eold; //copy back old energy
-    gf_acc = 1.0;
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
   }
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
@@ -64,7 +64,6 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
   FullPrecRealType enew(eold);
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
-  RealType gf_acc      = 1.0;
   mPosType K;
   mTensorType D;
   mTensorType Dchol;
@@ -188,7 +187,6 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
             ++nAcceptTemp;
             Psi.acceptMove(W, iat, true);
             rr_accepted += rr;
-            gf_acc *= prob; //accumulate the ratio
           }
           else
           {
@@ -238,7 +236,6 @@ void DMCUpdatePbyPL2::advanceWalker(Walker_t& thisWalker, bool recompute)
     thisWalker.Weight = wtmp;
     ++nAllRejected;
     enew   = eold; //copy back old energy
-    gf_acc = 1.0;
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
   }
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -66,7 +66,6 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
   FullPrecRealType enew(eold);
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
-  RealType gf_acc      = 1.0;
   {
     ScopedTimer local_timer(myTimers[SODMC_movePbyP]);
     for (int ig = 0; ig < W.groups(); ++ig) //loop over species
@@ -125,7 +124,6 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
             ++nAcceptTemp;
             Psi.acceptMove(W, iat, true);
             rr_accepted += rr;
-            gf_acc *= prob; //accumulate the ratio
           }
           else
           {
@@ -176,7 +174,6 @@ void SODMCUpdatePbyPWithRejectionFast::advanceWalker(Walker_t& thisWalker, bool 
     thisWalker.Weight = wtmp;
     ++nAllRejected;
     enew   = eold; //copy back old energy
-    gf_acc = 1.0;
     thisWalker.Weight *= branchEngine->branchWeight(enew, eold);
   }
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/Optimizers/DescentEngine.cpp
+++ b/src/QMCDrivers/Optimizers/DescentEngine.cpp
@@ -1026,15 +1026,6 @@ void DescentEngine::computeFinalizationUncertainties(std::vector<ValueType>& wei
     this->mpi_unbiased_ratio_of_means(n, wtv, nmv, dnv, currentMean, currentVar, currentErr);
 
     app_log() << "Blocking analysis error for per process length " << n << " is: " << currentErr << std::endl;
-    int new_len;
-    if (n % 2 == 0)
-    {
-      new_len = n / 2;
-    }
-    else
-    {
-      new_len = n / 2 + 1;
-    }
 
     std::vector<ValueType> tmp1, tmp2, tmp3;
 

--- a/src/QMCDrivers/RMC/RMCUpdateAll.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.cpp
@@ -116,7 +116,6 @@ void RMCUpdateAllWithDrift::advanceWalkersVMC()
   //app_log()<<"Old phase = "<<Psi.getPhase()<< std::endl;
   makeGaussRandomWithEngine(deltaR, RandomGen);
   RealType r2proposed = Dot(deltaR, deltaR);
-  RealType r2accept   = 0.0;
   //      W.reptile->r2prop += r2proposed;
   //      W.reptile->r2samp++;
   if (!W.makeMoveAllParticlesWithDrift(curhead, drift, deltaR, m_sqrttau))
@@ -239,8 +238,6 @@ void RMCUpdateAllWithDrift::advanceWalkersVMC()
   if (RandomGen() < acceptProb)
   {
     //Assuming the VMC step is fine, we are forcing the move.
-    r2accept = r2proposed;
-    //        W.reptile->r2accept+=r2accept;
     MCWalkerConfiguration::Walker_t& overwriteWalker(W.reptile->getNewHead());
 
     W.saveWalker(overwriteWalker);

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -139,7 +139,6 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
   RealType enew(eold);
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
-  RealType gf_acc      = 1.0;
   movepbyp_timer_.start();
   for (int ig = 0; ig < W.groups(); ++ig) //loop over species
   {
@@ -186,7 +185,6 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
           ++nAcceptTemp;
           Psi.acceptMove(W, iat, true);
           rr_accepted += rr;
-          gf_acc *= prob; //accumulate the ratio
         }
         else
         {
@@ -233,7 +231,6 @@ void RMCUpdatePbyPWithDrift::advanceWalkersVMC()
     H.rejectedMove(W, curhead);
     curhead.Weight = wtmp;
     ++nAllRejected;
-    gf_acc = 1.0;
     nReject++;
   }
   Walker_t& centerbead = W.reptile->getCenter();
@@ -270,7 +267,6 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
   RealType vqold(prophead.Properties(WP::DRIFTSCALE));
   RealType rr_proposed = 0.0;
   RealType rr_accepted = 0.0;
-  RealType gf_acc      = 1.0;
   movepbyp_timer_.start();
   for (int ig = 0; ig < W.groups(); ++ig) //loop over species
   {
@@ -317,7 +313,6 @@ void RMCUpdatePbyPWithDrift::advanceWalkersRMC()
           ++nAcceptTemp;
           Psi.acceptMove(W, iat, true);
           rr_accepted += rr;
-          gf_acc *= prob; //accumulate the ratio
         }
         else
         {

--- a/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
+++ b/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
@@ -59,10 +59,9 @@ int HamiltonianRef::addObservables(ParticleSet& P)
   P.Collectables.rewind();
   for (int i = 0; i < Hrefs_.size(); ++i)
     Hrefs_[i].get().addObservables(Observables, P.Collectables);
-  int last_obs;
   int myIndex = P.PropertyList.add(Observables.Names[0]);
   for (int i = 1; i < Observables.size(); ++i)
-    last_obs = P.PropertyList.add(Observables.Names[i]);
+    P.PropertyList.add(Observables.Names[i]);
   P.Collectables.size();
   app_log() << "\n  QMCHamiltonian::add2WalkerProperty added"
             << "\n    " << Observables.size() << " to P::PropertyList "

--- a/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCorrelatedSamplingLinearOptimize.cpp
@@ -111,7 +111,6 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
   //this is the small amount added to the diagonal to stabilize the eigenvalue equation. e^stabilityBase
   RealType stabilityBase(exp0);
   std::vector<std::vector<RealType>> LastDirections;
-  RealType deltaPrms(-1.0);
   bool acceptedOneMove(false);
   int failedTries(0);
   Matrix<RealType> Left(N, N);
@@ -166,13 +165,12 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
         LeftT(i, i) += std::exp(XS);
       app_log() << "  Using XS:" << XS << std::endl;
     }
-    RealType lowestEV(0);
     RealType bigVec(0);
     eigenvalue_timer_.start();
     //                     lowestEV =getLowestEigenvector(LeftT,RightT,currentParameterDirections);
     if (GEVtype != "sd")
     {
-      lowestEV = getLowestEigenvector(LeftT, currentParameterDirections);
+      getLowestEigenvector(LeftT, currentParameterDirections);
       Lambda   = getNonLinearRescale(currentParameterDirections, Right);
     }
     else
@@ -278,7 +276,6 @@ bool QMCCorrelatedSamplingLinearOptimize::run()
         bestParameters[i] = std::real(optTarget->Params(i));
       lastCost        = newCost;
       acceptedOneMove = true;
-      deltaPrms       = Lambda;
     }
     else if ((stability > 0) && (newCost - lastCost > -1e-5))
       stability = nstabilizers;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -162,8 +162,6 @@ QMCCostFunctionBase::Return_rt QMCCostFunctionBase::computedCost()
   // app_log() << "SumValue[SUM_ABSE_WGT] = " << SumValue[SUM_ABSE_WGT] << std::endl;
   // app_log() << "SumValue[SUM_E_WGT] = " << SumValue[SUM_E_WGT] << std::endl;
   // app_log() << "SumValue[SUM_ESQ_WGT] = " << SumValue[SUM_ESQ_WGT] << std::endl;
-  Return_rt wgt_var = SumValue[SUM_WGTSQ] - SumValue[SUM_WGT] * SumValue[SUM_WGT];
-  wgt_var *= wgtinv;
   CostValue             = 0.0;
   const Return_rt small = 1.0e-10;
   if (std::abs(w_abs) > small)

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -317,9 +317,8 @@ bool QMCFixedSampleLinearOptimize::run()
       for (int i = 1; i < N; i++)
         Right(i, i) += std::exp(XS);
       app_log() << "  Using XS:" << XS << " " << failedTries << " " << stability << std::endl;
-      RealType lowestEV(0);
       eigenvalue_timer_.start();
-      lowestEV = getLowestEigenvector(Right, currentParameterDirections);
+      getLowestEigenvector(Right, currentParameterDirections);
       Lambda   = getNonLinearRescale(currentParameterDirections, S);
       eigenvalue_timer_.stop();
       //       biggest gradient in the parameter direction vector
@@ -886,7 +885,7 @@ void QMCFixedSampleLinearOptimize::solveShiftsWithoutLMYEngine(const std::vector
         std::swap(prdMat(i, j), prdMat(j, i));
 
     // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-    const RealType lowestEV = getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
+    getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
     Lambda = getNonLinearRescale(parameterDirections.at(shift_index), ovlMat);
@@ -1297,7 +1296,7 @@ bool QMCFixedSampleLinearOptimize::one_shift_run()
       std::swap(prdMat(i, j), prdMat(j, i));
 
   // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-  const RealType lowestEV = getLowestEigenvector(prdMat, parameterDirections);
+  getLowestEigenvector(prdMat, parameterDirections);
 
   // compute the scaling constant to apply to the update
   Lambda = getNonLinearRescale(parameterDirections, ovlMat);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -317,9 +317,8 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
       for (int i = 1; i < N; i++)
         Right(i, i) += std::exp(XS);
       app_log() << "  Using XS:" << XS << " " << failedTries << " " << stability << std::endl;
-      RealType lowestEV(0);
       eigenvalue_timer_.start();
-      lowestEV = getLowestEigenvector(Right, currentParameterDirections);
+      getLowestEigenvector(Right, currentParameterDirections);
       Lambda   = getNonLinearRescale(currentParameterDirections, S);
       eigenvalue_timer_.stop();
       //       biggest gradient in the parameter direction vector
@@ -899,7 +898,7 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
         std::swap(prdMat(i, j), prdMat(j, i));
 
     // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-    const RealType lowestEV = getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
+    getLowestEigenvector(prdMat, parameterDirections.at(shift_index));
 
     // compute the scaling constant to apply to the update
     Lambda = getNonLinearRescale(parameterDirections.at(shift_index), ovlMat);
@@ -1309,7 +1308,7 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
       std::swap(prdMat(i, j), prdMat(j, i));
 
   // compute the lowest eigenvalue of the product matrix and the corresponding eigenvector
-  const RealType lowestEV = getLowestEigenvector(prdMat, parameterDirections);
+  getLowestEigenvector(prdMat, parameterDirections);
 
   // compute the scaling constant to apply to the update
   Lambda = getNonLinearRescale(parameterDirections, ovlMat);

--- a/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCOptimizeBatched.cpp
@@ -102,7 +102,7 @@ bool QMCOptimizeBatched::run()
   // Hopefully this was not affecting anything.
   //optTarget->setTargetEnergy(branch_engine_->getEref());
   t1.restart();
-  bool success = optSolver->optimize(optTarget.get());
+  optSolver->optimize(optTarget.get());
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
   ;
   app_log() << "  </log>" << std::endl;
@@ -187,13 +187,12 @@ void QMCOptimizeBatched::process(xmlNodePtr q)
 
   optSolver->put(wfoptdriver_input_.get_opt_xml_node());
 
-  bool success = true;
   //allways reset optTarget
   optTarget =
       std::make_unique<QMCCostFunctionBatched>(W, population_.get_golden_twf(), population_.get_golden_hamiltonian(),
                                                samples_, opt_num_crowds, crowd_size, myComm);
   optTarget->setStream(&app_log());
-  success = optTarget->put(q);
+  optTarget->put(q);
 
   // This code is also called when setting up vmcEngine.  Would be nice to not duplicate the call.
   QMCDriverNew::AdjustedWalkerCounts awc =

--- a/src/QMCDrivers/WalkerControlBase.cpp
+++ b/src/QMCDrivers/WalkerControlBase.cpp
@@ -182,9 +182,9 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
 {
   MCWalkerConfiguration::iterator it(W.begin());
   MCWalkerConfiguration::iterator it_end(W.end());
-  FullPrecRealType esum = 0.0, e2sum = 0.0, wsum = 0.0, ecum = 0.0, w2sum = 0.0, besum = 0.0, bwgtsum = 0.0;
+  FullPrecRealType esum = 0.0, e2sum = 0.0, wsum = 0.0, ecum = 0.0, besum = 0.0, bwgtsum = 0.0;
   FullPrecRealType r2_accepted = 0.0, r2_proposed = 0.0;
-  int nrn(0), ncr(0), nfn(0), ngoodfn(0), nc(0);
+  int nrn(0), ncr(0), nfn(0), nc(0);
   for (; it != it_end; ++it)
   {
     bool inFN = (((*it)->ReleasedNodeAge) == 0);
@@ -196,7 +196,6 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
       else if ((*it)->ReleasedNodeAge == 0)
       {
         nfn += 1;
-        ngoodfn += nc;
       }
       r2_accepted += (*it)->Properties(WP::R2ACCEPTED);
       r2_proposed += (*it)->Properties(WP::R2PROPOSED);
@@ -207,7 +206,6 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
       esum += wgt * rnwgt * e;
       e2sum += wgt * rnwgt * e * e;
       wsum += rnwgt * wgt;
-      w2sum += rnwgt * rnwgt * wgt * wgt;
       ecum += e;
       besum += bfe * wgt;
       bwgtsum += wgt;
@@ -228,7 +226,6 @@ int WalkerControlBase::doNotBranch(int iter, MCWalkerConfiguration& W)
       esum += wgt * e;
       e2sum += wgt * e * e;
       wsum += wgt;
-      w2sum += wgt * wgt;
       ecum += e;
     }
   }
@@ -303,9 +300,9 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
   std::vector<int> ncopy_rn;
   NumWalkers = 0;
   MCWalkerConfiguration::iterator it_end(W.end());
-  FullPrecRealType esum = 0.0, e2sum = 0.0, wsum = 0.0, ecum = 0.0, w2sum = 0.0, besum = 0.0, bwgtsum = 0.0;
+  FullPrecRealType esum = 0.0, e2sum = 0.0, wsum = 0.0, ecum = 0.0, besum = 0.0, bwgtsum = 0.0;
   FullPrecRealType r2_accepted = 0.0, r2_proposed = 0.0;
-  int nfn(0), nrn(0), ngoodfn(0), ncr(0), nc(0);
+  int nfn(0), nrn(0), ncr(0), nc(0);
   while (it != it_end)
   {
     bool inFN = (((*it)->ReleasedNodeAge) == 0);
@@ -317,7 +314,6 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       else if ((*it)->ReleasedNodeAge == 0)
       {
         nfn += 1;
-        ngoodfn += nc;
       }
       r2_accepted += (*it)->Properties(WP::R2ACCEPTED);
       r2_proposed += (*it)->Properties(WP::R2PROPOSED);
@@ -328,7 +324,6 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       esum += wgt * rnwgt * local_energy;
       e2sum += wgt * rnwgt * local_energy * local_energy;
       wsum += rnwgt * wgt;
-      w2sum += rnwgt * rnwgt * wgt * wgt;
       ecum += local_energy;
       besum += alternate_energy * wgt;
       bwgtsum += wgt;
@@ -346,7 +341,6 @@ int WalkerControlBase::sortWalkers(MCWalkerConfiguration& W)
       esum += wgt * e;
       e2sum += wgt * e * e;
       wsum += wgt;
-      w2sum += wgt * wgt;
       ecum += e;
     }
 

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -267,21 +267,21 @@ void WaveFunctionTester::printEloc()
       //        W.R[closestElectron[iat]]=0.0;
       W.R[closestElectron[iat]][0] += x;
       W.update();
-      ValueType logpsi_p = Psi.evaluateLog(W);
+      Psi.evaluateLog(W);
       ValueType ene      = H.evaluate(W);
       out << ene << "  ";
       W.R[closestElectron[iat]] = source.R[iat];
       //        W.R[closestElectron[iat]]=0.0;
       W.R[closestElectron[iat]][1] += x;
       W.update();
-      logpsi_p = Psi.evaluateLog(W);
+      Psi.evaluateLog(W);
       ene      = H.evaluate(W);
       out << ene << "  ";
       W.R[closestElectron[iat]] = source.R[iat];
       //        W.R[closestElectron[iat]]=0.0;
       W.R[closestElectron[iat]][2] += x;
       W.update();
-      logpsi_p = Psi.evaluateLog(W);
+      Psi.evaluateLog(W);
       ene      = H.evaluate(W);
       out << ene << "  ";
       W.R[closestElectron[iat]] = tempR;
@@ -1696,7 +1696,7 @@ void WaveFunctionTester::runDerivTest()
   //W.R += deltaR;
   W.update();
   //ValueType psi = Psi.evaluate(W);
-  ValueType logpsi = Psi.evaluateLog(W);
+  Psi.evaluateLog(W);
   RealType eloc    = H.evaluate(W);
   app_log() << "  HamTest "
             << "  Total " << eloc << std::endl;
@@ -1734,7 +1734,7 @@ void WaveFunctionTester::runDerivTest()
   std::vector<RealType> PGradient(Nvars);
   std::vector<RealType> HGradient(Nvars);
   Psi.resetParameters(wfVars);
-  logpsi = Psi.evaluateLog(W);
+  Psi.evaluateLog(W);
 
   //reuse the sphere
   H.setPrimary(false);
@@ -1803,7 +1803,7 @@ void WaveFunctionTester::runDerivNLPPTest()
   //W.R += deltaR;
   W.update();
   //ValueType psi = Psi.evaluate(W);
-  ValueType logpsi = Psi.evaluateLog(W);
+  Psi.evaluateLog(W);
   RealType eloc    = H.evaluate(W);
 
   app_log() << "  HamTest "
@@ -1844,7 +1844,7 @@ void WaveFunctionTester::runDerivNLPPTest()
   std::vector<RealType> HGradient(Nvars);
   Psi.resetParameters(wfVars);
 
-  logpsi = Psi.evaluateLog(W);
+  Psi.evaluateLog(W);
 
   //reuse the sphere for non-local pp
   H.setPrimary(false);

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -39,9 +39,6 @@ namespace qmcplusplus
 {
 TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][dmc]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions;
   MCWalkerConfiguration elec;
 
@@ -134,9 +131,6 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
 TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dmc]")
 
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions;
   MCWalkerConfiguration elec;
 

--- a/src/QMCDrivers/tests/test_drift.cpp
+++ b/src/QMCDrivers/tests/test_drift.cpp
@@ -21,9 +21,6 @@ namespace qmcplusplus
 {
 TEST_CASE("drift pbyp and node correction real", "[drivers][drift]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   MCWalkerConfiguration elec;
 
   elec.setName("elec");
@@ -61,9 +58,6 @@ TEST_CASE("drift pbyp and node correction real", "[drivers][drift]")
 #ifdef QMC_COMPLEX
 TEST_CASE("drift pbyp and node correction complex", "[drivers][drift]")
 { // basically copy and pasted from real test, except "myi"
-  Communicate* c;
-  c = OHMMS::Controller;
-
   MCWalkerConfiguration elec;
 
   elec.setName("elec");
@@ -100,9 +94,6 @@ TEST_CASE("drift pbyp and node correction complex", "[drivers][drift]")
 
 TEST_CASE("get scaled drift real", "[drivers][drift]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   MCWalkerConfiguration elec;
 
   elec.setName("elec");
@@ -138,9 +129,6 @@ TEST_CASE("get scaled drift real", "[drivers][drift]")
 #ifdef QMC_COMPLEX
 TEST_CASE("get scaled drift complex", "[drivers][drift]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   MCWalkerConfiguration elec;
 
   elec.setName("elec");

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -39,9 +39,6 @@ namespace qmcplusplus
 {
 TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions;
   MCWalkerConfiguration elec;
 

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -382,11 +382,10 @@ void CoulombPBCAB::initBreakup(ParticleSet& P)
     Qspec[spec]       = tspeciesB(ChargeAttribIndxB, spec);
     NofSpeciesB[spec] = static_cast<int>(tspeciesB(MemberAttribIndxB, spec));
   }
-  RealType totQ = 0.0;
   for (int iat = 0; iat < NptclA; iat++)
-    totQ += Zat[iat] = Zspec[PtclA.GroupID[iat]];
+    Zat[iat] = Zspec[PtclA.GroupID[iat]];
   for (int iat = 0; iat < NptclB; iat++)
-    totQ += Qat[iat] = Qspec[P.GroupID[iat]];
+    Qat[iat] = Qspec[P.GroupID[iat]];
   //    if(totQ>std::numeric_limits<RealType>::epsilon())
   //    {
   //      LOGMSG("PBCs not yet finished for non-neutral cells");

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -96,11 +96,10 @@ void ForceChiesaPBCAA::initBreakup(ParticleSet& P)
   {
     Qspec[spec] = tspeciesB(ChargeAttribIndxB, spec);
   }
-  RealType totQ = 0.0;
   for (int iat = 0; iat < NptclA; iat++)
-    totQ += Zat[iat] = Zspec[PtclA.GroupID[iat]];
+    Zat[iat] = Zspec[PtclA.GroupID[iat]];
   for (int iat = 0; iat < NptclB; iat++)
-    totQ += Qat[iat] = Qspec[P.GroupID[iat]];
+    Qat[iat] = Qspec[P.GroupID[iat]];
   dAB = LRCoulombSingleton::getDerivHandler(P);
 }
 

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -440,7 +440,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
     cur = cur->next;
   }
   //add observables with physical and simple estimators
-  int howmany = targetH->addObservables(targetPtcl);
+  targetH->addObservables(targetPtcl);
   //do correction
   bool dmc_correction = false;
   cur                 = cur_saved->children;
@@ -480,7 +480,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
   }
   //evaluate the observables again
   if (dmc_correction)
-    howmany = targetH->addObservables(targetPtcl);
+    targetH->addObservables(targetPtcl);
   return true;
 }
 

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -182,7 +182,6 @@ void MPC::init_f_G()
   f_0 += 0.4 * M_PI * L * L * volInv;
   // std::cerr << "f_0 = " << f_0/volInv << std::endl;
   double worst = 0.0, worstLin = 0.0, worstQuad = 0.0;
-  int iworst = 0;
   for (int iG = 0; iG < numG; iG++)
   {
     TinyVector<double, 2> g_12(g_G_2N[iG], g_G_4N[iG]);
@@ -193,7 +192,6 @@ void MPC::init_f_G()
     if (diff > worst)
     {
       worst     = diff;
-      iworst    = iG;
       worstLin  = linearExtrap;
       worstQuad = quadExtrap;
     }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -214,10 +214,9 @@ int QMCHamiltonian::addObservables(ParticleSet& P)
     H[i]->addObservables(Observables, P.Collectables);
   for (int i = 0; i < auxH.size(); ++i)
     auxH[i]->addObservables(Observables, P.Collectables);
-  int last_obs;
   myIndex = P.PropertyList.add(Observables.Names[0]);
   for (int i = 1; i < Observables.size(); ++i)
-    last_obs = P.PropertyList.add(Observables.Names[i]);
+    P.PropertyList.add(Observables.Names[i]);
   numCollectables = P.Collectables.size();
   app_log() << "\n  QMCHamiltonian::add2WalkerProperty added"
             << "\n    " << Observables.size() << " to P::PropertyList "

--- a/src/QMCHamiltonians/SpaceGrid.cpp
+++ b/src/QMCHamiltonians/SpaceGrid.cpp
@@ -518,7 +518,6 @@ bool SpaceGrid::initialize_rectilinear(xmlNodePtr cur, std::string& coord, std::
   }
   Point du, uc, ubc, rc;
   RealType vol     = 0.0;
-  RealType vol_tot = 0.0;
   RealType vscale  = std::abs(det(axes));
   for (int i = 0; i < dimensions[0]; i++)
   {
@@ -563,7 +562,6 @@ bool SpaceGrid::initialize_rectilinear(xmlNodePtr cur, std::string& coord, std::
           break;
         }
         vol *= vscale;
-        vol_tot += vol;
         rc = dot(axes, ubc) + origin;
         //app_log()<< std::endl;
         //app_log()<<"umin "<<uc-du/2<< std::endl;

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -83,11 +83,10 @@ void StressPBC::initBreakup(ParticleSet& P)
   }
 
   for (int spec = 0; spec < NumSpeciesA; spec++) {}
-  RealType totQ = 0.0;
   for (int iat = 0; iat < NptclA; iat++)
-    totQ += Zat[iat] = Zspec[PtclA.GroupID[iat]];
+    Zat[iat] = Zspec[PtclA.GroupID[iat]];
   for (int iat = 0; iat < NptclB; iat++)
-    totQ += Qat[iat] = Qspec[P.GroupID[iat]];
+    Qat[iat] = Qspec[P.GroupID[iat]];
 
   AA = LRCoulombSingleton::getDerivHandler(P);
 }

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -30,9 +30,6 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
 
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(1.0);
@@ -73,9 +70,6 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
@@ -120,9 +114,6 @@ TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
 TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
@@ -28,9 +28,6 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(1.0);
@@ -73,9 +70,6 @@ TEST_CASE("Coulomb PBC A-A Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(3.77945227);
@@ -121,9 +115,6 @@ TEST_CASE("Coulomb PBC A-A BCC H Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A elec Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(1.0);

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -33,8 +33,7 @@ namespace qmcplusplus
 {
 TEST_CASE("Bare Force", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
+  Communicate* c = OHMMS::Controller;
 
   ParticleSet ions;
   ParticleSet elec;
@@ -140,9 +139,6 @@ void check_force_copy(ForceChiesaPBCAA& force, ForceChiesaPBCAA& force2)
 // PBC case
 TEST_CASE("Chiesa Force", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(5.0);
@@ -277,9 +273,6 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
 // Open BC case
 TEST_CASE("Ceperley Force", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   //CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   //Lattice.BoxBConds = false; // periodic
   //Lattice.R.diagonal(5.0);
@@ -369,9 +362,6 @@ TEST_CASE("Ceperley Force", "[hamiltonian]")
 // Test construction of Coulomb forces in OBC
 TEST_CASE("Ion-ion Force", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions;
   ParticleSet elec;
 

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -125,9 +125,6 @@ TEST_CASE("Chiesa Force BCC H Ewald3D", "[hamiltonian]")
 // test SR and LR pieces separately
 TEST_CASE("fccz sr lr clone", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(3.77945227);
@@ -228,9 +225,6 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
 // 3 H atoms randomly distributed in a box
 TEST_CASE("fccz h3", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(3.77945227);

--- a/src/QMCTools/CMakeLists.txt
+++ b/src/QMCTools/CMakeLists.txt
@@ -17,39 +17,25 @@
 
 project(qmctools)
 
-set(MOSRCS QMCGaussianParserBase.cpp GaussianFCHKParser.cpp GamesAsciiParser.cpp LCAOHDFParser.cpp)
+add_executable(convert4qmc convert4qmc.cpp QMCGaussianParserBase.cpp GaussianFCHKParser.cpp GamesAsciiParser.cpp
+                           LCAOHDFParser.cpp)
+target_link_libraries(convert4qmc PUBLIC qmcparticle)
+if(USE_OBJECT_TARGET)
+  target_link_libraries(convert4qmc PUBLIC qmcutil containers platform_omptarget)
+endif()
 
-# create libmocommon
-add_library(mocommon ${MOSRCS})
-target_link_libraries(mocommon PUBLIC qmcparticle)
-
-set(QTOOLS convert4qmc qmc-extract-eshdf-kvectors)
-foreach(p ${QTOOLS})
-
-  add_executable(${p} ${p}.cpp)
-  target_link_libraries(${p} mocommon)
-  if(USE_OBJECT_TARGET)
-    target_link_libraries(${p} qmcparticle qmcutil containers platform_omptarget)
-  endif()
-
-  install(TARGETS ${p} RUNTIME DESTINATION bin)
-
-endforeach(p ${QTOOLS})
+add_executable(qmc-extract-eshdf-kvectors qmc-extract-eshdf-kvectors.cpp)
+target_link_libraries(qmc-extract-eshdf-kvectors PUBLIC qmcio)
 
 add_executable(qmc-get-supercell getSupercell.cpp)
-install(TARGETS qmc-get-supercell RUNTIME DESTINATION bin)
 
 add_executable(qmc-check-affinity check-affinity.cpp)
 if(HAVE_MPI)
   target_link_libraries(qmc-check-affinity MPI::MPI_CXX)
 endif()
 
-install(TARGETS qmc-check-affinity RUNTIME DESTINATION bin)
-
 add_executable(convertpw4qmc convertpw4qmc.cpp XmlRep.cpp WriteEshdf.cpp)
 target_link_libraries(convertpw4qmc qmcutil Math::FFTW3)
-
-install(TARGETS convertpw4qmc RUNTIME DESTINATION bin)
 
 set(FSSRCS QMCFiniteSize/QMCFiniteSize.cpp QMCFiniteSize/SkParserBase.cpp QMCFiniteSize/SkParserASCII.cpp
            QMCFiniteSize/SkParserScalarDat.cpp QMCFiniteSize/SkParserHDF5.cpp QMCFiniteSize/FSUtilities.cpp)
@@ -63,6 +49,7 @@ if(USE_OBJECT_TARGET)
   target_link_libraries(qmcfinitesize qmcparticle qmcutil containers platform_omptarget)
 endif()
 
-install(TARGETS qmcfinitesize RUNTIME DESTINATION bin)
+install(TARGETS convert4qmc qmc-extract-eshdf-kvectors qmc-get-supercell qmc-check-affinity convertpw4qmc qmcfinitesize
+        RUNTIME DESTINATION bin)
 
 add_subdirectory(ppconvert)

--- a/src/QMCTools/GamesAsciiParser.cpp
+++ b/src/QMCTools/GamesAsciiParser.cpp
@@ -465,7 +465,6 @@ void GamesAsciiParser::getGeometry(std::istream& is)
 
 void GamesAsciiParser::getGaussianCenters(std::istream& is)
 {
-  int ng;
   gBound.resize(NumberOfAtoms + 1);
   std::string aline;
   std::map<std::string, int> basisDataMap;
@@ -522,7 +521,6 @@ void GamesAsciiParser::getGaussianCenters(std::istream& is)
     if (currentWords[0] == "TOTAL" && currentWords[1] == "NUMBER" && currentWords[2] == "OF" &&
         currentWords[3] == "BASIS")
     {
-      ng = atoi(currentWords.back().c_str());
       break;
     }
     if (currentWords.size() == 1) //found Species

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -67,7 +67,6 @@ bool QMCFiniteSize::validateXML()
   while (cur != NULL)
   {
     std::string cname((const char*)cur->name);
-    bool inputnode = true;
     if (cname == "particleset")
     {
       ptclPool.put(cur);
@@ -83,7 +82,7 @@ bool QMCFiniteSize::validateXML()
       if (a)
       {
         pushDocument((const char*)a);
-        inputnode = processPWH(XmlDocStack.top()->getRoot());
+        processPWH(XmlDocStack.top()->getRoot());
         popDocument();
       }
     }

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -1667,22 +1667,17 @@ void EinsplineSetExtended<double>::evaluate_notranspose(const ParticleSet& P,
   for (int iat = first, i = 0; iat < last; iat++, i++)
   {
     const PosType& r(P.activeR(iat));
+
     // Do core states first
-    int icore = NumValenceOrbs;
-    for (int tin = 0; tin < MuffinTins.size(); tin++)
-    {
+    if (MuffinTins.size())
       APP_ABORT("MuffinTins not implemented with Hessian evaluation.\n");
-      //        MuffinTins[tin].evaluateCore(r, StorageValueVector, StorageGradVector,
-      //                                     StorageHessVector, icore);
-      icore += MuffinTins[tin].get_num_core();
-    }
+
     // Check if we are in the muffin tin;  if so, evaluate
     bool inTin = false, need2blend = false;
     PosType disp;
     for (int tin = 0; tin < MuffinTins.size(); tin++)
-    {
       APP_ABORT("MuffinTins not implemented with Hessian evaluation.\n");
-    }
+
     bool inAtom = false;
     // Otherwise, evaluate the B-splines
     if (!inTin || need2blend)

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -475,19 +475,6 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     int n_tot_irred(0);
     for (int si = 0; si < numSuperTwists; si++)
     {
-      //      bool irreducible(false);
-      int irrep_wgt(0);
-      // 	 for (int i=0; i<superSets[si].size(); i++)
-      if (TwistSymmetry[superSets[si][0]] == 1)
-      {
-        irrep_wgt = TwistWeight[superSets[si][0]];
-        //        irreducible=true;
-        n_tot_irred++;
-      }
-      //	if((irreducible) and ((Version[0] >= 2) and (Version[1] >= 0)))
-      //	  fprintf (stderr, "Super twist #%d:  [ %9.5f %9.5f %9.5f ]  IRREDUCIBLE-K %d  %d \n",
-      // 		 si, superFracs[si][0], superFracs[si][1], superFracs[si][2], si, irrep_wgt);
-      //	else
       char buf[1000];
       snprintf(buf, 1000, "Super twist #%d:  [ %9.5f %9.5f %9.5f ]\n", si, superFracs[si][0], superFracs[si][1],
                superFracs[si][2]);

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -92,11 +92,11 @@ class DiracMatrixComputeCUDA : public Resource
    */
   template<typename TMAT, typename TREAL>
   inline void mw_computeInvertAndLog(cublasHandle_t h_cublas,
-                                  RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
-                                  RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
-                                  const int n,
-                                  const int lda,
-                                  OffloadPinnedVector<std::complex<TREAL>>& log_values)
+                                     RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
+                                     RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
+                                     const int n,
+                                     const int lda,
+                                     OffloadPinnedVector<std::complex<TREAL>>& log_values)
   {
     // This is probably dodgy
     int nw = log_values.size();
@@ -153,7 +153,7 @@ class DiracMatrixComputeCUDA : public Resource
                    "cudaMemcpyAsync log_values failed!");
     cudaErrorCheck(cudaStreamSynchronize(hstream), "cudaStreamSynchronize failed!");
     // restore the pointer mode for this cublas handle.
-    cublasErrorCheck(cublasSetPointerMode(h_cublas, previous_pointer_mode), "cublasSetPointerMode failed");    
+    cublasErrorCheck(cublasSetPointerMode(h_cublas, previous_pointer_mode), "cublasSetPointerMode failed");
   }
 
 
@@ -169,11 +169,11 @@ class DiracMatrixComputeCUDA : public Resource
    */
   template<typename TREAL>
   inline void mw_computeInvertAndLog(cublasHandle_t h_cublas,
-                                  OffloadPinnedVector<TREAL>& psi_Ms,
-                                  OffloadPinnedVector<TREAL>& inv_Ms,
-                                  const int n,
-                                  const int lda,
-                                  OffloadPinnedVector<std::complex<TREAL>>& log_values)
+                                     OffloadPinnedVector<TREAL>& psi_Ms,
+                                     OffloadPinnedVector<TREAL>& inv_Ms,
+                                     const int n,
+                                     const int lda,
+                                     OffloadPinnedVector<std::complex<TREAL>>& log_values)
   {
     // This is probably dodgy
     int nw = log_values.size();
@@ -225,13 +225,11 @@ class DiracMatrixComputeCUDA : public Resource
   }
 
 public:
-  DiracMatrixComputeCUDA(cudaStream_t hstream) : Resource("DiracMatrixComputeCUDA"), hstream_(hstream)
-  {
-  }
+  DiracMatrixComputeCUDA(cudaStream_t hstream) : Resource("DiracMatrixComputeCUDA"), hstream_(hstream) {}
 
-  DiracMatrixComputeCUDA(const DiracMatrixComputeCUDA& other, cudaStream_t hstream) : Resource(other.getName()), hstream_(hstream)
-  {
-  }
+  DiracMatrixComputeCUDA(const DiracMatrixComputeCUDA& other, cudaStream_t hstream)
+      : Resource(other.getName()), hstream_(hstream)
+  {}
 
   Resource* makeClone(cudaStream_t hstream) const { return new DiracMatrixComputeCUDA(*this, hstream); }
   Resource* makeClone() const override { return new DiracMatrixComputeCUDA(*this, this->hstream_); }

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -499,7 +499,6 @@ public:
     rcopy.resize(norb);
     // invoke the Fahy's variant of Sherman-Morrison update.
     int dummy_handle  = 0;
-    int success       = 0;
     const T* phiV_ptr = phiV.data();
     T* Ainv_ptr       = Ainv.data();
     T* temp_ptr       = temp.data();
@@ -508,7 +507,7 @@ public:
                     map(always, from: Ainv_ptr[:Ainv.size()]) \
                     use_device_ptr(phiV_ptr, Ainv_ptr, temp_ptr, rcopy_ptr)")
     {
-      success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);
+      ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);
       PRAGMA_OFFLOAD("omp target is_device_ptr(Ainv_ptr, temp_ptr, rcopy_ptr)")
       {
         temp_ptr[rowchanged] -= cone;
@@ -516,8 +515,8 @@ public:
         for (int i = 0; i < norb; i++)
           rcopy_ptr[i] = Ainv_ptr[rowchanged * lda + i];
       }
-      success = ompBLAS::ger(dummy_handle, norb, norb, static_cast<T>(RATIOT(-1) / c_ratio_in), rcopy_ptr, 1, temp_ptr,
-                             1, Ainv_ptr, lda);
+      ompBLAS::ger(dummy_handle, norb, norb, static_cast<T>(RATIOT(-1) / c_ratio_in), rcopy_ptr, 1, temp_ptr, 1,
+                   Ainv_ptr, lda);
     }
   }
 

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -248,8 +248,8 @@ public:
         for (int i = 0; i < norb; i++)
           rcopy_ptr[i] = Ainv_ptr[rowchanged * lda + i];
       }
-      ompBLAS::ger(dummy_handle, norb, norb, static_cast<T>(RATIOT(-1) / c_ratio_in), rcopy_ptr, 1, temp_ptr,
-                   1, Ainv_ptr, lda);
+      ompBLAS::ger(dummy_handle, norb, norb, static_cast<T>(RATIOT(-1) / c_ratio_in), rcopy_ptr, 1, temp_ptr, 1,
+                   Ainv_ptr, lda);
     }
   }
 
@@ -321,8 +321,8 @@ public:
       T* ratio_inv_mw   = reinterpret_cast<T*>(buffer_H2D_ptr + sizeof(T*) * n_accepted * 8);
 
       // invoke the Fahy's variant of Sherman-Morrison update.
-      ompBLAS::gemv_batched(dummy_handle, 'T', norb, norb, cone_ptr, Ainv_mw_ptr, lda, phiV_mw_ptr, 1,
-                            czero_ptr, temp_mw_ptr, 1, n_accepted);
+      ompBLAS::gemv_batched(dummy_handle, 'T', norb, norb, cone_ptr, Ainv_mw_ptr, lda, phiV_mw_ptr, 1, czero_ptr,
+                            temp_mw_ptr, 1, n_accepted);
       PRAGMA_OFFLOAD("omp target teams distribute num_teams(n_accepted) is_device_ptr(Ainv_mw_ptr, temp_mw_ptr, \
                      rcopy_mw_ptr, dpsiM_mw_out, d2psiM_mw_out, dpsiM_mw_in, d2psiM_mw_in)")
       for (int iw = 0; iw < n_accepted; iw++)
@@ -349,8 +349,8 @@ public:
         }
       }
 
-      ompBLAS::ger_batched(dummy_handle, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1, temp_mw_ptr, 1,
-                           Ainv_mw_ptr, lda, n_accepted);
+      ompBLAS::ger_batched(dummy_handle, norb, norb, ratio_inv_mw, rcopy_mw_ptr, 1, temp_mw_ptr, 1, Ainv_mw_ptr, lda,
+                           n_accepted);
     }
   }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -77,7 +77,6 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
   ///save the current node
   xmlNodePtr curRoot = cur;
   xmlNodePtr BFnode  = nullptr;
-  bool success       = true;
   std::string cname, tname;
   std::map<std::string, SPOSetPtr> spomap;
   bool multiDet = false;
@@ -265,11 +264,11 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
         }
 
         multislaterdetfast_0->initialize();
-        success = createMSDFast(multislaterdetfast_0->Dets, *multislaterdetfast_0->C2node, *multislaterdetfast_0->C,
-                                *multislaterdetfast_0->CSFcoeff, *multislaterdetfast_0->DetsPerCSF,
-                                *multislaterdetfast_0->CSFexpansion, multislaterdetfast_0->usingCSF,
-                                *multislaterdetfast_0->myVars, multislaterdetfast_0->Optimizable,
-                                multislaterdetfast_0->CI_Optimizable, cur);
+        createMSDFast(multislaterdetfast_0->Dets, *multislaterdetfast_0->C2node, *multislaterdetfast_0->C,
+                      *multislaterdetfast_0->CSFcoeff, *multislaterdetfast_0->DetsPerCSF,
+                      *multislaterdetfast_0->CSFexpansion, multislaterdetfast_0->usingCSF,
+                      *multislaterdetfast_0->myVars, multislaterdetfast_0->Optimizable,
+                      multislaterdetfast_0->CI_Optimizable, cur);
 
         // The primary purpose of this function is to create all the optimizable orbital rotation parameters.
         // But if orbital rotation parameters were supplied by the user it will also apply a unitary transformation
@@ -293,12 +292,12 @@ WaveFunctionComponent* SlaterDetBuilder::buildComponent(xmlNodePtr cur)
           app_summary() << "    Using backflow transformation." << std::endl;
           multislaterdet_0 =
               new MultiSlaterDeterminantWithBackflow(targetPtcl, std::move(spo_up), std::move(spo_dn), BFTrans);
-          success = createMSD(multislaterdet_0, cur);
+          createMSD(multislaterdet_0, cur);
         }
         else
         {
           multislaterdet_0 = new MultiSlaterDeterminant(targetPtcl, std::move(spo_up), std::move(spo_dn));
-          success          = createMSD(multislaterdet_0, cur);
+          createMSD(multislaterdet_0, cur);
         }
       }
     }

--- a/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
@@ -121,12 +121,10 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
 
     // sum up the sigmoidal function expansion
     real_type sig_sum = 0.0;
-    real_type n = 2.0;
     real_type sn = s * s; // s^n
     for (int i = 0; i < B.size(); i++) {
       sig_sum += B[i] * sn / ( 1.0 + sn );
       sn *= s;  // update s^n
-      n += 1.0; // update n
     }
 
     // return U(r)
@@ -413,12 +411,10 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
     // evaluate derivatives with respect to the sigmoidal expansion coefficients
     if (Opt_B)
     {
-      real_type n = 2.0;
       real_type sn = s * s; // s^n
       for (int j = 0; j < B.size(); j++) {
         derivs[i] = -ex * sn / ( 1.0 + sn ); // dU/dB_j
         sn *= s;  // update s^n
-        n += 1.0; // update n
         ++i;      // increment the index tracking where to put derivatives
       }
     }

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -57,7 +57,6 @@ WaveFunctionComponent* PWOrbitalBuilder::buildComponent(xmlNodePtr cur)
   //no file, check the root
   if (hfileID < 0)
     hfileID = getH5(rootNode, "href");
-  bool success = true;
   //Move through the XML tree and read basis information
   cur = cur->children;
   while (cur != NULL)
@@ -84,7 +83,7 @@ WaveFunctionComponent* PWOrbitalBuilder::buildComponent(xmlNodePtr cur)
         APP_ABORT("  Cannot create a SlaterDet due to missing h5 file\n");
         OHMMS::Controller->abort();
       }
-      success = createPWBasis(cur);
+      createPWBasis(cur);
       slater_det = putSlaterDet(cur);
     }
     cur = cur->next;

--- a/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
@@ -30,9 +30,6 @@ namespace qmcplusplus
 {
 TEST_CASE("RPA Jastrow", "[wavefunction]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions_;
   ParticleSet elec_;
 

--- a/src/formic/utils/lmyengine/energy_target_accu.h
+++ b/src/formic/utils/lmyengine/energy_target_accu.h
@@ -607,11 +607,6 @@ template<typename S> class ETCompute {
       //MPI_Comm_rank(MPI_COMM_WORLD, & my_rank);
       //MPI_Comm_size(MPI_COMM_WORLD, & num_rank);
 
-      // compute mean and variance 
-      double mean = 0.0;
-      if ( !_ground_state )
-        mean = _hd_shift - 1.0 / _target_fn_val;
-
       double le_mean = _energy;
           
       if (my_rank == 0) {

--- a/src/formic/utils/lmyengine/spam_solver.cpp
+++ b/src/formic/utils/lmyengine/spam_solver.cpp
@@ -205,11 +205,11 @@ void cqmc::engine::SpamLMHD::solve_subspace_nonsymmetric(const bool outer)
     //Eigen::ArrayXcd eval_list = (es.eigenvalues()).array();
     std::complex<double> lowest_eval = e_evals.at(0);
 
-    double inner_eval = 0.0;
-    if ( !_ground ) 
-      inner_eval = 1.0 / (_hd_shift - _energy_inner);
-    else 
-      inner_eval = _energy_inner;
+    //double inner_eval = 0.0;
+    //if ( !_ground ) 
+    //  inner_eval = 1.0 / (_hd_shift - _energy_inner);
+    //else 
+    //  inner_eval = _energy_inner;
 
     // if it's outer iteration, we just make sure that we choose the lowest energy(target function)
     //if ( outer ) {

--- a/src/formic/utils/random.cpp
+++ b/src/formic/utils/random.cpp
@@ -28,8 +28,7 @@ void formic::set_seed(unsigned int seed) {
   // produce a different seed for each process
   std::vector<unsigned int> seeds(nproc);
   for (int i = 0; i < nproc; i++) {
-    unsigned int temp;
-    for (int j = 0; j < 1000000; j++) temp = formic::global_lcg(); // separate the seeds by a million random numbers
+    for (int j = 0; j < 1000000; j++) formic::global_lcg(); // separate the seeds by a million random numbers
     seeds.at(i) = formic::global_lcg();
   }
 

--- a/src/io/hdf/hdf_dataspace.h
+++ b/src/io/hdf/hdf_dataspace.h
@@ -27,8 +27,9 @@
  * - h5_space_type<Tensor<std::complex<T>,D>,RANK> // removed, picked up by template recursion
  */
 
-#include "hdf_datatype.h"
 #include <complex>
+#include <array>
+#include "hdf_datatype.h"
 #include "OhmmsPETE/TinyVector.h"
 #include "OhmmsPETE/Tensor.h"
 
@@ -69,7 +70,7 @@ struct h5_space_type<std::complex<T>, RANK> : public h5_space_type<T, RANK + 1>
 
 /** specialization of h5_space_type for std::array<T,D> for any intrinsic type T
  */
-template<typename T, unsigned D, hsize_t RANK>
+template<typename T, std::size_t D, hsize_t RANK>
 struct h5_space_type<std::array<T, D>, RANK> : public h5_space_type<T, RANK + 1>
 {
   using Base = h5_space_type<T, RANK + 1>;

--- a/src/io/hdf/hdf_dataspace.h
+++ b/src/io/hdf/hdf_dataspace.h
@@ -20,6 +20,7 @@
  * h5_space_type is a helper class for h5data_proxy and used internally
  * - h5_space_type<T,RANK>
  * - h5_space_type<std::complex<T>,RANK>
+ * - h5_space_type<std::array<T,D>,RANK>
  * - h5_space_type<TinyVector<T,D>,RANK>
  * - h5_space_type<TinyVector<std::complex<T>,D>,RANK> // removed, picked up by template recursion
  * - h5_space_type<Tensor<T,D>,RANK>
@@ -66,6 +67,19 @@ struct h5_space_type<std::complex<T>, RANK> : public h5_space_type<T, RANK + 1>
   inline static auto get_address(std::complex<T>* a) { return Base::get_address(reinterpret_cast<T*>(a)); }
 };
 
+/** specialization of h5_space_type for std::array<T,D> for any intrinsic type T
+ */
+template<typename T, unsigned D, hsize_t RANK>
+struct h5_space_type<std::array<T, D>, RANK> : public h5_space_type<T, RANK + 1>
+{
+  using Base = h5_space_type<T, RANK + 1>;
+  using Base::dims;
+  using Base::rank;
+  inline h5_space_type() { dims[RANK] = D; }
+  static constexpr int added_rank() { return Base::added_rank() + 1; }
+  inline static auto get_address(std::array<T, D>* a) { return Base::get_address(a->data()); }
+};
+
 /** specialization of h5_space_type for TinyVector<T,D> for any intrinsic type T
  */
 template<typename T, unsigned D, hsize_t RANK>
@@ -79,7 +93,7 @@ struct h5_space_type<TinyVector<T, D>, RANK> : public h5_space_type<T, RANK + 1>
   inline static auto get_address(TinyVector<T, D>* a) { return Base::get_address(a->data()); }
 };
 
-/** specialization of h5_space_type for TinyVector<T,D> for any intrinsic type T
+/** specialization of h5_space_type for Tensor<T,D> for any intrinsic type T
  */
 template<typename T, unsigned D, hsize_t RANK>
 struct h5_space_type<Tensor<T, D>, RANK> : public h5_space_type<T, RANK + 2>


### PR DESCRIPTION
## Proposed changes
Clang develop adds more warning which is so annoying.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'