### PR TITLE
Update timer and Summit recipe.

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -133,15 +133,6 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64" OR CMAKE_SYSTEM_PROCESSOR MATCHES 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=native")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
   endif() #(CMAKE_CXX_FLAGS MATCHES "-mcpu=" OR CMAKE_C_FLAGS MATCHES "-mcpu=")
-
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64")
-    # Ensure PowerPC builds include optimization flags in release and release-with-debug builds
-    # Otherwise these are missing (2020-06-22)
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -DNDEBUG")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG")
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O3 -DNDEBUG")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -DNDEBUG")
-  endif()
 endif()
 
 # Add static flags if necessary

--- a/config/build_olcf_summit_Clang.sh
+++ b/config/build_olcf_summit_Clang.sh
@@ -12,8 +12,7 @@ module load gcc/9.3.0
 module load spectrum-mpi
 module load cmake
 module load git
-# default cuda/11.0.3 causes frequent hanging with the offload code in production runs.
-module load cuda/10.1.243
+module load cuda/11.0.3
 module load essl
 module load netlib-lapack
 module load hdf5
@@ -26,8 +25,7 @@ if [[ ! -d /ccs/proj/mat151/opt/modules ]] ; then
   exit 1
 fi
 module use /ccs/proj/mat151/opt/modules
-# requires cuda/10.1.243 to have safe production runs.
-module load llvm/main-20210811-cuda10.1
+module load llvm/main-20220119-cuda11.0
 
 TYPE=Release
 Compiler=Clang
@@ -49,7 +47,7 @@ for name in offload_cuda_real_MP offload_cuda_real offload_cuda_cplx_MP offload_
             cpu_real_MP cpu_real cpu_cplx_MP cpu_cplx
 do
 
-CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$TYPE -DQMC_MATH_VENDOR=IBM_MASS -DMASS_ROOT=/sw/summit/xl/16.1.1-10/xlmass/9.1.1 -DMPIEXEC_EXECUTABLE=`which jsrun` -DMPIEXEC_NUMPROC_FLAG='-n' -DMPIEXEC_PREFLAGS='-c;16;-g;1;-b;packed:16;--smpiargs=off' -DCMAKE_CXX_STANDARD_LIBRARIES=/sw/summit/gcc/9.3.0-2/lib64/libstdc++.a"
+CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$TYPE -DQMC_MATH_VENDOR=IBM_MASS -DMASS_ROOT=/sw/summit/xl/16.1.1-10/xlmass/9.1.1 -DMPIEXEC_EXECUTABLE=`which jsrun` -DMPIEXEC_NUMPROC_FLAG='-n' -DMPIEXEC_PREFLAGS='-c;16;-g;1;-b;packed:16;--smpiargs=off'"
 
 if [[ $name == *"cplx"* ]]; then
   CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_COMPLEX=ON"
@@ -64,8 +62,7 @@ if [[ $name == *"offload"* ]]; then
 fi
 
 if [[ $name == *"cuda"* ]]; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=70 -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++"
-  CUDA_FLAGS="-Xcompiler -mno-float128"
+  CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=70 -DCMAKE_CUDA_HOST_COMPILER=`which g++`"
 fi
 
 folder=build_summit_${Compiler}_${name}
@@ -76,8 +73,7 @@ echo "**********************************"
 mkdir $folder
 cd $folder
 if [ ! -f CMakeCache.txt ] ; then
-cmake $CMAKE_FLAGS -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_CUDA_FLAGS="$CUDA_FLAGS" $source_folder
-cmake .
+cmake $CMAKE_FLAGS -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx $source_folder
 fi
 make -j16
 cd ..

--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -35,15 +35,14 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),
 #endif
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAA::evaluate_") + target.getName() +
-                                                       "_" + target.getName(),
-                                                   timer_level_fine)),
-        move_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAA::move_") + target.getName() + "_" +
-                                                   target.getName(),
+        evaluate_timer_(
+            *timer_manager.createTimer(std::string("DTAA::evaluate_") + target.getName() + "_" + target.getName(),
+                                       timer_level_fine)),
+        move_timer_(*timer_manager.createTimer(std::string("DTAA::move_") + target.getName() + "_" + target.getName(),
                                                timer_level_fine)),
-        update_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAA::update_") + target.getName() + "_" +
-                                                     target.getName(),
-                                                 timer_level_fine))
+        update_timer_(
+            *timer_manager.createTimer(std::string("DTAA::update_") + target.getName() + "_" + target.getName(),
+                                       timer_level_fine))
   {
     resize();
   }

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -66,14 +66,10 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),
 #endif
-        offload_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::offload_") + name_, timer_level_fine)),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::evaluate_") + name_,
-                                                   timer_level_fine)),
-        move_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::move_") + name_, timer_level_fine)),
-        update_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableAAOMPTarget::update_") + name_, timer_level_fine))
+        offload_timer_(*timer_manager.createTimer(std::string("DTAAOMPTarget::offload_") + name_, timer_level_fine)),
+        evaluate_timer_(*timer_manager.createTimer(std::string("DTAAOMPTarget::evaluate_") + name_, timer_level_fine)),
+        move_timer_(*timer_manager.createTimer(std::string("DTAAOMPTarget::move_") + name_, timer_level_fine)),
+        update_timer_(*timer_manager.createTimer(std::string("DTAAOMPTarget::update_") + name_, timer_level_fine))
 
   {
     auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&target.getCoordinates());

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -28,15 +28,14 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
   SoaDistanceTableAB(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.getLattice()),
         DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAB::evaluate_") + target.getName() +
-                                                       "_" + source.getName(),
-                                                   timer_level_fine)),
-        move_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAB::move_") + target.getName() + "_" +
-                                                   source.getName(),
+        evaluate_timer_(
+            *timer_manager.createTimer(std::string("DTAB::evaluate_") + target.getName() + "_" + source.getName(),
+                                       timer_level_fine)),
+        move_timer_(*timer_manager.createTimer(std::string("DTAB::move_") + target.getName() + "_" + source.getName(),
                                                timer_level_fine)),
-        update_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableAB::update_") + target.getName() + "_" +
-                                                     source.getName(),
-                                                 timer_level_fine))
+        update_timer_(
+            *timer_manager.createTimer(std::string("DTAB::update_") + target.getName() + "_" + source.getName(),
+                                       timer_level_fine))
   {
     resize();
   }

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -120,14 +120,10 @@ public:
   SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.getLattice()),
         DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
-        offload_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::offload_") + name_, timer_level_fine)),
-        evaluate_timer_(*timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::evaluate_") + name_,
-                                                   timer_level_fine)),
-        move_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::move_") + name_, timer_level_fine)),
-        update_timer_(
-            *timer_manager.createTimer(std::string("SoaDistanceTableABOMPTarget::update_") + name_, timer_level_fine))
+        offload_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::offload_") + name_, timer_level_fine)),
+        evaluate_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::evaluate_") + name_, timer_level_fine)),
+        move_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::move_") + name_, timer_level_fine)),
+        update_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::update_") + name_, timer_level_fine))
 
   {
     auto* coordinates_soa = dynamic_cast<const RealSpacePositionsOMPTarget*>(&source.getCoordinates());


### PR DESCRIPTION
## Proposed changes

The source code change is to make timer names more brief.

Update Summit recipe with up-to-date Clang and CUDA 11. Previously older versions of Clang may hang offload code at execution when CUDA 11 was used. This issue has been addressed in upstream and next clang 14 release (Feb) will be problem free.

Remove CMake workaround as the default installation 3.21.3 on Summit doesn't need it.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Summit

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'