### PR TITLE
Remove CMake global output directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,6 @@ include(macros)
 # Paths for library and executable for out-of-soruce compilation
 #--------------------------------------------------------------------
 set(QMCPACK_UNIT_TEST_DIR ${qmcpack_BINARY_DIR}/tests/bin)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
-    ${qmcpack_BINARY_DIR}/lib
-    CACHE PATH "Single output directory for building all libraries.")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
-    ${qmcpack_BINARY_DIR}/bin
-    CACHE PATH "Single output directory for building all executables.")
 
 ######################################################################
 # Build and install options

--- a/src/QMCApp/CMakeLists.txt
+++ b/src/QMCApp/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(qmc PUBLIC qmcdriver)
 # QMCPACK application
 ####################################
 add_executable(qmcpack qmcapp.cpp)
-
+set_target_properties(qmcpack PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${qmcpack_BINARY_DIR}/bin)
 if(QMC_COMPLEX)
   set_target_properties(qmcpack PROPERTIES OUTPUT_NAME "qmcpack_complex")
 endif(QMC_COMPLEX)

--- a/src/QMCTools/CMakeLists.txt
+++ b/src/QMCTools/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 project(qmctools)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${qmcpack_BINARY_DIR}/bin)
 add_executable(convert4qmc convert4qmc.cpp QMCGaussianParserBase.cpp GaussianFCHKParser.cpp GamesAsciiParser.cpp
     LCAOHDFParser.cpp DiracParser.cpp)
 


### PR DESCRIPTION
## Proposed changes
Prefer per executable control. No change on the user side. No output binary gets moved.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'