### PR TITLE
Nexus: Support file and comment for Lowdin example

### DIFF
--- a/nexus/examples/qmcpack/rsqmc_misc/diamond_lowdin/lowdin.py
+++ b/nexus/examples/qmcpack/rsqmc_misc/diamond_lowdin/lowdin.py
@@ -136,7 +136,9 @@ if __name__ == '__main__':
         quit()
     #end if
 
-    # Collect parameters from atomic_proj.xml
+    # Collect parameters from atomic_proj.xml.
+    # Note: if atomic_proj.xml was not generated from projwfc.x or if the <OVERLAPS> element is not present in atomic_proj.xml then
+    #       you should try re-running projwfc.x on a single core and single thread with "-ndiag 1" -- this can sometimes help
     nBands,nKpoints,kWeights,nAtomicWFC,nSpin,atomicProjections,atomicOverlaps,invAtomicOverlaps = collectValuesFromAtomicProj(pw_outdir+"/"+pw_prefix+".save/atomic_proj.xml")
 
     # Collect parameters from <prefix>.xml

--- a/nexus/examples/qmcpack/rsqmc_misc/diamond_lowdin/run_lowdin.sh
+++ b/nexus/examples/qmcpack/rsqmc_misc/diamond_lowdin/run_lowdin.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Uncomment below to run lowdin.py in nspin=1 case.
+# ./lowdin.py pwscf ./runs/nscf/pwscf_outdir ./runs/vmc_1rdm_noJ vmc_1rdm_noJ 0
+
+# Uncomment below to run lowdin.py in nspin=2 case. Spin up
+# ./lowdin.py pwscf ./runs_spin/nscf/pwscf_outdir ./runs/vmc_1rdm_noJ vmc_1rdm_noJ 0
+
+# Uncomment below to run lowdin.py in nspin=2 case. Spin down
+# ./lowdin.py pwscf ./runs_spin/nscf/pwscf_outdir ./runs/vmc_1rdm_down_noJ vmc_1rdm_down_noJ 1


### PR DESCRIPTION

## Proposed changes

Adding support file and comments to the Nexus Lowdin example in nexus (`nexus/examples/qmcpack/rsqmc_misc/diamond_lowdin`)
The support file is a short bash script that shows how to run `lowdin.py` for the different diamond examples. The comment (added to `lowdin.py`) explains what to do if `atomic_proj.xml` is not generated or does not contain the OVERLAPS element.

## What type(s) of changes does this code introduce?

- Other (please describe): support file and comments added to Nexus Lowdin example

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
