### PR TITLE
Add override to functions in legacy QMC_CUDA build

### DIFF
--- a/src/QMCDrivers/DMC/DMC_CUDA.h
+++ b/src/QMCDrivers/DMC/DMC_CUDA.h
@@ -36,8 +36,8 @@ public:
           QMCHamiltonian& h,
           Communicate* comm,
           bool enable_profiling);
-  bool run();
-  bool put(xmlNodePtr cur);
+  bool run() override;
+  bool put(xmlNodePtr cur) override;
   void resetUpdateEngine();
 
 private:
@@ -61,7 +61,7 @@ private:
   bool checkBounds(const PosType& newpos);
   void checkBounds(std::vector<PosType>& newpos, std::vector<bool>& valid);
 
-  QMCRunType getRunType() { return QMCRunType::DMC; }
+  QMCRunType getRunType() override { return QMCRunType::DMC; }
 
   ///hide initialization from the main function
   void resetRun();

--- a/src/QMCDrivers/VMC/VMC_CUDA.h
+++ b/src/QMCDrivers/VMC/VMC_CUDA.h
@@ -35,7 +35,7 @@ public:
           Communicate* comm,
           bool enable_profiling);
 
-  bool run();
+  bool run() override;
   bool runWithDrift();
 
   /// advance walkers without drift
@@ -43,7 +43,7 @@ public:
   /// advance walkers with drift
   void advanceWalkersWithDrift();
 
-  bool put(xmlNodePtr cur);
+  bool put(xmlNodePtr cur) override;
   RealType fillOverlapHamiltonianMatrices(Matrix<RealType>& LeftM, Matrix<RealType>& RightM);
   inline void setOpt(bool o) { forOpt = o; };
 
@@ -65,7 +65,7 @@ private:
   VMCcuda& operator=(const VMCcuda&) = delete;
   ///hide initialization from the main function
   bool checkBounds(std::vector<PosType>& newpos, std::vector<bool>& valid);
-  QMCRunType getRunType() { return QMCRunType::VMC; }
+  QMCRunType getRunType() override { return QMCRunType::VMC; }
   void resetRun();
 
   opt_variables_type dummy;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionCUDA.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionCUDA.h
@@ -39,12 +39,12 @@ public:
   QMCCostFunctionCUDA(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
 
   ///Destructor
-  ~QMCCostFunctionCUDA();
+  ~QMCCostFunctionCUDA() override;
 
-  void getConfigurations(const std::string& aroot);
-  void checkConfigurations();
-  void GradCost(std::vector<Return_rt>& PGradient, const std::vector<Return_rt>& PM, Return_rt FiniteDiff = 0);
-  Return_rt fillOverlapHamiltonianMatrices(Matrix<Return_rt>& Left, Matrix<Return_rt>& Right);
+  void getConfigurations(const std::string& aroot) override;
+  void checkConfigurations() override;
+  void GradCost(std::vector<Return_rt>& PGradient, const std::vector<Return_rt>& PM, Return_rt FiniteDiff = 0) override;
+  Return_rt fillOverlapHamiltonianMatrices(Matrix<Return_rt>& Left, Matrix<Return_rt>& Right) override;
 
 protected:
   using CTS = CUDAGlobalTypes;
@@ -68,8 +68,8 @@ protected:
   std::vector<Matrix<Return_rt>*> HDerivRecords;
 
   Return_rt CSWeight;
-  void resetPsi(bool final_reset = false);
-  Return_rt correlatedSampling(bool needDerivs);
+  void resetPsi(bool final_reset = false) override;
+  Return_rt correlatedSampling(bool needDerivs) override;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -471,7 +471,7 @@ struct BareKineticEnergy : public OperatorBase
   // Vectorized version for GPU //
   ////////////////////////////////
   // Nothing is done on GPU here, just copy into vector
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override
   {
     auto& walkers = W.WalkerList;
     for (int iw = 0; iw < walkers.size(); iw++)

--- a/src/QMCHamiltonians/ChiesaCorrection.h
+++ b/src/QMCHamiltonians/ChiesaCorrection.h
@@ -33,7 +33,7 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
 #ifdef QMC_CUDA
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 #endif
 
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -109,7 +109,7 @@ struct ConservedEnergy : public OperatorBase
   // Vectorized version for GPU //
   ////////////////////////////////
   // Nothing is done on GPU here, just copy into vector
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override
   {
     // Value of LocalEnergy is not used in caller because this is auxiliary H.
     auto& walkers = W.WalkerList;

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.h
@@ -47,7 +47,7 @@ struct CoulombPBCAA_CUDA : public CoulombPBCAA
   std::vector<gpu::host_vector<CUDA_PRECISION_FULL*>> RhoklistsHost;
   gpu::device_vector<CUDA_PRECISION_FULL> RhokGPU;
   void setupLongRangeGPU(ParticleSet& P);
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 
   void initBreakup(ParticleSet& P, bool cloning);
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
@@ -61,7 +61,7 @@ struct CoulombPBCAB_CUDA : public CoulombPBCAB
 
   void initBreakup(ParticleSet& P);
 
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.h
@@ -34,7 +34,7 @@ struct CoulombPotentialAA_CUDA : public CoulombPotential<OHMMS_PRECISION>
 
   gpu::device_vector<CUDA_PRECISION> SumGPU;
   gpu::host_vector<CUDA_PRECISION> SumHost;
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
@@ -56,7 +56,7 @@ struct CoulombPotentialAB_CUDA : public CoulombPotential<OHMMS_PRECISION>
   gpu::device_vector<CUDA_PRECISION> ZionGPU;
   gpu::device_vector<CUDA_PRECISION> IGPU;
 
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };

--- a/src/QMCHamiltonians/LocalECPotential_CUDA.h
+++ b/src/QMCHamiltonians/LocalECPotential_CUDA.h
@@ -41,7 +41,7 @@ struct LocalECPotential_CUDA : public LocalECPotential
   std::vector<PosType> SortedIons;
   void add(int groupID, std::unique_ptr<RadialPotentialType>&& ppot, RealType zion);
 
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 

--- a/src/QMCHamiltonians/MPC_CUDA.h
+++ b/src/QMCHamiltonians/MPC_CUDA.h
@@ -43,7 +43,7 @@ public:
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.h
@@ -80,10 +80,10 @@ public:
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
   void addEnergy(MCWalkerConfiguration& W,
                  std::vector<RealType>& LocalEnergy,
-                 std::vector<std::vector<NonLocalData>>& Txy);
+                 std::vector<std::vector<NonLocalData>>& Txy) override;
 };
 
 

--- a/src/QMCHamiltonians/SkEstimator_CUDA.h
+++ b/src/QMCHamiltonians/SkEstimator_CUDA.h
@@ -22,7 +22,7 @@ class SkEstimator_CUDA : public SkEstimator
 {
 public:
   SkEstimator_CUDA(ParticleSet& elns) : SkEstimator(elns) {}
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -152,10 +152,12 @@ void CompositeSPOSet::evaluateVGL(const ParticleSet& P,
   }
 }
 
+#ifdef QMC_CUDA
 void CompositeSPOSet::evaluate(const ParticleSet& P, PosType& r, ValueVector_t& psi)
 {
   not_implemented("evaluate(P,r,psi)");
 }
+#endif
 
 //methods to be implemented later
 void CompositeSPOSet::resetParameters(const opt_variables_type& optVariables)

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -73,7 +73,9 @@ public:
 
   //methods to be implemented in the future (possibly)
   void resetParameters(const opt_variables_type& optVariables) override;
+#ifdef QMC_CUDA
   void evaluate(const ParticleSet& P, PosType& r, ValueVector_t& psi) override;
+#endif
   void evaluate_notranspose(const ParticleSet& P,
                             int first,
                             int last,

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -73,7 +73,7 @@ public:
 
   //methods to be implemented in the future (possibly)
   void resetParameters(const opt_variables_type& optVariables) override;
-  void evaluate(const ParticleSet& P, PosType& r, ValueVector_t& psi);
+  void evaluate(const ParticleSet& P, PosType& r, ValueVector_t& psi) override;
   void evaluate_notranspose(const ParticleSet& P,
                             int first,
                             int last,

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantCUDA.h
@@ -149,54 +149,63 @@ protected:
 
 public:
   // safe-guard all CPU interfaces
-  DiracDeterminantCUDA* makeCopy(std::shared_ptr<SPOSet>&& spo) const
+  DiracDeterminantCUDA* makeCopy(std::shared_ptr<SPOSet>&& spo) const override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::makeCopy is illegal!");
     return nullptr;
   }
 
-  LogValueType evaluateLog(const ParticleSet& P, ParticleSet::ParticleGradient_t& G, ParticleSet::ParticleLaplacian_t& L)
+  LogValueType evaluateLog(const ParticleSet& P,
+                           ParticleSet::ParticleGradient_t& G,
+                           ParticleSet::ParticleLaplacian_t& L) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::evaluateLog is illegal!");
     return 0;
   }
 
-  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) { throw std::runtime_error("Calling DiracDeterminantCUDA::acceptMove is illegal!"); }
+  void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override
+  {
+    throw std::runtime_error("Calling DiracDeterminantCUDA::acceptMove is illegal!");
+  }
 
-  void restore(int iat) { throw std::runtime_error("Calling DiracDeterminantCUDA::restore is illegal!"); }
+  void restore(int iat) override { throw std::runtime_error("Calling DiracDeterminantCUDA::restore is illegal!"); }
 
-  PsiValueType ratio(ParticleSet& P, int iat)
+  PsiValueType ratio(ParticleSet& P, int iat) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::ratio is illegal!");
     return 0;
   }
 
-  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
+  PsiValueType ratioGrad(ParticleSet& P, int iat, GradType& grad_iat) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::ratioGrad is illegal!");
     return 0;
   }
 
-  void registerData(ParticleSet& P, WFBufferType& buf)
+  void registerData(ParticleSet& P, WFBufferType& buf) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::registerData is illegal!");
   }
 
-  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false)
+  LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::updateBuffer is illegal!");
     return 0;
   }
 
-  void copyFromBuffer(ParticleSet& P, WFBufferType& buf)
+  void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override
   {
     throw std::runtime_error("Calling DiracDeterminantCUDA::copyFromBuffer is illegal!");
   }
 
-  void update(MCWalkerConfiguration* W, std::vector<Walker_t*>& walkers, int iat, std::vector<bool>* acc, int k);
-  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList);
+  void update(MCWalkerConfiguration* W,
+              std::vector<Walker_t*>& walkers,
+              int iat,
+              std::vector<bool>* acc,
+              int k) override;
+  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList) override;
 
-  void reserve(PointerPool<gpu::device_vector<CTS::ValueType>>& pool, int kblocksize = 1)
+  void reserve(PointerPool<gpu::device_vector<CTS::ValueType>>& pool, int kblocksize = 1) override
   {
     RowStride         = ((NumOrbitals + 31) / 32) * 32;
     size_t kblock2    = ((kblocksize * kblocksize + 31) / 32) * 32;
@@ -224,48 +233,51 @@ public:
     Phi->reserve(pool);
   }
 
-  void recompute(MCWalkerConfiguration& W, bool firstTime);
+  void recompute(MCWalkerConfiguration& W, bool firstTime) override;
 
-  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi);
+  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi) override;
 
-  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad);
+  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad) override;
 
-  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad);
+  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad) override;
 
-  void ratio(MCWalkerConfiguration& W, int iat, std::vector<ValueType>& psi_ratios);
+  void ratio(MCWalkerConfiguration& W, int iat, std::vector<ValueType>& psi_ratios) override;
 
-  void ratio(MCWalkerConfiguration& W, int iat, std::vector<ValueType>& psi_ratios, std::vector<GradType>& grad);
+  void ratio(MCWalkerConfiguration& W,
+             int iat,
+             std::vector<ValueType>& psi_ratios,
+             std::vector<GradType>& grad) override;
 
   void ratio(MCWalkerConfiguration& W,
              int iat,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl);
+             std::vector<ValueType>& lapl) override;
   void calcRatio(MCWalkerConfiguration& W,
                  int iat,
                  std::vector<ValueType>& psi_ratios,
                  std::vector<GradType>& grad,
-                 std::vector<ValueType>& lapl);
+                 std::vector<ValueType>& lapl) override;
   void addRatio(MCWalkerConfiguration& W,
                 int iat,
                 int k,
                 std::vector<ValueType>& psi_ratios,
                 std::vector<GradType>& grad,
-                std::vector<ValueType>& lapl);
+                std::vector<ValueType>& lapl) override;
 
   void ratio(std::vector<Walker_t*>& walkers,
              std::vector<int>& iatList,
              std::vector<PosType>& rNew,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl);
+             std::vector<ValueType>& lapl) override;
 
-  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl);
+  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl) override;
 
   void NLratios(MCWalkerConfiguration& W,
                 std::vector<NLjob>& jobList,
                 std::vector<PosType>& quadPoints,
-                std::vector<ValueType>& psi_ratios);
+                std::vector<ValueType>& psi_ratios) override;
 
   void NLratios_CPU(MCWalkerConfiguration& W,
                     std::vector<NLjob>& jobList,
@@ -279,7 +291,7 @@ public:
                      int iat,
                      int k,
                      int kd,
-                     int nw);
+                     int nw) override;
 };
 } // namespace qmcplusplus
 #endif // QMCPLUSPLUS_DIRAC_DETERMINANT_CUDA_H

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
@@ -79,15 +79,19 @@ private:
 public:
   typedef ParticleSet::Walker_t Walker_t;
 
-  void resetParameters(const opt_variables_type& active);
-  void checkInVariables(opt_variables_type& active);
+  void resetParameters(const opt_variables_type& active) override;
+  void checkInVariables(opt_variables_type& active) override;
   void addFunc(int ig, FT* j, int jg = -1);
-  void recompute(MCWalkerConfiguration& W, bool firstTime);
+  void recompute(MCWalkerConfiguration& W, bool firstTime) override;
   void reserve(PointerPool<gpu::device_vector<CTS::RealType>>& pool);
-  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi);
-  void update(MCWalkerConfiguration* W, std::vector<Walker_t*>& walkers, int iat, std::vector<bool>* acc, int k);
+  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi) override;
+  void update(MCWalkerConfiguration* W,
+              std::vector<Walker_t*>& walkers,
+              int iat,
+              std::vector<bool>* acc,
+              int k) override;
 
-  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList)
+  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList) override
   {
     /* This function doesn't really need to return the ratio */
   }
@@ -95,24 +99,24 @@ public:
              int iat,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl);
+             std::vector<ValueType>& lapl) override;
   void calcRatio(MCWalkerConfiguration& W,
                  int iat,
                  std::vector<ValueType>& psi_ratios,
                  std::vector<GradType>& grad,
-                 std::vector<ValueType>& lapl);
+                 std::vector<ValueType>& lapl) override;
   void addRatio(MCWalkerConfiguration& W,
                 int iat,
                 int k,
                 std::vector<ValueType>& psi_ratios,
                 std::vector<GradType>& grad,
-                std::vector<ValueType>& lapl);
+                std::vector<ValueType>& lapl) override;
   void ratio(std::vector<Walker_t*>& walkers,
              std::vector<int>& iatList,
              std::vector<PosType>& rNew,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl)
+             std::vector<ValueType>& lapl) override
   {
     /* This function doesn't really need to return the ratio */
   }
@@ -124,22 +128,22 @@ public:
                      int iat,
                      int k,
                      int kd,
-                     int nw)
+                     int nw) override
   {
     /* The one-body jastrow can be calculated for the entire k-block, so this function doesn't need to return anything */
   }
 
-  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad);
-  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad);
-  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl);
+  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad) override;
+  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad) override;
+  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl) override;
   void NLratios(MCWalkerConfiguration& W,
                 std::vector<NLjob>& jobList,
                 std::vector<PosType>& quadPoints,
-                std::vector<ValueType>& psi_ratios);
+                std::vector<ValueType>& psi_ratios) override;
   void evaluateDerivatives(MCWalkerConfiguration& W,
                            const opt_variables_type& optvars,
                            RealMatrix_t& dlogpsi,
-                           RealMatrix_t& dlapl_over_psi);
+                           RealMatrix_t& dlapl_over_psi) override;
   OneBodyJastrowOrbitalBspline(const std::string& obj_name, ParticleSet& centers, ParticleSet& elecs)
       : J1OrbitalSoA<FT>(obj_name, centers, elecs),
         ElecRef(elecs),

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
@@ -74,15 +74,19 @@ private:
 public:
   typedef ParticleSet::Walker_t Walker_t;
 
-  void freeGPUmem();
-  void checkInVariables(opt_variables_type& active);
+  void freeGPUmem() override;
+  void checkInVariables(opt_variables_type& active) override;
   //void addFunc(const std::string& aname, int ia, int ib, FT* j);
   void addFunc(int ia, int ib, FT* j);
-  void recompute(MCWalkerConfiguration& W, bool firstTime);
+  void recompute(MCWalkerConfiguration& W, bool firstTime) override;
   void reserve(PointerPool<gpu::device_vector<CTS::RealType>>& pool);
-  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi);
-  void update(MCWalkerConfiguration* W, std::vector<Walker_t*>& walkers, int iat, std::vector<bool>* acc, int k);
-  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList)
+  void addLog(MCWalkerConfiguration& W, std::vector<RealType>& logPsi) override;
+  void update(MCWalkerConfiguration* W,
+              std::vector<Walker_t*>& walkers,
+              int iat,
+              std::vector<bool>* acc,
+              int k) override;
+  void update(const std::vector<Walker_t*>& walkers, const std::vector<int>& iatList) override
   {
     /* This function doesn't really need to return the ratio */
   }
@@ -91,24 +95,24 @@ public:
              int iat,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl);
+             std::vector<ValueType>& lapl) override;
   void calcRatio(MCWalkerConfiguration& W,
                  int iat,
                  std::vector<ValueType>& psi_ratios,
                  std::vector<GradType>& grad,
-                 std::vector<ValueType>& lapl);
+                 std::vector<ValueType>& lapl) override;
   void addRatio(MCWalkerConfiguration& W,
                 int iat,
                 int k,
                 std::vector<ValueType>& psi_ratios,
                 std::vector<GradType>& grad,
-                std::vector<ValueType>& lapl);
+                std::vector<ValueType>& lapl) override;
   void ratio(std::vector<Walker_t*>& walkers,
              std::vector<int>& iatList,
              std::vector<PosType>& rNew,
              std::vector<ValueType>& psi_ratios,
              std::vector<GradType>& grad,
-             std::vector<ValueType>& lapl)
+             std::vector<ValueType>& lapl) override
   {
     /* This function doesn't really need to return the ratio */
   }
@@ -120,7 +124,7 @@ public:
                      int iat,
                      int k,
                      int kd,
-                     int nw)
+                     int nw) override
   {
     /* The two-body jastrow depends on the accepted positions of other electrons,
        hence needs to be calculated every time here */
@@ -132,15 +136,15 @@ public:
     }
   }
 
-  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad);
-  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad);
-  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl);
+  void calcGradient(MCWalkerConfiguration& W, int iat, int k, std::vector<GradType>& grad) override;
+  void addGradient(MCWalkerConfiguration& W, int iat, std::vector<GradType>& grad) override;
+  void gradLapl(MCWalkerConfiguration& W, GradMatrix_t& grads, ValueMatrix_t& lapl) override;
   void NLratios(MCWalkerConfiguration& W,
                 std::vector<NLjob>& jobList,
                 std::vector<PosType>& quadPoints,
-                std::vector<ValueType>& psi_ratios);
+                std::vector<ValueType>& psi_ratios) override;
 
-  void resetParameters(const opt_variables_type& active);
+  void resetParameters(const opt_variables_type& active) override;
 
   // Evaluates the derivatives of log psi and laplacian log psi w.r.t.
   // the parameters for optimization.  First index of the ValueMatrix is
@@ -148,7 +152,7 @@ public:
   void evaluateDerivatives(MCWalkerConfiguration& W,
                            const opt_variables_type& optvars,
                            RealMatrix_t& dlogpsi,
-                           RealMatrix_t& dlapl_over_psi);
+                           RealMatrix_t& dlapl_over_psi) override;
 
   //TwoBodyJastrowOrbitalBspline(ParticleSet& pset, bool is_master) :
   //  TwoBodyJastrowOrbital<BsplineFunctor<WaveFunctionComponent::RealType> > (pset, is_master),


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Followup to #3269. I used the clang-tidy check `modernize-use-override` to all update all member functions in the legacy `QMC_CUDA=1` build.

Fixes issue #3262.

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
