### PR TITLE
Remove numParams and N member variables

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -211,8 +211,8 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
 {
   if (do_output_matrices_csv_ && !output_matrices_initialized_)
   {
-    int numParams = optTarget->getNumParams();
-    int N     = numParams + 1;
+    const int numParams = optTarget->getNumParams();
+    const int N         = numParams + 1;
     output_overlap_.init_file(get_root_name(), "ovl", N);
     output_hamiltonian_.init_file(get_root_name(), "ham", N);
     output_matrices_initialized_ = true;
@@ -246,8 +246,8 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
   bool Valid(true);
   int Total_iterations(0);
   //size of matrix
-  int numParams = optTarget->getNumParams();
-  int N         = numParams + 1;
+  const int numParams = optTarget->getNumParams();
+  const int N         = numParams + 1;
   //   where we are and where we are pointing
   std::vector<RealType> currentParameterDirections(N, 0);
   std::vector<RealType> currentParameters(numParams, 0);
@@ -339,8 +339,8 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
         if (std::abs(objFuncWrapper_.Lambda * bigVec) > bigChange)
         {
           goodStep = false;
-          app_log() << "  Failed Step. Magnitude of largest parameter change: " << std::abs(objFuncWrapper_.Lambda * bigVec)
-                    << std::endl;
+          app_log() << "  Failed Step. Magnitude of largest parameter change: "
+                    << std::abs(objFuncWrapper_.Lambda * bigVec) << std::endl;
           if (stability == 0)
           {
             failedTries++;
@@ -369,7 +369,7 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
           int npts(7);
           objFuncWrapper_.quadstep         = stepsize * objFuncWrapper_.Lambda;
           objFuncWrapper_.largeQuarticStep = bigChange / bigVec;
-          Valid                 = objFuncWrapper_.lineoptimization3(npts, evaluated_cost);
+          Valid                            = objFuncWrapper_.lineoptimization3(npts, evaluated_cost);
         }
         else
           Valid = objFuncWrapper_.lineoptimization2();
@@ -835,10 +835,10 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
   const int nshifts = shifts_i.size();
 
   // get number of optimizable parameters
-  int numParams = optTarget->getNumParams();
+  const int numParams = optTarget->getNumParams();
 
   // get dimension of the linear method matrices
-  int N = numParams + 1;
+  const int N = numParams + 1;
 
   // prepare vectors to hold the parameter updates
   parameterDirections.resize(nshifts);
@@ -944,7 +944,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   const int central_index = num_shifts / 2;
 
   // get number of optimizable parameters
-  int numParams = optTarget->getNumParams();
+  const int numParams = optTarget->getNumParams();
 
   // prepare the shifts that we will try
   const std::vector<double> shifts_i = prepare_shifts(bestShift_i);
@@ -997,7 +997,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   engine_start(EngineObj, *descentEngineObj, MinMethod);
 
   // get dimension of the linear method matrices
-  int N = numParams + 1;
+  const int N = numParams + 1;
 
   // have the cost function prepare derivative vectors
   EngineObj->energy_target_compute();
@@ -1242,10 +1242,10 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   start();
 
   // get number of optimizable parameters
-  int numParams = optTarget->getNumParams();
+  const int numParams = optTarget->getNumParams();
 
   // get dimension of the linear method matrices
-  int N = numParams + 1;
+  const int N = numParams + 1;
 
   // prepare vectors to hold the initial and current parameters
   std::vector<RealType> currentParameters(numParams, 0.0);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -211,7 +211,7 @@ bool QMCFixedSampleLinearOptimizeBatched::run()
 {
   if (do_output_matrices_csv_ && !output_matrices_initialized_)
   {
-    numParams = optTarget->getNumParams();
+    int numParams = optTarget->getNumParams();
     int N     = numParams + 1;
     output_overlap_.init_file(get_root_name(), "ovl", N);
     output_hamiltonian_.init_file(get_root_name(), "ham", N);
@@ -246,8 +246,8 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
   bool Valid(true);
   int Total_iterations(0);
   //size of matrix
-  numParams = optTarget->getNumParams();
-  N         = numParams + 1;
+  int numParams = optTarget->getNumParams();
+  int N         = numParams + 1;
   //   where we are and where we are pointing
   std::vector<RealType> currentParameterDirections(N, 0);
   std::vector<RealType> currentParameters(numParams, 0);
@@ -835,10 +835,10 @@ void QMCFixedSampleLinearOptimizeBatched::solveShiftsWithoutLMYEngine(
   const int nshifts = shifts_i.size();
 
   // get number of optimizable parameters
-  numParams = optTarget->getNumParams();
+  int numParams = optTarget->getNumParams();
 
   // get dimension of the linear method matrices
-  N = numParams + 1;
+  int N = numParams + 1;
 
   // prepare vectors to hold the parameter updates
   parameterDirections.resize(nshifts);
@@ -944,7 +944,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   const int central_index = num_shifts / 2;
 
   // get number of optimizable parameters
-  numParams = optTarget->getNumParams();
+  int numParams = optTarget->getNumParams();
 
   // prepare the shifts that we will try
   const std::vector<double> shifts_i = prepare_shifts(bestShift_i);
@@ -997,7 +997,7 @@ bool QMCFixedSampleLinearOptimizeBatched::adaptive_three_shift_run()
   engine_start(EngineObj, *descentEngineObj, MinMethod);
 
   // get dimension of the linear method matrices
-  N = numParams + 1;
+  int N = numParams + 1;
 
   // have the cost function prepare derivative vectors
   EngineObj->energy_target_compute();
@@ -1242,10 +1242,10 @@ bool QMCFixedSampleLinearOptimizeBatched::one_shift_run()
   start();
 
   // get number of optimizable parameters
-  numParams = optTarget->getNumParams();
+  int numParams = optTarget->getNumParams();
 
   // get dimension of the linear method matrices
-  N = numParams + 1;
+  int N = numParams + 1;
 
   // prepare vectors to hold the initial and current parameters
   std::vector<RealType> currentParameters(numParams, 0.0);

--- a/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCLinearOptimizeBatched.h
@@ -83,8 +83,6 @@ public:
 
   ///target cost function to optimize
   std::unique_ptr<QMCCostFunctionBase> optTarget;
-  ///Dimension of matrix and number of parameters
-  int N, numParams;
   ///vmc engine
   std::unique_ptr<VMCBatched> vmcEngine;
   ///xml node to be dumped


### PR DESCRIPTION
The value of`numParams` is obtained from `optTarget->getNumParams()` every time.  And  the value of `N` is derived from that.
These do not need to be member variables.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
