### PR TITLE
Make it possible to get a working ParticleSet for CPU fallback

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -124,6 +124,55 @@ ParticleSet::ParticleSet(const ParticleSet& p)
   L = p.L;
 }
 
+// \todo refactor most of this "copy" constructor out to common method
+ParticleSet::ParticleSet(const ParticleSet& other, MinimalDefault tag)
+    : IsGrouped(other.IsGrouped),
+      SameMass(true),
+      ThreadID(0),
+      mySpecies(other.getSpeciesSet()), // This we need
+      Properties(0, 0, 1, 1),           // This we don't make it empty
+      myTwist(0.0),                     // maybe?
+      ParentName(other.parentName()),   // ?
+      coordinates_(other.coordinates_->makeClone())
+{
+  coordinates_->setAllParticlePos(other.R); // Yes
+  setQuantumDomain(other.quantum_domain);   // Probably not.
+  assign(other);                            //copies some things and not others, a mystery to me
+  //need explicit copy:
+  Mass   = other.Mass;      // Maybe
+  Z      = other.Z;         // Maybe
+  myName = other.getName(); // Yes
+  for (int i = 0; i < other.DistTables.size(); ++i)
+    addTable(other.DistTables[i]->get_origin(), other.DistTables[i]->getModes());
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_medium);
+  myTwist = other.myTwist;
+}
+
+// Make a minimal Copy of Mr.ParticleSet without his enormous luggage
+// and with an implementation a CPU SPOSet can use.
+ParticleSet::ParticleSet(const ParticleSet& other, MinimalCPU tag)
+    : IsGrouped(other.IsGrouped),
+      SameMass(true),
+      ThreadID(0),
+      mySpecies(other.getSpeciesSet()),                                     // This we need
+      Properties(0, 0, 1, 1),                                               // This we don't make it empty
+      myTwist(0.0),                                                         // maybe?
+      ParentName(other.parentName()),                                       // ?
+      coordinates_(createDynamicCoordinates(DynamicCoordinateKind::DC_POS)) // Yes just vanilla
+{
+  coordinates_->setAllParticlePos(other.R); // Yes
+  setQuantumDomain(other.quantum_domain);   // Probably not.
+  assign(other);                            //copies some things and not others, a mystery to me
+  //need explicit copy:
+  Mass   = other.Mass;      // Maybe
+  Z      = other.Z;         // Maybe
+  myName = other.getName(); // Yes
+  for (int i = 0; i < other.DistTables.size(); ++i)
+    addTable(other.DistTables[i]->get_origin(), DTModes::NEED_FULL_TABLE_ANYTIME); // Why this is needed.
+  setup_timers(myTimers, generatePSetTimerNames(myName), timer_level_medium);
+  myTwist = other.myTwist;
+}
+
 ParticleSet::~ParticleSet()
 {
   DEBUG_MEMORY("ParticleSet::~ParticleSet");
@@ -382,6 +431,7 @@ int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
     app_debug() << "  ... ParticleSet::addTable Reuse Table #" << tid << " " << DistTables[tid]->getName() << std::endl;
   }
 
+  // This violates the prinicipal of least surprise and is undocumented!
   DistTables[tid]->setModes(DistTables[tid]->getModes() | modes);
 
   app_log().flush();

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -37,7 +37,6 @@ namespace qmcplusplus
 class DistanceTableData;
 class ResourceCollection;
 class StructFact;
-class CompositeSPOSet;
 
 /** Specialized paritlce class for atomistic simulations
  *
@@ -76,21 +75,6 @@ public:
   /// ParticleSet that will work with a CPU only SPOSet like CompositeSPOSet and who knows what else as we port Estimators.
   struct MinimalCPU
   {};
-
-  /** Compilers not compliant with c++17 17.8.3.2 (Explicit Specialization section)  may claim these can 
-   *  not be specialized in class scope.  They are wrong.
-   */
-  template<class T>
-  struct minimal_trait
-  {
-    using tag = MinimalDefault;
-  };
-  template<>
-  struct minimal_trait<CompositeSPOSet>
-  {
-    using tag = MinimalCPU;
-  };
-
 
   ///quantum_domain of the particles, default = classical
   quantum_domains quantum_domain;
@@ -765,6 +749,12 @@ protected:
    * @param iat the electron whose proposed move gets rejected.
    */
   void rejectMoveForwardMode(Index_t iat);
+};
+
+template<class T>
+struct ParticleSet_minimal_trait
+{
+  using tag = ParticleSet::MinimalDefault;
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -27,6 +27,15 @@ using std::string;
 
 namespace qmcplusplus
 {
+
+class TestMinimalTraitCPU {};
+
+template<>
+struct ParticleSet_minimal_trait<TestMinimalTraitCPU>
+{
+  using tag = ParticleSet::MinimalCPU;
+};
+
 TEST_CASE("ParticleSet minimal copy constructors", "[particle]")
 {
   Communicate* comm;
@@ -48,6 +57,12 @@ TEST_CASE("ParticleSet minimal copy constructors", "[particle]")
   // Just check for the NEED_FULL_TABLE_ANYTIME bit since that should make the distance table coherent for a CPU
   // side client
   CHECK(pset_minimal_cpu.getDistTable(table_id).getModes() & DTModes::NEED_FULL_TABLE_ANYTIME);
+  // Now the case we're actually likely to use where the client class defines it minimal need
+  // I.e. imagine your SPOSet type is TestMinimalTraitCPU
+  // You don't have to know that in your code.
+  TestMinimalTraitCPU tmtc;
+  ParticleSet pset_minimal_cpu_trait (pset_target, ParticleSet_minimal_trait<decltype(tmtc)>::tag{});
+  CHECK(pset_minimal_cpu_trait.getDistTable(table_id).getModes() & DTModes::NEED_FULL_TABLE_ANYTIME);
 }
 
 TEST_CASE("ParticleSet distance table management", "[particle]")


### PR DESCRIPTION
## Proposed changes
ParticleSet gets used to actually pass coordinates and via manipulation of its state machine access to distance tables to for those coordinates, this leads to access violations and/or synchronization errors if the recipient of the ParticleSet argument expects a different DistanceTable DTMode than the table actually has which is for instance true of any CPU only SPOSet implementation when ENABLE_OFFLOAD=1. Some/Most Estimators of ParticleSet arguments do not add their required distance tables they just assume they are there in the walker ParticleSet and of a usable implementation.

This allows us to get a a for sure working ParticleSet to use as the coordinate argument for an estimator. We need with as little of the unecessary other data in ParticleSet. This is also nice since we don't manipulate the state machine of an object that should really be const with respect to estimator accumulation.

I expect to need this further in the near/mid term so I did this "properly" with tag evaluation.

In the long term ParticleSet needs to be refactored/redesigned and functions that consume need to be fed arguments that reflect their actual data dependencies.
I'd also point out that makeMove does distance table updating whether or not they are used for the evaluation taking the ParticleSet argument which is bad.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New "feature"
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Leconte clang14
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
