### PR TITLE
Add member for number of rank-local samples.

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -100,7 +100,7 @@ public:
                 Return_rt FiniteDiff = 0) override{};
   ///return the number of optimizable parameters
   inline int getNumParams() const override { return OptVariables.size(); }
-  ///return the number of optimizable parameters
+  ///return the global number of samples
   inline int getNumSamples() const { return NumSamples; }
   inline void setNumSamples(int newNumSamples) { NumSamples = newNumSamples; }
   ///reset the wavefunction
@@ -204,7 +204,7 @@ protected:
   int PowerE;
   ///number of times cost function evaluated
   int NumCostCalls;
-  ///total number of samples to use in correlated sampling
+  /// global number of samples to use in correlated sampling
   int NumSamples;
   ///total number of optimizable variables
   int NumOptimizables;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -90,7 +90,7 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     Return_rt wgtinv   = 1.0 / SumValue[SUM_WGT];
     Return_rt delE_bar = 0;
     {
-      for (int iw = 0; iw < numSamples_; iw++)
+      for (int iw = 0; iw < rank_local_num_samples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -106,7 +106,7 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     for (int pm = 0; pm < NumOptimizables; pm++)
       HD_avg[pm] *= 1.0 / static_cast<Return_rt>(NumSamples);
     {
-      for (int iw = 0; iw < numSamples_; iw++)
+      for (int iw = 0; iw < rank_local_num_samples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -135,7 +135,7 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     myComm->allreduce(URV);
     Return_rt smpinv = 1.0 / static_cast<Return_rt>(NumSamples);
     {
-      for (int iw = 0; iw < numSamples_; iw++)
+      for (int iw = 0; iw < rank_local_num_samples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -199,18 +199,18 @@ void QMCCostFunctionBatched::getConfigurations(const std::string& aroot)
   }
   outputManager.resume();
 
-  numSamples_ = samples_.getNumSamples();
+  rank_local_num_samples_ = samples_.getNumSamples();
 
-  if (dLogPsi.size() != numSamples_)
+  if (dLogPsi.size() != rank_local_num_samples_)
   {
     delete_iter(dLogPsi.begin(), dLogPsi.end());
     delete_iter(d2LogPsi.begin(), d2LogPsi.end());
     int nptcl = W.getTotalNum();
-    dLogPsi.resize(numSamples_);
-    d2LogPsi.resize(numSamples_);
-    for (int i = 0; i < numSamples_; ++i)
+    dLogPsi.resize(rank_local_num_samples_);
+    d2LogPsi.resize(rank_local_num_samples_);
+    for (int i = 0; i < rank_local_num_samples_; ++i)
       dLogPsi[i] = new ParticleGradient_t(nptcl);
-    for (int i = 0; i < numSamples_; ++i)
+    for (int i = 0; i < rank_local_num_samples_; ++i)
       d2LogPsi[i] = new ParticleLaplacian_t(nptcl);
   }
 }
@@ -240,24 +240,24 @@ void QMCCostFunctionBatched::checkConfigurations()
   RealType e2_tot = 0.0;
 
   // Ensure number of samples did not change after getConfigurations
-  assert(numSamples_ == samples_.getNumSamples());
+  assert(rank_local_num_samples_ == samples_.getNumSamples());
 
   if (RecordsOnNode_.size1() == 0)
   {
-    RecordsOnNode_.resize(numSamples_, SUM_INDEX_SIZE);
+    RecordsOnNode_.resize(rank_local_num_samples_, SUM_INDEX_SIZE);
     if (needGrads)
     {
-      DerivRecords_.resize(numSamples_, NumOptimizables);
-      HDerivRecords_.resize(numSamples_, NumOptimizables);
+      DerivRecords_.resize(rank_local_num_samples_, NumOptimizables);
+      HDerivRecords_.resize(rank_local_num_samples_, NumOptimizables);
     }
   }
-  else if (RecordsOnNode_.size1() != numSamples_)
+  else if (RecordsOnNode_.size1() != rank_local_num_samples_)
   {
-    RecordsOnNode_.resize(numSamples_, SUM_INDEX_SIZE);
+    RecordsOnNode_.resize(rank_local_num_samples_, SUM_INDEX_SIZE);
     if (needGrads)
     {
-      DerivRecords_.resize(numSamples_, NumOptimizables);
-      HDerivRecords_.resize(numSamples_, NumOptimizables);
+      DerivRecords_.resize(rank_local_num_samples_, NumOptimizables);
+      HDerivRecords_.resize(rank_local_num_samples_, NumOptimizables);
     }
   }
   OperatorBase* nlpp = (includeNonlocalH == "no") ? nullptr : H.getHamiltonian(includeNonlocalH);
@@ -279,7 +279,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   // Divide samples among the crowds
   std::vector<int> samples_per_crowd(opt_num_crowds_ + 1);
-  FairDivide(numSamples_, opt_num_crowds_, samples_per_crowd);
+  FairDivide(rank_local_num_samples_, opt_num_crowds_, samples_per_crowd);
 
   // lambda to execute on each crowd
   auto evalOptConfig = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
@@ -422,7 +422,7 @@ void QMCCostFunctionBatched::checkConfigurations()
   //Need to sum over the processors
   std::vector<Return_rt> etemp(3);
   etemp[0] = et_tot;
-  etemp[1] = static_cast<Return_rt>(numSamples_);
+  etemp[1] = static_cast<Return_rt>(rank_local_num_samples_);
   etemp[2] = e2_tot;
   // Sum energy values over nodes
   myComm->allreduce(etemp);
@@ -497,7 +497,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   Return_rt wgt_tot2      = 0.0;
 
   // Ensure number of samples did not change after getConfiguration
-  assert(numSamples_ == samples_.getNumSamples());
+  assert(rank_local_num_samples_ == samples_.getNumSamples());
 
   Return_rt inv_n_samples = 1.0 / samples_.getGlobalNumSamples();
 
@@ -506,7 +506,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
   // Divide samples among crowds
   std::vector<int> samples_per_crowd(opt_num_crowds_ + 1);
-  FairDivide(numSamples_, opt_num_crowds_, samples_per_crowd);
+  FairDivide(rank_local_num_samples_, opt_num_crowds_, samples_per_crowd);
 
   // lambda to execute on each crowd
   auto evalOptCorrelated = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
@@ -658,7 +658,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   Return_rt wgtnorm = (wgt_tot == 0) ? 0 : wgt_tot;
   wgt_tot           = 0.0;
   {
-    for (int iw = 0; iw < numSamples_; iw++)
+    for (int iw = 0; iw < rank_local_num_samples_; iw++)
     {
       Return_rt* restrict saved = RecordsOnNode_[iw];
       saved[REWEIGHT] =
@@ -671,7 +671,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   wgtnorm = (wgt_tot == 0) ? 1 : 1.0 / wgt_tot;
   wgt_tot = 0.0;
   {
-    for (int iw = 0; iw < numSamples_; iw++)
+    for (int iw = 0; iw < rank_local_num_samples_; iw++)
     {
       Return_rt* restrict saved = RecordsOnNode_[iw];
       saved[REWEIGHT]           = std::min(saved[REWEIGHT] * wgtnorm, MaxWeight);
@@ -683,7 +683,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   for (int i = 0; i < SumValue.size(); i++)
     SumValue[i] = 0.0;
   {
-    for (int iw = 0; iw < numSamples_; iw++)
+    for (int iw = 0; iw < rank_local_num_samples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       //      Return_t weight=saved[REWEIGHT]*wgt_tot;
@@ -742,7 +742,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::fillOverlapHamiltonian
   std::vector<Return_rt> D_avg(getNumParams(), 0.0);
   Return_rt wgtinv = 1.0 / SumValue[SUM_WGT];
   {
-    for (int iw = 0; iw < numSamples_; iw++)
+    for (int iw = 0; iw < rank_local_num_samples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -757,7 +757,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::fillOverlapHamiltonian
   myComm->allreduce(D_avg);
 
   {
-    for (int iw = 0; iw < numSamples_; iw++)
+    for (int iw = 0; iw < rank_local_num_samples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       Return_rt weight                = saved[REWEIGHT] * wgtinv;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -89,9 +89,8 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     std::vector<Return_rt> HD_avg(NumOptimizables, 0.0);
     Return_rt wgtinv   = 1.0 / SumValue[SUM_WGT];
     Return_rt delE_bar = 0;
-    int numSamples     = samples_.getNumSamples();
     {
-      for (int iw = 0; iw < numSamples; iw++)
+      for (int iw = 0; iw < numSamples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -107,7 +106,7 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     for (int pm = 0; pm < NumOptimizables; pm++)
       HD_avg[pm] *= 1.0 / static_cast<Return_rt>(NumSamples);
     {
-      for (int iw = 0; iw < numSamples; iw++)
+      for (int iw = 0; iw < numSamples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -136,7 +135,7 @@ void QMCCostFunctionBatched::GradCost(std::vector<Return_rt>& PGradient,
     myComm->allreduce(URV);
     Return_rt smpinv = 1.0 / static_cast<Return_rt>(NumSamples);
     {
-      for (int iw = 0; iw < numSamples; iw++)
+      for (int iw = 0; iw < numSamples_; iw++)
       {
         const Return_rt* restrict saved = RecordsOnNode_[iw];
         Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -200,18 +199,18 @@ void QMCCostFunctionBatched::getConfigurations(const std::string& aroot)
   }
   outputManager.resume();
 
-  int numSamples = samples_.getNumSamples();
+  numSamples_ = samples_.getNumSamples();
 
-  if (dLogPsi.size() != numSamples)
+  if (dLogPsi.size() != numSamples_)
   {
     delete_iter(dLogPsi.begin(), dLogPsi.end());
     delete_iter(d2LogPsi.begin(), d2LogPsi.end());
     int nptcl = W.getTotalNum();
-    dLogPsi.resize(numSamples);
-    d2LogPsi.resize(numSamples);
-    for (int i = 0; i < numSamples; ++i)
+    dLogPsi.resize(numSamples_);
+    d2LogPsi.resize(numSamples_);
+    for (int i = 0; i < numSamples_; ++i)
       dLogPsi[i] = new ParticleGradient_t(nptcl);
-    for (int i = 0; i < numSamples; ++i)
+    for (int i = 0; i < numSamples_; ++i)
       d2LogPsi[i] = new ParticleLaplacian_t(nptcl);
   }
 }
@@ -239,24 +238,26 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   RealType et_tot = 0.0;
   RealType e2_tot = 0.0;
-  int numSamples  = samples_.getNumSamples();
+
+  // Ensure number of samples did not change after getConfigurations
+  assert(numSamples_ == samples_.getNumSamples());
 
   if (RecordsOnNode_.size1() == 0)
   {
-    RecordsOnNode_.resize(numSamples, SUM_INDEX_SIZE);
+    RecordsOnNode_.resize(numSamples_, SUM_INDEX_SIZE);
     if (needGrads)
     {
-      DerivRecords_.resize(numSamples, NumOptimizables);
-      HDerivRecords_.resize(numSamples, NumOptimizables);
+      DerivRecords_.resize(numSamples_, NumOptimizables);
+      HDerivRecords_.resize(numSamples_, NumOptimizables);
     }
   }
-  else if (RecordsOnNode_.size1() != numSamples)
+  else if (RecordsOnNode_.size1() != numSamples_)
   {
-    RecordsOnNode_.resize(numSamples, SUM_INDEX_SIZE);
+    RecordsOnNode_.resize(numSamples_, SUM_INDEX_SIZE);
     if (needGrads)
     {
-      DerivRecords_.resize(numSamples, NumOptimizables);
-      HDerivRecords_.resize(numSamples, NumOptimizables);
+      DerivRecords_.resize(numSamples_, NumOptimizables);
+      HDerivRecords_.resize(numSamples_, NumOptimizables);
     }
   }
   OperatorBase* nlpp = (includeNonlocalH == "no") ? nullptr : H.getHamiltonian(includeNonlocalH);
@@ -278,7 +279,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   // Divide samples among the crowds
   std::vector<int> samples_per_crowd(opt_num_crowds_ + 1);
-  FairDivide(numSamples, opt_num_crowds_, samples_per_crowd);
+  FairDivide(numSamples_, opt_num_crowds_, samples_per_crowd);
 
   // lambda to execute on each crowd
   auto evalOptConfig = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
@@ -421,7 +422,7 @@ void QMCCostFunctionBatched::checkConfigurations()
   //Need to sum over the processors
   std::vector<Return_rt> etemp(3);
   etemp[0] = et_tot;
-  etemp[1] = static_cast<Return_rt>(numSamples);
+  etemp[1] = static_cast<Return_rt>(numSamples_);
   etemp[2] = e2_tot;
   // Sum energy values over nodes
   myComm->allreduce(etemp);
@@ -494,7 +495,10 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   const bool nlpp         = (includeNonlocalH != "no");
   Return_rt wgt_tot       = 0.0;
   Return_rt wgt_tot2      = 0.0;
-  int numSamples          = samples_.getNumSamples();
+
+  // Ensure number of samples did not change after getConfiguration
+  assert(numSamples_ == samples_.getNumSamples());
+
   Return_rt inv_n_samples = 1.0 / samples_.getGlobalNumSamples();
 
   bool compute_nlpp             = useNLPPDeriv && (includeNonlocalH != "no");
@@ -502,7 +506,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
   // Divide samples among crowds
   std::vector<int> samples_per_crowd(opt_num_crowds_ + 1);
-  FairDivide(numSamples, opt_num_crowds_, samples_per_crowd);
+  FairDivide(numSamples_, opt_num_crowds_, samples_per_crowd);
 
   // lambda to execute on each crowd
   auto evalOptCorrelated = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
@@ -654,7 +658,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   Return_rt wgtnorm = (wgt_tot == 0) ? 0 : wgt_tot;
   wgt_tot           = 0.0;
   {
-    for (int iw = 0; iw < numSamples; iw++)
+    for (int iw = 0; iw < numSamples_; iw++)
     {
       Return_rt* restrict saved = RecordsOnNode_[iw];
       saved[REWEIGHT] =
@@ -667,7 +671,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   wgtnorm = (wgt_tot == 0) ? 1 : 1.0 / wgt_tot;
   wgt_tot = 0.0;
   {
-    for (int iw = 0; iw < numSamples; iw++)
+    for (int iw = 0; iw < numSamples_; iw++)
     {
       Return_rt* restrict saved = RecordsOnNode_[iw];
       saved[REWEIGHT]           = std::min(saved[REWEIGHT] * wgtnorm, MaxWeight);
@@ -679,7 +683,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   for (int i = 0; i < SumValue.size(); i++)
     SumValue[i] = 0.0;
   {
-    for (int iw = 0; iw < numSamples; iw++)
+    for (int iw = 0; iw < numSamples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       //      Return_t weight=saved[REWEIGHT]*wgt_tot;
@@ -737,9 +741,8 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::fillOverlapHamiltonian
   RealType V_avg = curAvg2_w - curAvg_w * curAvg_w;
   std::vector<Return_rt> D_avg(getNumParams(), 0.0);
   Return_rt wgtinv = 1.0 / SumValue[SUM_WGT];
-  int numSamples   = samples_.getNumSamples();
   {
-    for (int iw = 0; iw < numSamples; iw++)
+    for (int iw = 0; iw < numSamples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       Return_rt weight                = saved[REWEIGHT] * wgtinv;
@@ -754,7 +757,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::fillOverlapHamiltonian
   myComm->allreduce(D_avg);
 
   {
-    for (int iw = 0; iw < numSamples; iw++)
+    for (int iw = 0; iw < numSamples_; iw++)
     {
       const Return_rt* restrict saved = RecordsOnNode_[iw];
       Return_rt weight                = saved[REWEIGHT] * wgtinv;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -79,8 +79,8 @@ protected:
 
   SampleStack& samples_;
 
-  // Number of samples local to each node
-  int numSamples_;
+  // Number of samples local to each MPI rank
+  int rank_local_num_samples_;
 
   int opt_batch_size_;
   int opt_num_crowds_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -79,6 +79,9 @@ protected:
 
   SampleStack& samples_;
 
+  // Number of samples local to each node
+  int numSamples_;
+
   int opt_batch_size_;
   int opt_num_crowds_;
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -62,10 +62,9 @@ public:
 
   void set_samples_and_param(int nsamples, int nparam)
   {
-    numSamples = nsamples;
-    numParam   = nparam;
-    samples.setTotalNum(1);
-    samples.setMaxSamples(numSamples);
+    numSamples         = nsamples;
+    numParam           = nparam;
+    costFn.numSamples_ = nsamples;
 
     costFn.OptVariables.insert("var1", 1.0);
     costFn.NumOptimizables = numParam;

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -64,7 +64,8 @@ public:
   {
     numSamples         = nsamples;
     numParam           = nparam;
-    costFn.numSamples_ = nsamples;
+
+    costFn.rank_local_num_samples_ = nsamples;
 
     costFn.OptVariables.insert("var1", 1.0);
     costFn.NumOptimizables = numParam;


### PR DESCRIPTION
Add a member variable (`numSamples_`) to track the number of samples local to each MPI rank.  Previously the number of samples was obtained from the SampleStack variable (`samples_`) every time.  For testing this required full initializing of the SampleStack.  Now, depending on the function being tested, it may only requires initialization of the `numSamples_` variable.

Sequence of calls:

  - constructor (SampleStack does not have any collected samples at this point, don't know actual number of samples)

  - getConfigurations - initializes dLogPsi and d2LogPsi (used to get WF derivatives). These are sized to the number of samples.

  - checkConfigurations - initializes RecordsOnNode, DerivRecords, and HDerivRecords and fills those in via WF and Hamiltonian evaluation (which use samples)

  - fillOverlapHamiltionMatrices - compute the linear matrices from RecordsOnNode, DerivRecords, and HDerivRecords
      The samples are not used here. The number of samples is needed for iterating over RecordsOnNode, etc.

There is a variable NumSamples in QMCCostFunctionBase.  Add comments clarifying that it is the global number of samples.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
