### PR TITLE
SPOSet::makeClone() returns a std::unique_ptr

### DIFF
--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -38,11 +38,16 @@ DensityMatrices1B::DensityMatrices1B(ParticleSet& P,
 
 
 DensityMatrices1B::DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi)
-    : OperatorBase(master), Lattice(P.Lattice), Psi(psi), Pq(P), Pc(master.Pc), wf_factory_(master.wf_factory_)
+    : OperatorBase(master),
+      basis_functions(master.basis_functions),
+      Lattice(P.Lattice),
+      Psi(psi),
+      Pq(P),
+      Pc(master.Pc),
+      wf_factory_(master.wf_factory_)
 {
   reset();
   set_state(master);
-  basis_functions.clone_from(master.basis_functions);
   initialize();
   for (int i = 0; i < basis_size; ++i)
     basis_norms[i] = master.basis_norms[i];
@@ -255,7 +260,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
 
   for (int i = 0; i < sposets.size(); ++i)
   {
-    basis_functions.add(wf_factory_.getSPOSet(sposets[i]));
+    basis_functions.add(wf_factory_.getSPOSet(sposets[i])->makeClone());
   }
   basis_size = basis_functions.size();
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -259,9 +259,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     APP_ABORT("DensityMatrices1B::put  basis must have at least one sposet");
 
   for (int i = 0; i < sposets.size(); ++i)
-  {
     basis_functions.add(wf_factory_.getSPOSet(sposets[i])->makeClone());
-  }
   basis_size = basis_functions.size();
 
   if (basis_size < 1)

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -259,7 +259,12 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     APP_ABORT("DensityMatrices1B::put  basis must have at least one sposet");
 
   for (int i = 0; i < sposets.size(); ++i)
-    basis_functions.add(wf_factory_.getSPOSet(sposets[i])->makeClone());
+  {
+    SPOSet* sposet = wf_factory_.getSPOSet(sposets[i]);
+    if (sposet == 0)
+      APP_ABORT("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist");
+    basis_functions.add(sposet->makeClone());
+  }
   basis_size = basis_functions.size();
 
   if (basis_size < 1)

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -29,6 +29,38 @@ OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, 
   comm = mpicomm;
 }
 
+OrbitalImages::OrbitalImages(const OrbitalImages& other)
+    : OperatorBase(other),
+      psetpool(other.psetpool),
+      Peln(other.Peln),
+      Pion(other.Pion),
+      comm(other.comm),
+      format(other.format),
+      value_types(other.value_types),
+      derivatives(other.derivatives),
+      sposet_names(other.sposet_names),
+      sposet_indices(other.sposet_indices),
+      center_grid(other.center_grid),
+      cell(other.cell),
+      corner(other.corner),
+      grid(other.grid),
+      gdims(other.gdims),
+      npoints(other.npoints),
+      batch_size(other.batch_size),
+      spo_vtmp(other.spo_vtmp),
+      spo_gtmp(other.spo_gtmp),
+      spo_ltmp(other.spo_ltmp),
+      batch_values(other.batch_values),
+      batch_gradients(other.batch_gradients),
+      batch_laplacians(other.batch_laplacians),
+      orbital(other.orbital),
+      wf_factory_(other.wf_factory_)
+{
+  for (auto& element : other.sposets)
+  {
+    sposets.push_back(element->makeClone());
+  }
+}
 
 std::unique_ptr<OperatorBase> OrbitalImages::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
 {
@@ -190,7 +222,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
     SPOSet* sposet = wf_factory_.getSPOSet(sposet_names[i]);
     if (sposet == 0)
       APP_ABORT("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist");
-    sposets.push_back(sposet);
+    sposets.push_back(sposet->makeClone());
     std::vector<int>& sposet_inds = *sposet_indices[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -57,9 +57,7 @@ OrbitalImages::OrbitalImages(const OrbitalImages& other)
       wf_factory_(other.wf_factory_)
 {
   for (auto& element : other.sposets)
-  {
     sposets.push_back(element->makeClone());
-  }
 }
 
 std::unique_ptr<OperatorBase> OrbitalImages::makeClone(ParticleSet& P, TrialWaveFunction& Psi)
@@ -67,12 +65,6 @@ std::unique_ptr<OperatorBase> OrbitalImages::makeClone(ParticleSet& P, TrialWave
   //cloning shouldn't strictly be necessary, but do it right just in case
   std::unique_ptr<OrbitalImages> clone = std::make_unique<OrbitalImages>(*this);
   clone->Peln                          = &P;
-  for (int i = 0; i < sposets.size(); ++i)
-  {
-    //FIXME eliminate new
-    clone->sposet_indices[i] = new std::vector<int>(*sposet_indices[i]);
-    clone->sposets[i]        = sposets[i]->makeClone();
-  }
   return clone;
 }
 
@@ -163,7 +155,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   //second pass parameter read to get orbital indices
   //  each parameter is named after the corresponding sposet
   for (int i = 0; i < sposet_names.size(); ++i)
-    sposet_indices.push_back(new std::vector<int>);
+    sposet_indices.push_back(std::vector<int>());
   for (int n = 0; n < other_elements.size(); ++n)
   {
     xmlNodePtr element = other_elements[n];
@@ -173,7 +165,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
       const XMLAttrString name(element, "name");
       for (int i = 0; i < sposet_names.size(); ++i)
         if (name == sposet_names[i])
-          putContent(*sposet_indices[i], element);
+          putContent(sposet_indices[i], element);
     }
   }
 
@@ -223,7 +215,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
     if (sposet == 0)
       APP_ABORT("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist");
     sposets.push_back(sposet->makeClone());
-    std::vector<int>& sposet_inds = *sposet_indices[i];
+    std::vector<int>& sposet_inds = sposet_indices[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)
         sposet_inds.push_back(n);
@@ -284,7 +276,7 @@ void OrbitalImages::report(const std::string& pad)
             << std::endl;
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    std::vector<int>& sposet_inds = *sposet_indices[i];
+    std::vector<int>& sposet_inds = sposet_indices[i];
     SPOSet& sposet                = *sposets[i];
     if (sposet_inds.size() == sposet.size())
       app_log() << pad << "  " << sposet_names[i] << " = all " << sposet.size() << " orbitals" << std::endl;
@@ -346,7 +338,7 @@ OrbitalImages::Return_t OrbitalImages::evaluate(ParticleSet& P)
       //get sposet information
       const std::string& sposet_name = sposet_names[i];
       app_log() << "  evaluating orbitals in " + sposet_name + " on the grid" << std::endl;
-      std::vector<int>& sposet_inds = *sposet_indices[i];
+      std::vector<int>& sposet_inds = sposet_indices[i];
       SPOSet& sposet                = *sposets[i];
       int nspo                      = sposet_inds.size();
 

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -154,8 +154,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
 
   //second pass parameter read to get orbital indices
   //  each parameter is named after the corresponding sposet
-  for (int i = 0; i < sposet_names.size(); ++i)
-    sposet_indices->push_back(std::vector<int>());
+  sposet_indices->resize(sposet_names.size());
   for (int n = 0; n < other_elements.size(); ++n)
   {
     xmlNodePtr element = other_elements[n];

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -155,7 +155,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   //second pass parameter read to get orbital indices
   //  each parameter is named after the corresponding sposet
   for (int i = 0; i < sposet_names.size(); ++i)
-    sposet_indices.push_back(std::vector<int>());
+    sposet_indices->push_back(std::vector<int>());
   for (int n = 0; n < other_elements.size(); ++n)
   {
     xmlNodePtr element = other_elements[n];
@@ -165,7 +165,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
       const XMLAttrString name(element, "name");
       for (int i = 0; i < sposet_names.size(); ++i)
         if (name == sposet_names[i])
-          putContent(sposet_indices[i], element);
+          putContent((*sposet_indices)[i], element);
     }
   }
 
@@ -215,7 +215,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
     if (sposet == 0)
       APP_ABORT("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist");
     sposets.push_back(sposet->makeClone());
-    std::vector<int>& sposet_inds = sposet_indices[i];
+    std::vector<int>& sposet_inds = (*sposet_indices)[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)
         sposet_inds.push_back(n);
@@ -272,11 +272,11 @@ void OrbitalImages::report(const std::string& pad)
 {
   app_log() << pad << "OrbitalImages report" << std::endl;
   app_log() << pad << "  derivatives = " << derivatives << std::endl;
-  app_log() << pad << "  nsposets    = " << sposets.size() << " " << sposet_names.size() << " " << sposet_indices.size()
-            << std::endl;
+  app_log() << pad << "  nsposets    = " << sposets.size() << " " << sposet_names.size() << " "
+            << sposet_indices->size() << std::endl;
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    std::vector<int>& sposet_inds = sposet_indices[i];
+    std::vector<int>& sposet_inds = (*sposet_indices)[i];
     SPOSet& sposet                = *sposets[i];
     if (sposet_inds.size() == sposet.size())
       app_log() << pad << "  " << sposet_names[i] << " = all " << sposet.size() << " orbitals" << std::endl;
@@ -338,7 +338,7 @@ OrbitalImages::Return_t OrbitalImages::evaluate(ParticleSet& P)
       //get sposet information
       const std::string& sposet_name = sposet_names[i];
       app_log() << "  evaluating orbitals in " + sposet_name + " on the grid" << std::endl;
-      std::vector<int>& sposet_inds = sposet_indices[i];
+      std::vector<int>& sposet_inds = (*sposet_indices)[i];
       SPOSet& sposet                = *sposets[i];
       int nspo                      = sposet_inds.size();
 

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -168,7 +168,7 @@ public:
   std::vector<std::string> sposet_names;
 
   ///indices of orbitals within each sposet to evaluate
-  std::vector<std::vector<int>> sposet_indices;
+  const std::shared_ptr<std::vector<std::vector<int>>> sposet_indices;
 
   ///sposets obtained by name from WaveFunctionFactory
   std::vector<std::unique_ptr<SPOSet>> sposets;

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -168,7 +168,7 @@ public:
   std::vector<std::string> sposet_names;
 
   ///indices of orbitals within each sposet to evaluate
-  std::vector<std::vector<int>*> sposet_indices;
+  std::vector<std::vector<int>> sposet_indices;
 
   ///sposets obtained by name from WaveFunctionFactory
   std::vector<std::unique_ptr<SPOSet>> sposets;

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -171,7 +171,7 @@ public:
   std::vector<std::vector<int>*> sposet_indices;
 
   ///sposets obtained by name from WaveFunctionFactory
-  std::vector<SPOSet*> sposets;
+  std::vector<std::unique_ptr<SPOSet>> sposets;
 
   ///evaluate points at grid cell centers instead of edges
   bool center_grid;
@@ -215,10 +215,9 @@ public:
   ///temporary array to hold values of a single orbital at all grid points
   std::vector<ValueType> orbital;
 
-
-  //constructor/destructor
+  //constructors
   OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory);
-  ~OrbitalImages() override{};
+  OrbitalImages(const OrbitalImages& other);
 
   //standard interface
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& P, TrialWaveFunction& psi) final;

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -114,7 +114,7 @@ public:
   using SPOSet::acquireResource;
   using SPOSet::releaseResource;
 
-  SPOSet* makeClone() const override = 0;
+  std::unique_ptr<SPOSet> makeClone() const override = 0;
 
   void resetParameters(const opt_variables_type& active) override {}
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -59,7 +59,7 @@ public:
     this->KeyWord   = "Hybrid" + this->KeyWord;
   }
 
-  SPOSet* makeClone() const override { return new HybridRepCplx(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepCplx>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -61,7 +61,7 @@ public:
     this->KeyWord   = "Hybrid" + this->KeyWord;
   }
 
-  SPOSet* makeClone() const override { return new HybridRepReal(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepReal>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -84,7 +84,7 @@ public:
     KeyWord    = "SplineC2C";
   }
 
-  SPOSet* makeClone() const override { return new SplineC2C(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2C>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -155,7 +155,7 @@ public:
     collection.takebackResource(std::move(phi_leader.mw_mem_));
   }
 
-  virtual SPOSet* makeClone() const override { return new SplineC2COMPTarget(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2COMPTarget>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -88,7 +88,7 @@ public:
     KeyWord    = "SplineC2R";
   }
 
-  SPOSet* makeClone() const override { return new SplineC2R(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2R>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -159,7 +159,7 @@ public:
     collection.takebackResource(std::move(phi_leader.mw_mem_));
   }
 
-  virtual SPOSet* makeClone() const override { return new SplineC2ROMPTarget(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2ROMPTarget>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -79,7 +79,7 @@ public:
     KeyWord    = "SplineR2R";
   }
 
-  SPOSet* makeClone() const override { return new SplineR2R(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineR2R>(*this); }
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -62,21 +62,12 @@ void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
     component_offsets.push_back(0); //add 0
 
   int norbs = component->size();
-  ValueVector_t values;
-  GradVector_t gradients;
-  ValueVector_t laplacians;
-
-  values.resize(norbs);
-  gradients.resize(norbs);
-  laplacians.resize(norbs);
-
   components.push_back(std::move(component));
-  component_values.push_back(std::move(values));
-  component_gradients.push_back(std::move(gradients));
-  component_laplacians.push_back(std::move(laplacians));
+  component_values.emplace_back(norbs);
+  component_gradients.emplace_back(norbs);
+  component_laplacians.emplace_back(norbs);
 
   OrbitalSetSize += norbs;
-
   component_offsets.push_back(OrbitalSetSize);
 }
 

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -59,9 +59,7 @@ CompositeSPOSet::~CompositeSPOSet() = default;
 void CompositeSPOSet::add(std::unique_ptr<SPOSet> component)
 {
   if (components.empty())
-  {
     component_offsets.push_back(0); //add 0
-  }
 
   int norbs = component->size();
   ValueVector_t values;

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -26,21 +26,22 @@ class CompositeSPOSet : public SPOSet
 {
 public:
   ///component SPOSets
-  std::vector<SPOSet*> components;
+  std::vector<std::unique_ptr<SPOSet>> components;
   ///temporary storage for values
-  std::vector<ValueVector_t*> component_values;
+  std::vector<ValueVector_t> component_values;
   ///temporary storage for gradients
-  std::vector<GradVector_t*> component_gradients;
+  std::vector<GradVector_t> component_gradients;
   ///temporary storage for laplacians
-  std::vector<ValueVector_t*> component_laplacians;
+  std::vector<ValueVector_t> component_laplacians;
   ///store the precomputed offsets
   std::vector<int> component_offsets;
 
   CompositeSPOSet();
+  CompositeSPOSet(const CompositeSPOSet& other);
   ~CompositeSPOSet() override;
 
   ///add a sposet component to this composite sposet
-  void add(SPOSet* component);
+  void add(std::unique_ptr<SPOSet> component);
 
   ///print out component info
   void report();
@@ -49,12 +50,7 @@ public:
   ///size is determined by component sposets and nothing else
   inline void setOrbitalSetSize(int norbs) override {}
 
-  SPOSet* makeClone() const override;
-
-  /** add sposet clones from another Composite SPOSet
-     *   should only be used in makeClone functions following shallow copy
-     */
-  void clone_from(const CompositeSPOSet& master);
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override;
 

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -1753,9 +1753,9 @@ void EinsplineSetExtended<StorageType>::registerTimers()
 
 
 template<typename StorageType>
-SPOSet* EinsplineSetExtended<StorageType>::makeClone() const
+std::unique_ptr<SPOSet> EinsplineSetExtended<StorageType>::makeClone() const
 {
-  EinsplineSetExtended<StorageType>* clone = new EinsplineSetExtended<StorageType>(*this);
+  auto clone = std::make_unique<EinsplineSetExtended<StorageType>>(*this);
   clone->registerTimers();
   for (int iat = 0; iat < clone->AtomicOrbitals.size(); iat++)
     clone->AtomicOrbitals[iat].registerTimers();
@@ -1778,9 +1778,9 @@ std::string EinsplineSetHybrid<double>::Type()
 
 
 template<typename StorageType>
-SPOSet* EinsplineSetHybrid<StorageType>::makeClone() const
+std::unique_ptr<SPOSet> EinsplineSetHybrid<StorageType>::makeClone() const
 {
-  EinsplineSetHybrid<StorageType>* clone = new EinsplineSetHybrid<StorageType>(*this);
+  auto clone = std::make_unique<EinsplineSetHybrid<StorageType>>(*this);
   clone->registerTimers();
   return clone;
 }

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -495,7 +495,7 @@ public:
   PosType get_k(int orb) override { return kPoints[orb]; }
 
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   EinsplineSetExtended()
       : MultiSpline(NULL),
@@ -651,7 +651,7 @@ public:
 
   std::string Type();
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   EinsplineSetHybrid();
 };

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h
@@ -34,7 +34,7 @@ struct EGOSet : public SPOSet
   EGOSet(const std::vector<PosType>& k, const std::vector<RealType>& k2);
   EGOSet(const std::vector<PosType>& k, const std::vector<RealType>& k2, const std::vector<int>& d);
 
-  SPOSet* makeClone() const override { return new EGOSet(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<EGOSet>(*this); }
 
   void resetParameters(const opt_variables_type& optVariables) override {}
   void setOrbitalSetSize(int norbs) override {}

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h
@@ -44,7 +44,7 @@ struct RealEGOSet : public SPOSet
   void resetParameters(const opt_variables_type& optVariables) override {}
   void setOrbitalSetSize(int norbs) override {}
 
-  SPOSet* makeClone() const override { return new RealEGOSet(*this); }
+  std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<RealEGOSet>(*this); }
 
   PosType get_k(int i) override
   {

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -421,7 +421,7 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
   resize(s.NumPtcls);
 }
 
-SPOSetPtr MultiDiracDeterminant::clonePhi() const { return Phi->makeClone(); }
+std::unique_ptr<SPOSet> MultiDiracDeterminant::clonePhi() const { return Phi->makeClone(); }
 
 std::unique_ptr<WaveFunctionComponent> MultiDiracDeterminant::makeClone(ParticleSet& tqp) const
 {

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -73,7 +73,7 @@ public:
 
   /** return a clone of Phi
    */
-  SPOSetPtr clonePhi() const;
+  std::unique_ptr<SPOSet> clonePhi() const;
 
   SPOSetPtr getPhi() { return Phi.get(); };
 

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
@@ -64,7 +64,7 @@ void SHOSet::initialize()
 SHOSet::~SHOSet() {}
 
 
-SPOSet* SHOSet::makeClone() const { return new SHOSet(*this); }
+std::unique_ptr<SPOSet> SHOSet::makeClone() const { return std::make_unique<SHOSet>(*this); }
 
 
 void SHOSet::report(const std::string& pad) const

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
@@ -72,7 +72,7 @@ struct SHOSet : public SPOSet
 
 
   //SPOSet interface methods
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   void evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi) override;
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -79,7 +79,7 @@ void LCAOrbitalSet::checkObject() const
   }
 }
 
-SPOSet* LCAOrbitalSet::makeClone() const { return new LCAOrbitalSet(*this); }
+std::unique_ptr<SPOSet> LCAOrbitalSet::makeClone() const { return std::make_unique<LCAOrbitalSet>(*this); }
 
 void LCAOrbitalSet::evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi)
 {

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -47,7 +47,7 @@ public:
 
   LCAOrbitalSet(const LCAOrbitalSet& in);
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   void storeParamsBeforeRotation() override { C_copy = *C; }
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
@@ -28,7 +28,10 @@ void LCAOrbitalSetWithCorrection::setOrbitalSetSize(int norbs)
 }
 
 
-SPOSet* LCAOrbitalSetWithCorrection::makeClone() const { return new LCAOrbitalSetWithCorrection(*this); }
+std::unique_ptr<SPOSet> LCAOrbitalSetWithCorrection::makeClone() const
+{
+  return std::make_unique<LCAOrbitalSetWithCorrection>(*this);
+}
 
 void LCAOrbitalSetWithCorrection::evaluateValue(const ParticleSet& P, int iat, ValueVector_t& psi)
 {

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
@@ -37,7 +37,7 @@ public:
 
   LCAOrbitalSetWithCorrection(const LCAOrbitalSetWithCorrection& in) = default;
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   void setOrbitalSetSize(int norbs) override;
 

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -27,9 +27,9 @@ PWOrbitalSet::~PWOrbitalSet()
     delete C;
 }
 
-SPOSet* PWOrbitalSet::makeClone() const
+std::unique_ptr<SPOSet> PWOrbitalSet::makeClone() const
 {
-  PWOrbitalSet* myclone = new PWOrbitalSet(*this);
+  auto myclone          = std::make_unique<PWOrbitalSet>(*this);
   myclone->myBasisSet   = new PWBasis(*myBasisSet);
   myclone->IsCloned     = true;
   return myclone;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -54,7 +54,7 @@ public:
    */
   ~PWOrbitalSet() override;
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
   /** resize  the orbital base
    * @param bset PWBasis
    * @param nbands number of bands

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -30,10 +30,10 @@ PWRealOrbitalSet::~PWRealOrbitalSet()
     delete myBasisSet;
 }
 
-SPOSet* PWRealOrbitalSet::makeClone() const
+std::unique_ptr<SPOSet> PWRealOrbitalSet::makeClone() const
 {
-  PWRealOrbitalSet* myclone = new PWRealOrbitalSet(*this);
-  myclone->myBasisSet       = new PWBasis(*myBasisSet);
+  auto myclone        = std::make_unique<PWRealOrbitalSet>(*this);
+  myclone->myBasisSet = new PWBasis(*myBasisSet);
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -58,7 +58,7 @@ public:
    */
   ~PWRealOrbitalSet() override;
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   /** resize  the orbital base
    * @param bset PWBasis

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1036,9 +1036,9 @@ void RotatedSPOs::table_method_evalWF(std::vector<ValueType>& dlogpsi,
 }
 
 
-SPOSet* RotatedSPOs::makeClone() const
+std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
 {
-  RotatedSPOs* myclone = new RotatedSPOs(std::unique_ptr<SPOSet>(Phi->makeClone()));
+  auto myclone = std::make_unique<RotatedSPOs>(std::unique_ptr<SPOSet>(Phi->makeClone()));
 
   myclone->params          = this->params;
   myclone->params_supplied = this->params_supplied;

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -46,7 +46,7 @@ public:
   /// the number of electrons of the majority spin
   size_t nel_major_;
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
   // myG_temp (myL_temp) is the Gradient (Laplacian) value of of the Determinant part of the wfn
   // myG_J is the Gradient of the all other parts of the wavefunction (typically just the Jastrow).

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -159,10 +159,10 @@ void SPOSet::evaluate_notranspose(const ParticleSet& P,
 }
 
 
-SPOSet* SPOSet::makeClone() const
+std::unique_ptr<SPOSet> SPOSet::makeClone() const
 {
   APP_ABORT("Missing  SPOSet::makeClone for " + className);
-  return 0;
+  return std::unique_ptr<SPOSet>();
 }
 
 void SPOSet::basic_report(const std::string& pad) const

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -453,7 +453,7 @@ public:
   /** make a clone of itself
    * every derived class must implement this to have threading working correctly.
    */
-  virtual SPOSet* makeClone() const;
+  virtual std::unique_ptr<SPOSet> makeClone() const;
 
   /** Used only by cusp correction in AOS LCAO.
    * Ye: the SoA LCAO moves all this responsibility to the builder.

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -248,9 +248,9 @@ void SpinorSet::evaluate_spin(const ParticleSet& P, int iat, ValueVector_t& psi,
   dpsi = eye * (eis * psi_work_up - emis * psi_work_down);
 }
 
-SPOSet* SpinorSet::makeClone() const
+std::unique_ptr<SPOSet> SpinorSet::makeClone() const
 {
-  SpinorSet* myclone = new SpinorSet();
+  auto myclone = std::make_unique<SpinorSet>();
   std::unique_ptr<SPOSet> cloneup(spo_up->makeClone());
   std::unique_ptr<SPOSet> clonedn(spo_dn->makeClone());
   myclone->set_spos(std::move(cloneup), std::move(clonedn));

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -111,7 +111,7 @@ public:
    */
   void evaluate_spin(const ParticleSet& P, int iat, ValueVector_t& psi, ValueVector_t& dpsi) override;
 
-  SPOSet* makeClone() const override;
+  std::unique_ptr<SPOSet> makeClone() const override;
 
 private:
   //Sposet for the up and down channels of our spinors.


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

SPOSet::makeClone() and derived classes now return a std::unique_ptr<SPOset>, improving memory safety.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted

