### PR TITLE
Check for out-of-source build directory existence in GitHub Action CI config step

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -7,6 +7,13 @@ case "$1" in
   # Configure qmcpack using cmake out-of-source builds 
   configure)
     
+    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build ]
+    then
+      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build, removing"
+      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build
+    fi
+    
+    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build"
     cd ${GITHUB_WORKSPACE}/..
     mkdir qmcpack-build
     cd qmcpack-build


### PR DESCRIPTION
## Proposed changes

Affect self-hosted runners which must rerun in a clean directory every time
Add log messages
From feedback in #3260 when testing CI on self-hosted runners

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass GitHub Actions CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
