### PR TITLE
Update qmcfinitesize to use UBsplines instead of NUBsplines

### DIFF
--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -5,9 +5,6 @@
 #include <cmath>
 #include "Configuration.h"
 #include "einspline/bspline_eval_d.h"
-#include "einspline/nubspline_eval_d.h"
-#include "einspline/nugrid.h"
-#include "einspline/nubspline_create.h"
 #include "QMCTools/QMCFiniteSize/FSUtilities.h"
 #include "Utilities/RandomGenerator.h"
 

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -115,7 +115,7 @@ void QMCFiniteSize::wfnPut(xmlNodePtr cur)
   pAttrib.put(cur);
   ParticleSet* qp = ptclPool.getParticleSet(target);
 
-  if(qp == nullptr)
+  if (qp == nullptr)
     throw std::runtime_error("target particle set named '" + target + "' not found");
 }
 
@@ -305,15 +305,17 @@ QMCFiniteSize::RealType QMCFiniteSize::sphericalAvgSk(UBspline_3d_d* spline, Rea
   return sum / RealType(ngrid);
 }
 
-NUBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
-                                              vector<RealType>& vals,
-                                              RealType lVal,
-                                              RealType rVal)
+UBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
+                                             vector<RealType>& vals,
+                                             RealType lVal,
+                                             RealType rVal)
 {
   //hack to interface to NUgrid stuff in double prec for MIXED build
   vector<FullPrecRealType> grid_fp(grid.begin(), grid.end());
-  auto grid1d =
-      std::unique_ptr<NUgrid, void (*)(NUgrid*)>{create_general_grid(grid_fp.data(), grid_fp.size()), destroy_grid};
+
+  Grid_t lingrid;
+  lingrid.set(grid_fp[0], grid_fp.back(), grid_fp.size());
+  Ugrid esgrid = lingrid.einspline_grid();
 
   BCtype_d xBC;
   xBC.lVal  = lVal;
@@ -322,14 +324,14 @@ NUBspline_1d_d* QMCFiniteSize::spline_clamped(vector<RealType>& grid,
   xBC.rCode = DERIV1;
   //hack to interface to NUgrid stuff in double prec for MIXED build
   vector<FullPrecRealType> vals_fp(vals.begin(), vals.end());
-  return create_NUBspline_1d_d(grid1d.get(), xBC, vals_fp.data());
+  return create_UBspline_1d_d(esgrid, xBC, vals_fp.data());
 }
 
 //Integrate the spline using Simpson's 5/8 rule.  For Bsplines, this should be exact
 //provided your delta is smaller than the smallest bspline mesh spacing.
 // JPT 13/03/2018 - Fixed an intermittant segfault that occurred b/c
 //                  eval_NUB_spline_1d_d sometimes went out of bounds.
-QMCFiniteSize::RealType QMCFiniteSize::integrate_spline(NUBspline_1d_d* spline, RealType a, RealType b, IndexType N)
+QMCFiniteSize::RealType QMCFiniteSize::integrate_spline(UBspline_1d_d* spline, RealType a, RealType b, IndexType N)
 {
   if (N % 2 != 0) // if N odd, warn that destruction is imminent
   {
@@ -344,15 +346,15 @@ QMCFiniteSize::RealType QMCFiniteSize::integrate_spline(NUBspline_1d_d* spline, 
   for (int i = 1; i < N / 2; i++)
   {
     xi = a + (2 * i - 2) * eps;
-    eval_NUBspline_1d_d(spline, xi, &tmp);
+    eval_UBspline_1d_d(spline, xi, &tmp);
     sum += RealType(tmp);
 
     xi = a + (2 * i - 1) * eps;
-    eval_NUBspline_1d_d(spline, xi, &tmp);
+    eval_UBspline_1d_d(spline, xi, &tmp);
     sum += 4 * tmp;
 
     xi = a + (2 * i) * eps;
-    eval_NUBspline_1d_d(spline, xi, &tmp);
+    eval_UBspline_1d_d(spline, xi, &tmp);
     sum += tmp;
   }
 
@@ -476,26 +478,25 @@ QMCFiniteSize::RealType QMCFiniteSize::calcPotentialInt(vector<RealType> sk)
   RealType kmax   = AA->get_kc();
   IndexType ngrid = 2 * Klist.kshell.size() - 1; //make a lager kmesh
 
-  vector<RealType> nonunigrid1d, k2vksk;
+  vector<RealType> unigrid1d, k2vksk;
   RealType dk = kmax / ngrid;
 
-  nonunigrid1d.push_back(0.0);
+  unigrid1d.push_back(0.0);
   k2vksk.push_back(0.0);
   for (int i = 1; i < ngrid; i++)
   {
     RealType kval = i * dk;
-    nonunigrid1d.push_back(kval);
+    unigrid1d.push_back(kval);
     RealType skavg = sphericalAvgSk(spline.get(), kval);
     RealType k2vk  = kval * kval * AA->evaluate_vlr_k(kval); //evaluation for arbitrary kshell for any LRHandler
     k2vksk.push_back(0.5 * k2vk * skavg);
   }
 
   k2vksk.push_back(0.0);
-  nonunigrid1d.push_back(kmax);
+  unigrid1d.push_back(kmax);
 
   auto integrand =
-      std::unique_ptr<NUBspline_1d_d, void (*)(void*)>{spline_clamped(nonunigrid1d, k2vksk, 0.0, 0.0),
-                                                                 destroy_Bspline};
+      std::unique_ptr<UBspline_1d_d, void (*)(void*)>{spline_clamped(unigrid1d, k2vksk, 0.0, 0.0), destroy_Bspline};
 
   //Integrate the spline and compute the thermodynamic limit.
   RealType integratedval = integrate_spline(integrand.get(), 0.0, kmax, 200);

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
@@ -42,8 +42,8 @@ public:
   UBspline_3d_d* getSkSpline(vector<RealType> sk, RealType limit = 1.0);
   RealType sphericalAvgSk(UBspline_3d_d* spline, RealType k);
 
-  RealType integrate_spline(NUBspline_1d_d* spline, RealType a, RealType b, IndexType N);
-  NUBspline_1d_d* spline_clamped(vector<RealType>& grid, vector<RealType>& vals, RealType lVal, RealType rVal);
+  RealType integrate_spline(UBspline_1d_d* spline, RealType a, RealType b, IndexType N);
+  UBspline_1d_d* spline_clamped(vector<RealType>& grid, vector<RealType>& vals, RealType lVal, RealType rVal);
 
   void initialize();
   void calcPotentialCorrection();

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.h
@@ -6,7 +6,6 @@
 #include "Particle/ParticleSetPool.h"
 #include "LongRange/LRCoulombSingleton.h"
 #include "einspline/bspline_structs.h"
-#include "einspline/nubspline_structs.h"
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This PR removes the dependence of qmcfinitesize on the non-uniform bsplines in favor of uniform bsplines. 
I recently noticed a bug on my mac with gnu compilers for the qmcfinitesize tool where I was getting unreasonably large error bars. I ended up removing the random resampling techniques and worked with just fixed S(k) data (which should always give the same FS correction since the input data is fixed and there is no resampling), and I would see that every few executions of the code I would get erroneous finite size corrections. I ultimately tracked this down specifically to the use of NUBspline_1d_d for the integral part of the finite size correction. Even though all of the underlying input data was the same to generate the spline, either the construction or evaluation of the NUBspline would sometimes break and I'm entirely sure why.  

The use of NUBspline use was a remnant carried over from the original tool, and we no longer actually define the integrand on a nonuniform grid anyway, so I switched everything to using UBsplines, and every evaluation is now consistent and gives the expected answer. I have only ever noticed this with gnu compilers on my mac...when I used intel compilers on one our compute nodes I never saw this behavior iirc. 

I'm not even sure if NUBspline is well tested, whereas UBsplines are used more commonly throughout the code...so making the switch would probably be a good thing even if there wasn't this strange bug. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my macbook, gnu-11

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
