### PR TITLE
Remove stale parameters

### DIFF
--- a/src/Optimize/NRCOptimization.h
+++ b/src/Optimize/NRCOptimization.h
@@ -69,6 +69,7 @@ struct NRCOptimization
   Return_t quadstep;
   Return_t quadoffset;
   Return_t largeQuarticStep;
+  Return_t stepsize;
   bool validFuncVal;
   //if tol is absolute, not a percent
   bool AbsFuncTol;
@@ -89,6 +90,7 @@ struct NRCOptimization
     quadstep         = 0.01;
     quadoffset       = 0.0;
     largeQuarticStep = 2.0;
+    stepsize         = 0.25;
     validFuncVal     = true;
     AbsFuncTol       = false;
   }

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -67,7 +67,6 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
       stabilizerScale(2.0),
       bigChange(50),
       exp0(-16),
-      stepsize(0.25),
       bestShift_i(-1.0),
       bestShift_s(-1.0),
       shift_i_input(0.01),
@@ -180,9 +179,6 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
                                                      shift_scales, app_log());
 #endif
 
-
-  //   stale parameters
-  //   m_param.add(stepsize,"stepsize");
 }
 
 /** Clean up the vector */
@@ -460,7 +456,7 @@ bool QMCFixedSampleLinearOptimizeBatched::previous_linear_methods_run()
         if (MinMethod == "quartic")
         {
           int npts(7);
-          objFuncWrapper_.quadstep         = stepsize * objFuncWrapper_.Lambda;
+          objFuncWrapper_.quadstep         = objFuncWrapper_.stepsize * objFuncWrapper_.Lambda;
           objFuncWrapper_.largeQuarticStep = bigChange / bigVec;
           Valid                            = objFuncWrapper_.lineoptimization3(npts, evaluated_cost);
         }

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -68,9 +68,6 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
       bigChange(50),
       exp0(-16),
       stepsize(0.25),
-      GEVtype("mixed"),
-      StabilizerMethod("best"),
-      GEVSplit("no"),
       bestShift_i(-1.0),
       bestShift_s(-1.0),
       shift_i_input(0.01),
@@ -185,18 +182,7 @@ QMCFixedSampleLinearOptimizeBatched::QMCFixedSampleLinearOptimizeBatched(const P
 
 
   //   stale parameters
-  //   m_param.add(eigCG,"eigcg");
-  //   m_param.add(TotalCGSteps,"cgsteps");
-  //   m_param.add(w_beta,"beta");
-  //   quadstep=-1.0;
-  //   m_param.add(quadstep,"quadstep");
   //   m_param.add(stepsize,"stepsize");
-  //   m_param.add(exp1,"exp1");
-  //   m_param.add(GEVtype,"GEVMethod");
-  //   m_param.add(GEVSplit,"GEVSplit");
-  //   m_param.add(StabilizerMethod,"StabilizerMethod");
-  //   m_param.add(LambdaMax,"LambdaMax");
-  //Set parameters for line minimization:
 }
 
 /** Clean up the vector */

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -181,13 +181,7 @@ private:
 
   ///Number of iterations maximum before generating new configurations.
   int nstabilizers;
-  RealType stabilizerScale, bigChange, exp0, exp1, stepsize, savedQuadstep;
-  std::string GEVtype, StabilizerMethod, GEVSplit;
-  RealType w_beta;
-  /// number of previous steps to orthogonalize to.
-  int eigCG;
-  /// total number of cg steps per iterations
-  int TotalCGSteps;
+  RealType stabilizerScale, bigChange, exp0, stepsize;
   /// the previous best identity shift
   RealType bestShift_i;
   /// the previous best overlap shift

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -181,7 +181,7 @@ private:
 
   ///Number of iterations maximum before generating new configurations.
   int nstabilizers;
-  RealType stabilizerScale, bigChange, exp0, stepsize;
+  RealType stabilizerScale, bigChange, exp0;
   /// the previous best identity shift
   RealType bestShift_i;
   /// the previous best overlap shift


### PR DESCRIPTION
Most of the removed parameters were listed under the "stale parameters" comment.

The `stepsize` variable was used in the same place as  number of similar parameters located in `NRCOptimization` for quartic optimization. so move it there.
This reduces the number of members in the `QMCFixedSampleLinearOptimizerBatched` class.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
