### PR TITLE
Bump nightly wall-clock time request on spock

### DIFF
--- a/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
@@ -3,7 +3,7 @@
 #SBATCH -J nightly_spock
 #SBATCH -o nightly_spock.%j
 #SBATCH -e nightly_spock.%j
-#SBATCH -t 00:20:00
+#SBATCH -t 00:25:00
 #SBATCH -p ecp
 #SBATCH -N 1
 

--- a/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
@@ -3,7 +3,7 @@
 #SBATCH -J nightly_spock
 #SBATCH -o nightly_spock.%j
 #SBATCH -e nightly_spock.%j
-#SBATCH -t 00:15:00
+#SBATCH -t 00:20:00
 #SBATCH -p ecp
 #SBATCH -N 1
 
@@ -57,7 +57,7 @@ CTEST_FLAGS="-DCMAKE_C_COMPILER=gcc \
 
 ctest ${CTEST_FLAGS} \
       -S $(pwd)/../CMake/ctest_script.cmake,release \
-      --stop-time $(date --date=now+15mins +%H:%M:%S) \
+      --stop-time $(date --date=now+20mins +%H:%M:%S) \
       -VV -L 'deterministic' --timeout 600 &> \
       ${log_dir}/${QMCPACK_TEST_SUBMIT_NAME}.log
 
@@ -79,7 +79,7 @@ CTEST_FLAGS="-DCMAKE_C_COMPILER=gcc \
 
 ctest ${CTEST_FLAGS} \
       -S $(pwd)/../CMake/ctest_script.cmake,release \
-      --stop-time $(date --date=now+15mins +%H:%M:%S) \
+      --stop-time $(date --date=now+20mins +%H:%M:%S) \
       -VV -L 'deterministic' --timeout 600 &> \
       ${log_dir}/${QMCPACK_TEST_SUBMIT_NAME}.log
 


### PR DESCRIPTION
## Proposed changes

Looks like nightly runs on spock might need more time, so recursion can kick in. 
Changes are part of initial observations on spock and balancing core-hour usage.
Note: need to be in `develop` branch before retesting on spock.
Related to #3402 for adding AMD GPU testing

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests) nightly

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
`spock.olcf.ornl.gov`

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
