### PR TITLE
fix for get_first_neighbor if there is only one particle

### DIFF
--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -118,6 +118,8 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
+    //ensure there are neighbors
+    assert(N_targets > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -317,6 +317,8 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
+    //ensure there are neighbors
+    assert(N_targets > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -127,6 +127,8 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
+    //ensure there are neighbors
+    assert(N_sources > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -405,6 +405,8 @@ public:
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
+    //ensure there are neighbors
+    assert(N_sources > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -185,8 +185,9 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
     {
       AtomicCentersInfo.non_overlapping_radius[i] = std::numeric_limits<RealType>::max();
       //should only call get_first_neighbor to set non_overlapping_radius if there are more than one atom  in the cell
-      for (int j = 0; j < Super2Prim.size() && (Super2Prim.size() > 1); j++)
-      {
+      if (Super2Prim.size() == 1)
+        continue;
+      for (int j = 0; j < Super2Prim.size(); j++)
         if (Super2Prim[j] == i)
         {
           // set GroupID for each ion in primitive cell
@@ -209,7 +210,6 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
           AtomicCentersInfo.non_overlapping_radius[i] = 0.5 * r;
           break;
         }
-      }
     }
 
     // load cutoff_radius, spline_radius, spline_npoints, lmax if exists.

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -182,7 +182,11 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
     const auto& ii_table = SourcePtcl->getDistTable(table_id);
     SourcePtcl->update(true);
     for (int i = 0; i < IonPos.size(); i++)
-      for (int j = 0; j < Super2Prim.size(); j++)
+    {
+      AtomicCentersInfo.non_overlapping_radius[i] = std::numeric_limits<RealType>::max();
+      //should only call get_first_neighbor to set non_overlapping_radius if there are more than one atom  in the cell
+      for (int j = 0; j < Super2Prim.size() && (Super2Prim.size() > 1); j++)
+      {
         if (Super2Prim[j] == i)
         {
           // set GroupID for each ion in primitive cell
@@ -205,6 +209,8 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
           AtomicCentersInfo.non_overlapping_radius[i] = 0.5 * r;
           break;
         }
+      }
+    }
 
     // load cutoff_radius, spline_radius, spline_npoints, lmax if exists.
     const int inner_cutoff_ind   = SourcePtcl->mySpecies.findAttribute("inner_cutoff");


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This PR fixes an issue that was introduced in #3288 which causes the code to crash in the case where there is only one atom in the simulation cell. 

The distance tables function get_first_neighbor should only be called if there are actually neighbors, so an assertion is added in each of these functions. 

Also, in EinsplineSetBuilderESHDF.fft.cpp, now the get_first_neighbor is only called if there are multiple atoms in the simulation cell. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my workstation, gnu 9.2.0

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
