### PR TITLE
Address libc++ related bugs with no MPI compilation

### DIFF
--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -73,8 +73,9 @@ struct Array : base_type{
 	sizes_type shape() const{return base_type::sizes();}
 	void resize(sizes_type sizes){resizeAndPreserve(sizes);}
 	void resizeAndPreserve(sizes_type sizes){
-		// must do a reinterpret_cast due to failure with libc++ type automatic conversion
-		base_type::reextent(reinterpret_cast<typename base_type::extensions_type const&>(sizes));
+		// explicit conversion due to failure with libc++ type automatic conversion
+		 	base_type::reextent(std::apply([](auto... ss){return typename base_type::extensions_type{static_cast<typename base_type::size_type>(ss)...};}, sizes));
+
 	}
 	template<class... Ints>
 	void resize(Ints... ns){base_type::reextent(std::make_tuple(ns...));}

--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -72,7 +72,10 @@ struct Array : base_type{
 	using sizes_type = decltype(std::declval<base_type const&>().sizes());
 	sizes_type shape() const{return base_type::sizes();}
 	void resize(sizes_type sizes){resizeAndPreserve(sizes);}
-	void resizeAndPreserve(sizes_type sizes){base_type::reextent(sizes);}
+	void resizeAndPreserve(sizes_type sizes){
+		// must do a reinterpret_cast due to failure with libc++ type automatic conversion
+		base_type::reextent(reinterpret_cast<typename base_type::extensions_type const&>(sizes));
+	}
 	template<class... Ints>
 	void resize(Ints... ns){base_type::reextent(std::make_tuple(ns...));}
 	typename base_type::element_ptr       data()      {return base_type::data_elements();}

--- a/src/QMCWaveFunctions/ElectronGas/HEGGrid.h
+++ b/src/QMCWaveFunctions/ElectronGas/HEGGrid.h
@@ -19,6 +19,7 @@
 #include "Lattice/CrystalLattice.h"
 #include <map>
 #include <optional>
+#include <array>
 
 namespace qmcplusplus
 {


### PR DESCRIPTION
## Proposed changes

Address libc++ issues detected due to missing header and type conversion (hack with `reinterpret_cast`)
Attempts to fix #3698 (note that we don't have FreeBSD CI)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Ubuntu 20.04 with clang 10 and libc++ without MPI.
Must pass CI for other configurations.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted (ppconvert)
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
