### PR TITLE
Clean up ham unit tests

### DIFF
--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/BareKineticEnergy.h"
 
 #include "QMCWaveFunctions/TrialWaveFunction.h"
@@ -31,9 +30,6 @@ namespace qmcplusplus
 {
 TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   ParticleSet ions;
   ParticleSet elec;
 
@@ -59,9 +55,6 @@ TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
 
   elec.addTable(ions);
   elec.update();
-
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
 
   const char* particles = "<tmp> \
@@ -161,8 +154,6 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
   ions.resetGroups();
 

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -16,7 +16,6 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/MCWalkerConfiguration.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/CoulombPBCAB_CUDA.h"
 #include "QMCHamiltonians/CoulombPBCAA_CUDA.h"
 
@@ -32,9 +31,6 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type   = LRCoulombSingleton::ESLER;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
@@ -78,10 +74,6 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
   elec.addTable(ions);
   elec.update();
 
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
-
-
   CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
@@ -97,8 +89,6 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type   = LRCoulombSingleton::ESLER;
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
@@ -155,9 +145,6 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
   elec.copyWalkersToGPU();
   elec.updateLists_GPU();
 
-  ParticleSetPool ptcl = ParticleSetPool(c);
-
-
   CoulombPBCAB_CUDA cab(ions, elec);
 
   // Background charge term
@@ -183,9 +170,6 @@ TEST_CASE("Coulomb PBC A-A CUDA BCC H", "[hamiltonian][CUDA]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
   LRCoulombSingleton::this_lr_type   = LRCoulombSingleton::ESLER;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/CoulombPBCAA.h"
 
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA_ewald.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "LongRange/EwaldHandler3D.h"
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/CoulombPBCAB.h"
 #include "QMCHamiltonians/CoulombPBCAA.h"
 
@@ -30,9 +29,6 @@ namespace qmcplusplus
 TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
@@ -82,9 +78,6 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   elec.update();
 
 
-  ParticleSetPool ptcl = ParticleSetPool(c);
-
-
   CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
@@ -106,9 +99,6 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
-
-  Communicate* c;
-  c = OHMMS::Controller;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
@@ -162,10 +152,6 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   elec.addTable(ions);
   elec.resetGroups();
   elec.update();
-
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
-
 
   CoulombPBCAB cab(ions, elec);
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/CoulombPBCAB.h"
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "LongRange/EwaldHandler3D.h"
@@ -29,9 +28,6 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(1.0);
@@ -81,8 +77,6 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   elec.update();
 
 
-  ParticleSetPool ptcl = ParticleSetPool(c);
-
   LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
 
@@ -112,9 +106,6 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(3.77945227);
@@ -170,8 +161,6 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   elec.resetGroups();
   elec.update();
 
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
   LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -33,7 +33,6 @@
 
 //for Hamiltonian manipulations.
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "LongRange/EwaldHandler3D.h"
 
 #ifdef QMC_COMPLEX //This is for the spinor test.
@@ -227,8 +226,6 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   tspecies(massIdx, downIdx)   = 1.0;
 
   elec.createSK();
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
   ions.resetGroups();
 
@@ -485,10 +482,6 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   tspecies(massIdx, upIdx)   = 1.0;
 
   elec.createSK();
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
-  ptcl.addParticleSet(std::move(elec_uptr));
-  ptcl.addParticleSet(std::move(ions_uptr));
 
   ions.resetGroups();
   elec.resetGroups();

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "QMCHamiltonians/ForceChiesaPBCAA.h"
 #include "QMCHamiltonians/ForceCeperley.h"
 #include "QMCHamiltonians/CoulombPotential.h"
@@ -79,8 +78,6 @@ TEST_CASE("Bare Force", "[hamiltonian]")
 
   elec.addTable(ions);
   elec.update();
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
   BareForce force(ions, elec);
   force.addionion = false;

--- a/src/QMCHamiltonians/tests/test_spacewarp.cpp
+++ b/src/QMCHamiltonians/tests/test_spacewarp.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "QMCHamiltonians/SpaceWarpTransformation.h"
 //#include "QMCWaveFunctions/SPOSetBuilderFactory.h"

--- a/src/QMCHamiltonians/tests/test_stress.cpp
+++ b/src/QMCHamiltonians/tests/test_stress.cpp
@@ -15,7 +15,6 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/ParticleSetPool.h"
 #include "LongRange/EwaldHandler3D.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCHamiltonians/StressPBC.h"
@@ -30,9 +29,6 @@ namespace qmcplusplus
 // PBC case
 TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
 {
-  Communicate* c;
-  c = OHMMS::Controller;
-
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true; // periodic
   Lattice.R.diagonal(3.24957306);
@@ -80,8 +76,6 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
   tspecies(massIdx, upIdx)     = 1.0;
 
   elec.createSK();
-
-  ParticleSetPool ptcl = ParticleSetPool(c);
 
   ions.resetGroups();
 

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -232,7 +232,7 @@ public:
    * use read() for inbuilt error checking
    * @return true if successful
    */
-  template<typename T>
+  template<typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
   bool readEntry(T& data, const std::string& aname)
   {
     if (Mode[NOIO])
@@ -245,7 +245,7 @@ public:
   /** read the data from the group aname and check status
    * runtime error is issued on I/O error
    */
-  template<typename T>
+  template<typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
   void read(T& data, const std::string& aname)
   {
     if (!readEntry(data, aname))
@@ -260,7 +260,7 @@ public:
    * @param aname dataset name in the file
    * runtime error is issued on I/O error
    */
-  template<typename T, typename IT, std::size_t RANK>
+  template<typename T, typename IT, std::size_t RANK, typename = std::enable_if_t<!std::is_const<T>::value>>
   void readSlabReshaped(T& data, const std::array<IT, RANK>& shape, const std::string& aname)
   {
     std::array<hsize_t, RANK> globals, counts, offsets;
@@ -284,7 +284,7 @@ public:
    * for example, if the dataset was [5,2,6] and the vector contained (2,1,-1),
    * this would grab 6 elements corresponding to [2,1,:]
    */
-  template<typename T, typename IT, std::size_t RANK>
+  template<typename T, typename IT, std::size_t RANK, typename = std::enable_if_t<!std::is_const<T>::value>>
   void readSlabSelection(T& data, const std::array<IT, RANK>& readSpec, const std::string& aname)
   {
     std::array<hsize_t, RANK> globals, counts, offsets;


### PR DESCRIPTION
## Proposed changes
1. remove ParticleSetPool dependency in most Hamiltonian unit tests
2. Use SFINAE to remove read functions when containers are const. The error message is much more readable than tons of template compilation failure.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'