### PR TITLE
Move constructors marked noexcept

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          '-*,readability-identifier-naming'
+Checks:          '-*,readability-identifier-naming,modernize-use-override,performance-noexcept-move-constructor'
 WarningsAsErrors: ''
 FormatStyle:     file
 HeaderFilterRegex: 'src/.*'

--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -68,7 +68,7 @@ struct VectorSoaContainer
   }
 
   ///move constructor
-  VectorSoaContainer(VectorSoaContainer&& in)
+  VectorSoaContainer(VectorSoaContainer&& in) noexcept
       : nLocal(in.nLocal), nGhosts(in.nGhosts), nAllocated(in.nAllocated), myData(std::move(in.myData))
   {
     in.myData     = nullptr;

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -35,7 +35,7 @@ ParticleSetPool::ParticleSetPool(Communicate* c, const char* aname) : MPIObjectB
   myName    = aname;
 }
 
-ParticleSetPool::ParticleSetPool(ParticleSetPool&& other)
+ParticleSetPool::ParticleSetPool(ParticleSetPool&& other) noexcept
     : MPIObjectBase(other.myComm),
       SimulationCell(std::move(other.SimulationCell)),
       TileMatrix(other.TileMatrix),

--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -43,7 +43,7 @@ public:
 
   ParticleSetPool(const ParticleSetPool&) = delete;
   ParticleSetPool& operator=(const ParticleSetPool&) = delete;
-  ParticleSetPool(ParticleSetPool&& pset);
+  ParticleSetPool(ParticleSetPool&& pset) noexcept;
   ParticleSetPool& operator=(ParticleSetPool&&) = default;
 
   bool put(xmlNodePtr cur);

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -33,8 +33,8 @@ public:
   QMCDriverInput()                      = default;
   QMCDriverInput(const QMCDriverInput&) = default;
   QMCDriverInput& operator=(const QMCDriverInput&) = default;
-  QMCDriverInput(QMCDriverInput&&);
-  QMCDriverInput& operator=(QMCDriverInput&&);
+  QMCDriverInput(QMCDriverInput&&) noexcept;
+  QMCDriverInput& operator=(QMCDriverInput&&) noexcept;
 
 protected:
 
@@ -129,8 +129,8 @@ public:
 };
 
 // These will cause a compiler error if the implicit move constructor has been broken
-inline QMCDriverInput::QMCDriverInput(QMCDriverInput&&) = default;
-inline QMCDriverInput& QMCDriverInput::operator=(QMCDriverInput&&) = default;
+inline QMCDriverInput::QMCDriverInput(QMCDriverInput&&) noexcept = default;
+inline QMCDriverInput& QMCDriverInput::operator=(QMCDriverInput&&) noexcept = default;
 
 } // namespace qmcplusplus
 

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -248,8 +248,8 @@ public:
 
   ScopeGuard(const ScopeGuard&) = delete;
   ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ScopeGuard(ScopeGuard&&) = default;
-  ScopeGuard& operator=(ScopeGuard&&) = default;
+  ScopeGuard(ScopeGuard&&) noexcept        = default;
+  ScopeGuard& operator=(ScopeGuard&&) noexcept = default;
 
   ~ScopeGuard()
   {

--- a/src/type_traits/TypeRequire.hpp
+++ b/src/type_traits/TypeRequire.hpp
@@ -43,7 +43,7 @@ struct force_rvo : public T
   force_rvo() {}
   using T::T;
   force_rvo(const force_rvo&);
-  force_rvo(force_rvo&&);
+  force_rvo(force_rvo&&) noexcept;
 };
 
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

After setting up clang-tidy #3269, It tried a few other checks. Warnings from [performance-noexcept-move-constructor](https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html) caught my attention. I don't know if any of these objects are used in STL containers, but adding this is good practice. 

Marking the defaulted move constructor and move assignment operator gives a compiler error if either would throw.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted