### PR TITLE
BoostRandom: Use compiler-generated copy and copy-assignment operators

### DIFF
--- a/src/Utilities/BoostRandom.h
+++ b/src/Utilities/BoostRandom.h
@@ -61,29 +61,6 @@ public:
         uni(generator_type(iseed), boost::uniform_real<T>(0, 1))
   {}
 
-  ///copy constructor
-  BoostRandom(const BoostRandom& rng)
-      : ClassName(rng.ClassName),
-        EngineName(rng.EngineName),
-        myContext(rng.myContext),
-        nContexts(rng.nContexts),
-        baseOffset(rng.baseOffset),
-        uni(rng.uni)
-  {}
-
-  ///copy operator (unnecessary but why not)
-  BoostRandom<T, RNG>& operator=(const BoostRandom& r)
-  {
-    ClassName  = r.ClassName;
-    EngineName = r.EngineName;
-    myContext  = r.myContext;
-    nContexts  = r.nContexts;
-    baseOffset = r.baseOffset, uni = r.uni;
-    return *this;
-  }
-
-  ~BoostRandom() {}
-
   /** initialize the generator
    * @param i thread index
    * @param nstr number of threads


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Noticed that these match the default compiler-generated copy constructor, copy-assignment operator and destructor. Let's follow the rule-of-zero and use those instead.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted

