### PR TITLE
Save and restore variational parameters in HDF

### DIFF
--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -358,7 +358,7 @@ struct VariableSet
 
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
 
-  // Save variational paramters to an HDF file
+  // Save variational parameters to an HDF file
   void saveAsHDF(const std::string& filename) const;
 
   /// Read variational parameters from an HDF file.

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -357,6 +357,13 @@ struct VariableSet
   void setDefaults(bool optimize_all);
 
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
+
+  // Save variational paramters to an HDF file
+  void saveAsHDF(const std::string& filename) const;
+
+  /// Read variational parameters from an HDF file.
+  /// This assumes VariableSet is already set up.
+  void readFromHDF(const std::string& filename);
 };
 } // namespace optimize
 

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -19,6 +19,7 @@
 #include <string>
 
 using std::string;
+using qmcplusplus::ValueApprox;
 
 namespace optimize
 {
@@ -109,5 +110,28 @@ TEST_CASE("VariableSet output", "[optimize]")
 
   REQUIRE(o.str() == formatted_output);
 }
+
+TEST_CASE("VariableSet HDF output and input", "[optimize]")
+{
+  VariableSet vs;
+  VariableSet::value_type first_val(11234.56789);
+  VariableSet::value_type second_val(0.000256789);
+  VariableSet::value_type third_val(-1.2);
+  vs.insert("s", first_val);
+  vs.insert("second", second_val);
+  vs.insert("really_really_really_long_name", third_val);
+  vs.saveAsHDF("vp.h5");
+
+  VariableSet vs2;
+  vs2.insert("s", 0.0);
+  vs2.insert("second", 0.0);
+  vs2.readFromHDF("vp.h5");
+  CHECK(vs2.find("s")->second == ValueApprox(first_val));
+  CHECK(vs2.find("second")->second == ValueApprox(second_val));
+  // This value as in the file, but not in the VariableSet that loaded the file,
+  // so the value does not get added.
+  CHECK(vs2.find("really_really_really_long_name") == vs2.end());
+}
+
 
 } // namespace optimize


### PR DESCRIPTION
This stores the parameter names as one array and the parameter values as another array.

Upon loading, only values that already exist in the VariableSet get set a new value from the file.

This is the save/load functionality from the prototype in #3634.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
