### PR TITLE
restoring multithreaded unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,6 +890,9 @@ else()
   message(STATUS "VTune ittnotify APIs disabled")
 endif()
 
+# consider making this always on if OpenMP is no longer UB with Thread Support Library
+# We should test out abstractions consistently and c++17 stdlib's all have support for
+# std::thread and std::atomic
 option(QMC_EXP_THREADING "Experimental non openmp threading models" OFF)
 mark_as_advanced(QMC_EXP_THREADING)
 if(QMC_EXP_THREADING)

--- a/src/Concurrency/tests/CMakeLists.txt
+++ b/src/Concurrency/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 #// This file is distributed under the University of Illinois/NCSA Open Source License.
 #// See LICENSE file in top directory for details.
 #//
-#// Copyright (c) 2019 QMCPACK developers.
+#// Copyright (c) 2021 QMCPACK developers.
 #//
 #// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 #//
@@ -23,4 +23,4 @@ add_executable(${UTEST_EXE} ${SRCS})
 
 target_link_libraries(${UTEST_EXE} catch_main)
 
-add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+add_unit_test(${UTEST_NAME} 1 3 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")

--- a/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
+++ b/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
@@ -48,10 +48,6 @@ TEST_CASE("ParallelExecutor<OPENMP> lambda case", "[concurrency]")
   REQUIRE(count == num_threads);
 }
 
-// Sadly this test case is not straight forward with openmp
-// Wouldn't be with std::thread either both call terminate when
-// the exception is not caught
-//
 TEST_CASE("ParallelExecutor<OPENMP> nested case", "[concurrency]")
 {
   int num_threads = 1;

--- a/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
+++ b/src/Concurrency/tests/test_ParallelExecutorOPENMP.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
@@ -35,6 +35,7 @@ TEST_CASE("ParallelExecutor<OPENMP> function case", "[concurrency]")
 TEST_CASE("ParallelExecutor<OPENMP> lambda case", "[concurrency]")
 {
   const int num_threads = omp_get_max_threads();
+  std::cout << "omp_get_max_threads() == " << num_threads << '\n';
   ParallelExecutor<Executor::OPENMP> test_block;
   int count(0);
   test_block(
@@ -49,7 +50,7 @@ TEST_CASE("ParallelExecutor<OPENMP> lambda case", "[concurrency]")
 
 // Sadly this test case is not straight forward with openmp
 // Wouldn't be with std::thread either both call terminate when
-// the exception is not
+// the exception is not caught
 //
 TEST_CASE("ParallelExecutor<OPENMP> nested case", "[concurrency]")
 {

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -108,7 +108,7 @@ if(NOT QMC_CUDA)
       platform_omptarget)
   endif()
 
-  add_unit_test(${UTEST_NAME} 1 1 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
+  add_unit_test(${UTEST_NAME} 1 8 "${QMCPACK_UNIT_TEST_DIR}/${UTEST_EXE}")
   set_tests_properties(${UTEST_NAME} PROPERTIES WORKING_DIRECTORY ${UTEST_DIR})
 
   if(HAVE_MPI)


### PR DESCRIPTION
## Proposed changes

Fix regression where unit tests written to be run with multiple threads are no longer run on multiple threads. Actually testing concurrent code concurrently is a good idea and #3373 reminded me that we should have more of this. When I went and look for an example I discovered previous tests I wrote were not actually being run with multiple threads anymore.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
