### PR TITLE
Changes in advance of design update to MatrixDelayUpdateCUDA and DDB

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -12,99 +12,107 @@
 #ifndef QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_CUDA_H
 #define QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_CUDA_H
 
+#include <type_traits>
+
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "DualAllocatorAliases.hpp"
 #include "Platforms/CUDA/CUDALinearAlgebraHandles.h"
 #include "Platforms/CUDA/cuBLAS.hpp"
 #include "detail/CUDA/cuBLAS_LU.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "Message/OpenMP.h"
 #include "CPU/SIMD/simd.hpp"
 #include "ResourceCollection.h"
 
 namespace qmcplusplus
 {
-/** helper class to compute matrix inversion and the log value of determinant
- *  of a batch of DiracMatrixes.
- * @tparam T_FP the datatype used in the actual computation of matrix inversion
- *  
+/** class defining a compute and memory resource to compute matrix inversion and 
+ *  the log value of determinant of a batch of DiracMatrixes.
  *  Multiplicty is one per crowd not one per MatrixUpdateEngine.
  *  Matching the multiplicity of the call and resource requirement.
+ *  At least for CUDA this is useful since memory movement
+ *  and computation can be handled on the same stream which is idea for maximum async.
+ *
+ *  @tparam VALUE_FP the datatype used in the actual computation of matrix inversion
+ *              currently we only support std::complex<double>
  */
-template<typename T_FP>
+template<typename VALUE_FP>
 class DiracMatrixComputeCUDA : public Resource
 {
-  // Why not just use QMCTraits::FullPrecRealType?
-  using FullPrecReal = typename scalar_traits<T_FP>::real_type;
+  using FullPrecReal = RealAlias<VALUE_FP>;
 
   template<typename T>
-  using OffloadPinnedMatrix = Matrix<T, PinnedDualAllocator<T>>;
+  using DualMatrix = Matrix<T, PinnedDualAllocator<T>>;
 
   template<typename T>
-  using OffloadPinnedVector = Vector<T, PinnedDualAllocator<T>>;
+  using DualVector = Vector<T, PinnedDualAllocator<T>>;
 
   cudaStream_t hstream_;
 
   // Contiguous memory for fp precision Matrices for each walker, n^2 * nw elements
-  OffloadPinnedVector<T_FP> psiM_fp_;
-  OffloadPinnedVector<T_FP> invM_fp_;
+  DualVector<VALUE_FP> psiM_fp_;
+  DualVector<VALUE_FP> invM_fp_;
 
   // working vectors
-  OffloadPinnedVector<T_FP> LU_diags_fp_;
-  OffloadPinnedVector<int> pivots_;
-  OffloadPinnedVector<int> infos_;
+  DualVector<VALUE_FP> LU_diags_fp_;
+  DualVector<int> pivots_;
+  DualVector<int> infos_;
 
-  //OffloadPinnedMatrix<T_FP> temp_mat_;
+  //DualMatrix<T_FP> temp_mat_;
 
   // For device pointers to matrices
   Vector<char, OffloadPinnedAllocator<char>> psiM_ptrs_;
   Vector<char, OffloadPinnedAllocator<char>> invM_ptrs_;
 
   // cuBLAS geam wants these.
-  T_FP host_one{1.0};
-  T_FP host_zero{0.0};
+  VALUE_FP host_one{1.0};
+  VALUE_FP host_zero{0.0};
 
   /** Calculates the actual inv and log determinant on accelerator
    *
    *  \param[in]      h_cublas    cublas handle, hstream handle is retrieved from it.			
    *  \param[in,out]  a_mats      dual A matrices, they will be transposed on the device side as a side effect.
-   *  \param[out]     inv_a_mats  the invM matrices
+   *  \param[out]     inv_a_mats  dual invM matrices
    *  \param[in]      n           matrices rank.								
    *  \param[in]      lda         leading dimension of each matrix					
    *  \param[out]     log_values  log determinant value for each matrix, batch_size = log_values.size()
    *
-   *  This is the prefered interface for calling computeInvertAndLog when the T_FP and TMAT are equal.
+   *  This is the prefered interface for calling computeInvertAndLog when the VALUE_FP and TMAT are equal.
    *  On Volta so far little seems to be achieved by having the mats continuous.
    */
-  template<typename TMAT, typename TREAL>
-  inline void mw_computeInvertAndLog(cublasHandle_t h_cublas,
-                                     RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
-                                     RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
+  template<typename TMAT>
+  inline void mw_computeInvertAndLog(CUDALinearAlgebraHandles& cuda_handles,
+                                     RefVector<DualMatrix<TMAT>>& a_mats,
+                                     RefVector<DualMatrix<TMAT>>& inv_a_mats,
                                      const int n,
                                      const int lda,
-                                     OffloadPinnedVector<std::complex<TREAL>>& log_values)
+                                     DualVector<std::complex<FullPrecReal>>& log_values)
   {
-    // This is probably dodgy
-    int nw = log_values.size();
+    int nw = a_mats.size();
+    assert(a_mats.size() == inv_a_mats.size());
+
     psiM_ptrs_.resize(sizeof(TMAT*) * nw);
     invM_ptrs_.resize(sizeof(TMAT*) * nw);
     //temp_mat_.resize(n,lda);
-    Vector<const T_FP*> M_ptr_buffer(reinterpret_cast<const TMAT**>(psiM_ptrs_.data()), nw);
-    Vector<const T_FP*> invM_ptr_buffer(reinterpret_cast<const TMAT**>(invM_ptrs_.data()), nw);
-    cudaStream_t hstream;
-    cublasErrorCheck(cublasGetStream(h_cublas, &hstream), "cublasGetStream failed!");
+    int ldinv = inv_a_mats[0].get().cols();
+    Vector<const VALUE_FP*> M_ptr_buffer(reinterpret_cast<const TMAT**>(psiM_ptrs_.data()), nw);
+    Vector<const VALUE_FP*> invM_ptr_buffer(reinterpret_cast<const TMAT**>(invM_ptrs_.data()), nw);
+    cudaStream_t hstream = cuda_handles.hstream;
+    cublasHandle_t h_cublas = cuda_handles.h_cublas;
 
     for (int iw = 0; iw < nw; ++iw)
     {
       M_ptr_buffer[iw]    = a_mats[iw].get().device_data();
       invM_ptr_buffer[iw] = inv_a_mats[iw].get().device_data();
-      // We copy a_mat to inv_a_mat on the device so we can transpose it into a_mat on the device
-      cudaErrorCheck(cudaMemcpyAsync((void*)(inv_a_mats[iw].get().device_data()), (void*)(a_mats[iw].get().data()),
-                                     a_mats[iw].get().size() * sizeof(TMAT), cudaMemcpyHostToDevice, hstream),
+      // Since inv_a_mat can have a different leading dimension from a_mat first we remap copy on the host
+      simd::remapCopy(n, n, a_mats[iw].get().data(), lda, inv_a_mats[iw].get().data(), ldinv);
+      // Then copy a_mat in inv_a_mats to the device
+      cudaErrorCheck(cudaMemcpyAsync((void*)(inv_a_mats[iw].get().device_data()), (void*)(inv_a_mats[iw].get().data()),
+                                     inv_a_mats[iw].get().size() * sizeof(TMAT), cudaMemcpyHostToDevice, hstream),
                      "cudaMemcpyAsync failed copying DiracMatrixBatch::psiM to device");
       // On the device Here we transpose to a_mat;
       cublasErrorCheck(cuBLAS::geam(h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, n, n, &host_one,
-                                    inv_a_mats[iw].get().device_data(), lda, &host_zero,
+                                    inv_a_mats[iw].get().device_data(), ldinv, &host_zero,
                                     a_mats[iw].get().device_data(), lda, a_mats[iw].get().device_data(), lda),
                        "cuBLAS::geam failed.");
     }
@@ -129,13 +137,15 @@ class DiracMatrixComputeCUDA : public Resource
                      "cudaMemcpyAsync failed copying DiracMatrixBatch::inv_psiM to host");
     }
     cudaErrorCheck(cudaMemcpyAsync(log_values.data(), log_values.device_data(),
-                                   log_values.size() * sizeof(std::complex<TREAL>), cudaMemcpyDeviceToHost, hstream),
+                                   log_values.size() * sizeof(std::complex<FullPrecReal>), cudaMemcpyDeviceToHost,
+                                   hstream),
                    "cudaMemcpyAsync log_values failed!");
     cudaErrorCheck(cudaStreamSynchronize(hstream), "cudaStreamSynchronize failed!");
   }
 
 
-  /** Calculates the actual inv and log determinant on accelerator
+  /** Calculates the actual inv and log determinant on accelerator with psiMs and invMs widened to full precision
+   *  and copied into continuous vectors.
    *
    *  \param[in]      h_cublas    cublas handle, hstream handle is retrieved from it.			
    *  \param[in,out]  psi_Ms      matrices flattened into single pinned vector, returned with LU matrices.
@@ -145,20 +155,19 @@ class DiracMatrixComputeCUDA : public Resource
    *  \param[out]     log_values  log determinant value for each matrix, batch_size = log_values.size()
    *
    */
-  template<typename TREAL>
-  inline void mw_computeInvertAndLog(cublasHandle_t h_cublas,
-                                     OffloadPinnedVector<TREAL>& psi_Ms,
-                                     OffloadPinnedVector<TREAL>& inv_Ms,
+  inline void mw_computeInvertAndLog(CUDALinearAlgebraHandles& cuda_handles,
+                                     DualVector<VALUE_FP>& psi_Ms,
+                                     DualVector<VALUE_FP>& inv_Ms,
                                      const int n,
                                      const int lda,
-                                     OffloadPinnedVector<std::complex<TREAL>>& log_values)
+                                     DualVector<std::complex<FullPrecReal>>& log_values)
   {
     // This is probably dodgy
     int nw = log_values.size();
-    psiM_ptrs_.resize(sizeof(TREAL*) * nw);
-    invM_ptrs_.resize(sizeof(TREAL*) * nw);
-    Vector<const T_FP*> M_ptr_buffer(reinterpret_cast<const TREAL**>(psiM_ptrs_.data()), nw);
-    Vector<const T_FP*> invM_ptr_buffer(reinterpret_cast<const TREAL**>(invM_ptrs_.data()), nw);
+    psiM_ptrs_.resize(sizeof(VALUE_FP*) * nw);
+    invM_ptrs_.resize(sizeof(VALUE_FP*) * nw);
+    Vector<const VALUE_FP*> M_ptr_buffer(reinterpret_cast<const VALUE_FP**>(psiM_ptrs_.data()), nw);
+    Vector<const VALUE_FP*> invM_ptr_buffer(reinterpret_cast<const VALUE_FP**>(invM_ptrs_.data()), nw);
     for (int iw = 0; iw < nw; ++iw)
     {
       M_ptr_buffer[iw]    = psi_Ms.device_data() + iw * n * lda;
@@ -167,10 +176,10 @@ class DiracMatrixComputeCUDA : public Resource
     pivots_.resize(n * nw);
     infos_.resize(nw);
     LU_diags_fp_.resize(n * nw);
-    cudaStream_t hstream;
-    cublasErrorCheck(cublasGetStream(h_cublas, &hstream), "cublasGetStream failed!");
-    assert(hstream == hstream_);
-    cudaErrorCheck(cudaMemcpyAsync(psi_Ms.device_data(), psi_Ms.data(), psi_Ms.size() * sizeof(T_FP),
+
+    cudaStream_t hstream = cuda_handles.hstream;
+    cublasHandle_t h_cublas = cuda_handles.h_cublas;
+    cudaErrorCheck(cudaMemcpyAsync(psi_Ms.device_data(), psi_Ms.data(), psi_Ms.size() * sizeof(VALUE_FP),
                                    cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync failed copying DiracMatrixBatch::psiM_fp to device");
     cudaErrorCheck(cudaMemcpyAsync(psiM_ptrs_.device_data(), psiM_ptrs_.data(), psiM_ptrs_.size(),
@@ -179,8 +188,8 @@ class DiracMatrixComputeCUDA : public Resource
     cudaErrorCheck(cudaMemcpyAsync(invM_ptrs_.device_data(), invM_ptrs_.data(), invM_ptrs_.size(),
                                    cudaMemcpyHostToDevice, hstream),
                    "cudaMemcpyAsync invM_ptrs_ failed!");
-    TREAL** psiM_mw_ptr = reinterpret_cast<TREAL**>(psiM_ptrs_.device_data());
-    TREAL** invM_mw_ptr = reinterpret_cast<TREAL**>(invM_ptrs_.device_data());
+    VALUE_FP** psiM_mw_ptr = reinterpret_cast<VALUE_FP**>(psiM_ptrs_.device_data());
+    VALUE_FP** invM_mw_ptr = reinterpret_cast<VALUE_FP**>(invM_ptrs_.device_data());
 
     cuBLAS_LU::computeInverseAndDetLog_batched(h_cublas, hstream, n, lda, psiM_mw_ptr, invM_mw_ptr,
                                                LU_diags_fp_.device_data(), pivots_.device_data(), infos_.data(),
@@ -193,11 +202,12 @@ class DiracMatrixComputeCUDA : public Resource
     cudaErrorCheck(cudaMemcpyAsync(invM_ptrs_.data(), invM_ptrs_.device_data(), invM_ptrs_.size(),
                                    cudaMemcpyDeviceToHost, hstream),
                    "cudaMemcpyAsync invM_ptrs_ failed!");
-    cudaErrorCheck(cudaMemcpyAsync(inv_Ms.data(), inv_Ms.device_data(), inv_Ms.size() * sizeof(TREAL),
+    cudaErrorCheck(cudaMemcpyAsync(inv_Ms.data(), inv_Ms.device_data(), inv_Ms.size() * sizeof(VALUE_FP),
                                    cudaMemcpyDeviceToHost, hstream),
                    "cudaMemcpyAsync failed copying back DiracMatrixBatch::invM_fp from device");
     cudaErrorCheck(cudaMemcpyAsync(log_values.data(), log_values.device_data(),
-                                   log_values.size() * sizeof(std::complex<TREAL>), cudaMemcpyDeviceToHost, hstream),
+                                   log_values.size() * sizeof(std::complex<FullPrecReal>), cudaMemcpyDeviceToHost,
+                                   hstream),
                    "cudaMemcpyAsync log_values failed!");
     cudaErrorCheck(cudaStreamSynchronize(hstream), "cudaStreamSynchronize failed!");
   }
@@ -221,32 +231,34 @@ public:
    *  vector is used to match the primary batched interface to the accelerated routings.
    *  There is no optimization (yet) for TMAT same type as TREAL
    */
-  template<typename TMAT, typename TREAL>
+  template<typename TMAT>
   void invert_transpose(CUDALinearAlgebraHandles& cuda_handles,
-                        OffloadPinnedMatrix<TMAT>& a_mat,
-                        OffloadPinnedMatrix<TMAT>& inv_a_mat,
-                        OffloadPinnedVector<std::complex<TREAL>>& log_values)
+                        DualMatrix<TMAT>& a_mat,
+                        DualMatrix<TMAT>& inv_a_mat,
+                        DualVector<std::complex<FullPrecReal>>& log_values)
   {
-    const int n   = a_mat.rows();
-    const int lda = a_mat.cols();
+    const int n        = a_mat.rows();
+    const int lda      = a_mat.cols();
     psiM_fp_.resize(n * lda);
     invM_fp_.resize(n * lda);
-    std::fill(log_values.begin(), log_values.end(), std::complex<TREAL>{0.0, 0.0});
+    std::fill(log_values.begin(), log_values.end(), std::complex<FullPrecReal>{0.0, 0.0});
     // making sure we know the log_values are zero'd on the device.
     cudaErrorCheck(cudaMemcpyAsync(log_values.device_data(), log_values.data(),
-                                   log_values.size() * sizeof(std::complex<TREAL>), cudaMemcpyHostToDevice,
+                                   log_values.size() * sizeof(std::complex<FullPrecReal>), cudaMemcpyHostToDevice,
                                    cuda_handles.hstream),
                    "cudaMemcpyAsync failed copying DiracMatrixBatch::log_values to device");
     simd::transpose(a_mat.data(), n, lda, psiM_fp_.data(), n, lda);
-    cudaErrorCheck(cudaMemcpyAsync(psiM_fp_.device_data(), psiM_fp_.data(), psiM_fp_.size() * sizeof(T_FP),
+    cudaErrorCheck(cudaMemcpyAsync(psiM_fp_.device_data(), psiM_fp_.data(), psiM_fp_.size() * sizeof(VALUE_FP),
                                    cudaMemcpyHostToDevice, cuda_handles.hstream),
                    "cudaMemcpyAsync failed copying DiracMatrixBatch::psiM_fp to device");
-    mw_computeInvertAndLog(cuda_handles.h_cublas, psiM_fp_, invM_fp_, n, lda, log_values);
-    OffloadPinnedMatrix<T_FP> data_ref_matrix;
+    mw_computeInvertAndLog(cuda_handles, psiM_fp_, invM_fp_, n, lda, log_values);
+    DualMatrix<VALUE_FP> data_ref_matrix;
 
     data_ref_matrix.attachReference(invM_fp_.data(), n, n);
-    // Use ohmms matrix to do element wise assignment with possible narrowing conversion.
-    inv_a_mat = data_ref_matrix;
+
+    // We can't use operator= with different lda, ldb which can happen so we use this assignment which is over the
+    // smaller of the two's dimensions
+    inv_a_mat.assignUpperRight(data_ref_matrix);
     cudaErrorCheck(cudaMemcpyAsync(inv_a_mat.device_data(), inv_a_mat.data(), inv_a_mat.size() * sizeof(TMAT),
                                    cudaMemcpyHostToDevice, cuda_handles.hstream),
                    "cudaMemcpyAsync of inv_a_mat to device failed!");
@@ -256,27 +268,25 @@ public:
    *  When TMAT is not full precision we need to still do the inversion and log
    *  at full precision. This is not yet optimized to transpose on the GPU
    */
-  template<typename TMAT, typename TREAL>
-  inline std::enable_if_t<!std::is_same<T_FP, TMAT>::value> mw_invertTranspose(
-      Resource& resource,
-      RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
-      RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
-      OffloadPinnedVector<std::complex<TREAL>>& log_values,
+  template<typename TMAT>
+  inline std::enable_if_t<!std::is_same<VALUE_FP, TMAT>::value> mw_invertTranspose(
+      CUDALinearAlgebraHandles& cuda_handles,
+      RefVector<DualMatrix<TMAT>>& a_mats,
+      RefVector<DualMatrix<TMAT>>& inv_a_mats,
+      DualVector<std::complex<FullPrecReal>>& log_values,
       const std::vector<bool>& compute_mask)
   {
     assert(log_values.size() == a_mats.size());
-    auto& cuda_handles = dynamic_cast<CUDALinearAlgebraHandles&>(resource);
     int nw             = a_mats.size();
     const int n        = a_mats[0].get().rows();
     const int lda      = a_mats[0].get().cols();
-    const int ldb      = inv_a_mats[0].get().cols();
     size_t nsqr        = n * n;
     psiM_fp_.resize(n * lda * nw);
     invM_fp_.resize(n * lda * nw);
-    std::fill(log_values.begin(), log_values.end(), std::complex<TREAL>{0.0, 0.0});
+    std::fill(log_values.begin(), log_values.end(), std::complex<FullPrecReal>{0.0, 0.0});
     // making sure we know the log_values are zero'd on the device.
     cudaErrorCheck(cudaMemcpyAsync(log_values.device_data(), log_values.data(),
-                                   log_values.size() * sizeof(std::complex<TREAL>), cudaMemcpyHostToDevice,
+                                   log_values.size() * sizeof(std::complex<FullPrecReal>), cudaMemcpyHostToDevice,
                                    cuda_handles.hstream),
                    "cudaMemcpyAsync failed copying DiracMatrixBatch::log_values to device");
     for (int iw = 0; iw < nw; ++iw)
@@ -284,10 +294,11 @@ public:
     mw_computeInvertAndLog(cuda_handles.h_cublas, psiM_fp_, invM_fp_, n, lda, log_values);
     for (int iw = 0; iw < a_mats.size(); ++iw)
     {
-      OffloadPinnedMatrix<T_FP> data_ref_matrix;
-      data_ref_matrix.attachReference(invM_fp_.data() + nsqr * iw, n, n);
-      // Use ohmms matrix to do element wise assignment with possible narrowing conversion.
-      inv_a_mats[iw].get() = data_ref_matrix;
+      DualMatrix<VALUE_FP> data_ref_matrix;
+      data_ref_matrix.attachReference(invM_fp_.data() + nsqr * iw, n, lda);
+      // We can't use operator= with different lda, ldb which can happen so we use this assignment which is over the
+      // smaller of the two's dimensions
+      inv_a_mats[iw].get().assignUpperRight(data_ref_matrix);
       cudaErrorCheck(cudaMemcpyAsync(inv_a_mats[iw].get().device_data(), inv_a_mats[iw].get().data(),
                                      inv_a_mats[iw].get().size() * sizeof(TMAT), cudaMemcpyHostToDevice,
                                      cuda_handles.hstream),
@@ -297,22 +308,21 @@ public:
 
   /** Batched inversion and calculation of log determinants.
    *  When TMAT is full precision we can use the a_mat and inv_mat directly
+   *  Side effect of this is after this call a_mats contains the LU factorization
+   *  matrix.
    */
-  template<typename TMAT, typename TREAL>
-  inline std::enable_if_t<std::is_same<T_FP, TMAT>::value> mw_invertTranspose(
-      Resource& resource,
-      RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
-      RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
-      OffloadPinnedVector<std::complex<TREAL>>& log_values,
+  template<typename TMAT>
+  inline std::enable_if_t<std::is_same<VALUE_FP, TMAT>::value> mw_invertTranspose(
+      CUDALinearAlgebraHandles& cuda_handles,
+      RefVector<DualMatrix<TMAT>>& a_mats,
+      RefVector<DualMatrix<TMAT>>& inv_a_mats,
+      DualVector<std::complex<FullPrecReal>>& log_values,
       const std::vector<bool>& compute_mask)
   {
     assert(log_values.size() == a_mats.size());
-    auto& cuda_handles = dynamic_cast<CUDALinearAlgebraHandles&>(resource);
-    const int n        = a_mats[0].get().rows();
-    const int lda      = a_mats[0].get().cols();
-    const int ldb      = inv_a_mats[0].get().cols();
-    size_t nsqr        = n * n;
-    mw_computeInvertAndLog(cuda_handles.h_cublas, a_mats, inv_a_mats, n, lda, log_values);
+    const int n   = a_mats[0].get().rows();
+    const int lda = a_mats[0].get().cols();
+    mw_computeInvertAndLog(cuda_handles, a_mats, inv_a_mats, n, lda, log_values);
   }
 };
 

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -18,7 +18,7 @@
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "DiracMatrix.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "type_traits/template_types.hpp"
 #include "Message/OpenMP.h"
 #include "CPU/SIMD/simd.hpp"
@@ -26,38 +26,45 @@
 
 namespace qmcplusplus
 {
-/** helper class to compute matrix inversion and the log value of determinant
+/** class to compute matrix inversion and the log value of determinant
  *  of a batch of DiracMatrixes.
- * @tparam T_FP the datatype used in the actual computation of matrix inversion
+ *
+ *  @tparam VALUE_FP the datatype used in the actual computation of the matrix
  *  
  *  There is one per crowd not one per MatrixUpdateEngine.
  *  this puts ownership of the scratch resources in a sensible place.
- *  Even for CPU this is better.
+ *  
+ *  Currently this is CPU only but its external API is somewhat written to
+ *  enforce the passing Dual data objects as arguments.  Except for the single
+ *  particle API log_value which is not Dual type but had better have an address in a OMPtarget
+ *  mapped region if target is used with it. This makes this API incompatible to
+ *  that used by MatrixDelayedUpdateCuda and DiracMatrixComputeCUDA.
  */
-template<typename T_FP>
+template<typename VALUE_FP>
 class DiracMatrixComputeOMPTarget : public Resource
 {
-  // Why not just use QMCTraits::FullPrecRealType?
-  using FullPrecReal = typename scalar_traits<T_FP>::real_type;
+  using FullPrecReal = RealAlias<VALUE_FP>;
 
   template<typename T>
   using OffloadPinnedAllocator = OMPallocator<T, PinnedAlignedAllocator<T>>;
-
   template<typename T>
   using OffloadPinnedMatrix = Matrix<T, OffloadPinnedAllocator<T>>;
-
   template<typename T>
   using OffloadPinnedVector = Vector<T, OffloadPinnedAllocator<T>>;
 
-  aligned_vector<T_FP> m_work_;
+  aligned_vector<VALUE_FP> m_work_;
   int lwork_;
-  //Unlike DiracMatrix.h these are contiguous packed representations of the Matrices
-  // Contiguous Matrices for each walker, n^2 * nw  elements
-  OffloadPinnedVector<T_FP> psiM_fp_;
-  OffloadPinnedVector<T_FP> logdets_fp_;
-  OffloadPinnedVector<T_FP> LU_diags_fp_;
+
+  /// Matrices held in memory matrices n^2 * nw  elements
+  OffloadPinnedVector<VALUE_FP> psiM_fp_;
+
+  OffloadPinnedVector<VALUE_FP> LU_diags_fp_;
+
   OffloadPinnedVector<int> pivots_;
   OffloadPinnedVector<int> infos_;
+
+  // maybe you'll want a resource someday, then change here.
+  using HandleResource = DummyResource;
 
   Vector<char, OffloadPinnedAllocator<char>> psiM_ptrs_;
   /** reset internal work space.
@@ -65,14 +72,14 @@ class DiracMatrixComputeOMPTarget : public Resource
    *
    *  it smells that this is so complex.
    */
-  inline void reset(OffloadPinnedVector<T_FP>& psi_Ms, const int n, const int lda, const int batch_size)
+  inline void reset(OffloadPinnedVector<VALUE_FP>& psi_Ms, const int n, const int lda, const int batch_size)
   {
     int nw = batch_size;
     pivots_.resize(lda * nw);
     for (int iw = 0; iw < nw; ++iw)
     {
       lwork_ = -1;
-      T_FP tmp;
+      VALUE_FP tmp;
       FullPrecReal lw;
       auto psi_M_ptr = psi_Ms.data() + iw * n * n;
       Xgetri(lda, psi_M_ptr, lda, pivots_.data() + iw * n, &tmp, lwork_);
@@ -93,7 +100,7 @@ class DiracMatrixComputeOMPTarget : public Resource
     pivots_.resize(lda);
     LU_diags_fp_.resize(lda);
     lwork_ = -1;
-    T_FP tmp;
+    VALUE_FP tmp;
     FullPrecReal lw;
     Xgetri(lda, psi_M.data(), lda, pivots_.data(), &tmp, lwork_);
     convert(tmp, lw);
@@ -103,27 +110,27 @@ class DiracMatrixComputeOMPTarget : public Resource
 
   /** compute the inverse of invMat (in place) and the log value of determinant
    * @tparam TREAL real type
-   * @param n invMat is n x n matrix
-   * @param lda the first dimension of invMat
-   * @param LogDet log determinant value of invMat before inversion
+   * \param[inout] a_mat      the matrix
+   * \param[in]    n          actual dimension of square matrix (no guarantee it really has full column rank)
+   * \param[in]    lda        leading dimension of Matrix container
+   * \param[out]   log_value  log a_mat before inversion
    */
   template<typename TREAL>
-  inline void computeInvertAndLog(OffloadPinnedMatrix<TREAL>& invMat,
+  inline void computeInvertAndLog(OffloadPinnedMatrix<TREAL>& a_mat,
                                   const int n,
                                   const int lda,
-                                  std::complex<T_FP>& log_value)
+                                  std::complex<VALUE_FP>& log_value)
   {
     BlasThreadingEnv knob(getNextLevelNumThreads());
     if (lwork_ < lda)
-      reset(invMat, n, lda);
-    Xgetrf(n, n, invMat.data(), lda, pivots_.data());
+      reset(a_mat, n, lda);
+    Xgetrf(n, n, a_mat.data(), lda, pivots_.data());
     for (int i = 0; i < n; i++)
-      LU_diags_fp_[i] = invMat.data()[i * lda + i];
+      LU_diags_fp_[i] = a_mat.data()[i * lda + i];
     log_value = {0.0, 0.0};
     computeLogDet(LU_diags_fp_.data(), n, pivots_.data(), log_value);
-    Xgetri(n, invMat.data(), lda, pivots_.data(), m_work_.data(), lwork_);
+    Xgetri(n, a_mat.data(), lda, pivots_.data(), m_work_.data(), lwork_);
   }
-
 
   template<typename TREAL>
   inline void computeInvertAndLog(OffloadPinnedVector<TREAL>& psi_Ms,
@@ -139,7 +146,7 @@ class DiracMatrixComputeOMPTarget : public Resource
     LU_diags_fp_.resize(n * nw);
     for (int iw = 0; iw < nw; ++iw)
     {
-      T_FP* LU_M = psi_Ms.data() + iw * n * n;
+      VALUE_FP* LU_M = psi_Ms.data() + iw * n * n;
       Xgetrf(n, n, LU_M, lda, pivots_.data() + iw * n);
       for (int i = 0; i < n; i++)
         *(LU_diags_fp_.data() + iw * n + i) = LU_M[i * lda + i];
@@ -156,31 +163,42 @@ public:
   Resource* makeClone() const override { return new DiracMatrixComputeOMPTarget(*this); }
 
   /** compute the inverse of the transpose of matrix A and its determinant value in log
-   * when T_FP and TMAT are the same
+   * when VALUE_FP and TMAT are the same
    * @tparam TMAT matrix value type
    * @tparam TREAL real type
+   * \param [in]    resource          compute resource
+   * \param [in]    a_mat             matrix to be inverted
+   * \param [out]   inv_a_mat         the inverted matrix
+   * \param [out]   log_value         breaks compatibility of MatrixUpdateOmpTarget with
+   *                                  DiracMatrixComputeCUDA but is fine for OMPTarget        
    */
-  template<typename TMAT, typename TREAL>
-  inline std::enable_if_t<std::is_same<T_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
-                                                                            OffloadPinnedMatrix<TMAT>& inv_a_mat,
-                                                                            std::complex<TREAL>& log_value)
+  template<typename TMAT>
+  inline std::enable_if_t<std::is_same<VALUE_FP, TMAT>::value> invert_transpose(
+      HandleResource& resource,
+      const OffloadPinnedMatrix<TMAT>& a_mat,
+      OffloadPinnedMatrix<TMAT>& inv_a_mat,
+      std::complex<FullPrecReal>& log_value)
   {
     const int n   = a_mat.rows();
     const int lda = a_mat.cols();
     const int ldb = inv_a_mat.cols();
     simd::transpose(a_mat.data(), n, lda, inv_a_mat.data(), n, ldb);
+    // In this case we just pass the value since
+    // that makes sense for a single walker API
     computeInvertAndLog(inv_a_mat, n, ldb, log_value);
   }
 
   /** compute the inverse of the transpose of matrix A and its determinant value in log
-   * when T_FP and TMAT are the different
+   * when VALUE_FP and TMAT are the different
    * @tparam TMAT matrix value type
    * @tparam TREAL real type
    */
-  template<typename TMAT, typename TREAL>
-  inline std::enable_if_t<!std::is_same<T_FP, TMAT>::value> invert_transpose(const OffloadPinnedMatrix<TMAT>& a_mat,
-                                                                             OffloadPinnedMatrix<TMAT>& inv_a_mat,
-                                                                             std::complex<TREAL>& log_value)
+  template<typename TMAT>
+  inline std::enable_if_t<!std::is_same<VALUE_FP, TMAT>::value> invert_transpose(
+      HandleResource& resource,
+      const OffloadPinnedMatrix<TMAT>& a_mat,
+      OffloadPinnedMatrix<TMAT>& inv_a_mat,
+      std::complex<FullPrecReal>& log_value)
   {
     const int n   = a_mat.rows();
     const int lda = a_mat.cols();
@@ -188,7 +206,8 @@ public:
 
     psiM_fp_.resize(n * lda);
     simd::transpose(a_mat.data(), n, lda, psiM_fp_.data(), n, lda);
-    computeInvertAndLog(psiM_fp_, n, lda, log_value);
+    OffloadPinnedMatrix<VALUE_FP> psiM_fp_view(psiM_fp_, psiM_fp_.data(), n, lda);
+    computeInvertAndLog(psiM_fp_view, n, lda, log_value);
 
     //Matrix<TMAT> data_ref_matrix;
     //maybe n, lda
@@ -202,7 +221,8 @@ public:
    *  \todo measure if using the a_mats without a copy to contiguous vector is better.
    */
   template<typename TMAT, typename TREAL>
-  inline void mw_invertTranspose(RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
+  inline void mw_invertTranspose(HandleResource& resource,
+                                 RefVector<OffloadPinnedMatrix<TMAT>>& a_mats,
                                  RefVector<OffloadPinnedMatrix<TMAT>>& inv_a_mats,
                                  OffloadPinnedVector<std::complex<TREAL>>& log_values,
                                  const std::vector<bool>& recompute)
@@ -225,9 +245,5 @@ public:
   }
 };
 } // namespace qmcplusplus
-
-// template<typename TREAL>
-// inline void computeInvertAndLog(T_FP* invMat, const int n, const int lda, std::complex<TREAL>& log_value);
-
 
 #endif // QMCPLUSPLUS_DIRAC_MATRIX_COMPUTE_OMPTARGET_H

--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -30,7 +30,8 @@ struct MatrixUpdateOMPTargetMultiWalkerMem : public Resource
   using OffloadValueVector_t       = Vector<T, OffloadAllocator<T>>;
   using OffloadPinnedValueVector_t = Vector<T, OffloadPinnedAllocator<T>>;
   using OffloadPinnedValueMatrix_t = Matrix<T, OffloadPinnedAllocator<T>>;
-
+  using HandleResource = DummyResource;
+  
   // constant array value T(1)
   OffloadValueVector_t cone_vec;
   // constant array value T(0)

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeCUDA.cpp
@@ -11,7 +11,6 @@
 
 #include <catch.hpp>
 #include <algorithm>
-#include "Configuration.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/OhmmsVector.h"
@@ -47,19 +46,19 @@ TEST_CASE("DiracMatrixComputeCUDA_cuBLAS_geam_call", "[wavefunction][fermion]")
 
   double host_one(1.0);
   double host_zero(0.0);
-  
+
   std::vector<double> A{2, 5, 8, 7, 5, 2, 2, 8, 7, 5, 6, 6, 5, 4, 4, 8};
   std::copy_n(A.begin(), 16, mat_a.data());
   auto cuda_handles = std::make_unique<CUDALinearAlgebraHandles>();
-  int lda= n;
-  cudaCheck(cudaMemcpyAsync((void*)(temp_mat.device_data()), (void*)(mat_a.data()),
-                            mat_a.size() * sizeof(double), cudaMemcpyHostToDevice, cuda_handles->hstream));
+  int lda           = n;
+  cudaCheck(cudaMemcpyAsync((void*)(temp_mat.device_data()), (void*)(mat_a.data()), mat_a.size() * sizeof(double),
+                            cudaMemcpyHostToDevice, cuda_handles->hstream));
   cublasErrorCheck(cuBLAS::geam(cuda_handles->h_cublas, CUBLAS_OP_T, CUBLAS_OP_N, n, n, &host_one,
-                                    temp_mat.device_data(), lda, &host_zero,
-                                mat_c.device_data(), lda, mat_a.device_data(), lda),
+                                temp_mat.device_data(), lda, &host_zero, mat_c.device_data(), lda, mat_a.device_data(),
+                                lda),
                    "cuBLAS::geam failed.");
 }
-  
+
 TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermion]")
 {
   OffloadPinnedMatrix<double> mat_a;
@@ -133,10 +132,10 @@ TEST_CASE("DiracMatrixComputeCUDA_different_batch_sizes", "[wavefunction][fermio
 
 TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefunction][fermion]")
 {
-  int n = 64;
+  int n             = 64;
   auto cuda_handles = std::make_unique<CUDALinearAlgebraHandles>();
 
-  DiracMatrixComputeCUDA<std::complex<double>> dmcc(cuda_handles->hstream);;
+  DiracMatrixComputeCUDA<std::complex<double>> dmcc(cuda_handles->hstream);
 
   Matrix<std::complex<double>> mat_spd;
   mat_spd.resize(n, n);
@@ -160,7 +159,7 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
   for (int i = 0; i < n; ++i)
     for (int j = 0; j < n; ++j)
       mat_a2(i, j) = mat_spd2(i, j);
-  
+
   OffloadPinnedVector<std::complex<double>> log_values;
   log_values.resize(2);
   OffloadPinnedMatrix<std::complex<double>> inv_mat_a;
@@ -177,7 +176,7 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
   Matrix<std::complex<double>> inv_mat_test(n, n);
   std::complex<double> det_log_value;
   dmat.invert_transpose(mat_spd, inv_mat_test, det_log_value);
-  
+
   auto check_matrix_result = checkMatrix(inv_mat_a, inv_mat_test);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
@@ -188,10 +187,10 @@ TEST_CASE("DiracMatrixComputeCUDA_complex_determinants_against_legacy", "[wavefu
 
 TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunction][fermion]")
 {
-  int n = 64;
+  int n             = 64;
   auto cuda_handles = std::make_unique<CUDALinearAlgebraHandles>();
 
-  DiracMatrixComputeCUDA<double> dmcc(cuda_handles->hstream);;
+  DiracMatrixComputeCUDA<double> dmcc(cuda_handles->hstream);
 
   Matrix<double> mat_spd;
   mat_spd.resize(n, n);
@@ -215,7 +214,7 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunc
   for (int i = 0; i < n; ++i)
     for (int j = 0; j < n; ++j)
       mat_a2(i, j) = mat_spd2(i, j);
-  
+
   OffloadPinnedVector<std::complex<double>> log_values;
   log_values.resize(2);
   OffloadPinnedMatrix<double> inv_mat_a;
@@ -232,7 +231,7 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunc
   Matrix<double> inv_mat_test(n, n);
   std::complex<double> det_log_value;
   dmat.invert_transpose(mat_spd, inv_mat_test, det_log_value);
-  
+
   auto check_matrix_result = checkMatrix(inv_mat_a, inv_mat_test);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 
@@ -240,6 +239,5 @@ TEST_CASE("DiracMatrixComputeCUDA_large_determinants_against_legacy", "[wavefunc
   check_matrix_result = checkMatrix(inv_mat_a2, inv_mat_test);
   CHECKED_ELSE(check_matrix_result.result) { FAIL(check_matrix_result.result_message); }
 }
-
 
 } // namespace qmcplusplus

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -29,5 +29,15 @@ private:
   int index_in_collection_ = -1;
   friend class ResourceCollection;
 };
+
+/** For the sake of generic code sometimes an dummy resource is needed to pass API.
+ */
+class DummyResource : public Resource
+{
+public:
+  DummyResource() : Resource("Dummy") {}
+  DummyResource(const std::string& name) : Resource(name) {}
+  DummyResource* makeClone() const override { return new DummyResource(); }
+};
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -33,6 +33,15 @@ TEST_CASE("Resource", "[utilities]")
   REQUIRE(res_copy->data.size() == 5);
 }
 
+TEST_CASE("DummyResource", "[utilities]")
+{
+  DummyResource dummy;
+  std::unique_ptr<DummyResource> dummy2(dummy.makeClone());
+  REQUIRE(dummy.getName() == "Dummy");
+  DummyResource dummy_alt("dummy_alt_name");
+  REQUIRE(dummy_alt.getName() == "dummy_alt_name");
+}
+
 class WFCResourceConsumer
 {
 public:


### PR DESCRIPTION
## Proposed changes

API updates for DiracDeterminantComputeCUDA and DiracDeterminantComputeOMPTarget. This is to support changes in classes above to move away from the confused 1 walker to 1 batched object and then a batched leader design which is left over from the 1 manager per walker with only the index 0 being an actual manager design of legacy.  SingleWalker API that are not exposed above DiracDeterminantBatched also have a resource argument added to allow passing in thread local resource handles making it possible to use streams to efficiently transfer and launch kernels without OMP target. An dummy resource needs to be passed by OMPtarget code.

The reason these two classes should be 1 per batch is simple. It makes sense for the batched compute objects to manage or acquire the temporary resources used for used computation, i.e. streams, scratch host or device memory. It doesn't make sense to have 1 of a set of identical 1 per walker classes acquire the compute and memory resource needed for batching and operate on its peers and then just not use those resources for single walker calls.

This is a first step to fixing that from the bottom up.
 
## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Documentation changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte 

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
