### PR TITLE
Fix the latdev estimator failure

### DIFF
--- a/tests/estimator/latdev/latdev_check.py
+++ b/tests/estimator/latdev/latdev_check.py
@@ -30,7 +30,8 @@ if __name__ == '__main__':
 
     # get particle-resolved latdev from stat.dat
     fp = h5py.File(fstat)
-    latdev = fp['latdev/value'].value
+    # The trailing [:] converts the Dataset to numpy array
+    latdev = fp['latdev/value'][:]
     latdir = latdev.reshape(nblock,natom,ndim).mean(axis=1)
     lat_cols = [col for col in df.columns if col.startswith('latdev')]
     slatdir  = df.loc[:,lat_cols].values

--- a/tests/estimator/sofk/check_collectables_h5dat.py
+++ b/tests/estimator/sofk/check_collectables_h5dat.py
@@ -23,7 +23,7 @@ def get_last_sk(fdat,fh5):
 
   # get S(k) from stat.h5
   fp = h5py.File(fh5, 'r')
-  h5y = fp['h5sk/value'].value.T[-1]
+  h5y = fp['h5sk/value'][:].T[-1]
   fp.close()
 
   return myy, h5y

--- a/tests/estimator/sofk/check_properties_h5dat.py
+++ b/tests/estimator/sofk/check_properties_h5dat.py
@@ -52,7 +52,7 @@ def compare_columns_dat_h5(fdat, fh5):
 
     # get .h5 values
     h5_loc = os.path.join(col, 'value')
-    h5y  = fp[h5_loc].value[:,-1]
+    h5y  = fp[h5_loc][:][:,-1]
 
     # get .dat values
     daty = df.loc[:,col].values


### PR DESCRIPTION
The ".value" method to an h5py Datatset was removed in version 3.
Use a different technique to convert to a numpy array.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
