### PR TITLE
c++17 API for lowerCase, removal of tolower and XMLAttrString refactor of getNodeString

### DIFF
--- a/src/Estimators/InputSection.cpp
+++ b/src/Estimators/InputSection.cpp
@@ -45,12 +45,11 @@ void InputSection::readXML(xmlNodePtr cur)
     if (ename == "parameter")
     {
       XMLAttrString name(element, "name");
-      for (auto& c : name)
-        c = tolower(c);
+      name.setValue(lowerCase(name.getValue()));
       if (!is_parameter(name))
       {
         std::stringstream error;
-        error << "InputSection::readXML name " << name << " is not a parameter of " << section_name << "\n";
+        error << "InputSection::readXML name " << name.getValue() << " is not a parameter of " << section_name << "\n";
         throw UniformCommunicateError(error.str());
       }
       std::istringstream stream(XMLNodeString{element});
@@ -197,8 +196,7 @@ void InputSection::report() const
 
 std::any InputSection::lookupAnyEnum(const std::string& enum_name, const std::string& enum_value, const std::unordered_map<std::string, std::any>& enum_map)
 {
-  std::string enum_value_str(enum_name + "-" + enum_value);
-  tolower(enum_value_str);
+  std::string enum_value_str(lowerCase(enum_name + "-" + enum_value));
   try
   {
     return enum_map.at(enum_value_str);

--- a/src/Estimators/InputSection.cpp
+++ b/src/Estimators/InputSection.cpp
@@ -44,12 +44,11 @@ void InputSection::readXML(xmlNodePtr cur)
       c = tolower(c);
     if (ename == "parameter")
     {
-      XMLAttrString name(element, "name");
-      name.setValue(lowerCase(name.getValue()));
+      std::string name(lowerCase(getXMLAttributeValue(element, "name")));
       if (!is_parameter(name))
       {
         std::stringstream error;
-        error << "InputSection::readXML name " << name.getValue() << " is not a parameter of " << section_name << "\n";
+        error << "InputSection::readXML name " << name << " is not a parameter of " << section_name << "\n";
         throw UniformCommunicateError(error.str());
       }
       std::istringstream stream(XMLNodeString{element});

--- a/src/Estimators/SpinDensityInput.cpp
+++ b/src/Estimators/SpinDensityInput.cpp
@@ -39,32 +39,32 @@ void SpinDensityInput::readXML(xmlNodePtr cur)
     if (ename == "parameter")
     {
       const XMLAttrString name(element, "name");
-      if (name == "dr")
+      if (name.getValue() == "dr")
       {
         have_dr_ = true;
         putContent(dr_, element);
       }
-      else if (name == "grid")
+      else if (name.getValue() == "grid")
       {
         have_grid_ = true;
         putContent(grid_, element);
       }
-      else if (name == "corner")
+      else if (name.getValue() == "corner")
       {
         have_corner_ = true;
         putContent(corner_, element);
       }
-      else if (name == "center")
+      else if (name.getValue() == "center")
       {
         have_center_ = true;
         putContent(center_, element);
       }
-      else if (name == "cell")
+      else if (name.getValue() == "cell")
       {
         have_cell_ = true;
         putContent(axes, element);
       }
-      else if (name == "test_moves")
+      else if (name.getValue() == "test_moves")
         putContent(test_moves, element);
     }
     element = element->next;

--- a/src/Estimators/SpinDensityInput.cpp
+++ b/src/Estimators/SpinDensityInput.cpp
@@ -38,33 +38,33 @@ void SpinDensityInput::readXML(xmlNodePtr cur)
     std::string ename((const char*)element->name);
     if (ename == "parameter")
     {
-      const XMLAttrString name(element, "name");
-      if (name.getValue() == "dr")
+      const std::string name(getXMLAttributeValue(element, "name"));
+      if (name == "dr")
       {
         have_dr_ = true;
         putContent(dr_, element);
       }
-      else if (name.getValue() == "grid")
+      else if (name == "grid")
       {
         have_grid_ = true;
         putContent(grid_, element);
       }
-      else if (name.getValue() == "corner")
+      else if (name == "corner")
       {
         have_corner_ = true;
         putContent(corner_, element);
       }
-      else if (name.getValue() == "center")
+      else if (name == "center")
       {
         have_center_ = true;
         putContent(center_, element);
       }
-      else if (name.getValue() == "cell")
+      else if (name == "cell")
       {
         have_cell_ = true;
         putContent(axes, element);
       }
-      else if (name.getValue() == "test_moves")
+      else if (name == "test_moves")
         putContent(test_moves, element);
     }
     element = element->next;

--- a/src/Estimators/TraceManager.h
+++ b/src/Estimators/TraceManager.h
@@ -29,6 +29,7 @@
 #include "OhmmsPETE/OhmmsArray.h"
 #include "Particle/ParticleSet.h"
 #include "Utilities/IteratorUtility.h"
+#include "Utilities/ModernStringUtils.hpp"
 #include "Message/Communicate.h"
 #include "hdf/hdf_archive.h"
 #include "Message/OpenMP.h"
@@ -1556,7 +1557,7 @@ public:
       bool use_scalar_defaults = scalar_defaults == "yes";
       bool use_array_defaults  = array_defaults == "yes";
       verbose                  = verbose_write == "yes";
-      tolower(format);
+      format = lowerCase(format);
       if (format == "hdf")
       {
         hdf_format = true;

--- a/src/Estimators/TraceManager.h
+++ b/src/Estimators/TraceManager.h
@@ -29,7 +29,7 @@
 #include "OhmmsPETE/OhmmsArray.h"
 #include "Particle/ParticleSet.h"
 #include "Utilities/IteratorUtility.h"
-#include "Utilities/ModernStringUtils.hpp"
+#include "ModernStringUtils.hpp"
 #include "Message/Communicate.h"
 #include "hdf/hdf_archive.h"
 #include "Message/OpenMP.h"

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -106,7 +106,7 @@ public:
     else
     {
       for (size_t id = 0; id < size; ++id)
-#if defined(MIXED_RECISION)
+#if defined(MIXED_PRECISION)
         CHECK(ref_in[id] == Approx(test_in[id]).epsilon(1e-4));
 #else
         CHECK(ref_in[id] == Approx(test_in[id]));

--- a/src/Numerics/GaussianTimesRN.h
+++ b/src/Numerics/GaussianTimesRN.h
@@ -235,8 +235,8 @@ void GaussianTimesRN<T>::reset()
 template<class T>
 bool GaussianTimesRN<T>::putBasisGroup(xmlNodePtr cur, int baseOff)
 {
-  const XMLAttrString t(cur, "basePower");
-  if (t.hasValue()) basePower = std::stoi(t.getValue());
+  const std::string t(getXMLAttributeValue(cur, "basePower"));
+  if (!t.empty()) basePower = std::stoi(t);
   basePower += baseOff;
   cur = cur->children;
   while (cur != NULL)

--- a/src/Numerics/GaussianTimesRN.h
+++ b/src/Numerics/GaussianTimesRN.h
@@ -236,7 +236,7 @@ template<class T>
 bool GaussianTimesRN<T>::putBasisGroup(xmlNodePtr cur, int baseOff)
 {
   const XMLAttrString t(cur, "basePower");
-  if (!t.empty()) basePower = std::stoi(t);
+  if (t.hasValue()) basePower = std::stoi(t.getValue());
   basePower += baseOff;
   cur = cur->children;
   while (cur != NULL)

--- a/src/Particle/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/Particle/ParticleIO/ParticleLayoutIO.cpp
@@ -24,7 +24,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 #include "LongRange/LRCoulombSingleton.h"
-#include "Utilities/ModernStringUtils.hpp"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/Particle/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/Particle/ParticleIO/ParticleLayoutIO.cpp
@@ -44,8 +44,6 @@ bool LatticeParser::put(xmlNodePtr cur)
   bool bconds_defined  = false;
   int boxsum           = 0;
 
-  std::string handler_type("opt_breakup");
-
   app_summary() << std::endl;
   app_summary() << " Lattice" << std::endl;
   app_summary() << " -------" << std::endl;
@@ -111,7 +109,7 @@ bool LatticeParser::put(xmlNodePtr cur)
       }
       else if (aname == "LR_handler")
       {
-        std::string handler_type;
+        std::string handler_type("opt_breakup");
         //This chops whitespace so the simple str == comparisons work
         putContent(handler_type, cur);
         handler_type = lowerCase(handler_type);

--- a/src/Particle/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/Particle/ParticleIO/ParticleLayoutIO.cpp
@@ -24,6 +24,7 @@
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 #include "LongRange/LRCoulombSingleton.h"
+#include "Utilities/ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {
@@ -55,24 +56,24 @@ bool LatticeParser::put(xmlNodePtr cur)
     if (cname == "parameter")
     {
       const XMLAttrString aname(cur, "name");
-      if (aname == "scale")
+      if (aname.getValue() == "scale")
       {
         putContent(a0, cur);
       }
-      else if (aname == "lattice")
+      else if (aname.getValue() == "lattice")
       {
         const XMLAttrString units_prop(cur, "units");
-        if (!units_prop.empty() && units_prop != "bohr")
+        if (units_prop.hasValue() && units_prop.getValue() != "bohr")
         {
           APP_ABORT("LatticeParser::put. Only atomic units (bohr) supported for lattice units. Input file uses: "
-                    << std::string(units_prop));
+                    << std::string(units_prop.getValue()));
         }
 
         putContent(lattice_in, cur);
         lattice_defined = true;
         //putContent(ref_.R,cur);
       }
-      else if (aname == "bconds")
+      else if (aname.getValue() == "bconds")
       {
         putContent(bconds, cur);
         bconds_defined = true;
@@ -100,18 +101,20 @@ bool LatticeParser::put(xmlNodePtr cur)
                 "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic ones.");
         }
       }
-      else if (aname == "vacuum")
+      else if (aname.getValue() == "vacuum")
       {
         putContent(ref_.VacuumScale, cur);
       }
-      else if (aname == "LR_dim_cutoff")
+      else if (aname.getValue() == "LR_dim_cutoff")
       {
         putContent(ref_.LR_dim_cutoff, cur);
       }
-      else if (aname == "LR_handler")
+      else if (aname.getValue() == "LR_handler")
       {
+        std::string handler_type;
+        //This chops whitespace so the simple str == comparisons work
         putContent(handler_type, cur);
-        tolower(handler_type);
+        handler_type = lowerCase(handler_type);
         if (handler_type == "ewald")
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::EWALD;
         else if (handler_type == "opt_breakup")
@@ -121,11 +124,11 @@ bool LatticeParser::put(xmlNodePtr cur)
         else
           APP_ABORT("\n  Long range breakup handler not recognized.\n");
       }
-      else if (aname == "LR_tol")
+      else if (aname.getValue() == "LR_tol")
       {
         putContent(ref_.LR_tol, cur);
       }
-      else if (aname == "rs")
+      else if (aname.getValue() == "rs")
       {
         lattice_defined = true;
         OhmmsAttributeSet rAttrib;
@@ -135,7 +138,7 @@ bool LatticeParser::put(xmlNodePtr cur)
         rAttrib.put(cur);
         putContent(rs, cur);
       }
-      else if (aname == "nparticles")
+      else if (aname.getValue() == "nparticles")
       {
         putContent(nptcl, cur);
       }

--- a/src/Particle/ParticleIO/ParticleLayoutIO.cpp
+++ b/src/Particle/ParticleIO/ParticleLayoutIO.cpp
@@ -55,25 +55,25 @@ bool LatticeParser::put(xmlNodePtr cur)
     std::string cname((const char*)cur->name);
     if (cname == "parameter")
     {
-      const XMLAttrString aname(cur, "name");
-      if (aname.getValue() == "scale")
+      const std::string aname(getXMLAttributeValue(cur, "name"));
+      if (aname == "scale")
       {
         putContent(a0, cur);
       }
-      else if (aname.getValue() == "lattice")
+      else if (aname == "lattice")
       {
-        const XMLAttrString units_prop(cur, "units");
-        if (units_prop.hasValue() && units_prop.getValue() != "bohr")
+        const std::string units_prop(getXMLAttributeValue(cur, "units"));
+        if (!units_prop.empty() && units_prop != "bohr")
         {
           APP_ABORT("LatticeParser::put. Only atomic units (bohr) supported for lattice units. Input file uses: "
-                    << std::string(units_prop.getValue()));
+                    << units_prop);
         }
 
         putContent(lattice_in, cur);
         lattice_defined = true;
         //putContent(ref_.R,cur);
       }
-      else if (aname.getValue() == "bconds")
+      else if (aname == "bconds")
       {
         putContent(bconds, cur);
         bconds_defined = true;
@@ -101,15 +101,15 @@ bool LatticeParser::put(xmlNodePtr cur)
                 "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic ones.");
         }
       }
-      else if (aname.getValue() == "vacuum")
+      else if (aname == "vacuum")
       {
         putContent(ref_.VacuumScale, cur);
       }
-      else if (aname.getValue() == "LR_dim_cutoff")
+      else if (aname == "LR_dim_cutoff")
       {
         putContent(ref_.LR_dim_cutoff, cur);
       }
-      else if (aname.getValue() == "LR_handler")
+      else if (aname == "LR_handler")
       {
         std::string handler_type;
         //This chops whitespace so the simple str == comparisons work
@@ -124,11 +124,11 @@ bool LatticeParser::put(xmlNodePtr cur)
         else
           APP_ABORT("\n  Long range breakup handler not recognized.\n");
       }
-      else if (aname.getValue() == "LR_tol")
+      else if (aname == "LR_tol")
       {
         putContent(ref_.LR_tol, cur);
       }
-      else if (aname.getValue() == "rs")
+      else if (aname == "rs")
       {
         lattice_defined = true;
         OhmmsAttributeSet rAttrib;
@@ -138,7 +138,7 @@ bool LatticeParser::put(xmlNodePtr cur)
         rAttrib.put(cur);
         putContent(rs, cur);
       }
-      else if (aname.getValue() == "nparticles")
+      else if (aname == "nparticles")
       {
         putContent(nptcl, cur);
       }

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -455,9 +455,9 @@ bool QMCMain::validateXML()
     {
       //file is provided
       const XMLAttrString include_name(cur, "href");
-      if (!include_name.empty())
+      if (include_name.hasValue())
       {
-        bool success = pushDocument(include_name);
+        bool success = pushDocument(include_name.getValue());
         if (success)
         {
           inputnode = processPWH(XmlDocStack.top()->getRoot());

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -454,10 +454,10 @@ bool QMCMain::validateXML()
     else if (cname == "include")
     {
       //file is provided
-      const XMLAttrString include_name(cur, "href");
-      if (include_name.hasValue())
+      const std::string include_name(getXMLAttributeValue(cur, "href"));
+      if (!include_name.empty())
       {
-        bool success = pushDocument(include_name.getValue());
+        bool success = pushDocument(include_name);
         if (success)
         {
           inputnode = processPWH(XmlDocStack.top()->getRoot());

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -108,8 +108,8 @@ use_fake_rng(qmcdriver_unit)
 target_include_directories(qmcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(qmcdriver_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators qmcio_xml)
-target_link_libraries(qmcdriver_unit PUBLIC qmcham_unit qmcestimators_unit qmcio_xml)
+target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators)
+target_link_libraries(qmcdriver_unit PUBLIC qmcham_unit qmcestimators_unit)
 
 target_link_libraries(qmcdriver PRIVATE platform_LA)
 target_link_libraries(qmcdriver_unit PRIVATE platform_LA)

--- a/src/QMCDrivers/CMakeLists.txt
+++ b/src/QMCDrivers/CMakeLists.txt
@@ -108,8 +108,8 @@ use_fake_rng(qmcdriver_unit)
 target_include_directories(qmcdriver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(qmcdriver_unit PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators)
-target_link_libraries(qmcdriver_unit PUBLIC qmcham_unit qmcestimators_unit)
+target_link_libraries(qmcdriver PUBLIC qmcham qmcestimators qmcio_xml)
+target_link_libraries(qmcdriver_unit PUBLIC qmcham_unit qmcestimators_unit qmcio_xml)
 
 target_link_libraries(qmcdriver PRIVATE platform_LA)
 target_link_libraries(qmcdriver_unit PRIVATE platform_LA)

--- a/src/QMCDrivers/Optimizers/HybridEngine.cpp
+++ b/src/QMCDrivers/Optimizers/HybridEngine.cpp
@@ -48,7 +48,7 @@ bool HybridEngine::processXML(const xmlNodePtr opt_xml)
       if (children_MinMethod.empty())
         throw std::runtime_error("MinMethod must be given!\n");
       XMLAttrString updates_string(cur, "num_updates");
-      app_log() << "HybridEngine saved MinMethod " << children_MinMethod << " num_updates = " << updates_string
+      app_log() << "HybridEngine saved MinMethod " << children_MinMethod << " num_updates = " << updates_string.getValue()
                 << std::endl;
       auto iter = OptimizerNames.find(children_MinMethod);
       if (iter == OptimizerNames.end())

--- a/src/QMCDrivers/Optimizers/HybridEngine.cpp
+++ b/src/QMCDrivers/Optimizers/HybridEngine.cpp
@@ -47,9 +47,8 @@ bool HybridEngine::processXML(const xmlNodePtr opt_xml)
 
       if (children_MinMethod.empty())
         throw std::runtime_error("MinMethod must be given!\n");
-      XMLAttrString updates_string(cur, "num_updates");
-      app_log() << "HybridEngine saved MinMethod " << children_MinMethod << " num_updates = " << updates_string.getValue()
-                << std::endl;
+      std::string updates_string(getXMLAttributeValue(cur, "num_updates"));
+      app_log() << "HybridEngine saved MinMethod " << children_MinMethod << " num_updates = " << updates_string << '\n';
       auto iter = OptimizerNames.find(children_MinMethod);
       if (iter == OptimizerNames.end())
         throw std::runtime_error("Unknown MinMethod!\n");

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -554,8 +554,8 @@ xmlNodePtr QMCDriver::getQMCNode()
     std::string cname((const char*)(cur->name));
     if (cname == "parameter")
     {
-      const XMLAttrString name(cur, "name");
-      if (name.getValue() == "current")
+      const std::string name(getXMLAttributeValue(cur, "name"));
+      if (name == "current")
         current_ptr = cur;
     }
     cur = cur->next;

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -555,7 +555,7 @@ xmlNodePtr QMCDriver::getQMCNode()
     if (cname == "parameter")
     {
       const XMLAttrString name(cur, "name");
-      if (name == "current")
+      if (name.getValue() == "current")
         current_ptr = cur;
     }
     cur = cur->next;

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -179,9 +179,9 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
     if (xmlStrEqual(tcur->name, (const xmlChar*)"qmcsystem"))
     {
       const XMLAttrString wf_name(tcur, "wavefunction");
-      if (!wf_name.empty())
+      if (wf_name.hasValue())
       {
-        targetPsi.push(wavefunction_pool.getWaveFunction(wf_name));
+        targetPsi.push(wavefunction_pool.getWaveFunction(wf_name.getValue()));
       }
       else
       {
@@ -189,9 +189,9 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
         targetPsi.push(0);
       }
       const XMLAttrString ham_name(tcur, "hamiltonian");
-      if (!ham_name.empty())
+      if (ham_name.hasValue())
       {
-        targetH.push(hamiltonian_pool.getHamiltonian(ham_name));
+        targetH.push(hamiltonian_pool.getHamiltonian(ham_name.getValue()));
       }
       else
       {

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -178,20 +178,20 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     if (xmlStrEqual(tcur->name, (const xmlChar*)"qmcsystem"))
     {
-      const XMLAttrString wf_name(tcur, "wavefunction");
-      if (wf_name.hasValue())
+      const std::string wf_name(getXMLAttributeValue(tcur, "wavefunction"));
+      if (!wf_name.empty())
       {
-        targetPsi.push(wavefunction_pool.getWaveFunction(wf_name.getValue()));
+        targetPsi.push(wavefunction_pool.getWaveFunction(wf_name));
       }
       else
       {
         app_warning() << " qmcsystem does not have wavefunction. Assign 0" << std::endl;
         targetPsi.push(0);
       }
-      const XMLAttrString ham_name(tcur, "hamiltonian");
-      if (ham_name.hasValue())
+      const std::string ham_name(getXMLAttributeValue(tcur, "hamiltonian"));
+      if (!ham_name.empty())
       {
-        targetH.push(hamiltonian_pool.getHamiltonian(ham_name.getValue()));
+        targetH.push(hamiltonian_pool.getHamiltonian(ham_name));
       }
       else
       {

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -548,8 +548,8 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      XMLAttrString aname(cur, "id");
-      if (!aname.hasValue())
+      std::string aname(getXMLAttributeValue(cur, "id"));
+      if (aname.empty())
         continue;
       if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())
         paramNodes[aname] = cur;
@@ -560,16 +560,16 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      XMLAttrString aname(cur, "id");
-      if (!aname.hasValue())
+      std::string aname(getXMLAttributeValue(cur, "id"));
+      if (aname.empty())
         continue;
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"exponent"); aptr != nullptr)
       {
-        std::string expID = aname.getValue() + "_E";
+        std::string expID = aname + "_E";
         if (auto oit = OptVariablesForPsi.find(expID); oit != OptVariablesForPsi.end())
           attribNodes[expID] = std::pair<xmlNodePtr, std::string>(cur, "exponent");
       }
-      std::string cID = aname.getValue() + "_C";
+      std::string cID = aname + "_C";
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"contraction"); aptr != nullptr)
         if (auto oit = OptVariablesForPsi.find(cID); oit != OptVariablesForPsi.end())
           attribNodes[cID] = std::pair<xmlNodePtr, std::string>(cur, "contraction");
@@ -580,8 +580,8 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      XMLAttrString aname(cur, "id");
-      if (!aname.hasValue())
+      std::string aname(getXMLAttributeValue(cur, "id"));
+      if (aname.empty())
         continue;
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
@@ -595,8 +595,8 @@ void QMCCostFunctionBase::updateXmlNodes()
     for (int iparam = 0; iparam < result->nodesetval->nodeNr; iparam++)
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
-      XMLAttrString aname(cur, "id");
-      if (!aname.hasValue())
+      std::string aname(getXMLAttributeValue(cur, "id"));
+      if (aname.empty())
         continue;
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != nullptr)
         if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -343,7 +343,7 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
   m_param.add(output_override_str, "output_vp_override", {"no", "yes"});
   m_param.put(q);
 
-  tolower(targetExcitedStr);
+  targetExcitedStr = lowerCase(targetExcitedStr);
   targetExcited = (targetExcitedStr == "yes");
 
   if (output_override_str == "yes")
@@ -549,7 +549,7 @@ void QMCCostFunctionBase::updateXmlNodes()
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
       XMLAttrString aname(cur, "id");
-      if (aname.empty())
+      if (!aname.hasValue())
         continue;
       if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())
         paramNodes[aname] = cur;
@@ -561,15 +561,15 @@ void QMCCostFunctionBase::updateXmlNodes()
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
       XMLAttrString aname(cur, "id");
-      if (aname.empty())
+      if (!aname.hasValue())
         continue;
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"exponent"); aptr != nullptr)
       {
-        std::string expID = aname + "_E";
+        std::string expID = aname.getValue() + "_E";
         if (auto oit = OptVariablesForPsi.find(expID); oit != OptVariablesForPsi.end())
           attribNodes[expID] = std::pair<xmlNodePtr, std::string>(cur, "exponent");
       }
-      std::string cID = aname + "_C";
+      std::string cID = aname.getValue() + "_C";
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"contraction"); aptr != nullptr)
         if (auto oit = OptVariablesForPsi.find(cID); oit != OptVariablesForPsi.end())
           attribNodes[cID] = std::pair<xmlNodePtr, std::string>(cur, "contraction");
@@ -581,7 +581,7 @@ void QMCCostFunctionBase::updateXmlNodes()
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
       XMLAttrString aname(cur, "id");
-      if (aname.empty())
+      if (!aname.hasValue())
         continue;
       xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff");
       opt_variables_type::iterator oit(OptVariablesForPsi.find(aname));
@@ -596,7 +596,7 @@ void QMCCostFunctionBase::updateXmlNodes()
     {
       xmlNodePtr cur = result->nodesetval->nodeTab[iparam];
       XMLAttrString aname(cur, "id");
-      if (aname.empty())
+      if (!aname.hasValue())
         continue;
       if (xmlAttrPtr aptr = xmlHasProp(cur, (const xmlChar*)"coeff"); aptr != nullptr)
         if (auto oit = OptVariablesForPsi.find(aname); oit != OptVariablesForPsi.end())

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -514,10 +514,10 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml,
                                                  bool useGPU)
 {
   m_param.put(opt_xml);
-  tolower(targetExcitedStr);
+  targetExcitedStr = lowerCase(targetExcitedStr);
   targetExcited = (targetExcitedStr == "yes");
 
-  tolower(block_lmStr);
+  block_lmStr = lowerCase(block_lmStr);
   block_lm = (block_lmStr == "yes");
 
   auto iter = OptimizerNames.find(MinMethod);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -616,7 +616,7 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
     if (cname == "optimize")
     {
       const XMLAttrString att(element, "method");
-      if (!att.empty() && att == "gradient_test")
+      if (att.hasValue() && att.getValue() == "gradient_test")
       {
         GradientTestInput test_grad_input;
         test_grad_input.readXML(element);
@@ -628,7 +628,7 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
       else
       {
         std::stringstream error_msg;
-        app_log() << "Unknown or missing 'method' attribute in optimize tag: " << att << "\n";
+        app_log() << "Unknown or missing 'method' attribute in optimize tag: " << att.getValue() << "\n";
         throw UniformCommunicateError(error_msg.str());
       }
     }
@@ -661,10 +661,10 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
                                                         bool useGPU)
 {
   m_param.put(opt_xml);
-  tolower(targetExcitedStr);
+  targetExcitedStr = lowerCase(targetExcitedStr);
   targetExcited = (targetExcitedStr == "yes");
 
-  tolower(block_lmStr);
+  block_lmStr = lowerCase(block_lmStr);
   block_lm = (block_lmStr == "yes");
 
   auto iter = OptimizerNames.find(MinMethod);

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -615,8 +615,8 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
   processChildren(q, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "optimize")
     {
-      const XMLAttrString att(element, "method");
-      if (att.hasValue() && att.getValue() == "gradient_test")
+      const std::string att(getXMLAttributeValue(element, "method"));
+      if (!att.empty() && att == "gradient_test")
       {
         GradientTestInput test_grad_input;
         test_grad_input.readXML(element);
@@ -628,7 +628,7 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
       else
       {
         std::stringstream error_msg;
-        app_log() << "Unknown or missing 'method' attribute in optimize tag: " << att.getValue() << "\n";
+        app_log() << "Unknown or missing 'method' attribute in optimize tag: " << att << "\n";
         throw UniformCommunicateError(error_msg.str());
       }
     }

--- a/src/QMCDrivers/WFOpt/WFOptDriverInput.cpp
+++ b/src/QMCDrivers/WFOpt/WFOptDriverInput.cpp
@@ -31,9 +31,9 @@ void WFOptDriverInput::readXML(xmlNodePtr xml_input)
     std::string cname((const char*)(cur->name));
     if (cname.find("optimize") < cname.size())
     {
-      const XMLAttrString att(cur, "method");
-      if (att.hasValue())
-        opt_method_ = att.getValue();
+      const std::string att(getXMLAttributeValue(cur, "method"));
+      if (!att.empty())
+        opt_method_ = att;
       opt_xml_node_ = cur;
     }
     cur = cur->next;

--- a/src/QMCDrivers/WFOpt/WFOptDriverInput.cpp
+++ b/src/QMCDrivers/WFOpt/WFOptDriverInput.cpp
@@ -32,8 +32,8 @@ void WFOptDriverInput::readXML(xmlNodePtr xml_input)
     if (cname.find("optimize") < cname.size())
     {
       const XMLAttrString att(cur, "method");
-      if (!att.empty())
-        opt_method_ = att;
+      if (att.hasValue())
+        opt_method_ = att.getValue();
       opt_xml_node_ = cur;
     }
     cur = cur->next;

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -156,42 +156,42 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     if (ename == "parameter")
     {
       const XMLAttrString name(element, "name");
-      if (name == "basis")
+      if (name.getValue() == "basis")
         putContent(sposets, element);
-      else if (name == "energy_matrix")
+      else if (name.getValue() == "energy_matrix")
         putContent(emstr, element);
-      else if (name == "integrator")
+      else if (name.getValue() == "integrator")
         putContent(igstr, element);
-      else if (name == "evaluator")
+      else if (name.getValue() == "evaluator")
         putContent(evstr, element);
-      else if (name == "scale")
+      else if (name.getValue() == "scale")
         putContent(scale, element);
-      else if (name == "center")
+      else if (name.getValue() == "center")
       {
         putContent(center, element);
         center_defined = true;
       }
-      else if (name == "points")
+      else if (name.getValue() == "points")
         putContent(points, element);
-      else if (name == "samples")
+      else if (name.getValue() == "samples")
         putContent(samples, element);
-      else if (name == "warmup")
+      else if (name.getValue() == "warmup")
         putContent(warmup, element);
-      else if (name == "timestep")
+      else if (name.getValue() == "timestep")
         putContent(timestep, element);
-      else if (name == "use_drift")
+      else if (name.getValue() == "use_drift")
         putContent(udstr, element);
-      else if (name == "check_overlap")
+      else if (name.getValue() == "check_overlap")
         putContent(costr, element);
-      else if (name == "check_derivatives")
+      else if (name.getValue() == "check_derivatives")
         putContent(cdstr, element);
-      else if (name == "acceptance_ratio")
+      else if (name.getValue() == "acceptance_ratio")
         putContent(arstr, element);
-      else if (name == "rstats")
+      else if (name.getValue() == "rstats")
         putContent(wrstr, element);
-      else if (name == "normalized")
+      else if (name.getValue() == "normalized")
         putContent(nmstr, element);
-      else if (name == "volume_normed")
+      else if (name.getValue() == "volume_normed")
         putContent(vnstr, element);
     }
     element = element->next;

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -155,43 +155,43 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     std::string ename((const char*)element->name);
     if (ename == "parameter")
     {
-      const XMLAttrString name(element, "name");
-      if (name.getValue() == "basis")
+      const std::string name(getXMLAttributeValue(element, "name"));
+      if (name == "basis")
         putContent(sposets, element);
-      else if (name.getValue() == "energy_matrix")
+      else if (name == "energy_matrix")
         putContent(emstr, element);
-      else if (name.getValue() == "integrator")
+      else if (name == "integrator")
         putContent(igstr, element);
-      else if (name.getValue() == "evaluator")
+      else if (name == "evaluator")
         putContent(evstr, element);
-      else if (name.getValue() == "scale")
+      else if (name == "scale")
         putContent(scale, element);
-      else if (name.getValue() == "center")
+      else if (name == "center")
       {
         putContent(center, element);
         center_defined = true;
       }
-      else if (name.getValue() == "points")
+      else if (name == "points")
         putContent(points, element);
-      else if (name.getValue() == "samples")
+      else if (name == "samples")
         putContent(samples, element);
-      else if (name.getValue() == "warmup")
+      else if (name == "warmup")
         putContent(warmup, element);
-      else if (name.getValue() == "timestep")
+      else if (name == "timestep")
         putContent(timestep, element);
-      else if (name.getValue() == "use_drift")
+      else if (name == "use_drift")
         putContent(udstr, element);
-      else if (name.getValue() == "check_overlap")
+      else if (name == "check_overlap")
         putContent(costr, element);
-      else if (name.getValue() == "check_derivatives")
+      else if (name == "check_derivatives")
         putContent(cdstr, element);
-      else if (name.getValue() == "acceptance_ratio")
+      else if (name == "acceptance_ratio")
         putContent(arstr, element);
-      else if (name.getValue() == "rstats")
+      else if (name == "rstats")
         putContent(wrstr, element);
-      else if (name.getValue() == "normalized")
+      else if (name == "normalized")
         putContent(nmstr, element);
-      else if (name.getValue() == "volume_normed")
+      else if (name == "volume_normed")
         putContent(vnstr, element);
     }
     element = element->next;

--- a/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
@@ -112,8 +112,8 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
 
   std::string vFormat("V");
   const XMLAttrString v_str(cur, "format");
-  if (!v_str.empty())
-    vFormat = v_str;
+  if (v_str.hasValue())
+    vFormat = v_str.getValue();
 
   int vPowerCorrection = 1;
   if (vFormat == "r*V")

--- a/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.1.cpp
@@ -35,7 +35,7 @@ void ECPComponentBuilder::addSemiLocal(xmlNodePtr cur)
     else if (cname == "vps")
     {
       //should be able to overwrite rmax
-      int l           = angMon[XMLAttrString{cur, "l"}];
+      int l           = angMon[getXMLAttributeValue(cur, "l")];
       Lmax            = std::max(l, Lmax);
       xmlNodePtr cur1 = cur->children;
       while (cur1 != NULL)
@@ -111,9 +111,9 @@ void ECPComponentBuilder::buildLocal(xmlNodePtr cur)
     return; //something is wrong
 
   std::string vFormat("V");
-  const XMLAttrString v_str(cur, "format");
-  if (v_str.hasValue())
-    vFormat = v_str.getValue();
+  const std::string v_str(getXMLAttributeValue(cur, "format"));
+  if (!v_str.empty())
+    vFormat = v_str;
 
   int vPowerCorrection = 1;
   if (vFormat == "r*V")

--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -61,8 +61,8 @@ ECPComponentBuilder::ECPComponentBuilder(const std::string& aname, Communicate* 
 bool ECPComponentBuilder::parse(const std::string& fname, xmlNodePtr cur)
 {
   const XMLAttrString cutoff_str(cur, "cutoff");
-  if (!cutoff_str.empty())
-    RcutMax = std::stod(cutoff_str);
+  if (cutoff_str.hasValue())
+    RcutMax = std::stod(cutoff_str.getValue());
 
   return read_pp_file(fname);
 }

--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -60,9 +60,9 @@ ECPComponentBuilder::ECPComponentBuilder(const std::string& aname, Communicate* 
 
 bool ECPComponentBuilder::parse(const std::string& fname, xmlNodePtr cur)
 {
-  const XMLAttrString cutoff_str(cur, "cutoff");
-  if (cutoff_str.hasValue())
-    RcutMax = std::stod(cutoff_str.getValue());
+  const std::string cutoff_str(getXMLAttributeValue(cur, "cutoff"));
+  if (!cutoff_str.empty())
+    RcutMax = std::stod(cutoff_str);
 
   return read_pp_file(fname);
 }
@@ -172,8 +172,8 @@ bool ECPComponentBuilder::put(xmlNodePtr cur)
     std::string cname((const char*)cur->name);
     if (cname == "header")
     {
-      Zeff         = std::stoi(XMLAttrString{cur, "zval"});
-      AtomicNumber = std::stoi(XMLAttrString{cur, "atomic-number"});
+      Zeff         = std::stoi(getXMLAttributeValue(cur, "zval"));
+      AtomicNumber = std::stoi(getXMLAttributeValue(cur, "atomic-number"));
     }
     else if (cname == "grid")
     {

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -110,38 +110,38 @@ bool OrbitalImages::put(xmlNodePtr cur)
     std::string ename((const char*)element->name);
     if (ename == "parameter")
     {
-      const XMLAttrString name(element, "name");
-      if (name.getValue() == "sposets")
+      const std::string name(getXMLAttributeValue(element, "name"));
+      if (name == "sposets")
         putContent(sposet_names, element);
-      else if (name.getValue() == "batch_size")
+      else if (name == "batch_size")
         putContent(batch_size, element);
-      else if (name.getValue() == "grid")
+      else if (name == "grid")
       {
         have_grid = true;
         putContent(grid, element);
       }
-      else if (name.getValue() == "center_grid")
+      else if (name == "center_grid")
         putContent(cg_str, element);
-      else if (name.getValue() == "corner")
+      else if (name == "corner")
       {
         have_corner = true;
         putContent(corner, element);
       }
-      else if (name.getValue() == "center")
+      else if (name == "center")
       {
         have_center = true;
         putContent(center, element);
       }
-      else if (name.getValue() == "cell")
+      else if (name == "cell")
       {
         have_cell = true;
         putContent(axes, element);
       }
-      else if (name.getValue() == "value")
+      else if (name == "value")
         putContent(valtypes, element);
-      else if (name.getValue() == "derivatives")
+      else if (name == "derivatives")
         putContent(der_str, element);
-      else if (name.getValue() == "format")
+      else if (name == "format")
         putContent(file_format, element);
       else
         other_elements.push_back(element);
@@ -161,9 +161,9 @@ bool OrbitalImages::put(xmlNodePtr cur)
     std::string ename((const char*)element->name);
     if (ename == "parameter")
     {
-      const XMLAttrString name(element, "name");
+      const std::string name(getXMLAttributeValue(element, "name"));
       for (int i = 0; i < sposet_names.size(); ++i)
-        if (name.getValue() == sposet_names[i])
+        if (name == sposet_names[i])
           putContent((*sposet_indices)[i], element);
     }
   }

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -111,37 +111,37 @@ bool OrbitalImages::put(xmlNodePtr cur)
     if (ename == "parameter")
     {
       const XMLAttrString name(element, "name");
-      if (name == "sposets")
+      if (name.getValue() == "sposets")
         putContent(sposet_names, element);
-      else if (name == "batch_size")
+      else if (name.getValue() == "batch_size")
         putContent(batch_size, element);
-      else if (name == "grid")
+      else if (name.getValue() == "grid")
       {
         have_grid = true;
         putContent(grid, element);
       }
-      else if (name == "center_grid")
+      else if (name.getValue() == "center_grid")
         putContent(cg_str, element);
-      else if (name == "corner")
+      else if (name.getValue() == "corner")
       {
         have_corner = true;
         putContent(corner, element);
       }
-      else if (name == "center")
+      else if (name.getValue() == "center")
       {
         have_center = true;
         putContent(center, element);
       }
-      else if (name == "cell")
+      else if (name.getValue() == "cell")
       {
         have_cell = true;
         putContent(axes, element);
       }
-      else if (name == "value")
+      else if (name.getValue() == "value")
         putContent(valtypes, element);
-      else if (name == "derivatives")
+      else if (name.getValue() == "derivatives")
         putContent(der_str, element);
-      else if (name == "format")
+      else if (name.getValue() == "format")
         putContent(file_format, element);
       else
         other_elements.push_back(element);
@@ -163,7 +163,7 @@ bool OrbitalImages::put(xmlNodePtr cur)
     {
       const XMLAttrString name(element, "name");
       for (int i = 0; i < sposet_names.size(); ++i)
-        if (name == sposet_names[i])
+        if (name.getValue() == sposet_names[i])
           putContent((*sposet_indices)[i], element);
     }
   }

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -89,32 +89,32 @@ bool SpinDensity::put(xmlNodePtr cur)
     if (ename == "parameter")
     {
       const XMLAttrString name(element, "name");
-      if (name == "dr")
+      if (name.getValue() == "dr")
       {
         have_dr = true;
         putContent(dr, element);
       }
-      else if (name == "grid")
+      else if (name.getValue() == "grid")
       {
         have_grid = true;
         putContent(grid, element);
       }
-      else if (name == "corner")
+      else if (name.getValue() == "corner")
       {
         have_corner = true;
         putContent(corner, element);
       }
-      else if (name == "center")
+      else if (name.getValue() == "center")
       {
         have_center = true;
         putContent(center, element);
       }
-      else if (name == "cell")
+      else if (name.getValue() == "cell")
       {
         have_cell = true;
         putContent(axes, element);
       }
-      else if (name == "test_moves")
+      else if (name.getValue() == "test_moves")
         putContent(test_moves, element);
     }
     element = element->next;

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -88,33 +88,33 @@ bool SpinDensity::put(xmlNodePtr cur)
     std::string ename((const char*)element->name);
     if (ename == "parameter")
     {
-      const XMLAttrString name(element, "name");
-      if (name.getValue() == "dr")
+      const std::string name(getXMLAttributeValue(element, "name"));
+      if (name == "dr")
       {
         have_dr = true;
         putContent(dr, element);
       }
-      else if (name.getValue() == "grid")
+      else if (name == "grid")
       {
         have_grid = true;
         putContent(grid, element);
       }
-      else if (name.getValue() == "corner")
+      else if (name == "corner")
       {
         have_corner = true;
         putContent(corner, element);
       }
-      else if (name.getValue() == "center")
+      else if (name == "center")
       {
         have_center = true;
         putContent(center, element);
       }
-      else if (name.getValue() == "cell")
+      else if (name == "cell")
       {
         have_cell = true;
         putContent(axes, element);
       }
-      else if (name.getValue() == "test_moves")
+      else if (name == "test_moves")
         putContent(test_moves, element);
     }
     element = element->next;

--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -2468,8 +2468,7 @@ xmlNodePtr QMCGaussianParserBase::createHamiltonian(const std::string& ion_tag, 
       xmlAddChild(hamPtr, pairpot3);
     }
 
-    std::string tmp_codename = CodeName;
-    tolower(tmp_codename);
+    std::string tmp_codename(lowerCase(CodeName));
 
     if (tmp_codename == "rmg")
     {

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -34,7 +34,7 @@ bool AGPDeterminantBuilder::createAGP(BasisBuilderT* abuilder, xmlNodePtr cur)
   cur                                            = cur->xmlChildrenNode;
   while (cur != NULL)
   {
-    std::string cname((const char*)(cur->name));
+    std::string cname(castXMLCharToChar(cur->name));
     if (cname == "coefficient" || cname == "coefficients")
     {
       if (agpDet == nullptr)
@@ -102,7 +102,7 @@ std::unique_ptr<WaveFunctionComponent> AGPDeterminantBuilder::buildComponent(xml
   app_log() << "  AGPDeterminantBuilder Creating AGPDeterminant." << std::endl;
   xmlNodePtr curRoot = cur;
   bool success       = true;
-  std::string cname, tname;
+  std::string tname;
   xmlNodePtr cPtr = NULL;
   xmlNodePtr uPtr = NULL;
   OhmmsAttributeSet oAttrib;
@@ -112,7 +112,7 @@ std::unique_ptr<WaveFunctionComponent> AGPDeterminantBuilder::buildComponent(xml
   cur = cur->children;
   while (cur != NULL)
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname.find("coeff") < cname.size())
     {
       cPtr = cur;

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -201,7 +201,7 @@ if(QMC_CUDA OR ENABLE_CUDA)
 endif(QMC_CUDA OR ENABLE_CUDA)
 
 target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcwfs PUBLIC qmcparticle platform_runtime)
+target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime)
 target_link_libraries(qmcwfs PRIVATE einspline platform_LA Math::FFTW3)
 
 # do not merge with qmcwfs target unless all qmcwfs unit tests pass santitizers.

--- a/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.cpp
@@ -59,11 +59,10 @@ std::unique_ptr<WaveFunctionComponent> ElectronGasOrbitalBuilder::buildComponent
     nc2 = nc;
   xmlNodePtr curRoot = cur;
   xmlNodePtr BFNode(NULL);
-  std::string cname;
   cur = curRoot->children;
   while (cur != NULL) //check the basis set
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == backflow_tag)
     {
       // FIX FIX FIX !!!

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -43,12 +43,11 @@ BackflowBuilder::BackflowBuilder(ParticleSet& els, PtclPoolType& pool) : cutOff(
 std::unique_ptr<BackflowTransformation> BackflowBuilder::buildBackflowTransformation(xmlNodePtr cur)
 {
   xmlNodePtr curRoot = cur;
-  std::string cname;
   auto BFTrans = std::make_unique<BackflowTransformation>(targetPtcl);
   cur          = curRoot->children;
   while (cur != NULL)
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == "transf" || cname == "transformation")
     {
       OhmmsAttributeSet spoAttrib;
@@ -130,10 +129,9 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
     //    new Backflow_eI_spin<BsplineFunctor<RealType>>(*ions, targetPtcl);
     //tbf1->numParams = 0;
     //xmlNodePtr cur1 = cur->children;
-    //std::string cname;
     //while (cur1 != NULL)
     //{
-    //  getNodeName(cname, cur1);
+    //  std::string cname (getNodeName(cur1));
     //  if (cname == "correlation")
     //  {
     //    RealType my_cusp = 0.0;
@@ -190,7 +188,7 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
     cur = curRoot->children;
     while (cur != NULL)
     {
-      getNodeName(cname, cur);
+      std::string cname(getNodeName(cur));
       if (cname == "correlation")
       {
         RealType my_cusp = 0.0;
@@ -204,11 +202,10 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
         if (unique == "yes") // look for <index> block, and map based on that
         {
           xmlNodePtr kids = cur;
-          std::string aname;
           kids = cur->children;
           while (kids != NULL)
           {
-            getNodeName(aname, kids);
+            std::string aname(getNodeName(kids));
             if (aname == "index")
             {
               std::vector<int> pos;
@@ -304,11 +301,10 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addTwoBody(xmlNodePtr cur
   {
     app_log() << "Using BsplineFunctor type. \n";
     //         BsplineFunctor<RealType> *bsp = new BsplineFunctor<RealType>(cusp);
-    std::string cname;
     cur = curRoot->children;
     while (cur != NULL)
     {
-      getNodeName(cname, cur);
+      std::string cname(getNodeName(cur));
       if (cname == "correlation")
       {
         RealType cusp = 0;
@@ -440,11 +436,10 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addRPA(xmlNodePtr cur)
   std::unique_ptr<Backflow_ee<BsplineFunctor<RealType>>> tbf;
   Backflow_ee_kSpace* tbfks = 0;
   // now look for components
-  std::string cname;
   cur = cur->children;
   while (cur != NULL)
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == "correlation")
     {
       std::string type = "none";

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -538,8 +538,8 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
   }
 
   bool success = true;
-  XMLAttrString HDF5Path(DetListNode, "href");
-  if (HDF5Path.hasValue())
+  std::string HDF5Path(getXMLAttributeValue(DetListNode, "href"));
+  if (!HDF5Path.empty())
   {
     app_log() << "Found Multideterminants in H5 File" << std::endl;
     success = readDetListH5(cur, uniqueConfgs, C2nodes, CItags, C, optimizeCI, nptcls);
@@ -666,8 +666,8 @@ bool SlaterDetBuilder::createMSD(MultiSlaterDeterminant& multiSD,
       DetListNode = curTemp;
     curTemp = curTemp->next;
   }
-  XMLAttrString HDF5Path(DetListNode, "href");
-  if (HDF5Path.hasValue())
+  std::string HDF5Path(getXMLAttributeValue(DetListNode, "href"));
+  if (!HDF5Path.empty())
   {
     app_log() << "Found Multideterminants in H5 File" << std::endl;
     success = readDetListH5(cur, uniqueConfgs, C2nodes, CItags, multiSD.C, optimizeCI, nels);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -69,7 +69,6 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
   ReportEngine PRE(ClassName, "put(xmlNodePtr)");
   ///save the current node
   xmlNodePtr curRoot = cur;
-  std::string cname, tname;
   std::map<std::string, SPOSetPtr> spomap;
   bool multiDet = false;
   std::string msd_algorithm;
@@ -89,7 +88,7 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
   cur = curRoot->children;
   while (cur != NULL) //check the basis set
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == sposet_tag)
     {
       app_warning() << "!!!!!!! Deprecated input style: creating SPO set inside determinantset. Support for this usage "
@@ -130,7 +129,7 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
   cur = curRoot->children;
   while (cur != NULL)
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == sd_tag)
     {
       app_summary() << std::endl;
@@ -145,7 +144,7 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
       xmlNodePtr tcur   = cur->children;
       while (tcur != NULL)
       {
-        getNodeName(tname, tcur);
+        std::string tname(getNodeName(tcur));
         if (tname == det_tag || tname == rn_tag)
         {
           if (spin_group >= targetPtcl.groups())
@@ -532,8 +531,7 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
   curTemp = curTemp->children;
   while (curTemp != NULL) //check the basis set
   {
-    std::string cname;
-    getNodeName(cname, curTemp);
+    std::string cname(getNodeName(curTemp));
     if (cname == "detlist")
       DetListNode = curTemp;
     curTemp = curTemp->next;
@@ -541,7 +539,7 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
 
   bool success = true;
   XMLAttrString HDF5Path(DetListNode, "href");
-  if (HDF5Path != "")
+  if (HDF5Path.hasValue())
   {
     app_log() << "Found Multideterminants in H5 File" << std::endl;
     success = readDetListH5(cur, uniqueConfgs, C2nodes, CItags, C, optimizeCI, nptcls);
@@ -663,14 +661,13 @@ bool SlaterDetBuilder::createMSD(MultiSlaterDeterminant& multiSD,
   curTemp = curTemp->children;
   while (curTemp != NULL) //check the basis set
   {
-    std::string cname;
-    getNodeName(cname, curTemp);
+    std::string cname(getNodeName(curTemp));
     if (cname == "detlist")
       DetListNode = curTemp;
     curTemp = curTemp->next;
   }
   XMLAttrString HDF5Path(DetListNode, "href");
-  if (HDF5Path != "")
+  if (HDF5Path.hasValue())
   {
     app_log() << "Found Multideterminants in H5 File" << std::endl;
     success = readDetListH5(cur, uniqueConfgs, C2nodes, CItags, multiSD.C, optimizeCI, nels);
@@ -814,11 +811,10 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
   ciAttrib.put(cur);
   optimizeCI         = (optCI == "yes");
   xmlNodePtr curRoot = cur, DetListNode = nullptr;
-  std::string cname, cname0;
   cur = curRoot->children;
   while (cur != NULL) //check the basis set
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == "detlist")
     {
       DetListNode = cur;
@@ -897,7 +893,7 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
     app_log() << "Reading CSFs." << std::endl;
     while (cur != NULL) //check the basis set
     {
-      getNodeName(cname, cur);
+      std::string cname(getNodeName(cur));
       if (cname == "csf")
       {
         RealType exctLvl, qc_ci = 0.0;
@@ -944,7 +940,7 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
         xmlNodePtr csf = cur->children;
         while (csf != NULL)
         {
-          getNodeName(cname0, csf);
+          std::string cname0(getNodeName(csf));
           if (cname0 == "det")
           {
             std::vector<std::string> occs(nGroups);
@@ -1056,7 +1052,7 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
     std::vector<std::unordered_map<std::string, int>> MyMaps(nGroups);
     while (cur != NULL) //check the basis set
     {
-      getNodeName(cname, cur);
+      std::string cname(getNodeName(cur));
       if (cname == "configuration" || cname == "ci")
       {
         RealType qc_ci = 0.0;
@@ -1180,11 +1176,11 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
   ciAttrib.put(cur);
   optimizeCI         = (optCI == "yes");
   xmlNodePtr curRoot = cur, DetListNode = nullptr;
-  std::string cname, cname0, multidetH5path;
+  std::string multidetH5path;
   cur = curRoot->children;
   while (cur != NULL) //check the basis set
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == "detlist")
     {
       DetListNode = cur;

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -165,7 +165,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ2(xmlNodePtr
   using DiffJ2Type = typename JastrowTypeHelper<RadFuncType, Implementation>::DiffJ2Type;
 
   XMLAttrString input_name(cur, "name");
-  std::string j2name = input_name.empty() ? "J2_" + Jastfunction : input_name;
+  std::string j2name = input_name.hasValue() ? "J2_" + Jastfunction : input_name;
   SpeciesSet& species(targetPtcl.getSpeciesSet());
   auto J2  = std::make_unique<J2Type>(j2name, targetPtcl);
   auto dJ2 = std::make_unique<DiffJ2Type>(targetPtcl);
@@ -349,7 +349,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
   using J1Type = typename std::conditional<SPIN, typename TH::J1SpinType, typename TH::J1Type>::type;
 
   XMLAttrString input_name(cur, "name");
-  std::string jname = input_name.empty() ? Jastfunction : input_name;
+  std::string jname = input_name.hasValue() ? Jastfunction : input_name;
 
   auto J1 = std::make_unique<J1Type>(jname, *SourcePtcl, targetPtcl);
 
@@ -362,8 +362,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
   bool Opt(true);
   while (kids != NULL)
   {
-    std::string kidsname = (char*)kids->name;
-    tolower(kidsname);
+    std::string kidsname(lowerCase(castXMLCharToChar(kids->name)));
     if (kidsname == "correlation")
     {
       std::string speciesA;
@@ -520,10 +519,10 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::buildComponent(xmlN
   aAttrib.add(useGPU, "gpu", {"yes", "no"});
 #endif
   aAttrib.put(cur);
-  tolower(NameOpt);
-  tolower(TypeOpt);
-  tolower(Jastfunction);
-  tolower(SpinOpt);
+  NameOpt = lowerCase(NameOpt);
+  TypeOpt = lowerCase(TypeOpt);
+  Jastfunction = lowerCase(Jastfunction);
+  SpinOpt = lowerCase(SpinOpt);
 
   SpeciesSet& species(targetPtcl.getSpeciesSet());
   int chargeInd = species.addAttribute("charge");

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -164,8 +164,8 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ2(xmlNodePtr
   using J2Type     = typename JastrowTypeHelper<RadFuncType, Implementation>::J2Type;
   using DiffJ2Type = typename JastrowTypeHelper<RadFuncType, Implementation>::DiffJ2Type;
 
-  XMLAttrString input_name(cur, "name");
-  std::string j2name = input_name.hasValue() ? "J2_" + Jastfunction : input_name;
+  std::string input_name(getXMLAttributeValue(cur, "name"));
+  std::string j2name = !input_name.empty() ? input_name : "J2_" + Jastfunction;
   SpeciesSet& species(targetPtcl.getSpeciesSet());
   auto J2  = std::make_unique<J2Type>(j2name, targetPtcl);
   auto dJ2 = std::make_unique<DiffJ2Type>(targetPtcl);
@@ -348,8 +348,8 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
   using TH     = JastrowTypeHelper<RadFuncType, Implementation>;
   using J1Type = typename std::conditional<SPIN, typename TH::J1SpinType, typename TH::J1Type>::type;
 
-  XMLAttrString input_name(cur, "name");
-  std::string jname = input_name.hasValue() ? Jastfunction : input_name;
+  std::string input_name(getXMLAttributeValue(cur, "name"));
+  std::string jname = !input_name.empty() ? input_name : Jastfunction;
 
   auto J1 = std::make_unique<J1Type>(jname, *SourcePtcl, targetPtcl);
 

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -165,7 +165,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ2(xmlNodePtr
   using DiffJ2Type = typename JastrowTypeHelper<RadFuncType, Implementation>::DiffJ2Type;
 
   std::string input_name(getXMLAttributeValue(cur, "name"));
-  std::string j2name = !input_name.empty() ? input_name : "J2_" + Jastfunction;
+  std::string j2name = input_name.empty() ? "J2_" + Jastfunction : input_name;
   SpeciesSet& species(targetPtcl.getSpeciesSet());
   auto J2  = std::make_unique<J2Type>(j2name, targetPtcl);
   auto dJ2 = std::make_unique<DiffJ2Type>(targetPtcl);
@@ -349,7 +349,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
   using J1Type = typename std::conditional<SPIN, typename TH::J1SpinType, typename TH::J1Type>::type;
 
   std::string input_name(getXMLAttributeValue(cur, "name"));
-  std::string jname = !input_name.empty() ? input_name : Jastfunction;
+  std::string jname = input_name.empty() ? Jastfunction : input_name;
 
   auto J1 = std::make_unique<J1Type>(jname, *SourcePtcl, targetPtcl);
 

--- a/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
@@ -21,7 +21,7 @@
 #include <stdexcept>
 #include "OhmmsPETE/TinyVector.h"
 #include "Utilities/ProgressReportEngine.h"
-#include "Utilities/ModernStringUtils.hpp"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include "OhmmsPETE/TinyVector.h"
 #include "Utilities/ProgressReportEngine.h"
+#include "Utilities/ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {
@@ -445,7 +446,7 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
       id_to_set = id;
 
     // if we are to optimize the variable, add it to the optimizable variable set
-    tolower(optimize);
+    optimize = lowerCase(optimize);
     if ( optimize == "yes" ) {
       if ( id == "string_not_set" )
         PRE.error("\"id\" must be set if we are going to optimize variable " + name, true);
@@ -497,9 +498,7 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
       }
 
       // get the name of the child node
-      std::string cname((const char*)childPtr->name);
-      tolower(cname); // make it case insensitive
-
+      std::string cname(lowerCase(castXMLCharToChar(childPtr->name)));
       // read in a variable
       if (cname == "var")
       {
@@ -548,7 +547,7 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
           ID_B = id;
 
         // if the coefficients are to be optimized, add them to the variable set
-        tolower(optimize);
+        optimize = lowerCase(optimize);
         if ( optimize == "yes" ) {
           if ( id == "string_not_set" )
             PRE.error("\"id\" must be set if we are going to optimize B coefficients", true);

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -129,8 +129,8 @@ std::unique_ptr<WaveFunctionComponent> eeI_JastrowBuilder::buildComponent(xmlNod
     tAttrib.add(ftype, "function");
     tAttrib.put(cur);
 
-    XMLAttrString input_name(cur, "name");
-    std::string jname = input_name.hasValue() ? input_name : "JeeI_" + ftype;
+    std::string input_name(getXMLAttributeValue(cur, "name"));
+    std::string jname = !input_name.empty() ? input_name : "JeeI_" + ftype;
     SpeciesSet& iSet = sourcePtcl->getSpeciesSet();
     if (ftype == "polynomial")
     {

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -130,8 +130,7 @@ std::unique_ptr<WaveFunctionComponent> eeI_JastrowBuilder::buildComponent(xmlNod
     tAttrib.put(cur);
 
     XMLAttrString input_name(cur, "name");
-    std::string jname = input_name.empty() ? "JeeI_" + ftype : input_name;
-
+    std::string jname = input_name.hasValue() ? input_name : "JeeI_" + ftype;
     SpeciesSet& iSet = sourcePtcl->getSpeciesSet();
     if (ftype == "polynomial")
     {

--- a/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/eeI_JastrowBuilder.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<WaveFunctionComponent> eeI_JastrowBuilder::buildComponent(xmlNod
     tAttrib.put(cur);
 
     std::string input_name(getXMLAttributeValue(cur, "name"));
-    std::string jname = !input_name.empty() ? input_name : "JeeI_" + ftype;
+    std::string jname = input_name.empty() ? "JeeI_" + ftype : input_name;
     SpeciesSet& iSet = sourcePtcl->getSpeciesSet();
     if (ftype == "polynomial")
     {

--- a/src/QMCWaveFunctions/LCAO/AOBasisBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/AOBasisBuilder.cpp
@@ -210,7 +210,7 @@ std::unique_ptr<COT> AOBasisBuilder<COT>::createAOSet(xmlNodePtr cur)
     if (cname1 == "basisGroup")
     {
       radGroup.push_back(cur1);
-      const int l = std::stoi(XMLAttrString{cur1, "l"});
+      const int l = std::stoi(getXMLAttributeValue(cur1, "l"));
       Lmax        = std::max(Lmax, l);
       //expect that only Rnl is given
       if (expandlm == CARTESIAN_EXPAND || expandlm == DIRAC_CARTESIAN_EXPAND)

--- a/src/QMCWaveFunctions/LCAO/CuspCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrection.cpp
@@ -28,7 +28,6 @@ bool readCuspInfo(const std::string& cuspInfoFile,
                   Matrix<CuspCorrectionParameters>& info)
 {
   bool success = true;
-  std::string cname;
   int ncenter = info.rows();
   app_log() << "Reading cusp info from : " << cuspInfoFile << std::endl;
   Libxml2Document adoc;
@@ -43,7 +42,7 @@ bool readCuspInfo(const std::string& cuspInfoFile,
   xmlNodePtr cur  = NULL, ctr;
   while (head != NULL)
   {
-    getNodeName(cname, head);
+    std::string cname(getNodeName(head));
     if (cname == "sposet")
     {
       std::string name;
@@ -71,7 +70,7 @@ bool readCuspInfo(const std::string& cuspInfoFile,
   cur = cur->children;
   while (cur != NULL)
   {
-    getNodeName(cname, cur);
+    std::string cname(getNodeName(cur));
     if (cname == "center")
     {
       int num = -1;
@@ -85,7 +84,7 @@ bool readCuspInfo(const std::string& cuspInfoFile,
       ctr = cur->children;
       while (ctr != NULL)
       {
-        getNodeName(cname, ctr);
+        std::string cname(getNodeName(ctr));
         if (cname == "orbital")
         {
           int orb = -1;

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -132,8 +132,8 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
   processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "basisset")
     {
-      XMLAttrString basisset_name_input(element, "name");
-      std::string basisset_name(basisset_name_input.hasValue() ? basisset_name_input.getValue() : "LCAOBSet" );
+      std::string basisset_name_input(getXMLAttributeValue(element, "name"));
+      std::string basisset_name(!basisset_name_input.empty() ? basisset_name_input : "LCAOBSet" );
       if (basisset_map_.find(basisset_name) != basisset_map_.end())
       {
         std::ostringstream err_msg;
@@ -850,9 +850,9 @@ bool LCAOrbitalBuilder::putOccupation(LCAOrbitalSet& spo, xmlNodePtr occ_ptr)
   }
   else
   {
-    const XMLAttrString o(occ_ptr, "mode");
-    if (o.hasValue())
-      occ_mode = o.getValue();
+    const std::string o(getXMLAttributeValue(occ_ptr, "mode"));
+    if (!o.empty())
+      occ_mode = o;
   }
   //Do nothing if mode == ground
   if (occ_mode == "excited")

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -133,7 +133,7 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
     if (cname == "basisset")
     {
       XMLAttrString basisset_name_input(element, "name");
-      std::string basisset_name(basisset_name_input.empty() ? "LCAOBSet" : basisset_name_input.c_str());
+      std::string basisset_name(basisset_name_input.hasValue() ? basisset_name_input.getValue() : "LCAOBSet" );
       if (basisset_map_.find(basisset_name) != basisset_map_.end())
       {
         std::ostringstream err_msg;
@@ -851,8 +851,8 @@ bool LCAOrbitalBuilder::putOccupation(LCAOrbitalSet& spo, xmlNodePtr occ_ptr)
   else
   {
     const XMLAttrString o(occ_ptr, "mode");
-    if (!o.empty())
-      occ_mode = o;
+    if (o.hasValue())
+      occ_mode = o.getValue();
   }
   //Do nothing if mode == ground
   if (occ_mode == "excited")

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -133,7 +133,7 @@ LCAOrbitalBuilder::LCAOrbitalBuilder(ParticleSet& els, ParticleSet& ions, Commun
     if (cname == "basisset")
     {
       std::string basisset_name_input(getXMLAttributeValue(element, "name"));
-      std::string basisset_name(!basisset_name_input.empty() ? basisset_name_input : "LCAOBSet" );
+      std::string basisset_name(basisset_name_input.empty() ? "LCAOBSet" : basisset_name_input);
       if (basisset_map_.find(basisset_name) != basisset_map_.end())
       {
         std::ostringstream err_msg;

--- a/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
+++ b/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
@@ -111,7 +111,7 @@ public:
   bool put(xmlNodePtr cur)
   {
     const XMLAttrString a(cur, "normalized");
-    if (a == "no")
+    if (a.getValue() == "no")
       Normalized = false;
     return true;
   }

--- a/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
+++ b/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
@@ -110,8 +110,8 @@ public:
   bool openNumericalBasisH5(xmlNodePtr cur) { return true; }
   bool put(xmlNodePtr cur)
   {
-    const XMLAttrString a(cur, "normalized");
-    if (a.getValue() == "no")
+    const std::string a(lowerCase(getXMLAttributeValue(cur, "normalized")));
+    if (a == "no")
       Normalized = false;
     return true;
   }

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -62,8 +62,8 @@ std::unique_ptr<WaveFunctionComponent> PWOrbitalBuilder::buildComponent(xmlNodeP
     if (cname == "basisset")
     {
       const XMLAttrString a(cur, "ecut");
-      if (!a.empty())
-        myParam->Ecut = std::stod(a);
+      if (!a.hasValue())
+        myParam->Ecut = std::stod(a.getValue());
     }
     else if (cname == "coefficients")
     {
@@ -480,12 +480,12 @@ void PWOrbitalBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, 
 hid_t PWOrbitalBuilder::getH5(xmlNodePtr cur, const char* aname)
 {
   const XMLAttrString a(cur, aname);
-  if (a.empty())
+  if (!a.hasValue())
     return -1;
-  hid_t h = H5Fopen(a.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  hid_t h = H5Fopen(a.getValue().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   if (h < 0)
   {
-    app_error() << " Cannot open " << a << " file." << std::endl;
+    app_error() << " Cannot open " << a.getValue() << " file." << std::endl;
     OHMMS::Controller->abort();
   }
   myParam->checkVersion(h);

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -61,9 +61,9 @@ std::unique_ptr<WaveFunctionComponent> PWOrbitalBuilder::buildComponent(xmlNodeP
     std::string cname((const char*)(cur->name));
     if (cname == "basisset")
     {
-      const XMLAttrString a(cur, "ecut");
-      if (!a.hasValue())
-        myParam->Ecut = std::stod(a.getValue());
+      const std::string a(getXMLAttributeValue(cur, "ecut"));
+      if (!a.empty())
+        myParam->Ecut = std::stod(a);
     }
     else if (cname == "coefficients")
     {
@@ -479,13 +479,13 @@ void PWOrbitalBuilder::transform2GridData(PWBasis::GIndex_t& nG, int spinIndex, 
 
 hid_t PWOrbitalBuilder::getH5(xmlNodePtr cur, const char* aname)
 {
-  const XMLAttrString a(cur, aname);
-  if (!a.hasValue())
+  const std::string a(getXMLAttributeValue(cur, aname));
+  if (a.empty())
     return -1;
-  hid_t h = H5Fopen(a.getValue().c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  hid_t h = H5Fopen(a.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   if (h < 0)
   {
-    app_error() << " Cannot open " << a.getValue() << " file." << std::endl;
+    app_error() << " Cannot open " << a << " file." << std::endl;
     OHMMS::Controller->abort();
   }
   myParam->checkVersion(h);

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -20,7 +20,7 @@
 #include "QMCWaveFunctions/SPOSetScanner.h"
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
-#include "Utilities/ModernStringUtils.hpp"
+#include "ModernStringUtils.hpp"
 #if OHMMS_DIM == 3
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/SPOSetScanner.h"
 #include "QMCWaveFunctions/ElectronGas/ElectronGasOrbitalBuilder.h"
 #include "QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.h"
+#include "Utilities/ModernStringUtils.hpp"
 #if OHMMS_DIM == 3
 #include "QMCWaveFunctions/LCAO/LCAOrbitalBuilder.h"
 
@@ -116,7 +117,7 @@ SPOSetBuilder& SPOSetBuilderFactory::createSPOSetBuilder(xmlNodePtr rootNode)
     aAttrib.put(rootNode);
 
   std::string type_in = type;
-  tolower(type);
+  type = lowerCase(type);
 
   //when name is missing, type becomes the input
   if (name.empty())

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -82,8 +82,7 @@ public:
         OhmmsAttributeSet aAttrib;
         aAttrib.add(trace_name, "name");
         aAttrib.put(cur);
-        std::string cname;
-        getNodeName(cname, cur);
+        std::string cname(getNodeName(cur));
         std::string prefix(sposet->getName() + "_" + cname + "_" + trace_name);
         if (cname == "path")
         {

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -7,11 +7,6 @@
 #// File developed by: Peter Doak, , doakpw@ornl.gov, Oak Ridge National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-# there is a provides a utilities target for qmcio that doesn't create a circular
-# dependence
-add_library(qmcutil_basic ModernStringUtils.cpp)
-target_include_directories(qmcutil_basic PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-
 set(UTILITIES
     qmc_common.cpp
     RandomGenerator.cpp
@@ -25,20 +20,18 @@ set(UTILITIES
     unit_conversion.cpp
     ResourceCollection.cpp
     ProjectData.cpp
-    RandomNumberControl.cpp)
-add_library(qmcutil_integrated ${UTILITIES})
+    RandomNumberControl.cpp
+    ModernStringUtils.cpp)
+add_library(qmcutil ${UTILITIES})
 
 if(IS_GIT_PROJECT)
-  add_dependencies(qmcutil_integrated gitrev)
+  add_dependencies(qmcutil gitrev)
 endif()
 
-target_link_libraries(qmcutil_integrated PUBLIC message qmcio)
-target_link_libraries(qmcutil_integrated PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
+target_link_libraries(qmcutil PUBLIC message qmcio)
+target_link_libraries(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
 
-add_library(qmcutil INTERFACE)
-target_include_directories(qmcutil INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcutil INTERFACE qmcutil_basic qmcutil_integrated)
-
+target_include_directories(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Put the fake RNG in a separate library so production code doesn't
 # accidentally link to it

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -7,6 +7,9 @@
 #// File developed by: Peter Doak, , doakpw@ornl.gov, Oak Ridge National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
+add_library(cxx_helpers ModernStringUtils.cpp)
+target_include_directories(cxx_helpers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
 set(UTILITIES
     qmc_common.cpp
     RandomGenerator.cpp
@@ -20,15 +23,14 @@ set(UTILITIES
     unit_conversion.cpp
     ResourceCollection.cpp
     ProjectData.cpp
-    RandomNumberControl.cpp
-    ModernStringUtils.cpp)
+    RandomNumberControl.cpp)
 add_library(qmcutil ${UTILITIES})
 
 if(IS_GIT_PROJECT)
   add_dependencies(qmcutil gitrev)
 endif()
 
-target_link_libraries(qmcutil PUBLIC message qmcio)
+target_link_libraries(qmcutil PUBLIC cxx_helpers message qmcio)
 target_link_libraries(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
 
 target_include_directories(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -7,6 +7,11 @@
 #// File developed by: Peter Doak, , doakpw@ornl.gov, Oak Ridge National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
+# there is a provides a utilities target for qmcio that doesn't create a circular
+# dependence
+add_library(qmcutil_basic ModernStringUtils.cpp)
+target_include_directories(qmcutil_basic PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+
 set(UTILITIES
     qmc_common.cpp
     RandomGenerator.cpp
@@ -21,15 +26,19 @@ set(UTILITIES
     ResourceCollection.cpp
     ProjectData.cpp
     RandomNumberControl.cpp)
-add_library(qmcutil ${UTILITIES})
+add_library(qmcutil_integrated ${UTILITIES})
 
 if(IS_GIT_PROJECT)
-  add_dependencies(qmcutil gitrev)
+  add_dependencies(qmcutil_integrated gitrev)
 endif()
 
-target_include_directories(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcutil PUBLIC message qmcio)
-target_link_libraries(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
+target_link_libraries(qmcutil_integrated PUBLIC message qmcio)
+target_link_libraries(qmcutil_integrated PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
+
+add_library(qmcutil INTERFACE)
+target_include_directories(qmcutil INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(qmcutil INTERFACE qmcutil_basic qmcutil_integrated)
+
 
 # Put the fake RNG in a separate library so production code doesn't
 # accidentally link to it

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -30,10 +30,9 @@ if(IS_GIT_PROJECT)
   add_dependencies(qmcutil gitrev)
 endif()
 
+target_include_directories(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcutil PUBLIC cxx_helpers message qmcio)
 target_link_libraries(qmcutil PUBLIC LibXml2::LibXml2 Boost::boost ${QMC_UTIL_LIBS})
-
-target_include_directories(qmcutil PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Put the fake RNG in a separate library so production code doesn't
 # accidentally link to it

--- a/src/Utilities/ModernStringUtils.cpp
+++ b/src/Utilities/ModernStringUtils.cpp
@@ -1,0 +1,27 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "ModernStringUtils.hpp"
+#include <algorithm>
+#include <cctype>
+
+namespace qmcplusplus
+{
+
+std::string lowerCase(const std::string_view s)
+{
+  std::string lower_str{s};
+  std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return lower_str;
+}
+
+} // namespace qmcplusplus

--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
+#define QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
+
+#include <string>
+#include <string_view>
+#include <cctype>
+
+namespace qmcplusplus
+{
+
+/** @ingroup C++17 string utility functions
+ *  @{
+ */
+/** take string_view (or something that can be implicitly converted to one) and return lcase string.
+ *  Don't call on anything but ASCII strings.
+ *
+ *  This would eventually replace the potentially unsafe to UTF-8 strtings tolower call in OhmmsElementBase.h
+ *  which is used pretty randomly throughout the code.  The global function in Ohmmselement always operates inplace
+ *  on the string buffer which is undesirable and should be explicitly evident in the code.
+ *  i.e.
+ *  my_string = strToLower(my_string);
+ *
+ *  According to en.cppreference.com std::tolower is only defined for usigned char and EOF. the std::tolower conversion
+ *  is based on the _c_ locale which to makes it unclear on what might happen to char > 127. 
+ *  *  For tags, and keywords where we define explicitly define they are ASCII encoded and this is fine. 
+ *  *  For other XML derived text this should never be used since we should assume that to be UTF-8 encoded.
+ */
+inline std::string strToLower(const std::string_view s)
+{
+  std::string lower_str{s};
+  std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return lower_str;
+}
+/** @} */
+
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -14,7 +14,6 @@
 
 #include <string>
 #include <string_view>
-#include <cctype>
 
 namespace qmcplusplus
 {
@@ -25,24 +24,12 @@ namespace qmcplusplus
 /** take string_view (or something that can be implicitly converted to one) and return lcase string.
  *  Don't call on anything but ASCII strings.
  *
- *  This would eventually replace the potentially unsafe to UTF-8 strtings tolower call in OhmmsElementBase.h
- *  which is used pretty randomly throughout the code.  The global function in Ohmmselement always operates inplace
- *  on the string buffer which is undesirable and should be explicitly evident in the code.
- *  i.e.
- *  my_string = strToLower(my_string);
- *
  *  According to en.cppreference.com std::tolower is only defined for usigned char and EOF. the std::tolower conversion
  *  is based on the _c_ locale which to makes it unclear on what might happen to char > 127. 
  *  *  For tags, and keywords where we define explicitly define they are ASCII encoded and this is fine. 
  *  *  For other XML derived text this should never be used since we should assume that to be UTF-8 encoded.
  */
-inline std::string lowerCase(const std::string_view s)
-{
-  std::string lower_str{s};
-  std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return lower_str;
-}
+std::string lowerCase(const std::string_view s);
 /** @} */
 
 

--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -36,7 +36,7 @@ namespace qmcplusplus
  *  *  For tags, and keywords where we define explicitly define they are ASCII encoded and this is fine. 
  *  *  For other XML derived text this should never be used since we should assume that to be UTF-8 encoded.
  */
-inline std::string strToLower(const std::string_view s)
+inline std::string lowerCase(const std::string_view s)
 {
   std::string lower_str{s};
   std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -177,10 +177,10 @@ bool ProjectData::PreviousRoot(std::string& oldroot) const
 bool ProjectData::put(xmlNodePtr cur)
 {
   m_cur   = cur;
-  m_title = XMLAttrString(cur, "id");
-  const XMLAttrString series_str(cur, "series");
-  if (series_str.hasValue())
-    m_series = std::stoi(series_str.getValue());
+  m_title = getXMLAttributeValue(cur, "id");
+  const std::string series_str(getXMLAttributeValue(cur, "series"));
+  if (!series_str.empty())
+    m_series = std::stoi(series_str);
 
   ParameterSet m_param;
   m_param.add(max_cpu_secs_, "max_seconds");

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -179,8 +179,8 @@ bool ProjectData::put(xmlNodePtr cur)
   m_cur   = cur;
   m_title = XMLAttrString(cur, "id");
   const XMLAttrString series_str(cur, "series");
-  if (!series_str.empty())
-    m_series = std::stoi(series_str);
+  if (series_str.hasValue())
+    m_series = std::stoi(series_str.getValue());
 
   ParameterSet m_param;
   m_param.add(max_cpu_secs_, "max_seconds");

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   test_project_data.cpp
   test_rng_control.cpp
   test_output_manager.cpp
+  test_ModernStringUtils.cpp
   test_StlPrettyPrint.cpp
   test_StdRandom.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcutil)

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+#include "ModernStringUtils.hpp"
+
+/** \file
+ */
+namespace qmcplusplus
+{
+
+TEST_CASE("ModernStringUtils_strToLower", "[utilities]")
+{
+  std::string test_string("IamAMixedCaseTest_String");
+  std::string lcase_string = strToLower(test_string);
+  CHECK(lcase_string == "iamamixedcasetest_string");
+  std::string i_am_not_just_ascii{"\xab"
+                                  "not_Just_ASCII"};
+  // very imcomplete check if we are in a c locale that clobbers char beyond ASII
+  // \todo If you know C locales well is this ever a worry?
+  i_am_not_just_ascii = strToLower(i_am_not_just_ascii);
+  CHECK(i_am_not_just_ascii ==
+        "\xab"
+        "not_just_ascii");
+}
+} // namespace qmcplusplus

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -20,13 +20,13 @@ namespace qmcplusplus
 TEST_CASE("ModernStringUtils_strToLower", "[utilities]")
 {
   std::string test_string("IamAMixedCaseTest_String");
-  std::string lcase_string = strToLower(test_string);
+  std::string lcase_string = lowerCase(test_string);
   CHECK(lcase_string == "iamamixedcasetest_string");
   std::string i_am_not_just_ascii{"\xab"
                                   "not_Just_ASCII"};
   // very imcomplete check if we are in a c locale that clobbers char beyond ASII
   // \todo If you know C locales well is this ever a worry?
-  i_am_not_just_ascii = strToLower(i_am_not_just_ascii);
+  i_am_not_just_ascii = lowerCase(i_am_not_just_ascii);
   CHECK(i_am_not_just_ascii ==
         "\xab"
         "not_just_ascii");

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -12,6 +12,10 @@
 add_subdirectory(hdf)
 add_subdirectory(OhmmsData)
 
+# qmcio is intended to be an interface library servicing codes outside src/io.
+# header files inclusion from outside src/io needs to treat src/io being the root for
+# the header file inclusion.
+# qmcio_hdf qmcio_xml are targets for internal use only.
 add_library(qmcio INTERFACE)
 target_include_directories(qmcio INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcio INTERFACE qmcio_hdf qmcio_xml)

--- a/src/io/OhmmsData/CMakeLists.txt
+++ b/src/io/OhmmsData/CMakeLists.txt
@@ -9,7 +9,7 @@
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-set(IO_XML_SRC Libxml2Doc.cpp)
+set(IO_XML_SRC Libxml2Doc.cpp XMLParsingString.cpp)
 
 add_library(qmcio_xml ${IO_XML_SRC})
 

--- a/src/io/OhmmsData/CMakeLists.txt
+++ b/src/io/OhmmsData/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(qmcio_xml ${IO_XML_SRC})
 # headers used both in and out of the module include based on src/io being the root for
 # io header inclusion
 target_include_directories(qmcio_xml PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../")
-target_link_libraries(qmcio_xml PUBLIC qmcutil_basic containers LibXml2::LibXml2)
+target_link_libraries(qmcio_xml PUBLIC qmcutil containers LibXml2::LibXml2)
 
 if(BUILD_UNIT_TESTS)
   add_subdirectory(tests)

--- a/src/io/OhmmsData/CMakeLists.txt
+++ b/src/io/OhmmsData/CMakeLists.txt
@@ -2,19 +2,22 @@
 #// This file is distributed under the University of Illinois/NCSA Open Source License.
 #// See LICENSE file in top directory for details.
 #//
-#// Copyright (c) 2020 QMCPACK developers.
+#// Copyright (c) 2021 QMCPACK developers.
 #//
 #// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+#//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 #//
 #// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//////////////////////////////////////////////////////////////////////////////////////
 
-set(IO_XML_SRC Libxml2Doc.cpp XMLParsingString.cpp)
+set(IO_XML_SRC Libxml2Doc.cpp XMLParsingString.cpp ParameterSet.cpp libxmldefs.cpp)
 
 add_library(qmcio_xml ${IO_XML_SRC})
 
-#TARGET_INCLUDE_DIRECTORIES(qmcio_xml PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcio_xml PUBLIC containers LibXml2::LibXml2)
+# headers used both in and out of the module include based on src/io being the root for
+# io header inclusion
+target_include_directories(qmcio_xml PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../")
+target_link_libraries(qmcio_xml PUBLIC qmcutil_basic containers LibXml2::LibXml2)
 
 if(BUILD_UNIT_TESTS)
   add_subdirectory(tests)

--- a/src/io/OhmmsData/CMakeLists.txt
+++ b/src/io/OhmmsData/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(qmcio_xml ${IO_XML_SRC})
 
 # headers used both in and out of the module include based on src/io being the root for
 # io header inclusion
-target_include_directories(qmcio_xml PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../")
+target_include_directories(qmcio_xml PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_link_libraries(qmcio_xml PUBLIC cxx_helpers containers LibXml2::LibXml2)
 
 if(BUILD_UNIT_TESTS)

--- a/src/io/OhmmsData/CMakeLists.txt
+++ b/src/io/OhmmsData/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(qmcio_xml ${IO_XML_SRC})
 # headers used both in and out of the module include based on src/io being the root for
 # io header inclusion
 target_include_directories(qmcio_xml PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../")
-target_link_libraries(qmcio_xml PUBLIC qmcutil containers LibXml2::LibXml2)
+target_link_libraries(qmcio_xml PUBLIC cxx_helpers containers LibXml2::LibXml2)
 
 if(BUILD_UNIT_TESTS)
   add_subdirectory(tests)

--- a/src/io/OhmmsData/OhmmsElementBase.h
+++ b/src/io/OhmmsData/OhmmsElementBase.h
@@ -99,13 +99,4 @@ protected:
   std::string myName;
 };
 
-//add tolower function here
-
-inline void tolower(std::string& s)
-{
-  for (int i = 0; i < s.size(); ++i)
-    s[i] = tolower(s[i]);
-  //std::transform(s.begin(), s.end(), s.begin(), std::tolower);
-}
-
 #endif

--- a/src/io/OhmmsData/ParameterSet.cpp
+++ b/src/io/OhmmsData/ParameterSet.cpp
@@ -1,0 +1,98 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: D. Das, University of Illinois at Urbana-Champaign
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// Refactored from: ParameterSet.h
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "ParameterSet.h"
+#include <vector>
+#include <libxml/xmlmemory.h>
+#include <libxml/tree.h>
+#include "ModernStringUtils.hpp"
+#include "libxmldefs.h"
+
+bool ParameterSet::put(xmlNodePtr cur)
+{
+  using namespace qmcplusplus;
+  if (cur == NULL)
+    return true; //handle empty node
+  cur            = cur->xmlChildrenNode;
+  bool something = false;
+  while (cur != NULL)
+  {
+    std::string cname(lowerCase(castXMLCharToChar(cur->name)));
+    if (auto it_tag = m_param.find(cname); it_tag == m_param.end())
+    {
+      if (cname == myName)
+      {
+        std::string aname(lowerCase(getXMLAttributeValue(cur, "name")));
+        if (!aname.empty())
+        {
+          if (auto it = m_param.find(aname); it != m_param.end())
+          {
+            something = true;
+            it->second->put(cur);
+          }
+        }
+      }
+    }
+    else
+    {
+      something = true;
+      it_tag->second->put(cur);
+    }
+    cur = cur->next;
+  }
+  return something;
+}
+
+template<class PDT>
+void ParameterSet::add(PDT& aparam, const std::string& aname_in, std::vector<PDT>&& candidate_values, TagStatus status)
+{
+  using namespace qmcplusplus;
+  std::string aname(lowerCase(aname_in));
+  if (auto it = m_param.find(aname); it == m_param.end())
+  {
+    m_param[aname] = std::make_unique<OhmmsParameter<PDT>>(aparam, aname, std::move(candidate_values), status);
+  }
+}
+
+template<class PDT>
+void ParameterSet::setValue(const std::string& aname_in, PDT aval)
+{
+  using namespace qmcplusplus;
+  std::string aname(lowerCase(aname_in));
+  if (auto it = m_param.find(aname); it != m_param.end())
+  {
+    (dynamic_cast<OhmmsParameter<PDT>&>(*it->second)).setValue(aval);
+  }
+}
+
+template void ParameterSet::add(std::string&, const std::string&, std::vector<std::string>&&, TagStatus);
+template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>&&, TagStatus);
+template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>&&, TagStatus);
+template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>&&, TagStatus);
+template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>&&, TagStatus);
+template void ParameterSet::add<std::complex<double>>(std::complex<double>&,
+                                                      const std::string&,
+                                                      std::vector<std::complex<double>>&&,
+                                                      TagStatus);
+template void ParameterSet::add<std::complex<float>>(std::complex<float>&,
+                                                     const std::string&,
+                                                     std::vector<std::complex<float>>&&,
+                                                     TagStatus);
+
+template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(qmcplusplus::TinyVector<int, 3u>&,
+                                                                  const std::string&,
+                                                                  std::vector<qmcplusplus::TinyVector<int, 3u>>&&,
+                                                                  TagStatus);
+
+template void ParameterSet::setValue<int>(const std::string& aname_in, int aval);

--- a/src/io/OhmmsData/ParameterSet.h
+++ b/src/io/OhmmsData/ParameterSet.h
@@ -17,11 +17,12 @@
 
 #include <map>
 #include <string>
+#include <complex>
 #include "OhmmsData/OhmmsParameter.h"
 #include "ModernStringUtils.hpp"
+#include "OhmmsPETE/TinyVector.h"
+
 /** class to handle a set of parameters
- *
- *This may become an inherited class from OhmmsElementBase.
  */
 struct ParameterSet : public OhmmsElementBase
 {
@@ -49,40 +50,7 @@ struct ParameterSet : public OhmmsElementBase
    * - <parameter name="aname"> value </parameter>
    * aname is converted into lower cases.
    */
-  inline bool put(xmlNodePtr cur) override
-  {
-    using namespace qmcplusplus;
-    if (cur == NULL)
-      return true; //handle empty node
-    cur            = cur->xmlChildrenNode;
-    bool something = false;
-    while (cur != NULL)
-    {
-      std::string cname(lowerCase(castXMLCharToChar(cur->name)));
-      if (auto it_tag = m_param.find(cname); it_tag == m_param.end())
-      {
-        if (cname == myName)
-        {
-          std::string aname(lowerCase(getXMLAttributeValue(cur, "name")));
-          if (!aname.empty())
-          {
-            if (auto it = m_param.find(aname); it != m_param.end())
-            {
-              something = true;
-              it->second->put(cur);
-            }
-          }
-        }
-      }
-      else
-      {
-        something = true;
-        it_tag->second->put(cur);
-      }
-      cur = cur->next;
-    }
-    return something;
-  }
+  bool put(xmlNodePtr cur) override;
 
   inline void reset() override {}
 
@@ -93,28 +61,37 @@ struct ParameterSet : public OhmmsElementBase
    *@param status Tag status, See OhmmsParameter.h for more details
    */
   template<class PDT>
-  inline void add(PDT& aparam,
-                  const std::string& aname_in,
-                  std::vector<PDT>&& candidate_values = {},
-                  TagStatus status                    = TagStatus::OPTIONAL)
-  {
-    using namespace qmcplusplus;
-    std::string aname(lowerCase(aname_in));
-    if (auto it = m_param.find(aname); it == m_param.end())
-    {
-      m_param[aname] = std::make_unique<OhmmsParameter<PDT>>(aparam, aname, std::move(candidate_values), status);
-    }
-  }
+  void add(PDT& aparam,
+           const std::string& aname_in,
+           std::vector<PDT>&& candidate_values = {},
+           TagStatus status                    = TagStatus::OPTIONAL);
 
   template<class PDT>
-  inline void setValue(const std::string& aname_in, PDT aval)
-  {
-    using namespace qmcplusplus;
-    std::string aname(lowerCase(aname_in));
-    if (auto it = m_param.find(aname); it != m_param.end())
-    {
-      (dynamic_cast<OhmmsParameter<PDT>&>(*it->second)).setValue(aval);
-    }
-  }
+  void setValue(const std::string& aname_in, PDT aval);
 };
+
+extern template void ParameterSet::add<std::string>(std::string&,
+                                                    const std::string&,
+                                                    std::vector<std::string>&&,
+                                                    TagStatus);
+extern template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>&&, TagStatus);
+extern template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>&&, TagStatus);
+extern template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>&&, TagStatus);
+extern template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>&&, TagStatus);
+extern template void ParameterSet::add<std::complex<double>>(std::complex<double>&,
+                                                             const std::string&,
+                                                             std::vector<std::complex<double>>&&,
+                                                             TagStatus);
+extern template void ParameterSet::add<std::complex<float>>(std::complex<float>&,
+                                                            const std::string&,
+                                                            std::vector<std::complex<float>>&&,
+                                                            TagStatus);
+extern template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(
+    qmcplusplus::TinyVector<int, 3u>&,
+    const std::string&,
+    std::vector<qmcplusplus::TinyVector<int, 3u>>&&,
+    TagStatus);
+
+extern template void ParameterSet::setValue<int>(const std::string& aname_in, int aval);
+
 #endif /*OHMMS_OHMMSPARAMETERSET_H*/

--- a/src/io/OhmmsData/ParameterSet.h
+++ b/src/io/OhmmsData/ParameterSet.h
@@ -63,11 +63,10 @@ struct ParameterSet : public OhmmsElementBase
       {
         if (cname == myName)
         {
-          XMLAttrString aname(cur, "name");
-          if (aname.hasValue())
+          std::string aname(lowerCase(getXMLAttributeValue(cur, "name")));
+          if (!aname.empty())
           {
-            aname.setValue(lowerCase(aname.getValue()));
-            if (auto it = m_param.find(aname.getValue()); it != m_param.end())
+            if (auto it = m_param.find(aname); it != m_param.end())
             {
               something = true;
               it->second->put(cur);

--- a/src/io/OhmmsData/ParameterSet.h
+++ b/src/io/OhmmsData/ParameterSet.h
@@ -18,7 +18,7 @@
 #include <map>
 #include <string>
 #include "OhmmsData/OhmmsParameter.h"
-
+#include "ModernStringUtils.hpp"
 /** class to handle a set of parameters
  *
  *This may become an inherited class from OhmmsElementBase.
@@ -51,23 +51,23 @@ struct ParameterSet : public OhmmsElementBase
    */
   inline bool put(xmlNodePtr cur) override
   {
+    using namespace qmcplusplus;
     if (cur == NULL)
       return true; //handle empty node
     cur            = cur->xmlChildrenNode;
     bool something = false;
     while (cur != NULL)
     {
-      std::string cname((const char*)(cur->name));
-      tolower(cname);
+      std::string cname(lowerCase(castXMLCharToChar(cur->name)));
       if (auto it_tag = m_param.find(cname); it_tag == m_param.end())
       {
         if (cname == myName)
         {
           XMLAttrString aname(cur, "name");
-          if (!aname.empty())
+          if (aname.hasValue())
           {
-            tolower(aname);
-            if (auto it = m_param.find(aname); it != m_param.end())
+            aname.setValue(lowerCase(aname.getValue()));
+            if (auto it = m_param.find(aname.getValue()); it != m_param.end())
             {
               something = true;
               it->second->put(cur);
@@ -99,8 +99,8 @@ struct ParameterSet : public OhmmsElementBase
                   std::vector<PDT>&& candidate_values = {},
                   TagStatus status                    = TagStatus::OPTIONAL)
   {
-    std::string aname(aname_in);
-    tolower(aname);
+    using namespace qmcplusplus;
+    std::string aname(lowerCase(aname_in));
     if (auto it = m_param.find(aname); it == m_param.end())
     {
       m_param[aname] = std::make_unique<OhmmsParameter<PDT>>(aparam, aname, std::move(candidate_values), status);
@@ -110,8 +110,8 @@ struct ParameterSet : public OhmmsElementBase
   template<class PDT>
   inline void setValue(const std::string& aname_in, PDT aval)
   {
-    std::string aname(aname_in);
-    tolower(aname);
+    using namespace qmcplusplus;
+    std::string aname(lowerCase(aname_in));
     if (auto it = m_param.find(aname); it != m_param.end())
     {
       (dynamic_cast<OhmmsParameter<PDT>&>(*it->second)).setValue(aval);

--- a/src/io/OhmmsData/XMLParsingString.cpp
+++ b/src/io/OhmmsData/XMLParsingString.cpp
@@ -1,0 +1,29 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File refactored from: XMLParsingString.hpp
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file
+ */
+#include "XMLParsingString.h"
+#include "libxmldefs.h"
+
+std::string getXMLAttributeValue(const xmlNodePtr cur, const std::string_view name)
+{
+  std::string attr_value;
+  xmlChar* attr_char = xmlGetProp(cur, castCharToXMLChar(name.data()));
+  if (attr_char)
+  {
+    attr_value.assign(castXMLCharToChar(attr_char));
+    xmlFree(attr_char);
+  }
+  return attr_value;
+}

--- a/src/io/OhmmsData/XMLParsingString.h
+++ b/src/io/OhmmsData/XMLParsingString.h
@@ -32,30 +32,21 @@
  *
  *  This is fine with UTF-8 bytes going into a std::string.
  */
-inline char* castXMLCharToChar(xmlChar* c)
-{
-  return static_cast<char*>(static_cast<void *>(c));
-}
+inline char* castXMLCharToChar(xmlChar* c) { return static_cast<char*>(static_cast<void*>(c)); }
 
 /** unsafe const xmlChar* to const char* cast
  */
-inline const char* castXMLCharToChar(const xmlChar * c)
-{
-  return static_cast<const char*>(static_cast<const void *>(c));
-}
+inline const char* castXMLCharToChar(const xmlChar* c) { return static_cast<const char*>(static_cast<const void*>(c)); }
 
 /** unsafe char* to xmlChar* cast
  */
-inline xmlChar* castCharToXMLChar(char* c)
-{
-  return static_cast<xmlChar*>(static_cast<void *>(c));
-}
+inline xmlChar* castCharToXMLChar(char* c) { return static_cast<xmlChar*>(static_cast<void*>(c)); }
 
 /** unsafe const char* to const xmlChar* cast
  */
-inline const xmlChar* castCharToXMLChar(const char * c)
+inline const xmlChar* castCharToXMLChar(const char* c)
 {
-  return static_cast<const xmlChar*>(static_cast<const void *>(c));
+  return static_cast<const xmlChar*>(static_cast<const void*>(c));
 }
 
 /** convert xmlNode contents into a std::string
@@ -70,7 +61,7 @@ public:
   XMLNodeString(const xmlNodePtr cur)
   {
     xmlChar* node_char = xmlNodeListGetString(cur->doc, cur->xmlChildrenNode, 1);
-    if(node_char)
+    if (node_char)
     {
       assign((const char*)node_char);
       xmlFree(node_char);
@@ -78,21 +69,24 @@ public:
   }
 
   /// expose base class constructors
-  XMLNodeString(const std::string& in) : std::string(in) { }
+  XMLNodeString(const std::string& in) : std::string(in) {}
 
-  XMLNodeString(const char* in) : std::string(in) { }
+  XMLNodeString(const char* in) : std::string(in) {}
 
   /// write a string to an xmlNode
-  void setXMLNodeContent(xmlNodePtr cur) const
-  {
-    xmlNodeSetContent(cur, (const xmlChar*)(this->c_str()));
-  }
+  void setXMLNodeContent(xmlNodePtr cur) const { xmlNodeSetContent(cur, (const xmlChar*)(this->c_str())); }
 };
 
+/** get the value string for attribute name
+ *  if name is unfound in cur you get an empty string back
+ *  this is the same behavior XMLAttrString provides. Without the complication
+ *  of a composite type you don't need.
+ */
+std::string getXMLAttributeValue(const xmlNodePtr cur, const std::string_view name);
+
 /** convert an xmlNode attribute into a name value pair.
- * used to inherit from std::string but to no advantage
- * and repeated confusion about whether comparisons to an attribute string were between
- * name or value etc.
+ * attribute_ is an empty string if attribute_name_
+ is not found.
  * if parsing multiple attributes is needed, use OhmmsAttributeSet
  */
 class XMLAttrString
@@ -100,28 +94,28 @@ class XMLAttrString
   // ordering same as crazy value, name signature of constructor
   std::string attribute_;
   const std::string attribute_name_;
+
 public:
   /// construct a string from an xmlNode
-  XMLAttrString(const xmlNodePtr cur, const char* name)
-      : attribute_name_(name)
+  XMLAttrString(const xmlNodePtr cur, const char* name) : attribute_name_(name)
   {
     xmlChar* attr_char = xmlGetProp(cur, castCharToXMLChar(name));
-    if(attr_char)
+    if (attr_char)
     {
       attribute_.assign(castXMLCharToChar(attr_char));
       xmlFree(attr_char);
     }
   }
-  
-  /// expose base class constructors
-  XMLAttrString(const std::string& in, const std::string& name) : attribute_(in), attribute_name_(name) { }
 
-  XMLAttrString(const char* in, const char* name) : attribute_(in), attribute_name_(name) { }
+  /// expose base class constructors
+  XMLAttrString(const std::string& in, const std::string& name) : attribute_(in), attribute_name_(name) {}
+
+  XMLAttrString(const char* in, const char* name) : attribute_(in), attribute_name_(name) {}
 
   /** i.e. does it have a value
    */
-  auto hasValue() const { return ! attribute_.empty(); };
-  
+  auto hasValue() const { return !attribute_.empty(); };
+
   /// write a string to an xmlNode
   void createXMLAttribute(xmlNodePtr cur) const
   {
@@ -138,11 +132,10 @@ public:
    *  can also operate as just a string of its value
    *  \todo remove this its a footgun and makes for less readable code
    */
-  operator const std::string&() { return attribute_; }
+  //operator const std::string&() { return attribute_; }
 
   const std::string& getName() const { return attribute_name_; }
   const std::string& getValue() const { return attribute_; }
-  void setValue(const std::string_view value) { attribute_.assign(value); } 
-  
+  void setValue(const std::string_view value) { attribute_.assign(value); }
 };
 #endif

--- a/src/io/OhmmsData/XMLParsingString.h
+++ b/src/io/OhmmsData/XMLParsingString.h
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers.
+// Copyright (c) 2021 QMCPACK developers.
 //
 // File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
@@ -22,32 +23,6 @@
 #include <string_view>
 #include <libxml/xmlmemory.h>
 #include <libxml/tree.h>
-
-// I think these should be in libxmldefs.h
-// but it includes XMLParsingString so these cast functions need to be here.
-
-/** xmlChar* to char* cast
- *  certainly not typesafe but at this interface between libxml and c++
- *  well it beats c style casts and might be more correct than a reinterpret.
- *
- *  This is fine with UTF-8 bytes going into a std::string.
- */
-inline char* castXMLCharToChar(xmlChar* c) { return static_cast<char*>(static_cast<void*>(c)); }
-
-/** unsafe const xmlChar* to const char* cast
- */
-inline const char* castXMLCharToChar(const xmlChar* c) { return static_cast<const char*>(static_cast<const void*>(c)); }
-
-/** unsafe char* to xmlChar* cast
- */
-inline xmlChar* castCharToXMLChar(char* c) { return static_cast<xmlChar*>(static_cast<void*>(c)); }
-
-/** unsafe const char* to const xmlChar* cast
- */
-inline const xmlChar* castCharToXMLChar(const char* c)
-{
-  return static_cast<const xmlChar*>(static_cast<const void*>(c));
-}
 
 /** convert xmlNode contents into a std::string
  *  \todo this should just be a function that takes a cur
@@ -84,58 +59,4 @@ public:
  */
 std::string getXMLAttributeValue(const xmlNodePtr cur, const std::string_view name);
 
-/** convert an xmlNode attribute into a name value pair.
- * attribute_ is an empty string if attribute_name_
- is not found.
- * if parsing multiple attributes is needed, use OhmmsAttributeSet
- */
-class XMLAttrString
-{
-  // ordering same as crazy value, name signature of constructor
-  std::string attribute_;
-  const std::string attribute_name_;
-
-public:
-  /// construct a string from an xmlNode
-  XMLAttrString(const xmlNodePtr cur, const char* name) : attribute_name_(name)
-  {
-    xmlChar* attr_char = xmlGetProp(cur, castCharToXMLChar(name));
-    if (attr_char)
-    {
-      attribute_.assign(castXMLCharToChar(attr_char));
-      xmlFree(attr_char);
-    }
-  }
-
-  /// expose base class constructors
-  XMLAttrString(const std::string& in, const std::string& name) : attribute_(in), attribute_name_(name) {}
-
-  XMLAttrString(const char* in, const char* name) : attribute_(in), attribute_name_(name) {}
-
-  /** i.e. does it have a value
-   */
-  auto hasValue() const { return !attribute_.empty(); };
-
-  /// write a string to an xmlNode
-  void createXMLAttribute(xmlNodePtr cur) const
-  {
-    xmlNewProp(cur, castCharToXMLChar(attribute_name_.c_str()), castCharToXMLChar(attribute_.c_str()));
-  }
-
-  /// write a string to an xmlNode
-  void setXMLAttribute(xmlNodePtr cur) const
-  {
-    xmlSetProp(cur, castCharToXMLChar(attribute_name_.c_str()), castCharToXMLChar(attribute_.c_str()));
-  }
-
-  /** retain surprising behavior where this inherently name value object 
-   *  can also operate as just a string of its value
-   *  \todo remove this its a footgun and makes for less readable code
-   */
-  //operator const std::string&() { return attribute_; }
-
-  const std::string& getName() const { return attribute_name_; }
-  const std::string& getValue() const { return attribute_; }
-  void setValue(const std::string_view value) { attribute_.assign(value); }
-};
 #endif

--- a/src/io/OhmmsData/libxmldefs.cpp
+++ b/src/io/OhmmsData/libxmldefs.cpp
@@ -1,0 +1,7 @@
+#include "libxmldefs.h"
+#include "ModernStringUtils.hpp"
+
+std::string getNodeName(xmlNodePtr cur)
+{
+  return qmcplusplus::lowerCase(castXMLCharToChar(cur->name));
+}

--- a/src/io/OhmmsData/libxmldefs.h
+++ b/src/io/OhmmsData/libxmldefs.h
@@ -79,6 +79,12 @@ inline const xmlChar* castCharToXMLChar(const char* c)
 
 std::string getNodeName(xmlNodePtr cur);
 
+/** replaces a's value with the first "element" in the "string"
+ *  returned by XMLNodeString{cur}.
+ *  but if that string is empty then then doesn't touch a.
+ *  See documentation of the interaction between operator>>
+ *  streams and the FormattedInputFunction requirement in the c++ standard.
+ */
 template<class T>
 bool putContent(T& a, xmlNodePtr cur)
 {

--- a/src/io/OhmmsData/libxmldefs.h
+++ b/src/io/OhmmsData/libxmldefs.h
@@ -25,7 +25,7 @@
 #include <algorithm>
 #include <typeinfo>
 #include "XMLParsingString.h"
-#include "Utilities/ModernStringUtils.hpp"
+#include "ModernStringUtils.hpp"
 
 /**\file libxmldefs.h
  *\brief A collection of put/get functions to read from or write to a xmlNode defined in libxml2.

--- a/src/io/OhmmsData/libxmldefs.h
+++ b/src/io/OhmmsData/libxmldefs.h
@@ -25,14 +25,11 @@
 #include <algorithm>
 #include <typeinfo>
 #include "XMLParsingString.h"
+#include "Utilities/ModernStringUtils.hpp"
 
-template<typename _CharT>
-inline void getNodeName(std::basic_string<_CharT>& cname, xmlNodePtr cur)
+inline std::string getNodeName(xmlNodePtr cur)
 {
-  cname = (const char*)cur->name;
-  for (int i = 0; i < cname.size(); i++)
-    cname[i] = tolower(cname[i]);
-  //std::transform(cname.begin(), cname.end(), cname.begin(), std::tolower);
+  return qmcplusplus::lowerCase(castXMLCharToChar(cur->name));
 }
 
 /**\file libxmldefs.h

--- a/src/io/OhmmsData/libxmldefs.h
+++ b/src/io/OhmmsData/libxmldefs.h
@@ -27,11 +27,6 @@
 #include "XMLParsingString.h"
 #include "Utilities/ModernStringUtils.hpp"
 
-inline std::string getNodeName(xmlNodePtr cur)
-{
-  return qmcplusplus::lowerCase(castXMLCharToChar(cur->name));
-}
-
 /**\file libxmldefs.h
  *\brief A collection of put/get functions to read from or write to a xmlNode defined in libxml2.
  *
@@ -58,6 +53,32 @@ inline std::string getNodeName(xmlNodePtr cur)
   };
  \endcode
  */
+
+/** xmlChar* to char* cast
+ *  certainly not typesafe but at this interface between libxml and c++
+ *  well it beats c style casts and might be more correct than a reinterpret.
+ *
+ *  This is fine with UTF-8 bytes going into a std::string.
+ */
+inline char* castXMLCharToChar(xmlChar* c) { return static_cast<char*>(static_cast<void*>(c)); }
+
+/** unsafe const xmlChar* to const char* cast
+ */
+inline const char* castXMLCharToChar(const xmlChar* c) { return static_cast<const char*>(static_cast<const void*>(c)); }
+
+/** unsafe char* to xmlChar* cast
+ */
+inline xmlChar* castCharToXMLChar(char* c) { return static_cast<xmlChar*>(static_cast<void*>(c)); }
+
+/** unsafe const char* to const xmlChar* cast
+ */
+inline const xmlChar* castCharToXMLChar(const char* c)
+{
+  return static_cast<const xmlChar*>(static_cast<const void*>(c));
+}
+
+std::string getNodeName(xmlNodePtr cur);
+
 template<class T>
 bool putContent(T& a, xmlNodePtr cur)
 {

--- a/src/io/OhmmsData/tests/CMakeLists.txt
+++ b/src/io/OhmmsData/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 set(UTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(${UTEST_EXE} test_xml.cpp)
-target_link_libraries(${UTEST_EXE} catch_main qmcutil)
+target_include_directories(${UTEST_EXE} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+target_link_libraries(${UTEST_EXE} catch_main qmcutil_basic qmcio_xml)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/simple.xml" ${UTEST_DIR})
 

--- a/src/io/OhmmsData/tests/CMakeLists.txt
+++ b/src/io/OhmmsData/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ set(UTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(${UTEST_EXE} test_xml.cpp)
 target_include_directories(${UTEST_EXE} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../../")
-target_link_libraries(${UTEST_EXE} catch_main qmcutil_basic qmcio_xml)
+target_link_libraries(${UTEST_EXE} catch_main qmcutil qmcio_xml)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/simple.xml" ${UTEST_DIR})
 

--- a/src/io/OhmmsData/tests/test_xml.cpp
+++ b/src/io/OhmmsData/tests/test_xml.cpp
@@ -71,6 +71,9 @@ aa \
 
   const std::string attr_string(getXMLAttributeValue(root, "name"));
   REQUIRE(attr_string == "qmc");
+
+  const std::string attr_string_missing(getXMLAttributeValue(root, "not_here"));
+  REQUIRE(attr_string_missing.empty());
 }
 
 TEST_CASE("putContent", "[xml]")

--- a/src/io/OhmmsData/tests/test_xml.cpp
+++ b/src/io/OhmmsData/tests/test_xml.cpp
@@ -69,8 +69,8 @@ aa \
   const XMLNodeString node_string(root);
   REQUIRE(node_string == " aa ");
 
-  const XMLAttrString attr_string(root, "name");
-  REQUIRE(attr_string.getValue() == "qmc");
+  const std::string attr_string(getXMLAttributeValue(root, "name"));
+  REQUIRE(attr_string == "qmc");
 }
 
 TEST_CASE("putContent", "[xml]")

--- a/src/io/OhmmsData/tests/test_xml.cpp
+++ b/src/io/OhmmsData/tests/test_xml.cpp
@@ -47,8 +47,7 @@ TEST_CASE("parseString", "[xml]")
 
   REQUIRE((char*)root->name == string("simulation"));
 
-  string root_name;
-  getNodeName(root_name, root);
+  std::string root_name(getNodeName(root));
 
   REQUIRE(root_name == "simulation");
 }
@@ -71,7 +70,7 @@ aa \
   REQUIRE(node_string == " aa ");
 
   const XMLAttrString attr_string(root, "name");
-  REQUIRE(attr_string == "qmc");
+  REQUIRE(attr_string.getValue() == "qmc");
 }
 
 TEST_CASE("putContent", "[xml]")


### PR DESCRIPTION
## Proposed changes

* add a std::string_view based lowerCase to replace OhmmsElementBase.h tolower function.
* add sub target for qmcutil, qmcutil_basic to allow linking for this function without pulling in message and qmcio.

* remove XMLAttrString and replace with std::string and getXMLAttributeValue function. Nothing actually makes use of the extra state and methods of the derived class and it complicates string processing.

* refactor getNodeString to actually return a string rather than write to output argument.  This combined with a large amount of sloppy scoping / premature optimization. Allows it to be chained with lowerCase as well.

* add castCharToXMLChar and castXMLCharToChar casting functions to replace c casts. As we overhaul input we should use these to eliminate c cast from the application xml parser boundary code.

* Add implementation file ParameterSet.cpp and explict instantiations of all used member template functions.

This will be used by future PR's improving input handling in EstimatorManagerNew.

## What type(s) of changes does this code introduce?
- New feature
- Code style update (formatting, renaming)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
