### PR TITLE
Replace parser raw pointer with std::unique_ptr in convert4qmc

### DIFF
--- a/src/QMCTools/QMCGaussianParserBase.h
+++ b/src/QMCTools/QMCGaussianParserBase.h
@@ -119,6 +119,8 @@ struct QMCGaussianParserBase
   QMCGaussianParserBase();
   QMCGaussianParserBase(int argc, char** argv);
 
+  virtual ~QMCGaussianParserBase() = default;
+
   void setOccupationNumbers();
 
   void createGridNode(int argc, char** argv);

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -61,8 +61,8 @@ int main(int argc, char** argv)
       std::cout.setf(std::ios::right, std::ios::adjustfield);
       std::cout.precision(12);
       QMCGaussianParserBase::init();
-      QMCGaussianParserBase* parser = 0;
-      int iargc                     = 0;
+      std::unique_ptr<QMCGaussianParserBase> parser;
+      int iargc = 0;
       std::string in_file(argv[1]);
 
 
@@ -90,12 +90,12 @@ int main(int argc, char** argv)
         std::string a(argv[iargc]);
         if (a == "-gaussian")
         {
-          parser  = new GaussianFCHKParser(argc, argv);
+          parser  = std::make_unique<GaussianFCHKParser>(argc, argv);
           in_file = argv[++iargc];
         }
         else if (a == "-gamess")
         {
-          parser  = new GamesAsciiParser(argc, argv);
+          parser  = std::make_unique<GamesAsciiParser>(argc, argv);
           in_file = argv[++iargc];
         }
         else if (a == "-dirac")
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
         }
         else if (a == "-orbitals")
         {
-          parser  = new LCAOHDFParser(argc, argv);
+          parser  = std::make_unique<LCAOHDFParser>(argc, argv);
           h5      = true;
           in_file = argv[++iargc];
         }
@@ -213,17 +213,17 @@ int main(int argc, char** argv)
         if (ext == "Fchk")
         {
           WARNMSG("Creating GaussianFCHKParser")
-          parser = new GaussianFCHKParser(argc, argv);
+          parser = std::make_unique<GaussianFCHKParser>(argc, argv);
         }
         else if (ext == "h5")
         {
           WARNMSG("Creating LCAOHDFParser")
-          parser = new LCAOHDFParser(argc, argv);
+          parser = std::make_unique<LCAOHDFParser>(argc, argv);
         }
         else if (ext == "out")
         {
           WARNMSG("Creating GamesAsciiParser")
-          parser = new GamesAsciiParser(argc, argv);
+          parser = std::make_unique<GamesAsciiParser>(argc, argv);
         }
         else
         {

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
         }
         else if (a == "-dirac")
         {
-          parser  = new DiracParser(argc, argv);
+          parser  = std::make_unique<DiracParser>(argc, argv);
           in_file = argv[++iargc];
           usehdf5 = true;
         }


### PR DESCRIPTION
## Proposed changes

Fix leaks associates with parser constructor in converter tests replacing raw pointer with `std::unique_ptr`.
Add virtual destructor to base class as required for `std::unique_ptr` implicit destructor. 
Related to #3312 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
