### PR TITLE
Increase error bar on He example total energy test

### DIFF
--- a/examples/molecules/He/CMakeLists.txt
+++ b/examples/molecules/He/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT QMC_CUDA AND NOT QMC_COMPLEX)
     HE_SIMPLE_DMC_SCALARS # series for DMC data
   )
 
-  list(APPEND HE_SIMPLE_OPT_SCALARS "totenergy" "-2.88 .004") # total energy
+  list(APPEND HE_SIMPLE_OPT_SCALARS "totenergy" "-2.88 .005") # total energy
 
   qmc_run_and_check(
     example_He_simple_opt


### PR DESCRIPTION
## Proposed changes

Fix a statistical error seen a macOS build with macports llvm-13 and Apple accelerate framework:
```
          Start 1271: example_He_example_wf-1-1-totenergy
1271/1273 Test #1271: example_He_example_wf-1-1-totenergy ...............................................................***Failed    0.05 sec
Tests for series 10
  Testing quantity: LocalEnergy
    reference mean value     :  -2.88000000
    reference error bar      :   0.00400000
    computed  mean value     :  -2.89218066
    computed  error bar      :   0.00388356
    pass tolerance           :   0.01200000  (  3.00000000 sigma)
    deviation from reference :  -0.01218066  ( -3.04516603 sigma)
    error bar of deviation   :   0.00557513
    significance probability :   0.99767434  (gaussian statistics)
    status of this test      :   fail

Test status: fail
```


## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
