### PR TITLE
Refactoring members naming in OperatorBase, derived classes and consumers

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -181,7 +181,7 @@ Class private/protected data members names should follow the convention of varia
 (Member) function names
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Function names should start with a lowercase character and have a capital letter for each new word.
+Function names should start with a lowercase character and have a capital letter for each new word. The exception are the special cases for prefixed multiwalker (``mw_``) and flex (``flex_``) batched API functions. Coding convention should follow after those prefixes.
 
 Template Parameters
 ~~~~~~~~~~~~~~~~~~~

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -327,7 +327,7 @@ void MomentumDistribution::registerOperatorEstimator(hid_t gid)
   ng[0] = nofK.size();
   h5desc_.emplace_back(std::make_unique<ObservableHelper>("nofk"));
   auto& h5o = h5desc_.back();
-  //h5o.set_dimensions(ng, myIndex);
+  //h5o.set_dimensions(ng, my_index_);
   h5o->set_dimensions(ng, 0); // JTK: doesn't seem right
   h5o->open(gid);
   h5o->addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints");

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -188,8 +188,8 @@ public:
    * @param P the target particle set
    */
   virtual void evaluate(ParticleSet& P) = 0;
-  virtual void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                           const RefVectorWithLeader<ParticleSet>& p_list) const
+  virtual void mwEvaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list) const
   {
 #pragma omp parallel for
     for (int iw = 0; iw < dt_list.size(); iw++)

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -188,8 +188,8 @@ public:
    * @param P the target particle set
    */
   virtual void evaluate(ParticleSet& P) = 0;
-  virtual void mwEvaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list) const
+  virtual void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list) const
   {
 #pragma omp parallel for
     for (int iw = 0; iw < dt_list.size(); iw++)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -413,7 +413,7 @@ void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool
   for (int i = 0; i < dts.size(); ++i)
   {
     const auto dt_list(extractDTRefList(p_list, i));
-    dts[i]->mwEvaluate(dt_list, p_list);
+    dts[i]->mw_evaluate(dt_list, p_list);
   }
 
   if (!skipSK && p_leader.SK)

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -92,7 +92,7 @@ ParticleSet::ParticleSet(const ParticleSet& p)
       ParentName(p.parentName()),
       coordinates_(p.coordinates_->makeClone())
 {
-  set_quantum_domain(p.quantum_domain);
+  setQuantumDomain(p.quantum_domain);
   assign(p); //only the base is copied, assumes that other properties are not assignable
   //need explicit copy:
   Mass = p.Mass;
@@ -155,12 +155,12 @@ void ParticleSet::create(const std::vector<int>& agroup)
   }
 }
 
-void ParticleSet::set_quantum_domain(quantum_domains qdomain)
+void ParticleSet::setQuantumDomain(quantum_domains qdomain)
 {
-  if (quantum_domain_valid(qdomain))
+  if (quantumDomainValid(qdomain))
     quantum_domain = qdomain;
   else
-    APP_ABORT("ParticleSet::set_quantum_domain\n  input quantum domain is not valid for particles");
+    APP_ABORT("ParticleSet::setQuantumDomain\n  input quantum domain is not valid for particles");
 }
 
 void ParticleSet::resetGroups()
@@ -413,7 +413,7 @@ void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool
   for (int i = 0; i < dts.size(); ++i)
   {
     const auto dt_list(extractDTRefList(p_list, i));
-    dts[i]->mw_evaluate(dt_list, p_list);
+    dts[i]->mwEvaluate(dt_list, p_list);
   }
 
   if (!skipSK && p_leader.SK)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -210,7 +210,7 @@ public:
   bool put(xmlNodePtr cur) override;
 
   ///specify quantum_domain of particles
-  void set_quantum_domain(quantum_domains qdomain);
+  void setQuantumDomain(quantum_domains qdomain);
 
   void set_quantum() { quantum_domain = quantum; }
 
@@ -219,10 +219,10 @@ public:
   inline bool is_quantum() const { return quantum_domain == quantum; }
 
   ///check whether quantum domain is valid for particles
-  inline bool quantum_domain_valid(quantum_domains qdomain) const { return qdomain != no_quantum_domain; }
+  inline bool quantumDomainValid(quantum_domains qdomain) const { return qdomain != no_quantum_domain; }
 
   ///check whether quantum domain is valid for particles
-  inline bool quantum_domain_valid() const { return quantum_domain_valid(quantum_domain); }
+  inline bool quantumDomainValid() const { return quantumDomainValid(quantum_domain); }
 
   /** add a distance table
    * @param psrc source particle set

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -425,7 +425,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     // if the distance table is not updated by mw_move during p-by-p, needs to recompute the whole table
     // before being used by Hamiltonian.
     if (!(modes_ & DTModes::NEED_TEMP_DATA_ON_HOST))
-      mw_evaluate(dt_list, p_list);
+      mwEvaluate(dt_list, p_list);
   }
 
 private:

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -425,7 +425,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     // if the distance table is not updated by mw_move during p-by-p, needs to recompute the whole table
     // before being used by Hamiltonian.
     if (!(modes_ & DTModes::NEED_TEMP_DATA_ON_HOST))
-      mwEvaluate(dt_list, p_list);
+      mw_evaluate(dt_list, p_list);
   }
 
 private:

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -238,8 +238,8 @@ public:
     }
   }
 
-  inline void mwEvaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                         const RefVectorWithLeader<ParticleSet>& p_list) const override
+  inline void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
     assert(this == &dt_list.getLeader());
     auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
@@ -358,7 +358,7 @@ public:
                            const RefVectorWithLeader<ParticleSet>& p_list,
                            const std::vector<bool>& recompute) const override
   {
-    mwEvaluate(dt_list, p_list);
+    mw_evaluate(dt_list, p_list);
   }
 
   ///evaluate the temporary pair relations

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -238,8 +238,8 @@ public:
     }
   }
 
-  inline void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list) const override
+  inline void mwEvaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+                         const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
     assert(this == &dt_list.getLeader());
     auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
@@ -358,7 +358,7 @@ public:
                            const RefVectorWithLeader<ParticleSet>& p_list,
                            const std::vector<bool>& recompute) const override
   {
-    mw_evaluate(dt_list, p_list);
+    mwEvaluate(dt_list, p_list);
   }
 
   ///evaluate the temporary pair relations

--- a/src/QMCApp/CoupledMC.cpp
+++ b/src/QMCApp/CoupledMC.cpp
@@ -77,7 +77,7 @@ bool QMCMain::executeCMCSection(xmlNodePtr cur)
     ions->R[iat] += deltaR[iat];
 
     ions->update(); //update position and distance table of itself
-    primaryH->update_source(*ions);
+    primaryH->updateSource(*ions);
 
     qmcSystem->update();
     double logpsi2 = primaryPsi->evaluateLog(*qmcSystem);
@@ -91,7 +91,7 @@ bool QMCMain::executeCMCSection(xmlNodePtr cur)
 
     ions->R[iat] -= deltaR[iat];
     ions->update(); //update position and distance table of itself
-    primaryH->update_source(*ions);
+    primaryH->updateSource(*ions);
 
     qmcSystem->update();
     double logpsi3 = primaryPsi->evaluateLog(*qmcSystem);
@@ -108,7 +108,7 @@ bool QMCMain::executeCMCSection(xmlNodePtr cur)
   //{
   //  ions->R[i]+=deltaR(i);
   //  ions->update();
-  //  primaryH->update_source(*ions);
+  //  primaryH->updateSource(*ions);
   //  qmcDriver->run();
   //}
   return success;

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
@@ -38,7 +38,7 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
   rng_ptr_list_.resize(crowd_size);
 
   // build a temporary H_KE for later calling makeClone
-  // need makeClone to setup internal myIndex of a new copy.
+  // need makeClone to setup internal my_index_ of a new copy.
   QMCHamiltonian H_KE;
   for (const std::string& node_name : H_KE_node_names)
     H_KE.addOperator(H.getHamiltonian(node_name)->makeClone(P, Psi), node_name);

--- a/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
+++ b/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
@@ -59,14 +59,14 @@ int HamiltonianRef::addObservables(ParticleSet& P)
   P.Collectables.rewind();
   for (int i = 0; i < Hrefs_.size(); ++i)
     Hrefs_[i].get().addObservables(Observables, P.Collectables);
-  int myIndex = P.PropertyList.add(Observables.Names[0]);
+  int my_index_ = P.PropertyList.add(Observables.Names[0]);
   for (int i = 1; i < Observables.size(); ++i)
     P.PropertyList.add(Observables.Names[i]);
   P.Collectables.size();
   app_log() << "\n  QMCHamiltonian::add2WalkerProperty added"
             << "\n    " << Observables.size() << " to P::PropertyList "
             << "\n    " << P.Collectables.size() << " to P::Collectables "
-            << "\n    starting Index of the observables in P::PropertyList = " << myIndex << std::endl;
+            << "\n    starting Index of the observables in P::PropertyList = " << my_index_ << std::endl;
   return Observables.size();
 }
 

--- a/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
+++ b/src/QMCDrivers/WFOpt/HamiltonianRef.cpp
@@ -59,14 +59,14 @@ int HamiltonianRef::addObservables(ParticleSet& P)
   P.Collectables.rewind();
   for (int i = 0; i < Hrefs_.size(); ++i)
     Hrefs_[i].get().addObservables(Observables, P.Collectables);
-  int my_index_ = P.PropertyList.add(Observables.Names[0]);
+  const int myIndex = P.PropertyList.add(Observables.Names[0]);
   for (int i = 1; i < Observables.size(); ++i)
     P.PropertyList.add(Observables.Names[i]);
   P.Collectables.size();
   app_log() << "\n  QMCHamiltonian::add2WalkerProperty added"
             << "\n    " << Observables.size() << " to P::PropertyList "
             << "\n    " << P.Collectables.size() << " to P::Collectables "
-            << "\n    starting Index of the observables in P::PropertyList = " << my_index_ << std::endl;
+            << "\n    starting Index of the observables in P::PropertyList = " << myIndex << std::endl;
   return Observables.size();
 }
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -393,7 +393,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       else
       {
         // Energy
-        auto energy_list = QMCHamiltonian::mw_evaluate(h_list, wf_list, p_list);
+        auto energy_list = QMCHamiltonian::mwEvaluate(h_list, wf_list, p_list);
 
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
@@ -594,7 +594,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
         int is = base_sample_index + ib;
         wf_list[ib].G += *gradPsi[is];
         wf_list[ib].L += *lapPsi[is];
-        // This is needed to get the KE correct in QMCHamiltonian::mw_evaluate below
+        // This is needed to get the KE correct in QMCHamiltonian::mwEvaluate below
         p_list[ib].G += *gradPsi[is];
         p_list[ib].L += *lapPsi[is];
         Return_rt weight            = vmc_or_dmc * (opt_data.get_log_psi_opt()[ib] - RecordsOnNode[is][LOGPSI_FREE]);
@@ -637,7 +637,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
       else
       {
         // Just energy needed if no gradients
-        auto energy_list = QMCHamiltonian::mw_evaluate(h0_list, wf_list, p_list);
+        auto energy_list = QMCHamiltonian::mwEvaluate(h0_list, wf_list, p_list);
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
           int is                        = base_sample_index + ib;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -393,7 +393,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       else
       {
         // Energy
-        auto energy_list = QMCHamiltonian::mwEvaluate(h_list, wf_list, p_list);
+        auto energy_list = QMCHamiltonian::mw_evaluate(h_list, wf_list, p_list);
 
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
@@ -594,7 +594,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
         int is = base_sample_index + ib;
         wf_list[ib].G += *gradPsi[is];
         wf_list[ib].L += *lapPsi[is];
-        // This is needed to get the KE correct in QMCHamiltonian::mwEvaluate below
+        // This is needed to get the KE correct in QMCHamiltonian::mw_evaluate below
         p_list[ib].G += *gradPsi[is];
         p_list[ib].L += *lapPsi[is];
         Return_rt weight            = vmc_or_dmc * (opt_data.get_log_psi_opt()[ib] - RecordsOnNode[is][LOGPSI_FREE]);
@@ -637,7 +637,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
       else
       {
         // Just energy needed if no gradients
-        auto energy_list = QMCHamiltonian::mwEvaluate(h0_list, wf_list, p_list);
+        auto energy_list = QMCHamiltonian::mw_evaluate(h0_list, wf_list, p_list);
         for (int ib = 0; ib < curr_crowd_size; ib++)
         {
           int is                        = base_sample_index + ib;

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -70,9 +70,9 @@ void BareKineticEnergy::contributeParticleQuantities()
 
 void BareKineticEnergy::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(name_) || request_.streaming_array(name_ + "_complex") ||
+  streaming_particles_ = request_.streaming_array(name_) || request_.streaming_array(name_ + "_complex") ||
       request_.streaming_array("momentum");
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     T_sample      = tm.checkout_real<1>(name_, Ps);
     T_sample_comp = tm.checkout_complex<1>(name_ + "_complex", Ps);
@@ -82,7 +82,7 @@ void BareKineticEnergy::checkoutParticleQuantities(TraceManager& tm)
 
 void BareKineticEnergy::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     delete T_sample;
     delete T_sample_comp;
@@ -95,7 +95,7 @@ void BareKineticEnergy::deleteParticleQuantities()
 Return_t BareKineticEnergy::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     value_ = evaluate_sp(P);
   }
@@ -359,9 +359,9 @@ void BareKineticEnergy::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   auto& walkers = W.WalkerList;
   for (int iw = 0; iw < walkers.size(); iw++)
   {
-    Walker_t& w                                      = *(walkers[iw]);
-    RealType KE                                      = -OneOver2M * (Dot(w.G, w.G) + Sum(w.L));
-    w.getPropertyBase()[WP::NUMPROPERTIES + myIndex] = KE;
+    Walker_t& w                                        = *(walkers[iw]);
+    RealType KE                                        = -OneOver2M * (Dot(w.G, w.G) + Sum(w.L));
+    w.getPropertyBase()[WP::NUMPROPERTIES + my_index_] = KE;
     LocalEnergy[iw] += KE;
   }
 }

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -38,8 +38,8 @@ using Return_t = BareKineticEnergy::Return_t;
    */
 BareKineticEnergy::BareKineticEnergy(ParticleSet& p) : Ps(p)
 {
-  set_energy_domain(KINETIC);
-  one_body_quantum_domain(p);
+  setEnergyDomain(KINETIC);
+  oneBodyQuantumDomain(p);
   streaming_kinetic      = false;
   streaming_kinetic_comp = false;
   streaming_momentum     = false;
@@ -61,14 +61,14 @@ BareKineticEnergy::BareKineticEnergy(ParticleSet& p) : Ps(p)
 BareKineticEnergy::~BareKineticEnergy() = default;
 
 #if !defined(REMOVE_TRACEMANAGER)
-void BareKineticEnergy::contribute_particle_quantities()
+void BareKineticEnergy::contributeParticleQuantities()
 {
   request_.contribute_array(name_);
   request_.contribute_array(name_ + "_complex");
   request_.contribute_array("momentum");
 }
 
-void BareKineticEnergy::checkout_particle_quantities(TraceManager& tm)
+void BareKineticEnergy::checkoutParticleQuantities(TraceManager& tm)
 {
   streaming_particles = request_.streaming_array(name_) || request_.streaming_array(name_ + "_complex") ||
       request_.streaming_array("momentum");
@@ -80,7 +80,7 @@ void BareKineticEnergy::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void BareKineticEnergy::delete_particle_quantities()
+void BareKineticEnergy::deleteParticleQuantities()
 {
   if (streaming_particles)
   {

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -77,9 +77,9 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override {}
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
-  void delete_particle_quantities() override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
@@ -117,8 +117,7 @@ public:
    *
    * Nothing is done but should check the mass
    */
-  bool put(xmlNodePtr)
-  override;
+  bool put(xmlNodePtr) override;
 
   bool get(std::ostream& os) const override;
 

--- a/src/QMCHamiltonians/ChiesaCorrection.cpp
+++ b/src/QMCHamiltonians/ChiesaCorrection.cpp
@@ -36,7 +36,7 @@ void ChiesaCorrection::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>
   auto& walkers = W.WalkerList;
   for (int iw = 0; iw < LocalEnergy.size(); iw++)
   {
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = corr;
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = corr;
     LocalEnergy[iw] += corr;
   }
 }

--- a/src/QMCHamiltonians/ConservedEnergy.h
+++ b/src/QMCHamiltonians/ConservedEnergy.h
@@ -125,7 +125,7 @@ struct ConservedEnergy : public OperatorBase
 #else
       flux = lap + 2 * gradsq;
 #endif
-      w.getPropertyBase()[WP::NUMPROPERTIES + myIndex] = flux;
+      w.getPropertyBase()[WP::NUMPROPERTIES + my_index_] = flux;
     }
   }
 #endif

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -120,7 +120,7 @@ void CoulombPBCAA::updateSource(ParticleSet& s)
     eL = evalLR(s);
     eS = evalSR(s);
   }
-  NewValue = value_ = eL + eS + myConst;
+  new_value_ = value_ = eL + eS + myConst;
 }
 
 void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
@@ -138,8 +138,8 @@ void CoulombPBCAA::contributeParticleQuantities() { request_.contribute_array(na
 
 void CoulombPBCAA::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(name_);
-  if (streaming_particles)
+  streaming_particles_ = request_.streaming_array(name_);
+  if (streaming_particles_)
   {
     Ps.turnOnPerParticleSK();
     V_sample = tm.checkout_real<1>(name_, Ps);
@@ -150,7 +150,7 @@ void CoulombPBCAA::checkoutParticleQuantities(TraceManager& tm)
 
 void CoulombPBCAA::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streaming_particles_)
     delete V_sample;
 }
 #endif
@@ -161,7 +161,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate(ParticleSet& P)
   if (is_active)
   {
 #if !defined(REMOVE_TRACEMANAGER)
-    if (streaming_particles)
+    if (streaming_particles_)
       value_ = evaluate_sp(P);
     else
 #endif

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -32,20 +32,20 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
       d_aa_ID(ref.addTable(ref))
 {
   ReportEngine PRE("CoulombPBCAA", "CoulombPBCAA");
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ref);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ref);
   PtclRefName = ref.getDistTable(d_aa_ID).getName();
   initBreakup(ref);
 
   if (ComputeForces)
   {
     ref.turnOnPerParticleSK();
-    update_source(ref);
+    updateSource(ref);
   }
   if (!is_active)
   {
     ref.update();
-    update_source(ref);
+    updateSource(ref);
 
     ewaldref::RealMat A;
     ewaldref::PosArray R;
@@ -106,7 +106,7 @@ void CoulombPBCAA::addObservables(PropertySetType& plist, BufferType& collectabl
     addObservablesF(plist);
 }
 
-void CoulombPBCAA::update_source(ParticleSet& s)
+void CoulombPBCAA::updateSource(ParticleSet& s)
 {
   mRealType eL(0.0), eS(0.0);
   if (ComputeForces)
@@ -134,9 +134,9 @@ void CoulombPBCAA::resetTargetParticleSet(ParticleSet& P)
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAA::contribute_particle_quantities() { request_.contribute_array(name_); }
+void CoulombPBCAA::contributeParticleQuantities() { request_.contribute_array(name_); }
 
-void CoulombPBCAA::checkout_particle_quantities(TraceManager& tm)
+void CoulombPBCAA::checkoutParticleQuantities(TraceManager& tm)
 {
   streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
@@ -148,7 +148,7 @@ void CoulombPBCAA::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void CoulombPBCAA::delete_particle_quantities()
+void CoulombPBCAA::deleteParticleQuantities()
 {
   if (streaming_particles)
     delete V_sample;

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -89,7 +89,7 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
                                  TrialWaveFunction& psi,
                                  ParticleSet::ParticlePos_t& hf_terms,
                                  ParticleSet::ParticlePos_t& pulay_terms) override;
-  void update_source(ParticleSet& s) override;
+  void updateSource(ParticleSet& s) override;
 
   /** Do nothing */
   bool put(xmlNodePtr cur) override { return true; }
@@ -105,10 +105,10 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
   void initBreakup(ParticleSet& P);
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evalSR(ParticleSet& P);

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -91,7 +91,7 @@ void CoulombPBCAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   {
     for (int iw = 0; iw < walkers.size(); iw++)
     {
-      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+      walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = value_;
       LocalEnergy[iw] += value_;
     }
     return;
@@ -156,7 +156,7 @@ void CoulombPBCAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   for (int iw = 0; iw < walkers.size(); iw++)
   {
     // fprintf (stderr, "Energy = %18.6f\n", SumHost[iw]);
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = SumHost[iw] + myConst;
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = SumHost[iw] + myConst;
     LocalEnergy[iw] += SumHost[iw] + myConst;
   }
 }

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -62,7 +62,7 @@ void CoulombPBCAB::resetTargetParticleSet(ParticleSet& P)
 
 void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(name_.c_str());
+  my_index_ = plist.add(name_.c_str());
   if (ComputeForces)
     addObservablesF(plist);
 }
@@ -73,8 +73,8 @@ void CoulombPBCAB::contributeParticleQuantities() { request_.contribute_array(na
 
 void CoulombPBCAB::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(name_);
-  if (streaming_particles)
+  streaming_particles_ = request_.streaming_array(name_);
+  if (streaming_particles_)
   {
     Pion.turnOnPerParticleSK();
     Peln.turnOnPerParticleSK();
@@ -85,7 +85,7 @@ void CoulombPBCAB::checkoutParticleQuantities(TraceManager& tm)
 
 void CoulombPBCAB::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     delete Ve_sample;
     delete Vi_sample;
@@ -103,7 +103,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate(ParticleSet& P)
   }
   else
 #if !defined(REMOVE_TRACEMANAGER)
-      if (streaming_particles)
+      if (streaming_particles_)
     value_ = evaluate_sp(P);
   else
 #endif

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -32,8 +32,8 @@ CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeFor
       Peln(elns)
 {
   ReportEngine PRE("CoulombPBCAB", "CoulombPBCAB");
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ions, elns);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ions, elns);
   if (ComputeForces)
     PtclA.turnOnPerParticleSK();
   initBreakup(elns);
@@ -69,9 +69,9 @@ void CoulombPBCAB::addObservables(PropertySetType& plist, BufferType& collectabl
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-void CoulombPBCAB::contribute_particle_quantities() { request_.contribute_array(name_); }
+void CoulombPBCAB::contributeParticleQuantities() { request_.contribute_array(name_); }
 
-void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
+void CoulombPBCAB::checkoutParticleQuantities(TraceManager& tm)
 {
   streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
@@ -83,7 +83,7 @@ void CoulombPBCAB::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void CoulombPBCAB::delete_particle_quantities()
+void CoulombPBCAB::deleteParticleQuantities()
 {
   if (streaming_particles)
   {

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -134,10 +134,10 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
 
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
 

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -225,7 +225,7 @@ void CoulombPBCAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType
   for (int iw = 0; iw < walkers.size(); iw++)
   {
     // fprintf (stderr, "Energy = %18.6f\n", SumHost[iw]);
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = esum[iw] + myConst;
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = esum[iw] + myConst;
     LocalEnergy[iw] += esum[iw] + myConst;
   }
 }

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -112,8 +112,8 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
   void checkoutParticleQuantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(name_);
-    if (streaming_particles)
+    streaming_particles_ = request_.streaming_array(name_);
+    if (streaming_particles_)
     {
       Va_sample = tm.checkout_real<1>(name_, Pa);
       if (!is_AA)
@@ -127,7 +127,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
   void deleteParticleQuantities() override
   {
-    if (streaming_particles)
+    if (streaming_particles_)
     {
       delete Va_sample;
       if (!is_AA)
@@ -148,7 +148,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   {
     T res = 0.0;
 #if !defined(REMOVE_TRACEMANAGER)
-    if (streaming_particles)
+    if (streaming_particles_)
       res = evaluate_spAA(d, Z);
     else
 #endif
@@ -189,7 +189,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     constexpr T czero(0);
     T res = czero;
 #if !defined(REMOVE_TRACEMANAGER)
-    if (streaming_particles)
+    if (streaming_particles_)
       res = evaluate_spAB(d, Za, Zb);
     else
 #endif
@@ -230,11 +230,11 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     }
     res *= 2.0;
 #if defined(TRACE_CHECK)
-    auto sptmp          = streaming_particles;
-    streaming_particles = false;
-    T Vnow              = res;
-    T Vsum              = Va_samp.sum();
-    T Vorig             = evaluateAA(d, Z);
+    auto sptmp           = streaming_particles_;
+    streaming_particles_ = false;
+    T Vnow               = res;
+    T Vsum               = Va_samp.sum();
+    T Vorig              = evaluateAA(d, Z);
     if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
     {
       app_log() << "versiontest: CoulombPotential::evaluateAA()" << std::endl;
@@ -249,7 +249,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       app_log() << "accumtest:   sum:" << Vsum << std::endl;
       APP_ABORT("Trace check failed");
     }
-    streaming_particles = sptmp;
+    streaming_particles_ = sptmp;
 #endif
     return res;
   }
@@ -281,13 +281,13 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     res *= 2.0;
 
 #if defined(TRACE_CHECK)
-    auto sptmp          = streaming_particles;
-    streaming_particles = false;
-    T Vnow              = res;
-    T Vasum             = Va_samp.sum();
-    T Vbsum             = Vb_samp.sum();
-    T Vsum              = Vasum + Vbsum;
-    T Vorig             = evaluateAB(d, Za, Zb);
+    auto sptmp           = streaming_particles_;
+    streaming_particles_ = false;
+    T Vnow               = res;
+    T Vasum              = Va_samp.sum();
+    T Vbsum              = Vb_samp.sum();
+    T Vsum               = Vasum + Vbsum;
+    T Vorig              = evaluateAB(d, Za, Zb);
     if (std::abs(Vorig - Vnow) > TraceManager::trace_tol)
     {
       app_log() << "versiontest: CoulombPotential::evaluateAB()" << std::endl;
@@ -309,7 +309,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       app_log() << "sharetest:   b share:" << Vbsum << std::endl;
       APP_ABORT("Trace check failed");
     }
-    streaming_particles = sptmp;
+    streaming_particles_ = sptmp;
 #endif
     return res;
   }
@@ -406,8 +406,8 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       {
         W.loadWalker(*walkers[iw], false);
         W.update();
-        value_                                                      = evaluate(W);
-        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+        value_                                                        = evaluate(W);
+        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = value_;
         LocalEnergy[iw] += value_;
       }
     }
@@ -415,7 +415,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
       // assuminig the same results for all the walkers when the set is not active
       for (int iw = 0; iw < LocalEnergy.size(); iw++)
       {
-        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = value_;
+        walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = value_;
         LocalEnergy[iw] += value_;
       }
   }

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -72,8 +72,8 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(computeForces)
   {
-    set_energy_domain(POTENTIAL);
-    two_body_quantum_domain(s, s);
+    setEnergyDomain(POTENTIAL);
+    twoBodyQuantumDomain(s, s);
     nCenters = s.getTotalNum();
     prefix   = "F_AA";
 
@@ -102,15 +102,15 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         is_active(active),
         ComputeForces(false)
   {
-    set_energy_domain(POTENTIAL);
-    two_body_quantum_domain(s, t);
+    setEnergyDomain(POTENTIAL);
+    twoBodyQuantumDomain(s, t);
     nCenters = s.getTotalNum();
   }
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override { request_.contribute_array(name_); }
+  void contributeParticleQuantities() override { request_.contribute_array(name_); }
 
-  void checkout_particle_quantities(TraceManager& tm) override
+  void checkoutParticleQuantities(TraceManager& tm) override
   {
     streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
@@ -125,7 +125,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     }
   }
 
-  void delete_particle_quantities() override
+  void deleteParticleQuantities() override
   {
     if (streaming_particles)
     {
@@ -323,7 +323,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
   ~CoulombPotential() override {}
 
-  void update_source(ParticleSet& s) override
+  void updateSource(ParticleSet& s) override
   {
     if (is_AA)
     {

--- a/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPotential_CUDA.cpp
@@ -37,7 +37,7 @@ void CoulombPotentialAA_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Re
   SumHost = SumGPU;
   for (int iw = 0; iw < walkers.size(); iw++)
   {
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = SumHost[iw];
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = SumHost[iw];
     LocalEnergy[iw] += SumHost[iw];
   }
 }
@@ -90,7 +90,7 @@ void CoulombPotentialAB_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Re
   SumHost = SumGPU;
   for (int iw = 0; iw < walkers.size(); iw++)
   {
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = SumHost[iw];
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = SumHost[iw];
     LocalEnergy[iw] += SumHost[iw];
   }
 }

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -43,7 +43,7 @@ void DensityEstimator::resetTargetParticleSet(ParticleSet& P) {}
 
 DensityEstimator::Return_t DensityEstimator::evaluate(ParticleSet& P)
 {
-  RealType wgt = tWalker->Weight;
+  RealType wgt = t_walker_->Weight;
   if (Periodic)
   {
     for (int iat = 0; iat < P.getTotalNum(); ++iat)
@@ -110,7 +110,7 @@ void DensityEstimator::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>
 void DensityEstimator::addObservables(PropertySetType& plist, BufferType& collectables)
 {
   //current index
-  myIndex = collectables.current();
+  my_index_ = collectables.current();
   std::vector<RealType> tmp(NumGrids[OHMMS_DIM]);
   collectables.add(tmp.begin(), tmp.end());
   //potentialIndex=collectables.current();
@@ -126,7 +126,7 @@ void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5des
     ng[i] = NumGrids[i];
   h5desc.emplace_back(name_);
   auto& h5o = h5desc.back();
-  h5o.set_dimensions(ng, myIndex);
+  h5o.set_dimensions(ng, my_index_);
   h5o.open(gid);
 }
 

--- a/src/QMCHamiltonians/DensityEstimator.h
+++ b/src/QMCHamiltonians/DensityEstimator.h
@@ -44,7 +44,7 @@ public:
   bool get(std::ostream& os) const override;
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 
-  inline int getGridIndex(int i, int j, int k) const { return myIndex + k + NumGrids[2] * (j + NumGrids[1] * i); }
+  inline int getGridIndex(int i, int j, int k) const { return my_index_ + k + NumGrids[2] * (j + NumGrids[1] * i); }
 
   inline int getGridIndexPotential(int i, int j, int k) const
   {

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -487,7 +487,7 @@ void DensityMatrices1B::report(const std::string& pad)
 }
 
 
-void DensityMatrices1B::get_required_traces(TraceManager& tm)
+void DensityMatrices1B::getRequiredTraces(TraceManager& tm)
 {
   w_trace = tm.get_real_trace("weight");
   if (energy_mat)

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -504,7 +504,7 @@ void DensityMatrices1B::getRequiredTraces(TraceManager& tm)
 
     E_samp.resize(nparticles);
   }
-  have_required_traces = true;
+  have_required_traces_ = true;
 }
 
 
@@ -518,8 +518,8 @@ void DensityMatrices1B::addObservables(PropertySetType& plist, BufferType& colle
 #else
   int nentries = basis_size * basis_size * nspecies;
 #endif
-  myIndex = collectables.current();
-  nindex  = myIndex;
+  my_index_ = collectables.current();
+  nindex    = my_index_;
   std::vector<RealType> ntmp(nentries);
   collectables.add(ntmp.begin(), ntmp.end());
   if (energy_mat)
@@ -596,7 +596,7 @@ void DensityMatrices1B::warmup_sampling()
 DensityMatrices1B::Return_t DensityMatrices1B::evaluate(ParticleSet& P)
 {
   ScopedTimer t(timers[DM_eval]);
-  if (have_required_traces || !energy_mat)
+  if (have_required_traces_ || !energy_mat)
   {
     if (check_derivatives)
       test_derivatives();
@@ -621,7 +621,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_matrix(ParticleSet& P)
   if (energy_mat)
     weight = w_trace->sample[0] * metric;
   else
-    weight = tWalker->Weight * metric;
+    weight = t_walker_->Weight * metric;
 
   if (energy_mat)
     get_energies(E_N); // energies        : particles x 1
@@ -848,7 +848,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
   if (energy_mat)
     weight = w_trace->sample[0] * metric;
   else
-    weight = tWalker->Weight * metric;
+    weight = t_walker_->Weight * metric;
   int nparticles = P.getTotalNum();
   generate_samples(weight);
   int n = 0;

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -166,7 +166,7 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
   //optional standard interface
-  void get_required_traces(TraceManager& tm) override;
+  void getRequiredTraces(TraceManager& tm) override;
   void setRandomGenerator(RandomGenerator_t* rng) override;
 
   //required for Collectables interface
@@ -177,10 +177,10 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override {}
   void setObservables(PropertySetType& plist) override {}
   void setParticlePropertyList(PropertySetType& plist, int offset) override {}
-  void contribute_scalar_quantities() override {}
-  void checkout_scalar_quantities(TraceManager& tm) override {}
-  void collect_scalar_quantities() override {}
-  void delete_scalar_quantities() override {}
+  void contributeScalarQuantities() override {}
+  void checkoutScalarQuantities(TraceManager& tm) override {}
+  void collectScalarQuantities() override {}
+  void deleteScalarQuantities() override {}
 
   //obsolete?
   bool get(std::ostream& os) const override { return false; }

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -211,7 +211,7 @@ void EnergyDensityEstimator::getRequiredTraces(TraceManager& tm)
   Vd_trace   = tm.get_real_combined_trace(*Pdynamic, "LocalPotential");
   if (Pstatic)
     Vs_trace = tm.get_real_combined_trace(*Pstatic, "LocalPotential");
-  have_required_traces = true;
+  have_required_traces_ = true;
 }
 
 
@@ -257,7 +257,7 @@ void EnergyDensityEstimator::resetTargetParticleSet(ParticleSet& P)
 
 EnergyDensityEstimator::Return_t EnergyDensityEstimator::evaluate(ParticleSet& P)
 {
-  if (have_required_traces)
+  if (have_required_traces_)
   {
     Pdynamic = &P;
     //Collect positions from ParticleSets
@@ -457,7 +457,7 @@ void EnergyDensityEstimator::write_nonzero_domains(const ParticleSet& P)
 
 void EnergyDensityEstimator::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = collectables.size();
+  my_index_ = collectables.size();
   //allocate space for energy density outside of any spacegrid
   outside_buffer_offset = collectables.size();
   int nvalues           = (int)nEDValues;

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -203,7 +203,7 @@ ParticleSet* EnergyDensityEstimator::get_particleset(std::string& psname)
 }
 
 
-void EnergyDensityEstimator::get_required_traces(TraceManager& tm)
+void EnergyDensityEstimator::getRequiredTraces(TraceManager& tm)
 {
   bool write = omp_get_thread_num() == 0;
   w_trace    = tm.get_real_trace("weight");

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -100,12 +100,12 @@ private:
   CombinedTraceSample<TraceReal>* Vd_trace;
   CombinedTraceSample<TraceReal>* Vs_trace;
 
-  void get_required_traces(TraceManager& tm) override;
+  void getRequiredTraces(TraceManager& tm) override;
 
-  void contribute_scalar_quantities() override {}
-  void checkout_scalar_quantities(TraceManager& tm) override {}
-  void collect_scalar_quantities() override {}
-  void delete_scalar_quantities() override {}
+  void contributeScalarQuantities() override {}
+  void checkoutScalarQuantities(TraceManager& tm) override {}
+  void collectScalarQuantities() override {}
+  void deleteScalarQuantities() override {}
 };
 
 

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<OperatorBase> BareForce::makeClone(ParticleSet& qp, TrialWaveFun
 void BareForce::addObservables(PropertySetType& plist, BufferType& collectables)
 {
   addObservablesF(plist);
-  myIndex = FirstForceIndex;
+  my_index_ = FirstForceIndex;
 }
 
 BareForce::Return_t BareForce::evaluate(ParticleSet& P)

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -227,7 +227,7 @@ void ForceChiesaPBCAA::resetTargetParticleSet(ParticleSet& P) { dAB->resetTarget
 
 void ForceChiesaPBCAA::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.add(name_.c_str());
+  my_index_ = plist.add(name_.c_str());
   addObservablesF(plist);
 }
 

--- a/src/QMCHamiltonians/ForwardWalking.cpp
+++ b/src/QMCHamiltonians/ForwardWalking.cpp
@@ -163,8 +163,8 @@ void ForwardWalking::addObservables(PropertySetType& plist)
 
 void ForwardWalking::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.size();
-  int nc  = 0;
+  my_index_ = plist.size();
+  int nc    = 0;
   for (int i = 0; i < nObservables; ++i)
     for (int j = 0; j < walkerLengths[i][1]; ++j, ++nc)
     {
@@ -174,6 +174,6 @@ void ForwardWalking::addObservables(PropertySetType& plist, BufferType& collecta
       //         myIndex=std::min(myIndex,id);
       //app_log() <<" Observables named "<<sstr.str() << " at " << id << std::endl;
     }
-  app_log() << "ForwardWalking::Observables [" << myIndex << ", " << myIndex + nc << ")" << std::endl;
+  app_log() << "ForwardWalking::Observables [" << my_index_ << ", " << my_index_ + nc << ")" << std::endl;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/ForwardWalking.h
+++ b/src/QMCHamiltonians/ForwardWalking.h
@@ -45,10 +45,10 @@ struct ForwardWalking : public OperatorBase
   {
     for (int i = 0; i < nObservables; i++)
     {
-      int lastindex = tWalker->PHindex[Pindices[i]] - 1;
+      int lastindex = t_walker_->PHindex[Pindices[i]] - 1;
       if (lastindex < 0)
         lastindex += walkerLengths[i][2];
-      tWalker->addPropertyHistoryPoint(Pindices[i], tWalker->PropertyHistory[Pindices[i]][lastindex]);
+      t_walker_->addPropertyHistoryPoint(Pindices[i], t_walker_->PropertyHistory[Pindices[i]][lastindex]);
     }
     calculate(P);
     return 0.0;
@@ -60,18 +60,18 @@ struct ForwardWalking : public OperatorBase
     for (int i = 0; i < nObservables; i++)
     {
       int j       = 0;
-      int FWindex = tWalker->PHindex[Pindices[i]] - 1;
+      int FWindex = t_walker_->PHindex[Pindices[i]] - 1;
       while (j < walkerLengths[i][1])
       {
         FWindex -= walkerLengths[i][0];
         if (FWindex < 0)
           FWindex += walkerLengths[i][2];
-        (*Vit) = tWalker->PropertyHistory[Pindices[i]][FWindex];
+        (*Vit) = t_walker_->PropertyHistory[Pindices[i]][FWindex];
         j++;
         Vit++;
       }
     }
-    copy(Values.begin(), Values.end(), tWalker->getPropertyBase() + FirstHamiltonian + myIndex);
+    copy(Values.begin(), Values.end(), t_walker_->getPropertyBase() + FirstHamiltonian + my_index_);
     return 0.0;
   }
 
@@ -79,7 +79,7 @@ struct ForwardWalking : public OperatorBase
   inline Return_t evaluate(ParticleSet& P) override
   {
     for (int i = 0; i < nObservables; i++)
-      tWalker->addPropertyHistoryPoint(Pindices[i], P.PropertyList[Hindices[i]]);
+      t_walker_->addPropertyHistoryPoint(Pindices[i], P.PropertyList[Hindices[i]]);
     calculate(P);
     return 0.0;
   }
@@ -101,11 +101,14 @@ struct ForwardWalking : public OperatorBase
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
 
-  void setObservables(PropertySetType& plist) override { copy(Values.begin(), Values.end(), plist.begin() + myIndex); }
+  void setObservables(PropertySetType& plist) override
+  {
+    copy(Values.begin(), Values.end(), plist.begin() + my_index_);
+  }
 
   void setParticlePropertyList(PropertySetType& plist, int offset) override
   {
-    copy(Values.begin(), Values.end(), plist.begin() + myIndex + offset);
+    copy(Values.begin(), Values.end(), plist.begin() + my_index_ + offset);
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/GridExternalPotential.cpp
+++ b/src/QMCHamiltonians/GridExternalPotential.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<OperatorBase> GridExternalPotential::makeClone(ParticleSet& P, T
 GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
+  if (streaming_particles_)
     value_ = evaluate_sp(P);
   else
   {
@@ -132,7 +132,7 @@ GridExternalPotential::Return_t GridExternalPotential::evaluate(ParticleSet& P)
 GridExternalPotential::Return_t GridExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  value_                       = 0.0;
+  value_                      = 0.0;
   for (int i = 0; i < P.getTotalNum(); ++i)
   {
     PosType r   = P.R[i];

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -38,8 +38,8 @@ struct GridExternalPotential : public OperatorBase
   //construction/destruction
   GridExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(POTENTIAL);
-    one_body_quantum_domain(P);
+    setEnergyDomain(POTENTIAL);
+    oneBodyQuantumDomain(P);
   }
 
   //unneeded interface functions
@@ -56,16 +56,16 @@ struct GridExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request_.contribute_array(name_); }
+  void contributeParticleQuantities() override { request_.contribute_array(name_); }
 
-  void checkout_particle_quantities(TraceManager& tm) override
+  void checkoutParticleQuantities(TraceManager& tm) override
   {
     streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
       V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
-  void delete_particle_quantities() override
+  void deleteParticleQuantities() override
   {
     if (streaming_particles)
       delete V_sample;

--- a/src/QMCHamiltonians/GridExternalPotential.h
+++ b/src/QMCHamiltonians/GridExternalPotential.h
@@ -60,14 +60,14 @@ struct GridExternalPotential : public OperatorBase
 
   void checkoutParticleQuantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(name_);
-    if (streaming_particles)
+    streaming_particles_ = request_.streaming_array(name_);
+    if (streaming_particles_)
       V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
   void deleteParticleQuantities() override
   {
-    if (streaming_particles)
+    if (streaming_particles_)
       delete V_sample;
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.cpp
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.cpp
@@ -63,12 +63,12 @@ std::unique_ptr<OperatorBase> HarmonicExternalPotential::makeClone(ParticleSet& 
 HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
+  if (streaming_particles_)
     value_ = evaluate_sp(P);
   else
   {
 #endif
-    value_              = 0.0;
+    value_             = 0.0;
     RealType prefactor = .5 * energy / (length * length);
     for (int i = 0; i < P.getTotalNum(); ++i)
     {
@@ -86,7 +86,7 @@ HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate(Particle
 HarmonicExternalPotential::Return_t HarmonicExternalPotential::evaluate_sp(ParticleSet& P)
 {
   Array<TraceReal, 1>& V_samp = *V_sample;
-  value_                       = 0.0;
+  value_                      = 0.0;
   RealType prefactor          = .5 * energy / (length * length);
   for (int i = 0; i < P.getTotalNum(); ++i)
   {

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -60,14 +60,14 @@ struct HarmonicExternalPotential : public OperatorBase
 
   void checkoutParticleQuantities(TraceManager& tm) override
   {
-    streaming_particles = request_.streaming_array(name_);
-    if (streaming_particles)
+    streaming_particles_ = request_.streaming_array(name_);
+    if (streaming_particles_)
       V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
   void deleteParticleQuantities() override
   {
-    if (streaming_particles)
+    if (streaming_particles_)
       delete V_sample;
   }
 

--- a/src/QMCHamiltonians/HarmonicExternalPotential.h
+++ b/src/QMCHamiltonians/HarmonicExternalPotential.h
@@ -36,8 +36,8 @@ struct HarmonicExternalPotential : public OperatorBase
   //construction/destruction
   HarmonicExternalPotential(ParticleSet& P) : Ps(P)
   {
-    set_energy_domain(POTENTIAL);
-    one_body_quantum_domain(P);
+    setEnergyDomain(POTENTIAL);
+    oneBodyQuantumDomain(P);
   }
 
   ~HarmonicExternalPotential() override {}
@@ -56,16 +56,16 @@ struct HarmonicExternalPotential : public OperatorBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   //traces interface
-  void contribute_particle_quantities() override { request_.contribute_array(name_); }
+  void contributeParticleQuantities() override { request_.contribute_array(name_); }
 
-  void checkout_particle_quantities(TraceManager& tm) override
+  void checkoutParticleQuantities(TraceManager& tm) override
   {
     streaming_particles = request_.streaming_array(name_);
     if (streaming_particles)
       V_sample = tm.checkout_real<1>(name_, Ps);
   }
 
-  void delete_particle_quantities() override
+  void deleteParticleQuantities() override
   {
     if (streaming_particles)
       delete V_sample;

--- a/src/QMCHamiltonians/Hdispatcher.cpp
+++ b/src/QMCHamiltonians/Hdispatcher.cpp
@@ -26,7 +26,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluate(
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mwEvaluate(ham_list, wf_list, p_list);
+    return QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());
@@ -43,7 +43,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluateWithTope
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mwEvaluateWithToperator(ham_list, wf_list, p_list);
+    return QMCHamiltonian::mw_evaluateWithToperator(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());

--- a/src/QMCHamiltonians/Hdispatcher.cpp
+++ b/src/QMCHamiltonians/Hdispatcher.cpp
@@ -26,7 +26,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluate(
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
+    return QMCHamiltonian::mwEvaluate(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());
@@ -43,7 +43,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> Hdispatcher::flex_evaluateWithTope
 {
   assert(ham_list.size() == p_list.size());
   if (use_batch_)
-    return QMCHamiltonian::mw_evaluateWithToperator(ham_list, wf_list, p_list);
+    return QMCHamiltonian::mwEvaluateWithToperator(ham_list, wf_list, p_list);
   else
   {
     std::vector<FullPrecRealType> local_energies(ham_list.size());

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -18,8 +18,8 @@ namespace qmcplusplus
 {
 L2Potential::L2Potential(const ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi) : IonConfig(ions)
 {
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);
   size_t ns    = ions.getSpeciesSet().getTotalNum();
@@ -62,7 +62,7 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
 
   // compute v_L2(r)*L^2 for all electron-ion pairs
   const DistanceTableData& d_table(P.getDistTable(myTableIndex));
-  value_              = 0.0;
+  value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
   {

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -98,7 +98,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   value_ = 0.0;
   std::fill(xyz2.begin(), xyz2.end(), 0.0);
 
-  RealType wgt        = tWalker->Weight;
+  RealType wgt        = t_walker_->Weight;
   const auto& d_table = P.getDistTable(myTableID_);
 
   // temp variables
@@ -171,7 +171,7 @@ void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferTyp
   // get myIndex for scalar.dat
   if (per_xyz)
   {
-    myIndex = plist.size();
+    my_index_ = plist.size();
     for (int idir = 0; idir < OHMMS_DIM; idir++)
     {
       std::stringstream ss;
@@ -181,7 +181,7 @@ void LatticeDeviationEstimator::addObservables(PropertySetType& plist, BufferTyp
   }
   else
   {
-    myIndex = plist.add(name_); // same as OperatorBase::addObservables
+    my_index_ = plist.add(name_); // same as OperatorBase::addObservables
   }
 
   // get h5_index for stat.h5
@@ -205,11 +205,11 @@ void LatticeDeviationEstimator::setObservables(PropertySetType& plist)
 {
   if (per_xyz)
   {
-    copy(xyz2.begin(), xyz2.end(), plist.begin() + myIndex);
+    copy(xyz2.begin(), xyz2.end(), plist.begin() + my_index_);
   }
   else
   {
-    plist[myIndex] = value_; // default behavior
+    plist[my_index_] = value_; // default behavior
   }
 }
 

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -62,8 +62,8 @@ void LocalECPotential::contributeParticleQuantities() { request_.contribute_arra
 
 void LocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(name_);
-  if (streaming_particles)
+  streaming_particles_ = request_.streaming_array(name_);
+  if (streaming_particles_)
   {
     Ve_sample = tm.checkout_real<1>(name_, Peln);
     Vi_sample = tm.checkout_real<1>(name_, Pion);
@@ -72,7 +72,7 @@ void LocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 
 void LocalECPotential::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     delete Ve_sample;
     delete Vi_sample;
@@ -84,7 +84,7 @@ void LocalECPotential::deleteParticleQuantities()
 LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
 {
 #if !defined(REMOVE_TRACEMANAGER)
-  if (streaming_particles)
+  if (streaming_particles_)
     value_ = evaluate_sp(P);
   else
 #endif

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -23,8 +23,8 @@ namespace qmcplusplus
 {
 LocalECPotential::LocalECPotential(const ParticleSet& ions, ParticleSet& els) : IonConfig(ions), Peln(els), Pion(ions)
 {
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ions, els);
   NumIons      = ions.getTotalNum();
   myTableIndex = els.addTable(ions);
   //allocate null
@@ -58,9 +58,9 @@ void LocalECPotential::add(int groupID, std::unique_ptr<RadialPotentialType>&& p
 }
 
 #if !defined(REMOVE_TRACEMANAGER)
-void LocalECPotential::contribute_particle_quantities() { request_.contribute_array(name_); }
+void LocalECPotential::contributeParticleQuantities() { request_.contribute_array(name_); }
 
-void LocalECPotential::checkout_particle_quantities(TraceManager& tm)
+void LocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 {
   streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
@@ -70,7 +70,7 @@ void LocalECPotential::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void LocalECPotential::delete_particle_quantities()
+void LocalECPotential::deleteParticleQuantities()
 {
   if (streaming_particles)
   {

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -66,10 +66,10 @@ struct LocalECPotential : public OperatorBase
   void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
   Return_t evaluate_sp(ParticleSet& P); //collect
-  void delete_particle_quantities() override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evaluate(ParticleSet& P) override;

--- a/src/QMCHamiltonians/LocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/LocalECPotential_CUDA.cpp
@@ -117,7 +117,7 @@ void LocalECPotential_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<Real
   for (int iw = 0; iw < walkers.size(); iw++)
   {
     // fprintf (stderr, "Energy = %18.6f\n", SumHost[iw]);
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = esum[iw];
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = esum[iw];
     LocalEnergy[iw] += esum[iw];
   }
 }

--- a/src/QMCHamiltonians/MPC_CUDA.cpp
+++ b/src/QMCHamiltonians/MPC_CUDA.cpp
@@ -130,8 +130,8 @@ void MPC_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalE
 
   for (int iw = 0; iw < nw; iw++)
   {
-    double e                                                    = esum[iw] + SumHost[iw] + Vconst;
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = e;
+    double e                                                      = esum[iw] + SumHost[iw] + Vconst;
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = e;
     LocalEnergy[iw] += e;
   }
 }

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -80,8 +80,8 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
   }
   if (hdf5_out)
   {
-    RealType w = tWalker->Weight * norm_nofK;
-    int j      = myIndex;
+    RealType w = t_walker_->Weight * norm_nofK;
+    int j      = my_index_;
     for (int ik = 0; ik < nofK.size(); ++ik, ++j)
       P.Collectables[j] += w * nofK[ik];
   }
@@ -104,7 +104,7 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     ng[0] = nofK.size();
     h5desc.emplace_back("nofk");
     auto& h5o = h5desc.back();
-    h5o.set_dimensions(ng, myIndex);
+    h5o.set_dimensions(ng, my_index_);
     h5o.open(gid);
     h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints");
     h5o.addProperty(const_cast<std::vector<int>&>(kWeights), "kweights");
@@ -116,12 +116,12 @@ void MomentumEstimator::addObservables(PropertySetType& plist, BufferType& colle
 {
   if (hdf5_out)
   {
-    myIndex = collectables.size();
+    my_index_ = collectables.size();
     collectables.add(nofK.begin(), nofK.end());
   }
   else
   {
-    myIndex = plist.size();
+    my_index_ = plist.size();
     for (int i = 0; i < nofK.size(); i++)
     {
       std::stringstream sstr;
@@ -136,7 +136,7 @@ void MomentumEstimator::setObservables(PropertySetType& plist)
 {
   if (!hdf5_out)
   {
-    copy(nofK.begin(), nofK.end(), plist.begin() + myIndex);
+    copy(nofK.begin(), nofK.end(), plist.begin() + my_index_);
   }
 }
 
@@ -144,7 +144,7 @@ void MomentumEstimator::setParticlePropertyList(PropertySetType& plist, int offs
 {
   if (!hdf5_out)
   {
-    copy(nofK.begin(), nofK.end(), plist.begin() + myIndex + offset);
+    copy(nofK.begin(), nofK.end(), plist.begin() + my_index_ + offset);
   }
 }
 
@@ -425,7 +425,7 @@ std::unique_ptr<OperatorBase> MomentumEstimator::makeClone(ParticleSet& qp, Tria
 {
   std::unique_ptr<MomentumEstimator> myclone = std::make_unique<MomentumEstimator>(qp, psi);
   myclone->resize(kPoints, M);
-  myclone->myIndex   = myIndex;
+  myclone->my_index_ = my_index_;
   myclone->norm_nofK = norm_nofK;
   myclone->hdf5_out  = hdf5_out;
   return myclone;

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -111,9 +111,9 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateDeterministic(Particl
   return value_;
 }
 
-void NonLocalECPotential::mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                                     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                     const RefVectorWithLeader<ParticleSet>& p_list) const
+void NonLocalECPotential::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                                      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   mw_evaluateImpl(o_list, wf_list, p_list, false);
 }
@@ -127,9 +127,9 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithToperator(Particl
   return value_;
 }
 
-void NonLocalECPotential::mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                  const RefVectorWithLeader<ParticleSet>& p_list) const
+void NonLocalECPotential::mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                   const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   if (UseTMove == TMOVE_V0 || UseTMove == TMOVE_V3)
     mw_evaluateImpl(o_list, wf_list, p_list, true);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -81,8 +81,8 @@ void NonLocalECPotential::contributeParticleQuantities() { request_.contribute_a
 
 void NonLocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 {
-  streaming_particles = request_.streaming_array(name_);
-  if (streaming_particles)
+  streaming_particles_ = request_.streaming_array(name_);
+  if (streaming_particles_)
   {
     Ve_sample = tm.checkout_real<1>(name_, Peln);
     Vi_sample = tm.checkout_real<1>(name_, IonConfig);
@@ -91,7 +91,7 @@ void NonLocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 
 void NonLocalECPotential::deleteParticleQuantities()
 {
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     delete Ve_sample;
     delete Vi_sample;
@@ -146,7 +146,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid
 #if !defined(REMOVE_TRACEMANAGER)
   auto& Ve_samp = *Ve_sample;
   auto& Vi_samp = *Vi_sample;
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     Ve_samp = 0.0;
     Vi_samp = 0.0;
@@ -207,7 +207,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid
             value_ += pairpot;
             NeighborIons.push_back(iat);
             IonNeighborElecs.getNeighborList(iat).push_back(jel);
-            if (streaming_particles)
+            if (streaming_particles_)
             {
               Ve_samp(jel) += 0.5 * pairpot;
               Vi_samp(iat) += 0.5 * pairpot;
@@ -218,7 +218,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid
   }
 
 #if !defined(TRACE_CHECK)
-  if (streaming_particles)
+  if (streaming_particles_)
   {
     Return_t Vnow  = value_;
     RealType Visum = Vi_sample->sum();

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -56,8 +56,8 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
       UseTMove(TMOVE_OFF),
       nonLocalOps(els.getTotalNum())
 {
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();
   //els.resizeSphere(NumIons);
@@ -77,9 +77,9 @@ NonLocalECPotential::NonLocalECPotential(ParticleSet& ions,
 NonLocalECPotential::~NonLocalECPotential() = default;
 
 #if !defined(REMOVE_TRACEMANAGER)
-void NonLocalECPotential::contribute_particle_quantities() { request_.contribute_array(name_); }
+void NonLocalECPotential::contributeParticleQuantities() { request_.contribute_array(name_); }
 
-void NonLocalECPotential::checkout_particle_quantities(TraceManager& tm)
+void NonLocalECPotential::checkoutParticleQuantities(TraceManager& tm)
 {
   streaming_particles = request_.streaming_array(name_);
   if (streaming_particles)
@@ -89,7 +89,7 @@ void NonLocalECPotential::checkout_particle_quantities(TraceManager& tm)
   }
 }
 
-void NonLocalECPotential::delete_particle_quantities()
+void NonLocalECPotential::deleteParticleQuantities()
 {
   if (streaming_particles)
   {
@@ -111,9 +111,9 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateDeterministic(Particl
   return value_;
 }
 
-void NonLocalECPotential::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                                      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                      const RefVectorWithLeader<ParticleSet>& p_list) const
+void NonLocalECPotential::mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                                     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                     const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   mw_evaluateImpl(o_list, wf_list, p_list, false);
 }
@@ -127,9 +127,9 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithToperator(Particl
   return value_;
 }
 
-void NonLocalECPotential::mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                   const RefVectorWithLeader<ParticleSet>& p_list) const
+void NonLocalECPotential::mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                  const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   if (UseTMove == TMOVE_V0 || UseTMove == TMOVE_V3)
     mw_evaluateImpl(o_list, wf_list, p_list, true);

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -40,22 +40,22 @@ public:
   void resetTargetParticleSet(ParticleSet& P) override;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  void contribute_particle_quantities() override;
-  void checkout_particle_quantities(TraceManager& tm) override;
-  void delete_particle_quantities() override;
+  void contributeParticleQuantities() override;
+  void checkoutParticleQuantities(TraceManager& tm) override;
+  void deleteParticleQuantities() override;
 #endif
 
   Return_t evaluate(ParticleSet& P) override;
   Return_t evaluateDeterministic(ParticleSet& P) override;
-  void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                   const RefVectorWithLeader<ParticleSet>& p_list) const override;
+  void mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                  const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;
 
-  void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                const RefVectorWithLeader<ParticleSet>& p_list) const override;
+  void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                               const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
@@ -188,7 +188,7 @@ private:
    */
   void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
 
-  /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
+  /** the actual implementation for batched walkers, used by mwEvaluate and mwEvaluateWithToperator
    * @param o_list the list of NonLocalECPotential in a walker batch
    * @param p_list the list of ParticleSet in a walker batch
    * @param Tmove whether Txy for Tmove is updated

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -47,15 +47,15 @@ public:
 
   Return_t evaluate(ParticleSet& P) override;
   Return_t evaluateDeterministic(ParticleSet& P) override;
-  void mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                  const RefVectorWithLeader<ParticleSet>& p_list) const override;
+  void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                   const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                   const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithToperator(ParticleSet& P) override;
 
-  void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                               const RefVectorWithLeader<ParticleSet>& p_list) const override;
+  void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
   Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
@@ -188,7 +188,7 @@ private:
    */
   void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
 
-  /** the actual implementation for batched walkers, used by mwEvaluate and mwEvaluateWithToperator
+  /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
    * @param o_list the list of NonLocalECPotential in a walker batch
    * @param p_list the list of ParticleSet in a walker batch
    * @param Tmove whether Txy for Tmove is updated

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
@@ -329,7 +329,7 @@ void NonLocalECPotential_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<R
   {
     // if (std::isnan(esum[iw]))
     // 	app_log() << "NAN in esum.\n";
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = esum[iw];
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = esum[iw];
     LocalEnergy[iw] += esum[iw];
   }
 }
@@ -445,7 +445,7 @@ void NonLocalECPotential_CUDA::addEnergy(MCWalkerConfiguration& W,
     }
   for (int iw = 0; iw < walkers.size(); iw++)
   {
-    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex] = esum[iw];
+    walkers[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_] = esum[iw];
     LocalEnergy[iw] += esum[iw];
   }
 }

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -22,15 +22,15 @@
 
 namespace qmcplusplus
 {
-OperatorBase::OperatorBase() : value_(0.0), myIndex(-1), tWalker(0)
+OperatorBase::OperatorBase() : value_(0.0), my_index_(-1), t_walker_(0)
 {
-  quantum_domain = NO_QUANTUM_DOMAIN;
-  energy_domain  = NO_ENERGY_DOMAIN;
+  quantum_domain_ = NO_QUANTUM_DOMAIN;
+  energy_domain_  = NO_ENERGY_DOMAIN;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  streaming_scalars    = false;
-  streaming_particles  = false;
-  have_required_traces = false;
+  streaming_scalars_    = false;
+  streaming_particles_  = false;
+  have_required_traces_ = false;
 #endif
   update_mode_.set(PRIMARY, 1);
 }
@@ -119,7 +119,7 @@ void OperatorBase::mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<
 void OperatorBase::setEnergyDomain(EnergyDomains edomain)
 {
   if (energyDomainValid(edomain))
-    energy_domain = edomain;
+    energy_domain_ = edomain;
   else
     APP_ABORT("QMCHamiltonainBase::setEnergyDomain\n  input energy domain is invalid");
 }
@@ -127,7 +127,7 @@ void OperatorBase::setEnergyDomain(EnergyDomains edomain)
 void OperatorBase::setQuantumDomain(QuantumDomains qdomain)
 {
   if (quantumDomainValid(qdomain))
-    quantum_domain = qdomain;
+    quantum_domain_ = qdomain;
   else
     APP_ABORT("QMCHamiltonainBase::setQuantumDomain\n  input quantum domain is invalid");
 }
@@ -135,9 +135,9 @@ void OperatorBase::setQuantumDomain(QuantumDomains qdomain)
 void OperatorBase::oneBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = CLASSICAL;
+    quantum_domain_ = CLASSICAL;
   else if (P.is_quantum())
-    quantum_domain = QUANTUM;
+    quantum_domain_ = QUANTUM;
   else
     APP_ABORT("OperatorBase::oneBodyQuantumDomain\n  quantum domain of input particles is invalid");
 }
@@ -145,9 +145,9 @@ void OperatorBase::oneBodyQuantumDomain(const ParticleSet& P)
 void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
-    quantum_domain = CLASSICAL_CLASSICAL;
+    quantum_domain_ = CLASSICAL_CLASSICAL;
   else if (P.is_quantum())
-    quantum_domain = QUANTUM_QUANTUM;
+    quantum_domain_ = QUANTUM_QUANTUM;
   else
     APP_ABORT("OperatorBase::twoBodyQuantumDomain(P)\n  quantum domain of input particles is invalid");
 }
@@ -159,11 +159,11 @@ void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet
   bool q1 = P1.is_quantum();
   bool q2 = P2.is_quantum();
   if (c1 && c2)
-    quantum_domain = CLASSICAL_CLASSICAL;
+    quantum_domain_ = CLASSICAL_CLASSICAL;
   else if ((q1 && c2) || (c1 && q2))
-    quantum_domain = QUANTUM_CLASSICAL;
+    quantum_domain_ = QUANTUM_CLASSICAL;
   else if (q1 && q2)
-    quantum_domain = QUANTUM_QUANTUM;
+    quantum_domain_ = QUANTUM_QUANTUM;
   else
     APP_ABORT("OperatorBase::twoBodyQuantumDomain(P1,P2)\n  quantum domain of input particles is invalid");
 }
@@ -188,7 +188,7 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hi
     h5desc.emplace_back(name_);
     auto& oh = h5desc.back();
     std::vector<int> onedim(1, 1);
-    oh.set_dimensions(onedim, myIndex);
+    oh.set_dimensions(onedim, my_index_);
     oh.open(gid);
   }
 }

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -56,9 +56,9 @@ OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P) { ret
  * really should reduce vector of local_energies. matching the ordering and size of o list
  * the this can be call for 1 or more QMCHamiltonians
  */
-void OperatorBase::mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                              const RefVectorWithLeader<ParticleSet>& p_list) const
+void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                               const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(this == &o_list.getLeader());
 /**  Temporary raw omp pragma for simple thread parallelism
@@ -90,11 +90,11 @@ void OperatorBase::mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
     o_list[iw].evaluate(p_list[iw]);
 }
 
-void OperatorBase::mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                      const RefVectorWithLeader<ParticleSet>& p_list,
-                                                      const opt_variables_type& optvars,
-                                                      RecordArray<ValueType>& dlogpsi,
-                                                      RecordArray<ValueType>& dhpsioverpsi) const
+void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                       const RefVectorWithLeader<ParticleSet>& p_list,
+                                                       const opt_variables_type& optvars,
+                                                       RecordArray<ValueType>& dlogpsi,
+                                                       RecordArray<ValueType>& dhpsioverpsi) const
 {
   const int nparam = dlogpsi.nparam();
   std::vector<ValueType> tmp_dlogpsi(nparam);

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -56,9 +56,9 @@ OperatorBase::Return_t OperatorBase::evaluateDeterministic(ParticleSet& P) { ret
  * really should reduce vector of local_energies. matching the ordering and size of o list
  * the this can be call for 1 or more QMCHamiltonians
  */
-void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                               const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                               const RefVectorWithLeader<ParticleSet>& p_list) const
+void OperatorBase::mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list) const
 {
   assert(this == &o_list.getLeader());
 /**  Temporary raw omp pragma for simple thread parallelism
@@ -90,11 +90,11 @@ void OperatorBase::mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
     o_list[iw].evaluate(p_list[iw]);
 }
 
-void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                                       const opt_variables_type& optvars,
-                                                       RecordArray<ValueType>& dlogpsi,
-                                                       RecordArray<ValueType>& dhpsioverpsi) const
+void OperatorBase::mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                                      const opt_variables_type& optvars,
+                                                      RecordArray<ValueType>& dlogpsi,
+                                                      RecordArray<ValueType>& dhpsioverpsi) const
 {
   const int nparam = dlogpsi.nparam();
   std::vector<ValueType> tmp_dlogpsi(nparam);
@@ -116,43 +116,43 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
 }
 
 
-void OperatorBase::set_energy_domain(EnergyDomains edomain)
+void OperatorBase::setEnergyDomain(EnergyDomains edomain)
 {
-  if (energy_domain_valid(edomain))
+  if (energyDomainValid(edomain))
     energy_domain = edomain;
   else
-    APP_ABORT("QMCHamiltonainBase::set_energy_domain\n  input energy domain is invalid");
+    APP_ABORT("QMCHamiltonainBase::setEnergyDomain\n  input energy domain is invalid");
 }
 
-void OperatorBase::set_quantum_domain(QuantumDomains qdomain)
+void OperatorBase::setQuantumDomain(QuantumDomains qdomain)
 {
-  if (quantum_domain_valid(qdomain))
+  if (quantumDomainValid(qdomain))
     quantum_domain = qdomain;
   else
-    APP_ABORT("QMCHamiltonainBase::set_quantum_domain\n  input quantum domain is invalid");
+    APP_ABORT("QMCHamiltonainBase::setQuantumDomain\n  input quantum domain is invalid");
 }
 
-void OperatorBase::one_body_quantum_domain(const ParticleSet& P)
+void OperatorBase::oneBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
     quantum_domain = CLASSICAL;
   else if (P.is_quantum())
     quantum_domain = QUANTUM;
   else
-    APP_ABORT("OperatorBase::one_body_quantum_domain\n  quantum domain of input particles is invalid");
+    APP_ABORT("OperatorBase::oneBodyQuantumDomain\n  quantum domain of input particles is invalid");
 }
 
-void OperatorBase::two_body_quantum_domain(const ParticleSet& P)
+void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P)
 {
   if (P.is_classical())
     quantum_domain = CLASSICAL_CLASSICAL;
   else if (P.is_quantum())
     quantum_domain = QUANTUM_QUANTUM;
   else
-    APP_ABORT("OperatorBase::two_body_quantum_domain(P)\n  quantum domain of input particles is invalid");
+    APP_ABORT("OperatorBase::twoBodyQuantumDomain(P)\n  quantum domain of input particles is invalid");
 }
 
-void OperatorBase::two_body_quantum_domain(const ParticleSet& P1, const ParticleSet& P2)
+void OperatorBase::twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet& P2)
 {
   bool c1 = P1.is_classical();
   bool c2 = P2.is_classical();
@@ -165,10 +165,10 @@ void OperatorBase::two_body_quantum_domain(const ParticleSet& P1, const Particle
   else if (q1 && q2)
     quantum_domain = QUANTUM_QUANTUM;
   else
-    APP_ABORT("OperatorBase::two_body_quantum_domain(P1,P2)\n  quantum domain of input particles is invalid");
+    APP_ABORT("OperatorBase::twoBodyQuantumDomain(P1,P2)\n  quantum domain of input particles is invalid");
 }
 
-bool OperatorBase::quantum_domain_valid(QuantumDomains qdomain) { return qdomain != NO_QUANTUM_DOMAIN; }
+bool OperatorBase::quantumDomainValid(QuantumDomains qdomain) { return qdomain != NO_QUANTUM_DOMAIN; }
 
 void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
 {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -149,11 +149,11 @@ public:
   TraceRequest& getRequest() noexcept;
 #endif
 
-  inline bool isClassical() { return quantum_domain == CLASSICAL; }
-  inline bool isQuantum() { return quantum_domain == QUANTUM; }
-  inline bool isClassicalClassical() { return quantum_domain == CLASSICAL_CLASSICAL; }
-  inline bool isQuantumClassical() { return quantum_domain == QUANTUM_CLASSICAL; }
-  inline bool isQuantumQuantum() { return quantum_domain == QUANTUM_QUANTUM; }
+  inline bool isClassical() { return quantum_domain_ == CLASSICAL; }
+  inline bool isQuantum() { return quantum_domain_ == QUANTUM; }
+  inline bool isClassicalClassical() { return quantum_domain_ == CLASSICAL_CLASSICAL; }
+  inline bool isQuantumClassical() { return quantum_domain_ == QUANTUM_CLASSICAL; }
+  inline bool isQuantumQuantum() { return quantum_domain_ == QUANTUM_QUANTUM; }
 
   /** return the mode i
    * @param i index among PRIMARY, OPTIMIZABLE, RATIOUPDATE, PHYSICAL
@@ -193,12 +193,12 @@ public:
    * Default implementation is to assign Value which is updated
    * by evaluate  function using myIndex.
    */
-  virtual void setObservables(PropertySetType& plist) { plist[myIndex] = value_; }
+  virtual void setObservables(PropertySetType& plist) { plist[my_index_] = value_; }
 
-  virtual void setParticlePropertyList(PropertySetType& plist, int offset) { plist[myIndex + offset] = value_; }
+  virtual void setParticlePropertyList(PropertySetType& plist, int offset) { plist[my_index_ + offset] = value_; }
 
   //virtual void setHistories(Walker<Return_t, ParticleSet::ParticleGradient_t>& ThisWalker)
-  virtual void setHistories(Walker_t& ThisWalker) { tWalker = &(ThisWalker); }
+  virtual void setHistories(Walker_t& ThisWalker) { t_walker_ = &(ThisWalker); }
 
   /** reset the data with the target ParticleSet
    * @param P new target ParticleSet
@@ -354,9 +354,9 @@ public:
   {
     deleteScalarQuantities();
     deleteParticleQuantities();
-    streaming_scalars    = false;
-    streaming_particles  = false;
-    have_required_traces = false;
+    streaming_scalars_    = false;
+    streaming_particles_  = false;
+    have_required_traces_ = false;
     request_.reset();
   }
 
@@ -388,17 +388,17 @@ protected:
 #endif
 
   ///starting index of this object
-  int myIndex;
+  int my_index_;
 
   ///a new value for a proposed move
-  Return_t NewValue;
+  Return_t new_value_;
 
   ///reference to the current walker
-  Walker_t* tWalker;
+  Walker_t* t_walker_;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  bool streaming_particles;
-  bool have_required_traces;
+  bool streaming_particles_;
+  bool have_required_traces_;
 #endif
 
   /**
@@ -412,21 +412,21 @@ protected:
 
   virtual void checkoutScalarQuantities(TraceManager& tm)
   {
-    streaming_scalars = request_.streaming_scalar(name_);
-    if (streaming_scalars)
-      value_sample = tm.checkout_real<1>(name_);
+    streaming_scalars_ = request_.streaming_scalar(name_);
+    if (streaming_scalars_)
+      value_sample_ = tm.checkout_real<1>(name_);
   }
 
   virtual void collectScalarQuantities()
   {
-    if (streaming_scalars)
-      (*value_sample)(0) = value_;
+    if (streaming_scalars_)
+      (*value_sample_)(0) = value_;
   }
 
   virtual void deleteScalarQuantities()
   {
-    if (streaming_scalars)
-      delete value_sample;
+    if (streaming_scalars_)
+      delete value_sample_;
   }
 
   virtual void contributeParticleQuantities(){};
@@ -463,33 +463,33 @@ protected:
   inline void addValue(PropertySetType& plist)
   {
     if (!update_mode_[COLLECTABLE])
-      myIndex = plist.add(name_.c_str());
+      my_index_ = plist.add(name_.c_str());
   }
 
 private:
-  ///quantum_domain of the (particle) operator, default = no_quantum_domain
-  QuantumDomains quantum_domain;
+  ///quantum_domain_ of the (particle) operator, default = no_quantum_domain
+  QuantumDomains quantum_domain_;
   ///energy domain of the operator (kinetic/potential), default = no_energy_domain
-  EnergyDomains energy_domain;
+  EnergyDomains energy_domain_;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  bool streaming_scalars;
+  bool streaming_scalars_;
 
   ///array to store sample value
-  Array<RealType, 1>* value_sample;
+  Array<RealType, 1>* value_sample_;
 #endif
 
   ///return whether the energy domain is valid
   inline bool energyDomainValid(EnergyDomains edomain) const { return edomain != NO_ENERGY_DOMAIN; }
 
   ///return whether the energy domain is valid
-  inline bool energyDomainValid() const { return energyDomainValid(energy_domain); }
+  inline bool energyDomainValid() const { return energyDomainValid(energy_domain_); }
 
   ///return whether the quantum domain is valid
   bool quantumDomainValid(QuantumDomains qdomain);
 
   ///return whether the quantum domain is valid
-  inline bool quantumDomainValid() { return quantumDomainValid(quantum_domain); }
+  inline bool quantumDomainValid() { return quantumDomainValid(quantum_domain_); }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -149,11 +149,11 @@ public:
   TraceRequest& getRequest() noexcept;
 #endif
 
-  inline bool is_classical() { return quantum_domain == CLASSICAL; }
-  inline bool is_quantum() { return quantum_domain == QUANTUM; }
-  inline bool is_classical_classical() { return quantum_domain == CLASSICAL_CLASSICAL; }
-  inline bool is_quantum_classical() { return quantum_domain == QUANTUM_CLASSICAL; }
-  inline bool is_quantum_quantum() { return quantum_domain == QUANTUM_QUANTUM; }
+  inline bool isClassical() { return quantum_domain == CLASSICAL; }
+  inline bool isQuantum() { return quantum_domain == QUANTUM; }
+  inline bool isClassicalClassical() { return quantum_domain == CLASSICAL_CLASSICAL; }
+  inline bool isQuantumClassical() { return quantum_domain == QUANTUM_CLASSICAL; }
+  inline bool isQuantumQuantum() { return quantum_domain == QUANTUM_QUANTUM; }
 
   /** return the mode i
    * @param i index among PRIMARY, OPTIMIZABLE, RATIOUPDATE, PHYSICAL
@@ -216,15 +216,15 @@ public:
    */
   virtual Return_t evaluateDeterministic(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                           const RefVectorWithLeader<ParticleSet>& p_list) const;
+  virtual void mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-  virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                   const RefVectorWithLeader<ParticleSet>& p_list,
-                                                   const opt_variables_type& optvars,
-                                                   RecordArray<ValueType>& dlogpsi,
-                                                   RecordArray<ValueType>& dhpsioverpsi) const;
+  virtual void mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                  const RefVectorWithLeader<ParticleSet>& p_list,
+                                                  const opt_variables_type& optvars,
+                                                  RecordArray<ValueType>& dlogpsi,
+                                                  RecordArray<ValueType>& dhpsioverpsi) const;
 
 
   virtual Return_t rejectedMove(ParticleSet& P) { return 0; }
@@ -235,11 +235,11 @@ public:
   virtual Return_t evaluateWithToperator(ParticleSet& P) { return evaluate(P); }
 
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                        const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                        const RefVectorWithLeader<ParticleSet>& p_list) const
+  virtual void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                       const RefVectorWithLeader<ParticleSet>& p_list) const
   {
-    mw_evaluate(o_list, wf_list, p_list);
+    mwEvaluate(o_list, wf_list, p_list);
   }
 
   /** evaluate value and derivatives wrt the optimizables
@@ -294,7 +294,7 @@ public:
    *
    * Default implementation does nothing. Only A-A interactions for s needs to implement its own method.
    */
-  virtual void update_source(ParticleSet& s) {}
+  virtual void updateSource(ParticleSet& s) {}
 
   /** return an average value by collective operation
    */
@@ -328,39 +328,39 @@ public:
 
 #if !defined(REMOVE_TRACEMANAGER)
   ///make trace quantities available
-  inline void contribute_trace_quantities()
+  inline void contributeTraceQuantities()
   {
-    contribute_scalar_quantities();
-    contribute_particle_quantities();
+    contributeScalarQuantities();
+    contributeParticleQuantities();
   }
 
   ///checkout trace arrays
-  inline void checkout_trace_quantities(TraceManager& tm)
+  inline void checkoutTraceQuantities(TraceManager& tm)
   {
     //derived classes must guard individual checkouts using request info
-    checkout_scalar_quantities(tm);
-    checkout_particle_quantities(tm);
+    checkoutScalarQuantities(tm);
+    checkoutParticleQuantities(tm);
   }
 
   ///collect scalar trace data
-  inline void collect_scalar_traces()
+  inline void collectScalarTraces()
   {
-    //app_log()<<"OperatorBase::collect_scalar_traces"<< std::endl;
-    collect_scalar_quantities();
+    //app_log()<<"OperatorBase::collectScalarTraces"<< std::endl;
+    collectScalarQuantities();
   }
 
   ///delete trace arrays
-  inline void delete_trace_quantities()
+  inline void deleteTraceQuantities()
   {
-    delete_scalar_quantities();
-    delete_particle_quantities();
+    deleteScalarQuantities();
+    deleteParticleQuantities();
     streaming_scalars    = false;
     streaming_particles  = false;
     have_required_traces = false;
     request_.reset();
   }
 
-  virtual void get_required_traces(TraceManager& tm){};
+  virtual void getRequiredTraces(TraceManager& tm){};
 #endif
 
   virtual void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
@@ -408,30 +408,30 @@ protected:
   virtual bool put(xmlNodePtr cur) = 0;
 
 #if !defined(REMOVE_TRACEMANAGER)
-  virtual void contribute_scalar_quantities() { request_.contribute_scalar(name_); }
+  virtual void contributeScalarQuantities() { request_.contribute_scalar(name_); }
 
-  virtual void checkout_scalar_quantities(TraceManager& tm)
+  virtual void checkoutScalarQuantities(TraceManager& tm)
   {
     streaming_scalars = request_.streaming_scalar(name_);
     if (streaming_scalars)
       value_sample = tm.checkout_real<1>(name_);
   }
 
-  virtual void collect_scalar_quantities()
+  virtual void collectScalarQuantities()
   {
     if (streaming_scalars)
       (*value_sample)(0) = value_;
   }
 
-  virtual void delete_scalar_quantities()
+  virtual void deleteScalarQuantities()
   {
     if (streaming_scalars)
       delete value_sample;
   }
 
-  virtual void contribute_particle_quantities(){};
-  virtual void checkout_particle_quantities(TraceManager& tm){};
-  virtual void delete_particle_quantities(){};
+  virtual void contributeParticleQuantities(){};
+  virtual void checkoutParticleQuantities(TraceManager& tm){};
+  virtual void deleteParticleQuantities(){};
 #endif
 
   virtual void setComputeForces(bool compute)
@@ -440,19 +440,19 @@ protected:
   }
 
   ///set energy domain
-  void set_energy_domain(EnergyDomains edomain);
+  void setEnergyDomain(EnergyDomains edomain);
 
   ///set quantum domain
-  void set_quantum_domain(QuantumDomains qdomain);
+  void setQuantumDomain(QuantumDomains qdomain);
 
   ///set quantum domain for one-body operator
-  void one_body_quantum_domain(const ParticleSet& P);
+  void oneBodyQuantumDomain(const ParticleSet& P);
 
   ///set quantum domain for two-body operator
-  void two_body_quantum_domain(const ParticleSet& P);
+  void twoBodyQuantumDomain(const ParticleSet& P);
 
   ///set quantum domain for two-body operator
-  void two_body_quantum_domain(const ParticleSet& P1, const ParticleSet& P2);
+  void twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet& P2);
 
   /**
    * named values to  the property list
@@ -480,16 +480,16 @@ private:
 #endif
 
   ///return whether the energy domain is valid
-  inline bool energy_domain_valid(EnergyDomains edomain) const { return edomain != NO_ENERGY_DOMAIN; }
+  inline bool energyDomainValid(EnergyDomains edomain) const { return edomain != NO_ENERGY_DOMAIN; }
 
   ///return whether the energy domain is valid
-  inline bool energy_domain_valid() const { return energy_domain_valid(energy_domain); }
+  inline bool energyDomainValid() const { return energyDomainValid(energy_domain); }
 
   ///return whether the quantum domain is valid
-  bool quantum_domain_valid(QuantumDomains qdomain);
+  bool quantumDomainValid(QuantumDomains qdomain);
 
   ///return whether the quantum domain is valid
-  inline bool quantum_domain_valid() { return quantum_domain_valid(quantum_domain); }
+  inline bool quantumDomainValid() { return quantumDomainValid(quantum_domain); }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -216,15 +216,15 @@ public:
    */
   virtual Return_t evaluateDeterministic(ParticleSet& P);
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mwEvaluate(const RefVectorWithLeader<OperatorBase>& o_list,
-                          const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list) const;
+  virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
+                           const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-  virtual void mwEvaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
-                                                  const RefVectorWithLeader<ParticleSet>& p_list,
-                                                  const opt_variables_type& optvars,
-                                                  RecordArray<ValueType>& dlogpsi,
-                                                  RecordArray<ValueType>& dhpsioverpsi) const;
+  virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
+                                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                                   const opt_variables_type& optvars,
+                                                   RecordArray<ValueType>& dlogpsi,
+                                                   RecordArray<ValueType>& dhpsioverpsi) const;
 
 
   virtual Return_t rejectedMove(ParticleSet& P) { return 0; }
@@ -235,11 +235,11 @@ public:
   virtual Return_t evaluateWithToperator(ParticleSet& P) { return evaluate(P); }
 
   /** Evaluate the contribution of this component of multiple walkers */
-  virtual void mwEvaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
-                                       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                       const RefVectorWithLeader<ParticleSet>& p_list) const
+  virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
+                                        const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                        const RefVectorWithLeader<ParticleSet>& p_list) const
   {
-    mwEvaluate(o_list, wf_list, p_list);
+    mw_evaluate(o_list, wf_list, p_list);
   }
 
   /** evaluate value and derivatives wrt the optimizables

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -229,7 +229,7 @@ public:
   Return_t evaluate(ParticleSet& P) override;
 
   //optional standard interface
-  //void get_required_traces(TraceManager& tm);
+  //void getRequiredTraces(TraceManager& tm);
   //void setRandomGenerator(RandomGenerator_t* rng);
 
   //required for Collectables interface

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -118,7 +118,7 @@ PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
         const int loc     = static_cast<int>(DeltaInv * r);
         const int jg      = P.GroupID[j];
         const int pair_id = ig * (ig + 1) / 2 + jg;
-        collectables[pair_id * NumBins + loc + myIndex] += norm_factor(pair_id + 1, loc);
+        collectables[pair_id * NumBins + loc + my_index_] += norm_factor(pair_id + 1, loc);
       }
     }
   }
@@ -138,7 +138,7 @@ PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
         {
           int toff = (gid[j] + koff) * NumBins;
           int loc  = static_cast<int>(DeltaInv * r);
-          collectables[toff + loc + myIndex] += norm_factor(0, loc) * overNI;
+          collectables[toff + loc + my_index_] += norm_factor(0, loc) * overNI;
         }
       }
     }
@@ -149,7 +149,7 @@ PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
 void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5list, hid_t gid) const
 {
   std::vector<int> onedim(1, NumBins);
-  int offset = myIndex;
+  int offset = my_index_;
   for (int i = 0; i < gof_r_prefix.size(); ++i)
   {
     h5list.emplace_back(gof_r_prefix[i]);
@@ -168,7 +168,7 @@ void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5li
 
 void PairCorrEstimator::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = collectables.size();
+  my_index_ = collectables.size();
   std::vector<RealType> g(gof_r_prefix.size() * NumBins, 0);
   collectables.add(g.begin(), g.end());
   ////only while debugging

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -172,12 +172,12 @@ const std::string& QMCHamiltonian::getOperatorType(const std::string& name)
 //  return false;
 //}
 
-void QMCHamiltonian::update_source(ParticleSet& s)
+void QMCHamiltonian::updateSource(ParticleSet& s)
 {
   for (int i = 0; i < H.size(); ++i)
-    H[i]->update_source(s);
+    H[i]->updateSource(s);
   for (int i = 0; i < auxH.size(); ++i)
-    auxH[i]->update_source(s);
+    auxH[i]->updateSource(s);
 }
 
 /** add a number of properties to the ParticleSet
@@ -280,15 +280,15 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   for (int i = 1; i < H.size(); ++i)
   {
     OperatorBase& h = *H[i];
-    if (h.is_quantum())
+    if (h.isQuantum())
       Vq.push_back(h.getName());
-    else if (h.is_classical())
+    else if (h.isClassical())
       Vc.push_back(h.getName());
-    else if (h.is_quantum_quantum())
+    else if (h.isQuantumQuantum())
       Vqq.push_back(h.getName());
-    else if (h.is_quantum_classical())
+    else if (h.isQuantumClassical())
       Vqc.push_back(h.getName());
-    else if (h.is_classical_classical())
+    else if (h.isClassicalClassical())
       Vcc.push_back(h.getName());
     else if (omp_get_thread_num() == 0)
       app_log() << "  warning: potential named " << h.getName()
@@ -308,9 +308,9 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
   request.contribute_scalar("weight", true);       //default trace quantity
   request.contribute_array("position");
   for (int i = 0; i < H.size(); ++i)
-    H[i]->contribute_trace_quantities();
+    H[i]->contributeTraceQuantities();
   for (int i = 0; i < auxH.size(); ++i)
-    auxH[i]->contribute_trace_quantities();
+    auxH[i]->contributeTraceQuantities();
 
 
   //note availability of combined quantities
@@ -390,14 +390,14 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < H.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << H[i]->getName() << std::endl;
-      H[i]->checkout_trace_quantities(tm);
+        app_log() << "    OperatorBase::checkoutTraceQuantities  " << H[i]->getName() << std::endl;
+      H[i]->checkoutTraceQuantities(tm);
     }
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::checkout_trace_quantities  " << auxH[i]->getName() << std::endl;
-      auxH[i]->checkout_trace_quantities(tm);
+        app_log() << "    OperatorBase::checkoutTraceQuantities  " << auxH[i]->getName() << std::endl;
+      auxH[i]->checkoutTraceQuantities(tm);
     }
     //setup combined traces that depend on H information
     //  LocalEnergy, LocalPotential, Vq, Vc, Vqq, Vqc, Vcc
@@ -426,8 +426,8 @@ void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
     for (int i = 0; i < auxH.size(); ++i)
     {
       if (trace_log)
-        app_log() << "    OperatorBase::get_required_traces  " << auxH[i]->getName() << std::endl;
-      auxH[i]->get_required_traces(tm);
+        app_log() << "    OperatorBase::getRequiredTraces  " << auxH[i]->getName() << std::endl;
+      auxH[i]->getRequiredTraces(tm);
     }
     //report
 
@@ -476,9 +476,9 @@ void QMCHamiltonian::finalize_traces()
   if (request.streaming())
   {
     for (int i = 0; i < H.size(); ++i)
-      H[i]->delete_trace_quantities();
+      H[i]->deleteTraceQuantities();
     for (int i = 0; i < auxH.size(); ++i)
-      auxH[i]->delete_trace_quantities();
+      auxH[i]->deleteTraceQuantities();
   }
   streaming_position = false;
   request.reset();
@@ -502,7 +502,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-    H[i]->collect_scalar_traces();
+    H[i]->collectScalarTraces();
 #endif
     H[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
@@ -526,7 +526,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-    H[i]->collect_scalar_traces();
+    H[i]->collectScalarTraces();
 #endif
     H[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
@@ -553,7 +553,7 @@ void QMCHamiltonian::updateKinetic(OperatorBase& op, QMCHamiltonian& ham, Partic
   pset.PropertyList[WP::LOCALPOTENTIAL] = ham.LocalEnergy - ham.KineticEnergy;
 }
 
-std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
+std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluate(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
@@ -582,7 +582,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     //   op.setObservables(ham.Observables);
     //   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
     // };
-    ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
+    ham_leader.H[i_ham_op]->mwEvaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -643,7 +643,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
       ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
       const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
-      ham_leader.H[i_ham_op]->mw_evaluateWithParameterDerivatives(HC_list, p_list, optvars, dlogpsi, dhpsioverpsi);
+      ham_leader.H[i_ham_op]->mwEvaluateWithParameterDerivatives(HC_list, p_list, optvars, dlogpsi, dhpsioverpsi);
 
       for (int iw = 0; iw < ham_list.size(); iw++)
         updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
@@ -676,7 +676,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
     local_energies =
         QMCHamiltonian::mw_evaluateValueAndDerivativesInner(ham_list, wf_list, p_list, optvars, dlogpsi, dhpsioverpsi);
   else
-    local_energies = QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
+    local_energies = QMCHamiltonian::mwEvaluate(ham_list, wf_list, p_list);
 
   return local_energies;
 }
@@ -702,7 +702,7 @@ void QMCHamiltonian::auxHevaluate(ParticleSet& P)
     RealType sink = auxH[i]->evaluate(P);
     auxH[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-    auxH[i]->collect_scalar_traces();
+    auxH[i]->collectScalarTraces();
 #endif
     auxH[i]->setParticlePropertyList(P.PropertyList, myIndex);
     //H[i]->setParticlePropertyList(P.PropertyList,myIndex);
@@ -721,7 +721,7 @@ void QMCHamiltonian::auxHevaluate(ParticleSet& P, Walker_t& ThisWalker)
     RealType sink = auxH[i]->evaluate(P);
     auxH[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-    auxH[i]->collect_scalar_traces();
+    auxH[i]->collectScalarTraces();
 #endif
     auxH[i]->setParticlePropertyList(P.PropertyList, myIndex);
   }
@@ -742,7 +742,7 @@ void QMCHamiltonian::auxHevaluate(ParticleSet& P, Walker_t& ThisWalker, bool do_
       RealType sink = auxH[i]->evaluate(P);
       auxH[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-      auxH[i]->collect_scalar_traces();
+      auxH[i]->collectScalarTraces();
 #endif
       auxH[i]->setParticlePropertyList(P.PropertyList, myIndex);
     }
@@ -778,7 +778,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleS
     LocalEnergy += H[i]->evaluateWithToperator(P);
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
-    H[i]->collect_scalar_traces();
+    H[i]->collectScalarTraces();
 #endif
   }
   KineticEnergy                      = H[0]->getValue();
@@ -788,7 +788,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleS
   return LocalEnergy;
 }
 
-std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithToperator(
+std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluateWithToperator(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
@@ -803,7 +803,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
     ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
-    ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
+    ham_leader.H[i_ham_op]->mwEvaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); ++iw)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -553,7 +553,7 @@ void QMCHamiltonian::updateKinetic(OperatorBase& op, QMCHamiltonian& ham, Partic
   pset.PropertyList[WP::LOCALPOTENTIAL] = ham.LocalEnergy - ham.KineticEnergy;
 }
 
-std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluate(
+std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
@@ -582,7 +582,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluate(
     //   op.setObservables(ham.Observables);
     //   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
     // };
-    ham_leader.H[i_ham_op]->mwEvaluate(HC_list, wf_list, p_list);
+    ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -643,7 +643,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
       ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
       const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
-      ham_leader.H[i_ham_op]->mwEvaluateWithParameterDerivatives(HC_list, p_list, optvars, dlogpsi, dhpsioverpsi);
+      ham_leader.H[i_ham_op]->mw_evaluateWithParameterDerivatives(HC_list, p_list, optvars, dlogpsi, dhpsioverpsi);
 
       for (int iw = 0; iw < ham_list.size(); iw++)
         updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
@@ -676,7 +676,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateValueAn
     local_energies =
         QMCHamiltonian::mw_evaluateValueAndDerivativesInner(ham_list, wf_list, p_list, optvars, dlogpsi, dhpsioverpsi);
   else
-    local_energies = QMCHamiltonian::mwEvaluate(ham_list, wf_list, p_list);
+    local_energies = QMCHamiltonian::mw_evaluate(ham_list, wf_list, p_list);
 
   return local_energies;
 }
@@ -788,7 +788,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleS
   return LocalEnergy;
 }
 
-std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluateWithToperator(
+std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithToperator(
     const RefVectorWithLeader<QMCHamiltonian>& ham_list,
     const RefVectorWithLeader<TrialWaveFunction>& wf_list,
     const RefVectorWithLeader<ParticleSet>& p_list)
@@ -803,7 +803,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mwEvaluateWithTope
     ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
-    ham_leader.H[i_ham_op]->mwEvaluateWithToperator(HC_list, wf_list, p_list);
+    ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); ++iw)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -97,7 +97,7 @@ public:
   void initialize_traces(TraceManager& tm, ParticleSet& P);
 
   // ///collect scalar trace data
-  //void collect_scalar_traces();
+  //void collectScalarTraces();
 
   ///collect walker trace data
   void collect_walker_traces(Walker_t& walker, int step);
@@ -178,7 +178,7 @@ public:
     copy(first + myIndex, first + myIndex + Observables.size(), Observables.begin());
   }
 
-  void update_source(ParticleSet& s);
+  void updateSource(ParticleSet& s);
 
   ////return the LocalEnergy \f$=\sum_i H^{qmc}_{i}\f$
   inline FullPrecRealType getLocalEnergy() { return LocalEnergy; }
@@ -244,10 +244,9 @@ public:
    *  Bugs could easily be created by accessing this scope.
    *  This should be set to static and fixed.
    */
-  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluate(
-      const RefVectorWithLeader<QMCHamiltonian>& ham_list,
-      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-      const RefVectorWithLeader<ParticleSet>& p_list);
+  static std::vector<QMCHamiltonian::FullPrecRealType> mwEvaluate(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+                                                                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                                  const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** evaluate Local energy with Toperators updated.
    * @param P ParticleSEt
@@ -257,7 +256,7 @@ public:
 
   /** batched version of evaluate Local energy with Toperators updated.
    */
-  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluateWithToperator(
+  static std::vector<QMCHamiltonian::FullPrecRealType> mwEvaluateWithToperator(
       const RefVectorWithLeader<QMCHamiltonian>& ham_list,
       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<ParticleSet>& p_list);

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -244,9 +244,10 @@ public:
    *  Bugs could easily be created by accessing this scope.
    *  This should be set to static and fixed.
    */
-  static std::vector<QMCHamiltonian::FullPrecRealType> mwEvaluate(const RefVectorWithLeader<QMCHamiltonian>& ham_list,
-                                                                  const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                                  const RefVectorWithLeader<ParticleSet>& p_list);
+  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluate(
+      const RefVectorWithLeader<QMCHamiltonian>& ham_list,
+      const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+      const RefVectorWithLeader<ParticleSet>& p_list);
 
   /** evaluate Local energy with Toperators updated.
    * @param P ParticleSEt
@@ -256,7 +257,7 @@ public:
 
   /** batched version of evaluate Local energy with Toperators updated.
    */
-  static std::vector<QMCHamiltonian::FullPrecRealType> mwEvaluateWithToperator(
+  static std::vector<QMCHamiltonian::FullPrecRealType> mw_evaluateWithToperator(
       const RefVectorWithLeader<QMCHamiltonian>& ham_list,
       const RefVectorWithLeader<TrialWaveFunction>& wf_list,
       const RefVectorWithLeader<ParticleSet>& p_list);

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -96,9 +96,6 @@ public:
   ///initialize trace data
   void initialize_traces(TraceManager& tm, ParticleSet& P);
 
-  // ///collect scalar trace data
-  //void collectScalarTraces();
-
   ///collect walker trace data
   void collect_walker_traces(Walker_t& walker, int step);
 

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -23,8 +23,8 @@ namespace qmcplusplus
 SOECPotential::SOECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi)
     : myRNG(nullptr), IonConfig(ions), Psi(psi), Peln(els), ElecNeighborIons(els), IonNeighborElecs(ions)
 {
-  set_energy_domain(POTENTIAL);
-  two_body_quantum_domain(ions, els);
+  setEnergyDomain(POTENTIAL);
+  twoBodyQuantumDomain(ions, els);
   myTableIndex = els.addTable(ions);
   NumIons      = ions.getTotalNum();
   PP.resize(NumIons, nullptr);

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -105,7 +105,7 @@ void SkAllEstimator::evaluateIonIon()
 SkAllEstimator::Return_t SkAllEstimator::evaluate(ParticleSet& P)
 {
   // Segfaults unless setHistories() is called prior
-  RealType w = tWalker->Weight;
+  RealType w = t_walker_->Weight;
 #if defined(USE_REAL_STRUCT_FACTOR)
   //sum over species
   std::copy(P.SK->rhok_r[0], P.SK->rhok_r[0] + NumK, RhokTot_r.begin());
@@ -129,7 +129,7 @@ SkAllEstimator::Return_t SkAllEstimator::evaluate(ParticleSet& P)
 
   if (hdf5_out)
   {
-    int kc = myIndex;
+    int kc = my_index_;
     for (int k = 0; k < NumK; k++, kc++)
       P.Collectables[kc] += values[k];
     for (int k = 0; k < NumK; k++, kc++)
@@ -163,7 +163,7 @@ SkAllEstimator::Return_t SkAllEstimator::evaluate(ParticleSet& P)
   //    }
   if (hdf5_out)
   {
-    int kc = myIndex;
+    int kc = my_index_;
     for (int k = 0; k < NumK; k++, kc++)
       P.Collectables[kc] += values[k];
     for (int k = 0; k < NumK; k++, kc++)
@@ -189,13 +189,13 @@ void SkAllEstimator::addObservables(PropertySetType& plist, BufferType& collecta
 {
   if (hdf5_out)
   {
-    myIndex = collectables.size();
+    my_index_ = collectables.size();
     std::vector<RealType> tmp(3 * NumK); // space for e-e modulus, e real, e imag
     collectables.add(tmp.begin(), tmp.end());
   }
   else
   {
-    myIndex = plist.size();
+    my_index_ = plist.size();
     //First the electron structure factor
     for (int i = 0; i < NumK; i++)
     {
@@ -227,7 +227,7 @@ void SkAllEstimator::addObservables(PropertySetType& plist, BufferType& collecta
 
 void SkAllEstimator::addObservables(PropertySetType& plist)
 {
-  myIndex = plist.size();
+  my_index_ = plist.size();
   //First the electron structure factor
   for (int i = 0; i < NumK; i++)
   {
@@ -258,13 +258,13 @@ void SkAllEstimator::addObservables(PropertySetType& plist)
 void SkAllEstimator::setObservables(PropertySetType& plist)
 {
   if (!hdf5_out)
-    std::copy(values.begin(), values.end(), plist.begin() + myIndex);
+    std::copy(values.begin(), values.end(), plist.begin() + my_index_);
 }
 
 void SkAllEstimator::setParticlePropertyList(PropertySetType& plist, int offset)
 {
   if (!hdf5_out)
-    std::copy(values.begin(), values.end(), plist.begin() + myIndex + offset);
+    std::copy(values.begin(), values.end(), plist.begin() + my_index_ + offset);
 }
 
 
@@ -287,17 +287,17 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
     //  modulus
     h5desc.emplace_back("rhok_e_e");
     auto& ohRhoKEE = h5desc.back();
-    ohRhoKEE.set_dimensions(ng, myIndex);
+    ohRhoKEE.set_dimensions(ng, my_index_);
     ohRhoKEE.open(sgid); // add to SkAll hdf group
     //  real part
     h5desc.emplace_back("rhok_e_r");
     auto& ohRhoKER = h5desc.back();
-    ohRhoKER.set_dimensions(ng, myIndex + NumK);
+    ohRhoKER.set_dimensions(ng, my_index_ + NumK);
     ohRhoKER.open(sgid); // add to SkAll hdf group
     //  imaginary part
     h5desc.emplace_back("rhok_e_i");
     auto& ohRhoKEI = h5desc.back();
-    ohRhoKEI.set_dimensions(ng, myIndex + 2 * NumK);
+    ohRhoKEI.set_dimensions(ng, my_index_ + 2 * NumK);
     ohRhoKEI.open(sgid); // add to SkAll hdf group
   }
 }
@@ -345,7 +345,7 @@ std::unique_ptr<OperatorBase> SkAllEstimator::makeClone(ParticleSet& qp, TrialWa
 {
   std::unique_ptr<SkAllEstimator> myclone = std::make_unique<SkAllEstimator>(*this);
   myclone->hdf5_out                       = hdf5_out;
-  myclone->myIndex                        = myIndex;
+  myclone->my_index_                      = my_index_;
   return myclone;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -62,7 +62,7 @@ SkEstimator::Return_t SkEstimator::evaluate(ParticleSet& P)
   {
     Vector<RealType>::const_iterator iit_r(RhokTot_r.begin()), iit_r_end(RhokTot_r.end());
     Vector<RealType>::const_iterator iit_i(RhokTot_i.begin()), iit_i_end(RhokTot_i.end());
-    for (int i = myIndex; iit_r != iit_r_end; ++iit_r, ++iit_i, ++i)
+    for (int i = my_index_; iit_r != iit_r_end; ++iit_r, ++iit_i, ++i)
       P.Collectables[i] += OneOverN * ((*iit_r) * (*iit_r) + (*iit_i) * (*iit_i));
   }
   else
@@ -80,7 +80,7 @@ SkEstimator::Return_t SkEstimator::evaluate(ParticleSet& P)
   if (hdf5_out)
   {
     Vector<ComplexType>::const_iterator iit(RhokTot.begin()), iit_end(RhokTot.end());
-    for (int i = myIndex; iit != iit_end; ++iit, ++i)
+    for (int i = my_index_; iit != iit_end; ++iit, ++i)
       P.Collectables[i] += OneOverN * ((*iit).real() * (*iit).real() + (*iit).imag() * (*iit).imag());
   }
   else
@@ -97,13 +97,13 @@ void SkEstimator::addObservables(PropertySetType& plist, BufferType& collectable
 {
   if (hdf5_out)
   {
-    myIndex = collectables.size();
+    my_index_ = collectables.size();
     std::vector<RealType> tmp(NumK);
     collectables.add(tmp.begin(), tmp.end());
   }
   else
   {
-    myIndex = plist.size();
+    my_index_ = plist.size();
     for (int i = 0; i < NumK; i++)
     {
       std::stringstream sstr;
@@ -115,7 +115,7 @@ void SkEstimator::addObservables(PropertySetType& plist, BufferType& collectable
 
 void SkEstimator::addObservables(PropertySetType& plist)
 {
-  myIndex = plist.size();
+  my_index_ = plist.size();
   for (int i = 0; i < NumK; i++)
   {
     std::stringstream sstr;
@@ -127,13 +127,13 @@ void SkEstimator::addObservables(PropertySetType& plist)
 void SkEstimator::setObservables(PropertySetType& plist)
 {
   if (!hdf5_out)
-    std::copy(values.begin(), values.end(), plist.begin() + myIndex);
+    std::copy(values.begin(), values.end(), plist.begin() + my_index_);
 }
 
 void SkEstimator::setParticlePropertyList(PropertySetType& plist, int offset)
 {
   if (!hdf5_out)
-    std::copy(values.begin(), values.end(), plist.begin() + myIndex + offset);
+    std::copy(values.begin(), values.end(), plist.begin() + my_index_ + offset);
 }
 
 
@@ -144,7 +144,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     std::vector<int> ndim(1, NumK);
     h5desc.emplace_back(name_);
     auto& h5o = h5desc.back();
-    h5o.set_dimensions(ndim, myIndex);
+    h5o.set_dimensions(ndim, my_index_);
     h5o.open(gid);
 
     hsize_t kdims[2];
@@ -182,7 +182,7 @@ std::unique_ptr<OperatorBase> SkEstimator::makeClone(ParticleSet& qp, TrialWaveF
 {
   std::unique_ptr<SkEstimator> myclone = std::make_unique<SkEstimator>(*this);
   myclone->hdf5_out                    = hdf5_out;
-  myclone->myIndex                     = myIndex;
+  myclone->my_index_                   = my_index_;
   return myclone;
 }
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SkEstimator_CUDA.cpp
+++ b/src/QMCHamiltonians/SkEstimator_CUDA.cpp
@@ -39,13 +39,13 @@ void SkEstimator_CUDA::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>
     if (hdf5_out)
     {
       for (int ik = 0; ik < NumK; ik++)
-        W.Collectables[myIndex + ik] += OneOverN * OneOverNW *
+        W.Collectables[my_index_ + ik] += OneOverN * OneOverNW *
             (rhok_total[2 * ik + 0] * rhok_total[2 * ik + 0] + rhok_total[2 * ik + 1] * rhok_total[2 * ik + 1]);
     }
     else
     {
       for (int ik = 0; ik < NumK; ik++)
-        W.WalkerList[iw]->getPropertyBase()[WP::NUMPROPERTIES + myIndex + ik] = OneOverN *
+        W.WalkerList[iw]->getPropertyBase()[WP::NUMPROPERTIES + my_index_ + ik] = OneOverN *
             (rhok_total[2 * ik + 0] * rhok_total[2 * ik + 0] + rhok_total[2 * ik + 1] * rhok_total[2 * ik + 1]);
     }
   }

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -66,7 +66,7 @@ bool SpeciesKineticEnergy::get(std::ostream& os) const
 
 void SpeciesKineticEnergy::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = plist.size();
+  my_index_ = plist.size();
   for (int ispec = 0; ispec < num_species; ispec++)
   { // make columns named "$myName_u", "$myName_d" etc.
     plist.add(name_ + "_" + species_names[ispec]);
@@ -93,13 +93,13 @@ void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h
 
 void SpeciesKineticEnergy::setObservables(PropertySetType& plist)
 { // slots in plist must be allocated by addObservables() first
-  copy(species_kinetic.begin(), species_kinetic.end(), plist.begin() + myIndex);
+  copy(species_kinetic.begin(), species_kinetic.end(), plist.begin() + my_index_);
 }
 
 SpeciesKineticEnergy::Return_t SpeciesKineticEnergy::evaluate(ParticleSet& P)
 {
   std::fill(species_kinetic.begin(), species_kinetic.end(), 0.0);
-  RealType wgt = tWalker->Weight;
+  RealType wgt = t_walker_->Weight;
 
   for (int iat = 0; iat < P.getTotalNum(); iat++)
   {

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -184,7 +184,7 @@ void SpinDensity::report(const std::string& pad)
 
 void SpinDensity::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = collectables.current();
+  my_index_ = collectables.current();
   std::vector<RealType> tmp(nspecies * npoints);
   collectables.add(tmp.begin(), tmp.end());
 }
@@ -205,7 +205,7 @@ void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
   {
     h5desc.emplace_back(species_name[s]);
     auto& oh = h5desc.back();
-    oh.set_dimensions(ng, myIndex + s * npoints);
+    oh.set_dimensions(ng, my_index_ + s * npoints);
     oh.open(sgid);
   }
 }
@@ -213,9 +213,9 @@ void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
 
 SpinDensity::Return_t SpinDensity::evaluate(ParticleSet& P)
 {
-  RealType w = tWalker->Weight;
+  RealType w = t_walker_->Weight;
   int p      = 0;
-  int offset = myIndex;
+  int offset = my_index_;
   for (int s = 0; s < nspecies; ++s, offset += npoints)
     for (int ps = 0; ps < species_size[s]; ++ps, ++p)
     {
@@ -291,7 +291,7 @@ void SpinDensity::addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& Loc
     Walker_t& w     = *W.WalkerList[iw];
     RealType weight = w.Weight / nw;
     int p           = 0;
-    int offset      = myIndex;
+    int offset      = my_index_;
     for (int s = 0; s < nspecies; ++s, offset += npoints)
       for (int ps = 0; ps < species_size[s]; ++ps, ++p)
       {

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -101,7 +101,7 @@ void StaticStructureFactor::report(const std::string& pad)
 
 void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& collectables)
 {
-  myIndex = collectables.current();
+  my_index_ = collectables.current();
   std::vector<RealType> tmp(nspecies * 2 * nkpoints); // real & imag parts
   collectables.add(tmp.begin(), tmp.end());
 }
@@ -122,7 +122,7 @@ void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& 
   {
     h5desc.emplace_back(species_name[s]);
     auto& ohSpeciesName = h5desc.back();
-    ohSpeciesName.set_dimensions(ng, myIndex + s * 2 * nkpoints);
+    ohSpeciesName.set_dimensions(ng, my_index_ + s * 2 * nkpoints);
     ohSpeciesName.open(sgid);
   }
 }
@@ -130,13 +130,13 @@ void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& 
 
 StaticStructureFactor::Return_t StaticStructureFactor::evaluate(ParticleSet& P)
 {
-  RealType w                     = tWalker->Weight;
+  RealType w                     = t_walker_->Weight;
   const Matrix<RealType>& rhok_r = P.SK->rhok_r;
   const Matrix<RealType>& rhok_i = P.SK->rhok_i;
   int nkptot                     = rhok_r.cols();
   for (int s = 0; s < nspecies; ++s)
   {
-    int kc = myIndex + s * 2 * nkpoints;
+    int kc = my_index_ + s * 2 * nkpoints;
     //int kstart  = s*nkptot;
     //for(int k=kstart;k<kstart+nkpoints;++k,++kc)
     //  P.Collectables[kc] += w*rhok_r(k);

--- a/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
@@ -198,10 +198,10 @@ TEST_CASE("SkAll", "[hamiltonian]")
   skall.addObservables(elec->PropertyList, elec->Collectables);
   skall.get(app_log()); // pretty print settings
 
-  // Hack to make a walker so that tWalker points to something
-  // Only used to set tWalker->Weight = 1 so that skall->evaluate()
+  // Hack to make a walker so that t_walker_ points to something
+  // Only used to set t_walker_->Weight = 1 so that skall->evaluate()
   // doesn't segfault.
-  // NB: setHistories(dummy) attaches dummy to tWalker
+  // NB: setHistories(dummy) attaches dummy to t_walker_
   ParticleSet::Walker_t dummy = ParticleSet::Walker_t(1);
   skall.setHistories(dummy);
   skall.evaluate(*elec);
@@ -211,7 +211,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   // In order to compare to analytic result, need the list
   // of k-vectors in cartesian coordinates.
   // Luckily, ParticleSet stores that in SK->getKLists().kpts_cart
-  int nkpts      = elec->SK->getKLists().numk;
+  int nkpts = elec->SK->getKLists().numk;
   std::cout << "\n";
   std::cout << "SkAll results:\n";
   std::cout << std::fixed;


### PR DESCRIPTION
## Proposed changes

Rename protected and private members of `OperatorBase`, derived classes and consumers
Member variables and functions to follow coding standards
Component of #3412
Related to #3411


## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
