### PR TITLE
Keep only lower triangle in AA distances

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -55,9 +55,11 @@ protected:
   /*@{*/
   /** distances_[i][j] , [N_targets][N_sources]
    *  Note: Derived classes decide if it is a memory view or the actual storage
-   *        For derived AA, only the lower triangle (j<i) is defined and up-to-date after pbyp move.
-   *          The upper triangle is symmetric to the lower one only when the full table is evaluated from scratch.
-   *          Avoid using the upper triangle because we may change the code to only allocate the lower triangle part.
+   *        For derived AA, only the lower triangle (j<i) data can be accessed safely.
+   *            There is no bound check to protect j>=i terms as the nature of operator[].
+   *            When the storage of the table is allocated as a single memory segment,
+   *            out-of-bound access is still within the segment and
+   *            thus doesn't trigger an alarm by the address sanitizer.
    *        For derived AB, the full table is up-to-date after pbyp move
    */
   std::vector<DistRow> distances_;
@@ -65,7 +67,7 @@ protected:
   /** displacements_[N_targets]x[3][N_sources]
    *  Note: Derived classes decide if it is a memory view or the actual storage
    *        displacements_[i][j] = r_A2[j] - r_A1[i], the opposite sign of AoS dr
-   *        For derived AA, A1=A2=A, only the lower triangle (j<i) is defined.
+   *        For derived AA, A1=A2=A, only the lower triangle (j<i) is defined. See the note of distances_
    *        For derived AB, A1=A, A2=B, the full table is allocated.
    */
   std::vector<DisplRow> displacements_;

--- a/src/Particle/InitMolecularSystem.cpp
+++ b/src/Particle/InitMolecularSystem.cpp
@@ -101,7 +101,6 @@ void InitMolecularSystem::initMolecule(ParticleSet* ions, ParticleSet* els)
 
   const int d_ii_ID = ions->addTable(*ions);
   ions->update();
-  const auto& d_ii = ions->getDistTable(d_ii_ID);
   const ParticleSet::ParticleIndex_t& grID(ions->GroupID);
   SpeciesSet& Species(ions->getSpeciesSet());
   int Centers = ions->getTotalNum();
@@ -127,14 +126,14 @@ void InitMolecularSystem::initMolecule(ParticleSet* ions, ParticleSet* els)
   RealType rmin = cutoff;
   ParticleSet::SingleParticlePos_t cm;
 
+  const auto& dist = ions->getDistTable(d_ii_ID).getDistances();
   // Step 1. Distribute even Q[iat] of atomic center iat. If Q[iat] is odd, put Q[iat]-1 and save the lone electron.
   for (size_t iat = 0; iat < Centers; iat++)
   {
     cm += ions->R[iat];
-    const auto& dist = d_ii.getDistRow(iat);
     for (size_t jat = iat + 1; jat < Centers; ++jat)
     {
-      rmin = std::min(rmin, dist[jat]);
+      rmin = std::min(rmin, dist[jat][iat]);
     }
     //use 40% of the minimum bond
     RealType sep = rmin * 0.4;

--- a/src/Particle/Lattice/ParticleBConds3DSoa.h
+++ b/src/Particle/Lattice/ParticleBConds3DSoa.h
@@ -15,7 +15,8 @@
 
 #include <config.h>
 #include <algorithm>
-#include "Lattice/CrystalLattice.h"
+#include "CrystalLattice.h"
+#include "ParticleBConds.h"
 
 namespace qmcplusplus
 {

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -93,7 +93,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
     for (int iat = 0; iat < N_targets; ++iat)
     {
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], P.getCoordinates().getAllParticlePos(), distances_[iat].data(),
-                                             displacements_[iat], 0, N_targets, iat);
+                                             displacements_[iat], 0, iat, iat);
       distances_[iat][iat] = BigR; //assign big distance
     }
   }
@@ -128,19 +128,28 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
           min_dist = temp_r_[jat];
           index    = jat;
         }
-      if (index >= 0)
-        dr = temp_dr_[index];
+      assert(index >= 0);
+      dr = temp_dr_[index];
     }
     else
     {
-      for (int jat = 0; jat < N_targets; ++jat)
-        if (distances_[iat][jat] < min_dist && jat != iat)
+      for (int jat = 0; jat < iat; ++jat)
+        if (distances_[iat][jat] < min_dist)
         {
           min_dist = distances_[iat][jat];
           index    = jat;
         }
-      if (index >= 0)
+      for (int jat = iat + 1; jat < N_targets; ++jat)
+        if (distances_[jat][iat] < min_dist)
+        {
+          min_dist = distances_[jat][iat];
+          index    = jat;
+        }
+      assert(index != iat && index >= 0);
+      if (index < iat)
         dr = displacements_[iat][index];
+      else
+        dr = displacements_[index][iat];
     }
     r = min_dist;
     return index;

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -25,8 +25,8 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   ///number of targets with padding
   int Ntargets_padded;
 
-  ///actual memory for displacements_
-  aligned_vector<RealType> memory_pool_displs_;
+  ///actual memory for dist and displacements_
+  aligned_vector<RealType> memory_pool_;
 
   /// old distances
   DistRow old_r_;
@@ -66,13 +66,13 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
     // initialize memory containers and views
     Ntargets_padded         = getAlignedSize<T>(N_targets);
     const size_t total_size = compute_size(N_targets);
-    memory_pool_displs_.resize(total_size * D);
+    memory_pool_.resize(total_size * (1 + D));
     distances_.resize(N_targets);
     displacements_.resize(N_targets);
     for (int i = 0; i < N_targets; ++i)
     {
-      distances_[i].resize(Ntargets_padded);
-      displacements_[i].attachReference(i, total_size, memory_pool_displs_.data() + compute_size(i));
+      distances_[i].attachReference(memory_pool_.data() + compute_size(i), i);
+      displacements_[i].attachReference(i, total_size, memory_pool_.data() + total_size + compute_size(i));
     }
 
     old_r_.resize(N_targets);
@@ -90,12 +90,9 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   {
     ScopedTimer local_timer(evaluate_timer_);
     constexpr T BigR = std::numeric_limits<T>::max();
-    for (int iat = 0; iat < N_targets; ++iat)
-    {
+    for (int iat = 1; iat < N_targets; ++iat)
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], P.getCoordinates().getAllParticlePos(), distances_[iat].data(),
                                              displacements_[iat], 0, iat, iat);
-      distances_[iat][iat] = BigR; //assign big distance
-    }
   }
 
   ///evaluate the temporary pair relations

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -12,6 +12,9 @@
 // -*- C++ -*-
 #ifndef QMCPLUSPLUS_DTDIMPL_AA_H
 #define QMCPLUSPLUS_DTDIMPL_AA_H
+
+#include "Lattice/ParticleBConds3DSoa.h"
+#include "DistanceTableData.h"
 #include "CPU/SIMD/algorithm.hpp"
 
 namespace qmcplusplus
@@ -54,7 +57,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   SoaDistanceTableAA(const SoaDistanceTableAA&) = delete;
   ~SoaDistanceTableAA() override {}
 
-  size_t compute_size(int N)
+  size_t compute_size(int N) const
   {
     const size_t N_padded  = getAlignedSize<T>(N);
     const size_t Alignment = getAlignment<T>();

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -14,6 +14,8 @@
 #ifndef QMCPLUSPLUS_DTDIMPL_AA_OMPTARGET_H
 #define QMCPLUSPLUS_DTDIMPL_AA_OMPTARGET_H
 
+#include "Lattice/ParticleBConds3DSoa.h"
+#include "DistanceTableData.h"
 #include "CPU/SIMD/algorithm.hpp"
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -146,7 +146,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     for (int iat = 0; iat < N_targets; ++iat)
     {
       DTD_BConds<T, D, SC>::computeDistances(P.R[iat], P.getCoordinates().getAllParticlePos(), distances_[iat].data(),
-                                             displacements_[iat], 0, N_targets, iat);
+                                             displacements_[iat], 0, iat, iat);
       distances_[iat][iat] = BigR; //assign big distance
     }
   }
@@ -302,19 +302,28 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
           min_dist = temp_r_[jat];
           index    = jat;
         }
-      if (index >= 0)
-        dr = temp_dr_[index];
+      assert(index >= 0);
+      dr = temp_dr_[index];
     }
     else
     {
-      for (int jat = 0; jat < N_targets; ++jat)
-        if (distances_[iat][jat] < min_dist && jat != iat)
+      for (int jat = 0; jat < iat; ++jat)
+        if (distances_[iat][jat] < min_dist)
         {
           min_dist = distances_[iat][jat];
           index    = jat;
         }
-      if (index >= 0)
+      for (int jat = iat + 1; jat < N_targets; ++jat)
+        if (distances_[jat][iat] < min_dist)
+        {
+          min_dist = distances_[jat][iat];
+          index    = jat;
+        }
+      assert(index != iat && index >= 0);
+      if (index < iat)
         dr = displacements_[iat][index];
+      else
+        dr = displacements_[index][iat];
     }
     r = min_dist;
     return index;

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -13,6 +13,7 @@
 #ifndef QMCPLUSPLUS_DTDIMPL_AB_H
 #define QMCPLUSPLUS_DTDIMPL_AB_H
 
+#include "Lattice/ParticleBConds3DSoa.h"
 #include "Utilities/FairDivide.h"
 #include "Message/OpenMP.h"
 

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -14,6 +14,8 @@
 #ifndef QMCPLUSPLUS_DTDIMPL_AB_OMPTARGET_H
 #define QMCPLUSPLUS_DTDIMPL_AB_OMPTARGET_H
 
+#include "Lattice/ParticleBConds3DSoa.h"
+#include "DistanceTableData.h"
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"

--- a/src/Particle/createDistanceTable.h
+++ b/src/Particle/createDistanceTable.h
@@ -15,7 +15,6 @@
 #define QMCPLUSPLUS_DISTANCETABLE_H
 
 #include "Particle/ParticleSet.h"
-#include "Utilities/PooledData.h"
 
 namespace qmcplusplus
 {

--- a/src/Particle/createDistanceTableAA.cpp
+++ b/src/Particle/createDistanceTableAA.cpp
@@ -16,9 +16,8 @@
 
 #include "Particle/createDistanceTable.h"
 #include "Particle/DistanceTableData.h"
-#include "Lattice/ParticleBConds.h"
-#include "Lattice/ParticleBConds3DSoa.h"
 #include "Particle/SoaDistanceTableAA.h"
+
 namespace qmcplusplus
 {
 /** Adding SymmetricDTD to the list, e.g., el-el distance table

--- a/src/Particle/createDistanceTableAAOMPTarget.cpp
+++ b/src/Particle/createDistanceTableAAOMPTarget.cpp
@@ -16,9 +16,8 @@
 
 #include "Particle/createDistanceTable.h"
 #include "Particle/DistanceTableData.h"
-#include "Lattice/ParticleBConds.h"
-#include "Lattice/ParticleBConds3DSoa.h"
 #include "Particle/SoaDistanceTableAAOMPTarget.h"
+
 namespace qmcplusplus
 {
 /** Adding SymmetricDTD to the list, e.g., el-el distance table

--- a/src/Particle/createDistanceTableAB.cpp
+++ b/src/Particle/createDistanceTableAB.cpp
@@ -16,10 +16,9 @@
 
 #include "Particle/createDistanceTable.h"
 #include "Particle/DistanceTableData.h"
-#include "Lattice/ParticleBConds.h"
-#include "CPU/SIMD/algorithm.hpp"
-#include "Lattice/ParticleBConds3DSoa.h"
 #include "Particle/SoaDistanceTableAB.h"
+#include "CPU/SIMD/algorithm.hpp"
+
 namespace qmcplusplus
 {
 /** Adding AsymmetricDTD to the list, e.g., el-el distance table

--- a/src/Particle/createDistanceTableABOMPTarget.cpp
+++ b/src/Particle/createDistanceTableABOMPTarget.cpp
@@ -16,10 +16,9 @@
 
 #include "Particle/createDistanceTable.h"
 #include "Particle/DistanceTableData.h"
-#include "Lattice/ParticleBConds.h"
-#include "CPU/SIMD/algorithm.hpp"
-#include "Lattice/ParticleBConds3DSoa.h"
 #include "Particle/SoaDistanceTableABOMPTarget.h"
+#include "CPU/SIMD/algorithm.hpp"
+
 namespace qmcplusplus
 {
 /** Adding AsymmetricDTD to the list, e.g., el-el distance table

--- a/src/Particle/tests/CMakeLists.txt
+++ b/src/Particle/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UTEST_EXE test_${SRC_DIR})
 set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 
 add_executable(${UTEST_EXE} test_particle.cpp test_distance_table.cpp test_walker.cpp test_particle_pool.cpp
-                            test_sample_stack.cpp test_DTModes.cpp)
+                            test_sample_stack.cpp test_DTModes.cpp test_SoaDistanceTableAA.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle Math::scalar_vector_functions)
 if(USE_OBJECT_TARGET)
   target_link_libraries(${UTEST_EXE} qmcutil containers platform_omptarget)

--- a/src/Particle/tests/test_SoaDistanceTableAA.cpp
+++ b/src/Particle/tests/test_SoaDistanceTableAA.cpp
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include <vector>
+#include <iostream>
+#include "ParticleSet.h"
+#include "Lattice/ParticleBConds3DSoa.h"
+#include "SoaDistanceTableAA.h"
+
+namespace qmcplusplus
+{
+TEST_CASE("SoaDistanceTableAA compute_size", "[distance_table]")
+{
+  ParticleSet elec;
+
+  elec.setName("e");
+  elec.create({6, 4});
+  
+  // using open BC
+  SoaDistanceTableAA<OHMMS_PRECISION, OHMMS_DIM, SUPERCELL_OPEN + SOA_OFFSET> dt_ee(elec);
+
+  const size_t Alignment = getAlignment<OHMMS_PRECISION>();
+
+  // create reference values
+  assert(elec.getTotalNum() == 10);
+  std::vector<int> ref_results(10);
+  if (Alignment == 4)
+    ref_results = {0, 4, 8, 12, 16, 24, 32, 40, 48, 60};
+  else if (Alignment == 8)
+    ref_results = {0, 8, 16, 24, 32, 40, 48, 56, 64, 80};
+
+  // run checks
+  if (Alignment == 4 || Alignment == 8)
+  {
+    std::cout << "testing Alignment = " << Alignment << std::endl;
+    for (int i = 0; i < ref_results.size(); i++)
+      CHECK(dt_ee.compute_size(i) == ref_results[i]);
+  }
+}
+} // namespace qmcplusplus

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -91,14 +91,10 @@ TEST_CASE("symmetric_distance_table OpenBC", "[particle]")
   const auto& aa_dists  = d_aa.getDistances();
   const auto& aa_displs = d_aa.getDisplacements();
 
-  REQUIRE(aa_dists[0][1] == Approx(1.62788206));
-  REQUIRE(aa_dists[1][0] == Approx(1.62788206));
-  REQUIRE(aa_displs[0][1][0] == Approx(1.1));
-  REQUIRE(aa_displs[0][1][1] == Approx(0.0));
-  REQUIRE(aa_displs[0][1][2] == Approx(1.2));
-  REQUIRE(aa_displs[1][0][0] == Approx(-1.1));
-  REQUIRE(aa_displs[1][0][1] == Approx(0.0));
-  REQUIRE(aa_displs[1][0][2] == Approx(-1.2));
+  CHECK(aa_dists[1][0] == Approx(1.62788206));
+  CHECK(aa_displs[1][0][0] == Approx(-1.1));
+  CHECK(aa_displs[1][0][1] == Approx(0.0));
+  CHECK(aa_displs[1][0][2] == Approx(-1.2));
 }
 
 TEST_CASE("symmetric_distance_table PBC", "[particle]")
@@ -126,14 +122,10 @@ TEST_CASE("symmetric_distance_table PBC", "[particle]")
   const auto& aa_dists  = d_aa.getDistances();
   const auto& aa_displs = d_aa.getDisplacements();
 
-  REQUIRE(aa_dists[1][2] == Approx(2.9212432441));
-  REQUIRE(aa_dists[2][1] == Approx(2.9212432441));
-  REQUIRE(aa_displs[1][2][0] == Approx(1.68658057));
-  REQUIRE(aa_displs[1][2][1] == Approx(1.68658057));
-  REQUIRE(aa_displs[1][2][2] == Approx(-1.68658058));
-  REQUIRE(aa_displs[2][1][0] == Approx(-1.68658057));
-  REQUIRE(aa_displs[2][1][1] == Approx(-1.68658057));
-  REQUIRE(aa_displs[2][1][2] == Approx(1.68658057));
+  CHECK(aa_dists[2][1] == Approx(2.9212432441));
+  CHECK(aa_displs[2][1][0] == Approx(-1.68658057));
+  CHECK(aa_displs[2][1][1] == Approx(-1.68658057));
+  CHECK(aa_displs[2][1][2] == Approx(1.68658057));
 }
 
 TEST_CASE("particle set lattice with vacuum", "[particle]")


### PR DESCRIPTION
review after #3287

## Proposed changes
Keep the table up-to-date and symmetry is costly in human effort, memory and computational cost. So I changed all the
lower triangle only.
The displacements has been changed to lower triangle when SoA was developed. Now just make one more step.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'