### PR TITLE
Remove inheritance from NRCOptimization

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -61,10 +61,10 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
                                samples,
                                comm,
                                "QMCFixedSampleLinearOptimizeBatched"),
+      opt_(*this),
 #ifdef HAVE_LMY_ENGINE
       vdeps(1, std::vector<double>()),
 #endif
-      opt_(*this),
       Max_iterations(1),
       nstabilizers(3),
       stabilizerScale(2.0),

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -37,8 +37,20 @@ namespace qmcplusplus
  * generated from VMC.
  */
 
-class QMCFixedSampleLinearOptimizeBatched : public QMCLinearOptimizeBatched,
-                                            private NRCOptimization<QMCTraits::RealType>
+class QMCFixedSampleLinearOptimizeBatched;
+
+// Wrapper class for evaluation of Func so QMCFixedSampleLinearOptimizeBatched
+// can avoid inheriting from NRCOptimization
+class OptimizationFunction : public NRCOptimization<QMCTraits::RealType>
+{
+public:
+  QMCFixedSampleLinearOptimizeBatched& object;
+  OptimizationFunction(QMCFixedSampleLinearOptimizeBatched& o) : object(o) {}
+  Return_t Func(Return_t dl) override;
+};
+
+
+class QMCFixedSampleLinearOptimizeBatched : public QMCLinearOptimizeBatched
 {
 public:
   ///Constructor.
@@ -60,9 +72,10 @@ public:
   ///process xml node value (parameters for both VMC and OPT) for the actual optimization
   bool processOptXML(xmlNodePtr cur, const std::string& vmcMove, bool reportH5, bool useGPU);
 
-  RealType Func(RealType dl) override;
+  RealType costFunc(RealType dl);
 
 private:
+  OptimizationFunction opt_;
   inline bool ValidCostFunction(bool valid)
   {
     if (!valid)


### PR DESCRIPTION
Remove the inheritance of NRCOptimization by QMCFIxedSampleLinearOptimizeBatched

Create a minimal wrapper that does inherit from NRCOptimization for the purpose of calling the objective function.

I changed the name of Func in QMCFixedSampleLinearOptimizeBatched to emphasize that it is no longer overriding Func from NRCOptimization.  And to avoid any unexpected name collisions.


This is the start of cleaning up QMCLinearOptimizeBatched and QMCFIxedSampleLinearOptimizeBatched.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No


## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
