### PR TITLE
Add diamondC_1x1x1_pp/qmc_short_optbatch test

### DIFF
--- a/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/diamondC_1x1x1_pp/CMakeLists.txt
@@ -95,6 +95,18 @@ qmc_run_and_check(
   DIAMOND_OPT_SCALARS # VMC
 )
 
+qmc_run_and_check(
+  short-diamondC_1x1x1_pp-optbatch_sdj
+  "${qmcpack_SOURCE_DIR}/tests/solids/diamondC_1x1x1_pp"
+  qmc_short
+  qmc_short_optbatch.in.xml
+  1
+  3
+  ${SUCCESS_STATUS_MP}
+  3
+  DIAMOND_OPT_SCALARS # VMC
+)
+
 # Reference DMC run in qmc-ref "-10.531583 0.000265"
 list(APPEND DIAMOND_DMC_SCALARS "totenergy" "-10.5316 0.0024")
 list(APPEND DIAMOND_DMC_SCALARS "kinetic" "11.4857 0.0231")

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
@@ -82,16 +82,15 @@
    </qmcsystem>
 
 <loop max="4">
-  <qmc method="linear" move="pbyp" checkpoint="-1" gpu="yes">
-      <parameter name="walkers"             >    16              </parameter>
+  <qmc method="linear_batch" move="pbyp" checkpoint="-1" gpu="yes">
+      <parameter name="walkers_per_rank"    >    16              </parameter>
       <parameter name="blocks"              >    100            </parameter>
-      <!--parameter name="steps"               >    40             </parameter-->
+      <parameter name="steps"               >    80             </parameter>
       <parameter name="subSteps"            >    2               </parameter>
       <parameter name="timestep"            >    0.5             </parameter>
       <parameter name="warmupSteps"         >    50             </parameter>
       <parameter name="useDrift"            >    no              </parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="samples"             >    128000          </parameter>
       <parameter name="nonlocalpp"          >    no              </parameter>
       <parameter name="MinMethod"           >    OneShiftOnly </parameter>
          <cost name="energy">                   0.95 </cost>


### PR DESCRIPTION
## Proposed changes
Add a linear_batch short test mirroring the non-batched driver test. Everything is good so far.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
