### PR TITLE
Adjust multi walker resource acquire/release API in TWF and Ham

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -78,95 +78,90 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
                                                                 crowd.get_walker_hamiltonians());
 
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
+  ResourceCollectionTeamLock<TrialWaveFunction> twfs_res_lock(crowd.getSharedResource().twf_res, walker_twfs);
+  ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(crowd.getSharedResource().ham_res, walker_hamiltonians);
 
   {
-    DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
-                                                 crowd.get_walker_hamiltonians()[0]);
-
-    int nnode_crossing(0);
-
-    {
-      ScopedTimer recompute_timer(dmc_timers.step_begin_recompute_timer);
-      std::vector<bool> recompute_mask;
-      recompute_mask.reserve(walkers.size());
-      for (MCPWalker& awalker : walkers)
-        if (awalker.wasTouched)
-        {
-          recompute_mask.push_back(true);
-          awalker.wasTouched = false;
-        }
-        else
-          recompute_mask.push_back(false);
-      ps_dispatcher.flex_loadWalker(walker_elecs, walkers, recompute_mask, true);
-      twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
-    }
-
-    const int num_walkers = crowd.size();
-
-    //This generates an entire steps worth of deltas.
-    step_context.nextDeltaRs(num_walkers * sft.population.get_num_particles());
-    auto it_delta_r = step_context.deltaRsBegin();
-
-    std::vector<TrialWaveFunction::GradType> grads_now(num_walkers, TrialWaveFunction::GradType(0.0));
-    std::vector<TrialWaveFunction::GradType> grads_new(num_walkers, TrialWaveFunction::GradType(0.0));
-    std::vector<TrialWaveFunction::PsiValueType> ratios(num_walkers, TrialWaveFunction::PsiValueType(0.0));
-    std::vector<PosType> drifts(num_walkers, 0.0);
-    std::vector<RealType> log_gf(num_walkers, 0.0);
-    std::vector<RealType> log_gb(num_walkers, 0.0);
-    std::vector<RealType> prob(num_walkers, 0.0);
-
-    // local list to handle accept/reject
-    std::vector<bool> isAccepted;
-    isAccepted.reserve(num_walkers);
-
-    //save the old energies for branching needs.
-    std::vector<FullPrecRealType> old_energies(num_walkers);
-    for (int iw = 0; iw < num_walkers; ++iw)
-      old_energies[iw] = walkers[iw].get().Properties(WP::LOCALENERGY);
-
-    std::vector<RealType> rr_proposed(num_walkers, 0.0);
-    std::vector<RealType> rr_accepted(num_walkers, 0.0);
-
-    {
-      ScopedTimer pbyp_local_timer(timers.movepbyp_timer);
-      for (int ig = 0; ig < step_context.get_num_groups(); ++ig)
+    ScopedTimer recompute_timer(dmc_timers.step_begin_recompute_timer);
+    std::vector<bool> recompute_mask;
+    recompute_mask.reserve(walkers.size());
+    for (MCPWalker& awalker : walkers)
+      if (awalker.wasTouched)
       {
-        RealType tauovermass = sft.qmcdrv_input.get_tau() * sft.population.get_ptclgrp_inv_mass()[ig];
-        RealType oneover2tau = 0.5 / (tauovermass);
-        RealType sqrttau     = std::sqrt(tauovermass);
+        recompute_mask.push_back(true);
+        awalker.wasTouched = false;
+      }
+      else
+        recompute_mask.push_back(false);
+    ps_dispatcher.flex_loadWalker(walker_elecs, walkers, recompute_mask, true);
+    twf_dispatcher.flex_recompute(walker_twfs, walker_elecs, recompute_mask);
+  }
 
-        twf_dispatcher.flex_prepareGroup(walker_twfs, walker_elecs, ig);
+  const int num_walkers = crowd.size();
 
-        int start_index = step_context.getPtclGroupStart(ig);
-        int end_index   = step_context.getPtclGroupEnd(ig);
-        for (int iat = start_index; iat < end_index; ++iat)
-        {
-          auto delta_r_start = it_delta_r + iat * num_walkers;
-          auto delta_r_end   = delta_r_start + num_walkers;
+  //This generates an entire steps worth of deltas.
+  step_context.nextDeltaRs(num_walkers * sft.population.get_num_particles());
+  auto it_delta_r = step_context.deltaRsBegin();
 
-          //This is very useful thing to be able to look at in the debugger
+  std::vector<TrialWaveFunction::GradType> grads_now(num_walkers, TrialWaveFunction::GradType(0.0));
+  std::vector<TrialWaveFunction::GradType> grads_new(num_walkers, TrialWaveFunction::GradType(0.0));
+  std::vector<TrialWaveFunction::PsiValueType> ratios(num_walkers, TrialWaveFunction::PsiValueType(0.0));
+  std::vector<PosType> drifts(num_walkers, 0.0);
+  std::vector<RealType> log_gf(num_walkers, 0.0);
+  std::vector<RealType> log_gb(num_walkers, 0.0);
+  std::vector<RealType> prob(num_walkers, 0.0);
+
+  // local list to handle accept/reject
+  std::vector<bool> isAccepted;
+  isAccepted.reserve(num_walkers);
+
+  //save the old energies for branching needs.
+  std::vector<FullPrecRealType> old_energies(num_walkers);
+  for (int iw = 0; iw < num_walkers; ++iw)
+    old_energies[iw] = walkers[iw].get().Properties(WP::LOCALENERGY);
+
+  std::vector<RealType> rr_proposed(num_walkers, 0.0);
+  std::vector<RealType> rr_accepted(num_walkers, 0.0);
+
+  {
+    ScopedTimer pbyp_local_timer(timers.movepbyp_timer);
+    for (int ig = 0; ig < step_context.get_num_groups(); ++ig)
+    {
+      RealType tauovermass = sft.qmcdrv_input.get_tau() * sft.population.get_ptclgrp_inv_mass()[ig];
+      RealType oneover2tau = 0.5 / (tauovermass);
+      RealType sqrttau     = std::sqrt(tauovermass);
+
+      twf_dispatcher.flex_prepareGroup(walker_twfs, walker_elecs, ig);
+
+      int start_index = step_context.getPtclGroupStart(ig);
+      int end_index   = step_context.getPtclGroupEnd(ig);
+      for (int iat = start_index; iat < end_index; ++iat)
+      {
+        auto delta_r_start = it_delta_r + iat * num_walkers;
+        auto delta_r_end   = delta_r_start + num_walkers;
+
+        //This is very useful thing to be able to look at in the debugger
 #ifndef NDEBUG
-          std::vector<int> walkers_who_have_been_on_wire(num_walkers, 0);
-          ;
-          for (int iw = 0; iw < walkers.size(); ++iw)
-          {
-            walkers[iw].get().get_has_been_on_wire() ? walkers_who_have_been_on_wire[iw] = 1
-                                                     : walkers_who_have_been_on_wire[iw] = 0;
-          }
+        std::vector<int> walkers_who_have_been_on_wire(num_walkers, 0);
+        for (int iw = 0; iw < walkers.size(); ++iw)
+        {
+          walkers[iw].get().get_has_been_on_wire() ? walkers_who_have_been_on_wire[iw] = 1
+                                                   : walkers_who_have_been_on_wire[iw] = 0;
+        }
 #endif
-          //get the displacement
-          twf_dispatcher.flex_evalGrad(walker_twfs, walker_elecs, iat, grads_now);
-          sft.drift_modifier.getDrifts(tauovermass, grads_now, drifts);
+        //get the displacement
+        twf_dispatcher.flex_evalGrad(walker_twfs, walker_elecs, iat, grads_now);
+        sft.drift_modifier.getDrifts(tauovermass, grads_now, drifts);
 
-          std::transform(drifts.begin(), drifts.end(), delta_r_start, drifts.begin(),
-                         [sqrttau](PosType& drift, PosType& delta_r) { return drift + (sqrttau * delta_r); });
+        std::transform(drifts.begin(), drifts.end(), delta_r_start, drifts.begin(),
+                       [sqrttau](PosType& drift, PosType& delta_r) { return drift + (sqrttau * delta_r); });
 
-          // only DMC does this
-          // TODO: rr needs a real name
-          std::vector<RealType> rr(num_walkers, 0.0);
-          assert(rr.size() == delta_r_end - delta_r_start);
-          std::transform(delta_r_start, delta_r_end, rr.begin(),
-                         [tauovermass](auto& delta_r) { return tauovermass * dot(delta_r, delta_r); });
+        // only DMC does this
+        // TODO: rr needs a real name
+        std::vector<RealType> rr(num_walkers, 0.0);
+        assert(rr.size() == delta_r_end - delta_r_start);
+        std::transform(delta_r_start, delta_r_end, rr.begin(),
+                       [tauovermass](auto& delta_r) { return tauovermass * dot(delta_r, delta_r); });
 
 // in DMC this was done here, changed to match VMCBatched pending factoring to common source
 // if (rr > m_r2max)
@@ -175,120 +170,113 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 //   continue;
 // }
 #ifndef NDEBUG
-          for (int i = 0; i < rr.size(); ++i)
-            assert(std::isfinite(rr[i]));
+        for (int i = 0; i < rr.size(); ++i)
+          assert(std::isfinite(rr[i]));
 #endif
-          ps_dispatcher.flex_makeMove(walker_elecs, iat, drifts);
+        ps_dispatcher.flex_makeMove(walker_elecs, iat, drifts);
 
-          twf_dispatcher.flex_calcRatioGrad(walker_twfs, walker_elecs, iat, ratios, grads_new);
+        twf_dispatcher.flex_calcRatioGrad(walker_twfs, walker_elecs, iat, ratios, grads_new);
 
-          // This lambda is not nested thread safe due to the nreject, nnode_crossing updates
-          auto checkPhaseChanged = [&sft, &nnode_crossing](const TrialWaveFunction& twf, int& is_reject) {
-            if (sft.branch_engine.phaseChanged(twf.getPhaseDiff()))
-            {
-              ++nnode_crossing;
-              is_reject = 1;
-            }
-            else
-              is_reject = 0;
-          };
+        auto checkPhaseChanged = [&sft](const TrialWaveFunction& twf, int& is_reject) {
+          if (sft.branch_engine.phaseChanged(twf.getPhaseDiff()))
+            is_reject = 1;
+          else
+            is_reject = 0;
+        };
 
-          // Hopefully a phase change doesn't make any of these transformations fail.
-          std::vector<int> rejects(num_walkers); // instead of std::vector<bool>
-          for (int iw = 0; iw < num_walkers; ++iw)
-          {
-            checkPhaseChanged(walker_twfs[iw], rejects[iw]);
-            //This is just convenient to do here
-            rr_proposed[iw] += rr[iw];
-          }
-
-          std::transform(delta_r_start, delta_r_end, log_gf.begin(), [](auto& delta_r) {
-            constexpr RealType mhalf(-0.5);
-            return mhalf * dot(delta_r, delta_r);
-          });
-
-          sft.drift_modifier.getDrifts(tauovermass, grads_new, drifts);
-
-          std::transform(crowd.beginElectrons(), crowd.endElectrons(), drifts.begin(), drifts.begin(),
-                         [iat](auto& elecs, auto& drift) {
-                           return elecs.get().R[iat] - elecs.get().activePos - drift;
-                         });
-
-          std::transform(drifts.begin(), drifts.end(), log_gb.begin(),
-                         [oneover2tau](auto& drift) { return -oneover2tau * dot(drift, drift); });
-
-          for (int iw = 0; iw < num_walkers; ++iw)
-            prob[iw] = std::norm(ratios[iw]) * std::exp(log_gb[iw] - log_gf[iw]);
-
-          isAccepted.clear();
-
-          for (int iw = 0; iw < num_walkers; ++iw)
-          {
-            if ((!rejects[iw]) && prob[iw] >= std::numeric_limits<RealType>::epsilon() &&
-                step_context.get_random_gen()() < prob[iw])
-            {
-              crowd.incAccept();
-              isAccepted.push_back(true);
-              rr_accepted[iw] += rr[iw];
-            }
-            else
-            {
-              crowd.incReject();
-              isAccepted.push_back(false);
-            }
-          }
-
-          twf_dispatcher.flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
-
-          ps_dispatcher.flex_accept_rejectMove(walker_elecs, iat, isAccepted);
+        // Hopefully a phase change doesn't make any of these transformations fail.
+        std::vector<int> rejects(num_walkers); // instead of std::vector<bool>
+        for (int iw = 0; iw < num_walkers; ++iw)
+        {
+          checkPhaseChanged(walker_twfs[iw], rejects[iw]);
+          //This is just convenient to do here
+          rr_proposed[iw] += rr[iw];
         }
+
+        std::transform(delta_r_start, delta_r_end, log_gf.begin(), [](auto& delta_r) {
+          constexpr RealType mhalf(-0.5);
+          return mhalf * dot(delta_r, delta_r);
+        });
+
+        sft.drift_modifier.getDrifts(tauovermass, grads_new, drifts);
+
+        std::transform(crowd.beginElectrons(), crowd.endElectrons(), drifts.begin(), drifts.begin(),
+                       [iat](auto& elecs, auto& drift) { return elecs.get().R[iat] - elecs.get().activePos - drift; });
+
+        std::transform(drifts.begin(), drifts.end(), log_gb.begin(),
+                       [oneover2tau](auto& drift) { return -oneover2tau * dot(drift, drift); });
+
+        for (int iw = 0; iw < num_walkers; ++iw)
+          prob[iw] = std::norm(ratios[iw]) * std::exp(log_gb[iw] - log_gf[iw]);
+
+        isAccepted.clear();
+
+        for (int iw = 0; iw < num_walkers; ++iw)
+        {
+          if ((!rejects[iw]) && prob[iw] >= std::numeric_limits<RealType>::epsilon() &&
+              step_context.get_random_gen()() < prob[iw])
+          {
+            crowd.incAccept();
+            isAccepted.push_back(true);
+            rr_accepted[iw] += rr[iw];
+          }
+          else
+          {
+            crowd.incReject();
+            isAccepted.push_back(false);
+          }
+        }
+
+        twf_dispatcher.flex_accept_rejectMove(walker_twfs, walker_elecs, iat, isAccepted, true);
+
+        ps_dispatcher.flex_accept_rejectMove(walker_elecs, iat, isAccepted);
       }
-
-      twf_dispatcher.flex_completeUpdates(walker_twfs);
-      ps_dispatcher.flex_donePbyP(walker_elecs);
     }
 
-    { // collect GL for KE.
-      ScopedTimer buffer_local(timers.buffer_timer);
-      twf_dispatcher.flex_evaluateGL(walker_twfs, walker_elecs, recompute);
-      ps_dispatcher.flex_saveWalker(walker_elecs, walkers);
+    twf_dispatcher.flex_completeUpdates(walker_twfs);
+    ps_dispatcher.flex_donePbyP(walker_elecs);
+  }
+
+  { // collect GL for KE.
+    ScopedTimer buffer_local(timers.buffer_timer);
+    twf_dispatcher.flex_evaluateGL(walker_twfs, walker_elecs, recompute);
+    ps_dispatcher.flex_saveWalker(walker_elecs, walkers);
+  }
+
+  { // hamiltonian
+    ScopedTimer ham_local(timers.hamiltonian_timer);
+
+    std::vector<QMCHamiltonian::FullPrecRealType> new_energies(
+        ham_dispatcher.flex_evaluateWithToperator(walker_hamiltonians, walker_elecs));
+    assert(QMCDriverNew::checkLogAndGL(crowd));
+
+    auto resetSigNLocalEnergy = [](MCPWalker& walker, TrialWaveFunction& twf, auto local_energy, auto rr_acc,
+                                   auto rr_prop) {
+      walker.resetProperty(twf.getLogPsi(), twf.getPhase(), local_energy, rr_acc, rr_prop, 1.0);
+    };
+
+    for (int iw = 0; iw < walkers.size(); ++iw)
+    {
+      resetSigNLocalEnergy(walkers[iw], walker_twfs[iw], new_energies[iw], rr_accepted[iw], rr_proposed[iw]);
+      FullPrecRealType branch_weight = sft.branch_engine.branchWeight(new_energies[iw], old_energies[iw]);
+      walkers[iw].get().Weight *= branch_weight;
+      if (rr_proposed[iw] > 0)
+        walkers[iw].get().Age = 0;
+      else
+        walkers[iw].get().Age++;
     }
+  }
 
-    { // hamiltonian
-      ScopedTimer ham_local(timers.hamiltonian_timer);
+  { // estimator collectables
+    ScopedTimer collectable_local(timers.collectables_timer);
 
-      std::vector<QMCHamiltonian::FullPrecRealType> new_energies(
-          ham_dispatcher.flex_evaluateWithToperator(walker_hamiltonians, walker_elecs));
-      assert(QMCDriverNew::checkLogAndGL(crowd));
+    // evaluate non-physical hamiltonian elements
+    for (int iw = 0; iw < walkers.size(); ++iw)
+      walker_hamiltonians[iw].auxHevaluate(walker_elecs[iw], walkers[iw]);
 
-      auto resetSigNLocalEnergy = [](MCPWalker& walker, TrialWaveFunction& twf, auto local_energy, auto rr_acc,
-                                     auto rr_prop) {
-        walker.resetProperty(twf.getLogPsi(), twf.getPhase(), local_energy, rr_acc, rr_prop, 1.0);
-      };
-
-      for (int iw = 0; iw < walkers.size(); ++iw)
-      {
-        resetSigNLocalEnergy(walkers[iw], walker_twfs[iw], new_energies[iw], rr_accepted[iw], rr_proposed[iw]);
-        FullPrecRealType branch_weight = sft.branch_engine.branchWeight(new_energies[iw], old_energies[iw]);
-        walkers[iw].get().Weight *= branch_weight;
-        if (rr_proposed[iw] > 0)
-          walkers[iw].get().Age = 0;
-        else
-          walkers[iw].get().Age++;
-      }
-    }
-
-    { // estimator collectables
-      ScopedTimer collectable_local(timers.collectables_timer);
-
-      // evaluate non-physical hamiltonian elements
-      for (int iw = 0; iw < walkers.size(); ++iw)
-        walker_hamiltonians[iw].auxHevaluate(walker_elecs[iw], walkers[iw]);
-
-      // save properties into walker
-      for (int iw = 0; iw < walkers.size(); ++iw)
-        walker_hamiltonians[iw].saveProperty(walkers[iw].get().getPropertyBase());
-    }
+    // save properties into walker
+    for (int iw = 0; iw < walkers.size(); ++iw)
+      walker_hamiltonians[iw].saveProperty(walkers[iw].get().getPropertyBase());
   }
 
   { // T-moves
@@ -305,8 +293,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     for (int iw = 0; iw < walkers.size(); ++iw)
     {
-      DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[iw],
-                                                    crowd.get_walker_hamiltonians()[iw]);
       walker_non_local_moves_accepted[iw] = walker_hamiltonians[iw].makeNonLocalMoves(walker_elecs[iw]);
 
       if (walker_non_local_moves_accepted[iw] > 0)
@@ -320,9 +306,6 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
     if (moved_nonlocal_walkers.size())
     {
-      DriverWalkerResourceCollectionLock tmove_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
-                                                    crowd.get_walker_hamiltonians()[0]);
-
       twf_dispatcher.flex_evaluateGL(moved_nonlocal_walker_twfs, moved_nonlocal_walker_elecs, false);
       assert(QMCDriverNew::checkLogAndGL(crowd));
       ps_dispatcher.flex_saveWalker(moved_nonlocal_walker_elecs, moved_nonlocal_walkers);

--- a/src/QMCDrivers/DriverWalkerTypes.h
+++ b/src/QMCDrivers/DriverWalkerTypes.h
@@ -35,22 +35,5 @@ struct DriverWalkerResourceCollection
 
   DriverWalkerResourceCollection() : pset_res("ParticleSet"), twf_res("TrialWaveFunction"), ham_res("Hamiltonian") {}
 };
-
-/** DriverWalkerResourceCollection locks
- * Helper class for acquiring and releasing multi walker resources
- */
-class DriverWalkerResourceCollectionLock
-{
-public:
-  DriverWalkerResourceCollectionLock(DriverWalkerResourceCollection& driverwalker_res,
-                                     TrialWaveFunction& twf,
-                                     QMCHamiltonian& ham)
-      : twf_res_lock_(driverwalker_res.twf_res, twf), ham_res_lock_(driverwalker_res.ham_res, ham)
-  {}
-
-private:
-  ResourceCollectionLock<TrialWaveFunction> twf_res_lock_;
-  ResourceCollectionLock<QMCHamiltonian> ham_res_lock_;
-};
 } // namespace qmcplusplus
 #endif

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -315,16 +315,16 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
   auto& twf_dispatcher = crowd.dispatchers_.twf_dispatcher_;
   auto& ham_dispatcher = crowd.dispatchers_.ham_dispatcher_;
 
-  auto& walkers = crowd.get_walkers();
-  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
-                                               crowd.get_walker_hamiltonians()[0]);
   const RefVectorWithLeader<ParticleSet> walker_elecs(crowd.get_walker_elecs()[0], crowd.get_walker_elecs());
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                 crowd.get_walker_hamiltonians());
 
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
+  ResourceCollectionTeamLock<TrialWaveFunction> twfs_res_lock(crowd.getSharedResource().twf_res, walker_twfs);
+  ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(crowd.getSharedResource().ham_res, walker_hamiltonians);
 
+  auto& walkers = crowd.get_walkers();
   std::vector<bool> recompute_mask(walkers.size(), true);
   ps_dispatcher.flex_loadWalker(walker_elecs, walkers, recompute_mask, true);
   ps_dispatcher.flex_donePbyP(walker_elecs);

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -51,8 +51,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   const RefVectorWithLeader<TrialWaveFunction> walker_twfs(crowd.get_walker_twfs()[0], crowd.get_walker_twfs());
 
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
-  DriverWalkerResourceCollectionLock pbyp_lock(crowd.getSharedResource(), crowd.get_walker_twfs()[0],
-                                               crowd.get_walker_hamiltonians()[0]);
+  ResourceCollectionTeamLock<TrialWaveFunction> twfs_res_lock(crowd.getSharedResource().twf_res, walker_twfs);
 
   assert(QMCDriverNew::checkLogAndGL(crowd));
 
@@ -176,6 +175,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   timers.hamiltonian_timer.start();
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                 crowd.get_walker_hamiltonians());
+  ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(crowd.getSharedResource().ham_res, walker_hamiltonians);
   std::vector<QMCHamiltonian::FullPrecRealType> local_energies(
       ham_dispatcher.flex_evaluate(walker_hamiltonians, walker_elecs));
   timers.hamiltonian_timer.stop();

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -632,17 +632,19 @@ void NonLocalECPotential::createResource(ResourceCollection& collection) const
   auto resource_index = collection.addResource(std::move(new_res));
 }
 
-void NonLocalECPotential::acquireResource(ResourceCollection& collection)
+void NonLocalECPotential::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const
 {
+  auto& O_leader = O_list.getCastedLeader<NonLocalECPotential>();
   auto res_ptr = dynamic_cast<NonLocalECPotentialMultiWalkerResource*>(collection.lendResource().release());
   if (!res_ptr)
     throw std::runtime_error("NonLocalECPotential::acquireResource dynamic_cast failed");
-  mw_res_.reset(res_ptr);
+  O_leader.mw_res_.reset(res_ptr);
 }
 
-void NonLocalECPotential::releaseResource(ResourceCollection& collection)
+void NonLocalECPotential::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const
 {
-  collection.takebackResource(std::move(mw_res_));
+  auto& O_leader = O_list.getCastedLeader<NonLocalECPotential>();
+  collection.takebackResource(std::move(O_leader.mw_res_));
 }
 
 std::unique_ptr<OperatorBase> NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -106,11 +106,11 @@ public:
 
   /** acquire a shared resource from a collection
    */
-  void acquireResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const override;
 
   /** return a shared resource to a collection
    */
-  void releaseResource(ResourceCollection& collection) override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -350,11 +350,11 @@ struct OperatorBase : public QMCTraits
 
   /** acquire a shared resource from a collection
    */
-  virtual void acquireResource(ResourceCollection& collection) {}
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const {}
 
   /** return a shared resource to a collection
    */
-  virtual void releaseResource(ResourceCollection& collection) {}
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const {}
 
   virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -981,16 +981,24 @@ void QMCHamiltonian::createResource(ResourceCollection& collection) const
     H[i]->createResource(collection);
 }
 
-void QMCHamiltonian::acquireResource(ResourceCollection& collection)
+void QMCHamiltonian::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
-  for (int i = 0; i < H.size(); ++i)
-    H[i]->acquireResource(collection);
+  auto& ham_leader = ham_list.getLeader();
+  for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
+  {
+    const auto HC_list(extract_HC_list(ham_list, i_ham_op));
+    ham_leader.H[i_ham_op]->acquireResource(collection, HC_list);
+  }
 }
 
-void QMCHamiltonian::releaseResource(ResourceCollection& collection)
+void QMCHamiltonian::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
-  for (int i = 0; i < H.size(); ++i)
-    H[i]->releaseResource(collection);
+  auto& ham_leader = ham_list.getLeader();
+  for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
+  {
+    const auto HC_list(extract_HC_list(ham_list, i_ham_op));
+    ham_leader.H[i_ham_op]->releaseResource(collection, HC_list);
+  }
 }
 
 QMCHamiltonian* QMCHamiltonian::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -407,11 +407,11 @@ public:
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void acquireResource(ResourceCollection& collection);
+  static void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list);
   /** release external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void releaseResource(ResourceCollection& collection);
+  static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list);
 
   /** return a clone */
   QMCHamiltonian* makeClone(ParticleSet& qp, TrialWaveFunction& psi);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -138,15 +138,22 @@ public:
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>());
   }
 
-  void acquireResource(ResourceCollection& collection) override
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
+    assert(this == &spo_list.getLeader());
+    auto& phi_leader = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
     auto res_ptr = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, ComplexT>*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SplineC2COMPTarget::acquireResource dynamic_cast failed");
-    mw_mem_.reset(res_ptr);
+    phi_leader.mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
+  {
+    assert(this == &spo_list.getLeader());
+    auto& phi_leader = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
+    collection.takebackResource(std::move(phi_leader.mw_mem_));
+  }
 
   virtual SPOSet* makeClone() const override { return new SplineC2COMPTarget(*this); }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -142,15 +142,22 @@ public:
     auto resource_index = collection.addResource(std::make_unique<SplineOMPTargetMultiWalkerMem<ST, TT>>());
   }
 
-  void acquireResource(ResourceCollection& collection) override
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
+    assert(this == &spo_list.getLeader());
+    auto& phi_leader = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
     auto res_ptr = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, TT>*>(collection.lendResource().release());
     if (!res_ptr)
       throw std::runtime_error("SplineC2ROMPTarget::acquireResource dynamic_cast failed");
-    mw_mem_.reset(res_ptr);
+    phi_leader.mw_mem_.reset(res_ptr);
   }
 
-  void releaseResource(ResourceCollection& collection) override { collection.takebackResource(std::move(mw_mem_)); }
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
+  {
+    assert(this == &spo_list.getLeader());
+    auto& phi_leader = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
+    collection.takebackResource(std::move(phi_leader.mw_mem_));
+  }
 
   virtual SPOSet* makeClone() const override { return new SplineC2ROMPTarget(*this); }
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -705,15 +705,29 @@ void DiracDeterminant<DU_TYPE>::createResource(ResourceCollection& collection) c
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::acquireResource(ResourceCollection& collection)
+void DiracDeterminant<DU_TYPE>::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  Phi->acquireResource(collection);
+  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<DU_TYPE>>();
+  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  for (WaveFunctionComponent& wfc : wfc_list)
+  {
+    auto& det = static_cast<DiracDeterminant<DU_TYPE>&>(wfc);
+    phi_list.push_back(*det.Phi);
+  }
+  wfc_leader.Phi->acquireResource(collection, phi_list);
 }
 
 template<typename DU_TYPE>
-void DiracDeterminant<DU_TYPE>::releaseResource(ResourceCollection& collection)
+void DiracDeterminant<DU_TYPE>::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  Phi->releaseResource(collection);
+  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminant<DU_TYPE>>();
+  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  for (WaveFunctionComponent& wfc : wfc_list)
+  {
+    auto& det = static_cast<DiracDeterminant<DU_TYPE>&>(wfc);
+    phi_list.push_back(*det.Phi);
+  }
+  wfc_leader.Phi->releaseResource(collection, phi_list);
 }
 
 template class DiracDeterminant<>;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.h
@@ -172,8 +172,8 @@ public:
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
   void createResource(ResourceCollection& collection) const override;
-  void acquireResource(ResourceCollection& collection) override;
-  void releaseResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wf_list) const override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wf_list) const override;
 
   /** cloning function
    * @param tqp target particleset

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -939,22 +939,38 @@ void DiracDeterminantBatched<DET_ENGINE>::createResource(ResourceCollection& col
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::acquireResource(ResourceCollection& collection)
+void DiracDeterminantBatched<DET_ENGINE>::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
+  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
   auto res_ptr = dynamic_cast<DiracDeterminantBatchedMultiWalkerResource*>(collection.lendResource().release());
   if (!res_ptr)
     throw std::runtime_error("DiracDeterminantBatched::acquireResource dynamic_cast failed");
-  mw_res_.reset(res_ptr);
-  Phi->acquireResource(collection);
-  det_engine_.acquireResource(collection);
+  wfc_leader.mw_res_.reset(res_ptr);
+
+  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  for (WaveFunctionComponent& wfc : wfc_list)
+  {
+    auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE>&>(wfc);
+    phi_list.push_back(*det.Phi);
+  }
+  wfc_leader.Phi->acquireResource(collection, phi_list);
+
+  wfc_leader.det_engine_.acquireResource(collection);
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::releaseResource(ResourceCollection& collection)
+void DiracDeterminantBatched<DET_ENGINE>::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  collection.takebackResource(std::move(mw_res_));
-  Phi->releaseResource(collection);
-  det_engine_.releaseResource(collection);
+  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
+  collection.takebackResource(std::move(wfc_leader.mw_res_));
+  RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
+  for (WaveFunctionComponent& wfc : wfc_list)
+  {
+    auto& det = static_cast<DiracDeterminantBatched<DET_ENGINE>&>(wfc);
+    phi_list.push_back(*det.Phi);
+  }
+  wfc_leader.Phi->releaseResource(collection, phi_list);
+  wfc_leader.det_engine_.releaseResource(collection);
 }
 
 template class DiracDeterminantBatched<>;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -195,8 +195,8 @@ public:
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override;
 
   void createResource(ResourceCollection& collection) const override;
-  void acquireResource(ResourceCollection& collection) override;
-  void releaseResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
 
   /** cloning function
    * @param tqp target particleset

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -208,16 +208,22 @@ void SlaterDet::createResource(ResourceCollection& collection) const
     Dets[i]->createResource(collection);
 }
 
-void SlaterDet::acquireResource(ResourceCollection& collection)
+void SlaterDet::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   for (int i = 0; i < Dets.size(); ++i)
-    Dets[i]->acquireResource(collection);
+  {
+    const auto det_list(extract_DetRef_list(wfc_list, i));
+    Dets[i]->acquireResource(collection, det_list);
+  }
 }
 
-void SlaterDet::releaseResource(ResourceCollection& collection)
+void SlaterDet::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   for (int i = 0; i < Dets.size(); ++i)
-    Dets[i]->releaseResource(collection);
+  {
+    const auto det_list(extract_DetRef_list(wfc_list, i));
+    Dets[i]->releaseResource(collection, det_list);
+  }
 }
 
 void SlaterDet::registerData(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -99,9 +99,9 @@ public:
 
   void createResource(ResourceCollection& collection) const override;
 
-  void acquireResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
 
-  void releaseResource(ResourceCollection& collection) override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
 
   inline void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override
   {

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
@@ -46,18 +46,20 @@ void J2OMPTarget<FT>::createResource(ResourceCollection& collection) const
 }
 
 template<typename FT>
-void J2OMPTarget<FT>::acquireResource(ResourceCollection& collection)
+void J2OMPTarget<FT>::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
+  auto& wfc_leader = wfc_list.getCastedLeader<J2OMPTarget<FT>>();
   auto res_ptr = dynamic_cast<J2OMPTargetMultiWalkerMem<RealType>*>(collection.lendResource().release());
   if (!res_ptr)
     throw std::runtime_error("VirtualParticleSet::acquireResource dynamic_cast failed");
-  mw_mem_.reset(res_ptr);
+  wfc_leader.mw_mem_.reset(res_ptr);
 }
 
 template<typename FT>
-void J2OMPTarget<FT>::releaseResource(ResourceCollection& collection)
+void J2OMPTarget<FT>::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  collection.takebackResource(std::move(mw_mem_));
+  auto& wfc_leader = wfc_list.getCastedLeader<J2OMPTarget<FT>>();
+  collection.takebackResource(std::move(wfc_leader.mw_mem_));
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
@@ -112,9 +112,9 @@ public:
 
   void createResource(ResourceCollection& collection) const override;
 
-  void acquireResource(ResourceCollection& collection) override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
 
-  void releaseResource(ResourceCollection& collection) override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const override;
 
   /** check in an optimizable parameter
    * @param o a super set of optimizable variables

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -444,11 +444,11 @@ public:
 
   /** acquire a shared resource from collection
    */
-  virtual void acquireResource(ResourceCollection& collection) {}
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const {}
 
   /** return a shared resource to collection
    */
-  virtual void releaseResource(ResourceCollection& collection) {}
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const {}
 
   /** make a clone of itself
    * every derived class must implement this to have threading working correctly.

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1185,16 +1185,28 @@ void TrialWaveFunction::createResource(ResourceCollection& collection) const
     Z[i]->createResource(collection);
 }
 
-void TrialWaveFunction::acquireResource(ResourceCollection& collection)
+void TrialWaveFunction::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<TrialWaveFunction>& wf_list)
 {
-  for (int i = 0; i < Z.size(); ++i)
-    Z[i]->acquireResource(collection);
+  auto& wf_leader = wf_list.getLeader();
+  auto& wavefunction_components = wf_leader.Z;
+  const int num_wfc             = wf_leader.Z.size();
+  for (int i = 0; i < num_wfc; ++i)
+  {
+    const auto wfc_list(extractWFCRefList(wf_list, i));
+    wavefunction_components[i]->acquireResource(collection, wfc_list);
+  }
 }
 
-void TrialWaveFunction::releaseResource(ResourceCollection& collection)
+void TrialWaveFunction::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<TrialWaveFunction>& wf_list)
 {
-  for (int i = 0; i < Z.size(); ++i)
-    Z[i]->releaseResource(collection);
+  auto& wf_leader = wf_list.getLeader();
+  auto& wavefunction_components = wf_leader.Z;
+  const int num_wfc             = wf_leader.Z.size();
+  for (int i = 0; i < num_wfc; ++i)
+  {
+    const auto wfc_list(extractWFCRefList(wf_list, i));
+    wavefunction_components[i]->releaseResource(collection, wfc_list);
+  }
 }
 
 RefVectorWithLeader<WaveFunctionComponent> TrialWaveFunction::extractWFCRefList(

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -409,11 +409,11 @@ public:
   /** acquire external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void acquireResource(ResourceCollection& collection);
+  static void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<TrialWaveFunction>& wf_list);
   /** release external resource
    * Note: use RAII ResourceCollectionLock whenever possible
    */
-  void releaseResource(ResourceCollection& collection);
+  static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<TrialWaveFunction>& wf_list);
 
   RealType KECorrection() const;
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -429,11 +429,11 @@ struct WaveFunctionComponent : public QMCTraits
 
   /** acquire a shared resource from a collection
    */
-  virtual void acquireResource(ResourceCollection& collection) {}
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const {}
 
   /** return a shared resource to a collection
    */
-  virtual void releaseResource(ResourceCollection& collection) {}
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const {}
 
   /** make clone
    * @param tqp target Quantum ParticleSet

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -21,6 +21,7 @@
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
+#include <ResourceCollection.h>
 
 namespace qmcplusplus
 {
@@ -150,7 +151,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   // make a TrialWaveFunction Clone
-  TrialWaveFunction* psi_clone = psi.makeClone(elec_clone);
+  std::unique_ptr<TrialWaveFunction> psi_clone(psi.makeClone(elec_clone));
 
   elec_clone.update();
   double logpsi_clone = psi_clone->evaluateLog(elec_clone);
@@ -202,38 +203,38 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   // testing batched interfaces
-  std::vector<ParticleSet*> P_list(2, nullptr);
-  P_list[0] = &elec_;
-  P_list[1] = &elec_clone;
+  ResourceCollection pset_res("test_pset_res");
+  ResourceCollection twf_res("test_twf_res");
 
-  std::vector<TrialWaveFunction*> WF_list(2, nullptr);
-  WF_list[0] = &psi;
-  WF_list[1] = psi_clone;
+  elec_.createResource(pset_res);
+  psi.createResource(twf_res);
 
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
   RefVectorWithLeader<ParticleSet> p_ref_list(elec_, {elec_, elec_clone});
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
+  ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_twf_lock(twf_res, wf_ref_list);
+
   ParticleSet::mw_update(p_ref_list);
   TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(0.4351202455204972, 6.665972664860828)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-0.1201465271523596, 6.345732826640545)));
 #else
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-0.6365029797784554, 3.141592653589793)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-1.471840358291562, 3.141592653589793)));
 #endif
 
-
   std::vector<GradType> grad_old(2);
 
-  grad_old[0] = WF_list[0]->evalGrad(*P_list[0], moved_elec_id);
-  grad_old[1] = WF_list[1]->evalGrad(*P_list[1], moved_elec_id);
+  grad_old[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
+  grad_old[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
   std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
             << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
@@ -256,8 +257,9 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   PosType delta_sign_changed(0.1, 0.1, -0.2);
-  p_ref_list[0].makeMove(moved_elec_id, delta_sign_changed);
-  p_ref_list[1].makeMove(moved_elec_id, delta_sign_changed);
+
+  std::vector<PosType> displs{delta_sign_changed, delta_sign_changed};
+  ParticleSet::mw_makeMove(p_ref_list, moved_elec_id, displs);
 
   ValueType r_0 = wf_ref_list[0].calcRatio(p_ref_list[0], moved_elec_id);
   GradType grad_temp;
@@ -277,8 +279,8 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   PosType delta_zero(0, 0, 0);
-  p_ref_list[0].makeMove(moved_elec_id, delta_zero);
-  p_ref_list[1].makeMove(moved_elec_id, delta);
+  displs = {delta_zero, delta};
+  ParticleSet::mw_makeMove(p_ref_list, moved_elec_id, displs);
 
   std::vector<PsiValueType> ratios(2);
   TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
@@ -294,8 +296,8 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   std::fill(ratios.begin(), ratios.end(), 0);
   std::vector<GradType> grad_new(2);
 
-  ratios[0] = WF_list[0]->calcRatioGrad(*P_list[0], moved_elec_id, grad_new[0]);
-  ratios[1] = WF_list[1]->calcRatioGrad(*P_list[1], moved_elec_id, grad_new[1]);
+  ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
+  ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
 
   std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
             << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
@@ -328,14 +330,14 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   std::vector<bool> isAccepted(2, true);
   TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted);
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(0.4351202455204972, 6.665972664860828)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(0.4351202455204972, 6.665972664860828)));
 #else
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-0.6365029797784554, 3.141592653589793)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-0.6365029797784554, 3.141592653589793)));
 #endif
 
@@ -356,9 +358,6 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   REQUIRE(grad_old[1][2] == Approx(4.8529516184558));
 #endif
 
-
-  //FIXME more thinking and fix about ownership and schope are needed for exiting clean
-  delete psi_clone;
 #endif
 }
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -12,6 +12,7 @@
 
 #include "catch.hpp"
 
+#include <regex>
 #include "OhmmsData/Libxml2Doc.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
@@ -21,8 +22,7 @@
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
-
-#include <regex>
+#include <ResourceCollection.h>
 
 namespace qmcplusplus
 {
@@ -242,42 +242,42 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 
   // testing batched interfaces
-  std::vector<ParticleSet*> P_list(2, nullptr);
-  P_list[0] = &elec_;
-  P_list[1] = &elec_clone;
+  ResourceCollection pset_res("test_pset_res");
+  ResourceCollection twf_res("test_twf_res");
 
-  std::vector<TrialWaveFunction*> WF_list(2, nullptr);
-  WF_list[0] = &psi;
-  WF_list[1] = psi_clone.get();
+  elec_.createResource(pset_res);
+  psi.createResource(twf_res);
 
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
   RefVectorWithLeader<ParticleSet> p_ref_list(elec_, {elec_, elec_clone});
   RefVectorWithLeader<TrialWaveFunction> wf_ref_list(psi, {psi, *psi_clone});
 
+  ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_twf_lock(twf_res, wf_ref_list);
+
   ParticleSet::mw_update(p_ref_list);
   TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
-  std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi() << " "
-            << WF_list[0]->getPhase() << std::endl;
-  std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi() << " "
-            << WF_list[1]->getPhase() << std::endl;
+  std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
+            << wf_ref_list[0].getPhase() << std::endl;
+  std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
+            << wf_ref_list[1].getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-4.546410485374186, -3.141586279080522)));
 #else
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-8.013162503965042, 6.283185307179586)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-5.932711221043984, 6.283185307179586)));
 #endif
 
-
   std::vector<GradType> grad_old(2);
 
-  grad_old[0] = WF_list[0]->evalGrad(*P_list[0], moved_elec_id);
-  grad_old[1] = WF_list[1]->evalGrad(*P_list[1], moved_elec_id);
+  grad_old[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
+  grad_old[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
   std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
             << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
@@ -300,8 +300,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(grad_old[1][2] == Approx(-118.46550094069).epsilon(precision));
 #endif
   PosType delta_sign_changed(0.1, 0.1, -0.2);
-  p_ref_list[0].makeMove(moved_elec_id, delta_sign_changed);
-  p_ref_list[1].makeMove(moved_elec_id, delta_sign_changed);
+  std::vector<PosType> displs{delta_sign_changed, delta_sign_changed};
+  ParticleSet::mw_makeMove(p_ref_list, moved_elec_id, displs);
 
   ValueType r_0 = wf_ref_list[0].calcRatio(p_ref_list[0], moved_elec_id);
   GradType grad_temp;
@@ -323,8 +323,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 
   PosType delta_zero(0, 0, 0);
-  p_ref_list[0].makeMove(moved_elec_id, delta_zero);
-  p_ref_list[1].makeMove(moved_elec_id, delta);
+  displs = {delta_zero, delta};
+  ParticleSet::mw_makeMove(p_ref_list, moved_elec_id, displs);
 
   std::vector<PsiValueType> ratios(2);
   TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
@@ -345,8 +345,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   std::fill(ratios.begin(), ratios.end(), 0);
   std::vector<GradType> grad_new(2);
 
-  ratios[0] = WF_list[0]->calcRatioGrad(*P_list[0], moved_elec_id, grad_new[0]);
-  ratios[1] = WF_list[1]->calcRatioGrad(*P_list[1], moved_elec_id, grad_new[1]);
+  ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
+  ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
 
   std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
             << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
@@ -354,7 +354,6 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
-
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
   std::cout << "flex_calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
             << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
@@ -381,19 +380,19 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   std::vector<bool> isAccepted(2, true);
   TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted, true);
-  std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << WF_list[0]->getLogPsi()
-            << " " << WF_list[0]->getPhase() << std::endl;
-  std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << WF_list[1]->getLogPsi()
-            << " " << WF_list[1]->getPhase() << std::endl;
+  std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi()
+            << " " << wf_ref_list[0].getPhase() << std::endl;
+  std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi()
+            << " " << wf_ref_list[1].getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-6.626861768296886, -3.141586279081995)));
 #else
-  REQUIRE(std::complex<RealType>(WF_list[0]->getLogPsi(), WF_list[0]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-8.013162503965155, 6.283185307179586)));
-  REQUIRE(std::complex<RealType>(WF_list[1]->getLogPsi(), WF_list[1]->getPhase()) ==
+  REQUIRE(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-8.013162503965223, 6.283185307179586)));
 #endif
 


### PR DESCRIPTION
## Proposed changes
Adopt the same multiwalker resource management API as  #3015 for ParticleSet.
The benefit of added arguments is allowing managing views when resources are acquired and released.
It makes certain optimization possible.
Remove the resource redistribution in DMC T-moves. More static behavior should reduce potential bugs.

If something goes wrong, I should see segfault but both deterministic tests and performance tests (intended for T-moves) runs happily.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'