### PR TITLE
Fix memory leak in short-H4-opt-adaptive-1-16

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -19,6 +19,7 @@
 #include "Particle/MCWalkerConfiguration.h"
 #include "OhmmsData/AttributeSet.h"
 #include "OhmmsData/ParameterSet.h"
+#include "OhmmsData/XMLParsingString.h"
 #include "Message/CommOperators.h"
 #include "Optimize/LeastSquaredFit.h"
 #include <set>
@@ -27,8 +28,6 @@
 
 namespace qmcplusplus
 {
-using xmlCharUptr = std::unique_ptr<xmlChar, decltype(xmlFree)>;
-
 QMCCostFunctionBase::QMCCostFunctionBase(MCWalkerConfiguration& w,
                                          TrialWaveFunction& psi,
                                          QMCHamiltonian& h,
@@ -534,15 +533,11 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
-      if (iptr == nullptr)
+      XMLAttrString aname(cur, "id");
+      if (aname.empty())
         continue;
-      std::string aname((const char*)iptr.get());
-      opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
-      if (oit != OptVariablesForPsi.end())
-      {
+      if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())
         paramNodes[aname] = cur;
-      }
     }
     xmlXPathFreeObject(result);
     //check radfunc
@@ -550,24 +545,19 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
-      if (iptr == nullptr)
+      XMLAttrString aname(cur, "id");
+      if (aname.empty())
         continue;
-      std::string aname((const char*)iptr.get());
-      std::string expID = aname + "_E";
-      xmlAttrPtr aptr   = xmlHasProp(cur, (const xmlChar*)"exponent");
-      opt_variables_type::iterator oit(OptVariablesForPsi.find(expID));
-      if (aptr != NULL && oit != OptVariablesForPsi.end())
+      if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"exponent"); aptr != nullptr)
       {
-        attribNodes[expID] = std::pair<xmlNodePtr, std::string>(cur, "exponent");
+        std::string expID = aname + "_E";
+        if (auto oit = OptVariablesForPsi.find(expID); oit != OptVariablesForPsi.end())
+          attribNodes[expID] = std::pair<xmlNodePtr, std::string>(cur, "exponent");
       }
       std::string cID = aname + "_C";
-      aptr            = xmlHasProp(cur, (const xmlChar*)"contraction");
-      oit             = OptVariablesForPsi.find(cID);
-      if (aptr != NULL && oit != OptVariablesForPsi.end())
-      {
-        attribNodes[cID] = std::pair<xmlNodePtr, std::string>(cur, "contraction");
-      }
+      if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"contraction"); aptr != nullptr)
+        if (auto oit = OptVariablesForPsi.find(cID); oit != OptVariablesForPsi.end())
+          attribNodes[cID] = std::pair<xmlNodePtr, std::string>(cur, "contraction");
     }
     xmlXPathFreeObject(result);
     //check ci
@@ -575,16 +565,14 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
-      if (iptr == nullptr)
+      XMLAttrString aname(cur, "id");
+      if (aname.empty())
         continue;
-      std::string aname((const char*)iptr.get());
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
-      if (aptr != NULL && oit != OptVariablesForPsi.end())
-      {
-        attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
-      }
+      if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != NULL)
+        if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())
+          attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
     }
     xmlXPathFreeObject(result);
     //check csf
@@ -592,16 +580,12 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
-      if (iptr == nullptr)
+      XMLAttrString aname(cur, "id");
+      if (aname.empty())
         continue;
-      std::string aname((const char*)iptr.get());
-      xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
-      opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
-      if (aptr != NULL && oit != OptVariablesForPsi.end())
-      {
-        attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
-      }
+      if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != nullptr)
+        if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())
+          attribNodes[aname] = std::pair<xmlNodePtr, std::string>(cur, "coeff");
     }
     xmlXPathFreeObject(result);
     if (CI_Opt)

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -27,6 +27,8 @@
 
 namespace qmcplusplus
 {
+using xmlCharUptr = std::unique_ptr<xmlChar, decltype(xmlFree)>;
+
 QMCCostFunctionBase::QMCCostFunctionBase(MCWalkerConfiguration& w,
                                          TrialWaveFunction& psi,
                                          QMCHamiltonian& h,
@@ -532,11 +534,10 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      xmlChar* iptr  = xmlGetProp(cur, (const xmlChar*)"id");
-      if (iptr == NULL)
+      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
+      if (iptr == nullptr)
         continue;
-      std::string aname((const char*)iptr);
-      xmlFree(iptr);
+      std::string aname((const char*)iptr.get());
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
       if (oit != OptVariablesForPsi.end())
       {
@@ -548,11 +549,11 @@ void QMCCostFunctionBase::updateXmlNodes()
     result = xmlXPathEvalExpression((const xmlChar*)"//radfunc", acontext);
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
-      xmlNodePtr cur      = result->nodesetval->nodeTab[iparam];
-      const xmlChar* iptr = xmlGetProp(cur, (const xmlChar*)"id");
-      if (iptr == NULL)
+      xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
+      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
+      if (iptr == nullptr)
         continue;
-      std::string aname((const char*)iptr);
+      std::string aname((const char*)iptr.get());
       std::string expID = aname + "_E";
       xmlAttrPtr aptr   = xmlHasProp(cur, (const xmlChar*)"exponent");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(expID));
@@ -573,11 +574,11 @@ void QMCCostFunctionBase::updateXmlNodes()
     result = xmlXPathEvalExpression((const xmlChar*)"//ci", acontext);
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
-      xmlNodePtr cur      = result->nodesetval->nodeTab[iparam];
-      const xmlChar* iptr = xmlGetProp(cur, (const xmlChar*)"id");
-      if (iptr == NULL)
+      xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
+      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
+      if (iptr == nullptr)
         continue;
-      std::string aname((const char*)iptr);
+      std::string aname((const char*)iptr.get());
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
       if (aptr != NULL && oit != OptVariablesForPsi.end())
@@ -590,11 +591,11 @@ void QMCCostFunctionBase::updateXmlNodes()
     result = xmlXPathEvalExpression((const xmlChar*)"//csf", acontext);
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
-      xmlNodePtr cur      = result->nodesetval->nodeTab[iparam];
-      const xmlChar* iptr = xmlGetProp(cur, (const xmlChar*)"id");
-      if (iptr == NULL)
+      xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
+      auto iptr      = xmlCharUptr(xmlGetProp(cur, (const xmlChar*)"id"), xmlFree);
+      if (iptr == nullptr)
         continue;
-      std::string aname((const char*)iptr);
+      std::string aname((const char*)iptr.get());
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
       if (aptr != NULL && oit != OptVariablesForPsi.end())


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This fixes a memory leak in `short-H4-opt-adaptive-1-16`. This time I used std::unique_ptr with a custom deleter and updated everything in the file following the same pattern.

```
303: Direct leak of 132 byte(s) in 12 object(s) allocated from:
303:     #0 0x4ad8cd in malloc (/home/svh/Documents/qmcpack/build/bin/qmcpack+0x4ad8cd)
303:     #1 0x7f745192e1a4 in xmlStrndup__internal_alias /home/svh/Documents/libxml2/xmlstring.c:45:23
303:     #2 0x7f745192e2f7 in xmlStrdup__internal_alias /home/svh/Documents/libxml2/xmlstring.c:71:12
303:     #3 0x7f745178a6ce in xmlGetPropNodeValueInternal /home/svh/Documents/libxml2/tree.c:6664:10
303:     #4 0x7f74517895d8 in xmlGetProp__internal_alias /home/svh/Documents/libxml2/tree.c:6776:12
303:     #5 0x694c9b in qmcplusplus::QMCCostFunctionBase::updateXmlNodes() /home/svh/Documents/qmcpack/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp:594:29
303:     #6 0x6ad7c2 in qmcplusplus::QMCCostFunctionBase::reportParameters() /home/svh/Documents/qmcpack/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp:242:5
303:     #7 0x929a4f in qmcplusplus::QMCLinearOptimize::finish() /home/svh/Documents/qmcpack/src/QMCDrivers/WFOpt/QMCLinearOptimize.cpp:163:14
303:     #8 0x5c90a4 in qmcplusplus::QMCFixedSampleLinearOptimize::adaptive_three_shift_run() /home/svh/Documents/qmcpack/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp:1080:3
303:     #9 0x5dc4cb in qmcplusplus::QMCFixedSampleLinearOptimize::run() /home/svh/Documents/qmcpack/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp:230:12
303:     #10 0x4ef599 in qmcplusplus::QMCMain::runQMC(_xmlNode*, bool) /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:615:17
303:     #11 0x4ee889 in qmcplusplus::QMCMain::executeQMCSection(_xmlNode*, bool) /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:364:18
303:     #12 0x4ed769 in qmcplusplus::QMCMain::executeLoop(_xmlNode*) /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:337:24
303:     #13 0x4f6a22 in qmcplusplus::QMCMain::execute() /home/svh/Documents/qmcpack/src/QMCApp/QMCMain.cpp:255:7
303:     #14 0x4e500c in main /home/svh/Documents/qmcpack/src/QMCApp/qmcapp.cpp:225:28
303:     #15 0x7f744ef6f0b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
```

@walshmm is separately addressing the leak in `RngSaved`.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
