### PR TITLE
rename LogValue variables, make protected with accessors

### DIFF
--- a/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
@@ -71,7 +71,7 @@ void SOVMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
           W.spins[iat] = thisWalker.spins[iat] + invSqrtSpinMass * SqrtTauOverMass[iat] * deltaS[iat];
 
         // W.R += dR*dt; W.DistTables,SK are updated; W.G,L are now stale
-        RealType logpsi = Psi.evaluateLog(W); // update W.G,L at changed W.R; update Psi.LogValue,PhaseValue
+        RealType logpsi = Psi.evaluateLog(W); // update W.G,L at changed W.R; update Psi.log_real_,PhaseValue
         RealType g      = std::exp(2.0 * (logpsi - logpsi_old));
         if (RandomGen() <= g)
         {                        // move is accepted; logpsi_old and R_old are stale

--- a/src/QMCDrivers/VMC/VMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.cpp
@@ -55,7 +55,7 @@ void VMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
       assignDrift(Tau, MassInvP, thisWalker.G, drift); // fill variable drift
       if (W.makeMoveAllParticlesWithDrift(thisWalker, drift, deltaR, SqrtTauOverMass))
       { // W.R = thisWalker.R + drift + deltaR; W.DistTables,SK are updated; W.G,L are now stale
-        RealType logpsi = Psi.evaluateLog(W); // update W.G,L; update Psi.PhaseValue,LogValue
+        RealType logpsi = Psi.evaluateLog(W); // update W.G,L; update Psi.PhaseValue,log_real_
         RealType logGf  = -0.5 * Dot(deltaR, deltaR);
         assignDrift(Tau, MassInvP, W.G, drift);      // update drift at proposed configuration
         deltaR         = thisWalker.R - W.R - drift; // hijack deltaR to hold reverse move
@@ -77,7 +77,7 @@ void VMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
     {
       if (W.makeMoveAllParticles(thisWalker, deltaR, SqrtTauOverMass))
       {                                       // W.R += dR*dt; W.DistTables,SK are updated; W.G,L are now stale
-        RealType logpsi = Psi.evaluateLog(W); // update W.G,L at changed W.R; update Psi.LogValue,PhaseValue
+        RealType logpsi = Psi.evaluateLog(W); // update W.G,L at changed W.R; update Psi.log_real_,PhaseValue
         RealType g      = std::exp(2.0 * (logpsi - logpsi_old));
         if (RandomGen() <= g)
         {                        // move is accepted; logpsi_old and R_old are stale

--- a/src/QMCWaveFunctions/AGPDeterminant.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminant.cpp
@@ -106,7 +106,7 @@ AGPDeterminant::LogValueType AGPDeterminant::evaluateLog(const ParticleSet& P,
   evaluateLogAndStore(P);
   G += myG;
   L += myL;
-  return LogValue;
+  return log_value_;
 }
 
 void AGPDeterminant::evaluateLogAndStore(const ParticleSet& P)
@@ -132,7 +132,7 @@ void AGPDeterminant::evaluateLogAndStore(const ParticleSet& P)
     }
   }
   //CurrentDet = Invert(psiM.data(),Nup,Nup,WorkSpace.data(),Pivot.data());
-  InvertWithLog(psiM.data(), Nup, Nup, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiM.data(), Nup, Nup, WorkSpace.data(), Pivot.data(), log_value_);
   for (int iat = 0; iat < Nup; iat++)
   {
     for (int d = 0, jat = Nup; d < Ndown; d++, jat++)
@@ -177,7 +177,7 @@ void AGPDeterminant::registerData(ParticleSet& P, WFBufferType& buf)
 {
   //add the data: determinant, inverse, gradient and laplacians
   //buf.add(CurrentDet);
-  buf.add(LogValue);
+  buf.add(log_value_);
   buf.add(psiM.begin(), psiM.end());
   buf.add(phiT.begin(), phiT.end());
   buf.add(d2psiU.begin(), d2psiU.end());
@@ -199,7 +199,7 @@ AGPDeterminant::LogValueType AGPDeterminant::updateBuffer(ParticleSet& P, WFBuff
   //if(UseBuffer)
   {
     //buf.put(CurrentDet);
-    buf.put(LogValue);
+    buf.put(log_value_);
     buf.put(psiM.begin(), psiM.end());
     buf.put(phiT.begin(), phiT.end());
     buf.put(d2psiU.begin(), d2psiU.end());
@@ -212,7 +212,7 @@ AGPDeterminant::LogValueType AGPDeterminant::updateBuffer(ParticleSet& P, WFBuff
     buf.put(myL.first_address(), myL.last_address());
     //buf.put(myL.begin(), myL.end());
   }
-  return LogValue;
+  return log_value_;
   //return CurrentDet;
 }
 
@@ -221,7 +221,7 @@ void AGPDeterminant::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
   //if(UseBuffer)
   {
     //buf.get(CurrentDet);
-    buf.get(LogValue);
+    buf.get(log_value_);
     buf.get(psiM.begin(), psiM.end());
     buf.get(phiT.begin(), phiT.end());
     buf.get(d2psiU.begin(), d2psiU.end());
@@ -355,7 +355,7 @@ void AGPDeterminant::ratioDown(ParticleSet& P, int iat)
  */
 void AGPDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
-  LogValue += convertValueToLog(curRatio);
+  log_value_ += convertValueToLog(curRatio);
   //CurrentDet *= curRatio;
   if (UpdateMode == ORB_PBYP_RATIO)
   {

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -106,8 +106,8 @@ ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(const ParticleS
 
   double u = A * r12 / (B * r12 + 1) - A / B;
 
-  LogValue = -Z * (r1 + r2) + std::log(norm * norm) - u;
-  return LogValue;
+  log_value_ = -Z * (r1 + r2) + std::log(norm * norm) - u;
+  return log_value_;
 }
 
 ExampleHeComponent::PsiValueType ExampleHeComponent::ratio(ParticleSet& P, int iat)

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdate.h
@@ -72,9 +72,9 @@ public:
    * @param Ainv inverse matrix
    */
   template<typename TREAL>
-  inline void invert_transpose(const Matrix<T>& logdetT, Matrix<T>& Ainv, std::complex<TREAL>& LogValue)
+  inline void invert_transpose(const Matrix<T>& logdetT, Matrix<T>& Ainv, std::complex<TREAL>& log_value)
   {
-    detEng.invert_transpose(logdetT, Ainv, LogValue);
+    detEng.invert_transpose(logdetT, Ainv, log_value);
     // safe mechanism
     delay_count = 0;
   }

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
@@ -160,7 +160,7 @@ public:
    */
   template<typename TMAT, typename TREAL, typename = std::enable_if_t<std::is_same<TMAT, T>::value>>
   std::enable_if_t<std::is_same<TMAT, T_FP>::value>
-  invert_transpose(const Matrix<TMAT>& logdetT, Matrix<TMAT>& Ainv, std::complex<TREAL>& LogValue)
+  invert_transpose(const Matrix<TMAT>& logdetT, Matrix<TMAT>& Ainv, std::complex<TREAL>& log_value)
   {
     // safe mechanism
     delay_count = 0;
@@ -193,7 +193,7 @@ public:
                        "cusolver::getrs failed!");
     cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, hstream),
                    "cudaMemcpyAsync failed!");
-    computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, LogValue);
+    computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(cudaMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(T), cudaMemcpyDeviceToHost,
                                    hstream),
                    "cudaMemcpyAsync failed!");
@@ -214,7 +214,7 @@ public:
    */
   template<typename TMAT, typename TREAL, typename = std::enable_if_t<std::is_same<TMAT, T>::value>>
   std::enable_if_t<!std::is_same<TMAT, T_FP>::value>
-  invert_transpose(const Matrix<TMAT>& logdetT, Matrix<TMAT>& Ainv, std::complex<TREAL>& LogValue)
+  invert_transpose(const Matrix<TMAT>& logdetT, Matrix<TMAT>& Ainv, std::complex<TREAL>& log_value)
   {
     // safe mechanism
     delay_count = 0;
@@ -249,7 +249,7 @@ public:
     copy_matrix_cuda(norb, norb, Mat1_gpu.data(), norb, (T*)Mat2_gpu.data(), norb, hstream);
     cudaErrorCheck(cudaMemcpyAsync(ipiv.data(), ipiv_gpu.data(), sizeof(int), cudaMemcpyDeviceToHost, hstream),
                    "cudaMemcpyAsync failed!");
-    computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, LogValue);
+    computeLogDet(LU_diag.data(), norb, ipiv.data() + 1, log_value);
     cudaErrorCheck(cudaMemcpyAsync(Ainv.data(), Ainv_gpu.data(), Ainv.size() * sizeof(T), cudaMemcpyDeviceToHost,
                                    hstream),
                    "cudaMemcpyAsync failed!");

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -61,7 +61,7 @@ template<typename DU_TYPE>
 void DiracDeterminant<DU_TYPE>::invertPsiM(const ValueMatrix_t& logdetT, ValueMatrix_t& invMat)
 {
   ScopedTimer local_timer(InverseTimer);
-  updateEng.invert_transpose(logdetT, invMat, LogValue);
+  updateEng.invert_transpose(logdetT, invMat, log_value_);
 }
 
 
@@ -237,7 +237,7 @@ void DiracDeterminant<DU_TYPE>::acceptMove(ParticleSet& P, int iat, bool safe_to
   ScopedTimer local_timer(UpdateTimer);
   const int WorkingIndex = iat - FirstIndex;
   assert(WorkingIndex >= 0);
-  LogValue += convertValueToLog(curRatio);
+  log_value_ += convertValueToLog(curRatio);
   updateEng.acceptRow(psiM, WorkingIndex, psiV, curRatio);
   if (!safe_to_delay)
     updateEng.updateInvMat(psiM);
@@ -324,7 +324,7 @@ void DiracDeterminant<DU_TYPE>::registerData(ParticleSet& P, WFBufferType& buf)
     // std::cerr << ("You really should know whether you have registered this objects data previously!, consider this an error in the unified code");
 #endif
   }
-  buf.add(LogValue);
+  buf.add(log_value_);
 }
 
 template<typename DU_TYPE>
@@ -338,7 +338,7 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::eval
     evaluateLog(P, G, L);
   else
     updateAfterSweep(P, G, L);
-  return LogValue;
+  return log_value_;
 }
 
 template<typename DU_TYPE>
@@ -350,9 +350,9 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::upda
   {
     ScopedTimer local_timer(BufferTimer);
     buf.forward(Bytes_in_WFBuffer);
-    buf.put(LogValue);
+    buf.put(log_value_);
   }
-  return LogValue;
+  return log_value_;
 }
 
 template<typename DU_TYPE>
@@ -362,7 +362,7 @@ void DiracDeterminant<DU_TYPE>::copyFromBuffer(ParticleSet& P, WFBufferType& buf
   psiM.attachReference(buf.lendReference<ValueType>(psiM.size()));
   dpsiM.attachReference(buf.lendReference<GradType>(dpsiM.size()));
   d2psiM.attachReference(buf.lendReference<ValueType>(d2psiM.size()));
-  buf.get(LogValue);
+  buf.get(log_value_);
   // start with invRow labelled invalid
   invRow_id = -1;
   updateEng.initializeInv(psiM);
@@ -658,7 +658,7 @@ typename DiracDeterminant<DU_TYPE>::LogValueType DiracDeterminant<DU_TYPE>::eval
       L[iat] += lap - dot(rv, rv);
     }
   }
-  return LogValue;
+  return log_value_;
 }
 
 template<typename DU_TYPE>
@@ -672,7 +672,7 @@ void DiracDeterminant<DU_TYPE>::recompute(const ParticleSet& P)
   {
     ValueType det = psiM_temp(0, 0);
     psiM(0, 0)    = RealType(1) / det;
-    LogValue      = convertValueToLog(det);
+    log_value_      = convertValueToLog(det);
   }
   else
     invertPsiM(psiM_temp, psiM);

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -131,7 +131,7 @@ void DiracDeterminantWithBackflow::registerData(ParticleSet& P, WFBufferType& bu
   myG_temp = 0.0;
   myL_temp = 0.0;
   //ValueType x=evaluate(P,myG,myL);
-  LogValue = evaluateLog(P, myG_temp, myL_temp);
+  log_value_ = evaluateLog(P, myG_temp, myL_temp);
   P.G += myG_temp;
   P.L += myL_temp;
   //add the data: determinant, inverse, gradient and laplacians
@@ -142,7 +142,7 @@ void DiracDeterminantWithBackflow::registerData(ParticleSet& P, WFBufferType& bu
   buf.add(FirstAddressOfG, LastAddressOfG);
   buf.add(FirstAddressOfFm, LastAddressOfFm);
   buf.add(psiMinv.first_address(), psiMinv.last_address());
-  buf.add(LogValue);
+  buf.add(log_value_);
 }
 
 DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::updateBuffer(ParticleSet& P,
@@ -154,7 +154,7 @@ DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::updateB
   UpdateTimer.start();
   myG_temp = 0.0;
   myL_temp = 0.0;
-  LogValue = evaluateLog(P, myG_temp, myL_temp);
+  log_value_ = evaluateLog(P, myG_temp, myL_temp);
   P.G += myG_temp;
   P.L += myL_temp;
   //copy psiM to psiM_temp
@@ -166,9 +166,9 @@ DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::updateB
   buf.put(FirstAddressOfG, LastAddressOfG);
   buf.put(FirstAddressOfFm, LastAddressOfFm);
   buf.put(psiMinv.first_address(), psiMinv.last_address());
-  buf.put(LogValue);
+  buf.put(log_value_);
   UpdateTimer.stop();
-  return LogValue;
+  return log_value_;
 }
 
 void DiracDeterminantWithBackflow::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
@@ -180,7 +180,7 @@ void DiracDeterminantWithBackflow::copyFromBuffer(ParticleSet& P, WFBufferType& 
   buf.get(FirstAddressOfG, LastAddressOfG);
   buf.get(FirstAddressOfFm, LastAddressOfFm);
   buf.get(psiMinv.first_address(), psiMinv.last_address());
-  buf.get(LogValue);
+  buf.get(log_value_);
   //re-evaluate it for testing
   //Phi.evaluate(P, FirstIndex, LastIndex, psiM, dpsiM, d2psiM);
   //CurrentDet = Invert(psiM.data(),NumPtcls,NumOrbitals);
@@ -225,7 +225,7 @@ DiracDeterminantWithBackflow::PsiValueType DiracDeterminantWithBackflow::ratio(P
   LogValueType NewLog;
   InvertWithLog(psiMinv_temp.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), NewLog);
   InverseTimer.stop();
-  return curRatio = LogToValue<PsiValueType>::convert(NewLog - LogValue);
+  return curRatio = LogToValue<PsiValueType>::convert(NewLog - log_value_);
 }
 
 void DiracDeterminantWithBackflow::evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios)
@@ -305,7 +305,7 @@ DiracDeterminantWithBackflow::PsiValueType DiracDeterminantWithBackflow::ratioGr
     Fmatdiag_temp[j] = simd::dot(psiMinv_temp[j], dpsiM_temp[j], NumOrbitals);
     grad_iat += dot(BFTrans->Amat_temp(iat, FirstIndex + j), Fmatdiag_temp[j]);
   }
-  return curRatio = LogToValue<PsiValueType>::convert(NewLog - LogValue);
+  return curRatio = LogToValue<PsiValueType>::convert(NewLog - log_value_);
 }
 
 void DiracDeterminantWithBackflow::testL(ParticleSet& P)
@@ -343,7 +343,7 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -404,7 +404,7 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
       evaluate_SPO(psiM, dpsiM, grad_grad_psiM);
       psiMinv = psiM;
       InverseTimer.start();
-      InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+      InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
       InverseTimer.stop();
       for (int j = 0; j < NumPtcls; j++)
       {
@@ -421,7 +421,7 @@ void DiracDeterminantWithBackflow::testL(ParticleSet& P)
       evaluate_SPO(psiM, dpsiM, grad_grad_psiM);
       psiMinv = psiM;
       InverseTimer.start();
-      InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+      InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
       InverseTimer.stop();
       for (int j = 0; j < NumPtcls; j++)
       {
@@ -497,7 +497,7 @@ DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluat
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -560,7 +560,7 @@ DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluat
     L[i] += myL[i];
     G[i] += myG[i];
   }
-  return LogValue;
+  return log_value_;
 }
 
 
@@ -568,7 +568,7 @@ DiracDeterminantWithBackflow::LogValueType DiracDeterminantWithBackflow::evaluat
 */
 void DiracDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 {
-  LogValue += convertValueToLog(curRatio);
+  log_value_ += convertValueToLog(curRatio);
   UpdateTimer.start();
   switch (UpdateMode)
   {
@@ -626,7 +626,7 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     psiMinv = psiM;
     //       invert backflow matrix
     InverseTimer.start();
-    InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+    InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
     InverseTimer.stop();
     //       calculate F matrix (gradients wrt bf coordinates)
     //       could use dgemv with increments of 3*nCols
@@ -768,7 +768,7 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -891,7 +891,7 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -1203,7 +1203,7 @@ void DiracDeterminantWithBackflow::testDerivFjj(ParticleSet& P, int pa)
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -1222,7 +1222,7 @@ void DiracDeterminantWithBackflow::testDerivFjj(ParticleSet& P, int pa)
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -1240,7 +1240,7 @@ void DiracDeterminantWithBackflow::testDerivFjj(ParticleSet& P, int pa)
   psiMinv = psiM;
   // invert backflow matrix
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   // calculate F matrix (gradients wrt bf coordinates)
   // could use dgemv with increments of 3*nCols
@@ -1332,7 +1332,7 @@ void DiracDeterminantWithBackflow::dummyEvalLi(ValueType& L1, ValueType& L2, Val
   evaluate_SPO(psiM, dpsiM, grad_grad_psiM);
   psiMinv = psiM;
   InverseTimer.start();
-  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), LogValue);
+  InvertWithLog(psiMinv.data(), NumPtcls, NumOrbitals, WorkSpace.data(), Pivot.data(), log_value_);
   InverseTimer.stop();
   for (int i = 0; i < NumPtcls; i++)
     for (int j = 0; j < NumPtcls; j++)

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -383,10 +383,10 @@ public:
 
   /** compute the inverse of the transpose of matrix logdetT, result is in psiMinv
    * @param logdetT orbital value matrix
-   * @param LogValue log(det(logdetT))
+   * @param log_value log(det(logdetT))
    */
   template<typename TREAL>
-  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)
+  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& log_value)
   {
     // make this class unit tests friendly without the need of setup resources.
     if (!cuda_handles_)
@@ -396,7 +396,7 @@ public:
 
     auto& Ainv = psiMinv;
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-    detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
+    detEng.invert_transpose(logdetT, Ainv_host_view, log_value);
     T* Ainv_ptr = Ainv.data();
     PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
   }
@@ -404,7 +404,7 @@ public:
   template<typename TREAL>
   static void mw_invert_transpose(const RefVectorWithLeader<This_t>& engines,
                                   const RefVector<const Matrix<T>>& logdetT_list,
-                                  const RefVector<std::complex<TREAL>>& LogValues)
+                                  const RefVector<std::complex<TREAL>>& log_values)
   {
     auto& engine_leader = engines.getLeader();
     // make this class unit tests friendly without the need of setup resources.
@@ -430,7 +430,7 @@ public:
     {
       auto& Ainv = engines[iw].psiMinv;
       Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
+      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, log_values[iw].get());
       T* Ainv_ptr = Ainv.data();
       PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
     }

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -132,14 +132,14 @@ public:
 
   /** compute the inverse of the transpose of matrix logdetT, result is in psiMinv
    * @param logdetT orbital value matrix
-   * @param LogValue log(det(logdetT))
+   * @param log_value log(det(logdetT))
    */
   template<typename TREAL>
-  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& LogValue)
+  inline void invert_transpose(const Matrix<T>& logdetT, std::complex<TREAL>& log_value)
   {
     auto& Ainv = psiMinv;
     Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-    detEng.invert_transpose(logdetT, Ainv_host_view, LogValue);
+    detEng.invert_transpose(logdetT, Ainv_host_view, log_value);
     T* Ainv_ptr = Ainv.data();
     PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
   }
@@ -147,7 +147,7 @@ public:
   template<typename TREAL>
   static void mw_invert_transpose(const RefVectorWithLeader<This_t>& engines,
                                   const RefVector<const Matrix<T>>& logdetT_list,
-                                  const RefVector<std::complex<TREAL>>& LogValues)
+                                  const RefVector<std::complex<TREAL>>& log_values)
   {
     auto& engine_leader = engines.getLeader();
     // make this class unit tests friendly without the need of setup resources.
@@ -163,7 +163,7 @@ public:
     {
       auto& Ainv = engines[iw].psiMinv;
       Matrix<T> Ainv_host_view(Ainv.data(), Ainv.rows(), Ainv.cols());
-      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, LogValues[iw].get());
+      engine_leader.detEng.invert_transpose(logdetT_list[iw].get(), Ainv_host_view, log_values[iw].get());
       T* Ainv_ptr = Ainv.data();
       PRAGMA_OFFLOAD("omp target update to(Ainv_ptr[:Ainv.size()])")
     }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -191,7 +191,7 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminant::evaluateLog(const Pa
                                                                         ParticleSet::ParticleGradient_t& G,
                                                                         ParticleSet::ParticleLaplacian_t& L)
 {
-  return LogValue = convertValueToLog(evaluate(P, G, L));
+  return log_value_ = convertValueToLog(evaluate(P, G, L));
 }
 
 WaveFunctionComponent::GradType MultiSlaterDeterminant::evalGrad(ParticleSet& P, int iat)
@@ -382,7 +382,7 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
       // ratio(P,iat)
       for (int i = 0; i < detValues_up.size(); i++)
         detValues_up[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_PARTIAL:
@@ -392,7 +392,7 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
         detValues_up[i] *= detsRatios[i];
         grads_up[i][iat] = grad_temp[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_ALL:
@@ -403,13 +403,13 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
         grads_up[i] = tempgrad[i];
         lapls_up[i] = templapl[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     default:
       for (int i = 0; i < detValues_up.size(); i++)
         detValues_up[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     }
@@ -424,7 +424,7 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
       // ratio(P,iat)
       for (int i = 0; i < detValues_dn.size(); i++)
         detValues_dn[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_PARTIAL:
@@ -434,7 +434,7 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
         detValues_dn[i] *= detsRatios[i];
         grads_dn[i][iat] = grad_temp[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_ALL:
@@ -445,13 +445,13 @@ void MultiSlaterDeterminant::acceptMove(ParticleSet& P, int iat, bool safe_to_de
         grads_dn[i] = tempgrad[i];
         lapls_dn[i] = templapl[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     default:
       for (int i = 0; i < detValues_dn.size(); i++)
         detValues_dn[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     }
@@ -580,7 +580,7 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminant::updateBuffer(Particl
   for (int i = 0; i < P.L.size(); i++)
     P.L[i] += myL[i] - dot(myG[i], myG[i]);
   UpdateTimer.stop();
-  return LogValue = convertValueToLog(psi);
+  return log_value_ = convertValueToLog(psi);
   ;
 }
 
@@ -691,7 +691,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
     if (usingCSF)
     {
       int n            = P.getTotalNum();
-      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
+      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(log_value_);
 
       ValueType lapl_sum = 0.0;
       ParticleSet::ParticleGradient_t g(n), gmP(n);
@@ -755,7 +755,7 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
     else
     {
       int n            = P.getTotalNum();
-      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
+      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(log_value_);
 
       ValueType lapl_sum = 0.0;
       ParticleSet::ParticleGradient_t g(n), gmP(n);

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantFast.cpp
@@ -156,13 +156,13 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::evaluateLog(cons
       Dets[id]->evaluateForWalkerMove(P);
   }
 
-  LogValue = evaluate_vgl_impl(P, myG, myL);
+  log_value_ = evaluate_vgl_impl(P, myG, myL);
 
   G += myG;
   for (size_t i = 0; i < L.size(); i++)
     L[i] += myL[i] - dot(myG[i], myG[i]);
 
-  return LogValue;
+  return log_value_;
 }
 
 WaveFunctionComponent::PsiValueType MultiSlaterDeterminantFast::evalGrad_impl(ParticleSet& P,
@@ -708,7 +708,7 @@ void MultiSlaterDeterminantFast::acceptMove(ParticleSet& P, int iat, bool safe_t
   ScopedTimer local_timer(AccRejTimer);
   // update psi_ratio_to_ref_det_,myG_temp,myL_temp
   psi_ratio_to_ref_det_ = new_psi_ratio_to_new_ref_det_;
-  LogValue += convertValueToLog(curRatio);
+  log_value_ += convertValueToLog(curRatio);
   curRatio = 1.0;
 
   Dets[getDetID(iat)]->acceptMove(P, iat, safe_to_delay);
@@ -730,7 +730,7 @@ void MultiSlaterDeterminantFast::registerData(ParticleSet& P, WFBufferType& buf)
   for (size_t id = 0; id < Dets.size(); id++)
     Dets[id]->registerData(P, buf);
 
-  buf.add(LogValue);
+  buf.add(log_value_);
   buf.add(psi_ratio_to_ref_det_);
 }
 
@@ -743,16 +743,16 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantFast::updateBuffer(Par
   for (size_t id = 0; id < Dets.size(); id++)
     Dets[id]->updateBuffer(P, buf, fromscratch);
 
-  LogValue = evaluate_vgl_impl(P, myG, myL);
+  log_value_ = evaluate_vgl_impl(P, myG, myL);
 
   P.G += myG;
   for (int i = 0; i < P.L.size(); i++)
     P.L[i] += myL[i] - dot(myG[i], myG[i]);
 
-  buf.put(LogValue);
+  buf.put(log_value_);
   buf.put(psi_ratio_to_ref_det_);
 
-  return LogValue;
+  return log_value_;
 }
 
 void MultiSlaterDeterminantFast::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
@@ -761,7 +761,7 @@ void MultiSlaterDeterminantFast::copyFromBuffer(ParticleSet& P, WFBufferType& bu
   for (size_t id = 0; id < Dets.size(); id++)
     Dets[id]->copyFromBuffer(P, buf);
 
-  buf.get(LogValue);
+  buf.get(log_value_);
   buf.get(psi_ratio_to_ref_det_);
 }
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminantWithBackflow.cpp
@@ -173,7 +173,7 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::evaluate
                                                                                     ParticleSet::ParticleGradient_t& G,
                                                                                     ParticleSet::ParticleLaplacian_t& L)
 {
-  return LogValue = convertValueToLog(evaluate(P, G, L));
+  return log_value_ = convertValueToLog(evaluate(P, G, L));
 }
 
 WaveFunctionComponent::GradType MultiSlaterDeterminantWithBackflow::evalGrad(ParticleSet& P, int iat)
@@ -368,7 +368,7 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
       // ratio(P,iat)
       for (int i = 0; i < detValues_up.size(); i++)
         detValues_up[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_PARTIAL:
@@ -378,7 +378,7 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
         detValues_up[i] *= detsRatios[i];
         grads_up[i][iat] = grad_temp[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_ALL:
@@ -389,13 +389,13 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
         grads_up[i] = tempgrad[i];
         lapls_up[i] = templapl[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     default:
       for (int i = 0; i < detValues_up.size(); i++)
         detValues_up[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     }
@@ -410,7 +410,7 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
       // ratio(P,iat)
       for (int i = 0; i < detValues_dn.size(); i++)
         detValues_dn[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_PARTIAL:
@@ -420,7 +420,7 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
         detValues_dn[i] *= detsRatios[i];
         grads_dn[i][iat] = grad_temp[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     case ORB_PBYP_ALL:
@@ -431,13 +431,13 @@ void MultiSlaterDeterminantWithBackflow::acceptMove(ParticleSet& P, int iat, boo
         grads_dn[i] = tempgrad[i];
         lapls_dn[i] = templapl[i];
       }
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     default:
       for (int i = 0; i < detValues_dn.size(); i++)
         detValues_dn[i] *= detsRatios[i];
-      LogValue += convertValueToLog(curRatio);
+      log_value_ += convertValueToLog(curRatio);
       curRatio = 1.0;
       break;
     }
@@ -576,7 +576,7 @@ WaveFunctionComponent::LogValueType MultiSlaterDeterminantWithBackflow::updateBu
   for (int i = 0; i < P.L.size(); i++)
     P.L[i] += myL[i] - dot(myG[i], myG[i]);
   UpdateTimer.stop();
-  return LogValue = convertValueToLog(psi);
+  return log_value_ = convertValueToLog(psi);
   ;
 }
 
@@ -698,7 +698,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     if (usingCSF)
     {
       int n            = P.getTotalNum();
-      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
+      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(log_value_);
 
       ValueType lapl_sum = 0.0;
       ParticleSet::ParticleGradient_t g(n), gmP(n);
@@ -760,7 +760,7 @@ void MultiSlaterDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
     else
     {
       int n            = P.getTotalNum();
-      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(LogValue);
+      ValueType psiinv = ValueType(1) / LogToValue<ValueType>::convert(log_value_);
 
       ValueType lapl_sum = 0.0;
       ParticleSet::ParticleGradient_t g(n), gmP(n);

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -113,10 +113,10 @@ SlaterDet::LogValueType SlaterDet::evaluateLog(const ParticleSet& P,
                                                ParticleSet::ParticleGradient_t& G,
                                                ParticleSet::ParticleLaplacian_t& L)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Dets.size(); ++i)
-    LogValue += Dets[i]->evaluateLog(P, G, L);
-  return LogValue;
+    log_value_ += Dets[i]->evaluateLog(P, G, L);
+  return log_value_;
 }
 
 void SlaterDet::mw_evaluateLog(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -127,14 +127,14 @@ void SlaterDet::mw_evaluateLog(const RefVectorWithLeader<WaveFunctionComponent>&
   constexpr LogValueType czero(0);
 
   for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.LogValue = czero;
+    wfc.log_value() = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateLog(Det_list, p_list, G_list, L_list);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].LogValue += Det_list[iw].LogValue;
+      wfc_list[iw].log_value() += Det_list[iw].get_log_value();
   }
 }
 
@@ -143,10 +143,10 @@ SlaterDet::LogValueType SlaterDet::evaluateGL(const ParticleSet& P,
                                               ParticleSet::ParticleLaplacian_t& L,
                                               bool from_scratch)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Dets.size(); ++i)
-    LogValue += Dets[i]->evaluateGL(P, G, L, from_scratch);
-  return LogValue;
+    log_value_ += Dets[i]->evaluateGL(P, G, L, from_scratch);
+  return log_value_;
 }
 
 void SlaterDet::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -158,14 +158,14 @@ void SlaterDet::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& 
   constexpr LogValueType czero(0);
 
   for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.LogValue = czero;
+    wfc.log_value() = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateGL(Det_list, p_list, G_list, L_list, fromscratch);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].LogValue += Det_list[iw].LogValue;
+      wfc_list[iw].log_value() += Det_list[iw].get_log_value();
   }
 }
 
@@ -237,11 +237,11 @@ void SlaterDet::registerData(ParticleSet& P, WFBufferType& buf)
 SlaterDet::LogValueType SlaterDet::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch)
 {
   DEBUG_PSIBUFFER(" SlaterDet::updateBuffer ", buf.current());
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Dets.size(); ++i)
-    LogValue += Dets[i]->updateBuffer(P, buf, fromscratch);
+    log_value_ += Dets[i]->updateBuffer(P, buf, fromscratch);
   DEBUG_PSIBUFFER(" SlaterDet::updateBuffer ", buf.current());
-  return LogValue;
+  return log_value_;
 }
 
 void SlaterDet::copyFromBuffer(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -172,9 +172,9 @@ public:
   {
     Dets[getDetID(iat)]->acceptMove(P, iat, safe_to_delay);
 
-    LogValue = 0.0;
+    log_value_ = 0.0;
     for (int i = 0; i < Dets.size(); ++i)
-      LogValue += Dets[i]->LogValue;
+      log_value_ += Dets[i]->get_log_value();
   }
 
   void mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -187,7 +187,7 @@ public:
 
     for (int iw = 0; iw < wfc_list.size(); iw++)
       if (isAccepted[iw])
-        wfc_list[iw].LogValue = czero;
+        wfc_list[iw].log_value() = czero;
 
     for (int i = 0; i < Dets.size(); ++i)
     {
@@ -198,7 +198,7 @@ public:
 
       for (int iw = 0; iw < wfc_list.size(); iw++)
         if (isAccepted[iw])
-          wfc_list[iw].LogValue += Det_list[iw].LogValue;
+          wfc_list[iw].log_value() += Det_list[iw].get_log_value();
     }
   }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetWithBackflow.cpp
@@ -41,10 +41,10 @@ SlaterDetWithBackflow::LogValueType SlaterDetWithBackflow::evaluateLog(const Par
                                                                        ParticleSet::ParticleLaplacian_t& L)
 {
   BFTrans->evaluate(P);
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Dets.size(); ++i)
-    LogValue += Dets[i]->evaluateLog(P, G, L);
-  return LogValue;
+    log_value_ += Dets[i]->evaluateLog(P, G, L);
+  return log_value_;
 }
 
 void SlaterDetWithBackflow::registerData(ParticleSet& P, WFBufferType& buf)
@@ -61,10 +61,10 @@ SlaterDetWithBackflow::LogValueType SlaterDetWithBackflow::updateBuffer(Particle
   //BFTrans->updateBuffer(P,buf,fromscratch);
   BFTrans->updateBuffer(P, buf, fromscratch);
   //BFTrans->evaluate(P);
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Dets.size(); ++i)
-    LogValue += Dets[i]->updateBuffer(P, buf, fromscratch);
-  return LogValue;
+    log_value_ += Dets[i]->updateBuffer(P, buf, fromscratch);
+  return log_value_;
 }
 
 void SlaterDetWithBackflow::copyFromBuffer(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -219,15 +219,15 @@ public:
       G[i] += Jgrad[i];
       L[i] += Jlap[i];
     }
-    LogValue = Jval;
-    return LogValue;
+    log_value_ = Jval;
+    return log_value_;
   }
 
 
   void recompute(const ParticleSet& P) override
   {
     evaluateExponents(P);
-    LogValue = Jval;
+    log_value_ = Jval;
   }
 
   void evaluateExponents(const ParticleSet& P)
@@ -372,7 +372,7 @@ public:
   GradType evalGrad(ParticleSet& P, int iat) override
   {
     evaluateExponents(P);
-    LogValue = Jval;
+    log_value_ = Jval;
     return Jgrad[iat];
   }
 
@@ -396,7 +396,7 @@ public:
     }
     // update exponent values to that at proposed position
     Jval     = Jval_t;
-    LogValue = Jval;
+    log_value_ = Jval;
     for (int i = 0; i < num_els; ++i)
     {
       Jgrad[i] = Jgrad_t[i];

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -377,7 +377,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       G[iat] += Grad[iat];
     for (size_t iat = 0; iat < Nelec; ++iat)
       L[iat] -= Lap[iat];
-    return LogValue = -simd::accumulate_n(Vat.data(), Nelec, valT());
+    return log_value_ = -simd::accumulate_n(Vat.data(), Nelec, valT());
   }
 
   /** compute gradient and lap
@@ -473,7 +473,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).getTempDispls(), curGrad);
     }
 
-    LogValue += Vat[iat] - curAt;
+    log_value_ += Vat[iat] - curAt;
     Vat[iat]  = curAt;
     Grad[iat] = curGrad;
     Lap[iat]  = curLap;
@@ -504,7 +504,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   {
     evaluateGL(P, P.G, P.L, false);
     buf.forward(Bytes_in_WFBuffer);
-    return LogValue;
+    return log_value_;
   }
 
   inline void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
@@ -236,7 +236,7 @@ typename J2OMPTarget<FT>::LogValueType J2OMPTarget<FT>::updateBuffer(ParticleSet
 {
   evaluateGL(P, P.G, P.L, false);
   buf.forward(Bytes_in_WFBuffer);
-  return LogValue;
+  return log_value_;
 }
 
 template<typename FT>
@@ -579,7 +579,7 @@ void J2OMPTarget<FT>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
     }
     cur_dUat[idim] = cur_g;
   }
-  LogValue += Uat[iat] - cur_Uat;
+  log_value_ += Uat[iat] - cur_Uat;
   Uat[iat]   = cur_Uat;
   dUat(iat)  = cur_dUat;
   d2Uat[iat] = cur_d2Uat;
@@ -606,7 +606,7 @@ void J2OMPTarget<FT>::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctio
   for (int iw = 0; iw < nw; iw++)
   {
     auto& wfc = wfc_list.getCastedElement<J2OMPTarget<FT>>(iw);
-    wfc.LogValue += wfc.Uat[iat] - mw_vgl[iw][0];
+    wfc.log_value() += wfc.Uat[iat] - mw_vgl[iw][0];
   }
 
   /* this call may go asynchronous, then need to wait at mw_calcRatio mw_ratioGrad and mw_completeUpdates */
@@ -719,7 +719,7 @@ WaveFunctionComponent::LogValueType J2OMPTarget<FT>::evaluateGL(const ParticleSe
 {
   if (fromscratch)
     recompute(P);
-  return LogValue = computeGL(G, L);
+  return log_value_ = computeGL(G, L);
 }
 
 template<typename FT>
@@ -739,14 +739,14 @@ void J2OMPTarget<FT>::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionCompon
   for (int iw = 0; iw < wfc_list.size(); iw++)
   {
     auto& wfc    = wfc_list.getCastedElement<J2OMPTarget<FT>>(iw);
-    wfc.LogValue = wfc.computeGL(G_list[iw], L_list[iw]);
+    wfc.log_value() = wfc.computeGL(G_list[iw], L_list[iw]);
   }
 }
 
 template<typename FT>
 void J2OMPTarget<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   const DistanceTableData& d_ee(P.getDistTable(my_table_ID_));
   valT dudr, d2udr2;
 
@@ -767,7 +767,7 @@ void J2OMPTarget<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_ps
       auto dr   = displ[j];
       auto jg   = P.GroupID[j];
       auto uij  = F[igt + jg]->evaluate(r, dudr, d2udr2);
-      LogValue -= uij;
+      log_value_ -= uij;
       auto hess = rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
       grad_grad_psi[i] -= hess;
       grad_grad_psi[j] -= hess;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -124,7 +124,7 @@ typename J2OrbitalSoA<FT>::LogValueType J2OrbitalSoA<FT>::updateBuffer(ParticleS
 {
   evaluateGL(P, P.G, P.L, false);
   buf.forward(Bytes_in_WFBuffer);
-  return LogValue;
+  return log_value_;
 }
 
 template<typename FT>
@@ -390,7 +390,7 @@ void J2OrbitalSoA<FT>::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
     }
     cur_dUat[idim] = cur_g;
   }
-  LogValue += Uat[iat] - cur_Uat;
+  log_value_ += Uat[iat] - cur_Uat;
   Uat[iat]   = cur_Uat;
   dUat(iat)  = cur_dUat;
   d2Uat[iat] = cur_d2Uat;
@@ -462,21 +462,21 @@ WaveFunctionComponent::LogValueType J2OrbitalSoA<FT>::evaluateGL(const ParticleS
 {
   if (fromscratch)
     recompute(P);
-  LogValue = valT(0);
+  log_value_ = valT(0);
   for (int iat = 0; iat < N; ++iat)
   {
-    LogValue += Uat[iat];
+    log_value_ += Uat[iat];
     G[iat] += dUat[iat];
     L[iat] += d2Uat[iat];
   }
 
-  return LogValue = -LogValue * 0.5;
+  return log_value_ = -log_value_ * 0.5;
 }
 
 template<typename FT>
 void J2OrbitalSoA<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   const DistanceTableData& d_ee(P.getDistTable(my_table_ID_));
   valT dudr, d2udr2;
 
@@ -497,7 +497,7 @@ void J2OrbitalSoA<FT>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_p
       auto dr   = displ[j];
       auto jg   = P.GroupID[j];
       auto uij  = F[igt + jg]->evaluate(r, dudr, d2udr2);
-      LogValue -= uij;
+      log_value_ -= uij;
       auto hess = rinv * rinv * outerProduct(dr, dr) * (d2udr2 - dudr * rinv) + ident * dudr * rinv;
       grad_grad_psi[i] -= hess;
       grad_grad_psi[j] -= hess;

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -502,7 +502,7 @@ public:
         save_g[jel] += new_g[jel] - old_g[jel];
     }
 
-    LogValue += Uat[iat] - cur_Uat;
+    log_value_ += Uat[iat] - cur_Uat;
     Uat[iat]   = cur_Uat;
     dUat(iat)  = cur_dUat;
     d2Uat[iat] = cur_d2Uat;
@@ -831,7 +831,7 @@ public:
   {
     evaluateGL(P, P.G, P.L, false);
     buf.forward(Bytes_in_WFBuffer);
-    return LogValue;
+    return log_value_;
   }
 
   inline void copyFromBuffer(ParticleSet& P, WFBufferType& buf) override
@@ -849,15 +849,15 @@ public:
   {
     if (fromscratch)
       recompute(P);
-    LogValue = valT(0);
+    log_value_ = valT(0);
     for (int iat = 0; iat < Nelec; ++iat)
     {
-      LogValue += Uat[iat];
+      log_value_ += Uat[iat];
       G[iat] += dUat[iat];
       L[iat] += d2Uat[iat];
     }
 
-    return LogValue = -LogValue * 0.5;
+    return log_value_ = -log_value_ * 0.5;
   }
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -235,10 +235,10 @@ RPAJastrow::LogValueType RPAJastrow::evaluateLog(const ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& G,
                                                  ParticleSet::ParticleLaplacian_t& L)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Psi.size(); i++)
-    LogValue += Psi[i]->evaluateLog(P, G, L);
-  return LogValue;
+    log_value_ += Psi[i]->evaluateLog(P, G, L);
+  return log_value_;
 }
 
 RPAJastrow::PsiValueType RPAJastrow::ratio(ParticleSet& P, int iat)
@@ -288,10 +288,10 @@ void RPAJastrow::registerData(ParticleSet& P, WFBufferType& buf)
 
 RPAJastrow::LogValueType RPAJastrow::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch)
 {
-  LogValue = 0.0;
+  log_value_ = 0.0;
   for (int i = 0; i < Psi.size(); i++)
-    LogValue += Psi[i]->updateBuffer(P, buf, fromscratch);
-  return LogValue;
+    log_value_ += Psi[i]->updateBuffer(P, buf, fromscratch);
+  return log_value_;
 }
 
 void RPAJastrow::copyFromBuffer(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -627,7 +627,7 @@ void kSpaceJastrow::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
 
 void kSpaceJastrow::registerData(ParticleSet& P, WFBufferType& buf)
 {
-  LogValue = evaluateLog(P, P.G, P.L);
+  log_value_ = evaluateLog(P, P.G, P.L);
   // eikr.resize(NumPtcls,MaxK);
   // eikr_new.resize(MaxK);
   // delta_eikr.resize(MaxK);
@@ -642,7 +642,7 @@ void kSpaceJastrow::registerData(ParticleSet& P, WFBufferType& buf)
 
 kSpaceJastrow::LogValueType kSpaceJastrow::updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch)
 {
-  LogValue = evaluateLog(P, P.G, P.L);
+  log_value_ = evaluateLog(P, P.G, P.L);
   // for(int iat=0; iat<NumPtcls; iat++)
   //   copy(P.SK->eikr[iat],P.SK->eikr[iat]+MaxK,eikr[iat]);
   // buf.put(Rhok.first_address(), Rhok.last_address());
@@ -650,7 +650,7 @@ kSpaceJastrow::LogValueType kSpaceJastrow::updateBuffer(ParticleSet& P, WFBuffer
   // buf.put(d2U.first_address(), d2U.last_address());
   // buf.put(FirstAddressOfdU,LastAddressOfdU);
   // return LogValue;
-  return LogValue;
+  return log_value_;
 }
 
 void kSpaceJastrow::copyFromBuffer(ParticleSet& P, WFBufferType& buf)

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -63,7 +63,7 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(const P
 {
   const auto& d_table = P.getDistTable(myTableID);
   int icent           = 0;
-  LogValue            = 0.0;
+  log_value_            = 0.0;
   RealType dist       = 0.0;
   PosType disp        = 0.0;
   for (int iat = 0; iat < NumTargetPtcls; iat++)
@@ -76,14 +76,14 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(const P
     {
       dist = d_table.getDistRow(iat)[icent];
       disp = -1.0 * d_table.getDisplRow(iat)[icent];
-      LogValue -= a * dist * dist;
+      log_value_ -= a * dist * dist;
       U[iat] += a * dist * dist;
       G[iat] -= 2.0 * a * disp;
       L[iat] -= 6.0 * a;
       icent++;
     }
   }
-  return LogValue;
+  return log_value_;
 }
 
 /** evaluate the ratio \f$exp(U(iat)-U_0(iat))\f$
@@ -147,7 +147,7 @@ void LatticeGaussianProduct::evaluateLogAndStore(const ParticleSet& P,
   RealType dist       = 0.0;
   PosType disp        = 0.0;
   int icent           = 0;
-  LogValue            = 0.0;
+  log_value_            = 0.0;
   U                   = 0.0;
   dU                  = 0.0;
   d2U                 = 0.0;
@@ -158,7 +158,7 @@ void LatticeGaussianProduct::evaluateLogAndStore(const ParticleSet& P,
     {
       dist = d_table.getDistRow(iat)[icent];
       disp = -1.0 * d_table.getDisplRow(iat)[icent];
-      LogValue -= a * dist * dist;
+      log_value_ -= a * dist * dist;
       U[iat] += a * dist * dist;
       dU[iat] -= 2.0 * a * disp;
       d2U[iat] -= 6.0 * a;
@@ -187,7 +187,7 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::updateBuffer(Partic
   buf.put(U.first_address(), U.last_address());
   buf.put(d2U.first_address(), d2U.last_address());
   buf.put(FirstAddressOfdU, LastAddressOfdU);
-  return LogValue;
+  return log_value_;
 }
 
 /** copy the current data from a buffer

--- a/src/QMCWaveFunctions/LinearOrbital.h
+++ b/src/QMCWaveFunctions/LinearOrbital.h
@@ -52,8 +52,8 @@ public:
       G[i] = coeff;
     }
     L        = 0.0;
-    LogValue = convertValueToLog(v);
-    return LogValue;
+    log_value_ = convertValueToLog(v);
+    return log_value_;
   }
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override {}

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -47,7 +47,7 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, boo
       BufferCursor_scalar(0),
       PhaseValue(0.0),
       PhaseDiff(0.0),
-      LogValue(0.0),
+      log_real_(0.0),
       OneOverM(1.0),
       use_tasking_(tasking)
 {
@@ -127,9 +127,9 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateLog(ParticleSet& P)
   G = P.G;
   L = P.L;
 
-  LogValue   = std::real(logpsi);
+  log_real_   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
-  return LogValue;
+  return log_real_;
 }
 
 void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
@@ -153,7 +153,7 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
     lapl.resize(num_particles);
     grad           = czero;
     lapl           = czero;
-    twf.LogValue   = czero;
+    twf.log_real_   = czero;
     twf.PhaseValue = czero;
   };
   for (int iw = 0; iw < wf_list.size(); iw++)
@@ -175,8 +175,8 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
 
     for (int i = 0; i < num_wfc; ++i)
     {
-      twf.LogValue += std::real(twf.Z[i]->LogValue);
-      twf.PhaseValue += std::imag(twf.Z[i]->LogValue);
+      twf.log_real_ += std::real(twf.Z[i]->get_log_value());
+      twf.PhaseValue += std::imag(twf.Z[i]->get_log_value());
     }
 
     // Ye: temporal workaround to have P.G/L always defined.
@@ -226,7 +226,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
     if (Z[i]->Optimizable)
       logpsi += Z[i]->evaluateLog(P, P.G, P.L);
   }
-  LogValue   = std::real(logpsi);
+  log_real_   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
 
   //In case we need to recompute orbitals, initialize dummy vectors for G and L.
@@ -244,7 +244,7 @@ TrialWaveFunction::RealType TrialWaveFunction::evaluateDeltaLog(ParticleSet& P, 
         Z[i]->evaluateLog(P, dummyG, dummyL);
     }
   }
-  return LogValue;
+  return log_real_;
 }
 
 void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
@@ -297,7 +297,7 @@ void TrialWaveFunction::mw_evaluateDeltaLogSetup(const RefVectorWithLeader<Trial
     lapl.resize(num_particles);
     grad           = czero;
     lapl           = czero;
-    twf.LogValue   = czero;
+    twf.log_real_   = czero;
     twf.PhaseValue = czero;
   };
   for (int iw = 0; iw < wf_list.size(); iw++)
@@ -312,13 +312,13 @@ void TrialWaveFunction::mw_evaluateDeltaLogSetup(const RefVectorWithLeader<Trial
     {
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
       for (int iw = 0; iw < wf_list.size(); iw++)
-        logpsi_opt_list[iw] += std::real(wfc_list[iw].LogValue);
+        logpsi_opt_list[iw] += std::real(wfc_list[iw].get_log_value());
     }
     else
     {
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, fixedG_list, fixedL_list);
       for (int iw = 0; iw < wf_list.size(); iw++)
-        logpsi_fixed_list[iw] += std::real(wfc_list[iw].LogValue);
+        logpsi_fixed_list[iw] += std::real(wfc_list[iw].get_log_value());
     }
   }
 
@@ -356,7 +356,7 @@ void TrialWaveFunction::mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveF
     lapl.resize(num_particles);
     grad           = czero;
     lapl           = czero;
-    twf.LogValue   = czero;
+    twf.log_real_   = czero;
     twf.PhaseValue = czero;
   };
   for (int iw = 0; iw < wf_list.size(); iw++)
@@ -374,7 +374,7 @@ void TrialWaveFunction::mw_evaluateDeltaLog(const RefVectorWithLeader<TrialWaveF
       const auto wfc_list(extractWFCRefList(wf_list, i));
       wavefunction_components[i]->mw_evaluateLog(wfc_list, p_list, g_list, l_list);
       for (int iw = 0; iw < wf_list.size(); iw++)
-        logpsi_list[iw] += std::real(wfc_list[iw].LogValue);
+        logpsi_list[iw] += std::real(wfc_list[iw].get_log_value());
     }
 
   // Temporary workaround to have P.G/L always defined.
@@ -731,9 +731,9 @@ void TrialWaveFunction::acceptMove(ParticleSet& P, int iat, bool safe_to_delay)
   }
   PhaseValue += PhaseDiff;
   PhaseDiff = 0.0;
-  LogValue  = 0;
+  log_real_  = 0;
   for (int i = 0; i < Z.size(); i++)
-    LogValue += std::real(Z[i]->LogValue);
+    log_real_ += std::real(Z[i]->get_log_value());
 }
 
 void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
@@ -750,7 +750,7 @@ void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWave
   for (int iw = 0; iw < wf_list.size(); iw++)
     if (isAccepted[iw])
     {
-      wf_list[iw].LogValue   = 0;
+      wf_list[iw].log_real_   = 0;
       wf_list[iw].PhaseValue = 0;
     }
 
@@ -763,8 +763,8 @@ void TrialWaveFunction::mw_accept_rejectMove(const RefVectorWithLeader<TrialWave
     for (int iw = 0; iw < wf_list.size(); iw++)
       if (isAccepted[iw])
       {
-        wf_list[iw].LogValue += std::real(wfc_list[iw].LogValue);
-        wf_list[iw].PhaseValue += std::imag(wfc_list[iw].LogValue);
+        wf_list[iw].log_real_ += std::real(wfc_list[iw].get_log_value());
+        wf_list[iw].PhaseValue += std::imag(wfc_list[iw].get_log_value());
       }
   }
 }
@@ -810,7 +810,7 @@ TrialWaveFunction::LogValueType TrialWaveFunction::evaluateGL(ParticleSet& P, bo
   // remove when KineticEnergy use WF.G/L instead of P.G/L
   G          = P.G;
   L          = P.L;
-  LogValue   = std::real(logpsi);
+  log_real_   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
   return logpsi;
 }
@@ -834,7 +834,7 @@ void TrialWaveFunction::mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunctio
     wfs.L.resize(num_particles);
     wfs.G          = czero;
     wfs.L          = czero;
-    wfs.LogValue   = czero;
+    wfs.log_real_   = czero;
     wfs.PhaseValue = czero;
   }
 
@@ -855,8 +855,8 @@ void TrialWaveFunction::mw_evaluateGL(const RefVectorWithLeader<TrialWaveFunctio
 
     for (int i = 0; i < num_wfc; ++i)
     {
-      twf.LogValue += std::real(twf.Z[i]->LogValue);
-      twf.PhaseValue += std::imag(twf.Z[i]->LogValue);
+      twf.log_real_ += std::real(twf.Z[i]->get_log_value());
+      twf.PhaseValue += std::imag(twf.Z[i]->get_log_value());
     }
 
     // Ye: temporal workaround to have P.G/L always defined.
@@ -896,7 +896,7 @@ void TrialWaveFunction::getLogs(std::vector<RealType>& lvals)
   lvals.resize(Z.size(), 0);
   for (int i = 0; i < Z.size(); i++)
   {
-    lvals[i] = std::real(Z[i]->LogValue);
+    lvals[i] = std::real(Z[i]->get_log_value());
   }
 }
 
@@ -905,7 +905,7 @@ void TrialWaveFunction::getPhases(std::vector<RealType>& pvals)
   pvals.resize(Z.size(), 0);
   for (int i = 0; i < Z.size(); i++)
   {
-    pvals[i] = std::imag(Z[i]->LogValue);
+    pvals[i] = std::imag(Z[i]->get_log_value());
   }
 }
 
@@ -921,7 +921,7 @@ void TrialWaveFunction::registerData(ParticleSet& P, WFBufferType& buf)
     Z[i]->registerData(P, buf);
   }
   buf.add(PhaseValue);
-  buf.add(LogValue);
+  buf.add(log_real_);
 }
 
 void TrialWaveFunction::debugOnlyCheckBuffer(WFBufferType& buffer)
@@ -955,14 +955,14 @@ TrialWaveFunction::RealType TrialWaveFunction::updateBuffer(ParticleSet& P, WFBu
   G = P.G;
   L = P.L;
 
-  LogValue   = std::real(logpsi);
+  log_real_   = std::real(logpsi);
   PhaseValue = std::imag(logpsi);
   //printGL(P.G,P.L);
   buf.put(PhaseValue);
-  buf.put(LogValue);
+  buf.put(log_real_);
   // Ye: temperal added check, to be removed
   debugOnlyCheckBuffer(buf);
-  return LogValue;
+  return log_real_;
 }
 
 void TrialWaveFunction::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
@@ -976,7 +976,7 @@ void TrialWaveFunction::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
   }
   //get the gradients and laplacians from the buffer
   buf.get(PhaseValue);
-  buf.get(LogValue);
+  buf.get(log_real_);
   debugOnlyCheckBuffer(buf);
 }
 
@@ -1098,7 +1098,7 @@ void TrialWaveFunction::evaluateDerivatives(ParticleSet& P,
       else
         Z[i]->multiplyDerivsByOrbR(dlogpsi);
     }
-    RealType psiValue = std::exp(-LogValue) * std::cos(PhaseValue);
+    RealType psiValue = std::exp(-log_real_) * std::cos(PhaseValue);
     for (int i = 0; i < dlogpsi.size(); i++)
       dlogpsi[i] *= psiValue;
   }

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -112,8 +112,8 @@ public:
 
   inline RealType getPhaseDiff() const { return PhaseDiff; }
   inline void resetPhaseDiff() { PhaseDiff = 0.0; }
-  inline RealType getLogPsi() const { return LogValue; }
-  inline void setLogPsi(RealType LogPsi_new) { LogValue = LogPsi_new; }
+  inline RealType getLogPsi() const { return log_real_; }
+  inline void setLogPsi(RealType LogPsi_new) { log_real_ = LogPsi_new; }
 
   /** add a WaveFunctionComponent
    * @param aterm a WaveFunctionComponent pointer
@@ -480,8 +480,8 @@ private:
   ///diff of the phase of the trial wave function during ratio calls
   RealType PhaseDiff;
 
-  ///log of the trial wave function
-  RealType LogValue;
+  ///real part of trial wave function log 
+  RealType log_real_;
 
   ///One over mass of target particleset, needed for Local Energy Derivatives
   RealType OneOverM;

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -28,11 +28,11 @@ WaveFunctionComponent::WaveFunctionComponent(const std::string& class_name, cons
       Optimizable(true),
       is_fermionic(false),
       UpdateMode(ORB_WALKER),
-      LogValue(0.0),
       dPsi(nullptr),
       ClassName(class_name),
       myName(obj_name),
-      Bytes_in_WFBuffer(0)
+      Bytes_in_WFBuffer(0),
+      log_value_(0.0)
 {
   if (ClassName.empty())
     throw std::runtime_error("WaveFunctionComponent ClassName cannot be empty!");

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -48,7 +48,7 @@ struct NLjob
 #endif
 
 ///forward declaration
-struct WaveFunctionComponent;
+class WaveFunctionComponent;
 struct DiffWaveFunctionComponent;
 class ResourceCollection;
 
@@ -69,8 +69,9 @@ class ResourceCollection;
  * which are required to be base class pointers of the same derived class type.
  * all the mw_ routines must be implemented in a way either stateless or maintains states of every walker.
  */
-struct WaveFunctionComponent : public QMCTraits
+class WaveFunctionComponent : public QMCTraits
 {
+public:
   /** enum for a update mode */
   enum
   {
@@ -107,9 +108,6 @@ struct WaveFunctionComponent : public QMCTraits
 
   /** current update mode */
   int UpdateMode;
-  /** current \f$\log\phi \f$
-   */
-  LogValueType LogValue;
   /** Pointer to the differential WaveFunctionComponent of this object
    *
    * If dPsi=0, this WaveFunctionComponent is constant with respect to the optimizable variables
@@ -128,6 +126,16 @@ struct WaveFunctionComponent : public QMCTraits
   ///Bytes in WFBuffer
   size_t Bytes_in_WFBuffer;
 
+protected:
+  /** current \f$\log\phi \f$
+   */
+  LogValueType log_value_;
+
+public:
+  const LogValueType get_log_value() const { return log_value_; }
+  LogValueType& log_value() { return log_value_; }
+  
+  
   /// default constructor
   WaveFunctionComponent(const std::string& class_name, const std::string& obj_name = "");
   ///default destructor
@@ -139,7 +147,7 @@ struct WaveFunctionComponent : public QMCTraits
   virtual void setDiffOrbital(std::unique_ptr<DiffWaveFunctionComponent> d);
 
   ///assembles the full value
-  PsiValueType getValue() const { return LogToValue<PsiValueType>::convert(LogValue); }
+  PsiValueType getValue() const { return LogToValue<PsiValueType>::convert(log_value_); }
 
   /** check in optimizable parameters
    * @param active a super set of optimizable variables
@@ -476,7 +484,7 @@ struct WaveFunctionComponent : public QMCTraits
 
   virtual void multiplyDerivsByOrbR(std::vector<ValueType>& dlogpsi)
   {
-    RealType myrat = std::real(LogToValue<PsiValueType>::convert(LogValue));
+    RealType myrat = std::real(LogToValue<PsiValueType>::convert(log_value_));
     for (int j = 0; j < myVars.size(); j++)
     {
       int loc = myVars.where(j);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -148,7 +148,7 @@ TEST_CASE("DiracDeterminant_first", "[wavefunction][fermion]")
   elec.acceptMove(1);
 
   CHECK(std::real(ratio_1) == Approx(0.9308456444));
-  CHECK(std::real(ddb.LogValue) == Approx(1.9891064655));
+  CHECK(std::real(ddb.get_log_value()) == Approx(1.9891064655));
 }
 
 //#define DUMP_INFO
@@ -223,9 +223,9 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
                   scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
   std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
@@ -242,7 +242,7 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
   std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
@@ -258,7 +258,7 @@ TEST_CASE("DiracDeterminant_second", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
   std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
@@ -352,9 +352,9 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
                   scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
   std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
@@ -378,7 +378,7 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
   std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
@@ -398,7 +398,7 @@ TEST_CASE("DiracDeterminant_delayed_update", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
   std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -151,7 +151,7 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
   elec.acceptMove(1);
 
   CHECK(std::real(ratio_1) == Approx(0.9308456444));
-  CHECK(std::real(ddb.LogValue) == Approx(1.9891064655));
+  CHECK(std::real(ddb.get_log_value()) == Approx(1.9891064655));
 }
 
 //#define DUMP_INFO
@@ -226,9 +226,9 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
                   scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
   std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
@@ -245,7 +245,7 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
   std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
@@ -261,7 +261,7 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddb.LogValue) << std::endl;
+  std::cout << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
   std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
@@ -355,9 +355,9 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
                   scratchT.cols());
   LogValueType det_update1;
   dm.invert_transpose(scratchT, a_update1, det_update1);
-  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.LogValue);
+  PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
   std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
@@ -381,7 +381,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
   std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
@@ -401,7 +401,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddc.LogValue) << std::endl;
+  std::cout << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
   std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
   std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -229,6 +229,6 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   elec_.acceptMove(1);
 
   REQUIRE(std::real(ratio_1) == Approx(0.9871985577));
-  REQUIRE(std::real(j2->LogValue) == Approx(0.0883791773));
+  REQUIRE(std::real(j2->get_log_value()) == Approx(0.0883791773));
 }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_bspline_jastrow.cpp
@@ -296,7 +296,7 @@ TEST_CASE("BSpline builder Jastrow J1", "[wavefunction]")
   elec_.acceptMove(1);
 
   REQUIRE(std::real(ratio_1) == Approx(1.0040884258));
-  REQUIRE(std::real(j1->LogValue) == Approx(0.32013531536));
+  REQUIRE(std::real(j1->get_log_value()) == Approx(0.32013531536));
 
   // test to make sure that setting cusp for J1 works properly
   const char* particles2 = "<tmp> \

--- a/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_counting_jastrow.cpp
@@ -395,7 +395,7 @@ TEST_CASE("CountingJastrow","[wavefunction]")
     optVars[p] = 0;
   cj->resetParameters(optVars);
   cj->recompute(elec);
-  REQUIRE( cj->LogValue == LogValueType(0) );
+  REQUIRE( cj->get_log_value() == LogValueType(0) );
 #endif
 
 }

--- a/src/QMCWaveFunctions/tests/test_dirac_matrix.cpp
+++ b/src/QMCWaveFunctions/tests/test_dirac_matrix.cpp
@@ -37,7 +37,7 @@ TEST_CASE("DiracMatrix_identity", "[wavefunction][fermion]")
   DiracMatrix<ValueType> dm;
 
   Matrix<ValueType> m, m_invT;
-  LogValueType LogValue;
+  LogValueType log_value;
   m.resize(3, 3);
   m_invT.resize(3, 3);
 
@@ -45,8 +45,8 @@ TEST_CASE("DiracMatrix_identity", "[wavefunction][fermion]")
   m(1, 1) = 1.0;
   m(2, 2) = 1.0;
 
-  dm.invert_transpose(m, m_invT, LogValue);
-  REQUIRE(LogValue == LogComplexApprox(0.0));
+  dm.invert_transpose(m, m_invT, log_value);
+  REQUIRE(log_value == LogComplexApprox(0.0));
 
   Matrix<ValueType> eye;
   eye.resize(3, 3);
@@ -63,7 +63,7 @@ TEST_CASE("DiracMatrix_inverse", "[wavefunction][fermion]")
   DiracMatrix<ValueType> dm;
 
   Matrix<ValueType> a, a_T, a_inv;
-  LogValueType LogValue;
+  LogValueType log_value;
   a.resize(3, 3);
   a_T.resize(3, 3);
   a_inv.resize(3, 3);
@@ -79,8 +79,8 @@ TEST_CASE("DiracMatrix_inverse", "[wavefunction][fermion]")
   a(2, 2) = 4.9;
 
   simd::transpose(a.data(), a.rows(), a.cols(), a_T.data(), a_T.rows(), a_T.cols());
-  dm.invert_transpose(a_T, a_inv, LogValue);
-  REQUIRE(LogValue == LogComplexApprox(3.78518913425));
+  dm.invert_transpose(a_T, a_inv, log_value);
+  REQUIRE(log_value == LogComplexApprox(3.78518913425));
 
   Matrix<ValueType> b;
   b.resize(3, 3);
@@ -104,7 +104,7 @@ TEST_CASE("DiracMatrix_inverse_matching", "[wavefunction][fermion]")
   DiracMatrix<double> dm;
 
   Matrix<double> a, a_T, a_inv;
-  LogValueType LogValue;
+  LogValueType log_value;
   a.resize(4, 4);
   a_T.resize(4, 4);
   a_inv.resize(4, 4);
@@ -127,8 +127,8 @@ TEST_CASE("DiracMatrix_inverse_matching", "[wavefunction][fermion]")
   a(3, 3) = 8;
 
   simd::transpose(a.data(), a.rows(), a.cols(), a_T.data(), a_T.rows(), a_T.cols());
-  dm.invert_transpose(a_T, a_inv, LogValue);
-  CHECK(LogValue == LogComplexApprox(std::complex<double>{5.50533, 6.28319}));
+  dm.invert_transpose(a_T, a_inv, log_value);
+  CHECK(log_value == LogComplexApprox(std::complex<double>{5.50533, 6.28319}));
 
   Matrix<std::complex<double>> inv_M;
   inv_M.resize(4, 4);
@@ -158,7 +158,7 @@ TEST_CASE("DiracMatrix_inverse_matching_2", "[wavefunction][fermion]")
   DiracMatrix<double> dm;
 
   Matrix<double> a, a_T, a_inv;
-  LogValueType LogValue;
+  LogValueType log_value;
   a.resize(4, 4);
   a_T.resize(4, 4);
   a_inv.resize(4, 4);
@@ -206,8 +206,8 @@ TEST_CASE("DiracMatrix_inverse_matching_2", "[wavefunction][fermion]")
   auto check_matrix_result = checkMatrix(lu_mat, a_T);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
-  dm.invert_transpose(a, a_inv, LogValue);
-  CHECK(LogValue == LogComplexApprox(std::complex<double>{5.50533, 6.28319}));
+  dm.invert_transpose(a, a_inv, log_value);
+  CHECK(log_value == LogComplexApprox(std::complex<double>{5.50533, 6.28319}));
 
   Matrix<std::complex<double>> inv_M;
   inv_M.resize(4, 4);
@@ -241,7 +241,7 @@ TEST_CASE("DiracMatrix_inverse_complex", "[wavefunction][fermion]")
   DiracMatrix<std::complex<double>> dm;
 
   Matrix<std::complex<double>> a, a_T, a_inv;
-  LogValueType LogValue;
+  LogValueType log_value;
   a.resize(4, 4);
   a_T.resize(4, 4);
   a_inv.resize(4, 4);
@@ -304,8 +304,8 @@ TEST_CASE("DiracMatrix_inverse_complex", "[wavefunction][fermion]")
   auto check_matrix_result = checkMatrix(lu_mat, a_T);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
-  dm.invert_transpose(a, a_inv, LogValue);
-  CHECK(LogValue == LogComplexApprox(std::complex<double>{5.603777579195571, 0.12452497406076501}));
+  dm.invert_transpose(a, a_inv, log_value);
+  CHECK(log_value == LogComplexApprox(std::complex<double>{5.603777579195571, 0.12452497406076501}));
 
   Matrix<std::complex<double>> b;
   b.resize(4, 4);
@@ -338,7 +338,7 @@ TEST_CASE("DiracMatrix_update_row", "[wavefunction][fermion]")
   updateEng.resize(3, 1);
 
   Matrix<ValueType> a, a_T, a_inv;
-  LogValueType LogValue;
+  LogValueType log_value;
   a.resize(3, 3);
   a_T.resize(3, 3);
   a_inv.resize(3, 3);
@@ -354,7 +354,7 @@ TEST_CASE("DiracMatrix_update_row", "[wavefunction][fermion]")
   a(2, 2) = 4.9;
 
   simd::transpose(a.data(), a.rows(), a.cols(), a_T.data(), a_T.rows(), a_T.cols());
-  dm.invert_transpose(a_T, a_inv, LogValue);
+  dm.invert_transpose(a_T, a_inv, log_value);
 
   // new row
   Vector<ValueType> v(3), invRow(3);

--- a/src/Sandbox/determinant.hpp
+++ b/src/Sandbox/determinant.hpp
@@ -140,7 +140,7 @@ template<typename T, typename INVT = double>
 struct DiracDet
 {
   ///log|det|
-  std::complex<INVT> LogValue;
+  std::complex<INVT> log_value;
   ///current ratio
   INVT curRatio;
   ///workspace size
@@ -182,7 +182,7 @@ struct DiracDet
     psiMsave -= shift;
 
     transpose(psiMsave.data(), psiM.data(), nels, nels);
-    InvertWithLog(psiM.data(), nels, nels, work.data(), LWork, pivot.data(), LogValue);
+    InvertWithLog(psiM.data(), nels, nels, work.data(), LWork, pivot.data(), log_value);
     copy_n(psiM.data(), nels * nels, psiMinv.data());
 
     if (omp_get_num_threads() == 1)
@@ -245,8 +245,8 @@ struct DiracDet
           std::complex<INVT> newlog;
           InvertWithLog(psiM.data(), nels, nels, work.data(), pivot.data(), newlog);
 
-          ratio_full = std::exp(std::real(newlog - LogValue));
-          LogValue   = newlog;
+          ratio_full = std::exp(std::real(newlog - log_value));
+          log_value   = newlog;
           double err = r / ratio_full - 1;
           ratio_error += err;
 #pragma omp master


### PR DESCRIPTION
## Proposed changes
Rename all the LogValue variables to log_value or log_value_.
They look like types and block the LogValueType -> LogValue type rename.

Why?
We should make some general improvements to the code as we work.
It is not a waste of time to make the code easier to read and understand.

I've fixed every LogValue in a cpp|hpp|h file that I can find through the clang AST and with ag.  I have not bothered to fix things in Sandbox (why is this still in the code tree) or comments that should just be deleted.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes)
- Documentation changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
