### PR TITLE
Make sure converter leaks are marked as failures with ASAN/LSAN

### DIFF
--- a/tests/converter/CMakeLists.txt
+++ b/tests/converter/CMakeLists.txt
@@ -15,8 +15,8 @@ function(ADD_CONVERTER_TEST test_name)
            COMMAND "${CMAKE_CURRENT_BINARY_DIR}/converter_test.py" "${CMAKE_CURRENT_BINARY_DIR}/${test_name}" --exe
                    "${EXE_NAME}" --h5diff "${HDF5_DIFF_EXECUTABLE}")
   set_tests_properties(converter_${test_name} PROPERTIES 
-                       FAIL_REGULAR_EXPRESSION "ERROR"
-                       PASS_REGULAR_EXPRESSION "PASS"
+                       FAIL_REGULAR_EXPRESSION "  FAIL"
+                       PASS_REGULAR_EXPRESSION "  pass"
                        TIMEOUT 120 LABELS "converter;deterministic")
 endfunction()
 
@@ -28,8 +28,8 @@ function(ADD_PWCONVERTER_TEST test_name)
            COMMAND "${CMAKE_CURRENT_BINARY_DIR}/pwconverter_test.py" "${CMAKE_CURRENT_BINARY_DIR}/${test_name}" --exe
                    "${EXE_NAME}" --h5diff "${HDF5_DIFF_EXECUTABLE}")
   set_tests_properties(converter_${test_name} PROPERTIES 
-                       FAIL_REGULAR_EXPRESSION "ERROR"
-                       PASS_REGULAR_EXPRESSION "PASS" 
+                       FAIL_REGULAR_EXPRESSION "  FAIL"
+                       PASS_REGULAR_EXPRESSION "  pass" 
                        TIMEOUT 120 LABELS "converter;deterministic")
 endfunction()
 

--- a/tests/converter/CMakeLists.txt
+++ b/tests/converter/CMakeLists.txt
@@ -14,7 +14,10 @@ function(ADD_CONVERTER_TEST test_name)
   add_test(NAME converter_${test_name}
            COMMAND "${CMAKE_CURRENT_BINARY_DIR}/converter_test.py" "${CMAKE_CURRENT_BINARY_DIR}/${test_name}" --exe
                    "${EXE_NAME}" --h5diff "${HDF5_DIFF_EXECUTABLE}")
-  set_tests_properties(converter_${test_name} PROPERTIES TIMEOUT 120 LABELS "converter;deterministic")
+  set_tests_properties(converter_${test_name} PROPERTIES 
+                       FAIL_REGULAR_EXPRESSION "ERROR"
+                       PASS_REGULAR_EXPRESSION "PASS"
+                       TIMEOUT 120 LABELS "converter;deterministic")
 endfunction()
 
 function(ADD_PWCONVERTER_TEST test_name)
@@ -24,8 +27,10 @@ function(ADD_PWCONVERTER_TEST test_name)
   add_test(NAME converter_${test_name}
            COMMAND "${CMAKE_CURRENT_BINARY_DIR}/pwconverter_test.py" "${CMAKE_CURRENT_BINARY_DIR}/${test_name}" --exe
                    "${EXE_NAME}" --h5diff "${HDF5_DIFF_EXECUTABLE}")
-  set_tests_properties(converter_${test_name} PROPERTIES TIMEOUT 120 LABELS "converter;deterministic"
-                                                         PASS_REGULAR_EXPRESSION "  pass")
+  set_tests_properties(converter_${test_name} PROPERTIES 
+                       FAIL_REGULAR_EXPRESSION "ERROR"
+                       PASS_REGULAR_EXPRESSION "PASS" 
+                       TIMEOUT 120 LABELS "converter;deterministic")
 endfunction()
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/converter_test.py"


### PR DESCRIPTION
## Proposed changes

Currently `converter-*` tests leak memory, but they are not marked as failures by `ctest` when running with asan/lsan sanitizers
Needed for implementing asan/lsan on deterministic tests
Similar to #3202
Related to #3312
Fixes to follow

## What type(s) of changes does this code introduce?

- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?
Ubuntu 20.04, should pass CI as leaks are not checked

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
