### PR TITLE
Switch HDFWalkerOutput raw pointer to std::unique to address leak

### DIFF
--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -285,7 +285,7 @@ void MCWalkerConfiguration::loadEnsemble()
 //}
 
 bool MCWalkerConfiguration::dumpEnsemble(std::vector<MCWalkerConfiguration*>& others,
-                                         HDFWalkerOutput* out,
+                                         HDFWalkerOutput& out,
                                          int np,
                                          int nBlock)
 {

--- a/src/Particle/MCWalkerConfiguration.h
+++ b/src/Particle/MCWalkerConfiguration.h
@@ -196,7 +196,7 @@ public:
    * @param np number of processors
    * @return true with non-zero samples
    */
-  bool dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput* out, int np, int nBlock);
+  bool dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput& out, int np, int nBlock);
   ///clear the ensemble
   void clearEnsemble();
 

--- a/src/Particle/SampleStack.cpp
+++ b/src/Particle/SampleStack.cpp
@@ -75,7 +75,7 @@ void SampleStack::loadSample(ParticleSet& pset, size_t iw) const
   pset.spins = sample_vector_[iw]->spins;
 }
 
-bool SampleStack::dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput* out, int np, int nBlock)
+bool SampleStack::dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput& out, int np, int nBlock)
 {
   MCWalkerConfiguration wtemp;
   wtemp.resize(0, total_num_);
@@ -88,7 +88,7 @@ bool SampleStack::dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFW
     nwoff[ip + 1] = nwoff[ip] + w;
   wtemp.setGlobalNumWalkers(nwoff[np]);
   wtemp.setWalkerOffsets(nwoff);
-  out->dump(wtemp, nBlock);
+  out.dump(wtemp, nBlock);
   return true;
 }
 

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -56,7 +56,7 @@ public:
 
   void appendSample(MCSample&& sample);
 
-  bool dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput* out, int np, int nBlock);
+  bool dumpEnsemble(std::vector<MCWalkerConfiguration*>& others, HDFWalkerOutput& out, int np, int nBlock);
   ///clear the ensemble
   void clearEnsemble();
   //@}

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -34,10 +34,7 @@ typedef int TraceManager;
 namespace qmcplusplus
 {
 /// Constructor.
-CSVMC::CSVMC(MCWalkerConfiguration& w,
-             TrialWaveFunction& psi,
-             QMCHamiltonian& h,
-             Communicate* comm)
+CSVMC::CSVMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm)
     : QMCDriver(w, psi, h, comm, "CSVMC"), UseDrift("yes"), multiEstimator(0), Mover(0)
 {
   RootName = "csvmc";
@@ -199,7 +196,7 @@ bool CSVMC::run()
   bool wrotesamples = DumpConfig;
   if (DumpConfig)
   {
-    wrotesamples = W.dumpEnsemble(wClones, wOut, myComm->size(), nBlocks);
+    wrotesamples = W.dumpEnsemble(wClones, *wOut, myComm->size(), nBlocks);
     if (wrotesamples)
       app_log() << "  samples are written to the config.h5" << std::endl;
   }

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -55,7 +55,6 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
       W(w),
       Psi(psi),
       H(h),
-      wOut(nullptr),
       driver_scope_timer_(*timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(enable_profiling)
 {

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -55,7 +55,7 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
       W(w),
       Psi(psi),
       H(h),
-      wOut(0),
+      wOut(nullptr),
       driver_scope_timer_(*timer_manager.createTimer(QMC_driver_type, timer_level_coarse)),
       driver_scope_profiler_(enable_profiling)
 {
@@ -227,8 +227,8 @@ void QMCDriver::process(xmlNodePtr cur)
 #endif
   branchEngine->put(cur);
   Estimators->put(H, cur);
-  if (wOut == 0)
-    wOut = new HDFWalkerOutput(W, RootName, myComm);
+  if (!wOut)
+    wOut = std::make_unique<HDFWalkerOutput>(W, RootName, myComm);
   branchEngine->start(RootName);
   branchEngine->write(RootName);
   //use new random seeds
@@ -338,8 +338,6 @@ bool QMCDriver::finalize(int block, bool dumpwalkers)
 {
   if (DumpConfig && dumpwalkers)
     wOut->dump(W, block);
-  delete wOut;
-  wOut           = 0;
   nTargetWalkers = W.getActiveWalkers();
   MyCounter++;
   infoSummary.flush();

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -311,7 +311,7 @@ protected:
   QMCHamiltonian& H;
 
   ///record engine for walkers
-  HDFWalkerOutput* wOut;
+  std::unique_ptr<HDFWalkerOutput> wOut;
 
   ///a list of TrialWaveFunctions for multiple method
   std::vector<TrialWaveFunction*> Psi1;

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -136,7 +136,7 @@ bool VMC::run()
   bool wrotesamples = DumpConfig;
   if (DumpConfig)
   {
-    wrotesamples = W.dumpEnsemble(wClones, wOut, myComm->size(), nBlocks);
+    wrotesamples = W.dumpEnsemble(wClones, *wOut, myComm->size(), nBlocks);
     if (wrotesamples)
       app_log() << "  samples are written to the config.h5" << std::endl;
   }


### PR DESCRIPTION
## Proposed changes

Switch `HDF5WalkerOutput` member object from raw to `std::unique` in `QMCDriver`
Address leak observed in deterministic tests
Related to #3312

## What type(s) of changes does this code introduce?

- Bugfix
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Testing: fixing leaks in deterministic tests

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
