### PR TITLE
DualAllocator Fix and Better const consistency for Dual space containers

### DIFF
--- a/src/Containers/OhmmsPETE/OhmmsMatrix.h
+++ b/src/Containers/OhmmsPETE/OhmmsMatrix.h
@@ -144,6 +144,22 @@ public:
     assign(*this, rhs);
   }
 
+  /** This assigns from a matrix with larger row size (used for alignment)
+   *  to whatever the rowsize is here.
+   *  Hacky but so is just making the matrix n x (n + padding) to handle row alignment.
+   *  This is unoptimized.
+   */
+  template<typename CONTAINER>
+  void assignUpperRight(const CONTAINER& other)
+  {
+    auto& this_ref = *this;
+    size_t cols = std::max(this_ref.cols(), other.cols());
+    size_t rows = std::max(this_ref.rows(), other.rows());
+    for(int j = 0; j < cols; ++j)
+      for(int i = 0; i < rows; ++i)
+        this_ref(i,j) = other(i,j);
+  }
+  
   // Assignment Operators
   inline This_t& operator=(const This_t& rhs)
   {

--- a/src/Containers/OhmmsPETE/OhmmsVector.h
+++ b/src/Containers/OhmmsPETE/OhmmsVector.h
@@ -153,7 +153,7 @@ public:
     nLocal     = n;
     nAllocated = 0;
     X          = ref;
-    qmc_allocator_traits<Alloc>::attachReference(other.mAllocator, mAllocator, ref - other.data());
+    qmc_allocator_traits<Alloc>::attachReference(other.mAllocator, mAllocator, other.data(), ref);
   }
 
   //! return the current size
@@ -236,12 +236,12 @@ public:
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   inline pointer device_data()
   {
-    return mAllocator.getDevicePtr();
+    return mAllocator.get_device_ptr();
   }
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   inline const_pointer device_data() const
   {
-    return mAllocator.getDevicePtr();
+    return mAllocator.get_device_ptr();
   }
 
   inline pointer first_address() { return X; }

--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -256,25 +256,25 @@ struct VectorSoaContainer
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   __forceinline T* device_data()
   {
-    return mAllocator.getDevicePtr();
+    return mAllocator.get_device_ptr();
   }
   ///return the base, device
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   __forceinline const T* device_data() const
   {
-    return mAllocator.getDevicePtr();
+    return mAllocator.get_device_ptr();
   }
   ///return the pointer of the i-th components, device
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   __forceinline T* restrict device_data(size_t i)
   {
-    return mAllocator.getDevicePtr() + i * nGhosts;
+    return mAllocator.get_device_ptr() + i * nGhosts;
   }
   ///return the const pointer of the i-th components, device
   template<typename Allocator = Alloc, typename = IsDualSpace<Allocator>>
   __forceinline const T* restrict device_data(size_t i) const
   {
-    return mAllocator.getDevicePtr() + i * nGhosts;
+    return mAllocator.get_device_ptr() + i * nGhosts;
   }
 
   // Abstract Dual Space Transfers

--- a/src/Platforms/DualAllocator.hpp
+++ b/src/Platforms/DualAllocator.hpp
@@ -92,11 +92,11 @@ struct DualAllocator : public HostAllocator
   {
     std::ptrdiff_t ptr_offset = ref - from_data;
     host_ptr_                 = ref;
-    device_ptr_               = from.getDevicePtr() + ptr_offset;
+    device_ptr_               = from.get_device_ptr() + ptr_offset;
   }
 
-  T* getDevicePtr() { return device_ptr_; }
-  const T* getDevicePtr() const { return device_ptr_; }
+  T* get_device_ptr() { return device_ptr_; }
+  const T* get_device_ptr() const { return device_ptr_; }
 
   DeviceAllocator& get_device_allocator() { return device_allocator_; }
   const DeviceAllocator& get_device_allocator() const { return device_allocator_; }
@@ -138,7 +138,7 @@ struct qmc_allocator_traits<DualAllocator<T, DeviceAllocator, HostAllocator>>
   static void updateTo(DualAlloc& alloc, T* host_ptr, size_t n)
   {
     assert(host_ptr = alloc.get_host_ptr());
-    alloc.get_device_allocator().copyToDevice(alloc.getDevicePtr(), host_ptr, n);
+    alloc.get_device_allocator().copyToDevice(alloc.get_device_ptr(), host_ptr, n);
   }
 
   /** update from the device, assumes you are copying starting with the device_ptr to the implicit host_ptr.
@@ -146,12 +146,12 @@ struct qmc_allocator_traits<DualAllocator<T, DeviceAllocator, HostAllocator>>
   static void updateFrom(DualAlloc& alloc, T* host_ptr, size_t n)
   {
     assert(host_ptr = alloc.get_host_ptr());
-    alloc.get_device_allocator().copyFromDevice(host_ptr, alloc.getDevicePtr(), n);
+    alloc.get_device_allocator().copyFromDevice(host_ptr, alloc.get_device_ptr(), n);
   }
 
   static void deviceSideCopyN(DualAlloc& alloc, size_t to, size_t n, size_t from)
   {
-    T* device_ptr = alloc.getDevicePtr();
+    T* device_ptr = alloc.get_device_ptr();
     T* to_ptr     = device_ptr + to;
     T* from_ptr   = device_ptr + from;
     alloc.get_device_allocator().copyDeviceToDevice(to_ptr, n, from_ptr);

--- a/src/Platforms/OMPTarget/OMPallocator.hpp
+++ b/src/Platforms/OMPTarget/OMPallocator.hpp
@@ -66,10 +66,6 @@ struct OMPallocator : public HostAllocator
    *  our < c++11 compliant containers may expect it.
    */
   OMPallocator(const OMPallocator&) : device_ptr_(nullptr) {}
-
-  // these semantics are surprising and "incorrect" considering OMPallocator is stateful.
-  OMPallocator& operator=(const OMPallocator&) { device_ptr_ = nullptr; }
-
   template<class U, class V>
   OMPallocator(const OMPallocator<U, V>&) : device_ptr_(nullptr)
   {}
@@ -97,20 +93,17 @@ struct OMPallocator : public HostAllocator
     HostAllocator::deallocate(pt, n);
   }
 
-  void attachReference(OMPallocator& from, std::ptrdiff_t ptr_offset)
+  void attachReference(const OMPallocator& from, std::ptrdiff_t ptr_offset)
   {
-    device_ptr_ = from.getDevicePtr() + ptr_offset;
+    device_ptr_ = const_cast<typename OMPallocator::pointer>(from.get_device_ptr()) + ptr_offset;
   }
 
-  T* getDevicePtr() { return device_ptr_; }
-  const T* getDevicePtr() const { return device_ptr_; }
+  T* get_device_ptr() { return device_ptr_; }
+  const T* get_device_ptr() const { return device_ptr_; }
 
 private:
   // pointee is on device.
   T* device_ptr_         = nullptr;
-
-public:
-  T* get_device_ptr() const { return device_ptr_; }
 };
 
 /** Specialization for OMPallocator which is a special DualAllocator with fused
@@ -128,7 +121,7 @@ struct qmc_allocator_traits<OMPallocator<T, HostAllocator>>
     //PRAGMA_OFFLOAD("omp target update to(ptr[:n])")
   }
 
-  static void attachReference(OMPallocator<T, HostAllocator>& from, OMPallocator<T, HostAllocator>& to, T* from_data, T* ref)
+  static void attachReference(const OMPallocator<T, HostAllocator>& from, OMPallocator<T, HostAllocator>& to, const T* from_data, T* ref)
   {
     std::ptrdiff_t ptr_offset = ref - from_data;
     to.attachReference(from, ptr_offset);
@@ -147,7 +140,7 @@ struct qmc_allocator_traits<OMPallocator<T, HostAllocator>>
   // Not very optimized device side copy.  Only used for testing.
   static void deviceSideCopyN(OMPallocator<T, HostAllocator>& alloc, size_t to, size_t n, size_t from)
   {
-    auto* dev_ptr = alloc.getDevicePtr();
+    auto* dev_ptr = alloc.get_device_ptr();
     PRAGMA_OFFLOAD("omp target teams distribute parallel for is_device_ptr(dev_ptr)")
     for (int i = 0; i < n; i++)
       dev_ptr[to + i] = dev_ptr[from + i];

--- a/src/Platforms/OMPTarget/OMPallocator.hpp
+++ b/src/Platforms/OMPTarget/OMPallocator.hpp
@@ -82,7 +82,7 @@ struct OMPallocator : public HostAllocator
     value_type* pt = HostAllocator::allocate(n);
     PRAGMA_OFFLOAD("omp target enter data map(alloc:pt[0:n])")
     OMPallocator_device_mem_allocated += n * sizeof(T);
-    device_ptr_         = getOffloadDevicePtr(pt);
+    device_ptr_ = getOffloadDevicePtr(pt);
     return pt;
   }
 
@@ -103,7 +103,7 @@ struct OMPallocator : public HostAllocator
 
 private:
   // pointee is on device.
-  T* device_ptr_         = nullptr;
+  T* device_ptr_ = nullptr;
 };
 
 /** Specialization for OMPallocator which is a special DualAllocator with fused
@@ -121,7 +121,10 @@ struct qmc_allocator_traits<OMPallocator<T, HostAllocator>>
     //PRAGMA_OFFLOAD("omp target update to(ptr[:n])")
   }
 
-  static void attachReference(const OMPallocator<T, HostAllocator>& from, OMPallocator<T, HostAllocator>& to, const T* from_data, T* ref)
+  static void attachReference(const OMPallocator<T, HostAllocator>& from,
+                              OMPallocator<T, HostAllocator>& to,
+                              const T* from_data,
+                              T* ref)
   {
     std::ptrdiff_t ptr_offset = ref - from_data;
     to.attachReference(from, ptr_offset);


### PR DESCRIPTION
## Proposed changes
DualAllocator needed a change to really work for dual space Ohmms containers

This seems to me to be a more consistent and logical arrangement of const. Still need one const_cast.

Also did a rename since `getDevicePtr()` simply returns a private member variable and my convention is that it be `get_device_ptr()` both were floating around in the code.

follows from #3271 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Leconte

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes Documentation has been added (if appropriate)
