### PR TITLE
batched evaluation of evaluate_notranspose for SpinorSet

### DIFF
--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -265,7 +265,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
 
 #pragma omp parallel for
   for (int iw = 0; iw < nw; iw++)
-  {
     for (int iat = 0; iat < nelec; iat++)
     {
       ParticleSet::Scalar_t s = P_list[iw].activeSpin(iat);
@@ -284,7 +283,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
             eis * up_d2logdet_list[iw].get()(iat, no) + emis * dn_d2logdet_list[iw].get()(iat, no);
       }
     }
-  }
 }
 
 void SpinorSet::evaluate_notranspose_spin(const ParticleSet& P,

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -199,8 +199,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   RefVectorWithLeader<SPOSet> dn_spo_list(dn_spo_leader);
   up_spo_list.reserve(nw);
   dn_spo_list.reserve(nw);
-  up_spo_list.clear();
-  dn_spo_list.clear();
 
   std::vector<ValueMatrix_t> mw_up_logdet, mw_dn_logdet;
   std::vector<GradMatrix_t> mw_up_dlogdet, mw_dn_dlogdet;
@@ -211,12 +209,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   mw_dn_dlogdet.reserve(nw);
   mw_up_d2logdet.reserve(nw);
   mw_dn_d2logdet.reserve(nw);
-  mw_up_logdet.clear();
-  mw_dn_logdet.clear();
-  mw_up_dlogdet.clear();
-  mw_dn_dlogdet.clear();
-  mw_up_d2logdet.clear();
-  mw_dn_d2logdet.clear();
 
   RefVector<ValueMatrix_t> up_logdet_list, dn_logdet_list;
   RefVector<GradMatrix_t> up_dlogdet_list, dn_dlogdet_list;
@@ -227,12 +219,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   dn_dlogdet_list.reserve(nw);
   up_d2logdet_list.reserve(nw);
   dn_d2logdet_list.reserve(nw);
-  up_logdet_list.clear();
-  dn_logdet_list.clear();
-  up_dlogdet_list.clear();
-  dn_dlogdet_list.clear();
-  up_d2logdet_list.clear();
-  dn_d2logdet_list.clear();
 
   ValueMatrix_t tmp_val_mat(nelec, OrbitalSetSize);
   GradMatrix_t tmp_grad_mat(nelec, OrbitalSetSize);

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -178,6 +178,115 @@ void SpinorSet::evaluate_notranspose(const ParticleSet& P,
   }
 }
 
+void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_list,
+                                        const RefVectorWithLeader<ParticleSet>& P_list,
+                                        int first,
+                                        int last,
+                                        const RefVector<ValueMatrix_t>& logdet_list,
+                                        const RefVector<GradMatrix_t>& dlogdet_list,
+                                        const RefVector<ValueMatrix_t>& d2logdet_list) const
+{
+  auto& spo_leader = spo_list.getCastedLeader<SpinorSet>();
+  auto& P_leader   = P_list.getLeader();
+  assert(this == &spo_leader);
+
+  IndexType nw    = spo_list.size();
+  IndexType nelec = P_leader.getTotalNum();
+
+  SPOSet& up_spo_leader = *(spo_leader.spo_up);
+  SPOSet& dn_spo_leader = *(spo_leader.spo_dn);
+  RefVectorWithLeader<SPOSet> up_spo_list(up_spo_leader);
+  RefVectorWithLeader<SPOSet> dn_spo_list(dn_spo_leader);
+  up_spo_list.reserve(nw);
+  dn_spo_list.reserve(nw);
+  up_spo_list.clear();
+  dn_spo_list.clear();
+
+  std::vector<ValueMatrix_t> mw_up_logdet, mw_dn_logdet;
+  std::vector<GradMatrix_t> mw_up_dlogdet, mw_dn_dlogdet;
+  std::vector<ValueMatrix_t> mw_up_d2logdet, mw_dn_d2logdet;
+  mw_up_logdet.reserve(nw);
+  mw_dn_logdet.reserve(nw);
+  mw_up_dlogdet.reserve(nw);
+  mw_dn_dlogdet.reserve(nw);
+  mw_up_d2logdet.reserve(nw);
+  mw_dn_d2logdet.reserve(nw);
+  mw_up_logdet.clear();
+  mw_dn_logdet.clear();
+  mw_up_dlogdet.clear();
+  mw_dn_dlogdet.clear();
+  mw_up_d2logdet.clear();
+  mw_dn_d2logdet.clear();
+
+  RefVector<ValueMatrix_t> up_logdet_list, dn_logdet_list;
+  RefVector<GradMatrix_t> up_dlogdet_list, dn_dlogdet_list;
+  RefVector<ValueMatrix_t> up_d2logdet_list, dn_d2logdet_list;
+  up_logdet_list.reserve(nw);
+  dn_logdet_list.reserve(nw);
+  up_dlogdet_list.reserve(nw);
+  dn_dlogdet_list.reserve(nw);
+  up_d2logdet_list.reserve(nw);
+  dn_d2logdet_list.reserve(nw);
+  up_logdet_list.clear();
+  dn_logdet_list.clear();
+  up_dlogdet_list.clear();
+  dn_dlogdet_list.clear();
+  up_d2logdet_list.clear();
+  dn_d2logdet_list.clear();
+
+  ValueMatrix_t tmp_val_mat(nelec, OrbitalSetSize);
+  GradMatrix_t tmp_grad_mat(nelec, OrbitalSetSize);
+  for (int iw = 0; iw < nw; iw++)
+  {
+    SpinorSet& spinor = spo_list.getCastedElement<SpinorSet>(iw);
+    up_spo_list.emplace_back(*(spinor.spo_up));
+    dn_spo_list.emplace_back(*(spinor.spo_dn));
+
+    mw_up_logdet.emplace_back(tmp_val_mat);
+    up_logdet_list.emplace_back(mw_up_logdet.back());
+    mw_dn_logdet.emplace_back(tmp_val_mat);
+    dn_logdet_list.emplace_back(mw_dn_logdet.back());
+
+    mw_up_dlogdet.emplace_back(tmp_grad_mat);
+    up_dlogdet_list.emplace_back(mw_up_dlogdet.back());
+    mw_dn_dlogdet.emplace_back(tmp_grad_mat);
+    dn_dlogdet_list.emplace_back(mw_dn_dlogdet.back());
+
+    mw_up_d2logdet.emplace_back(tmp_val_mat);
+    up_d2logdet_list.emplace_back(mw_up_d2logdet.back());
+    mw_dn_d2logdet.emplace_back(tmp_val_mat);
+    dn_d2logdet_list.emplace_back(mw_dn_d2logdet.back());
+  }
+
+  up_spo_leader.mw_evaluate_notranspose(up_spo_list, P_list, first, last, up_logdet_list, up_dlogdet_list,
+                                        up_d2logdet_list);
+  dn_spo_leader.mw_evaluate_notranspose(dn_spo_list, P_list, first, last, dn_logdet_list, dn_dlogdet_list,
+                                        dn_d2logdet_list);
+
+#pragma omp parallel for
+  for (int iw = 0; iw < nw; iw++)
+  {
+    for (int iat = 0; iat < nelec; iat++)
+    {
+      ParticleSet::Scalar_t s = P_list[iw].activeSpin(iat);
+      RealType coss           = std::cos(s);
+      RealType sins           = std::sin(s);
+      ValueType eis(coss, sins);
+      ValueType emis(coss, -sins);
+
+      for (int no = 0; no < OrbitalSetSize; no++)
+      {
+        logdet_list[iw].get()(iat, no) =
+            eis * up_logdet_list[iw].get()(iat, no) + emis * dn_logdet_list[iw].get()(iat, no);
+        dlogdet_list[iw].get()(iat, no) =
+            eis * up_dlogdet_list[iw].get()(iat, no) + emis * dn_dlogdet_list[iw].get()(iat, no);
+        d2logdet_list[iw].get()(iat, no) =
+            eis * up_d2logdet_list[iw].get()(iat, no) + emis * dn_d2logdet_list[iw].get()(iat, no);
+      }
+    }
+  }
+}
+
 void SpinorSet::evaluate_notranspose_spin(const ParticleSet& P,
                                           int first,
                                           int last,

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -95,6 +95,14 @@ public:
                             GradMatrix_t& dlogdet,
                             ValueMatrix_t& d2logdet) override;
 
+  void mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_list,
+                               const RefVectorWithLeader<ParticleSet>& P_list,
+                               int first,
+                               int last,
+                               const RefVector<ValueMatrix_t>& logdet_list,
+                               const RefVector<GradMatrix_t>& dlogdet_list,
+                               const RefVector<ValueMatrix_t>& d2logdet_list) const override;
+
   void evaluate_notranspose_spin(const ParticleSet& P,
                                  int first,
                                  int last,

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -435,6 +435,26 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 
     elec_.rejectMove(iat);
   }
+
+  // test batched interface
+  ParticleSet elec_2(elec_);
+  // permute electrons
+  elec_2.R[0]     = elec_.R[1];
+  elec_2.R[1]     = elec_.R[2];
+  elec_2.R[2]     = elec_.R[0];
+  elec_2.spins[0] = elec_.spins[1];
+  elec_2.spins[1] = elec_.spins[2];
+  elec_2.spins[2] = elec_.spins[1];
+  RefVectorWithLeader<ParticleSet> p_list(elec_);
+  p_list.push_back(elec_);
+  p_list.push_back(elec_2);
+
+  std::unique_ptr<SPOSet> spo_2(spo->makeClone());
+  RefVectorWithLeader<SPOSet> spo_list(*spo);
+  spo_list.push_back(*spo);
+  spo_list.push_back(*spo_2);
+
+
 }
 #endif //QMC_COMPLEX
 

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -444,7 +444,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   elec_2.R[2]     = elec_.R[0];
   elec_2.spins[0] = elec_.spins[1];
   elec_2.spins[1] = elec_.spins[2];
-  elec_2.spins[2] = elec_.spins[1];
+  elec_2.spins[2] = elec_.spins[0];
   RefVectorWithLeader<ParticleSet> p_list(elec_);
   p_list.push_back(elec_);
   p_list.push_back(elec_2);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -483,10 +483,35 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
     CHECK(logdet_list[0].get()[iat][0] == ComplexApprox(psiM_ref[iat][0]).epsilon(h));
     CHECK(logdet_list[0].get()[iat][1] == ComplexApprox(psiM_ref[iat][1]).epsilon(h));
     CHECK(logdet_list[0].get()[iat][2] == ComplexApprox(psiM_ref[iat][2]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][0][0] == ComplexApprox(dpsiM_ref[iat][0][0]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][0][1] == ComplexApprox(dpsiM_ref[iat][0][1]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][0][2] == ComplexApprox(dpsiM_ref[iat][0][2]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][1][0] == ComplexApprox(dpsiM_ref[iat][1][0]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][1][1] == ComplexApprox(dpsiM_ref[iat][1][1]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][1][2] == ComplexApprox(dpsiM_ref[iat][1][2]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][2][0] == ComplexApprox(dpsiM_ref[iat][2][0]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][2][1] == ComplexApprox(dpsiM_ref[iat][2][1]).epsilon(h));
+    CHECK(dlogdet_list[0].get()[iat][2][2] == ComplexApprox(dpsiM_ref[iat][2][2]).epsilon(h));
+    CHECK(d2logdet_list[0].get()[iat][0] == ComplexApprox(d2psiM_ref[iat][0]).epsilon(h2));
+    CHECK(d2logdet_list[0].get()[iat][1] == ComplexApprox(d2psiM_ref[iat][1]).epsilon(h2));
+    CHECK(d2logdet_list[0].get()[iat][2] == ComplexApprox(d2psiM_ref[iat][2]).epsilon(h2));
+
     //walker 1, permuted from reference
     CHECK(logdet_list[1].get()[iat][0] == ComplexApprox(psiM_ref[(iat + 1) % 3][0]).epsilon(h));
     CHECK(logdet_list[1].get()[iat][1] == ComplexApprox(psiM_ref[(iat + 1) % 3][1]).epsilon(h));
     CHECK(logdet_list[1].get()[iat][2] == ComplexApprox(psiM_ref[(iat + 1) % 3][2]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][0][0] == ComplexApprox(dpsiM_ref[(iat+1) % 3][0][0]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][0][1] == ComplexApprox(dpsiM_ref[(iat+1) % 3][0][1]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][0][2] == ComplexApprox(dpsiM_ref[(iat+1) % 3][0][2]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][1][0] == ComplexApprox(dpsiM_ref[(iat+1) % 3][1][0]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][1][1] == ComplexApprox(dpsiM_ref[(iat+1) % 3][1][1]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][1][2] == ComplexApprox(dpsiM_ref[(iat+1) % 3][1][2]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][2][0] == ComplexApprox(dpsiM_ref[(iat+1) % 3][2][0]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][2][1] == ComplexApprox(dpsiM_ref[(iat+1) % 3][2][1]).epsilon(h));
+    CHECK(dlogdet_list[1].get()[iat][2][2] == ComplexApprox(dpsiM_ref[(iat+1) % 3][2][2]).epsilon(h));
+    CHECK(d2logdet_list[1].get()[iat][0] == ComplexApprox(d2psiM_ref[(iat + 1) % 3][0]).epsilon(h2));
+    CHECK(d2logdet_list[1].get()[iat][1] == ComplexApprox(d2psiM_ref[(iat + 1) % 3][1]).epsilon(h2));
+    CHECK(d2logdet_list[1].get()[iat][2] == ComplexApprox(d2psiM_ref[(iat + 1) % 3][2]).epsilon(h2));
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -18,6 +18,7 @@
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
+#include "Utilities/ResourceCollection.h"
 
 #include <stdio.h>
 #include <string>
@@ -452,9 +453,15 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   elec_2.spins[0] = elec_.spins[1];
   elec_2.spins[1] = elec_.spins[2];
   elec_2.spins[2] = elec_.spins[0];
+
+  ResourceCollection pset_res("test_pset_res");
+  elec_.createResource(pset_res);
+
   RefVectorWithLeader<ParticleSet> p_list(elec_);
   p_list.push_back(elec_);
   p_list.push_back(elec_2);
+
+  ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
 
   std::unique_ptr<SPOSet> spo_2(spo->makeClone());
   RefVectorWithLeader<SPOSet> spo_list(*spo);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -463,6 +463,9 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
 
+  //update all walkers
+  elec_.mw_update(p_list);
+
   std::unique_ptr<SPOSet> spo_2(spo->makeClone());
   RefVectorWithLeader<SPOSet> spo_list(*spo);
   spo_list.push_back(*spo);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This is the first mw_ function in SpinorSet. I wanted to implement this first before following up with the rest of the functions to keep it small and easier to review. 

This implements mw_evaluate_notranspose. Since a SpinorSet has unique_ptr<SPOSet> for both up and down SPOSets, in order to utilize the batched evaluations for the individual spin components I had to form intermediate reference vectors. After these are formed, I simply can call mw_evaluate_notranspose for each of the spin components. Afterwards, I finish up by reconstructing the spinors from the spin components. 

Unit test is updated, I simply add a second walker by permuting the  electrons in the original particleset so that I can use the same reference data. 

This will be one of the needed PRs to close #3712 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOSX

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
