### PR TITLE
Nexus: fix syntax warnings

### DIFF
--- a/nexus/lib/pwscf_analyzer.py
+++ b/nexus/lib/pwscf_analyzer.py
@@ -924,14 +924,14 @@ class PwscfAnalyzer(SimulationAnalyzer):
                 #end if              
             #end for
             for ln, li in enumerate(labels):
-                if li is not '':
+                if li != '':
                     axvline(x[ln], ymin=-100, ymax=100, linewidth=3, color='k')
                     if li == 'GAMMA':
                         labels[ln] = r'$\Gamma$'
-                    elif li is not '':
+                    elif li != '':
                         labels[ln] = '${0}$'.format(li)
                     #end if
-                    if labels[ln-1] is not '' and ln > 0:
+                    if labels[ln-1] != '' and ln > 0:
                         labels[ln] = labels[ln-1]+'|'+labels[ln]
                         labels[ln-1] = ''
                     #end if

--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -5377,7 +5377,7 @@ def generate_jastrow1(function='bspline',size=8,rcut=None,coeff=None,cusp=0.,ena
     corrs = []
     for i in range(len(elements)):
         element = elements[i]
-        if cusp is 'Z':
+        if cusp == 'Z':
             QmcpackInput.class_error('need to implement Z cusp','generate_jastrow1')
         else:
             lcusp  = cusp

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -5562,7 +5562,7 @@ def _getseekpath(
         structure = structure.folded_structure
     #end if
     structure = structure.copy()
-    if structure.units is not 'A':
+    if structure.units != 'A':
         structure.change_units('A')
     #end if
     axes       = structure.axes
@@ -6783,9 +6783,9 @@ class Crystal(Structure):
         pos  = []
         if basis_vectors is None:
             basis_vectors = axes
-        elif basis_vectors is 'primitive':
+        elif basis_vectors=='primitive':
             basis_vectors = axes_prim
-        elif basis_vectors is 'conventional':
+        elif basis_vectors=='conventional':
             basis_vectors = axes_conv
         #end if
         nbasis = len(atoms)

--- a/nexus/lib/structure.py
+++ b/nexus/lib/structure.py
@@ -6783,10 +6783,12 @@ class Crystal(Structure):
         pos  = []
         if basis_vectors is None:
             basis_vectors = axes
-        elif basis_vectors=='primitive':
-            basis_vectors = axes_prim
-        elif basis_vectors=='conventional':
-            basis_vectors = axes_conv
+        elif isinstance(basis_vectors,str):
+            if basis_vectors=='primitive':
+                basis_vectors = axes_prim
+            elif basis_vectors=='conventional':
+                basis_vectors = axes_conv
+            #end if
         #end if
         nbasis = len(atoms)
         for point in points:


### PR DESCRIPTION
## Proposed changes

More recent python versions now generate syntax warnings (de-linting).  Fix the few that exist so as not to scare off users.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Workstation

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

