### PR TITLE
Add SANDBOX_ONLY configuration to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -23,6 +23,7 @@ jobs:
             GCC9-NoMPI-Debug-Real,
             GCC9-NoMPI-NoOMP-Real,
             GCC9-NoMPI-NoOMP-Complex,
+            GCC9-NoMPI-Sandbox-Real,
             GCC9-MPI-Gcov-Real,
             GCC9-MPI-Gcov-Complex,
             GCC11-NoMPI-Werror-Real,
@@ -44,6 +45,11 @@ jobs:
               options: -u 1001
 
           - jobname: GCC9-NoMPI-NoOMP-Complex
+            container:
+              image: williamfgc/qmcpack-ci:ubuntu20-openmpi
+              options: -u 1001
+
+          - jobname: GCC9-NoMPI-Sandbox-Real
             container:
               image: williamfgc/qmcpack-ci:ubuntu20-openmpi
               options: -u 1001

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -79,6 +79,17 @@ case "$1" in
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ${GITHUB_WORKSPACE}
       ;;
+      *"GCC9-NoMPI-Sandbox-"*)
+        echo 'Configure for enabling sandbox (minimal) only option with gcc'
+        cmake -GNinja \
+              -DCMAKE_C_COMPILER=gcc \
+              -DCMAKE_CXX_COMPILER=g++ \
+              -DQMC_MPI=0 \
+              -DQMC_BUILD_SANDBOX_ONLY=ON \
+              -DQMC_COMPLEX=$IS_COMPLEX \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              ${GITHUB_WORKSPACE}
+      ;;
       *"GCC9-MPI-Gcov-"*)
         echo 'Configure for code coverage with gcc and gcovr -DENABLE_GCOV=TRUE and upload reports to Codecov'
         cmake -GNinja \


### PR DESCRIPTION
## Proposed changes
Adds small footprint sandbox configuration `-DQMC_BUILD_SANDBOX_ONLY=ON` to GitHub Actions CI
Fixes #3743 

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests) CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
