### PR TITLE
update distance table internal API

### DIFF
--- a/src/Particle/Lattice/ParticleBConds3DSoa.h
+++ b/src/Particle/Lattice/ParticleBConds3DSoa.h
@@ -58,6 +58,7 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -69,8 +70,8 @@ struct DTD_BConds<T, 3, SUPERCELL_OPEN + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -134,6 +135,7 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -145,8 +147,8 @@ struct DTD_BConds<T, 3, PPPO + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -240,6 +242,7 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -251,8 +254,8 @@ struct DTD_BConds<T, 3, PPPS + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -410,6 +413,7 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -421,8 +425,8 @@ struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -566,6 +570,7 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -577,8 +582,8 @@ struct DTD_BConds<T, 3, PPNG + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -664,6 +669,7 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -675,8 +681,8 @@ struct DTD_BConds<T, 3, PPNO + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -754,6 +760,7 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -765,8 +772,8 @@ struct DTD_BConds<T, 3, PPNS + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -834,6 +841,7 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -845,8 +853,8 @@ struct DTD_BConds<T, 3, SUPERCELL_WIRE + SOA_OFFSET>
     const T z0 = pos[2];
 
     const T* restrict px = R0;
-    const T* restrict py = R0 + padded_size;
-    const T* restrict pz = R0 + padded_size * 2;
+    const T* restrict py = R0 + r0_stride;
+    const T* restrict pz = R0 + r0_stride * 2;
 
     T* restrict dx = temp_dr;
     T* restrict dy = temp_dr + padded_size;
@@ -925,6 +933,7 @@ struct DTD_BConds<T, 3, PPPX + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,
@@ -987,6 +996,7 @@ struct DTD_BConds<T, 3, PPNX + SOA_OFFSET>
 
   void computeDistancesOffload(const T pos[3],
                                const T* restrict R0,
+                               int r0_stride,
                                T* restrict temp_r,
                                T* restrict temp_dr,
                                int padded_size,

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -25,9 +25,6 @@ namespace qmcplusplus
 template<typename T, unsigned D, int SC>
 struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableData
 {
-  ///number of targets with padding
-  int Ntargets_padded;
-
   ///actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
 
@@ -40,6 +37,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   SoaDistanceTableAA(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
         DistanceTableData(target, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        Ntargets_padded(getAlignedSize<T>(N_targets)),
         evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAA::evaluate_") + target.getName() +
                                                        "_" + target.getName(),
                                                    timer_level_fine)),
@@ -67,7 +65,6 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   void resize()
   {
     // initialize memory containers and views
-    Ntargets_padded         = getAlignedSize<T>(N_targets);
     const size_t total_size = compute_size(N_targets);
     memory_pool_.resize(total_size * (1 + D));
     distances_.resize(N_targets);
@@ -202,6 +199,8 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
   }
 
 private:
+  ///number of targets with padding
+  const int Ntargets_padded;
   /// timer for evaluate()
   NewTimer& evaluate_timer_;
   /// timer for move()

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -127,8 +127,6 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
-    //ensure there are neighbors
-    assert(N_sources > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)
@@ -159,6 +157,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableDat
         dr = displacements_[iat][index];
       }
     }
+    assert(index >= 0 && index < N_sources);
     return index;
   }
 

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -41,7 +41,7 @@ private:
   ///multi walker shared memory buffer
   struct DTABMultiWalkerMem : public Resource
   {
-    ///accelerator output array for multiple walkers, N_targets x N_sources_padded x (D+1) (distances, displacements)
+    ///accelerator output array for multiple walkers, [1+D][N_targets][N_sources_padded] (distances, displacements)
     OffloadPinnedVector<T> mw_r_dr;
     ///accelerator input buffer for multiple data set
     OffloadPinnedVector<char> offload_input;
@@ -231,8 +231,8 @@ public:
 
           PRAGMA_OFFLOAD("omp parallel for")
           for (int iel = first; iel < last; iel++)
-            DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iat_ptr, dr_iat_ptr, N_sources_padded,
-                                                          iel);
+            DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, N_sources_padded, r_iat_ptr, dr_iat_ptr,
+                                                          N_sources_padded, iel);
         }
     }
   }
@@ -337,8 +337,8 @@ public:
 
           PRAGMA_OFFLOAD("omp parallel for")
           for (int iel = first; iel < last; iel++)
-            DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, r_iat_ptr, dr_iat_ptr, N_sources_padded,
-                                                          iel);
+            DTD_BConds<T, D, SC>::computeDistancesOffload(pos, source_pos_ptr, N_sources_padded, r_iat_ptr, dr_iat_ptr,
+                                                          N_sources_padded, iel);
         }
 
       if (!(modes_ & DTModes::MW_EVALUATE_RESULT_NO_TRANSFER_TO_HOST))

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -405,8 +405,6 @@ public:
 
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
-    //ensure there are neighbors
-    assert(N_sources > 1);
     RealType min_dist = std::numeric_limits<RealType>::max();
     int index         = -1;
     if (newpos)
@@ -437,6 +435,7 @@ public:
         dr = displacements_[iat][index];
       }
     }
+    assert(index >= 0 && index < N_sources);
     return index;
   }
 


### PR DESCRIPTION
## Proposed changes
All distance table internal change.
Update the boundary condition computeDistancesOffload API.
There will be use cases where the stride size of position array is different from the stride size of r/dr.
So it is better to keep them separate.

Also added a minor fix, I don't remember why I asked Cody to add assert(size>1) to AB table in  #3375. it should not.

## What type(s) of changes does this code introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'