### PR TITLE
Nexus: Allow bandstructure plotting with custom k-path

### DIFF
--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -843,8 +843,9 @@ class PwscfAnalyzer(SimulationAnalyzer):
     #end def make_movie
 
 
-    def plot_bandstructure(self, filename=None, filepath=None, max_min_e = None, show=False, save=True, show_vbm_cbm=True):
+    def plot_bandstructure(self, filename=None, filepath=None, max_min_e = None, show=False, save=True, show_vbm_cbm=True,k_labels=None):
         if 'bands' in self:
+            success = True
             from structure import get_kpath
             if filename==None:
                 filename = 'band_structure.pdf'
@@ -877,10 +878,35 @@ class PwscfAnalyzer(SimulationAnalyzer):
             #end if
             fig    = figure()
             ax     = gca()
-            kpath  = get_kpath(structure=self.input_structure, check_standard=False)
-            x      = kpath['explicit_path_linearcoords']
-            labels = kpath['explicit_kpoints_labels']
             nbands = self.input.system.nbnd
+
+            if k_labels is None:
+                kpath  = get_kpath(structure=self.input_structure, check_standard=False)
+                x      = kpath['explicit_path_linearcoords']
+                labels = kpath['explicit_kpoints_labels']
+            else:
+                labels = k_labels
+                # Calculate linear coordinates from self.kpoints_cart
+                x = []
+                prev_label = ''
+                ref_kpt = self.kpoints_cart[0]
+                ref_kpt_norm = np.linalg.norm(self.kpoints_cart[0])
+                for kpt_idx,kpt in enumerate(self.kpoints_cart):
+                    curr_label = labels[kpt_idx]
+                    if curr_label != '' and prev_label == '':
+                        ref_kpt_norm+=np.linalg.norm(kpt-ref_kpt)
+                        ref_kpt = kpt
+                    elif curr_label != '' and prev_label != '':
+                        ref_kpt = kpt
+                        ref_kpt_norm+=np.linalg.norm(kpt-ref_kpt)
+                    else:
+                        pass
+                    #end if
+                    x.append(ref_kpt_norm+np.linalg.norm(kpt-ref_kpt))
+                    #x.append(kpt_idx)
+                    prev_label = curr_label
+                #end for
+            #end if
             for nb in range(nbands):
                 y = []
                 for bi in self.bands.up:
@@ -942,128 +968,6 @@ class PwscfAnalyzer(SimulationAnalyzer):
             show()
         #end if
     #end def plot_bandstructure
-
-
-    def plot_custom_bandstructure(self, filename=None, filepath=None, max_min_e = None, show=False, save=True, show_vbm_cbm=True, k_labels=None):
-        if k_labels is None:
-            self.error('The labels of the high-symetry kpoints must be given, e.g., k_labels=[\'G\',\'\',\'\',\'\',\'M\',\'\',...]')
-        #end if
-        if 'bands' in self:
-            success = True
-            if filename==None:
-                filename = 'band_structure.pdf'
-            if filepath==None:
-                filepath = os.path.join(self.abspath,filename)
-            else:
-                filepath = os.path.join(filepath,filename)
-            #end if
-            try:
-                import matplotlib
-                gui_envs = ['GTKAgg','TKAgg','agg','Qt4Agg','WXAgg']
-                for gui in gui_envs:
-                    try:
-                        matplotlib.use(gui,warn=False, force=True)
-                        from matplotlib import pyplot
-                        success = True
-                        break
-                    except:
-                        continue
-                    #end try
-                #end for
-                from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,rc,savefig,gca,xticks,axvline, scatter
-                params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
-                              'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
-                rcParams.update(params)
-            except(ImportError, RuntimeError):
-                success = False
-            if not success:
-                figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
-            #end if
-            fig    = figure()
-            ax     = gca()
-            labels = k_labels
-            nbands = self.input.system.nbnd
-            # Calculate linear coordinates from self.kpoints_cart
-            x = []
-            prev_label = ''
-            ref_kpt = self.kpoints_cart[0]
-            ref_kpt_norm = np.linalg.norm(self.kpoints_cart[0])
-            for kpt_idx,kpt in enumerate(self.kpoints_cart):
-                curr_label = labels[kpt_idx]
-                if curr_label != '' and prev_label == '':
-                    ref_kpt_norm+=np.linalg.norm(kpt-ref_kpt)
-                    ref_kpt = kpt
-                elif curr_label != '' and prev_label != '':
-                    ref_kpt = kpt
-                    ref_kpt_norm+=np.linalg.norm(kpt-ref_kpt)
-                else:
-                    pass
-                #end if
-                x.append(ref_kpt_norm+np.linalg.norm(kpt-ref_kpt))
-                #x.append(kpt_idx)
-                prev_label = curr_label
-            #end for
-            for nb in range(nbands):
-                y = []
-                for bi in self.bands.up:
-                    y.append(bi['eigs'][nb])
-                #end for
-                y = array(y) - self.bands.vbm.energy
-                plot(x, y, 'k')
-                if len(self.bands.down) > 0:
-                    y = []
-                    for bi in self.bands.down:
-                        y.append(bi['eigs'][nb])
-                    #end for
-                    y = array(y) - self.bands.vbm.energy
-                    plot(x, y, 'r')
-                #end if              
-            #end for
-            for ln, li in enumerate(labels):
-                if li is not '':
-                    axvline(x[ln], ymin=-100, ymax=100, linewidth=3, color='k')
-                    if li == 'GAMMA':
-                        labels[ln] = r'$\Gamma$'
-                    elif li is not '':
-                        labels[ln] = '${0}$'.format(li)
-                    #end if
-                    if labels[ln-1] is not '' and ln > 0:
-                        labels[ln] = labels[ln-1]+'|'+labels[ln]
-                        labels[ln-1] = ''
-                    #end if
-                #end if
-            #end for
-            
-            xlim([min(x), max(x)])
-            if max_min_e is None:
-                ylim(-5, +5)
-            else:
-                ylim(max_min_e[0],max_min_e[1])
-            #end if
-            ylabel('Energy (eV)')
-            xticks(x, labels)
-            ax.tick_params(axis='x', which='both', length=0)
-            ax.tick_params(axis='x', which='both', pad=10)
-        #end if
-        if show_vbm_cbm:
-            vbm = self.bands.vbm
-            cbm = self.bands.cbm
-            for kn, ki in enumerate(self.bands.up):
-                if (vbm.kpoint_rel == ki['kpoint_rel']).all():
-                    scatter(x[kn], 0, c='green', s=100)
-                #end if
-                if (cbm.kpoint_rel == ki['kpoint_rel']).all():
-                    scatter(x[kn], cbm.energy-vbm.energy, c='r', s=100)
-                #end if
-            #end for
-        #end if
-        if save:
-            savefig(filename, format='pdf',bbox_inches='tight')
-        #end if
-        if show:
-            show()
-        #end if
-    #end def plot_custom_bandstructure
 
 #end class PwscfAnalyzer
         

--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -943,5 +943,108 @@ class PwscfAnalyzer(SimulationAnalyzer):
         #end if
     #end def plot_bandstructure
 
+
+    def plot_custom_bandstructure(self, filename=None, filepath=None, max_min_e = None, show=False, save=True, show_vbm_cbm=True):
+        if 'bands' in self:
+            if filename==None:
+                filename = 'band_structure.pdf'
+            if filepath==None:
+                filepath = os.path.join(self.abspath,filename)
+            else:
+                filepath = os.path.join(filepath,filename)
+            #end if
+            try:
+                import matplotlib
+                gui_envs = ['GTKAgg','TKAgg','agg','Qt4Agg','WXAgg']
+                for gui in gui_envs:
+                    try:
+                        matplotlib.use(gui,warn=False, force=True)
+                        from matplotlib import pyplot
+                        success = True
+                        break
+                    except:
+                        continue
+                    #end try
+                #end for
+                from matplotlib.pyplot import figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,rc,savefig,gca,xticks,axvline, scatter
+                params = {'legend.fontsize':14,'figure.facecolor':'white','figure.subplot.hspace':0.,
+                              'axes.labelsize':16,'xtick.labelsize':14,'ytick.labelsize':14}
+                rcParams.update(params)
+            except(ImportError, RuntimeError):
+                success = False
+            if not success:
+                figure,plot,xlabel,ylabel,title,show,ylim,legend,xlim,rcParams,savefig,bar,xticks,subplot,grid,setp,errorbar,loglog,semilogx,semilogy,text = unavailable('matplotlib.pyplot','figure','plot','xlabel','ylabel','title','show','ylim','legend','xlim','rcParams','savefig','bar','xticks','subplot','grid','setp','errorbar','loglog','semilogx','semilogy','text')
+            #end if
+            fig    = figure()
+            ax     = gca()
+            kpath  = get_kpath(structure=self.input_structure, check_standard=False)
+            print(kpath)
+            quit()
+            #kpath  = # USER SUPPLIED KPOINTS?    #get_kpath(structure=self.input_structure, check_standard=False)
+            #x      = # CALCULATED FROM KPOINTS?  #kpath['explicit_path_linearcoords']
+            #labels = # USER SUPPLIED LABELS?      #kpath['explicit_kpoints_labels']
+            nbands = self.input.system.nbnd
+            for nb in range(nbands):
+                y = []
+                for bi in self.bands.up:
+                    y.append(bi['eigs'][nb])
+                #end for
+                y = array(y) - self.bands.vbm.energy
+                plot(x, y, 'k')
+                if len(self.bands.down) > 0:
+                    y = []
+                    for bi in self.bands.down:
+                        y.append(bi['eigs'][nb])
+                    #end for
+                    y = array(y) - self.bands.vbm.energy
+                    plot(x, y, 'r')
+                #end if              
+            #end for
+            for ln, li in enumerate(labels):
+                if li is not '':
+                    axvline(x[ln], ymin=-100, ymax=100, linewidth=3, color='k')
+                    if li == 'GAMMA':
+                        labels[ln] = r'$\Gamma$'
+                    elif li is not '':
+                        labels[ln] = '${0}$'.format(li)
+                    #end if
+                    if labels[ln-1] is not '' and ln > 0:
+                        labels[ln] = labels[ln-1]+'|'+labels[ln]
+                        labels[ln-1] = ''
+                    #end if
+                #end if
+            #end for
+            
+            xlim([min(x), max(x)])
+            if max_min_e is None:
+                ylim(-5, +5)
+            else:
+                ylim(max_min_e[0],max_min_e[1])
+            #end if
+            ylabel('Energy (eV)')
+            xticks(x, labels)
+            ax.tick_params(axis='x', which='both', length=0)
+            ax.tick_params(axis='x', which='both', pad=10)
+        #end if
+        if show_vbm_cbm:
+            vbm = self.bands.vbm
+            cbm = self.bands.cbm
+            for kn, ki in enumerate(self.bands.up):
+                if (vbm.kpoint_rel == ki['kpoint_rel']).all():
+                    scatter(x[kn], 0, c='green', s=100)
+                #end if
+                if (cbm.kpoint_rel == ki['kpoint_rel']).all():
+                    scatter(x[kn], cbm.energy-vbm.energy, c='r', s=100)
+                #end if
+            #end for
+        #end if
+        if save:
+            savefig(filename, format='pdf',bbox_inches='tight')
+        #end if
+        if show:
+            show()
+        #end if
+    #end def plot_custom_bandstructure
+
 #end class PwscfAnalyzer
         


### PR DESCRIPTION

## Proposed changes

This PR adds to the function `plot_bandstructure` in `./nexus/lib/pwscf_analyzer.py`. It allows the user to provide a custom set of labels for the high symmetry k-points (in the form k_labels=['GAMMA','','','','M','','',...]) where the length of the label array should match the number of k-points in the analyzer object. When custom labels are give, spglib is no longer used since it is assume that the k-points in the analyzer object are different from the ones that would be generated by spglib.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop. Linux

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
