### PR TITLE
converter extension: basis/labeled atoms

### DIFF
--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -190,7 +190,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
 
   #Dataset Number Of Species 
   #Species contains (Atom_Name, Atom_Number,Atom_Charge,Atom_Core)
-  l_atoms = [ (loc_cell.atom_symbol(x),IonName[loc_cell.atom_symbol(x)],loc_cell.atom_charge(x),loc_cell.atom_nelec_core(x)) for x in  range(natom)  ] 
+  l_atoms = [ (loc_cell.atom_pure_symbol(x),IonName[loc_cell.atom_pure_symbol(x)],loc_cell.atom_charge(x),loc_cell.atom_nelec_core(x)) for x in  range(natom)  ] 
 
 
   d = defaultdict(list)
@@ -323,6 +323,10 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
          strList=['gaussian']
          asciiList = [n.encode("ascii", "ignore") for n in strList]
          atomicBasisSetGroup.create_dataset('name', (1,),'S8', asciiList)
+      elif isinstance(loc_cell.basis,dict):
+         strList=['custom']
+         asciiList = [n.encode("ascii", "ignore") for n in strList]
+         atomicBasisSetGroup.create_dataset('name', (1,),'S6', asciiList)
       else:
          strList=[loc_cell.basis]
          asciiList = [n.encode("ascii", "ignore") for n in strList]


### PR DESCRIPTION
## Proposed changes

This pull request slightly extends the PyscfToQmcpack converter for treating molecular systems imported into PySCF via a Molden file.

The first change allows for cases where a Molden is imported into PySCF which leads to numbered atoms in `loc_cell.atom_symbol`. The current converter would fail with the following message:
```
  File "/home/amandad/software/qmcpack/src/QMCTools/PyscfToQmcpack.py", line 193, in <listcomp>
    l_atoms = [ (loc_cell.atom_symbol(x),IonName[loc_cell.atom_symbol(x)],loc_cell.atom_charge(x),loc_cell.atom_nelec_core(x)) for x in  range(natom)  ]
KeyError: 'Fe1'
```
This can be avoided by using `loc_cell.atom_pure_symbol(x)` instead.

The second change allows for the converting of a basis set that is defined by a dictionary. The basis set as a dictionary can occur for a user custom-defined basis set or a basis set read in from a Molden file. 
The parsing of the dictionary seems to work fine, but naming the hdf5 dataset throws an error as the dictionary cannot be encoded.
This pull request has a simple fix which assigns the label 'custom' if the basis is an instance of a dictionary.
The error of the current code is:
```
File "/home/amandad/software/qmcpack/src/QMCTools/PyscfToQmcpack.py", line 332, in <listcomp>
    asciiList = [n.encode("ascii", "ignore") for n in strList]
AttributeError: 'dict' object has no attribute 'encode'
```

## What type(s) of changes does this code introduce?
- Bug fix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Two molecules read into PySCF from Molden files: ferrocene and C$_6$N$_4$. The basis set fix was also needed when a basis was custom set in a dictionary within the PySCF file for ferrocene.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
  - this pull request only changes the Python converter. 
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
  - I have an Molden file for ferrocene which demonstrates the issues. Can this be used to make a test for this case or would it be better to try and create a Molden for the existing diamond system being tested? 
- N/A. Documentation has been added (if appropriate)
