### PR TITLE
Fix distance table AA out of bound

### DIFF
--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -80,9 +80,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
     old_r_.resize(N_targets);
     old_dr_.resize(N_targets);
-    // The padding of temp_r_ and temp_dr_ is necessary for the memory copy in the update function
-    // temp_r_ is padded explicitly while temp_dr_ is padded internally
-    temp_r_.resize(Ntargets_padded);
+    temp_r_.resize(N_targets);
     temp_dr_.resize(N_targets);
   }
 
@@ -159,16 +157,15 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   }
 
   /** After accepting the iat-th particle, update the iat-th row of distances_ and displacements_.
-   * Since the upper triangle is not needed in the later computation,
-   * only the [0,iat-1) columns need to save the new values.
-   * The memory copy goes up to the padded size only for better performance.
+   * Upper triangle is not needed in the later computation and thus not updated
    */
   inline void update(IndexType iat) override
   {
     ScopedTimer local_timer(update_timer_);
-    //update by a cache line
-    const int nupdate = getAlignedSize<T>(iat);
+    //update [0, iat)
+    const int nupdate = iat;
     //copy row
+    assert(nupdate <= temp_r_.size());
     std::copy_n(temp_r_.data(), nupdate, distances_[iat].data());
     for (int idim = 0; idim < D; ++idim)
       std::copy_n(temp_dr_.data(idim), nupdate, displacements_[iat].data(idim));
@@ -183,11 +180,12 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   void updatePartial(IndexType jat, bool from_temp) override
   {
     ScopedTimer local_timer(update_timer_);
-    //update by a cache line
-    const int nupdate = getAlignedSize<T>(jat);
+    //update [0, jat)
+    const int nupdate = jat;
     if (from_temp)
     {
       //copy row
+      assert(nupdate <= temp_r_.size());
       std::copy_n(temp_r_.data(), nupdate, distances_[jat].data());
       for (int idim = 0; idim < D; ++idim)
         std::copy_n(temp_dr_.data(idim), nupdate, displacements_[jat].data(idim));
@@ -196,6 +194,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
     {
       assert(old_prepared_elec_id == jat);
       //copy row
+      assert(nupdate <= old_r_.size());
       std::copy_n(old_r_.data(), nupdate, distances_[jat].data());
       for (int idim = 0; idim < D; ++idim)
         std::copy_n(old_dr_.data(idim), nupdate, displacements_[jat].data(idim));

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -111,9 +111,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
     old_r_mem_.resize(N_targets);
     old_dr_mem_.resize(N_targets);
-    // The padding of temp_r_ and temp_dr_ is necessary for the memory copy in the update function
-    // temp_r_ is padded explicitly while temp_dr_ is padded internally
-    temp_r_mem_.resize(Ntargets_padded);
+    temp_r_mem_.resize(N_targets);
     temp_dr_mem_.resize(N_targets);
   }
 
@@ -358,16 +356,15 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   }
 
   /** After accepting the iat-th particle, update the iat-th row of distances_ and displacements_.
-   * Since the upper triangle is not needed in the later computation,
-   * only the [0,iat-1) columns need to save the new values.
-   * The memory copy goes up to the padded size only for better performance.
+   * Upper triangle is not needed in the later computation and thus not updated
    */
   inline void update(IndexType iat) override
   {
     ScopedTimer local_timer(update_timer_);
-    //update by a cache line
-    const int nupdate = getAlignedSize<T>(iat);
+    //update [0, iat) columns
+    const int nupdate = iat;
     //copy row
+    assert(nupdate <= temp_r_.size());
     std::copy_n(temp_r_.data(), nupdate, distances_[iat].data());
     for (int idim = 0; idim < D; ++idim)
       std::copy_n(temp_dr_.data(idim), nupdate, displacements_[iat].data(idim));
@@ -383,11 +380,12 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   {
     ScopedTimer local_timer(update_timer_);
 
-    //update by a cache line
-    const int nupdate = getAlignedSize<T>(jat);
+    //update [0, jat)
+    const int nupdate = jat;
     if (from_temp)
     {
       //copy row
+      assert(nupdate <= temp_r_.size());
       std::copy_n(temp_r_.data(), nupdate, distances_[jat].data());
       for (int idim = 0; idim < D; ++idim)
         std::copy_n(temp_dr_.data(idim), nupdate, displacements_[jat].data(idim));
@@ -396,6 +394,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     {
       assert(old_prepared_elec_id == jat);
       //copy row
+      assert(nupdate <= old_r_.size());
       std::copy_n(old_r_.data(), nupdate, distances_[jat].data());
       for (int idim = 0; idim < D; ++idim)
         std::copy_n(old_dr_.data(idim), nupdate, displacements_[jat].data(idim));

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -341,24 +341,19 @@ void parse_electron_ion_pbc_z(ParticleSet& ions, ParticleSet& electrons)
      <parameter name=\"LR_dim_cutoff\"       >    15                 </parameter>\
   </simulationcell>\
   <particleset name=\"e\">\
-     <group name=\"u\" size=\"4\" mass=\"1.0\">\
+     <group name=\"u\" size=\"2\" mass=\"1.0\">\
         <parameter name=\"charge\"              >    -1                    </parameter>\
         <parameter name=\"mass\"                >    1.0                   </parameter>\
         <attrib name=\"position\" datatype=\"posArray\" condition=\"0\">\
                  0.00000000        0.00000000        0.00000000\
                  3.00000000        0.00000000        0.00000000\
-                 0.00000000        3.00000000        0.00000000\
-                 3.00000000        3.00000000        0.00000000\
         </attrib>\
      </group>\
-     <group name=\"d\" size=\"4\" mass=\"1.0\">\
+     <group name=\"d\" size=\"1\" mass=\"1.0\">\
         <parameter name=\"charge\"              >    -1                    </parameter>\
         <parameter name=\"mass\"                >    1.0                   </parameter>\
         <attrib name=\"position\" datatype=\"posArray\" condition=\"0\">\
                  0.00000000        0.00000000        3.00000000\
-                 3.00000000        0.00000000        3.00000000\
-                 0.00000000        3.00000000        3.00000000\
-                 3.00000000        3.00000000        3.00000000\
         </attrib>\
      </group>\
   </particleset>\
@@ -464,11 +459,6 @@ TEST_CASE("distance_pbc_z", "[distance_table][xml]")
   disp[1] = -6.0;
   electrons.makeMove(1, disp);
   electrons.acceptMove(1);
-
-  // move some more more
-  disp[2] = 12.0;
-  electrons.makeMove(3, disp);
-  electrons.acceptMove(3);
 
   idx = 0;
   for (int iat = 0; iat < num_src; iat++)


### PR DESCRIPTION
## Proposed changes
#2913 introduced a bug which copies more elements than old_r_ has due to padding.
The issue is similar to #1334 but I'm consider a different solution by removing the padding requirement.
Alignment is always satisfied. Adding padding only removes the remainder loop.
I consider the claimed performance benefit is negligible.

I tried asan but it doesn't report invalid access. So I think somewhere in the memory management adds padding and prevents crash.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'