### PR TITLE
[WIP] Refactoring OperatorBase

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -42,58 +42,58 @@
 
 namespace qmcplusplus
 {
-/** traits for QMC variables
- *
- *typedefs for the QMC data types
+/**
+ *  Traits for QMC variables
+ *  QMC data types
  */
 struct QMCTraits
 {
-  enum
-  {
-    DIM = OHMMS_DIM
-  };
-  using QTBase = QMCTypes<OHMMS_PRECISION, DIM>;
-  using QTFull = QMCTypes<OHMMS_PRECISION_FULL, DIM>;
-  typedef QTBase::RealType RealType;
-  typedef QTBase::ComplexType ComplexType;
-  typedef QTBase::ValueType ValueType;
-  typedef QTBase::PosType PosType;
-  typedef QTBase::GradType GradType;
-  typedef QTBase::TensorType TensorType;
-  ///define other types
-  typedef OHMMS_INDEXTYPE IndexType;
-  typedef QTFull::RealType FullPrecRealType;
-  typedef QTFull::ValueType FullPrecValueType;
-  ///define PropertyList_t
-  typedef RecordNamedProperty<FullPrecRealType> PropertySetType;
+  static constexpr int DIM = OHMMS_DIM;
+  using QTBase             = QMCTypes<OHMMS_PRECISION, DIM>;
+  using QTFull             = QMCTypes<OHMMS_PRECISION_FULL, DIM>;
+  using RealType           = QTBase::RealType;
+  using ComplexType        = QTBase::ComplexType;
+  using ValueType          = QTBase::ValueType;
+  using PosType            = QTBase::PosType;
+  using GradType           = QTBase::GradType;
+  using TensorType         = QTBase::TensorType;
+
+  // define other types
+  using IndexType         = OHMMS_INDEXTYPE;
+  using FullPrecRealType  = QTFull::RealType;
+  using FullPrecValueType = QTFull::ValueType;
+
+  // define PropertyList_t
+  using PropertySetType = RecordNamedProperty<FullPrecRealType>;
 
   // Type for particle group index pairs
-  using PtclGrpIndexes = std::vector<std::pair<int,int>>;
+  using PtclGrpIndexes = std::vector<std::pair<int, int>>;
 };
 
-/** Particle traits to use UniformGridLayout for the ParticleLayout.
+/**
+ * Particle traits to use UniformGridLayout for the ParticleLayout.
  */
 struct PtclOnLatticeTraits
 {
   using ParticleLayout_t = CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>;
-  using QTFull = QMCTraits::QTFull;
+  using QTFull           = QMCTraits::QTFull;
 
-  typedef int Index_t;
-  typedef QTFull::RealType Scalar_t;
-  typedef QTFull::ComplexType Complex_t;
+  using Index_t   = int;
+  using Scalar_t  = QTFull::RealType;
+  using Complex_t = QTFull::ComplexType;
 
-  typedef ParticleLayout_t::SingleParticleIndex_t SingleParticleIndex_t;
-  typedef ParticleLayout_t::SingleParticlePos_t SingleParticlePos_t;
-  typedef ParticleLayout_t::Tensor_t Tensor_t;
+  using SingleParticleIndex_t = ParticleLayout_t::SingleParticleIndex_t;
+  using SingleParticlePos_t   = ParticleLayout_t::SingleParticlePos_t;
+  using Tensor_t              = ParticleLayout_t::Tensor_t;
 
-  typedef ParticleAttrib<Index_t> ParticleIndex_t;
-  typedef ParticleAttrib<Scalar_t> ParticleScalar_t;
-  typedef ParticleAttrib<SingleParticlePos_t> ParticlePos_t;
-  typedef ParticleAttrib<Tensor_t> ParticleTensor_t;
+  using ParticleIndex_t  = ParticleAttrib<Index_t>;
+  using ParticleScalar_t = ParticleAttrib<Scalar_t>;
+  using ParticlePos_t    = ParticleAttrib<SingleParticlePos_t>;
+  using ParticleTensor_t = ParticleAttrib<Tensor_t>;
 
-  typedef ParticleAttrib<QTFull::GradType> ParticleGradient_t;
-  typedef ParticleAttrib<QTFull::ValueType> ParticleLaplacian_t;
-  typedef QTFull::ValueType SingleParticleValue_t;
+  using ParticleGradient_t    = ParticleAttrib<QTFull::GradType>;
+  using ParticleLaplacian_t   = ParticleAttrib<QTFull::ValueType>;
+  using SingleParticleValue_t = QTFull::ValueType;
 };
 
 
@@ -101,9 +101,9 @@ struct PtclOnLatticeTraits
 //  Check if we are compiling with Catch defined.  Could use other symbols if needed.
 #ifdef TEST_CASE
 #ifdef QMC_COMPLEX
-  using ValueApprox = Catch::Detail::ComplexApprox;
+using ValueApprox = Catch::Detail::ComplexApprox;
 #else
-  using ValueApprox = Catch::Detail::Approx;
+using ValueApprox = Catch::Detail::Approx;
 #endif
 #endif
 

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -247,8 +247,8 @@ bool DMCcuda::run()
           const NonLocalData* oneTMove = NLop.selectMove(Random(), Txy[iw]);
           if (oneTMove)
           {
-            int iat = oneTMove->PID;
-            PosType newpos(W[iw]->R[iat] + oneTMove->Delta);
+            int iat = oneTMove->pid;
+            PosType newpos(W[iw]->R[iat] + oneTMove->delta);
             if (checkBounds(newpos))
             {
               accepted.push_back(W[iw]);

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -314,7 +314,7 @@ void QMCCostFunction::checkConfigurations()
       e2 += etmp * etmp;
       saved[ENERGY_FIXED] = hClones[ip]->getLocalPotential();
       if (nlpp)
-        saved[ENERGY_FIXED] -= nlpp->Value;
+        saved[ENERGY_FIXED] -= nlpp->value;
     }
     //add them all using reduction
     et_tot += e0;
@@ -460,7 +460,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
       e2 += etmp * etmp;
       saved[ENERGY_FIXED] = hClones[ip]->getLocalPotential();
       if (nlpp)
-        saved[ENERGY_FIXED] -= nlpp->Value;
+        saved[ENERGY_FIXED] -= nlpp->value;
     }
 
     //add them all using reduction

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -385,7 +385,7 @@ void QMCCostFunctionBatched::checkConfigurations()
           if (includeNonlocalH != "no")
           {
             OperatorBase* nlpp = h_list[ib].getHamiltonian(includeNonlocalH);
-            RecordsOnNode[is][ENERGY_FIXED] -= nlpp->Value;
+            RecordsOnNode[is][ENERGY_FIXED] -= nlpp->value;
           }
         }
       }

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -80,7 +80,7 @@ void ACForce::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamilt
   std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi, ham_in);
   if (myclone)
   {
-    ham_in.addOperator(std::move(myclone), myName, UpdateMode[PHYSICAL]);
+    ham_in.addOperator(std::move(myclone), myName, updateMode[PHYSICAL]);
   }
 }
 ACForce::Return_t ACForce::evaluate(ParticleSet& P)
@@ -92,7 +92,7 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   sw_grad     = 0;
   //This function returns d/dR of the sum of all observables in the physical hamiltonian.
   //Note that the sign will be flipped based on definition of force = -d/dR.
-  Value = ham.evaluateIonDerivs(P, ions, psi, hf_force, pulay_force, wf_grad);
+  value = ham.evaluateIonDerivs(P, ions, psi, hf_force, pulay_force, wf_grad);
 
   if (useSpaceWarp)
   {
@@ -155,7 +155,7 @@ void ACForce::setObservables(PropertySetType& plist)
       // add the minus one to be a force.
       plist[myindex++] = -hf_force[iat][iondim];
       plist[myindex++] = -(pulay_force[iat][iondim] + sw_pulay[iat][iondim]);
-      plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
+      plist[myindex++] = -value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
 
       //TODO: Remove when ACForce is production ready
@@ -177,7 +177,7 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
     {
       plist[myindex++] = -hf_force[iat][iondim];
       plist[myindex++] = -(pulay_force[iat][iondim] + sw_pulay[iat][iondim]);
-      plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
+      plist[myindex++] = -value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       //TODO: Remove when ACForce is production ready
       //      if(useSpaceWarp)

--- a/src/QMCHamiltonians/ACForce.h
+++ b/src/QMCHamiltonians/ACForce.h
@@ -10,8 +10,10 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-/**@file ACForce.h
- *@brief Declaration of ACForce, Assaraf-Caffarel ZVZB style force estimation.
+/**
+ * @file ACForce.h
+ * @brief Declaration of ACForce, Assaraf-Caffarel ZVZB style force estimation.
+ * @brief https://arxiv.org/abs/physics/0310035
  */
 #ifndef QMCPLUSPLUS_ACFORCE_H
 #define QMCPLUSPLUS_ACFORCE_H
@@ -23,15 +25,15 @@
 
 namespace qmcplusplus
 {
-struct ACForce : public OperatorBase
+using Force_t = ParticleSet::ParticlePos_t;
+
+class ACForce : public OperatorBase
 {
-  typedef ParticleSet::ParticlePos_t Force_t;
+public:
   /** Constructor **/
   ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& psi, QMCHamiltonian& H);
   /** Destructor **/
   ~ACForce() override{};
-  /** Copy constructor **/
-  //ACForce(const ACForce& ac)  {};
 
   /** I/O Routines */
   bool put(xmlNodePtr cur) override;
@@ -55,8 +57,9 @@ struct ACForce : public OperatorBase
   /** Evaluate **/
   Return_t evaluate(ParticleSet& P) override;
 
+private:
   ///Finite difference timestep
-  RealType delta; 
+  RealType delta;
 
   //** Internal variables **/
   //  I'm assuming that psi, ions, elns, and the hamiltonian are bound to this

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -137,8 +137,8 @@ struct BareKineticEnergy : public OperatorBase
    */
   BareKineticEnergy(RealType m = 1.0) : SameMass(true), M(m), OneOver2M(0.5 / m)
   {
-    set_energy_domain(kinetic);
-    set_quantum_domain(quantum);
+    set_energy_domain(energy_domains::kinetic);
+    set_quantum_domain(quantum_domains::quantum);
     streaming_kinetic      = false;
     streaming_kinetic_comp = false;
     streaming_momentum     = false;
@@ -153,7 +153,7 @@ struct BareKineticEnergy : public OperatorBase
    */
   BareKineticEnergy(ParticleSet& p) : Ps(p)
   {
-    set_energy_domain(kinetic);
+    set_energy_domain(energy_domains::kinetic);
     one_body_quantum_domain(p);
     streaming_kinetic      = false;
     streaming_kinetic_comp = false;

--- a/src/QMCHamiltonians/ChiesaCorrection.cpp
+++ b/src/QMCHamiltonians/ChiesaCorrection.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<OperatorBase> ChiesaCorrection::makeClone(ParticleSet& qp, Trial
   return std::make_unique<ChiesaCorrection>(qp, psi);
 }
 
-ChiesaCorrection::Return_t ChiesaCorrection::evaluate(ParticleSet& P) { return Value = psi_ref.KECorrection(); }
+ChiesaCorrection::Return_t ChiesaCorrection::evaluate(ParticleSet& P) { return value = psi_ref.KECorrection(); }
 #ifdef QMC_CUDA
 void ChiesaCorrection::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
 {

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -83,9 +83,9 @@ struct ConservedEnergy : public OperatorBase
     RealType lap    = Sum(P.L);
 #ifdef QMC_COMPLEX
     RealType gradsq_cc = Dot_CC(P.G, P.G);
-    Value              = lap + gradsq + gradsq_cc;
+    value              = lap + gradsq + gradsq_cc;
 #else
-    Value = lap + 2 * gradsq;
+    value = lap + 2 * gradsq;
 #endif
     return 0.0;
   }

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -32,7 +32,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       d_aa_ID(ref.addTable(ref))
 {
   ReportEngine PRE("CoulombPBCAA", "CoulombPBCAA");
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ref);
   PtclRefName = ref.getDistTable(d_aa_ID).getName();
   initBreakup(ref);

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -89,7 +89,7 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos_t& hf_terms,
                                  ParticleSet::ParticlePos_t& pulay_terms) override;
-  void update_source(ParticleSet& s) override;
+  void updateSource(ParticleSet& s) override;
 
   /** Do nothing */
   bool put(xmlNodePtr cur) override { return true; }
@@ -105,10 +105,10 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
   void initBreakup(ParticleSet& P);
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evalSR(ParticleSet& P);

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -91,8 +91,8 @@ void CoulombPBCAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   {
     for (int iw = 0; iw < walkers.size(); iw++)
     {
-      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = Value;
-      LocalEnergy[iw] += Value;
+      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value;
+      LocalEnergy[iw] += value;
     }
     return;
   }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -32,7 +32,7 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
       Peln(elns)
 {
   ReportEngine PRE("CoulombPBCAB", "CoulombPBCAB");
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ions, elns);
   if (ComputeForces)
     PtclA.turnOnPerParticleSK();
@@ -181,7 +181,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesA; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Zspec[s] * q *
-              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i], RhoKB.eikr_i[i]);
+              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i],
+                           RhoKB.eikr_i[i]);
 #else
           v1 += Zspec[s] * q * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
 #endif
@@ -195,7 +196,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesB; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Qspec[s] * q *
-              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i], RhoKA.eikr_i[i]);
+              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i],
+                           RhoKA.eikr_i[i]);
 #else
           v1 += Qspec[s] * q * AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
 #endif
@@ -331,7 +333,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
 #if !defined(USE_REAL_STRUCT_FACTOR)
       const int slab_dir = OHMMS_DIM - 1;
       for (int nn = d_ab.M[iat], jat = 0; nn < d_ab.M[iat + 1]; ++nn, ++jat)
-        u += Qat[jat] * AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
+        u += Qat[jat] *
+            AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -32,8 +32,8 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
       Peln(elns)
 {
   ReportEngine PRE("CoulombPBCAB", "CoulombPBCAB");
-  set_energy_domain(energy_domains::potential);
-  two_body_quantum_domain(ions, elns);
+  setEnergyDomain(energy_domains::potential);
+  twoBodyQuantumDomain(ions, elns);
   if (ComputeForces)
     PtclA.turnOnPerParticleSK();
   initBreakup(elns);
@@ -69,12 +69,12 @@ void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectabl
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAB::contribute_particle_quantities() { request.contribute_array(myName); }
+void CoulombPBCAB::contributeParticleQuantities() { request.contribute_array(myName); }
 
-void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
+void CoulombPBCAB::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request.streaming_array(myName);
-  if (streaming_particles)
+  streamingParticles = request.streaming_array(myName);
+  if (streamingParticles)
   {
     Pion.turnOnPerParticleSK();
     Peln.turnOnPerParticleSK();
@@ -83,9 +83,9 @@ void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void CoulombPBCAB::delete_particle_quantities()
+void CoulombPBCAB::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streamingParticles)
   {
     delete Ve_sample;
     delete Vi_sample;
@@ -99,16 +99,16 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   if (ComputeForces)
   {
     forces = 0.0;
-    Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
+    value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
   }
   else
 #if !defined(REMOVE_TRACEMANAGER)
-      if (streaming_particles)
-    Value = evaluate_sp(P);
+      if (streamingParticles)
+    value = evaluate_sp(P);
   else
 #endif
-    Value = evalLR(P) + evalSR(P) + myConst;
-  return Value;
+    value = evalLR(P) + evalSR(P) + myConst;
+  return value;
 }
 
 CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
@@ -120,13 +120,13 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
   if (ComputeForces)
   {
     forces = 0.0;
-    Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
+    value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
     hf_terms -= forces;
     //And no Pulay contribution.
   }
   else
-    Value = evalLR(P) + evalSR(P) + myConst;
-  return Value;
+    value = evalLR(P) + evalSR(P) + myConst;
+  return value;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -210,7 +210,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
     Ve_samp(i) += Ve_const(i);
   for (int i = 0; i < Vi_samp.size(); ++i)
     Vi_samp(i) += Vi_const(i);
-  Value = Vsr + Vlr + Vc;
+  value = Vsr + Vlr + Vc;
 #if defined(TRACE_CHECK)
   RealType Vlrnow = evalLR(P);
   RealType Vsrnow = evalSR(P);
@@ -250,7 +250,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
   }
 
 #endif
-  return Value;
+  return value;
 }
 #endif
 

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -134,10 +134,10 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
 

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -72,7 +72,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(computeForces)
   {
-    set_energy_domain(potential);
+    set_energy_domain(energy_domains::potential);
     two_body_quantum_domain(s, s);
     nCenters = s.getTotalNum();
     prefix   = "F_AA";
@@ -102,7 +102,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(false)
   {
-    set_energy_domain(potential);
+    set_energy_domain(energy_domains::potential);
     two_body_quantum_domain(s, t);
     nCenters = s.getTotalNum();
   }

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -30,7 +30,7 @@ typedef LRCoulombSingleton::RadFunctorType RadFunctorType;
 
 DensityEstimator::DensityEstimator(ParticleSet& elns)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   Periodic = (elns.Lattice.SuperCellEnum != SUPERCELL_OPEN);
   for (int dim = 0; dim < OHMMS_DIM; ++dim)
   {

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -82,7 +82,7 @@ void DensityMatrices1B::reset()
   eindex         = -1;
   uniform_random = NULL;
   // basic HamiltonianBase info
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   // default values
   energy_mat             = false;
   integrator             = uniform_grid;
@@ -487,7 +487,7 @@ void DensityMatrices1B::report(const std::string& pad)
 }
 
 
-void DensityMatrices1B::get_required_traces(TraceManager& tm)
+void DensityMatrices1B::getRequiredTraces(TraceManager& tm)
 {
   w_trace = tm.get_real_trace("weight");
   if (energy_mat)
@@ -504,7 +504,7 @@ void DensityMatrices1B::get_required_traces(TraceManager& tm)
 
     E_samp.resize(nparticles);
   }
-  have_required_traces = true;
+  haveRequiredTraces = true;
 }
 
 
@@ -596,7 +596,7 @@ void DensityMatrices1B::warmup_sampling()
 DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
 {
   ScopedTimer t(timers[DM_eval]);
-  if (have_required_traces || !energy_mat)
+  if (haveRequiredTraces || !energy_mat)
   {
     if (check_derivatives)
       test_derivatives();

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -166,7 +166,7 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
   //optional standard interface
-  void get_required_traces(TraceManager& tm) override;
+  void getRequiredTraces(TraceManager& tm) override;
   void setRandomGenerator(RandomGenerator_t* rng) override;
 
   //required for Collectables interface
@@ -177,10 +177,10 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
-  void contribute_scalar_quantities() override {}
-  void checkout_scalar_quantities(TraceManager& tm) override {}
-  void collect_scalar_quantities() override {}
-  void delete_scalar_quantities() override {}
+  void contributeScalarQuantities() override {}
+  void checkoutScalarQuantities(TraceManager& tm) override {}
+  void collectScalarQuantities() override {}
+  void deleteScalarQuantities() override {}
 
   //obsolete?
   bool get(std::ostream& os) const override { return false; }

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -26,7 +26,7 @@ namespace qmcplusplus
 EnergyDensityEstimator::EnergyDensityEstimator(PSPool& PSP, const std::string& defaultKE)
     : psetpool(PSP), Pdynamic(0), Pstatic(0), w_trace(0), Td_trace(0), Vd_trace(0), Vs_trace(0)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   defKE      = defaultKE;
   nsamples   = 0;
   ion_points = false;
@@ -203,7 +203,7 @@ ParticleSet* EnergyDensityEstimator::get_particleset(std::string& psname)
 }
 
 
-void EnergyDensityEstimator::get_required_traces(TraceManager& tm)
+void EnergyDensityEstimator::getRequiredTraces(TraceManager& tm)
 {
   bool write = omp_get_thread_num() == 0;
   w_trace    = tm.get_real_trace("weight");
@@ -211,7 +211,7 @@ void EnergyDensityEstimator::get_required_traces(TraceManager& tm)
   Vd_trace   = tm.get_real_combined_trace(*Pdynamic, "LocalPotential");
   if (Pstatic)
     Vs_trace = tm.get_real_combined_trace(*Pstatic, "LocalPotential");
-  have_required_traces = true;
+  haveRequiredTraces = true;
 }
 
 
@@ -257,7 +257,7 @@ void EnergyDensityEstimator::resetTargetParticleSet(ParticleSet& P)
 
 EnergyDensityEstimator::Return_t EnergyDensityEstimator::evaluate(ParticleSet& P)
 {
-  if (have_required_traces)
+  if (haveRequiredTraces)
   {
     Pdynamic = &P;
     //Collect positions from ParticleSets

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -100,12 +100,12 @@ private:
   CombinedTraceSample<TraceReal>* Vd_trace;
   CombinedTraceSample<TraceReal>* Vs_trace;
 
-  void get_required_traces(TraceManager& tm) override;
+  void getRequiredTraces(TraceManager& tm) override;
 
-  void contribute_scalar_quantities() override {}
-  void checkout_scalar_quantities(TraceManager& tm) override {}
-  void collect_scalar_quantities() override {}
-  void delete_scalar_quantities() override {}
+  void contributeScalarQuantities() override {}
+  void checkoutScalarQuantities(TraceManager& tm) override {}
+  void collectScalarQuantities() override {}
+  void deleteScalarQuantities() override {}
 };
 
 

--- a/src/QMCHamiltonians/ForwardWalking.h
+++ b/src/QMCHamiltonians/ForwardWalking.h
@@ -34,7 +34,7 @@ struct ForwardWalking : public OperatorBase
 
   /** constructor
    */
-  ForwardWalking() { UpdateMode.set(OPTIMIZABLE, 1); }
+  ForwardWalking() { updateMode.set(OPTIMIZABLE, 1); }
 
   ///destructor
   ~ForwardWalking() override {}

--- a/src/QMCHamiltonians/GridExternalPotential.cpp
+++ b/src/QMCHamiltonians/GridExternalPotential.cpp
@@ -106,12 +106,12 @@ std::unique_ptr<OperatorBase> GridExternalPotential::makeClone(ParticleSet& P, T
 GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
-    Value = evaluate_sp(P);
+  if (streamingParticles)
+    value = evaluate_sp(P);
   else
   {
 #endif
-    Value = 0.0;
+    value = 0.0;
     for (int i = 0; i < P.getTotalNum(); ++i)
     {
       PosType r = P.R[i];
@@ -119,12 +119,12 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
       double val = 0.0;
       eval_UBspline_3d_d(spline_data.get(), r[0], r[1], r[2], &val);
 
-      Value += val;
+      value += val;
     }
 #if !defined(REMOVE_TRACEMANAGER)
   }
 #endif
-  return Value;
+  return value;
 }
 
 
@@ -132,15 +132,15 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 GridExternalPotential::Return_t GridExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  Value                       = 0.0;
+  value                       = 0.0;
   for (int i = 0; i < P.getTotalNum(); ++i)
   {
     PosType r   = P.R[i];
     RealType v1 = dot(r, r);
     V_samp(i)   = v1;
-    Value += v1;
+    value += v1;
   }
-  return Value;
+  return value;
 }
 #endif
 

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -38,8 +38,8 @@ struct GridExternalPotential : public OperatorBase
   //construction/destruction
   GridExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(energy_domains::potential);
-    one_body_quantum_domain(P);
+    setEnergyDomain(energy_domains::potential);
+    oneBodyQuantumDomain(P);
   }
 
   ~GridExternalPotential() override {}
@@ -58,18 +58,18 @@ struct GridExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request.contribute_array(myName); }
+  void contributeParticleQuantities() override { request.contribute_array(myName); }
 
-  void checkout_particle_quantities(TraceManager& tm) override
+  void checkoutParticleQuantities(TraceManager& tm) override
   {
-    streaming_particles = request.streaming_array(myName);
-    if (streaming_particles)
+    streamingParticles = request.streaming_array(myName);
+    if (streamingParticles)
       V_sample = tm.checkout_real<1>(myName, Ps);
   }
 
-  void delete_particle_quantities() override
+  void deleteParticleQuantities() override
   {
-    if (streaming_particles)
+    if (streamingParticles)
       delete V_sample;
   }
 

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -38,7 +38,7 @@ struct GridExternalPotential : public OperatorBase
   //construction/destruction
   GridExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(potential);
+    set_energy_domain(energy_domains::potential);
     one_body_quantum_domain(P);
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.cpp
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.cpp
@@ -63,22 +63,22 @@ std::unique_ptr<OperatorBase> HarmonicExternalPotential::makeClone(ParticleSet& 
 HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
-    Value = evaluate_sp(P);
+  if (streamingParticles)
+    value = evaluate_sp(P);
   else
   {
 #endif
-    Value              = 0.0;
+    value              = 0.0;
     RealType prefactor = .5 * energy / (length * length);
     for (int i = 0; i < P.getTotalNum(); ++i)
     {
       PosType r = P.R[i] - center;
-      Value += prefactor * dot(r, r);
+      value += prefactor * dot(r, r);
     }
 #if !defined(REMOVE_TRACEMANAGER)
   }
 #endif
-  return Value;
+  return value;
 }
 
 
@@ -86,16 +86,16 @@ HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(Particle
 HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  Value                       = 0.0;
+  value                       = 0.0;
   RealType prefactor          = .5 * energy / (length * length);
   for (int i = 0; i < P.getTotalNum(); ++i)
   {
     PosType r   = P.R[i] - center;
     RealType v1 = prefactor * dot(r, r);
     V_samp(i)   = v1;
-    Value += v1;
+    value += v1;
   }
-  return Value;
+  return value;
 }
 #endif
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -36,8 +36,8 @@ struct HarmonicExternalPotential : public OperatorBase
   //construction/destruction
   HarmonicExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(energy_domains::potential);
-    one_body_quantum_domain(P);
+    setEnergyDomain(energy_domains::potential);
+    oneBodyQuantumDomain(P);
   }
 
   ~HarmonicExternalPotential() override {}
@@ -56,18 +56,18 @@ struct HarmonicExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request.contribute_array(myName); }
+  void contributeParticleQuantities() override { request.contribute_array(myName); }
 
-  void checkout_particle_quantities(TraceManager& tm) override
+  void checkoutParticleQuantities(TraceManager& tm) override
   {
-    streaming_particles = request.streaming_array(myName);
-    if (streaming_particles)
+    streamingParticles = request.streaming_array(myName);
+    if (streamingParticles)
       V_sample = tm.checkout_real<1>(myName, Ps);
   }
 
-  void delete_particle_quantities() override
+  void deleteParticleQuantities() override
   {
-    if (streaming_particles)
+    if (streamingParticles)
       delete V_sample;
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -36,7 +36,7 @@ struct HarmonicExternalPotential : public OperatorBase
   //construction/destruction
   HarmonicExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(potential);
+    set_energy_domain(energy_domains::potential);
     one_body_quantum_domain(P);
   }
 

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -18,7 +18,7 @@ namespace qmcplusplus
 {
 L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi) : IonConfig(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -18,8 +18,8 @@ namespace qmcplusplus
 {
 L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi) : IonConfig(ions)
 {
-  set_energy_domain(energy_domains::potential);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(energy_domains::potential);
+  twoBodyQuantumDomain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);
   size_t ns    = ions.getSpeciesSet().getTotalNum();
@@ -62,7 +62,7 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
 
   // compute v_L2(r)*L^2 for all electron-ion pairs
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value              = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -87,9 +87,9 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
         esum += v * PP[iat]->evaluate(dist[iat]);
       }
     }
-    Value += esum;
+    value += esum;
   }
-  return Value;
+  return value;
 }
 
 

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -67,7 +67,7 @@ bool LatticeDeviationEstimator::put(xmlNodePtr cur)
   {
     // change the default behavior of addValue() called by addObservables()
     // YY: does this still matter if I have overwritten addObservables()?
-    UpdateMode.set(COLLECTABLE, 1);
+    updateMode.set(COLLECTABLE, 1);
   }
 
   if (xyz_flag == "yes")
@@ -95,7 +95,7 @@ bool LatticeDeviationEstimator::get(std::ostream& os) const
 
 LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(ParticleSet& P)
 { // calculate <r^2> averaged over lattice sites
-  Value = 0.0;
+  value = 0.0;
   std::fill(xyz2.begin(), xyz2.end(), 0.0);
 
   RealType wgt        = tWalker->Weight;
@@ -118,7 +118,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
           // distance between particle iat in source pset, and jat in target pset
           r  = d_table.getDistRow(jat)[iat];
           r2 = r * r;
-          Value += r2;
+          value += r2;
 
           if (hdf5_out & !per_xyz)
           { // store deviration for each lattice site if h5 file is available
@@ -154,7 +154,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   }
 
   // average per site
-  Value /= num_sites;
+  value /= num_sites;
   if (per_xyz)
   {
     for (int idir = 0; idir < OHMMS_DIM; idir++)
@@ -163,7 +163,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
     }
   }
 
-  return Value;
+  return value;
 }
 
 void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferType& collectables)
@@ -209,7 +209,7 @@ void LatticeDeviationEstimator::setObservables(PropertySetType& plist)
   }
   else
   {
-    plist[myIndex] = Value; // default behavior
+    plist[myIndex] = value; // default behavior
   }
 }
 

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -23,8 +23,8 @@ namespace qmcplusplus
 {
 LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : IonConfig(ions), Peln(els), Pion(ions)
 {
-  set_energy_domain(energy_domains::potential);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(energy_domains::potential);
+  twoBodyQuantumDomain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);
   //allocate null
@@ -58,21 +58,21 @@ void LocalECPotential::add(int groupID, std::unique_ptr<RadialPotentialType>&& p
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void LocalECPotential::contribute_particle_quantities() { request.contribute_array(myName); }
+void LocalECPotential::contributeParticleQuantities() { request.contribute_array(myName); }
 
-void LocalECPotential::checkout_particle_quantities(TraceManager& tm)
+void LocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request.streaming_array(myName);
-  if (streaming_particles)
+  streamingParticles = request.streaming_array(myName);
+  if (streamingParticles)
   {
     Ve_sample = tm.checkout_real<1>(myName, Peln);
     Vi_sample = tm.checkout_real<1>(myName, Pion);
   }
 }
 
-void LocalECPotential::delete_particle_quantities()
+void LocalECPotential::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streamingParticles)
   {
     delete Ve_sample;
     delete Vi_sample;
@@ -84,13 +84,13 @@ void LocalECPotential::delete_particle_quantities()
 LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
-    Value = evaluate_sp(P);
+  if (streamingParticles)
+    value = evaluate_sp(P);
   else
 #endif
   {
     const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-    Value              = 0.0;
+    value              = 0.0;
     const size_t Nelec = P.getTotalNum();
     for (size_t iel = 0; iel < Nelec; ++iel)
     {
@@ -99,10 +99,10 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
       for (size_t iat = 0; iat < NumIons; ++iat)
         if (PP[iat] != nullptr)
           esum += PP[iat]->splint(dist[iat]) * Zeff[iat] / dist[iat];
-      Value -= esum;
+      value -= esum;
     }
   }
-  return Value;
+  return value;
 }
 
 LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
@@ -112,7 +112,7 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
                                                                    ParticleSet::ParticlePos_t& pulay_terms)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value              = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -135,16 +135,16 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
         esum += -Zeff[iat] * v * rinv;
       }
     }
-    Value += esum;
+    value += esum;
   }
-  return Value;
+  return value;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
 LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value                       = 0.0;
+  value                       = 0.0;
   Array<RealType, 1>& Ve_samp = *Ve_sample;
   Array<RealType, 1>& Vi_samp = *Vi_sample;
   Ve_samp                     = 0.0;
@@ -163,12 +163,12 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
         Ve_samp(iel) += pairpot;
         esum += pairpot;
       }
-    Value += esum;
+    value += esum;
   }
-  Value *= 2.0;
+  value *= 2.0;
 
 #if defined(TRACE_CHECK)
-  RealType Vnow  = Value;
+  RealType Vnow  = value;
   RealType Visum = Vi_samp.sum();
   RealType Vesum = Ve_samp.sum();
   RealType Vsum  = Vesum + Visum;
@@ -195,7 +195,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
     APP_ABORT("Trace check failed");
   }
 #endif
-  return Value;
+  return value;
 }
 #endif
 
@@ -203,7 +203,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value              = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -212,9 +212,9 @@ LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
     for (size_t iat = 0; iat < NumIons; ++iat)
       if (PP[iat] != nullptr)
         esum += PP[iat]->splint(dist[iat]) * Zeff[iat] / dist[iat];
-    Value -= esum;
+    value -= esum;
   }
-  return Value;
+  return value;
 }
 
 std::unique_ptr<OperatorBase> LocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 {
 LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : IonConfig(ions), Peln(els), Pion(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -66,10 +66,10 @@ struct LocalECPotential : public OperatorBase
   void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evaluate(ParticleSet& P) override;

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -359,8 +359,8 @@ MPC::Return_t MPC::evalLR(ParticleSet& P) const
 MPC::Return_t MPC::evaluate(ParticleSet& P)
 {
   //if (FirstTime || P.tag() == PtclRef->tag())
-  Value = evalSR(P) + evalLR(P) + Vconst;
-  return Value;
+  value = evalSR(P) + evalLR(P) + Vconst;
+  return value;
 }
 
 void MPC::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -28,7 +28,7 @@ namespace qmcplusplus
 MomentumEstimator::MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi)
     : M(40), refPsi(psi), Lattice(elns.Lattice), norm_nofK(1), hdf5_out(false)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   psi_ratios.resize(elns.getTotalNum());
   twist = elns.getTwist();
 }

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -56,7 +56,7 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
       UseTMove(TMOVE_OFF),
       nonLocalOps(els.getTotalNum())
 {
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();
@@ -632,16 +632,18 @@ void NonLocalECPotential::createResource(ResourceCollection& collection) const
   auto resource_index = collection.addResource(std::move(new_res));
 }
 
-void NonLocalECPotential::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const
+void NonLocalECPotential::acquireResource(ResourceCollection& collection,
+                                          const RefVectorWithLeader<OperatorBase>& O_list) const
 {
   auto& O_leader = O_list.getCastedLeader<NonLocalECPotential>();
-  auto res_ptr = dynamic_cast<NonLocalECPotentialMultiWalkerResource*>(collection.lendResource().release());
+  auto res_ptr   = dynamic_cast<NonLocalECPotentialMultiWalkerResource*>(collection.lendResource().release());
   if (!res_ptr)
     throw std::runtime_error("NonLocalECPotential::acquireResource dynamic_cast failed");
   O_leader.mw_res_.reset(res_ptr);
 }
 
-void NonLocalECPotential::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const
+void NonLocalECPotential::releaseResource(ResourceCollection& collection,
+                                          const RefVectorWithLeader<OperatorBase>& O_list) const
 {
   auto& O_leader = O_list.getCastedLeader<NonLocalECPotential>();
   collection.takebackResource(std::move(O_leader.mw_res_));

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -23,7 +23,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
                                                                                const std::vector<ValueType>& dlogpsi,
                                                                                std::vector<ValueType>& dhpsioverpsi)
 {
-  Value = 0.0;
+  value = 0.0;
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
@@ -34,10 +34,10 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
     const auto& displ = myTable.getDisplRow(jel);
     for (int iat = 0; iat < NumIons; iat++)
       if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
-        Value += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
+        value += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
                                                       dhpsioverpsi);
   }
-  return Value;
+  return value;
 }
 
 /** evaluate the non-local potential of the iat-th ionic center

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -40,19 +40,19 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
-  void delete_particle_quantities() override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
   Return_t evaluateDeterministic(ParticleSet& P) override;
-  void mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
+  void mwEvaluate(const RefVectorWithLeader<OperatorBase>& O_list,
                    const RefVectorWithLeader<ParticleSet>& P_list) const override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;
 
-  void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
+  void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
                                 const RefVectorWithLeader<ParticleSet>& P_list) const override;
 
   Return_t evaluateWithIonDerivs(ParticleSet& P,

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
@@ -438,7 +438,7 @@ void NonLocalECPotential_CUDA::addEnergy(MCWalkerConfiguration& W,
             for (int ip = 0; ip < pp.nchannel; ip++)
               lsum += vrad[ip] * lpol[pp.angpp_m[ip]];
             esum[iw] += lsum * ratio;
-            Txy[iw][iTxy[iw]++].Weight = lsum * ratio;
+            Txy[iw][iTxy[iw]++].weight = lsum * ratio;
           }
         }
       }

--- a/src/QMCHamiltonians/NonLocalTOperator.cpp
+++ b/src/QMCHamiltonians/NonLocalTOperator.cpp
@@ -104,13 +104,13 @@ const NonLocalData* NonLocalTOperator::selectMove(RealType prob, std::vector<Non
   RealType wgt_t = 1.0;
   for (int i = 0; i < txy.size(); i++)
   {
-    if (txy[i].Weight > 0)
+    if (txy[i].weight > 0)
     {
-      wgt_t += txy[i].Weight *= plusFactor;
+      wgt_t += txy[i].weight *= plusFactor;
     }
     else
     {
-      wgt_t += txy[i].Weight *= minusFactor;
+      wgt_t += txy[i].weight *= minusFactor;
     }
   }
   prob *= wgt_t;
@@ -118,7 +118,7 @@ const NonLocalData* NonLocalTOperator::selectMove(RealType prob, std::vector<Non
   int ibar      = 0;
   while (wsum < prob)
   {
-    wsum += txy[ibar].Weight;
+    wsum += txy[ibar].weight;
     ibar++;
   }
   return ibar > 0 ? &(txy[ibar - 1]) : nullptr;
@@ -134,7 +134,7 @@ void NonLocalTOperator::group_by_elec()
 
   for (int i = 0; i < Txy.size(); i++)
   {
-    Txy_by_elec[Txy[i].PID].push_back(Txy[i]);
+    Txy_by_elec[Txy[i].pid].push_back(Txy[i]);
   }
 }
 

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -23,43 +23,43 @@
 namespace qmcplusplus
 {
 //NonLocalData
-NonLocalData::NonLocalData() : PID(-1), Weight(1.0) {}
+NonLocalData::NonLocalData() : pid(-1), weight(1.0) {}
 
-NonLocalData::NonLocalData(IndexType id, RealType w, const PosType& d) : PID(id), Weight(w), Delta(d) {}
+NonLocalData::NonLocalData(IndexType id, RealType w, const PosType& d) : pid(id), weight(w), delta(d) {}
 
 //OperatorBase
 
 //PUBLIC
 OperatorBase::OperatorBase()
-    : UpdateMode(std::move(std::bitset<8>{}.set(PRIMARY, 1))),
-      Value(0.0),
+    : updateMode(std::move(std::bitset<8>{}.set(PRIMARY, 1))),
+      value(0.0),
       myIndex(-1),
-      NewValue(0.0),
+      newValue(0.0),
       tWalker(0),
 #if !defined(REMOVE_TRACEMANAGER)
-      have_required_traces(false),
-      streaming_particles(false),
+      haveRequiredTraces(false),
+      streamingParticles(false),
 #endif
-      quantum_domain(quantum_domains::no_quantum_domain),
-      energy_domain(energy_domains::no_energy_domain)
+      quantumDomain(quantum_domains::no_quantum_domain),
+      energyDomain(energy_domains::no_energy_domain)
 #if !defined(REMOVE_TRACEMANAGER)
       ,
-      streaming_scalars(false),
-      value_sample(nullptr)
+      streamingScalars(false),
+      valueSample(nullptr)
 #endif
 {}
 
 OperatorBase::Return_t OperatorBase::getEnsembleAverage() { return 0.0; }
 
-void OperatorBase::update_source(ParticleSet& s) {}
+void OperatorBase::updateSource(ParticleSet& s) {}
 
-void OperatorBase::setObservables(PropertySetType& plist) { plist[myIndex] = Value; }
+void OperatorBase::setObservables(PropertySetType& plist) { plist[myIndex] = value; }
 
 void OperatorBase::addObservables(PropertySetType& plist, BufferType& collectables) { addValue(plist); }
 
 void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  bool collect = UpdateMode.test(COLLECTABLE);
+  bool collect = updateMode.test(COLLECTABLE);
   //exclude collectables
   if (!collect)
   {
@@ -73,9 +73,9 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hi
 
 void OperatorBase::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const {}
 
-void OperatorBase::get_required_traces(TraceManager& tm) {}
+void OperatorBase::getRequiredTraces(TraceManager& tm) {}
 
-void OperatorBase::setParticlePropertyList(PropertySetType& plist, int offset) { plist[myIndex + offset] = Value; }
+void OperatorBase::setParticlePropertyList(PropertySetType& plist, int offset) { plist[myIndex + offset] = value; }
 
 void OperatorBase::setRandomGenerator(RandomGenerator_t* rng) {}
 
@@ -114,7 +114,7 @@ OperatorBase::Return_t OperatorBase::evaluateValueAndDerivatives(ParticleSet& P,
 }
 
 
-void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
+void OperatorBase::mwEvaluate(const RefVectorWithLeader<OperatorBase>& O_list,
                                const RefVectorWithLeader<ParticleSet>& P_list) const
 {
   assert(this == &O_list.getLeader());
@@ -147,7 +147,7 @@ void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
     O_list[iw].evaluate(P_list[iw]);
 }
 
-void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
+void OperatorBase::mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
                                                        const RefVectorWithLeader<ParticleSet>& P_list,
                                                        const opt_variables_type& optvars,
                                                        RecordArray<ValueType>& dlogpsi,
@@ -172,10 +172,10 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
   }
 }
 
-void OperatorBase::mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
+void OperatorBase::mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
                                             const RefVectorWithLeader<ParticleSet>& P_list) const
 {
-  mw_evaluate(O_list, P_list);
+  mwEvaluate(O_list, P_list);
 }
 
 void OperatorBase::setHistories(Walker_t& ThisWalker) { tWalker = &(ThisWalker); }
@@ -187,7 +187,7 @@ void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCH
   std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi);
   if (myclone)
   {
-    targetH.addOperator(std::move(myclone), myName, UpdateMode[PHYSICAL]);
+    targetH.addOperator(std::move(myclone), myName, updateMode[PHYSICAL]);
   }
 }
 
@@ -201,81 +201,81 @@ void OperatorBase::releaseResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& O_list) const
 {}
 
-bool OperatorBase::is_classical() const noexcept { return quantum_domain == quantum_domains::classical; }
+bool OperatorBase::isClassical() const noexcept { return quantumDomain == quantum_domains::classical; }
 
-bool OperatorBase::is_quantum() const noexcept { return quantum_domain == quantum_domains::quantum; }
+bool OperatorBase::isQuantum() const noexcept { return quantumDomain == quantum_domains::quantum; }
 
-bool OperatorBase::is_classical_classical() const noexcept
+bool OperatorBase::isClassicalClassical() const noexcept
 {
-  return quantum_domain == quantum_domains::classical_classical;
+  return quantumDomain == quantum_domains::classical_classical;
 }
 
-bool OperatorBase::is_quantum_classical() const noexcept
+bool OperatorBase::isQuantumClassical() const noexcept
 {
-  return quantum_domain == quantum_domains::quantum_classical;
+  return quantumDomain == quantum_domains::quantum_classical;
 }
 
-bool OperatorBase::is_quantum_quantum() const noexcept { return quantum_domain == quantum_domains::quantum_quantum; }
+bool OperatorBase::isQuantumQuantum() const noexcept { return quantumDomain == quantum_domains::quantum_quantum; }
 
-bool OperatorBase::isNonLocal() const noexcept { return UpdateMode[NONLOCAL]; }
+bool OperatorBase::isNonLocal() const noexcept { return updateMode[NONLOCAL]; }
 
-bool OperatorBase::getMode(int i) const noexcept { return UpdateMode[i]; }
+bool OperatorBase::getMode(int i) const noexcept { return updateMode[i]; }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void OperatorBase::contribute_trace_quantities()
+void OperatorBase::contributeTraceQuantities()
 {
-  contribute_scalar_quantities();
-  contribute_particle_quantities();
+  contributeScalarQuantities();
+  contributeParticleQuantities();
 }
 
-void OperatorBase::collect_scalar_traces() { collect_scalar_quantities(); }
+void OperatorBase::collectScalarTraces() { collectScalarQuantities(); }
 #endif
 
-void OperatorBase::checkout_trace_quantities(TraceManager& tm)
+void OperatorBase::checkoutTraceQuantities(TraceManager& tm)
 {
   //derived classes must guard individual checkouts using request info
-  checkout_scalar_quantities(tm);
-  checkout_particle_quantities(tm);
+  checkoutScalarQuantities(tm);
+  checkoutParticleQuantities(tm);
 }
 
-void OperatorBase::delete_trace_quantities()
+void OperatorBase::deleteTraceQuantities()
 {
-  delete_scalar_quantities();
-  delete_particle_quantities();
-  streaming_scalars    = false;
-  streaming_particles  = false;
-  have_required_traces = false;
+  deleteScalarQuantities();
+  deleteParticleQuantities();
+  streamingScalars    = false;
+  streamingParticles  = false;
+  haveRequiredTraces = false;
   request.reset();
 }
 
 // PROTECTED
 #if !defined(REMOVE_TRACEMANAGER)
-void OperatorBase::contribute_scalar_quantities() { request.contribute_scalar(myName); }
+void OperatorBase::contributeScalarQuantities() { request.contribute_scalar(myName); }
 
-void OperatorBase::checkout_scalar_quantities(TraceManager& tm)
+void OperatorBase::checkoutScalarQuantities(TraceManager& tm)
 {
-  streaming_scalars = request.streaming_scalar(myName);
-  if (streaming_scalars)
-    value_sample = tm.checkout_real<1>(myName);
+  streamingScalars = request.streaming_scalar(myName);
+  if (streamingScalars)
+    valueSample = tm.checkout_real<1>(myName);
 }
 
-void OperatorBase::collect_scalar_quantities()
+void OperatorBase::collectScalarQuantities()
 {
-  if (streaming_scalars)
-    (*value_sample)(0) = Value;
+  if (streamingScalars)
+    (*valueSample)(0) = value;
 }
 
-void OperatorBase::delete_scalar_quantities()
+void OperatorBase::deleteScalarQuantities()
 {
-  if (streaming_scalars)
-    delete value_sample;
+  if (streamingScalars)
+    delete valueSample;
 }
 
-void OperatorBase::contribute_particle_quantities(){};
+void OperatorBase::contributeParticleQuantities(){};
 
-void OperatorBase::checkout_particle_quantities(TraceManager& /*tm*/){};
+void OperatorBase::checkoutParticleQuantities(TraceManager& /*tm*/){};
 
-void OperatorBase::delete_particle_quantities(){};
+void OperatorBase::deleteParticleQuantities(){};
 
 #endif
 
@@ -294,79 +294,79 @@ void OperatorBase::addEnergy(MCWalkerConfiguration& W,
 
 void OperatorBase::setComputeForces(bool compute) {}
 
-void OperatorBase::set_energy_domain(energy_domains edomain)
+void OperatorBase::setEnergyDomain(energy_domains edomain)
 {
-  if (energy_domain_valid(edomain))
-    energy_domain = edomain;
+  if (energyDomainValid(edomain))
+    energyDomain = edomain;
   else
     APP_ABORT("QMCHamiltonainBase::set_energy_domain\n  input energy domain is invalid");
 }
 
-void OperatorBase::set_quantum_domain(quantum_domains qdomain)
+void OperatorBase::setQuantumDomain(quantum_domains qdomain)
 {
-  if (quantum_domain_valid(qdomain))
-    quantum_domain = qdomain;
+  if (quantumDomainValid(qdomain))
+    quantumDomain = qdomain;
   else
     APP_ABORT("QMCHamiltonainBase::set_quantum_domain\n  input quantum domain is invalid");
 }
 
-void OperatorBase::one_body_quantum_domain(const ParticleSet& P)
+void OperatorBase::oneBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = quantum_domains::classical;
+    quantumDomain = quantum_domains::classical;
   else if (P.is_quantum())
-    quantum_domain = quantum_domains::quantum;
+    quantumDomain = quantum_domains::quantum;
   else
     APP_ABORT("OperatorBase::one_body_quantum_domain\n  quantum domain of input particles is invalid");
 }
 
-void OperatorBase::two_body_quantum_domain(const ParticleSet& P)
+void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = quantum_domains::classical_classical;
+    quantumDomain = quantum_domains::classical_classical;
   else if (P.is_quantum())
-    quantum_domain = quantum_domains::quantum_quantum;
+    quantumDomain = quantum_domains::quantum_quantum;
   else
     APP_ABORT("OperatorBase::two_body_quantum_domain(P)\n  quantum domain of input particles is invalid");
 }
 
-void OperatorBase::two_body_quantum_domain(const ParticleSet& P1, const ParticleSet& P2)
+void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet& P2)
 {
   bool c1 = P1.is_classical();
   bool c2 = P2.is_classical();
   bool q1 = P1.is_quantum();
   bool q2 = P2.is_quantum();
   if (c1 && c2)
-    quantum_domain = quantum_domains::classical_classical;
+    quantumDomain = quantum_domains::classical_classical;
   else if ((q1 && c2) || (c1 && q2))
-    quantum_domain = quantum_domains::quantum_classical;
+    quantumDomain = quantum_domains::quantum_classical;
   else if (q1 && q2)
-    quantum_domain = quantum_domains::quantum_quantum;
+    quantumDomain = quantum_domains::quantum_quantum;
   else
     APP_ABORT("OperatorBase::two_body_quantum_domain(P1,P2)\n  quantum domain of input particles is invalid");
 }
 
 void OperatorBase::addValue(PropertySetType& plist)
 {
-  if (!UpdateMode[COLLECTABLE])
+  if (!updateMode[COLLECTABLE])
     myIndex = plist.add(myName.c_str());
 }
 
 
 // PRIVATE
-bool OperatorBase::energy_domain_valid(const energy_domains edomain) const noexcept
+bool OperatorBase::energyDomainValid(const energy_domains edomain) const noexcept
 {
   return edomain != energy_domains::no_energy_domain;
 }
 
-bool OperatorBase::energy_domain_valid() const noexcept { return energy_domain_valid(energy_domain); }
+bool OperatorBase::energyDomainValid() const noexcept { return energyDomainValid(energyDomain); }
 
-bool OperatorBase::quantum_domain_valid(const quantum_domains qdomain) const noexcept
+bool OperatorBase::quantumDomainValid(const quantum_domains qdomain) const noexcept
 {
   return qdomain != quantum_domains::no_quantum_domain;
 }
 
-bool OperatorBase::quantum_domain_valid() const noexcept { return quantum_domain_valid(quantum_domain); }
+bool OperatorBase::quantumDomainValid() const noexcept { return quantumDomainValid(quantumDomain); }
 
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -31,13 +31,13 @@ NonLocalData::NonLocalData(IndexType id, RealType w, const PosType& d) : PID(id)
 
 //PUBLIC
 OperatorBase::OperatorBase()
-    : myIndex(-1),
+    : quantum_domain(quantum_domains::no_quantum_domain),
+      energy_domain(energy_domains::no_energy_domain),
+      myIndex(-1),
       Dependants(0),
       Value(0.0),
       NewValue(0.0),
       tWalker(0),
-      quantum_domain(quantum_domains::no_quantum_domain),
-      energy_domain(energy_domains::no_energy_domain),
       value_sample(nullptr)
 {
 #if !defined(REMOVE_TRACEMANAGER)
@@ -64,16 +64,102 @@ bool OperatorBase::is_quantum_classical() const noexcept
 
 bool OperatorBase::is_quantum_quantum() const noexcept { return quantum_domain == quantum_domains::quantum_quantum; }
 
+bool OperatorBase::isNonLocal() const noexcept { return UpdateMode[NONLOCAL]; }
 
-/** The correct behavior of this routine requires estimators with non-deterministic components
- * in their evaluate() function to override this function.
- */
+bool OperatorBase::getMode(int i) const noexcept { return UpdateMode[i]; }
+
+OperatorBase::Return_t OperatorBase::getEnsembleAverage() { return 0.0; }
+
+void OperatorBase::update_source(ParticleSet& s) {}
+
+void OperatorBase::setObservables(PropertySetType& plist) { plist[myIndex] = Value; }
+
+void OperatorBase::addObservables(PropertySetType& plist, BufferType& collectables) { addValue(plist); }
+
+void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+{
+  bool collect = UpdateMode.test(COLLECTABLE);
+  //exclude collectables
+  if (!collect)
+  {
+    h5desc.emplace_back(myName);
+    auto& oh = h5desc.back();
+    std::vector<int> onedim(1, 1);
+    oh.set_dimensions(onedim, myIndex);
+    oh.open(gid);
+  }
+}
+
+void OperatorBase::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const {}
+
+#if !defined(REMOVE_TRACEMANAGER)
+void OperatorBase::contribute_trace_quantities()
+{
+  contribute_scalar_quantities();
+  contribute_particle_quantities();
+}
+
+void OperatorBase::collect_scalar_traces() { collect_scalar_quantities(); }
+#endif
+
+void OperatorBase::checkout_trace_quantities(TraceManager& tm)
+{
+  //derived classes must guard individual checkouts using request info
+  checkout_scalar_quantities(tm);
+  checkout_particle_quantities(tm);
+}
+
+void OperatorBase::get_required_traces(TraceManager& tm) {}
+
+void OperatorBase::delete_trace_quantities()
+{
+  delete_scalar_quantities();
+  delete_particle_quantities();
+  streaming_scalars    = false;
+  streaming_particles  = false;
+  have_required_traces = false;
+  request.reset();
+}
+
+void OperatorBase::setParticlePropertyList(PropertySetType& plist, int offset) { plist[myIndex + offset] = Value; }
+
+void OperatorBase::setRandomGenerator(RandomGenerator_t* rng) {}
+
 OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P) { return evaluate(P); }
-/** Take o_list and p_list update evaluation result variables in o_list?
- *
- * really should reduce vector of local_energies. matching the ordering and size of o list
- * the this can be call for 1 or more QMCHamiltonians
- */
+
+OperatorBase::Return_t OperatorBase::evaluateWithToperator(ParticleSet& P) { return evaluate(P); }
+
+// FIXME: unused variables commented off
+OperatorBase::Return_t OperatorBase::evaluateWithIonDerivs(ParticleSet& P,
+                                                           ParticleSet& /*ions*/,
+                                                           TrialWaveFunction& /*psi*/,
+                                                           ParticleSet::ParticlePos_t& /*hf_term*/,
+                                                           ParticleSet::ParticlePos_t& /*pulay_term*/)
+{
+  return evaluate(P);
+}
+
+OperatorBase::Return_t OperatorBase::evaluateWithIonDerivsDeterministic(ParticleSet& P,
+                                                                        ParticleSet& ions,
+                                                                        TrialWaveFunction& psi,
+                                                                        ParticleSet::ParticlePos_t& hf_term,
+                                                                        ParticleSet::ParticlePos_t& pulay_term)
+{
+  //If there's no stochastic component, defaults to above defined evaluateWithIonDerivs.
+  //If not otherwise specified, this defaults to evaluate().
+  return evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_term);
+}
+
+// FIXME: unused variables commented off
+OperatorBase::Return_t OperatorBase::evaluateValueAndDerivatives(ParticleSet& P,
+                                                                 const opt_variables_type& /*optvars*/,
+                                                                 const std::vector<ValueType>& /*dlogpsi*/,
+                                                                 std::vector<ValueType>& /*dhpsioverpsi*/)
+{
+  return evaluate(P);
+}
+
+
 void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
                                const RefVectorWithLeader<ParticleSet>& P_list) const
 {
@@ -132,6 +218,35 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
   }
 }
 
+void OperatorBase::mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
+                                            const RefVectorWithLeader<ParticleSet>& P_list) const
+{
+  mw_evaluate(O_list, P_list);
+}
+
+void OperatorBase::setHistories(Walker_t& ThisWalker) { tWalker = &(ThisWalker); }
+
+OperatorBase::Return_t OperatorBase::rejectedMove(ParticleSet& P) { return 0; }
+
+void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
+{
+  std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi);
+  if (myclone)
+  {
+    targetH.addOperator(std::move(myclone), myName, UpdateMode[PHYSICAL]);
+  }
+}
+
+void OperatorBase::createResource(ResourceCollection& collection) const {}
+
+void OperatorBase::acquireResource(ResourceCollection& collection,
+                                   const RefVectorWithLeader<OperatorBase>& O_list) const
+{}
+
+void OperatorBase::releaseResource(ResourceCollection& collection,
+                                   const RefVectorWithLeader<OperatorBase>& O_list) const
+{}
+
 // PROTECTED
 void OperatorBase::set_energy_domain(energy_domains edomain)
 {
@@ -185,35 +300,26 @@ void OperatorBase::two_body_quantum_domain(const ParticleSet& P1, const Particle
     APP_ABORT("OperatorBase::two_body_quantum_domain(P1,P2)\n  quantum domain of input particles is invalid");
 }
 
+void OperatorBase::addValue(PropertySetType& plist)
+{
+  if (!UpdateMode[COLLECTABLE])
+    myIndex = plist.add(myName.c_str());
+}
+
+// PRIVATE
+bool OperatorBase::energy_domain_valid(energy_domains edomain) const noexcept
+{
+  return edomain != energy_domains::no_energy_domain;
+}
+
+bool OperatorBase::energy_domain_valid() const noexcept { return energy_domain_valid(energy_domain); }
+
 bool OperatorBase::quantum_domain_valid(const quantum_domains qdomain) const noexcept
 {
   return qdomain != quantum_domains::no_quantum_domain;
 }
 
 bool OperatorBase::quantum_domain_valid() const noexcept { return quantum_domain_valid(quantum_domain); }
-
-void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
-{
-  std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi);
-  if (myclone)
-  {
-    targetH.addOperator(std::move(myclone), myName, UpdateMode[PHYSICAL]);
-  }
-}
-
-void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
-{
-  bool collect = UpdateMode.test(COLLECTABLE);
-  //exclude collectables
-  if (!collect)
-  {
-    h5desc.emplace_back(myName);
-    auto& oh = h5desc.back();
-    std::vector<int> onedim(1, 1);
-    oh.set_dimensions(onedim, myIndex);
-    oh.open(gid);
-  }
-}
 
 void OperatorBase::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
 {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -31,6 +31,7 @@
 #include "Estimators/TraceManager.h"
 #endif
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
+
 #include <bitset>
 #include <memory> // std::unique_ptr
 
@@ -49,9 +50,9 @@ class ResourceCollection;
 // TODO add documentation
 struct NonLocalData : public QMCTraits
 {
-  IndexType PID;
-  RealType Weight;
-  PosType Delta;
+  IndexType pid;
+  RealType weight;
+  PosType delta;
   NonLocalData();
   NonLocalData(IndexType id, RealType w, const PosType& d);
 };
@@ -68,7 +69,7 @@ public:
   /// type of return value of evaluate
   using Return_t = FullPrecRealType;
   /**
-   * alias the serialized buffer
+   * alias for the serialized buffer
    * PooledData<RealType> is used to serialized an anonymous buffer
    */
   using BufferType = ParticleSet::Buffer_t;
@@ -77,7 +78,7 @@ public:
   /// alias for the ParticleScalar
   using ParticleScalar_t = ParticleSet::Scalar_t;
 
-  ///enum to denote energy domain of operators
+  ///enum class to denote energy domain of operators
   enum class energy_domains
   {
     kinetic = 0,
@@ -85,7 +86,7 @@ public:
     no_energy_domain
   };
 
-  ///enum to denote quantum domain of operators
+  ///enum class to denote quantum domain of operators
   enum class quantum_domains
   {
     no_quantum_domain = 0,
@@ -105,10 +106,10 @@ public:
   static constexpr int NONLOCAL    = 5;
 
   ///set the current update mode
-  std::bitset<8> UpdateMode;
+  std::bitset<8> updateMode;
 
   ///current value TODO: add better docs
-  Return_t Value;
+  Return_t value;
 
   ///name of this object
   std::string myName;
@@ -154,7 +155,7 @@ public:
    * @param s
    * Default implementation does nothing. Only A-A interactions for s needs to implement its own method.
    */
-  virtual void update_source(ParticleSet& s);
+  virtual void updateSource(ParticleSet& s);
 
   /**
    * set the values evaluated by this object to plist
@@ -194,7 +195,7 @@ public:
   virtual void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
 
   // TODO add documentation
-  virtual void get_required_traces(TraceManager& tm);
+  virtual void getRequiredTraces(TraceManager& tm);
 
   // TODO add documentation
   virtual void setParticlePropertyList(PropertySetType& plist, int offset);
@@ -269,11 +270,11 @@ public:
      * @param P_list
      * TODO add parameter documentation above
      */
-  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
+  virtual void mwEvaluate(const RefVectorWithLeader<OperatorBase>& O_list,
                            const RefVectorWithLeader<ParticleSet>& P_list) const;
 
   // TODO add documentation
-  virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
+  virtual void mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
                                                    const RefVectorWithLeader<ParticleSet>& P_list,
                                                    const opt_variables_type& optvars,
                                                    RecordArray<ValueType>& dlogpsi,
@@ -285,7 +286,7 @@ public:
      * @param P_list
      * TODO add documentation
      */
-  virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
+  virtual void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
                                         const RefVectorWithLeader<ParticleSet>& P_list) const;
 
   // TODO add documentation
@@ -318,11 +319,11 @@ public:
   virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const;
 
   // TODO add documentation
-  bool is_classical() const noexcept;
-  bool is_quantum() const noexcept;
-  bool is_classical_classical() const noexcept;
-  bool is_quantum_classical() const noexcept;
-  bool is_quantum_quantum() const noexcept;
+  bool isClassical() const noexcept;
+  bool isQuantum() const noexcept;
+  bool isClassicalClassical() const noexcept;
+  bool isQuantumClassical() const noexcept;
+  bool isQuantumQuantum() const noexcept;
   bool isNonLocal() const noexcept;
 
   /**
@@ -333,17 +334,17 @@ public:
 
 #if !defined(REMOVE_TRACEMANAGER)
   ///make trace quantities available
-  void contribute_trace_quantities();
+  void contributeTraceQuantities();
 
   ///collect scalar trace data
-  void collect_scalar_traces();
+  void collectScalarTraces();
 #endif
 
   ///checkout trace arrays
-  void checkout_trace_quantities(TraceManager& tm);
+  void checkoutTraceQuantities(TraceManager& tm);
 
   ///delete trace arrays
-  void delete_trace_quantities();
+  void deleteTraceQuantities();
 
 
 protected:
@@ -351,16 +352,16 @@ protected:
   int myIndex;
 
   /// a new value for a proposed move
-  Return_t NewValue;
+  Return_t newValue;
 
   ///reference to the current walker
   Walker_t* tWalker = nullptr;
 
 #if !defined(REMOVE_TRACEMANAGER)
   // TODO add documentation
-  bool have_required_traces;
+  bool haveRequiredTraces;
 
-  bool streaming_particles;
+  bool streamingParticles;
 #endif
 
   /**
@@ -371,19 +372,19 @@ protected:
 
   //TODO add documentation
 #if !defined(REMOVE_TRACEMANAGER)
-  virtual void contribute_scalar_quantities();
+  virtual void contributeScalarQuantities();
 
-  virtual void checkout_scalar_quantities(TraceManager& tm);
+  virtual void checkoutScalarQuantities(TraceManager& tm);
 
-  virtual void collect_scalar_quantities();
+  virtual void collectScalarQuantities();
 
-  virtual void delete_scalar_quantities();
+  virtual void deleteScalarQuantities();
 
-  virtual void contribute_particle_quantities();
+  virtual void contributeParticleQuantities();
 
-  virtual void checkout_particle_quantities(TraceManager& tm);
+  virtual void checkoutParticleQuantities(TraceManager& tm);
 
-  virtual void delete_particle_quantities();
+  virtual void deleteParticleQuantities();
 #endif
 
   virtual void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
@@ -396,19 +397,19 @@ protected:
   virtual void setComputeForces(bool compute);
 
   ///set energy domain
-  void set_energy_domain(energy_domains edomain);
+  void setEnergyDomain(energy_domains edomain);
 
   ///set quantum domain
-  void set_quantum_domain(quantum_domains qdomain);
+  void setQuantumDomain(quantum_domains qdomain);
 
   ///set quantum domain for one-body operator
-  void one_body_quantum_domain(const ParticleSet& P);
+  void oneBodyQuantumDomain(const ParticleSet& P);
 
   ///set quantum domain for two-body operator
-  void two_body_quantum_domain(const ParticleSet& P);
+  void twoBodyQuantumDomain(const ParticleSet& P);
 
   ///set quantum domain for two-body operator
-  void two_body_quantum_domain(const ParticleSet& P1, const ParticleSet& P2);
+  void twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet& P2);
 
   /**
      * Named values to  the property list
@@ -420,32 +421,32 @@ protected:
 
 private:
   ///quantum_domain of the (particle) operator, default = no_quantum_domain
-  quantum_domains quantum_domain;
+  quantum_domains quantumDomain;
 
   ///energy domain of the operator (kinetic/potential), default = no_energy_domain
-  energy_domains energy_domain;
+  energy_domains energyDomain;
 
 #if !defined(REMOVE_TRACEMANAGER)
   //TODO add documentation
-  bool streaming_scalars;
+  bool streamingScalars;
 
-  std::vector<RealType> ValueVector;
+  std::vector<RealType> valueVector;
 
   ///array to store sample value
-  Array<RealType, 1>* value_sample;
+  Array<RealType, 1>* valueSample;
 #endif
 
   ///return whether the energy domain is valid
-  bool energy_domain_valid(const energy_domains edomain) const noexcept;
+  bool energyDomainValid(const energy_domains edomain) const noexcept;
 
   ///return whether the energy domain is valid
-  bool energy_domain_valid() const noexcept;
+  bool energyDomainValid() const noexcept;
 
   ///return whether the quantum domain is valid
-  bool quantum_domain_valid(const quantum_domains qdomain) const noexcept;
+  bool quantumDomainValid(const quantum_domains qdomain) const noexcept;
 
   ///return whether the quantum domain is valid
-  bool quantum_domain_valid() const noexcept;
+  bool quantumDomainValid() const noexcept;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -25,7 +25,7 @@ namespace qmcplusplus
 PairCorrEstimator::PairCorrEstimator(ParticleSet& elns, std::string& sources)
     : Dmax(10.), Delta(0.5), num_species(2), d_aa_ID_(elns.addTable(elns))
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   num_species = elns.groups();
   n_vec.resize(num_species, 0);
   for (int i = 0; i < num_species; i++)

--- a/src/QMCHamiltonians/Pressure.h
+++ b/src/QMCHamiltonians/Pressure.h
@@ -43,7 +43,7 @@ struct Pressure : public OperatorBase
    */
   Pressure(ParticleSet& P)
   {
-    UpdateMode.set(OPTIMIZABLE, 1);
+    updateMode.set(OPTIMIZABLE, 1);
     pNorm = 1.0 / (P.Lattice.DIM * P.Lattice.Volume);
   }
   ///destructor
@@ -53,8 +53,8 @@ struct Pressure : public OperatorBase
 
   inline Return_t evaluate(ParticleSet& P) override
   {
-    Value = 2.0 * P.PropertyList[WP::LOCALENERGY] - P.PropertyList[WP::LOCALPOTENTIAL];
-    Value *= pNorm;
+    value = 2.0 * P.PropertyList[WP::LOCALENERGY] - P.PropertyList[WP::LOCALPOTENTIAL];
+    value *= pNorm;
     return 0.0;
   }
 

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -201,7 +201,7 @@ public:
   inline void setPrimary(bool primary)
   {
     for (int i = 0; i < H.size(); i++)
-      H[i]->UpdateMode.set(OperatorBase::PRIMARY, primary);
+      H[i]->updateMode.set(OperatorBase::PRIMARY, primary);
   }
 
   /////Set Tau inside each of the Hamiltonian elements

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -23,8 +23,8 @@ namespace qmcplusplus
 SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi)
     : myRNG(nullptr), IonConfig(ions), Psi(psi), Peln(els), ElecNeighborIons(els), IonNeighborElecs(ions)
 {
-  set_energy_domain(energy_domains::potential);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(energy_domains::potential);
+  twoBodyQuantumDomain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();
   PP.resize(NumIons, nullptr);
@@ -35,7 +35,7 @@ void SOECPotential::resetTargetParticleSet(ParticleSet& P) {}
 
 SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
 {
-  Value = 0.0;
+  value = 0.0;
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
@@ -54,12 +54,12 @@ SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
       if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
       {
         RealType pairpot = PP[iat]->evaluateOne(P, iat, Psi, jel, dist[iat], -displ[iat]);
-        Value += pairpot;
+        value += pairpot;
         NeighborIons.push_back(iat);
         IonNeighborElecs.getNeighborList(iat).push_back(jel);
       }
   }
-  return Value;
+  return value;
 }
 
 std::unique_ptr<OperatorBase> SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi)
     : myRNG(nullptr), IonConfig(ions), Psi(psi), Peln(els), ElecNeighborIons(els), IonNeighborElecs(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(energy_domains::potential);
   two_body_quantum_domain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -29,7 +29,7 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   ions          = &source;
   NumeSpecies   = elns->getSpeciesSet().getTotalNum();
   NumIonSpecies = ions->getSpeciesSet().getTotalNum();
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
 
   NumK      = source.SK->getKLists().numk;
   OneOverN  = 1.0 / static_cast<RealType>(source.getTotalNum());

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 SkEstimator::SkEstimator(ParticleSet& source)
 {
   sourcePtcl = &source;
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   NumSpecies = source.getSpeciesSet().getTotalNum();
   NumK       = source.SK->getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -49,11 +49,11 @@ SkPot::Return_t SkPot::evaluate(ParticleSet& P)
   for (int i = 1; i < NumSpecies; ++i)
     accumulate_elements(P.SK->rhok[i], P.SK->rhok[i] + NumK, RhokTot.begin());
   Vector<ComplexType>::const_iterator iit(RhokTot.begin()), iit_end(RhokTot.end());
-  Value = 0.0;
+  value = 0.0;
   for (int i = 0; iit != iit_end; ++iit, ++i)
-    Value += Fk[i] * ((*iit).real() * (*iit).real() + (*iit).imag() * (*iit).imag());
+    value += Fk[i] * ((*iit).real() * (*iit).real() + (*iit).imag() * (*iit).imag());
 #endif
-  return Value;
+  return value;
 }
 
 bool SkPot::put(xmlNodePtr cur)

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -53,7 +53,7 @@ bool SpeciesKineticEnergy::put(xmlNodePtr cur)
 
   if (hdf5_out)
   { // add this estimator to stat.h5
-    UpdateMode.set(COLLECTABLE, 1);
+    updateMode.set(COLLECTABLE, 1);
   }
   return true;
 }
@@ -112,8 +112,8 @@ SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
     species_kinetic[ispec] += my_kinetic;
   }
 
-  Value = 0.0; // Value is no longer used
-  return Value;
+  value = 0.0; // Value is no longer used
+  return value;
 }
 
 std::unique_ptr<OperatorBase> SpeciesKineticEnergy::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -48,7 +48,7 @@ SpinDensity::SpinDensity(ParticleSet& P)
 void SpinDensity::reset()
 {
   myName = "SpinDensity";
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   corner = 0.0;
 }
 

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -38,7 +38,7 @@ StaticStructureFactor::StaticStructureFactor(ParticleSet& P) : Pinit(P)
 void StaticStructureFactor::reset()
 {
   myName = "StaticStructureFactor";
-  UpdateMode.set(COLLECTABLE, 1);
+  updateMode.set(COLLECTABLE, 1);
   ecut     = -1.0;
   nkpoints = -1;
 }


### PR DESCRIPTION
## Proposed changes

Major refactoring of the base class OperatorBase and files.
- Make it an actual class and determine the appropriate encapsulation (public, protected, private)
- Separate declaration (h) from implementation (cpp) to be more cache friendly as translation units are separated
- Remove inline functions in header and move them to cpp
- Rename all member variables functions to camelCase (affects derived classes)
- Functional tests (`deterministic`) cover most of the current functionality
- Introduce `enum class` to replace plain old `enum` for strongly typed enums
- Introduce `static constexpr int` instead of empty enums
- Remove unused variables/code
- Replace `typedef` with `using` for type alias
- Added several `TODO` `FIXME` for pending tasks (e.g. docs).

To do:
- Check that coverage increases 
- Agree that this is the route to follow from community feedback
- See if it's worth adding a unit test to cover untouched code

Related to #3411 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
