### PR TITLE
Add a stopper to catch user requested number of orbitals exceeding what h5 provides

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -234,7 +234,8 @@ public:
   // clone
   std::vector<TinyVector<int, OHMMS_DIM>> UseTwists;
   std::vector<int> IncludeTwists, DistinctTwists;
-  bool UseRealOrbitals;
+  /// if false, splines are conceptually complex valued
+  bool use_real_splines_;
   int NumDistinctOrbitals, NumCoreOrbs, NumValenceOrbs;
   // This is true if the corresponding twist in DistinctTwists should
   // should be used to generate two distinct orbitals from the real and

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -621,7 +621,7 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     }
   }
   // Find out if we can make real orbitals
-  UseRealOrbitals = true;
+  use_real_splines_ = true;
   for (int i = 0; i < DistinctTwists.size(); i++)
   {
     int ti        = DistinctTwists[i];
@@ -629,18 +629,18 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     for (int j = 0; j < OHMMS_DIM; j++)
       if (std::abs(twist[j] - 0.0) > MatchingTol && std::abs(twist[j] - 0.5) > MatchingTol &&
           std::abs(twist[j] + 0.5) > MatchingTol)
-        UseRealOrbitals = false;
+        use_real_splines_ = false;
   }
-  if (UseRealOrbitals && (DistinctTwists.size() > 1))
+  if (use_real_splines_ && (DistinctTwists.size() > 1))
   {
     app_log() << "***** Use of real orbitals is possible, but not currently implemented\n"
               << "      with more than one twist angle.\n";
-    UseRealOrbitals = false;
+    use_real_splines_ = false;
   }
-  if (UseRealOrbitals)
-    app_log() << "Using real orbitals.\n";
+  if (use_real_splines_)
+    app_log() << "Using real splines.\n";
   else
-    app_log() << "Using complex orbitals.\n";
+    app_log() << "Using complex splines.\n";
 #else
   DistinctTwists.resize(IncludeTwists.size());
   MakeTwoCopies.resize(IncludeTwists.size());
@@ -649,7 +649,7 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     DistinctTwists[i] = IncludeTwists[i];
     MakeTwoCopies[i]  = false;
   }
-  UseRealOrbitals = false;
+  use_real_splines_ = false;
 #endif
 }
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -468,6 +468,13 @@ void EinsplineSetBuilder::OccupyBands_ESHDF(int spin, int sortBands, int numOrbs
         maxOrbs++;
     }
   }
+
+  app_log() << SortBands.size() << " complex-valued orbitals supplied by h5 can be expanded up to " << maxOrbs
+            << " SPOs." << std::endl;
+  if (maxOrbs < numOrbs)
+    myComm->barrier_and_abort("EinsplineSetBuilder::OccupyBands_ESHDF user input requests "
+                              "more orbitals than what the h5 file supplies.");
+
   // Now sort the bands by energy
   if (sortBands == 2)
   {
@@ -644,7 +651,7 @@ void EinsplineSetBuilder::OccupyBands_ESHDF(int spin, int sortBands, int numOrbs
     orbIndex++;
   }
   NumDistinctOrbitals = orbIndex;
-  app_log() << "We will read " << NumDistinctOrbitals << " distinct orbitals.\n";
+  app_log() << "We will read " << NumDistinctOrbitals << " distinct complex-valued orbitals from h5.\n";
   app_log() << "There are " << NumCoreOrbs << " core states and " << NumValenceOrbs << " valence states.\n";
 }
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -41,7 +41,7 @@ namespace qmcplusplus
 void EinsplineSetBuilder::set_metadata(int numOrbs, int TwistNum_inp, bool skipChecks)
 {
   // 1. set a lot of internal parameters in the EinsplineSetBuilder class
-  //  e.g. TileMatrix, UseRealOrbitals, DistinctTwists, MakeTwoCopies.
+  //  e.g. TileMatrix, use_real_splines_, DistinctTwists, MakeTwoCopies.
   // 2. this is also where metadata for the orbitals are read from the wavefunction hdf5 file
   //  and broadcast to MPI groups. Variables broadcasted are listed in
   //  EinsplineSetBuilderCommon.cpp EinsplineSetBuilder::BroadcastOrbitalInfo()
@@ -263,7 +263,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   // set the internal parameters
   if (spinSet == 0)
     set_metadata(numOrbs, TwistNum_inp, skipChecks);
-  //if (use_complex_orb == "yes") UseRealOrbitals = false; // override given user input
+  //if (use_complex_orb == "yes") use_real_splines_ = false; // override given user input
 
   // look for <backflow>, would be a lot easier with xpath, but I cannot get it to work
   bool has_backflow = false;
@@ -289,8 +289,8 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     kid = kid->next;
   }
 
-  if (has_backflow && use_einspline_set_extended == "yes" && UseRealOrbitals)
-    APP_ABORT("backflow optimization is broken with UseRealOrbitals");
+  if (has_backflow && use_einspline_set_extended == "yes" && use_real_splines_)
+    APP_ABORT("backflow optimization is broken with use_real_splines_");
 
   //////////////////////////////////
   // Create the OrbitalSet object
@@ -308,7 +308,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     APP_ABORT("The 'truncate' feature of spline SPO has been removed. Please use hybrid orbital representation.");
 
 #if !defined(QMC_COMPLEX)
-  if (UseRealOrbitals)
+  if (use_real_splines_)
   {
     //if(TargetPtcl.Lattice.SuperCellEnum != SUPERCELL_BULK && truncate=="yes")
     if (MixedSplineReader == 0)
@@ -350,7 +350,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 #endif
   {
     EinsplineSet* new_OrbitalSet;
-    if (UseRealOrbitals)
+    if (use_real_splines_)
     {
       EinsplineSetExtended<double>* temp_OrbitalSet;
 #if defined(QMC_CUDA)

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
 
   std::string useGPU("no");
 #if !defined(QMC_COMPLEX)
-  if (UseRealOrbitals)
+  if (use_real_splines_)
   {
     if (MixedSplineReader == 0)
     {


### PR DESCRIPTION
## Proposed changes
src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp contains added guard.

All the rest is renaming UseRealOrbitals to use_real_splines_ to reduce the confusion from overloaded word "orbitals"

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'