### PR TITLE
Initial CI documentation on AMD Hardware

### DIFF
--- a/docs/github_actions.rst
+++ b/docs/github_actions.rst
@@ -17,48 +17,57 @@ Summary of Test Jobs
 
 The following is a summary of the jobs run in the CI process required for a PR:
 
-+----------------------------------------------+--------+---------------+------+----------+
-| Job Name with                                | Runner | Tests         | Time | Trigger  |
-| Build Info                                   | Host   | ctest -L      | min  | event    |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC9-MPI-Gcov-Real*                          | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC9-MPI-Gcov-Complex*                       | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC11-NoMPI-Werror-Real                      | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC11-NoMPI-Werror-Complex                   | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang10-NoMPI-ASan-Real                      | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang10-NoMPI-ASan-Complex                   | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang10-NoMPI-UBSan-Real                     | GitHub | deterministic | 60   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang12-NoMPI-Offload-Real                   | GitHub | unit          | 35   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| macOS-GCC11-NoMPI-Real                       | GitHub | deterministic | 27   | PR/merge |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-NoMPI-Legacy-CUDA-Real-Mixed            | sulfur | deterministic | 2    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-NoMPI-Legacy-CUDA-Complex-Mixed         | sulfur | deterministic | 2    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-NoMPI-Legacy-CUDA-Real                  | sulfur | deterministic | 2    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-NoMPI-Legacy-CUDA-Complex               | sulfur | deterministic | 2    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-MPI-CUDA-AFQMC-Real-Mixed               | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-MPI-CUDA-AFQMC-Complex-Mixed            | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-MPI-CUDA-AFQMC-Real                     | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| GCC8-MPI-CUDA-AFQMC-Complex                  | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang14Dev-MPI-CUDA-AFQMC-Offload-Real-Mixed | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
-| Clang14Dev-MPI-CUDA-AFQMC-Offload-Real       | sulfur | deterministic | 6    | manual   |
-+----------------------------------------------+--------+---------------+------+----------+
++----------------------------------------------+----------+---------------+------+----------+
+| Job Name with                                | Runner   | Tests         | Time | Trigger  |
+| Build Info                                   | Host     | ctest -L      | min  | event    |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC9-MPI-Gcov-Real*                          | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC9-MPI-Gcov-Complex*                       | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC11-NoMPI-Werror-Real                      | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC11-NoMPI-Werror-Complex                   | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang10-NoMPI-ASan-Real                      | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang10-NoMPI-ASan-Complex                   | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang10-NoMPI-UBSan-Real                     | GitHub   | deterministic | 60   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang12-NoMPI-Offload-Real                   | GitHub   | unit          | 35   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| macOS-GCC11-NoMPI-Real                       | GitHub   | deterministic | 27   | PR/merge |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-NoMPI-Legacy-CUDA-Real-Mixed            | sulfur   | deterministic | 2    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-NoMPI-Legacy-CUDA-Complex-Mixed         | sulfur   | deterministic | 2    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-NoMPI-Legacy-CUDA-Real                  | sulfur   | deterministic | 2    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-NoMPI-Legacy-CUDA-Complex               | sulfur   | deterministic | 2    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-MPI-CUDA-AFQMC-Real-Mixed               | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-MPI-CUDA-AFQMC-Complex-Mixed            | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-MPI-CUDA-AFQMC-Real                     | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| GCC8-MPI-CUDA-AFQMC-Complex                  | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang14Dev-MPI-CUDA-AFQMC-Offload-Real-Mixed | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| Clang14Dev-MPI-CUDA-AFQMC-Offload-Real       | sulfur   | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| ROCm-Clang13-NoMPI-CUDA2HIP-Real-Mixed       | nitrogen | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| ROCm-Clang13-NoMPI-CUDA2HIP-Real             | nitrogen | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| ROCm-Clang13-NoMPI-CUDA2HIP-Complex-Mixed    | nitrogen | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+| ROCm-Clang13-NoMPI-CUDA2HIP-Complex          | nitrogen | deterministic | 6    | manual   |
++----------------------------------------------+----------+---------------+------+----------+
+
 
 Jobs running on GitHub hosted runners are triggered automatically. Permission from an admin is required to run jobs on self-hosted runners (e.g. sulfur) for security reasons. In addition, jobs running on GitHub hosted runners run automatically in parallel and the time each job takes may vary depending on system utilization. For information on the underlying hardware see the GitHub Actions `docs on the topic <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners>`_.  
 


### PR DESCRIPTION
## Proposed changes

Initial documentation on GitHub Actions CI using AMD hardware
Use this PR to trigger CI on AMD hardware
Related to #3582 and #3402 


Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.
## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Newly CI on AMD self-hosted hardware must pass

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
