### PR TITLE
Hamiltonian batched APIs depend on TWF

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -247,7 +247,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     ScopedTimer ham_local(timers.hamiltonian_timer);
 
     std::vector<QMCHamiltonian::FullPrecRealType> new_energies(
-        ham_dispatcher.flex_evaluateWithToperator(walker_hamiltonians, walker_elecs));
+        ham_dispatcher.flex_evaluateWithToperator(walker_hamiltonians, walker_twfs, walker_elecs));
     assert(QMCDriverNew::checkLogAndGL(crowd));
 
     auto resetSigNLocalEnergy = [](MCPWalker& walker, TrialWaveFunction& twf, auto local_energy, auto rr_acc,

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -337,7 +337,7 @@ void QMCDriverNew::initialLogEvaluation(int crowd_id,
     saveElecPosAndGLToWalkers(walker_elecs[iw], walkers[iw]);
 
   std::vector<QMCHamiltonian::FullPrecRealType> local_energies(
-      ham_dispatcher.flex_evaluate(walker_hamiltonians, walker_elecs));
+      ham_dispatcher.flex_evaluate(walker_hamiltonians, walker_twfs, walker_elecs));
 
   // \todo rename these are sets not resets.
   auto resetSigNLocalEnergy = [](MCPWalker& walker, TrialWaveFunction& twf, auto local_energy) {

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -177,7 +177,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
                                                                 crowd.get_walker_hamiltonians());
   ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(crowd.getSharedResource().ham_res, walker_hamiltonians);
   std::vector<QMCHamiltonian::FullPrecRealType> local_energies(
-      ham_dispatcher.flex_evaluate(walker_hamiltonians, walker_elecs));
+      ham_dispatcher.flex_evaluate(walker_hamiltonians, walker_twfs, walker_elecs));
   timers.hamiltonian_timer.stop();
 
   auto resetSigNLocalEnergy = [](MCPWalker& walker, TrialWaveFunction& twf, auto& local_energy) {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -355,8 +355,9 @@ void QMCCostFunctionBatched::checkConfigurations()
         TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, optVars, dlogpsi_array, dhpsioverpsi_array);
 
 
-        auto energy_list = QMCHamiltonian::mw_evaluateValueAndDerivatives(h_list, p_list, optVars, dlogpsi_array,
-                                                                          dhpsioverpsi_array, compute_nlpp);
+        auto energy_list =
+            QMCHamiltonian::mw_evaluateValueAndDerivatives(h_list, wf_list, p_list, optVars, dlogpsi_array,
+                                                           dhpsioverpsi_array, compute_nlpp);
 
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
@@ -392,7 +393,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       else
       {
         // Energy
-        auto energy_list = QMCHamiltonian::mw_evaluate(h_list, p_list);
+        auto energy_list = QMCHamiltonian::mw_evaluate(h_list, wf_list, p_list);
 
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
@@ -614,8 +615,9 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
 
         // Energy
-        auto energy_list = QMCHamiltonian::mw_evaluateValueAndDerivatives(h0_list, p_list, optVars, dlogpsi_array,
-                                                                          dhpsioverpsi_array, compute_nlpp);
+        auto energy_list =
+            QMCHamiltonian::mw_evaluateValueAndDerivatives(h0_list, wf_list, p_list, optVars, dlogpsi_array,
+                                                           dhpsioverpsi_array, compute_nlpp);
 
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
@@ -635,7 +637,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
       else
       {
         // Just energy needed if no gradients
-        auto energy_list = QMCHamiltonian::mw_evaluate(h0_list, p_list);
+        auto energy_list = QMCHamiltonian::mw_evaluate(h0_list, wf_list, p_list);
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
           int is                        = base_sample_index + ib;

--- a/src/QMCHamiltonians/Hdispatcher.cpp
+++ b/src/QMCHamiltonians/Hdispatcher.cpp
@@ -21,11 +21,12 @@ Hdispatcher::Hdispatcher(bool use_batch) : use_batch_(use_batch) {}
 
 std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluate(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mw_evaluate(ham_list, p_list);
+    return QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());
@@ -37,11 +38,12 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluate(
 
 std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluateWithToperator(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mw_evaluateWithToperator(ham_list, p_list);
+    return QMCHamiltonian::mw_evaluateWithToperator(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());
@@ -52,11 +54,12 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluateWithTope
 }
 
 std::vector<int> Hdispatcher::flex_makeNonLocalMoves(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                                     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                      const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mw_makeNonLocalMoves(ham_list, p_list);
+    return QMCHamiltonian::mw_makeNonLocalMoves(ham_list, wf_list, p_list);
   else
   {
     std::vector<int> num_accepts(ham_list.size());

--- a/src/QMCHamiltonians/Hdispatcher.h
+++ b/src/QMCHamiltonians/Hdispatcher.h
@@ -29,13 +29,15 @@ public:
   Hdispatcher(bool use_batch);
 
   std::vector<FullPrecRealType> flex_evaluate(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
-                                                              const RefVectorWithLeader<ParticleSet>& p_list) const;
+                                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                              const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-  std::vector<FullPrecRealType> flex_evaluateWithToperator(
-      const RefVectorWithLeader<QMCHamiltonian>& ham_list,
-      const RefVectorWithLeader<ParticleSet>& p_list) const;
+  std::vector<FullPrecRealType> flex_evaluateWithToperator(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                           const RefVectorWithLeader<ParticleSet>& p_list) const;
 
   std::vector<int> flex_makeNonLocalMoves(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                           const RefVectorWithLeader<ParticleSet>& p_list) const;
 
 private:

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -47,13 +47,15 @@ public:
 
   Return_t evaluate(ParticleSet& P) override;
   Return_t evaluateDeterministic(ParticleSet& P) override;
-  void mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
-                   const RefVectorWithLeader<ParticleSet>& P_list) const override;
+  void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                   const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;
 
-  void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
-                                const RefVectorWithLeader<ParticleSet>& P_list) const override;
+  void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
@@ -106,11 +108,11 @@ public:
 
   /** acquire a shared resource from a collection
    */
-  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const override;
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
   /** return a shared resource to a collection
    */
-  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const override;
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
@@ -131,8 +133,9 @@ public:
 
   /** Set the flag whether to compute forces or not.
    * @param val The boolean value for computing forces
-   */ 
-  inline void setComputeForces(bool val) override {ComputeForces=val;}
+   */
+  inline void setComputeForces(bool val) override { ComputeForces = val; }
+
 protected:
   ///random number generator
   RandomGenerator_t* myRNG;
@@ -186,12 +189,13 @@ private:
   void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
 
   /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
-   * @param O_list the list of NonLocalECPotential in a walker batch
-   * @param P_list the list of ParticleSet in a walker batch
+   * @param o_list the list of NonLocalECPotential in a walker batch
+   * @param p_list the list of ParticleSet in a walker batch
    * @param Tmove whether Txy for Tmove is updated
    */
-  static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& O_list,
-                              const RefVectorWithLeader<ParticleSet>& P_list,
+  static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
                               bool Tmove);
 
   void evalIonDerivsImpl(ParticleSet& P,

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -44,10 +44,11 @@ OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P) { ret
  * really should reduce vector of local_energies. matching the ordering and size of o list
  * the this can be call for 1 or more QMCHamiltonians
  */
-void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
-                               const RefVectorWithLeader<ParticleSet>& P_list) const
+void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                               const RefVectorWithLeader<ParticleSet>& p_list) const
 {
-  assert(this == &O_list.getLeader());
+  assert(this == &o_list.getLeader());
 /**  Temporary raw omp pragma for simple thread parallelism
    *   ignoring the driver level concurrency
    *   
@@ -73,12 +74,12 @@ void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
    *  set of anything involved in an Operator.evaluate.
    */
 #pragma omp parallel for
-  for (int iw = 0; iw < O_list.size(); iw++)
-    O_list[iw].evaluate(P_list[iw]);
+  for (int iw = 0; iw < o_list.size(); iw++)
+    o_list[iw].evaluate(p_list[iw]);
 }
 
-void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
-                                                       const RefVectorWithLeader<ParticleSet>& P_list,
+void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                       const RefVectorWithLeader<ParticleSet>& p_list,
                                                        const opt_variables_type& optvars,
                                                        RecordArray<ValueType>& dlogpsi,
                                                        RecordArray<ValueType>& dhpsioverpsi) const
@@ -86,14 +87,14 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
   const int nparam = dlogpsi.nparam();
   std::vector<ValueType> tmp_dlogpsi(nparam);
   std::vector<ValueType> tmp_dhpsioverpsi(nparam);
-  for (int iw = 0; iw < O_list.size(); iw++)
+  for (int iw = 0; iw < o_list.size(); iw++)
   {
     for (int j = 0; j < nparam; j++)
     {
       tmp_dlogpsi[j] = dlogpsi.getValue(j, iw);
     }
 
-    O_list[iw].evaluateValueAndDerivatives(P_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
+    o_list[iw].evaluateValueAndDerivatives(p_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
 
     for (int j = 0; j < nparam; j++)
     {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -254,11 +254,12 @@ struct OperatorBase : public QMCTraits
    */
   virtual Return_t evaluateDeterministic(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& O_list,
-                           const RefVectorWithLeader<ParticleSet>& P_list) const;
+  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-  virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& O_list,
-                                                   const RefVectorWithLeader<ParticleSet>& P_list,
+  virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                   const RefVectorWithLeader<ParticleSet>& p_list,
                                                    const opt_variables_type& optvars,
                                                    RecordArray<ValueType>& dlogpsi,
                                                    RecordArray<ValueType>& dhpsioverpsi) const;
@@ -272,10 +273,11 @@ struct OperatorBase : public QMCTraits
   virtual Return_t evaluateWithToperator(ParticleSet& P) { return evaluate(P); }
 
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& O_list,
-                                        const RefVectorWithLeader<ParticleSet>& P_list) const
+  virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                        const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                        const RefVectorWithLeader<ParticleSet>& p_list) const
   {
-    mw_evaluate(O_list, P_list);
+    mw_evaluate(o_list, wf_list, p_list);
   }
 
   /** evaluate value and derivatives wrt the optimizables
@@ -322,8 +324,8 @@ struct OperatorBase : public QMCTraits
                                                       ParticleSet::ParticlePos_t& pulay_term)
   {
     //If there's no stochastic component, defaults to above defined evaluateWithIonDerivs.
-    //If not otherwise specified, this defaults to evaluate().  
-    return evaluateWithIonDerivs(P,ions,psi,hf_term,pulay_term);
+    //If not otherwise specified, this defaults to evaluate().
+    return evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_term);
   }
   /** update data associated with a particleset
    * @param s source particle set
@@ -350,11 +352,11 @@ struct OperatorBase : public QMCTraits
 
   /** acquire a shared resource from a collection
    */
-  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const {}
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const {}
 
   /** return a shared resource to a collection
    */
-  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& O_list) const {}
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const {}
 
   virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -555,6 +555,7 @@ void QMCHamiltonian::updateKinetic(OperatorBase& op, QMCHamiltonian& ham, Partic
 
 std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
 {
   auto& ham_leader = ham_list.getLeader();
@@ -581,7 +582,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     //   op.setObservables(ham.Observables);
     //   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
     // };
-    ham_leader.H[i_ham_op]->mw_evaluate(HC_list, p_list);
+    ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -623,6 +624,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateValueAndDerivatives(Par
 
 std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAndDerivativesInner(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list,
     const opt_variables_type& optvars,
     RecordArray<ValueType>& dlogpsi,
@@ -662,6 +664,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
 
 std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAndDerivatives(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list,
     const opt_variables_type& optvars,
     RecordArray<ValueType>& dlogpsi,
@@ -671,9 +674,9 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
   std::vector<FullPrecRealType> local_energies(ham_list.size(), 0.0);
   if (compute_deriv)
     local_energies =
-        QMCHamiltonian::mw_evaluateValueAndDerivativesInner(ham_list, p_list, optvars, dlogpsi, dhpsioverpsi);
+        QMCHamiltonian::mw_evaluateValueAndDerivativesInner(ham_list, wf_list, p_list, optvars, dlogpsi, dhpsioverpsi);
   else
-    local_energies = QMCHamiltonian::mw_evaluate(ham_list, p_list);
+    local_energies = QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
 
   return local_energies;
 }
@@ -787,6 +790,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleS
 
 std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithToperator(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
 {
   for (QMCHamiltonian& ham : ham_list)
@@ -799,7 +803,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
     ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
-    ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, p_list);
+    ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); ++iw)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -965,6 +969,7 @@ int QMCHamiltonian::makeNonLocalMoves(ParticleSet& P)
 
 
 std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                                      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                       const RefVectorWithLeader<ParticleSet>& p_list)
 {
   auto& ham_leader = ham_list.getLeader();
@@ -984,7 +989,8 @@ void QMCHamiltonian::createResource(ResourceCollection& collection) const
     H[i]->createResource(collection);
 }
 
-void QMCHamiltonian::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list)
+void QMCHamiltonian::acquireResource(ResourceCollection& collection,
+                                     const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
   auto& ham_leader = ham_list.getLeader();
   for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
@@ -994,7 +1000,8 @@ void QMCHamiltonian::acquireResource(ResourceCollection& collection, const RefVe
   }
 }
 
-void QMCHamiltonian::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list)
+void QMCHamiltonian::releaseResource(ResourceCollection& collection,
+                                     const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
   auto& ham_leader = ham_list.getLeader();
   for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -244,8 +244,10 @@ public:
    *  Bugs could easily be created by accessing this scope.
    *  This should be set to static and fixed.
    */
-  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluate(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
-                                                                   const RefVectorWithLeader<ParticleSet>& p_list);
+  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluate(
+      const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+      const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** evaluate Local energy with Toperators updated.
    * @param P ParticleSEt
@@ -257,6 +259,7 @@ public:
    */
   static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluateWithToperator(
       const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<ParticleSet>& p_list);
 
 
@@ -275,6 +278,7 @@ public:
 
   static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluateValueAndDerivatives(
       const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<ParticleSet>& p_list,
       const opt_variables_type& optvars,
       RecordArray<ValueType>& dlogpsi,
@@ -283,6 +287,7 @@ public:
 
   static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluateValueAndDerivativesInner(
       const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<ParticleSet>& p_list,
       const opt_variables_type& optvars,
       RecordArray<ValueType>& dlogpsi,
@@ -327,11 +332,11 @@ public:
   * @return Local Energy.
   */
   FullPrecRealType evaluateIonDerivsDeterministic(ParticleSet& P,
-                                     ParticleSet& ions,
-                                     TrialWaveFunction& psi,
-                                     ParticleSet::ParticlePos_t& hf_terms,
-                                     ParticleSet::ParticlePos_t& pulay_terms,
-                                     ParticleSet::ParticlePos_t& wf_grad);
+                                                  ParticleSet& ions,
+                                                  TrialWaveFunction& psi,
+                                                  ParticleSet::ParticlePos_t& hf_terms,
+                                                  ParticleSet::ParticlePos_t& pulay_terms,
+                                                  ParticleSet::ParticlePos_t& wf_grad);
   /** set non local moves options
    * @param cur the xml input
    */
@@ -374,6 +379,7 @@ public:
   }
 
   static std::vector<int> mw_makeNonLocalMoves(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                                const RefVectorWithLeader<ParticleSet>& p_list);
   /** evaluate energy 
    * @param P quantum particleset


### PR DESCRIPTION
## Proposed changes
Hamiltonian depends on ParticleSet and TrialWaveFunction. The former is passed in via the arguments but the latter is handled based on the actual Hamiltonian component. It is better to avoid holding any references inside an object and always pass in via argument.
So all the batched APIs have TrialWaveFunction added in this PR.
This is part of #2554

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
