### PR TITLE
Make hdf_archive support writting data from const object.

### DIFF
--- a/src/QMCDrivers/BranchIO.cpp
+++ b/src/QMCDrivers/BranchIO.cpp
@@ -58,24 +58,19 @@ struct h5data_proxy<accumulator_set<T>> : public h5_space_type<T, 1>
   };
   using h5_space_type<T, 1>::dims;
   using h5_space_type<T, 1>::get_address;
-  typedef accumulator_set<T> data_type;
-  data_type& ref_;
+  using data_type = accumulator_set<T>;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = CAPACITY; }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline h5data_proxy(const data_type& a) { dims[0] = CAPACITY; }
+
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_read(grp, aname, get_address(ref_.properties), xfer_plist);
+    return h5d_read(grp, aname, get_address(ref.properties), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), this->size(), dims, get_address(ref_.properties), xfer_plist);
+    return h5d_write(grp, aname.c_str(), this->size(), dims, get_address(ref.properties), xfer_plist);
   }
-
-  /** return the start address */
-  inline T* begin() { return ref_.properties; }
-  /** return the end address */
-  inline T* end() { return ref_.properties + CAPACITY; }
 };
 
 template<class SFNB>

--- a/src/io/hdf/HDFVersion.h
+++ b/src/io/hdf/HDFVersion.h
@@ -84,16 +84,16 @@ struct HDFVersion //: public HDFAttribIOBase
 
   inline bool operator<(const HDFVersion& other) const { return serialized() < other.serialized(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     h5data_proxy<data_type> vin(version);
-    return vin.read(grp, aname, xfer_plist);
+    return vin.read(version, grp, aname, xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     h5data_proxy<data_type> vout(version);
-    return vout.write(grp, aname, xfer_plist);
+    return vout.write(version, grp, aname, xfer_plist);
   }
 };
 
@@ -113,17 +113,18 @@ inline std::istream& operator>>(std::istream& is, HDFVersion& v)
 template<>
 struct h5data_proxy<HDFVersion>
 {
-  HDFVersion& ref;
-  h5data_proxy(HDFVersion& a) : ref(a) {}
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  h5data_proxy(const HDFVersion& a) {}
+
+  inline bool read(HDFVersion& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     h5data_proxy<HDFVersion::data_type> vin(ref.version);
-    return vin.read(grp, aname, xfer_plist);
+    return vin.read(ref.version, grp, aname, xfer_plist);
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const HDFVersion& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     h5data_proxy<HDFVersion::data_type> vout(ref.version);
-    return vout.write(grp, aname, xfer_plist);
+    return vout.write(ref.version, grp, aname, xfer_plist);
   }
 };
 

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -27,7 +27,13 @@
 #include <stack>
 #include <bitset>
 #ifdef HAVE_MPI
-namespace boost { namespace mpi3 { class communicator; } }
+namespace boost
+{
+namespace mpi3
+{
+class communicator;
+}
+} // namespace boost
 #endif
 
 class Communicate;
@@ -217,10 +223,10 @@ public:
   void writeSlabReshaped(T& data, const std::array<IT, RANK>& shape, const std::string& aname)
   {
     std::array<hsize_t, RANK> globals, counts, offsets;
-    for(int dim = 0; dim < RANK; dim++)
+    for (int dim = 0; dim < RANK; dim++)
     {
       globals[dim] = static_cast<hsize_t>(shape[dim]);
-      counts[dim] = static_cast<hsize_t>(shape[dim]);
+      counts[dim]  = static_cast<hsize_t>(shape[dim]);
       offsets[dim] = 0;
     }
 
@@ -264,10 +270,10 @@ public:
   void readSlabReshaped(T& data, const std::array<IT, RANK>& shape, const std::string& aname)
   {
     std::array<hsize_t, RANK> globals, counts, offsets;
-    for(int dim = 0; dim < RANK; dim++)
+    for (int dim = 0; dim < RANK; dim++)
     {
       globals[dim] = static_cast<hsize_t>(shape[dim]);
-      counts[dim] = static_cast<hsize_t>(shape[dim]);
+      counts[dim]  = static_cast<hsize_t>(shape[dim]);
       offsets[dim] = 0;
     }
 
@@ -288,17 +294,17 @@ public:
   void readSlabSelection(T& data, const std::array<IT, RANK>& readSpec, const std::string& aname)
   {
     std::array<hsize_t, RANK> globals, counts, offsets;
-    for(int dim = 0; dim < RANK; dim++)
+    for (int dim = 0; dim < RANK; dim++)
     {
       globals[dim] = 0;
       if (readSpec[dim] < 0)
       {
-        counts[dim] = 0;
+        counts[dim]  = 0;
         offsets[dim] = 0;
       }
       else
       {
-        counts[dim] = 1;
+        counts[dim]  = 1;
         offsets[dim] = static_cast<hsize_t>(readSpec[dim]);
       }
     }

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -191,8 +191,8 @@ public:
     if (!(Mode[IS_PARALLEL] || Mode[IS_MASTER]))
       throw std::runtime_error("Only write data in parallel or by master but not every rank!");
     hid_t p = group_id.empty() ? file_id : group_id.top();
-    h5data_proxy<T> e(data);
-    return e.write(p, aname, xfer_plist);
+    h5data_proxy<typename std::remove_const<T>::type> e(data);
+    return e.write(data, p, aname, xfer_plist);
   }
 
   /** write the data to the group aname and check status
@@ -239,7 +239,7 @@ public:
       return true;
     hid_t p = group_id.empty() ? file_id : group_id.top();
     h5data_proxy<T> e(data);
-    return e.read(p, aname, xfer_plist);
+    return e.read(data, p, aname, xfer_plist);
   }
 
   /** read the data from the group aname and check status

--- a/src/io/hdf/hdf_dataproxy.h
+++ b/src/io/hdf/hdf_dataproxy.h
@@ -32,7 +32,7 @@ struct h5data_proxy : public h5_space_type<T, 0>
   using FileSpace::dims;
   using FileSpace::get_address;
 
-  inline h5data_proxy(const data_type& a) { }
+  inline h5data_proxy(const data_type& a) {}
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
@@ -43,7 +43,6 @@ struct h5data_proxy : public h5_space_type<T, 0>
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref), xfer_plist);
   }
-
 };
 
 /** specialization for bool, convert to int
@@ -56,13 +55,13 @@ struct h5data_proxy<bool> : public h5_space_type<int, 0>
   using FileSpace::dims;
   using FileSpace::get_address;
 
-  inline h5data_proxy(const data_type& a) { }
+  inline h5data_proxy(const data_type& a) {}
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    int copy = static_cast<int>(ref);
+    int copy  = static_cast<int>(ref);
     bool okay = h5d_read(grp, aname, get_address(&copy), xfer_plist);
-    ref = static_cast<bool>(copy);
+    ref       = static_cast<bool>(copy);
     return okay;
   }
 
@@ -71,7 +70,6 @@ struct h5data_proxy<bool> : public h5_space_type<int, 0>
     int copy = static_cast<int>(ref);
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&copy), xfer_plist);
   }
-
 };
 
 } // namespace qmcplusplus

--- a/src/io/hdf/hdf_dataproxy.h
+++ b/src/io/hdf/hdf_dataproxy.h
@@ -23,6 +23,7 @@ namespace qmcplusplus
 {
 
 /** generic h5data_proxy<T> for scalar basic datatypes defined in hdf_dataspace.h
+ * Note if the dataset to be written has const specifier, T should not carry const.
  */
 template<typename T>
 struct h5data_proxy : public h5_space_type<T, 0>

--- a/src/io/hdf/hdf_dataproxy.h
+++ b/src/io/hdf/hdf_dataproxy.h
@@ -31,18 +31,17 @@ struct h5data_proxy : public h5_space_type<T, 0>
   using FileSpace = h5_space_type<T, 0>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { }
+  inline h5data_proxy(const data_type& a) { }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_read(grp, aname, get_address(&ref_), xfer_plist);
+    return h5d_read(grp, aname, get_address(&ref), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref_), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref), xfer_plist);
   }
 
 };
@@ -56,21 +55,20 @@ struct h5data_proxy<bool> : public h5_space_type<int, 0>
   using FileSpace = h5_space_type<int, 0>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { }
+  inline h5data_proxy(const data_type& a) { }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    int copy = static_cast<int>(ref_);
+    int copy = static_cast<int>(ref);
     bool okay = h5d_read(grp, aname, get_address(&copy), xfer_plist);
-    ref_ = static_cast<bool>(copy);
+    ref = static_cast<bool>(copy);
     return okay;
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    int copy = static_cast<int>(ref_);
+    int copy = static_cast<int>(ref);
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&copy), xfer_plist);
   }
 

--- a/src/io/hdf/hdf_dataspace.h
+++ b/src/io/hdf/hdf_dataspace.h
@@ -51,6 +51,7 @@ struct h5_space_type
   static constexpr int added_rank() { return 0; }
   ///return the address
   inline static auto get_address(T* a) { return a; }
+  inline static auto get_address(const T* a) { return a; }
 };
 
 /** specialization of h5_space_type for std::complex<T>
@@ -66,6 +67,7 @@ struct h5_space_type<std::complex<T>, RANK> : public h5_space_type<T, RANK + 1>
   static constexpr int added_rank() { return Base::added_rank() + 1; }
   inline h5_space_type() { dims[RANK] = 2; }
   inline static auto get_address(std::complex<T>* a) { return Base::get_address(reinterpret_cast<T*>(a)); }
+  inline static auto get_address(const std::complex<T>* a) { return Base::get_address(reinterpret_cast<const T*>(a)); }
 };
 
 /** specialization of h5_space_type for std::array<T,D> for any intrinsic type T
@@ -79,6 +81,7 @@ struct h5_space_type<std::array<T, D>, RANK> : public h5_space_type<T, RANK + 1>
   inline h5_space_type() { dims[RANK] = D; }
   static constexpr int added_rank() { return Base::added_rank() + 1; }
   inline static auto get_address(std::array<T, D>* a) { return Base::get_address(a->data()); }
+  inline static auto get_address(const std::array<T, D>* a) { return Base::get_address(a->data()); }
 };
 
 /** specialization of h5_space_type for TinyVector<T,D> for any intrinsic type T
@@ -92,6 +95,7 @@ struct h5_space_type<TinyVector<T, D>, RANK> : public h5_space_type<T, RANK + 1>
   inline h5_space_type() { dims[RANK] = D; }
   static constexpr int added_rank() { return Base::added_rank() + 1; }
   inline static auto get_address(TinyVector<T, D>* a) { return Base::get_address(a->data()); }
+  inline static auto get_address(const TinyVector<T, D>* a) { return Base::get_address(a->data()); }
 };
 
 /** specialization of h5_space_type for Tensor<T,D> for any intrinsic type T
@@ -109,6 +113,7 @@ struct h5_space_type<Tensor<T, D>, RANK> : public h5_space_type<T, RANK + 2>
   }
   static constexpr int added_rank() { return Base::added_rank() + 2; }
   inline static auto get_address(Tensor<T, D>* a) { return Base::get_address(a->data()); }
+  inline static auto get_address(const Tensor<T, D>* a) { return Base::get_address(a->data()); }
 };
 
 } // namespace qmcplusplus

--- a/src/io/hdf/hdf_double_hyperslab.h
+++ b/src/io/hdf/hdf_double_hyperslab.h
@@ -106,37 +106,37 @@ struct double_hyperslab_proxy : public container_proxy<CT>
 template<typename CT, unsigned MAXDIM>
 struct h5data_proxy<double_hyperslab_proxy<CT, MAXDIM>>
 {
-  double_hyperslab_proxy<CT, MAXDIM>& ref_;
-  h5data_proxy(double_hyperslab_proxy<CT, MAXDIM>& a) : ref_(a) {}
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  double_hyperslab_proxy<CT, MAXDIM>& ref;
+  h5data_proxy(double_hyperslab_proxy<CT, MAXDIM>& a) {}
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    if (ref_.use_slab)
+    if (ref.use_slab)
     {
-      return h5d_read(grp, aname.c_str(), ref_.slab_rank, ref_.slab_dims.data(), ref_.slab_dims_local.data(),
-                      ref_.slab_offset.data(), ref_.mem_rank, ref_.mem_dims.data(), ref_.mem_dims_local.data(),
-                      ref_.mem_offset.data(), ref_.data(), xfer_plist);
+      return h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
+                      ref.slab_offset.data(), ref.mem_rank, ref.mem_dims.data(), ref.mem_dims_local.data(),
+                      ref.mem_offset.data(), ref.data(), xfer_plist);
     }
     else
     {
-      int rank = ref_.slab_rank;
-      if (!get_space(grp, aname, rank, ref_.slab_dims.data(), true))
+      int rank = ref.slab_rank;
+      if (!get_space(grp, aname, rank, ref.slab_dims.data(), true))
       {
-        ref_.change_shape();
+        ref.change_shape();
       }
-      return h5d_read(grp, aname, ref_.data(), xfer_plist);
+      return h5d_read(grp, aname, ref.data(), xfer_plist);
     }
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    if (ref_.use_slab)
+    if (ref.use_slab)
     {
-      return h5d_write(grp, aname.c_str(), ref_.slab_rank, ref_.slab_dims.data(), ref_.slab_dims_local.data(),
-                       ref_.slab_offset.data(), ref_.mem_rank, ref_.mem_dims.data(), ref_.mem_dims_local.data(),
-                       ref_.mem_offset.data(), ref_.data(), xfer_plist);
+      return h5d_write(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
+                       ref.slab_offset.data(), ref.mem_rank, ref.mem_dims.data(), ref.mem_dims_local.data(),
+                       ref.mem_offset.data(), ref.data(), xfer_plist);
     }
     else
     {
-      return h5d_write(grp, aname.c_str(), ref_.slab_rank, ref_.slab_dims.data(), ref_.data(), xfer_plist);
+      return h5d_write(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.data(), xfer_plist);
     }
   }
 };

--- a/src/io/hdf/hdf_hyperslab.h
+++ b/src/io/hdf/hdf_hyperslab.h
@@ -72,9 +72,9 @@ struct hyperslab_proxy
     static_assert(std::is_unsigned<IT>::value, "only accept unsigned integer types like size_t");
     for (int i = 0; i < slab_rank; ++i)
     {
-      file_space.dims[i] = static_cast<hsize_t>(dims_in[i]);
+      file_space.dims[i]     = static_cast<hsize_t>(dims_in[i]);
       selected_space.dims[i] = static_cast<hsize_t>(selected_in[i]);
-      slab_offset[i] = static_cast<hsize_t>(offsets_in[i]);
+      slab_offset[i]         = static_cast<hsize_t>(offsets_in[i]);
     }
 
     /// element_type related dimensions always have offset 0
@@ -149,7 +149,6 @@ struct hyperslab_proxy
         selected_space.dims[dim] = file_space.dims[dim];
     }
   }
-
 };
 
 template<typename CT, unsigned RANK>
@@ -165,20 +164,22 @@ struct h5data_proxy<hyperslab_proxy<CT, RANK>>
     getDataShape<typename data_type::element_type>(grp, aname, sizes_file);
     ref.adaptShape(sizes_file);
     ref.checkUserRankSizes();
-    if(!ref.checkContainerCapacity())
+    if (!ref.checkContainerCapacity())
       container_traits<CT>::resize(ref.ref_, ref.selected_space.dims, ref.slab_rank);
     return h5d_read(grp, aname.c_str(), ref.file_space.rank, ref.file_space.dims, ref.selected_space.dims,
-                    ref.slab_offset.data(), hyperslab_proxy<CT, RANK>::SpaceType::get_address(container_traits<CT>::getElementPtr(ref.ref_)),
+                    ref.slab_offset.data(),
+                    hyperslab_proxy<CT, RANK>::SpaceType::get_address(container_traits<CT>::getElementPtr(ref.ref_)),
                     xfer_plist);
   }
 
   inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     ref.checkUserRankSizes();
-    if(!ref.checkContainerCapacity())
+    if (!ref.checkContainerCapacity())
       throw std::runtime_error("Not large enough container capacity!\n");
     return h5d_write(grp, aname.c_str(), ref.file_space.rank, ref.file_space.dims, ref.selected_space.dims,
-                     ref.slab_offset.data(), hyperslab_proxy<CT, RANK>::SpaceType::get_address(container_traits<CT>::getElementPtr(ref.ref_)),
+                     ref.slab_offset.data(),
+                     hyperslab_proxy<CT, RANK>::SpaceType::get_address(container_traits<CT>::getElementPtr(ref.ref_)),
                      xfer_plist);
   }
 };

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -37,7 +37,7 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 1, Alloc>;
 
-  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.num_elements(); }
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
@@ -47,7 +47,7 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
     return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
@@ -63,16 +63,18 @@ struct h5data_proxy<boost::multi::array<T, 2, Alloc>> : public h5_space_type<T, 
 
   inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref.size(0);
-    dims[1] = ref.size(1);
+    dims[0] = a.size(0);
+    dims[1] = a.size(1);
   }
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
       ref.reextent({dims[0], dims[1]});
     return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
@@ -86,7 +88,7 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, Ptr>> : public h5_space_type<T
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 1, Ptr>;
 
-  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.num_elements(); }
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
@@ -102,7 +104,7 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, Ptr>> : public h5_space_type<T
     return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
@@ -118,9 +120,10 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, Ptr>> : public h5_space_type<T
 
   inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref.size(0);
-    dims[1] = ref.size(1);
+    dims[0] = a.size(0);
+    dims[1] = a.size(1);
   }
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
@@ -134,7 +137,8 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, Ptr>> : public h5_space_type<T
     }
     return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
@@ -153,7 +157,7 @@ struct h5data_proxy<boost::multi::array<T, 1, device::device_allocator<T>>> : pu
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 1, device::device_allocator<T>>;
 
-  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.num_elements(); }
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
@@ -167,7 +171,7 @@ struct h5data_proxy<boost::multi::array<T, 1, device::device_allocator<T>>> : pu
     return ret;
   }
 
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
@@ -184,9 +188,10 @@ struct h5data_proxy<boost::multi::array<T, 2, device::device_allocator<T>>> : pu
 
   inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref.size(0);
-    dims[1] = ref.size(1);
+    dims[0] = a.size(0);
+    dims[1] = a.size(1);
   }
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
@@ -198,7 +203,8 @@ struct h5data_proxy<boost::multi::array<T, 2, device::device_allocator<T>>> : pu
     device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
@@ -213,7 +219,7 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, device::device_pointer<T>>> : 
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 1, device::device_pointer<T>>;
 
-  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.num_elements(); }
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
@@ -234,7 +240,7 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, device::device_pointer<T>>> : 
     return ret;
   }
 
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
@@ -251,9 +257,10 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
 
   inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref.size(0);
-    dims[1] = ref.size(1);
+    dims[0] = a.size(0);
+    dims[1] = a.size(1);
   }
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
@@ -272,7 +279,8 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
     device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
@@ -282,9 +290,11 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
 template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_allocator<T>>, RANK>>
 {
-  typedef boost::multi::array<T, 2, device::device_allocator<T>> CT;
-  hyperslab_proxy<CT, RANK>& ref;
-  h5data_proxy(hyperslab_proxy<CT, RANK>& a) {}
+  using CT = boost::multi::array<T, 2, device::device_allocator<T>>;
+  using data_type = hyperslab_proxy<CT, RANK>;
+  
+  h5data_proxy(const data_type& a) {}
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (ref.use_slab)
@@ -308,7 +318,8 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_all
       return h5d_read(grp, aname, ref.data(), xfer_plist);
     }
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     std::cerr << " Disabled hyperslab write with boost::multi::array<gpu_allocator>.\n";
     return false;
@@ -318,9 +329,11 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_all
 template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>, RANK>>
 {
-  typedef boost::multi::array_ref<T, 2, device::device_pointer<T>> CT;
-  hyperslab_proxy<CT, RANK>& ref;
-  h5data_proxy(hyperslab_proxy<CT, RANK>& a) {}
+  using CT = boost::multi::array_ref<T, 2, device::device_pointer<T>>;
+  using data_type = hyperslab_proxy<CT, RANK>;
+
+  h5data_proxy(const data_type& a) {}
+
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (ref.use_slab)
@@ -344,7 +357,8 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device
       return h5d_read(grp, aname, ref.data(), xfer_plist);
     }
   }
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     std::cerr << " Disabled hyperslab write with boost::multi::array_ref<gpu_ptr>.\n";
     return false;

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -36,21 +36,20 @@ struct h5data_proxy<boost::multi::array<T, 1, Alloc>> : public h5_space_type<T, 
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 1, Alloc>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     using iextensions = typename boost::multi::iextensions<1u>;
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.reextent(iextensions{dims[0]});
-    return h5d_read(grp, aname, get_address(std::addressof(*ref_.origin())), xfer_plist);
+      ref.reextent(iextensions{dims[0]});
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 };
 
@@ -61,22 +60,21 @@ struct h5data_proxy<boost::multi::array<T, 2, Alloc>> : public h5_space_type<T, 
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 2, Alloc>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref_.size(0);
-    dims[1] = ref_.size(1);
+    dims[0] = ref.size(0);
+    dims[1] = ref.size(1);
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.reextent({dims[0], dims[1]});
-    return h5d_read(grp, aname, get_address(std::addressof(*ref_.origin())), xfer_plist);
+      ref.reextent({dims[0], dims[1]});
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 };
 
@@ -87,27 +85,26 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, Ptr>> : public h5_space_type<T
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 1, Ptr>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
     {
       if (dims[0] > 0)
       {
         std::cerr << " Error: multi::array_ref can't be resized in h5data_proxy<>::read." << std::endl;
-        std::cerr << dims[0] << " " << ref_.size(0) << std::endl;
+        std::cerr << dims[0] << " " << ref.size(0) << std::endl;
       }
       return false;
     }
-    return h5d_read(grp, aname, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 };
 
@@ -118,29 +115,28 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, Ptr>> : public h5_space_type<T
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 2, Ptr>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref_.size(0);
-    dims[1] = ref_.size(1);
+    dims[0] = ref.size(0);
+    dims[1] = ref.size(1);
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
     {
       if (dims[0] * dims[1] > 0)
       {
         std::cerr << " Error: multi::array_ref can't be resized in h5data_proxy<>::read." << std::endl;
-        std::cerr << dims[0] << " " << dims[1] << " " << ref_.size(0) << " " << ref_.size(1) << std::endl;
+        std::cerr << dims[0] << " " << dims[1] << " " << ref.size(0) << " " << ref.size(1) << std::endl;
       }
       return false;
     }
-    return h5d_read(grp, aname, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_read(grp, aname, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(std::addressof(*ref.origin())), xfer_plist);
   }
 };
 
@@ -156,26 +152,25 @@ struct h5data_proxy<boost::multi::array<T, 1, device::device_allocator<T>>> : pu
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 1, device::device_allocator<T>>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.reextent({dims[0]});
-    std::size_t sz    = ref_.num_elements();
+      ref.reextent({dims[0]});
+    std::size_t sz    = ref.num_elements();
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref_.origin());
+    device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
   }
 };
 
@@ -186,28 +181,27 @@ struct h5data_proxy<boost::multi::array<T, 2, device::device_allocator<T>>> : pu
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array<T, 2, device::device_allocator<T>>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref_.size(0);
-    dims[1] = ref_.size(1);
+    dims[0] = ref.size(0);
+    dims[1] = ref.size(1);
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.reextent({dims[0], dims[1]});
-    std::size_t sz    = ref_.num_elements();
+      ref.reextent({dims[0], dims[1]});
+    std::size_t sz    = ref.num_elements();
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref_.origin());
+    device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
   }
 };
 
@@ -218,33 +212,32 @@ struct h5data_proxy<boost::multi::array_ref<T, 1, device::device_pointer<T>>> : 
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 1, device::device_pointer<T>>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.num_elements(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = ref.num_elements(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
     {
       if (dims[0] > 0)
       {
         std::cerr << " Error: multi::array_ref can't be resized in h5data_proxy<>::read." << std::endl;
-        std::cerr << dims[0] << " " << ref_.size(0) << std::endl;
+        std::cerr << dims[0] << " " << ref.size(0) << std::endl;
       }
       return false;
     }
-    std::size_t sz    = ref_.num_elements();
+    std::size_t sz    = ref.num_elements();
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref_.origin());
+    device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
   }
 };
 
@@ -255,35 +248,34 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
   using FileSpace::dims;
   using FileSpace::get_address;
   using data_type = boost::multi::array_ref<T, 2, device::device_pointer<T>>;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref_.size(0);
-    dims[1] = ref_.size(1);
+    dims[0] = ref.size(0);
+    dims[1] = ref.size(1);
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
     {
       if (dims[0] * dims[1] > 0)
       {
         std::cerr << " Error: multi::array_ref can't be resized in h5data_proxy<>::read." << std::endl;
-        std::cerr << dims[0] << " " << dims[1] << " " << ref_.size(0) << " " << ref_.size(1) << std::endl;
+        std::cerr << dims[0] << " " << dims[1] << " " << ref.size(0) << " " << ref.size(1) << std::endl;
       }
       return false;
     }
-    std::size_t sz    = ref_.num_elements();
+    std::size_t sz    = ref.num_elements();
     using iextensions = typename boost::multi::iextensions<1u>;
     boost::multi::array<T, 1> buf(iextensions{sz});
     auto ret = h5d_read(grp, aname, get_address(buf.data()), xfer_plist);
-    device::copy_n(buf.data(), sz, ref_.origin());
+    device::copy_n(buf.data(), sz, ref.origin());
     return ret;
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     throw std::runtime_error(" write from gpu not implemented yet.");
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref_.origin())), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(to_address(ref.origin())), xfer_plist);
   }
 };
 
@@ -291,32 +283,32 @@ template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_allocator<T>>, RANK>>
 {
   typedef boost::multi::array<T, 2, device::device_allocator<T>> CT;
-  hyperslab_proxy<CT, RANK>& ref_;
-  h5data_proxy(hyperslab_proxy<CT, RANK>& a) : ref_(a) {}
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  hyperslab_proxy<CT, RANK>& ref;
+  h5data_proxy(hyperslab_proxy<CT, RANK>& a) {}
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    if (ref_.use_slab)
+    if (ref.use_slab)
     {
       // later on specialize h5d_read for fancy pointers
-      std::size_t sz = ref_.ref.num_elements();
+      std::size_t sz = ref.ref.num_elements();
       boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extensions_type{sz});
-      auto ret = h5d_read(grp, aname.c_str(), ref_.slab_rank, ref_.slab_dims.data(), ref_.slab_dims_local.data(),
-                          ref_.slab_offset.data(), buf.origin(), xfer_plist);
-      device::copy_n(buf.data(), sz, ref_.ref.origin());
+      auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
+                          ref.slab_offset.data(), buf.origin(), xfer_plist);
+      device::copy_n(buf.data(), sz, ref.ref.origin());
       return ret;
     }
     else
     {
-      int rank = ref_.slab_rank;
-      if (!checkShapeConsistency<T>(grp, aname, rank, ref_.slab_dims.data(), true))
+      int rank = ref.slab_rank;
+      if (!checkShapeConsistency<T>(grp, aname, rank, ref.slab_dims.data(), true))
       {
         std::cerr << " Disabled hyperslab resize with boost::multi::array<gpu_allocator>.\n";
         return false;
       }
-      return h5d_read(grp, aname, ref_.data(), xfer_plist);
+      return h5d_read(grp, aname, ref.data(), xfer_plist);
     }
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     std::cerr << " Disabled hyperslab write with boost::multi::array<gpu_allocator>.\n";
     return false;
@@ -327,32 +319,32 @@ template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>, RANK>>
 {
   typedef boost::multi::array_ref<T, 2, device::device_pointer<T>> CT;
-  hyperslab_proxy<CT, RANK>& ref_;
-  h5data_proxy(hyperslab_proxy<CT, RANK>& a) : ref_(a) {}
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  hyperslab_proxy<CT, RANK>& ref;
+  h5data_proxy(hyperslab_proxy<CT, RANK>& a) {}
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    if (ref_.use_slab)
+    if (ref.use_slab)
     {
       // later on specialize h5d_read for fancy pointers
-      std::size_t sz = ref_.ref.num_elements();
+      std::size_t sz = ref.ref.num_elements();
       boost::multi::array<T, 1> buf(typename boost::multi::layout_t<1u>::extensions_type{sz});
-      auto ret = h5d_read(grp, aname.c_str(), ref_.slab_rank, ref_.slab_dims.data(), ref_.slab_dims_local.data(),
-                          ref_.slab_offset.data(), buf.origin(), xfer_plist);
-      device::copy_n(buf.data(), sz, ref_.ref.origin());
+      auto ret = h5d_read(grp, aname.c_str(), ref.slab_rank, ref.slab_dims.data(), ref.slab_dims_local.data(),
+                          ref.slab_offset.data(), buf.origin(), xfer_plist);
+      device::copy_n(buf.data(), sz, ref.ref.origin());
       return ret;
     }
     else
     {
-      int rank = ref_.slab_rank;
-      if (!checkShapeConsistency<T>(grp, aname, rank, ref_.slab_dims.data(), true))
+      int rank = ref.slab_rank;
+      if (!checkShapeConsistency<T>(grp, aname, rank, ref.slab_dims.data(), true))
       {
         std::cerr << " Disabled hyperslab resize with boost::multi::array_ref<gpu_ptr>.\n";
         return false;
       }
-      return h5d_read(grp, aname, ref_.data(), xfer_plist);
+      return h5d_read(grp, aname, ref.data(), xfer_plist);
     }
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     std::cerr << " Disabled hyperslab write with boost::multi::array_ref<gpu_ptr>.\n";
     return false;

--- a/src/io/hdf/hdf_multi.h
+++ b/src/io/hdf/hdf_multi.h
@@ -290,9 +290,9 @@ struct h5data_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>> : 
 template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_allocator<T>>, RANK>>
 {
-  using CT = boost::multi::array<T, 2, device::device_allocator<T>>;
+  using CT        = boost::multi::array<T, 2, device::device_allocator<T>>;
   using data_type = hyperslab_proxy<CT, RANK>;
-  
+
   h5data_proxy(const data_type& a) {}
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
@@ -329,7 +329,7 @@ struct h5data_proxy<hyperslab_proxy<boost::multi::array<T, 2, device::device_all
 template<typename T, unsigned RANK>
 struct h5data_proxy<hyperslab_proxy<boost::multi::array_ref<T, 2, device::device_pointer<T>>, RANK>>
 {
-  using CT = boost::multi::array_ref<T, 2, device::device_pointer<T>>;
+  using CT        = boost::multi::array_ref<T, 2, device::device_pointer<T>>;
   using data_type = hyperslab_proxy<CT, RANK>;
 
   h5data_proxy(const data_type& a) {}

--- a/src/io/hdf/hdf_pete.h
+++ b/src/io/hdf/hdf_pete.h
@@ -31,20 +31,19 @@ struct h5data_proxy<Vector<T>> : public h5_space_type<T, 1>
   using FileSpace::dims;
   using FileSpace::get_address;
   typedef Vector<T> data_type;
-  data_type& ref_;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.size(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.size(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.resize(dims[0]);
-    return h5d_read(grp, aname, get_address(ref_.data()), xfer_plist);
+      ref.resize(dims[0]);
+    return h5d_read(grp, aname, get_address(ref.data()), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref_.data()), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref.data()), xfer_plist);
   }
 };
 
@@ -56,21 +55,22 @@ struct h5data_proxy<Matrix<T>> : public h5_space_type<T, 2>
   using FileSpace::dims;
   using FileSpace::get_address;
   typedef Matrix<T> data_type;
-  data_type& ref_;
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
-    dims[0] = ref_.rows();
-    dims[1] = ref_.cols();
+    dims[0] = a.rows();
+    dims[1] = a.cols();
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.resize(dims[0], dims[1]);
-    return h5d_read(grp, aname, get_address(ref_.data()), xfer_plist);
+      ref.resize(dims[0], dims[1]);
+    return h5d_read(grp, aname, get_address(ref.data()), xfer_plist);
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref_.data()), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref.data()), xfer_plist);
   }
 };
 
@@ -82,21 +82,22 @@ struct h5data_proxy<Array<T, D>> : public h5_space_type<T, D>
   using FileSpace::dims;
   using FileSpace::get_address;
   typedef Array<T, D> data_type;
-  data_type& ref_;
-  inline h5data_proxy(data_type& a) : ref_(a)
+  inline h5data_proxy(const data_type& a)
   {
     for (int i = 0; i < D; ++i)
-      dims[i] = ref_.size(i);
+      dims[i] = a.size(i);
   }
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.resize(dims);
-    return h5d_read(grp, aname, get_address(ref_.data()), xfer_plist);
+      ref.resize(dims);
+    return h5d_read(grp, aname, get_address(ref.data()), xfer_plist);
   }
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref_.data()), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref.data()), xfer_plist);
   }
 };
 

--- a/src/io/hdf/hdf_pete.h
+++ b/src/io/hdf/hdf_pete.h
@@ -30,7 +30,7 @@ struct h5data_proxy<Vector<T>> : public h5_space_type<T, 1>
   using FileSpace = h5_space_type<T, 1>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  typedef Vector<T> data_type;
+  using data_type = Vector<T>;
 
   inline h5data_proxy(const data_type& a) { dims[0] = a.size(); }
 
@@ -54,7 +54,8 @@ struct h5data_proxy<Matrix<T>> : public h5_space_type<T, 2>
   using FileSpace = h5_space_type<T, 2>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  typedef Matrix<T> data_type;
+  using data_type = Matrix<T>;
+
   inline h5data_proxy(const data_type& a)
   {
     dims[0] = a.rows();
@@ -81,7 +82,8 @@ struct h5data_proxy<Array<T, D>> : public h5_space_type<T, D>
   using FileSpace = h5_space_type<T, D>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  typedef Array<T, D> data_type;
+  using data_type = Array<T, D>;
+
   inline h5data_proxy(const data_type& a)
   {
     for (int i = 0; i < D; ++i)

--- a/src/io/hdf/hdf_stl.h
+++ b/src/io/hdf/hdf_stl.h
@@ -29,26 +29,25 @@ struct h5data_proxy<std::vector<T>> : public h5_space_type<T, 1>
   using FileSpace = h5_space_type<T, 1>;
   using FileSpace::dims;
   using FileSpace::get_address;
-  typedef std::vector<T> data_type;
-  data_type& ref_;
+  using data_type = std::vector<T>;
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dims[0] = ref_.size(); }
+  inline h5data_proxy(const data_type& a) { dims[0] = a.size(); }
 
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     if (!checkShapeConsistency<T>(grp, aname, FileSpace::rank, dims))
-      ref_.resize(dims[0]);
-    return h5d_read(grp, aname, get_address(&ref_[0]), xfer_plist);
+      ref.resize(dims[0]);
+    return h5d_read(grp, aname, get_address(&ref[0]), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref_[0]), xfer_plist);
+    return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref[0]), xfer_plist);
   }
 
-  inline bool write(hid_t grp, const std::string& aname, const std::vector<hsize_t>& dvec, hid_t xfer_plist)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, const std::vector<hsize_t>& dvec, hid_t xfer_plist) const
   {
-    return h5d_write(grp, aname.c_str(), dvec.size(), dvec.data(), get_address(&ref_[0]), xfer_plist);
+    return h5d_write(grp, aname.c_str(), dvec.size(), dvec.data(), get_address(&ref[0]), xfer_plist);
   }
 };
 
@@ -57,29 +56,28 @@ struct h5data_proxy<std::vector<T>> : public h5_space_type<T, 1>
 template<std::size_t N>
 struct h5data_proxy<std::bitset<N>>
 {
-  typedef std::bitset<N> ArrayType_t;
-  ArrayType_t& ref;
+  using data_type = std::bitset<N>;
 
-  h5data_proxy<ArrayType_t>(ArrayType_t& a) : ref(a) {}
+  h5data_proxy(const data_type& a) {}
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     unsigned long c = ref.to_ulong();
     h5data_proxy<unsigned long> hc(c);
-    return hc.write(grp, aname, xfer_plist);
-  }
-
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
-  {
-    unsigned long c = ref.to_ulong();
-    h5data_proxy<unsigned long> hc(c);
-    if (hc.read(grp, aname, xfer_plist))
+    if (hc.read(ref, grp, aname, xfer_plist))
     {
       ref = c;
       return true;
     }
     else
       return false;
+  }
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
+  {
+    unsigned long c = ref.to_ulong();
+    h5data_proxy<unsigned long> hc(c);
+    return hc.write(ref, grp, aname, xfer_plist);
   }
 };
 
@@ -88,36 +86,11 @@ struct h5data_proxy<std::bitset<N>>
 template<>
 struct h5data_proxy<std::string>
 {
-  typedef std::string ArrayType_t;
-  ArrayType_t& ref;
+  using data_type = std::string;
 
-  h5data_proxy<ArrayType_t>(ArrayType_t& a) : ref(a) {}
+  h5data_proxy(const data_type& a) {}
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
-  {
-    hid_t str80 = H5Tcopy(H5T_C_S1);
-    H5Tset_size(str80, ref.size());
-    hsize_t dim = 1;
-
-    herr_t ret = -1;
-    hid_t h1   = H5Dopen(grp, aname.c_str());
-    if (h1 < 0) // missing create one
-    {
-      hid_t dataspace = H5Screate_simple(1, &dim, NULL);
-      hid_t dataset   = H5Dcreate(grp, aname.c_str(), str80, dataspace, H5P_DEFAULT);
-      ret             = H5Dwrite(dataset, str80, H5S_ALL, H5S_ALL, xfer_plist, ref.data());
-      H5Sclose(dataspace);
-      H5Dclose(dataset);
-    }
-    else
-    {
-      ret = H5Dwrite(h1, str80, H5S_ALL, H5S_ALL, xfer_plist, ref.data());
-    }
-    H5Dclose(h1);
-    return ret != -1;
-  }
-
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     hid_t dataset = H5Dopen(grp, aname.c_str());
     if (dataset > -1)
@@ -142,51 +115,41 @@ struct h5data_proxy<std::string>
     }
     return false;
   }
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
+  {
+    hid_t str80 = H5Tcopy(H5T_C_S1);
+    H5Tset_size(str80, ref.size());
+    hsize_t dim = 1;
+
+    herr_t ret = -1;
+    hid_t h1   = H5Dopen(grp, aname.c_str());
+    if (h1 < 0) // missing create one
+    {
+      hid_t dataspace = H5Screate_simple(1, &dim, NULL);
+      hid_t dataset   = H5Dcreate(grp, aname.c_str(), str80, dataspace, H5P_DEFAULT);
+      ret             = H5Dwrite(dataset, str80, H5S_ALL, H5S_ALL, xfer_plist, ref.data());
+      H5Sclose(dataspace);
+      H5Dclose(dataset);
+    }
+    else
+    {
+      ret = H5Dwrite(h1, str80, H5S_ALL, H5S_ALL, xfer_plist, ref.data());
+    }
+    H5Dclose(h1);
+    return ret != -1;
+  }
 };
 
 /// Specialization for vector of strings
 template<>
 struct h5data_proxy<std::vector<std::string>>
 {
-  using ArrayType = std::vector<std::string>;
-  ArrayType& ref;
+  using data_type = std::vector<std::string>;
 
-  h5data_proxy<ArrayType>(ArrayType& a) : ref(a) {}
+  h5data_proxy(const data_type& a) {}
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
-  {
-    // See the section in the HDF user's manual on datatypes,
-    // particularly the subsection on strings.
-    // (e.g. http://davis.lbl.gov/Manuals/HDF5-1.8.7/UG/11_Datatypes.html)
-    // and stackoverflow
-    // https://stackoverflow.com/questions/6184817/hdf5-inserting-a-set-of-strings-in-a-dataset
-    hid_t datatype = H5Tcopy(H5T_C_S1);
-    H5Tset_size(datatype, H5T_VARIABLE);
-    hsize_t dim = ref.size();
-
-    // Create vector of pointers to the actual string data
-    std::vector<char*> char_list;
-    for (int i = 0; i < ref.size(); i++)
-      char_list.push_back(ref[i].data());
-
-    hid_t h1   = H5Dopen(grp, aname.c_str());
-    herr_t ret = -1;
-    if (h1 < 0) // missing create one
-    {
-      hid_t dataspace = H5Screate_simple(1, &dim, NULL);
-      hid_t dataset   = H5Dcreate(grp, aname.c_str(), datatype, dataspace, H5P_DEFAULT);
-      ret             = H5Dwrite(dataset, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
-      H5Sclose(dataspace);
-      H5Dclose(dataset);
-    }
-    else
-      ret = H5Dwrite(h1, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
-
-    H5Dclose(h1);
-    return ret >= 0;
-  }
-
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
     hid_t datatype = H5Tcopy(H5T_C_S1);
     H5Tset_size(datatype, H5T_VARIABLE);
@@ -214,24 +177,56 @@ struct h5data_proxy<std::vector<std::string>>
 
     return ret >= 0;
   }
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
+  {
+    // See the section in the HDF user's manual on datatypes,
+    // particularly the subsection on strings.
+    // (e.g. http://davis.lbl.gov/Manuals/HDF5-1.8.7/UG/11_Datatypes.html)
+    // and stackoverflow
+    // https://stackoverflow.com/questions/6184817/hdf5-inserting-a-set-of-strings-in-a-dataset
+    hid_t datatype = H5Tcopy(H5T_C_S1);
+    H5Tset_size(datatype, H5T_VARIABLE);
+    hsize_t dim = ref.size();
+
+    // Create vector of pointers to the actual string data
+    std::vector<const char*> char_list;
+    for (int i = 0; i < ref.size(); i++)
+      char_list.push_back(ref[i].data());
+
+    hid_t h1   = H5Dopen(grp, aname.c_str());
+    herr_t ret = -1;
+    if (h1 < 0) // missing create one
+    {
+      hid_t dataspace = H5Screate_simple(1, &dim, NULL);
+      hid_t dataset   = H5Dcreate(grp, aname.c_str(), datatype, dataspace, H5P_DEFAULT);
+      ret             = H5Dwrite(dataset, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
+      H5Sclose(dataspace);
+      H5Dclose(dataset);
+    }
+    else
+      ret = H5Dwrite(h1, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
+
+    H5Dclose(h1);
+    return ret >= 0;
+  }
 };
 
 template<>
 struct h5data_proxy<std::ostringstream>
 {
-  typedef std::ostringstream Data_t;
-  Data_t& ref;
+  using data_type = std::ostringstream;
 
-  h5data_proxy<Data_t>(Data_t& a) : ref(a) {}
+  h5data_proxy(const data_type& a) {}
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, char* name, hid_t xfer_plist = H5P_DEFAULT) { return false; }
+
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
     std::string clone(ref.str());
     h5data_proxy<std::string> proxy(clone);
-    return proxy.write(grp, aname);
+    return proxy.write(clone, grp, aname);
   }
-
-  inline bool read(hid_t grp, const char* name, hid_t xfer_plist = H5P_DEFAULT) { return false; }
 };
 
 } // namespace qmcplusplus

--- a/src/io/hdf/hdf_stl.h
+++ b/src/io/hdf/hdf_stl.h
@@ -45,7 +45,11 @@ struct h5data_proxy<std::vector<T>> : public h5_space_type<T, 1>
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref[0]), xfer_plist);
   }
 
-  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, const std::vector<hsize_t>& dvec, hid_t xfer_plist) const
+  inline bool write(const data_type& ref,
+                    hid_t grp,
+                    const std::string& aname,
+                    const std::vector<hsize_t>& dvec,
+                    hid_t xfer_plist) const
   {
     return h5d_write(grp, aname.c_str(), dvec.size(), dvec.data(), get_address(&ref[0]), xfer_plist);
   }

--- a/src/io/hdf/hdf_wrapper_functions.h
+++ b/src/io/hdf/hdf_wrapper_functions.h
@@ -69,7 +69,8 @@ inline bool getDataShape(hid_t grp, const std::string& aname, std::vector<IT>& s
         if (sizes_in[dim] != TSpace.dims[dim_type])
           size_match = false;
       if (!size_match)
-        throw std::runtime_error("The lower dimensions (container element type) of " + aname + " dataset do not match the requested data type");
+        throw std::runtime_error("The lower dimensions (container element type) of " + aname +
+                                 " dataset do not match the requested data type");
       else
       {
         // save the sizes of each directions excluding dimensions contributed by the data type
@@ -99,7 +100,7 @@ inline bool checkShapeConsistency(hid_t grp, const std::string& aname, int rank,
   using TSpaceType = h5_space_type<T, 0>;
 
   std::vector<hsize_t> dims_in;
-  if(getDataShape<T>(grp, aname, dims_in))
+  if (getDataShape<T>(grp, aname, dims_in))
   {
     const int user_rank = rank - TSpaceType::added_rank();
     if (dims_in.size() != user_rank)

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -50,7 +50,7 @@ TEST_CASE("hdf_archive_simple_data", "[hdf]")
 {
   hdf_archive hd;
   hd.create("test_simple_data.hdf");
-  bool b = true;
+  bool b    = true;
   bool okay = hd.writeEntry(b, "bool");
   REQUIRE(okay);
 
@@ -63,7 +63,7 @@ TEST_CASE("hdf_archive_simple_data", "[hdf]")
   REQUIRE(okay);
 
   const double d = 4.5;
-  okay     = hd.writeEntry(d, "double");
+  okay           = hd.writeEntry(d, "double");
   REQUIRE(okay);
 
   std::complex<float> cf(2.3, 3.4);
@@ -88,7 +88,7 @@ TEST_CASE("hdf_archive_simple_data", "[hdf]")
   hdf_archive hd2;
   hd2.open("test_simple_data.hdf");
   bool b2 = false;
-  okay = hd2.readEntry(b2, "bool");
+  okay    = hd2.readEntry(b2, "bool");
   REQUIRE(okay);
   REQUIRE(b == b2);
 

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -62,7 +62,7 @@ TEST_CASE("hdf_archive_simple_data", "[hdf]")
   okay    = hd.writeEntry(f, "float");
   REQUIRE(okay);
 
-  double d = 4.5;
+  const double d = 4.5;
   okay     = hd.writeEntry(d, "double");
   REQUIRE(okay);
 
@@ -176,6 +176,10 @@ TEST_CASE("hdf_archive_vector", "[hdf]")
   bool okay = hd.writeEntry(v, "vector_double");
   REQUIRE(okay);
 
+  const vector<double> v_const(v);
+  okay = hd.writeEntry(v_const, "vector_double_const");
+  REQUIRE(okay);
+
   hd.close();
 
   hdf_archive hd2;
@@ -186,9 +190,13 @@ TEST_CASE("hdf_archive_vector", "[hdf]")
   okay = hd2.readEntry(v2, "vector_double");
   REQUIRE(v2.size() == 3);
   for (int i = 0; i < v.size(); i++)
-  {
-    REQUIRE(v[i] == v2[i]);
-  }
+    CHECK(v[i] == v2[i]);
+
+  vector<double> v2_for_const;
+  okay = hd2.readEntry(v2_for_const, "vector_double_const");
+  REQUIRE(v2_for_const.size() == 3);
+  for (int i = 0; i < v_const.size(); i++)
+    CHECK(v_const[i] == v2_for_const[i]);
 }
 
 TEST_CASE("hdf_archive_group", "[hdf]")

--- a/src/io/hdf/tests/test_hdf_hyperslab.cpp
+++ b/src/io/hdf/tests/test_hdf_hyperslab.cpp
@@ -44,7 +44,9 @@ TEST_CASE("hdf_read_partial", "[hdf]")
   }
 
   hd.write(allData, "matrix");
-  hd.write(allData_cplx, "matrix_cplx_float");
+
+  const auto& const_allData_cplx = allData_cplx;
+  hd.write(const_allData_cplx, "matrix_cplx_float");
   hd.close();
 
   hdf_archive hd2;

--- a/src/io/hdf/tests/test_hdf_hyperslab.cpp
+++ b/src/io/hdf/tests/test_hdf_hyperslab.cpp
@@ -38,8 +38,8 @@ TEST_CASE("hdf_read_partial", "[hdf]")
   {
     for (int j = 0; j < 4; j++)
     {
-      allData(i, j) = i + j * 0.1;
-      allData_cplx(i, j) = std::complex<float>(i,j * 0.1);
+      allData(i, j)      = i + j * 0.1;
+      allData_cplx(i, j) = std::complex<float>(i, j * 0.1);
     }
   }
 
@@ -149,7 +149,7 @@ TEST_CASE("hdf_read_partial", "[hdf]")
   for (int i = 0; i < 3; i++)
   {
     REQUIRE(locob2.data()[i] == Approx(allData(i, 2)));
-    REQUIRE(locob2(i) == Approx(allData(i,2)));
+    REQUIRE(locob2(i) == Approx(allData(i, 2)));
   }
 
   readSpec[0] = 2;

--- a/src/io/hdf/tests/test_hdf_reshape.cpp
+++ b/src/io/hdf/tests/test_hdf_reshape.cpp
@@ -37,7 +37,7 @@ TEST_CASE("hdf_write_reshape_with_matrix", "[hdf]")
   v[4] = 1.1;
   v[5] = 1.2;
 
-  std::array<int, 2> shape{2,3};
+  std::array<int, 2> shape{2, 3};
   hd.writeSlabReshaped(v, shape, "matrix_from_vector");
 
   std::vector<std::complex<float>> v_cplx(6);

--- a/src/spline/einspline_util.hpp
+++ b/src/spline/einspline_util.hpp
@@ -132,21 +132,19 @@ struct h5data_proxy<einspline_engine<ENGT>>
   using Base::get_address;
   typedef einspline_engine<ENGT> data_type;
 
-  data_type& ref_;
+  inline h5data_proxy(const data_type& a) { dim_traits<D + 1>::setdim(a, dims); }
 
-  inline h5data_proxy(data_type& a) : ref_(a) { dim_traits<D + 1>::setdim(a, dims); }
-
-  inline bool read(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    if (ref_.spliner)
-      return h5d_read(grp, aname, get_address(ref_.spliner->coefs), xfer_plist);
+    if (ref.spliner)
+      return h5d_read(grp, aname, get_address(ref.spliner->coefs), xfer_plist);
     else
       return false;
   }
 
-  inline bool write(hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
+  inline bool write(const data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT) const
   {
-    return h5d_write(grp, aname.c_str(), Base::rank, dims, get_address(ref_.spliner->coefs), xfer_plist);
+    return h5d_write(grp, aname.c_str(), Base::rank, dims, get_address(ref.spliner->coefs), xfer_plist);
   }
 };
 


### PR DESCRIPTION
## Proposed changes
In the hdf_archive abstraction, there was an issue that writing data from a const object caused compilation failure.
```
hdf_archive h5("abc.h5");
const int a = 0;
h5.write(a, "data"); // compilation failure.
```

It was causing by the design of h5data_proxy class which keeps a reference of the data object.
By removing this reference and passing the object via arguments, const data object can be written properly.
This fix is restrict to the internal detail of hdf_archive and there is no change to the library interface.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed