### PR TITLE
Fix restrict type qualifier misuse.

### DIFF
--- a/src/Numerics/Quadrature.h
+++ b/src/Numerics/Quadrature.h
@@ -297,7 +297,6 @@ struct Quadrature3D
     std::vector<PosType>& grid = xyz_m;
     std::vector<RealType>& w   = weight_m;
     SoaSphericalTensor<RealType> Ylm(lexact);
-    const RealType* restrict Ylm_v = Ylm[0];
     for (int l1 = 0; l1 <= lexact; l1++)
       for (int l2 = 0; l2 <= (lexact - l1); l2++)
         for (int m1 = -l1; m1 <= l1; m1++)
@@ -307,6 +306,7 @@ struct Quadrature3D
             for (int k = 0; k < grid.size(); k++)
             {
               Ylm.evaluateV(grid[k][0], grid[k][1], grid[k][2]);
+              const RealType* Ylm_v = Ylm[0];
               RealType v1 = Ylm_v[Ylm.index(l1, m1)];
               RealType v2 = Ylm_v[Ylm.index(l2, m2)];
               sum += 4.0 * M_PI * w[k] * v1 * v2;


### PR DESCRIPTION
## Proposed changes
NVHPC compiler engineers identified this issue.

We define `const RealType* restrict Ylm_v = Ylm[0];` but then directly modified it via `Ylm.evaluateV(grid[k][0], grid[k][1], grid[k][2]);`
Now we just define `Ylm_v` after `Ylm.evaluateV` and removed restrict which doesn't really have benefit in this case.

## What type(s) of changes does this code introduce?
- Bugfix
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'