### PR TITLE
Nexus: no longer require mpirun for test passage

### DIFF
--- a/nexus/tests/unit/test_simulation_module.py
+++ b/nexus/tests/unit/test_simulation_module.py
@@ -2361,8 +2361,11 @@ def test_execute():
 
     tpath = testing.setup_unit_test_output_directory('simulation','test_execute',divert=True)
 
+    import shutil
+    serial = shutil.which('mpirun') is None
+
     s = get_test_sim(
-        job = job(machine='ws1',app_command='echo run'),
+        job = job(machine='ws1',app_command='echo run',serial=serial),
         )
 
     s.create_directories()


### PR DESCRIPTION
## Proposed changes

Addresses #3120.  Nexus tests no longer strictly require mpirun.  If mpirun is detected in the path, it is executed in the tests ("mpirun -np 1 echo run").  Otherwise a serial test is performed ("echo run").

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

