### PR TITLE
Cache results from slow python script test_labels.py

### DIFF
--- a/CMake/test_labels.cmake
+++ b/CMake/test_labels.cmake
@@ -1,18 +1,20 @@
 function(ADD_TEST_LABELS TEST_NAME TEST_LABELS)
-  set(SUCCESS FALSE)
   set(TEST_LABELS_TEMP "")
-  execute_process(
-    COMMAND ${qmcpack_SOURCE_DIR}/tests/scripts/test_labels.py ${TEST_NAME} ${QMC_CUDA} ${QMC_COMPLEX}
-            ${QMC_MIXED_PRECISION}
-    OUTPUT_VARIABLE TEST_LABELS_TEMP
-    RESULT_VARIABLE SUCCESS)
-  #MESSAGE("  Label script return value: ${SUCCESS}")
-  if(NOT ${SUCCESS} STREQUAL "0")
-    message("Warning: test labeling failed.  Test labeling error output:\n${TEST_LABELS_TEMP}")
-    set(TEST_LABELS_TEMP "")
-    #ELSE()
-    #  MESSAGE("  Test: ${TEST_NAME}")
-    #  MESSAGE("    ${TEST_LABELS_TEMP}")
+  if (DEFINED TEST_LABELS_${TEST_NAME}_${QMC_CUDA}_${QMC_COMPLEX}_${QMC_MIXED_PRECISION})
+    set(TEST_LABELS_TEMP TEST_LABELS_${${TEST_NAME}_${QMC_CUDA}_${QMC_COMPLEX}_${QMC_MIXED_PRECISION}})
+  else()
+    set(SUCCESS FALSE)
+    execute_process(
+      COMMAND ${qmcpack_SOURCE_DIR}/tests/scripts/test_labels.py ${TEST_NAME} ${QMC_CUDA} ${QMC_COMPLEX}
+              ${QMC_MIXED_PRECISION}
+      OUTPUT_VARIABLE TEST_LABELS_TEMP
+      RESULT_VARIABLE SUCCESS)
+    if(${SUCCESS} STREQUAL "0")
+      set(TEST_LABELS_${TEST_NAME}_${QMC_CUDA}_${QMC_COMPLEX}_${QMC_MIXED_PRECISION} ${TEST_LABELS_TEMP} CACHE INTERNAL "for internal use only; do not modify")
+    else()
+      message("Warning: test labeling failed.  Test labeling error output:\n${TEST_LABELS_TEMP}")
+      set(TEST_LABELS_TEMP "")
+    endif()
   endif()
   # Remove unstable label from direct execution.
   # It will still be added to statistical child tests.

--- a/tests/scripts/test_labels.py
+++ b/tests/scripts/test_labels.py
@@ -579,11 +579,7 @@ except:
 
 # make a ctest list of the labels
 try:
-    ctest_labels = ''
-    for label in labels:
-        ctest_labels += label+';'
-    #end for
-    ctest_labels = ctest_labels.rstrip(';')
+    ctest_labels = ';'.join(labels)
 except:
     error()
 #end try


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Noticed that the python script test_labels.py is being rerun each time cmake is run. This caches the result in a unique variable

This is part of #2227. I hope we can further speed up generation of TEST_LABELS.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
