### PR TITLE
Refactor OperatorBase into a single translation unit

### DIFF
--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -23,16 +23,22 @@
 namespace qmcplusplus
 {
 // PUBLIC
-OperatorBase::OperatorBase() : value_(0.0), my_index_(-1), t_walker_(0)
-{
-  quantum_domain_ = NO_QUANTUM_DOMAIN;
-  energy_domain_  = NO_ENERGY_DOMAIN;
 
+OperatorBase::OperatorBase()
+    : value_(0.0),
+      my_index_(-1),
+      t_walker_(0),
 #if !defined(REMOVE_TRACEMANAGER)
-  streaming_scalars_    = false;
-  streaming_particles_  = false;
-  have_required_traces_ = false;
+      streaming_particles_(false),
+      have_required_traces_(false),
 #endif
+      quantum_domain_(NO_QUANTUM_DOMAIN),
+      energy_domain_(NO_ENERGY_DOMAIN)
+#if !defined(REMOVE_TRACEMANAGER)
+      ,
+      streaming_scalars_(false)
+#endif
+{
   update_mode_.set(PRIMARY, 1);
 }
 

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -346,6 +346,9 @@ void OperatorBase::addValue(PropertySetType& plist)
     my_index_ = plist.add(name_.c_str());
 }
 
-bool OperatorBase::quantumDomainValid(QuantumDomains qdomain) { return qdomain != NO_QUANTUM_DOMAIN; }
+////// PRIVATE FUNCTIONS
+bool OperatorBase::energyDomainValid(EnergyDomains edomain) const noexcept { return edomain != NO_ENERGY_DOMAIN; }
+
+bool OperatorBase::quantumDomainValid(QuantumDomains qdomain) const noexcept { return qdomain != NO_QUANTUM_DOMAIN; }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -31,13 +31,10 @@ OperatorBase::OperatorBase()
 #if !defined(REMOVE_TRACEMANAGER)
       streaming_particles_(false),
       have_required_traces_(false),
+      streaming_scalars_(false),
 #endif
       quantum_domain_(NO_QUANTUM_DOMAIN),
       energy_domain_(NO_ENERGY_DOMAIN)
-#if !defined(REMOVE_TRACEMANAGER)
-      ,
-      streaming_scalars_(false)
-#endif
 {
   update_mode_.set(PRIMARY, 1);
 }

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -534,17 +534,17 @@ protected:
   void addValue(PropertySetType& plist);
 
 private:
-  ///quantum_domain_ of the (particle) operator, default = no_quantum_domain
-  QuantumDomains quantum_domain_;
-  ///energy domain of the operator (kinetic/potential), default = no_energy_domain
-  EnergyDomains energy_domain_;
-
 #if !defined(REMOVE_TRACEMANAGER)
   bool streaming_scalars_;
 
   ///array to store sample value
   Array<RealType, 1>* value_sample_;
 #endif
+
+  ///quantum_domain_ of the (particle) operator, default = no_quantum_domain
+  QuantumDomains quantum_domain_;
+  ///energy domain of the operator (kinetic/potential), default = no_energy_domain
+  EnergyDomains energy_domain_;
 
   ///return whether the energy domain is valid
   bool energyDomainValid(EnergyDomains edomain) const noexcept;

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -548,16 +548,10 @@ private:
 #endif
 
   ///return whether the energy domain is valid
-  inline bool energyDomainValid(EnergyDomains edomain) const { return edomain != NO_ENERGY_DOMAIN; }
-
-  ///return whether the energy domain is valid
-  inline bool energyDomainValid() const { return energyDomainValid(energy_domain_); }
+  bool energyDomainValid(EnergyDomains edomain) const noexcept;
 
   ///return whether the quantum domain is valid
-  bool quantumDomainValid(QuantumDomains qdomain);
-
-  ///return whether the quantum domain is valid
-  inline bool quantumDomainValid() { return quantumDomainValid(quantum_domain_); }
+  bool quantumDomainValid(QuantumDomains qdomain) const noexcept;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -492,38 +492,26 @@ protected:
   //////VIRTUAL FUNCTIONS
 
 #if !defined(REMOVE_TRACEMANAGER)
-  virtual void contributeScalarQuantities() { request_.contribute_scalar(name_); }
+  virtual void contributeScalarQuantities();
 
-  virtual void checkoutScalarQuantities(TraceManager& tm)
-  {
-    streaming_scalars_ = request_.streaming_scalar(name_);
-    if (streaming_scalars_)
-      value_sample_ = tm.checkout_real<1>(name_);
-  }
+  virtual void checkoutScalarQuantities(TraceManager& tm);
 
-  virtual void collectScalarQuantities()
-  {
-    if (streaming_scalars_)
-      (*value_sample_)(0) = value_;
-  }
+  virtual void collectScalarQuantities();
 
-  virtual void deleteScalarQuantities()
-  {
-    if (streaming_scalars_)
-      delete value_sample_;
-  }
+  virtual void deleteScalarQuantities();
 
-  virtual void contributeParticleQuantities(){};
-  virtual void checkoutParticleQuantities(TraceManager& tm){};
-  virtual void deleteParticleQuantities(){};
+  virtual void contributeParticleQuantities();
+  virtual void checkoutParticleQuantities(TraceManager& tm);
+  virtual void deleteParticleQuantities();
 #endif
 
-  virtual void setComputeForces(bool compute)
-  {
-    // empty
-  }
+  virtual void setComputeForces(bool compute);
 
-  ///set energy domain
+  /**
+   * @brief Set the Energy Domain
+   * 
+   * @param edomain 
+   */
   void setEnergyDomain(EnergyDomains edomain);
 
   ///set quantum domain
@@ -539,16 +527,12 @@ protected:
   void twoBodyQuantumDomain(const ParticleSet& P1, const ParticleSet& P2);
 
   /**
-   * named values to  the property list
+   * @brief named values to  the property list
    * @param plist RecordNameProperty
    *
    * Previously addObservables but it is renamed and a non-virtial function.
    */
-  inline void addValue(PropertySetType& plist)
-  {
-    if (!update_mode_[COLLECTABLE])
-      my_index_ = plist.add(name_.c_str());
-  }
+  void addValue(PropertySetType& plist);
 
 private:
   ///quantum_domain_ of the (particle) operator, default = no_quantum_domain

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -480,7 +480,6 @@ protected:
   bool have_required_traces_;
 #endif
 
-
   /////PURELY VIRTUAL FUNCTIONS
 
   /**

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -110,33 +110,40 @@ public:
     NONLOCAL    = 5,
   };
 
-  ///constructor
+  /**
+   * @brief Construct a new Operator Base object
+   * Default and unique empty constructor. Initializes with default values.
+   */
   OperatorBase();
 
-  ///virtual destructor
-  virtual ~OperatorBase() {}
+  virtual ~OperatorBase() = default;
 
-  // getter for update_mode member
+  //////// GETTER AND SETTER FUNCTIONS ////////////////
+
   /**
-   * @brief get update_mode_ 
+   * @brief get update_mode_ reference
+   * 
    * @return std::bitset<8>& reference of get_update_mode_
    */
   std::bitset<8>& getUpdateMode() noexcept;
 
   /**
    * @brief get a copy of value_
+   * 
    * @return Return_t copy of value_
    */
   Return_t getValue() const noexcept;
 
   /**
    * @brief getter a copy of my_name_, rvalue small string optimization
+   * 
    * @return std::string copy of my_name_ member
    */
   std::string getName() const noexcept;
 
   /**
    * @brief Set my_name member, uses small string optimization (pass by value)
+   * 
    * @param name input
    */
   void setName(const std::string name) noexcept;
@@ -144,233 +151,305 @@ public:
 #if !defined(REMOVE_TRACEMANAGER)
   /**
    * @brief Get request_ member
+   * 
    * @return TraceRequest& reference to request_
    */
   TraceRequest& getRequest() noexcept;
 #endif
 
-  inline bool isClassical() { return quantum_domain_ == CLASSICAL; }
-  inline bool isQuantum() { return quantum_domain_ == QUANTUM; }
-  inline bool isClassicalClassical() { return quantum_domain_ == CLASSICAL_CLASSICAL; }
-  inline bool isQuantumClassical() { return quantum_domain_ == QUANTUM_CLASSICAL; }
-  inline bool isQuantumQuantum() { return quantum_domain_ == QUANTUM_QUANTUM; }
-
-  /** return the mode i
-   * @param i index among PRIMARY, OPTIMIZABLE, RATIOUPDATE, PHYSICAL
-   */
-  inline bool getMode(int i) { return update_mode_[i]; }
-
-  inline bool isNonLocal() const { return update_mode_[NONLOCAL]; }
-
-  /** named values to  the property list
-   * @param plist RecordNameProperty
-   * @param collectables Observables that are accumulated by evaluate
-   *
-   * Default implementaton uses addValue(plist)
-   */
-  virtual void addObservables(PropertySetType& plist, BufferType& collectables) { addValue(plist); }
-
-  /*** add to observable descriptor for hdf5
-   * @param h5desc contains a set of hdf5 descriptors for a scalar observable
-   * @param gid hdf5 group to which the observables belong
-   *
-   * The default implementation is to register a scalar for this->Value
-   */
-  virtual void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
-
-  /*** add to collectables descriptor for hdf5
-   * @param h5desc contains a set of hdf5 descriptors for a scalar observable
-   * @param gid hdf5 group to which the observables belong
-   *
-   * The default implementation does nothing. The derived classes which compute
-   * big data, e.g. density, should overwrite this function.
-   */
-  virtual void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const {}
-
-  /** set the values evaluated by this object to plist
-   * @param plist RecordNameProperty
-   *
-   * Default implementation is to assign Value which is updated
-   * by evaluate  function using myIndex.
-   */
-  virtual void setObservables(PropertySetType& plist) { plist[my_index_] = value_; }
-
-  virtual void setParticlePropertyList(PropertySetType& plist, int offset) { plist[my_index_ + offset] = value_; }
-
-  //virtual void setHistories(Walker<Return_t, ParticleSet::ParticleGradient_t>& ThisWalker)
-  virtual void setHistories(Walker_t& ThisWalker) { t_walker_ = &(ThisWalker); }
-
-  /** reset the data with the target ParticleSet
+  //////// PURELY VIRTUAL FUNCTIONS ////////////////
+  /** 
+   * @brief Reset the data with the target ParticleSet
    * @param P new target ParticleSet
    */
   virtual void resetTargetParticleSet(ParticleSet& P) = 0;
 
-  /** Evaluate the local energy contribution of this component
-   *@param P input configuration containing N particles
-   *@return the value of the Hamiltonian component
+  /** 
+   * @brief Evaluate the local energy contribution of this component
+   * @param P input configuration containing N particles
+   * @return the value of the Hamiltonian component
    */
   virtual Return_t evaluate(ParticleSet& P) = 0;
-  /** Evaluate the local energy contribution of this component, deterministically based on current state.
-   *@param P input configuration containing N particles
-   *@return the value of the Hamiltonian component
+
+  /** write about the class */
+  virtual bool get(std::ostream& os) const = 0;
+
+  // TODO: add docs
+  virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
+
+  //////// VIRTUAL FUNCTIONS ////////////////
+
+  /** 
+   * @brief named values to  the property list
+   * Default implementaton uses addValue(plist_)
+   * 
+   * @param plist RecordNameProperty
+   * @param collectables Observables that are accumulated by evaluate
+   */
+  virtual void addObservables(PropertySetType& plist, BufferType& collectables);
+
+  /** 
+   * @brief add to observable descriptor for hdf5
+   * The default implementation is to register a scalar for this->value_
+   * 
+   * @param h5desc contains a set of hdf5 descriptors for a scalar observable
+   * @param gid hdf5 group to which the observables belong
+   */
+  virtual void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+
+  /*** 
+   * @brief add to collectables descriptor for hdf5
+   * The default implementation does nothing. The derived classes which compute
+   * big data, e.g. density, should overwrite this function.
+   * 
+   * @param h5desc contains a set of hdf5 descriptors for a scalar observable
+   * @param gid hdf5 group to which the observables belong
+   */
+  virtual void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+
+  /** 
+   * @brief Set the values evaluated by this object to plist
+   * Default implementation is to assign Value which is updated
+   * by evaluate function using my_index_.
+   *
+   * @param plist RecordNameProperty
+   */
+  virtual void setObservables(PropertySetType& plist);
+
+  // TODO: add docs
+  virtual void setParticlePropertyList(PropertySetType& plist, int offset);
+
+  // TODO: add docs
+  virtual void setHistories(Walker_t& ThisWalker);
+
+  /** 
+   * @brief Evaluate the local energy contribution of this component, deterministically based on current state.
+   * The correct behavior of this routine requires estimators with non-deterministic components
+   * in their evaluate() function to override this function.
+
+   * @param P input configuration containing N particles
+   * @return the value of the Hamiltonian component
    */
   virtual Return_t evaluateDeterministic(ParticleSet& P);
-  /** Evaluate the contribution of this component of multiple walkers */
+
+  /**
+   * @brief Evaluate the contribution of this component of multiple walkers.
+   * Take o_list and p_list update evaluation result variables in o_list?
+   * really should reduce vector of local_energies. matching the ordering and size of o list
+   * the this can be call for 1 or more QMCHamiltonians
+
+   * @param o_list 
+   * @param wf_list 
+   * @param p_list 
+   */
   virtual void mw_evaluate(const RefVectorWithLeader<OperatorBase>& o_list,
                            const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                            const RefVectorWithLeader<ParticleSet>& p_list) const;
 
+  /**
+   * @brief TODO: add docs
+
+   * @param o_list 
+   * @param p_list 
+   * @param optvars 
+   * @param dlogpsi 
+   * @param dhpsioverpsi 
+   */
   virtual void mw_evaluateWithParameterDerivatives(const RefVectorWithLeader<OperatorBase>& o_list,
                                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                                    const opt_variables_type& optvars,
                                                    RecordArray<ValueType>& dlogpsi,
                                                    RecordArray<ValueType>& dhpsioverpsi) const;
 
-
-  virtual Return_t rejectedMove(ParticleSet& P) { return 0; }
-  /** Evaluate the local energy contribution of this component with Toperators updated if requested
-   *@param P input configuration containing N particles
-   *@return the value of the Hamiltonian component
+  /**
+   * @brief TODO: add docs
+   * 
+   * @param P 
+   * @return Return_t 
    */
-  virtual Return_t evaluateWithToperator(ParticleSet& P) { return evaluate(P); }
+  virtual Return_t rejectedMove(ParticleSet& P);
 
-  /** Evaluate the contribution of this component of multiple walkers */
+  /** 
+   * @brief Evaluate the local energy contribution of this component with Toperators updated if requested
+
+   * @param P input configuration containing N particles
+   * @return the value of the Hamiltonian component
+   */
+  virtual Return_t evaluateWithToperator(ParticleSet& P);
+
+  /**
+   * @brief Evaluate the contribution of this component of multiple walkers
+
+   * @param o_list 
+   * @param wf_list 
+   * @param p_list 
+   */
   virtual void mw_evaluateWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
                                         const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                        const RefVectorWithLeader<ParticleSet>& p_list) const
-  {
-    mw_evaluate(o_list, wf_list, p_list);
-  }
+                                        const RefVectorWithLeader<ParticleSet>& p_list) const;
 
-  /** evaluate value and derivatives wrt the optimizables
-   *
-   * Default uses evaluate
+  /**
+   * @brief Evaluate value and derivatives wrt the optimizables. Default uses evaluate.
+
+   * @param P 
+   * @param optvars 
+   * @param dlogpsi 
+   * @param dhpsioverpsi 
+   * @return Return_t 
    */
   virtual Return_t evaluateValueAndDerivatives(ParticleSet& P,
                                                const opt_variables_type& optvars,
                                                const std::vector<ValueType>& dlogpsi,
-                                               std::vector<ValueType>& dhpsioverpsi)
-  {
-    return evaluate(P);
-  }
+                                               std::vector<ValueType>& dhpsioverpsi);
 
-  /** evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.  
-  * @param P target particle set (electrons)
-  * @param ions source particle set (ions)
-  * @param psi Trial wave function
-  * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
-  * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
-  * @return Contribution of OperatorBase to Local Energy.
-  */
+  /** 
+   * @brief Evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.  
+
+   * @param P target particle set (electrons)
+   * @param ions source particle set (ions)
+   * @param psi Trial wave function
+   * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
+   * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
+   * @return Contribution of OperatorBase to Local Energy.
+   */
   virtual Return_t evaluateWithIonDerivs(ParticleSet& P,
                                          ParticleSet& ions,
                                          TrialWaveFunction& psi,
                                          ParticleSet::ParticlePos_t& hf_term,
-                                         ParticleSet::ParticlePos_t& pulay_term)
-  {
-    return evaluate(P);
-  }
+                                         ParticleSet::ParticlePos_t& pulay_term);
 
-  /** evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.  
-  * @param P target particle set (electrons)
-  * @param ions source particle set (ions)
-  * @param psi Trial wave function
-  * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
-  * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
-  * @return Contribution of OperatorBase to Local Energy.
-  */
+  /** 
+   * @brief Evaluate contribution to local energy  and derivatives w.r.t ionic coordinates from OperatorBase.
+   * If there's no stochastic component, defaults to evaluateWithIonDerivs.
+   * If not otherwise specified, this defaults to evaluate().
+
+   * @param P target particle set (electrons)
+   * @param ions source particle set (ions)
+   * @param psi Trial wave function
+   * @param hf_terms  Adds OperatorBase's contribution to Re [(dH)Psi]/Psi
+   * @param pulay_terms Adds OperatorBase's contribution to Re [(H-E_L)dPsi]/Psi 
+   * @return Contribution of OperatorBase to Local Energy.
+   */
   virtual Return_t evaluateWithIonDerivsDeterministic(ParticleSet& P,
                                                       ParticleSet& ions,
                                                       TrialWaveFunction& psi,
                                                       ParticleSet::ParticlePos_t& hf_term,
-                                                      ParticleSet::ParticlePos_t& pulay_term)
-  {
-    //If there's no stochastic component, defaults to above defined evaluateWithIonDerivs.
-    //If not otherwise specified, this defaults to evaluate().
-    return evaluateWithIonDerivs(P, ions, psi, hf_term, pulay_term);
-  }
-  /** update data associated with a particleset
-   * @param s source particle set
-   *
+                                                      ParticleSet::ParticlePos_t& pulay_term);
+
+  /** 
+   * @brief Update data associated with a particleset.
    * Default implementation does nothing. Only A-A interactions for s needs to implement its own method.
+
+   * @param s source particle set
    */
-  virtual void updateSource(ParticleSet& s) {}
+  virtual void updateSource(ParticleSet& s);
 
-  /** return an average value by collective operation
+  /** 
+   * @brief Return an average value by collective operation
    */
-  virtual Return_t getEnsembleAverage() { return 0.0; }
+  virtual Return_t getEnsembleAverage();
 
-  /** write about the class */
-  virtual bool get(std::ostream& os) const = 0;
+  /**
+   * @brief Initialize a shared resource and hand it to a collection
 
-  /** initialize a shared resource and hand it to a collection
+   * @param collection 
    */
-  virtual void createResource(ResourceCollection& collection) const {}
+  virtual void createResource(ResourceCollection& collection) const;
 
-  /** acquire a shared resource from a collection
+  /**
+   * @brief Acquire a shared resource from a collection
+
+   * @param collection 
+   * @param o_list 
    */
-  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const {}
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const;
 
-  /** return a shared resource to a collection
+  /**
+   * @brief Return a shared resource to a collection
+   * 
+   * @param collection 
+   * @param o_list 
    */
-  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const {}
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const;
 
-  virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) = 0;
+  /**
+   * @brief Set the Random Generator object
+   * TODO: add docs
+   * @param rng 
+   */
+  virtual void setRandomGenerator(RandomGenerator_t* rng);
 
-  //virtual std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& H);
-
-  virtual void setRandomGenerator(RandomGenerator_t* rng)
-  {
-    //empty
-  }
-
+  /**
+   * @brief TODO: add docs
+   * 
+   * @param qp 
+   * @param psi 
+   * @param targetH 
+   */
   virtual void add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH);
 
 #if !defined(REMOVE_TRACEMANAGER)
-  ///make trace quantities available
-  inline void contributeTraceQuantities()
-  {
-    contributeScalarQuantities();
-    contributeParticleQuantities();
-  }
-
-  ///checkout trace arrays
-  inline void checkoutTraceQuantities(TraceManager& tm)
-  {
-    //derived classes must guard individual checkouts using request info
-    checkoutScalarQuantities(tm);
-    checkoutParticleQuantities(tm);
-  }
-
-  ///collect scalar trace data
-  inline void collectScalarTraces()
-  {
-    //app_log()<<"OperatorBase::collectScalarTraces"<< std::endl;
-    collectScalarQuantities();
-  }
-
-  ///delete trace arrays
-  inline void deleteTraceQuantities()
-  {
-    deleteScalarQuantities();
-    deleteParticleQuantities();
-    streaming_scalars_    = false;
-    streaming_particles_  = false;
-    have_required_traces_ = false;
-    request_.reset();
-  }
-
-  virtual void getRequiredTraces(TraceManager& tm){};
+  /**
+   * @brief TODO: add docs
+   * 
+   * @param tm 
+   */
+  virtual void getRequiredTraces(TraceManager& tm);
 #endif
+
+  // TODO: add docs
 
   virtual void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy);
 
   virtual void addEnergy(MCWalkerConfiguration& W,
                          std::vector<RealType>& LocalEnergy,
-                         std::vector<std::vector<NonLocalData>>& Txy)
-  {
-    addEnergy(W, LocalEnergy);
-  }
+                         std::vector<std::vector<NonLocalData>>& Txy);
+
+  bool isClassical() const noexcept;
+  bool isQuantum() const noexcept;
+  bool isClassicalClassical() const noexcept;
+  bool isQuantumClassical() const noexcept;
+  bool isQuantumQuantum() const noexcept;
+
+  /** 
+   * @brief Return the mode i
+   * @param i index among PRIMARY, OPTIMIZABLE, RATIOUPDATE, PHYSICAL
+   */
+  bool getMode(const int i) const noexcept;
+
+  /**
+   * @brief TODO: add docs
+   * 
+   * @return true 
+   * @return false 
+   */
+  bool isNonLocal() const noexcept;
+
+
+#if !defined(REMOVE_TRACEMANAGER)
+
+  /**
+   * @brief Make trace quantities available
+   */
+  void contributeTraceQuantities();
+
+  /**
+   * @brief Checkout trace arrays 
+   * Derived classes must guard individual checkouts using request info 
+   * @param tm 
+   */
+  void checkoutTraceQuantities(TraceManager& tm);
+
+  /**
+   * @brief Collect scalar trace data
+   */
+  void collectScalarTraces();
+
+  /**
+   * @brief delete trace arrays
+   */
+  void deleteTraceQuantities();
+#endif
 
 protected:
   ///set the current update mode
@@ -401,11 +480,16 @@ protected:
   bool have_required_traces_;
 #endif
 
+
+  /////PURELY VIRTUAL FUNCTIONS
+
   /**
    * Read the input parameter
    * @param cur xml node for a OperatorBase object
    */
   virtual bool put(xmlNodePtr cur) = 0;
+
+  //////VIRTUAL FUNCTIONS
 
 #if !defined(REMOVE_TRACEMANAGER)
   virtual void contributeScalarQuantities() { request_.contribute_scalar(name_); }


### PR DESCRIPTION
## Proposed changes

Refactor functions in `OperatorBase` to a single translation unit moving all definition to `OperatorBase.cpp` (ccache friendly). 
Make `OperatorBase.h` declaration only with doxygen API docs where appropriate (some missing/TODO).
Mark `const` and `noexcept` functions where appropriate.
Make constructor RAII.
Remove unused private functions.
Remove `inline`.
Component of #3412 
Related to #3411

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Build related changes (remove inline functions)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04. Must pass CI.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
