### PR TITLE
removed unused struct HDFAttribIO<hsize_t> : public HDFAttribIOBase

### DIFF
--- a/src/Numerics/HDFNumericAttrib.h
+++ b/src/Numerics/HDFNumericAttrib.h
@@ -57,33 +57,6 @@ struct HDFAttribIO<std::string>: public HDFAttribIOBase {
   }
   };*/
 
-
-/** Specialization for hsize_t */
-template<>
-struct HDFAttribIO<hsize_t> : public HDFAttribIOBase
-{
-  hsize_t& ref;
-
-  HDFAttribIO<hsize_t>(hsize_t& a) : ref(a) {}
-
-  inline void write(hid_t grp, const char* name) override
-  {
-    hsize_t dim     = 1;
-    hid_t dataspace = H5Screate_simple(1, &dim, NULL);
-    hid_t dataset   = H5Dcreate(grp, name, H5T_NATIVE_INT, dataspace, H5P_DEFAULT);
-    hid_t ret       = H5Dwrite(dataset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ref);
-    H5Sclose(dataspace);
-    H5Dclose(dataset);
-  }
-
-  inline void read(hid_t grp, const char* name) override
-  {
-    hid_t h1  = H5Dopen(grp, name);
-    hid_t ret = H5Dread(h1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &ref);
-    H5Dclose(h1);
-  }
-};
-
 template<>
 struct HDFAttribIO<unsigned long> : public HDFAttribIOBase
 {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Fixes #3648 by removing unused code associated with using hsize_t.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- 
### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Summit

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
