### PR TITLE
Fix git info printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,11 +856,8 @@ endif()
 # All the settings related to building QMCPACK are complete
 ######################################################################
 
-# set up config.h
-configure_file(${qmcpack_SOURCE_DIR}/src/config.h.cmake.in ${qmcpack_BINARY_DIR}/src/config.h)
 #include build/src
 include_directories(${qmcpack_BINARY_DIR}/src)
-
 #include qmcpack/src
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
@@ -911,6 +908,9 @@ find_package(Git)
 if(GIT_FOUND AND EXISTS "${qmcpack_SOURCE_DIR}/.git")
   set(IS_GIT_PROJECT 1)
 endif()
+
+# set up config.h
+configure_file(${qmcpack_SOURCE_DIR}/src/config.h.cmake.in ${qmcpack_BINARY_DIR}/src/config.h)
 
 ######################################################################
 # Testing related settings


### PR DESCRIPTION
## Proposed changes
#3392 caused missing git info header in the printout.

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'