### PR TITLE
Support initializer list for ParticleAttrib for tests with PSet

### DIFF
--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -68,6 +69,9 @@ struct TinyVector
 
   // Copy Constructor
   inline TinyVector(const TinyVector& rhs) = default;
+
+  // Move Constructor
+  inline TinyVector(TinyVector&& rhs) = default;
 
   // Templated TinyVector constructor.
   template<class T1>
@@ -151,6 +155,7 @@ struct TinyVector
   inline int byteSize() const { return D * sizeof(T); }
 
   inline TinyVector& operator=(const TinyVector& rhs) = default;
+  inline TinyVector& operator=(TinyVector&& rhs) = default;
 
   template<class T1>
   inline TinyVector<T, D>& operator=(const TinyVector<T1, D>& rhs)

--- a/src/Containers/OhmmsPETE/tests/test_vector.cpp
+++ b/src/Containers/OhmmsPETE/tests/test_vector.cpp
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
-// File developed by:  Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -13,6 +14,7 @@
 #include "catch.hpp"
 
 #include "OhmmsPETE/OhmmsVector.h"
+#include "OhmmsPETE/TinyVector.h"
 
 #include <stdio.h>
 #include <string>
@@ -50,6 +52,25 @@ TEST_CASE("vector", "[OhmmsPETE]")
   vec_t C(2);
   REQUIRE(A != B);
   REQUIRE(A != B);
+}
+
+TEST_CASE("Vector simple intializer list", "[OhmmsPETE]")
+{
+  //empty list should work
+  Vector<int> vec_int{};
+  Vector<double> vec_double{5.0,4.0,3.0,2.0,1.0};
+  CHECK(vec_double[0]==Approx(5.0));
+  CHECK(vec_double[4]==Approx(1.0));
+}
+
+TEST_CASE("Vector nested intializer list", "[OhmmsPETE]")
+{
+  Vector<TinyVector<double, 3>> vec_tinyd3({{1,2,3},{4,5,6},{7,8,9}});
+  CHECK(vec_tinyd3[1][1] == 5);
+  CHECK(vec_tinyd3[2][0] == 7);
+  Vector<std::pair<int, int>> vec_pair{{1,2},{3,4}};
+  CHECK(vec_pair[0].first == 1);
+  CHECK(vec_pair[1].second == 4);
 }
 
 TEST_CASE("VectorViewer", "[OhmmsPETE]")

--- a/src/Particle/ParticleBase/ParticleAttrib.h
+++ b/src/Particle/ParticleBase/ParticleAttrib.h
@@ -2,9 +2,9 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
-// File developed by:
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
 // File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
 //////////////////////////////////////////////////////////////////////////////////////
@@ -45,6 +45,9 @@ public:
   explicit inline ParticleAttrib(T* ref, size_t n) : __my_base(ref, n), InUnit(PosUnit::Cartesian) {}
 
   ParticleAttrib(const ParticleAttrib& rhs) = default;
+
+  ParticleAttrib(std::initializer_list<T> ts) : __my_base(ts), InUnit(PosUnit::Cartesian) {};
+
   inline ParticleAttrib& operator=(const ParticleAttrib& rhs) = default;
 
   /** assignment operator to enable PETE */

--- a/src/Utilities/for_testing/NativeInitializerPrint.hpp
+++ b/src/Utilities/for_testing/NativeInitializerPrint.hpp
@@ -1,0 +1,42 @@
+
+#include <iostream>
+
+namespace qmcplusplus
+{
+
+/** This wrapper is to allow us to leave the user facing operator<< for classes alone
+ */
+template<typename OBJECT>
+class NativePrint
+{
+public:
+  using type_t = OBJECT;
+  NativePrint(const OBJECT& obj) : obj_(obj) {}
+  const OBJECT& get_obj() const { return obj_; }
+private:
+  OBJECT obj_;
+};
+
+template<class T, unsigned D>
+std::ostream& operator<<(std::ostream& out, const NativePrint<TinyVector<T, D>>& np_vec)
+{
+  out << "{ ";
+  auto vec = np_vec.get_obj();
+  for(int i = 0 ; i < D - 1; ++i)
+    out << std::setw(12) << std::setprecision(10) << vec[i] << ", ";
+  out << std::setw(12) << std::setprecision(10) << vec[D - 1] << " }";
+  return out;
+}
+
+template<class T>
+std::ostream& operator<<(std::ostream& out, const NativePrint<std::vector<T>>& np_vec)
+{
+  out << "{ ";
+  auto vec = np_vec.get_obj();
+  for(T& t : vec)
+    out << std::setprecision(10) << t << ", ";
+  out << " }";
+  return out;
+}
+
+} // namespace qmcplusplus

--- a/src/type_traits/template_types.hpp
+++ b/src/type_traits/template_types.hpp
@@ -37,12 +37,16 @@ template<typename T>
 using UPtrVector = std::vector<std::unique_ptr<T>>;
 /** }@ */
 
-
-/** temporary helper function you have a vector of derived class but what to pass
- *  a vector of base class references to an API.
+/** helper function to take vector of class A to refvector of any valid reference type for A
+ *
+ *  intended usage looks like this
+ *  std::vector<DerivedType> vdt
+ *  auto refvecbase = makeRefVector<BaseType>(vdt)
+ *  or if you just want a refvector of type vdt
+ *  auto refvec = makeRefVector<decltype(vdt)::value_type>(vdt)
  *
  *  godbolt.org indicates at least with clang 11&12 we get RVO here.
- *  auto ref_whatevers = makeRefVector(whatevers);
+ *  auto ref_whatevers = makeRefVector<ValidTypeForReference>(whatevers);
  *  makes no extra copy.
  */
 template<class TR, class T>

--- a/src/type_traits/tests/test_template_types.cpp
+++ b/src/type_traits/tests/test_template_types.cpp
@@ -17,18 +17,44 @@
 namespace qmcplusplus
 {
 
+TEST_CASE("makeRefVector", "[type_traits]")
+{
+  struct Dummy
+  {
+    double d;
+    std::string s;
+  };
+
+  struct DerivedDummy : Dummy
+  {
+    float f;
+  };
+
+  std::vector<DerivedDummy> ddvec;
+  for (int i = 0; i < 3; ++i)
+    ddvec.push_back(DerivedDummy());
+
+  RefVector<Dummy> bdum(makeRefVector<Dummy>(ddvec));
+  auto bdum2 = makeRefVector<Dummy>(ddvec);
+  CHECK(std::is_same<RefVector<Dummy>, decltype(bdum2)>::value);
+
+  auto bdum3 = makeRefVector<decltype(ddvec)::value_type>(ddvec);
+}
+
 TEST_CASE("convertUPtrToRefvector", "[type_traits]")
 {
-  struct Dummy {
+  struct Dummy
+  {
     double d;
     std::string s;
   };
 
   UPtrVector<Dummy> uvec;
-  for(int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
     uvec.emplace_back(std::make_unique<Dummy>());
 
   RefVector<Dummy> rdum(convertUPtrToRefVector(uvec));
+  auto rdum2 = convertUPtrToRefVector(uvec);
 }
 
 TEST_CASE("convertPtrToRefvectorSubset", "[type_traits]")
@@ -51,4 +77,4 @@ TEST_CASE("convertPtrToRefvectorSubset", "[type_traits]")
   for (int i = 0; i < 5; ++i)
     delete pvec[i];
 }
-}
+} // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

Add initializer list support for ParticleAttrib so ParticleSet R can be easily initialized using the native C++ initializer list format. This requires small changes in OhmmsVector and TinyVector. I have added unit tests to cover the changes in OhmmsVector.  I have not added unit tests to TinyVector since I just added the default move constructor and move assignment to the class.

As found by @jtkrogel in #3475 There is a surprising issue with writing unit tests.

We have a global Random object to support legacy code that wants to just grab a nondeterministic random number this is bad practice for many reasons but in tests that rely on boot strapping objects through the legacy put methods i.e. with MinimalWhateverPools or larger mocking of the application environment it means you will get ParticleSets whose initialized R vary based runtime ordering.
i.e. We can't reason about the state of the global Random in tests. 

Also due to use of FakeRandom in unit tests and the fact that we bundle unit tests into module level executables with many many tests cases we break the ODR in a way that is not caught at compile or link time. The type and accessibility global Random is unpredictable for a particular test. Whether it will be the same as the legacy object using global random is unpredictable. So we can't just initialize it to a known state in each test case.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
