### PR TITLE
Split and rename scalar_traits.h

### DIFF
--- a/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/KPTHCOps.hpp
@@ -26,7 +26,7 @@
 #include "multi/array.hpp"
 #include "multi/array_ref.hpp"
 #include "AFQMC/Numerics/ma_operations.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "AFQMC/Wavefunctions/Excitations.hpp"
 #include "AFQMC/Wavefunctions/phmsd_helpers.hpp"
 #include "AFQMC/Utilities/myTimer.h"

--- a/src/AFQMC/HamiltonianOperations/THCOps.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOps.hpp
@@ -24,7 +24,7 @@
 #include "Utilities/FairDivide.h"
 #include "AFQMC/Utilities/taskgroup.h"
 #include "mpi3/shared_communicator.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "AFQMC/Wavefunctions/Excitations.hpp"
 #include "AFQMC/Wavefunctions/phmsd_helpers.hpp"
 #include "AFQMC/Numerics/batched_operations.hpp"

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp
@@ -22,7 +22,7 @@
 #include "AFQMC/SlaterDeterminantOperations/mixed_density_matrix.hpp"
 #include "AFQMC/SlaterDeterminantOperations/apply_expM.hpp"
 
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 
 namespace qmcplusplus
 {

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_serial.hpp
@@ -23,7 +23,7 @@
 #include "AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp"
 
 #include "mpi3/shared_communicator.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "AFQMC/Utilities/type_conversion.hpp"
 #include "AFQMC/Memory/buffer_managers.h"
 

--- a/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
+++ b/src/AFQMC/SlaterDeterminantOperations/SlaterDetOperations_shared.hpp
@@ -23,7 +23,7 @@
 #include "AFQMC/SlaterDeterminantOperations/SlaterDetOperations_base.hpp"
 
 #include "mpi3/shared_communicator.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "AFQMC/Memory/buffer_managers.h"
 
 namespace qmcplusplus

--- a/src/AFQMC/Wavefunctions/NOMSD.icc
+++ b/src/AFQMC/Wavefunctions/NOMSD.icc
@@ -27,6 +27,7 @@
 #include "AFQMC/Numerics/csr_blas.hpp"
 #include "AFQMC/Numerics/tensor_operations.hpp"
 #include "AFQMC/Walkers/WalkerSet.hpp"
+#include "type_traits/complex_help.hpp"
 
 //#include "AFQMC/Wavefunctions/NOMSD.h"
 

--- a/src/Numerics/Quadrature.h
+++ b/src/Numerics/Quadrature.h
@@ -17,7 +17,7 @@
 
 #include <assert.h>
 #include "Numerics/Ylm.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "QMCWaveFunctions/LCAO/SoaSphericalTensor.h"
 
 namespace qmcplusplus

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -281,7 +281,7 @@ bool DMCcuda::run()
           v2bar += dot(wG_scaled, wG_scaled);
 #ifdef QMC_COMPLEX
           PosType wG_real;
-          convert2real(W.G[iat], wG_real);
+          convertToReal(W.G[iat], wG_real);
           v2 += dot(wG_real, wG_real);
 #else
           // should be removed when things work fine

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -23,7 +23,6 @@
 #include "QMCDrivers/DriftOperators.h"
 #include "Utilities/RunTimeManager.h"
 #include "Message/CommOperators.h"
-#include "type_traits/scalar_traits.h"
 #ifdef USE_NVTX_API
 #include <nvToolsExt.h>
 #endif

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -281,7 +281,7 @@ bool DMCcuda::run()
           v2bar += dot(wG_scaled, wG_scaled);
 #ifdef QMC_COMPLEX
           PosType wG_real;
-          convert(W.G[iat], wG_real);
+          convert2real(W.G[iat], wG_real);
           v2 += dot(wG_real, wG_real);
 #else
           // should be removed when things work fine

--- a/src/QMCDrivers/DriftOperators.h
+++ b/src/QMCDrivers/DriftOperators.h
@@ -15,7 +15,7 @@
 
 #ifndef QMCPLUSPLUS_QMCDRIFTOPERATORS_H
 #define QMCPLUSPLUS_QMCDRIFTOPERATORS_H
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 namespace qmcplusplus
@@ -36,7 +36,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getScaledDrift(Tt tau, const TinyVector<TG, D>& qf, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert2real(qf, drift);
+  convertToReal(qf, drift);
   T vsq = dot(drift, drift);
   T sc  = (vsq < std::numeric_limits<T>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * tau * vsq)) / vsq);
   //Apply the umrigar scaled drift.
@@ -52,7 +52,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getScaledDriftL2(Tt tau, const TinyVector<TG, D>& qf, const Tensor<T, D>& Dmat, TinyVector<T, D>& Kvec, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert2real(qf, drift);
+  convertToReal(qf, drift);
   //modify the bare drift in the presence of L2 potentials
   drift = dot(Dmat, drift) - Kvec;
   T vsq = dot(drift, drift);
@@ -70,7 +70,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getUnscaledDrift(Tt tau, const TinyVector<TG, D>& qf, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert2real(qf, drift);
+  convertToReal(qf, drift);
   drift *= tau;
 }
 
@@ -90,7 +90,7 @@ inline T setScaledDriftPbyPandNodeCorr(T tau,
   T norm = 0.0, norm_scaled = 0.0, tau2 = tau * tau;
   for (int iat = 0; iat < qf.size(); ++iat)
   {
-    convert2real(qf[iat], drift[iat]);
+    convertToReal(qf[iat], drift[iat]);
     T vsq = dot(drift[iat], drift[iat]);
     T sc  = (vsq < std::numeric_limits<T>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * tau * vsq)) / vsq);
     norm_scaled += vsq * sc * sc;
@@ -140,7 +140,7 @@ inline T setScaledDriftPbyPandNodeCorr(T tau_au,
     // !!!! assume timestep is scaled by mass
     T tau_over_mass = tau_au * massinv[iat];
     // save real part of wf log derivative in drift
-    convert2real(qf[iat], drift[iat]);
+    convertToReal(qf[iat], drift[iat]);
     T vsq = dot(drift[iat], drift[iat]);
     // calculate drift scalar "sc" of Umrigar, JCP 99, 2865 (1993); eq. (34) * tau
     // use naive drift if vsq may cause numerical instability in the denominator
@@ -193,7 +193,7 @@ inline void setScaledDrift(T tau,
                            ParticleAttrib<TinyVector<T, D>>& drift)
 {
   for (int iat = 0; iat < qf.size(); ++iat)
-    convert2real(qf[iat], drift[iat]);
+    convertToReal(qf[iat], drift[iat]);
 
   T s = getDriftScale(tau, drift);
   drift *= s;

--- a/src/QMCDrivers/DriftOperators.h
+++ b/src/QMCDrivers/DriftOperators.h
@@ -15,7 +15,7 @@
 
 #ifndef QMCPLUSPLUS_QMCDRIFTOPERATORS_H
 #define QMCPLUSPLUS_QMCDRIFTOPERATORS_H
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 namespace qmcplusplus
@@ -36,7 +36,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getScaledDrift(Tt tau, const TinyVector<TG, D>& qf, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert(qf, drift);
+  convert2real(qf, drift);
   T vsq = dot(drift, drift);
   T sc  = (vsq < std::numeric_limits<T>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * tau * vsq)) / vsq);
   //Apply the umrigar scaled drift.
@@ -52,7 +52,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getScaledDriftL2(Tt tau, const TinyVector<TG, D>& qf, const Tensor<T, D>& Dmat, TinyVector<T, D>& Kvec, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert(qf, drift);
+  convert2real(qf, drift);
   //modify the bare drift in the presence of L2 potentials
   drift = dot(Dmat, drift) - Kvec;
   T vsq = dot(drift, drift);
@@ -70,7 +70,7 @@ template<class Tt, class TG, class T, unsigned D>
 inline void getUnscaledDrift(Tt tau, const TinyVector<TG, D>& qf, TinyVector<T, D>& drift)
 {
   //We convert the complex gradient to real and temporarily store in drift.
-  convert(qf, drift);
+  convert2real(qf, drift);
   drift *= tau;
 }
 
@@ -90,7 +90,7 @@ inline T setScaledDriftPbyPandNodeCorr(T tau,
   T norm = 0.0, norm_scaled = 0.0, tau2 = tau * tau;
   for (int iat = 0; iat < qf.size(); ++iat)
   {
-    convert(qf[iat], drift[iat]);
+    convert2real(qf[iat], drift[iat]);
     T vsq = dot(drift[iat], drift[iat]);
     T sc  = (vsq < std::numeric_limits<T>::epsilon()) ? tau : ((-1.0 + std::sqrt(1.0 + 2.0 * tau * vsq)) / vsq);
     norm_scaled += vsq * sc * sc;
@@ -140,7 +140,7 @@ inline T setScaledDriftPbyPandNodeCorr(T tau_au,
     // !!!! assume timestep is scaled by mass
     T tau_over_mass = tau_au * massinv[iat];
     // save real part of wf log derivative in drift
-    convert(qf[iat], drift[iat]);
+    convert2real(qf[iat], drift[iat]);
     T vsq = dot(drift[iat], drift[iat]);
     // calculate drift scalar "sc" of Umrigar, JCP 99, 2865 (1993); eq. (34) * tau
     // use naive drift if vsq may cause numerical instability in the denominator
@@ -193,7 +193,7 @@ inline void setScaledDrift(T tau,
                            ParticleAttrib<TinyVector<T, D>>& drift)
 {
   for (int iat = 0; iat < qf.size(); ++iat)
-    convert(qf[iat], drift[iat]);
+    convert2real(qf[iat], drift[iat]);
 
   T s = getDriftScale(tau, drift);
   drift *= s;

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -13,14 +13,14 @@
 #include <sstream>
 #include "DriftModifierUNR.h"
 #include "OhmmsData/ParameterSet.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
 void DriftModifierUNR::getDrift(RealType tau, const GradType& qf, PosType& drift) const
 {
   // convert the complex WF gradient to real
-  convert(qf, drift);
+  convert2real(qf, drift);
 #ifndef NDEBUG
   PosType debug_drift = drift;
 #endif
@@ -54,7 +54,7 @@ void DriftModifierUNR::getDrift(RealType tau, const GradType& qf, PosType& drift
 void DriftModifierUNR::getDrift(RealType tau, const ComplexType& qf, ParticleSet::Scalar_t& drift) const
 {
   // convert the complex WF gradient to real
-  convert(qf, drift);
+  convert2real(qf, drift);
   RealType vsq = drift * drift;
   RealType sc  = vsq < std::numeric_limits<RealType>::epsilon()
       ? tau

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include "DriftModifierUNR.h"
 #include "OhmmsData/ParameterSet.h"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
+++ b/src/QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.cpp
@@ -13,14 +13,14 @@
 #include <sstream>
 #include "DriftModifierUNR.h"
 #include "OhmmsData/ParameterSet.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
 void DriftModifierUNR::getDrift(RealType tau, const GradType& qf, PosType& drift) const
 {
   // convert the complex WF gradient to real
-  convert2real(qf, drift);
+  convertToReal(qf, drift);
 #ifndef NDEBUG
   PosType debug_drift = drift;
 #endif
@@ -54,7 +54,7 @@ void DriftModifierUNR::getDrift(RealType tau, const GradType& qf, PosType& drift
 void DriftModifierUNR::getDrift(RealType tau, const ComplexType& qf, ParticleSet::Scalar_t& drift) const
 {
   // convert the complex WF gradient to real
-  convert2real(qf, drift);
+  convertToReal(qf, drift);
   RealType vsq = drift * drift;
   RealType sc  = vsq < std::numeric_limits<RealType>::epsilon()
       ? tau

--- a/src/QMCDrivers/VMC/VMC_CUDA.cpp
+++ b/src/QMCDrivers/VMC/VMC_CUDA.cpp
@@ -20,7 +20,6 @@
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Message/CommOperators.h"
 #include "QMCDrivers/DriftOperators.h"
-#include "type_traits/scalar_traits.h"
 #include "Utilities/RunTimeManager.h"
 #include "Utilities/qmc_common.h"
 #ifdef USE_NVTX_API

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -23,7 +23,7 @@
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -191,7 +191,7 @@ Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
     }
     iongradpsi_[iat] = psi.evalGradSource(P, ions, iat, iongrad_grad_, iongrad_lapl_);
     //conversion from potentially complex to definitely real.
-    convert2real(iongradpsi_[iat], iongradpsireal_[iat]);
+    convertToReal(iongradpsi_[iat], iongradpsireal_[iat]);
     if (SameMass)
     {
       for (int iondim = 0; iondim < OHMMS_DIM; iondim++)
@@ -220,7 +220,7 @@ Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
       }
     }
     //convert to real.
-    convert2real(pulaytmp_[iat], pulaytmpreal_[iat]);
+    convertToReal(pulaytmp_[iat], pulaytmpreal_[iat]);
   }
 
   if (SameMass)

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -23,7 +23,7 @@
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -191,7 +191,7 @@ Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
     }
     iongradpsi_[iat] = psi.evalGradSource(P, ions, iat, iongrad_grad_, iongrad_lapl_);
     //conversion from potentially complex to definitely real.
-    convert(iongradpsi_[iat], iongradpsireal_[iat]);
+    convert2real(iongradpsi_[iat], iongradpsireal_[iat]);
     if (SameMass)
     {
       for (int iondim = 0; iondim < OHMMS_DIM; iondim++)
@@ -220,7 +220,7 @@ Return_t BareKineticEnergy::evaluateWithIonDerivs(ParticleSet& P,
       }
     }
     //convert to real.
-    convert(pulaytmp_[iat], pulaytmpreal_[iat]);
+    convert2real(pulaytmp_[iat], pulaytmpreal_[iat]);
   }
 
   if (SameMass)

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -18,7 +18,7 @@
 #include "NonLocalECPComponent.h"
 #include "NLPPJob.h"
 #include "NonLocalData.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -319,7 +319,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       gradtmp_ *= psiratio[j];
 #if defined(QMC_COMPLEX)
       //And now we take the real part and save it.
-      convert(gradtmp_, gradpsiratio[j]);
+      convert2real(gradtmp_, gradpsiratio[j]);
 #else
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
@@ -471,7 +471,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       gradtmp_ *= psiratio[j];
 #if defined(QMC_COMPLEX)
       //And now we take the real part and save it.
-      convert(gradtmp_, gradpsiratio[j]);
+      convert2real(gradtmp_, gradpsiratio[j]);
 #else
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
@@ -520,7 +520,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       iongradtmp_ = psi.evalGradSource(W, ions, jat);
       iongradtmp_ *= psiratio[j];
 #ifdef QMC_COMPLEX
-      convert(iongradtmp_, pulay_quad[j][jat]);
+      convert2real(iongradtmp_, pulay_quad[j][jat]);
 #endif
       pulay_quad[j][jat] = iongradtmp_;
       //And move the particle back.

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -18,7 +18,7 @@
 #include "NonLocalECPComponent.h"
 #include "NLPPJob.h"
 #include "NonLocalData.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -319,7 +319,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       gradtmp_ *= psiratio[j];
 #if defined(QMC_COMPLEX)
       //And now we take the real part and save it.
-      convert2real(gradtmp_, gradpsiratio[j]);
+      convertToReal(gradtmp_, gradpsiratio[j]);
 #else
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
@@ -471,7 +471,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       gradtmp_ *= psiratio[j];
 #if defined(QMC_COMPLEX)
       //And now we take the real part and save it.
-      convert2real(gradtmp_, gradpsiratio[j]);
+      convertToReal(gradtmp_, gradpsiratio[j]);
 #else
       //Real nonlocalpp forces seem to differ from those in the complex build.  Since
       //complex build has been validated against QE, that indicates there's a bug for the real build.
@@ -520,7 +520,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
       iongradtmp_ = psi.evalGradSource(W, ions, jat);
       iongradtmp_ *= psiratio[j];
 #ifdef QMC_COMPLEX
-      convert2real(iongradtmp_, pulay_quad[j][jat]);
+      convertToReal(iongradtmp_, pulay_quad[j][jat]);
 #endif
       pulay_quad[j][jat] = iongradtmp_;
       //And move the particle back.

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -18,6 +18,7 @@
 #include "NonLocalECPComponent.h"
 #include "NLPPJob.h"
 #include "NonLocalData.h"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -26,7 +26,7 @@
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -875,7 +875,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivs(ParticleSet& 
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
     wfgradraw_[iat] = psi.evalGradSource(P, ions, iat);
-    convert2real(wfgradraw_[iat], wf_grad[iat]);
+    convertToReal(wfgradraw_[iat], wf_grad[iat]);
   }
   return localEnergy;
 }
@@ -897,7 +897,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministic(
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
     wfgradraw_[iat] = psi.evalGradSource(P, ions, iat);
-    convert2real(wfgradraw_[iat], wf_grad[iat]);
+    convertToReal(wfgradraw_[iat], wf_grad[iat]);
   }
   return localEnergy;
 }

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -26,6 +26,7 @@
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -26,7 +26,7 @@
 #ifdef QMC_CUDA
 #include "Particle/MCWalkerConfiguration.h"
 #endif
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -875,7 +875,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivs(ParticleSet& 
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
     wfgradraw_[iat] = psi.evalGradSource(P, ions, iat);
-    convert(wfgradraw_[iat], wf_grad[iat]);
+    convert2real(wfgradraw_[iat], wf_grad[iat]);
   }
   return localEnergy;
 }
@@ -897,7 +897,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministic(
   for (int iat = 0; iat < ions.getTotalNum(); iat++)
   {
     wfgradraw_[iat] = psi.evalGradSource(P, ions, iat);
-    convert(wfgradraw_[iat], wf_grad[iat]);
+    convert2real(wfgradraw_[iat], wf_grad[iat]);
   }
   return localEnergy;
 }

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -1,6 +1,6 @@
 #include "QMCHamiltonians/SpaceWarpTransformation.h"
 #include "Particle/DistanceTable.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 namespace qmcplusplus
 {
 SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions)
@@ -77,7 +77,7 @@ void SpaceWarpTransformation::computeSWT(ParticleSet& P,
       el_contribution[iat] += w[iel] * dEl[iel];
 
 #if defined(QMC_COMPLEX)
-      convert2real(dlogpsi[iel], gwfn);
+      convertToReal(dlogpsi[iel], gwfn);
 #else
       gwfn = dlogpsi[iel];
 #endif

--- a/src/QMCHamiltonians/SpaceWarpTransformation.cpp
+++ b/src/QMCHamiltonians/SpaceWarpTransformation.cpp
@@ -1,6 +1,6 @@
 #include "QMCHamiltonians/SpaceWarpTransformation.h"
 #include "Particle/DistanceTable.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 namespace qmcplusplus
 {
 SpaceWarpTransformation::SpaceWarpTransformation(ParticleSet& elns, const ParticleSet& ions)
@@ -77,7 +77,7 @@ void SpaceWarpTransformation::computeSWT(ParticleSet& P,
       el_contribution[iat] += w[iel] * dEl[iel];
 
 #if defined(QMC_COMPLEX)
-      convert(dlogpsi[iel], gwfn);
+      convert2real(dlogpsi[iel], gwfn);
 #else
       gwfn = dlogpsi[iel];
 #endif

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -13,12 +13,14 @@
 #include "catch.hpp"
 
 #include "type_traits/template_types.hpp"
+#include "type_traits/scalar_traits.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "Utilities/RandomGenerator.h"
+
 namespace qmcplusplus
 {
 void create_CN_particlesets(ParticleSet& elec, ParticleSet& ions)

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -13,7 +13,7 @@
 #include "catch.hpp"
 
 #include "type_traits/template_types.hpp"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
@@ -193,8 +193,8 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert2real(wfgradraw[0], wf_grad[0]);
-  convert2real(wfgradraw[1], wf_grad[1]);
+  convertToReal(wfgradraw[0], wf_grad[0]);
+  convertToReal(wfgradraw[1], wf_grad[1]);
 
   //Reference from finite differences on this configuration.
   REQUIRE(wf_grad[0][0] == Approx(-1.9044650674260308));
@@ -378,8 +378,8 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert2real(wfgradraw[0], wf_grad[0]);
-  convert2real(wfgradraw[1], wf_grad[1]);
+  convertToReal(wfgradraw[0], wf_grad[0]);
+  convertToReal(wfgradraw[1], wf_grad[1]);
 
   //Reference from finite differences on this configuration.
   REQUIRE(wf_grad[0][0] == Approx(-1.8996878390353797));
@@ -562,8 +562,8 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert2real(wfgradraw[0], wf_grad[0]);
-  convert2real(wfgradraw[1], wf_grad[1]);
+  convertToReal(wfgradraw[0], wf_grad[0]);
+  convertToReal(wfgradraw[1], wf_grad[1]);
 
   //This is not implemented yet.  Uncomment to perform check after implementation.
   //Reference from finite differences on this configuration.
@@ -718,8 +718,8 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert2real(wfgradraw[0], wf_grad[0]);
-  convert2real(wfgradraw[1], wf_grad[1]);
+  convertToReal(wfgradraw[0], wf_grad[0]);
+  convertToReal(wfgradraw[1], wf_grad[1]);
 
   //This is not implemented yet.  Uncomment to perform check after implementation.
   //Reference from finite differences on this configuration.

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -13,7 +13,7 @@
 #include "catch.hpp"
 
 #include "type_traits/template_types.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
@@ -193,8 +193,8 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert(wfgradraw[0], wf_grad[0]);
-  convert(wfgradraw[1], wf_grad[1]);
+  convert2real(wfgradraw[0], wf_grad[0]);
+  convert2real(wfgradraw[1], wf_grad[1]);
 
   //Reference from finite differences on this configuration.
   REQUIRE(wf_grad[0][0] == Approx(-1.9044650674260308));
@@ -378,8 +378,8 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert(wfgradraw[0], wf_grad[0]);
-  convert(wfgradraw[1], wf_grad[1]);
+  convert2real(wfgradraw[0], wf_grad[0]);
+  convert2real(wfgradraw[1], wf_grad[1]);
 
   //Reference from finite differences on this configuration.
   REQUIRE(wf_grad[0][0] == Approx(-1.8996878390353797));
@@ -562,8 +562,8 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert(wfgradraw[0], wf_grad[0]);
-  convert(wfgradraw[1], wf_grad[1]);
+  convert2real(wfgradraw[0], wf_grad[0]);
+  convert2real(wfgradraw[1], wf_grad[1]);
 
   //This is not implemented yet.  Uncomment to perform check after implementation.
   //Reference from finite differences on this configuration.
@@ -718,8 +718,8 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   wfgradraw[0] = psi->evalGradSource(elec, ions, 0); //On the C atom.
   wfgradraw[1] = psi->evalGradSource(elec, ions, 1); //On the N atom.
 
-  convert(wfgradraw[0], wf_grad[0]);
-  convert(wfgradraw[1], wf_grad[1]);
+  convert2real(wfgradraw[0], wf_grad[0]);
+  convert2real(wfgradraw[1], wf_grad[1]);
 
   //This is not implemented yet.  Uncomment to perform check after implementation.
   //Reference from finite differences on this configuration.

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -19,7 +19,7 @@
 #include "EinsplineSet.h"
 #include "einspline/multi_bspline.h"
 #include "CPU/math.hpp"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -1125,7 +1125,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert2real(e_mikr * StorageValueVector[i], psi[i]);
+    convertToReal(e_mikr * StorageValueVector[i], psi[i]);
   }
   ValueTimer.stop();
 }
@@ -1163,10 +1163,10 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert2real(e_mikr * u, psi[j]);
-    convert2real(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    convertToReal(e_mikr * u, psi[j]);
+    convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    convert2real(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi[j]);
+    convertToReal(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi[j]);
   }
   VGLTimer.stop();
 }
@@ -1208,11 +1208,11 @@ void EinsplineSetExtended<StorageType>::evaluateVGH(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert2real(e_mikr * u, psi[j]);
-    convert2real(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    convertToReal(e_mikr * u, psi[j]);
+    convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    //convert2real(e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu), d2psi[j]);
-    convert2real(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
+    //convertToReal(e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu), d2psi[j]);
+    convertToReal(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
             grad_grad_psi[j]);
   }
   VGLTimer.stop();
@@ -1583,11 +1583,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert2real(e_mikr * u, psi(i, j));
-      //convert2real(e_mikr * u, psi(j,i));
-      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convertToReal(e_mikr * u, psi(i, j));
+      //convertToReal(e_mikr * u, psi(j,i));
+      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convert2real(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi(i, j));
+      convertToReal(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi(i, j));
     }
   }
   VGLMatTimer.stop();
@@ -1632,11 +1632,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert2real(e_mikr * u, psi(i, j));
-      //convert2real(e_mikr * u, psi(j,i));
-      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convertToReal(e_mikr * u, psi(i, j));
+      //convertToReal(e_mikr * u, psi(j,i));
+      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convert2real(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
+      convertToReal(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
               grad_grad_psi(i, j));
     }
   }
@@ -1685,15 +1685,15 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
     TinyVector<Tensor<std::complex<double>, OHMMS_DIM>, OHMMS_DIM> tmpghs, hvdot;
     for (int j = 0; j < NumValenceOrbs; j++)
     {
-      convert2real(dot(PG, StorageGradVector[j]), StorageGradVector[j]);
-      convert2real(dot(PG, StorageHessVector[j]), tmphs);
-      convert2real(dot(tmphs, TPG), StorageHessVector[j]);
+      convertToReal(dot(PG, StorageGradVector[j]), StorageGradVector[j]);
+      convertToReal(dot(PG, StorageHessVector[j]), tmphs);
+      convertToReal(dot(tmphs, TPG), StorageHessVector[j]);
       for (int n = 0; n < OHMMS_DIM; n++)
       {
-        convert2real(dot(PG, StorageGradHessVector[j][n]), tmpghs[n]);
-        convert2real(dot(tmpghs[n], TPG), StorageGradHessVector[j][n]);
+        convertToReal(dot(PG, StorageGradHessVector[j][n]), tmpghs[n]);
+        convertToReal(dot(tmpghs[n], TPG), StorageGradHessVector[j][n]);
       }
-      convert2real(dot(PG, StorageGradHessVector[j]), StorageGradHessVector[j]);
+      convertToReal(dot(PG, StorageGradHessVector[j]), StorageGradHessVector[j]);
       //              grad_grad_grad_logdet(i,j)=StorageGradHessVector[j];
       //              grad_grad_psi(i,j)=StorageHessVector[j];
       //              dpsi(i,j)=StorageGradVector[j];
@@ -1715,9 +1715,9 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert2real(e_mikr * u, psi(i, j));
-      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
-      convert2real(e_mikr *
+      convertToReal(e_mikr * u, psi(i, j));
+      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convertToReal(e_mikr *
                   (tmphs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
               grad_grad_psi(i, j));
       //Is this right?
@@ -1729,7 +1729,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
                 (meye * (ck[a0] * tmphs(a1, a2) + ck[a1] * tmphs(a0, a2) + ck[a2] * tmphs(a0, a1)) -
                  (ck[a0] * ck[a1] * gradu[a2] + ck[a0] * ck[a2] * gradu[a1] + ck[a1] * ck[a2] * gradu[a0]) +
                  eye * ck[a0] * ck[a1] * ck[a2] * u);
-      convert2real(StorageGradHessVector[j], grad_grad_grad_logdet(i, j));
+      convertToReal(StorageGradHessVector[j], grad_grad_grad_logdet(i, j));
     }
   }
 }

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -1125,7 +1125,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convertToReal(e_mikr * StorageValueVector[i], psi[i]);
+    psi[i] = e_mikr * StorageValueVector[i];
   }
   ValueTimer.stop();
 }
@@ -1163,10 +1163,10 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convertToReal(e_mikr * u, psi[j]);
-    convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    psi[j] = e_mikr * u;
+    dpsi[j] = e_mikr * (-eye * u * ck + gradu);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    convertToReal(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi[j]);
+    d2psi[j] = e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu);
   }
   VGLTimer.stop();
 }
@@ -1208,12 +1208,11 @@ void EinsplineSetExtended<StorageType>::evaluateVGH(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convertToReal(e_mikr * u, psi[j]);
-    convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    psi[j] = e_mikr * u;
+    dpsi[j] = e_mikr * (-eye * u * ck + gradu);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    //convertToReal(e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu), d2psi[j]);
-    convertToReal(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
-            grad_grad_psi[j]);
+    //d2psi[j] = e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu);
+    grad_grad_psi[j] = e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck));
   }
   VGLTimer.stop();
 }
@@ -1583,11 +1582,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convertToReal(e_mikr * u, psi(i, j));
-      //convertToReal(e_mikr * u, psi(j,i));
-      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      psi(i, j) = e_mikr * u;
+      //psi(j,i) = e_mikr * u;
+      dpsi(i, j) = e_mikr * (-eye * u * ck + gradu);
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convertToReal(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi(i, j));
+      d2psi(i, j) = e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu);
     }
   }
   VGLMatTimer.stop();
@@ -1632,12 +1631,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convertToReal(e_mikr * u, psi(i, j));
-      //convertToReal(e_mikr * u, psi(j,i));
-      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      psi(i, j) = e_mikr * u;
+      //psi(j,i) = e_mikr * u;
+      dpsi(i, j) = e_mikr * (-eye * u * ck + gradu);
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convertToReal(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
-              grad_grad_psi(i, j));
+      grad_grad_psi(i, j) = e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck));
     }
   }
   VGLMatTimer.stop();
@@ -1685,15 +1683,15 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
     TinyVector<Tensor<std::complex<double>, OHMMS_DIM>, OHMMS_DIM> tmpghs, hvdot;
     for (int j = 0; j < NumValenceOrbs; j++)
     {
-      convertToReal(dot(PG, StorageGradVector[j]), StorageGradVector[j]);
-      convertToReal(dot(PG, StorageHessVector[j]), tmphs);
-      convertToReal(dot(tmphs, TPG), StorageHessVector[j]);
+      StorageGradVector[j] = dot(PG, StorageGradVector[j]);
+      tmphs = dot(PG, StorageHessVector[j]);
+      StorageHessVector[j] = dot(tmphs, TPG);
       for (int n = 0; n < OHMMS_DIM; n++)
       {
-        convertToReal(dot(PG, StorageGradHessVector[j][n]), tmpghs[n]);
-        convertToReal(dot(tmpghs[n], TPG), StorageGradHessVector[j][n]);
+        tmpghs[n] = dot(PG, StorageGradHessVector[j][n]);
+        StorageGradHessVector[j][n] = dot(tmpghs[n], TPG);
       }
-      convertToReal(dot(PG, StorageGradHessVector[j]), StorageGradHessVector[j]);
+      StorageGradHessVector[j] = dot(PG, StorageGradHessVector[j]);
       //              grad_grad_grad_logdet(i,j)=StorageGradHessVector[j];
       //              grad_grad_psi(i,j)=StorageHessVector[j];
       //              dpsi(i,j)=StorageGradVector[j];
@@ -1715,11 +1713,10 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convertToReal(e_mikr * u, psi(i, j));
-      convertToReal(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
-      convertToReal(e_mikr *
-                  (tmphs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
-              grad_grad_psi(i, j));
+      psi(i, j) = e_mikr * u;
+      dpsi(i, j) = e_mikr * (-eye * u * ck + gradu);
+      grad_grad_psi(i, j) = e_mikr *
+                  (tmphs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck));
       //Is this right?
       StorageGradHessVector[j] *= e_mikr;
       for (unsigned a0(0); a0 < OHMMS_DIM; a0++)
@@ -1729,7 +1726,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
                 (meye * (ck[a0] * tmphs(a1, a2) + ck[a1] * tmphs(a0, a2) + ck[a2] * tmphs(a0, a1)) -
                  (ck[a0] * ck[a1] * gradu[a2] + ck[a0] * ck[a2] * gradu[a1] + ck[a1] * ck[a2] * gradu[a0]) +
                  eye * ck[a0] * ck[a1] * ck[a2] * u);
-      convertToReal(StorageGradHessVector[j], grad_grad_grad_logdet(i, j));
+      grad_grad_grad_logdet(i, j) = StorageGradHessVector[j];
     }
   }
 }

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -19,6 +19,7 @@
 #include "EinsplineSet.h"
 #include "einspline/multi_bspline.h"
 #include "CPU/math.hpp"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -19,7 +19,7 @@
 #include "EinsplineSet.h"
 #include "einspline/multi_bspline.h"
 #include "CPU/math.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -1125,7 +1125,7 @@ void EinsplineSetExtended<StorageType>::evaluateValue(const ParticleSet& P, int 
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert(e_mikr * StorageValueVector[i], psi[i]);
+    convert2real(e_mikr * StorageValueVector[i], psi[i]);
   }
   ValueTimer.stop();
 }
@@ -1163,10 +1163,10 @@ void EinsplineSetExtended<StorageType>::evaluateVGL(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert(e_mikr * u, psi[j]);
-    convert(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    convert2real(e_mikr * u, psi[j]);
+    convert2real(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    convert(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi[j]);
+    convert2real(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi[j]);
   }
   VGLTimer.stop();
 }
@@ -1208,11 +1208,11 @@ void EinsplineSetExtended<StorageType>::evaluateVGH(const ParticleSet& P,
     double phase = -dot(r, k);
     qmcplusplus::sincos(phase, &s, &c);
     std::complex<double> e_mikr(c, s);
-    convert(e_mikr * u, psi[j]);
-    convert(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
+    convert2real(e_mikr * u, psi[j]);
+    convert2real(e_mikr * (-eye * u * ck + gradu), dpsi[j]);
     //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi[j]);
-    //convert(e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu), d2psi[j]);
-    convert(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
+    //convert2real(e_mikr*(-dot(k,k)*u - 2.0*eye*dot(ck,gradu) + laplu), d2psi[j]);
+    convert2real(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
             grad_grad_psi[j]);
   }
   VGLTimer.stop();
@@ -1583,11 +1583,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert(e_mikr * u, psi(i, j));
-      //convert(e_mikr * u, psi(j,i));
-      convert(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convert2real(e_mikr * u, psi(i, j));
+      //convert2real(e_mikr * u, psi(j,i));
+      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convert(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi(i, j));
+      convert2real(e_mikr * (-dot(k, k) * u - 2.0 * eye * dot(ck, gradu) + laplu), d2psi(i, j));
     }
   }
   VGLMatTimer.stop();
@@ -1632,11 +1632,11 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert(e_mikr * u, psi(i, j));
-      //convert(e_mikr * u, psi(j,i));
-      convert(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convert2real(e_mikr * u, psi(i, j));
+      //convert2real(e_mikr * u, psi(j,i));
+      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
       //convertVec(e_mikr*(-eye*u*ck + gradu), dpsi(i,j));
-      convert(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
+      convert2real(e_mikr * (hs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
               grad_grad_psi(i, j));
     }
   }
@@ -1685,15 +1685,15 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
     TinyVector<Tensor<std::complex<double>, OHMMS_DIM>, OHMMS_DIM> tmpghs, hvdot;
     for (int j = 0; j < NumValenceOrbs; j++)
     {
-      convert(dot(PG, StorageGradVector[j]), StorageGradVector[j]);
-      convert(dot(PG, StorageHessVector[j]), tmphs);
-      convert(dot(tmphs, TPG), StorageHessVector[j]);
+      convert2real(dot(PG, StorageGradVector[j]), StorageGradVector[j]);
+      convert2real(dot(PG, StorageHessVector[j]), tmphs);
+      convert2real(dot(tmphs, TPG), StorageHessVector[j]);
       for (int n = 0; n < OHMMS_DIM; n++)
       {
-        convert(dot(PG, StorageGradHessVector[j][n]), tmpghs[n]);
-        convert(dot(tmpghs[n], TPG), StorageGradHessVector[j][n]);
+        convert2real(dot(PG, StorageGradHessVector[j][n]), tmpghs[n]);
+        convert2real(dot(tmpghs[n], TPG), StorageGradHessVector[j][n]);
       }
-      convert(dot(PG, StorageGradHessVector[j]), StorageGradHessVector[j]);
+      convert2real(dot(PG, StorageGradHessVector[j]), StorageGradHessVector[j]);
       //              grad_grad_grad_logdet(i,j)=StorageGradHessVector[j];
       //              grad_grad_psi(i,j)=StorageHessVector[j];
       //              dpsi(i,j)=StorageGradVector[j];
@@ -1715,9 +1715,9 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
       double phase = -dot(r, k);
       qmcplusplus::sincos(phase, &s, &c);
       std::complex<double> e_mikr(c, s);
-      convert(e_mikr * u, psi(i, j));
-      convert(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
-      convert(e_mikr *
+      convert2real(e_mikr * u, psi(i, j));
+      convert2real(e_mikr * (-eye * u * ck + gradu), dpsi(i, j));
+      convert2real(e_mikr *
                   (tmphs - u * outerProduct(ck, ck) - eye * outerProduct(ck, gradu) - eye * outerProduct(gradu, ck)),
               grad_grad_psi(i, j));
       //Is this right?
@@ -1729,7 +1729,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
                 (meye * (ck[a0] * tmphs(a1, a2) + ck[a1] * tmphs(a0, a2) + ck[a2] * tmphs(a0, a1)) -
                  (ck[a0] * ck[a1] * gradu[a2] + ck[a0] * ck[a2] * gradu[a1] + ck[a1] * ck[a2] * gradu[a0]) +
                  eye * ck[a0] * ck[a1] * ck[a2] * u);
-      convert(StorageGradHessVector[j], grad_grad_grad_logdet(i, j));
+      convert2real(StorageGradHessVector[j], grad_grad_grad_logdet(i, j));
     }
   }
 }

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
@@ -53,8 +53,6 @@ public:
 template<typename T, typename T_FP>
 class DelayedUpdateCUDA
 {
-  /// define real type
-  using real_type = typename scalar_traits<T>::real_type;
   // Data staged during for delayed acceptRows
   Matrix<T, CUDAHostAllocator<T>> U;
   Matrix<T, CUDAHostAllocator<T>> Binv;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -20,7 +20,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "OhmmsPETE/Tensor.h"
 #include "CPU/SIMD/simd.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -863,8 +863,8 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
       } // k
     }   // j
 #if defined(QMC_COMPLEX)
-    convert(dpsia, dlogpsi(offset, pa));
-    convert(dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp)), dL(offset, pa));
+    convert2real(dpsia, dlogpsi(offset, pa));
+    convert2real(dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp)), dL(offset, pa));
 #else
     dlogpsi(offset, pa) = dpsia; // \nabla_pa ln(D)
     dL(offset, pa)      = dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp));

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -20,6 +20,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "OhmmsPETE/Tensor.h"
 #include "CPU/SIMD/simd.hpp"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantWithBackflow.cpp
@@ -20,7 +20,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "OhmmsPETE/Tensor.h"
 #include "CPU/SIMD/simd.hpp"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -863,8 +863,8 @@ void DiracDeterminantWithBackflow::evaluateDerivatives(ParticleSet& P,
       } // k
     }   // j
 #if defined(QMC_COMPLEX)
-    convert2real(dpsia, dlogpsi(offset, pa));
-    convert2real(dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp)), dL(offset, pa));
+    convertToReal(dpsia, dlogpsi(offset, pa));
+    convertToReal(dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp)), dL(offset, pa));
 #else
     dlogpsi(offset, pa) = dpsia; // \nabla_pa ln(D)
     dL(offset, pa)      = dLa + sumL * dpsia + dotG * dpsia + static_cast<ValueType>(2.0 * Dot(myG, Gtemp));

--- a/src/QMCWaveFunctions/Fermion/DiracMatrix.h
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrix.h
@@ -15,7 +15,7 @@
 #include "CPU/Blasf.h"
 #include "CPU/BlasThreadingEnv.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "Message/OpenMP.h"
 #include "CPU/SIMD/simd.hpp"
 
@@ -111,7 +111,7 @@ inline void computeLogDet(const T* restrict diag, int n, const int* restrict piv
 template<typename T_FP>
 class DiracMatrix
 {
-  typedef typename scalar_traits<T_FP>::real_type real_type_fp;
+  using Real_FP = RealAlias<T_FP>;
   aligned_vector<T_FP> m_work;
   aligned_vector<int> m_pivot;
   int Lwork;
@@ -126,7 +126,7 @@ class DiracMatrix
     m_pivot.resize(lda);
     Lwork = -1;
     T_FP tmp;
-    real_type_fp lw;
+    Real_FP lw;
     int status = Xgetri(lda, invMat_ptr, lda, m_pivot.data(), &tmp, Lwork);
     if (status != 0)
     {
@@ -135,7 +135,7 @@ class DiracMatrix
       throw std::runtime_error(msg.str());
     }
 
-    convert(tmp, lw);
+    lw = std::real(tmp);
     Lwork = static_cast<int>(lw);
     m_work.resize(Lwork);
     LU_diag.resize(lda);

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -104,7 +104,7 @@ private:
     VALUE_FP tmp;
     FullPrecReal lw;
     Xgetri(lda, psi_M.data(), lda, pivots_.data(), &tmp, lwork_);
-    convert(tmp, lw);
+    lw = std::real(tmp);
     lwork_ = static_cast<int>(lw);
     m_work_.resize(lwork_);
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -743,13 +743,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
           //           v2 += tmp*(Dot(P.G,grads_dn[dnC])-Dot(g,grads_dn[dnC]));
           cnt++;
         }
-        convertToReal(cdet, dlogpsi[kk]);
+        dlogpsi[kk] = cdet;
         ValueType dhpsi = (RealType)(-0.5) * (q0 - cdet * lapl_sum) - cdet * gg + v1;
         //                            -cdet*gg-v1-v2;
         //ValueType dhpsi =  -0.5*(tmp1*laplSum_up[upC]+tmp2*laplSum_dn[dnC]
         //                         -cdet*lapl_sum)
         //                   -cdet*gg-(tmp1*v1+tmp2*v2);
-        convertToReal(dhpsi, dhpsioverpsi[kk]);
+        dhpsioverpsi[kk] = dhpsi;
       }
     }
     else
@@ -790,13 +790,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
         int upC        = C2node_up[ip];
         int dnC        = C2node_dn[ip];
         ValueType cdet = detValues_up[upC] * detValues_dn[dnC] * psiinv;
-        convertToReal(cdet, dlogpsi[kk]);
+        dlogpsi[kk] = cdet;
         ValueType dhpsi = ((RealType)(-0.5) * cdet) *
             (tempstorage_up[upC] + tempstorage_dn[dnC] - lapl_sum +
              (RealType)2.0 * (gg - static_cast<ValueType>(Dot(gmP, grads_up[upC]) + Dot(gmP, grads_dn[dnC]))));
         //+2.0*(gg-Dot(g,grads_up[upC])-Dot(g,grads_dn[dnC])
         //+Dot(P.G,grads_up[upC])+Dot(P.G,grads_dn[dnC])-ggP));
-        convertToReal(dhpsi, dhpsioverpsi[kk]);
+        dhpsioverpsi[kk] = dhpsi;
       }
     }
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -15,7 +15,7 @@
 
 #include "MultiSlaterDeterminant.h"
 #include "ParticleBase/ParticleAttribOps.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -743,13 +743,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
           //           v2 += tmp*(Dot(P.G,grads_dn[dnC])-Dot(g,grads_dn[dnC]));
           cnt++;
         }
-        convert2real(cdet, dlogpsi[kk]);
+        convertToReal(cdet, dlogpsi[kk]);
         ValueType dhpsi = (RealType)(-0.5) * (q0 - cdet * lapl_sum) - cdet * gg + v1;
         //                            -cdet*gg-v1-v2;
         //ValueType dhpsi =  -0.5*(tmp1*laplSum_up[upC]+tmp2*laplSum_dn[dnC]
         //                         -cdet*lapl_sum)
         //                   -cdet*gg-(tmp1*v1+tmp2*v2);
-        convert2real(dhpsi, dhpsioverpsi[kk]);
+        convertToReal(dhpsi, dhpsioverpsi[kk]);
       }
     }
     else
@@ -790,13 +790,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
         int upC        = C2node_up[ip];
         int dnC        = C2node_dn[ip];
         ValueType cdet = detValues_up[upC] * detValues_dn[dnC] * psiinv;
-        convert2real(cdet, dlogpsi[kk]);
+        convertToReal(cdet, dlogpsi[kk]);
         ValueType dhpsi = ((RealType)(-0.5) * cdet) *
             (tempstorage_up[upC] + tempstorage_dn[dnC] - lapl_sum +
              (RealType)2.0 * (gg - static_cast<ValueType>(Dot(gmP, grads_up[upC]) + Dot(gmP, grads_dn[dnC]))));
         //+2.0*(gg-Dot(g,grads_up[upC])-Dot(g,grads_dn[dnC])
         //+Dot(P.G,grads_up[upC])+Dot(P.G,grads_dn[dnC])-ggP));
-        convert2real(dhpsi, dhpsioverpsi[kk]);
+        convertToReal(dhpsi, dhpsioverpsi[kk]);
       }
     }
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -15,7 +15,7 @@
 
 #include "MultiSlaterDeterminant.h"
 #include "ParticleBase/ParticleAttribOps.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -743,13 +743,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
           //           v2 += tmp*(Dot(P.G,grads_dn[dnC])-Dot(g,grads_dn[dnC]));
           cnt++;
         }
-        convert(cdet, dlogpsi[kk]);
+        convert2real(cdet, dlogpsi[kk]);
         ValueType dhpsi = (RealType)(-0.5) * (q0 - cdet * lapl_sum) - cdet * gg + v1;
         //                            -cdet*gg-v1-v2;
         //ValueType dhpsi =  -0.5*(tmp1*laplSum_up[upC]+tmp2*laplSum_dn[dnC]
         //                         -cdet*lapl_sum)
         //                   -cdet*gg-(tmp1*v1+tmp2*v2);
-        convert(dhpsi, dhpsioverpsi[kk]);
+        convert2real(dhpsi, dhpsioverpsi[kk]);
       }
     }
     else
@@ -790,13 +790,13 @@ void MultiSlaterDeterminant::evaluateDerivatives(ParticleSet& P,
         int upC        = C2node_up[ip];
         int dnC        = C2node_dn[ip];
         ValueType cdet = detValues_up[upC] * detValues_dn[dnC] * psiinv;
-        convert(cdet, dlogpsi[kk]);
+        convert2real(cdet, dlogpsi[kk]);
         ValueType dhpsi = ((RealType)(-0.5) * cdet) *
             (tempstorage_up[upC] + tempstorage_dn[dnC] - lapl_sum +
              (RealType)2.0 * (gg - static_cast<ValueType>(Dot(gmP, grads_up[upC]) + Dot(gmP, grads_dn[dnC]))));
         //+2.0*(gg-Dot(g,grads_up[upC])-Dot(g,grads_dn[dnC])
         //+Dot(P.G,grads_up[upC])+Dot(P.G,grads_dn[dnC])-ggP));
-        convert(dhpsi, dhpsioverpsi[kk]);
+        convert2real(dhpsi, dhpsioverpsi[kk]);
       }
     }
   }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDeterminant.cpp
@@ -15,6 +15,7 @@
 
 #include "MultiSlaterDeterminant.h"
 #include "ParticleBase/ParticleAttribOps.h"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
@@ -14,7 +14,6 @@
 #include "SHOSet.h"
 #include "Utilities/string_utils.h"
 
-
 namespace qmcplusplus
 {
 SHOSet::SHOSet(RealType l, PosType c, const std::vector<SHOState*>& sho_states) : length(l), center(c)

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -21,7 +21,7 @@
 #include "LongRange/StructFact.h"
 #include "CPU/math.hpp"
 #include "CPU/e2iphi.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -864,8 +864,8 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
           {
             //real part of coeff
             dlogpsi[kk] += ValueType(Prefactor * real(z));
-            //convert2real(dot(OneBodyGvecs[i],P.G[iat]),tmp_dot);
-            convert2real(dot(P.G[iat], OneBodyGvecs[i]), tmp_dot);
+            //convertToReal(dot(OneBodyGvecs[i],P.G[iat]),tmp_dot);
+            convertToReal(dot(P.G[iat], OneBodyGvecs[i]), tmp_dot);
             dhpsioverpsi[kk] += ValueType(0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(z) +
                                           Prefactor * real(z * eye) * tmp_dot);
             //	+ Prefactor*real(z*eye)*real(dot(OneBodyGvecs[i],P.G[iat]));
@@ -913,7 +913,7 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
         int kk        = myVars.where(TwoBodyVarMap[i]);
         if (kk > 0)
         {
-          convert2real(dot(P.G[iat], Gvec), tmp_dot);
+          convertToReal(dot(P.G[iat], Gvec), tmp_dot);
           //dhpsioverpsi[kk] -= Prefactor*dot(Gvec,Gvec)*(-real(z*qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) - Prefactor*2.0*real(dot(P.G[iat],Gvec))*imag(qmcplusplus::conj(TwoBody_rhoG[i])*z);
           dhpsioverpsi[kk] -=
               ValueType(Prefactor * dot(Gvec, Gvec) * (-real(z * qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) -

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -21,7 +21,7 @@
 #include "LongRange/StructFact.h"
 #include "CPU/math.hpp"
 #include "CPU/e2iphi.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -864,8 +864,8 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
           {
             //real part of coeff
             dlogpsi[kk] += ValueType(Prefactor * real(z));
-            //convert(dot(OneBodyGvecs[i],P.G[iat]),tmp_dot);
-            convert(dot(P.G[iat], OneBodyGvecs[i]), tmp_dot);
+            //convert2real(dot(OneBodyGvecs[i],P.G[iat]),tmp_dot);
+            convert2real(dot(P.G[iat], OneBodyGvecs[i]), tmp_dot);
             dhpsioverpsi[kk] += ValueType(0.5 * Prefactor * dot(OneBodyGvecs[i], OneBodyGvecs[i]) * real(z) +
                                           Prefactor * real(z * eye) * tmp_dot);
             //	+ Prefactor*real(z*eye)*real(dot(OneBodyGvecs[i],P.G[iat]));
@@ -913,7 +913,7 @@ void kSpaceJastrow::evaluateDerivatives(ParticleSet& P,
         int kk        = myVars.where(TwoBodyVarMap[i]);
         if (kk > 0)
         {
-          convert(dot(P.G[iat], Gvec), tmp_dot);
+          convert2real(dot(P.G[iat], Gvec), tmp_dot);
           //dhpsioverpsi[kk] -= Prefactor*dot(Gvec,Gvec)*(-real(z*qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) - Prefactor*2.0*real(dot(P.G[iat],Gvec))*imag(qmcplusplus::conj(TwoBody_rhoG[i])*z);
           dhpsioverpsi[kk] -=
               ValueType(Prefactor * dot(Gvec, Gvec) * (-real(z * qmcplusplus::conj(TwoBody_rhoG[i])) + 1.0) -

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -16,12 +16,12 @@
 
 
 #include "kSpaceJastrow.h"
+#include <sstream>
+#include <algorithm>
 #include "LongRange/StructFact.h"
 #include "CPU/math.hpp"
 #include "CPU/e2iphi.h"
-#include <sstream>
-#include <algorithm>
-
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/OrbitalSetTraits.h
+++ b/src/QMCWaveFunctions/OrbitalSetTraits.h
@@ -20,9 +20,10 @@
 #define QMCPLUSPLUS_ORBITALSETTRAITS_H
 
 #include "Configuration.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/complex_help.hpp"
 #include "VariableSet.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
 
 namespace qmcplusplus
 {
@@ -53,8 +54,8 @@ struct OrbitalSetTraits //: public OrbitalTraits<T>
   {
     DIM = OHMMS_DIM
   };
-  typedef typename scalar_traits<T>::real_type RealType;
-  typedef typename scalar_traits<T>::value_type ValueType;
+  using RealType = RealAlias<T>;
+  using ValueType = T;
   typedef int IndexType;
   typedef TinyVector<RealType, DIM> PosType;
   typedef TinyVector<ValueType, DIM> GradType;

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -21,7 +21,7 @@
 #include "Message/Communicate.h"
 #include "PWRealOrbitalSet.h"
 #include "Numerics/MatrixOperators.h"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -140,8 +140,8 @@ void PWRealOrbitalSet::evaluate_notranspose(const ParticleSet& P,
     const ComplexType* restrict tptr = Temp.data();
     for (int j = 0; j < OrbitalSetSize; j++, tptr += PW_MAXINDEX)
     {
-      convert2real(tptr[PW_VALUE], logdet(i, j));
-      convert2real(tptr[PW_LAP], d2logdet(i, j));
+      convertToReal(tptr[PW_VALUE], logdet(i, j));
+      convertToReal(tptr[PW_LAP], d2logdet(i, j));
 #if OHMMS_DIM == 3
       dlogdet(i, j) = GradType(tptr[PW_GRADX].real(), tptr[PW_GRADY].real(), tptr[PW_GRADZ].real());
 #elif OHMMS_DIM == 2

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -21,7 +21,7 @@
 #include "Message/Communicate.h"
 #include "PWRealOrbitalSet.h"
 #include "Numerics/MatrixOperators.h"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -140,8 +140,8 @@ void PWRealOrbitalSet::evaluate_notranspose(const ParticleSet& P,
     const ComplexType* restrict tptr = Temp.data();
     for (int j = 0; j < OrbitalSetSize; j++, tptr += PW_MAXINDEX)
     {
-      convert(tptr[PW_VALUE], logdet(i, j));
-      convert(tptr[PW_LAP], d2logdet(i, j));
+      convert2real(tptr[PW_VALUE], logdet(i, j));
+      convert2real(tptr[PW_LAP], d2logdet(i, j));
 #if OHMMS_DIM == 3
       dlogdet(i, j) = GradType(tptr[PW_GRADX].real(), tptr[PW_GRADY].real(), tptr[PW_GRADZ].real());
 #elif OHMMS_DIM == 2

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -21,6 +21,7 @@
 #include "Message/Communicate.h"
 #include "PWRealOrbitalSet.h"
 #include "Numerics/MatrixOperators.h"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -22,6 +22,7 @@
 #include "ResourceCollection.h"
 #include "Utilities/IteratorUtility.h"
 #include "Concurrency/Info.hpp"
+#include "type_traits/scalar_traits.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -22,7 +22,7 @@
 #include "ResourceCollection.h"
 #include "Utilities/IteratorUtility.h"
 #include "Concurrency/Info.hpp"
-#include "type_traits/scalar_traits.h"
+#include "type_traits/convert2real.h"
 
 namespace qmcplusplus
 {
@@ -272,8 +272,8 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
   }
   P.G += fixedG;
   P.L += fixedL;
-  convert(logpsi_fixed, logpsi_fixed_r);
-  convert(logpsi_opt, logpsi_opt_r);
+  convert2real(logpsi_fixed, logpsi_fixed_r);
+  convert2real(logpsi_opt, logpsi_opt_r);
 }
 
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -22,7 +22,7 @@
 #include "ResourceCollection.h"
 #include "Utilities/IteratorUtility.h"
 #include "Concurrency/Info.hpp"
-#include "type_traits/convert2real.h"
+#include "type_traits/ConvertToReal.h"
 
 namespace qmcplusplus
 {
@@ -272,8 +272,8 @@ void TrialWaveFunction::evaluateDeltaLog(ParticleSet& P,
   }
   P.G += fixedG;
   P.L += fixedL;
-  convert2real(logpsi_fixed, logpsi_fixed_r);
-  convert2real(logpsi_opt, logpsi_opt_r);
+  convertToReal(logpsi_fixed, logpsi_fixed_r);
+  convertToReal(logpsi_opt, logpsi_opt_r);
 }
 
 

--- a/src/mpi/mpi_datatype.h
+++ b/src/mpi/mpi_datatype.h
@@ -13,8 +13,6 @@
 #ifndef QMCPLUSPLUS_MPI_DATATYPEDEFINE_H
 #define QMCPLUSPLUS_MPI_DATATYPEDEFINE_H
 
-
-#include "type_traits/scalar_traits.h"
 #if defined(HAVE_MPI)
 #include <mpi.h>
 #else

--- a/src/type_traits/ConvertToReal.h
+++ b/src/type_traits/ConvertToReal.h
@@ -16,7 +16,9 @@
 
 #ifndef QMCPLUSPLUS_CONVERT2REAL_H
 #define QMCPLUSPLUS_CONVERT2REAL_H
+
 #include <complex>
+#include "complex_help.hpp"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/Tensor.h"
 #include "OhmmsPETE/OhmmsVector.h"
@@ -26,7 +28,7 @@ namespace qmcplusplus
 {
 /** generic conversion from type T1 to type T2 using implicit conversion
 */
-template<typename T1, typename T2>
+template<typename T1, typename T2, IsReal<T2> = true>
 inline void convertToReal(const T1& in, T2& out)
 {
   out = static_cast<T2>(in);
@@ -34,7 +36,7 @@ inline void convertToReal(const T1& in, T2& out)
 
 /** specialization of conversion from complex to real
 */
-template<typename T1, typename T2>
+template<typename T1, typename T2, IsReal<T2> = true>
 inline void convertToReal(const std::complex<T1>& in, T2& out)
 {
   out = in.real();
@@ -48,15 +50,6 @@ inline void convertToReal(const TinyVector<T1, D>& in, TinyVector<T2, D>& out)
 {
   for (int i = 0; i < D; ++i)
     convertToReal(in[i], out[i]);
-}
-
-/** specialization for 3D */
-template<typename T1, typename T2>
-inline void convertToReal(const TinyVector<T1, 3>& in, TinyVector<T2, 3>& out)
-{
-  convertToReal(in[0], out[0]);
-  convertToReal(in[1], out[1]);
-  convertToReal(in[2], out[2]);
 }
 
 /** specialization for D tensory*/
@@ -93,11 +86,5 @@ inline void convertToReal(const Matrix<T1>& in, Matrix<T2>& out)
   convertToReal(in.data(), out.data(), in.size());
 }
 
-/** specialization for a vector */
-template<typename T1, typename T2>
-inline void convertToReal(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
-{
-  convertToReal(in.data(), out.data(), in.size());
-}
 } // namespace qmcplusplus
 #endif

--- a/src/type_traits/ConvertToReal.h
+++ b/src/type_traits/ConvertToReal.h
@@ -27,7 +27,7 @@ namespace qmcplusplus
 /** generic conversion from type T1 to type T2 using implicit conversion
 */
 template<typename T1, typename T2>
-inline void convert2real(const T1& in, T2& out)
+inline void convertToReal(const T1& in, T2& out)
 {
   out = static_cast<T2>(in);
 }
@@ -35,7 +35,7 @@ inline void convert2real(const T1& in, T2& out)
 /** specialization of conversion from complex to real
 */
 template<typename T1, typename T2>
-inline void convert2real(const std::complex<T1>& in, T2& out)
+inline void convertToReal(const std::complex<T1>& in, T2& out)
 {
   out = in.real();
 }
@@ -44,27 +44,27 @@ inline void convert2real(const std::complex<T1>& in, T2& out)
  *
  */
 template<typename T1, typename T2, unsigned D>
-inline void convert2real(const TinyVector<T1, D>& in, TinyVector<T2, D>& out)
+inline void convertToReal(const TinyVector<T1, D>& in, TinyVector<T2, D>& out)
 {
   for (int i = 0; i < D; ++i)
-    convert2real(in[i], out[i]);
+    convertToReal(in[i], out[i]);
 }
 
 /** specialization for 3D */
 template<typename T1, typename T2>
-inline void convert2real(const TinyVector<T1, 3>& in, TinyVector<T2, 3>& out)
+inline void convertToReal(const TinyVector<T1, 3>& in, TinyVector<T2, 3>& out)
 {
-  convert2real(in[0], out[0]);
-  convert2real(in[1], out[1]);
-  convert2real(in[2], out[2]);
+  convertToReal(in[0], out[0]);
+  convertToReal(in[1], out[1]);
+  convertToReal(in[2], out[2]);
 }
 
 /** specialization for D tensory*/
 template<typename T1, typename T2, unsigned D>
-inline void convert2real(const Tensor<T1, D>& in, Tensor<T2, D>& out)
+inline void convertToReal(const Tensor<T1, D>& in, Tensor<T2, D>& out)
 {
   for (int i = 0; i < D * D; ++i)
-    convert2real(in[i], out[i]);
+    convertToReal(in[i], out[i]);
 }
 
 /** generic function to convert arrays
@@ -73,31 +73,31 @@ inline void convert2real(const Tensor<T1, D>& in, Tensor<T2, D>& out)
  * @param n size of in/out
  */
 template<typename T1, typename T2>
-inline void convert2real(const T1* restrict in, T2* restrict out, std::size_t n)
+inline void convertToReal(const T1* restrict in, T2* restrict out, std::size_t n)
 {
   for (int i = 0; i < n; ++i)
-    convert2real(in[i], out[i]);
+    convertToReal(in[i], out[i]);
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert2real(const Vector<T1>& in, Vector<T2>& out)
+inline void convertToReal(const Vector<T1>& in, Vector<T2>& out)
 {
-  convert2real(in.data(), out.data(), in.size());
+  convertToReal(in.data(), out.data(), in.size());
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert2real(const Matrix<T1>& in, Matrix<T2>& out)
+inline void convertToReal(const Matrix<T1>& in, Matrix<T2>& out)
 {
-  convert2real(in.data(), out.data(), in.size());
+  convertToReal(in.data(), out.data(), in.size());
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert2real(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
+inline void convertToReal(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
 {
-  convert2real(in.data(), out.data(), in.size());
+  convertToReal(in.data(), out.data(), in.size());
 }
 } // namespace qmcplusplus
 #endif

--- a/src/type_traits/complex_help.hpp
+++ b/src/type_traits/complex_help.hpp
@@ -44,12 +44,12 @@ struct RealAlias_impl<T, IsComplex<T>> { using value_type = typename T::value_ty
 template <typename T>
 using RealAlias = typename RealAlias_impl<T>::value_type;
 
-///real part of a scalar. Cannot be replaced by std::real
+///real part of a scalar. Cannot be replaced by std::real due to AFQMC specific needs.
 inline float real(const float& c) { return c; }
 inline double real(const double& c) { return c; }
 inline float real(const std::complex<float>& c) { return c.real(); }
 inline double real(const std::complex<double>& c) { return c.real(); }
-///imaginary part of a scalar. Cannot be replaced by std::imag
+///imaginary part of a scalar. Cannot be replaced by std::imag due to AFQMC specific needs.
 inline float imag(const float& c) { return 0; }
 inline double imag(const double& c) { return 0; }
 inline float imag(const std::complex<float>& c) { return c.imag(); }

--- a/src/type_traits/complex_help.hpp
+++ b/src/type_traits/complex_help.hpp
@@ -43,6 +43,20 @@ struct RealAlias_impl<T, IsComplex<T>> { using value_type = typename T::value_ty
  */
 template <typename T>
 using RealAlias = typename RealAlias_impl<T>::value_type;
+
+///real part of a scalar
+inline float real(const float& c) { return c; }
+inline double real(const double& c) { return c; }
+inline float real(const std::complex<float>& c) { return c.real(); }
+inline double real(const std::complex<double>& c) { return c.real(); }
+//using std::real;
+///imaginary part of a scalar
+using std::imag;
+///Fix to allow conj on scalar to return real instead of complex
+inline float conj(const float& c) { return c; }
+inline double conj(const double& c) { return c; }
+inline std::complex<float> conj(const std::complex<float>& c) { return std::conj(c); }
+inline std::complex<double> conj(const std::complex<double>& c) { return std::conj(c); }
   
 } // namespace qmcplusplus
 

--- a/src/type_traits/complex_help.hpp
+++ b/src/type_traits/complex_help.hpp
@@ -44,15 +44,17 @@ struct RealAlias_impl<T, IsComplex<T>> { using value_type = typename T::value_ty
 template <typename T>
 using RealAlias = typename RealAlias_impl<T>::value_type;
 
-///real part of a scalar
+///real part of a scalar. Cannot be replaced by std::real
 inline float real(const float& c) { return c; }
 inline double real(const double& c) { return c; }
 inline float real(const std::complex<float>& c) { return c.real(); }
 inline double real(const std::complex<double>& c) { return c.real(); }
-//using std::real;
-///imaginary part of a scalar
-using std::imag;
-///Fix to allow conj on scalar to return real instead of complex
+///imaginary part of a scalar. Cannot be replaced by std::imag
+inline float imag(const float& c) { return 0; }
+inline double imag(const double& c) { return 0; }
+inline float imag(const std::complex<float>& c) { return c.imag(); }
+inline double imag(const std::complex<double>& c) { return c.imag(); }
+///Workaround to allow conj on scalar to return real instead of complex
 inline float conj(const float& c) { return c; }
 inline double conj(const double& c) { return c; }
 inline std::complex<float> conj(const std::complex<float>& c) { return std::conj(c); }

--- a/src/type_traits/container_proxy.h
+++ b/src/type_traits/container_proxy.h
@@ -17,13 +17,36 @@
 
 #include <stdexcept>
 
-#include "type_traits/scalar_traits.h"
 #include "OhmmsPETE/Tensor.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include "Pools/PooledData.h"
 
 namespace qmcplusplus
 {
+template<class T>
+struct scalar_traits
+{
+  enum
+  {
+    DIM = 1
+  };
+  typedef T real_type;
+  typedef T value_type;
+  static inline T* get_address(T* a) { return a; }
+};
+
+template<typename T>
+struct scalar_traits<std::complex<T>>
+{
+  enum
+  {
+    DIM = 2
+  };
+  typedef T real_type;
+  typedef std::complex<T> value_type;
+  static inline T* get_address(std::complex<T>* a) { return reinterpret_cast<T*>(a); }
+};
+
 template<typename T>
 struct container_proxy
 {

--- a/src/type_traits/convert2real.h
+++ b/src/type_traits/convert2real.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
@@ -14,8 +14,8 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef QMCPLUSPLUS_SCLAR_TRAITS_H
-#define QMCPLUSPLUS_SCLAR_TRAITS_H
+#ifndef QMCPLUSPLUS_CONVERT2REAL_H
+#define QMCPLUSPLUS_CONVERT2REAL_H
 #include <complex>
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "OhmmsPETE/Tensor.h"
@@ -27,7 +27,7 @@ namespace qmcplusplus
 /** generic conversion from type T1 to type T2 using implicit conversion
 */
 template<typename T1, typename T2>
-inline void convert(const T1& in, T2& out)
+inline void convert2real(const T1& in, T2& out)
 {
   out = static_cast<T2>(in);
 }
@@ -35,7 +35,7 @@ inline void convert(const T1& in, T2& out)
 /** specialization of conversion from complex to real
 */
 template<typename T1, typename T2>
-inline void convert(const std::complex<T1>& in, T2& out)
+inline void convert2real(const std::complex<T1>& in, T2& out)
 {
   out = in.real();
 }
@@ -44,27 +44,27 @@ inline void convert(const std::complex<T1>& in, T2& out)
  *
  */
 template<typename T1, typename T2, unsigned D>
-inline void convert(const TinyVector<T1, D>& in, TinyVector<T2, D>& out)
+inline void convert2real(const TinyVector<T1, D>& in, TinyVector<T2, D>& out)
 {
   for (int i = 0; i < D; ++i)
-    convert(in[i], out[i]);
+    convert2real(in[i], out[i]);
 }
 
 /** specialization for 3D */
 template<typename T1, typename T2>
-inline void convert(const TinyVector<T1, 3>& in, TinyVector<T2, 3>& out)
+inline void convert2real(const TinyVector<T1, 3>& in, TinyVector<T2, 3>& out)
 {
-  convert(in[0], out[0]);
-  convert(in[1], out[1]);
-  convert(in[2], out[2]);
+  convert2real(in[0], out[0]);
+  convert2real(in[1], out[1]);
+  convert2real(in[2], out[2]);
 }
 
 /** specialization for D tensory*/
 template<typename T1, typename T2, unsigned D>
-inline void convert(const Tensor<T1, D>& in, Tensor<T2, D>& out)
+inline void convert2real(const Tensor<T1, D>& in, Tensor<T2, D>& out)
 {
   for (int i = 0; i < D * D; ++i)
-    convert(in[i], out[i]);
+    convert2real(in[i], out[i]);
 }
 
 /** generic function to convert arrays
@@ -73,31 +73,31 @@ inline void convert(const Tensor<T1, D>& in, Tensor<T2, D>& out)
  * @param n size of in/out
  */
 template<typename T1, typename T2>
-inline void convert(const T1* restrict in, T2* restrict out, std::size_t n)
+inline void convert2real(const T1* restrict in, T2* restrict out, std::size_t n)
 {
   for (int i = 0; i < n; ++i)
-    convert(in[i], out[i]);
+    convert2real(in[i], out[i]);
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert(const Vector<T1>& in, Vector<T2>& out)
+inline void convert2real(const Vector<T1>& in, Vector<T2>& out)
 {
-  convert(in.data(), out.data(), in.size());
+  convert2real(in.data(), out.data(), in.size());
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert(const Matrix<T1>& in, Matrix<T2>& out)
+inline void convert2real(const Matrix<T1>& in, Matrix<T2>& out)
 {
-  convert(in.data(), out.data(), in.size());
+  convert2real(in.data(), out.data(), in.size());
 }
 
 /** specialization for a vector */
 template<typename T1, typename T2>
-inline void convert(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
+inline void convert2real(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
 {
-  convert(in.data(), out.data(), in.size());
+  convert2real(in.data(), out.data(), in.size());
 }
 } // namespace qmcplusplus
 #endif

--- a/src/type_traits/scalar_traits.h
+++ b/src/type_traits/scalar_traits.h
@@ -24,30 +24,6 @@
 
 namespace qmcplusplus
 {
-template<class T>
-struct scalar_traits
-{
-  enum
-  {
-    DIM = 1
-  };
-  typedef T real_type;
-  typedef T value_type;
-  static inline T* get_address(T* a) { return a; }
-};
-
-template<typename T>
-struct scalar_traits<std::complex<T>>
-{
-  enum
-  {
-    DIM = 2
-  };
-  typedef T real_type;
-  typedef std::complex<T> value_type;
-  static inline T* get_address(std::complex<T>* a) { return reinterpret_cast<T*>(a); }
-};
-
 /** generic conversion from type T1 to type T2 using implicit conversion
 */
 template<typename T1, typename T2>
@@ -58,14 +34,8 @@ inline void convert(const T1& in, T2& out)
 
 /** specialization of conversion from complex to real
 */
-template<typename T1>
-inline void convert(const std::complex<T1>& in, double& out)
-{
-  out = in.real();
-}
-
-template<typename T1>
-inline void convert(const std::complex<T1>& in, float& out)
+template<typename T1, typename T2>
+inline void convert(const std::complex<T1>& in, T2& out)
 {
   out = in.real();
 }
@@ -129,24 +99,5 @@ inline void convert(const Tensor<T1, 3>& in, Tensor<T2, 3>& out)
 {
   convert(in.data(), out.data(), in.size());
 }
-
-
-// Fix to allow real, imag, conj on scalar and complex types
-///real part of a scalar
-inline float real(const float& c) { return c; }
-inline double real(const double& c) { return c; }
-inline float real(const std::complex<float>& c) { return c.real(); }
-inline double real(const std::complex<double>& c) { return c.real(); }
-///imaginary part of a scalar
-inline float imag(const float& c) { return 0; }
-inline double imag(const double& c) { return 0; }
-inline float imag(const std::complex<float>& c) { return c.imag(); }
-inline double imag(const std::complex<double>& c) { return c.imag(); }
-///complex conjugate of a scalar
-inline float conj(const float& c) { return c; }
-inline double conj(const double& c) { return c; }
-inline std::complex<float> conj(const std::complex<float>& c) { return std::conj(c); }
-inline std::complex<double> conj(const std::complex<double>& c) { return std::conj(c); }
-
 } // namespace qmcplusplus
 #endif


### PR DESCRIPTION
## Proposed changes
Close #3378
1. Move scalar_traits class to container_proxy.h
2. Rename all the convert() to convert2real to reduce confusion. We have other functions called convert and do other things.
3. Thus rename file scalar_traits.h as convert2real.h

## What type(s) of changes does this code introduce?
- Code style update (formatting, renaming)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'