### PR TITLE
Add GitHub Actions CI for AFQMC ENABLE_CUDA variants

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -26,6 +26,10 @@ jobs:
           gcc-complex-gpu-cuda-mixed,
           gcc-real-gpu-cuda-full,   # full precision
           gcc-complex-gpu-cuda-full,
+          gcc-real-gpu-enable-cuda-afqmc-mixed,   # auxiliary field, requires MPI
+          gcc-complex-gpu-enable-cuda-afqmc-mixed,
+          gcc-real-gpu-enable-cuda-afqmc-full,
+          gcc-complex-gpu-enable-cuda-afqmc-full
         ]
 
     steps:

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -90,6 +90,18 @@ case "$1" in
                       -DUSE_OBJECT_TARGET=ON -DQMC_MPI=0 \
                       ${GITHUB_WORKSPACE}
       ;;
+      *"gpu-enable-cuda-afqmc"*)
+        echo 'Configure for building with ENABLE CUDA and AFQMC, need recent OpenBLAS'
+        cmake -GNinja -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
+                      -DCMAKE_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx \
+                      -DMPIEXEC_EXECUTABLE=/usr/lib64/openmpi/bin/mpirun \
+                      -DBUILD_AFQMC=ON \
+                      -DENABLE_CUDA=ON \
+                      -DCMAKE_PREFIX_PATH=/opt/OpenBLAS/0.3.18 \
+                      -DQMC_COMPLEX=$IS_COMPLEX \
+                      -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
+                      ${GITHUB_WORKSPACE}
+      ;;
       *"gpu-cuda"*)
         echo 'Configure for building GPU CUDA legacy'
         cmake -GNinja -DQMC_CUDA=1 \
@@ -154,9 +166,15 @@ case "$1" in
        TEST_LABEL="-L unit"
     fi
     
-    if [[ "${GH_JOBNAME}" =~ (gpu-cuda) ]]
+    if [[ "${GH_JOBNAME}" =~ (cuda) ]]
     then
        export LD_LIBRARY_PATH=/usr/local/cuda/lib/:/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}
+    fi
+
+    if [[ "${GH_JOBNAME}" =~ (cuda-afqmc) ]]
+    then
+       # Avoid polluting the stderr output with libfabric error message
+       export OMPI_MCA_btl=self
     fi
     
     ctest --output-on-failure $TEST_LABEL


### PR DESCRIPTION
## Proposed changes

Add 4 variants to run on self-hosted runner
Uses MPI due to AFQMC
Requires `export OMPI_MCA_btl=self` and custom built recent OpenBLAS (v0.3.18)
Related to #3402 
TO DO:
add documentation 


## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests) CI

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Sulfur, must pass CI. Note that new jobs won't run on GitHub Actions until this PR is merged.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate) TO DO
