### PR TITLE
Collapsed style in StlPrettyPrint.

### DIFF
--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -121,12 +121,13 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
  * - initialize Estimators
  * - initialize Walkers
  */
-void QMCDriverNew::startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc)
+void QMCDriverNew::startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCounts& awc)
 {
-  app_summary() << this->QMCType << " Driver running with target_walkers = " << awc.global_walkers << std::endl
-                << "                               walkers_per_rank = " << awc.walkers_per_rank << std::endl
-                << "                               num_crowds = " << awc.walkers_per_crowd.size() << std::endl
-                << "                    on rank 0, walkers_per_crowd = " << awc.walkers_per_crowd << std::endl
+  app_summary() << QMCType << " Driver running with" << std::endl
+                << "             total_walkers     = " << awc.global_walkers << std::endl
+                << "             walkers_per_rank  = " << awc.walkers_per_rank << std::endl
+                << "             num_crowds        = " << awc.walkers_per_crowd.size() << std::endl
+                << "  on rank 0, walkers_per_crowd = " << awc.walkers_per_crowd << std::endl
                 << std::endl;
 
   // set num_global_walkers explicitly and then make local walkers.

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -221,7 +221,7 @@ public:
    *        And these are the arguments to the branch_engine and estimator_manager
    *        Constructors or these objects should be created elsewhere.
    */
-  void startup(xmlNodePtr cur, QMCDriverNew::AdjustedWalkerCounts awc);
+  void startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCounts& awc);
 
   static void initialLogEvaluation(int crowd_id, UPtrVector<Crowd>& crowds, UPtrVector<ContextForSteps>& step_context);
 

--- a/src/Utilities/StlPrettyPrint.hpp
+++ b/src/Utilities/StlPrettyPrint.hpp
@@ -18,20 +18,32 @@
 namespace qmcplusplus
 {
 
+/** collapsed vector printout
+ * [3, 3, 2, 2] is printed as [3(x2), 2(x2)]
+ */
 template<typename T>
 std::ostream& operator<<(std::ostream& out, const std::vector<T>& rhs)
 {
   out << "[";
-  if (!rhs.empty())
+  auto cursor = rhs.begin();
+  while (cursor != rhs.end())
   {
-    auto last = rhs.end();
-    last--;
-    copy(rhs.begin(), last, std::ostream_iterator<T>(out, ", "));
-    out << *last;
+    // each iteration handles one unique value
+    const T ref_value = *cursor;
+    size_t count      = 1;
+    while (++cursor != rhs.end() && *cursor == ref_value)
+      count++;
+    out << ref_value;
+    // identical elements are collapsed
+    if (count > 1)
+      out << "(x" << count << ")";
+    // if not the last element, add a separator
+    if (cursor != rhs.end())
+      out << ", ";
   }
   out << "]";
   return out;
 }
 
-}
+} // namespace qmcplusplus
 #endif

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   test_project_data.cpp
   test_rng_control.cpp
   test_output_manager.cpp
+  test_StlPrettyPrint.cpp
   test_StdRandom.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcutil)
 

--- a/src/Utilities/tests/for_testing/test_RandomForTest.cpp
+++ b/src/Utilities/tests/for_testing/test_RandomForTest.cpp
@@ -11,9 +11,6 @@
 
 #include "catch.hpp"
 #include "RandomForTest.cpp"
-#include "../StlPrettyPrint.hpp"
-#include <iostream>
-#include <string>
 
 /** \file
  */

--- a/src/Utilities/tests/test_StlPrettyPrint.cpp
+++ b/src/Utilities/tests/test_StlPrettyPrint.cpp
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+#include <sstream>
+#include "StlPrettyPrint.hpp"
+
+namespace qmcplusplus
+{
+TEST_CASE("StlPrettyPrint", "[utilities]")
+{
+  std::ostringstream msg;
+  std::vector<int> vec;
+
+  msg << vec;
+  CHECK(msg.str() == "[]");
+
+  msg.str(std::string());
+  vec = {4, 4, 3, 3};
+  msg << vec;
+  CHECK(msg.str() == "[4(x2), 3(x2)]");
+
+  msg.str(std::string());
+  vec = {4, 4, 3};
+  msg << vec;
+  CHECK(msg.str() == "[4(x2), 3]");
+
+  msg.str(std::string());
+  vec = {4, 3, 3};
+  msg << vec;
+  CHECK(msg.str() == "[4, 3(x2)]");
+
+  msg.str(std::string());
+  vec = {4, 3, 2};
+  msg << vec;
+  CHECK(msg.str() == "[4, 3, 2]");
+}
+} // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
Long vectors are lengthy. walkers_per_crowd has num_crowd elements. walkers_per_rank has num_rank elements.
num_crowd can be hundreds in CPU runs and num_ranks can be tens of thousands.
Usually these vectors has very limited distinct values and are better printed in collapsed style.
[3, 3, 2, 2] is printed as [3(x2), 2(x2)]

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed