### PR TITLE
Correct logging call print location and fix a typo

### DIFF
--- a/src/QMCWaveFunctions/LCAO/AOBasisBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/AOBasisBuilder.cpp
@@ -121,9 +121,6 @@ bool AOBasisBuilder<COT>::putH5(hdf_archive& hin)
   myComm->bcast(basisType);
   myComm->bcast(addsignforM);
 
-  app_log() << "<input node=\"atomicBasisSet\" name=\"" << basisName << "\" expandYlm=\"" << Morder << "\" angular=\""
-            << sph << "\" elementType=\"" << CenterID << "\" normalized=\"" << Normalized << "\" type=\"" << basisType
-            << "\" expM=\"" << addsignforM << "\" />" << std::endl;
   if (sph == "spherical")
     addsignforM = 1; //include (-1)^m
 
@@ -156,6 +153,9 @@ bool AOBasisBuilder<COT>::putH5(hdf_archive& hin)
     if (sph != "cartesian")
       myComm->barrier_and_abort(" Error: expandYlm='Dirac' only compatible with angular='cartesian'. Aborting\n");
   }
+  app_log() << "<input node=\"atomicBasisSet\" name=\"" << basisName << "\" expandYlm=\"" << Morder << "\" angular=\""
+            << sph << "\" elementType=\"" << CenterID << "\" normalized=\"" << Normalized << "\" type=\"" << basisType
+            << "\" expM=\"" << addsignforM << "\" />" << std::endl;
 
   return true;
 }

--- a/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
@@ -177,7 +177,7 @@ bool RadialOrbitalSetBuilder<COT>::addGrid(xmlNodePtr cur, const std::string& ra
 template<typename COT>
 bool RadialOrbitalSetBuilder<COT>::addGridH5(hdf_archive& hin)
 {
-  app_log() << "   Grid is created by the input paremters in h5" << std::endl;
+  app_log() << "   Grid is created by the input parameters in h5" << std::endl;
 
   std::string gridtype;
   if (myComm->rank() == 0)


### PR DESCRIPTION
## Proposed changes
Two minor changes are proposed. The first is a confusing logging call that logs a variable that is changed after it is logged. The second is a minor typo.
For the logging:
```
old logging position <input node="atomicBasisSet" name="H" expandYlm="natural" angular="spherical" elementType="H" normalized="no" type="Numerical" expM="0" />
new logging position <input node="atomicBasisSet" name="H" expandYlm="natural" angular="spherical" elementType="H" normalized="no" type="Numerical" expM="1" />
```

## What type(s) of changes does this code introduce?
- Bugfix (sort of?)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ryzen workstation
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
