### PR TITLE
Nexus: Small fix to excitation checks

### DIFF
--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -582,10 +582,10 @@ class Qmcpack(Simulation):
                         # einspline orbital ordering for excited state
                         excited = excited[:nelec]
                         # hand-crafted orbital order for excited state
-                        hc_excited = ground[:orb1]+ground[orb2-1]+ground[orb1+1:nelec]
+                        hc_excited = np.array(list(ground[:orb1-1])+[ground[orb2-1]]+list(ground[orb1:nelec]))
                             
                         etol = 1e-6
-                        if np.abs(hc_excited-excited).max() > tol:
+                        if np.abs(hc_excited-excited).max() > etol:
                             msg  = 'WARNING: You requested \'{}\' excitation of type \'{}\',\n'
                             msg += '         however, the second orbital \'{}\' is not occupied (see einspline file).\n'
                             msg += '         Please check your input.'


### PR DESCRIPTION

## Proposed changes

This PR provides a fix to an off-by-one error when checking that the einspline files contain the correct excitation.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No. All `nxs-test` tests pass

## What systems has this change been tested on?

ALCF Theta

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
