### PR TITLE
Update spock dependencies

### DIFF
--- a/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
+++ b/tests/test_automation/nightly_test_scripts/nightly_olcf_spock.sh
@@ -18,7 +18,9 @@ export https_proxy=http://proxy.ccs.ornl.gov:3128/
 log_dir=${base_dir}/log/$(date +%y_%m_%d)
 mkdir -p ${log_dir}
 
-# module load llvm # has a conflict with serial cray-hdf5/1.12.0.6
+# required to load openblas
+module load PrgEnv-gnu
+# module load llvm # has a conflict with serial cray-hdf5
 module load gcc
 module load cmake
 module load git
@@ -26,9 +28,9 @@ module load git
 # QMCPACK dependencies
 module load libxml2/2.9.12
 module load fftw
-module load cray-hdf5/1.12.0.6 # require serial hdf5
+module load cray-hdf5 # require serial hdf5
 module load boost
-module load openblas
+module load openblas/0.3.17-omp
 module load rocm
 
 module list


### PR DESCRIPTION
## Proposed changes

Just update nightly dependencies on spock after recent OLCF packages updates on the system.
Current nightly can't find `openblas` and `cray-hdf5` modules

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests) nightly

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
spock, must pass nightly

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
