### PR TITLE
Fix includes for unique_ptr

### DIFF
--- a/src/OhmmsApp/RandomNumberControl.h
+++ b/src/OhmmsApp/RandomNumberControl.h
@@ -14,6 +14,7 @@
 
 #ifndef OHMMS_RANDOMNUMBERCONTROL_H__
 #define OHMMS_RANDOMNUMBERCONTROL_H__
+#include <memory>
 #include <libxml/xpath.h>
 #include "OhmmsData/OhmmsElementBase.h"
 #include "Utilities/RandomGenerator.h"

--- a/src/Utilities/TimerManager.h
+++ b/src/Utilities/TimerManager.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <mutex>
 #include <map>
+#include <memory>
 #include "NewTimer.h"
 #include "config.h"
 #include "OhmmsData/Libxml2Doc.h"


### PR DESCRIPTION
## Proposed changes

Fix gcc development build (broken on cdash) due to missing includes. unique_ptr is in `<memory>`


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

sulfur, no mpi build

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
