### PR TITLE
Save and restore variational parameters to XML

### DIFF
--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -357,6 +357,14 @@ struct VariableSet
   void setDefaults(bool optimize_all);
 
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
+
+  /// Save variational parameters to an XML file
+  void saveAsXML(const std::string& filename) const;
+
+  /// Read variational parameters from an XML file.
+  /// This assumes the VPs are already set up. It will only set existing named values.
+  /// If the name does not exist in the list, it will be added.
+  bool readFromXML(const std::string& filename);
 };
 } // namespace optimize
 

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -19,6 +19,7 @@
 #include <string>
 
 using std::string;
+using qmcplusplus::ValueApprox;
 
 namespace optimize
 {
@@ -108,6 +109,27 @@ TEST_CASE("VariableSet output", "[optimize]")
   #endif
 
   REQUIRE(o.str() == formatted_output);
+}
+
+TEST_CASE("VariableSet XML output and input", "[optimize]")
+{
+  VariableSet vs;
+  VariableSet::value_type first_val(11234.56789);
+  VariableSet::value_type second_val(0.000256789);
+  VariableSet::value_type third_val(-1.2);
+  vs.insert("s", first_val);
+  vs.insert("second", second_val);
+  vs.insert("really_long_name", third_val);
+  vs.saveAsXML("vp.xml");
+
+  VariableSet vs2;
+  vs2.insert("s", 0.0);
+  vs2.insert("second", 0.0);
+  vs2.readFromXML("vp.xml");
+  CHECK(vs2.find("s")->second == ValueApprox(first_val));
+  CHECK(vs2.find("second")->second == ValueApprox(second_val));
+  // Was not present in vs2, reading from XML will not add it
+  CHECK(vs2.find("really_long_name") == vs2.end());
 }
 
 } // namespace optimize


### PR DESCRIPTION
The first step towards a solution to save and restore all variational parameters (VP) as discussed in #3619

Reading from a VP file is not intended to create the list of variational parameters.  The usage model is that the variational parameters are set up as usual in the code, and then new values for those parameters are read in from the file.

This enables a workflow where some subset of parameters is optimized and then the wavefunction is enlarged (or the optimization of more parameters enabled) and further optimization is performed. Values that are not present in the VP file are not changed. Reading the VP file acts like an overlay of its values on the existing values read in from the wavefunction section.

The the list of values is contained under a "name_value_pairs" tag.  In the future one might want to store values differently, and that could be done under a different tag. For example, coefficients are often stored as Coeff_0, Coeff_1, etc. for a large number of values. It would take less space to store the prefix once and store all the values in an array.

XML is being used to get this capability started.  Eventually it will use HDF.

The XML file looks like this (from the unit test):
```
<?xml version="1.0"?>
<variational_parameters>
  <name_value_pairs>
    <vp>
      <name>s</name>
      <value>11234.6</value>
    </vp>
    <vp>
      <name>second</name>
      <value>0.000256789</value>
    </vp>
    <vp>
      <name>really_long_name</name>
      <value>-1.2</value>
    </vp>
  </name_value_pairs>
</variational_parameters>
```


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
