### PR TITLE
Refactoring OperatorBase public members naming

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -176,7 +176,7 @@ used to separate words.
 Class data members
 ~~~~~~~~~~~~~~~~~~
 
-Class private/protected data members names should follow the convention of variable names with a trailing underscore (``_``).
+Class private/protected data members names should follow the convention of variable names with a trailing underscore (``_``). The use of public member functions is discourage, rethink the need for it in the first place. Instead ``get`` and ``set`` functions are the preferred access method.
 
 (Member) function names
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
+++ b/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
@@ -45,7 +45,7 @@ FullPrecRealType HamiltonianRef::evaluate(ParticleSet& P)
   {
     const auto LocalEnergyComponent = Hrefs_[i].get().evaluate(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + Hrefs_[i].get().myName + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + Hrefs_[i].get().getMyName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
   }
   return LocalEnergy;

--- a/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
+++ b/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
@@ -45,7 +45,7 @@ FullPrecRealType HamiltonianRef::evaluate(ParticleSet& P)
   {
     const auto LocalEnergyComponent = Hrefs_[i].get().evaluate(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + Hrefs_[i].get().getMyName() + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + Hrefs_[i].get().getName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
   }
   return LocalEnergy;

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -166,7 +166,7 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
     if (NumWalkersEff < MinNumWalkers * NumSamples)
     {
       WARNMSG("CostFunction-> Number of Effective Walkers is too small " << NumWalkersEff << "Minimum required"
-                                                                          << MinNumWalkers * NumSamples)
+                                                                         << MinNumWalkers * NumSamples)
       IsValid = false;
     }
   }
@@ -314,7 +314,7 @@ void QMCCostFunction::checkConfigurations()
       e2 += etmp * etmp;
       saved[ENERGY_FIXED] = hClones[ip]->getLocalPotential();
       if (nlpp)
-        saved[ENERGY_FIXED] -= nlpp->Value;
+        saved[ENERGY_FIXED] -= nlpp->getValue();
     }
     //add them all using reduction
     et_tot += e0;
@@ -460,7 +460,7 @@ void QMCCostFunction::engine_checkConfigurations(cqmc::engine::LMYEngine<Return_
       e2 += etmp * etmp;
       saved[ENERGY_FIXED] = hClones[ip]->getLocalPotential();
       if (nlpp)
-        saved[ENERGY_FIXED] -= nlpp->Value;
+        saved[ENERGY_FIXED] -= nlpp->getValue();
     }
 
     //add them all using reduction

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -386,7 +386,7 @@ void QMCCostFunctionBatched::checkConfigurations()
           if (includeNonlocalH != "no")
           {
             OperatorBase* nlpp = h_list[ib].getHamiltonian(includeNonlocalH);
-            RecordsOnNode[is][ENERGY_FIXED] -= nlpp->Value;
+            RecordsOnNode[is][ENERGY_FIXED] -= nlpp->getValue();
           }
         }
       }

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -29,8 +29,8 @@ ACForce::ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& ps
       useSpaceWarp(false),
       swt(target, source)
 {
-  prefix   = "ACForce";
-  my_name_ = prefix;
+  prefix = "ACForce";
+  name_  = prefix;
 
   hf_force.resize(Nions);
   pulay_force.resize(Nions);
@@ -80,7 +80,7 @@ void ACForce::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamilt
   std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi, ham_in);
   if (myclone)
   {
-    ham_in.addOperator(std::move(myclone), my_name_, update_mode_[PHYSICAL]);
+    ham_in.addOperator(std::move(myclone), name_, update_mode_[PHYSICAL]);
   }
 }
 ACForce::Return_t ACForce::evaluate(ParticleSet& P)

--- a/src/QMCHamiltonians/ACForce.cpp
+++ b/src/QMCHamiltonians/ACForce.cpp
@@ -29,8 +29,8 @@ ACForce::ACForce(ParticleSet& source, ParticleSet& target, TrialWaveFunction& ps
       useSpaceWarp(false),
       swt(target, source)
 {
-  prefix = "ACForce";
-  myName = prefix;
+  prefix   = "ACForce";
+  my_name_ = prefix;
 
   hf_force.resize(Nions);
   pulay_force.resize(Nions);
@@ -80,7 +80,7 @@ void ACForce::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamilt
   std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi, ham_in);
   if (myclone)
   {
-    ham_in.addOperator(std::move(myclone), myName, UpdateMode[PHYSICAL]);
+    ham_in.addOperator(std::move(myclone), my_name_, update_mode_[PHYSICAL]);
   }
 }
 ACForce::Return_t ACForce::evaluate(ParticleSet& P)
@@ -92,7 +92,7 @@ ACForce::Return_t ACForce::evaluate(ParticleSet& P)
   sw_grad     = 0;
   //This function returns d/dR of the sum of all observables in the physical hamiltonian.
   //Note that the sign will be flipped based on definition of force = -d/dR.
-  Value = ham.evaluateIonDerivs(P, ions, psi, hf_force, pulay_force, wf_grad);
+  value_ = ham.evaluateIonDerivs(P, ions, psi, hf_force, pulay_force, wf_grad);
 
   if (useSpaceWarp)
   {
@@ -155,7 +155,7 @@ void ACForce::setObservables(PropertySetType& plist)
       // add the minus one to be a force.
       plist[myindex++] = -hf_force[iat][iondim];
       plist[myindex++] = -(pulay_force[iat][iondim] + sw_pulay[iat][iondim]);
-      plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
+      plist[myindex++] = -value_ * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
 
       //TODO: Remove when ACForce is production ready
@@ -177,7 +177,7 @@ void ACForce::setParticlePropertyList(PropertySetType& plist, int offset)
     {
       plist[myindex++] = -hf_force[iat][iondim];
       plist[myindex++] = -(pulay_force[iat][iondim] + sw_pulay[iat][iondim]);
-      plist[myindex++] = -Value * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
+      plist[myindex++] = -value_ * (wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       plist[myindex++] = -(wf_grad[iat][iondim] + sw_grad[iat][iondim]);
       //TODO: Remove when ACForce is production ready
       //      if(useSpaceWarp)

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -38,7 +38,7 @@ using Return_t = BareKineticEnergy::Return_t;
    */
 BareKineticEnergy::BareKineticEnergy(ParticleSet& p) : Ps(p)
 {
-  set_energy_domain(kinetic);
+  set_energy_domain(KINETIC);
   one_body_quantum_domain(p);
   streaming_kinetic      = false;
   streaming_kinetic_comp = false;

--- a/src/QMCHamiltonians/ChiesaCorrection.cpp
+++ b/src/QMCHamiltonians/ChiesaCorrection.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<OperatorBase> ChiesaCorrection::makeClone(ParticleSet& qp, Trial
   return std::make_unique<ChiesaCorrection>(qp, psi);
 }
 
-ChiesaCorrection::Return_t ChiesaCorrection::evaluate(ParticleSet& P) { return Value = psi_ref.KECorrection(); }
+ChiesaCorrection::Return_t ChiesaCorrection::evaluate(ParticleSet& P) { return value_ = psi_ref.KECorrection(); }
 #ifdef QMC_CUDA
 void ChiesaCorrection::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
 {

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -83,9 +83,9 @@ struct ConservedEnergy : public OperatorBase
     RealType lap    = Sum(P.L);
 #ifdef QMC_COMPLEX
     RealType gradsq_cc = Dot_CC(P.G, P.G);
-    Value              = lap + gradsq + gradsq_cc;
+    value_             = lap + gradsq + gradsq_cc;
 #else
-    Value = lap + 2 * gradsq;
+    value_ = lap + 2 * gradsq;
 #endif
     return 0.0;
   }

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -62,7 +62,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
     }
 
     RealType Vii_ref        = ewaldref::ewaldEnergy(A, R, Q);
-    RealType Vdiff_per_atom = std::abs(Value - Vii_ref) / NumCenters;
+    RealType Vdiff_per_atom = std::abs(value_ - Vii_ref) / NumCenters;
     app_log() << "Checking ion-ion Ewald energy against reference..." << std::endl;
     if (Vdiff_per_atom > Ps.Lattice.LR_tol)
     {
@@ -71,9 +71,9 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       msg << "in ion-ion Ewald energy exceeds " << Ps.Lattice.LR_tol << " Ha/atom tolerance." << std::endl;
       msg << std::endl;
       msg << "  Reference ion-ion energy: " << Vii_ref << std::endl;
-      msg << "  QMCPACK   ion-ion energy: " << Value << std::endl;
-      msg << "            ion-ion diff  : " << Value - Vii_ref << std::endl;
-      msg << "            diff/atom     : " << (Value - Vii_ref) / NumCenters << std::endl;
+      msg << "  QMCPACK   ion-ion energy: " << value_ << std::endl;
+      msg << "            ion-ion diff  : " << value_ - Vii_ref << std::endl;
+      msg << "            diff/atom     : " << (value_ - Vii_ref) / NumCenters << std::endl;
       msg << "            tolerance     : " << Ps.Lattice.LR_tol << std::endl;
       msg << std::endl;
       msg << "Please try increasing the LR_dim_cutoff parameter in the <simulationcell/>" << std::endl;
@@ -94,7 +94,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
   app_log() << "  Maximum K shell " << AA->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << AA->Fk.size() << std::endl;
   app_log() << "  Fixed Coulomb potential for " << ref.getName();
-  app_log() << "\n    e-e Madelung Const. =" << MC0 << "\n    Vtot     =" << Value << std::endl;
+  app_log() << "\n    e-e Madelung Const. =" << MC0 << "\n    Vtot     =" << value_ << std::endl;
 }
 
 CoulombPBCAA::~CoulombPBCAA() = default;
@@ -120,7 +120,7 @@ void CoulombPBCAA::update_source(ParticleSet& s)
     eL = evalLR(s);
     eS = evalSR(s);
   }
-  NewValue = Value = eL + eS + myConst;
+  NewValue = value_ = eL + eS + myConst;
 }
 
 void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
@@ -134,15 +134,15 @@ void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAA::contribute_particle_quantities() { request.contribute_array(myName); }
+void CoulombPBCAA::contribute_particle_quantities() { request_.contribute_array(my_name_); }
 
 void CoulombPBCAA::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request.streaming_array(myName);
+  streaming_particles = request_.streaming_array(my_name_);
   if (streaming_particles)
   {
     Ps.turnOnPerParticleSK();
-    V_sample = tm.checkout_real<1>(myName, Ps);
+    V_sample = tm.checkout_real<1>(my_name_, Ps);
     if (!is_active)
       evaluate_sp(Ps);
   }
@@ -162,12 +162,12 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate(ParticleSet& P)
   {
 #if !defined(REMOVE_TRACEMANAGER)
     if (streaming_particles)
-      Value = evaluate_sp(P);
+      value_ = evaluate_sp(P);
     else
 #endif
-      Value = evalLR(P) + evalSR(P) + myConst;
+      value_ = evalLR(P) + evalSR(P) + myConst;
   }
-  return Value;
+  return value_;
 }
 
 CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
@@ -179,7 +179,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluateWithIonDerivs(ParticleSet& P,
   if (ComputeForces and !is_active)
     hf_terms -= forces;
   //No pulay term.
-  return Value;
+  return value_;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -242,7 +242,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate_sp(ParticleSet& P)
   }
   for (int i = 0; i < V_samp.size(); ++i)
     V_samp(i) += V_const(i);
-  Value = Vsr + Vlr + Vc;
+  value_ = Vsr + Vlr + Vc;
 #if defined(TRACE_CHECK)
   RealType Vlrnow = evalLR(P);
   RealType Vsrnow = evalSR(P);
@@ -265,7 +265,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate_sp(ParticleSet& P)
     APP_ABORT("Trace check failed");
   }
 #endif
-  return Value;
+  return value_;
 }
 #endif
 

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -134,15 +134,15 @@ void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAA::contribute_particle_quantities() { request_.contribute_array(my_name_); }
+void CoulombPBCAA::contribute_particle_quantities() { request_.contribute_array(name_); }
 
 void CoulombPBCAA::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(my_name_);
+  streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
   {
     Ps.turnOnPerParticleSK();
-    V_sample = tm.checkout_real<1>(my_name_, Ps);
+    V_sample = tm.checkout_real<1>(name_, Ps);
     if (!is_active)
       evaluate_sp(Ps);
   }

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -32,7 +32,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       d_aa_ID(ref.addTable(ref))
 {
   ReportEngine PRE("CoulombPBCAA", "CoulombPBCAA");
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ref);
   PtclRefName = ref.getDistTable(d_aa_ID).getName();
   initBreakup(ref);

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -91,8 +91,8 @@ void CoulombPBCAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   {
     for (int iw = 0; iw < walkers.size(); iw++)
     {
-      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = Value;
-      LocalEnergy[iw] += Value;
+      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+      LocalEnergy[iw] += value_;
     }
     return;
   }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -62,24 +62,24 @@ void CoulombPBCAB::resetTargetParticleSet(ParticleSet& P)
 
 void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(myName.c_str());
+  myIndex = plist.add(my_name_.c_str());
   if (ComputeForces)
     addObservablesF(plist);
 }
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAB::contribute_particle_quantities() { request.contribute_array(myName); }
+void CoulombPBCAB::contribute_particle_quantities() { request_.contribute_array(my_name_); }
 
 void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request.streaming_array(myName);
+  streaming_particles = request_.streaming_array(my_name_);
   if (streaming_particles)
   {
     Pion.turnOnPerParticleSK();
     Peln.turnOnPerParticleSK();
-    Ve_sample = tm.checkout_real<1>(myName, Peln);
-    Vi_sample = tm.checkout_real<1>(myName, Pion);
+    Ve_sample = tm.checkout_real<1>(my_name_, Peln);
+    Vi_sample = tm.checkout_real<1>(my_name_, Pion);
   }
 }
 
@@ -99,16 +99,16 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   if (ComputeForces)
   {
     forces = 0.0;
-    Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
+    value_ = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
   }
   else
 #if !defined(REMOVE_TRACEMANAGER)
       if (streaming_particles)
-    Value = evaluate_sp(P);
+    value_ = evaluate_sp(P);
   else
 #endif
-    Value = evalLR(P) + evalSR(P) + myConst;
-  return Value;
+    value_ = evalLR(P) + evalSR(P) + myConst;
+  return value_;
 }
 
 CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
@@ -120,13 +120,13 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluateWithIonDerivs(ParticleSet& P,
   if (ComputeForces)
   {
     forces = 0.0;
-    Value  = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
+    value_ = evalLRwithForces(P) + evalSRwithForces(P) + myConst;
     hf_terms -= forces;
     //And no Pulay contribution.
   }
   else
-    Value = evalLR(P) + evalSR(P) + myConst;
-  return Value;
+    value_ = evalLR(P) + evalSR(P) + myConst;
+  return value_;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
@@ -210,7 +210,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
     Ve_samp(i) += Ve_const(i);
   for (int i = 0; i < Vi_samp.size(); ++i)
     Vi_samp(i) += Vi_const(i);
-  Value = Vsr + Vlr + Vc;
+  value_ = Vsr + Vlr + Vc;
 #if defined(TRACE_CHECK)
   RealType Vlrnow = evalLR(P);
   RealType Vsrnow = evalSR(P);
@@ -250,7 +250,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
   }
 
 #endif
-  return Value;
+  return value_;
 }
 #endif
 

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -32,7 +32,7 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
       Peln(elns)
 {
   ReportEngine PRE("CoulombPBCAB", "CoulombPBCAB");
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ions, elns);
   if (ComputeForces)
     PtclA.turnOnPerParticleSK();
@@ -181,7 +181,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesA; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Zspec[s] * q *
-              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i], RhoKB.eikr_i[i]);
+              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i],
+                           RhoKB.eikr_i[i]);
 #else
           v1 += Zspec[s] * q * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
 #endif
@@ -195,7 +196,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesB; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Qspec[s] * q *
-              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i], RhoKA.eikr_i[i]);
+              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i],
+                           RhoKA.eikr_i[i]);
 #else
           v1 += Qspec[s] * q * AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
 #endif
@@ -331,7 +333,8 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
 #if !defined(USE_REAL_STRUCT_FACTOR)
       const int slab_dir = OHMMS_DIM - 1;
       for (int nn = d_ab.M[iat], jat = 0; nn < d_ab.M[iat + 1]; ++nn, ++jat)
-        u += Qat[jat] * AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
+        u += Qat[jat] *
+            AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -62,24 +62,24 @@ void CoulombPBCAB::resetTargetParticleSet(ParticleSet& P)
 
 void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(my_name_.c_str());
+  myIndex = plist.add(name_.c_str());
   if (ComputeForces)
     addObservablesF(plist);
 }
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAB::contribute_particle_quantities() { request_.contribute_array(my_name_); }
+void CoulombPBCAB::contribute_particle_quantities() { request_.contribute_array(name_); }
 
 void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(my_name_);
+  streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
   {
     Pion.turnOnPerParticleSK();
     Peln.turnOnPerParticleSK();
-    Ve_sample = tm.checkout_real<1>(my_name_, Peln);
-    Vi_sample = tm.checkout_real<1>(my_name_, Pion);
+    Ve_sample = tm.checkout_real<1>(name_, Peln);
+    Vi_sample = tm.checkout_real<1>(name_, Pion);
   }
 }
 

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -72,7 +72,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(computeForces)
   {
-    set_energy_domain(potential);
+    set_energy_domain(POTENTIAL);
     two_body_quantum_domain(s, s);
     nCenters = s.getTotalNum();
     prefix   = "F_AA";
@@ -102,7 +102,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(false)
   {
-    set_energy_domain(potential);
+    set_energy_domain(POTENTIAL);
     two_body_quantum_domain(s, t);
     nCenters = s.getTotalNum();
   }
@@ -406,7 +406,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       {
         W.loadWalker(*walkers[iw], false);
         W.update();
-        Value = evaluate(W);
+        Value                                                       = evaluate(W);
         walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = Value;
         LocalEnergy[iw] += Value;
       }

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -81,7 +81,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     {
       if (!copy)
         s.update();
-      Value = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
+      value_ = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
       if (ComputeForces)
         evaluateAAForces(s.getDistTable(myTableIndex), s.Z.first_address());
     }
@@ -108,17 +108,17 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   }
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override { request.contribute_array(myName); }
+  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request.streaming_array(myName);
+    streaming_particles = request_.streaming_array(my_name_);
     if (streaming_particles)
     {
-      Va_sample = tm.checkout_real<1>(myName, Pa);
+      Va_sample = tm.checkout_real<1>(my_name_, Pa);
       if (!is_AA)
       {
-        Vb_sample = tm.checkout_real<1>(myName, Pb);
+        Vb_sample = tm.checkout_real<1>(my_name_, Pb);
       }
       else if (!is_active)
         evaluate_spAA(Pa.getDistTable(myTableIndex), Pa.Z.first_address());
@@ -327,7 +327,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   {
     if (is_AA)
     {
-      Value = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
+      value_ = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
     }
   }
 
@@ -336,11 +336,11 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     if (is_active)
     {
       if (is_AA)
-        Value = evaluateAA(P.getDistTable(myTableIndex), P.Z.first_address());
+        value_ = evaluateAA(P.getDistTable(myTableIndex), P.Z.first_address());
       else
-        Value = evaluateAB(P.getDistTable(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
+        value_ = evaluateAB(P.getDistTable(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
     }
-    return Value;
+    return value_;
   }
 
   inline Return_t evaluateWithIonDerivs(ParticleSet& P,
@@ -350,10 +350,10 @@ struct CoulombPotential : public OperatorBase, public ForceBase
                                         ParticleSet::ParticlePos_t& pulay_terms) override
   {
     if (is_active)
-      Value = evaluate(P); // No forces for the active
+      value_ = evaluate(P); // No forces for the active
     else
       hf_terms -= forces; // No Pulay here
-    return Value;
+    return value_;
   }
 
   bool put(xmlNodePtr cur) override { return true; }
@@ -406,17 +406,17 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       {
         W.loadWalker(*walkers[iw], false);
         W.update();
-        Value                                                       = evaluate(W);
-        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = Value;
-        LocalEnergy[iw] += Value;
+        value_                                                      = evaluate(W);
+        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+        LocalEnergy[iw] += value_;
       }
     }
     else
       // assuminig the same results for all the walkers when the set is not active
       for (int iw = 0; iw < LocalEnergy.size(); iw++)
       {
-        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = Value;
-        LocalEnergy[iw] += Value;
+        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+        LocalEnergy[iw] += value_;
       }
   }
 };

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -108,17 +108,17 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   }
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
+  void contribute_particle_quantities() override { request_.contribute_array(name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(my_name_);
+    streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
     {
-      Va_sample = tm.checkout_real<1>(my_name_, Pa);
+      Va_sample = tm.checkout_real<1>(name_, Pa);
       if (!is_AA)
       {
-        Vb_sample = tm.checkout_real<1>(my_name_, Pb);
+        Vb_sample = tm.checkout_real<1>(name_, Pb);
       }
       else if (!is_active)
         evaluate_spAA(Pa.getDistTable(myTableIndex), Pa.Z.first_address());

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -30,7 +30,7 @@ typedef LRCoulombSingleton::RadFunctorType RadFunctorType;
 
 DensityEstimator::DensityEstimator(ParticleSet& elns)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   Periodic = (elns.Lattice.SuperCellEnum != SUPERCELL_OPEN);
   for (int dim = 0; dim < OHMMS_DIM; ++dim)
   {
@@ -124,7 +124,7 @@ void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5des
   std::vector<int> ng(OHMMS_DIM);
   for (int i = 0; i < OHMMS_DIM; ++i)
     ng[i] = NumGrids[i];
-  h5desc.emplace_back(myName);
+  h5desc.emplace_back(my_name_);
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ng, myIndex);
   h5o.open(gid);
@@ -172,7 +172,7 @@ bool DensityEstimator::put(xmlNodePtr cur)
 
 bool DensityEstimator::get(std::ostream& os) const
 {
-  os << myName << " bin =" << Delta << " bohrs " << std::endl;
+  os << my_name_ << " bin =" << Delta << " bohrs " << std::endl;
   return true;
 }
 

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -124,7 +124,7 @@ void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5des
   std::vector<int> ng(OHMMS_DIM);
   for (int i = 0; i < OHMMS_DIM; ++i)
     ng[i] = NumGrids[i];
-  h5desc.emplace_back(my_name_);
+  h5desc.emplace_back(name_);
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ng, myIndex);
   h5o.open(gid);
@@ -172,7 +172,7 @@ bool DensityEstimator::put(xmlNodePtr cur)
 
 bool DensityEstimator::get(std::ostream& os) const
 {
-  os << my_name_ << " bin =" << Delta << " bohrs " << std::endl;
+  os << name_ << " bin =" << Delta << " bohrs " << std::endl;
   return true;
 }
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -546,7 +546,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   int nentries = ng[0] * ng[1];
 #endif
 
-  std::string dname = my_name_;
+  std::string dname = name_;
   hid_t dgid        = H5Gcreate(gid, dname.c_str(), 0);
 
   std::string nname = "number_matrix";

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -82,7 +82,7 @@ void DensityMatrices1B::reset()
   eindex         = -1;
   uniform_random = NULL;
   // basic HamiltonianBase info
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   // default values
   energy_mat             = false;
   integrator             = uniform_grid;
@@ -104,13 +104,13 @@ void DensityMatrices1B::reset()
   check_overlap          = false;
   check_derivatives      = false;
   // trace data is required
-  request.request_scalar("weight");
-  request.request_array("Kinetic_complex");
-  request.request_array("Vq");
-  request.request_array("Vc");
-  request.request_array("Vqq");
-  request.request_array("Vqc");
-  request.request_array("Vcc");
+  request_.request_scalar("weight");
+  request_.request_array("Kinetic_complex");
+  request_.request_array("Vq");
+  request_.request_array("Vc");
+  request_.request_array("Vqq");
+  request_.request_array("Vqc");
+  request_.request_array("Vcc");
   // has not been initialized
   initialized = false;
 }
@@ -546,7 +546,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   int nentries = ng[0] * ng[1];
 #endif
 
-  std::string dname = myName;
+  std::string dname = my_name_;
   hid_t dgid        = H5Gcreate(gid, dname.c_str(), 0);
 
   std::string nname = "number_matrix";

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -53,11 +53,11 @@ bool EnergyDensityEstimator::put(xmlNodePtr cur)
 {
   input_xml = cur;
   //initialize simple xml attributes
-  my_name_ = "EnergyDensity";
+  name_ = "EnergyDensity";
   std::string dyn, stat = "";
   ion_points = false;
   OhmmsAttributeSet attrib;
-  attrib.add(my_name_, "name");
+  attrib.add(name_, "name");
   attrib.add(dyn, "dynamic");
   attrib.add(stat, "static");
   attrib.add(ion_points, "ion_points");
@@ -480,7 +480,7 @@ void EnergyDensityEstimator::addObservables(PropertySetType& plist, BufferType& 
 
 void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t g = H5Gcreate(gid, my_name_.c_str(), 0);
+  hid_t g = H5Gcreate(gid, name_.c_str(), 0);
   h5desc.emplace_back("variables");
   auto& oh = h5desc.back();
   oh.open(g);

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -26,14 +26,14 @@ namespace qmcplusplus
 EnergyDensityEstimator::EnergyDensityEstimator(PSPool& PSP, const std::string& defaultKE)
     : psetpool(PSP), Pdynamic(0), Pstatic(0), w_trace(0), Td_trace(0), Vd_trace(0), Vs_trace(0)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   defKE      = defaultKE;
   nsamples   = 0;
   ion_points = false;
   nions      = -1;
-  request.request_scalar("weight");
-  request.request_array("Kinetic");
-  request.request_array("LocalPotential");
+  request_.request_scalar("weight");
+  request_.request_array("Kinetic");
+  request_.request_array("LocalPotential");
 }
 
 
@@ -53,11 +53,11 @@ bool EnergyDensityEstimator::put(xmlNodePtr cur)
 {
   input_xml = cur;
   //initialize simple xml attributes
-  myName = "EnergyDensity";
+  my_name_ = "EnergyDensity";
   std::string dyn, stat = "";
   ion_points = false;
   OhmmsAttributeSet attrib;
-  attrib.add(myName, "name");
+  attrib.add(my_name_, "name");
   attrib.add(dyn, "dynamic");
   attrib.add(stat, "static");
   attrib.add(ion_points, "ion_points");
@@ -480,7 +480,7 @@ void EnergyDensityEstimator::addObservables(PropertySetType& plist, BufferType& 
 
 void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t g = H5Gcreate(gid, myName.c_str(), 0);
+  hid_t g = H5Gcreate(gid, my_name_.c_str(), 0);
   h5desc.emplace_back("variables");
   auto& oh = h5desc.back();
   oh.open(g);

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -137,8 +137,8 @@ void ForceBase::setParticleSetStress(QMCTraits::PropertySetType& plist, int offs
 
 BareForce::BareForce(ParticleSet& ions, ParticleSet& elns) : ForceBase(ions, elns), d_ei_ID(elns.addTable(ions))
 {
-  my_name_ = "HF_Force_Base";
-  prefix   = "HFBase";
+  name_  = "HF_Force_Base";
+  prefix = "HFBase";
 }
 
 void BareForce::resetTargetParticleSet(ParticleSet& P) {}

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -137,8 +137,8 @@ void ForceBase::setParticleSetStress(QMCTraits::PropertySetType& plist, int offs
 
 BareForce::BareForce(ParticleSet& ions, ParticleSet& elns) : ForceBase(ions, elns), d_ei_ID(elns.addTable(ions))
 {
-  myName = "HF_Force_Base";
-  prefix = "HFBase";
+  my_name_ = "HF_Force_Base";
+  prefix   = "HFBase";
 }
 
 void BareForce::resetTargetParticleSet(ParticleSet& P) {}

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -29,8 +29,8 @@ ForceCeperley::ForceCeperley(ParticleSet& ions, ParticleSet& elns)
     : ForceBase(ions, elns), d_aa_ID(ions.addTable(ions)), d_ei_ID(elns.addTable(ions))
 {
   ReportEngine PRE("ForceCeperley", "ForceCeperley");
-  myName = "Ceperley_Force_Base";
-  prefix = "HFCep";
+  my_name_ = "Ceperley_Force_Base";
+  prefix   = "HFCep";
   // Defaults
   Rcut    = 0.4;
   m_exp   = 2;

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -29,8 +29,8 @@ ForceCeperley::ForceCeperley(ParticleSet& ions, ParticleSet& elns)
     : ForceBase(ions, elns), d_aa_ID(ions.addTable(ions)), d_ei_ID(elns.addTable(ions))
 {
   ReportEngine PRE("ForceCeperley", "ForceCeperley");
-  my_name_ = "Ceperley_Force_Base";
-  prefix   = "HFCep";
+  name_  = "Ceperley_Force_Base";
+  prefix = "HFCep";
   // Defaults
   Rcut    = 0.4;
   m_exp   = 2;

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -30,8 +30,8 @@ ForceChiesaPBCAA::ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool fi
       d_ei_ID(elns.addTable(ions))
 {
   ReportEngine PRE("ForceChiesaPBCAA", "ForceChiesaPBCAA");
-  my_name_ = "Chiesa_Force_Base_PBCAB";
-  prefix   = "FChiesaPBC";
+  name_  = "Chiesa_Force_Base_PBCAB";
+  prefix = "FChiesaPBC";
   //Defaults for the chiesa S-wave polynomial filtering.
   Rcut          = 0.4;
   m_exp         = 2;
@@ -227,7 +227,7 @@ void ForceChiesaPBCAA::resetTargetParticleSet(ParticleSet& P) { dAB->resetTarget
 
 void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(my_name_.c_str());
+  myIndex = plist.add(name_.c_str());
   addObservablesF(plist);
 }
 

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -30,8 +30,8 @@ ForceChiesaPBCAA::ForceChiesaPBCAA(ParticleSet& ions, ParticleSet& elns, bool fi
       d_ei_ID(elns.addTable(ions))
 {
   ReportEngine PRE("ForceChiesaPBCAA", "ForceChiesaPBCAA");
-  myName = "Chiesa_Force_Base_PBCAB";
-  prefix = "FChiesaPBC";
+  my_name_ = "Chiesa_Force_Base_PBCAB";
+  prefix   = "FChiesaPBC";
   //Defaults for the chiesa S-wave polynomial filtering.
   Rcut          = 0.4;
   m_exp         = 2;
@@ -227,7 +227,7 @@ void ForceChiesaPBCAA::resetTargetParticleSet(ParticleSet& P) { dAB->resetTarget
 
 void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(myName.c_str());
+  myIndex = plist.add(my_name_.c_str());
   addObservablesF(plist);
 }
 

--- a/src/QMCHamiltonians/ForwardWalking.h
+++ b/src/QMCHamiltonians/ForwardWalking.h
@@ -34,7 +34,7 @@ struct ForwardWalking : public OperatorBase
 
   /** constructor
    */
-  ForwardWalking() { UpdateMode.set(OPTIMIZABLE, 1); }
+  ForwardWalking() { update_mode_.set(OPTIMIZABLE, 1); }
 
   ///destructor
   ~ForwardWalking() override {}

--- a/src/QMCHamiltonians/GridExternalPotential.cpp
+++ b/src/QMCHamiltonians/GridExternalPotential.cpp
@@ -107,11 +107,11 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
   if (streaming_particles)
-    Value = evaluate_sp(P);
+    value_ = evaluate_sp(P);
   else
   {
 #endif
-    Value = 0.0;
+    value_ = 0.0;
     for (int i = 0; i < P.getTotalNum(); ++i)
     {
       PosType r = P.R[i];
@@ -119,12 +119,12 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
       double val = 0.0;
       eval_UBspline_3d_d(spline_data.get(), r[0], r[1], r[2], &val);
 
-      Value += val;
+      value_ += val;
     }
 #if !defined(REMOVE_TRACEMANAGER)
   }
 #endif
-  return Value;
+  return value_;
 }
 
 
@@ -132,15 +132,15 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 GridExternalPotential::Return_t GridExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  Value                       = 0.0;
+  value_                       = 0.0;
   for (int i = 0; i < P.getTotalNum(); ++i)
   {
     PosType r   = P.R[i];
     RealType v1 = dot(r, r);
     V_samp(i)   = v1;
-    Value += v1;
+    value_ += v1;
   }
-  return Value;
+  return value_;
 }
 #endif
 

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -56,13 +56,13 @@ struct GridExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request.contribute_array(myName); }
+  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request.streaming_array(myName);
+    streaming_particles = request_.streaming_array(my_name_);
     if (streaming_particles)
-      V_sample = tm.checkout_real<1>(myName, Ps);
+      V_sample = tm.checkout_real<1>(my_name_, Ps);
   }
 
   void delete_particle_quantities() override

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -56,13 +56,13 @@ struct GridExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
+  void contribute_particle_quantities() override { request_.contribute_array(name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(my_name_);
+    streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
-      V_sample = tm.checkout_real<1>(my_name_, Ps);
+      V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
   void delete_particle_quantities() override

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -38,7 +38,7 @@ struct GridExternalPotential : public OperatorBase
   //construction/destruction
   GridExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(potential);
+    set_energy_domain(POTENTIAL);
     one_body_quantum_domain(P);
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.cpp
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.cpp
@@ -64,21 +64,21 @@ HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(Particle
 {
 #if !defined(REMOVE_TRACEMANAGER)
   if (streaming_particles)
-    Value = evaluate_sp(P);
+    value_ = evaluate_sp(P);
   else
   {
 #endif
-    Value              = 0.0;
+    value_              = 0.0;
     RealType prefactor = .5 * energy / (length * length);
     for (int i = 0; i < P.getTotalNum(); ++i)
     {
       PosType r = P.R[i] - center;
-      Value += prefactor * dot(r, r);
+      value_ += prefactor * dot(r, r);
     }
 #if !defined(REMOVE_TRACEMANAGER)
   }
 #endif
-  return Value;
+  return value_;
 }
 
 
@@ -86,16 +86,16 @@ HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(Particle
 HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  Value                       = 0.0;
+  value_                       = 0.0;
   RealType prefactor          = .5 * energy / (length * length);
   for (int i = 0; i < P.getTotalNum(); ++i)
   {
     PosType r   = P.R[i] - center;
     RealType v1 = prefactor * dot(r, r);
     V_samp(i)   = v1;
-    Value += v1;
+    value_ += v1;
   }
-  return Value;
+  return value_;
 }
 #endif
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -36,7 +36,7 @@ struct HarmonicExternalPotential : public OperatorBase
   //construction/destruction
   HarmonicExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(potential);
+    set_energy_domain(POTENTIAL);
     one_body_quantum_domain(P);
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -56,13 +56,13 @@ struct HarmonicExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
+  void contribute_particle_quantities() override { request_.contribute_array(name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(my_name_);
+    streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
-      V_sample = tm.checkout_real<1>(my_name_, Ps);
+      V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
   void delete_particle_quantities() override

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -56,13 +56,13 @@ struct HarmonicExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request.contribute_array(myName); }
+  void contribute_particle_quantities() override { request_.contribute_array(my_name_); }
 
   void checkout_particle_quantities(TraceManager& tm) override
   {
-    streaming_particles = request.streaming_array(myName);
+    streaming_particles = request_.streaming_array(my_name_);
     if (streaming_particles)
-      V_sample = tm.checkout_real<1>(myName, Ps);
+      V_sample = tm.checkout_real<1>(my_name_, Ps);
   }
 
   void delete_particle_quantities() override

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -18,7 +18,7 @@ namespace qmcplusplus
 {
 L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi) : IonConfig(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -62,7 +62,7 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
 
   // compute v_L2(r)*L^2 for all electron-ion pairs
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value_              = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -87,9 +87,9 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
         esum += v * PP[iat]->evaluate(dist[iat]);
       }
     }
-    Value += esum;
+    value_ += esum;
   }
-  return Value;
+  return value_;
 }
 
 

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -67,7 +67,7 @@ bool LatticeDeviationEstimator::put(xmlNodePtr cur)
   {
     // change the default behavior of addValue() called by addObservables()
     // YY: does this still matter if I have overwritten addObservables()?
-    UpdateMode.set(COLLECTABLE, 1);
+    update_mode_.set(COLLECTABLE, 1);
   }
 
   if (xyz_flag == "yes")
@@ -89,13 +89,13 @@ bool LatticeDeviationEstimator::put(xmlNodePtr cur)
 
 bool LatticeDeviationEstimator::get(std::ostream& os) const
 { // class description
-  os << "LatticeDeviationEstimator: " << myName << "lattice = " << spset.getName();
+  os << "LatticeDeviationEstimator: " << my_name_ << "lattice = " << spset.getName();
   return true;
 }
 
 LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(ParticleSet& P)
 { // calculate <r^2> averaged over lattice sites
-  Value = 0.0;
+  value_ = 0.0;
   std::fill(xyz2.begin(), xyz2.end(), 0.0);
 
   RealType wgt        = tWalker->Weight;
@@ -118,7 +118,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
           // distance between particle iat in source pset, and jat in target pset
           r  = d_table.getDistRow(jat)[iat];
           r2 = r * r;
-          Value += r2;
+          value_ += r2;
 
           if (hdf5_out & !per_xyz)
           { // store deviration for each lattice site if h5 file is available
@@ -154,7 +154,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   }
 
   // average per site
-  Value /= num_sites;
+  value_ /= num_sites;
   if (per_xyz)
   {
     for (int idir = 0; idir < OHMMS_DIM; idir++)
@@ -163,7 +163,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
     }
   }
 
-  return Value;
+  return value_;
 }
 
 void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferType& collectables)
@@ -176,12 +176,12 @@ void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferTyp
     {
       std::stringstream ss;
       ss << idir;
-      plist.add(myName + "_dir" + ss.str());
+      plist.add(my_name_ + "_dir" + ss.str());
     }
   }
   else
   {
-    myIndex = plist.add(myName); // same as OperatorBase::addObservables
+    myIndex = plist.add(my_name_); // same as OperatorBase::addObservables
   }
 
   // get h5_index for stat.h5
@@ -209,7 +209,7 @@ void LatticeDeviationEstimator::setObservables(PropertySetType& plist)
   }
   else
   {
-    plist[myIndex] = Value; // default behavior
+    plist[myIndex] = value_; // default behavior
   }
 }
 
@@ -238,7 +238,7 @@ void LatticeDeviationEstimator::registerCollectables(std::vector<ObservableHelpe
     }
 
     // open hdf5 entry and resize
-    h5desc.emplace_back(myName);
+    h5desc.emplace_back(my_name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, h5_index);
     h5o.open(gid);

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -89,7 +89,7 @@ bool LatticeDeviationEstimator::put(xmlNodePtr cur)
 
 bool LatticeDeviationEstimator::get(std::ostream& os) const
 { // class description
-  os << "LatticeDeviationEstimator: " << my_name_ << "lattice = " << spset.getName();
+  os << "LatticeDeviationEstimator: " << name_ << "lattice = " << spset.getName();
   return true;
 }
 
@@ -176,12 +176,12 @@ void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferTyp
     {
       std::stringstream ss;
       ss << idir;
-      plist.add(my_name_ + "_dir" + ss.str());
+      plist.add(name_ + "_dir" + ss.str());
     }
   }
   else
   {
-    myIndex = plist.add(my_name_); // same as OperatorBase::addObservables
+    myIndex = plist.add(name_); // same as OperatorBase::addObservables
   }
 
   // get h5_index for stat.h5
@@ -238,7 +238,7 @@ void LatticeDeviationEstimator::registerCollectables(std::vector<ObservableHelpe
     }
 
     // open hdf5 entry and resize
-    h5desc.emplace_back(my_name_);
+    h5desc.emplace_back(name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, h5_index);
     h5o.open(gid);

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -58,15 +58,15 @@ void LocalECPotential::add(int groupID, std::unique_ptr<RadialPotentialType>&& p
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void LocalECPotential::contribute_particle_quantities() { request.contribute_array(myName); }
+void LocalECPotential::contribute_particle_quantities() { request_.contribute_array(my_name_); }
 
 void LocalECPotential::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request.streaming_array(myName);
+  streaming_particles = request_.streaming_array(my_name_);
   if (streaming_particles)
   {
-    Ve_sample = tm.checkout_real<1>(myName, Peln);
-    Vi_sample = tm.checkout_real<1>(myName, Pion);
+    Ve_sample = tm.checkout_real<1>(my_name_, Peln);
+    Vi_sample = tm.checkout_real<1>(my_name_, Pion);
   }
 }
 
@@ -85,12 +85,12 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
   if (streaming_particles)
-    Value = evaluate_sp(P);
+    value_ = evaluate_sp(P);
   else
 #endif
   {
     const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-    Value              = 0.0;
+    value_             = 0.0;
     const size_t Nelec = P.getTotalNum();
     for (size_t iel = 0; iel < Nelec; ++iel)
     {
@@ -99,10 +99,10 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
       for (size_t iat = 0; iat < NumIons; ++iat)
         if (PP[iat] != nullptr)
           esum += PP[iat]->splint(dist[iat]) * Zeff[iat] / dist[iat];
-      Value -= esum;
+      value_ -= esum;
     }
   }
-  return Value;
+  return value_;
 }
 
 LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& P,
@@ -112,7 +112,7 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
                                                                    ParticleSet::ParticlePos_t& pulay_terms)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -135,16 +135,16 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
         esum += -Zeff[iat] * v * rinv;
       }
     }
-    Value += esum;
+    value_ += esum;
   }
-  return Value;
+  return value_;
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
 LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value                       = 0.0;
+  value_                      = 0.0;
   Array<RealType, 1>& Ve_samp = *Ve_sample;
   Array<RealType, 1>& Vi_samp = *Vi_sample;
   Ve_samp                     = 0.0;
@@ -163,9 +163,9 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
         Ve_samp(iel) += pairpot;
         esum += pairpot;
       }
-    Value += esum;
+    value_ += esum;
   }
-  Value *= 2.0;
+  value_ *= 2.0;
 
 #if defined(TRACE_CHECK)
   RealType Vnow  = Value;
@@ -195,7 +195,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
     APP_ABORT("Trace check failed");
   }
 #endif
-  return Value;
+  return value_;
 }
 #endif
 
@@ -203,7 +203,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
 {
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  Value              = 0.0;
+  value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
@@ -212,9 +212,9 @@ LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
     for (size_t iat = 0; iat < NumIons; ++iat)
       if (PP[iat] != nullptr)
         esum += PP[iat]->splint(dist[iat]) * Zeff[iat] / dist[iat];
-    Value -= esum;
+    value_ -= esum;
   }
-  return Value;
+  return value_;
 }
 
 std::unique_ptr<OperatorBase> LocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -58,15 +58,15 @@ void LocalECPotential::add(int groupID, std::unique_ptr<RadialPotentialType>&& p
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void LocalECPotential::contribute_particle_quantities() { request_.contribute_array(my_name_); }
+void LocalECPotential::contribute_particle_quantities() { request_.contribute_array(name_); }
 
 void LocalECPotential::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(my_name_);
+  streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
   {
-    Ve_sample = tm.checkout_real<1>(my_name_, Peln);
-    Vi_sample = tm.checkout_real<1>(my_name_, Pion);
+    Ve_sample = tm.checkout_real<1>(name_, Peln);
+    Vi_sample = tm.checkout_real<1>(name_, Pion);
   }
 }
 

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 {
 LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : IonConfig(ions), Peln(els), Pion(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -29,8 +29,7 @@ namespace qmcplusplus
 {
 void MPC::resetTargetParticleSet(ParticleSet& ptcl) {}
 
-MPC::MPC(ParticleSet& ptcl, double cutoff)
-    : Ecut(cutoff), d_aa_ID(ptcl.addTable(ptcl)), PtclRef(&ptcl), FirstTime(true)
+MPC::MPC(ParticleSet& ptcl, double cutoff) : Ecut(cutoff), d_aa_ID(ptcl.addTable(ptcl)), PtclRef(&ptcl), FirstTime(true)
 {
   initBreakup();
 }
@@ -273,7 +272,9 @@ void MPC::init_spline()
   bc0.lCode = bc0.rCode = PERIODIC;
   bc1.lCode = bc1.rCode = PERIODIC;
   bc2.lCode = bc2.rCode = PERIODIC;
-  VlongSpline = std::shared_ptr<UBspline_3d_d>(create_UBspline_3d_d(grid0, grid1, grid2, bc0, bc1, bc2, splineData.data()), destroy_Bspline);
+  VlongSpline =
+      std::shared_ptr<UBspline_3d_d>(create_UBspline_3d_d(grid0, grid1, grid2, bc0, bc1, bc2, splineData.data()),
+                                     destroy_Bspline);
   //     grid0.num = PtclRef->Density_r.size(0);
   //     grid1.num = PtclRef->Density_r.size(1);
   //     grid2.num = PtclRef->Density_r.size(2);
@@ -359,8 +360,8 @@ MPC::Return_t MPC::evalLR(ParticleSet& P) const
 MPC::Return_t MPC::evaluate(ParticleSet& P)
 {
   //if (FirstTime || P.tag() == PtclRef->tag())
-  Value = evalSR(P) + evalLR(P) + Vconst;
-  return Value;
+  value_ = evalSR(P) + evalLR(P) + Vconst;
+  return value_;
 }
 
 void MPC::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -28,7 +28,7 @@ namespace qmcplusplus
 MomentumEstimator::MomentumEstimator(ParticleSet& elns, TrialWaveFunction& psi)
     : M(40), refPsi(psi), Lattice(elns.Lattice), norm_nofK(1), hdf5_out(false)
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   psi_ratios.resize(elns.getTotalNum());
   twist = elns.getTwist();
 }
@@ -107,7 +107,7 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     h5o.set_dimensions(ng, myIndex);
     h5o.open(gid);
     h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints");
-    h5o.addProperty(const_cast<std::vector<int>&>(kWeights), "kweights");    
+    h5o.addProperty(const_cast<std::vector<int>&>(kWeights), "kweights");
   }
 }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -77,15 +77,15 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
 NonLocalECPotential::~NonLocalECPotential() = default;
 
 #if !defined(REMOVE_TRACEMANAGER)
-void NonLocalECPotential::contribute_particle_quantities() { request_.contribute_array(my_name_); }
+void NonLocalECPotential::contribute_particle_quantities() { request_.contribute_array(name_); }
 
 void NonLocalECPotential::checkout_particle_quantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(my_name_);
+  streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
   {
-    Ve_sample = tm.checkout_real<1>(my_name_, Peln);
-    Vi_sample = tm.checkout_real<1>(my_name_, IonConfig);
+    Ve_sample = tm.checkout_real<1>(name_, Peln);
+    Vi_sample = tm.checkout_real<1>(name_, IonConfig);
   }
 }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -56,7 +56,7 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
       UseTMove(TMOVE_OFF),
       nonLocalOps(els.getTotalNum())
 {
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();
@@ -342,7 +342,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     for (size_t iw = 0; iw < nw; iw++)
     {
       const auto& O = o_list.getCastedElement<NonLocalECPotential>(iw);
-      max_num_jobs = std::max(max_num_jobs, O.nlpp_jobs[ig].size());
+      max_num_jobs  = std::max(max_num_jobs, O.nlpp_jobs[ig].size());
     }
 
     for (size_t jobid = 0; jobid < max_num_jobs; jobid++)

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -23,7 +23,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
                                                                                const std::vector<ValueType>& dlogpsi,
                                                                                std::vector<ValueType>& dhpsioverpsi)
 {
-  Value = 0.0;
+  value_ = 0.0;
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
@@ -34,10 +34,10 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
     const auto& displ = myTable.getDisplRow(jel);
     for (int iat = 0; iat < NumIons; iat++)
       if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
-        Value += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
+        value_ += PP[iat]->evaluateValueAndDerivatives(P, iat, Psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
                                                       dhpsioverpsi);
   }
-  return Value;
+  return value_;
 }
 
 /** evaluate the non-local potential of the iat-th ionic center

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -24,8 +24,8 @@ namespace qmcplusplus
 {
 OperatorBase::OperatorBase() : Dependants(0), Value(0.0), myIndex(-1), tWalker(0)
 {
-  quantum_domain = no_quantum_domain;
-  energy_domain  = no_energy_domain;
+  quantum_domain = NO_QUANTUM_DOMAIN;
+  energy_domain  = NO_ENERGY_DOMAIN;
 
 #if !defined(REMOVE_TRACEMANAGER)
   streaming_scalars    = false;
@@ -104,7 +104,7 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
 }
 
 
-void OperatorBase::set_energy_domain(energy_domains edomain)
+void OperatorBase::set_energy_domain(EnergyDomains edomain)
 {
   if (energy_domain_valid(edomain))
     energy_domain = edomain;
@@ -112,7 +112,7 @@ void OperatorBase::set_energy_domain(energy_domains edomain)
     APP_ABORT("QMCHamiltonainBase::set_energy_domain\n  input energy domain is invalid");
 }
 
-void OperatorBase::set_quantum_domain(quantum_domains qdomain)
+void OperatorBase::set_quantum_domain(QuantumDomains qdomain)
 {
   if (quantum_domain_valid(qdomain))
     quantum_domain = qdomain;
@@ -123,9 +123,9 @@ void OperatorBase::set_quantum_domain(quantum_domains qdomain)
 void OperatorBase::one_body_quantum_domain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = classical;
+    quantum_domain = CLASSICAL;
   else if (P.is_quantum())
-    quantum_domain = quantum;
+    quantum_domain = QUANTUM;
   else
     APP_ABORT("OperatorBase::one_body_quantum_domain\n  quantum domain of input particles is invalid");
 }
@@ -133,9 +133,9 @@ void OperatorBase::one_body_quantum_domain(const ParticleSet& P)
 void OperatorBase::two_body_quantum_domain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = classical_classical;
+    quantum_domain = CLASSICAL_CLASSICAL;
   else if (P.is_quantum())
-    quantum_domain = quantum_quantum;
+    quantum_domain = QUANTUM_QUANTUM;
   else
     APP_ABORT("OperatorBase::two_body_quantum_domain(P)\n  quantum domain of input particles is invalid");
 }
@@ -147,16 +147,16 @@ void OperatorBase::two_body_quantum_domain(const ParticleSet& P1, const Particle
   bool q1 = P1.is_quantum();
   bool q2 = P2.is_quantum();
   if (c1 && c2)
-    quantum_domain = classical_classical;
+    quantum_domain = CLASSICAL_CLASSICAL;
   else if ((q1 && c2) || (c1 && q2))
-    quantum_domain = quantum_classical;
+    quantum_domain = QUANTUM_CLASSICAL;
   else if (q1 && q2)
-    quantum_domain = quantum_quantum;
+    quantum_domain = QUANTUM_QUANTUM;
   else
     APP_ABORT("OperatorBase::two_body_quantum_domain(P1,P2)\n  quantum domain of input particles is invalid");
 }
 
-bool OperatorBase::quantum_domain_valid(quantum_domains qdomain) { return qdomain != no_quantum_domain; }
+bool OperatorBase::quantum_domain_valid(QuantumDomains qdomain) { return qdomain != NO_QUANTUM_DOMAIN; }
 
 void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
 {

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -39,9 +39,9 @@ std::bitset<8>& OperatorBase::getUpdateMode() noexcept { return update_mode_; }
 
 OperatorBase::Return_t OperatorBase::getValue() const noexcept { return value_; }
 
-std::string OperatorBase::getMyName() const noexcept { return my_name_; }
+std::string OperatorBase::getName() const noexcept { return name_; }
 
-void OperatorBase::setMyName(const std::string name) noexcept { my_name_ = name; }
+void OperatorBase::setName(const std::string name) noexcept { name_ = name; }
 
 #if !defined(REMOVE_TRACEMANAGER)
 TraceRequest& OperatorBase::getRequest() noexcept { return request_; }
@@ -175,7 +175,7 @@ void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCH
   std::unique_ptr<OperatorBase> myclone = makeClone(qp, psi);
   if (myclone)
   {
-    targetH.addOperator(std::move(myclone), my_name_, update_mode_[PHYSICAL]);
+    targetH.addOperator(std::move(myclone), name_, update_mode_[PHYSICAL]);
   }
 }
 
@@ -185,7 +185,7 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hi
   //exclude collectables
   if (!collect)
   {
-    h5desc.emplace_back(my_name_);
+    h5desc.emplace_back(name_);
     auto& oh = h5desc.back();
     std::vector<int> onedim(1, 1);
     oh.set_dimensions(onedim, myIndex);
@@ -195,7 +195,7 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hi
 
 void OperatorBase::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy)
 {
-  APP_ABORT("Need specialization for " + my_name_ +
+  APP_ABORT("Need specialization for " + name_ +
             "::addEnergy(MCWalkerConfiguration &W).\n Required functionality not implemented\n");
 }
 

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -67,36 +67,39 @@ class OperatorBase : public QMCTraits
 public:
   /** type of return value of evaluate
    */
-  typedef FullPrecRealType Return_t;
+  using Return_t = FullPrecRealType;
+
   /** typedef for the serialized buffer
    *
    * PooledData<RealType> is used to serialized an anonymous buffer
    */
-  typedef ParticleSet::Buffer_t BufferType;
+  using BufferType = ParticleSet::Buffer_t;
+
   ///typedef for the walker
-  typedef ParticleSet::Walker_t Walker_t;
+  using Walker_t = ParticleSet::Walker_t;
+
   ///typedef for the ParticleScalar
-  typedef ParticleSet::Scalar_t ParticleScalar_t;
+  using ParticleScalar_t = ParticleSet::Scalar_t;
 
   ///enum to denote energy domain of operators
-  enum energy_domains
+  enum EnergyDomains
   {
-    kinetic = 0,
-    potential,
-    no_energy_domain
+    KINETIC = 0,
+    POTENTIAL,
+    NO_ENERGY_DOMAIN
   };
 
-  enum quantum_domains
+  enum QuantumDomains
   {
-    no_quantum_domain = 0,
-    classical,
-    quantum,
-    classical_classical,
-    quantum_classical,
-    quantum_quantum
+    NO_QUANTUM_DOMAIN = 0,
+    CLASSICAL,
+    QUANTUM,
+    CLASSICAL_CLASSICAL,
+    QUANTUM_CLASSICAL,
+    QUANTUM_QUANTUM
   };
 
-  ///enum for UpdateMode
+  ///enum for update_mode
   enum
   {
     PRIMARY     = 0,
@@ -139,11 +142,11 @@ public:
   ///virtual destructor
   virtual ~OperatorBase() {}
 
-  inline bool is_classical() { return quantum_domain == classical; }
-  inline bool is_quantum() { return quantum_domain == quantum; }
-  inline bool is_classical_classical() { return quantum_domain == classical_classical; }
-  inline bool is_quantum_classical() { return quantum_domain == quantum_classical; }
-  inline bool is_quantum_quantum() { return quantum_domain == quantum_quantum; }
+  inline bool is_classical() { return quantum_domain == CLASSICAL; }
+  inline bool is_quantum() { return quantum_domain == QUANTUM; }
+  inline bool is_classical_classical() { return quantum_domain == CLASSICAL_CLASSICAL; }
+  inline bool is_quantum_classical() { return quantum_domain == QUANTUM_CLASSICAL; }
+  inline bool is_quantum_quantum() { return quantum_domain == QUANTUM_QUANTUM; }
 
   /** return the mode i
    * @param i index among PRIMARY, OPTIMIZABLE, RATIOUPDATE, PHYSICAL
@@ -416,10 +419,10 @@ protected:
   }
 
   ///set energy domain
-  void set_energy_domain(energy_domains edomain);
+  void set_energy_domain(EnergyDomains edomain);
 
   ///set quantum domain
-  void set_quantum_domain(quantum_domains qdomain);
+  void set_quantum_domain(QuantumDomains qdomain);
 
   ///set quantum domain for one-body operator
   void one_body_quantum_domain(const ParticleSet& P);
@@ -444,9 +447,9 @@ protected:
 
 private:
   ///quantum_domain of the (particle) operator, default = no_quantum_domain
-  quantum_domains quantum_domain;
+  QuantumDomains quantum_domain;
   ///energy domain of the operator (kinetic/potential), default = no_energy_domain
-  energy_domains energy_domain;
+  EnergyDomains energy_domain;
 
 #if !defined(REMOVE_TRACEMANAGER)
   bool streaming_scalars;
@@ -456,13 +459,13 @@ private:
 #endif
 
   ///return whether the energy domain is valid
-  inline bool energy_domain_valid(energy_domains edomain) const { return edomain != no_energy_domain; }
+  inline bool energy_domain_valid(EnergyDomains edomain) const { return edomain != NO_ENERGY_DOMAIN; }
 
   ///return whether the energy domain is valid
   inline bool energy_domain_valid() const { return energy_domain_valid(energy_domain); }
 
   ///return whether the quantum domain is valid
-  bool quantum_domain_valid(quantum_domains qdomain);
+  bool quantum_domain_valid(QuantumDomains qdomain);
 
   ///return whether the quantum domain is valid
   inline bool quantum_domain_valid() { return quantum_domain_valid(quantum_domain); }

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -133,13 +133,13 @@ public:
    * @brief getter a copy of my_name_, rvalue small string optimization
    * @return std::string copy of my_name_ member
    */
-  std::string getMyName() const noexcept;
+  std::string getName() const noexcept;
 
   /**
    * @brief Set my_name member, uses small string optimization (pass by value)
    * @param name input
    */
-  void setMyName(const std::string name) noexcept;
+  void setName(const std::string name) noexcept;
 
 #if !defined(REMOVE_TRACEMANAGER)
   /**
@@ -380,7 +380,7 @@ protected:
   Return_t value_;
 
   ///name of this object
-  std::string my_name_;
+  std::string name_;
 
 #if !defined(REMOVE_TRACEMANAGER)
   ///whether traces are being collected
@@ -408,13 +408,13 @@ protected:
   virtual bool put(xmlNodePtr cur) = 0;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  virtual void contribute_scalar_quantities() { request_.contribute_scalar(my_name_); }
+  virtual void contribute_scalar_quantities() { request_.contribute_scalar(name_); }
 
   virtual void checkout_scalar_quantities(TraceManager& tm)
   {
-    streaming_scalars = request_.streaming_scalar(my_name_);
+    streaming_scalars = request_.streaming_scalar(name_);
     if (streaming_scalars)
-      value_sample = tm.checkout_real<1>(my_name_);
+      value_sample = tm.checkout_real<1>(name_);
   }
 
   virtual void collect_scalar_quantities()
@@ -463,7 +463,7 @@ protected:
   inline void addValue(PropertySetType& plist)
   {
     if (!update_mode_[COLLECTABLE])
-      myIndex = plist.add(my_name_.c_str());
+      myIndex = plist.add(name_.c_str());
   }
 
 private:

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -74,7 +74,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   app_log() << "OrbitalImages::put" << std::endl;
 
   //set defaults
-  myName      = "OrbitalImages";
+  my_name_    = "OrbitalImages";
   derivatives = false;
   center_grid = false;
   corner      = 0.0;
@@ -84,7 +84,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   std::string write_report = "yes";
   std::string ion_psname   = "ion0";
   OhmmsAttributeSet attrib;
-  attrib.add(myName, "name");
+  attrib.add(my_name_, "name");
   attrib.add(ion_psname, "ions");
   attrib.add(write_report, "report");
   attrib.put(cur);

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -74,7 +74,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   app_log() << "OrbitalImages::put" << std::endl;
 
   //set defaults
-  my_name_    = "OrbitalImages";
+  name_       = "OrbitalImages";
   derivatives = false;
   center_grid = false;
   corner      = 0.0;
@@ -84,7 +84,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
   std::string write_report = "yes";
   std::string ion_psname   = "ion0";
   OhmmsAttributeSet attrib;
-  attrib.add(my_name_, "name");
+  attrib.add(name_, "name");
   attrib.add(ion_psname, "ions");
   attrib.add(write_report, "report");
   attrib.put(cur);

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -312,7 +312,7 @@ void PairCorrEstimator::report()
 
 bool PairCorrEstimator::get(std::ostream& os) const
 {
-  os << my_name_ << " dmax=" << Dmax << std::endl;
+  os << name_ << " dmax=" << Dmax << std::endl;
   return true;
 }
 

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -25,7 +25,7 @@ namespace qmcplusplus
 PairCorrEstimator::PairCorrEstimator(ParticleSet& elns, std::string& sources)
     : Dmax(10.), Delta(0.5), num_species(2), d_aa_ID_(elns.addTable(elns))
 {
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   num_species = elns.groups();
   n_vec.resize(num_species, 0);
   for (int i = 0; i < num_species; i++)
@@ -312,7 +312,7 @@ void PairCorrEstimator::report()
 
 bool PairCorrEstimator::get(std::ostream& os) const
 {
-  os << myName << " dmax=" << Dmax << std::endl;
+  os << my_name_ << " dmax=" << Dmax << std::endl;
   return true;
 }
 

--- a/src/QMCHamiltonians/Pressure.h
+++ b/src/QMCHamiltonians/Pressure.h
@@ -43,7 +43,7 @@ struct Pressure : public OperatorBase
    */
   Pressure(ParticleSet& P)
   {
-    UpdateMode.set(OPTIMIZABLE, 1);
+    update_mode_.set(OPTIMIZABLE, 1);
     pNorm = 1.0 / (P.Lattice.DIM * P.Lattice.Volume);
   }
   ///destructor
@@ -53,8 +53,8 @@ struct Pressure : public OperatorBase
 
   inline Return_t evaluate(ParticleSet& P) override
   {
-    Value = 2.0 * P.PropertyList[WP::LOCALENERGY] - P.PropertyList[WP::LOCALPOTENTIAL];
-    Value *= pNorm;
+    value_ = 2.0 * P.PropertyList[WP::LOCALENERGY] - P.PropertyList[WP::LOCALPOTENTIAL];
+    value_ *= pNorm;
     return 0.0;
   }
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -1041,7 +1041,6 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W, std::vector<RealType>& e
   if (LocalEnergyVector.size() != nw)
   {
     LocalEnergyVector.resize(nw);
-    KineticEnergyVector.resize(nw);
     AuxEnergyVector.resize(nw);
   }
   if (energyVector.size() != nw)
@@ -1082,7 +1081,6 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W,
   if (LocalEnergyVector.size() != nw)
   {
     LocalEnergyVector.resize(nw);
-    KineticEnergyVector.resize(nw);
     AuxEnergyVector.resize(nw);
   }
   if (energyVector.size() != nw)

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -67,7 +67,7 @@ bool QMCHamiltonian::get(std::ostream& os) const
   for (int i = 0; i < H.size(); i++)
   {
     os.setf(std::ios::left);
-    os << "  " << std::setw(16) << H[i]->myName;
+    os << "  " << std::setw(16) << H[i]->getMyName();
     H[i]->get(os);
     os << "\n";
   }
@@ -82,19 +82,19 @@ bool QMCHamiltonian::get(std::ostream& os) const
 void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase>&& h, const std::string& aname, bool physical)
 {
   //change UpdateMode[PHYSICAL] of h so that cloning can be done correctly
-  h->UpdateMode[OperatorBase::PHYSICAL] = physical;
+  h->getUpdateMode()[OperatorBase::PHYSICAL] = physical;
   if (physical)
   {
     for (int i = 0; i < H.size(); ++i)
     {
-      if (H[i]->myName == aname)
+      if (H[i]->getMyName() == aname)
       {
         app_warning() << "QMCHamiltonian::addOperator cannot " << aname << ". The name is already used" << std::endl;
         return;
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to H, physical Hamiltonian " << std::endl;
-    h->myName = aname;
+    h->setMyName(aname);
     H.push_back(std::move(h));
     std::string tname = "Hamiltonian:" + aname;
     my_timers_.push_back(*timer_manager.createTimer(tname, timer_level_fine));
@@ -104,14 +104,14 @@ void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase>&& h, const std::s
     //ignore timers for now
     for (int i = 0; i < auxH.size(); ++i)
     {
-      if (auxH[i]->myName == aname)
+      if (auxH[i]->getMyName() == aname)
       {
         app_warning() << "QMCHamiltonian::addOperator cannot " << aname << ". The name is already used" << std::endl;
         return;
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to auxH " << std::endl;
-    h->myName = aname;
+    h->setMyName(aname);
     auxH.push_back(std::move(h));
   }
 
@@ -271,9 +271,9 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   std::vector<std::string> Vloc;
   std::vector<std::string> Vq, Vc, Vqq, Vqc, Vcc;
   for (int i = 0; i < H.size(); ++i)
-    Eloc.push_back(H[i]->myName);
+    Eloc.push_back(H[i]->getMyName());
   for (int i = 1; i < H.size(); ++i)
-    Vloc.push_back(H[i]->myName);
+    Vloc.push_back(H[i]->getMyName());
 
   // These contributions are based on the potential energy components.
   // Loop starts at one to skip the kinetic energy component.
@@ -281,17 +281,17 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   {
     OperatorBase& h = *H[i];
     if (h.is_quantum())
-      Vq.push_back(h.myName);
+      Vq.push_back(h.getMyName());
     else if (h.is_classical())
-      Vc.push_back(h.myName);
+      Vc.push_back(h.getMyName());
     else if (h.is_quantum_quantum())
-      Vqq.push_back(h.myName);
+      Vqq.push_back(h.getMyName());
     else if (h.is_quantum_classical())
-      Vqc.push_back(h.myName);
+      Vqc.push_back(h.getMyName());
     else if (h.is_classical_classical())
-      Vcc.push_back(h.myName);
+      Vcc.push_back(h.getMyName());
     else if (omp_get_thread_num() == 0)
-      app_log() << "  warning: potential named " << h.myName
+      app_log() << "  warning: potential named " << h.getMyName()
                 << " has not been classified according to its quantum domain (q,c,qq,qc,cc)\n    estimators depending "
                    "on this classification may not function properly"
                 << std::endl;
@@ -334,10 +334,10 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   requests.push_back(&request);
   //  requests from Hamiltonian components
   for (int i = 0; i < H.size(); ++i)
-    requests.push_back(&H[i]->request);
+    requests.push_back(&H[i]->getRequest());
   //  requests from other observables
   for (int i = 0; i < auxH.size(); ++i)
-    requests.push_back(&auxH[i]->request);
+    requests.push_back(&auxH[i]->getRequest());
 
   //collect trace quantity availability/requests from contributors/requestors
   for (int i = 0; i < requests.size(); ++i)
@@ -390,13 +390,13 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < H.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << H[i]->myName << std::endl;
+        app_log() << "    OperatorBase::checkout_trace_quantities  " << H[i]->getMyName() << std::endl;
       H[i]->checkout_trace_quantities(tm);
     }
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << auxH[i]->myName << std::endl;
+        app_log() << "    OperatorBase::checkout_trace_quantities  " << auxH[i]->getMyName() << std::endl;
       auxH[i]->checkout_trace_quantities(tm);
     }
     //setup combined traces that depend on H information
@@ -426,7 +426,7 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::get_required_traces  " << auxH[i]->myName << std::endl;
+        app_log() << "    OperatorBase::get_required_traces  " << auxH[i]->getMyName() << std::endl;
       auxH[i]->get_required_traces(tm);
     }
     //report
@@ -498,7 +498,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluate(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->myName + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getMyName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -506,7 +506,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
 #endif
     H[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
-  KineticEnergy                      = H[0]->Value;
+  KineticEnergy                      = H[0]->getValue();
   P.PropertyList[WP::LOCALENERGY]    = LocalEnergy;
   P.PropertyList[WP::LOCALPOTENTIAL] = LocalEnergy - KineticEnergy;
   // auxHevaluate(P);
@@ -522,7 +522,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluateDeterministic(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->myName + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getMyName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -530,7 +530,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
 #endif
     H[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
-  KineticEnergy                      = H[0]->Value;
+  KineticEnergy                      = H[0]->getValue();
   P.PropertyList[WP::LOCALENERGY]    = LocalEnergy;
   P.PropertyList[WP::LOCALPOTENTIAL] = LocalEnergy - KineticEnergy;
   // auxHevaluate(P);
@@ -538,17 +538,17 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
 }
 void QMCHamiltonian::updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset)
 {
-  if (std::isnan(op.Value))
-    APP_ABORT("QMCHamiltonian::evaluate component " + op.myName + " returns NaN\n");
+  if (std::isnan(op.getValue()))
+    APP_ABORT("QMCHamiltonian::evaluate component " + op.getMyName() + " returns NaN\n");
   // The following is a ridiculous breach of encapsulation.
-  ham.LocalEnergy += op.Value;
+  ham.LocalEnergy += op.getValue();
   op.setObservables(ham.Observables);
   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
 }
 
 void QMCHamiltonian::updateKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset)
 {
-  ham.KineticEnergy                     = op.Value;
+  ham.KineticEnergy                     = op.getValue();
   pset.PropertyList[WP::LOCALENERGY]    = ham.LocalEnergy;
   pset.PropertyList[WP::LOCALPOTENTIAL] = ham.LocalEnergy - ham.KineticEnergy;
 }
@@ -781,7 +781,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleS
     H[i]->collect_scalar_traces();
 #endif
   }
-  KineticEnergy                      = H[0]->Value;
+  KineticEnergy                      = H[0]->getValue();
   P.PropertyList[WP::LOCALENERGY]    = LocalEnergy;
   P.PropertyList[WP::LOCALPOTENTIAL] = LocalEnergy - KineticEnergy;
   //   auxHevaluate(P);
@@ -918,10 +918,10 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::getEnsembleAverage()
 OperatorBase* QMCHamiltonian::getHamiltonian(const std::string& aname)
 {
   for (int i = 0; i < H.size(); ++i)
-    if (H[i]->myName == aname)
+    if (H[i]->getMyName() == aname)
       return H[i].get();
   for (int i = 0; i < auxH.size(); ++i)
-    if (auxH[i]->myName == aname)
+    if (auxH[i]->getMyName() == aname)
       return auxH[i].get();
   return nullptr;
 }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -67,7 +67,7 @@ bool QMCHamiltonian::get(std::ostream& os) const
   for (int i = 0; i < H.size(); i++)
   {
     os.setf(std::ios::left);
-    os << "  " << std::setw(16) << H[i]->getMyName();
+    os << "  " << std::setw(16) << H[i]->getName();
     H[i]->get(os);
     os << "\n";
   }
@@ -87,14 +87,14 @@ void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase>&& h, const std::s
   {
     for (int i = 0; i < H.size(); ++i)
     {
-      if (H[i]->getMyName() == aname)
+      if (H[i]->getName() == aname)
       {
         app_warning() << "QMCHamiltonian::addOperator cannot " << aname << ". The name is already used" << std::endl;
         return;
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to H, physical Hamiltonian " << std::endl;
-    h->setMyName(aname);
+    h->setName(aname);
     H.push_back(std::move(h));
     std::string tname = "Hamiltonian:" + aname;
     my_timers_.push_back(*timer_manager.createTimer(tname, timer_level_fine));
@@ -104,14 +104,14 @@ void QMCHamiltonian::addOperator(std::unique_ptr<OperatorBase>&& h, const std::s
     //ignore timers for now
     for (int i = 0; i < auxH.size(); ++i)
     {
-      if (auxH[i]->getMyName() == aname)
+      if (auxH[i]->getName() == aname)
       {
         app_warning() << "QMCHamiltonian::addOperator cannot " << aname << ". The name is already used" << std::endl;
         return;
       }
     }
     app_log() << "  QMCHamiltonian::addOperator " << aname << " to auxH " << std::endl;
-    h->setMyName(aname);
+    h->setName(aname);
     auxH.push_back(std::move(h));
   }
 
@@ -271,9 +271,9 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   std::vector<std::string> Vloc;
   std::vector<std::string> Vq, Vc, Vqq, Vqc, Vcc;
   for (int i = 0; i < H.size(); ++i)
-    Eloc.push_back(H[i]->getMyName());
+    Eloc.push_back(H[i]->getName());
   for (int i = 1; i < H.size(); ++i)
-    Vloc.push_back(H[i]->getMyName());
+    Vloc.push_back(H[i]->getName());
 
   // These contributions are based on the potential energy components.
   // Loop starts at one to skip the kinetic energy component.
@@ -281,17 +281,17 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   {
     OperatorBase& h = *H[i];
     if (h.is_quantum())
-      Vq.push_back(h.getMyName());
+      Vq.push_back(h.getName());
     else if (h.is_classical())
-      Vc.push_back(h.getMyName());
+      Vc.push_back(h.getName());
     else if (h.is_quantum_quantum())
-      Vqq.push_back(h.getMyName());
+      Vqq.push_back(h.getName());
     else if (h.is_quantum_classical())
-      Vqc.push_back(h.getMyName());
+      Vqc.push_back(h.getName());
     else if (h.is_classical_classical())
-      Vcc.push_back(h.getMyName());
+      Vcc.push_back(h.getName());
     else if (omp_get_thread_num() == 0)
-      app_log() << "  warning: potential named " << h.getMyName()
+      app_log() << "  warning: potential named " << h.getName()
                 << " has not been classified according to its quantum domain (q,c,qq,qc,cc)\n    estimators depending "
                    "on this classification may not function properly"
                 << std::endl;
@@ -390,13 +390,13 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < H.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << H[i]->getMyName() << std::endl;
+        app_log() << "    OperatorBase::checkout_trace_quantities  " << H[i]->getName() << std::endl;
       H[i]->checkout_trace_quantities(tm);
     }
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << auxH[i]->getMyName() << std::endl;
+        app_log() << "    OperatorBase::checkout_trace_quantities  " << auxH[i]->getName() << std::endl;
       auxH[i]->checkout_trace_quantities(tm);
     }
     //setup combined traces that depend on H information
@@ -426,7 +426,7 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::get_required_traces  " << auxH[i]->getMyName() << std::endl;
+        app_log() << "    OperatorBase::get_required_traces  " << auxH[i]->getName() << std::endl;
       auxH[i]->get_required_traces(tm);
     }
     //report
@@ -498,7 +498,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluate(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getMyName() + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -522,7 +522,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluateDeterministic(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getMyName() + " returns NaN\n");
+      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getName() + " returns NaN\n");
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -539,7 +539,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
 void QMCHamiltonian::updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset)
 {
   if (std::isnan(op.getValue()))
-    APP_ABORT("QMCHamiltonian::evaluate component " + op.getMyName() + " returns NaN\n");
+    APP_ABORT("QMCHamiltonian::evaluate component " + op.getName() + " returns NaN\n");
   // The following is a ridiculous breach of encapsulation.
   ham.LocalEnergy += op.getValue();
   op.setObservables(ham.Observables);
@@ -918,10 +918,10 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::getEnsembleAverage()
 OperatorBase* QMCHamiltonian::getHamiltonian(const std::string& aname)
 {
   for (int i = 0; i < H.size(); ++i)
-    if (H[i]->getMyName() == aname)
+    if (H[i]->getName() == aname)
       return H[i].get();
   for (int i = 0; i < auxH.size(); ++i)
-    if (auxH[i]->getMyName() == aname)
+    if (auxH[i]->getName() == aname)
       return auxH[i].get();
   return nullptr;
 }
@@ -1054,7 +1054,7 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W, std::vector<RealType>& e
     H[i]->addEnergy(W, LocalEnergyVector);
     //H[i]->setObservables(Observables);
   }
-  //KineticEnergyVector=H[0]->ValueVector;
+
   for (int iw = 0; iw < walkers.size(); iw++)
   {
     walkers[iw]->getPropertyBase()[WP::LOCALENERGY] = LocalEnergyVector[iw];
@@ -1095,7 +1095,7 @@ void QMCHamiltonian::evaluate(MCWalkerConfiguration& W,
     ScopedTimer h_timer(my_timers_[i]);
     H[i]->addEnergy(W, LocalEnergyVector, Txy);
   }
-  KineticEnergyVector = H[0]->ValueVector;
+
   for (int iw = 0; iw < walkers.size(); iw++)
   {
     walkers[iw]->getPropertyBase()[WP::LOCALENERGY] = LocalEnergyVector[iw];

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -435,7 +435,7 @@ private:
   /////////////////////
   // Vectorized data //
   /////////////////////
-  std::vector<QMCHamiltonian::FullPrecRealType> LocalEnergyVector, KineticEnergyVector, AuxEnergyVector;
+  std::vector<QMCHamiltonian::FullPrecRealType> LocalEnergyVector, AuxEnergyVector;
 #endif
 
 private:

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -201,7 +201,7 @@ public:
   inline void setPrimary(bool primary)
   {
     for (int i = 0; i < H.size(); i++)
-      H[i]->UpdateMode.set(OperatorBase::PRIMARY, primary);
+      H[i]->getUpdateMode().set(OperatorBase::PRIMARY, primary);
   }
 
   /////Set Tau inside each of the Hamiltonian elements

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi)
     : myRNG(nullptr), IonConfig(ions), Psi(psi), Peln(els), ElecNeighborIons(els), IonNeighborElecs(ions)
 {
-  set_energy_domain(potential);
+  set_energy_domain(POTENTIAL);
   two_body_quantum_domain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -35,7 +35,7 @@ void SOECPotential::resetTargetParticleSet(ParticleSet& P) {}
 
 SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
 {
-  Value = 0.0;
+  value_ = 0.0;
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
@@ -54,12 +54,12 @@ SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
       if (PP[iat] != nullptr && dist[iat] < PP[iat]->getRmax())
       {
         RealType pairpot = PP[iat]->evaluateOne(P, iat, Psi, jel, dist[iat], -displ[iat]);
-        Value += pairpot;
+        value_ += pairpot;
         NeighborIons.push_back(iat);
         IonNeighborElecs.getNeighborList(iat).push_back(jel);
       }
   }
-  return Value;
+  return value_;
 }
 
 std::unique_ptr<OperatorBase> SOECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -29,7 +29,7 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   ions          = &source;
   NumeSpecies   = elns->getSpeciesSet().getTotalNum();
   NumIonSpecies = ions->getSpeciesSet().getTotalNum();
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
 
   NumK      = source.SK->getKLists().numk;
   OneOverN  = 1.0 / static_cast<RealType>(source.getTotalNum());
@@ -175,9 +175,9 @@ SkAllEstimator::Return_t SkAllEstimator::evaluate(ParticleSet& P)
   {
     for (int k = 0, count = 0; k < NumK; k++)
     {
-      value[NumK + count] = w * rhok[k].real();
+      value_[NumK + count] = w * rhok[k].real();
       count++;
-      value[NumK + count] = w * rhok[k].imag();
+      value_[NumK + count] = w * rhok[k].imag();
       count++;
     }
   }
@@ -273,7 +273,7 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
   if (hdf5_out)
   {
     // Create HDF group in stat.h5 with SkAllEstimator's name
-    hid_t sgid = H5Gcreate(gid, myName.c_str(), 0);
+    hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
 
     // Add k-point information
     h5desc.emplace_back("kpoints");

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -273,7 +273,7 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
   if (hdf5_out)
   {
     // Create HDF group in stat.h5 with SkAllEstimator's name
-    hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
+    hid_t sgid = H5Gcreate(gid, name_.c_str(), 0);
 
     // Add k-point information
     h5desc.emplace_back("kpoints");

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -23,7 +23,7 @@ namespace qmcplusplus
 SkEstimator::SkEstimator(ParticleSet& source)
 {
   sourcePtcl = &source;
-  UpdateMode.set(COLLECTABLE, 1);
+  update_mode_.set(COLLECTABLE, 1);
   NumSpecies = source.getSpeciesSet().getTotalNum();
   NumK       = source.SK->getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());
@@ -142,7 +142,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
   if (hdf5_out)
   {
     std::vector<int> ndim(1, NumK);
-    h5desc.emplace_back(myName);
+    h5desc.emplace_back(my_name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, myIndex);
     h5o.open(gid);
@@ -150,7 +150,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     hsize_t kdims[2];
     kdims[0]          = NumK;
     kdims[1]          = OHMMS_DIM;
-    std::string kpath = myName + "/kpoints";
+    std::string kpath = my_name_ + "/kpoints";
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
     hid_t k_set       = H5Dcreate(gid, kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -142,7 +142,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
   if (hdf5_out)
   {
     std::vector<int> ndim(1, NumK);
-    h5desc.emplace_back(my_name_);
+    h5desc.emplace_back(name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, myIndex);
     h5o.open(gid);
@@ -150,7 +150,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     hsize_t kdims[2];
     kdims[0]          = NumK;
     kdims[1]          = OHMMS_DIM;
-    std::string kpath = my_name_ + "/kpoints";
+    std::string kpath = name_ + "/kpoints";
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
     hid_t k_set       = H5Dcreate(gid, kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -49,11 +49,11 @@ SkPot::Return_t SkPot::evaluate(ParticleSet& P)
   for (int i = 1; i < NumSpecies; ++i)
     accumulate_elements(P.SK->rhok[i], P.SK->rhok[i] + NumK, RhokTot.begin());
   Vector<ComplexType>::const_iterator iit(RhokTot.begin()), iit_end(RhokTot.end());
-  Value = 0.0;
+  value_ = 0.0;
   for (int i = 0; iit != iit_end; ++iit, ++i)
-    Value += Fk[i] * ((*iit).real() * (*iit).real() + (*iit).imag() * (*iit).imag());
+    value_ += Fk[i] * ((*iit).real() * (*iit).real() + (*iit).imag() * (*iit).imag());
 #endif
-  return Value;
+  return value_;
 }
 
 bool SkPot::put(xmlNodePtr cur)

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -60,7 +60,7 @@ bool SpeciesKineticEnergy::put(xmlNodePtr cur)
 
 bool SpeciesKineticEnergy::get(std::ostream& os) const
 { // class description
-  os << "SpeciesKineticEnergy: " << my_name_;
+  os << "SpeciesKineticEnergy: " << name_;
   return true;
 }
 
@@ -69,7 +69,7 @@ void SpeciesKineticEnergy::addObservables(PropertySetType& plist, BufferType& co
   myIndex = plist.size();
   for (int ispec = 0; ispec < num_species; ispec++)
   { // make columns named "$myName_u", "$myName_d" etc.
-    plist.add(my_name_ + "_" + species_names[ispec]);
+    plist.add(name_ + "_" + species_names[ispec]);
   }
   if (hdf5_out)
   { // make room in h5 file and save its index
@@ -84,7 +84,7 @@ void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h
   if (hdf5_out)
   {
     std::vector<int> ndim(1, num_species);
-    h5desc.emplace_back(my_name_);
+    h5desc.emplace_back(name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, h5_index);
     h5o.open(gid);

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -53,14 +53,14 @@ bool SpeciesKineticEnergy::put(xmlNodePtr cur)
 
   if (hdf5_out)
   { // add this estimator to stat.h5
-    UpdateMode.set(COLLECTABLE, 1);
+    update_mode_.set(COLLECTABLE, 1);
   }
   return true;
 }
 
 bool SpeciesKineticEnergy::get(std::ostream& os) const
 { // class description
-  os << "SpeciesKineticEnergy: " << myName;
+  os << "SpeciesKineticEnergy: " << my_name_;
   return true;
 }
 
@@ -69,7 +69,7 @@ void SpeciesKineticEnergy::addObservables(PropertySetType& plist, BufferType& co
   myIndex = plist.size();
   for (int ispec = 0; ispec < num_species; ispec++)
   { // make columns named "$myName_u", "$myName_d" etc.
-    plist.add(myName + "_" + species_names[ispec]);
+    plist.add(my_name_ + "_" + species_names[ispec]);
   }
   if (hdf5_out)
   { // make room in h5 file and save its index
@@ -84,7 +84,7 @@ void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h
   if (hdf5_out)
   {
     std::vector<int> ndim(1, num_species);
-    h5desc.emplace_back(myName);
+    h5desc.emplace_back(my_name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, h5_index);
     h5o.open(gid);
@@ -112,8 +112,8 @@ SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
     species_kinetic[ispec] += my_kinetic;
   }
 
-  Value = 0.0; // Value is no longer used
-  return Value;
+  value_ = 0.0; // Value is no longer used
+  return value_;
 }
 
 std::unique_ptr<OperatorBase> SpeciesKineticEnergy::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -47,8 +47,8 @@ SpinDensity::SpinDensity(ParticleSet& P)
 
 void SpinDensity::reset()
 {
-  myName = "SpinDensity";
-  UpdateMode.set(COLLECTABLE, 1);
+  my_name_ = "SpinDensity";
+  update_mode_.set(COLLECTABLE, 1);
   corner = 0.0;
 }
 
@@ -66,7 +66,7 @@ bool SpinDensity::put(xmlNodePtr cur)
   reset();
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
-  attrib.add(myName, "name");
+  attrib.add(my_name_, "name");
   attrib.add(write_report, "report");
   attrib.put(cur);
 
@@ -192,7 +192,7 @@ void SpinDensity::addObservables(PropertySetType& plist, BufferType& collectable
 
 void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t sgid = H5Gcreate(gid, myName.c_str(), 0);
+  hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
 
   //vector<int> ng(DIM);
   //for(int d=0;d<DIM;++d)

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -47,7 +47,7 @@ SpinDensity::SpinDensity(ParticleSet& P)
 
 void SpinDensity::reset()
 {
-  my_name_ = "SpinDensity";
+  name_ = "SpinDensity";
   update_mode_.set(COLLECTABLE, 1);
   corner = 0.0;
 }
@@ -66,7 +66,7 @@ bool SpinDensity::put(xmlNodePtr cur)
   reset();
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
-  attrib.add(my_name_, "name");
+  attrib.add(name_, "name");
   attrib.add(write_report, "report");
   attrib.put(cur);
 
@@ -192,7 +192,7 @@ void SpinDensity::addObservables(PropertySetType& plist, BufferType& collectable
 
 void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
+  hid_t sgid = H5Gcreate(gid, name_.c_str(), 0);
 
   //vector<int> ng(DIM);
   //for(int d=0;d<DIM;++d)

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -37,7 +37,7 @@ StaticStructureFactor::StaticStructureFactor(ParticleSet& P) : Pinit(P)
 
 void StaticStructureFactor::reset()
 {
-  my_name_ = "StaticStructureFactor";
+  name_ = "StaticStructureFactor";
   update_mode_.set(COLLECTABLE, 1);
   ecut     = -1.0;
   nkpoints = -1;
@@ -58,7 +58,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
-  attrib.add(my_name_, "name");
+  attrib.add(name_, "name");
   //attrib.add(ecut,"ecut");
   attrib.add(write_report, "report");
   attrib.put(cur);
@@ -89,7 +89,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 void StaticStructureFactor::report(const std::string& pad)
 {
   app_log() << pad << "StaticStructureFactor report" << std::endl;
-  app_log() << pad << "  name     = " << my_name_ << std::endl;
+  app_log() << pad << "  name     = " << name_ << std::endl;
   app_log() << pad << "  ecut     = " << ecut << std::endl;
   app_log() << pad << "  nkpoints = " << nkpoints << std::endl;
   app_log() << pad << "  nspecies = " << nspecies << std::endl;
@@ -109,7 +109,7 @@ void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& c
 
 void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
+  hid_t sgid = H5Gcreate(gid, name_.c_str(), 0);
   h5desc.emplace_back("kpoints");
   auto& oh = h5desc.back();
   oh.open(sgid); // add to SkAll hdf group

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -37,8 +37,8 @@ StaticStructureFactor::StaticStructureFactor(ParticleSet& P) : Pinit(P)
 
 void StaticStructureFactor::reset()
 {
-  myName = "StaticStructureFactor";
-  UpdateMode.set(COLLECTABLE, 1);
+  my_name_ = "StaticStructureFactor";
+  update_mode_.set(COLLECTABLE, 1);
   ecut     = -1.0;
   nkpoints = -1;
 }
@@ -58,7 +58,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
-  attrib.add(myName, "name");
+  attrib.add(my_name_, "name");
   //attrib.add(ecut,"ecut");
   attrib.add(write_report, "report");
   attrib.put(cur);
@@ -89,7 +89,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 void StaticStructureFactor::report(const std::string& pad)
 {
   app_log() << pad << "StaticStructureFactor report" << std::endl;
-  app_log() << pad << "  name     = " << myName << std::endl;
+  app_log() << pad << "  name     = " << my_name_ << std::endl;
   app_log() << pad << "  ecut     = " << ecut << std::endl;
   app_log() << pad << "  nkpoints = " << nkpoints << std::endl;
   app_log() << pad << "  nspecies = " << nspecies << std::endl;
@@ -109,7 +109,7 @@ void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& c
 
 void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
 {
-  hid_t sgid = H5Gcreate(gid, myName.c_str(), 0);
+  hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
   h5desc.emplace_back("kpoints");
   auto& oh = h5desc.back();
   oh.open(sgid); // add to SkAll hdf group

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -35,8 +35,8 @@ StressPBC::StressPBC(ParticleSet& ions, ParticleSet& elns, TrialWaveFunction& Ps
       firstTimeStress(true)
 {
   ReportEngine PRE("StressPBC", "StressPBC");
-  myName = "StressPBC";
-  prefix = "StressPBC";
+  my_name_ = "StressPBC";
+  prefix   = "StressPBC";
   //This sets up the long range breakups.
   initBreakup(PtclTarg);
   stress_eI_const = 0.0;
@@ -105,7 +105,8 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AB(ParticleSet& 
     {
 #if defined(USE_REAL_STRUCT_FACTOR)
       esum += Qspec[j] *
-          AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
+          AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j],
+                             RhoKB.rhok_i[j]);
 #else
       esum += Qspec[j] * AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
 

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -35,8 +35,8 @@ StressPBC::StressPBC(ParticleSet& ions, ParticleSet& elns, TrialWaveFunction& Ps
       firstTimeStress(true)
 {
   ReportEngine PRE("StressPBC", "StressPBC");
-  my_name_ = "StressPBC";
-  prefix   = "StressPBC";
+  name_  = "StressPBC";
+  prefix = "StressPBC";
   //This sets up the long range breakups.
   initBreakup(PtclTarg);
   stress_eI_const = 0.0;


### PR DESCRIPTION
## Proposed changes

Refactoring public members in `OperatorBase` class to accommodate to QMCPACK developer guide
Replace `typedef` with `using`
Rename current public member variables across the hierarchy
Remove unused `IonForce` and `depName`
Component of original PR #3412 
Related to #3411 

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
