### PR TITLE
Portable Datasets and Groups check in h5py readers

### DIFF
--- a/nexus/lib/hdfreader.py
+++ b/nexus/lib/hdfreader.py
@@ -267,8 +267,10 @@ class HDFgroup(DevBase):
 
 
 class HDFreader(DevBase):
-    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>"])
-    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>"])
+    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>",
+                    "<class 'h5py._debian_h5py_serial._hl.dataset.Dataset'>"])
+    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>",
+                    "<class 'h5py._debian_h5py_serial._hl.group.Group'>"])
     
     def __init__(self,fpath,verbose=False,view=False):
         

--- a/nexus/lib/hdfreader.py
+++ b/nexus/lib/hdfreader.py
@@ -267,10 +267,6 @@ class HDFgroup(DevBase):
 
 
 class HDFreader(DevBase):
-    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>",
-                    "<class 'h5py._debian_h5py_serial._hl.dataset.Dataset'>"])
-    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>",
-                    "<class 'h5py._debian_h5py_serial._hl.group.Group'>"])
     
     def __init__(self,fpath,verbose=False,view=False):
         
@@ -312,14 +308,12 @@ class HDFreader(DevBase):
             for kr,v in hcur.items():
                 k=cur._escape_name(kr)
                 if valid_variable_name(k):
-                    vtype = str(type(v))
-                    if vtype in HDFreader.datasets:
+                    if isinstance(v, h5py.Dataset):
                         self.add_dataset(cur,k,v)
-                    elif vtype in HDFreader.groups:
+                    elif isinstance(v, h5py.Group):
                         self.add_group(hcur,cur,k,v)
                     else:
-                        self.error('encountered invalid type: '+vtype)
-                    #end if
+                        self.error('encountered invalid type: '+str(type(v)))
                 else:
                     self.warn('attribute '+k+' is not a valid variable name and has been ignored')
                 #end if
@@ -374,10 +368,9 @@ class HDFreader(DevBase):
         for kr,v in hcur.items():
             k=cur._escape_name(kr)
             if valid_variable_name(k):
-                vtype = str(type(v))
-                if vtype in HDFreader.datasets:
+                if isinstance(v, h5py.Dataset):
                     self.add_dataset(cur,k,v)
-                elif vtype in HDFreader.groups:
+                elif isinstance(v, h5py.Group):
                     self.add_group(hcur,cur,k,v)
                 #end if
             else:

--- a/tests/scripts/check_traces.py
+++ b/tests/scripts/check_traces.py
@@ -332,8 +332,10 @@ class HDFgroup(DevBase):
 
 
 class HDFreader(DevBase):
-    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>"])
-    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>"])
+    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>",
+                    "<class 'h5py._debian_h5py_serial._hl.dataset.Dataset'>"])
+    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>",
+                    "<class 'h5py._debian_h5py_serial._hl.group.Group'>"])
     
     def __init__(self,fpath,verbose=False,view=False):
         

--- a/tests/scripts/check_traces.py
+++ b/tests/scripts/check_traces.py
@@ -332,10 +332,6 @@ class HDFgroup(DevBase):
 
 
 class HDFreader(DevBase):
-    datasets = set(["<class 'h5py.highlevel.Dataset'>","<class 'h5py._hl.dataset.Dataset'>",
-                    "<class 'h5py._debian_h5py_serial._hl.dataset.Dataset'>"])
-    groups   = set(["<class 'h5py.highlevel.Group'>","<class 'h5py._hl.group.Group'>",
-                    "<class 'h5py._debian_h5py_serial._hl.group.Group'>"])
     
     def __init__(self,fpath,verbose=False,view=False):
         
@@ -376,13 +372,12 @@ class HDFreader(DevBase):
             hcur  = self.hcur[self.ilevel]
             for kr,v in hcur.items():
                 k=cur._escape_name(kr)
-                vtype = str(type(v))
-                if vtype in HDFreader.datasets:
+                if isinstance(v, h5py.Dataset):
                     self.add_dataset(cur,k,v)
-                elif vtype in HDFreader.groups:
+                elif isinstance(v, h5py.Group):
                     self.add_group(hcur,cur,k,v)
                 else:
-                    self.error('encountered invalid type: '+vtype)
+                    self.error('encountered invalid type: '+str(type(v)))
                 #end if
             #end for
         #end if
@@ -434,10 +429,9 @@ class HDFreader(DevBase):
         hcur  = self.hcur[self.ilevel]
         for kr,v in hcur.items():
             k=cur._escape_name(kr)
-            vtype = str(type(v))
-            if vtype in HDFreader.datasets:
+            if isinstance(v, h5py.Dataset):
                 self.add_dataset(cur,k,v)
-            elif vtype in HDFreader.groups:
+            elif isinstance(v, h5py.Group):
                 self.add_group(hcur,cur,k,v)
             #end if
         #end for


### PR DESCRIPTION
## Proposed changes
Bug seen with python3-h5py2.10 + Ubuntu 20.10 + gcc-11 in which debian specific class types are picked up for Datasets and Groups.
In anticipation to adding gcc-11 on CI.
Fixes #3366 

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 21.10 + gcc-11 + python3-h5py2.10 docker image on Ubuntu 20.04 host

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
