### PR TITLE
[NFC] renaming methods and variables to current coding standards

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -67,7 +67,7 @@ private:
    *  \todo remove after copy constructor that directly shares or copys basis_set_ is done
    */
   ParticleSet& very_temp_pset_;
-  
+
   /** @ingroup Derived simulation parameters determined by computation based in input
    *  @{
    */
@@ -84,55 +84,41 @@ private:
   /** @} */
 
   //data members \todo remove unecessary state
-  CompositeSPOSet basis_functions;
-  Vector<Value> basis_values;
-  Vector<Value> basis_norms;
-  Vector<Grad> basis_gradients;
-  Vector<Value> basis_laplacians;
-  std::vector<Position> rsamples;
-  Vector<Real> sample_weights;
-  std::vector<Value> psi_ratios;
-  Real dens;
-  Position drift;
-  int nindex;
-  bool volume_normed;
-  int basis_size;
-  std::vector<int> species_size;
-  std::vector<std::string> species_name;
-  std::vector<Matrix<Value>> Phi_NB, Psi_NM, Phi_Psi_NB, N_BB, E_BB;
-  Matrix<Value> Phi_MB;
-  bool check_overlap;
-  bool check_derivatives;
-
-// \todo this seems like developement clutter remove?
-//#define DMCHECK
-#ifdef DMCHECK
-  std::vector<Vector<Value>*> E_Ntmp;
-  std::vector<Matrix<Value>*> Phi_NBtmp, Psi_NMtmp, Phi_Psi_NBtmp, N_BBtmp, E_BBtmp;
-  Matrix_t Phi_MBtmp;
-#endif
+  CompositeSPOSet basis_functions_;
+  Vector<Value> basis_values_;
+  Vector<Value> basis_norms_;
+  Vector<Grad> basis_gradients_;
+  Vector<Value> basis_laplacians_;
+  std::vector<Position> rsamples_;
+  Vector<Real> samples_weights_;
+  std::vector<Value> psi_ratios_;
+  int basis_size_;
+  std::vector<int> species_sizes_;
+  std::vector<std::string> species_names_;
+  std::vector<Matrix<Value>> Phi_NB_, Psi_NM_, Phi_Psi_NB_, N_BB_;
+  Matrix<Value> Phi_MB_;
 
   /** @ingroup DensityIntegration only used for density integration
    *  @{
    */
   /// number of moves
-  int nmoves = 0;
+  int nmoves_ = 0;
   /// number of accepted samples
-  int naccepted = 0;
+  int naccepted_ = 0;
   /// running acceptance ratio over all samples
-  Real acceptance_ratio = 0.0;
-  bool write_acceptance_ratio;
+  Real acceptance_ratio_ = 0.0;
   int ind_dims_[OHMMS_DIM];
   /// }@
 
   Real metric_;
 
+  // \todo is this state necessay, would it be better passed down the call stack?
   /// current position
-  Position rpcur;
+  Position rpcur_;
   /// current drift
-  Position dpcur;
+  Position dpcur_;
   /// current density
-  Real rhocur;
+  Real rhocur_;
 
 public:
   /** Standard Constructor
@@ -180,26 +166,21 @@ private:
   void generateSamples(Real weight, ParticleSet& pset_target, RNG_GEN& rng, int steps = 0);
   // These functions deserve unit tests and likely should be pure functions.
   template<class RNG_GEN>
-  void generate_uniform_grid(RNG_GEN& rng);
+  void generateUniformGrid(RNG_GEN& rng);
   template<class RNG_GEN>
-  void generate_uniform_samples(RNG_GEN& rng);
+  void generateUniformSamples(RNG_GEN& rng);
   template<class RNG_GEN>
-  void generate_density_samples(bool save, int steps, RNG_GEN& rng, ParticleSet& pset_target);
+  void generateDensitySamples(bool save, int steps, RNG_GEN& rng, ParticleSet& pset_target);
   /// produce a position difference vector from timestep
   template<class RNG_GEN>
-  Position diffusion(const Real sqt, RNG_GEN& rng);
-  void density_only(const Position& r, Real& dens, ParticleSet& pset_target);
-  void density_drift(const Position& r, Real& dens, Position& drift, ParticleSet& pset_target);
+  Position diffuse(const Real sqt, RNG_GEN& rng);
+  void calcDensity(const Position& r, Real& dens, ParticleSet& pset_target);
+  void calcDensityDrift(const Position& r, Real& dens, Position& drift, ParticleSet& pset_target);
   //  basis & wavefunction ratio matrix construction
-  void get_energies(std::vector<Vector<Value>*>& E_n);
-  void generate_sample_basis(Matrix<Value>& Phi_mb, ParticleSet& pset_target, TrialWaveFunction& psi_target);
-  void generate_sample_ratios(std::vector<Matrix<Value>>& Psi_nm,
-                              ParticleSet& pset_target,
-                              TrialWaveFunction& psi_target);
-  void generate_particle_basis(ParticleSet& P, std::vector<Matrix<Value>>& Phi_nb, ParticleSet& pset_target);
+  void generateSampleBasis(Matrix<Value>& Phi_mb, ParticleSet& pset_target, TrialWaveFunction& psi_target);
   //  basis set updates
-  void update_basis(const Position& r, ParticleSet& pset_target);
-  void update_basis_d012(const Position& r, ParticleSet& pset_target);
+  void updateBasis(const Position& r, ParticleSet& pset_target);
+  void updateBasisD012(const Position& r, ParticleSet& pset_target);
 
   struct OneBodyDensityMatrixTimers
   {
@@ -227,13 +208,6 @@ public:
   template<typename T>
   friend class testing::OneBodyDensityMatricesTests;
 };
-
-/** OneBodyDensityMatrices factory function
- */
-UPtr<OneBodyDensityMatrices> createOneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
-                                                          const PtclOnLatticeTraits::ParticleLayout_t lattice,
-                                                          const SpeciesSet& species);
-
 
 extern template void OneBodyDensityMatrices::generateSamples<RandomGenerator_t>(Real weight,
                                                                                 ParticleSet& pset_target,

--- a/src/Estimators/OneBodyDensityMatricesInput.cpp
+++ b/src/Estimators/OneBodyDensityMatricesInput.cpp
@@ -27,7 +27,7 @@ OneBodyDensityMatricesInput::OneBodyDensityMatricesInput(xmlNodePtr cur)
   setIfInInput(check_overlap_, "check_overlap");
   setIfInInput(check_derivatives_, "check_derivatives");
   setIfInInput(rstats_, "rstats");
-  setIfInInput(acceptance_ratio_, "acceptance_ratio");
+  setIfInInput(write_acceptance_ratio_, "acceptance_ratio");
   setIfInInput(integrator_, "integrator");
   setIfInInput(evaluator_, "evaluator");
   setIfInInput(scale_, "scale");
@@ -58,13 +58,13 @@ void OneBodyDensityMatricesInput::OneBodyDensityMatrixInputSection::checkParticu
   if (get<std::string>("integrator") != "density")
   {
     if (has("acceptance_ratio") && get<bool>("acceptance_ratio") == true)
-      throw UniformCommunicateError(
-          error_tag + "acceptance_ratio can only be true for density integrator");
+      throw UniformCommunicateError(error_tag + "acceptance_ratio can only be true for density integrator");
   }
   if (get<std::string>("integrator") == "uniform_grid")
   {
-    if(has("samples"))
-      throw UniformCommunicateError(error_tag + "samples are set from points for uniform_grid integrator and are invalid input");
+    if (has("samples"))
+      throw UniformCommunicateError(error_tag +
+                                    "samples are set from points for uniform_grid integrator and are invalid input");
   }
 }
 
@@ -75,8 +75,10 @@ std::any OneBodyDensityMatricesInput::OneBodyDensityMatrixInputSection::assignAn
   try
   {
     return lookup_input_enum_value.at(enum_value_str);
-  } catch (std::out_of_range& oor_exc) {
-    std::throw_with_nested( std::logic_error("bad_enum_tag_value: " + enum_value_str) );
+  }
+  catch (std::out_of_range& oor_exc)
+  {
+    std::throw_with_nested(std::logic_error("bad_enum_tag_value: " + enum_value_str));
   }
 }
 

--- a/src/Estimators/OneBodyDensityMatricesInput.h
+++ b/src/Estimators/OneBodyDensityMatricesInput.h
@@ -62,22 +62,24 @@ public:
     /** parse time definition of input parameters */
     OneBodyDensityMatrixInputSection()
     {
-      section_name = "OneBodyDensityMatrix";
-      attributes   = {"name", "type"};
-      parameters   = {"basis",      "energy_matrix", "integrator",        "evaluator",        "scale",
-                    "center",     "points",        "samples",           "warmup",           "timestep",
-                    "use_drift",  "check_overlap", "check_derivatives", "acceptance_ratio", "rstats",
-                    "normalized", "volumed_normed"};
-      bools        = {"energy_matrix", "use_drift",         "normalized", "volume_normed",
-               "check_overlap", "check_derivatives", "rstats",     "acceptance_ratio"};
-      enums        = {"integrator", "evaluator"};
-      strings      = {"name", "type"};
+      // clang-format off
+      section_name  = "OneBodyDensityMatrix";
+      attributes    = {"name", "type"};
+      parameters    = {"basis", "energy_matrix", "integrator", "evaluator", "scale",
+                       "center", "points", "samples", "warmup", "timestep",
+                       "use_drift", "check_overlap", "check_derivatives", "acceptance_ratio", "rstats",
+                       "normalized", "volumed_normed"};
+      bools         = {"energy_matrix", "use_drift", "normalized", "volume_normed",
+                       "check_overlap", "check_derivatives", "rstats", "acceptance_ratio"};
+      enums         = {"integrator", "evaluator"};
+      strings       = {"name", "type"};
       multi_strings = {"basis"};
-      integers     = {"points", "samples"};
-      reals        = {"scale", "timestep"};
-      positions    = {"center"};
-      required     = {"name", "basis"};
+      integers      = {"points", "samples"};
+      reals         = {"scale", "timestep"};
+      positions     = {"center"};
+      required      = {"name", "basis"};
       // I'd much rather see the default defined in simple native c++ as below
+      // clang-format on
     }
 
     /** do parse time checks of input */
@@ -95,14 +97,14 @@ private:
   OneBodyDensityMatrixInputSection input_section_;
 
   // Default parameters for OneBodyDensityMatrices
-  bool energy_matrix_     = false;
-  bool use_drift_         = false;
-  bool normalized_        = true;
-  bool volume_normalized_ = true;
-  bool check_overlap_     = false;
-  bool check_derivatives_ = false;
-  bool rstats_            = false;
-  bool acceptance_ratio_  = false;
+  bool energy_matrix_          = false;
+  bool use_drift_              = false;
+  bool normalized_             = true;
+  bool volume_normalized_      = true;
+  bool check_overlap_          = false;
+  bool check_derivatives_      = false;
+  bool rstats_                 = false;
+  bool write_acceptance_ratio_ = false;
   /// This flag is derived from input so if you construct an OBDMI directly with center it must be set.
   bool center_defined_   = false;
   Integrator integrator_ = Integrator::UNIFORM_GRID;
@@ -124,7 +126,7 @@ public:
   bool get_check_overlap() const { return check_overlap_; }
   bool get_check_derivatives() const { return check_derivatives_; }
   bool get_rstats() const { return rstats_; }
-  bool get_acceptance_ratio() const { return acceptance_ratio_; }
+  bool get_write_acceptance_ratio() const { return write_acceptance_ratio_; }
   Integrator get_integrator() const { return integrator_; }
   Evaluator get_evaluator() const { return evaluator_; }
   Real get_scale() const { return scale_; }

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -49,15 +49,15 @@ public:
     {
     case (valid_obdm_input):
       obdm.generateSamples(1.0, pset_target, rng);
-      CHECK(obdm.nmoves == 64);
+      CHECK(obdm.nmoves_ == 64);
       break;
     case (valid_obdm_input_scale):
       obdm.generateSamples(1.0, pset_target, rng);
-      CHECK(obdm.nmoves == 0);
+      CHECK(obdm.nmoves_ == 0);
       break;
     case (valid_obdm_input_grid):
       obdm.generateSamples(1.0, pset_target, rng);
-      CHECK(obdm.nmoves == 0);
+      CHECK(obdm.nmoves_ == 0);
       CHECK(obdm.samples_ == pow(22, OHMMS_DIM));
       break;
     }


### PR DESCRIPTION
renaming methods to current coding standards
## Proposed changes

Rather than continue to have the overhead of current and past naming conventions in continued work on OBDM this collects all the rename refactors into a single PR.  I also delete (most) of the unused variables.

## What type(s) of changes does this code introduce?
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
