### PR TITLE
Add full precision CUDA legacy tests on self-hosted CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -22,8 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         jobname: [
-          gcc-real-gpu-cuda,
-          gcc-complex-gpu-cuda,
+          gcc-real-gpu-cuda-mixed,  # mixed precision
+          gcc-complex-gpu-cuda-mixed,
+          gcc-real-gpu-cuda-full,   # full precision
+          gcc-complex-gpu-cuda-full,
         ]
 
     steps:

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -18,6 +18,7 @@ case "$1" in
     mkdir qmcpack-build
     cd qmcpack-build
     
+    # Real or Complex
     case "${GH_JOBNAME}" in
       *"real"*)
         echo 'Configure for real build -DQMC_COMPLEX=0'
@@ -26,6 +27,18 @@ case "$1" in
       *"complex"*)
         echo 'Configure for complex build -DQMC_COMPLEX=1'
         IS_COMPLEX=1
+      ;; 
+    esac
+    
+    # Mixed of Full precision, used in GPU code (cuda jobs) as it's more mature
+    case "${GH_JOBNAME}" in
+      *"full"*)
+        echo 'Configure for real build -DQMC_MIXED_PRECISION=0'
+        IS_MIXED_PRECISION=0
+      ;;
+      *"mixed"*)
+        echo 'Configure for complex build -DQMC_MIXED_PRECISION=1'
+        IS_MIXED_PRECISION=1
       ;; 
     esac
     
@@ -82,6 +95,7 @@ case "$1" in
         cmake -GNinja -DQMC_CUDA=1 \
                       -DQMC_MPI=0 \
                       -DQMC_COMPLEX=$IS_COMPLEX \
+                      -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
                       ${GITHUB_WORKSPACE}
       ;;
       # Configure with default compilers


### PR DESCRIPTION
## Proposed changes

Existing tests only run on mixed precision on self-hosted CI
Now run the following combinations: (4 in total, 2 before)
real: full, mixed
complex: full, mixed
This PR must be merged into `develop` before changes take effect on CI.

## What type(s) of changes does this code introduce?

- Testing changes: Add CUDA Legacy configurations on self-hosted CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, all 4 configurations must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
