### PR TITLE
Fix missing Codecov reports

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -84,11 +84,11 @@ jobs:
         run: tests/test_automation/github-actions/ci/run_step.sh test
 
       - name: Coverage
-        if: contains(matrix.jobname, 'coverage')
+        if: contains(matrix.jobname, 'Gcov')
         run: tests/test_automation/github-actions/ci/run_step.sh coverage
 
       - name: Upload Coverage
-        if: contains(matrix.jobname, 'coverage') && github.repository_owner == 'QMCPACK'
+        if: contains(matrix.jobname, 'Gcov') && github.repository_owner == 'QMCPACK'
         uses: codecov/codecov-action@v1
         with:
           file: ../qmcpack-build/coverage.xml


### PR DESCRIPTION
## Proposed changes

Current coverage reports on CI from Gcov are not uploaded to Codecov
This PR patches the if condition to point at the correct job names
Bug introduced by #3598

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
NA

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
