### PR TITLE
QMCCostFunctionBase: Use range-based for and structured bindings to clean up loops

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -605,13 +605,13 @@ void QMCCostFunctionBase::updateXmlNodes()
     addCJParams(acontext, "//jastrow");
     xmlXPathFreeContext(acontext);
   }
-  for (auto& [pname, pptr] : paramNodes)
+  for (const auto& [pname, pptr] : paramNodes)
   {
     //FIXME real value is forced here to makde sure that the code builds
     Return_rt v = std::real(OptVariablesForPsi[pname]);
     getContent(v, pptr);
   }
-  for (auto& [aname, attrib] : attribNodes)
+  for (const auto& [aname, attrib] : attribNodes)
   {
     std::ostringstream vout;
     vout.setf(std::ios::scientific, std::ios::floatfield);
@@ -619,7 +619,7 @@ void QMCCostFunctionBase::updateXmlNodes()
     vout << OptVariablesForPsi[aname];
     xmlSetProp(attrib.first, (const xmlChar*)attrib.second.c_str(), (const xmlChar*)vout.str().c_str());
   }
-  for (auto& [cname, cptr] : coeffNodes)
+  for (const auto& [cname, cptr] : coeffNodes)
   {
     std::string rname(cname);
     OhmmsAttributeSet cAttrib;
@@ -633,7 +633,7 @@ void QMCCostFunctionBase::updateXmlNodes()
       //
       aname.append("_");
       std::vector<Return_rt> c;
-      for (auto& [name, value] : OptVariablesForPsi)
+      for (const auto& [name, value] : OptVariablesForPsi)
       {
         if (name.find(aname) == 0)
         {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -605,53 +605,43 @@ void QMCCostFunctionBase::updateXmlNodes()
     addCJParams(acontext, "//jastrow");
     xmlXPathFreeContext(acontext);
   }
-  //     Psi.reportStatus(app_log());
-  std::map<std::string, xmlNodePtr>::iterator pit(paramNodes.begin()), pit_end(paramNodes.end());
-  while (pit != pit_end)
+  for (auto& [pname, pptr] : paramNodes)
   {
     //FIXME real value is forced here to makde sure that the code builds
-    Return_rt v = std::real(OptVariablesForPsi[(*pit).first]);
-    getContent(v, (*pit).second);
-    //         vout <<(*pit).second<< std::endl;
-    ++pit;
+    Return_rt v = std::real(OptVariablesForPsi[pname]);
+    getContent(v, pptr);
   }
-  std::map<std::string, std::pair<xmlNodePtr, std::string>>::iterator ait(attribNodes.begin()),
-      ait_end(attribNodes.end());
-  while (ait != ait_end)
+  for (auto& [aname, attrib] : attribNodes)
   {
     std::ostringstream vout;
     vout.setf(std::ios::scientific, std::ios::floatfield);
     vout.precision(16);
-    vout << OptVariablesForPsi[(*ait).first];
-    xmlSetProp((*ait).second.first, (const xmlChar*)(*ait).second.second.c_str(), (const xmlChar*)vout.str().c_str());
-    ++ait;
+    vout << OptVariablesForPsi[aname];
+    xmlSetProp(attrib.first, (const xmlChar*)attrib.second.c_str(), (const xmlChar*)vout.str().c_str());
   }
-  std::map<std::string, xmlNodePtr>::iterator cit(coeffNodes.begin()), cit_end(coeffNodes.end());
-  while (cit != cit_end)
+  for (auto& [cname, cptr] : coeffNodes)
   {
-    std::string rname((*cit).first);
+    std::string rname(cname);
     OhmmsAttributeSet cAttrib;
     std::string datatype("none");
     std::string aname("0");
     cAttrib.add(datatype, "type");
     cAttrib.add(aname, "id");
-    cAttrib.put((*cit).second);
+    cAttrib.put(cptr);
     if (datatype == "Array")
     {
       //
       aname.append("_");
-      opt_variables_type::iterator vit(OptVariablesForPsi.begin());
       std::vector<Return_rt> c;
-      while (vit != OptVariablesForPsi.end())
+      for (auto& [name, value] : OptVariablesForPsi)
       {
-        if ((*vit).first.find(aname) == 0)
+        if (name.find(aname) == 0)
         {
           //FIXME real value is forced here to makde sure that the code builds
-          c.push_back(std::real((*vit).second));
+          c.push_back(std::real(value));
         }
-        ++vit;
       }
-      xmlNodePtr contentPtr = cit->second;
+      xmlNodePtr contentPtr = cptr;
       if (xmlNodeIsText(contentPtr->children))
         contentPtr = contentPtr->children;
       getContent(c, contentPtr);
@@ -659,11 +649,11 @@ void QMCCostFunctionBase::updateXmlNodes()
     // counting jastrow variables
     else if (rname.find("cj_") == 0)
     {
-      printCJParams(cit->second, rname);
+      printCJParams(cptr, rname);
     }
     else
     {
-      xmlNodePtr cur = (*cit).second->children;
+      xmlNodePtr cur = cptr->children;
       while (cur != NULL)
       {
         std::string cname((const char*)(cur->name));
@@ -693,7 +683,6 @@ void QMCCostFunctionBase::updateXmlNodes()
         cur = cur->next;
       }
     }
-    ++cit;
   }
 }
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -656,8 +656,8 @@ void QMCCostFunctionBase::updateXmlNodes()
       xmlNodePtr cur = cptr->children;
       while (cur != NULL)
       {
-        std::string cname((const char*)(cur->name));
-        if (cname == "lambda")
+        std::string childName((const char*)(cur->name));
+        if (childName == "lambda")
         {
           int i = 0;
           int j = -1;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This is a continuation of #3429

Range-based for and structured bindings provide cleaner variable names than interators and pairs.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
