### PR TITLE
Use unique_ptr to fix memory leak in short-bccH_1x1x1_ae-rmc_sdj-1-16

### DIFF
--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -26,6 +26,7 @@
 #include "LongRange/StructFact.h"
 #include "Particle/HDFWalkerOutput.h"
 #include "Particle/MCSample.h"
+#include "Particle/Reptile.h"
 #include "hdf/hdf_hyperslab.h"
 #include "hdf/HDFVersion.h"
 #include <map>
@@ -78,6 +79,8 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
   Properties       = mcw.Properties;
   //initPropertyList();
 }
+
+MCWalkerConfiguration::~MCWalkerConfiguration() = default;
 
 void MCWalkerConfiguration::createWalkers(int n)
 {

--- a/src/Particle/MCWalkerConfiguration.h
+++ b/src/Particle/MCWalkerConfiguration.h
@@ -78,7 +78,7 @@ public:
   ///const_iterator of Walker container
   typedef WalkerList_t::const_iterator const_iterator;
 
-  typedef std::vector<Reptile*> ReptileList_t;
+  typedef UPtrVector<Reptile> ReptileList_t;
 
   // Data for GPU-acceleration via CUDA
   // These hold a list of pointers to the positions, gradients, and
@@ -122,7 +122,7 @@ public:
 
   ///default constructor: copy only ParticleSet
   MCWalkerConfiguration(const MCWalkerConfiguration& mcw);
-
+  ~MCWalkerConfiguration();
   /** create numWalkers Walkers
    *
    * Append Walkers to WalkerList.

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -249,12 +249,8 @@ void RMC::resetRun()
   {
     Movers[ip]->put(qmcNode);
     Movers[ip]->resetRun(branchEngine.get(), estimatorClones[ip], traceClones[ip], DriftModifier);
-    // wClones[ip]->reptile = new Reptile(*wClones[ip], W.begin()+wPerRank[ip],W.begin()+wPerRank[ip+1]);
-    wClones[ip]->reptile = W.ReptileList[ip];
-    //app_log()<<"Thread # "<<ip<< std::endl;
-    // printf(" Thread# %d  WalkerList.size()=%d \n",ip,wClones[ip]->WalkerList.size());
 
-    // wClones[ip]->reptile->printState();
+    wClones[ip]->reptile = W.ReptileList[ip].get();
     wClones[ip]->activeBead = 0;
     wClones[ip]->direction  = +1;
 
@@ -304,8 +300,6 @@ bool RMC::put(xmlNodePtr q)
 //This will resize the MCWalkerConfiguration and initialize the ReptileList.  Does not care for previous runs.
 void RMC::resetReptiles(int nReptiles_in, int nbeads_in, RealType tau)
 {
-  for (MCWalkerConfiguration::ReptileList_t::iterator it = W.ReptileList.begin(); it != W.ReptileList.end(); it++)
-    delete *it;
   W.ReptileList.clear();
   // Maybe we should be more vigorous in cleaning the MCWC WalkerList?
   std::vector<int> repWalkerSlice;
@@ -316,7 +310,7 @@ void RMC::resetReptiles(int nReptiles_in, int nbeads_in, RealType tau)
 
   for (int i = 0; i < nReptiles_in; i++)
   {
-    W.ReptileList.push_back(new Reptile(W, W.begin() + repWalkerSlice[i], W.begin() + repWalkerSlice[i + 1]));
+    W.ReptileList.push_back(std::make_unique<Reptile>(W, W.begin() + repWalkerSlice[i], W.begin() + repWalkerSlice[i + 1]));
     W.ReptileList[i]->setTau(tau);
   }
 }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Address Sanitizer reports a direct memory leak 

```
246: Direct leak of 34816 byte(s) in 256 object(s) allocated from:
246:     #0 0x4de78d in operator new(unsigned long) (/home/svh/Documents/qmcpack/build/bin/qmcpack_complex+0x4de78d)
246:     #1 0x9b0551 in qmcplusplus::RMC::resetReptiles(int, int, double) /home/svh/Documents/qmcpack/src/QMCDrivers/RMC/RMC.cpp:319:29
246:     #2 0x9abcdc in qmcplusplus::RMC::resetReptiles(std::vector<qmcplusplus::ParticleAttrib<qmcplusplus::TinyVector<double, 3u>, std::allocator<qmcplusplus::TinyVector<double, 3u> > >, std::allocator<qmcplusplus::ParticleAttrib<qmcplusplus::TinyVector<double, 3u>, std::allocator<qmcplusplus::TinyVector<double, 3u> > > > >&, int, double) /home/svh/Documents/qmcpack/src/QMCDrivers/RMC/RMC.cpp:352:5
246:     #3 0x9a98d8 in qmcplusplus::RMC::resetRun() /home/svh/Documents/qmcpack/src/QMCDrivers/RMC/RMC.cpp:192:5
246:     #4 0x9b0c22 in qmcplusplus::RMC::run() /home/svh/Documents/qmcpack/src/QMCDrivers/RMC/RMC.cpp:61:3
246:     #5 0x4ef399 in qmcplusplus::QMCMain::runQMC(_xmlNode*, bool) /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:615:17
246:     #6 0x4ee689 in qmcplusplus::QMCMain::executeQMCSection(_xmlNode*, bool) /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:364:18
246:     #7 0x4f675d in qmcplusplus::QMCMain::execute() /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:249:7
246:     #8 0x4e4e0c in main /home/svh/Documents/qmcpack/src/QMCApp/qmcapp.cpp:225:28
246:     #9 0x7f2ef16500b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
246: 
```
I fixed the leak by changing `ReptileList_t` to `std::vector<std::unique_ptr<Reptile>>`.

What might we add to the deterministic tests to reproduce this bug and validate it stays fixed?

~~Should the zeroth thread owns an array of unique_pointers and all other threads have a raw pointer? Would it be better flipped around, so each element in wClones owns a `Reptile` and the list is non-owning?~~

This is part of #3401.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests) ???

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed