### PR TITLE
set active spin val in mw_makeMove

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -451,8 +451,8 @@ void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
 
   for (int iw = 0; iw < p_list.size(); iw++)
   {
-    p_list[iw].active_ptcl_ = iat;
-    p_list[iw].active_pos_  = p_list[iw].R[iat] + displs[iw];
+    p_list[iw].active_ptcl_     = iat;
+    p_list[iw].active_pos_      = p_list[iw].R[iat] + displs[iw];
     p_list[iw].active_spin_val_ = p_list[iw].spins[iat];
     new_positions.push_back(p_list[iw].active_pos_);
   }

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -453,6 +453,7 @@ void ParticleSet::mw_makeMove(const RefVectorWithLeader<ParticleSet>& p_list,
   {
     p_list[iw].active_ptcl_ = iat;
     p_list[iw].active_pos_  = p_list[iw].R[iat] + displs[iw];
+    p_list[iw].active_spin_val_ = p_list[iw].spins[iat];
     new_positions.push_back(p_list[iw].active_pos_);
   }
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

fixes a small bug in particle set for mw_makeMove. active_spin_val_ needs to be set to the current spin, just like how it is done for the single walker API.  noticed while making a unit test for a coming PR. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOSX

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
