### PR TITLE
Add fixed unit tests to asan checks

### DIFF
--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -116,9 +116,6 @@ if(NOT QMC_CUDA)
 
   add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
-  if("${ENABLE_SANITIZER}" STREQUAL "asan")
-    set_property(TEST ${UTEST_NAME} APPEND PROPERTY LABELS noasan)
-  endif()
 
   if(HAVE_MPI)
     set(UTEST_EXE test_${SRC_DIR}_mpi)

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -65,7 +65,8 @@ foreach(CATEGORY coulomb force ham)
   add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
 
-  if("${ENABLE_SANITIZER}" STREQUAL "asan")
+  set(NOASAN_LIST ham)
+  if("${ENABLE_SANITIZER}" STREQUAL "asan" AND ${CATEGORY} IN_LIST NOASAN_LIST)
     set_property(
       TEST ${UTEST_NAME}
       APPEND

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -126,7 +126,7 @@ foreach(CATEGORY trialwf sposet jastrow determinant)
   add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
   
-  set(NOASAN_LIST trialwf jastrow)
+  set(NOASAN_LIST jastrow)
   if("${ENABLE_SANITIZER}" STREQUAL "asan" AND ${CATEGORY} IN_LIST NOASAN_LIST)
     set_property(
       TEST ${UTEST_NAME}

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -126,7 +126,7 @@ foreach(CATEGORY trialwf sposet jastrow determinant)
   add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
   
-  set(NOASAN_LIST jastrow)
+  set(NOASAN_LIST trialwf jastrow)
   if("${ENABLE_SANITIZER}" STREQUAL "asan" AND ${CATEGORY} IN_LIST NOASAN_LIST)
     set_property(
       TEST ${UTEST_NAME}


### PR DESCRIPTION
## Proposed changes

Adds to asan/lsan checks the following unit-tests after leaks are fixed by removing the `noasan` label
- ~deterministic-unit_test_wavefunction_trialwf~ not yet, due to #3077 
- deterministic-unit_test_hamiltonian_coulomb
- deterministic-unit_test_hamiltonian_force
- deterministic-unit_test_new_drivers

Related to #3083 

## What type(s) of changes does this code introduce?

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests) asan added unit tests

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 18.04, must pass CI 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
