### PR TITLE
Add GitHub Actions CI jobs on AMD hardware

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -105,3 +105,99 @@ jobs:
           state: ${{job.status}}
           sha: ${{fromJson(steps.request.outputs.data).head.sha}}
           target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+  gpu-rocm:
+    if: |
+      github.repository_owner == 'QMCPACK' &&
+      github.event.issue.pull_request &&
+      ( startsWith(github.event.comment.body, 'Test this please') || 
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    runs-on: [self-hosted, Linux, X64, gpu, rocm]
+
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname:
+          [
+            ROCm-Clang13-NoMPI-CUDA2HIP-Real-Mixed,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Real,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Complex-Mixed,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Complex,
+          ]
+
+    steps:
+      - name: Verify actor
+        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
+        # this is in-line with the current workflow
+        env:
+          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
+        id: check
+        run: |
+          echo "::set-output name=triggered::true"
+
+      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
+      - name: GitHub API Request
+        if: steps.check.outputs.triggered == 'true'
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{github.event.issue.pull_request.url}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Create a separate PR status pointing at GitHub Actions tab URL
+      # just like any other third-party service
+      - name: Create PR status
+        if: steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "GitHub Actions self-hosted CI ${{ matrix.jobname }}"
+          state: "pending"
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Get PR information
+        if: steps.check.outputs.triggered == 'true'
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+          ref: ${{steps.pr_data.outputs.branch}}
+
+      - name: Configure
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+      - name: Build
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh build
+
+      - name: Test
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh test
+
+      - name: Report PR status
+        if: always() && steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "GitHub Actions self-hosted CI ${{matrix.jobname}}"
+          state: ${{job.status}}
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -126,6 +126,20 @@ case "$1" in
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ${GITHUB_WORKSPACE}
       ;;
+      *"ROCm-Clang13-NoMPI-CUDA2HIP"*)
+        echo 'Configure for building CUDA2HIP with clang compilers shipped with ROCM on AMD hardware'
+        cmake -GNinja \
+              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+              -DQMC_MPI=0 \
+              -DENABLE_CUDA=ON \
+              -DQMC_CUDA2HIP=ON \
+              -DCMAKE_PREFIX_PATH="/opt/OpenBLAS/0.3.18" \
+              -DQMC_COMPLEX=$IS_COMPLEX \
+              -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              ${GITHUB_WORKSPACE}
+      ;;
       *"GCC8-MPI-CUDA-AFQMC"*)
         echo 'Configure for building with ENABLE_CUDA and AFQMC, need built-from-source OpenBLAS due to bug in rpm'
         cmake -GNinja \


### PR DESCRIPTION
## Proposed changes

Add CI for deterministic tests running on self-hosted AMD GPU hardware
Follows self-hosted workflow
Avoid cuda and cuda2hip conflict in workflow
Must be merged on develop to test CI jobs
TODO: add docs to trigger CI on a follow-up PR
Related to #3402 


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests) new CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
nitrogen, must be merged to test CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
