### PR TITLE
Altering DiracDeterminantBatched and friends to take Dual arguments.

### DIFF
--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -244,37 +244,36 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   REQUIRE(hf_term[1][2] + pulay_term[1][2] == Approx(-5.2293234395150989));
 #endif
 
- //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
- //QMCHamiltonian level to make sure there are no crashes.  
- 
+  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
+  //QMCHamiltonian level to make sure there are no crashes.
+
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  ham->evaluateIonDerivsDeterministic(elec,ions,*psi,hf_term,pulay_term,wf_grad);
- 
-  REQUIRE(dot(hf_term[0],hf_term[0]) != Approx(0));
-  REQUIRE(dot(pulay_term[0],pulay_term[0]) != Approx(0));
-  REQUIRE(dot(wf_grad[0],wf_grad[0]) != Approx(0));
- 
-  REQUIRE(dot(hf_term[1],hf_term[1]) != Approx(0));
-  REQUIRE(dot(pulay_term[1],pulay_term[1]) != Approx(0));
-  REQUIRE(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
+  ham->evaluateIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+
+  REQUIRE(dot(hf_term[0], hf_term[0]) != Approx(0));
+  REQUIRE(dot(pulay_term[0], pulay_term[0]) != Approx(0));
+  REQUIRE(dot(wf_grad[0], wf_grad[0]) != Approx(0));
+
+  REQUIRE(dot(hf_term[1], hf_term[1]) != Approx(0));
+  REQUIRE(dot(pulay_term[1], pulay_term[1]) != Approx(0));
+  REQUIRE(dot(wf_grad[1], wf_grad[1]) != Approx(0));
+
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
   RandomGenerator_t myrng;
   ham->setRandomGenerator(&myrng);
-  ham->evaluateIonDerivs(elec,ions,*psi,hf_term,pulay_term,wf_grad);
-  
-  REQUIRE(dot(hf_term[0],hf_term[0]) != Approx(0));
-  REQUIRE(dot(pulay_term[0],pulay_term[0]) != Approx(0));
-  REQUIRE(dot(wf_grad[0],wf_grad[0]) != Approx(0));
- 
-  REQUIRE(dot(hf_term[1],hf_term[1]) != Approx(0));
-  REQUIRE(dot(pulay_term[1],pulay_term[1]) != Approx(0));
-  REQUIRE(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
+  ham->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+
+  REQUIRE(dot(hf_term[0], hf_term[0]) != Approx(0));
+  REQUIRE(dot(pulay_term[0], pulay_term[0]) != Approx(0));
+  REQUIRE(dot(wf_grad[0], wf_grad[0]) != Approx(0));
+
+  REQUIRE(dot(hf_term[1], hf_term[1]) != Approx(0));
+  REQUIRE(dot(pulay_term[1], pulay_term[1]) != Approx(0));
+  REQUIRE(dot(wf_grad[1], wf_grad[1]) != Approx(0));
 }
 
 TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
@@ -429,37 +428,36 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   REQUIRE(hf_term[1][2] + pulay_term[1][2] == Approx(-4.5825638607333019));
 #endif
 
- //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
- //QMCHamiltonian level to make sure there are no crashes.  
- 
+  //End of deterministic tests.  Let's call evaluateIonDerivs and evaluateIonDerivsDeterministic at the
+  //QMCHamiltonian level to make sure there are no crashes.
+
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  ham->evaluateIonDerivsDeterministic(elec,ions,*psi,hf_term,pulay_term,wf_grad);
- 
-  REQUIRE(dot(hf_term[0],hf_term[0]) != Approx(0));
-  REQUIRE(dot(pulay_term[0],pulay_term[0]) != Approx(0));
-  REQUIRE(dot(wf_grad[0],wf_grad[0]) != Approx(0));
- 
-  REQUIRE(dot(hf_term[1],hf_term[1]) != Approx(0));
-  REQUIRE(dot(pulay_term[1],pulay_term[1]) != Approx(0));
-  REQUIRE(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
+  ham->evaluateIonDerivsDeterministic(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+
+  REQUIRE(dot(hf_term[0], hf_term[0]) != Approx(0));
+  REQUIRE(dot(pulay_term[0], pulay_term[0]) != Approx(0));
+  REQUIRE(dot(wf_grad[0], wf_grad[0]) != Approx(0));
+
+  REQUIRE(dot(hf_term[1], hf_term[1]) != Approx(0));
+  REQUIRE(dot(pulay_term[1], pulay_term[1]) != Approx(0));
+  REQUIRE(dot(wf_grad[1], wf_grad[1]) != Approx(0));
+
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
   RandomGenerator_t myrng;
   ham->setRandomGenerator(&myrng);
-  ham->evaluateIonDerivs(elec,ions,*psi,hf_term,pulay_term,wf_grad);
-  
-  REQUIRE(dot(hf_term[0],hf_term[0]) != Approx(0));
-  REQUIRE(dot(pulay_term[0],pulay_term[0]) != Approx(0));
-  REQUIRE(dot(wf_grad[0],wf_grad[0]) != Approx(0));
- 
-  REQUIRE(dot(hf_term[1],hf_term[1]) != Approx(0));
-  REQUIRE(dot(pulay_term[1],pulay_term[1]) != Approx(0));
-  REQUIRE(dot(wf_grad[1],wf_grad[1]) != Approx(0));
- 
+  ham->evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
+
+  REQUIRE(dot(hf_term[0], hf_term[0]) != Approx(0));
+  REQUIRE(dot(pulay_term[0], pulay_term[0]) != Approx(0));
+  REQUIRE(dot(wf_grad[0], wf_grad[0]) != Approx(0));
+
+  REQUIRE(dot(hf_term[1], hf_term[1]) != Approx(0));
+  REQUIRE(dot(pulay_term[1], pulay_term[1]) != Approx(0));
+  REQUIRE(dot(wf_grad[1], wf_grad[1]) != Approx(0));
 }
 
 TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -186,6 +186,9 @@ protected:
   ///number of particles which belong to this Dirac determinant
   const int NumPtcls;
 
+  // This is for debugging and testing in debug mode
+  // psiMinv is not a base class data member or public in most implementations
+  // it is frequently Dual and its consistency not guaranteed.
 #ifndef NDEBUG
   ValueMatrix_t dummy_vmt;
 #endif

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -186,10 +186,10 @@ protected:
   ///number of particles which belong to this Dirac determinant
   const int NumPtcls;
 
+#ifndef NDEBUG
   // This is for debugging and testing in debug mode
   // psiMinv is not a base class data member or public in most implementations
   // it is frequently Dual and its consistency not guaranteed.
-#ifndef NDEBUG
   ValueMatrix_t dummy_vmt;
 #endif
 

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -920,7 +920,6 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
       const_psiM_temp_list.push_back(det.psiM_temp);
       psiMinv_list.push_back(det.get_det_engine().get_ref_psiMinv());
     }
-    auto& mw_res = *wfc_leader.mw_res_;
     mw_invertPsiM(wfc_filtered_list, const_psiM_temp_list, psiMinv_list, recompute);
     PRAGMA_OFFLOAD("omp taskwait")
   }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -5,6 +5,7 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
@@ -13,8 +14,10 @@
 #include "DiracDeterminantBatched.h"
 #include "Numerics/DeterminantOperators.h"
 #include "CPU/BLAS.hpp"
+#include "OhmmsPETE/OhmmsMatrix.h"
 #include "Numerics/MatrixOperators.h"
 #include "CPU/SIMD/simd.hpp"
+#include <cassert>
 
 namespace qmcplusplus
 {
@@ -29,6 +32,16 @@ DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatched(std::shared_ptr<SPO
       D2HTimer(*timer_manager.createTimer("DiracDeterminantBatched::D2H", timer_level_fine)),
       H2DTimer(*timer_manager.createTimer("DiracDeterminantBatched::H2D", timer_level_fine))
 {
+  static_assert(std::is_same<SPOSet::ValueType, typename DET_ENGINE::Value>::value);
+}
+
+/** set the index of the first particle in the determinant and reset the size of the determinant
+ *@param first index of first particle
+ *@param nel number of particles in the determinant
+ */
+template<typename DET_ENGINE>
+void DiracDeterminantBatched<DET_ENGINE>::set(int first, int nel, int delay)
+{
   resize(NumPtcls, NumPtcls);
 
   if (Optimizable)
@@ -36,15 +49,23 @@ DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatched(std::shared_ptr<SPO
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::invertPsiM(const Matrix<Value>& logdetT)
+void DiracDeterminantBatched<DET_ENGINE>::invertPsiM(const DualMatrix<Value>& psiM, DualMatrix<Value>& psiMinv)
 {
   ScopedTimer inverse_timer(InverseTimer);
-  det_engine_.invert_transpose(logdetT, log_value_);
+  det_engine_.invert_transpose(psiM, psiMinv, log_value_);
+
+#ifndef NDEBUG
+  // This is easily breakable in that it assumes this function gets psiMinv == det_engine_.psiMinv_
+  auto& engine_psiMinv = det_engine_.get_ref_psiMinv();
+  dummy_vmt.attachReference(engine_psiMinv.data(), engine_psiMinv.rows(), engine_psiMinv.cols());
+#endif
 }
 
 template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::mw_invertPsiM(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                        const RefVector<const Matrix<Value>>& logdetT_list)
+                                                        RefVector<const DualMatrix<Value>>& logdetT_list,
+                                                        RefVector<DualMatrix<Value>>& a_inv_list,
+                                                        const std::vector<bool>& compute_mask) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
   ScopedTimer inverse_timer(wfc_leader.InverseTimer);
@@ -54,14 +75,30 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_invertPsiM(const RefVectorWithLeade
   RefVector<LogValue> log_value_list;
   engine_list.reserve(nw);
 
+  wfc_leader.mw_res_->log_values.resize(nw);
+
   for (int iw = 0; iw < nw; iw++)
   {
     auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
-    engine_list.push_back(det.det_engine_);
-    log_value_list.push_back(det.log_value());
+    engine_list.push_back(det.get_det_engine());
+    wfc_leader.mw_res_->log_values[iw] = {0.0, 0.0};
   }
 
-  DET_ENGINE::mw_invert_transpose(engine_list, logdetT_list, log_value_list);
+  DET_ENGINE::mw_invertTranspose(engine_list, logdetT_list, a_inv_list, wfc_leader.mw_res_->log_values, compute_mask);
+  for (int iw = 0; iw < nw; ++iw)
+  {
+    auto& det      = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
+    det.log_value_ = wfc_leader.mw_res_->log_values[iw];
+  }
+
+#ifndef NDEBUG
+  for (int iw = 0; iw < nw; ++iw)
+  {
+    auto& det            = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
+    auto& engine_psiMinv = det.get_det_engine().get_ref_psiMinv();
+    det.dummy_vmt.attachReference(engine_psiMinv.data(), engine_psiMinv.rows(), engine_psiMinv.cols());
+  }
+#endif
 }
 
 ///reset the size: with the number of particles and number of orbtials
@@ -73,27 +110,28 @@ void DiracDeterminantBatched<DET_ENGINE>::resize(int nel, int morb)
     norb = nel; // for morb == -1 (default)
   psiM_vgl.resize(nel * norb);
   // attach pointers VGL
-  psiM_temp.attachReference(psiM_vgl.data(0), nel, norb);
-  dpsiM.attachReference(reinterpret_cast<GradType*>(psiM_vgl.data(1)), nel, norb);
+  psiM_temp.attachReference(psiM_vgl, psiM_vgl.data(0), nel, norb);
+  psiM_host.attachReference(psiM_vgl.data(0), nel, norb);
+  dpsiM.attachReference(reinterpret_cast<Grad*>(psiM_vgl.data(1)), nel, norb);
   d2psiM.attachReference(psiM_vgl.data(4), nel, norb);
 
   det_engine_.resize(norb, ndelay_);
 
-  auto& engine_psiMinv = det_engine_.get_psiMinv();
-  psiMinv.attachReference(engine_psiMinv.data(), engine_psiMinv.rows(), engine_psiMinv.cols());
   psiV.resize(NumOrbitals);
   psiV_host_view.attachReference(psiV.data(), NumOrbitals);
   dpsiV.resize(NumOrbitals);
+  dpsiV_host_view.attachReference(dpsiV.data(), NumOrbitals);
   d2psiV.resize(NumOrbitals);
+  d2psiV_host_view.attachReference(d2psiV.data(), NumOrbitals);
 }
 
 template<typename DET_ENGINE>
-typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<DET_ENGINE>::evalGrad(ParticleSet& P,
-                                                                                                     int iat)
+typename DiracDeterminantBatched<DET_ENGINE>::Grad DiracDeterminantBatched<DET_ENGINE>::evalGrad(ParticleSet& P,
+                                                                                                 int iat)
 {
   ScopedTimer local_timer(RatioTimer);
   const int WorkingIndex = iat - FirstIndex;
-  GradType g             = simd::dot(psiMinv[WorkingIndex], dpsiM[WorkingIndex], NumOrbitals);
+  Grad g                 = simd::dot(det_engine_.get_ref_psiMinv()[WorkingIndex], dpsiM[WorkingIndex], NumOrbitals);
   assert(checkG(g));
   return g;
 }
@@ -109,14 +147,16 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGrad(const RefVectorWithLeader<
   ScopedTimer local_timer(RatioTimer);
 
   const int nw = wfc_list.size();
-  std::vector<const ValueType*> dpsiM_row_list(nw, nullptr);
+  std::vector<const Value*> dpsiM_row_list(nw, nullptr);
   RefVectorWithLeader<DET_ENGINE> engine_list(wfc_leader.det_engine_);
   engine_list.reserve(nw);
 
   const int WorkingIndex = iat - FirstIndex;
   for (int iw = 0; iw < nw; iw++)
   {
-    auto& det          = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
+    auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
+    // capacity is the size of each vector in the VGL so this advances us to the g then makes
+    // an offset into the gradients
     dpsiM_row_list[iw] = det.psiM_vgl.device_data() + psiM_vgl.capacity() + NumOrbitals * WorkingIndex * DIM;
     engine_list.push_back(det.det_engine_);
   }
@@ -130,28 +170,27 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evalGrad(const RefVectorWithLeader<
 }
 
 template<typename DET_ENGINE>
-typename DiracDeterminantBatched<DET_ENGINE>::PsiValue DiracDeterminantBatched<DET_ENGINE>::ratioGrad(
-    ParticleSet& P,
-    int iat,
-    Grad& grad_iat)
+typename DiracDeterminantBatched<DET_ENGINE>::PsiValue DiracDeterminantBatched<DET_ENGINE>::ratioGrad(ParticleSet& P,
+                                                                                                      int iat,
+                                                                                                      Grad& grad_iat)
 {
   UpdateMode = ORB_PBYP_PARTIAL;
 
   {
     ScopedTimer local_timer(SPOVGLTimer);
-    Phi->evaluateVGL(P, iat, psiV_host_view, dpsiV, d2psiV);
+    Phi->evaluateVGL(P, iat, psiV_host_view, dpsiV_host_view, d2psiV_host_view);
   }
 
   {
     ScopedTimer local_timer(RatioTimer);
+    auto& psiMinv          = det_engine_.get_ref_psiMinv();
     const int WorkingIndex = iat - FirstIndex;
     curRatio               = simd::dot(psiMinv[WorkingIndex], psiV.data(), NumOrbitals);
-    grad_iat += static_cast<ValueType>(static_cast<PsiValueType>(1.0) / curRatio) *
-        simd::dot(psiMinv[WorkingIndex], dpsiV.data(), NumOrbitals);
+    grad_iat += static_cast<Value>(static_cast<PsiValue>(1.0) / curRatio) *
+        simd::dot(det_engine_.get_ref_psiMinv()[WorkingIndex], dpsiV.data(), NumOrbitals);
   }
   return curRatio;
 }
-
 
 template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -167,14 +206,12 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGrad(const RefVectorWithLeader
   auto& phi_vgl_v      = mw_res.phi_vgl_v;
   auto& ratios_local   = mw_res.ratios_local;
   auto& grad_new_local = mw_res.grad_new_local;
-
   {
     ScopedTimer local_timer(SPOVGLTimer);
     RefVectorWithLeader<SPOSet> phi_list(*Phi);
     phi_list.reserve(wfc_list.size());
     RefVectorWithLeader<DET_ENGINE> engine_list(wfc_leader.det_engine_);
     engine_list.reserve(wfc_list.size());
-
     const int WorkingIndex = iat - FirstIndex;
     for (int iw = 0; iw < wfc_list.size(); iw++)
     {
@@ -189,7 +226,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_ratioGrad(const RefVectorWithLeader
     ratios_local.resize(wfc_list.size());
     grad_new_local.resize(wfc_list.size());
 
-    VectorSoaContainer<ValueType, DIM + 2> phi_vgl_v_view(phi_vgl_v.data(), NumOrbitals * wfc_list.size(),
+    VectorSoaContainer<Value, DIM + 2> phi_vgl_v_view(phi_vgl_v.data(), NumOrbitals * wfc_list.size(),
                                                           phi_vgl_v.capacity());
     wfc_leader.Phi->mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v_view,
                                                    ratios_local, grad_new_local);
@@ -251,20 +288,21 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_accept_rejectMove(
 
   RefVectorWithLeader<DET_ENGINE> engine_list(wfc_leader.det_engine_);
   engine_list.reserve(nw);
-  std::vector<ValueType*> psiM_g_dev_ptr_list(n_accepted, nullptr);
-  std::vector<ValueType*> psiM_l_dev_ptr_list(n_accepted, nullptr);
+  std::vector<Value*> psiM_g_dev_ptr_list(n_accepted, nullptr);
+  std::vector<Value*> psiM_l_dev_ptr_list(n_accepted, nullptr);
 
   const int WorkingIndex = iat - FirstIndex;
   for (int iw = 0, count = 0; iw < nw; iw++)
   {
-    auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
+    // This can be auto but some debuggers can't figure the type out.
+    DiracDeterminantBatched<DET_ENGINE>& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
     engine_list.push_back(det.det_engine_);
     if (isAccepted[iw])
     {
       psiM_g_dev_ptr_list[count] = det.psiM_vgl.device_data() + psiM_vgl.capacity() + NumOrbitals * WorkingIndex * DIM;
       psiM_l_dev_ptr_list[count] = det.psiM_vgl.device_data() + psiM_vgl.capacity() * 4 + NumOrbitals * WorkingIndex;
-      det.log_value() += convertValueToLog(det.curRatio);
-      count++;
+      det.log_value_ += convertValueToLog(det.curRatio);
+     count++;
     }
     det.curRatio = 1.0;
   }
@@ -340,6 +378,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_completeUpdates(
         // transfer device to host, total size 4, g(3) + l(1)
         PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4]) nowait")
       }
+      // The only tasks being waited on here are the psiM_vgl updates
       PRAGMA_OFFLOAD("omp taskwait")
     }
   }
@@ -349,6 +388,7 @@ template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::computeGL(ParticleSet::ParticleGradient_t& G,
                                                     ParticleSet::ParticleLaplacian_t& L) const
 {
+  auto& psiMinv = det_engine_.get_psiMinv();
   for (size_t i = 0, iat = FirstIndex; i < NumPtcls; ++i, ++iat)
   {
     Grad rv   = simd::dot(psiMinv[i], dpsiM[i], NumOrbitals);
@@ -366,15 +406,15 @@ typename DiracDeterminantBatched<DET_ENGINE>::LogValue DiracDeterminantBatched<D
     bool fromscratch)
 {
   if (fromscratch)
+    // this updates LogValue
     evaluateLog(P, G, L);
   else
   {
     if (UpdateMode == ORB_PBYP_RATIO)
     { //need to compute dpsiM and d2psiM. Do not touch psiM!
       ScopedTimer spo_timer(SPOVGLTimer);
-      Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
+      Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
     }
-
     computeGL(G, L);
   }
   return log_value_;
@@ -394,7 +434,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
   else
   {
     const auto nw = wfc_list.size();
-    RefVector<DET_ENGINE> engine_list;
+    RefVectorWithLeader<DET_ENGINE> engine_list(wfc_leader.get_det_engine());
     engine_list.reserve(nw);
 
     if (UpdateMode == ORB_PBYP_RATIO)
@@ -402,9 +442,9 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
       ScopedTimer spo_timer(SPOVGLTimer);
 
       RefVectorWithLeader<SPOSet> phi_list(*Phi);
-      RefVector<ValueMatrix_t> psiM_temp_list;
-      RefVector<GradMatrix_t> dpsiM_list;
-      RefVector<ValueMatrix_t> d2psiM_list;
+      RefVector<Matrix<Value>> psiM_temp_list;
+      RefVector<Matrix<Grad>> dpsiM_list;
+      RefVector<Matrix<Value>> d2psiM_list;
       phi_list.reserve(wfc_list.size());
       psiM_temp_list.reserve(nw);
       dpsiM_list.reserve(nw);
@@ -415,7 +455,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
         auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
         engine_list.push_back(det.det_engine_);
         phi_list.push_back(*det.Phi);
-        psiM_temp_list.push_back(det.psiM_temp);
+        psiM_temp_list.push_back(det.psiM_host);
         dpsiM_list.push_back(det.dpsiM);
         d2psiM_list.push_back(det.d2psiM);
       }
@@ -429,14 +469,14 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
 
 #ifndef NDEBUG
       GradMatrix_t dpsiM_from_device   = det.dpsiM;
-      ValueMatrix_t d2psiM_from_device = det.d2psiM;
+      Matrix<Value> d2psiM_from_device = det.d2psiM;
 
       auto& my_psiM_vgl  = det.psiM_vgl;
       auto* psiM_vgl_ptr = my_psiM_vgl.data();
       // transfer device to host, total size 4, g(3) + l(1)
       PRAGMA_OFFLOAD("omp target update from(psiM_vgl_ptr[my_psiM_vgl.capacity():my_psiM_vgl.capacity()*4])")
-
-      det.Phi->evaluate_notranspose(p_list[iw], FirstIndex, LastIndex, det.psiM_temp, det.dpsiM, det.d2psiM);
+      Matrix<Value> psiM_temp_host(det.psiM_temp.data(), det.psiM_temp.rows(), det.psiM_temp.cols());
+      det.Phi->evaluate_notranspose(p_list[iw], FirstIndex, LastIndex, psiM_temp_host, det.dpsiM, det.d2psiM);
 
       assert(dpsiM_from_device == det.dpsiM);
       assert(d2psiM_from_device == det.d2psiM);
@@ -450,6 +490,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateGL(const RefVectorWithLeade
 template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::registerData(ParticleSet& P, WFBufferType& buf)
 {
+  auto& psiMinv = det_engine_.get_psiMinv();
   buf.add(psiMinv.first_address(), psiMinv.last_address());
   buf.add(dpsiM.first_address(), dpsiM.last_address());
   buf.add(d2psiM.first_address(), d2psiM.last_address());
@@ -463,7 +504,7 @@ typename DiracDeterminantBatched<DET_ENGINE>::LogValue DiracDeterminantBatched<D
     bool fromscratch)
 {
   evaluateGL(P, P.G, P.L, fromscratch);
-
+  auto& psiMinv = det_engine_.get_psiMinv();
   ScopedTimer local_timer(BufferTimer);
   buf.put(psiMinv.first_address(), psiMinv.last_address());
   buf.put(dpsiM.first_address(), dpsiM.last_address());
@@ -476,6 +517,7 @@ template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::copyFromBuffer(ParticleSet& P, WFBufferType& buf)
 {
   ScopedTimer local_timer(BufferTimer);
+  auto& psiMinv = det_engine_.get_ref_psiMinv();
   buf.get(psiMinv.first_address(), psiMinv.last_address());
   buf.get(dpsiM.first_address(), dpsiM.last_address());
   buf.get(d2psiM.first_address(), d2psiM.last_address());
@@ -494,7 +536,7 @@ void DiracDeterminantBatched<DET_ENGINE>::copyFromBuffer(ParticleSet& P, WFBuffe
  */
 template<typename DET_ENGINE>
 typename DiracDeterminantBatched<DET_ENGINE>::PsiValue DiracDeterminantBatched<DET_ENGINE>::ratio(ParticleSet& P,
-                                                                                                      int iat)
+                                                                                                  int iat)
 {
   UpdateMode             = ORB_PBYP_RATIO;
   const int WorkingIndex = iat - FirstIndex;
@@ -503,6 +545,7 @@ typename DiracDeterminantBatched<DET_ENGINE>::PsiValue DiracDeterminantBatched<D
     Phi->evaluateValue(P, iat, psiV_host_view);
   }
   {
+    auto& psiMinv = det_engine_.get_ref_psiMinv();
     ScopedTimer local_timer(RatioTimer);
     curRatio = simd::dot(psiMinv[WorkingIndex], psiV.data(), NumOrbitals);
   }
@@ -544,8 +587,8 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_calcRatio(const RefVectorWithLeader
     ratios_local.resize(wfc_list.size());
     grad_new_local.resize(wfc_list.size());
 
-    VectorSoaContainer<ValueType, DIM + 2> phi_vgl_v_view(phi_vgl_v.data(), NumOrbitals * wfc_list.size(),
-                                                          phi_vgl_v.capacity());
+    VectorSoaContainer<Value, DIM + 2> phi_vgl_v_view(phi_vgl_v.data(), NumOrbitals * wfc_list.size(),
+                                                      phi_vgl_v.capacity());
     // calling Phi->mw_evaluateVGLandDetRatioGrads is a temporary workaround.
     // We may implement mw_evaluateVandDetRatio in the future.
     wfc_leader.Phi->mw_evaluateVGLandDetRatioGrads(phi_list, p_list, iat, psiMinv_row_dev_ptr_list, phi_vgl_v_view,
@@ -567,22 +610,22 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateRatios(const VirtualParticleSe
   {
     ScopedTimer local_timer(RatioTimer);
     const int WorkingIndex = VP.refPtcl - FirstIndex;
-    std::copy_n(psiMinv[WorkingIndex], d2psiV.size(), d2psiV.data());
+    std::copy_n(det_engine_.get_psiMinv()[WorkingIndex], d2psiV.size(), d2psiV.data());
   }
   {
     ScopedTimer local_timer(SPOVTimer);
-    Phi->evaluateDetRatios(VP, psiV_host_view, d2psiV, ratios);
+    Phi->evaluateDetRatios(VP, psiV_host_view, d2psiV_host_view, ratios);
   }
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                                            const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
-                                                            std::vector<std::vector<Value>>& ratios) const
+void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateRatios(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<const VirtualParticleSet>& vp_list,
+    std::vector<std::vector<Value>>& ratios) const
 {
   assert(this == &wfc_list.getLeader());
-  auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
-  const size_t nw  = wfc_list.size();
+  const size_t nw = wfc_list.size();
 
   RefVectorWithLeader<SPOSet> phi_list(*Phi);
   RefVector<Vector<Value>> psiV_list;
@@ -604,7 +647,7 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_evaluateRatios(const RefVectorWithL
       if (Phi->isOMPoffload())
         invRow_ptr_list.push_back(det.det_engine_.getRow_psiMinv_offload(WorkingIndex));
       else
-        invRow_ptr_list.push_back(det.psiMinv[WorkingIndex]);
+        invRow_ptr_list.push_back(det.det_engine_.get_ref_psiMinv()[WorkingIndex]);
     }
   }
 
@@ -621,6 +664,7 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateRatiosAlltoOne(ParticleSet& P,
     ScopedTimer local_timer(SPOVTimer);
     Phi->evaluateValue(P, -1, psiV_host_view);
   }
+  auto& psiMinv = det_engine_.get_ref_psiMinv();
   for (int i = 0; i < psiMinv.rows(); i++)
     ratios[FirstIndex + i] = simd::dot(psiMinv[i], psiV.data(), NumOrbitals);
 }
@@ -639,16 +683,17 @@ void DiracDeterminantBatched<DET_ENGINE>::resizeScratchObjectsForIonDerivs()
 }
 
 template<typename DET_ENGINE>
-typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<DET_ENGINE>::evalGradSource(
+typename DiracDeterminantBatched<DET_ENGINE>::Grad DiracDeterminantBatched<DET_ENGINE>::evalGradSource(
     ParticleSet& P,
     ParticleSet& source,
     int iat)
 {
-  GradType g(0.0);
+  Grad g(0.0);
   if (Phi->hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
     Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM);
+    auto& psiMinv = det_engine_.get_ref_psiMinv();
     // psiMinv columns have padding but grad_source_psiM ones don't
     for (int i = 0; i < psiMinv.rows(); i++)
       g += simd::dot(psiMinv[i], grad_source_psiM[i], NumOrbitals);
@@ -660,11 +705,14 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
 template<typename DET_ENGINE>
 void DiracDeterminantBatched<DET_ENGINE>::evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi)
 {
+  auto& psiMinv = det_engine_.get_ref_psiMinv();
   // Hessian is not often used, so only resize/allocate if used
   grad_grad_source_psiM.resize(psiMinv.rows(), NumOrbitals);
   //IM A HACK.  Assumes evaluateLog has already been executed.
-  Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, grad_grad_source_psiM);
-  invertPsiM(psiM_temp);
+  Matrix<Value> psiM_temp_host(psiM_temp.data(), psiM_temp.rows(), psiM_temp.cols());
+  Matrix<Grad> dpsiM_host(dpsiM.data(), dpsiM.rows(), dpsiM.cols());
+  Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp_host, dpsiM_host, grad_grad_source_psiM);
+  invertPsiM(psiM_temp, det_engine_.get_ref_psiMinv());
 
   phi_alpha_Minv      = 0.0;
   grad_phi_Minv       = 0.0;
@@ -674,9 +722,9 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateHessian(ParticleSet& P, HessVe
 
   for (int i = 0, iat = FirstIndex; i < NumPtcls; i++, iat++)
   {
-    GradType rv = simd::dot(psiMinv[i], dpsiM[i], NumOrbitals);
+    Grad rv = simd::dot(psiMinv[i], dpsiM[i], NumOrbitals);
     //  HessType hess_tmp=simd::dot(psiMinv[i],grad_grad_source_psiM[i],NumOrbitals);
-    HessType hess_tmp;
+    Hess hess_tmp;
     hess_tmp           = 0.0;
     hess_tmp           = simd::dot(psiMinv[i], grad_grad_source_psiM[i], NumOrbitals);
     grad_grad_psi[iat] = hess_tmp - outerProduct(rv, rv);
@@ -684,38 +732,22 @@ void DiracDeterminantBatched<DET_ENGINE>::evaluateHessian(ParticleSet& P, HessVe
 }
 
 template<typename DET_ENGINE>
-typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<DET_ENGINE>::evalGradSource(
+typename DiracDeterminantBatched<DET_ENGINE>::Grad DiracDeterminantBatched<DET_ENGINE>::evalGradSource(
     ParticleSet& P,
     ParticleSet& source,
     int iat,
     TinyVector<ParticleSet::ParticleGradient_t, OHMMS_DIM>& grad_grad,
     TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad)
 {
-  GradType gradPsi(0.0);
+  Grad gradPsi(0.0);
   if (Phi->hasIonDerivs())
   {
     resizeScratchObjectsForIonDerivs();
     Phi->evaluateGradSource(P, FirstIndex, LastIndex, source, iat, grad_source_psiM, grad_grad_source_psiM,
                             grad_lapl_source_psiM);
-    // HACK HACK HACK
-    // Phi->evaluateVGL(P, FirstIndex, LastIndex, psiMinv, dpsiM, d2psiM);
-    // psiM_temp = psiMinv;
-    // LogValue=InvertWithLog(psiMinv.data(),NumPtcls,NumOrbitals,
-    // 			   WorkSpace.data(),Pivot.data(),PhaseValue);
-    // for (int i=0; i<NumPtcls; i++)
-    //   for (int j=0; j<NumPtcls; j++) {
-    // 	double val = 0.0;
-    // 	for (int k=0; k<NumPtcls; k++)
-    // 	  val += psiMinv(i,k) * psiM_temp(k,j);
-    // 	val -= (i == j) ? 1.0 : 0.0;
-    // 	if (std::abs(val) > 1.0e-12)
-    // 	  std::cerr << "Error in inverse.\n";
-    //   }
-    // for (int i=0; i<NumPtcls; i++) {
-    //   P.G[FirstIndex+i] = GradType();
-    //   for (int j=0; j<NumOrbitals; j++)
-    // 	P.G[FirstIndex+i] += psiMinv(i,j)*dpsiM(i,j);
-    // }
+
+    auto& psiMinv = det_engine_.get_ref_psiMinv();
+
     // Compute matrices
     phi_alpha_Minv      = 0.0;
     grad_phi_Minv       = 0.0;
@@ -744,8 +776,8 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
     }
     for (int i = 0, iel = FirstIndex; i < NumPtcls; i++, iel++)
     {
-      HessType dval(0.0);
-      GradType d2val(0.0);
+      Hess dval(0.0);
+      Grad d2val(0.0);
       for (int dim = 0; dim < OHMMS_DIM; dim++)
         for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
           dval(dim, dim_el) = grad_phi_alpha_Minv(i, i)(dim, dim_el);
@@ -768,14 +800,14 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
           if (j == i)
             for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
               lapl_grad[dim][iel] -=
-                  (RealType)2.0 * grad_phi_alpha_Minv(j, i)(dim, dim_el) * grad_phi_Minv(i, j)[dim_el];
+                  (Real)2.0 * grad_phi_alpha_Minv(j, i)(dim, dim_el) * grad_phi_Minv(i, j)[dim_el];
           // Third term, eq 9
           // First term, eq 10
           lapl_grad[dim][iel] -= phi_alpha_Minv(j, i)[dim] * lapl_phi_Minv(i, j);
           // Second term, eq 11
           for (int dim_el = 0; dim_el < OHMMS_DIM; dim_el++)
             lapl_grad[dim][iel] +=
-                (RealType)2.0 * phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, i)[dim_el] * grad_phi_Minv(i, j)[dim_el];
+                (Real)2.0 * phi_alpha_Minv(j, i)[dim] * grad_phi_Minv(i, i)[dim_el] * grad_phi_Minv(i, j)[dim_el];
         }
       }
     }
@@ -783,12 +815,11 @@ typename DiracDeterminantBatched<DET_ENGINE>::GradType DiracDeterminantBatched<D
   return gradPsi;
 }
 
-
 /** Calculate the log value of the Dirac determinant for particles
  *@param P input configuration containing N particles
  *@param G a vector containing N gradients
  *@param L a vector containing N laplacians
- *@return the value of the determinant
+ *\return the complex value of the determinant
  *
  *\f$ (first,first+nel). \f$  Add the gradient and laplacian
  *contribution of the determinant to G(radient) and L(aplacian)
@@ -828,13 +859,13 @@ void DiracDeterminantBatched<DET_ENGINE>::recompute(const ParticleSet& P)
 {
   {
     ScopedTimer spo_timer(SPOVGLTimer);
-    Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_temp, dpsiM, d2psiM);
+
+    Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_host, dpsiM, d2psiM);
     auto* psiM_vgl_ptr = psiM_vgl.data();
     // transfer host to device, total size 4, g(3) + l(1)
     PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[psiM_vgl.capacity():psiM_vgl.capacity()*4])")
   }
-
-  invertPsiM(psiM_temp);
+  invertPsiM(psiM_temp, det_engine_.get_ref_psiMinv());
 }
 
 template<typename DET_ENGINE>
@@ -848,13 +879,19 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
   RefVectorWithLeader<WaveFunctionComponent> wfc_filtered_list(wfc_list.getLeader());
   RefVectorWithLeader<ParticleSet> p_filtered_list(p_list.getLeader());
   RefVectorWithLeader<SPOSet> phi_list(*wfc_leader.Phi);
-  RefVector<ValueMatrix_t> psiM_temp_list;
-  RefVector<GradMatrix_t> dpsiM_list;
-  RefVector<ValueMatrix_t> d2psiM_list;
+  std::vector<Matrix<Value>> psiM_host_views;
+  std::vector<Matrix<Grad>> dpsiM_host_views;
+  std::vector<Matrix<Value>> d2psiM_host_views;
+  RefVector<Matrix<Value>> psiM_temp_list;
+  RefVector<Matrix<Grad>> dpsiM_list;
+  RefVector<Matrix<Value>> d2psiM_list;
 
   wfc_filtered_list.reserve(nw);
   p_filtered_list.reserve(nw);
   phi_list.reserve(nw);
+  psiM_host_views.reserve(nw);
+  dpsiM_host_views.reserve(nw);
+  d2psiM_host_views.reserve(nw);
   psiM_temp_list.reserve(nw);
   dpsiM_list.reserve(nw);
   d2psiM_list.reserve(nw);
@@ -867,9 +904,12 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
 
       auto& det = wfc_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
       phi_list.push_back(*det.Phi);
-      psiM_temp_list.push_back(det.psiM_temp);
-      dpsiM_list.push_back(det.dpsiM);
-      d2psiM_list.push_back(det.d2psiM);
+      psiM_host_views.emplace_back(det.psiM_temp.data(), det.psiM_temp.rows(), det.psiM_temp.cols());
+      psiM_temp_list.push_back(psiM_host_views.back());
+      dpsiM_host_views.emplace_back(det.dpsiM.data(), det.dpsiM.rows(), det.dpsiM.cols());
+      dpsiM_list.push_back(dpsiM_host_views.back());
+      d2psiM_host_views.emplace_back(det.d2psiM.data(), det.d2psiM.rows(), det.d2psiM.cols());
+      d2psiM_list.push_back(d2psiM_host_views.back());
     }
 
   if (!wfc_filtered_list.size())
@@ -884,7 +924,9 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
   { // transfer dpsiM, d2psiM, psiMinv to device
     ScopedTimer d2h(H2DTimer);
 
-    RefVector<const ValueMatrix_t> const_psiM_temp_list;
+    RefVector<const DualMatrix<Value>> const_psiM_temp_list;
+    RefVector<DualMatrix<Value>> psiMinv_list;
+
     for (int iw = 0; iw < wfc_filtered_list.size(); iw++)
     {
       auto& det          = wfc_filtered_list.getCastedElement<DiracDeterminantBatched<DET_ENGINE>>(iw);
@@ -892,8 +934,10 @@ void DiracDeterminantBatched<DET_ENGINE>::mw_recompute(const RefVectorWithLeader
       size_t stride      = wfc_leader.psiM_vgl.capacity();
       PRAGMA_OFFLOAD("omp target update to(psiM_vgl_ptr[stride:stride*4]) nowait")
       const_psiM_temp_list.push_back(det.psiM_temp);
+      psiMinv_list.push_back(det.get_det_engine().get_ref_psiMinv());
     }
-    mw_invertPsiM(wfc_filtered_list, const_psiM_temp_list);
+    auto& mw_res = *wfc_leader.mw_res_;
+    mw_invertPsiM(wfc_filtered_list, const_psiM_temp_list, psiMinv_list, recompute);
     PRAGMA_OFFLOAD("omp taskwait")
   }
 }
@@ -923,10 +967,12 @@ void DiracDeterminantBatched<DET_ENGINE>::createResource(ResourceCollection& col
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
+void DiracDeterminantBatched<DET_ENGINE>::acquireResource(
+    ResourceCollection& collection,
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
-  auto res_ptr = dynamic_cast<DiracDeterminantBatchedMultiWalkerResource*>(collection.lendResource().release());
+  auto res_ptr     = dynamic_cast<DiracDeterminantBatchedMultiWalkerResource*>(collection.lendResource().release());
   if (!res_ptr)
     throw std::runtime_error("DiracDeterminantBatched::acquireResource dynamic_cast failed");
   wfc_leader.mw_res_.reset(res_ptr);
@@ -943,7 +989,9 @@ void DiracDeterminantBatched<DET_ENGINE>::acquireResource(ResourceCollection& co
 }
 
 template<typename DET_ENGINE>
-void DiracDeterminantBatched<DET_ENGINE>::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
+void DiracDeterminantBatched<DET_ENGINE>::releaseResource(
+    ResourceCollection& collection,
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<DiracDeterminantBatched<DET_ENGINE>>();
   collection.takebackResource(std::move(wfc_leader.mw_res_));

--- a/src/QMCWaveFunctions/Fermion/DiracMatrix.h
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrix.h
@@ -21,17 +21,18 @@
 
 namespace qmcplusplus
 {
+
+/** wrappers around xgetrf lapack routines 
+ *  \param[in] n      rows
+ *  \param[in] m      cols
+ *  \param[inout] a   matrix contains LU matrix after call
+ *  \param[in] lda    leading dimension of a
+ *  \param[out] piv   pivot vector
+ */
 inline int Xgetrf(int n, int m, float* restrict a, int lda, int* restrict piv)
 {
   int status;
   sgetrf(n, m, a, lda, piv, status);
-  return status;
-}
-
-inline int Xgetri(int n, float* restrict a, int lda, int* restrict piv, float* restrict work, int& lwork)
-{
-  int status;
-  sgetri(n, a, lda, piv, work, lwork, status);
   return status;
 }
 
@@ -42,7 +43,28 @@ inline int Xgetrf(int n, int m, std::complex<float>* restrict a, int lda, int* r
   return status;
 }
 
+inline int Xgetrf(int n, int m, double* restrict a, int lda, int* restrict piv)
+{
+  int status;
+  dgetrf(n, m, a, lda, piv, status);
+  return status;
+}
+
+inline int Xgetrf(int n, int m, std::complex<double>* restrict a, int lda, int* restrict piv)
+{
+  int status;
+  zgetrf(n, m, a, lda, piv, status);
+  return status;
+}
+
 /** inversion of a float matrix after lu factorization*/
+inline int Xgetri(int n, float* restrict a, int lda, int* restrict piv, float* restrict work, int& lwork)
+{
+  int status;
+  sgetri(n, a, lda, piv, work, lwork, status);
+  return status;
+}
+
 inline int Xgetri(int n,
                   std::complex<float>* restrict a,
                   int lda,
@@ -55,24 +77,10 @@ inline int Xgetri(int n,
   return status;
 }
 
-inline int Xgetrf(int n, int m, double* restrict a, int lda, int* restrict piv)
-{
-  int status;
-  dgetrf(n, m, a, lda, piv, status);
-  return status;
-}
-
 inline int Xgetri(int n, double* restrict a, int lda, int* restrict piv, double* restrict work, int& lwork)
 {
   int status;
   dgetri(n, a, lda, piv, work, lwork, status);
-  return status;
-}
-
-inline int Xgetrf(int n, int m, std::complex<double>* restrict a, int lda, int* restrict piv)
-{
-  int status;
-  zgetrf(n, m, a, lda, piv, status);
   return status;
 }
 
@@ -126,7 +134,7 @@ class DiracMatrix
       msg << "Xgetri failed with error " << status << std::endl;
       throw std::runtime_error(msg.str());
     }
-        
+
     convert(tmp, lw);
     Lwork = static_cast<int>(lw);
     m_work.resize(Lwork);

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -96,7 +96,11 @@ public:
 private:
   /// legacy single walker matrix inversion engine
   DiracMatrix<FullPrecValue> detEng;
-  /// inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$
+  /* inverse transpose of psiM(j,i) \f$= \psi_j({\bf r}_i)\f$
+   * Only NumOrbitals x NumOrbitals subblock has meaningful data
+   * The number of rows is equal to NumOrbitals
+   * The number of columns in each row is padded to a multiple of QMC_SIMD_ALIGNMENT
+   */
   DualMatrix<Value> psiMinv_;
   /// scratch space for rank-1 update
   UnpinnedDualVector<Value> temp;

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -117,15 +117,15 @@ void SlaterDet::mw_evaluateLog(const RefVectorWithLeader<WaveFunctionComponent>&
 {
   constexpr LogValueType czero(0);
 
-  for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.get_ref_log_value() = czero;
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    wfc_list.getCastedElement<SlaterDet>(iw).log_value_ = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateLog(Det_list, p_list, G_list, L_list);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
+      wfc_list.getCastedElement<SlaterDet>(iw).log_value_ += Det_list[iw].get_log_value();
   }
 }
 
@@ -148,15 +148,15 @@ void SlaterDet::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& 
 {
   constexpr LogValueType czero(0);
 
-  for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.get_ref_log_value() = czero;
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    wfc_list.getCastedElement<SlaterDet>(iw).log_value_ = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateGL(Det_list, p_list, G_list, L_list, fromscratch);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
+      wfc_list.getCastedElement<SlaterDet>(iw).log_value_ += Det_list[iw].get_log_value();
   }
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -118,14 +118,14 @@ void SlaterDet::mw_evaluateLog(const RefVectorWithLeader<WaveFunctionComponent>&
   constexpr LogValueType czero(0);
 
   for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.log_value() = czero;
+    wfc.get_ref_log_value() = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateLog(Det_list, p_list, G_list, L_list);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].log_value() += Det_list[iw].get_log_value();
+      wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
   }
 }
 
@@ -149,14 +149,14 @@ void SlaterDet::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& 
   constexpr LogValueType czero(0);
 
   for (WaveFunctionComponent& wfc : wfc_list)
-    wfc.log_value() = czero;
+    wfc.get_ref_log_value() = czero;
 
   for (int i = 0; i < Dets.size(); ++i)
   {
     const auto Det_list(extract_DetRef_list(wfc_list, i));
     Dets[i]->mw_evaluateGL(Det_list, p_list, G_list, L_list, fromscratch);
     for (int iw = 0; iw < wfc_list.size(); iw++)
-      wfc_list[iw].log_value() += Det_list[iw].get_log_value();
+      wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
   }
 }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -184,7 +184,7 @@ public:
     // having log_value_ as a data member asks for this sort of consistency issue when wfc can contain wfc.
     for (int iw = 0; iw < wfc_list.size(); iw++)
       if (isAccepted[iw])
-        wfc_list[iw].get_ref_log_value() = czero;
+        wfc_list.getCastedElement<SlaterDet>(iw).log_value_ = czero;
 
     for (int i = 0; i < Dets.size(); ++i)
     {
@@ -195,7 +195,7 @@ public:
 
       for (int iw = 0; iw < wfc_list.size(); iw++)
         if (isAccepted[iw])
-          wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
+          wfc_list.getCastedElement<SlaterDet>(iw).log_value_ += Det_list[iw].get_log_value();
     }
   }
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -184,7 +184,7 @@ public:
     // having log_value_ as a data member asks for this sort of consistency issue when wfc can contain wfc.
     for (int iw = 0; iw < wfc_list.size(); iw++)
       if (isAccepted[iw])
-        wfc_list[iw].log_value() = czero;
+        wfc_list[iw].get_ref_log_value() = czero;
 
     for (int i = 0; i < Dets.size(); ++i)
     {
@@ -195,7 +195,7 @@ public:
 
       for (int iw = 0; iw < wfc_list.size(); iw++)
         if (isAccepted[iw])
-          wfc_list[iw].log_value() += Det_list[iw].get_log_value();
+          wfc_list[iw].get_ref_log_value() += Det_list[iw].get_log_value();
     }
   }
 

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
@@ -606,7 +606,7 @@ void J2OMPTarget<FT>::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctio
   for (int iw = 0; iw < nw; iw++)
   {
     auto& wfc = wfc_list.getCastedElement<J2OMPTarget<FT>>(iw);
-    wfc.log_value() += wfc.Uat[iat] - mw_vgl[iw][0];
+    wfc.log_value_ += wfc.Uat[iat] - mw_vgl[iw][0];
   }
 
   /* this call may go asynchronous, then need to wait at mw_calcRatio mw_ratioGrad and mw_completeUpdates */
@@ -739,7 +739,7 @@ void J2OMPTarget<FT>::mw_evaluateGL(const RefVectorWithLeader<WaveFunctionCompon
   for (int iw = 0; iw < wfc_list.size(); iw++)
   {
     auto& wfc    = wfc_list.getCastedElement<J2OMPTarget<FT>>(iw);
-    wfc.log_value() = wfc.computeGL(G_list[iw], L_list[iw]);
+    wfc.log_value_ = wfc.computeGL(G_list[iw], L_list[iw]);
   }
 }
 

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -322,12 +322,12 @@ public:
   virtual void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix_t& grad_grad_grad_logdet);
 
   /** evaluate the values, gradients and laplacians of this single-particle orbital for [first,last) particles
-   * @param P current ParticleSet
-   * @param first starting index of the particles
-   * @param last ending index of the particles
-   * @param logdet determinant matrix to be inverted
-   * @param dlogdet gradients
-   * @param d2logdet laplacians
+   * @param[in] P current ParticleSet
+   * @param[in] first starting index of the particles
+   * @param[in] last ending index of the particles
+   * @param[out] logdet determinant matrix to be inverted
+   * @param[out] dlogdet gradients
+   * @param[out] d2logdet laplacians
    *
    */
   virtual void evaluate_notranspose(const ParticleSet& P,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -137,7 +137,7 @@ protected:
 
 public:
   const LogValueType get_log_value() const { return log_value_; }
-  LogValueType& log_value() { return log_value_; }
+  LogValueType& get_ref_log_value() { return log_value_; }
 
   /// default constructor
   WaveFunctionComponent(const std::string& class_name, const std::string& obj_name = "");
@@ -173,13 +173,13 @@ public:
   virtual void reportStatus(std::ostream& os) = 0;
 
   /** evaluate the value of the WaveFunctionComponent from scratch
-   * @param P  active ParticleSet
-   * @param G Gradients, \f$\nabla\ln\Psi\f$
-   * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
-   * @return the log value
+   * \param[in] P  active ParticleSet
+   * \param[out] G Gradients, \f$\nabla\ln\Psi\f$
+   * \param[out] L Laplacians, \f$\nabla^2\ln\Psi\f$
+   * \return the log value
    *
    * Mainly for walker-by-walker move. The initial stage of particle-by-particle
-   * move also uses this.
+   * move also uses this. causes complete state update in WFC's
    */
   virtual LogValueType evaluateLog(const ParticleSet& P,
                                    ParticleSet::ParticleGradient_t& G,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -136,8 +136,7 @@ protected:
   LogValueType log_value_;
 
 public:
-  const LogValueType get_log_value() const { return log_value_; }
-  LogValueType& get_ref_log_value() { return log_value_; }
+  const LogValueType& get_log_value() const { return log_value_; }
 
   /// default constructor
   WaveFunctionComponent(const std::string& class_name, const std::string& obj_name = "");

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -18,7 +18,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminantBatched.h"
 #include "QMCWaveFunctions/tests/FakeSPO.h"
-
+#include "checkMatrix.hpp"
 #ifdef QMC_COMPLEX //This is for the spinor test.
 #include "QMCWaveFunctions/ElectronGas/ElectronGasComplexOrbitalBuilder.h"
 #endif
@@ -48,18 +48,6 @@ typedef DiracDeterminantBatched<MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFu
 #else
 typedef DiracDeterminantBatched<> DetType;
 #endif
-
-template<typename T1, typename ALLOC1, typename T2, typename ALLOC2>
-void check_matrix(Matrix<T1, ALLOC1>& a, Matrix<T2, ALLOC2>& b)
-{
-  REQUIRE(a.rows() >= b.rows());
-  REQUIRE(a.cols() >= b.cols());
-  for (int i = 0; i < b.rows(); i++)
-    for (int j = 0; j < b.cols(); j++)
-    {
-      REQUIRE(a(i, j) == ValueApprox(b(i, j)));
-    }
-}
 
 TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
 {
@@ -92,8 +80,7 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
   b(2, 1) = -0.04586322768;
   b(2, 2) = 0.3927890292;
 
-  check_matrix(ddb.psiMinv, b);
-
+  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
 
   ParticleSet::GradType grad;
   PsiValueType det_ratio  = ddb.ratioGrad(elec, 0, grad);
@@ -112,7 +99,7 @@ TEST_CASE("DiracDeterminantBatched_first", "[wavefunction][fermion]")
   b(2, 1) = 0.7119205298;
   b(2, 2) = 0.9105960265;
 
-  check_matrix(ddb.psiMinv, b);
+  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), b);
 
   // set virtutal particle position
   PosType newpos(0.3, 0.2, 0.5);
@@ -184,7 +171,7 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
     }
   }
 
-  //check_matrix(ddb.psiMinv, b);
+  //check_matrix(ddb.getPsiMinv(), b);
   DiracMatrix<ValueType> dm;
 
   Matrix<ValueType> a_update1, scratchT;
@@ -273,10 +260,10 @@ TEST_CASE("DiracDeterminantBatched_second", "[wavefunction][fermion]")
   std::cout << "original " << std::endl;
   std::cout << orig_a << std::endl;
   std::cout << "block update " << std::endl;
-  std::cout << ddb.psiMinv << std::endl;
+  std::cout << ddb.getPsiMinv() << std::endl;
 #endif
 
-  check_matrix(ddb.psiMinv, orig_a);
+  checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), orig_a);
 }
 
 TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
@@ -310,7 +297,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
     }
   }
 
-  //check_matrix(ddc.psiMinv, b);
+  //check_matrix(ddc.getPsiMinv(), b);
   DiracMatrix<ValueType> dm;
 
   Matrix<ValueType> a_update1, scratchT;
@@ -364,7 +351,7 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   // force update Ainv in ddc using SM-1 code path
   ddc.completeUpdates();
 
-  check_matrix(ddc.psiMinv, a_update1);
+  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), a_update1);
 
   grad = ddc.evalGrad(elec, 1);
 
@@ -415,11 +402,11 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   std::cout << "original " << std::endl;
   std::cout << orig_a << std::endl;
   std::cout << "delayed update " << std::endl;
-  std::cout << ddc.psiMinv << std::endl;
+  std::cout << ddc.getPsiMinv() << std::endl;
 #endif
 
-  // compare all the elements of psiMinv in ddc and orig_a
-  check_matrix(ddc.psiMinv, orig_a);
+  // compare all the elements of get_ref_psiMinv() in ddc and orig_a
+  checkMatrix(ddc.get_det_engine().get_ref_psiMinv(), orig_a);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracMatrixComputeOMPTarget.cpp
@@ -70,7 +70,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
   OffloadPinnedMatrix<double> inv_mat_a2;
   inv_mat_a2.resize(4, 4);
 
-  RefVector<OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
+  RefVector<const OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
   log_values.resize(2);
@@ -93,7 +93,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_different_batch_sizes", "[wavefunction][f
 
   a_mats[1] = mat_a3;
 
-  RefVector<OffloadPinnedMatrix<double>> a_mats3{mat_a, mat_a2, mat_a3};
+  RefVector<const OffloadPinnedMatrix<double>> a_mats3{mat_a, mat_a2, mat_a3};
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats3{inv_mat_a, inv_mat_a2, inv_mat_a3};
 
   log_values.resize(3);
@@ -147,7 +147,7 @@ TEST_CASE("DiracMatrixComputeOMPTarget_large_determinants_against_legacy", "[wav
   OffloadPinnedMatrix<double> inv_mat_a2;
   inv_mat_a2.resize(n, n);
 
-  RefVector<OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
+  RefVector<const OffloadPinnedMatrix<double>> a_mats{mat_a, mat_a2};
   RefVector<OffloadPinnedMatrix<double>> inv_a_mats{inv_mat_a, inv_mat_a2};
 
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include <ResourceCollection.h>
 
 namespace qmcplusplus
 {
@@ -143,8 +144,18 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   psi.evaluateDerivatives(elec, var_param, dlogpsi, dhpsioverpsi);
 
 
+  // testing batched interfaces
+  ResourceCollection pset_res("test_pset_res");
+  ResourceCollection twf_res("test_twf_res");
+
+  elec.createResource(pset_res);
+  psi.createResource(twf_res);
+
   RefVectorWithLeader<TrialWaveFunction> wf_list(psi, {psi});
   RefVectorWithLeader<ParticleSet> p_list(elec, {elec});
+
+  ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_twf_lock(twf_res, wf_list);
 
   // Test list with one wavefunction
 
@@ -258,6 +269,17 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   auto fixedG_list     = convertUPtrToRefVector(fixedG_list_ptr);
   auto fixedL_list     = convertUPtrToRefVector(fixedL_list_ptr);
 
+  // testing batched interfaces
+  ResourceCollection pset_res("test_pset_res");
+  ResourceCollection twf_res("test_twf_res");
+
+  elec1b.createResource(pset_res);
+  psi.createResource(twf_res);
+
+  ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_twf_lock(twf_res, wf_list);
+
+  
   TrialWaveFunction::mw_evaluateDeltaLogSetup(wf_list, p_list, logpsi_fixed_list, logpsi_opt_list, fixedG_list,
                                               fixedL_list);
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -35,13 +35,18 @@ struct double_tag
 struct float_tag
 {};
 
+/** Templated test of TrialWF with different DiracDet flavors.
+ *  If QMC_CUDA there is no testing converage beyond setup.
+ *  \todo at the very least the prepocessor define QMC_CUDA shouldn't be 
+ *  used and a constexpr based on DeterminantTypes that actually depend on legacy cuda.
+ */
 template<class DiracDet, class SPO_precision>
 void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 {
 #if defined(MIXED_PRECISION)
   const double precision = 1e-4;
 #else
-  const double precision = std::is_same<SPO_precision, float_tag>::value ? 1e-4 : 1e-8;
+  const double precision                    = std::is_same<SPO_precision, float_tag>::value ? 1e-4 : 1e-8;
 #endif
   OHMMS::Controller->initialize(0, NULL);
   Communicate* c = OHMMS::Controller;
@@ -309,23 +314,23 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   if (kind_selected != DynamicCoordinateKind::DC_POS_OFFLOAD)
   {
-  ValueType r_0 = wf_ref_list[0].calcRatio(p_ref_list[0], moved_elec_id);
-  GradType grad_temp;
-  ValueType r_1 = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_temp);
-  std::cout << "calcRatio calcRatioGrad " << std::setprecision(14) << r_0 << " " << r_1 << " " << grad_temp[0] << " "
-            << grad_temp[1] << " " << grad_temp[2] << std::endl;
+    ValueType r_0 = wf_ref_list[0].calcRatio(p_ref_list[0], moved_elec_id);
+    GradType grad_temp;
+    ValueType r_1 = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_temp);
+    std::cout << "calcRatio calcRatioGrad " << std::setprecision(14) << r_0 << " " << r_1 << " " << grad_temp[0] << " "
+              << grad_temp[1] << " " << grad_temp[2] << std::endl;
 #if defined(QMC_COMPLEX)
-  REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791, -0.00034808849808193)).epsilon(1e-4));
-  REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059, -6.4240180082292e-05)).epsilon(1e-5));
-  REQUIRE(grad_temp[0] == ComplexApprox(ValueType(1.4567170375539, 0.00027263382943948)));
-  REQUIRE(grad_temp[1] == ComplexApprox(ValueType(1.4567170375539, 0.00027263382945093)));
-  REQUIRE(grad_temp[2] == ComplexApprox(ValueType(-1.2930978490431, -0.00027378452214318)));
+    REQUIRE(r_0 == ComplexApprox(ValueType(253.71869245791, -0.00034808849808193)).epsilon(1e-4));
+    REQUIRE(r_1 == ComplexApprox(ValueType(36.915636007059, -6.4240180082292e-05)).epsilon(1e-5));
+    REQUIRE(grad_temp[0] == ComplexApprox(ValueType(1.4567170375539, 0.00027263382943948)));
+    REQUIRE(grad_temp[1] == ComplexApprox(ValueType(1.4567170375539, 0.00027263382945093)));
+    REQUIRE(grad_temp[2] == ComplexApprox(ValueType(-1.2930978490431, -0.00027378452214318)));
 #else
-  REQUIRE(r_0 == Approx(253.71904054638).epsilon(2e-4));
-  REQUIRE(r_1 == Approx(36.915700247239));
-  REQUIRE(grad_temp[0] == Approx(1.4564444046733));
-  REQUIRE(grad_temp[1] == Approx(1.4564444046734));
-  REQUIRE(grad_temp[2] == Approx(-1.2928240654738));
+    REQUIRE(r_0 == Approx(253.71904054638).epsilon(2e-4));
+    REQUIRE(r_1 == Approx(36.915700247239));
+    REQUIRE(grad_temp[0] == Approx(1.4564444046733));
+    REQUIRE(grad_temp[1] == Approx(1.4564444046734));
+    REQUIRE(grad_temp[2] == Approx(-1.2928240654738));
 #endif
   }
 
@@ -354,12 +359,12 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   if (kind_selected != DynamicCoordinateKind::DC_POS_OFFLOAD)
   {
-  ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
-  ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
+    ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
+    ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
 
-  std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-            << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
-            << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
+    std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
+              << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
+              << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
   }
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
@@ -475,6 +480,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   TrialWaveFunction::mw_completeUpdates(wf_ref_list);
   TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
+#ifndef NDEBUG
   std::cout << "invMat next electron " << std::setprecision(14) << det_up->getPsiMinv()[0][0] << " "
             << det_up->getPsiMinv()[0][1] << " " << det_up->getPsiMinv()[1][0] << " " << det_up->getPsiMinv()[1][1]
             << " " << std::endl;
@@ -489,6 +495,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   REQUIRE(det_up->getPsiMinv()[1][0] == Approx(-54.376457060136).epsilon(1e-4));
   REQUIRE(det_up->getPsiMinv()[1][1] == Approx(45.51992500251).epsilon(1e-4));
 #endif
+#endif // NDEBUG
   std::vector<LogValueType> log_values(wf_ref_list.size());
   TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
   for (int iw = 0; iw < log_values.size(); iw++)
@@ -509,7 +516,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   for (int iw = 0; iw < log_values.size(); iw++)
     REQUIRE(LogComplexApprox(log_values[iw]) == LogValueType{wf_ref_list[iw].getLogPsi(), wf_ref_list[iw].getPhase()});
 
-#endif
+#endif // QMC_CUDA
 }
 
 TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")

--- a/src/type_traits/template_types.hpp
+++ b/src/type_traits/template_types.hpp
@@ -38,7 +38,13 @@ using UPtrVector = std::vector<std::unique_ptr<T>>;
 /** }@ */
 
 
-// temporary helper function
+/** temporary helper function you have a vector of derived class but what to pass
+ *  a vector of base class references to an API.
+ *
+ *  godbolt.org indicates at least with clang 11&12 we get RVO here.
+ *  auto ref_whatevers = makeRefVector(whatevers);
+ *  makes no extra copy.
+ */
 template<class TR, class T>
 static RefVector<TR> makeRefVector(std::vector<T>& vec_list)
 {
@@ -67,6 +73,17 @@ static RefVector<T> convertPtrToRefVector(const std::vector<T*>& ptr_list)
   RefVector<T> ref_list;
   ref_list.reserve(ptr_list.size());
   for (auto ptr : ptr_list)
+    ref_list.push_back(*ptr);
+  return ref_list;
+}
+
+// temporary helper function
+template<class T2, class T>
+static RefVector<T2> convertUPtrToRefVector(const UPtrVector<T>& ptr_list)
+{
+  RefVector<T2> ref_list;
+  ref_list.reserve(ptr_list.size());
+  for (const UPtr<T>& ptr : ptr_list)
     ref_list.push_back(*ptr);
   return ref_list;
 }


### PR DESCRIPTION
For portable accelerated Determinant inversion implementations APIs should reflect whether an argument is expected to be Dual (i.e. exist on host and accelerator) or not.

Also renaming of types and some member variables for clarity and readability.

Minimum change to existing implementation possible.

## Proposed changes
API argument changes.
Rename Refactorings

## What type(s) of changes does this code introduce?

- New feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Documentation changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
