### PR TITLE
Introduce skipSK in donePbyP and use it in Tmoves

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -792,18 +792,18 @@ void ParticleSet::mw_accept_rejectMove(const RefVectorWithLeader<ParticleSet>& p
   }
 }
 
-void ParticleSet::donePbyP()
+void ParticleSet::donePbyP(bool skipSK)
 {
   ScopedTimer donePbyP_scope(myTimers[PS_donePbyP]);
   coordinates_->donePbyP();
-  if (SK && !SK->DoUpdate)
+  if (!skipSK && SK && !SK->DoUpdate)
     SK->updateAllPart(*this);
   for (size_t i = 0; i < DistTables.size(); ++i)
     DistTables[i]->finalizePbyP(*this);
   activePtcl = -1;
 }
 
-void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
+void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK)
 {
   ParticleSet& p_leader = p_list.getLeader();
   ScopedTimer donePbyP_scope(p_leader.myTimers[PS_donePbyP]);
@@ -814,7 +814,7 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list)
     pset.activePtcl = -1;
   }
 
-  if (p_leader.SK && !p_leader.SK->DoUpdate)
+  if (!skipSK && p_leader.SK && !p_leader.SK->DoUpdate)
   {
     auto sk_list = extractSKRefList(p_list);
     StructFact::mw_updateAllPart(sk_list, p_list);

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -445,15 +445,16 @@ public:
   static void mw_saveWalker(const RefVectorWithLeader<ParticleSet>& psets, const RefVector<Walker_t>& walkers);
 
   /** update structure factor and unmark activePtcl
+   *@param skip SK update if skipSK is true
    *
    * The Coulomb interaction evaluation needs the structure factor.
    * For these reason, call donePbyP after the loop of single
    * electron moves before evaluating the Hamiltonian. Unmark
    * activePtcl is more of a safety measure probably not needed.
    */
-  void donePbyP();
+  void donePbyP(bool skipSK = false);
   /// batched version of donePbyP
-  static void mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list);
+  static void mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list, bool skipSK = false);
 
   ///return the address of the values of Hamiltonian terms
   inline FullPrecRealType* restrict getPropertyBase() { return Properties.data(); }

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -567,7 +567,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
   {
     Psi.completeUpdates();
     // this step also updates electron positions on the device.
-    P.donePbyP();
+    P.donePbyP(true);
   }
 
   return NonLocalMoveAccepted;


### PR DESCRIPTION
## Proposed changes
Fix performance regression.
#3524 pulling the whole donePbyP was just too heavy. It is better to let donePbyP() handle particle coordinates but skip structure factor related pieces.

## What type(s) of changes does this code introduce?
- Other (please describe): fix performance regression.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'