### PR TITLE
Enable GPU CI on GitHub Actions self-hosted runner

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -1,0 +1,96 @@
+
+name: GitHub Actions self-hosted CI
+
+on: 
+  issue_comment:
+    types: [created]
+
+jobs:
+  gpu-cuda:
+    if: github.repository_owner == 'QMCPACK'
+    runs-on: [self-hosted,Linux,X64,gpu,cuda]
+    
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname: [
+          gcc-real-gpu-cuda,
+          gcc-complex-gpu-cuda,
+        ]
+
+    steps:
+    - name: Check PR trigger in comments
+      uses: khan/pull-request-comment-trigger@master
+      id: check
+      # Only trigger for certain "actors" (those commenting the PR, not the PR originator) 
+      # this is in-line with the current workflow
+      env:
+        ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+        SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+      if: contains('${{env.SECRET_ACTORS}}', '${{env.ACTOR_TOKEN}}')
+      with:
+        trigger: 'Test this please'
+
+    # Request repo info, required since issue_comment doesn't point at PR commit, but develop 
+    - name: GitHub API Request
+      if: steps.check.outputs.triggered == 'true'
+      id: request
+      uses: octokit/request-action@v2.0.0
+      with:
+        route: ${{github.event.issue.pull_request.url}}
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    # Create a separate PR status pointing at GitHub Actions tab URL
+    # just like any other third-party service
+    - name: Create PR status
+      if: steps.check.outputs.triggered == 'true'
+      uses: Sibz/github-status-action@v1
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'GitHub Actions self-hosted CI ${{ matrix.jobname }}'
+        state: 'pending'
+        sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+        target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+    - name: Get PR information
+      if: steps.check.outputs.triggered == 'true'
+      id: pr_data
+      run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+    - name: Checkout PR branch
+      if: steps.check.outputs.triggered == 'true'
+      uses: actions/checkout@v2
+      with:
+        token: ${{secrets.GITHUB_TOKEN}}
+        repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+        ref: ${{steps.pr_data.outputs.branch}}
+
+    - name: Configure
+      if: steps.check.outputs.triggered == 'true'
+      run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+    - name: Build
+      if: steps.check.outputs.triggered == 'true'
+      run: tests/test_automation/github-actions/ci/run_step.sh build
+
+    - name: Test
+      if: steps.check.outputs.triggered == 'true'
+      run: tests/test_automation/github-actions/ci/run_step.sh test
+      
+    - name: Report PR status
+      if: steps.check.outputs.triggered == 'true'
+      uses: Sibz/github-status-action@v1
+      with: 
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'GitHub Actions self-hosted CI ${{matrix.jobname}}'
+        state: ${{job.status}}
+        sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+        target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -68,6 +68,13 @@ case "$1" in
                       -DUSE_OBJECT_TARGET=ON -DQMC_MPI=0 \
                       ${GITHUB_WORKSPACE}
       ;;
+      *"gpu-cuda"*)
+        echo 'Configure for building GPU CUDA legacy'
+        cmake -GNinja -DQMC_CUDA=1 \
+                      -DQMC_MPI=0 \
+                      -DQMC_COMPLEX=$IS_COMPLEX \
+                      ${GITHUB_WORKSPACE}
+      ;;
       # Configure with default compilers
       *)
         echo 'Configure for default system compilers and options'
@@ -111,6 +118,11 @@ case "$1" in
        export LD_LIBRARY_PATH=/usr/lib/llvm-12/lib/:${LD_LIBRARY_PATH}
        # Run only unit tests (reasonable for CI using openmp-offload)
        TEST_LABEL="-L unit"
+    fi
+    
+    if [[ "${GH_JOBNAME}" =~ (gpu-cuda) ]]
+    then
+       export LD_LIBRARY_PATH=/usr/local/cuda/lib/:/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}
     fi
     
     ctest --output-on-failure $TEST_LABEL


### PR DESCRIPTION
## Proposed changes

- This PR enables GPU CI using legacy CUDA on deterministic tests running on sulfur as a self-hosted runner on GitHub Actions.
- Set new workflow configuration file to trigger with current on-demand workflow: "Test this please" as PR comment by authorized user. Currently the new status will only show up if triggered.
- Set LD_LIBRARY_PATH to point at CUDA runtime libraries

To verify/understand:
- [ ] YAML GitHub Actions structure and functionality
- [ ] Make sure PR status is reported as a check when triggered 
- [ ] Directory structure for jobs on sulfur as a self-hosted runner (currently enabled)
- [ ] Status state is correctly reported through `${{job.status}}`
- [ ] Only authorized users can trigger the workflow

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature (GPU CI test)
- Testing changes (new CI workflow to test with `-DQMC_CUDA=1` on self-hosted runner)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur locally, entire workflow must run on GitHub Actions

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
