### PR TITLE
Fix uninitialized variable errors when building with gcc-11

### DIFF
--- a/src/Numerics/OneDimGridBase.h
+++ b/src/Numerics/OneDimGridBase.h
@@ -38,13 +38,13 @@ struct OneDimGridBase
   typedef CT Array_t;
 
 
-  int GridTag;
-  int num_points;
-  value_type lower_bound;
-  value_type upper_bound;
+  int GridTag            = 0;
+  int num_points         = 0;
+  value_type lower_bound = T();
+  value_type upper_bound = T();
   ///differential spacing of the grid
-  value_type Delta;
-  double DeltaInv;
+  value_type Delta = T();
+  double DeltaInv  = 0.;
 
   ///array to store the radial grid data
   Array_t X;

--- a/src/Numerics/OneDimGridBase.h
+++ b/src/Numerics/OneDimGridBase.h
@@ -38,19 +38,19 @@ struct OneDimGridBase
   typedef CT Array_t;
 
 
-  int GridTag            = 0;
-  int num_points         = 0;
-  value_type lower_bound = T();
-  value_type upper_bound = T();
+  int GridTag;
+  int num_points;
+  value_type lower_bound;
+  value_type upper_bound;
   ///differential spacing of the grid
-  value_type Delta = T();
-  double DeltaInv  = 0.;
+  value_type Delta;
+  double DeltaInv;
 
   ///array to store the radial grid data
   Array_t X;
 
 
-  inline OneDimGridBase() : num_points(0) {}
+  inline OneDimGridBase() : GridTag(0), num_points(0), lower_bound(0), upper_bound(0), Delta(0), DeltaInv(0.) {}
 
   virtual std::unique_ptr<OneDimGridBase<T, CT>> makeClone() const = 0;
 


### PR DESCRIPTION
## Proposed changes

Adding initialization in variables due to an error when building with gcc-11.
Fixes #3364 

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?
Ubuntu 20.10 + gcc-11 docker image on Ubuntu 20.04 host

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
