### PR TITLE
Fix stale call to move by makeVirtualMove

### DIFF
--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -222,7 +222,7 @@ public:
    * Note: some distance table consumers (WaveFunctionComponent) have optimized code paths which require prepare_old = true for accepting a move.
    * Drivers/Hamiltonians know whether moves will be accepted or not and manage this flag when calling ParticleSet::makeMoveXXX functions.
    */
-  virtual void move(const ParticleSet& P, const PosType& rnew, const IndexType iat = 0, bool prepare_old = true) = 0;
+  virtual void move(const ParticleSet& P, const PosType& rnew, const IndexType iat, bool prepare_old = true) = 0;
 
   /** walker batched version of move. this function may be implemented asynchronously.
    * Additional synchroniziation for collecting results should be handled by the caller.

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -833,7 +833,7 @@ void ParticleSet::makeVirtualMoves(const SingleParticlePos_t& newpos)
   activePtcl = -1;
   activePos  = newpos;
   for (size_t i = 0; i < DistTables.size(); ++i)
-    DistTables[i]->move(*this, newpos);
+    DistTables[i]->move(*this, newpos, activePtcl, false);
 }
 
 void ParticleSet::loadWalker(Walker_t& awalker, bool pbyp)

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -104,8 +104,9 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
     ScopedTimer local_timer(move_timer_);
 
     old_prepared_elec_id = prepare_old ? iat : -1;
+
     DTD_BConds<T, D, SC>::computeDistances(rnew, P.getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_, 0,
-                                           N_targets, P.activePtcl);
+                                           N_targets, iat);
     // set up old_r_ and old_dr_ for moves may get accepted.
     if (prepare_old)
     {

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -202,8 +202,9 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     temp_r_.attachReference(temp_r_mem_.data(), temp_r_mem_.size());
     temp_dr_.attachReference(temp_dr_mem_.size(), temp_dr_mem_.capacity(), temp_dr_mem_.data());
 
+    assert((prepare_old && iat >=0 && iat < N_targets) || !prepare_old);
     DTD_BConds<T, D, SC>::computeDistances(rnew, P.getCoordinates().getAllParticlePos(), temp_r_.data(), temp_dr_, 0,
-                                           N_targets, P.activePtcl);
+                                           N_targets, iat);
     // set up old_r_ and old_dr_ for moves may get accepted.
     if (prepare_old)
     {


### PR DESCRIPTION
## Proposed changes

Had to read through some of ParticlesSet and distance table code today.  Found what looks to be a nonsense collision of default arguments to DistanceTableData::move and ParticleSet::makeVirtualMoves.  Luckily it seems to only result in some unecessary old__r_ and old_dr_ state being updated in the distance tables. 

I fix this call and fix the grammitically incorrect name of makeVirtualMove.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix?

### Does this introduce a breaking change?

- No, at least according to the unit tests.  

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- No. No existing unit test to update.
- Yes Documentation has been added (if appropriate)
