### PR TITLE
Convert4qmc guess h5 format

### DIFF
--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -219,6 +219,7 @@ int main(int argc, char** argv)
         {
           WARNMSG("Creating LCAOHDFParser")
           parser = std::make_unique<LCAOHDFParser>(argc, argv);
+          h5      = true;
         }
         else if (ext == "out")
         {

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -302,21 +302,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        parser->addJastrow = false;
-        jastrow            = "noj";
-        parser->WFS_name   = jastrow;
-        if (parser->PBC)
-        {
-          std::cout << "Generating Inputs for Supertwist  with coordinates:" << parser->STwist_Coord[0] << "  "
-                    << parser->STwist_Coord[1] << "  " << parser->STwist_Coord[2] << std::endl;
-          parser->dumpPBC(psi_tag, ion_tag);
-        }
-        else
-          parser->dump(psi_tag, ion_tag);
-        parser->dumpStdInput(psi_tag, ion_tag);
-
-        parser->addJastrow = true;
-        jastrow            = "j";
+        parser->addJastrow = addJastrow;
         parser->WFS_name   = jastrow;
         if (parser->PBC)
         {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Fixes #3503. When an hdf5 file is used, the "-orbitals" tag can be omitted

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
