### PR TITLE
If ENABLE_OFFLOAD=1 particle set move requires mw resources

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -336,11 +336,11 @@ void DMCBatched::runDMCStep(int crowd_id,
   auto& rng = context_for_steps[crowd_id]->get_random_gen();
   crowd.setRNGForHamiltonian(rng);
 
-  int max_steps  = sft.qmcdrv_input.get_max_steps();
-  IndexType step = sft.step;
+  const int max_steps  = sft.qmcdrv_input.get_max_steps();
+  const IndexType step = sft.step;
   // Are we entering the the last step of a block to recompute at?
-  bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
-  bool accumulate_this_step = (sft.branch_engine.getWarmupToDoSteps() == 0);
+  const bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
+  const bool accumulate_this_step = true;
   advanceWalkers(sft, crowd, timers, dmc_timers, *context_for_steps[crowd_id], recompute_this_step, accumulate_this_step);
 }
 

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -447,17 +447,6 @@ bool DMCBatched::run()
       crowd_task(crowds_.size(), runDMCStep, dmc_state, timers_, dmc_timers_, std::ref(step_contexts_),
                  std::ref(crowds_));
 
-      // Accumulate on the whole population
-      // But it is now visible in the algorithm not hidden in the BranchEngine::branch.
-      // \todo make task block
-      // probably something smart can be done to include reduction over crowds below
-      // for (int crowd_id = 0; crowd_id < crowds_.size(); ++crowd_id)
-      // {
-      //   Crowd& crowd = *(crowds_[crowd_id]);
-      //   if (crowd.size() > 0)
-      //     crowd.accumulate(step_contexts_[crowd_id]->get_random_gen());
-      // }
-
       {
         int iter                 = block * qmcdriver_input_.get_max_steps() + step;
         const int population_now = walker_controller_->branch(iter, population_, iter == 0);

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -78,9 +78,11 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
   const RefVectorWithLeader<QMCHamiltonian> walker_hamiltonians(crowd.get_walker_hamiltonians()[0],
                                                                 crowd.get_walker_hamiltonians());
 
+  timers.resource_timer.start();
   ResourceCollectionTeamLock<ParticleSet> pset_res_lock(crowd.getSharedResource().pset_res, walker_elecs);
   ResourceCollectionTeamLock<TrialWaveFunction> twfs_res_lock(crowd.getSharedResource().twf_res, walker_twfs);
   ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(crowd.getSharedResource().ham_res, walker_hamiltonians);
+  timers.resource_timer.stop();
 
   {
     ScopedTimer recompute_timer(dmc_timers.step_begin_recompute_timer);

--- a/src/QMCDrivers/DMC/DMCBatched.h
+++ b/src/QMCDrivers/DMC/DMCBatched.h
@@ -137,7 +137,8 @@ private:
                              DriverTimers& timers,
                              DMCTimers& dmc_timers,
                              ContextForSteps& move_context,
-                             bool recompute);
+                             bool recompute,
+                             bool accumulate_this_step);
 
   friend class qmcplusplus::testing::DMCBatchedTest;
 };

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -285,6 +285,7 @@ protected:
     NewTimer& movepbyp_timer;
     NewTimer& hamiltonian_timer;
     NewTimer& collectables_timer;
+    NewTimer& resource_timer;
     DriverTimers(const std::string& prefix)
         : checkpoint_timer(*timer_manager.createTimer(prefix + "CheckPoint", timer_level_medium)),
           run_steps_timer(*timer_manager.createTimer(prefix + "RunSteps", timer_level_medium)),
@@ -293,7 +294,8 @@ protected:
           buffer_timer(*timer_manager.createTimer(prefix + "Buffer", timer_level_medium)),
           movepbyp_timer(*timer_manager.createTimer(prefix + "MovePbyP", timer_level_medium)),
           hamiltonian_timer(*timer_manager.createTimer(prefix + "Hamiltonian", timer_level_medium)),
-          collectables_timer(*timer_manager.createTimer(prefix + "Collectables", timer_level_medium))
+          collectables_timer(*timer_manager.createTimer(prefix + "Collectables", timer_level_medium)),
+          resource_timer(*timer_manager.createTimer(prefix + "Resources", timer_level_medium))
     {}
   };
 

--- a/src/QMCDrivers/SFNBranch.h
+++ b/src/QMCDrivers/SFNBranch.h
@@ -278,6 +278,7 @@ public:
   inline RealType getTau() const { return vParam[SBVP::TAU]; }
   inline RealType getTauEff() const { return vParam[SBVP::TAUEFF]; }
 
+  int getWarmupToDoSteps() const { return WarmUpToDoSteps; }
   /** perform branching
    * @param iter current step
    * @param w Walker configuration

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -225,13 +225,13 @@ void VMCBatched::runVMCStep(int crowd_id,
 {
   Crowd& crowd = *(crowds[crowd_id]);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
-  int max_steps = sft.qmcdrv_input.get_max_steps();
-  IndexType step = sft.step;
+  const int max_steps = sft.qmcdrv_input.get_max_steps();
+  const IndexType step = sft.step;
   // Are we entering the the last step of a block to recompute at?
-  bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
-  // For VMC we don't call this method for armup steps. So unlike DMC there is nothing to do here
+  const bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
+  // For VMC we don't call this method for const warmup steps. So unlike DMC there is nothing to do here
   // but this is here for symmetry with DMC driver and future accumulation features.
-  bool accumulate_this_step = true;
+  const bool accumulate_this_step = true;
   advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], recompute_this_step, accumulate_this_step);
 }
 
@@ -301,8 +301,8 @@ bool VMCBatched::run()
     auto runWarmupStep = [](int crowd_id, StateForThread& sft, DriverTimers& timers,
                             UPtrVector<ContextForSteps>& context_for_steps, UPtrVector<Crowd>& crowds) {
       Crowd& crowd = *(crowds[crowd_id]);
-      bool recompute = false;
-      bool accumulate_this_step = false;
+      const bool recompute = false;
+      const bool accumulate_this_step = false;
       advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], recompute, accumulate_this_step);
     };
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -229,8 +229,7 @@ void VMCBatched::runVMCStep(int crowd_id,
   const IndexType step = sft.step;
   // Are we entering the the last step of a block to recompute at?
   const bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
-  // For VMC we don't call this method for const warmup steps. So unlike DMC there is nothing to do here
-  // but this is here for symmetry with DMC driver and future accumulation features.
+  // For VMC we don't call this method for warmup steps.
   const bool accumulate_this_step = true;
   advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], recompute_this_step, accumulate_this_step);
 }

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -84,7 +84,8 @@ public:
                              Crowd& crowd,
                              DriverTimers& timers,
                              ContextForSteps& move_context,
-                             bool recompute);
+                             bool recompute,
+                             bool accumulate_this_step);
 
   // This is the task body executed at crowd scope
   // it does not have access to object member variables by design


### PR DESCRIPTION
## Proposed changes
Since ParticleSet doesn't need to support the legacy t-move code single walker API calls can rely on multiwalker resources. That means estimators must be in a scope where the crowd walker element reference vectors leaders hold resources.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
