### PR TITLE
Fix seg fault in batched optimizer

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -188,6 +188,7 @@ void QMCCostFunctionBatched::getConfigurations(const std::string& aroot)
     if (includeNonlocalH != "no")
     {
       OperatorBase* a(H.getHamiltonian(includeNonlocalH));
+      outputManager.resume();
       if (a)
       {
         app_log() << " Found non-local Hamiltonian element named " << includeNonlocalH << std::endl;
@@ -386,7 +387,8 @@ void QMCCostFunctionBatched::checkConfigurations()
           if (includeNonlocalH != "no")
           {
             OperatorBase* nlpp = h_list[ib].getHamiltonian(includeNonlocalH);
-            RecordsOnNode[is][ENERGY_FIXED] -= nlpp->getValue();
+            if (nlpp)
+              RecordsOnNode[is][ENERGY_FIXED] -= nlpp->getValue();
           }
         }
       }


### PR DESCRIPTION
When 'nonlocalpp' is specified in the optimization section of the input file, but the Hamiltonian doesn't use pseudopotentials, `nlpp` will be null and the access will cause a segfault.

Ignoring the value in the input file (by using a null pointer test) is the same behavior as the non-batched optimizer.

The input files produced by Nexus enable `nonlocalpp` by default.

Also enable output earlier so messages about the presence or absence of the non-local Hamiltonian elements get printed.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
