### PR TITLE
Remove an explicit use of pi

### DIFF
--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -327,7 +327,7 @@ void PairCorrEstimator::resize(int nbins)
   NumBins = nbins;
   norm_factor.resize((num_species * num_species - num_species) / 2 + num_species + 1, NumBins);
   RealType r  = Delta * 0.5;
-  RealType pf = Volume * DeltaInv / (4 * 3.14159265);
+  RealType pf = Volume * DeltaInv / (4 * M_PI);
   for (int i = 0; i < NumBins; ++i, r += Delta)
   {
     RealType rm2      = pf / r / r;


### PR DESCRIPTION
## Proposed changes

I saw this use of pi rather than the variable `M_PI` while reading the pair correlation estimator.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ryzen 5900X / Linux box
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
