### PR TITLE
qmcfinitesize fix for SkAll group name in hdf5

### DIFF
--- a/src/QMCTools/QMCFiniteSize/SkParserBase.cpp
+++ b/src/QMCTools/QMCFiniteSize/SkParserBase.cpp
@@ -4,7 +4,7 @@
 
 namespace qmcplusplus
 {
-SkParserBase::SkParserBase() : isParseSuccess(false), isGridComputed(false), isSkComputed(false)
+SkParserBase::SkParserBase() : isParseSuccess(false), isGridComputed(false), isSkComputed(false), skname("skall")
 {
   skraw.resize(0);
   sk.resize(0);

--- a/src/QMCTools/QMCFiniteSize/SkParserBase.cpp
+++ b/src/QMCTools/QMCFiniteSize/SkParserBase.cpp
@@ -4,7 +4,7 @@
 
 namespace qmcplusplus
 {
-SkParserBase::SkParserBase() : isParseSuccess(false), isGridComputed(false), isSkComputed(false), skname("skall")
+SkParserBase::SkParserBase() : isParseSuccess(false), isGridComputed(false), isSkComputed(false), skname("SkAll")
 {
   skraw.resize(0);
   sk.resize(0);

--- a/src/QMCTools/QMCFiniteSize/SkParserBase.h
+++ b/src/QMCTools/QMCFiniteSize/SkParserBase.h
@@ -28,6 +28,7 @@ public:
 
   virtual void parse(const string& fname) = 0;
 
+
   void get_grid(Grid_t& xgrid, Grid_t& ygrid, Grid_t& zgrid);
   void get_sk(vector<RealType>& sk, vector<RealType>& skerr);
 
@@ -43,6 +44,8 @@ public:
 
   inline bool is_normalized() { return isNormalized; }
   inline bool has_grid() { return hasGrid; }
+
+  void setName(std::string in_name) { skname = in_name; }
 
 protected:
   bool isParseSuccess;
@@ -62,6 +65,8 @@ protected:
   vector<RealType> sk;
   vector<RealType> skerr;
   vector<PosType> kgrid;
+
+  std::string skname;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCTools/QMCFiniteSize/SkParserHDF5.cpp
+++ b/src/QMCTools/QMCFiniteSize/SkParserHDF5.cpp
@@ -6,7 +6,6 @@ namespace qmcplusplus
 {
 void SkParserHDF5::parse(const string& fname)
 {
-
   bool result = statfile.open(fname);
   if (!result)
   {
@@ -16,11 +15,11 @@ void SkParserHDF5::parse(const string& fname)
 
   //read the kpoints
   vector<int> readShape;
-  statfile.getShape<int>(skname+"/kpoints/value", readShape);
+  statfile.getShape<int>(skname + "/kpoints/value", readShape);
   assert(readShape[1] == 3);
   array<int, 2> kdims{readShape[0], readShape[1]};
   vector<RealType> ktmp;
-  statfile.readSlabReshaped(ktmp, kdims, skname+"/kpoints/value");
+  statfile.readSlabReshaped(ktmp, kdims, skname + "/kpoints/value");
   for (int ik = 0; ik < readShape[0]; ik++)
   {
     PosType k;
@@ -32,26 +31,26 @@ void SkParserHDF5::parse(const string& fname)
   int nKpts = kgridraw.size();
 
   //read the <rho_-k*rho_k> term
-  statfile.getShape<int>(skname+"/rhok_e_e/value", readShape);
+  statfile.getShape<int>(skname + "/rhok_e_e/value", readShape);
   assert(readShape[1] == nKpts);
   vector<RealType> rhok_e_tmp;
   array<int, 2> rhok_e_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_e_tmp, rhok_e_dims, skname+"/rhok_e_e/value");
+  statfile.readSlabReshaped(rhok_e_tmp, rhok_e_dims, skname + "/rhok_e_e/value");
   int nBlocks = readShape[0];
 
   //read the Im(rho_k) term
-  statfile.getShape<int>(skname+"/rhok_e_i/value", readShape);
+  statfile.getShape<int>(skname + "/rhok_e_i/value", readShape);
   vector<RealType> rhok_i_tmp;
   array<int, 2> rhok_i_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_i_tmp, rhok_i_dims, skname+"/rhok_e_i/value");
+  statfile.readSlabReshaped(rhok_i_tmp, rhok_i_dims, skname + "/rhok_e_i/value");
   assert(readShape[0] == nBlocks);
   assert(readShape[1] == nKpts);
 
   //read the Re(rho_k)
-  statfile.getShape<int>(skname+"/rhok_e_r/value", readShape);
+  statfile.getShape<int>(skname + "/rhok_e_r/value", readShape);
   vector<RealType> rhok_r_tmp;
   array<int, 2> rhok_r_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_r_tmp, rhok_r_dims, skname+"/rhok_e_r/value");
+  statfile.readSlabReshaped(rhok_r_tmp, rhok_r_dims, skname + "/rhok_e_r/value");
   assert(readShape[0] == nBlocks);
   assert(readShape[1] == nKpts);
 

--- a/src/QMCTools/QMCFiniteSize/SkParserHDF5.cpp
+++ b/src/QMCTools/QMCFiniteSize/SkParserHDF5.cpp
@@ -6,6 +6,7 @@ namespace qmcplusplus
 {
 void SkParserHDF5::parse(const string& fname)
 {
+
   bool result = statfile.open(fname);
   if (!result)
   {
@@ -15,11 +16,11 @@ void SkParserHDF5::parse(const string& fname)
 
   //read the kpoints
   vector<int> readShape;
-  statfile.getShape<int>("skall/kpoints/value", readShape);
+  statfile.getShape<int>(skname+"/kpoints/value", readShape);
   assert(readShape[1] == 3);
   array<int, 2> kdims{readShape[0], readShape[1]};
   vector<RealType> ktmp;
-  statfile.readSlabReshaped(ktmp, kdims, "skall/kpoints/value");
+  statfile.readSlabReshaped(ktmp, kdims, skname+"/kpoints/value");
   for (int ik = 0; ik < readShape[0]; ik++)
   {
     PosType k;
@@ -31,28 +32,28 @@ void SkParserHDF5::parse(const string& fname)
   int nKpts = kgridraw.size();
 
   //read the <rho_-k*rho_k> term
-  statfile.getShape<int>("skall/rhok_e_e/value", readShape);
+  statfile.getShape<int>(skname+"/rhok_e_e/value", readShape);
   assert(readShape[1] == nKpts);
   vector<RealType> rhok_e_tmp;
   array<int, 2> rhok_e_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_e_tmp, rhok_e_dims, "skall/rhok_e_e/value");
+  statfile.readSlabReshaped(rhok_e_tmp, rhok_e_dims, skname+"/rhok_e_e/value");
   int nBlocks = readShape[0];
 
   //read the Im(rho_k) term
-  statfile.getShape<int>("skall/rhok_e_i/value", readShape);
+  statfile.getShape<int>(skname+"/rhok_e_i/value", readShape);
   vector<RealType> rhok_i_tmp;
   array<int, 2> rhok_i_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_i_tmp, rhok_i_dims, "skall/rhok_e_i/value");
+  statfile.readSlabReshaped(rhok_i_tmp, rhok_i_dims, skname+"/rhok_e_i/value");
+  assert(readShape[0] == nBlocks);
   assert(readShape[1] == nKpts);
-  assert(readShape[1] == nBlocks);
 
   //read the Re(rho_k)
-  statfile.getShape<int>("skall/rhok_e_r/value", readShape);
+  statfile.getShape<int>(skname+"/rhok_e_r/value", readShape);
   vector<RealType> rhok_r_tmp;
   array<int, 2> rhok_r_dims{readShape[0], readShape[1]};
-  statfile.readSlabReshaped(rhok_r_tmp, rhok_r_dims, "skall/rhok_e_r/value");
+  statfile.readSlabReshaped(rhok_r_tmp, rhok_r_dims, skname+"/rhok_e_r/value");
+  assert(readShape[0] == nBlocks);
   assert(readShape[1] == nKpts);
-  assert(readShape[1] == nBlocks);
 
   //For each k, evaluate the flucuating S(k) for all blocks.
   //Then perform a simple equilibration estimate for this particular S(k) value

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -60,6 +60,8 @@ int main(int argc, char** argv)
 
   bool show_usage = false;
   bool show_warn  = false;
+  std::string skname;
+  std::string skfile;
   /* For a successful execution of the code, atleast 3 arguments will need to be
    * provided along with the executable. Therefore, print usage information if
    * argc is less than 4.
@@ -80,7 +82,7 @@ int main(int argc, char** argv)
       if (a == "--ascii")
       {
         skparser = std::make_unique<SkParserASCII>();
-        skparser->parse(anxt);
+        skfile   = anxt;
         if (skf_found)
           show_warn = true;
         skf_found = true;
@@ -88,7 +90,7 @@ int main(int argc, char** argv)
       else if (a == "--scalardat")
       {
         skparser = std::make_unique<SkParserScalarDat>();
-        skparser->parse(anxt);
+        skfile   = anxt;
         if (skf_found)
           show_warn = true;
         skf_found = true;
@@ -96,10 +98,14 @@ int main(int argc, char** argv)
       else if (a == "--hdf5")
       {
         skparser = std::make_unique<SkParserHDF5>();
-        skparser->parse(anxt);
+        skfile   = anxt;
         if (skf_found)
           show_warn = true;
         skf_found = true;
+      }
+      else if (a == "--skname")
+      {
+        skname = anxt;
       }
       else
       {
@@ -112,16 +118,32 @@ int main(int argc, char** argv)
 
   if (show_usage)
   {
-    std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE]\n";
+    std::cout << "Usage:  qmcfinitesize [main.xml] --[skformat] [SK_FILE] --[optional_arg] [option]\n";
+    std::cout << "  [main.xml]\n";
+    std::cout << "    input file to qmcpack corresponding that calculated S(k) data. ";
     std::cout << "  [skformat]\n";
-    std::cout << "    --ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
-    std::cout << "    --scalardat:  File containing skall elements with energy.pl output format.\n";
-    std::cout << "    --hdf5:       stat.h5 file containing skall data.\n";
+    std::cout << "    ascii:      S(k) given in kx ky kz sk sk_err format.  Header necessary.\n";
+    std::cout << "    scalardat:  File containing skall elements with energy.pl output format.\n";
+    std::cout << "    hdf5:       stat.h5 file containing skall data.\n";
+    std::cout << "  [SK_FILE]\n";
+    std::cout << "    filename containing the S(k) data\n";
+    std::cout << "  [optional_args]\n";
+    std::cout << "    --skname:     in the stat.h5, the S(k) group name. Set to \"name\" defined in qmcpack input file where SkAll estimator was specified\n";
+    std::cout << "  [option]\n";
+    std::cout << "    option corresonding to the optional_arg\n";
+    std::cout << "---------------------------\n";
+    std::cout << "Examples:\n";
+    std::cout << "  qmcfinitesize qmc.in.xml --hdf5 qmc.g000.s000.stat.h5 --skname SkAll\n";
+    std::cout << "  qmcfinitesize qmc.in.xml --ascii processed_sk.dat\n";
     return 0;
   }
 
   if (show_warn)
     std::cout << "WARNING:  multiple skformats were provided. All but the last will be ignored.\n\n";
+
+  if (!skname.empty())
+    skparser->setName(skname);
+  skparser->parse(skfile);
 
   if (skparser == NULL)
   {

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -128,7 +128,8 @@ int main(int argc, char** argv)
     std::cout << "  [SK_FILE]\n";
     std::cout << "    filename containing the S(k) data\n";
     std::cout << "  [optional_args]\n";
-    std::cout << "    --skname:     in the stat.h5, the S(k) group name. Set to \"name\" defined in qmcpack input file where SkAll estimator was specified\n";
+    std::cout << "    --skname:     in the stat.h5, the S(k) group name. Set to \"name\" defined in qmcpack input file "
+                 "where SkAll estimator was specified\n";
     std::cout << "  [option]\n";
     std::cout << "    option corresonding to the optional_arg\n";
     std::cout << "---------------------------\n";


### PR DESCRIPTION

## Proposed changes

This closes #3285 

The SkAll estimator is written to the stat.h5 with whatever name the user chooses in the qmcpack xml file. 
Previous behavior assumed the name was always "skall".
This adds an input argument to `qmcfinitesize` to set the SkAll groupname to whatever was it is in the stat.h5 file.
The default also now assumes it is SkAll, which is consistent with the example in the manual. 

Also I added some more detailed usage information for qmcfinitesize

## What type(s) of changes does this code introduce?

- New feature/bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my workstation, gnu 9.2.0

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
