### PR TITLE
Fix memory leak in Backflow_eI member containers

### DIFF
--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -250,16 +250,16 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
       for (int i = 0; i < funs.size(); i++)
       {
         //           BsplineFunctor<RealType> *bsp = new BsplineFunctor<RealType>(cusps[i]);
-        BsplineFunctor<RealType>* bsp = new BsplineFunctor<RealType>();
-        bsp->cutoff_radius            = targetPtcl.Lattice.WignerSeitzRadius;
+        auto bsp           = std::make_unique<BsplineFunctor<RealType>>();
+        bsp->cutoff_radius = targetPtcl.Lattice.WignerSeitzRadius;
         bsp->put(funs[i]);
         if (bsp->cutoff_radius > cutOff)
           cutOff = bsp->cutoff_radius;
         bsp->myVars.setParameterType(optimize::BACKFLOW_P);
         //bsp->print();
-        dum->uniqueRadFun.push_back(bsp);
         offsets.push_back(num_params);
         num_params += bsp->NumParams;
+        dum->uniqueRadFun.push_back(std::move(bsp));
       }
       dum->derivs.resize(num_params);
       dum->offsetPrms.resize(nIons);
@@ -270,7 +270,7 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
         {
           APP_ABORT("backflowTransformation::put() ion not mapped to radial function.\n");
         }
-        dum->RadFun[i]     = dum->uniqueRadFun[ion2functor[i]];
+        dum->RadFun[i]     = dum->uniqueRadFun[ion2functor[i]].get();
         dum->offsetPrms[i] = offsets[ion2functor[i]];
       }
       tbf = std::move(dum);

--- a/src/QMCWaveFunctions/Fermion/Backflow_eI.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_eI.h
@@ -31,7 +31,7 @@ private:
 
 public:
   std::vector<FT*> RadFun;
-  std::vector<FT*> uniqueRadFun;
+  std::vector<std::unique_ptr<FT>> uniqueRadFun;
   std::vector<int> offsetPrms;
 
   Backflow_eI(ParticleSet& ions, ParticleSet& els) : BackflowFunctionBase(ions, els), myTableIndex_(els.addTable(ions))
@@ -60,15 +60,15 @@ public:
     clone->uniqueRadFun.resize(uniqueRadFun.size());
     clone->RadFun.resize(RadFun.size());
     for (int i = 0; i < uniqueRadFun.size(); i++)
-      clone->uniqueRadFun[i] = new FT(*(uniqueRadFun[i]));
+      clone->uniqueRadFun[i] = std::make_unique<FT>(*(uniqueRadFun[i]));
     for (int i = 0; i < RadFun.size(); i++)
     {
       bool done = false;
       for (int k = 0; k < uniqueRadFun.size(); k++)
-        if (RadFun[i] == uniqueRadFun[k])
+        if (RadFun[i] == uniqueRadFun[k].get())
         {
           done             = true;
-          clone->RadFun[i] = clone->uniqueRadFun[k];
+          clone->RadFun[i] = clone->uniqueRadFun[k].get();
           break;
         }
       if (!done)


### PR DESCRIPTION
## Proposed changes

Use `std::unique_ptr` for `Backflow_eI::uniqueRadFun` 

Failing tests with ASAN/LSAN:
508 - deterministic-bccH_2x2x2_ae_bf-opt-1-1 (Failed)
516 - deterministic-bccH_2x2x2_ae-vmc_bf-1-1 (Failed)
Related to #3312 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04 , must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
