### PR TITLE
Update CI docker container

### DIFF
--- a/config/docker/dependencies/ubuntu/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu/openmpi/Dockerfile
@@ -1,42 +1,48 @@
 FROM ubuntu:20.04
-MAINTAINER William F Godoy williamfgc@yahoo.com
+LABEL maintainer="williamfgc@yahoo.com"
 
 RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get clean &&\
     apt-get update -y &&\
     apt-get upgrade -y apt-utils
 
 # Dependencies
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc g++ \ 
-                    clang \
-                    clang-format \
-                    gcovr \
-                    python3 \
-                    cmake \
-                    ninja-build \
-                    libboost-all-dev \
-                    git \
-                    libopenmpi-dev \
-                    libhdf5-openmpi-dev \
-                    libhdf5-serial-dev \
-                    hdf5-tools \
-                    libfftw3-dev \
-                    libopenblas-openmp-dev \
-                    libxml2-dev \
-                    sudo \
-                    curl \
-                    rsync \
-                    wget \
-                    software-properties-common \
-                    vim \
-                    -y
+    clang \
+    clang-format \
+    gcovr \
+    python3 \
+    cmake \
+    ninja-build \
+    libboost-all-dev \
+    git \
+    libopenmpi-dev \
+    libhdf5-openmpi-dev \
+    libhdf5-serial-dev \
+    hdf5-tools \
+    libfftw3-dev \
+    libopenblas-openmp-dev \
+    libxml2-dev \
+    sudo \
+    curl \
+    rsync \
+    wget \
+    software-properties-common \
+    vim \
+    numdiff \
+    -y
 
 # Python packages for tests
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install python3-numpy \
-                    python3-h5py \
-                    python3-pandas \
-                    -y
+    python3-h5py \
+    python3-pandas \
+    python3-pip \
+    -y
+
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    pip3 install cif2cell
 
 # must add a user different from root 
 # to run MPI executables


### PR DESCRIPTION
## Proposed changes

Update the Dockerfile of the latest Ubuntu 20 docker container used in CI
Add `numdiff` for added `ppconvert` test from #3717
Add Python `cif2cell` from #3509
Remove deprecated MAINTAINER tag
Note that container is already hosted in [DockerHub](https://hub.docker.com/layers/141931100/williamfgc/qmcpack-ci/ubuntu20-openmpi/images/sha256-efb1446b9829d85d53d5886868bd9f87579826331eca6a98ad1b579713d15b32?context=repo)

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests) CI container 

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Docker local with a Ubuntu 20.04 host

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
