### PR TITLE
Check if cif2cell is available before running ntest_nexus_structure

### DIFF
--- a/nexus/lib/versions.py
+++ b/nexus/lib/versions.py
@@ -843,6 +843,7 @@ pydot_available      = False
 spglib_available     = False
 pycifrw_available    = False
 seekpath_available   = False
+cif2cell_available   = False
 
 numpy_supported      = False
 scipy_supported      = False
@@ -852,6 +853,7 @@ pydot_supported      = False
 spglib_supported     = False
 pycifrw_supported    = False
 seekpath_supported   = False
+cif2cell_supported   = False
 
 try: # versioning info is never worth failure
     versions = Versions()
@@ -864,6 +866,7 @@ try: # versioning info is never worth failure
     spglib_available     = versions.available('spglib')
     pycifrw_available    = versions.available('pycifrw')
     seekpath_available   = versions.available('seekpath')
+    cif2cell_available   = versions.available('cif2cell')
 
     numpy_supported      = versions.supported('numpy')
     scipy_supported      = versions.supported('scipy')
@@ -873,6 +876,7 @@ try: # versioning info is never worth failure
     spglib_supported     = versions.supported('spglib')
     pycifrw_supported    = versions.supported('pycifrw')
     seekpath_supported   = versions.supported('seekpath')
+    cif2cell_available   = versions.supported('cif2cell')
 except:
     versions = None
 #end try

--- a/nexus/lib/versions.py
+++ b/nexus/lib/versions.py
@@ -81,6 +81,7 @@ raw_version_data = dict(
     #   3.7  https://www.python.org/dev/peps/pep-0537/
     #   3.8  https://www.python.org/dev/peps/pep-0569/
     #   3.9  https://www.python.org/dev/peps/pep-0596/
+    #   3.10 https://www.python.org/dev/peps/pep-0619/
     python3 = '''
         3.3.0  2012-09-29
         3.3.1  2013-04-06
@@ -107,6 +108,7 @@ raw_version_data = dict(
         3.7.4  2019-07-08
         3.8.0  2019-10-21
         3.9.0  2020-06-08
+        3.10.0 2021-10-04
         ''',
     # numpy releases
     #   https://github.com/numpy/numpy/releases

--- a/nexus/tests/unit/test_structure.py
+++ b/nexus/tests/unit/test_structure.py
@@ -676,7 +676,7 @@ def test_read_write():
 
 
 
-if versions.pycifrw_available:
+if versions.pycifrw_available and versions.cif2cell_available:
     def test_read_cif():
         """
         Read La2CuO4 structure from a CIF file.


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Fixes #3509

cif2cell depends on pycifrw, so it's necessary to check for both before running tests.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Local machine

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
