### PR TITLE
Clean up ParticleSet/SK

### DIFF
--- a/src/Containers/OhmmsPETE/Tensor.h
+++ b/src/Containers/OhmmsPETE/Tensor.h
@@ -102,6 +102,7 @@ public:
     X[2] = x01;
     X[3] = x11;
   }
+
   Tensor(const T& x00,
          const T& x10,
          const T& x20,

--- a/src/Particle/LongRange/EwaldHandler.cpp
+++ b/src/Particle/LongRange/EwaldHandler.cpp
@@ -40,7 +40,7 @@ void EwaldHandler::initBreakup(ParticleSet& ref)
     PreFactors[1] = 2.0 * std::sqrt(M_PI) / (Sigma * Area); //\f$  \frac{2\pi}{A}\frac{1}{Sigma\pi}\f$
     PreFactors[2] = 1.0 / (2 * Sigma);                      //Used for the k-dependent term
   }
-  fillFk(ref.SK->KLists);
+  fillFk(ref.SK->getKLists());
 }
 
 EwaldHandler::EwaldHandler(const EwaldHandler& aLR, ParticleSet& ref)
@@ -51,7 +51,7 @@ EwaldHandler::EwaldHandler(const EwaldHandler& aLR, ParticleSet& ref)
     kMag = aLR.kMag;
 }
 
-void EwaldHandler::fillFk(KContainer& KList)
+void EwaldHandler::fillFk(const KContainer& KList)
 {
   Fk.resize(KList.kpts_cart.size());
   const std::vector<int>& kshell(KList.kshell);

--- a/src/Particle/LongRange/EwaldHandler.h
+++ b/src/Particle/LongRange/EwaldHandler.h
@@ -95,7 +95,7 @@ public:
 
   mRealType evaluate_vlr_k(mRealType k) const override;
 
-  void fillFk(KContainer& KList);
+  void fillFk(const KContainer& KList);
 
   /** evaluate k-dependent
    */

--- a/src/Particle/LongRange/EwaldHandler3D.cpp
+++ b/src/Particle/LongRange/EwaldHandler3D.cpp
@@ -40,9 +40,9 @@ void EwaldHandler3D::initBreakup(ParticleSet& ref)
   app_log() << "  Sigma=" << Sigma << std::endl;
   Volume     = ref.Lattice.Volume;
   PreFactors = 0.0;
-  fillFk(ref.SK->KLists);
-  fillYkgstrain(ref.SK->KLists);
-  filldFk_dk(ref.SK->KLists);
+  fillFk(ref.SK->getKLists());
+  fillYkgstrain(ref.SK->getKLists());
+  filldFk_dk(ref.SK->getKLists());
 }
 
 EwaldHandler3D::EwaldHandler3D(const EwaldHandler3D& aLR, ParticleSet& ref)
@@ -51,7 +51,7 @@ EwaldHandler3D::EwaldHandler3D(const EwaldHandler3D& aLR, ParticleSet& ref)
   SuperCellEnum = aLR.SuperCellEnum;
 }
 
-void EwaldHandler3D::fillFk(KContainer& KList)
+void EwaldHandler3D::fillFk(const KContainer& KList)
 {
   Fk.resize(KList.kpts_cart.size());
   Fkg.resize(KList.kpts_cart.size());

--- a/src/Particle/LongRange/EwaldHandler3D.h
+++ b/src/Particle/LongRange/EwaldHandler3D.h
@@ -99,9 +99,9 @@ public:
     return 2.0 * Sigma * std::exp(-Sigma * Sigma * r * r) / (std::sqrt(M_PI) * r) - erf(Sigma * r) * rinv * rinv;
   }
 
-  void fillFk(KContainer& KList);
+  void fillFk(const KContainer& KList);
 
-  void fillYkgstrain(KContainer& KList)
+  void fillYkgstrain(const KContainer& KList)
   {
     Fkgstrain.resize(KList.kpts_cart.size());
     const std::vector<int>& kshell(KList.kshell);
@@ -114,7 +114,7 @@ public:
     }
   }
 
-  void filldFk_dk(KContainer& KList)
+  void filldFk_dk(const KContainer& KList)
   {
     dFk_dstrain.resize(KList.kpts_cart.size());
 

--- a/src/Particle/LongRange/KContainer.cpp
+++ b/src/Particle/LongRange/KContainer.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-void KContainer::UpdateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere)
+void KContainer::updateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere)
 {
   kcutoff = kc;
   kcut2   = kc * kc;

--- a/src/Particle/LongRange/KContainer.cpp
+++ b/src/Particle/LongRange/KContainer.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-void KContainer::updateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere)
+void KContainer::updateKLists(const ParticleLayout& lattice, RealType kc, bool useSphere)
 {
   kcutoff = kc;
   kcut2   = kc * kc;
@@ -36,7 +36,7 @@ void KContainer::updateKLists(const ParticleLayout_t& lattice, RealType kc, bool
   app_log() << std::endl;
 }
 
-void KContainer::FindApproxMMax(const ParticleLayout_t& lattice)
+void KContainer::FindApproxMMax(const ParticleLayout& lattice)
 {
   //Estimate the size of the parallelpiped that encompasses a sphere of kcutoff.
   //mmax is stored as integer translations of the reciprocal cell vectors.
@@ -98,15 +98,15 @@ void KContainer::FindApproxMMax(const ParticleLayout_t& lattice)
     mmax[DIM] = std::max(mmax[i], mmax[DIM]);
 }
 
-void KContainer::BuildKLists(const ParticleLayout_t& lattice, bool useSphere)
+void KContainer::BuildKLists(const ParticleLayout& lattice, bool useSphere)
 {
   TinyVector<int, DIM + 1> TempActualMax;
   TinyVector<int, DIM> kvec;
   TinyVector<RealType, DIM> kvec_cart;
   RealType modk2;
   std::vector<TinyVector<int, DIM>> kpts_tmp;
-  VContainer_t kpts_cart_tmp;
-  SContainer_t ksq_tmp;
+  std::vector<PosType> kpts_cart_tmp;
+  std::vector<RealType> ksq_tmp;
   // reserve the space for memory efficiency
 #if OHMMS_DIM == 3
   if (useSphere)

--- a/src/Particle/LongRange/KContainer.cpp
+++ b/src/Particle/LongRange/KContainer.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-void KContainer::UpdateKLists(ParticleLayout_t& lattice, RealType kc, bool useSphere)
+void KContainer::UpdateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere)
 {
   kcutoff = kc;
   kcut2   = kc * kc;
@@ -36,7 +36,7 @@ void KContainer::UpdateKLists(ParticleLayout_t& lattice, RealType kc, bool useSp
   app_log() << std::endl;
 }
 
-void KContainer::FindApproxMMax(ParticleLayout_t& lattice)
+void KContainer::FindApproxMMax(const ParticleLayout_t& lattice)
 {
   //Estimate the size of the parallelpiped that encompasses a sphere of kcutoff.
   //mmax is stored as integer translations of the reciprocal cell vectors.
@@ -98,7 +98,7 @@ void KContainer::FindApproxMMax(ParticleLayout_t& lattice)
     mmax[DIM] = std::max(mmax[i], mmax[DIM]);
 }
 
-void KContainer::BuildKLists(ParticleLayout_t& lattice, bool useSphere)
+void KContainer::BuildKLists(const ParticleLayout_t& lattice, bool useSphere)
 {
   TinyVector<int, DIM + 1> TempActualMax;
   TinyVector<int, DIM> kvec;

--- a/src/Particle/LongRange/KContainer.h
+++ b/src/Particle/LongRange/KContainer.h
@@ -15,7 +15,7 @@
 #ifndef QMCPLUSPLUS_KCONTAINER_H
 #define QMCPLUSPLUS_KCONTAINER_H
 
-#include "Particle/ParticleSet.h"
+#include "Configuration.h"
 #include "Utilities/PooledData.h"
 #include "Utilities/IteratorUtility.h"
 namespace qmcplusplus
@@ -34,12 +34,8 @@ private:
   RealType kcut2;
 
 public:
-  //Typedef for the lattice-type. We don't need the full particle-set.
-  typedef ParticleSet::ParticleLayout_t ParticleLayout_t;
-  ///typedef of vector containers
-  typedef std::vector<PosType> VContainer_t;
-  ///typedef of scalar containers
-  typedef std::vector<RealType> SContainer_t;
+  //Typedef for the lattice-type
+  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout_t;
 
   ///number of k-points
   int numk;
@@ -55,10 +51,10 @@ public:
   std::vector<TinyVector<int, DIM>> kpts;
   /** K-vector in Cartesian coordinates
    */
-  VContainer_t kpts_cart;
+  std::vector<PosType> kpts_cart;
   /** squre of kpts in Cartesian coordniates
    */
-  SContainer_t ksq;
+  std::vector<RealType> ksq;
   /** Given a k index, return index to -k
    */
   std::vector<int> minusk;
@@ -77,15 +73,15 @@ public:
    * @param kc cutoff radius in the K
    * @param useSphere if true, use the |K|
    */
-  void updateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere = true);
+  void updateKLists(const ParticleLayout& lattice, RealType kc, bool useSphere = true);
 
 private:
   /** compute approximate parallelpiped that surrounds kc
    * @param lattice supercell
    */
-  void FindApproxMMax(const ParticleLayout_t& lattice);
+  void FindApproxMMax(const ParticleLayout& lattice);
   /** construct the container for k-vectors */
-  void BuildKLists(const ParticleLayout_t& lattice, bool useSphere);
+  void BuildKLists(const ParticleLayout& lattice, bool useSphere);
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/KContainer.h
+++ b/src/Particle/LongRange/KContainer.h
@@ -77,7 +77,7 @@ public:
    * @param kc cutoff radius in the K
    * @param useSphere if true, use the |K|
    */
-  void UpdateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere = true);
+  void updateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere = true);
 
 private:
   /** compute approximate parallelpiped that surrounds kc

--- a/src/Particle/LongRange/KContainer.h
+++ b/src/Particle/LongRange/KContainer.h
@@ -77,15 +77,15 @@ public:
    * @param kc cutoff radius in the K
    * @param useSphere if true, use the |K|
    */
-  void UpdateKLists(ParticleLayout_t& lattice, RealType kc, bool useSphere = true);
+  void UpdateKLists(const ParticleLayout_t& lattice, RealType kc, bool useSphere = true);
 
 private:
   /** compute approximate parallelpiped that surrounds kc
    * @param lattice supercell
    */
-  void FindApproxMMax(ParticleLayout_t& lattice);
+  void FindApproxMMax(const ParticleLayout_t& lattice);
   /** construct the container for k-vectors */
-  void BuildKLists(ParticleLayout_t& lattice, bool useSphere);
+  void BuildKLists(const ParticleLayout_t& lattice, bool useSphere);
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/LRBreakup.h
+++ b/src/Particle/LongRange/LRBreakup.h
@@ -334,7 +334,7 @@ int LRBreakup<BreakupBasis>::SetupKVecs(mRealType kc, mRealType kcont, mRealType
 {
   //Add low |k| ( < kcont) k-points with exact degeneracy
   KContainer kexact;
-  kexact.UpdateKLists(Basis.get_Lattice(), kcont);
+  kexact.updateKLists(Basis.get_Lattice(), kcont);
   bool findK    = true;
   mRealType kc2 = kc * kc;
   //use at least one shell

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -308,7 +308,7 @@ struct DummyLRHandler : public LRHandlerBase
     mRealType kcsq = LR_kc * LR_kc;
     auto& KList(ref.SK->getKLists());
     int maxshell = KList.kshell.size() - 1;
-    const KContainer::SContainer_t& kk(KList.ksq);
+    const auto& kk(KList.ksq);
     int ksh = 0, ik = 0;
     while (ksh < maxshell)
     {

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -189,7 +189,7 @@ struct LRHandlerBase
 #if !defined(USE_REAL_STRUCT_FACTOR)
     const Matrix<pComplexType>& e2ikrA = A.SK->eikr;
     const pComplexType* rhokB          = B.SK->rhok[specB];
-    const std::vector<PosType>& kpts   = A.SK->KLists.kpts_cart;
+    const std::vector<PosType>& kpts   = A.SK->getKLists().kpts_cart;
     for (int ki = 0; ki < Fk.size(); ki++)
     {
       PosType k = kpts[ki];
@@ -205,7 +205,7 @@ struct LRHandlerBase
     const Matrix<pRealType>& e2ikrA_i = A.SK->eikr_i;
     const pRealType* rhokB_r          = B.SK->rhok_r[specB];
     const pRealType* rhokB_i          = B.SK->rhok_i[specB];
-    const std::vector<PosType>& kpts  = A.SK->KLists.kpts_cart;
+    const std::vector<PosType>& kpts  = A.SK->getKLists().kpts_cart;
     for (int ki = 0; ki < Fk.size(); ki++)
     {
       PosType k = kpts[ki];
@@ -306,7 +306,7 @@ struct DummyLRHandler : public LRHandlerBase
   {
     mRealType norm = 4.0 * M_PI / ref.Lattice.Volume;
     mRealType kcsq = LR_kc * LR_kc;
-    KContainer& KList(ref.SK->KLists);
+    auto& KList(ref.SK->getKLists());
     int maxshell = KList.kshell.size() - 1;
     const KContainer::SContainer_t& kk(KList.ksq);
     int ksh = 0, ik = 0;

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -87,10 +87,10 @@ public:
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.LRBox, 1);
-    //    fillYk(ref.SK->KLists);
-    fillYkg(ref.SK->KLists);
+    //    fillYk(ref.SK->getKLists());
+    fillYkg(ref.SK->getKLists());
     //This is expensive to calculate.  Deprecating stresses for now.
-    //filldFk_dk(ref.SK->KLists);
+    //filldFk_dk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -99,10 +99,10 @@ public:
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.LRBox, 1);
-    //    fillYk(ref.SK->KLists);
-    fillYkg(ref.SK->KLists);
+    //    fillYk(ref.SK->getKLists());
+    fillYkg(ref.SK->getKLists());
     //This is expensive to calculate.  Deprecating stresses for now.
-    //filldFk_dk(ref.SK->KLists);
+    //filldFk_dk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -414,7 +414,7 @@ private:
     //  Fk[ki] = evalFk(k); //Call derived fn.
     //}
   }
-  void fillYkg(KContainer& KList)
+  void fillYkg(const KContainer& KList)
   {
     Fkg.resize(KList.kpts_cart.size());
     //LRHandlerSRCoulomb is the force handler now.  Only want

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -73,7 +73,7 @@ public:
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.LRBox)
   {
     myFunc.reset(ref);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override { return new LRHandlerTemp<Func, BreakupBasis>(*this, ref); }
@@ -81,7 +81,7 @@ public:
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.LRBox, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -91,7 +91,7 @@ public:
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.LRBox, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -263,7 +263,7 @@ private:
     }
   }
 
-  void fillFk(KContainer& KList)
+  void fillFk(const KContainer& KList)
   {
     Fk.resize(KList.kpts_cart.size());
     const std::vector<int>& kshell(KList.kshell);

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -71,7 +71,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.Lattice)
   {
     myFunc.reset(ref);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override
@@ -82,7 +82,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.Lattice, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -92,7 +92,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.Lattice, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -238,7 +238,7 @@ private:
     }
   }
 
-  void fillFk(KContainer& KList)
+  void fillFk(const KContainer& KList)
   {
     Fk.resize(KList.kpts_cart.size());
     const std::vector<int>& kshell(KList.kshell);

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -70,7 +70,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.Lattice)
   {
     myFunc.reset(ref);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override
@@ -81,7 +81,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.Lattice, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -94,7 +94,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
       rs = std::pow(3.0 / 4.0 / M_PI * ref.Lattice.Volume / static_cast<mRealType>(ref.getTotalNum()), 1.0 / 3.0);
     myFunc.reset(ref, rs);
     InitBreakup(ref.Lattice, 1);
-    fillFk(ref.SK->KLists);
+    fillFk(ref.SK->getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -240,7 +240,7 @@ private:
     }
   }
 
-  void fillFk(KContainer& KList)
+  void fillFk(const KContainer& KList)
   {
     Fk.resize(KList.kpts_cart.size());
     const std::vector<int>& kshell(KList.kshell);

--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -23,7 +23,7 @@
 namespace qmcplusplus
 {
 //Constructor - pass arguments to KLists' constructor
-StructFact::StructFact(ParticleSet& P, RealType kc)
+StructFact::StructFact(const ParticleSet& P, RealType kc)
     : DoUpdate(false), SuperCellEnum(SUPERCELL_BULK), KLists(std::make_shared<KContainer>()), StorePerParticle(false)
 {
   if (qmc_common.use_ewald && P.LRBox.SuperCellEnum == SUPERCELL_SLAB)
@@ -38,7 +38,7 @@ StructFact::StructFact(ParticleSet& P, RealType kc)
 //Destructor
 StructFact::~StructFact() {}
 
-void StructFact::UpdateNewCell(ParticleSet& P, RealType kc)
+void StructFact::UpdateNewCell(const ParticleSet& P, RealType kc)
 {
   //Generate the lists of k-vectors
   KLists->UpdateKLists(P.LRBox, kc);
@@ -69,12 +69,12 @@ void StructFact::resize(int ns, int nptcl, int nkpts)
 }
 
 
-void StructFact::UpdateAllPart(ParticleSet& P) { FillRhok(P); }
+void StructFact::UpdateAllPart(const ParticleSet& P) { FillRhok(P); }
 
 
 /** evaluate rok per species, eikr  per particle
  */
-void StructFact::FillRhok(ParticleSet& P)
+void StructFact::FillRhok(const ParticleSet& P)
 {
   int npart = P.getTotalNum();
 #if defined(USE_REAL_STRUCT_FACTOR)
@@ -213,7 +213,7 @@ void StructFact::rejectMove(int active, int gid)
   //do nothing
 }
 
-void StructFact::turnOnStorePerParticle(ParticleSet& P)
+void StructFact::turnOnStorePerParticle(const ParticleSet& P)
 {
 #if defined(USE_REAL_STRUCT_FACTOR)
   if (!StorePerParticle)

--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -36,20 +36,18 @@ StructFact::StructFact(const ParticleSet& P, RealType kc)
     SuperCellEnum = SUPERCELL_SLAB;
   }
 
-  UpdateNewCell(P, kc);
+  updateNewCell(P, kc);
 }
 
 //Destructor
-StructFact::~StructFact() {}
+StructFact::~StructFact() = default;
 
-void StructFact::UpdateNewCell(const ParticleSet& P, RealType kc)
+void StructFact::updateNewCell(const ParticleSet& P, RealType kc)
 {
   //Generate the lists of k-vectors
-  KLists->UpdateKLists(P.LRBox, kc);
+  KLists->updateKLists(P.LRBox, kc);
   //resize any array
   resize(P.getSpeciesSet().size(), P.getTotalNum(), KLists->numk);
-  //Compute the entire Rhok
-  FillRhok(P);
 }
 
 void StructFact::resize(int ns, int nptcl, int nkpts)
@@ -73,25 +71,25 @@ void StructFact::resize(int ns, int nptcl, int nkpts)
 }
 
 
-void StructFact::UpdateAllPart(const ParticleSet& P)
+void StructFact::updateAllPart(const ParticleSet& P)
 {
   ScopedTimer local(update_all_timer_);
-  FillRhok(P);
+  computeRhok(P);
 }
 
-void StructFact::mw_UpdateAllPart(const RefVectorWithLeader<StructFact>& sk_list,
+void StructFact::mw_updateAllPart(const RefVectorWithLeader<StructFact>& sk_list,
                                   const RefVectorWithLeader<ParticleSet>& p_list)
 {
   auto& sk_leader = sk_list.getLeader();
   ScopedTimer local(sk_leader.update_all_timer_);
   for (int iw = 0; iw < sk_list.size(); iw++)
-    sk_list[iw].FillRhok(p_list[iw]);
+    sk_list[iw].computeRhok(p_list[iw]);
 }
 
 
 /** evaluate rok per species, eikr  per particle
  */
-void StructFact::FillRhok(const ParticleSet& P)
+void StructFact::computeRhok(const ParticleSet& P)
 {
   int npart = P.getTotalNum();
 #if defined(USE_REAL_STRUCT_FACTOR)
@@ -239,7 +237,7 @@ void StructFact::turnOnStorePerParticle(const ParticleSet& P)
     const int nptcl  = P.getTotalNum();
     eikr_r.resize(nptcl, KLists->numk);
     eikr_i.resize(nptcl, KLists->numk);
-    FillRhok(P);
+    computeRhok(P);
   }
 #endif
 }

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -109,8 +109,8 @@ public:
   /// accessor of StorePerParticle
   bool isStorePerParticle() const { return StorePerParticle; }
 
-  /// access KLists read only
-  const KContainer& getKLists() const { return *KLists; }
+  /// access k_lists_ read only
+  const KContainer& getKLists() const { return *k_lists_; }
 
 private:
   /// Compute all rhok elements from the start
@@ -123,7 +123,7 @@ private:
   void resize(int nkpts);
 
   /// K-Vector List.
-  const std::shared_ptr<KContainer> KLists;
+  const std::shared_ptr<KContainer> k_lists_;
   /// number of particles
   const size_t num_ptcls;
   /// number of species

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -33,8 +33,6 @@ namespace qmcplusplus
 class StructFact : public QMCTraits
 {
 public:
-  typedef PooledData<RealType> BufferType;
-
   /** false, if the structure factor is not actively updated
    *
    * Default is false. Particle-by-particle update functions, makeMove,
@@ -97,63 +95,6 @@ public:
    * Do nothing
    */
   void rejectMove(int active, int gid);
-  /// Update Rhok if 1 particle moved
-  //void Update1Part(const PosType& rold, const PosType& rnew,int iat,int GroupID);
-
-  //Buffer methods. For PbyP MC where data must be stored in an anonymous
-  //buffer between iterations
-  /** @brief register rhok data to buf so that it can copyToBuffer and copyFromBuffer
-   *
-   * This function is used for particle-by-particle MC methods to register structure factor
-   * to an anonymous buffer.
-   */
-  inline void registerData(BufferType& buf)
-  {
-#if defined(USE_REAL_STRUCT_FACTOR)
-    buf.add(rhok_r.first_address(), rhok_r.last_address());
-    buf.add(rhok_i.first_address(), rhok_i.last_address());
-    buf.add(eikr_r.first_address(), eikr_r.last_address());
-    buf.add(eikr_i.first_address(), eikr_i.last_address());
-#else
-    buf.add(rhok.first_address(), rhok.last_address());
-    buf.add(eikr.first_address(), eikr.last_address());
-#endif
-  }
-
-  /** @brief put rhok data to buf
-   *
-   * This function is used for particle-by-particle MC methods
-   */
-  inline void updateBuffer(BufferType& buf)
-  {
-#if defined(USE_REAL_STRUCT_FACTOR)
-    buf.put(rhok_r.first_address(), rhok_r.last_address());
-    buf.put(rhok_i.first_address(), rhok_i.last_address());
-    buf.put(eikr_r.first_address(), eikr_r.last_address());
-    buf.put(eikr_i.first_address(), eikr_i.last_address());
-#else
-    buf.put(rhok.first_address(), rhok.last_address());
-    buf.put(eikr.first_address(), eikr.last_address());
-#endif
-  }
-
-  /** @brief copy the data from an anonymous buffer
-   *
-   * Any data that was used by the previous iteration will be copied from a buffer.
-   */
-  inline void copyFromBuffer(BufferType& buf)
-  {
-#if defined(USE_REAL_STRUCT_FACTOR)
-    buf.get(rhok_r.first_address(), rhok_r.last_address());
-    buf.get(rhok_i.first_address(), rhok_i.last_address());
-    buf.get(eikr_r.first_address(), eikr_r.last_address());
-    buf.get(eikr_i.first_address(), eikr_i.last_address());
-#else
-    buf.get(rhok.first_address(), rhok.last_address());
-    buf.get(eikr.first_address(), eikr.last_address());
-#endif
-  }
-
   /** @brief switch on the storage per particle
    * if StorePerParticle was false, this function allocates memory and precompute data
    * if StorePerParticle was true, this function is no-op

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -77,6 +77,9 @@ public:
    */
   void UpdateAllPart(const ParticleSet& P);
 
+  static void mw_UpdateAllPart(const RefVectorWithLeader<StructFact>& sk_list,
+                               const RefVectorWithLeader<ParticleSet>& p_list);
+
   /** evaluate eikr_temp for eikr for the proposed move
    * @param active index of the moved particle
    * @param pos proposed position
@@ -180,6 +183,8 @@ private:
    * storing data per particle specie is more cost-effective
    */
   bool StorePerParticle;
+  /// timer for UpdateAllPart
+  NewTimer& update_all_timer_;
 };
 } // namespace qmcplusplus
 

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -15,10 +15,11 @@
 #define QMCPLUSPLUS_STRUCTFACT_H
 
 //#define USE_REAL_STRUCT_FACTOR
-#include "Particle/ParticleSet.h"
-#include "Utilities/PooledData.h"
+#include "ParticleSet.h"
+#include "DynamicCoordinates.h"
 #include "LongRange/KContainer.h"
 #include "OhmmsPETE/OhmmsVector.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
 
 namespace qmcplusplus
 {
@@ -33,6 +34,8 @@ namespace qmcplusplus
 class StructFact : public QMCTraits
 {
 public:
+  //Typedef for the lattice-type
+  using ParticleLayout = PtclOnLatticeTraits::ParticleLayout_t;
   /** false, if the structure factor is not actively updated
    *
    * Default is false. Particle-by-particle update functions, makeMove,
@@ -60,17 +63,19 @@ public:
   Vector<ComplexType> eikr_temp;
 #endif
   /** Constructor - copy ParticleSet and init. k-shells
-   * @param P Reference particle set
+   * @param nptcls number of particles
+   * @param ns number of species
+   * @param lattice long range box
    * @param kc cutoff for k
    */
-  StructFact(const ParticleSet& P, RealType kc);
+  StructFact(int nptcls, int ns, const ParticleLayout& lattice, RealType kc);
   /// desructor
   ~StructFact();
 
   /** Recompute Rhok if lattice changed
    * @param kc cut-off K
    */
-  void updateNewCell(const ParticleSet& P, RealType kc);
+  void updateNewCell(const ParticleLayout& lattice, RealType kc);
   /**  Update Rhok if all particles moved
    */
   void updateAllPart(const ParticleSet& P);
@@ -115,10 +120,14 @@ private:
    * @param nptcl number of particles
    * @param nkpts
    */
-  void resize(int ns, int nptcl, int nkpts);
+  void resize(int nkpts);
 
   /// K-Vector List.
   const std::shared_ptr<KContainer> KLists;
+  /// number of particles
+  const size_t num_ptcls;
+  /// number of species
+  const size_t num_species;
   /** Whether intermediate data is stored per particle. default false
    * storing data per particle needs significant amount of memory but some calculation may request it.
    * storing data per particle specie is more cost-effective

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -65,17 +65,17 @@ public:
    * @param P Reference particle set
    * @param kc cutoff for k
    */
-  StructFact(ParticleSet& P, RealType kc);
+  StructFact(const ParticleSet& P, RealType kc);
   /// desructor
   ~StructFact();
 
   /** Recompute Rhok if lattice changed
    * @param kc cut-off K
    */
-  void UpdateNewCell(ParticleSet& P, RealType kc);
+  void UpdateNewCell(const ParticleSet& P, RealType kc);
   /**  Update Rhok if all particles moved
    */
-  void UpdateAllPart(ParticleSet& P);
+  void UpdateAllPart(const ParticleSet& P);
 
   /** evaluate eikr_temp for eikr for the proposed move
    * @param active index of the moved particle
@@ -155,7 +155,7 @@ public:
    * if StorePerParticle was false, this function allocates memory and precompute data
    * if StorePerParticle was true, this function is no-op
    */
-  void turnOnStorePerParticle(ParticleSet& P);
+  void turnOnStorePerParticle(const ParticleSet& P);
 
   /// accessor of StorePerParticle
   bool isStorePerParticle() const { return StorePerParticle; }
@@ -165,7 +165,7 @@ public:
 
 private:
   /// Compute all rhok elements from the start
-  void FillRhok(ParticleSet& P);
+  void FillRhok(const ParticleSet& P);
   /** resize the internal data
    * @param np number of species
    * @param nptcl number of particles

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -47,8 +47,6 @@ public:
    * Allow overwriting lattice::SuperCellEnum to use D-dim k-point sets with mixed BC
    */
   int SuperCellEnum;
-  /// K-Vector List.
-  KContainer KLists;
   ///1-D container for the phase
   Vector<RealType> phiV;
   ///2-D container for the phase
@@ -162,6 +160,9 @@ public:
   /// accessor of StorePerParticle
   bool isStorePerParticle() const { return StorePerParticle; }
 
+  /// access KLists read only
+  const KContainer& getKLists() const { return *KLists; }
+
 private:
   /// Compute all rhok elements from the start
   void FillRhok(ParticleSet& P);
@@ -172,6 +173,8 @@ private:
    */
   void resize(int ns, int nptcl, int nkpts);
 
+  /// K-Vector List.
+  const std::shared_ptr<KContainer> KLists;
   /** Whether intermediate data is stored per particle. default false
    * storing data per particle needs significant amount of memory but some calculation may request it.
    * storing data per particle specie is more cost-effective

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -70,12 +70,12 @@ public:
   /** Recompute Rhok if lattice changed
    * @param kc cut-off K
    */
-  void UpdateNewCell(const ParticleSet& P, RealType kc);
+  void updateNewCell(const ParticleSet& P, RealType kc);
   /**  Update Rhok if all particles moved
    */
-  void UpdateAllPart(const ParticleSet& P);
+  void updateAllPart(const ParticleSet& P);
 
-  static void mw_UpdateAllPart(const RefVectorWithLeader<StructFact>& sk_list,
+  static void mw_updateAllPart(const RefVectorWithLeader<StructFact>& sk_list,
                                const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** evaluate eikr_temp for eikr for the proposed move
@@ -109,7 +109,7 @@ public:
 
 private:
   /// Compute all rhok elements from the start
-  void FillRhok(const ParticleSet& P);
+  void computeRhok(const ParticleSet& P);
   /** resize the internal data
    * @param np number of species
    * @param nptcl number of particles
@@ -124,7 +124,7 @@ private:
    * storing data per particle specie is more cost-effective
    */
   bool StorePerParticle;
-  /// timer for UpdateAllPart
+  /// timer for updateAllPart
   NewTimer& update_all_timer_;
 };
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/TwoDEwaldHandler.cpp
+++ b/src/Particle/LongRange/TwoDEwaldHandler.cpp
@@ -29,7 +29,7 @@ void TwoDEwaldHandler::initBreakup(ParticleSet& ref)
   Sigma /= LR_rc;
   app_log() << "  Sigma=" << Sigma << std::endl;
   Volume = ref.Lattice.Volume;
-  fillFk(ref.SK->KLists);
+  fillFk(ref.SK->getKLists());
 }
 
 TwoDEwaldHandler::TwoDEwaldHandler(const TwoDEwaldHandler& aLR, ParticleSet& ref)

--- a/src/Particle/LongRange/TwoDEwaldHandler.h
+++ b/src/Particle/LongRange/TwoDEwaldHandler.h
@@ -77,7 +77,7 @@ public:
    */
   inline RealType srDf(RealType r, RealType rinv) const override { return 0.0; }
 
-  void fillFk(KContainer& KList);
+  void fillFk(const KContainer& KList);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -48,7 +48,7 @@ TEST_CASE("StructFact", "[lrhandler]")
   ref.R[2] = {0.3, 4.0, 1.4};
   ref.R[3] = {3.2, 4.7, 0.7};
 
-  StructFact sk(ref, 50);
+  StructFact sk(tspecies.size(), ref.getTotalNum(), ref.LRBox, 50);
   REQUIRE(sk.getKLists().numk == 263786);
   sk.updateAllPart(ref);
 

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -49,7 +49,7 @@ TEST_CASE("StructFact", "[lrhandler]")
   ref.R[3] = {3.2, 4.7, 0.7};
 
   StructFact sk(ref, 50);
-  REQUIRE(sk.KLists.numk == 263786);
+  REQUIRE(sk.getKLists().numk == 263786);
   sk.UpdateAllPart(ref);
 
   std::vector<std::complex<double>> rhok_sum_ref{-125.80618630936, 68.199075127271};
@@ -57,7 +57,7 @@ TEST_CASE("StructFact", "[lrhandler]")
   for (int i = 0; i < ref.groups(); i++)
   {
     std::complex<QMCTraits::RealType> rhok_sum, rhok_even_sum;
-    for (int ik = 0; ik < sk.KLists.numk; ik++)
+    for (int ik = 0; ik < sk.getKLists().numk; ik++)
       rhok_sum += std::complex<QMCTraits::RealType>(sk.rhok_r[i][ik], sk.rhok_i[i][ik]);
 
     //std::cout << std::setprecision(14) << rhok_sum << std::endl;

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -50,7 +50,7 @@ TEST_CASE("StructFact", "[lrhandler]")
 
   StructFact sk(ref, 50);
   REQUIRE(sk.getKLists().numk == 263786);
-  sk.UpdateAllPart(ref);
+  sk.updateAllPart(ref);
 
   std::vector<std::complex<double>> rhok_sum_ref{-125.80618630936, 68.199075127271};
 

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -35,10 +35,9 @@ TEST_CASE("ewald3d", "[lrhandler]")
   REQUIRE(Lattice.LR_rc == Approx(2.5));
   REQUIRE(Lattice.LR_kc == Approx(12));
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.KLists
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   EwaldHandler3D handler(ref, Lattice.LR_kc);
 
   // make sure initBreakup changes the default sigma
@@ -83,10 +82,9 @@ TEST_CASE("ewald3d df", "[lrhandler]")
   REQUIRE(Lattice.LR_rc == Approx(2.5));
   REQUIRE(Lattice.LR_kc == Approx(12));
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.KLists
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   EwaldHandler3D handler(ref, Lattice.LR_kc);
 
   // make sure initBreakup changes the default sigma

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -40,7 +40,7 @@ TEST_CASE("dummy", "[lrhandler]")
   REQUIRE(Lattice.LR_rc == Approx(2.5));
   REQUIRE(Lattice.LR_kc == Approx(12));
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
+  ParticleSet ref;          // handler needs ref.SK.getKLists()
   ref.Lattice    = Lattice; // !!!! crucial for access to Volume
   ref.LRBox      = Lattice; // !!!! crucial for S(k) update
   ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
@@ -61,13 +61,13 @@ TEST_CASE("dummy", "[lrhandler]")
   //  the full Coulomb potential should be retained in kspace
   for (int ish = 0; ish < handler.MaxKshell; ish++)
   {
-    int ik           = ref.SK->KLists.kshell[ish];
-    double k2        = ref.SK->KLists.ksq[ik];
+    int ik           = ref.SK->getKLists().kshell[ish];
+    double k2        = ref.SK->getKLists().ksq[ik];
     double fk_expect = fk(k2);
     REQUIRE(handler.Fk_symm[ish] == Approx(norm * fk_expect));
   }
   // ?? cannot access base class method, too many overloads?
-  // handler.evaluate(SK->KLists.kshell, rhok1.data(), rhok2.data());
+  // handler.evaluate(SK->getKLists().kshell, rhok1.data(), rhok2.data());
 }
 
 } // namespace qmcplusplus

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -40,10 +40,9 @@ TEST_CASE("dummy", "[lrhandler]")
   REQUIRE(Lattice.LR_rc == Approx(2.5));
   REQUIRE(Lattice.LR_kc == Approx(12));
 
-  ParticleSet ref;          // handler needs ref.SK.getKLists()
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.getKLists()
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   DummyLRHandler<CoulombF2> handler(Lattice.LR_kc);
 
   handler.initBreakup(ref);

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -46,10 +46,9 @@ TEST_CASE("srcoul", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_rc) == 2.5);
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.KLists
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 
   handler.initBreakup(ref);
@@ -89,10 +88,9 @@ TEST_CASE("srcoul df", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_rc) == 2.5);
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.KLists
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 
   handler.initBreakup(ref);

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -28,7 +28,7 @@ struct EslerCoulomb3D
   inline double Xk(double k, double rc) const { return -norm / (k * k) * std::cos(k * rc); }
   inline double Fk(double k, double rc) const { return -Xk(k, rc); }
   inline double integrate_r2(double r) const { return 0.5 * r * r; }
-  inline double df(double r) const { return 0; }                // ignore derivatives for now
+  inline double df(double r) const { return 0; }          // ignore derivatives for now
   void reset(ParticleSet& ref, double rs) { reset(ref); } // ignore rs
 };
 
@@ -47,10 +47,9 @@ TEST_CASE("temp3d", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_rc) == 2.5);
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
-  ParticleSet ref;          // handler needs ref.SK.KLists
-  ref.Lattice    = Lattice; // !!!! crucial for access to Volume
-  ref.LRBox      = Lattice; // !!!! crucial for S(k) update
-  ref.SK         = std::make_unique<StructFact>(ref, Lattice.LR_kc);
+  ParticleSet ref;       // handler needs ref.SK.KLists
+  ref.Lattice = Lattice; // !!!! crucial for access to Volume
+  ref.createSK();
   LRHandlerTemp<EslerCoulomb3D, LPQHIBasis> handler(ref);
 
   handler.initBreakup(ref);

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -394,7 +394,7 @@ void MCWalkerConfiguration::allocateGPU(size_t buffersize)
   int N    = WalkerList[0]->R.size();
   int Numk = 0;
   if (SK)
-    Numk = SK->KLists.numk;
+    Numk = SK->getKLists().numk;
   int NumSpecies = getSpeciesSet().TotalNum;
   for (int iw = 0; iw < WalkerList.size(); iw++)
   {

--- a/src/Particle/ParticleSet.BC.cpp
+++ b/src/Particle/ParticleSet.BC.cpp
@@ -69,7 +69,7 @@ void ParticleSet::createSK()
     }
 
     app_log() << "\n  Creating Structure Factor for periodic systems " << LRBox.LR_kc << std::endl;
-    SK = std::make_unique<StructFact>(*this, LRBox.LR_kc);
+    SK = std::make_unique<StructFact>(mySpecies.size(), TotalNum, LRBox, LRBox.LR_kc);
   }
 
   //set the mass array

--- a/src/Particle/ParticleSet.BC.cpp
+++ b/src/Particle/ParticleSet.BC.cpp
@@ -28,43 +28,8 @@ namespace qmcplusplus
  */
 void ParticleSet::createSK()
 {
-  //if(!sorted_ids && !reordered_ids)
-  //{
-  //  //save ID and GroupID
-  //  orgID=ID;
-  //  orgGroupID=GroupID;
-  //  if(groups()<1)
-  //  {
-  //    int nspecies=mySpecies.getTotalNum();
-  //    std::vector<int> ppg(nspecies,0);
-  //    for(int iat=0; iat<GroupID.size(); ++iat) ppg[GroupID[iat]]+=1;
-  //    SubPtcl.resize(nspecies+1);
-  //    SubPtcl[0]=0;
-  //    for(int i=0; i<nspecies; ++i) SubPtcl[i+1]=SubPtcl[i]+ppg[i];
-  //    int new_id=0;
-  //    for(int i=0; i<nspecies; ++i)
-  //      for(int iat=0; iat<GroupID.size(); ++iat) if(GroupID[iat]==i) orgID[new_id++]=ID[iat];
-  //    bool grouped=true;
-  //    for(int iat=0; iat<ID.size(); ++iat) grouped &= (orgID[iat]==ID[iat]);
-  //    if(grouped)
-  //    {
-  //      app_log() << "  ParticleSet is grouped. No need to reorder." << std::endl;
-  //    }
-  //    else
-  //    {
-  //      app_log() << "  Need to reorder. Only R is swapped." << std::endl;
-  //      ParticlePos_t oldR(R);
-  //      for(int iat=0; iat<R.size(); ++iat) R[iat]=oldR[orgID[iat]];
-  //      for(int i=0; i<groups(); ++i)
-  //        for(int iat=first(i); iat<last(i); ++iat) GroupID[iat]=i;
-  //      reordered_ids=true;
-  //    }
-  //  }//once group is set, nothing to be done
-  //  sorted_ids=true;
-  //}
-  //int membersize= mySpecies.addAttribute("membersize");
-  //for(int ig=0; ig<mySpecies.size(); ++ig)
-  //  SubPtcl[ig+1]=SubPtcl[ig]+mySpecies(membersize,ig);
+  if (SK)
+    throw std::runtime_error("Report bug! SK has already been created. Unexpected call sequence.");
 
   if (Lattice.explicitly_defined)
     convert2Cart(R); //make sure that R is in Cartesian coordinates
@@ -103,20 +68,10 @@ void ParticleSet::createSK()
       app_log() << "--------------------------------------- " << std::endl;
     }
 
-    if (SK)
-    {
-      app_log() << "\n  Structure Factor is reset by " << Lattice.LR_kc << std::endl;
-      SK->UpdateNewCell(*this, LRBox.LR_kc);
-    }
-    else
-    {
-      app_log() << "\n  Creating Structure Factor for periodic systems " << LRBox.LR_kc << std::endl;
-      SK = std::make_unique<StructFact>(*this, LRBox.LR_kc);
-    }
-    //Lattice.print(app_log());
-    //This uses the copy constructor to avoid recomputing the data.
-    //SKOld = new StructFact(*SK);
+    app_log() << "\n  Creating Structure Factor for periodic systems " << LRBox.LR_kc << std::endl;
+    SK = std::make_unique<StructFact>(*this, LRBox.LR_kc);
   }
+
   //set the mass array
   int beforemass = mySpecies.numAttributes();
   int massind    = mySpecies.addAttribute("mass");

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -811,9 +811,16 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
   for (ParticleSet& pset : p_list)
   {
     pset.coordinates_->donePbyP();
-    if (pset.SK && !pset.SK->DoUpdate)
-      pset.SK->UpdateAllPart(pset);
     pset.activePtcl = -1;
+  }
+
+  if (p_leader.SK && !p_leader.SK->DoUpdate)
+  {
+    RefVectorWithLeader<StructFact> sk_list(*p_leader.SK);
+    sk_list.reserve(p_list.size());
+    for (ParticleSet& pset : p_list)
+      sk_list.push_back(*pset.SK);
+    StructFact::mw_UpdateAllPart(sk_list, p_list);
   }
 
   auto& dts = p_leader.DistTables;

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -816,10 +816,7 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
 
   if (p_leader.SK && !p_leader.SK->DoUpdate)
   {
-    RefVectorWithLeader<StructFact> sk_list(*p_leader.SK);
-    sk_list.reserve(p_list.size());
-    for (ParticleSet& pset : p_list)
-      sk_list.push_back(*pset.SK);
+    auto sk_list = extractSKRefList(p_list);
     StructFact::mw_UpdateAllPart(sk_list, p_list);
   }
 
@@ -1032,6 +1029,15 @@ RefVectorWithLeader<DynamicCoordinates> ParticleSet::extractCoordsRefList(
   for (ParticleSet& p : p_list)
     coords_list.push_back(*p.coordinates_);
   return coords_list;
+}
+
+RefVectorWithLeader<StructFact> ParticleSet::extractSKRefList(const RefVectorWithLeader<ParticleSet>& p_list)
+{
+  RefVectorWithLeader<StructFact> sk_list(*p_list.getLeader().SK);
+  sk_list.reserve(p_list.size());
+  for (ParticleSet& p : p_list)
+    sk_list.push_back(*p.SK);
+  return sk_list;
 }
 
 } // namespace qmcplusplus

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -396,7 +396,7 @@ void ParticleSet::update(bool skipSK)
   for (int i = 0; i < DistTables.size(); i++)
     DistTables[i]->evaluate(*this);
   if (!skipSK && SK)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
 
   activePtcl = -1;
 }
@@ -420,7 +420,7 @@ void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool
   {
 #pragma omp parallel for
     for (int iw = 0; iw < p_list.size(); iw++)
-      p_list[iw].SK->UpdateAllPart(p_list[iw]);
+      p_list[iw].SK->updateAllPart(p_list[iw]);
   }
 }
 
@@ -556,7 +556,7 @@ bool ParticleSet::makeMoveAllParticles(const Walker_t& awalker, const ParticlePo
   for (int i = 0; i < DistTables.size(); i++)
     DistTables[i]->evaluate(*this);
   if (SK)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
   //every move is valid
   return true;
 }
@@ -588,7 +588,7 @@ bool ParticleSet::makeMoveAllParticles(const Walker_t& awalker,
   for (int i = 0; i < DistTables.size(); i++)
     DistTables[i]->evaluate(*this);
   if (SK)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
   //every move is valid
   return true;
 }
@@ -628,7 +628,7 @@ bool ParticleSet::makeMoveAllParticlesWithDrift(const Walker_t& awalker,
   for (int i = 0; i < DistTables.size(); i++)
     DistTables[i]->evaluate(*this);
   if (SK)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
   //every move is valid
   return true;
 }
@@ -662,7 +662,7 @@ bool ParticleSet::makeMoveAllParticlesWithDrift(const Walker_t& awalker,
   for (int i = 0; i < DistTables.size(); i++)
     DistTables[i]->evaluate(*this);
   if (SK)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
   //every move is valid
   return true;
 }
@@ -797,7 +797,7 @@ void ParticleSet::donePbyP()
   ScopedTimer donePbyP_scope(myTimers[PS_donePbyP]);
   coordinates_->donePbyP();
   if (SK && !SK->DoUpdate)
-    SK->UpdateAllPart(*this);
+    SK->updateAllPart(*this);
   for (size_t i = 0; i < DistTables.size(); ++i)
     DistTables[i]->finalizePbyP(*this);
   activePtcl = -1;
@@ -817,7 +817,7 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
   if (p_leader.SK && !p_leader.SK->DoUpdate)
   {
     auto sk_list = extractSKRefList(p_list);
-    StructFact::mw_UpdateAllPart(sk_list, p_list);
+    StructFact::mw_updateAllPart(sk_list, p_list);
   }
 
   auto& dts = p_leader.DistTables;
@@ -854,7 +854,7 @@ void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)
         DistTables[i]->evaluate(*this);
     //computed so that other objects can use them, e.g., kSpaceJastrow
     if (SK && SK->DoUpdate)
-      SK->UpdateAllPart(*this);
+      SK->updateAllPart(*this);
   }
 
   activePtcl = -1;
@@ -891,7 +891,7 @@ void ParticleSet::mw_loadWalker(const RefVectorWithLeader<ParticleSet>& p_list,
     {
 #pragma omp parallel for
       for (int iw = 0; iw < p_list.size(); iw++)
-        p_list[iw].SK->UpdateAllPart(p_list[iw]);
+        p_list[iw].SK->updateAllPart(p_list[iw]);
     }
   }
 }

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -663,6 +663,7 @@ public:
   static RefVectorWithLeader<DistanceTableData> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                  int id);
   static RefVectorWithLeader<DynamicCoordinates> extractCoordsRefList(const RefVectorWithLeader<ParticleSet>& p_list);
+  static RefVectorWithLeader<StructFact> extractSKRefList(const RefVectorWithLeader<ParticleSet>& p_list);
 
 protected:
   /** map to handle distance tables

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -130,59 +130,60 @@ TEST_CASE("symmetric_distance_table PBC", "[particle]")
 
 TEST_CASE("particle set lattice with vacuum", "[particle]")
 {
-  ParticleSet source;
-
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   // PPP case
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true;
-  Lattice.R(0)      = 1.0;
-  Lattice.R(1)      = 2.0;
-  Lattice.R(2)      = 3.0;
-
-  Lattice.R(3) = 0.0;
-  Lattice.R(4) = 1.0;
-  Lattice.R(5) = 0.0;
-
-  Lattice.R(6) = 0.0;
-  Lattice.R(7) = 0.0;
-  Lattice.R(8) = 1.0;
+  Lattice.R = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
 
   Lattice.VacuumScale = 2.0;
   Lattice.reset();
+  {
+    ParticleSet source;
+    source.setName("electrons");
+    source.Lattice = Lattice;
+    source.createSK();
 
-  source.setName("electrons");
-  source.Lattice = Lattice;
-  source.createSK();
-
-  REQUIRE(source.LRBox.R(0, 0) == 1.0);
-  REQUIRE(source.LRBox.R(0, 1) == 2.0);
-  REQUIRE(source.LRBox.R(0, 2) == 3.0);
+    CHECK(Lattice.SuperCellEnum == SUPERCELL_BULK);
+    CHECK(source.LRBox.R(0, 0) == 1.0);
+    CHECK(source.LRBox.R(0, 1) == 2.0);
+    CHECK(source.LRBox.R(0, 2) == 3.0);
+  }
 
   // PPN case
   Lattice.BoxBConds[2] = false;
   Lattice.reset();
-  source.Lattice = Lattice;
-  source.createSK();
+  {
+    ParticleSet source;
+    source.setName("electrons");
+    source.Lattice = Lattice;
+    source.createSK();
 
-  REQUIRE(source.LRBox.R(2, 0) == 0.0);
-  REQUIRE(source.LRBox.R(2, 1) == 0.0);
-  REQUIRE(source.LRBox.R(2, 2) == 2.0);
+    CHECK(Lattice.SuperCellEnum == SUPERCELL_SLAB);
+    CHECK(source.LRBox.R(2, 0) == 0.0);
+    CHECK(source.LRBox.R(2, 1) == 0.0);
+    CHECK(source.LRBox.R(2, 2) == 2.0);
+  }
 
   // PNN case
   Lattice.BoxBConds[1] = false;
   Lattice.reset();
-  source.Lattice = Lattice;
-  source.createSK();
+  {
+    ParticleSet source;
+    source.setName("electrons");
+    source.Lattice = Lattice;
+    source.createSK();
 
-  REQUIRE(source.LRBox.R(0, 0) == 1.0);
-  REQUIRE(source.LRBox.R(0, 1) == 2.0);
-  REQUIRE(source.LRBox.R(0, 2) == 3.0);
-  REQUIRE(source.LRBox.R(1, 0) == 0.0);
-  REQUIRE(source.LRBox.R(1, 1) == 2.0);
-  REQUIRE(source.LRBox.R(1, 2) == 0.0);
-  REQUIRE(source.LRBox.R(2, 0) == 0.0);
-  REQUIRE(source.LRBox.R(2, 1) == 0.0);
-  REQUIRE(source.LRBox.R(2, 2) == 2.0);
+    CHECK(Lattice.SuperCellEnum == SUPERCELL_WIRE);
+    CHECK(source.LRBox.R(0, 0) == 1.0);
+    CHECK(source.LRBox.R(0, 1) == 2.0);
+    CHECK(source.LRBox.R(0, 2) == 3.0);
+    CHECK(source.LRBox.R(1, 0) == 0.0);
+    CHECK(source.LRBox.R(1, 1) == 2.0);
+    CHECK(source.LRBox.R(1, 2) == 0.0);
+    CHECK(source.LRBox.R(2, 0) == 0.0);
+    CHECK(source.LRBox.R(2, 1) == 0.0);
+    CHECK(source.LRBox.R(2, 2) == 2.0);
+  }
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -229,10 +229,10 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate_sp(ParticleSet& P)
         {
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += z * Zspec[s] *
-              AA->evaluate(PtclRhoK.KLists.kshell, PtclRhoK.rhok_r[s], PtclRhoK.rhok_i[s], PtclRhoK.eikr_r[i],
+              AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[s], PtclRhoK.rhok_i[s], PtclRhoK.eikr_r[i],
                            PtclRhoK.eikr_i[i]);
 #else
-          v1 += z * Zspec[s] * AA->evaluate(PtclRhoK.KLists.kshell, PtclRhoK.rhok[s], PtclRhoK.eikr[i]);
+          v1 += z * Zspec[s] * AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[s], PtclRhoK.eikr[i]);
 #endif
         }
         V_samp(i) += v1;
@@ -479,7 +479,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
       for (int jat = 0; jat < iat; ++jat)
         u += Zat[jat] *
             AA->evaluate_slab(-d_slab[jat], //JK: Could be wrong. Check the SIGN
-                              PtclRhoK.KLists.kshell, PtclRhoK.eikr[iat], PtclRhoK.eikr[jat]);
+                              PtclRhoK.getKLists().kshell, PtclRhoK.eikr[iat], PtclRhoK.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }
@@ -492,10 +492,10 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
       for (int spec2 = spec1; spec2 < NumSpecies; spec2++)
       {
 #if defined(USE_REAL_STRUCT_FACTOR)
-        mRealType temp = AA->evaluate(PtclRhoK.KLists.kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
+        mRealType temp = AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
                                       PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
 #else
-        mRealType temp = AA->evaluate(PtclRhoK.KLists.kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
+        mRealType temp = AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
 #endif
         if (spec2 == spec1)
           temp *= 0.5;

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -70,11 +70,11 @@ void CoulombPBCAA_CUDA::setupLongRangeGPU(ParticleSet& P)
   if (is_active)
   {
     StructFact& SK = *(P.SK);
-    Numk           = SK.KLists.numk;
+    Numk           = SK.getKLists().numk;
     gpu::host_vector<CUDA_PRECISION_FULL> kpointsHost(OHMMS_DIM * Numk);
     for (int ik = 0; ik < Numk; ik++)
       for (int dim = 0; dim < OHMMS_DIM; dim++)
-        kpointsHost[ik * OHMMS_DIM + dim] = SK.KLists.kpts_cart[ik][dim];
+        kpointsHost[ik * OHMMS_DIM + dim] = SK.getKLists().kpts_cart[ik][dim];
     kpointsGPU = kpointsHost;
     gpu::host_vector<CUDA_PRECISION_FULL> FkHost(Numk);
     for (int ik = 0; ik < Numk; ik++)

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -181,9 +181,9 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesA; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Zspec[s] * q *
-              AB->evaluate(RhoKA.KLists.kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i], RhoKB.eikr_i[i]);
+              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i], RhoKB.eikr_i[i]);
 #else
-          v1 += Zspec[s] * q * AB->evaluate(RhoKA.KLists.kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
+          v1 += Zspec[s] * q * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
 #endif
         Ve_samp(i) += v1;
         Vlr += v1;
@@ -195,9 +195,9 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesB; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Qspec[s] * q *
-              AB->evaluate(RhoKB.KLists.kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i], RhoKA.eikr_i[i]);
+              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i], RhoKA.eikr_i[i]);
 #else
-          v1 += Qspec[s] * q * AB->evaluate(RhoKB.KLists.kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
+          v1 += Qspec[s] * q * AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
 #endif
         Vi_samp(i) += v1;
         Vlr += v1;
@@ -331,7 +331,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
 #if !defined(USE_REAL_STRUCT_FACTOR)
       const int slab_dir = OHMMS_DIM - 1;
       for (int nn = d_ab.M[iat], jat = 0; nn < d_ab.M[iat + 1]; ++nn, ++jat)
-        u += Qat[jat] * AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.KLists.kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
+        u += Qat[jat] * AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }
@@ -345,9 +345,9 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
       {
 #if defined(USE_REAL_STRUCT_FACTOR)
         esum += Qspec[j] *
-            AB->evaluate(RhoKA.KLists.kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
+            AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
 #else
-        esum += Qspec[j] * AB->evaluate(RhoKA.KLists.kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
+        esum += Qspec[j] * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
 #endif
       } //speceln
       res += Zspec[i] * esum;

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -103,11 +103,11 @@ void CoulombPBCAB_CUDA::add(int groupID, std::unique_ptr<RadFunctorType>&& ppot)
 void CoulombPBCAB_CUDA::setupLongRangeGPU()
 {
   StructFact& SK = *(ElecRef.SK);
-  Numk           = SK.KLists.numk;
+  Numk           = SK.getKLists().numk;
   gpu::host_vector<CUDA_PRECISION_FULL> kpointsHost(OHMMS_DIM * Numk);
   for (int ik = 0; ik < Numk; ik++)
     for (int dim = 0; dim < OHMMS_DIM; dim++)
-      kpointsHost[ik * OHMMS_DIM + dim] = SK.KLists.kpts_cart[ik][dim];
+      kpointsHost[ik * OHMMS_DIM + dim] = SK.getKLists().kpts_cart[ik][dim];
   kpointsGPU = kpointsHost;
   gpu::host_vector<CUDA_PRECISION_FULL> FkHost(Numk);
   for (int ik = 0; ik < Numk; ik++)
@@ -120,7 +120,7 @@ void CoulombPBCAB_CUDA::setupLongRangeGPU()
   {
     for (int ik = 0; ik < Numk; ik++)
     {
-      PosType k                 = SK.KLists.kpts_cart[ik];
+      PosType k                 = SK.getKLists().kpts_cart[ik];
       RhokIons_host[2 * ik + 0] = 0.0;
       RhokIons_host[2 * ik + 1] = 0.0;
       for (int ion = IonFirst[sp]; ion <= IonLast[sp]; ion++)

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -31,9 +31,9 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   NumIonSpecies = ions->getSpeciesSet().getTotalNum();
   UpdateMode.set(COLLECTABLE, 1);
 
-  NumK      = source.SK->KLists.numk;
+  NumK      = source.SK->getKLists().numk;
   OneOverN  = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell    = source.SK->KLists.kshell;
+  Kshell    = source.SK->getKLists().kshell;
   MaxKshell = Kshell.size() - 1;
 
 #if defined(USE_REAL_STRUCT_FACTOR)
@@ -50,7 +50,7 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.SK->KLists.ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.SK->getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
   hdf5_out = false;
@@ -75,7 +75,7 @@ void SkAllEstimator::evaluateIonIon()
 
   for (int k = 0; k < NumK; k++)
   {
-    PosType kvec = ions->SK->KLists.kpts_cart[k];
+    PosType kvec = ions->SK->getKLists().kpts_cart[k];
 
     filebuffer << kvec;
     for (int i = 0; i < NumIonSpecies; i++)
@@ -279,7 +279,7 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
     h5desc.emplace_back("kpoints");
     auto& ohKPoints = h5desc.back();
     ohKPoints.open(sgid); // add to SkAll hdf group
-    ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->SK->KLists.kpts_cart), "value");
+    ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->SK->getKLists().kpts_cart), "value");
 
     // Add electron-electron S(k)
     std::vector<int> ng(1);

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -25,9 +25,9 @@ SkEstimator::SkEstimator(ParticleSet& source)
   sourcePtcl = &source;
   UpdateMode.set(COLLECTABLE, 1);
   NumSpecies = source.getSpeciesSet().getTotalNum();
-  NumK       = source.SK->KLists.numk;
+  NumK       = source.SK->getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell     = source.SK->KLists.kshell;
+  Kshell     = source.SK->getKLists().kshell;
   MaxKshell  = Kshell.size() - 1;
 #if defined(USE_REAL_STRUCT_FACTOR)
   RhokTot_r.resize(NumK);
@@ -40,7 +40,7 @@ SkEstimator::SkEstimator(ParticleSet& source)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.SK->KLists.ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.SK->getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
   hdf5_out = true;
@@ -154,7 +154,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
     hid_t k_set       = H5Dcreate(gid, kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);
-    RealType* ptr     = &(sourcePtcl->SK->KLists.kpts_cart[0][0]);
+    auto* ptr         = &(sourcePtcl->SK->getKLists().kpts_cart[0][0]);
     herr_t ret        = H5Dwrite(k_set, H5T_NATIVE_DOUBLE, mem_space, k_space, H5P_DEFAULT, ptr);
     H5Dclose(k_set);
     H5Sclose(mem_space);

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -22,9 +22,9 @@ SkPot::SkPot(ParticleSet& source)
 {
   sourcePtcl = &source;
   NumSpecies = source.getSpeciesSet().getTotalNum();
-  NumK       = source.SK->KLists.numk;
+  NumK       = source.SK->getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell     = source.SK->KLists.kshell;
+  Kshell     = source.SK->getKLists().kshell;
   MaxKshell  = Kshell.size() - 1;
   RhokTot.resize(NumK);
   Fk.resize(NumK);
@@ -32,7 +32,7 @@ SkPot::SkPot(ParticleSet& source)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.SK->KLists.ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.SK->getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
 }

--- a/src/QMCHamiltonians/SkPot.h
+++ b/src/QMCHamiltonians/SkPot.h
@@ -41,7 +41,7 @@ public:
   {
     for (int ki = 0; ki < NumK; ki++)
     {
-      RealType k = dot(sourcePtcl->SK->KLists.kpts_cart[ki], sourcePtcl->SK->KLists.kpts_cart[ki]);
+      RealType k = dot(sourcePtcl->SK->getKLists().kpts_cart[ki], sourcePtcl->SK->getKLists().kpts_cart[ki]);
       k          = std::sqrt(k) - K_0;
       Fk[ki]     = OneOverN * V_0 * std::exp(-k * k);
       //         app_log()<<ki<<": "<<Fk[ki] << std::endl;

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -54,7 +54,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 {
   using std::sqrt;
   reset();
-  const k2_t& k2_init = Pinit.SK->KLists.ksq;
+  const k2_t& k2_init = Pinit.SK->getKLists().ksq;
 
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
@@ -113,7 +113,7 @@ void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& 
   h5desc.emplace_back("kpoints");
   auto& oh = h5desc.back();
   oh.open(sgid); // add to SkAll hdf group
-  oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.SK->KLists.kpts_cart), "value");
+  oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.SK->getKLists().kpts_cart), "value");
 
   std::vector<int> ng(2);
   ng[0] = 2;

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -105,9 +105,9 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AB(ParticleSet& 
     {
 #if defined(USE_REAL_STRUCT_FACTOR)
       esum += Qspec[j] *
-          AA->evaluateStress(RhoKA.KLists.kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
+          AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
 #else
-      esum += Qspec[j] * AA->evaluateStress(RhoKA.KLists.kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
+      esum += Qspec[j] * AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
 
 #endif
     }
@@ -182,10 +182,10 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AA(ParticleSet& 
     {
 #if !defined(USE_REAL_STRUCT_FACTOR)
       SymTensor<RealType, OHMMS_DIM> temp =
-          AA->evaluateStress(PtclRhoK.KLists.kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
+          AA->evaluateStress(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
 #else
       SymTensor<RealType, OHMMS_DIM> temp =
-          AA->evaluateStress(PtclRhoK.KLists.kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
+          AA->evaluateStress(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
                              PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
 #endif
       if (spec2 == spec1)

--- a/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
@@ -210,8 +210,8 @@ TEST_CASE("SkAll", "[hamiltonian]")
   // takes that pre-computed s(k) and pulls out rho(k)..
   // In order to compare to analytic result, need the list
   // of k-vectors in cartesian coordinates.
-  // Luckily, ParticleSet stores that in SK->KLists.kpts_cart
-  int nkpts      = elec->SK->KLists.numk;
+  // Luckily, ParticleSet stores that in SK->getKLists().kpts_cart
+  int nkpts      = elec->SK->getKLists().numk;
   std::cout << "\n";
   std::cout << "SkAll results:\n";
   std::cout << std::fixed;
@@ -232,7 +232,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   std::cout << std::setprecision(5);
   for (int k = 0; k < nkpts; k++)
   {
-    auto kvec      = elec->SK->KLists.kpts_cart[k];
+    auto kvec      = elec->SK->getKLists().kpts_cart[k];
     RealType kx    = kvec[0];
     RealType ky    = kvec[1];
     RealType kz    = kvec[2];

--- a/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_CUDA.cpp
@@ -53,6 +53,7 @@ TEST_CASE("Coulomb PBC A-B CUDA", "[hamiltonian][CUDA]")
   ion_species(pChargeIdx, pIdx) = 1;
   ions.Lattice                  = Lattice;
   ions.createSK();
+  ions.update();
 
 
   elec.Lattice = Lattice;
@@ -115,6 +116,7 @@ TEST_CASE("Coulomb PBC AB CUDA BCC H", "[hamiltonian][CUDA]")
   ion_species(pChargeIdx, pIdx) = 1;
   ions.Lattice                  = Lattice;
   ions.createSK();
+  ions.update();
 
 
   elec.Lattice = Lattice;

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -53,6 +53,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   ion_species(pMembersizeIdx, pIdx) = 1;
   ions.Lattice                      = Lattice;
   ions.createSK();
+  ions.update();
 
 
   elec.Lattice = Lattice;
@@ -71,10 +72,9 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   tspecies(chargeIdx, upIdx)     = -1;
   tspecies(massIdx, upIdx)       = 1.0;
 
-  elec.createSK();
-
-  elec.addTable(ions);
   elec.resetGroups();
+  elec.createSK();
+  elec.addTable(ions);
   elec.update();
 
 
@@ -126,7 +126,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   ion_species(pMembersizeIdx, pIdx) = 2;
   ions.Lattice                      = Lattice;
   ions.createSK();
-
+  ions.update();
 
   elec.Lattice = Lattice;
   elec.setName("elec");
@@ -147,10 +147,9 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   tspecies(chargeIdx, upIdx)     = -1;
   tspecies(massIdx, upIdx)       = 1.0;
 
-  elec.createSK();
-
-  elec.addTable(ions);
   elec.resetGroups();
+  elec.createSK();
+  elec.addTable(ions);
   elec.update();
 
   CoulombPBCAB cab(ions, elec);

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB_ewald.cpp
@@ -53,6 +53,7 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   ion_species(pMembersizeIdx, pIdx) = 1;
   ions.Lattice                      = Lattice;
   ions.createSK();
+  ions.update();
 
 
   elec.Lattice = Lattice;
@@ -71,8 +72,8 @@ TEST_CASE("Coulomb PBC A-B Ewald3D", "[hamiltonian]")
   tspecies(chargeIdx, upIdx)     = -1;
   tspecies(massIdx, upIdx)       = 1.0;
 
+  elec.resetGroups();
   elec.createSK();
-
   elec.addTable(ions);
   elec.update();
 
@@ -133,6 +134,7 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   ion_species(pMembersizeIdx, pIdx) = 2;
   ions.Lattice                      = Lattice;
   ions.createSK();
+  ions.update();
 
 
   elec.Lattice = Lattice;
@@ -155,10 +157,9 @@ TEST_CASE("Coulomb PBC A-B BCC H Ewald3D", "[hamiltonian]")
   tspecies(chargeIdx, upIdx)     = -1;
   tspecies(massIdx, upIdx)       = 1.0;
 
-  elec.createSK();
-
-  elec.addTable(ions);
   elec.resetGroups();
+  elec.createSK();
+  elec.addTable(ions);
   elec.update();
 
 

--- a/src/QMCHamiltonians/tests/test_stress.cpp
+++ b/src/QMCHamiltonians/tests/test_stress.cpp
@@ -54,8 +54,9 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
   int pChargeIdx                = ion_species.addAttribute("charge");
   ion_species(pChargeIdx, pIdx) = 1;
   ions.Lattice = Lattice;
+  ions.resetGroups();
   ions.createSK();
-
+  ions.update();
 
   elec.Lattice = Lattice;
   elec.setName("elec");
@@ -75,13 +76,10 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
   tspecies(chargeIdx, upIdx)   = -1;
   tspecies(massIdx, upIdx)     = 1.0;
 
-  elec.createSK();
-
-  ions.resetGroups();
-
   // The call to resetGroups is needed transfer the SpeciesSet
   // settings to the ParticleSet
   elec.resetGroups();
+  elec.createSK();
 
   TrialWaveFunction psi;
 

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -367,7 +367,7 @@ void QMCFiniteSize::initialize()
   Vol   = P->Lattice.Volume;
   rs    = std::pow(3.0 / (4 * M_PI) * Vol / RealType(Ne), 1.0 / 3.0);
   rho   = RealType(Ne) / Vol;
-  Klist = P->SK->KLists;
+  Klist = P->SK->getKLists();
   kpts  = Klist.kpts; //These are in reduced coordinates.
                       //Easier to spline, but will have to convert
                       //for real space integration.

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -418,8 +418,8 @@ void BackflowBuilder::addRPA(xmlNodePtr cur)
       Rs = 100.0;
     }
   }
-  int indx        = targetPtcl.SK->KLists.ksq.size() - 1;
-  RealType Kc_max = std::pow(targetPtcl.SK->KLists.ksq[indx], 0.5);
+  int indx        = targetPtcl.SK->getKLists().ksq.size() - 1;
+  RealType Kc_max = std::pow(targetPtcl.SK->getKLists().ksq[indx], 0.5);
   if (Kc < 0)
   {
     Kc = 2.0 * std::pow(2.25 * M_PI, 1.0 / 3.0) / tlen;
@@ -575,7 +575,7 @@ void BackflowBuilder::makeLongRange_twoBody(xmlNodePtr cur, Backflow_ee_kSpace* 
         fout << "# Backflow longrange  \n";
         for (int i = 0; i < tbfks->NumKShells; i++)
         {
-          fout << std::pow(targetPtcl.SK->KLists.ksq[targetPtcl.SK->KLists.kshell[i]], 0.5) << " " << yk[i]
+          fout << std::pow(targetPtcl.SK->getKLists().ksq[targetPtcl.SK->getKLists().kshell[i]], 0.5) << " " << yk[i]
                << std::endl;
         }
         fout.close();

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
@@ -264,7 +264,7 @@ public:
     copy(P.SK->rhok[0], P.SK->rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.SK->rhok[spec1], P.SK->rhok[spec1] + NumKVecs, Rhok.data());
-    const KContainer::VContainer_t& Kcart(P.SK->getKLists().kpts_cart);
+    const auto& Kcart(P.SK->getKLists().kpts_cart);
     std::vector<int>& kshell(P.SK->getKLists().kshell);
     for (int iel = 0; iel < NumTargets; iel++)
     {
@@ -302,7 +302,7 @@ public:
     copy(P.SK->rhok[0], P.SK->rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.SK->rhok[spec1], P.SK->rhok[spec1] + NumKVecs, Rhok.data());
-    const KContainer::VContainer_t& Kcart(P.SK->getKLists().kpts_cart);
+    const auto& Kcart(P.SK->getKLists().kpts_cart);
     std::vector<int>& kshell(P.SK->getKLists().kshell);
     GradType fact;
     HessType kakb;

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
@@ -66,7 +66,7 @@ public:
   {
     NumKShells = yk.size();
     Fk         = yk;
-    NumKVecs   = P.SK->KLists.kshell[NumKShells + 1];
+    NumKVecs   = P.SK->getKLists().kshell[NumKShells + 1];
     Rhok.resize(NumKVecs);
     if (Optimize)
       numParams = NumKShells;
@@ -264,8 +264,8 @@ public:
     copy(P.SK->rhok[0], P.SK->rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.SK->rhok[spec1], P.SK->rhok[spec1] + NumKVecs, Rhok.data());
-    const KContainer::VContainer_t& Kcart(P.SK->KLists.kpts_cart);
-    std::vector<int>& kshell(P.SK->KLists.kshell);
+    const KContainer::VContainer_t& Kcart(P.SK->getKLists().kpts_cart);
+    std::vector<int>& kshell(P.SK->getKLists().kshell);
     for (int iel = 0; iel < NumTargets; iel++)
     {
       const ComplexType* restrict eikr_ptr(P.SK->eikr[iel]);
@@ -302,15 +302,15 @@ public:
     copy(P.SK->rhok[0], P.SK->rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.SK->rhok[spec1], P.SK->rhok[spec1] + NumKVecs, Rhok.data());
-    const KContainer::VContainer_t& Kcart(P.SK->KLists.kpts_cart);
-    std::vector<int>& kshell(P.SK->KLists.kshell);
+    const KContainer::VContainer_t& Kcart(P.SK->getKLists().kpts_cart);
+    std::vector<int>& kshell(P.SK->getKLists().kshell);
     GradType fact;
     HessType kakb;
     for (int iel = 0; iel < NumTargets; iel++)
     {
       const ComplexType* restrict eikr_ptr(P.SK->eikr[iel]);
       const ComplexType* restrict rhok_ptr(Rhok.data());
-      const RealType* restrict ksq_ptr(P.SK->KLists.ksq.data());
+      const RealType* restrict ksq_ptr(P.SK->getKLists().ksq.data());
       int ki = 0;
       for (int ks = 0; ks < NumKShells; ks++, ksq_ptr++)
       {

--- a/src/QMCWaveFunctions/Jastrow/J2KECorrection.h
+++ b/src/QMCWaveFunctions/Jastrow/J2KECorrection.h
@@ -46,7 +46,7 @@ public:
       num_elec_in_groups_.push_back(targetPtcl.last(i) - targetPtcl.first(i));
 
     if (SK_enabled)
-      G0mag = std::sqrt(targetPtcl.SK->KLists.ksq[0]);
+      G0mag = std::sqrt(targetPtcl.SK->getKLists().ksq[0]);
   }
 
   RT computeKEcorr()

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -103,8 +103,8 @@ void RPAJastrow::buildOrbital(const std::string& name,
       Rs = 100.0;
     }
   }
-  int indx      = targetPtcl.SK->KLists.ksq.size() - 1;
-  double Kc_max = std::pow(targetPtcl.SK->KLists.ksq[indx], 0.5);
+  int indx      = targetPtcl.SK->getKLists().ksq.size() - 1;
+  double Kc_max = std::pow(targetPtcl.SK->getKLists().ksq[indx], 0.5);
   if (Kc < 0)
   {
     Kc = 2.0 * std::pow(2.25 * M_PI, 1.0 / 3.0) / tlen;

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -302,9 +302,9 @@ void RadialJastrowBuilder::computeJ2uk(const std::vector<RadFuncType*>& functors
     sprintf(fname, "uk.%s.g%03d.dat", NameOpt.c_str(), getGroupID());
     fout = fopen(fname, "w");
   }
-  for (int iG = 0; iG < targetPtcl.SK->KLists.ksq.size(); iG++)
+  for (int iG = 0; iG < targetPtcl.SK->getKLists().ksq.size(); iG++)
   {
-    RealType Gmag = std::sqrt(targetPtcl.SK->KLists.ksq[iG]);
+    RealType Gmag = std::sqrt(targetPtcl.SK->getKLists().ksq[iG]);
     RealType sum  = 0.0;
     RealType uk   = 0.0;
     for (int i = 0; i < targetPtcl.groups(); i++)


### PR DESCRIPTION
## Proposed changes
This is mostly non-functional change before I enable structure factor evaluation with offload.
1. Only allow ParticleSet::createSK being called if SK is nullptr.
2. change KContainer to shared_ptr in StructFact as the data is identical across walkers.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'