### PR TITLE
Remove TOKEN logging from EinsplineSet

### DIFF
--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -312,15 +312,6 @@ public:
    * @return true, if core is found
    */
   bool bcastSortBands(int splin, int N, bool root);
-
-  int MyToken;
-  inline void update_token(const char* f, int l, const char* msg)
-  {
-    app_debug() << "TOKEN=" << MyToken << " " << msg << " " << f << " " << l << std::endl;
-    MyToken++;
-  }
-  //inline void update_token(const char* f, int l, const char* msg)
-  //{}
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -61,7 +61,6 @@ EinsplineSetBuilder::EinsplineSetBuilder(ParticleSet& p, const PtclPoolType& pse
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       TileMatrix(i, j) = 0;
-  MyToken = 0;
 
   //invalidate states by the basis class
   states.clear();
@@ -94,8 +93,6 @@ EinsplineSetBuilder::~EinsplineSetBuilder()
 
 bool EinsplineSetBuilder::CheckLattice()
 {
-  update_token(__FILE__, __LINE__, "CheckLattice");
-
   double diff = 0.0;
   for (int i = 0; i < OHMMS_DIM; i++)
     for (int j = 0; j < OHMMS_DIM; j++)
@@ -316,8 +313,6 @@ void EinsplineSetBuilder::BroadcastOrbitalInfo()
 
 void EinsplineSetBuilder::TileIons()
 {
-  update_token(__FILE__, __LINE__, "TileIons");
-
   //set the primitive lattice
   SourcePtcl->PrimitiveLattice.set(Lattice);
 
@@ -659,7 +654,6 @@ void EinsplineSetBuilder::AnalyzeTwists2()
 void
 EinsplineSetBuilder::AnalyzeTwists()
 {
-  update_token(__FILE__,__LINE__,"AnalyzeTwists");
   PosType minTwist(TwistAngles[0]), maxTwist(TwistAngles[0]);
   for (int ti=0; ti<NumTwists; ti++)
     for (int i=0; i<3; i++)
@@ -772,7 +766,6 @@ EinsplineSetBuilder::AnalyzeTwists()
 
 void EinsplineSetBuilder::OccupyBands(int spin, int sortBands, int numOrbs, bool skipChecks)
 {
-  update_token(__FILE__, __LINE__, "OccupyBands");
   if (myComm->rank() != 0)
     return;
   if (spin >= NumSpins && !skipChecks)

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -41,7 +41,6 @@ bool sortByIndex(BandInfo leftB, BandInfo rightB)
 
 bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
 {
-  update_token(__FILE__, __LINE__, "ReadOrbitalInfo_ESHDF");
   app_log() << "  Reading orbital file in ESHDF format.\n";
   HDFAttribIO<TinyVector<int, 3>> h_version(Version);
   h_version.read(H5FileID, "/version");
@@ -420,7 +419,6 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
 
 void EinsplineSetBuilder::OccupyBands_ESHDF(int spin, int sortBands, int numOrbs)
 {
-  update_token(__FILE__, __LINE__, "OccupyBands_ESHDF");
   if (myComm->rank() != 0)
     return;
 
@@ -660,7 +658,6 @@ void EinsplineSetBuilder::OccupyBands_ESHDF(int spin, int sortBands, int numOrbs
 /** TODO: FIXME RotateBands_ESHDF need psi_r */
 void EinsplineSetBuilder::RotateBands_ESHDF (int spin, EinsplineSetExtended<std::complex<double > >* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"RotateBands_ESHDF:complex");
   bool root = (myComm->rank()==0);
   if (root)
   {
@@ -836,7 +833,6 @@ void EinsplineSetBuilder::RotateBands_ESHDF (int spin, EinsplineSetExtended<std:
 
 void EinsplineSetBuilder::RotateBands_ESHDF (int spin, EinsplineSetExtended<double>* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"RotateBands_ESHDF:double");
   bool root = (myComm->rank()==0);
   if (root)
   {

--- a/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderOld.cpp
@@ -30,7 +30,6 @@ namespace qmcplusplus
 {
 bool EinsplineSetBuilder::ReadOrbitalInfo(bool skipChecks)
 {
-  update_token(__FILE__, __LINE__, "ReadOrbitalInfo");
   // Handle failed file open gracefully by temporarily replacing error handler
   H5E_auto2_t old_efunc;
   void* old_efunc_data;
@@ -258,7 +257,6 @@ void
 EinsplineSetBuilder::ReadBands
 (int spin, EinsplineSetExtended<std::complex<double> >* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"ReadBands:complex");
   bool root = myComm->rank()==0;
   //bcastwith other stuff
   myComm->bcast(NumDistinctOrbitals);
@@ -508,7 +506,6 @@ void
 EinsplineSetBuilder::ReadBands
 (int spin, EinsplineSetExtended<double>* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"ReadBands:double");
   std::vector<BandInfo>& SortBands(*FullBands[spin]);
   bool root = myComm->rank()==0;
   // bcast other stuff

--- a/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderReadBands_ESHDF.cpp
@@ -24,7 +24,6 @@ namespace qmcplusplus
 #if 0
 void EinsplineSetBuilder::ReadBands_ESHDF(int spin, EinsplineSetExtended<std::complex<double > >* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"ReadBands_ESHDF:complex");
   ReportEngine PRE("EinsplineSetBuilder","ReadBands_ESHDF(EinsplineSetExtended<std::complex<double > >*");
   Timer c_prep, c_unpack,c_fft, c_phase, c_spline, c_newphase, c_h5, c_init;
   double t_prep=0.0, t_unpack=0.0, t_fft=0.0, t_phase=0.0, t_spline=0.0, t_newphase=0.0, t_h5=0.0, t_init=0.0;
@@ -299,7 +298,6 @@ void EinsplineSetBuilder::ReadBands_ESHDF(int spin, EinsplineSetExtended<std::co
 
 void EinsplineSetBuilder::ReadBands_ESHDF(int spin, EinsplineSetExtended<double>* orbitalSet)
 {
-  update_token(__FILE__,__LINE__,"ReadBands_ESHDF:double");
   ReportEngine PRE("EinsplineSetBuilder","ReadBands_ESHDF(EinsplineSetExtended<double>*");
   std::vector<AtomicOrbital<double> > realOrbs(AtomicOrbitals.size());
   for (int iat=0; iat<realOrbs.size(); iat++)
@@ -668,7 +666,6 @@ void EinsplineSetBuilder::ReadBands_ESHDF(int spin, EinsplineSetExtended<double>
 
 bool EinsplineSetBuilder::ReadGvectors_ESHDF()
 {
-  update_token(__FILE__, __LINE__, "ReadGvectors_ESHDF");
   bool root = myComm->rank() == 0;
   //this is always ugly
   MeshSize    = 0;

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -108,7 +108,6 @@ void EinsplineSetBuilder::set_metadata(int numOrbs, int TwistNum_inp, bool skipC
 
 std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
-  update_token(__FILE__, __LINE__, "createSPOSetFromXML");
   //use 2 bohr as the default when truncated orbitals are used based on the extend of the ions
   int numOrbs = 0;
   int sortBands(1);
@@ -467,8 +466,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 
 std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input_info)
 {
-  update_token(__FILE__, __LINE__, "createSPOSet(cur,input_info)");
-
   if (MixedSplineReader == 0)
     myComm->barrier_and_abort("EinsplineSetExtended<T> cannot create a SPOSet");
 

--- a/src/QMCWaveFunctions/einspline_helper.hpp
+++ b/src/QMCWaveFunctions/einspline_helper.hpp
@@ -399,8 +399,6 @@ inline void fix_phase_rotate(const Array<std::complex<T>, 3>& e2pi,
 
 inline bool EinsplineSetBuilder::bcastSortBands(int spin, int n, bool root)
 {
-  update_token(__FILE__, __LINE__, "bcastSortBands");
-
   std::vector<BandInfo>& SortBands(*FullBands[spin]);
 
   TinyVector<int, 4> nbands(int(SortBands.size()), n, NumValenceOrbs, NumCoreOrbs);


### PR DESCRIPTION
## Proposed changes

Removes the developer-focused logging from EinsplineSet. This wrote TOKEN, a comment, and source code file info on the standard QMCPACK output. The output already includes sufficient output and likely errors are already appropriately trapped.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Sulfur, gcc+mpi+mkl.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
