### PR TITLE
Fix accidentally moved executables by #3467

### DIFF
--- a/src/QMCTools/CMakeLists.txt
+++ b/src/QMCTools/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 project(qmctools)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${qmcpack_BINARY_DIR}/bin)
 add_executable(convert4qmc convert4qmc.cpp QMCGaussianParserBase.cpp GaussianFCHKParser.cpp GamesAsciiParser.cpp
     LCAOHDFParser.cpp DiracParser.cpp)
 

--- a/src/QMCTools/tests/CMakeLists.txt
+++ b/src/QMCTools/tests/CMakeLists.txt
@@ -10,6 +10,7 @@
 #//////////////////////////////////////////////////////////////////////////////////////
 
 
+unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
 set(SRC_DIR tools)
 set(UTEST_EXE test_${SRC_DIR})
 set(UTEST_NAME deterministic-unit_test_${SRC_DIR})

--- a/src/Sandbox/CMakeLists.txt
+++ b/src/Sandbox/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(Sandbox)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${qmcpack_BINARY_DIR}/bin)
 # add apps XYZ.cpp, e.g., qmc_particles.cpp
 set(ESTEST diff_distancetables einspline_spo einspline_spo_nested determinant restart determinant_delayed_update)
 


### PR DESCRIPTION
## Proposed changes
Executables from QMCTools should be pinned at `${qmcpack_BINARY_DIR}/bin`

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
