### PR TITLE
Nexus: Harden Nexus excitation checks

### DIFF
--- a/nexus/lib/qmcpack.py
+++ b/nexus/lib/qmcpack.py
@@ -582,7 +582,12 @@ class Qmcpack(Simulation):
                         # einspline orbital ordering for excited state
                         excited = excited[:nelec]
                         # hand-crafted orbital order for excited state
-                        hc_excited = np.array(list(ground[:orb1-1])+[ground[orb2-1]]+list(ground[orb1:nelec]))
+
+                        # ground can be list or ndarray, but we'll convert it to list
+                        # so we can concatenate with list syntax
+                        ground = np.asarray(ground).tolist()
+                        # After concatenating, convert back to ndarray
+                        hc_excited = np.array(ground[:orb1-1]+[ground[orb2-1]]+ground[orb1:nelec])
                             
                         etol = 1e-6
                         if np.abs(hc_excited-excited).max() > etol:


### PR DESCRIPTION
## Proposed changes

For the excitation checks in Nexus, add a bit of hardening such that the bahavior is the same regardless of whether the orbital data structure is a list or ndarray 

## What type(s) of changes does this code introduce?

- Code hardening

### Does this introduce a breaking change?

- No. All nxs-test tests pass

## What systems has this change been tested on?

Laptop, linux

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
