### PR TITLE
Remove Intel19 complex CI failed tests

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -34,7 +34,6 @@ jobs:
             Intel19-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
             Intel19-MPI-CUDA-AFQMC-Complex-Mixed,
             Intel19-MPI-CUDA-AFQMC-Real,
-            Intel19-MPI-CUDA-AFQMC-Complex,
           ]
 
     steps:


### PR DESCRIPTION
## Proposed changes

Remove failing CI job on sulfur preventing PRs to pass
Opened #3654 for tracking this bug

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests) CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI 

## Checklist

- No. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
