### PR TITLE
Nexus: Small fix to add_L2 function in pseudopotential.py

### DIFF
--- a/nexus/lib/pseudopotential.py
+++ b/nexus/lib/pseudopotential.py
@@ -596,7 +596,7 @@ class SemilocalPP(Pseudopotential):
 
     # test needed
     def add_L2(self,v):
-        self.set_component('L2',guard=True)
+        self.set_component('L2',v,guard=True)
     #end def add_L2
 
 


### PR DESCRIPTION
## Proposed changes

The argument `v` is missing to the `set_component` call inside `add_L2` within `pseudopotential.py`. This PR resolves this issue.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Linux laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
