### PR TITLE
Add ROCm compiler bug workaround and a bit more automation in CMake

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -14,10 +14,19 @@ endif()
 if(QMC_OMP)
   set(ENABLE_OPENMP 1)
   if(ENABLE_OFFLOAD AND NOT CMAKE_SYSTEM_NAME STREQUAL "CrayLinuxEnvironment")
+    if (QMC_CUDA2HIP)
+      set(OFFLOAD_TARGET_DEFAULT "amdgcn-amd-amdhsa")
+    else()
+      set(OFFLOAD_TARGET_DEFAULT "nvptx64-nvidia-cuda")
+    endif()
     set(OFFLOAD_TARGET
-        "nvptx64-nvidia-cuda"
+        ${OFFLOAD_TARGET_DEFAULT}
         CACHE STRING "Offload target architecture")
     set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
+
+    if(NOT DEFINED OFFLOAD_ARCH AND OFFLOAD_TARGET MATCHES "amdgcn")
+      set(OFFLOAD_ARCH gfx906)
+    endif()
 
     if(NOT DEFINED OFFLOAD_ARCH AND OFFLOAD_TARGET MATCHES "nvptx64" AND DEFINED CMAKE_CUDA_ARCHITECTURES)
       list(LENGTH CMAKE_CUDA_ARCHITECTURES NUMBER_CUDA_ARCHITECTURES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ message(STATUS "ENABLE_OMP_TASKLOOP is set to ${ENABLE_OMP_TASKLOOP}")
 # Set up OpenMP offload compile options
 #---------------------------------------------------------
 set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT OFF)
+set(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT OFF)
 if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
   message(STATUS "OpenMP offload CXX flags: ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
@@ -369,11 +370,25 @@ if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
     # when using OpenMP offload to AMD GPU together with HIP.
     set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT ON)
   endif()
+  if(${COMPILER} MATCHES "Clang" AND OPENMP_OFFLOAD_COMPILE_OPTIONS MATCHES "amdgcn")
+    # As of 11/2021, QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON is needed for
+    # ROCM/AOMP compilers when using OpenMP offload to AMD GPU.
+    set(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT ON)
+  endif()
 endif()
 # Some OpenMP offload runtime libraries have composibility issue with a vendor native runtime.
 # A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
-cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime" OFF
-                       "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
+cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime"
+                       ${QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT} "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
+cmake_dependent_option(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL "ROCM compiler offload bug workaround"
+                       ${QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT} "ENABLE_OFFLOAD" OFF)
+
+if(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
+  message(WARNING "QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON hurts performance. "
+                  "As of 11/2021, QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON is needed for "
+                  "ROCM/AOMP compilers when using OpenMP offload to AMD GPU. See bug report "
+                  "https://github.com/ROCm-Developer-Tools/aomp/issues/255")
+endif()
 
 #---------------------------------------------------------
 # consider making this always on if OpenMP is no longer UB with Thread Support Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,6 @@ endif()
 option(ENABLE_HIP "Build with with GPU support through explicit HIP source code" OFF)
 option(ENABLE_ROCM "Build with with GPU support through ROCM libraries" OFF)
 option(ENABLE_OFFLOAD "Enable OpenMP offload" OFF)
-# Some OpenMP offload runtime libraries have composibility issue with a vendor native runtime.
-# A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
-cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime" OFF
-                       "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
 # Use CMake object library targets to workaround clang linker not being able to handle fat
 # binary archives which contain both host and device codes, for example OpenMP offload regions.
 # CMake does not propagate indirect object files by design.
@@ -362,18 +358,22 @@ message(STATUS "ENABLE_OMP_TASKLOOP is set to ${ENABLE_OMP_TASKLOOP}")
 #---------------------------------------------------------
 # Set up OpenMP offload compile options
 #---------------------------------------------------------
+set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT OFF)
 if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
   message(STATUS "OpenMP offload CXX flags: ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
   if(${COMPILER} MATCHES "Clang"
      AND OPENMP_OFFLOAD_COMPILE_OPTIONS MATCHES "amdgcn"
-     AND QMC_CUDA2HIP
-     AND NOT QMC_OFFLOAD_MEM_ASSOCIATED)
-    message(WARNING "Detected ENABLE_OFFLOAD=ON and QMC_CUDA2HIP=ON but QMC_OFFLOAD_MEM_ASSOCIATED=OFF. "
-                    "As of 11/2021, QMC_OFFLOAD_MEM_ASSOCIATED=ON is needed for AMD and mainline LLVM compilers "
-                    "when using OpenMP offload to AMD GPU together with HIP.")
+     AND QMC_CUDA2HIP)
+    # As of 11/2021, QMC_OFFLOAD_MEM_ASSOCIATED=ON is needed for AMD and mainline LLVM compilers
+    # when using OpenMP offload to AMD GPU together with HIP.
+    set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT ON)
   endif()
 endif()
+# Some OpenMP offload runtime libraries have composibility issue with a vendor native runtime.
+# A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
+cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime" OFF
+                       "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
 
 #---------------------------------------------------------
 # consider making this always on if OpenMP is no longer UB with Thread Support Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ option(ENABLE_ROCM "Build with with GPU support through ROCM libraries" OFF)
 option(ENABLE_OFFLOAD "Enable OpenMP offload" OFF)
 # Some OpenMP offload runtime libraries have composibility issue with a vendor native runtime.
 # A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
-cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime"
-                       OFF "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
+cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime" OFF
+                       "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
 # Use CMake object library targets to workaround clang linker not being able to handle fat
 # binary archives which contain both host and device codes, for example OpenMP offload regions.
 # CMake does not propagate indirect object files by design.
@@ -81,10 +81,13 @@ if(ENABLE_OFFLOAD AND QMC_CUDA)
 endif()
 
 # set CMAKE_CUDA_ARCHITECTURES early such that offload compilers may take advantage of it
-if(ENABLE_CUDA OR QMC_CUDA AND NOT QMC_CUDA2HIP)
+if(ENABLE_CUDA
+   OR QMC_CUDA
+   AND NOT QMC_CUDA2HIP)
   if(DEFINED CUDA_ARCH)
     unset(CUDA_ARCH CACHE)
-    message(FATAL_ERROR "CUDA_ARCH option has been removed. Use -DCMAKE_CUDA_ARCHITECTURES=80 if -DCUDA_ARCH=sm_80 was used.")
+    message(
+      FATAL_ERROR "CUDA_ARCH option has been removed. Use -DCMAKE_CUDA_ARCHITECTURES=80 if -DCUDA_ARCH=sm_80 was used.")
   endif()
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES 70)
@@ -273,12 +276,6 @@ if(NOT CMAKE_CXX_COMPILER_ID STREQUAL CMAKE_C_COMPILER_ID)
                       "C compiler is ${CMAKE_C_COMPILER_ID} but C++ compiler is ${CMAKE_CXX_COMPILER_ID}.")
 endif()
 
-if(${COMPILER} MATCHES "Clang" AND ENABLE_OFFLOAD AND QMC_CUDA2HIP AND NOT QMC_OFFLOAD_MEM_ASSOCIATED)
-  message(WARNING "Ignore this if Cray compilers are used! "
-          "Detected ENABLE_OFFLOAD=ON and QMC_CUDA2HIP=ON but QMC_OFFLOAD_MEM_ASSOCIATED=OFF. "
-          "As of 11/2021, QMC_OFFLOAD_MEM_ASSOCIATED=ON is needed for AMD and mainline LLVM compilers.")
-endif()
-
 #-----------------------------------------------------------------------
 # Set C++ minimum standard and run basic checks
 #-----------------------------------------------------------------------
@@ -366,7 +363,16 @@ message(STATUS "ENABLE_OMP_TASKLOOP is set to ${ENABLE_OMP_TASKLOOP}")
 # Set up OpenMP offload compile options
 #---------------------------------------------------------
 if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
+  message(STATUS "OpenMP offload CXX flags: ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
+  if(${COMPILER} MATCHES "Clang"
+     AND OPENMP_OFFLOAD_COMPILE_OPTIONS MATCHES "amdgcn"
+     AND QMC_CUDA2HIP
+     AND NOT QMC_OFFLOAD_MEM_ASSOCIATED)
+    message(WARNING "Detected ENABLE_OFFLOAD=ON and QMC_CUDA2HIP=ON but QMC_OFFLOAD_MEM_ASSOCIATED=OFF. "
+                    "As of 11/2021, QMC_OFFLOAD_MEM_ASSOCIATED=ON is needed for AMD and mainline LLVM compilers "
+                    "when using OpenMP offload to AMD GPU together with HIP.")
+  endif()
 endif()
 
 #---------------------------------------------------------
@@ -687,7 +693,7 @@ if(QMC_CUDA OR ENABLE_CUDA)
   if(QMC_CUDA2HIP)
     message(STATUS "CUDA2HIP enabled") # all the HIP and ROCm settings will be handled by ENABLE_ROCM
   else(QMC_CUDA2HIP)
-    if (CMAKE_VERSION VERSION_LESS 3.18.0)
+    if(CMAKE_VERSION VERSION_LESS 3.18.0)
       message(FATAL_ERROR "QMC_CUDA or ENABLE_CUDA require CMake 3.18.0 or later")
     endif()
     # a few production machines use CUDA 10 which only supports C++14.

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -215,7 +215,9 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
       T* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
+#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
+#endif
       for (int j = 0; j < n_src; j++)
       {
         if (j == iat) continue;
@@ -321,7 +323,9 @@ struct BsplineFunctor : public OptimizableFunctorBase
       T** mw_coefs        = reinterpret_cast<T**>(transfer_buffer_ptr);
       T* mw_DeltaRInv     = reinterpret_cast<T*>(transfer_buffer_ptr + sizeof(T*) * num_groups);
       T* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
+#endif
       for (int j = 0; j < n_src; j++)
       {
         const int ig    = grp_ids[j];
@@ -562,7 +566,9 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
       T* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
+#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for")
+#endif
       for (int j = 0; j < n_src; j++)
       {
         if (j == iat) continue;

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -56,6 +56,9 @@
 /* Manage memory allocations via vendor APIs and associate them with the OpenMP runtime */
 #cmakedefine QMC_OFFLOAD_MEM_ASSOCIATED @QMC_OFFLOAD_MEM_ASSOCIATED@
 
+/* Workaround offload bug when branching happens in parallel */
+#cmakedefine QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL @QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL@
+
 /* Define to 1 if you have MPI library */
 #cmakedefine HAVE_MPI @HAVE_MPI@
 


### PR DESCRIPTION
## Proposed changes
Need to workaround the last ROCm/AOMP bug. https://github.com/ROCm-Developer-Tools/aomp/issues/255
Introduce `QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL` option.
This workaround hurt performance but make tests pass instead of crashing.
I would like to set `QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL` to OFF once upstream LLVM can robustly work.

I added a bit automation which I'm comfortable with both 
`QMC_OFFLOAD_MEM_ASSOCIATED`
and
`QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL`
being set automatically for ROCM/AOMP/upstream LLVM compilers when offload to AMD GPU is enabled.

Also with clang, if `QMC_CUDA2HIP=ON` and `ENABLE_OFFLOAD=ON`, there is no need to set the offload target to amdgcn-amd-amdhsa.
So `-DENABLE_OFFLOAD=ON -DENABLE_CUDA=ON -DQMC_CUDA2HIP=ON` adds OFFLOAD_TARGET=amdgcn-amd-amdhsa and OFFLOAD_ARCH=gfx906 for you and you still can override them via cmake command line as usual

## What type(s) of changes does this code introduce?
- Build related changes
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'