### PR TITLE
Switch QMCGaussianParserBase::gridPtr raw pointer into a std::unique_ptr

### DIFF
--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -94,7 +94,6 @@ QMCGaussianParserBase::QMCGaussianParserBase()
       gBound(0),
       Occ_alpha(0),
       Occ_beta(0),
-      gridPtr(0),
       X(0),
       Y(0),
       Z(0)
@@ -159,7 +158,6 @@ QMCGaussianParserBase::QMCGaussianParserBase(int argc, char** argv)
       gBound(0),
       Occ_alpha(0),
       Occ_beta(0),
-      gridPtr(0),
       X(0),
       Y(0),
       Z(0)
@@ -1342,7 +1340,7 @@ xmlNodePtr QMCGaussianParserBase::createCenter(int iat, int off_)
   xmlNewProp(abasis, (const xmlChar*)"type", (const xmlChar*)basisType.c_str());
   xmlNewProp(abasis, (const xmlChar*)"elementType", (const xmlChar*)CurrentCenter.c_str());
   xmlNewProp(abasis, (const xmlChar*)"normalized", (const xmlChar*)Normalized.c_str());
-  xmlAddChild(abasis, xmlCopyNode(gridPtr, 1));
+  xmlAddChild(abasis, xmlCopyNode(gridPtr.get(), 1));
   for (int ig = gBound[iat], n = 0; ig < gBound[iat + 1]; ig++, n++)
   {
     createShell(n, ig, off_, abasis);
@@ -1605,7 +1603,7 @@ xmlNodePtr QMCGaussianParserBase::createJ1()
 
 void QMCGaussianParserBase::createGridNode(int argc, char** argv)
 {
-  gridPtr = xmlNewNode(NULL, (const xmlChar*)"grid");
+  gridPtr = std::unique_ptr<xmlNode, void (*)(xmlNodePtr)>(xmlNewNode(NULL, (const xmlChar*)"grid"), xmlFreeNode);
   std::string gridType("log");
   std::string gridFirst("1.e-6");
   std::string gridLast("1.e2");
@@ -1636,10 +1634,10 @@ void QMCGaussianParserBase::createGridNode(int argc, char** argv)
     }
     ++iargc;
   }
-  xmlNewProp(gridPtr, (const xmlChar*)"type", (const xmlChar*)gridType.c_str());
-  xmlNewProp(gridPtr, (const xmlChar*)"ri", (const xmlChar*)gridFirst.c_str());
-  xmlNewProp(gridPtr, (const xmlChar*)"rf", (const xmlChar*)gridLast.c_str());
-  xmlNewProp(gridPtr, (const xmlChar*)"npts", (const xmlChar*)gridSize.c_str());
+  xmlNewProp(gridPtr.get(), (const xmlChar*)"type", (const xmlChar*)gridType.c_str());
+  xmlNewProp(gridPtr.get(), (const xmlChar*)"ri", (const xmlChar*)gridFirst.c_str());
+  xmlNewProp(gridPtr.get(), (const xmlChar*)"rf", (const xmlChar*)gridLast.c_str());
+  xmlNewProp(gridPtr.get(), (const xmlChar*)"npts", (const xmlChar*)gridSize.c_str());
 }
 
 void QMCGaussianParserBase::dump(const std::string& psi_tag, const std::string& ion_tag)

--- a/src/QMCTools/QMCGaussianParserBase.h
+++ b/src/QMCTools/QMCGaussianParserBase.h
@@ -103,7 +103,8 @@ struct QMCGaussianParserBase
   std::vector<value_type> EigVec;
   //std::vector<GaussianCombo<value_type> > gExp, gC0, gC1;
   //std::string EigVecU, EigVecD;
-  xmlNodePtr gridPtr;
+  std::unique_ptr<xmlNode, void (*)(xmlNodePtr)> gridPtr =
+      std::unique_ptr<xmlNode, void (*)(xmlNodePtr)>(nullptr, nullptr);
   std::vector<std::string> CIalpha, CIbeta;
   std::vector<std::string> CSFocc;
   std::vector<std::vector<std::string>> CSFalpha, CSFbeta;


### PR DESCRIPTION
## Proposed changes

`gridPtr` member in `QMCGaussianParserBase` is now a smart pointer
This addresses several leaks in converter deterministic tests.
Must provide default constructor in header due to custom deleter (passing `nullptr`).
Related to #3312 

## What type(s) of changes does this code introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
