### PR TITLE
Add debug mode configuration to CI

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         jobname:
           [
+            GCC9-NoMPI-Debug-Real,
             GCC9-MPI-Gcov-Real,
             GCC9-MPI-Gcov-Complex,
             GCC11-NoMPI-Werror-Real,
@@ -30,6 +31,11 @@ jobs:
             Clang12-NoMPI-Offload-Real,
           ]
         include:
+          - jobname: GCC9-NoMPI-Debug-Real
+            container:
+              image: williamfgc/qmcpack-ci:ubuntu20-openmpi
+              options: -u 1001
+
           - jobname: GCC9-MPI-Gcov-Real
             container:
               image: williamfgc/qmcpack-ci:ubuntu20-openmpi

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -59,6 +59,15 @@ case "$1" in
     esac
     
     case "${GH_JOBNAME}" in
+      *"GCC9-NoMPI-Debug-"*)
+        echo 'Configure for debug mode to capture asserts with gcc'
+        cmake -GNinja \
+              -DCMAKE_C_COMPILER=gcc \
+              -DCMAKE_CXX_COMPILER=g++ \
+              -DQMC_MPI=0 \
+              -DCMAKE_BUILD_TYPE=Debug \
+              ${GITHUB_WORKSPACE}
+      ;;
       *"GCC9-MPI-Gcov-"*)
         echo 'Configure for code coverage with gcc and gcovr -DENABLE_GCOV=TRUE and upload reports to Codecov'
         cmake -GNinja \


### PR DESCRIPTION
## Proposed changes

Add a debug mode configuration job to CI 
Expect to capture asserts
Need to observe runtimes on GitHub Actions CI
Related to #3691 and #3696 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests) CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass GitHub Actions CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
