### PR TITLE
Split DistanceTableData class

### DIFF
--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -25,7 +25,7 @@
 
 namespace qmcplusplus
 {
-class DistanceTableData;
+class DistanceTable;
 class TrialWaveFunction;
 
 /** @ingroup Estimators

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -25,7 +25,6 @@
 
 namespace qmcplusplus
 {
-class DistanceTable;
 class TrialWaveFunction;
 
 /** @ingroup Estimators

--- a/src/Particle/DTModes.h
+++ b/src/Particle/DTModes.h
@@ -28,7 +28,7 @@ enum class DTModes : uint_fast8_t
   /** whether temporary data set on the host is updated or not when a move is proposed.
    * Considering transferring data from accelerator to host is relatively expensive,
    * only request this when data on host is needed for unoptimized code path.
-   * This flag affects three subroutines mw_move, mw_updatePartial, mw_finalizePbyP in DistanceTableData.
+   * This flag affects three subroutines mw_move, mw_updatePartial, mw_finalizePbyP in DistanceTable.
    */
   NEED_TEMP_DATA_ON_HOST = 0x2,
   /** skip data transfer back to host after mw_evalaute full distance table.

--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -229,13 +229,11 @@ public:
   virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
-  virtual void acquireResource(ResourceCollection& collection,
-                               const RefVectorWithLeader<DistanceTable>& dt_list) const
+  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const
   {}
 
   /// return a shared resource to a collection
-  virtual void releaseResource(ResourceCollection& collection,
-                               const RefVectorWithLeader<DistanceTable>& dt_list) const
+  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const
   {}
 };
 
@@ -272,9 +270,7 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTableAA(const ParticleSet& target, DTModes modes)
-      : DistanceTable(target, target, modes)
-  {}
+  DistanceTableAA(const ParticleSet& target, DTModes modes) : DistanceTable(target, target, modes) {}
 
   /** return full table distances
    */

--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -31,10 +31,10 @@ class ResourceCollection;
 /** @ingroup nnlist
  * @brief Abstract class to manage pair data between two ParticleSets.
  *
- * Each DistanceTableData object is fined by Source and Target of ParticleSet types.
+ * Each DistanceTable object is fined by Source and Target of ParticleSet types.
  *
  */
-class DistanceTableData
+class DistanceTable
 {
 public:
   static constexpr unsigned DIM = OHMMS_DIM;
@@ -60,7 +60,7 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTableData(const ParticleSet& source, const ParticleSet& target, DTModes modes)
+  DistanceTable(const ParticleSet& source, const ParticleSet& target, DTModes modes)
       : origin_(source),
         num_sources_(source.getTotalNum()),
         num_targets_(target.getTotalNum()),
@@ -69,10 +69,10 @@ public:
   {}
 
   /// copy constructor. deleted
-  DistanceTableData(const DistanceTableData&) = delete;
+  DistanceTable(const DistanceTable&) = delete;
 
   ///virutal destructor
-  virtual ~DistanceTableData() = default;
+  virtual ~DistanceTable() = default;
 
   ///get modes
   inline DTModes getModes() const { return modes_; }
@@ -99,7 +99,7 @@ public:
    * @param P the target particle set
    */
   virtual void evaluate(ParticleSet& P) = 0;
-  virtual void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  virtual void mw_evaluate(const RefVectorWithLeader<DistanceTable>& dt_list,
                            const RefVectorWithLeader<ParticleSet>& p_list) const
   {
 #pragma omp parallel for
@@ -112,7 +112,7 @@ public:
    * @param p_list the target particle set batch
    * @param recompute if true, must recompute. Otherwise, implementation dependent.
    */
-  virtual void mw_recompute(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  virtual void mw_recompute(const RefVectorWithLeader<DistanceTable>& dt_list,
                             const RefVectorWithLeader<ParticleSet>& p_list,
                             const std::vector<bool>& recompute) const
   {
@@ -138,7 +138,7 @@ public:
    * If DTModes::NEED_TEMP_DATA_ON_HOST, host data will be updated.
    * If no consumer requests data on the host, the transfer is skipped.
    */
-  virtual void mw_move(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  virtual void mw_move(const RefVectorWithLeader<DistanceTable>& dt_list,
                        const RefVectorWithLeader<ParticleSet>& p_list,
                        const std::vector<PosType>& rnew_list,
                        const IndexType iat = 0,
@@ -169,7 +169,7 @@ public:
   /** walker batched version of updatePartial.
    * If not DTModes::NEED_TEMP_DATA_ON_HOST, host data is not up-to-date and host distance table will not be updated.
    */
-  virtual void mw_updatePartial(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  virtual void mw_updatePartial(const RefVectorWithLeader<DistanceTable>& dt_list,
                                 IndexType jat,
                                 const std::vector<bool>& from_temp)
   {
@@ -188,7 +188,7 @@ public:
    * If not DTModes::NEED_TEMP_DATA_ON_HOST, host distance table data is not updated at all during p-by-p
    * Thus, a recompute is necessary to update the whole host distance table for consumers like the Coulomb potential.
    */
-  virtual void mw_finalizePbyP(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  virtual void mw_finalizePbyP(const RefVectorWithLeader<DistanceTable>& dt_list,
                                const RefVectorWithLeader<ParticleSet>& p_list) const
   {
 #pragma omp parallel for
@@ -223,23 +223,23 @@ public:
    */
   virtual int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const = 0;
 
-  inline void print(std::ostream& os) { throw std::runtime_error("DistanceTableData::print is not supported"); }
+  inline void print(std::ostream& os) { throw std::runtime_error("DistanceTable::print is not supported"); }
 
   /// initialize a shared resource and hand it to a collection
   virtual void createResource(ResourceCollection& collection) const {}
 
   /// acquire a shared resource from a collection
   virtual void acquireResource(ResourceCollection& collection,
-                               const RefVectorWithLeader<DistanceTableData>& dt_list) const
+                               const RefVectorWithLeader<DistanceTable>& dt_list) const
   {}
 
   /// return a shared resource to a collection
   virtual void releaseResource(ResourceCollection& collection,
-                               const RefVectorWithLeader<DistanceTableData>& dt_list) const
+                               const RefVectorWithLeader<DistanceTable>& dt_list) const
   {}
 };
 
-class DistanceTableAA : public DistanceTableData
+class DistanceTableAA : public DistanceTable
 {
 protected:
   /** distances_[num_targets_][num_sources_], [i][3][j] = |r_A2[j] - r_A1[i]|
@@ -273,7 +273,7 @@ protected:
 public:
   ///constructor using source and target ParticleSet
   DistanceTableAA(const ParticleSet& target, DTModes modes)
-      : DistanceTableData(target, target, modes)
+      : DistanceTable(target, target, modes)
   {}
 
   /** return full table distances
@@ -316,7 +316,7 @@ public:
   }
 };
 
-class DistanceTableAB : public DistanceTableData
+class DistanceTableAB : public DistanceTable
 {
 protected:
   /** distances_[num_targets_][num_sources_], [i][3][j] = |r_A2[j] - r_A1[i]|
@@ -338,7 +338,7 @@ protected:
 public:
   ///constructor using source and target ParticleSet
   DistanceTableAB(const ParticleSet& source, const ParticleSet& target, DTModes modes)
-      : DistanceTableData(source, target, modes)
+      : DistanceTable(source, target, modes)
   {}
 
   /** return full table distances

--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -29,10 +29,11 @@ namespace qmcplusplus
 class ResourceCollection;
 
 /** @ingroup nnlist
- * @brief Abstract class to manage pair data between two ParticleSets.
+ * @brief Abstract class to manage operations on pair data between two ParticleSets.
  *
- * Each DistanceTable object is fined by Source and Target of ParticleSet types.
- *
+ * Each DistanceTable object is defined by Source and Target of ParticleSet types.
+ * This base class doesn't contain storage. It is intended for update/compute invoked by ParticleSet.
+ * Derived AA/AB classes handle the actual storage and data access.
  */
 class DistanceTable
 {
@@ -237,6 +238,7 @@ public:
   {}
 };
 
+/** AA type of DistanceTable containing storage */
 class DistanceTableAA : public DistanceTable
 {
 protected:
@@ -312,6 +314,7 @@ public:
   }
 };
 
+/** AB type of DistanceTable containing storage */
 class DistanceTableAB : public DistanceTable
 {
 protected:

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -272,8 +272,8 @@ protected:
 
 public:
   ///constructor using source and target ParticleSet
-  DistanceTableAA(const ParticleSet& source, const ParticleSet& target, DTModes modes)
-      : DistanceTableData(source, target, modes)
+  DistanceTableAA(const ParticleSet& target, DTModes modes)
+      : DistanceTableData(target, target, modes)
   {}
 
   /** return full table distances
@@ -291,6 +291,7 @@ public:
   /** return a row of displacements for a given target particle
    */
   const DisplRow& getDisplRow(int iel) const { return displacements_[iel]; }
+
   /** return the temporary distances when a move is proposed
    */
   const DistRow& getTempDists() const { return temp_r_; }

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -305,35 +305,13 @@ public:
     return nullptr;
   }
 
-  /// return multi-walker full (all pairs) distance table data pointer
-  virtual const RealType* getMultiWalkerDataPtr() const
-  {
-    throw std::runtime_error(name_ + " multi walker data pointer not supported");
-    return nullptr;
-  }
-
-  /// return stride of per target pctl data. full table data = stride * num of target particles
-  virtual size_t getPerTargetPctlStrideSize() const
-  {
-    throw std::runtime_error(name_ + " getPerTargetPctlStrideSize not supported");
-    return 0;
-  }
-
   /** return old distances set up by move() for optimized distance table consumers
    */
-  virtual const DistRow& getOldDists() const
-  {
-    throw std::runtime_error("DistanceTableData::getOldDists is used incorrectly! Contact developers on github.");
-    return temp_r_; // dummy return to avoid compiler warning.
-  }
+  virtual const DistRow& getOldDists() const = 0;
 
   /** return old displacements set up by move() for optimized distance table consumers
    */
-  virtual const DisplRow& getOldDispls() const
-  {
-    throw std::runtime_error("DistanceTableData::getOldDispls is used incorrectly! Contact developers on github.");
-    return temp_dr_; // dummy return to avoid compiler warning.
-  }
+  virtual const DisplRow& getOldDispls() const = 0;
 };
 
 class DistanceTableAB : public DistanceTableData
@@ -395,13 +373,6 @@ public:
    */
   const DisplRow& getTempDispls() const { return temp_dr_; }
 
-  /// return multi walker temporary pair distance table data pointer
-  virtual const RealType* getMultiWalkerTempDataPtr() const
-  {
-    throw std::runtime_error(name_ + " multi walker data pointer for temp not supported");
-    return nullptr;
-  }
-
   /// return multi-walker full (all pairs) distance table data pointer
   virtual const RealType* getMultiWalkerDataPtr() const
   {
@@ -415,23 +386,6 @@ public:
     throw std::runtime_error(name_ + " getPerTargetPctlStrideSize not supported");
     return 0;
   }
-
-  /** return old distances set up by move() for optimized distance table consumers
-   */
-  virtual const DistRow& getOldDists() const
-  {
-    throw std::runtime_error("DistanceTableData::getOldDists is used incorrectly! Contact developers on github.");
-    return temp_r_; // dummy return to avoid compiler warning.
-  }
-
-  /** return old displacements set up by move() for optimized distance table consumers
-   */
-  virtual const DisplRow& getOldDispls() const
-  {
-    throw std::runtime_error("DistanceTableData::getOldDispls is used incorrectly! Contact developers on github.");
-    return temp_dr_; // dummy return to avoid compiler warning.
-  }
-
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/InitMolecularSystem.cpp
+++ b/src/Particle/InitMolecularSystem.cpp
@@ -126,7 +126,7 @@ void InitMolecularSystem::initMolecule(ParticleSet* ions, ParticleSet* els)
   RealType rmin = cutoff;
   ParticleSet::SingleParticlePos_t cm;
 
-  const auto& dist = ions->getDistTable(d_ii_ID).getDistances();
+  const auto& dist = ions->getDistTableAA(d_ii_ID).getDistances();
   // Step 1. Distribute even Q[iat] of atomic center iat. If Q[iat] is odd, put Q[iat]-1 and save the lone electron.
   for (size_t iat = 0; iat < Centers; iat++)
   {

--- a/src/Particle/InitMolecularSystem.cpp
+++ b/src/Particle/InitMolecularSystem.cpp
@@ -22,7 +22,7 @@
 #include "InitMolecularSystem.h"
 #include "Particle/ParticleSetPool.h"
 #include "OhmmsData/AttributeSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 
 namespace qmcplusplus

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -18,7 +18,6 @@
 
 
 #include "MCWalkerConfiguration.h"
-#include "Particle/DistanceTable.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Message/Communicate.h"
 #include "Message/CommOperators.h"

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -18,7 +18,7 @@
 
 
 #include "MCWalkerConfiguration.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Message/Communicate.h"
 #include "Message/CommOperators.h"

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -388,8 +388,14 @@ int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
   return tid;
 }
 
-const DistanceTableAA& ParticleSet::getDistTableAA(int table_ID) const { return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]); }
-const DistanceTableAB& ParticleSet::getDistTableAB(int table_ID) const { return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]); }
+const DistanceTableAA& ParticleSet::getDistTableAA(int table_ID) const
+{
+  return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]);
+}
+const DistanceTableAB& ParticleSet::getDistTableAB(int table_ID) const
+{
+  return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]);
+}
 
 void ParticleSet::update(bool skipSK)
 {
@@ -1014,8 +1020,7 @@ void ParticleSet::releaseResource(ResourceCollection& collection, const RefVecto
     ps_leader.DistTables[i]->releaseResource(collection, extractDTRefList(p_list, i));
 }
 
-RefVectorWithLeader<DistanceTable> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
-                                                                     int id)
+RefVectorWithLeader<DistanceTable> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list, int id)
 {
   RefVectorWithLeader<DistanceTable> dt_list(*p_list.getLeader().DistTables[id]);
   dt_list.reserve(p_list.size());

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -392,6 +392,7 @@ const DistanceTableAA& ParticleSet::getDistTableAA(int table_ID) const
 {
   return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]);
 }
+
 const DistanceTableAB& ParticleSet::getDistTableAB(int table_ID) const
 {
   return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]);

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -21,7 +21,7 @@
 #include <iomanip>
 #include "ParticleSet.h"
 #include "Particle/DynamicCoordinatesBuilder.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/createDistanceTable.h"
 #include "LongRange/StructFact.h"
 #include "Utilities/IteratorUtility.h"
@@ -1014,10 +1014,10 @@ void ParticleSet::releaseResource(ResourceCollection& collection, const RefVecto
     ps_leader.DistTables[i]->releaseResource(collection, extractDTRefList(p_list, i));
 }
 
-RefVectorWithLeader<DistanceTableData> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
+RefVectorWithLeader<DistanceTable> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                      int id)
 {
-  RefVectorWithLeader<DistanceTableData> dt_list(*p_list.getLeader().DistTables[id]);
+  RefVectorWithLeader<DistanceTable> dt_list(*p_list.getLeader().DistTables[id]);
   dt_list.reserve(p_list.size());
   for (ParticleSet& p : p_list)
     dt_list.push_back(*p.DistTables[id]);

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -388,6 +388,9 @@ int ParticleSet::addTable(const ParticleSet& psrc, DTModes modes)
   return tid;
 }
 
+const DistanceTableAA& ParticleSet::getDistTableAA(int table_ID) const { return dynamic_cast<DistanceTableAA&>(*DistTables[table_ID]); }
+const DistanceTableAB& ParticleSet::getDistTableAB(int table_ID) const { return dynamic_cast<DistanceTableAB&>(*DistTables[table_ID]); }
+
 void ParticleSet::update(bool skipSK)
 {
   ScopedTimer update_scope(myTimers[PS_update]);

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -33,8 +33,8 @@
 
 namespace qmcplusplus
 {
-///forward declaration of DistanceTableData
-class DistanceTableData;
+///forward declaration of DistanceTable
+class DistanceTable;
 class DistanceTableAA;
 class DistanceTableAB;
 class ResourceCollection;
@@ -228,7 +228,7 @@ public:
 
   /** add a distance table
    * @param psrc source particle set
-   * @param modes bitmask DistanceTableData::DTModes
+   * @param modes bitmask DistanceTable::DTModes
    *
    * if this->myName == psrc.getName(), AA type. Otherwise, AB type.
    */
@@ -299,7 +299,7 @@ public:
    * @param maybe_accept if false, the caller guarantees that the proposed move will not be accepted.
    *
    * Update activePtcl index and activePos position (R[iat]+displ) for a proposed move.
-   * Evaluate the related distance table data DistanceTableData::Temp.
+   * Evaluate the related distance table data DistanceTable::Temp.
    * If maybe_accept = false, certain operations for accepting moves will be skipped for optimal performance.
    */
   void makeMove(Index_t iat, const SingleParticlePos_t& displ, bool maybe_accept = true);
@@ -317,7 +317,7 @@ public:
    * @return true, if the move is valid
    *
    * Update activePtcl index and activePos position (R[iat]+displ) for a proposed move.
-   * Evaluate the related distance table data DistanceTableData::Temp.
+   * Evaluate the related distance table data DistanceTable::Temp.
    *
    * When a Lattice is defined, passing two checks makes a move valid.
    * outOfBound(displ): invalid move, if displ is larger than half, currently, of the box in any direction
@@ -665,7 +665,7 @@ public:
    */
   static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
 
-  static RefVectorWithLeader<DistanceTableData> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
+  static RefVectorWithLeader<DistanceTable> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
                                                                  int id);
   static RefVectorWithLeader<DynamicCoordinates> extractCoordsRefList(const RefVectorWithLeader<ParticleSet>& p_list);
   static RefVectorWithLeader<StructFact> extractSKRefList(const RefVectorWithLeader<ParticleSet>& p_list);
@@ -679,7 +679,7 @@ protected:
   std::map<std::string, int> myDistTableMap;
 
   /// distance tables that need to be updated by moving this ParticleSet
-  std::vector<DistanceTableData*> DistTables;
+  std::vector<DistanceTable*> DistTables;
 
   /// Descriptions from distance table creation.  Same order as DistTables.
   std::vector<std::string> distTableDescriptions;

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -234,10 +234,11 @@ public:
    */
   int addTable(const ParticleSet& psrc, DTModes modes = DTModes::ALL_OFF);
 
-  /** get a distance table by table_ID
-   */
+  ///get a distance table by table_ID
   inline auto& getDistTable(int table_ID) const { return *DistTables[table_ID]; }
+  ///get a distance table by table_ID and dyanmic_cast to DistanceTableAA
   const DistanceTableAA& getDistTableAA(int table_ID) const;
+  ///get a distance table by table_ID and dyanmic_cast to DistanceTableAB
   const DistanceTableAB& getDistTableAB(int table_ID) const;
 
   /** reset all the collectable quantities during a MC iteration

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -665,8 +665,7 @@ public:
    */
   static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list);
 
-  static RefVectorWithLeader<DistanceTable> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list,
-                                                                 int id);
+  static RefVectorWithLeader<DistanceTable> extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list, int id);
   static RefVectorWithLeader<DynamicCoordinates> extractCoordsRefList(const RefVectorWithLeader<ParticleSet>& p_list);
   static RefVectorWithLeader<StructFact> extractSKRefList(const RefVectorWithLeader<ParticleSet>& p_list);
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -35,6 +35,8 @@ namespace qmcplusplus
 {
 ///forward declaration of DistanceTableData
 class DistanceTableData;
+class DistanceTableAA;
+class DistanceTableAB;
 class ResourceCollection;
 class StructFact;
 
@@ -234,7 +236,9 @@ public:
 
   /** get a distance table by table_ID
    */
-  inline const DistanceTableData& getDistTable(int table_ID) const { return *DistTables[table_ID]; }
+  inline auto& getDistTable(int table_ID) const { return *DistTables[table_ID]; }
+  const DistanceTableAA& getDistTableAA(int table_ID) const;
+  const DistanceTableAB& getDistTableAB(int table_ID) const;
 
   /** reset all the collectable quantities during a MC iteration
    */

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -25,14 +25,8 @@ namespace qmcplusplus
 template<typename T, unsigned D, int SC>
 struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
 {
-  ///actual memory for dist and displacements_
+  /// actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
-
-  /// old distances
-  DistRow old_r_;
-
-  /// old displacements
-  DisplRow old_dr_;
 
   SoaDistanceTableAA(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
@@ -83,9 +77,6 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
     temp_r_.resize(num_targets_);
     temp_dr_.resize(num_targets_);
   }
-
-  const DistRow& getOldDists() const override { return old_r_; }
-  const DisplRow& getOldDispls() const override { return old_dr_; }
 
   inline void evaluate(ParticleSet& P) override
   {

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -30,7 +30,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
 
   SoaDistanceTableAA(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
-        DistanceTableAA(target, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAA(target, DTModes::NEED_TEMP_DATA_ON_HOST),
         num_targets_padded_(getAlignedSize<T>(num_targets_)),
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -23,7 +23,7 @@ namespace qmcplusplus
  * @brief A derived classe from DistacneTableData, specialized for dense case
  */
 template<typename T, unsigned D, int SC>
-struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableData
+struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
 {
   ///actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
@@ -36,7 +36,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableDat
 
   SoaDistanceTableAA(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
-        DistanceTableData(target, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAA(target, target, DTModes::NEED_TEMP_DATA_ON_HOST),
         num_targets_padded_(getAlignedSize<T>(num_targets_)),
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -14,7 +14,7 @@
 #define QMCPLUSPLUS_DTDIMPL_AA_H
 
 #include "Lattice/ParticleBConds3DSoa.h"
-#include "DistanceTableData.h"
+#include "DistanceTable.h"
 #include "CPU/SIMD/algorithm.hpp"
 
 namespace qmcplusplus

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -61,7 +61,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
   SoaDistanceTableAAOMPTarget(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
-        DistanceTableAA(target, target, DTModes::ALL_OFF),
+        DistanceTableAA(target, DTModes::ALL_OFF),
         num_targets_padded_(getAlignedSize<T>(num_targets_)),
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
  * @brief A derived classe from DistacneTableData, specialized for dense case
  */
 template<typename T, unsigned D, int SC>
-struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableData
+struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableAA
 {
   ///actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
@@ -63,7 +63,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 
   SoaDistanceTableAAOMPTarget(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.Lattice),
-        DistanceTableData(target, target, DTModes::ALL_OFF),
+        DistanceTableAA(target, target, DTModes::ALL_OFF),
         num_targets_padded_(getAlignedSize<T>(num_targets_)),
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -15,7 +15,7 @@
 #define QMCPLUSPLUS_DTDIMPL_AA_OMPTARGET_H
 
 #include "Lattice/ParticleBConds3DSoa.h"
-#include "DistanceTableData.h"
+#include "DistanceTable.h"
 #include "CPU/SIMD/algorithm.hpp"
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
@@ -126,7 +126,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   }
 
   void acquireResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTAAMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
@@ -162,7 +162,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
   }
 
   void releaseResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>().mw_mem_));
     const size_t nw = dt_list.size();
@@ -218,7 +218,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
    * If the temporary pair distance are consumed on the device directly, the device to host data transfer can be
    * skipped as an optimization.
    */
-  void mw_move(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  void mw_move(const RefVectorWithLeader<DistanceTable>& dt_list,
                const RefVectorWithLeader<ParticleSet>& p_list,
                const std::vector<PosType>& rnew_list,
                const IndexType iat = 0,
@@ -401,7 +401,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     }
   }
 
-  void mw_updatePartial(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  void mw_updatePartial(const RefVectorWithLeader<DistanceTable>& dt_list,
                         IndexType jat,
                         const std::vector<bool>& from_temp) override
   {
@@ -414,7 +414,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
       dt_list[iw].updatePartial(jat, from_temp[iw]);
   }
 
-  void mw_finalizePbyP(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  void mw_finalizePbyP(const RefVectorWithLeader<DistanceTable>& dt_list,
                        const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
     // if the distance table is not updated by mw_move during p-by-p, needs to recompute the whole table

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -125,8 +125,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     auto resource_index = collection.addResource(std::make_unique<DTAAMultiWalkerMem>());
   }
 
-  void acquireResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTAAMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
@@ -161,8 +160,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     }
   }
 
-  void releaseResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>().mw_mem_));
     const size_t nw = dt_list.size();

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -30,19 +30,17 @@ namespace qmcplusplus
 template<typename T, unsigned D, int SC>
 struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableAA
 {
-  ///actual memory for dist and displacements_
+  /// actual memory for dist and displacements_
   aligned_vector<RealType> memory_pool_;
 
-  /// old distances
-  DistRow old_r_mem_;
-  DistRow old_r_;
-
-  /// old displacements
-  DisplRow old_dr_mem_;
-  DisplRow old_dr_;
-
+  /// actual memory for temp_r_
   DistRow temp_r_mem_;
+  /// actual memory for temp_dr_
   DisplRow temp_dr_mem_;
+  /// actual memory for old_r_
+  DistRow old_r_mem_;
+  /// actual memory for old_dr_
+  DisplRow old_dr_mem_;
 
   ///multi walker shared memory buffer
   struct DTAAMultiWalkerMem : public Resource
@@ -114,9 +112,6 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     temp_r_mem_.resize(num_targets_);
     temp_dr_mem_.resize(num_targets_);
   }
-
-  const DistRow& getOldDists() const override { return old_r_; }
-  const DisplRow& getOldDispls() const override { return old_dr_; }
 
   const RealType* getMultiWalkerTempDataPtr() const override
   {

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -23,11 +23,11 @@ namespace qmcplusplus
  * @brief A derived classe from DistacneTableData, specialized for AB using a transposed form
  */
 template<typename T, unsigned D, int SC>
-struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableData
+struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
 {
   SoaDistanceTableAB(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.Lattice),
-        DistanceTableData(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
         evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAB::evaluate_") + target.getName() +
                                                        "_" + source.getName(),
                                                    timer_level_fine)),

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -27,7 +27,7 @@ namespace qmcplusplus
  * @brief A derived classe from DistacneTableData, specialized for AB using a transposed form
  */
 template<typename T, unsigned D, int SC>
-class SoaDistanceTableABOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableData
+class SoaDistanceTableABOMPTarget : public DTD_BConds<T, D, SC>, public DistanceTableAB
 {
 private:
   template<typename DT>
@@ -119,7 +119,7 @@ private:
 public:
   SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.Lattice),
-        DistanceTableData(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
         offload_timer_(
             *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") + name_, timer_level_fine)),
         evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") + name_,

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -152,8 +152,7 @@ public:
     auto resource_index = collection.addResource(std::make_unique<DTABMultiWalkerMem>());
   }
 
-  void acquireResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTABMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
@@ -163,8 +162,7 @@ public:
     associateResource(dt_list);
   }
 
-  void releaseResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_));
     for (size_t iw = 0; iw < dt_list.size(); iw++)

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -15,7 +15,7 @@
 #define QMCPLUSPLUS_DTDIMPL_AB_OMPTARGET_H
 
 #include "Lattice/ParticleBConds3DSoa.h"
-#include "DistanceTableData.h"
+#include "DistanceTable.h"
 #include "OMPTarget/OMPallocator.hpp"
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"
@@ -77,7 +77,7 @@ private:
     }
   }
 
-  static void associateResource(const RefVectorWithLeader<DistanceTableData>& dt_list)
+  static void associateResource(const RefVectorWithLeader<DistanceTable>& dt_list)
   {
     auto& dt_leader = dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>();
 
@@ -153,7 +153,7 @@ public:
   }
 
   void acquireResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     auto res_ptr = dynamic_cast<DTABMultiWalkerMem*>(collection.lendResource().release());
     if (!res_ptr)
@@ -164,7 +164,7 @@ public:
   }
 
   void releaseResource(ResourceCollection& collection,
-                       const RefVectorWithLeader<DistanceTableData>& dt_list) const override
+                       const RefVectorWithLeader<DistanceTable>& dt_list) const override
   {
     collection.takebackResource(std::move(dt_list.getCastedLeader<SoaDistanceTableABOMPTarget>().mw_mem_));
     for (size_t iw = 0; iw < dt_list.size(); iw++)
@@ -238,7 +238,7 @@ public:
     }
   }
 
-  inline void mw_evaluate(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  inline void mw_evaluate(const RefVectorWithLeader<DistanceTable>& dt_list,
                           const RefVectorWithLeader<ParticleSet>& p_list) const override
   {
     assert(this == &dt_list.getLeader());
@@ -354,7 +354,7 @@ public:
     }
   }
 
-  inline void mw_recompute(const RefVectorWithLeader<DistanceTableData>& dt_list,
+  inline void mw_recompute(const RefVectorWithLeader<DistanceTable>& dt_list,
                            const RefVectorWithLeader<ParticleSet>& p_list,
                            const std::vector<bool>& recompute) const override
   {

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -17,7 +17,7 @@
 
 #include "Configuration.h"
 #include "VirtualParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/createDistanceTable.h"
 #include "QMCHamiltonians/NLPPJob.h"
 #include "ResourceCollection.h"

--- a/src/Particle/createDistanceTable.h
+++ b/src/Particle/createDistanceTable.h
@@ -18,7 +18,7 @@
 
 namespace qmcplusplus
 {
-/** Class to manage multiple DistanceTableData objects.
+/** Class to manage multiple DistanceTable objects.
  *
  * \date  2008-09-19
  * static data members are removed. DistanceTable::add functions
@@ -30,17 +30,17 @@ namespace qmcplusplus
  * DistanceTable in an application and the data are shared by many objects.
  * Note that static data members and functions are used
  * (based on singleton and factory patterns).
- *\todo DistanceTable should work as a factory, as well, to instantiate DistanceTableData
+ *\todo DistanceTable should work as a factory, as well, to instantiate DistanceTable
  * subject to different boundary conditions.
  * Lattice/CrystalLattice.h and Lattice/CrystalLattice.cpp can be owned by DistanceTable
  * to generically control the crystalline structure.
  */
 
 ///free function to create a distable table of s-s
-DistanceTableData* createDistanceTableAA(ParticleSet& s, std::ostream& description);
-DistanceTableData* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& description);
+DistanceTable* createDistanceTableAA(ParticleSet& s, std::ostream& description);
+DistanceTable* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& description);
 
-inline DistanceTableData* createDistanceTable(ParticleSet& s, std::ostream& description)
+inline DistanceTable* createDistanceTable(ParticleSet& s, std::ostream& description)
 {
   // during P-by-P move, the cost of single particle evaluation of distance tables
   // is determined by the number of source particles.
@@ -54,10 +54,10 @@ inline DistanceTableData* createDistanceTable(ParticleSet& s, std::ostream& desc
 }
 
 ///free function create a distable table of s-t
-DistanceTableData* createDistanceTableAB(const ParticleSet& s, ParticleSet& t, std::ostream& description);
-DistanceTableData* createDistanceTableABOMPTarget(const ParticleSet& s, ParticleSet& t, std::ostream& description);
+DistanceTable* createDistanceTableAB(const ParticleSet& s, ParticleSet& t, std::ostream& description);
+DistanceTable* createDistanceTableABOMPTarget(const ParticleSet& s, ParticleSet& t, std::ostream& description);
 
-inline DistanceTableData* createDistanceTable(const ParticleSet& s, ParticleSet& t, std::ostream& description)
+inline DistanceTable* createDistanceTable(const ParticleSet& s, ParticleSet& t, std::ostream& description)
 {
   // during P-by-P move, the cost of single particle evaluation of distance tables
   // is determined by the number of source particles.

--- a/src/Particle/createDistanceTableAA.cpp
+++ b/src/Particle/createDistanceTableAA.cpp
@@ -15,7 +15,7 @@
 
 
 #include "Particle/createDistanceTable.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/SoaDistanceTableAA.h"
 
 namespace qmcplusplus
@@ -24,7 +24,7 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTableAA(ParticleSet& s, std::ostream& description)
+DistanceTable* createDistanceTableAA(ParticleSet& s, std::ostream& description)
 {
   typedef OHMMS_PRECISION RealType;
   enum
@@ -32,7 +32,7 @@ DistanceTableData* createDistanceTableAA(ParticleSet& s, std::ostream& descripti
     DIM = OHMMS_DIM
   };
   int sc                = s.Lattice.SuperCellEnum;
-  DistanceTableData* dt = 0;
+  DistanceTable* dt = 0;
   std::ostringstream o;
   o << "  Distance table for similar particles (A-A):" << std::endl;
   o << "    source/target: " << s.getName() << std::endl;

--- a/src/Particle/createDistanceTableAA.cpp
+++ b/src/Particle/createDistanceTableAA.cpp
@@ -31,7 +31,7 @@ DistanceTable* createDistanceTableAA(ParticleSet& s, std::ostream& description)
   {
     DIM = OHMMS_DIM
   };
-  int sc                = s.Lattice.SuperCellEnum;
+  int sc            = s.Lattice.SuperCellEnum;
   DistanceTable* dt = 0;
   std::ostringstream o;
   o << "  Distance table for similar particles (A-A):" << std::endl;

--- a/src/Particle/createDistanceTableAAOMPTarget.cpp
+++ b/src/Particle/createDistanceTableAAOMPTarget.cpp
@@ -31,7 +31,7 @@ DistanceTable* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& desc
   {
     DIM = OHMMS_DIM
   };
-  int sc                = s.Lattice.SuperCellEnum;
+  int sc            = s.Lattice.SuperCellEnum;
   DistanceTable* dt = 0;
   std::ostringstream o;
   o << "  Distance table for similar particles (A-A):" << std::endl;

--- a/src/Particle/createDistanceTableAAOMPTarget.cpp
+++ b/src/Particle/createDistanceTableAAOMPTarget.cpp
@@ -15,7 +15,7 @@
 
 
 #include "Particle/createDistanceTable.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/SoaDistanceTableAAOMPTarget.h"
 
 namespace qmcplusplus
@@ -24,7 +24,7 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& description)
+DistanceTable* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& description)
 {
   typedef OHMMS_PRECISION RealType;
   enum
@@ -32,7 +32,7 @@ DistanceTableData* createDistanceTableAAOMPTarget(ParticleSet& s, std::ostream& 
     DIM = OHMMS_DIM
   };
   int sc                = s.Lattice.SuperCellEnum;
-  DistanceTableData* dt = 0;
+  DistanceTable* dt = 0;
   std::ostringstream o;
   o << "  Distance table for similar particles (A-A):" << std::endl;
   o << "    source/target: " << s.getName() << std::endl;

--- a/src/Particle/createDistanceTableAB.cpp
+++ b/src/Particle/createDistanceTableAB.cpp
@@ -15,7 +15,7 @@
 
 
 #include "Particle/createDistanceTable.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/SoaDistanceTableAB.h"
 #include "CPU/SIMD/algorithm.hpp"
 
@@ -25,14 +25,14 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTableAB(const ParticleSet& s, ParticleSet& t, std::ostream& description)
+DistanceTable* createDistanceTableAB(const ParticleSet& s, ParticleSet& t, std::ostream& description)
 {
   using RealType = ParticleSet::RealType;
   enum
   {
     DIM = OHMMS_DIM
   };
-  DistanceTableData* dt = 0;
+  DistanceTable* dt = 0;
   //int sc=s.Lattice.SuperCellEnum;
   int sc = t.Lattice.SuperCellEnum;
   std::ostringstream o;

--- a/src/Particle/createDistanceTableABOMPTarget.cpp
+++ b/src/Particle/createDistanceTableABOMPTarget.cpp
@@ -33,7 +33,7 @@ DistanceTable* createDistanceTableABOMPTarget(const ParticleSet& s, ParticleSet&
     DIM = OHMMS_DIM
   };
   DistanceTable* dt = 0;
-  int sc                = t.Lattice.SuperCellEnum;
+  int sc            = t.Lattice.SuperCellEnum;
   std::ostringstream o;
   o << "  Distance table for dissimilar particles (A-B):" << std::endl;
   o << "    source: " << s.getName() << "  target: " << t.getName() << std::endl;

--- a/src/Particle/createDistanceTableABOMPTarget.cpp
+++ b/src/Particle/createDistanceTableABOMPTarget.cpp
@@ -15,7 +15,7 @@
 
 
 #include "Particle/createDistanceTable.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/SoaDistanceTableABOMPTarget.h"
 #include "CPU/SIMD/algorithm.hpp"
 
@@ -25,14 +25,14 @@ namespace qmcplusplus
  *\param s source/target particle set
  *\return index of the distance table with the name
  */
-DistanceTableData* createDistanceTableABOMPTarget(const ParticleSet& s, ParticleSet& t, std::ostream& description)
+DistanceTable* createDistanceTableABOMPTarget(const ParticleSet& s, ParticleSet& t, std::ostream& description)
 {
   using RealType = ParticleSet::RealType;
   enum
   {
     DIM = OHMMS_DIM
   };
-  DistanceTableData* dt = 0;
+  DistanceTable* dt = 0;
   int sc                = t.Lattice.SuperCellEnum;
   std::ostringstream o;
   o << "  Distance table for dissimilar particles (A-B):" << std::endl;

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -97,7 +97,7 @@ TEST_CASE("distance_open_z", "[distance_table][xml]")
   electrons.update();
 
   // get target particle set's distance table data
-  const auto& dtable = electrons.getDistTable(tid);
+  const auto& dtable = electrons.getDistTableAB(tid);
   REQUIRE(dtable.getName() == "ion0_e");
 
   REQUIRE(dtable.sources() == ions.getTotalNum());
@@ -195,7 +195,7 @@ TEST_CASE("distance_open_xy", "[distance_table][xml]")
   electrons.update();
 
   // get distance table attached to target particle set (electrons)
-  const auto& dtable = electrons.getDistTable(tid);
+  const auto& dtable = electrons.getDistTableAB(tid);
   REQUIRE(dtable.getName() == "ion0_e");
 
   REQUIRE(dtable.sources() == ions.getTotalNum());
@@ -290,7 +290,7 @@ TEST_CASE("distance_open_species_deviation", "[distance_table][xml]")
   electrons.update();
 
   // get distance table attached to target particle set (electrons)
-  const auto& dtable = electrons.getDistTable(tid);
+  const auto& dtable = electrons.getDistTableAB(tid);
   REQUIRE(dtable.getName() == "ion0_e");
 
   // get the electron species set
@@ -430,7 +430,7 @@ TEST_CASE("distance_pbc_z", "[distance_table][xml]")
   ions.update();
 
   // get target particle set's distance table data
-  const auto& ei_dtable = electrons.getDistTable(ei_tid);
+  const auto& ei_dtable = electrons.getDistTableAB(ei_tid);
   CHECK(ei_dtable.getName() == "ion0_e");
 
   CHECK(ei_dtable.sources() == ions.getTotalNum());
@@ -472,7 +472,7 @@ TEST_CASE("distance_pbc_z", "[distance_table][xml]")
 
   const int ee_tid = electrons.addTable(electrons);
   // get target particle set's distance table data
-  const auto& ee_dtable = electrons.getDistTable(ee_tid);
+  const auto& ee_dtable = electrons.getDistTableAA(ee_tid);
   CHECK(ee_dtable.getName() == "e_e");
   electrons.update();
 
@@ -549,7 +549,7 @@ void test_distance_pbc_z_batched_APIs(DynamicCoordinateKind test_kind)
   ions.update();
   const int ee_tid = electrons.addTable(electrons);
   // get target particle set's distance table data
-  const auto& ee_dtable = electrons.getDistTable(ee_tid);
+  const auto& ee_dtable = electrons.getDistTableAA(ee_tid);
   CHECK(ee_dtable.getName() == "e_e");
   electrons.update();
 
@@ -602,7 +602,7 @@ void test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinat
   ions.update();
   const int ee_tid = electrons.addTable(electrons, DTModes::NEED_TEMP_DATA_ON_HOST);
   // get target particle set's distance table data
-  const auto& ee_dtable = electrons.getDistTable(ee_tid);
+  const auto& ee_dtable = electrons.getDistTableAA(ee_tid);
   CHECK(ee_dtable.getName() == "e_e");
   electrons.update();
 

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -18,7 +18,7 @@
 #include "Particle/ParticleSet.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "ParticleIO/ParticleLayoutIO.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include <ResourceCollection.h>
 
 #include <stdio.h>

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -133,7 +133,7 @@ TEST_CASE("particle set lattice with vacuum", "[particle]")
   // PPP case
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> Lattice;
   Lattice.BoxBConds = true;
-  Lattice.R = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  Lattice.R         = {1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
 
   Lattice.VacuumScale = 2.0;
   Lattice.reset();

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -87,7 +87,7 @@ TEST_CASE("symmetric_distance_table OpenBC", "[particle]")
 
   const int TableID = source.addTable(source);
   source.update();
-  const auto& d_aa      = source.getDistTable(TableID);
+  const auto& d_aa      = source.getDistTableAA(TableID);
   const auto& aa_dists  = d_aa.getDistances();
   const auto& aa_displs = d_aa.getDisplacements();
 
@@ -118,7 +118,7 @@ TEST_CASE("symmetric_distance_table PBC", "[particle]")
 
   const int TableID = source.addTable(source);
   source.update();
-  const auto& d_aa      = source.getDistTable(TableID);
+  const auto& d_aa      = source.getDistTableAA(TableID);
   const auto& aa_dists  = d_aa.getDistances();
   const auto& aa_displs = d_aa.getDisplacements();
 

--- a/src/Particle/tests/test_particle.cpp
+++ b/src/Particle/tests/test_particle.cpp
@@ -17,7 +17,7 @@
 #include "Lattice/CrystalLattice.h"
 #include "Lattice/ParticleBConds.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 
 #include <stdio.h>

--- a/src/QMCDrivers/ContextForSteps.h
+++ b/src/QMCDrivers/ContextForSteps.h
@@ -22,7 +22,7 @@
 
 namespace qmcplusplus
 {
-class DistanceTableData;
+class DistanceTable;
 
 /** Thread local context for moving walkers
  *

--- a/src/QMCDrivers/ContextForSteps.h
+++ b/src/QMCDrivers/ContextForSteps.h
@@ -22,8 +22,6 @@
 
 namespace qmcplusplus
 {
-class DistanceTable;
-
 /** Thread local context for moving walkers
  *
  *  created once per driver per crowd

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -1360,7 +1360,7 @@ void WaveFunctionTester::runRatioV()
 
   //cheating
   const ParticleSet& ions=W.DistTables[1]->origin();
-  DistanceTableData* dt_ie=W.DistTables[1];
+  DistanceTable* dt_ie=W.DistTables[1];
   double Rmax=2.0;
 
   ParticleSet::ParticlePos_t sphere(8);

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -16,7 +16,7 @@
 
 #include "EwaldRef.h"
 #include "CoulombPBCAA.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Utilities/ProgressReportEngine.h"
 #include <numeric>
 

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -192,7 +192,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate_sp(ParticleSet& P)
   V_samp                     = 0.0;
   {
     //SR
-    const DistanceTableData& d_aa(P.getDistTable(d_aa_ID));
+    const auto& d_aa(P.getDistTableAA(d_aa_ID));
     RealType z;
     for (int ipart = 1; ipart < NumCenters; ipart++)
     {
@@ -336,7 +336,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLRwithForces(ParticleSet& P)
 
 CoulombPBCAA::Return_t CoulombPBCAA::evalSRwithForces(ParticleSet& P)
 {
-  const DistanceTableData& d_aa(P.getDistTable(d_aa_ID));
+  const auto& d_aa(P.getDistTableAA(d_aa_ID));
   mRealType SR = 0.0;
   for (size_t ipart = 1; ipart < (NumCenters / 2 + 1); ipart++)
   {
@@ -438,7 +438,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalConsts(bool report)
 
 CoulombPBCAA::Return_t CoulombPBCAA::evalSR(ParticleSet& P)
 {
-  const DistanceTableData& d_aa(P.getDistTable(d_aa_ID));
+  const auto& d_aa(P.getDistTableAA(d_aa_ID));
   mRealType SR = 0.0;
 #pragma omp parallel for reduction(+ : SR)
   for (size_t ipart = 1; ipart < (NumCenters / 2 + 1); ipart++)
@@ -468,7 +468,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
   const StructFact& PtclRhoK(*(P.SK));
   if (PtclRhoK.SuperCellEnum == SUPERCELL_SLAB)
   {
-    const DistanceTableData& d_aa(P.getDistTable(d_aa_ID));
+    const auto& d_aa(P.getDistTableAA(d_aa_ID));
     //distance table handles jat<iat
     for (int iat = 1; iat < NumCenters; ++iat)
     {

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -19,7 +19,7 @@
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCHamiltonians/ForceBase.h"
 #include "LongRange/LRCoulombSingleton.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -141,7 +141,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
   Vi_samp                     = 0.0;
   {
     //SR
-    const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+    const auto& d_ab(P.getDistTableAB(myTableIndex));
     RealType z;
     //Loop over distinct eln-ion pairs
     for (size_t b = 0; b < NptclB; ++b)
@@ -304,7 +304,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalConsts(const ParticleSet& Peln, bool re
 CoulombPBCAB::Return_t CoulombPBCAB::evalSR(ParticleSet& P)
 {
   constexpr mRealType czero(0);
-  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+  const auto& d_ab(P.getDistTableAB(myTableIndex));
   mRealType res = czero;
   //can be optimized but not important enough
   for (size_t b = 0; b < NptclB; ++b)
@@ -326,7 +326,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
   const StructFact& RhoKB(*(P.SK));
   if (RhoKA.SuperCellEnum == SUPERCELL_SLAB)
   {
-    const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+    const auto& d_ab(P.getDistTableAB(myTableIndex));
     for (int iat = 0; iat < NptclA; ++iat)
     {
       mRealType u = 0;
@@ -567,7 +567,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLRwithForces(ParticleSet& P)
 CoulombPBCAB::Return_t CoulombPBCAB::evalSRwithForces(ParticleSet& P)
 {
   constexpr mRealType czero(0);
-  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+  const auto& d_ab(P.getDistTableAB(myTableIndex));
   mRealType res = czero;
   //Temporary variables for computing energy and forces.
   mRealType rV(0);

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -15,7 +15,7 @@
 
 
 #include "CoulombPBCAB.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Message/Communicate.h"
 #include "Utilities/ProgressReportEngine.h"
 

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -23,7 +23,7 @@
 #include "Numerics/OneDimGridFunctor.h"
 #include "Numerics/OneDimCubicSpline.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 namespace qmcplusplus
 {
 /** @ingroup hamiltonian

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -18,7 +18,7 @@
 #define QMCPLUSPLUS_COULOMBPOTENTIAL_H
 #include "ParticleSet.h"
 #include "WalkerSetRef.h"
-#include "DistanceTableData.h"
+#include "DistanceTable.h"
 #include "MCWalkerConfiguration.h"
 #include "QMCHamiltonians/ForceBase.h"
 #include "QMCHamiltonians/OperatorBase.h"

--- a/src/QMCHamiltonians/CoulombPotential.h
+++ b/src/QMCHamiltonians/CoulombPotential.h
@@ -81,9 +81,9 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     {
       if (!copy)
         s.update();
-      value_ = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
+      value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
       if (ComputeForces)
-        evaluateAAForces(s.getDistTable(myTableIndex), s.Z.first_address());
+        evaluateAAForces(s.getDistTableAA(myTableIndex), s.Z.first_address());
     }
   }
 
@@ -121,7 +121,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
         Vb_sample = tm.checkout_real<1>(name_, Pb);
       }
       else if (!is_active)
-        evaluate_spAA(Pa.getDistTable(myTableIndex), Pa.Z.first_address());
+        evaluate_spAA(Pa.getDistTableAA(myTableIndex), Pa.Z.first_address());
     }
   }
 
@@ -144,7 +144,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   }
 
   /** evaluate AA-type interactions */
-  inline T evaluateAA(const DistanceTableData& d, const ParticleScalar_t* restrict Z)
+  inline T evaluateAA(const DistanceTableAA& d, const ParticleScalar_t* restrict Z)
   {
     T res = 0.0;
 #if !defined(REMOVE_TRACEMANAGER)
@@ -164,7 +164,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
 
   /** evaluate AA-type forces */
-  inline void evaluateAAForces(const DistanceTableData& d, const ParticleScalar_t* restrict Z)
+  inline void evaluateAAForces(const DistanceTableAA& d, const ParticleScalar_t* restrict Z)
   {
     forces = 0.0;
     for (size_t iat = 1; iat < nCenters; ++iat)
@@ -182,7 +182,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
 
   /** JNKIM: Need to check the precision */
-  inline T evaluateAB(const DistanceTableData& d,
+  inline T evaluateAB(const DistanceTableAB& d,
                       const ParticleScalar_t* restrict Za,
                       const ParticleScalar_t* restrict Zb)
   {
@@ -210,7 +210,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
 
 #if !defined(REMOVE_TRACEMANAGER)
   /** evaluate AA-type interactions */
-  inline T evaluate_spAA(const DistanceTableData& d, const ParticleScalar_t* restrict Z)
+  inline T evaluate_spAA(const DistanceTableAA& d, const ParticleScalar_t* restrict Z)
   {
     T res = 0.0;
     T pairpot;
@@ -255,7 +255,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   }
 
 
-  inline T evaluate_spAB(const DistanceTableData& d,
+  inline T evaluate_spAB(const DistanceTableAB& d,
                          const ParticleScalar_t* restrict Za,
                          const ParticleScalar_t* restrict Zb)
   {
@@ -327,7 +327,7 @@ struct CoulombPotential : public OperatorBase, public ForceBase
   {
     if (is_AA)
     {
-      value_ = evaluateAA(s.getDistTable(myTableIndex), s.Z.first_address());
+      value_ = evaluateAA(s.getDistTableAA(myTableIndex), s.Z.first_address());
     }
   }
 
@@ -336,9 +336,9 @@ struct CoulombPotential : public OperatorBase, public ForceBase
     if (is_active)
     {
       if (is_AA)
-        value_ = evaluateAA(P.getDistTable(myTableIndex), P.Z.first_address());
+        value_ = evaluateAA(P.getDistTableAA(myTableIndex), P.Z.first_address());
       else
-        value_ = evaluateAB(P.getDistTable(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
+        value_ = evaluateAB(P.getDistTableAB(myTableIndex), Pa.Z.first_address(), P.Z.first_address());
     }
     return value_;
   }

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -19,7 +19,7 @@
 #include "DensityEstimator.h"
 #include "OhmmsData/AttributeSet.h"
 #include "LongRange/LRCoulombSingleton.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/MCWalkerConfiguration.h"
 
 namespace qmcplusplus

--- a/src/QMCHamiltonians/ECPComponentBuilder.h
+++ b/src/QMCHamiltonians/ECPComponentBuilder.h
@@ -17,7 +17,7 @@
  */
 #ifndef QMCPLUSPLUS_ECPCOMPONENT_BUILDER_H
 #define QMCPLUSPLUS_ECPCOMPONENT_BUILDER_H
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCHamiltonians/LocalECPotential.h"
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "QMCHamiltonians/SOECPComponent.h"

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -15,7 +15,7 @@
 #include "EnergyDensityEstimator.h"
 #include "OhmmsData/AttributeSet.h"
 #include "LongRange/LRCoulombSingleton.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "Utilities/string_utils.h"
 #include <string>

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -319,7 +319,7 @@ EnergyDensityEstimator::Return_t EnergyDensityEstimator::evaluate(ParticleSet& P
         }
     }
     //Accumulate energy density in spacegrids
-    const DistanceTableData& dtab(P.getDistTable(dtable_index));
+    const auto& dtab(P.getDistTableAB(dtable_index));
     fill(particles_outside.begin(), particles_outside.end(), true);
     for (int i = 0; i < spacegrids.size(); i++)
     {

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -16,7 +16,7 @@
 
 
 #include "ForceBase.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Message/Communicate.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Numerics/MatrixOperators.h"

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -157,7 +157,7 @@ void BareForce::addObservables(PropertySetType& plist, BufferType& collectables)
 BareForce::Return_t BareForce::evaluate(ParticleSet& P)
 {
   forces                                    = forces_IonIon;
-  const auto& d_ab                          = P.getDistTable(d_ei_ID);
+  const auto& d_ab                          = P.getDistTableAB(d_ei_ID);
   const ParticleSet::Scalar_t* restrict Zat = Ions.Z.first_address();
   const ParticleSet::Scalar_t* restrict Qat = P.Z.first_address();
   //Loop over distinct eln-ion pairs

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -15,7 +15,7 @@
 
 
 #include "ForceCeperley.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Message/Communicate.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Numerics/DeterminantOperators.h"

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -44,7 +44,7 @@ ForceCeperley::ForceCeperley(ParticleSet& ions, ParticleSet& elns)
 void ForceCeperley::evaluate_IonIon(ParticleSet::ParticlePos_t& forces) const
 {
   forces = 0.0;
-  const DistanceTableData& d_aa(Ions.getDistTable(d_aa_ID));
+  const auto& d_aa(Ions.getDistTableAA(d_aa_ID));
   const ParticleScalar_t* restrict Zat = Ions.Z.first_address();
   for (size_t ipart = 1; ipart < Nnuc; ipart++)
   {
@@ -85,7 +85,7 @@ ForceCeperley::Return_t ForceCeperley::evaluate(ParticleSet& P)
     forces = forces_IonIon;
   else
     forces = 0.0;
-  const auto& d_ab                     = P.getDistTable(d_ei_ID);
+  const auto& d_ab                     = P.getDistTableAB(d_ei_ID);
   const ParticleScalar_t* restrict Zat = Ions.Z.first_address();
   const ParticleScalar_t* restrict Qat = P.Z.first_address();
   for (int jat = 0; jat < Nel; jat++)

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -120,7 +120,7 @@ void ForceChiesaPBCAA::evaluateLR(ParticleSet& P)
 
 void ForceChiesaPBCAA::evaluateSR(ParticleSet& P)
 {
-  const DistanceTableData& d_ab(P.getDistTable(d_ei_ID));
+  const auto& d_ab(P.getDistTableAB(d_ei_ID));
   for (size_t jat = 0; jat < NptclB; ++jat)
   {
     const auto& dist  = d_ab.getDistRow(jat);
@@ -139,7 +139,7 @@ void ForceChiesaPBCAA::evaluateSR(ParticleSet& P)
 
 void ForceChiesaPBCAA::evaluateSR_AA()
 {
-  const DistanceTableData& d_aa(PtclA.getDistTable(d_aa_ID));
+  const auto& d_aa(PtclA.getDistTableAA(d_aa_ID));
   for (size_t ipart = 1; ipart < NptclA; ipart++)
   {
     const auto& dist  = d_aa.getDistRow(ipart);

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -12,7 +12,7 @@
 
 
 #include "ForceChiesaPBCAA.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Message/Communicate.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Numerics/DeterminantOperators.h"

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -61,7 +61,7 @@ L2Potential::Return_t L2Potential::evaluate(ParticleSet& P)
         D2[n](i, j) += P.G[n][i] * P.G[n][j];
 
   // compute v_L2(r)*L^2 for all electron-ion pairs
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
   value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
@@ -99,7 +99,7 @@ void L2Potential::evaluateDK(ParticleSet& P, int iel, TensorType& D, PosType& K)
   D = 0.0;
   D.diagonal(1.0);
 
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
 
   for (int iat = 0; iat < NumIons; iat++)
   {
@@ -127,7 +127,7 @@ void L2Potential::evaluateD(ParticleSet& P, int iel, TensorType& D)
   D = 0.0;
   D.diagonal(1.0);
 
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
 
   for (int iat = 0; iat < NumIons; iat++)
   {

--- a/src/QMCHamiltonians/L2Potential.cpp
+++ b/src/QMCHamiltonians/L2Potential.cpp
@@ -11,6 +11,7 @@
 
 
 #include "Particle/ParticleSet.h"
+#include "DistanceTable.h"
 #include "L2Potential.h"
 #include "Utilities/IteratorUtility.h"
 

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -99,7 +99,7 @@ LatticeDeviationEstimator::Return_t LatticeDeviationEstimator::evaluate(Particle
   std::fill(xyz2.begin(), xyz2.end(), 0.0);
 
   RealType wgt        = t_walker_->Weight;
-  const auto& d_table = P.getDistTable(myTableID_);
+  const auto& d_table = P.getDistTableAB(myTableID_);
 
   // temp variables
   RealType r, r2;

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.h
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.h
@@ -16,7 +16,7 @@
 #include "Particle/WalkerSetRef.h"
 #include "QMCHamiltonians/OperatorBase.h"
 #include "ParticleBase/ParticleAttribOps.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -89,7 +89,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate(ParticleSet& P)
   else
 #endif
   {
-    const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+    const auto& d_table(P.getDistTableAB(myTableIndex));
     value_             = 0.0;
     const size_t Nelec = P.getTotalNum();
     for (size_t iel = 0; iel < Nelec; ++iel)
@@ -111,7 +111,7 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
                                                                    ParticleSet::ParticlePos_t& hf_terms,
                                                                    ParticleSet::ParticlePos_t& pulay_terms)
 {
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
   value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)
@@ -143,7 +143,7 @@ LocalECPotential::Return_t LocalECPotential::evaluateWithIonDerivs(ParticleSet& 
 #if !defined(REMOVE_TRACEMANAGER)
 LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 {
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
   value_                      = 0.0;
   Array<RealType, 1>& Ve_samp = *Ve_sample;
   Array<RealType, 1>& Vi_samp = *Vi_sample;
@@ -202,7 +202,7 @@ LocalECPotential::Return_t LocalECPotential::evaluate_sp(ParticleSet& P)
 
 LocalECPotential::Return_t LocalECPotential::evaluate_orig(ParticleSet& P)
 {
-  const DistanceTableData& d_table(P.getDistTable(myTableIndex));
+  const auto& d_table(P.getDistTableAB(myTableIndex));
   value_             = 0.0;
   const size_t Nelec = P.getTotalNum();
   for (size_t iel = 0; iel < Nelec; ++iel)

--- a/src/QMCHamiltonians/LocalECPotential.cpp
+++ b/src/QMCHamiltonians/LocalECPotential.cpp
@@ -14,7 +14,7 @@
 
 
 #include "Particle/ParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCHamiltonians/OperatorBase.h"
 #include "LocalECPotential.h"
 #include "Utilities/IteratorUtility.h"

--- a/src/QMCHamiltonians/LocalECPotential.h
+++ b/src/QMCHamiltonians/LocalECPotential.h
@@ -22,7 +22,7 @@
 #include "Numerics/OneDimGridFunctor.h"
 #include "Numerics/OneDimLinearSpline.h"
 #include "Numerics/OneDimCubicSpline.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -17,7 +17,7 @@
 #include "Lattice/ParticleBConds.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include "OhmmsData/AttributeSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "Utilities/IteratorUtility.h"
 

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -326,7 +326,7 @@ std::unique_ptr<OperatorBase> MPC::makeClone(ParticleSet& qp, TrialWaveFunction&
 
 MPC::Return_t MPC::evalSR(ParticleSet& P) const
 {
-  const DistanceTableData& d_aa = P.getDistTable(d_aa_ID);
+  const auto& d_aa = P.getDistTableAA(d_aa_ID);
   RealType SR                   = 0.0;
   const RealType cone(1);
   for (size_t ipart = 0; ipart < NParticles; ipart++)

--- a/src/QMCHamiltonians/MPC.cpp
+++ b/src/QMCHamiltonians/MPC.cpp
@@ -327,7 +327,7 @@ std::unique_ptr<OperatorBase> MPC::makeClone(ParticleSet& qp, TrialWaveFunction&
 MPC::Return_t MPC::evalSR(ParticleSet& P) const
 {
   const auto& d_aa = P.getDistTableAA(d_aa_ID);
-  RealType SR                   = 0.0;
+  RealType SR      = 0.0;
   const RealType cone(1);
   for (size_t ipart = 0; ipart < NParticles; ipart++)
   {

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -19,7 +19,7 @@
 #include "CPU/BLAS.hpp"
 #include "OhmmsData/AttributeSet.h"
 #include "Utilities/SimpleParser.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Numerics/DeterminantOperators.h"
 #include <set>
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -14,7 +14,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "NonLocalECPComponent.h"
 #include "NLPPJob.h"
 #include "NonLocalData.h"

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -15,7 +15,7 @@
 
 
 #include "NonLocalECPotential.h"
-#include <DistanceTableData.h>
+#include <DistanceTable.h>
 #include <IteratorUtility.h>
 #include <ResourceCollection.h>
 #include "NonLocalECPComponent.h"

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -156,7 +156,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid
       if (!keepGrid)
         PPset[ipp]->randomize_grid(*myRNG);
   //loop over all the ions
-  const auto& myTable = P.getDistTable(myTableIndex);
+  const auto& myTable = P.getDistTableAB(myTableIndex);
   // clear all the electron and ion neighbor lists
   for (int iat = 0; iat < NumIons; iat++)
     IonNeighborElecs.getNeighborList(iat).clear();
@@ -266,7 +266,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         O.PPset[ipp]->randomize_grid(*O.myRNG);
 
     //loop over all the ions
-    const auto& myTable = P.getDistTable(O.myTableIndex);
+    const auto& myTable = P.getDistTableAB(O.myTableIndex);
     // clear all the electron and ion neighbor lists
     for (int iat = 0; iat < O.NumIons; iat++)
       O.IonNeighborElecs.getNeighborList(iat).clear();
@@ -412,7 +412,7 @@ void NonLocalECPotential::evalIonDerivsImpl(ParticleSet& P,
         PPset[ipp]->randomize_grid(*myRNG);
   }
   //loop over all the ions
-  const auto& myTable = P.getDistTable(myTableIndex);
+  const auto& myTable = P.getDistTableAB(myTableIndex);
   // clear all the electron and ion neighbor lists
   for (int iat = 0; iat < NumIons; iat++)
     IonNeighborElecs.getNeighborList(iat).clear();
@@ -468,7 +468,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateWithIonDerivsDetermin
 void NonLocalECPotential::computeOneElectronTxy(ParticleSet& P, const int ref_elec)
 {
   tmove_xy_.clear();
-  const auto& myTable                  = P.getDistTable(myTableIndex);
+  const auto& myTable                  = P.getDistTableAB(myTableIndex);
   const std::vector<int>& NeighborIons = ElecNeighborIons.getNeighborList(ref_elec);
 
   const auto& dist  = myTable.getDistRow(ref_elec);
@@ -554,7 +554,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
             Psi.calcRatioGrad(P, iat, grad_iat);
             Psi.acceptMove(P, iat, true);
             // mark all affected electrons
-            markAffectedElecs(P.getDistTable(myTableIndex), iat);
+            markAffectedElecs(P.getDistTableAB(myTableIndex), iat);
             P.acceptMove(iat);
             NonLocalMoveAccepted++;
           }
@@ -573,7 +573,7 @@ int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
   return NonLocalMoveAccepted;
 }
 
-void NonLocalECPotential::markAffectedElecs(const DistanceTableData& myTable, int iel)
+void NonLocalECPotential::markAffectedElecs(const DistanceTableAB& myTable, int iel)
 {
   std::vector<int>& NeighborIons = ElecNeighborIons.getNeighborList(iel);
   for (int iat = 0; iat < NumIons; iat++)

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -13,6 +13,7 @@
 
 #include "QMCHamiltonians/NonLocalECPComponent.h"
 #include "QMCHamiltonians/NonLocalECPotential.h"
+#include "DistanceTable.h"
 #include "CPU/BLAS.hpp"
 #include "Utilities/Timer.h"
 

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -27,7 +27,7 @@ NonLocalECPotential::Return_t NonLocalECPotential::evaluateValueAndDerivatives(P
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
-  const auto& myTable = P.getDistTable(myTableIndex);
+  const auto& myTable = P.getDistTableAB(myTableIndex);
   for (int jel = 0; jel < P.getTotalNum(); jel++)
   {
     const auto& dist  = myTable.getDistRow(jel);

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -218,7 +218,7 @@ private:
    * @param iel reference electron
    * Note this function should be called before acceptMove for a Tmove
    */
-  void markAffectedElecs(const DistanceTableData& myTable, int iel);
+  void markAffectedElecs(const DistanceTableAB& myTable, int iel);
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -42,7 +42,6 @@ class MCWalkerConfiguration;
  * @brief QMCHamiltonian and its component, OperatorBase
  *
  */
-class DistanceTable;
 class TrialWaveFunction;
 class QMCHamiltonian;
 class ResourceCollection;

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -42,7 +42,7 @@ class MCWalkerConfiguration;
  * @brief QMCHamiltonian and its component, OperatorBase
  *
  */
-class DistanceTableData;
+class DistanceTable;
 class TrialWaveFunction;
 class QMCHamiltonian;
 class ResourceCollection;

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -114,7 +114,7 @@ int PairCorrEstimator::gen_pair_id(const int ig, const int jg, const int ns)
 PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
 {
   BufferType& collectables(P.Collectables);
-  const DistanceTableData& dii(P.getDistTable(d_aa_ID_));
+  const auto& dii(P.getDistTableAA(d_aa_ID_));
   for (int iat = 1; iat < dii.centers(); ++iat)
   {
     const auto& dist = dii.getDistRow(iat);
@@ -133,7 +133,7 @@ PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
   }
   for (int k = 0; k < other_ids.size(); ++k)
   {
-    const DistanceTableData& d1(P.getDistTable(other_ids[k]));
+    const auto& d1(P.getDistTableAB(other_ids[k]));
     const ParticleSet::ParticleIndex_t& gid(d1.get_origin().GroupID);
     int koff        = other_offsets[k];
     RealType overNI = 1.0 / d1.centers();

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -15,7 +15,7 @@
 
 
 #include "PairCorrEstimator.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Utilities/SimpleParser.h"
 #include <set>
@@ -85,7 +85,7 @@ PairCorrEstimator::PairCorrEstimator(ParticleSet& elns, std::string& sources)
   int toff = gof_r_prefix.size();
   for (int k = 0; k < other_ids.size(); ++k)
   {
-    const DistanceTableData& t(elns.getDistTable(other_ids[k]));
+    const DistanceTable& t(elns.getDistTable(other_ids[k]));
     app_log() << "  GOFR for " << t.getName() << " starts at " << toff << std::endl;
     other_offsets[k] = toff;
     const SpeciesSet& species(t.get_origin().getSpeciesSet());

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -18,7 +18,7 @@
 
 #include "QMCHamiltonian.h"
 #include "Particle/WalkerSetRef.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "Utilities/TimerManager.h"

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "SOECPComponent.h"
 #include "Numerics/Ylm.h"
 

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -9,7 +9,7 @@
 // File created by: Cody A. Melton, cmelton@sandia.gov, Sandia National Laboratories
 //////////////////////////////////////////////////////////////////////////////////////
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "SOECPotential.h"
 #include "Utilities/IteratorUtility.h"
 

--- a/src/QMCHamiltonians/SOECPotential.cpp
+++ b/src/QMCHamiltonians/SOECPotential.cpp
@@ -39,7 +39,7 @@ SOECPotential::Return_t SOECPotential::evaluate(ParticleSet& P)
   for (int ipp = 0; ipp < PPset.size(); ipp++)
     if (PPset[ipp])
       PPset[ipp]->randomize_grid(*myRNG);
-  const auto& myTable = P.getDistTable(myTableIndex);
+  const auto& myTable = P.getDistTableAB(myTableIndex);
   for (int iat = 0; iat < NumIons; iat++)
     IonNeighborElecs.getNeighborList(iat).clear();
   for (int jel = 0; jel < P.getTotalNum(); jel++)

--- a/src/QMCHamiltonians/SpaceGrid.cpp
+++ b/src/QMCHamiltonians/SpaceGrid.cpp
@@ -823,7 +823,7 @@ void SpaceGrid::evaluate(const ParticlePos_t& R,
                          const Matrix<RealType>& values,
                          BufferType& buf,
                          std::vector<bool>& particles_outside,
-                         const DistanceTableData& dtab)
+                         const DistanceTableAB& dtab)
 {
   int p, v;
   int nparticles = values.size1();

--- a/src/QMCHamiltonians/SpaceGrid.h
+++ b/src/QMCHamiltonians/SpaceGrid.h
@@ -54,7 +54,7 @@ public:
                 const Matrix<RealType>& values,
                 BufferType& buf,
                 std::vector<bool>& particles_outside,
-                const DistanceTableData& dtab);
+                const DistanceTableAB& dtab);
 
   bool check_grid(void);
   inline int nDomains(void) { return ndomains; }

--- a/src/QMCHamiltonians/SpaceGrid.h
+++ b/src/QMCHamiltonians/SpaceGrid.h
@@ -19,7 +19,7 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Pools/PooledData.h"
 #include "QMCHamiltonians/ObservableHelper.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -1,5 +1,5 @@
 #include "QMCHamiltonians/SpaceWarpTransformation.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "type_traits/scalar_traits.h"
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -18,7 +18,7 @@ SpaceWarpTransformation::RealType SpaceWarpTransformation::df(RealType r) { retu
 //This allows the calculation of any space warp value or gradient by a matrix lookup, combined with a sum over columns.
 void SpaceWarpTransformation::computeSWTIntermediates(ParticleSet& P, const ParticleSet& ions)
 {
-  const DistanceTableData& d_ab(P.getDistTable(myTableIndex));
+  const auto& d_ab(P.getDistTableAB(myTableIndex));
   for (size_t iel = 0; iel < Nelec; ++iel)
   {
     const auto& dist = d_ab.getDistRow(iel);

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -13,6 +13,7 @@
 
 
 #include "StressPBC.h"
+#include "DistanceTable.h"
 #include "Message/Communicate.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "Numerics/DeterminantOperators.h"

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -120,7 +120,7 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AB(ParticleSet& 
 
 SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateSR_AB(ParticleSet& P)
 {
-  const auto& d_ab                   = P.getDistTable(ei_table_index);
+  const auto& d_ab                   = P.getDistTableAB(ei_table_index);
   SymTensor<RealType, OHMMS_DIM> res = 0.0;
   //Loop over distinct eln-ion pairs
   for (int jpart = 0; jpart < NptclB; jpart++)
@@ -138,7 +138,7 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateSR_AB(ParticleSet& 
 
 SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateSR_AA(ParticleSet& P, int itabSelf)
 {
-  const auto& d_aa = P.getDistTable(itabSelf);
+  const auto& d_aa = P.getDistTableAA(itabSelf);
 
   SymTensor<RealType, OHMMS_DIM> stress_aa;
   for (int ipart = 0; ipart < NptclB; ipart++)

--- a/src/QMCHamiltonians/tests/test_PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_PairCorrEstimator.cpp
@@ -14,7 +14,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "Lattice/CrystalLattice.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCHamiltonians/PairCorrEstimator.h"
 #include "Particle/ParticleSetPool.h"
 

--- a/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
@@ -15,7 +15,7 @@
 #include "Lattice/CrystalLattice.h"
 #include "LongRange/StructFact.h"
 #include "Particle/ParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCHamiltonians/SkAllEstimator.h"
 #include "Particle/ParticleSetPool.h"
 #include <stdio.h>

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -532,7 +532,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
 
   const int myTableIndex = elec.addTable(ions);
 
-  const auto& myTable = elec.getDistTable(myTableIndex);
+  const auto& myTable = elec.getDistTableAB(myTableIndex);
 
   // update all distance tables
   ions.update();

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -290,7 +290,7 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
 
   const int myTableIndex = elec.addTable(ions);
 
-  const auto& myTable = elec.getDistTable(myTableIndex);
+  const auto& myTable = elec.getDistTableAB(myTableIndex);
 
   // update all distance tables
   ions.update();

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -17,7 +17,7 @@
 #ifndef QMCPLUSPLUS_HYBRIDREP_CENTER_ORBITALS_H
 #define QMCPLUSPLUS_HYBRIDREP_CENTER_ORBITALS_H
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "Particle/VirtualParticleSet.h"
 #include "QMCWaveFunctions/LCAO/SoaSphericalTensor.h"
 #include "spline2/MultiBspline1D.hpp"
@@ -406,8 +406,8 @@ class HybridRepCenterOrbitals
 public:
   static const int D = 3;
   using PointType    = typename AtomicOrbitals<ST>::PointType;
-  using RealType     = typename DistanceTableData::RealType;
-  using PosType      = typename DistanceTableData::PosType;
+  using RealType     = typename DistanceTable::RealType;
+  using PosType      = typename DistanceTable::PosType;
 
 private:
   ///atomic centers

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -185,7 +185,7 @@ public:
 
     for (size_t lm = 0; lm < lm_tot; lm++)
     {
-#pragma omp simd aligned(val, local_val: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(val, local_val : QMC_SIMD_ALIGNMENT)
       for (size_t ib = 0; ib < myV.size(); ib++)
         val[ib] += Ylm_v[lm] * local_val[ib];
       local_val += Npad;
@@ -214,7 +214,7 @@ public:
       ST* restrict local_val = localV.data();
       for (size_t lm = 0; lm < lm_tot; lm++)
       {
-#pragma omp simd aligned(val, local_val: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(val, local_val : QMC_SIMD_ALIGNMENT)
         for (size_t ib = 0; ib < m; ib++)
           val[ib] += Ylm_v[lm] * local_val[ib];
         local_val += Npad;
@@ -283,7 +283,7 @@ public:
         const ST& r_power    = r_power_minus_l[lm];
         const ST Ylm_rescale = Ylm_v[lm] * r_power;
         const ST rhat_dot_G  = (rhatx * Ylm_gx[lm] + rhaty * Ylm_gy[lm] + rhatz * Ylm_gz[lm]) * r_power;
-#pragma omp simd aligned(val, g0, g1, g2, lapl, local_val, local_grad, local_lapl: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(val, g0, g1, g2, lapl, local_val, local_grad, local_lapl : QMC_SIMD_ALIGNMENT)
         for (size_t ib = 0; ib < myV.size(); ib++)
         {
           const ST local_v = local_val[ib];
@@ -329,7 +329,7 @@ public:
         const ST& r_power    = r_power_minus_l[lm];
         const ST Ylm_rescale = Ylm_v[lm] * r_power;
         const ST rhat_dot_G  = (Ylm_gx[lm] * rhatx + Ylm_gy[lm] * rhaty + Ylm_gz[lm] * rhatz) * r_power * r;
-#pragma omp simd aligned(val, g0, g1, g2, lapl, local_val, local_grad, local_lapl: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(val, g0, g1, g2, lapl, local_val, local_grad, local_lapl : QMC_SIMD_ALIGNMENT)
         for (size_t ib = 0; ib < myV.size(); ib++)
         {
           const ST local_v = local_val[ib];
@@ -360,7 +360,7 @@ public:
       std::cout << "Warning: an electron is on top of an ion!" << std::endl;
       // strictly zero
 
-#pragma omp simd aligned(val, lapl, local_val, local_lapl: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(val, lapl, local_val, local_lapl : QMC_SIMD_ALIGNMENT)
       for (size_t ib = 0; ib < myV.size(); ib++)
       {
         // value
@@ -377,7 +377,7 @@ public:
         //std::cout << std::endl;
         for (size_t lm = 1; lm < 4; lm++)
         {
-#pragma omp simd aligned(g0, g1, g2, local_grad: QMC_SIMD_ALIGNMENT)
+#pragma omp simd aligned(g0, g1, g2, local_grad : QMC_SIMD_ALIGNMENT)
           for (size_t ib = 0; ib < myV.size(); ib++)
           {
             const ST local_g = local_grad[ib];

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -541,7 +541,7 @@ public:
   template<typename VV>
   inline RealType evaluate_v(const ParticleSet& P, const int iat, VV& myV)
   {
-    const auto& ei_dist  = P.getDistTable(myTableID);
+    const auto& ei_dist  = P.getDistTableAB(myTableID);
     const int center_idx = ei_dist.get_first_neighbor(iat, dist_r, dist_dr, P.activePtcl == iat);
     if (center_idx < 0)
       abort();
@@ -569,7 +569,7 @@ public:
   {
     const int center_idx = VP.refSourcePtcl;
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
-    return VP.refPS.getDistTable(myTableID).getDistRow(VP.refPtcl)[center_idx] < myCenter.getNonOverlappingRadius();
+    return VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx] < myCenter.getNonOverlappingRadius();
   }
 
   // C2C, C2R cases
@@ -577,11 +577,11 @@ public:
   inline RealType evaluateValuesC2X(const VirtualParticleSet& VP, VM& multi_myV)
   {
     const int center_idx = VP.refSourcePtcl;
-    dist_r               = VP.refPS.getDistTable(myTableID).getDistRow(VP.refPtcl)[center_idx];
+    dist_r               = VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
     if (dist_r < myCenter.getCutoff())
     {
-      myCenter.evaluateValues(VP.getDistTable(myTableID).getDisplacements(), center_idx, dist_r, multi_myV);
+      myCenter.evaluateValues(VP.getDistTableAB(myTableID).getDisplacements(), center_idx, dist_r, multi_myV);
       return smooth_function(myCenter.getCutoffBuffer(), myCenter.getCutoff(), dist_r);
     }
     return RealType(-1);
@@ -596,11 +596,11 @@ public:
                                     SV& bc_signs)
   {
     const int center_idx = VP.refSourcePtcl;
-    dist_r               = VP.refPS.getDistTable(myTableID).getDistRow(VP.refPtcl)[center_idx];
+    dist_r               = VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
     if (dist_r < myCenter.getCutoff())
     {
-      const auto& displ = VP.getDistTable(myTableID).getDisplacements();
+      const auto& displ = VP.getDistTableAB(myTableID).getDisplacements();
       for (int ivp = 0; ivp < VP.getTotalNum(); ivp++)
       {
         r_image       = myCenter.getCenterPos() - displ[ivp][center_idx];
@@ -617,7 +617,7 @@ public:
   template<typename VV, typename GV>
   inline RealType evaluate_vgl(const ParticleSet& P, const int iat, VV& myV, GV& myG, VV& myL)
   {
-    const auto& ei_dist  = P.getDistTable(myTableID);
+    const auto& ei_dist  = P.getDistTableAB(myTableID);
     const int center_idx = ei_dist.get_first_neighbor(iat, dist_r, dist_dr, P.activePtcl == iat);
     if (center_idx < 0)
       abort();
@@ -636,7 +636,7 @@ public:
   template<typename VV, typename GV, typename HT>
   inline RealType evaluate_vgh(const ParticleSet& P, const int iat, VV& myV, GV& myG, HT& myH)
   {
-    const auto& ei_dist  = P.getDistTable(myTableID);
+    const auto& ei_dist  = P.getDistTableAB(myTableID);
     const int center_idx = ei_dist.get_first_neighbor(iat, dist_r, dist_dr, P.activePtcl == iat);
     if (center_idx < 0)
       abort();

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -25,7 +25,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
 #include "QMCWaveFunctions/BsplineFactory/BsplineReaderBase.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -14,7 +14,7 @@
 
 
 #include "QMCWaveFunctions/EinsplineSetBuilder.h"
-#include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
+#include "DistanceTable.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Utilities/Timer.h"
 #include "Message/Communicate.h"

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -25,7 +25,7 @@
 #include "Utilities/Timer.h"
 #include "Numerics/HDFSTLAttrib.h"
 #include "ParticleBase/RandomSeqGenerator.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include <fftw3.h>
 #include "Utilities/ProgressReportEngine.h"
 #include "QMCWaveFunctions/einspline_helper.hpp"

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -65,14 +65,14 @@ ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(const ParticleS
                                                                  ParticleSet::ParticleGradient_t& G,
                                                                  ParticleSet::ParticleLaplacian_t& L)
 {
-  const auto& ee_table  = P.getDistTable(my_table_ee_idx_);
+  const auto& ee_table  = P.getDistTableAA(my_table_ee_idx_);
   const auto& ee_dists  = ee_table.getDistances();
   const auto& ee_displs = ee_table.getDisplacements();
   // Only the lower triangle is up-to-date after particle-by-particle moves
   double r12  = ee_dists[1][0];
   auto rhat12 = ee_displs[1][0] / r12;
 
-  const auto& ei_table  = P.getDistTable(my_table_ei_idx_);
+  const auto& ei_table  = P.getDistTableAB(my_table_ei_idx_);
   const auto& ei_dists  = ei_table.getDistances();
   const auto& ei_displs = ei_table.getDisplacements();
 
@@ -112,7 +112,7 @@ ExampleHeComponent::LogValueType ExampleHeComponent::evaluateLog(const ParticleS
 
 ExampleHeComponent::PsiValueType ExampleHeComponent::ratio(ParticleSet& P, int iat)
 {
-  const auto& ee_table  = P.getDistTable(my_table_ee_idx_);
+  const auto& ee_table  = P.getDistTableAA(my_table_ee_idx_);
   const auto& ee_dists  = ee_table.getDistances();
   const auto& ee_temp_r = ee_table.getTempDists();
 
@@ -120,7 +120,7 @@ ExampleHeComponent::PsiValueType ExampleHeComponent::ratio(ParticleSet& P, int i
   double r12_old = ee_dists[1][0];
   double r12_new = ee_temp_r[iat == 0 ? 1 : 0];
 
-  const auto& ei_table  = P.getDistTable(my_table_ei_idx_);
+  const auto& ei_table  = P.getDistTableAB(my_table_ei_idx_);
   const auto& ei_dists  = ei_table.getDistances();
   const auto& ei_temp_r = ei_table.getTempDists();
 
@@ -138,14 +138,14 @@ ExampleHeComponent::PsiValueType ExampleHeComponent::ratio(ParticleSet& P, int i
 
 ExampleHeComponent::GradType ExampleHeComponent::evalGrad(ParticleSet& P, int iat)
 {
-  const auto& ei_table  = P.getDistTable(my_table_ei_idx_);
+  const auto& ei_table  = P.getDistTableAB(my_table_ei_idx_);
   const auto& ei_dists  = ei_table.getDistances();
   const auto& ei_displs = ei_table.getDisplacements();
 
   double r  = ei_dists[iat][0];
   auto rhat = ei_displs[iat][0] / r;
 
-  const auto& ee_table  = P.getDistTable(my_table_ee_idx_);
+  const auto& ee_table  = P.getDistTableAA(my_table_ee_idx_);
   const auto& ee_dists  = ee_table.getDistances();
   const auto& ee_displs = ee_table.getDisplacements();
 
@@ -160,7 +160,7 @@ ExampleHeComponent::GradType ExampleHeComponent::evalGrad(ParticleSet& P, int ia
 
 ExampleHeComponent::PsiValueType ExampleHeComponent::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
-  const auto& ee_table   = P.getDistTable(my_table_ee_idx_);
+  const auto& ee_table   = P.getDistTableAA(my_table_ee_idx_);
   const auto& ee_dists   = ee_table.getDistances();
   const auto& ee_displs  = ee_table.getDisplacements();
   const auto& ee_temp_r  = ee_table.getTempDists();
@@ -173,7 +173,7 @@ ExampleHeComponent::PsiValueType ExampleHeComponent::ratioGrad(ParticleSet& P, i
 
   auto rhat12 = ee_temp_dr[jat] / r12_new;
 
-  const auto& ei_table   = P.getDistTable(my_table_ei_idx_);
+  const auto& ei_table   = P.getDistTableAB(my_table_ei_idx_);
   const auto& ei_dists   = ei_table.getDistances();
   const auto& ei_displs  = ei_table.getDisplacements();
   const auto& ei_temp_r  = ei_table.getTempDists();
@@ -233,7 +233,7 @@ void ExampleHeComponent::evaluateDerivatives(ParticleSet& P,
 
   double tmpB = std::real(optvars[0]);
 
-  const auto& ee_table   = P.getDistTable(my_table_ee_idx_);
+  const auto& ee_table   = P.getDistTableAA(my_table_ee_idx_);
   const auto& ee_dists   = ee_table.getDistances();
   const auto& ee_displs  = ee_table.getDisplacements();
   const auto& ee_temp_r  = ee_table.getTempDists();
@@ -242,7 +242,7 @@ void ExampleHeComponent::evaluateDerivatives(ParticleSet& P,
   double r12  = ee_dists[1][0];
   auto rhat12 = ee_displs[1][0] / r12;
 
-  const auto& ei_table   = P.getDistTable(my_table_ei_idx_);
+  const auto& ei_table   = P.getDistTableAB(my_table_ei_idx_);
   const auto& ei_dists   = ei_table.getDistances();
   const auto& ei_displs  = ei_table.getDisplacements();
   const auto& ei_temp_r  = ei_table.getTempDists();

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -12,6 +12,7 @@
 
 #include "ExampleHeComponent.h"
 #include "OhmmsData/AttributeSet.h"
+#include "DistanceTable.h"
 
 /**@file ExampleHeComponent.cpp
  */

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -14,6 +14,8 @@
 
 
 #include "BackflowBuilder.h"
+#include <map>
+#include <cmath>
 #include "Utilities/ProgressReportEngine.h"
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
@@ -28,9 +30,8 @@
 #include "LongRange/LRHandlerTemp.h"
 #include "LongRange/LRRPABFeeHandlerTemp.h"
 #include "Particle/ParticleSet.h"
+#include "DistanceTable.h"
 #include "Configuration.h"
-#include <map>
-#include <cmath>
 #include "OhmmsPETE/OhmmsArray.h"
 #include "OhmmsData/ParameterSet.h"
 #include "Numerics/LinearFit.h"

--- a/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
@@ -336,7 +336,7 @@ public:
     activeParticle = iat;
     for (int i = 0; i < NumTargets; i++)
       oldQP[i] = newQP[i] = QP.R[i];
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     newQP[iat] -= myTable.getTempDispls()[iat];
     indexQP.clear();
     for (int i = 0; i < bfFuns.size(); i++)
@@ -381,7 +381,7 @@ public:
     activeParticle = iat;
     for (int i = 0; i < NumTargets; i++)
       oldQP[i] = newQP[i] = QP.R[i];
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     newQP[iat] -= myTable.getTempDispls()[iat];
     indexQP.clear();
     std::copy(FirstOfA, LastOfA, FirstOfA_temp);
@@ -406,7 +406,7 @@ public:
     activeParticle = iat;
     for (int i = 0; i < NumTargets; i++)
       oldQP[i] = newQP[i] = QP.R[i];
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
 
     // this is from AoS, is it needed or not?
     //newQP[iat] += myTable.Temp[iat].dr1;
@@ -715,7 +715,7 @@ public:
       dr[1] = 0.05;
       dr[2] = -0.3;
       P.makeMove(iat, dr);
-      const auto& myTable = P.getDistTable(myTableIndex_);
+      const auto& myTable = P.getDistTableAA(myTableIndex_);
 
       //app_log() << "Move: " << myTable.Temp[iat].dr1 << std::endl;
       //app_log() << "cutOff: " << cutOff << std::endl;

--- a/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
@@ -15,6 +15,13 @@
 
 #ifndef QMCPLUSPLUS_BACKFLOW_TRANSFORMATION_H
 #define QMCPLUSPLUS_BACKFLOW_TRANSFORMATION_H
+
+#include "Configuration.h"
+#include <map>
+#include <cmath>
+#include "Particle/ParticleSet.h"
+#include "DistanceTable.h"
+#include "Particle/ParticleBase/ParticleAttribOps.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "Utilities/ProgressReportEngine.h"
 #include "OhmmsData/AttributeSet.h"
@@ -24,11 +31,6 @@
 #include "QMCWaveFunctions/Fermion/Backflow_ee.h"
 #include "QMCWaveFunctions/Fermion/Backflow_eI.h"
 #include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
-#include "Particle/ParticleSet.h"
-#include "Particle/ParticleBase/ParticleAttribOps.h"
-#include "Configuration.h"
-#include <map>
-#include <cmath>
 #include "OhmmsPETE/OhmmsArray.h"
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/Backflow_eI.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_eI.h
@@ -191,7 +191,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluate(P,QP) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int i = 0; i < myTable.sources(); i++)
     //{
     //  for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -208,7 +208,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluate(P,QP,Bmat_vec,Amat) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int i = 0; i < myTable.sources(); i++)
     //{
     //  for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -236,7 +236,7 @@ public:
   inline void evaluate(const ParticleSet& P, ParticleSet& QP, GradMatrix_t& Bmat_full, HessMatrix_t& Amat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAB(myTableIndex_);
     for (int jel = 0; jel < P.getTotalNum(); jel++)
     {
       const auto& dist  = myTable.getDistRow(jel);
@@ -270,7 +270,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluatePbyP(P,QP,index_vec) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int maxI            = myTable.sources();
     //int iat             = index[0];
     //for (int j = 0; j < maxI; j++)
@@ -287,7 +287,7 @@ public:
   inline void evaluatePbyP(const ParticleSet& P, int iat, ParticleSet::ParticlePos_t& newQP) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAB(myTableIndex_);
     int maxI            = myTable.sources();
     for (int j = 0; j < maxI; j++)
     {
@@ -304,7 +304,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluatePbyP(P,QP,index_vec,Amat) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int maxI            = myTable.sources();
     //int iat             = index[0];
     //for (int j = 0; j < maxI; j++)
@@ -328,7 +328,7 @@ public:
                            HessMatrix_t& Amat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAB(myTableIndex_);
     int maxI            = myTable.sources();
     for (int j = 0; j < maxI; j++)
     {
@@ -356,7 +356,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluatePbyP(P,QP,index_vec,Bmat,Amat) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int maxI            = myTable.sources();
     //int iat             = index[0];
     //for (int j = 0; j < maxI; j++)
@@ -384,7 +384,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluatePbyP(P,iat,QP,Bmat,Amat) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int maxI            = myTable.sources();
     //for (int j = 0; j < maxI; j++)
     //{
@@ -410,7 +410,7 @@ public:
   {
     APP_ABORT("Backflow_eI.h::evaluateBmatOnly(P,QP,Bmat) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int i = 0; i < myTable.sources(); i++)
     //{
     //  for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -434,7 +434,7 @@ public:
                                       HessArray_t& Xmat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAB(myTableIndex_);
     for (int jel = 0; jel < P.getTotalNum(); jel++)
     {
       const auto& dist  = myTable.getDistRow(jel);

--- a/src/QMCWaveFunctions/Fermion/Backflow_eI_spin.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_eI_spin.h
@@ -244,7 +244,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluate")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
     //  for (int iat = s_offset[sg]; iat < s_offset[sg + 1]; ++iat)
@@ -271,7 +271,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluate")
     //RealType du, d2u, temp;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
     //  for (int iat = s_offset[sg]; iat < s_offset[sg + 1]; ++iat)
@@ -310,7 +310,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluate")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
     //  for (int iat = s_offset[sg]; iat < s_offset[sg + 1]; ++iat)
@@ -359,7 +359,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluatePbyP")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int tg = P.GroupID[iat]; //species of this particle
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
@@ -391,7 +391,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluatePbyP")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int tg = P.GroupID[iat]; //species of this particle
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
@@ -432,7 +432,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluatePbyP")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //int tg = P.GroupID[iat]; //species of this particle
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
@@ -465,7 +465,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluateBmatOnly")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
     //  for (int iat = s_offset[sg]; iat < s_offset[sg + 1]; ++iat)
@@ -500,7 +500,7 @@ public:
   {
     APP_ABORT("SoA implementation needed for Backflow_eI_spin::evaluateWithDerivatives")
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAB(myTableIndex_);
     //for (int sg = 0; sg < RadFunc.rows(); ++sg)
     //{
     //  for (int iat = s_offset[sg]; iat < s_offset[sg + 1]; ++iat)

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee.h
@@ -232,7 +232,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluate(P,QP) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAA(myTableIndex_);
     //for (int i = 0; i < myTable.sources(); i++)
     //{
     //  for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -253,7 +253,7 @@ public:
     APP_ABORT("This shouldn't be called: Backflow_ee::evaluate(Bmat)");
     PosType du, d2u, temp;
     APP_ABORT("Backflow_ee.h::evaluate(P,QP,Bmat_vec,Amat) not implemented for SoA\n");
-    //    const auto& myTable = P.getDistTable(myTableIndex_);
+    //    const auto& myTable = P.getDistTableAA(myTableIndex_);
     //    for (int i = 0; i < myTable.sources(); i++)
     //    {
     //      for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -293,7 +293,7 @@ public:
   inline void evaluate(const ParticleSet& P, ParticleSet& QP, GradMatrix_t& Bmat_full, HessMatrix_t& Amat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     for (int ig = 0; ig < NumGroups; ++ig)
     {
       for (int iat = P.first(ig), last = P.last(ig); iat < last; ++iat)
@@ -347,7 +347,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluatePbyP(P,QP,index_vec) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAA(myTableIndex_);
     //int maxI            = index.size();
     //int iat             = index[0];
     //for (int i = 1; i < maxI; i++)
@@ -365,7 +365,7 @@ public:
   inline void evaluatePbyP(const ParticleSet& P, int iat, ParticleSet::ParticlePos_t& newQP) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     for (int i = 0; i < iat; i++)
     {
       // Temp[j].dr1 = (ri - rj)
@@ -393,7 +393,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluatePbyP(P,QP,index_vec,Amat) not implemented for SoA\n");
     //    RealType du, d2u;
-    //    const auto& myTable = P.getDistTable(myTableIndex_);
+    //    const auto& myTable = P.getDistTableAA(myTableIndex_);
     //    int maxI            = index.size();
     //    int iat             = index[0];
     //    for (int i = 1; i < maxI; i++)
@@ -429,7 +429,7 @@ public:
                            HessMatrix_t& Amat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     for (int j = 0; j < iat; j++)
     {
       if (myTable.getTempDists()[j] > 0)
@@ -492,7 +492,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluatePbyP(P,QP,index_vec,Bmat,Amat) not implemented for SoA\n");
     //    RealType du, d2u;
-    //    const auto& myTable                                     = P.getDistTable(myTableIndex_);
+    //    const auto& myTable                                     = P.getDistTableAA(myTableIndex_);
     //    int maxI                                                = index.size();
     //    int iat                                                 = index[0];
     //    const std::vector<DistanceTableData::TempDistType>& TMP = myTable.Temp;
@@ -539,7 +539,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluatePbyP(P,iat,QP,Bmat,Amat) not implemented for SoA\n");
     //    RealType du, d2u;
-    //    const auto& myTable                                     = P.getDistTable(myTableIndex_);
+    //    const auto& myTable                                     = P.getDistTableAA(myTableIndex_);
     //    const std::vector<DistanceTableData::TempDistType>& TMP = myTable.Temp;
     //    for (int j = 0; j < iat; j++)
     //    {
@@ -610,7 +610,7 @@ public:
   {
     APP_ABORT("Backflow_ee.h::evaluateBmatOnly(P,QP,Bmat_full) not implemented for SoA\n");
     //RealType du, d2u;
-    //const auto& myTable = P.getDistTable(myTableIndex_);
+    //const auto& myTable = P.getDistTableAA(myTableIndex_);
     //for (int i = 0; i < myTable.sources(); i++)
     //{
     //  for (int nn = myTable.M[i]; nn < myTable.M[i + 1]; nn++)
@@ -638,7 +638,7 @@ public:
                                       HessArray_t& Xmat) override
   {
     RealType du, d2u;
-    const auto& myTable = P.getDistTable(myTableIndex_);
+    const auto& myTable = P.getDistTableAA(myTableIndex_);
     for (int ig = 0; ig < NumGroups; ++ig)
     {
       for (int iat = P.first(ig), last = P.last(ig); iat < last; ++iat)

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee.h
@@ -495,7 +495,7 @@ public:
     //    const auto& myTable                                     = P.getDistTableAA(myTableIndex_);
     //    int maxI                                                = index.size();
     //    int iat                                                 = index[0];
-    //    const std::vector<DistanceTableData::TempDistType>& TMP = myTable.Temp;
+    //    const std::vector<DistanceTable::TempDistType>& TMP = myTable.Temp;
     //    for (int i = 1; i < maxI; i++)
     //    {
     //      int j        = index[i];
@@ -540,7 +540,7 @@ public:
     APP_ABORT("Backflow_ee.h::evaluatePbyP(P,iat,QP,Bmat,Amat) not implemented for SoA\n");
     //    RealType du, d2u;
     //    const auto& myTable                                     = P.getDistTableAA(myTableIndex_);
-    //    const std::vector<DistanceTableData::TempDistType>& TMP = myTable.Temp;
+    //    const std::vector<DistanceTable::TempDistType>& TMP = myTable.Temp;
     //    for (int j = 0; j < iat; j++)
     //    {
     //      RealType uij = RadFun[PairID(iat, j)]->evaluate(TMP[j].r1, du, d2u);

--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -247,7 +247,7 @@ public:
       for (int p = 0; p < NumVars; ++p)
         (*lapLogPsi[p]) = 0.0;
       std::vector<TinyVector<RealType, 3>> derivs(NumVars);
-      const auto& d_table = P.getDistTable(my_table_ID_);
+      const auto& d_table = P.getDistTableAA(my_table_ID_);
       constexpr RealType cone(1);
       constexpr RealType lapfac(OHMMS_DIM - cone);
       const size_t n  = d_table.sources();

--- a/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
+++ b/src/QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h
@@ -18,7 +18,7 @@
 #define QMCPLUSPLUS_DIFFERENTIAL_TWOBODYJASTROW_H
 #include "Configuration.h"
 #include "QMCWaveFunctions/DiffWaveFunctionComponent.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "Utilities/IteratorUtility.h"
 

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -146,7 +146,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
   void recompute(const ParticleSet& P) override
   {
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       computeU3(P, iat, d_ie.getDistRow(iat));
@@ -164,7 +164,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override
   {
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     valT dudr, d2udr2;
 
     Tensor<valT, DIM> ident;
@@ -194,14 +194,14 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   PsiValueType ratio(ParticleSet& P, int iat) override
   {
     UpdateMode = ORB_PBYP_RATIO;
-    curAt      = computeU(P.getDistTable(myTableID).getTempDists());
+    curAt      = computeU(P.getDistTableAB(myTableID).getTempDists());
     return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
   }
 
   inline void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override
   {
     for (int k = 0; k < ratios.size(); ++k)
-      ratios[k] = std::exp(Vat[VP.refPtcl] - computeU(VP.getDistTable(myTableID).getDistRow(k)));
+      ratios[k] = std::exp(Vat[VP.refPtcl] - computeU(VP.getDistTableAB(myTableID).getDistRow(k)));
   }
 
   void evaluateDerivatives(ParticleSet& P,
@@ -251,7 +251,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     }
     if (recalculate)
     {
-      const auto& d_table = P.getDistTable(myTableID);
+      const auto& d_table = P.getDistTableAB(myTableID);
       dLogPsi             = 0.0;
       for (int p = 0; p < NumVars; ++p)
         (*gradLogPsi[p]) = 0.0;
@@ -340,7 +340,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
-    const auto& dist = P.getDistTable(myTableID).getTempDists();
+    const auto& dist = P.getDistTableAB(myTableID).getTempDists();
     curAt            = valT(0);
     if (NumGroups > 0)
     {
@@ -454,8 +454,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   {
     UpdateMode = ORB_PBYP_PARTIAL;
 
-    computeU3(P, iat, P.getDistTable(myTableID).getTempDists());
-    curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).getTempDispls(), curGrad);
+    computeU3(P, iat, P.getDistTableAB(myTableID).getTempDists());
+    curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTableAB(myTableID).getTempDispls(), curGrad);
     curAt  = simd::accumulate_n(U.data(), Nions, valT());
     grad_iat += curGrad;
     return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
@@ -469,8 +469,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   {
     if (UpdateMode == ORB_PBYP_RATIO)
     {
-      computeU3(P, iat, P.getDistTable(myTableID).getTempDists());
-      curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).getTempDispls(), curGrad);
+      computeU3(P, iat, P.getDistTableAB(myTableID).getTempDists());
+      curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTableAB(myTableID).getTempDispls(), curGrad);
     }
 
     log_value_ += Vat[iat] - curAt;
@@ -630,7 +630,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   inline GradType evalGradSource(ParticleSet& P, ParticleSet& source, int isrc) override
   {
     GradType g_return(0.0);
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       const auto& dist  = d_ie.getDistRow(iat);
@@ -656,7 +656,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
                                  TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad) override
   {
     GradType g_return(0.0);
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       const auto& dist  = d_ie.getDistRow(iat);

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -15,7 +15,7 @@
 #ifndef QMCPLUSPLUS_ONEBODYJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_ONEBODYJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "Utilities/qmc_common.h"
@@ -40,8 +40,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
   ///element position type
   using posT = TinyVector<valT, OHMMS_DIM>;
   ///use the same container
-  using DistRow  = DistanceTableData::DistRow;
-  using DisplRow = DistanceTableData::DisplRow;
+  using DistRow  = DistanceTable::DistRow;
+  using DisplRow = DistanceTable::DisplRow;
   ///table index
   const int myTableID;
   ///number of ions

--- a/src/QMCWaveFunctions/Jastrow/J1Spin.h
+++ b/src/QMCWaveFunctions/Jastrow/J1Spin.h
@@ -181,7 +181,7 @@ struct J1Spin : public WaveFunctionComponent
 
   void recompute(const ParticleSet& P) override
   {
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       computeU3(P, iat, d_ie.getDistRow(iat));
@@ -199,7 +199,7 @@ struct J1Spin : public WaveFunctionComponent
 
   void evaluateHessian(ParticleSet& P, HessVector_t& grad_grad_psi) override
   {
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     valT dudr, d2udr2;
 
     Tensor<valT, DIM> ident;
@@ -229,14 +229,14 @@ struct J1Spin : public WaveFunctionComponent
   PsiValueType ratio(ParticleSet& P, int iat) override
   {
     UpdateMode = ORB_PBYP_RATIO;
-    curAt      = computeU(P, iat, P.getDistTable(myTableID).getTempDists());
+    curAt      = computeU(P, iat, P.getDistTableAB(myTableID).getTempDists());
     return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
   }
 
   inline void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override
   {
     for (int k = 0; k < ratios.size(); ++k)
-      ratios[k] = std::exp(Vat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTable(myTableID).getDistRow(k)));
+      ratios[k] = std::exp(Vat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTableAB(myTableID).getDistRow(k)));
   }
 
   void evaluateDerivatives(ParticleSet& P,
@@ -286,7 +286,7 @@ struct J1Spin : public WaveFunctionComponent
     }
     if (recalculate)
     {
-      const auto& d_table = P.getDistTable(myTableID);
+      const auto& d_table = P.getDistTableAB(myTableID);
       dLogPsi             = 0.0;
       for (int p = 0; p < NumVars; ++p)
         gradLogPsi[p] = 0.0;
@@ -384,7 +384,7 @@ struct J1Spin : public WaveFunctionComponent
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
-    const auto& dist = P.getDistTable(myTableID).getTempDists();
+    const auto& dist = P.getDistTableAB(myTableID).getTempDists();
     curAt            = valT(0);
     if (NumGroups > 0)
     {
@@ -505,8 +505,8 @@ struct J1Spin : public WaveFunctionComponent
   {
     UpdateMode = ORB_PBYP_PARTIAL;
 
-    computeU3(P, iat, P.getDistTable(myTableID).getTempDists());
-    curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).getTempDispls(), curGrad);
+    computeU3(P, iat, P.getDistTableAB(myTableID).getTempDists());
+    curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTableAB(myTableID).getTempDispls(), curGrad);
     curAt  = simd::accumulate_n(U.data(), Nions, valT());
     grad_iat += curGrad;
     return std::exp(static_cast<PsiValueType>(Vat[iat] - curAt));
@@ -520,8 +520,8 @@ struct J1Spin : public WaveFunctionComponent
   {
     if (UpdateMode == ORB_PBYP_RATIO)
     {
-      computeU3(P, iat, P.getDistTable(myTableID).getTempDists());
-      curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTable(myTableID).getTempDispls(), curGrad);
+      computeU3(P, iat, P.getDistTableAB(myTableID).getTempDists());
+      curLap = accumulateGL(dU.data(), d2U.data(), P.getDistTableAB(myTableID).getTempDispls(), curGrad);
     }
 
     log_value_ += Vat[iat] - curAt;
@@ -681,7 +681,7 @@ struct J1Spin : public WaveFunctionComponent
   inline GradType evalGradSource(ParticleSet& P, ParticleSet& source, int isrc) override
   {
     GradType g_return(0.0);
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       const auto& dist  = d_ie.getDistRow(iat);
@@ -706,7 +706,7 @@ struct J1Spin : public WaveFunctionComponent
                                  TinyVector<ParticleSet::ParticleLaplacian_t, OHMMS_DIM>& lapl_grad) override
   {
     GradType g_return(0.0);
-    const DistanceTableData& d_ie(P.getDistTable(myTableID));
+    const auto& d_ie(P.getDistTableAB(myTableID));
     for (int iat = 0; iat < Nelec; ++iat)
     {
       const auto& dist  = d_ie.getDistRow(iat);

--- a/src/QMCWaveFunctions/Jastrow/J1Spin.h
+++ b/src/QMCWaveFunctions/Jastrow/J1Spin.h
@@ -15,7 +15,7 @@
 #ifndef QMCPLUSPLUS_ONEBODYSPINJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_ONEBODYSPINJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "Utilities/qmc_common.h"
@@ -40,8 +40,8 @@ struct J1Spin : public WaveFunctionComponent
   ///element position type
   using posT = TinyVector<valT, OHMMS_DIM>;
   ///use the same container
-  using DistRow  = DistanceTableData::DistRow;
-  using DisplRow = DistanceTableData::DisplRow;
+  using DistRow  = DistanceTable::DistRow;
+  using DisplRow = DistanceTable::DisplRow;
   ///table index
   const int myTableID;
   ///number of ions

--- a/src/QMCWaveFunctions/Jastrow/J1Spin.h
+++ b/src/QMCWaveFunctions/Jastrow/J1Spin.h
@@ -236,7 +236,8 @@ struct J1Spin : public WaveFunctionComponent
   inline void evaluateRatios(const VirtualParticleSet& VP, std::vector<ValueType>& ratios) override
   {
     for (int k = 0; k < ratios.size(); ++k)
-      ratios[k] = std::exp(Vat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTableAB(myTableID).getDistRow(k)));
+      ratios[k] =
+          std::exp(Vat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTableAB(myTableID).getDistRow(k)));
   }
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
@@ -21,7 +21,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h"
 #endif
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "LongRange/StructFact.h"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "J2KECorrection.h"
@@ -40,7 +40,7 @@ struct J2OMPTargetMultiWalkerMem;
  * for spins up-up/down-down and up-down/down-up.
  *
  * Based on J2OMPTarget.h with these considerations
- * - DistanceTableData using SoA containers
+ * - DistanceTable using SoA containers
  * - support mixed precision: FT::real_type != OHMMS_PRECISION
  * - loops over the groups: elminated PairID
  * - support simd function
@@ -58,8 +58,8 @@ public:
   ///element position type
   using posT = TinyVector<valT, DIM>;
   ///use the same container
-  using DistRow  = DistanceTableData::DistRow;
-  using DisplRow = DistanceTableData::DisplRow;
+  using DistRow  = DistanceTable::DistRow;
+  using DisplRow = DistanceTable::DisplRow;
 
 private:
   /** initialize storage Uat,dUat, d2Uat */

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -21,7 +21,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Jastrow/DiffTwoBodyJastrowOrbital.h"
 #endif
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "LongRange/StructFact.h"
 #include "CPU/SIMD/aligned_allocator.hpp"
 #include "J2KECorrection.h"
@@ -36,7 +36,7 @@ namespace qmcplusplus
  * for spins up-up/down-down and up-down/down-up.
  *
  * Based on J2OrbitalSoA.h with these considerations
- * - DistanceTableData using SoA containers
+ * - DistanceTable using SoA containers
  * - support mixed precision: FT::real_type != OHMMS_PRECISION
  * - loops over the groups: elminated PairID
  * - support simd function
@@ -54,8 +54,8 @@ public:
   ///element position type
   using posT = TinyVector<valT, OHMMS_DIM>;
   ///use the same container
-  using DistRow         = DistanceTableData::DistRow;
-  using DisplRow        = DistanceTableData::DisplRow;
+  using DistRow         = DistanceTable::DistRow;
+  using DisplRow        = DistanceTable::DisplRow;
   using gContainer_type = VectorSoaContainer<valT, OHMMS_DIM>;
 
 protected:

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -430,7 +430,7 @@ public:
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
     const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
-    const auto& eI_dists              = eI_table.getDistances();
+    const auto& eI_dists = eI_table.getDistances();
     const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
 
     for (int jg = 0; jg < eGroups; ++jg)
@@ -885,9 +885,9 @@ public:
       constexpr valT ctwo(2);
       constexpr valT lapfac = OHMMS_DIM - cone;
 
-      const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
-      const auto& ee_dists              = ee_table.getDistances();
-      const auto& ee_displs             = ee_table.getDisplacements();
+      const auto& ee_table  = P.getDistTableAA(ee_Table_ID_);
+      const auto& ee_dists  = ee_table.getDistances();
+      const auto& ee_displs = ee_table.getDisplacements();
 
       build_compact_list(P);
 

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -378,8 +378,8 @@ public:
 
   void build_compact_list(const ParticleSet& P)
   {
-    const auto& eI_dists  = P.getDistTable(ei_Table_ID_).getDistances();
-    const auto& eI_displs = P.getDistTable(ei_Table_ID_).getDisplacements();
+    const auto& eI_dists  = P.getDistTableAB(ei_Table_ID_).getDistances();
+    const auto& eI_displs = P.getDistTableAB(ei_Table_ID_).getDisplacements();
 
     for (int iat = 0; iat < Nion; ++iat)
       for (int jg = 0; jg < eGroups; ++jg)
@@ -411,8 +411,8 @@ public:
   {
     UpdateMode = ORB_PBYP_RATIO;
 
-    const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
-    const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+    const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
+    const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
     cur_Uat = computeU(P, iat, P.GroupID[iat], eI_table.getTempDists(), ee_table.getTempDists(), ions_nearby_new);
     DiffVal = Uat[iat] - cur_Uat;
     return std::exp(static_cast<PsiValueType>(DiffVal));
@@ -423,15 +423,15 @@ public:
     for (int k = 0; k < ratios.size(); ++k)
       ratios[k] = std::exp(Uat[VP.refPtcl] -
                            computeU(VP.refPS, VP.refPtcl, VP.refPS.GroupID[VP.refPtcl],
-                                    VP.getDistTable(ei_Table_ID_).getDistRow(k),
-                                    VP.getDistTable(ee_Table_ID_).getDistRow(k), ions_nearby_old));
+                                    VP.getDistTableAB(ei_Table_ID_).getDistRow(k),
+                                    VP.getDistTableAB(ee_Table_ID_).getDistRow(k), ions_nearby_old));
   }
 
   void evaluateRatiosAlltoOne(ParticleSet& P, std::vector<ValueType>& ratios) override
   {
-    const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
+    const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
     const auto& eI_dists              = eI_table.getDistances();
-    const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+    const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
 
     for (int jg = 0; jg < eGroups; ++jg)
     {
@@ -462,8 +462,8 @@ public:
   {
     UpdateMode = ORB_PBYP_PARTIAL;
 
-    const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
-    const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+    const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
+    const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
     computeU3(P, iat, eI_table.getTempDists(), eI_table.getTempDispls(), ee_table.getTempDists(),
               ee_table.getTempDispls(), cur_Uat, cur_dUat, cur_d2Uat, newUk, newdUk, newd2Uk, ions_nearby_new);
     DiffVal = Uat[iat] - cur_Uat;
@@ -475,8 +475,8 @@ public:
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false) override
   {
-    const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
-    const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+    const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
+    const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
     // get the old value, grad, lapl
     computeU3(P, iat, eI_table.getDistRow(iat), eI_table.getDisplRow(iat), ee_table.getOldDists(),
               ee_table.getOldDispls(), Uat[iat], dUat_temp, d2Uat[iat], oldUk, olddUk, oldd2Uk, ions_nearby_old);
@@ -565,8 +565,8 @@ public:
 
   inline void recompute(const ParticleSet& P) override
   {
-    const DistanceTableData& eI_table = P.getDistTable(ei_Table_ID_);
-    const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+    const auto& eI_table = P.getDistTableAB(ei_Table_ID_);
+    const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
 
     build_compact_list(P);
 
@@ -885,7 +885,7 @@ public:
       constexpr valT ctwo(2);
       constexpr valT lapfac = OHMMS_DIM - cone;
 
-      const DistanceTableData& ee_table = P.getDistTable(ee_Table_ID_);
+      const auto& ee_table = P.getDistTableAA(ee_Table_ID_);
       const auto& ee_dists              = ee_table.getDistances();
       const auto& ee_displs             = ee_table.getDisplacements();
 

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -16,7 +16,7 @@
 #if !defined(QMC_BUILD_SANDBOX_ONLY)
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #endif
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "CPU/SIMD/aligned_allocator.hpp"
 #include "CPU/SIMD/algorithm.hpp"
 #include <map>
@@ -40,8 +40,8 @@ class JeeIOrbitalSoA : public WaveFunctionComponent
   ///element position type
   using posT = TinyVector<valT, OHMMS_DIM>;
   ///use the same container
-  using DistRow  = DistanceTableData::DistRow;
-  using DisplRow = DistanceTableData::DisplRow;
+  using DistRow  = DistanceTable::DistRow;
+  using DisplRow = DistanceTable::DisplRow;
   ///table index for el-el
   const int ee_Table_ID_;
   ///table index for i-el

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
@@ -206,7 +206,7 @@ public:
     // for (int i=0; i<centers.getTotalNum(); i++)
     // 	for (int dim=0; dim<OHMMS_DIM; dim++)
     // 	  C_host[OHMMS_DIM*i+dim] = centers.R[i][dim];
-    C               = C_host;
+    C = C_host;
   }
 };
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowOrbitalBspline.h
@@ -16,7 +16,7 @@
 #ifndef ONE_BODY_JASTROW_ORBITAL_BSPLINE_H
 #define ONE_BODY_JASTROW_ORBITAL_BSPLINE_H
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCWaveFunctions/Jastrow/J1OrbitalSoA.h"
 #include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "QMCWaveFunctions/Jastrow/CudaSpline.h"

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowOrbitalBspline.h
@@ -16,7 +16,7 @@
 #ifndef TWO_BODY_JASTROW_ORBITAL_BSPLINE_H
 #define TWO_BODY_JASTROW_ORBITAL_BSPLINE_H
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCWaveFunctions/Jastrow/J2OrbitalSoA.h"
 #include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "Configuration.h"

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -14,7 +14,7 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "eeI_JastrowBuilder.h"
 #include "QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h"
 #include "Utilities/ProgressReportEngine.h"

--- a/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaCuspCorrection.cpp
@@ -37,7 +37,7 @@ inline void SoaCuspCorrection::evaluateVGL(const ParticleSet& P, int iat, VGLVec
 {
   myVGL = 0.0;
 
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
   for (int c = 0; c < NumCenters; c++)
@@ -78,7 +78,7 @@ void SoaCuspCorrection::evaluate_vgl(const ParticleSet& P,
 {
   myVGL = 0.0;
 
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
   for (int c = 0; c < NumCenters; c++)
@@ -113,7 +113,7 @@ void SoaCuspCorrection::evaluate_vgl(const ParticleSet& P,
 {
   myVGL = 0.0;
 
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
   for (int c = 0; c < NumCenters; c++)
@@ -145,7 +145,7 @@ void SoaCuspCorrection::evaluateV(const ParticleSet& P, int iat, ValueType* rest
 
   std::fill_n(tmp_vals, myVGL.size(), 0.0);
 
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
 
   //THIS IS SERIAL, only way to avoid this is to use myVGL

--- a/src/QMCWaveFunctions/LCAO/SoaCuspCorrectionBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaCuspCorrectionBasisSet.h
@@ -19,7 +19,7 @@
 
 #include "Configuration.h"
 #include "QMCWaveFunctions/BasisSetBase.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "MultiQuinticSpline1D.h"
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
@@ -104,7 +104,7 @@ void SoaLocalizedBasisSet<COT, ORBT>::evaluateVGL(const ParticleSet& P, int iat,
 {
   const auto& IonID(ions_.GroupID);
   const auto& coordR  = P.activeR(iat);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
 
@@ -122,7 +122,7 @@ template<class COT, typename ORBT>
 void SoaLocalizedBasisSet<COT, ORBT>::evaluateVGH(const ParticleSet& P, int iat, vgh_type& vgh)
 {
   const auto& IonID(ions_.GroupID);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
   for (int c = 0; c < NumCenters; c++)
@@ -137,7 +137,7 @@ void SoaLocalizedBasisSet<COT, ORBT>::evaluateVGHGH(const ParticleSet& P, int ia
   // APP_ABORT("SoaLocalizedBasisSet::evaluateVGH() not implemented\n");
 
   const auto& IonID(ions_.GroupID);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
   for (int c = 0; c < NumCenters; c++)
@@ -151,7 +151,7 @@ void SoaLocalizedBasisSet<COT, ORBT>::evaluateV(const ParticleSet& P, int iat, O
 {
   const auto& IonID(ions_.GroupID);
   const auto& coordR  = P.activeR(iat);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
 
@@ -185,7 +185,7 @@ void SoaLocalizedBasisSet<COT, ORBT>::evaluateGradSourceV(const ParticleSet& P,
   }
 
   const auto& IonID(ions_.GroupID);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
 
@@ -257,7 +257,7 @@ void SoaLocalizedBasisSet<COT, ORBT>::evaluateGradSourceVGL(const ParticleSet& P
   // Since jion is indexed on the source ions not the ions_ the distinction between
   // ions_ and ions is extremely important.
   const auto& IonID(ions.GroupID);
-  const auto& d_table = P.getDistTable(myTableIndex);
+  const auto& d_table = P.getDistTableAB(myTableIndex);
   const auto& dist    = (P.activePtcl == iat) ? d_table.getTempDists() : d_table.getDistRow(iat);
   const auto& displ   = (P.activePtcl == iat) ? d_table.getTempDispls() : d_table.getDisplRow(iat);
 

--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
@@ -12,7 +12,7 @@
 
 #include <memory>
 #include "SoaLocalizedBasisSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "SoaAtomicBasisSet.h"
 #include "MultiQuinticSpline1D.h"
 #include "MultiFunctorAdapter.h"

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.cpp
@@ -61,7 +61,7 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(const P
                                                                          ParticleSet::ParticleGradient_t& G,
                                                                          ParticleSet::ParticleLaplacian_t& L)
 {
-  const auto& d_table = P.getDistTable(myTableID);
+  const auto& d_table = P.getDistTableAB(myTableID);
   int icent           = 0;
   log_value_            = 0.0;
   RealType dist       = 0.0;
@@ -92,7 +92,7 @@ LatticeGaussianProduct::LogValueType LatticeGaussianProduct::evaluateLog(const P
  */
 PsiValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
 {
-  const auto& d_table = P.getDistTable(myTableID);
+  const auto& d_table = P.getDistTableAB(myTableID);
   int icent           = ParticleCenter[iat];
   if (icent == -1)
     return 1.0;
@@ -104,7 +104,7 @@ PsiValueType LatticeGaussianProduct::ratio(ParticleSet& P, int iat)
 
 GradType LatticeGaussianProduct::evalGrad(ParticleSet& P, int iat)
 {
-  const auto& d_table = P.getDistTable(myTableID);
+  const auto& d_table = P.getDistTableAB(myTableID);
   int icent           = ParticleCenter[iat];
   if (icent == -1)
     return GradType();
@@ -117,7 +117,7 @@ GradType LatticeGaussianProduct::evalGrad(ParticleSet& P, int iat)
 
 PsiValueType LatticeGaussianProduct::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)
 {
-  const auto& d_table = P.getDistTable(myTableID);
+  const auto& d_table = P.getDistTableAB(myTableID);
   int icent           = ParticleCenter[iat];
   if (icent == -1)
     return 1.0;
@@ -143,7 +143,7 @@ void LatticeGaussianProduct::evaluateLogAndStore(const ParticleSet& P,
                                                  ParticleSet::ParticleGradient_t& dG,
                                                  ParticleSet::ParticleLaplacian_t& dL)
 {
-  const auto& d_table = P.getDistTable(myTableID);
+  const auto& d_table = P.getDistTableAB(myTableID);
   RealType dist       = 0.0;
   PosType disp        = 0.0;
   int icent           = 0;

--- a/src/QMCWaveFunctions/LatticeGaussianProduct.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProduct.h
@@ -18,7 +18,7 @@
 #ifndef QMCPLUSPLUS_LATTICE_GAUSSIAN_PRODUCT
 #define QMCPLUSPLUS_LATTICE_GAUSSIAN_PRODUCT
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/MuffinTin.cpp
+++ b/src/QMCWaveFunctions/MuffinTin.cpp
@@ -18,7 +18,7 @@
 #include "einspline/nubspline.h"
 #include "einspline/multi_nubspline.h"
 #include "Numerics/DeterminantOperators.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "MuffinTin.h"
 #include "CPU/math.hpp"
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -23,7 +23,6 @@
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/VirtualParticleSet.h"
-#include "Particle/DistanceTable.h"
 #include "OhmmsData/RecordProperty.h"
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
 #include "Particle/MCWalkerConfiguration.h"
@@ -439,11 +438,15 @@ public:
 
   /** acquire a shared resource from a collection
    */
-  virtual void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const {}
+  virtual void acquireResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
+  {}
 
   /** return a shared resource to a collection
    */
-  virtual void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const {}
+  virtual void releaseResource(ResourceCollection& collection,
+                               const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
+  {}
 
   /** make clone
    * @param tqp target Quantum ParticleSet

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -23,7 +23,7 @@
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/VirtualParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "OhmmsData/RecordProperty.h"
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
 #include "Particle/MCWalkerConfiguration.h"

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -16,7 +16,7 @@
 #include "Message/Communicate.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -508,10 +508,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   vp.createResource(vp_res);
   ResourceCollectionTeamLock<VirtualParticleSet> mw_vp_lock(vp_res, vp_list);
 
-  const auto& ei_table1 = elec_.getDistTable(ei_table_index);
+  const auto& ei_table1 = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
   NLPPJob<RealType> job1(1, 0, elec_.R[0], ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
-  const auto& ei_table2 = elec_clone.getDistTable(ei_table_index);
+  const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
   NLPPJob<RealType> job2(3, 1, elec_clone.R[1], ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
 

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -14,6 +14,7 @@
 
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
+#include "DistanceTable.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"

--- a/src/Sandbox/diff_distancetables.cpp
+++ b/src/Sandbox/diff_distancetables.cpp
@@ -15,7 +15,7 @@
  */
 #include <Configuration.h>
 #include "Particle/ParticleSet.h"
-#include "Particle/DistanceTableData.h"
+#include "Particle/DistanceTable.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
 #include "random.hpp"
 #include "mpi/collectives.h"

--- a/src/Sandbox/diff_distancetables.cpp
+++ b/src/Sandbox/diff_distancetables.cpp
@@ -119,8 +119,8 @@ int main(int argc, char** argv)
   //copy of ParticleSet for validations
   ParticleSet::ParticlePos_t Rcopy(els.R);
 
-  const auto& d_ee = els.getDistTable(els.addTable(els));
-  const auto& d_ie = els.getDistTable(els.addTable(ions));
+  const auto& d_ee = els.getDistTableAA(els.addTable(els));
+  const auto& d_ie = els.getDistTableAB(els.addTable(ions));
 
   RealType Rsim = els.Lattice.WignerSeitzRadius;
 


### PR DESCRIPTION
## Proposed changes
DistanceTableData is spited in this PR.
All the control APIs are moved into DistanceTable for being managed by ParticleSet.
DistanceTableAA and DistanceTableAB are derived from DistanceTable.
Data and access APIs are implemented in DistanceTableAA/AB. Access control can be AA/AB type specific.
All the DistanceTable consumers know the actual AA/AB type. 

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted