### PR TITLE
Clear clones before exiting QMCMain

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -34,6 +34,7 @@
 #include "Particle/HDFWalkerIO.h"
 #include "Particle/InitMolecularSystem.h"
 #include "QMCDrivers/QMCDriver.h"
+#include "QMCDrivers/CloneManager.h"
 #include "Message/Communicate.h"
 #include "Message/OpenMP.h"
 #include <queue>
@@ -266,6 +267,7 @@ bool QMCMain::execute()
       xmlFreeNode(qmcactionPair.first);
 
   m_qmcaction.clear();
+  CloneManager::clearClones();
   t2->stop();
   app_log() << "  Total Execution time = " << std::setprecision(4) << t1.elapsed() << " secs" << std::endl;
   if (is_manager())

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -145,7 +145,12 @@ QMCMain::QMCMain(Communicate* c)
 }
 
 ///destructor
-QMCMain::~QMCMain() {}
+QMCMain::~QMCMain()
+{
+  // free last_driver before clearing P,Psi,H clones
+  last_driver.reset();
+  CloneManager::clearClones();
+}
 
 
 bool QMCMain::execute()
@@ -267,7 +272,6 @@ bool QMCMain::execute()
       xmlFreeNode(qmcactionPair.first);
 
   m_qmcaction.clear();
-  CloneManager::clearClones();
   t2->stop();
   app_log() << "  Total Execution time = " << std::setprecision(4) << t1.elapsed() << " secs" << std::endl;
   if (is_manager())

--- a/src/QMCApp/qmcapp.cpp
+++ b/src/QMCApp/qmcapp.cpp
@@ -17,7 +17,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include <stdexcept>
-
+#include <memory>
 #include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Utilities/SimpleParser.h"
@@ -206,17 +206,19 @@ int main(int argc, char** argv)
     //  MPI_Bcast(fname.c_str(),fname.size(),MPI_CHAR,0,OHMMS::Controller->getID());
     //#endif
 
-    QMCMain* qmc    = 0;
     bool validInput = false;
     app_log() << "  Input file(s): ";
     for (int k = 0; k < inputs.size(); ++k)
       app_log() << inputs[k] << " ";
     app_log() << std::endl;
-    qmc = new QMCMain(qmcComm);
+
+    auto qmc = std::make_unique<QMCMain>(qmcComm);
+
     if (inputs.size() > 1)
       validInput = qmc->parse(inputs[qmcComm->getGroupID()]);
     else
       validInput = qmc->parse(inputs[0]);
+
     if (!validInput)
       qmcComm->barrier_and_abort("main(). Input invalid.");
 
@@ -234,8 +236,9 @@ int main(int argc, char** argv)
       timingDoc.dump(qmc->getTitle() + ".info.xml");
     }
     timer_manager.print(qmcComm);
-    if (qmc)
-      delete qmc;
+
+    qmc.reset();
+
     if (useGPU)
       Finalize_CUDA();
   }

--- a/src/QMCDrivers/CloneManager.cpp
+++ b/src/QMCDrivers/CloneManager.cpp
@@ -55,11 +55,24 @@ std::vector<std::vector<TrialWaveFunction*>> CloneManager::PsiPoolClones;
 std::vector<UPtrVector<QMCHamiltonian>> CloneManager::HPoolClones_uptr;
 std::vector<std::vector<QMCHamiltonian*>> CloneManager::HPoolClones;
 
-// Clear the static clones so makeClones will work as expected.
-// For now only clearing wClones is strictly necessary.  The storage is not freed,
-// and this will leak memory.
-// Only for use in unit tests.
-void CloneManager::clear_for_unit_tests() { wClones.clear(); }
+void CloneManager::clearClones()
+{
+  HPoolClones.clear();
+  HPoolClones_uptr.clear();
+  PsiPoolClones.clear();
+  PsiPoolClones_uptr.clear();
+  WPoolClones.clear();
+  WPoolClones_uptr.clear();
+
+  hClones.clear();
+  hClones_uptr.clear();
+  guideClones.clear();
+  guideClones_uptr.clear();
+  psiClones.clear();
+  psiClones_uptr.clear();
+  wClones.clear();
+  wClones_uptr.clear();
+}
 
 /// Constructor.
 CloneManager::CloneManager() : NumThreads(omp_get_max_threads()) { wPerRank.resize(NumThreads + 1, 0); }

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -39,9 +39,8 @@ public:
   ///virtual destructor
   virtual ~CloneManager();
 
-  // Clear static array so makeClones will populate properly
-  // Only for using in unit testing.
-  static void clear_for_unit_tests();
+  // Clear static arrays of clones owned by the manager
+  static void clearClones();
 
   void makeClones(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& ham);
   void makeClones(MCWalkerConfiguration& w, std::vector<TrialWaveFunction*>& psi, std::vector<QMCHamiltonian*>& ham);

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -74,7 +74,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
   elec.addTable(ions);
   elec.update();
 
-  CloneManager::clear_for_unit_tests();
+  CloneManager::clearClones();
 
   TrialWaveFunction psi;
   psi.addComponent(std::make_unique<ConstantOrbital>());
@@ -159,7 +159,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
   elec.addTable(ions);
   elec.update();
 
-  CloneManager::clear_for_unit_tests();
+  CloneManager::clearClones();
 
   TrialWaveFunction psi;
   psi.addComponent(std::make_unique<ConstantOrbital>());

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -67,7 +67,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
   elec.addTable(ions);
   elec.update();
 
-  CloneManager::clear_for_unit_tests();
+  CloneManager::clearClones();
 
   TrialWaveFunction psi;
   psi.addComponent(std::make_unique<ConstantOrbital>());
@@ -148,7 +148,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
   elec.addTable(ions);
   elec.update();
 
-  CloneManager::clear_for_unit_tests();
+  CloneManager::clearClones();
 
   TrialWaveFunction psi;
   psi.addComponent(std::make_unique<ConstantOrbital>());
@@ -234,7 +234,7 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
   elec.addTable(ions);
   elec.update();
 
-  CloneManager::clear_for_unit_tests();
+  CloneManager::clearClones();
 
   TrialWaveFunction psi;
   psi.addComponent(std::make_unique<ConstantOrbital>());


### PR DESCRIPTION
## Proposed changes
Since #3356,
Crashes shown as https://cdash.qmcpack.org/CDash/testDetails.php?test=15105035&build=239150
are caused by freeing objects owned by CloneManager statically after CUDA runtime got destroyed (not controlled by QMCPACK).
This PR destroy those objects before exiting QMCMain.

## What type(s) of changes does this code introduce?
- Bugfix
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'