### PR TITLE
Downgrade Summit toolchain to cuda 10.1.243

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,7 +773,7 @@ if(QMC_CUDA OR ENABLE_CUDA)
       message(STATUS "Setting CUDA FLAGS=${CUDA_NVCC_FLAGS}")
     else(CUDA_NVCC_FLAGS MATCHES "arch")
       # Automatically set the default NVCC flags
-      set(CUDA_NVCC_FLAGS "-Drestrict=__restrict__;-DNO_CUDA_MAIN;-std=c++14")
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Drestrict=__restrict__;-DNO_CUDA_MAIN;-std=c++14")
       if(QMC_COMPLEX)
         set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-DQMC_COMPLEX")
       endif()

--- a/config/build_olcf_summit_Clang.sh
+++ b/config/build_olcf_summit_Clang.sh
@@ -12,7 +12,8 @@ module load gcc/9.3.0
 module load spectrum-mpi
 module load cmake
 module load git
-module load cuda
+# default cuda/11.0.3 causes frequent hanging with the offload code in production runs.
+module load cuda/10.1.243
 module load essl
 module load netlib-lapack
 module load hdf5
@@ -25,7 +26,8 @@ if [[ ! -d /ccs/proj/mat151/opt/modules ]] ; then
   exit 1
 fi
 module use /ccs/proj/mat151/opt/modules
-module load llvm/main-20210811
+# requires cuda/10.1.243 to have safe production runs.
+module load llvm/main-20210811-cuda10.1
 
 TYPE=Release
 Compiler=Clang
@@ -51,7 +53,7 @@ if [[ $name == *"offload"* ]]; then
 fi
 
 if [[ $name == *"cuda"* ]]; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_CUDA=1 -D CUDA_ARCH=sm_70 -D CUDA_HOST_COMPILER=`which gcc`"
+  CMAKE_FLAGS="$CMAKE_FLAGS -D ENABLE_CUDA=1 -D CUDA_ARCH=sm_70 -D CUDA_HOST_COMPILER=/usr/bin/gcc -D CUDA_NVCC_FLAGS='-Xcompiler;-mno-float128'"
 fi
 
 folder=build_summit_${Compiler}_${name}


### PR DESCRIPTION
## Proposed changes
The default CUDA 11.0.3 after OS upgrade on Summit, caused frequent hanging with the offload code in production runs.
Stick to CUDA 10.1.243 for now.

PS: a small change on CUDA_NVCC_FLAGS is needed to allow passing additional arguments via command line.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
