### PR TITLE
Increase epsilon for complex and mixed precision test on ROCm

### DIFF
--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -191,9 +191,11 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   for (size_t id = 0; id < ref_data.size(); ++id)
   {
      #ifdef MIXED_PRECISION
-     CHECK(data[id] == Approx(ref_data[id]).epsilon(0.00002));
+     CHECK(data[id] == Approx(ref_data[id]).epsilon(2.e-05));
      #else
-     CHECK(data[id] == Approx(ref_data[id]));
+     // default Catch2 epsilon std::numeric_limits<float>::epsilon()*100
+     // set value for x86_64
+     CHECK(data[id] == Approx(ref_data[id]).epsilon(1.192092896e-05));
      #endif
   }
 

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -189,7 +189,13 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   //std::cout<<"}\n\n\n";
 
   for (size_t id = 0; id < ref_data.size(); ++id)
-    CHECK(data[id] == Approx(ref_data[id]));
+  {
+     #ifdef MIXED_PRECISION
+     CHECK(data[id] == Approx(ref_data[id]).epsilon(0.00002));
+     #else
+     CHECK(data[id] == Approx(ref_data[id]));
+     #endif
+  }
 
   outputManager.resume();
 


### PR DESCRIPTION
## Proposed changes

Current CI is failing on nitrogen for complex and mixed precision tests
This PR just bumps epsilon in floating point comparison
Tests were recently added in #3592 
Failure seen in #3599 
Fixes #3601 

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
nitrogen

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
