### PR TITLE
Fix Werror uninitialized member error

### DIFF
--- a/src/QMCTools/ppconvert/src/CubicSpline.h
+++ b/src/QMCTools/ppconvert/src/CubicSpline.h
@@ -112,8 +112,7 @@ public:
   }
 
   /// Trivial constructor
-  CubSpline()
-    : StartDeriv(0.)
+  CubSpline() : StartDeriv(0.), EndDeriv(0.)
   {
     UpToDate    = false;
     Initialized = false;


### PR DESCRIPTION
## Proposed changes

Proposed Werror check with RelWithDebInfo in #3596 fails
This PR fixes that error due to an uninitialized member
Able to reproduce with gcc-10, not with gcc-9

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04 + gcc-10, must pass CI check with gcc-11

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
