### PR TITLE
Fix memory leaks in L2 tests

### DIFF
--- a/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder_L2.cpp
@@ -128,14 +128,14 @@ void ECPComponentBuilder::buildL2(xmlNodePtr cur)
     RealType r = d * i;
     new_vL2[i] = infunc.splint(r) / r;
   }
-  new_vL2[0]               = new_vL2[1];
-  new_vL2[ng - 1]          = 0.0;
-  RadialPotentialType* vL2 = new RadialPotentialType(std::move(grid), new_vL2);
+  new_vL2[0]      = new_vL2[1];
+  new_vL2[ng - 1] = 0.0;
+  auto vL2        = std::make_unique<RadialPotentialType>(std::move(grid), new_vL2);
   vL2->spline();
 
   // save the splined L2 potential
   pp_L2       = std::make_unique<L2RadialPotential>();
-  pp_L2->vL2  = vL2;
+  pp_L2->vL2  = std::move(vL2);
   pp_L2->rcut = rcut;
 
   //app_log()<<std::endl;

--- a/src/QMCHamiltonians/L2Potential.h
+++ b/src/QMCHamiltonians/L2Potential.h
@@ -27,7 +27,7 @@ struct L2RadialPotential : public QMCTraits
   typedef OneDimGridBase<RealType> GridType;
   typedef OneDimCubicSpline<RealType> RadialPotentialType;
 
-  RadialPotentialType* vL2;
+  std::unique_ptr<RadialPotentialType> vL2;
   RealType rcut;
 
   RealType evaluate(RealType r) { return vL2->splint(r); }
@@ -43,7 +43,7 @@ struct L2RadialPotential : public QMCTraits
   L2RadialPotential* makeClone()
   {
     auto c  = new L2RadialPotential();
-    c->vL2  = vL2->makeClone();
+    c->vL2.reset(vL2->makeClone());
     c->rcut = rcut;
     return c;
   }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This fixes memory leaks in 

	415 - deterministic-Co_L2_std-vmc_dmc-1-1 (Failed)
	426 - deterministic-Co_L2_L2-vmc_dmc-1-1 (Failed)

Part of issue #3312 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted