### PR TITLE
Adding OneBodyDensityMatricesInput and tests

### DIFF
--- a/src/Estimators/CMakeLists.txt
+++ b/src/Estimators/CMakeLists.txt
@@ -24,7 +24,7 @@ set(QMCEST_SRC
     OperatorEstBase.cpp
     SpinDensityNew.cpp
     MomentumDistribution.cpp
-    )
+    OneBodyDensityMatricesInput.cpp)
 
 ####################################
 # create libqmcestimators

--- a/src/Estimators/InputSection.cpp
+++ b/src/Estimators/InputSection.cpp
@@ -63,7 +63,6 @@ void InputSection::readXML(xmlNodePtr cur)
 
   // check input validity
   check_valid();
-
   //report();
 }
 
@@ -79,7 +78,6 @@ void InputSection::init(const std::unordered_map<std::string, std::any>& init_va
 
   // check input validity
   check_valid();
-
   //report();
 }
 
@@ -90,7 +88,6 @@ void InputSection::set_defaults()
     if (!has(name))
       set_from_value(name, default_value);
 }
-
 
 void InputSection::set_from_stream(const std::string& name, std::istringstream& svalue)
 {
@@ -158,7 +155,8 @@ void InputSection::check_valid()
             << " has not been assigned\n";
       throw UniformCommunicateError(error.str());
     }
-}
+  this->checkParticularValidity();
+};
 
 
 void InputSection::report() const

--- a/src/Estimators/InputSection.h
+++ b/src/Estimators/InputSection.h
@@ -61,7 +61,7 @@ public:
   // Enable read-only access to variable values.
   //   Needs updating to allow copy-less return.
   template<typename T>
-  T get(const std::string& name) const
+  const T get(const std::string& name) const
   {
     return std::any_cast<T>(values.at(name));
   }
@@ -74,6 +74,13 @@ public:
   // Initialize from unordered_map/initializer list
   void init(const std::unordered_map<std::string, std::any>& init_values);
 
+protected:
+  /** Do validation for a particular subtype of InputSection
+   *  Called by check_valid.
+   *  Default implementation is noop
+   */
+  virtual void checkParticularValidity() {}
+  
 private:
   // Query functions
   bool is_attribute(const std::string& name) const { return attributes.find(name) != attributes.end(); }

--- a/src/Estimators/OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/OneBodyDensityMatricesInput.cpp
@@ -1,0 +1,42 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// Some code refactored from: DensityMatrices1b.cpp
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "string_utils.h"
+#include "OneBodyDensityMatricesInput.h"
+
+namespace qmcplusplus
+{
+
+OneBodyDensityMatricesInput::OneBodyDensityMatricesInput(){};
+OneBodyDensityMatricesInput::OneBodyDensityMatricesInput(xmlNodePtr cur)
+{
+  // This results in checkParticularValidity being called on OneBodyDensityMatrixInputSection
+  input_section_.readXML(cur);
+}
+
+void OneBodyDensityMatricesInput::OneBodyDensityMatrixInputSection::checkParticularValidity()
+{
+  if (has("scale"))
+  {
+    Real scale = get<Real>("scale");
+    std::cout << "SCALE is :" << scale << '\n';
+    if (scale > 1.0 + 1e-10)
+      throw UniformCommunicateError("OneBodyDensityMatrices input: scale must be less than one");
+    else if (scale < 0.0 - 1e-10)
+      throw UniformCommunicateError("OneBodyDensityMatrices input: scale must be greater than zero");
+  }
+  std::string basis_str = get<std::string>("basis");
+  auto basis_set_names  = split(basis_str);
+  if (basis_set_names.size() == 0 || basis_set_names[0].size() == 0)
+    throw UniformCommunicateError("OneBodyDensityMatrices input: basis must have at least one sposet");
+}
+
+} // namespace qmcplusplus

--- a/src/Estimators/OneBodyDensityMatricesInput.h
+++ b/src/Estimators/OneBodyDensityMatricesInput.h
@@ -1,0 +1,120 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// Some code refactored from: DensityMatrices1b.h
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_ONE_BODY_DENSITY_MATRICES_INPUT_H
+#define QMCPLUSPLUS_ONE_BODY_DENSITY_MATRICES_INPUT_H
+
+#include "Configuration.h"
+#include "InputSection.h"
+
+namespace qmcplusplus
+{
+/** Native representation for DensityMatrices1B Estimator's inputs
+ */
+class OneBodyDensityMatricesInput
+{
+public:
+  enum class Integrators
+  {
+    UNIFORM_GRID,
+    UNIFORM,
+    DENSITY,
+    NO_INTEGRATOR
+  };
+
+  enum class Evaluators
+  {
+    LOOP,
+    MATRIX,
+    NO_EVALUATOR
+  };
+
+  enum class Samplings
+  {
+    VOLUME_BASED,
+    METROPOLIS,
+    NO_SAMPLING
+  };
+
+  class OneBodyDensityMatrixInputSection : public InputSection
+  {
+  public:
+    /** parse time definition of input parameters */
+    OneBodyDensityMatrixInputSection()
+    {
+      section_name = "OneBodyDensityMatrix";
+      attributes   = {"name", "type"};
+      parameters   = {"basis",      "energy_matrix", "integrator",        "evaluator",        "scale",
+                    "center",     "points",        "samples",           "warmup",           "timestep",
+                    "use_drift",  "check_overlap", "check_derivatives", "acceptance_ratio", "rstats",
+                    "normalized", "volumed_normed"};
+      bools        = {"energy_matrix", "use_drift",         "normalized", "volume_normed",
+               "check_overlap", "check_derivatives", "rstats",     "acceptance_ratio"};
+      strings      = {"name", "type", "basis", "integrator", "evaluator"};
+      integers     = {"points", "samples"};
+      reals        = {"scale", "timestep"};
+      required     = {"name", "basis"};
+      // I'd much rather see the default defined in simple native c++ as below
+    }
+
+    /** do parse time checks of input */
+    void checkParticularValidity() override;
+  };
+
+  using Position = QMCTraits::PosType;
+  using Real     = QMCTraits::FullPrecRealType;
+
+  OneBodyDensityMatricesInput();
+  OneBodyDensityMatricesInput(xmlNodePtr cur);
+
+private:
+  OneBodyDensityMatrixInputSection input_section_;
+
+  bool energy_matrix_     = false;
+  bool use_drift_         = false;
+  bool normalized_        = true;
+  bool volume_normalized_ = true;
+  bool check_overlap_     = false;
+  bool check_derivatives_ = false;
+  bool rstats_            = false;
+  bool acceptance_ratio_  = false;
+  Integrators integrator_ = Integrators::UNIFORM_GRID;
+  Samplings sampling_     = Samplings::VOLUME_BASED;
+  Evaluators evaluator_   = Evaluators::LOOP;
+  Real scale_             = 1.0;
+  Position center_        = 0.0;
+  Real timestep_          = 0.5;
+  int points_             = 10;
+  int samples_            = 10;
+  int warmup_samples_     = 30;
+public:
+  bool get_energy_matrix() const { return energy_matrix_; }
+  bool get_use_drift() const { return use_drift_; }
+  bool get_normalized() const { return normalized_; }
+  bool get_volume_normalized() const { return volume_normalized_; }
+  bool get_check_overlap() const { return check_overlap_; }
+  bool get_check_derivatives() const { return check_derivatives_; }
+  bool get_rstats() const { return rstats_; }
+  bool get_acceptance_ratio() const { return acceptance_ratio_; }
+  Integrators get_integrator() const { return integrator_; }
+  Samplings get_sampling() const { return sampling_; }
+  Evaluators get_evaluator() const { return evaluator_; }
+  Real get_scale() const { return scale_; }
+  Position get_center() const { return center_; }
+  Real get_timestep() const { return timestep_; }
+  int get_points() const { return points_; }
+  int get_samples() const { return samples_; }
+  int get_warmup_samples() const { return warmup_samples_; }
+};
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -23,10 +23,11 @@ set(SRCS
     test_manager.cpp
     test_EstimatorManagerNew.cpp
     test_trace_manager.cpp
-    SpinDensityTesting.cpp
+    EstimatorTesting.cpp
     test_SpinDensityInput.cpp
     test_SpinDensityNew.cpp
     test_InputSection.cpp
+    test_OneBodyDensityMatricesInput.cpp
     )
 
 add_executable(${UTEST_EXE} ${SRCS})

--- a/src/Estimators/tests/EstimatorTesting.cpp
+++ b/src/Estimators/tests/EstimatorTesting.cpp
@@ -2,28 +2,28 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
-#ifndef QMCPLUSPLUS_SPINDENSITYTESTING_H
-#define QMCPLUSPLUS_SPINDENSITYTESTING_H
-
-#include "ParticleSet.h"
+#include "EstimatorTesting.h"
 
 namespace qmcplusplus
 {
 namespace testing
 {
-
-using POLT    = PtclOnLatticeTraits;
-using Lattice = POLT::ParticleLayout_t;
-
-Lattice makeTestLattice();
-
+Lattice makeTestLattice()
+{
+  Lattice lattice;
+  lattice.BoxBConds = true; // periodic
+  lattice.R = ParticleSet::Tensor_t(3.37316115, 3.37316115, 0.00000000, 0.00000000, 3.37316115, 3.37316115, 3.37316115,
+                                    0.00000000, 3.37316115);
+  lattice.reset();
+  lattice.explicitly_defined = true;
+  return lattice;
 }
-}
-#endif
+} // namespace testing
+} // namespace qmcplusplus

--- a/src/Estimators/tests/EstimatorTesting.h
+++ b/src/Estimators/tests/EstimatorTesting.h
@@ -2,28 +2,28 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
 
-#include "SpinDensityTesting.h"
+#ifndef QMCPLUSPLUS_ESTIMATOR_TESTING_H
+#define QMCPLUSPLUS_ESTIMATOR_TESTING_H
+
+#include "ParticleSet.h"
 
 namespace qmcplusplus
 {
 namespace testing
 {
-Lattice makeTestLattice()
-{
-  Lattice lattice;
-  lattice.BoxBConds = true; // periodic
-  lattice.R = ParticleSet::Tensor_t(3.37316115, 3.37316115, 0.00000000, 0.00000000, 3.37316115, 3.37316115, 3.37316115,
-                                    0.00000000, 3.37316115);
-  lattice.reset();
-  lattice.explicitly_defined = true;
-  return lattice;
+
+using POLT    = PtclOnLatticeTraits;
+using Lattice = POLT::ParticleLayout_t;
+
+Lattice makeTestLattice();
+
 }
-} // namespace testing
-} // namespace qmcplusplus
+}
+#endif

--- a/src/Estimators/tests/InvalidOneBodyDensityMatricesInput.h
+++ b/src/Estimators/tests/InvalidOneBodyDensityMatricesInput.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_INVALID_OBDM_INPUT_H
+#define QMCPLUSPLUS_INVALID_OBDM_INPUT_H
+
+#include <array>
+
+namespace qmcplusplus
+{
+namespace testing
+{
+// clang-format: off
+constexpr std::array<const char*, 2> invalid_one_body_density_matrices_input_sections{
+    R"(
+<estimator type="dm1b" name="DensityMatrices">
+  <parameter name="basis"        >  spo_u spo_uv  </parameter>
+  <parameter name="evaluator"    >  matrix        </parameter>
+  <parameter name="integrator"   >  path          </parameter>
+  <parameter name="scale"        > -0.2           </parameter>
+  <parameter name="samples"      >  64            </parameter>
+  <parameter name="timestep"     >  0.5           </parameter>
+  <parameter name="use_drift"    >  no            </parameter>
+</estimator>
+)",
+    R"(
+<estimator type="dm1b" name="DensityMatrices">
+  <parameter name="basis"        >  dm_basis      </parameter>
+  <parameter name="evaluator"    >  loop          </parameter>
+  <parameter name="integrator"   >  uniform       </parameter>
+  <parameter name="samples"      >  128           </parameter>
+  <parameter name="scale"        >  1.1           </parameter>
+  <parameter name="timestep"     >  0.5           </parameter>
+  <parameter name="use_drift"    >  yes           </parameter>
+</estimator>
+)"
+    // clang-format: on
+};
+
+constexpr int invalid_obdm_input_bad_integrator = 0;
+constexpr int invalid_obdm_input_bad_scale      = 1;
+} // namespace testing
+} // namespace qmcplusplus
+
+#endif

--- a/src/Estimators/tests/ValidOneBodyDensityMatricesInput.h
+++ b/src/Estimators/tests/ValidOneBodyDensityMatricesInput.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_VALID_OBDM_INPUT_H
+#define QMCPLUSPLUS_VALID_OBDM_INPUT_H
+
+#include <array>
+
+namespace qmcplusplus
+{
+namespace testing
+{
+// clang-format: off
+constexpr std::array<const char*, 2> valid_one_body_density_matrices_input_sections{
+    R"(
+<estimator type="dm1b" name="DensityMatrices">
+  <parameter name="basis"        >  spo_u spo_uv  </parameter>
+  <parameter name="evaluator"    >  matrix        </parameter>
+  <parameter name="integrator"   >  density       </parameter>
+  <parameter name="samples"      >  64            </parameter>
+  <parameter name="timestep"     >  0.5           </parameter>
+  <parameter name="use_drift"    >  no            </parameter>
+</estimator>
+)",
+    R"(
+<estimator type="dm1b" name="DensityMatrices">
+  <parameter name="basis"        >  dm_basis      </parameter>
+  <parameter name="evaluator"    >  loop          </parameter>
+  <parameter name="integrator"   >  uniform       </parameter>
+  <parameter name="samples"      >  128           </parameter>
+  <parameter name="scale"        >  0.8           </parameter>
+  <parameter name="timestep"     >  0.5           </parameter>
+  <parameter name="use_drift"    >  yes           </parameter>
+</estimator>
+)"
+    // clang-format: on
+};
+
+constexpr int valid_obdm_input       = 0;
+constexpr int vlaid_obdm_input_scale = 1;
+
+} // namespace testing
+} // namespace qmcplusplus
+
+#endif

--- a/src/Estimators/tests/test_OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatricesInput.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
@@ -12,46 +12,42 @@
 
 #include "catch.hpp"
 
-#include "SpinDensityInput.h"
-#include "ValidSpinDensityInput.h"
+#include "OneBodyDensityMatricesInput.h"
+#include "ValidOneBodyDensityMatricesInput.h"
+#include "InvalidOneBodyDensityMatricesInput.h"
 #include "EstimatorTesting.h"
 #include "ParticleSet.h"
 #include "OhmmsData/Libxml2Doc.h"
+#include "Message/UniformCommunicateError.h"
 
-#include <stdio.h>
-#include <sstream>
+#include <iostream>
 
 namespace qmcplusplus
 {
-TEST_CASE("SpinDensityInput::readXML", "[estimators]")
+TEST_CASE("OneBodyDensityMatricesInput::from_xml", "[estimators]")
 {
   using POLT    = PtclOnLatticeTraits;
   using Lattice = POLT::ParticleLayout_t;
 
-  for (auto input_xml : testing::valid_spin_density_input_sections)
+  for (auto input_xml : testing::valid_one_body_density_matrices_input_sections)
   {
     Libxml2Document doc;
     bool okay = doc.parseFromString(input_xml);
     REQUIRE(okay);
     xmlNodePtr node = doc.getRoot();
-
-    SpinDensityInput sdi;
-    sdi.readXML(node);
-
-    Lattice lattice;
-    if (sdi.get_cell().explicitly_defined == true)
-      lattice = sdi.get_cell();
-    else
-      lattice = testing::makeTestLattice();
-
-    SpinDensityInput::DerivedParameters dev_par = sdi.calculateDerivedParameters(lattice);
-
-    CHECK(dev_par.npoints == 1000);
-    TinyVector<int, SpinDensityInput::DIM> grid(10, 10, 10);
-    CHECK(dev_par.grid == grid);
-    TinyVector<int, SpinDensityInput::DIM> gdims(100, 10, 1);
-    CHECK(dev_par.gdims == gdims);
+    OneBodyDensityMatricesInput obdmi(node);
   }
+
+  for (auto input_xml : testing::invalid_one_body_density_matrices_input_sections)
+  {
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(input_xml);
+    REQUIRE(okay);
+    xmlNodePtr node = doc.getRoot();
+    
+    CHECK_THROWS_AS(OneBodyDensityMatricesInput(node), UniformCommunicateError);
+  }
+
 }
 
 } // namespace qmcplusplus

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
@@ -18,7 +18,7 @@
 #include "RandomForTest.h"
 #include "ParticleSet.h"
 #include "TrialWaveFunction.h"
-#include "SpinDensityTesting.h"
+#include "EstimatorTesting.h"
 
 #include "OhmmsData/Libxml2Doc.h"
 


### PR DESCRIPTION
## Proposed changes

Initial Input class for OneBodyDensityMatrices (the port of DensityMatrices1B) to the unified driver setup.

Using InputSection for parsing and simple validation.  Input class has native type and default declaration/definition.

## What type(s) of changes does this code introduce?
- New feature
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
