### PR TITLE
Add GCC8-MKL-NoMPI configuration to CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -25,6 +25,10 @@ jobs:
             GCC8-NoMPI-Legacy-CUDA-Complex-Mixed,
             GCC8-NoMPI-Legacy-CUDA-Real, # full precision
             GCC8-NoMPI-Legacy-CUDA-Complex,
+            GCC8-NoMPI-MKL-Real-Mixed, # mixed precision
+            GCC8-NoMPI-MKL-Complex-Mixed,
+            GCC8-NoMPI-MKL-Real, # full precision
+            GCC8-NoMPI-MKL-Complex,
             GCC8-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
             GCC8-MPI-CUDA-AFQMC-Complex-Mixed,
             GCC8-MPI-CUDA-AFQMC-Real,

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -190,6 +190,19 @@ case "$1" in
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ${GITHUB_WORKSPACE}
       ;;
+      *"GCC8-NoMPI-MKL-"*)
+        echo 'Configure for building with GCC and Intel MKL'
+
+        source /opt/intel2020/mkl/bin/mklvars.sh intel64
+
+        cmake -GNinja \
+              -DBLA_VENDOR=Intel10_64lp \
+              -DQMC_MPI=0 \
+              -DQMC_COMPLEX=$IS_COMPLEX \
+              -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              ${GITHUB_WORKSPACE}
+      ;;
       *"macOS-GCC11-NoMPI-Real"*)
         echo 'Configure for building on macOS using gcc11'
         cmake -GNinja \
@@ -263,6 +276,11 @@ case "$1" in
     if [[ "${GH_JOBNAME}" =~ (Intel19) ]]
     then
        source /opt/intel2020/bin/compilervars.sh -arch intel64 -platform linux
+    fi
+
+    if [[ "${GH_JOBNAME}" =~ (MKL) ]]
+    then 
+       source /opt/intel2020/mkl/bin/mklvars.sh intel64
     fi
     
     ctest --output-on-failure $TEST_LABEL


### PR DESCRIPTION
## Proposed changes
Add GCC8-MKL-NoMPI configuration to CI
Using sulfur as GItHub Actions self-hosted runner
Related to #3639 to replace ANL runners

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
