### PR TITLE
Tmove needs donePbyP call.

### DIFF
--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -564,7 +564,11 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
   }
 
   if (NonLocalMoveAccepted > 0)
+  {
     Psi.completeUpdates();
+    // this step also updates electron positions on the device.
+    P.donePbyP();
+  }
 
   return NonLocalMoveAccepted;
 }


### PR DESCRIPTION
## Proposed changes
Not adding this call doesn't affect DMC classic driver but batched driver + GPU needs it to align consistent states on host and device.

NiO 32 atom cell.
Theta cpu classic driver -2970.494866 +/- 0.004216
Theta cpu batched driver 2970.509318 +/- 0.012635
Summit offload before fix -2970.393890 +/- 0.005694
Summit offload after fix -2970.492390 +/- 0.005676

We lack Tmove deterministic tests.
It is cumbersome to add a unit test right now. My current plan is to complete the work on refactoring Tmove out of NLPP class to its own.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
