### PR TITLE
Bump codecov-action to v2

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -89,9 +89,9 @@ jobs:
 
       - name: Upload Coverage
         if: contains(matrix.jobname, 'Gcov') && github.repository_owner == 'QMCPACK'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
-          file: ../qmcpack-build/coverage.xml
+          files: ../qmcpack-build/coverage.xml
           flags: tests-deterministic # optional
           name: codecov-QMCPACK # optional
           fail_ci_if_error: true # optional (default = false)


### PR DESCRIPTION
## Proposed changes

Bump codecov-action to v2
Upload GCov xml coverage reports to [codecov/QMCPACK/qmcpack](https://app.codecov.io/gh/QMCPACK/qmcpack) via GitHub Actions
v1 to be [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Other (please describe): codecov uploader

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
None, must pass CI and upload coverage reports

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
