### PR TITLE
Refactor memory locality handling out of estimators copy constructors

### DIFF
--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -21,7 +21,7 @@ EstimatorManagerCrowd::EstimatorManagerCrowd(EstimatorManagerNew& em)
   for (const auto& est : em.Estimators)
     scalar_estimators_.emplace_back(est->clone());
   for (const auto& upeb : em.operator_ests_)
-    operator_ests_.emplace_back(upeb->clone());
+    operator_ests_.emplace_back(upeb->spawnCrowdClone());
 }
 
 void EstimatorManagerCrowd::accumulate(const RefVector<MCPWalker>& walkers,

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -254,7 +254,7 @@ void EstimatorManagerNew::reduceOperatorEstimators()
     RefVector<OperatorEstBase> ref_op_ests = convertUPtrToRefVector(operator_ests_);
     for (int iop = 0; iop < operator_data_sizes.size(); ++iop)
     {
-      operator_data_sizes[iop] = operator_ests_[iop]->get_data()->size();
+      operator_data_sizes[iop] = operator_ests_[iop]->get_data().size();
     }
     // 1 larger because we put the weight in to avoid dependence of the Scalar estimators being reduced firt.
     size_t nops = *(std::max_element(operator_data_sizes.begin(), operator_data_sizes.end())) + 1;
@@ -265,7 +265,7 @@ void EstimatorManagerNew::reduceOperatorEstimators()
     for (int iop = 0; iop < operator_ests_.size(); ++iop)
     {
       auto& estimator      = *operator_ests_[iop];
-      auto& data           = estimator.get_data_ref();
+      auto& data           = estimator.get_data();
       size_t adjusted_size = data.size() + 1;
       operator_send_buffer.resize(adjusted_size, 0.0);
       operator_recv_buffer.resize(adjusted_size, 0.0);

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -77,13 +77,15 @@ public:
 
   //MomentumDistribution(const MomentumDistribution& md);
 
+  MomentumDistribution(const MomentumDistribution& md, DataLocality dl);
+  
   /** This allows us to allocate the necessary data for the DataLocality::queue 
    */
   void startBlock(int steps) override;
 
   /** standard interface
    */
-  std::unique_ptr<OperatorEstBase> clone() const override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** accumulate 1 or more walkers of MomentumDistribution samples
    */

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -5,6 +5,7 @@
 // Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File refactored from: MomentumEstimator.h
 //////////////////////////////////////////////////////////////////////////////////////
@@ -22,6 +23,10 @@
 
 namespace qmcplusplus
 {
+namespace testing
+{
+class MomentumDistributionTests;
+}
 /** Class that collects momentum distribution of electrons
  *  
  */
@@ -67,6 +72,7 @@ public:
   ///nofK
   aligned_vector<RealType> nofK;
 
+public:
   /** Constructor for MomentumDistributionInput 
    */
   MomentumDistribution(MomentumDistributionInput&& mdi,
@@ -75,10 +81,12 @@ public:
                        const LatticeType& lattice,
                        DataLocality dl = DataLocality::crowd);
 
-  //MomentumDistribution(const MomentumDistribution& md);
-
+  /** Constructor used when spawing crowd clones
+   *  needs to be public so std::make_unique can call it.
+   *  Do not use directly unless you've really thought it through.
+   */
   MomentumDistribution(const MomentumDistribution& md, DataLocality dl);
-  
+
   /** This allows us to allocate the necessary data for the DataLocality::queue 
    */
   void startBlock(int steps) override;
@@ -117,6 +125,10 @@ public:
    */
   void registerOperatorEstimator(hid_t gid) override;
 
+private:
+  MomentumDistribution(const MomentumDistribution& md) = default;
+
+  friend class testing::MomentumDistributionTests;
 };
 
 } // namespace qmcplusplus

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -31,16 +31,14 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
                                                const Lattice& lattice,
                                                const SpeciesSet& species,
                                                const WaveFunctionFactory& wf_factory,
-                                               ParticleSet& pset_target,
-                                               const DataLocality dl)
-    : OperatorEstBase(dl),
+                                               ParticleSet& pset_target)
+    : OperatorEstBase(DataLocality::crowd),
       input_(obdmi),
       lattice_(lattice),
       species_(species),
-      wf_factory_(wf_factory),
-      very_temp_pset_(pset_target),
       timers_("OneBodyDensityMatrix")
 {
+  my_name_ = "OneBodyDensityMatrices";
   lattice_.reset();
   if (input_.get_center_defined())
     center_ = input_.get_center();
@@ -146,25 +144,36 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
   // with respect to what?
   if (!input_.get_normalized())
   {
-    normalize(pset_target);
+    normalizeBasis(pset_target);
   }
 
-  data_ = createLocalData(calcFullDataSize(basis_size_, species_.size()), data_locality_);
+  data_.resize(calcFullDataSize(basis_size_, species_.size()), 0.0);
 }
 
-OneBodyDensityMatrices::OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm)
-    : OneBodyDensityMatrices(OneBodyDensityMatricesInput(obdm.input_),
-                             obdm.lattice_,
-                             obdm.species_,
-                             obdm.wf_factory_,
-                             obdm.very_temp_pset_)
-{}
+OneBodyDensityMatrices::OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm, DataLocality dl)
+    : OneBodyDensityMatrices(obdm)
+{
+  data_locality_ = dl;
+}
 
 OneBodyDensityMatrices::~OneBodyDensityMatrices() {}
 
-std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::clone() const
+std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::spawnCrowdClone() const
 {
-  return std::make_unique<OneBodyDensityMatrices>(*this);
+  std::size_t data_size    = data_.size();
+  auto spawn_data_locality = data_locality_;
+
+  if (data_locality_ == DataLocality::rank)
+  {
+    // This is just a stub until a memory saving optimization is deemed necessary
+    spawn_data_locality = DataLocality::queue;
+    data_size           = 0;
+    throw std::runtime_error("There is no memory savings implementation for OneBodyDensityMatrices");
+  }
+
+  auto spawn = std::make_unique<OneBodyDensityMatrices>(*this, spawn_data_locality);
+  spawn->get_data().resize(data_size, 0.0);
+  return spawn;
 }
 
 size_t OneBodyDensityMatrices::calcFullDataSize(const size_t basis_size, const int nspecies)
@@ -390,6 +399,7 @@ void OneBodyDensityMatrices::implAccumulate(const RefVector<MCPWalker>& walkers,
 {
   for (int iw = 0; iw < walkers.size(); ++iw)
   {
+    walkers_weight_ += walkers[iw].get().Weight;
     evaluateMatrix(psets[iw], wfns[iw], walkers[iw], rng);
   }
 }
@@ -438,10 +448,10 @@ void OneBodyDensityMatrices::evaluateMatrix(ParticleSet& pset_target,
       for (int n = 0; n < basis_size_sq; ++n)
       {
         Value val = NDM(n);
-        (*data_)[ij] += real(val);
+        data_[ij] += real(val);
         ij++;
 #if defined(QMC_COMPLEX)
-        (*data_)[ij] += imag(val);
+        data_[ij] += imag(val);
         ij++;
 #endif
       }
@@ -544,7 +554,7 @@ void OneBodyDensityMatrices::warmupSampling(ParticleSet& pset_target, RAN_GEN& r
   }
 }
 
-inline void OneBodyDensityMatrices::normalize(ParticleSet& pset_target)
+inline void OneBodyDensityMatrices::normalizeBasis(ParticleSet& pset_target)
 {
   int ngrid = std::max(200, input_.get_points());
   int ngtot = pow(ngrid, OHMMS_DIM);
@@ -579,6 +589,26 @@ inline void OneBodyDensityMatrices::normalize(ParticleSet& pset_target)
     basis_norms_[i] = 1.0 / std::sqrt(real(bnorms[i]));
 }
 
+void OneBodyDensityMatrices::registerOperatorEstimator(hid_t gid)
+{
+  hid_t sgid = H5Gcreate(gid, my_name_.c_str(), 0);
+  std::vector<int> my_indexes(2, basis_size_);
+  if constexpr (IsComplex_t<Value>::value)
+  {
+    my_indexes.push_back(2);
+  }
+  int nentries = std::accumulate(my_indexes.begin(), my_indexes.end(), 1);
+
+  std::string nname = "number_matrix";
+  hid_t ngid        = H5Gcreate(sgid, nname.c_str(), 0);
+  for (int s = 0; s < species_.size(); ++s)
+  {
+    h5desc_.emplace_back(std::make_unique<ObservableHelper>(species_.speciesName[s]));
+    auto& oh = h5desc_.back();
+    oh->set_dimensions(my_indexes, 0);
+    oh->open(ngid);
+  }
+}
 
 template void OneBodyDensityMatrices::generateSamples<RandomGenerator_t>(Real weight,
                                                                          ParticleSet& pset_target,

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -156,8 +156,6 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(const OneBodyDensityMatrices& obd
   data_locality_ = dl;
 }
 
-OneBodyDensityMatrices::~OneBodyDensityMatrices() {}
-
 std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -146,7 +146,7 @@ private:
 
 public:
   /** Standard Constructor
-   *  If you are making a new OBDM this is what you should be calling
+   *  Call this to make a new OBDM this is what you should be calling
    */
   OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                          const Lattice& lattice,
@@ -154,15 +154,11 @@ public:
                          const WaveFunctionFactory& wf_factory,
                          ParticleSet& pset_target);
 
-  /** Default copy constructor.
-   *  Instances of this estimator is assume to be thread scope, i.e. never
-   *  called by more than one thread at a time. note the OperatorEstBase copy constructor does
-   *  not copy or even allocate data_
+  /** Constructor used when spawing crowd clones
+   *  needs to be public so std::make_unique can call it.
+   *  Do not use directly unless you've really thought it through.
    */
-  OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm) = default;
   OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm, DataLocality dl);
-
-  ~OneBodyDensityMatrices() override;
 
   std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
@@ -182,6 +178,13 @@ public:
   void registerOperatorEstimator(hid_t gid) override;
 
 private:
+  /** Default copy constructor.
+   *  Instances of this estimator is assume to be thread scope, i.e. never
+   *  called by more than one thread at a time. note the OperatorEstBase copy constructor does
+   *  not copy or even allocate data_
+   */
+  OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm) = default;
+
   /** Unfortunate design RandomGenerator_t type aliasing and
    *  virtual inheritance requires this for testing.
    */

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -67,14 +67,6 @@ private:
   OneBodyDensityMatricesInput input_;
   Lattice lattice_;
   SpeciesSet species_;
-  /** WaveFunctionFactory reference to allow delegation of the copy constructor
-   *  \todo remove after copy constructor that directly shares or copys basis_set_ is done
-   */
-  const WaveFunctionFactory& wf_factory_;
-  /** target particleset  reference to allow delegation of the copy constructor
-   *  \todo remove after copy constructor that directly shares or copys basis_set_ is done
-   */
-  ParticleSet& very_temp_pset_;
 
   /** @ingroup Derived simulation parameters determined by computation based in input
    *  @{
@@ -160,18 +152,19 @@ public:
                          const Lattice& lattice,
                          const SpeciesSet& species,
                          const WaveFunctionFactory& wf_factory,
-                         ParticleSet& pset_target,
-                         const DataLocality dl = DataLocality::crowd);
+                         ParticleSet& pset_target);
 
-  /** copy constructor delegates to standard constructor
-   *  This results in a copy construct and move of OneBodyDensityMatricesInput
-   *  But for the OBDM itself its as if it went through the standard construction.
-   *  This will be replaced within a few PR's by an optimized copy constructor.
+  /** Default copy constructor.
+   *  Instances of this estimator is assume to be thread scope, i.e. never
+   *  called by more than one thread at a time. note the OperatorEstBase copy constructor does
+   *  not copy or even allocate data_
    */
-  OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm);
+  OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm) = default;
+  OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm, DataLocality dl);
+
   ~OneBodyDensityMatrices() override;
 
-  std::unique_ptr<OperatorEstBase> clone() const override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
@@ -186,7 +179,7 @@ public:
    * The default implementation does nothing. The derived classes which compute
    * big data, e.g. density, should overwrite this function.
    */
-  void registerOperatorEstimator(hid_t gid) override {}
+  void registerOperatorEstimator(hid_t gid) override;
 
 private:
   /** Unfortunate design RandomGenerator_t type aliasing and
@@ -200,7 +193,7 @@ private:
 
   size_t calcFullDataSize(size_t basis_size, int num_species);
   //local functions
-  void normalize(ParticleSet& pset_target);
+  void normalizeBasis(ParticleSet& pset_target);
   //  printing
   void report(const std::string& pad = "");
   template<class RNG_GEN>

--- a/src/Estimators/OperatorEstBase.cpp
+++ b/src/Estimators/OperatorEstBase.cpp
@@ -19,23 +19,13 @@ namespace qmcplusplus
 {
 OperatorEstBase::OperatorEstBase(DataLocality dl) : data_locality_(dl), walkers_weight_(0) {}
 
-OperatorEstBase::OperatorEstBase(const OperatorEstBase& oth) : data_locality_(oth.data_locality_), walkers_weight_(0) {}
-
-// I suspect this can be a pure function outside of the class.
-// In this case at least we don't care to copy the data_ as we are going to reduce these later and don't want
-// to end up with a multiplicative factor if we already have data.
-OperatorEstBase::Data OperatorEstBase::createLocalData(size_t size, DataLocality data_locality)
-{
-  Data new_data;
-  new_data = std::make_unique<std::vector<QMCT::RealType>>(size, 0);
-  return new_data;
-}
+  OperatorEstBase::OperatorEstBase(const OperatorEstBase& oth) : data_locality_(oth.data_locality_), my_name_(oth.my_name_), walkers_weight_(0) {}
 
 void OperatorEstBase::collect(const RefVector<OperatorEstBase>& type_erased_operator_estimators)
 {
   for (OperatorEstBase& crowd_oeb : type_erased_operator_estimators)
   {
-    std::transform(data_->begin(), data_->end(), crowd_oeb.get_data()->begin(), data_->begin(), std::plus<>{});
+    std::transform(data_.begin(), data_.end(), crowd_oeb.get_data().begin(), data_.begin(), std::plus<>{});
     walkers_weight_ += crowd_oeb.walkers_weight_;
     crowd_oeb.zero();
   }
@@ -43,8 +33,7 @@ void OperatorEstBase::collect(const RefVector<OperatorEstBase>& type_erased_oper
 
 void OperatorEstBase::normalize(QMCT::RealType invTotWgt)
 {
-  auto& data = *data_;
-  for (QMCT::RealType& elem : data)
+  for (QMCT::RealType& elem : data_)
     elem *= invTotWgt;
 }
 
@@ -56,25 +45,25 @@ void OperatorEstBase::write()
   // collectables in mixed precision were accumulated in float but always written
   // to hdf5 in double.
 #ifdef MIXED_PRECISION
-    std::vector<QMCT::FullPrecRealType> expanded_data(data_->size(), 0.0);
-    std::copy_n(data_->begin(), data_->size(), expanded_data.begin());
-    assert(data_->size() > 0);
+    std::vector<QMCT::FullPrecRealType> expanded_data(data_.size(), 0.0);
+    std::copy_n(data_.begin(), data_.size(), expanded_data.begin());
+    assert(data_.size() > 0);
     // auto total = std::accumulate(data_->begin(), data_->end(), 0.0);
     // std::cout << "data size: " << data_->size() << " : " << total << '\n';
     for (auto& h5d : h5desc_)
       h5d->write(expanded_data.data(), nullptr);
 #else
     for (auto& h5d : h5desc_)
-      h5d->write(data_->data(), nullptr);
+      h5d->write(data_.data(), nullptr);
 #endif
 }
 
 void OperatorEstBase::zero()
 {
   if (data_locality_ == DataLocality::rank || data_locality_ == DataLocality::crowd)
-    std::fill(data_->begin(), data_->end(), 0.0);
+    std::fill(data_.begin(), data_.end(), 0.0);
   else
-    data_->clear();
+    data_.clear();
   walkers_weight_ = 0;
 }
 

--- a/src/Estimators/OperatorEstBase.cpp
+++ b/src/Estimators/OperatorEstBase.cpp
@@ -19,7 +19,9 @@ namespace qmcplusplus
 {
 OperatorEstBase::OperatorEstBase(DataLocality dl) : data_locality_(dl), walkers_weight_(0) {}
 
-  OperatorEstBase::OperatorEstBase(const OperatorEstBase& oth) : data_locality_(oth.data_locality_), my_name_(oth.my_name_), walkers_weight_(0) {}
+OperatorEstBase::OperatorEstBase(const OperatorEstBase& oth)
+    : data_locality_(oth.data_locality_), my_name_(oth.my_name_), walkers_weight_(0)
+{}
 
 void OperatorEstBase::collect(const RefVector<OperatorEstBase>& type_erased_operator_estimators)
 {
@@ -41,20 +43,20 @@ void OperatorEstBase::write()
 {
   if (h5desc_.size() == 0)
     return;
-  // We have to do this to deal with the legacy design that Observables using
-  // collectables in mixed precision were accumulated in float but always written
-  // to hdf5 in double.
+    // We have to do this to deal with the legacy design that Observables using
+    // collectables in mixed precision were accumulated in float but always written
+    // to hdf5 in double.
 #ifdef MIXED_PRECISION
-    std::vector<QMCT::FullPrecRealType> expanded_data(data_.size(), 0.0);
-    std::copy_n(data_.begin(), data_.size(), expanded_data.begin());
-    assert(data_.size() > 0);
-    // auto total = std::accumulate(data_->begin(), data_->end(), 0.0);
-    // std::cout << "data size: " << data_->size() << " : " << total << '\n';
-    for (auto& h5d : h5desc_)
-      h5d->write(expanded_data.data(), nullptr);
+  std::vector<QMCT::FullPrecRealType> expanded_data(data_.size(), 0.0);
+  std::copy_n(data_.begin(), data_.size(), expanded_data.begin());
+  assert(data_.size() > 0);
+  // auto total = std::accumulate(data_->begin(), data_->end(), 0.0);
+  // std::cout << "data size: " << data_->size() << " : " << total << '\n';
+  for (auto& h5d : h5desc_)
+    h5d->write(expanded_data.data(), nullptr);
 #else
-    for (auto& h5d : h5desc_)
-      h5d->write(data_.data(), nullptr);
+  for (auto& h5d : h5desc_)
+    h5d->write(data_.data(), nullptr);
 #endif
 }
 

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -37,16 +37,23 @@ public:
   using QMCT      = QMCTraits;
   using MCPWalker = Walker<QMCTraits, PtclOnLatticeTraits>;
 
-  /** Everything gets packed into RealType for now
-   *  \todo template and use whatever makes sense for the derived estimator this is just asking for bugs
+  using Data = std::vector<QMCT::RealType>;
+    
+  /** locality for accumulation of estimator data.
+   *  This designates the memory scheme used for the estimator
+   *  The default is:
+   *  DataLocality::Crowd, each crowd and the rank level estimator have a full representation of the data
+   *  Memory Savings Schemes:
+   *  One:
+   *  DataLocality::Rank,  This estimator has the full representation of the data but its crowd spawn will have
+   *  One per crowd:
+   *  DataLocality::Queue  This estimator accumulates queue of values to collect to the Rank estimator data
+   *  DataLocality::?      Another way to reduce memory use on thread/crowd local estimators.
    */
-  using Data = UPtr<std::vector<QMCT::RealType>>;
-
-  /// locality for accumulation data. FIXME full documentation of this state machine.
   DataLocality data_locality_;
 
-  ///name of this object
-  std::string myName;
+  ///name of this object -- only used for debugging and h5 output
+  std::string my_name_;
 
   QMCT::FullPrecRealType get_walkers_weight() const { return walkers_weight_; }
   ///constructor
@@ -87,9 +94,7 @@ public:
 
   virtual void startBlock(int steps) = 0;
 
-  std::vector<QMCT::RealType>& get_data_ref() { return *data_; }
-
-  Data& get_data() { return data_; };
+  std::vector<QMCT::RealType>& get_data() { return data_; }
 
   /*** create and tie OperatorEstimator's observable_helper hdf5 wrapper to stat.h5 file
    * @param gid hdf5 group to which the observables belong
@@ -99,7 +104,7 @@ public:
    */
   virtual void registerOperatorEstimator(hid_t gid) {}
 
-  virtual std::unique_ptr<OperatorEstBase> clone() const = 0;
+  virtual std::unique_ptr<OperatorEstBase> spawnCrowdClone() const = 0;
 
   /** Write to previously registered observable_helper hdf5 wrapper.
    *
@@ -130,7 +135,7 @@ protected:
    *  And it make's datalocality fairly easy but
    *  more descriptive and safe data structures would be better
    */
-  static Data createLocalData(size_t size, DataLocality data_locality);
+  Data createLocalData(size_t size);
 
   Data data_;
 };

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -26,7 +26,10 @@
 namespace qmcplusplus
 {
 class TrialWaveFunction;
-
+namespace testing
+{
+class OEBAccessor;
+}
 /** @ingroup Estimators
  * @brief An abstract class for gridded estimators
  *
@@ -38,7 +41,7 @@ public:
   using MCPWalker = Walker<QMCTraits, PtclOnLatticeTraits>;
 
   using Data = std::vector<QMCT::RealType>;
-    
+
   /** locality for accumulation of estimator data.
    *  This designates the memory scheme used for the estimator
    *  The default is:
@@ -58,6 +61,13 @@ public:
   QMCT::FullPrecRealType get_walkers_weight() const { return walkers_weight_; }
   ///constructor
   OperatorEstBase(DataLocality dl);
+  /** Shallow copy constructor!
+   *  This alows us to keep the default copy constructors for derived classes which
+   *  is quite useful to the spawnCrowdClone design.
+   *  Data is likely to be quite large and since the OperatorEstBase design is that the children 
+   *  reduce to the parent it is infact undesirable for them to copy the data the parent has.
+   *  Initialization of Data (i.e. call to resize) if any is the responsibility of the derived class.
+   */
   OperatorEstBase(const OperatorEstBase& oth);
   ///virtual destructor
   virtual ~OperatorEstBase() = default;
@@ -127,17 +137,9 @@ protected:
   // convenient Descriptors hdf5 for Operator Estimators only populated for rank scope OperatorEstimator
   UPtrVector<ObservableHelper> h5desc_;
 
-  /** create the typed data block for the Operator.
-   *
-   *  this is only slightly better than a byte buffer
-   *  it allows easy porting of the legacy implementations
-   *  Which wrote into a shared buffer per walker.
-   *  And it make's datalocality fairly easy but
-   *  more descriptive and safe data structures would be better
-   */
-  Data createLocalData(size_t size);
-
   Data data_;
+
+  friend testing::OEBAccessor;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -23,7 +23,10 @@
 namespace qmcplusplus
 {
 class SpeciesSet;
-
+namespace testing
+{
+class SpinDensityNewTests;
+}
 /** Class that collects density per species of particle
  *
  *  commonly used for spin up and down electrons
@@ -48,17 +51,22 @@ public:
    *  Ideally when validating input is built up enough there would be only one constructor with
    *  signature
    *
-   *      SpinDensityNew(SpinDensityInput&& sdi, SpinDensityInput::DerivedParameters&& dev_par, SpeciesSet species, DataLocality dl);
+   *  SpinDensityNew(SpinDensityInput&& sdi, 
+   *                 SpinDensityInput::DerivedParameters&& dev_par, 
+   *                 SpeciesSet species,
+   *                 DataLocality dl);
    */
   SpinDensityNew(SpinDensityInput&& sdi,
                  const Lattice&,
                  const SpeciesSet& species,
                  const DataLocality dl = DataLocality::crowd);
 
-  SpinDensityNew(const SpinDensityNew& sdn) = default;
+  /** Constructor used when spawing crowd clones
+   *  needs to be public so std::make_unique can call it.
+   *  Do not use directly unless you've really thought it through.
+   */
   SpinDensityNew(const SpinDensityNew& sdn, DataLocality dl);
-                                                               
-  
+
   /** This allows us to allocate the necessary data for the DataLocality::queue 
    */
   void startBlock(int steps) override;
@@ -98,6 +106,8 @@ public:
   void registerOperatorEstimator(hid_t gid) override;
 
 private:
+  SpinDensityNew(const SpinDensityNew& sdn) = default;
+
   static std::vector<int> getSpeciesSize(const SpeciesSet& species);
   /** derived_parameters_ must be valid i.e. initialized with call to input_.calculateDerivedParameters
    */
@@ -123,6 +133,8 @@ private:
   Lattice lattice_;
   SpinDensityInput::DerivedParameters derived_parameters_;
   /**}@*/
+
+  friend class testing::SpinDensityNewTests;
 };
 
 } // namespace qmcplusplus

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -54,15 +54,18 @@ public:
                  const Lattice&,
                  const SpeciesSet& species,
                  const DataLocality dl = DataLocality::crowd);
-  SpinDensityNew(const SpinDensityNew& sdn);
 
+  SpinDensityNew(const SpinDensityNew& sdn) = default;
+  SpinDensityNew(const SpinDensityNew& sdn, DataLocality dl);
+                                                               
+  
   /** This allows us to allocate the necessary data for the DataLocality::queue 
    */
   void startBlock(int steps) override;
 
   /** standard interface
    */
-  std::unique_ptr<OperatorEstBase> clone() const override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** accumulate 1 or more walkers of SpinDensity samples
    */

--- a/src/Estimators/tests/EstimatorManagerNewTest.cpp
+++ b/src/Estimators/tests/EstimatorManagerNewTest.cpp
@@ -69,7 +69,7 @@ void EstimatorManagerNewTest::fakeSomeOperatorEstimatorSamples(int rank)
 {
   em.operator_ests_.emplace_back(new FakeOperatorEstimator(comm_->size(), DataLocality::crowd));
   FakeOperatorEstimator& foe        = dynamic_cast<FakeOperatorEstimator&>(*(em.operator_ests_.back()));
-  std::vector<QMCT::RealType>& data = foe.get_data_ref();
+  std::vector<QMCT::RealType>& data = foe.get_data();
   for (int id = 0; id < data.size(); ++id)
   {
     if (id > rank)

--- a/src/Estimators/tests/EstimatorManagerNewTest.h
+++ b/src/Estimators/tests/EstimatorManagerNewTest.h
@@ -52,7 +52,7 @@ public:
   bool testMakeBlockAverages();
   void testReduceOperatorEstimators();
 
-  std::vector<QMCT::RealType>& get_operator_data() { return em.operator_ests_[0]->get_data_ref(); }
+  std::vector<QMCT::RealType>& get_operator_data() { return em.operator_ests_[0]->get_data(); }
   
   EstimatorManagerNew em;
 private:

--- a/src/Estimators/tests/EstimatorTesting.cpp
+++ b/src/Estimators/tests/EstimatorTesting.cpp
@@ -48,5 +48,9 @@ SpeciesSet makeSpeciesSet(const SpeciesCases species_case)
   return species_set;
 }
 
+OEBAccessor::OEBAccessor(OperatorEstBase& oeb) : oeb_(oeb) {}
+
+OEBAccessor::value_type& OEBAccessor::operator[](size_t pos) { return oeb_.data_[pos]; }
+
 } // namespace testing
 } // namespace qmcplusplus

--- a/src/Estimators/tests/EstimatorTesting.h
+++ b/src/Estimators/tests/EstimatorTesting.h
@@ -13,6 +13,7 @@
 #define QMCPLUSPLUS_ESTIMATOR_TESTING_H
 
 #include "ParticleSet.h"
+#include "OperatorEstBase.h"
 
 namespace qmcplusplus
 {
@@ -30,9 +31,24 @@ enum class SpeciesCases
   NO_MEMBERSIZE
 };
 
- 
 Lattice makeTestLattice();
 SpeciesSet makeSpeciesSet(const SpeciesCases species_case);
-}
-}
+
+/** break encapsulation of data_ by  OperatorEstBase
+ *  only for testing!
+ */
+class OEBAccessor
+{
+public:
+  // break naming rule to make std::vector which we assume is the type of OperatorEstBase::Data
+  using value_type = OperatorEstBase::Data::value_type;
+  OEBAccessor(OperatorEstBase& oeb);
+  value_type& operator[](size_t pos);
+
+private:
+  OperatorEstBase& oeb_;
+};
+
+} // namespace testing
+} // namespace qmcplusplus
 #endif

--- a/src/Estimators/tests/FakeOperatorEstimator.cpp
+++ b/src/Estimators/tests/FakeOperatorEstimator.cpp
@@ -19,14 +19,13 @@ namespace qmcplusplus
     OperatorEstBase(data_locality)
 {
   data_locality_ = data_locality;
-  data_ = createLocalData(num_ranks * 10, data_locality_);
+  data_.resize(num_ranks * 10);
 }
 
 FakeOperatorEstimator::FakeOperatorEstimator(const FakeOperatorEstimator& foe)
   : OperatorEstBase(foe)
 {
-  size_t data_size = foe.data_->size();
-  data_ = createLocalData(data_size, data_locality_);
+  data_.resize(foe.data_.size());
 }
 
 }

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -39,7 +39,7 @@ public:
 
   void startBlock(int nsteps) override {}
 
-  std::unique_ptr<OperatorEstBase> clone() const override { return std::make_unique<FakeOperatorEstimator>(*this); }
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override { return std::make_unique<FakeOperatorEstimator>(*this); }
 
   void set_walker_weights(QMCT::RealType weight) { walkers_weight_ = weight; }
 };

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -172,9 +172,9 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   md.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
 
   //   Check data
-  std::vector<RealType>& data = md.get_data_ref();
+  std::vector<RealType>& data = md.get_data();
 
-  using Data = MomentumDistribution::Data::element_type;
+  using Data = MomentumDistribution::Data;
   Data ref_data;
 
   ref_data = {3.92261216, -5.752141485, 4.78276286, 8.307662762, -5.130834919, 0.08942598353, 

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -43,7 +43,7 @@ public:
   using Integrators = OneBodyDensityMatricesInput::Integrator;
   using Sampling    = OneBodyDensityMatrices::Sampling;
   using MCPWalker   = OneBodyDensityMatrices::MCPWalker;
-  using Data        = OneBodyDensityMatrices::Data::element_type;
+  using Data        = OneBodyDensityMatrices::Data;
   using Real        = Data::value_type;
 
 
@@ -106,7 +106,7 @@ public:
   {
     obdm.implAccumulate(walkers, psets, twfcs, rng);
     Data data(getAccumulateData());
-    auto& returned_data = *(obdm.data_);
+    auto& returned_data = obdm.data_;
     checkData(data.data(), returned_data.data(), data.size());
   }
 
@@ -120,13 +120,13 @@ public:
   {
     obdm.evaluateMatrix(pset, trial_wavefunction, walker, rng);
     Data data(getEvaluateMatrixData());
-    auto& returned_data = *(obdm.data_);
+    auto& returned_data = obdm.data_;
     checkData(returned_data.data(), data.data(), data.size());
   }
 
   void dumpData(OneBodyDensityMatrices& obdm)
   {
-    std::cout << "Here is what is in your OneBodyDensityMatrices:\n" << NativePrint(*(obdm.data_)) << '\n';
+    std::cout << "Here is what is in your OneBodyDensityMatrices:\n" << NativePrint(obdm.data_) << '\n';
   }
 
 private:
@@ -221,7 +221,7 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
   outputManager.resume();
 }
 
-TEST_CASE("OneBodyDensityMatrices::clone()", "[estimators]")
+TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
 {
   using namespace testing;
   using namespace onebodydensitymatrices;
@@ -249,7 +249,7 @@ TEST_CASE("OneBodyDensityMatrices::clone()", "[estimators]")
   OneBodyDensityMatricesInput obdmi(node);
 
   OneBodyDensityMatrices original(std::move(obdmi), pset_target.Lattice, species_set, wf_factory, pset_target);
-  auto clone = original.clone();
+  auto clone = original.spawnCrowdClone();
   REQUIRE(clone != nullptr);
   REQUIRE(clone.get() != &original);
   REQUIRE(dynamic_cast<decltype(&original)>(clone.get()) != nullptr);

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -30,6 +30,24 @@ namespace qmcplusplus
 
 using QMCT = QMCTraits;
 
+namespace testing
+{
+/** class to preserve access control in MomentumDistribution
+ */
+class SpinDensityNewTests
+{
+public:
+  void testCopyConstructor(const SpinDensityNew& sdn)
+  {
+    SpinDensityNew sdn2(sdn);
+
+    CHECK(sdn.species_size_ == sdn2.species_size_);
+    CHECK(sdn.data_ != sdn2.data_);
+  }
+};
+} // namespace testing
+
+
 void accumulateFromPsets(int ncrowds, SpinDensityNew& sdn, UPtrVector<OperatorEstBase>& crowd_sdns)
 {
   for (int iops = 0; iops < ncrowds; ++iops)
@@ -133,7 +151,13 @@ TEST_CASE("SpinDensityNew::SpinDensityNew(SPInput, Lattice, SpeciesSet)", "[esti
   int iattribute                    = species_set.addAttribute("membersize");
   species_set(iattribute, ispecies) = 2;
   auto lattice                      = testing::makeTestLattice();
-  SpinDensityNew(std::move(sdi), lattice, species_set);
+  SpinDensityNew sdn(std::move(sdi), lattice, species_set);
+  // make sure there is something in obdm's data
+  using namespace testing;
+  OEBAccessor oeba(sdn);
+  oeba[0] = 1.0;
+  SpinDensityNewTests sdnt;
+  sdnt.testCopyConstructor(sdn);
 }
 
 TEST_CASE("SpinDensityNew::spawnCrowdClone()", "[estimators]")

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -41,7 +41,7 @@ void accumulateFromPsets(int ncrowds, SpinDensityNew& sdn, UPtrVector<OperatorEs
 
     std::vector<ParticleSet> psets;
 
-    crowd_sdns.emplace_back(std::make_unique<SpinDensityNew>(sdn));
+    crowd_sdns.emplace_back(sdn.spawnCrowdClone());
     SpinDensityNew& crowd_sdn = dynamic_cast<SpinDensityNew&>(*(crowd_sdns.back()));
 
     for (int iw = 0; iw < nwalkers; ++iw)
@@ -136,7 +136,7 @@ TEST_CASE("SpinDensityNew::SpinDensityNew(SPInput, Lattice, SpeciesSet)", "[esti
   SpinDensityNew(std::move(sdi), lattice, species_set);
 }
 
-TEST_CASE("SpinDensityNew::clone()", "[estimators]")
+TEST_CASE("SpinDensityNew::spawnCrowdClone()", "[estimators]")
 {
   Libxml2Document doc;
   bool okay = doc.parseFromString(testing::valid_spin_density_input_sections[testing::valid_spindensity_input_no_cell]);
@@ -150,7 +150,7 @@ TEST_CASE("SpinDensityNew::clone()", "[estimators]")
   species_set(iattribute, ispecies) = 2;
   auto lattice                      = testing::makeTestLattice();
   SpinDensityNew original(std::move(sdi), lattice, species_set);
-  auto clone = original.clone();
+  auto clone = original.spawnCrowdClone();
   REQUIRE(clone != nullptr);
   REQUIRE(clone.get() != &original);
   REQUIRE(dynamic_cast<decltype(&original)>(clone.get()) != nullptr);
@@ -202,7 +202,7 @@ TEST_CASE("SpinDensityNew::accumulate", "[estimators]")
 
   sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
 
-  std::vector<QMCT::RealType>& data_ref = sdn.get_data_ref();
+  std::vector<QMCT::RealType>& data_ref = sdn.get_data();
   // There should be a check that the discretization of particle locations expressed in lattice coords
   // is correct.  This just checks it hasn't changed from how it was in SpinDensity which lacked testing.
   CHECK(data_ref[555] == 4);
@@ -239,7 +239,7 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::crowd)", "[estimators]")
     RefVector<OperatorEstBase> crowd_oeb_refs = convertUPtrToRefVector(crowd_sdns);
     sdn.collect(crowd_oeb_refs);
 
-    std::vector<QMCT::RealType>& data_ref = sdn.get_data_ref();
+    std::vector<QMCT::RealType>& data_ref = sdn.get_data();
     // There should be a check that the discretization of particle locations expressed in lattice coords
     // is correct.  This just checks it hasn't changed from how it was in SpinDensity which lacked testing.
     CHECK(data_ref[555] == 4 * ncrowds);
@@ -279,7 +279,7 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::rank)", "[estimators]")
     RefVector<OperatorEstBase> crowd_oeb_refs = convertUPtrToRefVector(crowd_sdns);
     sdn.collect(crowd_oeb_refs);
 
-    std::vector<QMCT::RealType>& data_ref = sdn.get_data_ref();
+    std::vector<QMCT::RealType>& data_ref = sdn.get_data();
     // There should be a check that the discretization of particle locations expressed in lattice coords
     // is correct.  This just checks it hasn't changed from how it was in SpinDensity which lacked testing.
     CHECK(data_ref[555] == 4 * ncrowds);
@@ -319,7 +319,7 @@ TEST_CASE("SpinDensityNew algorithm comparison", "[estimators]")
     randomUpdateAccumulate(rng_for_test_rank, crowd_sdns_rank);
   RefVector<OperatorEstBase> crowd_oeb_refs_rank = convertUPtrToRefVector(crowd_sdns_rank);
   sdn_rank.collect(crowd_oeb_refs_rank);
-  std::vector<QMCT::RealType>& data_ref_rank = sdn_rank.get_data_ref();
+  std::vector<QMCT::RealType>& data_ref_rank = sdn_rank.get_data();
 
   SpinDensityNew sdn_crowd(std::move(sdi), species_set, DataLocality::crowd);
   UPtrVector<OperatorEstBase> crowd_sdns_crowd;
@@ -329,7 +329,7 @@ TEST_CASE("SpinDensityNew algorithm comparison", "[estimators]")
     randomUpdateAccumulate(rng_for_test_crowd, crowd_sdns_crowd);
   RefVector<OperatorEstBase> crowd_oeb_refs_crowd = convertUPtrToRefVector(crowd_sdns_crowd);
   sdn_crowd.collect(crowd_oeb_refs_crowd);
-  std::vector<QMCT::RealType>& data_ref_crowd = sdn_crowd.get_data_ref();
+  std::vector<QMCT::RealType>& data_ref_crowd = sdn_crowd.get_data();
 
   for (size_t i = 0; i < data_ref_rank.size(); ++i)
   {

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -281,9 +281,12 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
     // save properties into walker
     for (int iw = 0; iw < walkers.size(); ++iw)
       walker_hamiltonians[iw].saveProperty(walkers[iw].get().getPropertyBase());
+  }
 
-    if(accumulate_this_step)
-      crowd.accumulate(step_context.get_random_gen());
+  if (accumulate_this_step)
+  {
+    ScopedTimer est_timer(timers.estimators_timer);
+    crowd.accumulate(step_context.get_random_gen());
   }
 
   { // T-moves
@@ -339,9 +342,10 @@ void DMCBatched::runDMCStep(int crowd_id,
   const int max_steps  = sft.qmcdrv_input.get_max_steps();
   const IndexType step = sft.step;
   // Are we entering the the last step of a block to recompute at?
-  const bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
+  const bool recompute_this_step  = (sft.is_recomputing_block && (step + 1) == max_steps);
   const bool accumulate_this_step = true;
-  advanceWalkers(sft, crowd, timers, dmc_timers, *context_for_steps[crowd_id], recompute_this_step, accumulate_this_step);
+  advanceWalkers(sft, crowd, timers, dmc_timers, *context_for_steps[crowd_id], recompute_this_step,
+                 accumulate_this_step);
 }
 
 void DMCBatched::process(xmlNodePtr node)

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -285,6 +285,7 @@ protected:
     NewTimer& movepbyp_timer;
     NewTimer& hamiltonian_timer;
     NewTimer& collectables_timer;
+    NewTimer& estimators_timer;
     NewTimer& resource_timer;
     DriverTimers(const std::string& prefix)
         : checkpoint_timer(*timer_manager.createTimer(prefix + "CheckPoint", timer_level_medium)),
@@ -295,6 +296,7 @@ protected:
           movepbyp_timer(*timer_manager.createTimer(prefix + "MovePbyP", timer_level_medium)),
           hamiltonian_timer(*timer_manager.createTimer(prefix + "Hamiltonian", timer_level_medium)),
           collectables_timer(*timer_manager.createTimer(prefix + "Collectables", timer_level_medium)),
+          estimators_timer(*timer_manager.createTimer(prefix + "Estimators", timer_level_medium)),
           resource_timer(*timer_manager.createTimer(prefix + "Resources", timer_level_medium))
     {}
   };

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -204,11 +204,13 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
   };
   for (int iw = 0; iw < crowd.size(); ++iw)
     savePropertiesIntoWalker(walker_hamiltonians[iw], walkers[iw]);
-
-  if(accumulate_this_step)
-    crowd.accumulate(step_context.get_random_gen());
-
   timers.collectables_timer.stop();
+
+  if (accumulate_this_step)
+  {
+    ScopedTimer est_timer(timers.estimators_timer);
+    crowd.accumulate(step_context.get_random_gen());
+  }
   // TODO:
   //  check if all moves failed
 }
@@ -225,7 +227,7 @@ void VMCBatched::runVMCStep(int crowd_id,
 {
   Crowd& crowd = *(crowds[crowd_id]);
   crowd.setRNGForHamiltonian(context_for_steps[crowd_id]->get_random_gen());
-  const int max_steps = sft.qmcdrv_input.get_max_steps();
+  const int max_steps  = sft.qmcdrv_input.get_max_steps();
   const IndexType step = sft.step;
   // Are we entering the the last step of a block to recompute at?
   const bool recompute_this_step = (sft.is_recomputing_block && (step + 1) == max_steps);
@@ -299,8 +301,8 @@ bool VMCBatched::run()
     // Run warm-up steps
     auto runWarmupStep = [](int crowd_id, StateForThread& sft, DriverTimers& timers,
                             UPtrVector<ContextForSteps>& context_for_steps, UPtrVector<Crowd>& crowds) {
-      Crowd& crowd = *(crowds[crowd_id]);
-      const bool recompute = false;
+      Crowd& crowd                    = *(crowds[crowd_id]);
+      const bool recompute            = false;
       const bool accumulate_this_step = false;
       advanceWalkers(sft, crowd, timers, *context_for_steps[crowd_id], recompute, accumulate_this_step);
     };


### PR DESCRIPTION
## Proposed changes

In preparation for integration of OneBodyDensityMatrices this PR cleans up complication of OperatorEstBase derived Estimators copy constructors.  All the non copying logic is moved to the clearly named spawnCrowdClone method. The estimator data is no longer a unique_ptr to vector created on the heap but just a vector. Minor renaming is included.
 
## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
