### PR TITLE
Rename RandomGenerator_t to RandomGenerator

### DIFF
--- a/src/AFQMC/Drivers/DriverFactory.cpp
+++ b/src/AFQMC/Drivers/DriverFactory.cpp
@@ -117,7 +117,7 @@ bool DriverFactory::executeAFQMCDriver(std::string title, int m_series, xmlNodeP
   int block0     = 0;
   double Eshift  = 0.0;
 
-  std::unique_ptr<RandomGenerator_t>& rng = RandomNumberControl::Children.front();
+  std::unique_ptr<RandomGenerator>& rng = RandomNumberControl::Children.front();
 
   app_log() << "\n****************************************************\n"
             << "****************************************************\n"

--- a/src/AFQMC/Estimators/tests/test_estimators.cpp
+++ b/src/AFQMC/Estimators/tests/test_estimators.cpp
@@ -124,7 +124,7 @@ void reduced_density_matrix(boost::mpi3::communicator& world)
     auto TG                   = TaskGroup_(gTG, std::string("WfnTG"), 1, gTG.getTotalCores());
     Allocator alloc_(make_localTG_allocator<ComplexType>(TG));
     int nwalk = 1; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
     Libxml2Document doc2;
     okay = doc2.parseFromString(wfn_xml_block);
     REQUIRE(okay);

--- a/src/AFQMC/Propagators/AFQMCBasePropagator.h
+++ b/src/AFQMC/Propagators/AFQMCBasePropagator.h
@@ -90,7 +90,7 @@ public:
                       Wavefunction& wfn_,
                       stdCMatrix&& h1_,
                       CVector&& vmf_,
-                      RandomGenerator_t* r)
+                      RandomGenerator* r)
       : AFQMCInfo(info),
         TG(tg_),
         buffer_manager(),
@@ -190,7 +190,7 @@ protected:
 
   CVector vMF;
 
-  RandomGenerator_t* rng;
+  RandomGenerator* rng;
 
   SlaterDetOperations* SDetOp;
 

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagator.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagator.h
@@ -56,7 +56,7 @@ public:
                              Wavefunction& wfn_,
                              stdCMatrix&& h1_,
                              CVector&& vmf_,
-                             RandomGenerator_t* r)
+                             RandomGenerator* r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         core_comm(tg_.TG().split(tg_.getLocalTGRank(), tg_.TG().rank()))
   //            ,core_comm()

--- a/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/AFQMCDistributedPropagatorDistCV.h
@@ -56,7 +56,7 @@ public:
                                    Wavefunction& wfn_,
                                    stdCMatrix&& h1_,
                                    CVector&& vmf_,
-                                   RandomGenerator_t* r)
+                                   RandomGenerator* r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         bpX(iextensions<1u>{1}, shared_allocator<ComplexType>{TG.TG_local()}),
         req_Gsend(MPI_REQUEST_NULL),

--- a/src/AFQMC/Propagators/PropagatorFactory.cpp
+++ b/src/AFQMC/Propagators/PropagatorFactory.cpp
@@ -23,7 +23,7 @@ namespace afqmc
 Propagator PropagatorFactory::buildAFQMCPropagator(TaskGroup_& TG,
                                                    xmlNodePtr cur,
                                                    Wavefunction& wfn,
-                                                   RandomGenerator_t* rng)
+                                                   RandomGenerator* rng)
 {
   // allocator for local memory
   using allocator = device_allocator<ComplexType>;

--- a/src/AFQMC/Propagators/PropagatorFactory.h
+++ b/src/AFQMC/Propagators/PropagatorFactory.h
@@ -54,7 +54,7 @@ public:
   }
 
   // returns a pointer to the base Propagator class associated with a given ID
-  Propagator& getPropagator(TaskGroup_& TG, const std::string& ID, Wavefunction& wfn, RandomGenerator_t* rng)
+  Propagator& getPropagator(TaskGroup_& TG, const std::string& ID, Wavefunction& wfn, RandomGenerator* rng)
   {
     auto xml = xmlBlocks.find(ID);
     if (xml == xmlBlocks.end())
@@ -94,7 +94,7 @@ protected:
   std::map<std::string, AFQMCInfo>& InfoMap;
 
   // generates a new Propagator and returns the pointer to the base class
-  Propagator buildPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomGenerator_t* rng)
+  Propagator buildPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomGenerator* rng)
   {
     std::string type("afqmc");
     OhmmsAttributeSet oAttrib;
@@ -116,7 +116,7 @@ protected:
     return Propagator{};
   }
 
-  Propagator buildAFQMCPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomGenerator_t* r);
+  Propagator buildAFQMCPropagator(TaskGroup_& TG, xmlNodePtr cur, Wavefunction& wfn, RandomGenerator* r);
 
   std::map<std::string, xmlNodePtr> xmlBlocks;
 

--- a/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.h
+++ b/src/AFQMC/Propagators/store/AFQMCDistributedPropagatorDistCV.h
@@ -59,7 +59,7 @@ public:
                                    Wavefunction& wfn_,
                                    CMatrix&& h1_,
                                    CVector&& vmf_,
-                                   RandomGenerator_t* r)
+                                   RandomGenerator* r)
       : base(info, cur, tg_, wfn_, std::move(h1_), std::move(vmf_), r),
         req_Gsend(MPI_REQUEST_NULL),
         req_Grecv(MPI_REQUEST_NULL),

--- a/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
+++ b/src/AFQMC/Propagators/tests/test_propagator_factory.cpp
@@ -97,7 +97,7 @@ void propg_fac_shared(boost::mpi3::communicator& world)
 
     auto TG   = TaskGroup_(gTG, std::string("WfnTG"), 1, gTG.getTotalCores());
     int nwalk = 11; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
     const char* wlk_xml_block_closed = "<WalkerSet name=\"wset0\">  \
       <parameter name=\"walker_type\">closed</parameter>  \
@@ -273,7 +273,7 @@ void propg_fac_distributed(boost::mpi3::communicator& world, int ngrp)
     auto TGprop = TaskGroup_(gTG, std::string("WfnTG"), ngrp, gTG.getTotalCores());
     //int nwalk = 4; // choose prime number to force non-trivial splits in shared routines
     int nwalk = 11; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
     qmcplusplus::Timer Time;
 
     const char* wlk_xml_block_closed = "<WalkerSet name=\"wset0\">  \

--- a/src/AFQMC/Walkers/SerialWalkerSet.hpp
+++ b/src/AFQMC/Walkers/SerialWalkerSet.hpp
@@ -44,7 +44,7 @@ class SerialWalkerSet : public WalkerSetBase<device_allocator<ComplexType>, devi
 
 public:
   /// constructor
-  SerialWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomGenerator_t* r)
+  SerialWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomGenerator* r)
       : Base(tg_, cur, info, r, device_allocator<ComplexType>{}, shared_allocator<ComplexType>{tg_.TG_local()})
   {}
 

--- a/src/AFQMC/Walkers/SharedWalkerSet.hpp
+++ b/src/AFQMC/Walkers/SharedWalkerSet.hpp
@@ -43,7 +43,7 @@ public:
   using Base = WalkerSetBase<shared_allocator<ComplexType>, ComplexType*>;
 
   /// constructor
-  SharedWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomGenerator_t* r)
+  SharedWalkerSet(afqmc::TaskGroup_& tg_, xmlNodePtr cur, AFQMCInfo& info, RandomGenerator* r)
       : Base(tg_,
              cur,
              info,

--- a/src/AFQMC/Walkers/WalkerSetBase.h
+++ b/src/AFQMC/Walkers/WalkerSetBase.h
@@ -87,7 +87,7 @@ public:
   WalkerSetBase(afqmc::TaskGroup_& tg_,
                 xmlNodePtr cur,
                 AFQMCInfo& info,
-                RandomGenerator_t* r,
+                RandomGenerator* r,
                 Allocator alloc_,
                 BPAllocator bpalloc_)
       : AFQMCInfo(info),
@@ -740,7 +740,7 @@ public:
 protected:
   afqmc::TaskGroup_& TG;
 
-  RandomGenerator_t* rng;
+  RandomGenerator* rng;
 
   int walker_size, walker_memory_usage;
   int bp_walker_size, bp_walker_memory_usage;

--- a/src/AFQMC/Walkers/WalkerSetFactory.hpp
+++ b/src/AFQMC/Walkers/WalkerSetFactory.hpp
@@ -46,7 +46,7 @@ public:
       return true;
   }
 
-  WalkerSet& getWalkerSet(TaskGroup_& TG, const std::string& ID, RandomGenerator_t* rng)
+  WalkerSet& getWalkerSet(TaskGroup_& TG, const std::string& ID, RandomGenerator* rng)
   {
     auto xml = xmlBlocks.find(ID);
     if (xml == xmlBlocks.end())
@@ -86,7 +86,7 @@ protected:
   std::map<std::string, AFQMCInfo>& InfoMap;
 
   // generates a new WalkerSet and returns the pointer to the base class
-  WalkerSet buildHandler(TaskGroup_& TG, xmlNodePtr cur, RandomGenerator_t* rng)
+  WalkerSet buildHandler(TaskGroup_& TG, xmlNodePtr cur, RandomGenerator* rng)
   {
     std::string type("shared");
     std::string info("info0");

--- a/src/AFQMC/Walkers/tests/test_sharedwset.cpp
+++ b/src/AFQMC/Walkers/tests/test_sharedwset.cpp
@@ -114,7 +114,7 @@ void test_basic_walker_features(bool serial, std::string wtype)
     initA[i][i] = Type(0.22);
   for (int i = 0; i < NAEB; i++)
     initB[i][i] = Type(0.22);
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 
   std::string xml_block;
   xml_block = "<WalkerSet name=\"wset0\">  \
@@ -417,7 +417,7 @@ void test_walker_io(std::string wtype)
     initA[i][i] = Type(0.22);
   for (int i = 0; i < NAEB; i++)
     initB[i][i] = Type(0.22);
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 
   std::string xml_block;
   xml_block = "<WalkerSet name=\"wset0\">  \

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -244,7 +244,7 @@ void test_phmsd(boost::mpi3::communicator& world)
     Libxml2Document doc3;
     okay = doc3.parseFromString(wlk_xml_block);
     REQUIRE(okay);
-    RandomGenerator_t rng;
+    RandomGenerator rng;
     WalkerSet wset(TG, doc3.getRoot(), InfoMap["info0"], &rng);
     auto initial_guess = WfnFac.getInitialGuess(wfn_name);
     REQUIRE(initial_guess.size(0) == 2);

--- a/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_wfn_factory.cpp
@@ -105,7 +105,7 @@ void wfn_fac(boost::mpi3::communicator& world)
     //auto TG = TaskGroup_(gTG,std::string("WfnTG"),1,1);
     auto TG   = TaskGroup_(gTG, std::string("WfnTG"), 1, gTG.getTotalCores());
     int nwalk = 11; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
     Allocator alloc_(make_localTG_allocator<ComplexType>(TG));
 
@@ -443,7 +443,7 @@ void wfn_fac_distributed(boost::mpi3::communicator& world, int ngroups)
     auto TG    = TaskGroup_(gTG, std::string("WfnTG"), 1, gTG.getTotalCores());
     auto TGwfn = TaskGroup_(gTG, std::string("WfnTG"), ngroups, gTG.getTotalCores());
     int nwalk  = 11; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
     Allocator alloc_(make_localTG_allocator<ComplexType>(TG));
 
@@ -821,7 +821,7 @@ TEST_CASE("wfn_fac_collinear_phmsd", "[wavefunction_factory]")
     //auto TG = TaskGroup_(gTG,std::string("WfnTG"),1,1);
     //int nwalk = 1; // choose prime number to force non-trivial splits in shared routines
     int nwalk = 11; // choose prime number to force non-trivial splits in shared routines
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
 const char *wlk_xml_block =
 "<WalkerSet name=\"wset0\">  \

--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -27,7 +27,7 @@ EstimatorManagerCrowd::EstimatorManagerCrowd(EstimatorManagerNew& em)
 void EstimatorManagerCrowd::accumulate(const RefVector<MCPWalker>& walkers,
                                        const RefVector<ParticleSet>& psets,
                                        const RefVector<TrialWaveFunction>& wfns,
-                                       RandomGenerator_t& rng)
+                                       RandomGenerator& rng)
 {
   block_num_samples_ += walkers.size();
   for (MCPWalker& awalker : walkers)

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -68,12 +68,12 @@ public:
    *  \param[in]     walkers         walkers in crowd
    *  \param[in]     psets           walker particle sets
    *  \param[in]     wfns            walker wavefunctions
-   *  \param[inout]  rng             crowd scope RandomGenerator_t
+   *  \param[inout]  rng             crowd scope RandomGenerator
    */ 
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomGenerator_t& rng);
+                  RandomGenerator& rng);
 
   RefVector<EstimatorType> get_scalar_estimators() { return convertUPtrToRefVector(scalar_estimators_); }
   RefVector<qmcplusplus::OperatorEstBase> get_operator_estimators() { return convertUPtrToRefVector(operator_ests_); }

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -239,7 +239,7 @@ void MomentumDistribution::startBlock(int steps)
 void MomentumDistribution::accumulate(const RefVector<MCPWalker>& walkers,
                                       const RefVector<ParticleSet>& psets,
                                       const RefVector<TrialWaveFunction>& wfns,
-                                      RandomGenerator_t& rng)
+                                      RandomGenerator& rng)
 {
   for (int iw = 0; iw < walkers.size(); ++iw)
   {

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -100,7 +100,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomGenerator_t& rng) override;
+                  RandomGenerator& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details
    *  of MomentumDistribution's data.

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -207,7 +207,7 @@ void OneBodyDensityMatrices::generateSamples(const Real weight, ParticleSet& pse
     save  = true;
     steps = samples_;
   }
-  
+
   switch (input_.get_integrator())
   {
   case Integrator::UNIFORM_GRID:
@@ -394,7 +394,7 @@ void OneBodyDensityMatrices::calcDensityDrift(const Position& r, Real& dens, Pos
 void OneBodyDensityMatrices::accumulate(const RefVector<MCPWalker>& walkers,
                                         const RefVector<ParticleSet>& psets,
                                         const RefVector<TrialWaveFunction>& wfns,
-                                        RandomGenerator_t& rng)
+                                        RandomGenerator& rng)
 {
   implAccumulate(walkers, psets, wfns, rng);
 }
@@ -618,26 +618,26 @@ void OneBodyDensityMatrices::registerOperatorEstimator(hid_t gid)
   }
 }
 
-template void OneBodyDensityMatrices::generateSamples<RandomGenerator_t>(Real weight,
-                                                                         ParticleSet& pset_target,
-                                                                         RandomGenerator_t& rng,
-                                                                         int steps);
+template void OneBodyDensityMatrices::generateSamples<RandomGenerator>(Real weight,
+                                                                       ParticleSet& pset_target,
+                                                                       RandomGenerator& rng,
+                                                                       int steps);
 template void OneBodyDensityMatrices::generateSamples<StdRandom<double>>(Real weight,
                                                                          ParticleSet& pset_target,
                                                                          StdRandom<double>& rng,
                                                                          int steps);
-template void OneBodyDensityMatrices::evaluateMatrix<RandomGenerator_t>(ParticleSet& pset_target,
-                                                                        TrialWaveFunction& psi_target,
-                                                                        const MCPWalker& walker,
-                                                                        RandomGenerator_t& rng);
+template void OneBodyDensityMatrices::evaluateMatrix<RandomGenerator>(ParticleSet& pset_target,
+                                                                      TrialWaveFunction& psi_target,
+                                                                      const MCPWalker& walker,
+                                                                      RandomGenerator& rng);
 template void OneBodyDensityMatrices::evaluateMatrix<StdRandom<double>>(ParticleSet& pset_target,
                                                                         TrialWaveFunction& psi_target,
                                                                         const MCPWalker& walker,
                                                                         StdRandom<double>& rng);
-template void OneBodyDensityMatrices::implAccumulate<RandomGenerator_t>(const RefVector<MCPWalker>& walkers,
-                                                                        const RefVector<ParticleSet>& psets,
-                                                                        const RefVector<TrialWaveFunction>& wfns,
-                                                                        RandomGenerator_t& rng);
+template void OneBodyDensityMatrices::implAccumulate<RandomGenerator>(const RefVector<MCPWalker>& walkers,
+                                                                      const RefVector<ParticleSet>& psets,
+                                                                      const RefVector<TrialWaveFunction>& wfns,
+                                                                      RandomGenerator& rng);
 template void OneBodyDensityMatrices::implAccumulate<StdRandom<double>>(const RefVector<MCPWalker>& walkers,
                                                                         const RefVector<ParticleSet>& psets,
                                                                         const RefVector<TrialWaveFunction>& wfns,

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -165,7 +165,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomGenerator_t& rng) override;
+                  RandomGenerator& rng) override;
 
   void startBlock(int steps) override;
 
@@ -185,7 +185,7 @@ private:
    */
   OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm) = default;
 
-  /** Unfortunate design RandomGenerator_t type aliasing and
+  /** Unfortunate design RandomGenerator type aliasing and
    *  virtual inheritance requires this for testing.
    */
   template<class RNG_GEN>
@@ -319,26 +319,26 @@ public:
   friend class testing::OneBodyDensityMatricesTests;
 };
 
-extern template void OneBodyDensityMatrices::generateSamples<RandomGenerator_t>(Real weight,
-                                                                                ParticleSet& pset_target,
-                                                                                RandomGenerator_t& rng,
-                                                                                int steps);
+extern template void OneBodyDensityMatrices::generateSamples<RandomGenerator>(Real weight,
+                                                                              ParticleSet& pset_target,
+                                                                              RandomGenerator& rng,
+                                                                              int steps);
 extern template void OneBodyDensityMatrices::generateSamples<StdRandom<double>>(Real weight,
                                                                                 ParticleSet& pset_target,
                                                                                 StdRandom<double>& rng,
                                                                                 int steps);
-extern template void OneBodyDensityMatrices::evaluateMatrix<RandomGenerator_t>(ParticleSet& pset_target,
-                                                                               TrialWaveFunction& psi_target,
-                                                                               const MCPWalker& walker,
-                                                                               RandomGenerator_t& rng);
+extern template void OneBodyDensityMatrices::evaluateMatrix<RandomGenerator>(ParticleSet& pset_target,
+                                                                             TrialWaveFunction& psi_target,
+                                                                             const MCPWalker& walker,
+                                                                             RandomGenerator& rng);
 extern template void OneBodyDensityMatrices::evaluateMatrix<StdRandom<double>>(ParticleSet& pset_target,
                                                                                TrialWaveFunction& psi_target,
                                                                                const MCPWalker& walker,
                                                                                StdRandom<double>& rng);
-extern template void OneBodyDensityMatrices::implAccumulate<RandomGenerator_t>(const RefVector<MCPWalker>& walkers,
-                                                                               const RefVector<ParticleSet>& psets,
-                                                                               const RefVector<TrialWaveFunction>& wfns,
-                                                                               RandomGenerator_t& rng);
+extern template void OneBodyDensityMatrices::implAccumulate<RandomGenerator>(const RefVector<MCPWalker>& walkers,
+                                                                             const RefVector<ParticleSet>& psets,
+                                                                             const RefVector<TrialWaveFunction>& wfns,
+                                                                             RandomGenerator& rng);
 extern template void OneBodyDensityMatrices::implAccumulate<StdRandom<double>>(const RefVector<MCPWalker>& walkers,
                                                                                const RefVector<ParticleSet>& psets,
                                                                                const RefVector<TrialWaveFunction>& wfns,

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -88,7 +88,7 @@ public:
   virtual void accumulate(const RefVector<MCPWalker>& walkers,
                           const RefVector<ParticleSet>& psets,
                           const RefVector<TrialWaveFunction>& wfns,
-                          RandomGenerator_t& rng) = 0;
+                          RandomGenerator& rng) = 0;
 
   /** Reduce estimator result data from crowds to rank
    *

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -115,7 +115,7 @@ void SpinDensityNew::startBlock(int steps)
 void SpinDensityNew::accumulate(const RefVector<MCPWalker>& walkers,
                                 const RefVector<ParticleSet>& psets,
                                 const RefVector<TrialWaveFunction>& wfns,
-                                RandomGenerator_t& rng)
+                                RandomGenerator& rng)
 {
   auto& dp_ = derived_parameters_;
   for (int iw = 0; iw < walkers.size(); ++iw)

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -80,7 +80,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomGenerator_t& rng) override;
+                  RandomGenerator& rng) override;
 
   /** this allows the EstimatorManagerNew to reduce without needing to know the details
    *  of SpinDensityNew's data.

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -32,7 +32,7 @@ public:
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,
                   const RefVector<TrialWaveFunction>& wfns,
-                  RandomGenerator_t& rng) override
+                  RandomGenerator& rng) override
   {}
 
   void registerOperatorEstimator(hid_t gid) override {}

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -182,7 +182,7 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   auto ref_wfns    = convertUPtrToRefVector(wfns);
 
   //   Setup RNG
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 
   //   Perform accumulate
   md.accumulate(ref_walkers, ref_psets, ref_wfns, rng);

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -77,7 +77,7 @@ void accumulateFromPsets(int ncrowds, SpinDensityNew& sdn, UPtrVector<OperatorEs
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
     crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
   }
@@ -114,7 +114,7 @@ void randomUpdateAccumulate(testing::RandomForTest<QMCT::RealType>& rft, UPtrVec
     auto ref_psets   = makeRefVector<ParticleSet>(psets);
     auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-    RandomGenerator_t rng;
+    RandomGenerator rng;
 
     crowd_sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
   }
@@ -222,7 +222,7 @@ TEST_CASE("SpinDensityNew::accumulate", "[estimators]")
   auto ref_psets   = makeRefVector<ParticleSet>(psets);
   auto ref_wfns    = makeRefVector<TrialWaveFunction>(wfns);
 
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 
   sdn.accumulate(ref_walkers, ref_psets, ref_wfns, rng);
 

--- a/src/QMCDrivers/ContextForSteps.cpp
+++ b/src/QMCDrivers/ContextForSteps.cpp
@@ -17,7 +17,7 @@ namespace qmcplusplus
 ContextForSteps::ContextForSteps(int num_walkers,
                                  int num_particles,
                                  std::vector<std::pair<int, int>> particle_group_indexes,
-                                 RandomGenerator_t& random_gen)
+                                 RandomGenerator& random_gen)
     : particle_group_indexes_(particle_group_indexes), random_gen_(random_gen)
 {
   /** glambda to create type T with constructor T(int) and put in it unique_ptr

--- a/src/QMCDrivers/ContextForSteps.h
+++ b/src/QMCDrivers/ContextForSteps.h
@@ -41,10 +41,10 @@ public:
   ContextForSteps(int num_walkers,
                   int num_particles,
                   std::vector<std::pair<int, int>> particle_group_indexes,
-                  RandomGenerator_t& random_gen);
+                  RandomGenerator& random_gen);
 
   int get_num_groups() const { return particle_group_indexes_.size(); }
-  RandomGenerator_t& get_random_gen() { return random_gen_; }
+  RandomGenerator& get_random_gen() { return random_gen_; }
 
   void nextDeltaRs(size_t num_rs)
   {
@@ -68,7 +68,7 @@ protected:
    */
   std::vector<std::pair<int, int>> particle_group_indexes_;
 
-  RandomGenerator_t& random_gen_;
+  RandomGenerator& random_gen_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.cpp
@@ -29,7 +29,7 @@ using WP = WalkerProperties::Indexes;
 CSUpdateBase::CSUpdateBase(MCWalkerConfiguration& w,
                            std::vector<TrialWaveFunction*>& psipool,
                            std::vector<QMCHamiltonian*>& hpool,
-                           RandomGenerator_t& rg)
+                           RandomGenerator& rg)
     : QMCUpdateBase(w, *psipool[0], *hpool[0], rg), nPsi(0), useDriftOption("no"), H1(hpool), Psi1(psipool)
 {
   myParams.add(useDriftOption, "useDrift");

--- a/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSUpdateBase.h
@@ -30,7 +30,7 @@ public:
   CSUpdateBase(MCWalkerConfiguration& w,
                std::vector<TrialWaveFunction*>& psi,
                std::vector<QMCHamiltonian*>& h,
-               RandomGenerator_t& rg);
+               RandomGenerator& rg);
 
   ~CSUpdateBase() override;
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -240,7 +240,7 @@ void CSVMC::resetRun()
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif
-      Rng[ip] = std::make_unique<RandomGenerator_t>(*RandomNumberControl::Children[ip]);
+      Rng[ip] = std::make_unique<RandomGenerator>(*RandomNumberControl::Children[ip]);
       if (qmc_driver_mode[QMC_UPDATE_MODE])
       {
         if (UseDrift == "yes")

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.cpp
@@ -33,7 +33,7 @@ using WP = WalkerProperties::Indexes;
 CSVMCUpdateAll::CSVMCUpdateAll(MCWalkerConfiguration& w,
                                std::vector<TrialWaveFunction*>& psi,
                                std::vector<QMCHamiltonian*>& h,
-                               RandomGenerator_t& rg)
+                               RandomGenerator& rg)
     : CSUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;
@@ -120,7 +120,7 @@ void CSVMCUpdateAll::advanceWalker(Walker_t& thisWalker, bool recompute)
 CSVMCUpdateAllWithDrift::CSVMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                                                  std::vector<TrialWaveFunction*>& psi,
                                                  std::vector<QMCHamiltonian*>& h,
-                                                 RandomGenerator_t& rg)
+                                                 RandomGenerator& rg)
     : CSUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdateAll.h
@@ -36,7 +36,7 @@ public:
   CSVMCUpdateAll(MCWalkerConfiguration& w,
                  std::vector<TrialWaveFunction*>& psi,
                  std::vector<QMCHamiltonian*>& h,
-                 RandomGenerator_t& rg);
+                 RandomGenerator& rg);
 
   void advanceWalker(Walker_t& thisWalker, bool recompute) override;
 
@@ -51,7 +51,7 @@ public:
   CSVMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                           std::vector<TrialWaveFunction*>& psi,
                           std::vector<QMCHamiltonian*>& h,
-                          RandomGenerator_t& rg);
+                          RandomGenerator& rg);
 
   void advanceWalker(Walker_t& thisWalker, bool recompute) override;
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.cpp
@@ -30,7 +30,7 @@ using WP = WalkerProperties::Indexes;
 CSVMCUpdatePbyP::CSVMCUpdatePbyP(MCWalkerConfiguration& w,
                                  std::vector<TrialWaveFunction*>& psi,
                                  std::vector<QMCHamiltonian*>& h,
-                                 RandomGenerator_t& rg)
+                                 RandomGenerator& rg)
     : CSUpdateBase(w, psi, h, rg)
 {}
 
@@ -150,7 +150,7 @@ void CSVMCUpdatePbyP::advanceWalker(Walker_t& thisWalker, bool recompute)
 CSVMCUpdatePbyPWithDriftFast::CSVMCUpdatePbyPWithDriftFast(MCWalkerConfiguration& w,
                                                            std::vector<TrialWaveFunction*>& psi,
                                                            std::vector<QMCHamiltonian*>& h,
-                                                           RandomGenerator_t& rg)
+                                                           RandomGenerator& rg)
     : CSUpdateBase(w, psi, h, rg){APP_ABORT("CSVMCUpdatePbyPWithDriftFast currently not working.  Please eliminate \
              drift option, or choose all electron moves instead.")}
 

--- a/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMCUpdatePbyP.h
@@ -28,7 +28,7 @@ public:
   CSVMCUpdatePbyP(MCWalkerConfiguration& w,
                   std::vector<TrialWaveFunction*>& psi,
                   std::vector<QMCHamiltonian*>& h,
-                  RandomGenerator_t& rg);
+                  RandomGenerator& rg);
 
   ~CSVMCUpdatePbyP() override;
 
@@ -47,7 +47,7 @@ public:
   CSVMCUpdatePbyPWithDriftFast(MCWalkerConfiguration& w,
                                std::vector<TrialWaveFunction*>& psi,
                                std::vector<QMCHamiltonian*>& h,
-                               RandomGenerator_t& rg);
+                               RandomGenerator& rg);
 
   ~CSVMCUpdatePbyPWithDriftFast() override;
 

--- a/src/QMCDrivers/Crowd.cpp
+++ b/src/QMCDrivers/Crowd.cpp
@@ -46,7 +46,7 @@ void Crowd::addWalker(MCPWalker& walker, ParticleSet& elecs, TrialWaveFunction& 
   walker_hamiltonians_.push_back(hamiltonian);
 };
 
-void Crowd::setRNGForHamiltonian(RandomGenerator_t& rng)
+void Crowd::setRNGForHamiltonian(RandomGenerator& rng)
 {
   for (QMCHamiltonian& ham : walker_hamiltonians_)
     ham.setRandomGenerator(&rng);

--- a/src/QMCDrivers/Crowd.h
+++ b/src/QMCDrivers/Crowd.h
@@ -67,14 +67,14 @@ public:
    */
   void clearWalkers();
 
-  void accumulate(RandomGenerator_t& rng)
+  void accumulate(RandomGenerator& rng)
   {
     if (this->size() == 0)
       return;
     estimator_manager_crowd_.accumulate(mcp_walkers_, walker_elecs_, walker_twfs_, rng);
   }
 
-  void setRNGForHamiltonian(RandomGenerator_t& rng);
+  void setRNGForHamiltonian(RandomGenerator& rng);
 
   auto beginWalkers() { return mcp_walkers_.begin(); }
   auto endWalkers() { return mcp_walkers_.end(); }

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -122,7 +122,7 @@ void DMC::resetUpdateEngines()
 #ifdef USE_FAKE_RNG
       Rng[ip] = std::make_unique<FakeRandom>();
 #else
-      Rng[ip] = std::make_unique<RandomGenerator_t>(*RandomNumberControl::Children[ip]);
+      Rng[ip] = std::make_unique<RandomGenerator>(*RandomNumberControl::Children[ip]);
       hClones[ip]->setRandomGenerator(Rng[ip].get());
 #endif
       if (W.isSpinor())

--- a/src/QMCDrivers/DMC/DMCUpdateAll.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.cpp
@@ -26,7 +26,7 @@ using WP = WalkerProperties::Indexes;
 DMCUpdateAllWithRejection::DMCUpdateAllWithRejection(MCWalkerConfiguration& w,
                                                      TrialWaveFunction& psi,
                                                      QMCHamiltonian& h,
-                                                     RandomGenerator_t& rg)
+                                                     RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;
@@ -138,7 +138,7 @@ void DMCUpdateAllWithRejection::advanceWalker(Walker_t& thisWalker, bool recompu
 DMCUpdateAllWithKill::DMCUpdateAllWithKill(MCWalkerConfiguration& w,
                                            TrialWaveFunction& psi,
                                            QMCHamiltonian& h,
-                                           RandomGenerator_t& rg)
+                                           RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/DMC/DMCUpdateAll.h
+++ b/src/QMCDrivers/DMC/DMCUpdateAll.h
@@ -20,7 +20,7 @@ class DMCUpdateAllWithRejection : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  DMCUpdateAllWithRejection(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  DMCUpdateAllWithRejection(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
   ///destructor
   ~DMCUpdateAllWithRejection() override;
 
@@ -36,7 +36,7 @@ class DMCUpdateAllWithKill : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  DMCUpdateAllWithKill(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  DMCUpdateAllWithKill(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
   ///destructor
   ~DMCUpdateAllWithKill() override;
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyP.h
@@ -26,7 +26,7 @@ public:
   DMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomGenerator_t& rg);
+                                 RandomGenerator& rg);
   ///destructor
   ~DMCUpdatePbyPWithRejectionFast() override;
 

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPFast.cpp
@@ -42,7 +42,7 @@ TimerNameList_t<DMCTimers> DMCTimerNames = {{DMC_buffer, "DMCUpdatePbyP::Buffer"
 DMCUpdatePbyPWithRejectionFast::DMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                                                TrialWaveFunction& psi,
                                                                QMCHamiltonian& h,
-                                                               RandomGenerator_t& rg)
+                                                               RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   setup_timers(myTimers, DMCTimerNames, timer_level_medium);

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.cpp
@@ -36,7 +36,7 @@ using WP = WalkerProperties::Indexes;
 DMCUpdatePbyPL2::DMCUpdatePbyPL2(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomGenerator_t& rg)
+                                 RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   setup_timers(myTimers, DMCTimerNames, timer_level_medium);

--- a/src/QMCDrivers/DMC/DMCUpdatePbyPL2.h
+++ b/src/QMCDrivers/DMC/DMCUpdatePbyPL2.h
@@ -27,7 +27,7 @@ public:
   DMCUpdatePbyPL2(MCWalkerConfiguration& w,
                   TrialWaveFunction& psi,
                   QMCHamiltonian& h,
-                  RandomGenerator_t& rg);
+                  RandomGenerator& rg);
   ///destructor
   ~DMCUpdatePbyPL2() override;
 

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyP.h
@@ -23,7 +23,7 @@ public:
   SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                    TrialWaveFunction& psi,
                                    QMCHamiltonian& h,
-                                   RandomGenerator_t& rg);
+                                   RandomGenerator& rg);
   ///destructor
   ~SODMCUpdatePbyPWithRejectionFast() override;
 

--- a/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
+++ b/src/QMCDrivers/DMC/SODMCUpdatePbyPFast.cpp
@@ -39,7 +39,7 @@ TimerNameList_t<SODMCTimers> SODMCTimerNames = {{SODMC_buffer, "SODMCUpdatePbyP:
 SODMCUpdatePbyPWithRejectionFast::SODMCUpdatePbyPWithRejectionFast(MCWalkerConfiguration& w,
                                                                    TrialWaveFunction& psi,
                                                                    QMCHamiltonian& h,
-                                                                   RandomGenerator_t& rg)
+                                                                   RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   setup_timers(myTimers, SODMCTimerNames, timer_level_medium);

--- a/src/QMCDrivers/DMC/WalkerControl.cpp
+++ b/src/QMCDrivers/DMC/WalkerControl.cpp
@@ -53,7 +53,7 @@ TimerNameList_t<WC_Timers> WalkerControlTimerNames = {{WC_branch, "WalkerControl
                                                       {WC_send, "WalkerControl::send"},
                                                       {WC_recv, "WalkerControl::recv"}};
 
-WalkerControl::WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop)
+WalkerControl::WalkerControl(Communicate* c, RandomGenerator& rng, bool use_fixed_pop)
     : MPIObjectBase(c),
       rng_(rng),
       use_fixed_pop_(use_fixed_pop),

--- a/src/QMCDrivers/DMC/WalkerControl.h
+++ b/src/QMCDrivers/DMC/WalkerControl.h
@@ -51,7 +51,7 @@ public:
    *
    * Set the SwapMode to zero so that instantiation can be done
    */
-  WalkerControl(Communicate* c, RandomGenerator_t& rng, bool use_fixed_pop = false);
+  WalkerControl(Communicate* c, RandomGenerator& rng, bool use_fixed_pop = false);
 
   /** empty destructor to clean up the derived classes */
   ~WalkerControl();
@@ -141,7 +141,7 @@ private:
   };
 
   ///random number generator
-  RandomGenerator_t& rng_;
+  RandomGenerator& rng_;
   ///if true, use fixed population
   bool use_fixed_pop_;
   ///minimum number of walkers

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -187,16 +187,16 @@ public:
   std::unique_ptr<TraceManager> Traces;
 
   ///return the random generators
-  inline RefVector<RandomGenerator_t> getRngRefs() const
+  inline RefVector<RandomGenerator> getRngRefs() const
   {
-    RefVector<RandomGenerator_t> RngRefs;
+    RefVector<RandomGenerator> RngRefs;
     for (int i = 0; i < Rng.size(); ++i)
       RngRefs.push_back(*Rng[i]);
     return RngRefs;
   }
 
   ///return the i-th random generator
-  inline RandomGenerator_t& getRng(int i) override { return (*Rng[i]); }
+  inline RandomGenerator& getRng(int i) override { return (*Rng[i]); }
 
   unsigned long getDriverMode() override { return qmc_driver_mode.to_ulong(); }
 
@@ -326,7 +326,7 @@ protected:
   std::vector<QMCHamiltonian*> H1;
 
   ///Random number generators
-  UPtrVector<RandomGenerator_t> Rng;
+  UPtrVector<RandomGenerator> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCDriverInterface.h
+++ b/src/QMCDrivers/QMCDriverInterface.h
@@ -40,10 +40,10 @@ public:
   virtual void recordBlock(int block) = 0;
 
   ///return the random generators
-  //virtual std::vector<RandomGenerator_t*>& getRng() = 0;
+  //virtual std::vector<RandomGenerator*>& getRng() = 0;
 
   ///return the i-th random generator
-  virtual RandomGenerator_t& getRng(int i) = 0;
+  virtual RandomGenerator& getRng(int i) = 0;
 
   virtual void setStatus(const std::string& aname, const std::string& h5name, bool append) = 0;
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -183,19 +183,19 @@ public:
   ///set global offsets of the walkers
   void setWalkerOffsets();
 
-  inline RefVector<RandomGenerator_t> getRngRefs() const
+  inline RefVector<RandomGenerator> getRngRefs() const
   {
-    RefVector<RandomGenerator_t> RngRefs;
+    RefVector<RandomGenerator> RngRefs;
     for (int i = 0; i < Rng.size(); ++i)
       RngRefs.push_back(*Rng[i]);
     return RngRefs;
   }
 
   // ///return the random generators
-  //       inline std::vector<std::unique_ptr RandomGenerator_t*>& getRng() { return Rng; }
+  //       inline std::vector<std::unique_ptr RandomGenerator*>& getRng() { return Rng; }
 
   ///return the i-th random generator
-  inline RandomGenerator_t& getRng(int i) override { return (*Rng[i]); }
+  inline RandomGenerator& getRng(int i) override { return (*Rng[i]); }
 
   std::string getEngineName() override { return QMCType; }
   unsigned long getDriverMode() override { return qmc_driver_mode_.to_ulong(); }
@@ -383,7 +383,7 @@ protected:
   std::vector<std::unique_ptr<ContextForSteps>> step_contexts_;
 
   ///Random number generators
-  UPtrVector<RandomGenerator_t> Rng;
+  UPtrVector<RandomGenerator> Rng;
 
   ///a list of mcwalkerset element
   std::vector<xmlNodePtr> mcwalkerNodePtr;

--- a/src/QMCDrivers/QMCUpdateBase.cpp
+++ b/src/QMCDrivers/QMCUpdateBase.cpp
@@ -34,7 +34,7 @@ QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w,
                              TrialWaveFunction& psi,
                              TrialWaveFunction& guide,
                              QMCHamiltonian& h,
-                             RandomGenerator_t& rg)
+                             RandomGenerator& rg)
     : csoffset(0),
       Traces(0),
       W(w),
@@ -50,7 +50,7 @@ QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w,
 }
 
 /// Constructor.
-QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg)
+QMCUpdateBase::QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg)
     : csoffset(0),
       Traces(0),
       W(w),

--- a/src/QMCDrivers/QMCUpdateBase.h
+++ b/src/QMCDrivers/QMCUpdateBase.h
@@ -78,13 +78,13 @@ public:
   bool UseDrift;
 
   /// Constructor.
-  QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  QMCUpdateBase(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
   ///Alt Constructor.
   QMCUpdateBase(MCWalkerConfiguration& w,
                 TrialWaveFunction& psi,
                 TrialWaveFunction& guide,
                 QMCHamiltonian& h,
-                RandomGenerator_t& rg);
+                RandomGenerator& rg);
   ///destructor
   virtual ~QMCUpdateBase();
 
@@ -209,7 +209,7 @@ public:
   //       virtual void estimateNormWalkers(std::vector<TrialWaveFunction*>& pclone
   //     , std::vector<MCWalkerConfiguration*>& wclone
   //     , std::vector<QMCHamiltonian*>& hclone
-  //     , std::vector<RandomGenerator_t*>& rng
+  //     , std::vector<RandomGenerator*>& rng
   //     , std::vector<RealType>& ratio_i_0){};
   int RMC_checkIndex(int N, int NMax)
   {
@@ -266,7 +266,7 @@ protected:
   ///Hamiltonian
   QMCHamiltonian& H;
   ///random number generator
-  RandomGenerator_t& RandomGen;
+  RandomGenerator& RandomGen;
   ///branch engine, stateless reference to the one in QMCDriver
   const BranchEngineType* branchEngine;
   ///drift modifer, stateless reference to the one in QMCDriver

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -212,7 +212,7 @@ void RMC::resetRun()
       estimatorClones[ip] = new EstimatorManagerBase(*Estimators); //,*hClones[ip]);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
-      Rng[ip] = std::make_unique<RandomGenerator_t>(*RandomNumberControl::Children[ip]);
+      Rng[ip] = std::make_unique<RandomGenerator>(*RandomNumberControl::Children[ip]);
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();
 #endif

--- a/src/QMCDrivers/RMC/RMC.h
+++ b/src/QMCDrivers/RMC/RMC.h
@@ -32,7 +32,7 @@ public:
   RMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
   bool run() override;
   bool put(xmlNodePtr cur) override;
-  //inline std::vector<RandomGenerator_t*>& getRng() { return Rng;}
+  //inline std::vector<RandomGenerator*>& getRng() { return Rng;}
   QMCRunType getRunType() override { return QMCRunType::RMC; }
 
 private:

--- a/src/QMCDrivers/RMC/RMCUpdateAll.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.cpp
@@ -40,7 +40,7 @@ using WP = WalkerProperties::Indexes;
 RMCUpdateAllWithDrift::RMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                                              TrialWaveFunction& psi,
                                              QMCHamiltonian& h,
-                                             RandomGenerator_t& rg,
+                                             RandomGenerator& rg,
                                              std::vector<int> act,
                                              std::vector<int> tp)
     : QMCUpdateBase(w, psi, h, rg), Action(act), TransProb(tp)

--- a/src/QMCDrivers/RMC/RMCUpdateAll.h
+++ b/src/QMCDrivers/RMC/RMCUpdateAll.h
@@ -34,7 +34,7 @@ public:
   RMCUpdateAllWithDrift(MCWalkerConfiguration& w,
                         TrialWaveFunction& psi,
                         QMCHamiltonian& h,
-                        RandomGenerator_t& rg,
+                        RandomGenerator& rg,
                         std::vector<int> act,
                         std::vector<int> tp);
   ~RMCUpdateAllWithDrift() override;

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.cpp
@@ -40,7 +40,7 @@ using WP = WalkerProperties::Indexes;
 RMCUpdatePbyPWithDrift::RMCUpdatePbyPWithDrift(MCWalkerConfiguration& w,
                                                TrialWaveFunction& psi,
                                                QMCHamiltonian& h,
-                                               RandomGenerator_t& rg,
+                                               RandomGenerator& rg,
                                                std::vector<int> act,
                                                std::vector<int> tp)
     : QMCUpdateBase(w, psi, h, rg),

--- a/src/QMCDrivers/RMC/RMCUpdatePbyP.h
+++ b/src/QMCDrivers/RMC/RMCUpdatePbyP.h
@@ -28,7 +28,7 @@ public:
   RMCUpdatePbyPWithDrift(MCWalkerConfiguration& w,
                          TrialWaveFunction& psi,
                          QMCHamiltonian& h,
-                         RandomGenerator_t& rg,
+                         RandomGenerator& rg,
                          std::vector<int> act,
                          std::vector<int> tp);
   ~RMCUpdatePbyPWithDrift() override;

--- a/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdateAll.cpp
@@ -24,7 +24,7 @@ using WP = WalkerProperties::Indexes;
 SOVMCUpdateAll::SOVMCUpdateAll(MCWalkerConfiguration& w,
                                TrialWaveFunction& psi,
                                QMCHamiltonian& h,
-                               RandomGenerator_t& rg)
+                               RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/VMC/SOVMCUpdateAll.h
+++ b/src/QMCDrivers/VMC/SOVMCUpdateAll.h
@@ -20,7 +20,7 @@ class SOVMCUpdateAll : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  SOVMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  SOVMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
 
   ~SOVMCUpdateAll() override;
 

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.cpp
@@ -26,7 +26,7 @@ namespace qmcplusplus
 SOVMCUpdatePbyP::SOVMCUpdatePbyP(MCWalkerConfiguration& w,
                                  TrialWaveFunction& psi,
                                  QMCHamiltonian& h,
-                                 RandomGenerator_t& rg)
+                                 RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg),
       buffer_timer_(*timer_manager.createTimer("SOVMCUpdatePbyP::Buffer", timer_level_medium)),
       movepbyp_timer_(*timer_manager.createTimer("SOVMCUpdatePbyP::MovePbyP", timer_level_medium)),

--- a/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
+++ b/src/QMCDrivers/VMC/SOVMCUpdatePbyP.h
@@ -23,7 +23,7 @@ class SOVMCUpdatePbyP : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  SOVMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  SOVMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
 
   ~SOVMCUpdatePbyP() override;
 

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -177,7 +177,7 @@ void VMC::resetRun()
 #ifdef USE_FAKE_RNG
       Rng[ip] = std::make_unique<FakeRandom>();
 #else
-      Rng[ip] = std::make_unique<RandomGenerator_t>(*RandomNumberControl::Children[ip]);
+      Rng[ip] = std::make_unique<RandomGenerator>(*RandomNumberControl::Children[ip]);
 #endif
       hClones[ip]->setRandomGenerator(Rng[ip].get());
       if (W.isSpinor())

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -29,7 +29,7 @@ public:
   bool run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::VMC; }
-  //inline std::vector<RandomGenerator_t*>& getRng() { return Rng;}
+  //inline std::vector<RandomGenerator*>& getRng() { return Rng;}
 private:
   int prevSteps;
   int prevStepsBetweenSamples;

--- a/src/QMCDrivers/VMC/VMCUpdateAll.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.cpp
@@ -21,7 +21,7 @@ namespace qmcplusplus
 {
 using WP = WalkerProperties::Indexes;
 
-VMCUpdateAll::VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg)
+VMCUpdateAll::VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg)
 {
   UpdatePbyP = false;

--- a/src/QMCDrivers/VMC/VMCUpdateAll.h
+++ b/src/QMCDrivers/VMC/VMCUpdateAll.h
@@ -25,7 +25,7 @@ class VMCUpdateAll : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  VMCUpdateAll(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
 
   ~VMCUpdateAll() override;
 

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.cpp
@@ -27,7 +27,7 @@ typedef int TraceManager;
 namespace qmcplusplus
 {
 /// Constructor
-VMCUpdatePbyP::VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg)
+VMCUpdatePbyP::VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg)
     : QMCUpdateBase(w, psi, h, rg),
       buffer_timer_(*timer_manager.createTimer("VMCUpdatePbyP::Buffer", timer_level_medium)),
       movepbyp_timer_(*timer_manager.createTimer("VMCUpdatePbyP::MovePbyP", timer_level_medium)),

--- a/src/QMCDrivers/VMC/VMCUpdatePbyP.h
+++ b/src/QMCDrivers/VMC/VMCUpdatePbyP.h
@@ -26,7 +26,7 @@ class VMCUpdatePbyP : public QMCUpdateBase
 {
 public:
   /// Constructor.
-  VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg);
+  VMCUpdatePbyP(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg);
 
   ~VMCUpdatePbyP() override;
 

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
@@ -20,7 +20,7 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
                                              TrialWaveFunction& Psi,
                                              QMCHamiltonian& H,
                                              std::vector<std::string>& H_KE_node_names,
-                                             RandomGenerator_t& Rng)
+                                             RandomGenerator& Rng)
     : e0_(0.0), e2_(0.0), wgt_(0.0), wgt2_(0.0)
 {
   P.createResource(driverwalker_resource_collection_.pset_res);
@@ -54,11 +54,11 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
     h_ptr_list_[ib]  = H.makeClone(pCopy, psiCopy);
     h0_ptr_list_[ib] = H_KE.makeClone(pCopy, psiCopy);
 
-    rng_ptr_list_[ib] = std::make_unique<RandomGenerator_t>(Rng);
+    rng_ptr_list_[ib] = std::make_unique<RandomGenerator>(Rng);
     h_ptr_list_[ib]->setRandomGenerator(rng_ptr_list_[ib].get());
     h0_ptr_list_[ib]->setRandomGenerator(rng_ptr_list_[ib].get());
 
-    rng_save_ptr_ = std::make_unique<RandomGenerator_t>(Rng);
+    rng_save_ptr_ = std::make_unique<RandomGenerator>(Rng);
   }
 }
 

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
@@ -36,7 +36,7 @@ public:
                         TrialWaveFunction& Psi,
                         QMCHamiltonian& H,
                         std::vector<std::string>& H_KE_node_names,
-                        RandomGenerator_t& Rng);
+                        RandomGenerator& Rng);
 
   /// Set the log_psi_* arrays to zero
   void zero_log_psi();
@@ -49,8 +49,8 @@ public:
   std::vector<Return_rt>& get_log_psi_fixed() { return log_psi_fixed_; }
   std::vector<Return_rt>& get_log_psi_opt() { return log_psi_opt_; }
 
-  UPtrVector<RandomGenerator_t>& get_rng_ptr_list() { return rng_ptr_list_; }
-  RandomGenerator_t& get_rng_save() { return *rng_save_ptr_; }
+  UPtrVector<RandomGenerator>& get_rng_ptr_list() { return rng_ptr_list_; }
+  RandomGenerator& get_rng_save() { return *rng_save_ptr_; }
 
   UPtrVector<TrialWaveFunction>& get_wf_ptr_list() { return wf_ptr_list_; }
 
@@ -72,13 +72,13 @@ private:
   UPtrVector<ParticleSet> p_ptr_list_;
   UPtrVector<QMCHamiltonian> h_ptr_list_;
   UPtrVector<QMCHamiltonian> h0_ptr_list_;
-  UPtrVector<RandomGenerator_t> rng_ptr_list_;
+  UPtrVector<RandomGenerator> rng_ptr_list_;
 
   // proivides multi walker resource
   DriverWalkerResourceCollection driverwalker_resource_collection_;
 
   // Saved RNG state to reset to before correlated sampling
-  std::unique_ptr<RandomGenerator_t> rng_save_ptr_;
+  std::unique_ptr<RandomGenerator> rng_save_ptr_;
 
   // Crowd-local accumulator variables
   Return_rt e0_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -87,7 +87,7 @@ QMCCostFunctionBase::~QMCCostFunctionBase()
     delete debug_stream;
 }
 
-void QMCCostFunctionBase::setRng(RefVector<RandomGenerator_t> r)
+void QMCCostFunctionBase::setRng(RefVector<RandomGenerator> r)
 {
   if (MoverRng.size() < r.size())
   {
@@ -97,7 +97,7 @@ void QMCCostFunctionBase::setRng(RefVector<RandomGenerator_t> r)
   for (int ip = 0; ip < r.size(); ++ip)
     MoverRng[ip] = &r[ip].get();
   for (int ip = 0; ip < r.size(); ++ip)
-    RngSaved[ip] = std::make_unique<RandomGenerator_t>(r[ip].get());
+    RngSaved[ip] = std::make_unique<RandomGenerator>(r[ip].get());
 }
 
 void QMCCostFunctionBase::setTargetEnergy(Return_rt et)

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -149,7 +149,7 @@ public:
 
 #endif
 
-  void setRng(RefVector<RandomGenerator_t> r);
+  void setRng(RefVector<RandomGenerator> r);
 
   inline bool getneedGrads() const { return needGrads; }
 
@@ -271,8 +271,8 @@ protected:
   std::string RootName;
 
   ///Random number generators
-  UPtrVector<RandomGenerator_t> RngSaved;
-  std::vector<RandomGenerator_t*> MoverRng;
+  UPtrVector<RandomGenerator> RngSaved;
+  std::vector<RandomGenerator*> MoverRng;
   std::string includeNonlocalH;
 
 

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -101,7 +101,7 @@ bool WaveFunctionTester::run()
 
   put(qmcNode);
 
-  auto Rng1 = std::make_unique<RandomGenerator_t>();
+  auto Rng1 = std::make_unique<RandomGenerator>();
   H.setRandomGenerator(Rng1.get());
   // Add to Rng so the object is eventually deleted
   Rng.emplace_back(std::move(Rng1));
@@ -1902,8 +1902,8 @@ void WaveFunctionTester::runDerivCloneTest()
 {
   app_log() << " ===== runDerivCloneTest =====\n";
   app_log() << " Testing derivatives clone" << std::endl;
-  auto Rng1      = std::make_unique<RandomGenerator_t>();
-  auto Rng2      = std::make_unique<RandomGenerator_t>();
+  auto Rng1      = std::make_unique<RandomGenerator>();
+  auto Rng2      = std::make_unique<RandomGenerator>();
   (*Rng1)        = (*Rng2);
   auto w_clone   = std::make_unique<MCWalkerConfiguration>(W);
   auto psi_clone = Psi.makeClone(*w_clone);

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -37,7 +37,7 @@ namespace qmcplusplus
 class FakeUpdate : public QMCUpdateBase
 {
 public:
-  FakeUpdate(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator_t& rg)
+  FakeUpdate(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, RandomGenerator& rg)
       : QMCUpdateBase(w, psi, h, rg)
   {}
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -508,7 +508,7 @@ void DensityMatrices1B::getRequiredTraces(TraceManager& tm)
 }
 
 
-void DensityMatrices1B::setRandomGenerator(RandomGenerator_t* rng) { uniform_random = rng; }
+void DensityMatrices1B::setRandomGenerator(RandomGenerator* rng) { uniform_random = rng; }
 
 
 void DensityMatrices1B::addObservables(PropertySetType& plist, BufferType& collectables)
@@ -901,7 +901,7 @@ DensityMatrices1B::Return_t DensityMatrices1B::evaluate_loop(ParticleSet& P)
 inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
 {
   ScopedTimer t(timers[DM_gen_samples]);
-  RandomGenerator_t& rng = *uniform_random;
+  RandomGenerator& rng = *uniform_random;
   bool save              = false;
   if (steps == 0)
   {
@@ -957,7 +957,7 @@ inline void DensityMatrices1B::generate_samples(RealType weight, int steps)
 }
 
 
-inline void DensityMatrices1B::generate_uniform_grid(RandomGenerator_t& rng)
+inline void DensityMatrices1B::generate_uniform_grid(RandomGenerator& rng)
 {
   PosType rp;
   PosType ushift = 0.0;
@@ -979,7 +979,7 @@ inline void DensityMatrices1B::generate_uniform_grid(RandomGenerator_t& rng)
 }
 
 
-inline void DensityMatrices1B::generate_uniform_samples(RandomGenerator_t& rng)
+inline void DensityMatrices1B::generate_uniform_samples(RandomGenerator& rng)
 {
   PosType rp;
   for (int s = 0; s < samples; ++s)
@@ -991,7 +991,7 @@ inline void DensityMatrices1B::generate_uniform_samples(RandomGenerator_t& rng)
 }
 
 
-inline void DensityMatrices1B::generate_density_samples(bool save, int steps, RandomGenerator_t& rng)
+inline void DensityMatrices1B::generate_density_samples(bool save, int steps, RandomGenerator& rng)
 {
   RealType sqt = std::sqrt(timestep);
   RealType ot  = 1.0 / timestep;

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -152,7 +152,7 @@ public:
   PosType dpcur;
   RealType rhocur;
 
-  RandomGenerator_t* uniform_random;
+  RandomGenerator* uniform_random;
 
 
   //constructor/destructor
@@ -167,7 +167,7 @@ public:
 
   //optional standard interface
   void getRequiredTraces(TraceManager& tm) override;
-  void setRandomGenerator(RandomGenerator_t* rng) override;
+  void setRandomGenerator(RandomGenerator* rng) override;
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override;
@@ -198,9 +198,9 @@ public:
   //  sample generation
   void warmup_sampling();
   void generate_samples(RealType weight, int steps = 0);
-  void generate_uniform_grid(RandomGenerator_t& rng);
-  void generate_uniform_samples(RandomGenerator_t& rng);
-  void generate_density_samples(bool save, int steps, RandomGenerator_t& rng);
+  void generate_uniform_grid(RandomGenerator& rng);
+  void generate_uniform_samples(RandomGenerator& rng);
+  void generate_density_samples(bool save, int steps, RandomGenerator& rng);
   void diffusion(RealType sqt, PosType& diff);
   void density_only(const PosType& r, RealType& dens);
   void density_drift(const PosType& r, RealType& dens, PosType& drift);

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -447,7 +447,7 @@ void MomentumEstimator::resize(const std::vector<PosType>& kin, const int Min)
     phases_vPos[im].resize(kPoints.size());
 }
 
-void MomentumEstimator::setRandomGenerator(RandomGenerator_t* rng)
+void MomentumEstimator::setRandomGenerator(RandomGenerator* rng)
 {
   //simply copy it
   myRNG = *rng;

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -34,7 +34,7 @@ public:
   bool put(xmlNodePtr cur) override { return false; };
   bool get(std::ostream& os) const override;
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
-  void setRandomGenerator(RandomGenerator_t* rng) override;
+  void setRandomGenerator(RandomGenerator* rng) override;
   //resize the internal data by input k-point list
   void resize(const std::vector<PosType>& kin, const int Min);
   ///number of samples
@@ -46,7 +46,7 @@ public:
   ///normalization factor for n(k)
   RealType norm_nofK;
   ///random generator
-  RandomGenerator_t myRNG;
+  RandomGenerator myRNG;
   ///sample positions
   std::vector<PosType> vPos;
   ///wavefunction ratios

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -597,7 +597,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
 }
 
 ///Randomly rotate sgrid_m
-void NonLocalECPComponent::randomize_grid(RandomGenerator_t& myRNG)
+void NonLocalECPComponent::randomize_grid(RandomGenerator& myRNG)
 {
   RealType phi(TWOPI * myRNG()), psi(TWOPI * myRNG()), cth(myRNG() - 0.5);
   RealType sph(std::sin(phi)), cph(std::cos(phi)), sth(std::sqrt(1.0 - cth * cth)), sps(std::sin(psi)),
@@ -609,7 +609,7 @@ void NonLocalECPComponent::randomize_grid(RandomGenerator_t& myRNG)
 }
 
 template<typename T>
-void NonLocalECPComponent::randomize_grid(std::vector<T>& sphere, RandomGenerator_t& myRNG)
+void NonLocalECPComponent::randomize_grid(std::vector<T>& sphere, RandomGenerator& myRNG)
 {
   RealType phi(TWOPI * myRNG()), psi(TWOPI * myRNG()), cth(myRNG() - 0.5);
   RealType sph(std::sin(phi)), cph(std::cos(phi)), sth(std::sqrt(1.0 - cth * cth)), sps(std::sin(psi)),
@@ -646,8 +646,8 @@ void NonLocalECPComponent::contributeTxy(int iel, std::vector<NonLocalData>& Txy
 }
 
 /// \relates NonLocalEcpComponent
-template void NonLocalECPComponent::randomize_grid(std::vector<float>& sphere, RandomGenerator_t& myRNG);
-template void NonLocalECPComponent::randomize_grid(std::vector<double>& sphere, RandomGenerator_t& myRNG);
+template void NonLocalECPComponent::randomize_grid(std::vector<float>& sphere, RandomGenerator& myRNG);
+template void NonLocalECPComponent::randomize_grid(std::vector<double>& sphere, RandomGenerator& myRNG);
 
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -130,9 +130,9 @@ public:
 
   void resize_warrays(int n, int m, int l);
 
-  void randomize_grid(RandomGenerator_t& myRNG);
+  void randomize_grid(RandomGenerator& myRNG);
   template<typename T>
-  void randomize_grid(std::vector<T>& sphere, RandomGenerator_t& myRNG);
+  void randomize_grid(std::vector<T>& sphere, RandomGenerator& myRNG);
 
   /** contribute local non-local move data
    * @param iel reference electron id.

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -484,7 +484,7 @@ void NonLocalECPotential::computeOneElectronTxy(ParticleSet& P, const int ref_el
 int NonLocalECPotential::makeNonLocalMovesPbyP(ParticleSet& P)
 {
   int NonLocalMoveAccepted = 0;
-  RandomGenerator_t& RandomGen(*myRNG);
+  RandomGenerator& RandomGen(*myRNG);
   if (UseTMove == TMOVE_V0)
   {
     const NonLocalData* oneTMove = nonLocalOps.selectMove(RandomGen(), tmove_xy_);

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -121,7 +121,7 @@ public:
   /** set the internal RNG pointer as the given pointer
    * @param rng input RNG pointer
    */
-  void setRandomGenerator(RandomGenerator_t* rng) override { myRNG = rng; }
+  void setRandomGenerator(RandomGenerator* rng) override { myRNG = rng; }
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
 
@@ -138,7 +138,7 @@ public:
 
 protected:
   ///random number generator
-  RandomGenerator_t* myRNG;
+  RandomGenerator* myRNG;
   ///the set of local-potentials (one for each ion)
   std::vector<NonLocalECPComponent*> PP;
   ///unique NonLocalECPComponent to remove

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -188,7 +188,7 @@ void OperatorBase::releaseResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {}
 
-void OperatorBase::setRandomGenerator(RandomGenerator_t* rng) {}
+void OperatorBase::setRandomGenerator(RandomGenerator* rng) {}
 
 void OperatorBase::add2Hamiltonian(ParticleSet& qp, TrialWaveFunction& psi, QMCHamiltonian& targetH)
 {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -368,7 +368,7 @@ public:
    * TODO: add docs
    * @param rng 
    */
-  virtual void setRandomGenerator(RandomGenerator_t* rng);
+  virtual void setRandomGenerator(RandomGenerator* rng);
 
   /**
    * @brief TODO: add docs

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -230,7 +230,7 @@ public:
 
   //optional standard interface
   //void getRequiredTraces(TraceManager& tm);
-  //void setRandomGenerator(RandomGenerator_t* rng);
+  //void setRandomGenerator(RandomGenerator* rng);
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override {}

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -934,7 +934,7 @@ void QMCHamiltonian::resetTargetParticleSet(ParticleSet& P)
     auxH[i]->resetTargetParticleSet(P);
 }
 
-void QMCHamiltonian::setRandomGenerator(RandomGenerator_t* rng)
+void QMCHamiltonian::setRandomGenerator(RandomGenerator* rng)
 {
   for (int i = 0; i < H.size(); i++)
     H[i]->setRandomGenerator(rng);

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -399,7 +399,7 @@ public:
 
   RealType get_LocalEnergy() const { return LocalEnergy; }
 
-  void setRandomGenerator(RandomGenerator_t* rng);
+  void setRandomGenerator(RandomGenerator* rng);
 
   static void updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
   static void updateKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -210,7 +210,7 @@ SOECPComponent::RealType SOECPComponent::evaluateOne(ParticleSet& W,
   return pairpot;
 }
 
-void SOECPComponent::randomize_grid(RandomGenerator_t& myRNG)
+void SOECPComponent::randomize_grid(RandomGenerator& myRNG)
 {
   RealType phi(TWOPI * myRNG()), psi(TWOPI * myRNG()), cth(myRNG() - 0.5);
   RealType sph(std::sin(phi)), cph(std::cos(phi)), sth(std::sqrt(1.0 - cth * cth)), sps(std::sin(psi)),
@@ -222,7 +222,7 @@ void SOECPComponent::randomize_grid(RandomGenerator_t& myRNG)
 }
 
 template<typename T>
-void SOECPComponent::randomize_grid(std::vector<T>& sphere, RandomGenerator_t& myRNG)
+void SOECPComponent::randomize_grid(std::vector<T>& sphere, RandomGenerator& myRNG)
 {
   RealType phi(TWOPI * myRNG()), psi(TWOPI * myRNG()), cth(myRNG() - 0.5);
   RealType sph(std::sin(phi)), cph(std::cos(phi)), sth(std::sqrt(1.0 - cth * cth)), sps(std::sin(psi)),
@@ -244,6 +244,6 @@ void SOECPComponent::randomize_grid(std::vector<T>& sphere, RandomGenerator_t& m
       sphere[OHMMS_DIM * i + j] = rrotsgrid_m[i][j];
 }
 
-template void SOECPComponent::randomize_grid(std::vector<float>& sphere, RandomGenerator_t& myRNG);
-template void SOECPComponent::randomize_grid(std::vector<double>& sphere, RandomGenerator_t& myRNG);
+template void SOECPComponent::randomize_grid(std::vector<float>& sphere, RandomGenerator& myRNG);
+template void SOECPComponent::randomize_grid(std::vector<double>& sphere, RandomGenerator& myRNG);
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -81,9 +81,9 @@ public:
 
   void resize_warrays(int n, int m, int s);
 
-  void randomize_grid(RandomGenerator_t& myRNG);
+  void randomize_grid(RandomGenerator& myRNG);
   template<typename T>
-  void randomize_grid(std::vector<T>& sphere, RandomGenerator_t& myRNG);
+  void randomize_grid(std::vector<T>& sphere, RandomGenerator& myRNG);
 
   ///API for accessing the value of an SO radial potential at distance r.  For unit and other testing.
   friend RealType getSplinedSOPot(SOECPComponent* so_pp, int l, double r);

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -38,10 +38,10 @@ public:
 
   void addComponent(int groupID, std::unique_ptr<SOECPComponent>&& pp);
 
-  void setRandomGenerator(RandomGenerator_t* rng) override { myRNG = rng; }
+  void setRandomGenerator(RandomGenerator* rng) override { myRNG = rng; }
 
 protected:
-  RandomGenerator_t* myRNG;
+  RandomGenerator* myRNG;
   std::vector<SOECPComponent*> PP;
   std::vector<std::unique_ptr<SOECPComponent>> PPset;
   ParticleSet& IonConfig;

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -238,7 +238,7 @@ SpinDensity::Return_t SpinDensity::evaluate(ParticleSet& P)
 void SpinDensity::test(int moves, ParticleSet& P)
 {
   app_log() << "  SpinDensity test" << std::endl;
-  RandomGenerator_t rng;
+  RandomGenerator rng;
   int particles = P.getTotalNum();
   int pmin      = std::numeric_limits<int>::max();
   int pmax      = std::numeric_limits<int>::min();

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -271,7 +271,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  RandomGenerator_t myrng;
+  RandomGenerator myrng;
   ham.setRandomGenerator(&myrng);
   ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
 
@@ -439,7 +439,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  RandomGenerator_t myrng;
+  RandomGenerator myrng;
   ham.setRandomGenerator(&myrng);
   ham.evaluateIonDerivs(elec, ions, *psi, hf_term, pulay_term, wf_grad);
 
@@ -1162,7 +1162,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   hf_term    = 0.0;
   pulay_term = 0.0;
   wf_grad    = 0.0;
-  RandomGenerator_t myrng;
+  RandomGenerator myrng;
   ham.setRandomGenerator(&myrng);
   ham.evaluateIonDerivs(elec,ions,*psi,hf_term,pulay_term,wf_grad);
   

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -511,7 +511,7 @@ void QMCFiniteSize::calcPotentialCorrection()
   vsums.resize(NumSamples);
   vints.resize(NumSamples);
 
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 #pragma omp parallel for
   for (int i = 0; i < NumSamples; i++)
   {
@@ -546,7 +546,7 @@ void QMCFiniteSize::calcPotentialCorrection()
 
 void QMCFiniteSize::calcLeadingOrderCorrections()
 {
-  RandomGenerator_t rng;
+  RandomGenerator rng;
 
   vector<RealType> bs(NumSamples);
 #pragma omp parallel for

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
   typedef ParticleSet::ParticleLayout_t LatticeType;
   typedef ParticleSet::TensorType TensorType;
   typedef ParticleSet::PosType PosType;
-  typedef RandomGenerator_t::uint_type uint_type;
+  typedef RandomGenerator::uint_type uint_type;
   typedef MCWalkerConfiguration::Walker_t Walker_t;
 
   //use the global generator
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
   double t0 = 0.0, t1 = 0.0;
 
   RandomNumberControl::make_seeds();
-  std::vector<RandomGenerator_t> myRNG(NumThreads);
+  std::vector<RandomGenerator> myRNG(NumThreads);
   std::vector<uint_type> mt(Random.state_size(), 0);
   std::vector<MCWalkerConfiguration> elecs(NumThreads);
 
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
 
     //create generator within the thread
     myRNG[ip]                    = *RandomNumberControl::Children[ip];
-    RandomGenerator_t& random_th = myRNG[ip];
+    RandomGenerator& random_th = myRNG[ip];
 
     const int nions = ions.getTotalNum();
     const int nels  = count_electrons(ions);
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
 #pragma omp parallel
   {
     int ip                       = omp_get_thread_num();
-    RandomGenerator_t& random_th = *RandomNumberControl::Children[ip];
+    RandomGenerator& random_th = *RandomNumberControl::Children[ip];
     std::vector<uint_type> vt(random_th.state_size(), 0);
     random_th.load(vt);
   }
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
 #pragma omp parallel reduction(+ : mismatch_count)
   {
     int ip                       = omp_get_thread_num();
-    RandomGenerator_t& random_th = myRNG[ip];
+    RandomGenerator& random_th = myRNG[ip];
     std::vector<uint_type> vt_orig(random_th.state_size());
     std::vector<uint_type> vt_load(random_th.state_size());
     random_th.save(vt_orig);

--- a/src/Utilities/RandomGenerator.h
+++ b/src/Utilities/RandomGenerator.h
@@ -61,12 +61,12 @@ extern template class RNGThreadSafe<BoostRandom<float>>;
 extern template class RNGThreadSafe<BoostRandom<double>>;
 
 #ifdef USE_FAKE_RNG
-using RandomGenerator_t = FakeRandom;
-extern RNGThreadSafe<RandomGenerator_t> fake_random_global;
+using RandomGenerator = FakeRandom;
+extern RNGThreadSafe<RandomGenerator> fake_random_global;
 #define Random fake_random_global
 #else
-using RandomGenerator_t = BoostRandom<OHMMS_PRECISION_FULL>;
-extern RNGThreadSafe<RandomGenerator_t> boost_random_global;
+using RandomGenerator = BoostRandom<OHMMS_PRECISION_FULL>;
+extern RNGThreadSafe<RandomGenerator> boost_random_global;
 #define Random boost_random_global
 #endif
 } // namespace qmcplusplus

--- a/src/Utilities/RandomNumberControl.cpp
+++ b/src/Utilities/RandomNumberControl.cpp
@@ -38,9 +38,9 @@
 namespace qmcplusplus
 {
 ///initialize the static data members
-PrimeNumberSet<RandomGenerator_t::uint_type> RandomNumberControl::PrimeNumbers;
-std::vector<std::unique_ptr<RandomGenerator_t>> RandomNumberControl::Children;
-RandomGenerator_t::uint_type RandomNumberControl::Offset = 11u;
+PrimeNumberSet<RandomGenerator::uint_type> RandomNumberControl::PrimeNumbers;
+std::vector<std::unique_ptr<RandomGenerator>> RandomNumberControl::Children;
+RandomGenerator::uint_type RandomNumberControl::Offset = 11u;
 
 /// constructors and destructors
 RandomNumberControl::RandomNumberControl(const char* aname)
@@ -93,7 +93,7 @@ void RandomNumberControl::make_children()
   int n        = nthreads - Children.size();
   while (n)
   {
-    Children.push_back(std::make_unique<RandomGenerator_t>());
+    Children.push_back(std::make_unique<RandomGenerator>());
     n--;
   }
   int rank       = OHMMS::Controller->rank();
@@ -126,7 +126,7 @@ void RandomNumberControl::test()
   {
     const int n = 1000000;
     double sum = 0.0, sum2 = 0.0;
-    RandomGenerator_t& myrand(*Children[ip]);
+    RandomGenerator& myrand(*Children[ip]);
     for (int i = 0; i < n; ++i)
     {
       double r = myrand.rand();

--- a/src/Utilities/RandomNumberControl.h
+++ b/src/Utilities/RandomNumberControl.h
@@ -35,10 +35,10 @@ namespace qmcplusplus
 class RandomNumberControl : public OhmmsElementBase
 {
 public:
-  typedef RandomGenerator_t::uint_type uint_type;
+  typedef RandomGenerator::uint_type uint_type;
   static PrimeNumberSet<uint_type> PrimeNumbers;
   //children random number generator
-  static std::vector<std::unique_ptr<RandomGenerator_t>> Children;
+  static std::vector<std::unique_ptr<RandomGenerator>> Children;
 
   /// constructors and destructors
   RandomNumberControl(const char* aname = "random");


### PR DESCRIPTION
## Proposed changes
Rename RandomGenerator_t to RandomGenerator according to the current naming rules.
To reduce #3699 review burden.

## What type(s) of changes does this code introduce?
- Code style update (formatting, renaming)
### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'