### PR TITLE
Provide encapsulation to OperatorBase members

### DIFF
--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -22,7 +22,7 @@
 
 namespace qmcplusplus
 {
-OperatorBase::OperatorBase() : myIndex(-1), Dependants(0), Value(0.0), tWalker(0)
+OperatorBase::OperatorBase() : Dependants(0), Value(0.0), myIndex(-1), tWalker(0)
 {
   quantum_domain = no_quantum_domain;
   energy_domain  = no_energy_domain;

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -129,6 +129,8 @@ public:
   ///whether traces are being collected
   TraceRequest request;
 
+  std::vector<RealType> ValueVector;
+
 #endif
 
   ///constructor
@@ -351,6 +353,15 @@ public:
   virtual void get_required_traces(TraceManager& tm){};
 #endif
 
+  virtual void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
+
+  virtual void addEnergy(MCWalkerConfiguration& W,
+                         std::vector<RealType>& LocalEnergy,
+                         std::vector<std::vector<NonLocalData>>& Txy)
+  {
+    addEnergy(W, LocalEnergy);
+  }
+
 protected:
   ///starting index of this object
   int myIndex;
@@ -399,15 +410,6 @@ protected:
   virtual void delete_particle_quantities(){};
 #endif
 
-  virtual void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
-
-  virtual void addEnergy(MCWalkerConfiguration& W,
-                         std::vector<RealType>& LocalEnergy,
-                         std::vector<std::vector<NonLocalData>>& Txy)
-  {
-    addEnergy(W, LocalEnergy);
-  }
-
   virtual void setComputeForces(bool compute)
   {
     // empty
@@ -448,8 +450,6 @@ private:
 
 #if !defined(REMOVE_TRACEMANAGER)
   bool streaming_scalars;
-
-  std::vector<RealType> ValueVector;
 
   ///array to store sample value
   Array<RealType, 1>* value_sample;


### PR DESCRIPTION
## Proposed changes

Start refactoring of OperatorBase turning it into a class
Add encapsulation to existing members
Avoid warning for member assigment ordering
Breaking original PR #3412 intro smaller PRs
Related to #3411 

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
