### PR TITLE
Fix leaks in unit-test-tools adding test to asan checks

### DIFF
--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -494,8 +494,8 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
   nonunigrid1d.push_back(kmax);
 
   auto integrand =
-      std::unique_ptr<NUBspline_1d_d, void (*)(NUBspline_1d_d*)>{spline_clamped(nonunigrid1d, k2vksk, 0.0, 0.0),
-                                                                 destroy_NUBspline_1d_d};
+      std::unique_ptr<NUBspline_1d_d, void (*)(void*)>{spline_clamped(nonunigrid1d, k2vksk, 0.0, 0.0),
+                                                                 destroy_Bspline};
 
   //Integrate the spline and compute the thermodynamic limit.
   RealType integratedval = integrate_spline(integrand.get(), 0.0, kmax, 200);

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -312,7 +312,8 @@ NUBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
 {
   //hack to interface to NUgrid stuff in double prec for MIXED build
   vector<FullPrecRealType> grid_fp(grid.begin(), grid.end());
-  NUgrid* grid1d = create_general_grid(grid_fp.data(), grid_fp.size());
+  auto grid1d =
+      std::unique_ptr<NUgrid, void (*)(NUgrid*)>{create_general_grid(grid_fp.data(), grid_fp.size()), destroy_grid};
 
   BCtype_d xBC;
   xBC.lVal  = lVal;
@@ -321,10 +322,7 @@ NUBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
   xBC.rCode = DERIV1;
   //hack to interface to NUgrid stuff in double prec for MIXED build
   vector<FullPrecRealType> vals_fp(vals.begin(), vals.end());
-  auto* nubspline_1d_d = create_NUBspline_1d_d(grid1d, xBC, vals_fp.data());
-  destroy_grid(grid1d);
-
-  return nubspline_1d_d;
+  return create_NUBspline_1d_d(grid1d.get(), xBC, vals_fp.data());
 }
 
 //Integrate the spline using Simpson's 5/8 rule.  For Bsplines, this should be exact
@@ -473,7 +471,7 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialDiscrete(vector<RealType> sk
 
 QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
 {
-  UBspline_3d_d* spline = getSkSpline(sk);
+  auto spline = std::unique_ptr<UBspline_3d_d, void (*)(void*)>{getSkSpline(sk), destroy_Bspline};
 
   RealType kmax   = AA->get_kc();
   IndexType ngrid = 2 * Klist.kshell.size() - 1; //make a lager kmesh
@@ -487,22 +485,23 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
   {
     RealType kval = i * dk;
     nonunigrid1d.push_back(kval);
-    RealType skavg = sphericalAvgSk(spline, kval);
+    RealType skavg = sphericalAvgSk(spline.get(), kval);
     RealType k2vk  = kval * kval * AA->evaluate_vlr_k(kval); //evaluation for arbitrary kshell for any LRHandler
     k2vksk.push_back(0.5 * k2vk * skavg);
   }
 
-  destroy_Bspline(spline);
   k2vksk.push_back(0.0);
   nonunigrid1d.push_back(kmax);
 
-  NUBspline_1d_d* integrand = spline_clamped(nonunigrid1d, k2vksk, 0.0, 0.0);
+  auto integrand =
+      std::unique_ptr<NUBspline_1d_d, void (*)(NUBspline_1d_d*)>{spline_clamped(nonunigrid1d, k2vksk, 0.0, 0.0),
+                                                                 destroy_NUBspline_1d_d};
 
   //Integrate the spline and compute the thermodynamic limit.
-  RealType integratedval = integrate_spline(integrand, 0.0, kmax, 200);
+  RealType integratedval = integrate_spline(integrand.get(), 0.0, kmax, 200);
   RealType intnorm       = Vol / 2.0 / M_PI / M_PI; //The volume factor here is because 1/Vol is
                                                     //included in QMCPACK's v_k.  See CoulombFunctor.
-  destroy_NUBspline_1d_d(integrand);
+
   return intnorm * integratedval;
 }
 

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -321,7 +321,10 @@ NUBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
   xBC.rCode = DERIV1;
   //hack to interface to NUgrid stuff in double prec for MIXED build
   vector<FullPrecRealType> vals_fp(vals.begin(), vals.end());
-  return create_NUBspline_1d_d(grid1d, xBC, vals_fp.data());
+  auto* nubspline_1d_d = create_NUBspline_1d_d(grid1d, xBC, vals_fp.data());
+  destroy_grid(grid1d);
+
+  return nubspline_1d_d;
 }
 
 //Integrate the spline using Simpson's 5/8 rule.  For Bsplines, this should be exact
@@ -489,6 +492,7 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
     k2vksk.push_back(0.5 * k2vk * skavg);
   }
 
+  destroy_Bspline(spline);
   k2vksk.push_back(0.0);
   nonunigrid1d.push_back(kmax);
 
@@ -498,7 +502,7 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
   RealType integratedval = integrate_spline(integrand, 0.0, kmax, 200);
   RealType intnorm       = Vol / 2.0 / M_PI / M_PI; //The volume factor here is because 1/Vol is
                                                     //included in QMCPACK's v_k.  See CoulombFunctor.
-
+  destroy_NUBspline_1d_d(integrand);
   return intnorm * integratedval;
 }
 

--- a/src/QMCTools/tests/CMakeLists.txt
+++ b/src/QMCTools/tests/CMakeLists.txt
@@ -31,12 +31,6 @@ endif()
 
 add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
 set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
-if("${ENABLE_SANITIZER}" STREQUAL "asan")
-  set_property(
-    TEST ${UTEST_NAME}
-    APPEND
-    PROPERTY LABELS noasan)
-endif()
 
 # Minimal test for qmc-check-affinity. Check for "OpenMP" in output, no errorcodes.
 if(HAVE_MPI)

--- a/src/einspline/nubspline_create.c
+++ b/src/einspline/nubspline_create.c
@@ -734,13 +734,6 @@ create_NUBspline_1d_c (NUgrid* x_grid, BCtype_c xBC, complex_float *data)
   return spline;
 }
 
-void destroy_NUBspline_1d_d(NUBspline_1d_d* spline)
-{
-    destroy_NUBasis(spline->x_basis);
-    free(spline->coefs);
-    free(spline);
-}
-
 NUBspline_2d_c *
 create_NUBspline_2d_c (NUgrid* x_grid, NUgrid* y_grid,
 		       BCtype_c xBC, BCtype_c yBC, complex_float *data)
@@ -1057,5 +1050,6 @@ destroy_NUBspline(Bspline *spline)
   default:
     break;
   }
+  free(spline);
 }
     

--- a/src/einspline/nubspline_create.c
+++ b/src/einspline/nubspline_create.c
@@ -734,6 +734,13 @@ create_NUBspline_1d_c (NUgrid* x_grid, BCtype_c xBC, complex_float *data)
   return spline;
 }
 
+void destroy_NUBspline_1d_d(NUBspline_1d_d* spline)
+{
+    destroy_NUBasis(spline->x_basis);
+    free(spline->coefs);
+    free(spline);
+}
+
 NUBspline_2d_c *
 create_NUBspline_2d_c (NUgrid* x_grid, NUgrid* y_grid,
 		       BCtype_c xBC, BCtype_c yBC, complex_float *data)

--- a/src/einspline/nubspline_create.h
+++ b/src/einspline/nubspline_create.h
@@ -60,8 +60,6 @@ extern "C" {
   create_NUBspline_1d_c (NUgrid* x_grid, BCtype_c xBC,
                          complex_float *data);
 
-  void destroy_NUBspline_1d_d(NUBspline_1d_d* spline);
-
   NUBspline_2d_c *
   create_NUBspline_2d_c (NUgrid* x_grid, NUgrid* y_grid,
                          BCtype_c xBC, BCtype_c yBC, complex_float *data);

--- a/src/einspline/nubspline_create.h
+++ b/src/einspline/nubspline_create.h
@@ -60,6 +60,8 @@ extern "C" {
   create_NUBspline_1d_c (NUgrid* x_grid, BCtype_c xBC,
                          complex_float *data);
 
+  void destroy_NUBspline_1d_d(NUBspline_1d_d* spline);
+
   NUBspline_2d_c *
   create_NUBspline_2d_c (NUgrid* x_grid, NUgrid* y_grid,
                          BCtype_c xBC, BCtype_c yBC, complex_float *data);


### PR DESCRIPTION
## Proposed changes

Fix leaks in `deterministic-unit-test-tools` test.
Remove `noasan` label reinstating test to asan CI checks
Leaks are due to interaction with C-based spline functions in `QMCTools/QMCFiniteSize`
Add function to free `NUBspline_1d_d` (spline might need future refactoring as more tests are added).
This is part of #3083 

## What type(s) of changes does this code introduce?

- Bugfix: leak
- Refactoring (no functional changes, no api changes)
- Testing changes: add `deterministic-unit-test-tools` test to asan CI checks

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 18.04, need to pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
