### PR TITLE
Reduce OneBodyDM Test Precision

### DIFF
--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -96,12 +96,21 @@ public:
       auto* ref_data  = reinterpret_cast<std::complex<Real>*>(ref_in);
       auto* test_data = reinterpret_cast<std::complex<Real>*>(test_in);
       for (size_t id = 0; id < size; id += 2)
-        CHECK(ref_data[id] == ComplexApprox(test_data[id]));
+#if defined(MIXED_PRECISION)
+        CHECK(ref_data[id] == ComplexApprox(test_data[id]).epsilon(1e-4));
+#else
+        CHECK(ref_data[id] == ComplexApprox(test_data[id])));
+#endif
+
     }
     else
     {
       for (size_t id = 0; id < size; ++id)
+#if defined(MIXED_RECISION)
+        CHECK(ref_in[id] == Approx(test_in[id]).epsilon(1e-4));
+#else
         CHECK(ref_in[id] == Approx(test_in[id]));
+#endif
     }
   }
 

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -99,7 +99,7 @@ public:
 #if defined(MIXED_PRECISION)
         CHECK(ref_data[id] == ComplexApprox(test_data[id]).epsilon(1e-4));
 #else
-        CHECK(ref_data[id] == ComplexApprox(test_data[id])));
+        CHECK(ref_data[id] == ComplexApprox(test_data[id]));
 #endif
 
     }


### PR DESCRIPTION
## Proposed changes

Closes #3621

Reduce precision in mixed precision builds

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Only in CI, but the precision problems have not occurred there. We will need to adjust the tolerances in later PRs if the nightlies do not pass.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
