### PR TITLE
Add tests for ompblas GEMV and fixed a bug

### DIFF
--- a/src/Platforms/CPU/BLAS.hpp
+++ b/src/Platforms/CPU/BLAS.hpp
@@ -114,6 +114,7 @@ namespace BLAS
 
   inline static void scal(int n, float alpha, std::complex<float>* x, int incx = 1) { csscal(n, alpha, x, incx); }
 
+  // amat is [n][m] in C
   inline static void gemv(int n, int m, const double* restrict amat, const double* restrict x, double* restrict y)
   {
     dgemv(NOTRANS, m, n, done, amat, m, x, INCX, dzero, y, INCY);
@@ -142,6 +143,7 @@ namespace BLAS
     cgemv(NOTRANS, m, n, cone, amat, m, x, INCX, czero, y, INCY);
   }
 
+  // amat is [n][m] in C
   inline static void gemv_trans(int n, int m, const double* restrict amat, const double* restrict x, double* restrict y)
   {
     dgemv(TRANS, m, n, done, amat, m, x, INCX, dzero, y, INCY);

--- a/src/Platforms/OMPTarget/ompBLAS.cpp
+++ b/src/Platforms/OMPTarget/ompBLAS.cpp
@@ -42,11 +42,11 @@ ompBLAS_status gemv_impl(ompBLAS_handle& handle,
       throw std::runtime_error("incx !=1 or incy != 1 are not implemented in ompBLAS::gemv_impl!");
 
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(m) is_device_ptr(A, x, y)")
-    for(size_t i = 0; i < m; i++)
+    for(size_t i = 0; i < n; i++)
     {
       T dot_sum(0);
       PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-      for(size_t j = 0; j < n; j++)
+      for(size_t j = 0; j < m; j++)
         dot_sum += x[j] * A[i * lda + j];
       if (beta == T(0))
         y[i] = alpha * dot_sum; // protecting NaN from y
@@ -152,11 +152,11 @@ ompBLAS_status gemv_batched_impl(ompBLAS_handle& handle,
 
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(batch_count * m) is_device_ptr(A, x, y, alpha, beta)")
     for(size_t ib = 0; ib < batch_count; ib++)
-      for(size_t i = 0; i < m; i++)
+      for(size_t i = 0; i < n; i++)
       {
         T dot_sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+: dot_sum)")
-        for(size_t j = 0; j < n; j++)
+        for(size_t j = 0; j < m; j++)
           dot_sum += x[ib][j] * A[ib][i * lda + j];
         if (beta[ib] == T(0))
           y[ib][i] = alpha[ib] * dot_sum; // protecting NaN from y

--- a/src/Platforms/tests/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/tests/OMPTarget/CMakeLists.txt
@@ -23,7 +23,7 @@ set(UTEST_EXE test_omptarget_blas)
 set(UTEST_NAME deterministic-unit_${UTEST_EXE})
 
 add_executable(${UTEST_EXE} test_ompBLAS.cpp)
-target_link_libraries(${UTEST_EXE} catch_main platform_LA utilities_for_test containers)
+target_link_libraries(${UTEST_EXE} catch_main platform_LA containers)
 
 if(USE_OBJECT_TARGET)
   target_link_libraries(${UTEST_EXE} platform_omptarget_LA)

--- a/src/Platforms/tests/OMPTarget/test_ompBLAS.cpp
+++ b/src/Platforms/tests/OMPTarget/test_ompBLAS.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
@@ -19,61 +19,184 @@
 #include <OhmmsPETE/OhmmsVector.h>
 #include <OhmmsPETE/OhmmsMatrix.h>
 #include <CPU/BLAS.hpp>
-#include <checkMatrix.hpp>
 
 namespace qmcplusplus
 {
 
 template<typename T>
-void test_gemvT(const int N)
+void test_gemv(const int M_b, const int N_b, const char trans)
 {
+  const int M = trans == 'T' ? M_b : N_b;
+  const int N = trans == 'T' ? N_b : M_b;
+
   using vec_t = Vector<T, OMPallocator<T>>;
   using mat_t = Matrix<T, OMPallocator<T>>;
 
   ompBLAS::ompBLAS_handle handle;
 
-  vec_t A(N);    // Input vector
-  mat_t B(N, N); // Input matrix
-  vec_t C(N);    // Result vector (test)
-  vec_t D(N);    // Result vector BLAS
+  vec_t A(N);        // Input vector
+  mat_t B(M_b, N_b); // Input matrix
+  vec_t C(M);        // Result vector ompBLAS
+  vec_t D(M);        // Result vector BLAS
 
-  for (int dim = 1; dim <= N; dim++)
+  // Fill data
+  for (int i = 0; i < N; i++)
+    A[i] = i;
+
+  for (int j = 0; j < M_b; j++)
+    for (int i = 0; i < N_b; i++)
+      B[j][i] = i + j * 2;
+
+  // Fill C and D with 0
+  for (int i = 0; i < M; i++)
+    C[i] = D[i] = T(0);
+
+  A.updateTo();
+  B.updateTo();
+
+  T alpha(1);
+  T beta(0);
+
+  // in Fortran, B[M][N] is viewed as B^T
+  // when trans == 'T', the actual calculation is B * A[N] = C[M]
+  // when trans == 'N', the actual calculation is B^T * A[M] = C[N]
+  ompBLAS::gemv(handle, trans, N_b, M_b, alpha, B.device_data(), N_b, A.device_data(), 1, beta, C.device_data(), 1);
+  C.updateFrom();
+
+  if (trans == 'T')
+    BLAS::gemv_trans(M_b, N_b, B.data(), A.data(), D.data());
+  else
+    BLAS::gemv(M_b, N_b, B.data(), A.data(), D.data());
+
+  for (int index = 0; index < M; index++)
+    CHECK(C[index] == D[index]);
+}
+
+template<typename T>
+void test_gemv_batched(const int M_b, const int N_b, const char trans, const int batch_count)
+{
+  const int M = trans == 'T' ? M_b : N_b;
+  const int N = trans == 'T' ? N_b : M_b;
+
+  using vec_t = Vector<T, OMPallocator<T>>;
+  using mat_t = Matrix<T, OMPallocator<T>>;
+
+  ompBLAS::ompBLAS_handle handle;
+
+  // Create input vector
+  std::vector<vec_t> As;
+  Vector<const T*, OMPallocator<const T*>> Aptrs;
+
+  // Create input matrix
+  std::vector<mat_t> Bs;
+  Vector<const T*, OMPallocator<const T*>> Bptrs;
+
+  // Create output vector (ompBLAS)
+  std::vector<vec_t> Cs;
+  Vector<T*, OMPallocator<T*>> Cptrs;
+
+  // Create output vector (BLAS)
+  std::vector<vec_t> Ds;
+  Vector<T*, OMPallocator<T*>> Dptrs;
+
+  // Resize pointer vectors
+  Aptrs.resize(batch_count);
+  Bptrs.resize(batch_count);
+  Cptrs.resize(batch_count);
+  Dptrs.resize(batch_count);
+
+  // Resize data vectors
+  As.resize(batch_count);
+  Bs.resize(batch_count);
+  Cs.resize(batch_count);
+  Ds.resize(batch_count);
+
+  // Fill data
+  for (int batch = 0; batch < batch_count; batch++)
   {
-    //std::cout << "checking dim " << dim << std::endl;
-    handle = dim;
-    for (int i = 0; i < dim; i++)
-    {
-      A[i] = i;
-      for (int j = 0; j < dim; j++)
-        B.data()[i * dim + j] = i + j;
-    }
+    handle = batch;
 
-    A.updateTo();
-    B.updateTo();
+    As[batch].resize(N);
+    Aptrs[batch] = As[batch].device_data();
 
-    // tests omp gemv
-    ompBLAS::gemv(handle, 'T', dim, dim, 1.0, B.device_data(), dim, A.device_data(), 1, 0.0, C.device_data(), 1);
-    C.updateFrom();
+    Bs[batch].resize(M_b, N_b);
+    Bptrs[batch] = Bs[batch].device_data();
 
-    BLAS::gemv(dim, dim, B.data(), A.data(), D.data());
+    Cs[batch].resize(M);
+    Cptrs[batch] = Cs[batch].device_data();
 
-    int index = 0;
-    do
-    {
-      CHECK(C[index] == D[index]);
-      index++;
-    } while (index < dim);
+    Ds[batch].resize(M);
+    Dptrs[batch] = Ds[batch].data();
+
+    for (int i = 0; i < N; i++)
+      As[batch][i] = i;
+
+    for (int j = 0; j < M_b; j++)
+      for (int i = 0; i < N_b; i++)
+        Bs[batch][j][i] = i + j * 2;
+
+    for (int i = 0; i < M; i++)
+      Cs[batch][i] = Ds[batch][i] = T(0);
+
+    As[batch].updateTo();
+    Bs[batch].updateTo();
+  }
+
+  Aptrs.updateTo();
+  Bptrs.updateTo();
+  Cptrs.updateTo();
+
+  // Run tests
+  Vector<T, OMPallocator<T>> alpha(batch_count);
+  Vector<T, OMPallocator<T>> beta(batch_count);
+
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    alpha[batch] = T(1);
+    beta[batch]  = T(0);
+  }
+
+  alpha.updateTo();
+  beta.updateTo();
+
+  ompBLAS::gemv_batched(handle, trans, N_b, M_b, alpha.device_data(), Bptrs.device_data(), N_b, Aptrs.device_data(), 1,
+                        beta.device_data(), Cptrs.device_data(), 1, batch_count);
+
+  for (int batch = 0; batch < batch_count; batch++)
+  {
+    Cs[batch].updateFrom();
+    if (trans == 'T')
+      BLAS::gemv_trans(M_b, N_b, Bs[batch].data(), As[batch].data(), Ds[batch].data());
+    else
+      BLAS::gemv(M_b, N_b, Bs[batch].data(), As[batch].data(), Ds[batch].data());
+
+    // Check results
+    for (int index = 0; index < M; index++)
+      CHECK(Cs[batch][index] == Ds[batch][index]);
   }
 }
 
 TEST_CASE("OmpBLAS gemv", "[OMP]")
 {
-  const int N = 100;
-  test_gemvT<float>(N);
-  test_gemvT<double>(N);
+  const int M           = 137;
+  const int N           = 79;
+  const int batch_count = 23;
+
+  // Non-batched test
+  std::cout << "Testing TRANS gemv" << std::endl;
+  test_gemv<float>(M, N, 'T');
+  test_gemv<double>(M, N, 'T');
 #if defined(QMC_COMPLEX)
-  test_gemvT<std::complex<float>>(N);
-  test_gemvT<std::complex<double>>(N);
+  test_gemv<std::complex<float>>(N, M, 'T');
+  test_gemv<std::complex<double>>(N, M, 'T');
+#endif
+  // Batched Test
+  std::cout << "Testing TRANS gemv_batched" << std::endl;
+  test_gemv_batched<float>(M, N, 'T', batch_count);
+  test_gemv_batched<double>(M, N, 'T', batch_count);
+#if defined(QMC_COMPLEX)
+  test_gemv_batched<std::complex<float>>(N, M, 'T', batch_count);
+  test_gemv_batched<std::complex<double>>(N, M, 'T', batch_count);
 #endif
 }
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
ompblas has incorrect M, N usage in gemv implementation. This was not affecting correctness because only M==N are used.

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted