### PR TITLE
Use GitHub Actions jobs.<job-id>.needs API

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -105,8 +105,9 @@ jobs:
       github.repository_owner == 'QMCPACK' &&
       github.event.issue.pull_request &&
       ( startsWith(github.event.comment.body, 'Test this please') || 
-        startsWith(github.event.comment.body, 'Start testing in-house') ) &&
-      github.event.cpu-intel64.conclusion == 'success'
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    needs: cpu-intel64
 
     runs-on: [self-hosted, Linux, X64, gpu, cuda]
 


### PR DESCRIPTION
## Proposed changes

Current jobs in sulfur GPU are skipped due to attempt in PR #3670 
Try Actions [jobs.\<job-name\>.needs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idneeds) to enable hierarchy in 1) CPU and 2) GPU tests

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
