### PR TITLE
Use standard check for python library instead of HAVE_PYSCF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,8 +1016,10 @@ include(python)
 # Check if PySCF is available
 #-------------------------------------------------------------------
 if(NOT QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
-  test_python_module(pyscf HAVE_PYSCF)
-  if(NOT HAVE_PYSCF)
+  if(NOT DEFINED HAS_PYSCF_PYTHON_MODULE)
+    test_python_module(pyscf HAS_PYSCF_PYTHON_MODULE)
+  endif()
+  if(NOT ${HAS_PYSCF_PYTHON_MODULE})
     message(STATUS "Unable to import PySCF python module. PySCF tests will not be run.")
   else()
     message(STATUS "Successfully imported PySCF python module.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,10 +1016,8 @@ include(python)
 # Check if PySCF is available
 #-------------------------------------------------------------------
 if(NOT QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
-  if(NOT DEFINED HAS_PYSCF_PYTHON_MODULE)
-    test_python_module(pyscf HAS_PYSCF_PYTHON_MODULE)
-  endif()
-  if(NOT ${HAS_PYSCF_PYTHON_MODULE})
+  check_python_reqs(pyscf "" HAVE_PYSCF)
+  if(NOT ${HAVE_PYSCF})
     message(STATUS "Unable to import PySCF python module. PySCF tests will not be run.")
   else()
     message(STATUS "Successfully imported PySCF python module.")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,10 +55,10 @@ if(BUILD_AFQMC)
   endif()
 endif()
 
-if(HAVE_PYSCF)
+if(HAS_PYSCF_PYTHON_MODULE)
   if(NOT QMC_COMPLEX)
     include("${qmcpack_SOURCE_DIR}/CMake/python.cmake")
-    check_python_reqs("numpy;h5py;pyscf;PyscfToQmcpack;PyscfToQmcpack_Spline" pyscf_workflow add_tests)
+    check_python_reqs("numpy;h5py;PyscfToQmcpack;PyscfToQmcpack_Spline" pyscf_workflow add_tests)
 
     if(add_tests)
       message("Python dependencies met. Adding PySCF workflow tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_AFQMC)
   endif()
 endif()
 
-if(HAS_PYSCF_PYTHON_MODULE)
+if(HAVE_PYSCF)
   if(NOT QMC_COMPLEX)
     include("${qmcpack_SOURCE_DIR}/CMake/python.cmake")
     check_python_reqs("numpy;h5py;PyscfToQmcpack;PyscfToQmcpack_Spline" pyscf_workflow add_tests)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

CMake code setting `HAVE_PYSCF` duplicates a check already done by `check_python_reqs`, but doesn't cache the result.

time cmake -G Ninja -DQMC_MPI=OFF ../

before:

(first run)
real	0m25.307s
user	0m32.837s
sys	0m30.663s

(second run)
real	0m5.391s
user	0m6.922s
sys	0m7.153s

after:

(first run)
real	0m24.239s
user	0m32.839s
sys	0m30.728s

(second run)
real	0m4.410s
user	0m6.521s
sys	0m7.020s

Part of #2227

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'

