### PR TITLE
Move KLists from StructureFactor to SimulationCell.

### DIFF
--- a/src/Particle/LongRange/EwaldHandler.cpp
+++ b/src/Particle/LongRange/EwaldHandler.cpp
@@ -40,7 +40,7 @@ void EwaldHandler::initBreakup(ParticleSet& ref)
     PreFactors[1] = 2.0 * std::sqrt(M_PI) / (Sigma * Area); //\f$  \frac{2\pi}{A}\frac{1}{Sigma\pi}\f$
     PreFactors[2] = 1.0 / (2 * Sigma);                      //Used for the k-dependent term
   }
-  fillFk(ref.getSK().getKLists());
+  fillFk(ref.getSimulationCell().getKLists());
 }
 
 EwaldHandler::EwaldHandler(const EwaldHandler& aLR, ParticleSet& ref)

--- a/src/Particle/LongRange/EwaldHandler3D.cpp
+++ b/src/Particle/LongRange/EwaldHandler3D.cpp
@@ -40,9 +40,9 @@ void EwaldHandler3D::initBreakup(ParticleSet& ref)
   app_log() << "  Sigma=" << Sigma << std::endl;
   Volume     = ref.getLattice().Volume;
   PreFactors = 0.0;
-  fillFk(ref.getSK().getKLists());
-  fillYkgstrain(ref.getSK().getKLists());
-  filldFk_dk(ref.getSK().getKLists());
+  fillFk(ref.getSimulationCell().getKLists());
+  fillYkgstrain(ref.getSimulationCell().getKLists());
+  filldFk_dk(ref.getSimulationCell().getKLists());
 }
 
 EwaldHandler3D::EwaldHandler3D(const EwaldHandler3D& aLR, ParticleSet& ref)

--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -189,7 +189,7 @@ struct LRHandlerBase
 #if !defined(USE_REAL_STRUCT_FACTOR)
     const Matrix<pComplexType>& e2ikrA = A.getSK().eikr;
     const pComplexType* rhokB          = B.getSK().rhok[specB];
-    const std::vector<PosType>& kpts   = A.getSK().getKLists().kpts_cart;
+    const std::vector<PosType>& kpts   = A.getSimulationCell().getKLists().kpts_cart;
     for (int ki = 0; ki < Fk.size(); ki++)
     {
       PosType k = kpts[ki];
@@ -205,7 +205,7 @@ struct LRHandlerBase
     const Matrix<pRealType>& e2ikrA_i = A.getSK().eikr_i;
     const pRealType* rhokB_r          = B.getSK().rhok_r[specB];
     const pRealType* rhokB_i          = B.getSK().rhok_i[specB];
-    const std::vector<PosType>& kpts  = A.getSK().getKLists().kpts_cart;
+    const std::vector<PosType>& kpts  = A.getSimulationCell().getKLists().kpts_cart;
     for (int ki = 0; ki < Fk.size(); ki++)
     {
       PosType k = kpts[ki];
@@ -306,7 +306,7 @@ struct DummyLRHandler : public LRHandlerBase
   {
     mRealType norm = 4.0 * M_PI / ref.getLattice().Volume;
     mRealType kcsq = LR_kc * LR_kc;
-    auto& KList(ref.getSK().getKLists());
+    auto& KList(ref.getSimulationCell().getKLists());
     int maxshell = KList.kshell.size() - 1;
     const auto& kk(KList.ksq);
     int ksh = 0, ik = 0;

--- a/src/Particle/LongRange/LRHandlerSRCoulomb.h
+++ b/src/Particle/LongRange/LRHandlerSRCoulomb.h
@@ -88,10 +88,10 @@ public:
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.getLRBox(), 1);
-    //    fillYk(ref.getSK().getKLists());
-    fillYkg(ref.getSK().getKLists());
+    //    fillYk(ref.getSimulationCell().getKLists());
+    fillYkg(ref.getSimulationCell().getKLists());
     //This is expensive to calculate.  Deprecating stresses for now.
-    //filldFk_dk(ref.getSK().getKLists());
+    //filldFk_dk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -100,10 +100,10 @@ public:
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.getLRBox(), 1);
-    //    fillYk(ref.getSK().getKLists());
-    fillYkg(ref.getSK().getKLists());
+    //    fillYk(ref.getSimulationCell().getKLists());
+    fillYkg(ref.getSimulationCell().getKLists());
     //This is expensive to calculate.  Deprecating stresses for now.
-    //filldFk_dk(ref.getSK().getKLists());
+    //filldFk_dk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 

--- a/src/Particle/LongRange/LRHandlerTemp.h
+++ b/src/Particle/LongRange/LRHandlerTemp.h
@@ -73,7 +73,7 @@ public:
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.getLRBox())
   {
     myFunc.reset(ref);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override
@@ -84,7 +84,7 @@ public:
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.getLRBox(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -94,7 +94,7 @@ public:
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.getLRBox(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 

--- a/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPABFeeHandlerTemp.h
@@ -71,7 +71,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.getLattice())
   {
     myFunc.reset(ref);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override
@@ -82,7 +82,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.getLattice(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -92,7 +92,7 @@ struct LRRPABFeeHandlerTemp : public LRHandlerBase
     rs = rs_ext;
     myFunc.reset(ref, rs);
     InitBreakup(ref.getLattice(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 

--- a/src/Particle/LongRange/LRRPAHandlerTemp.h
+++ b/src/Particle/LongRange/LRRPAHandlerTemp.h
@@ -71,7 +71,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
       : LRHandlerBase(aLR), FirstTime(true), Basis(aLR.Basis, ref.getLattice())
   {
     myFunc.reset(ref);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
   }
 
   LRHandlerBase* makeClone(ParticleSet& ref) const override
@@ -82,7 +82,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
   void initBreakup(ParticleSet& ref) override
   {
     InitBreakup(ref.getLattice(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 
@@ -95,7 +95,7 @@ struct LRRPAHandlerTemp : public LRHandlerBase
       rs = std::pow(3.0 / 4.0 / M_PI * ref.getLattice().Volume / static_cast<mRealType>(ref.getTotalNum()), 1.0 / 3.0);
     myFunc.reset(ref, rs);
     InitBreakup(ref.getLattice(), 1);
-    fillFk(ref.getSK().getKLists());
+    fillFk(ref.getSimulationCell().getKLists());
     LR_rc = Basis.get_rc();
   }
 

--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -23,10 +23,10 @@
 namespace qmcplusplus
 {
 //Constructor - pass arguments to k_lists_' constructor
-StructFact::StructFact(int nptcls, int ns, const ParticleLayout& lattice, RealType kc)
+StructFact::StructFact(int nptcls, int ns, const ParticleLayout& lattice, const KContainer& k_lists)
     : DoUpdate(false),
       SuperCellEnum(SUPERCELL_BULK),
-      k_lists_(std::make_shared<KContainer>()),
+      k_lists_(k_lists),
       num_ptcls(nptcls),
       num_species(ns),
       StorePerParticle(false),
@@ -38,19 +38,11 @@ StructFact::StructFact(int nptcls, int ns, const ParticleLayout& lattice, RealTy
     SuperCellEnum = SUPERCELL_SLAB;
   }
 
-  updateNewCell(lattice, kc);
+  resize(k_lists_.numk);
 }
 
 //Destructor
 StructFact::~StructFact() = default;
-
-void StructFact::updateNewCell(const ParticleLayout& lattice, RealType kc)
-{
-  //Generate the lists of k-vectors
-  k_lists_->updateKLists(lattice, kc);
-  //resize any array
-  resize(k_lists_->numk);
-}
 
 void StructFact::resize(int nkpts)
 {
@@ -98,7 +90,7 @@ void StructFact::computeRhok(const ParticleSet& P)
   rhok_r = 0.0;
   rhok_i = 0.0;
   //algorithmA
-  const int nk = k_lists_->numk;
+  const int nk = k_lists_.numk;
   if (StorePerParticle)
   {
     // save per particle and species value
@@ -112,7 +104,7 @@ void StructFact::computeRhok(const ParticleSet& P)
 #pragma omp simd
       for (int ki = 0; ki < nk; ki++)
       {
-        qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], pos), &eikr_i_ptr[ki], &eikr_r_ptr[ki]);
+        qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], pos), &eikr_i_ptr[ki], &eikr_r_ptr[ki]);
         rhok_r_ptr[ki] += eikr_r_ptr[ki];
         rhok_i_ptr[ki] += eikr_i_ptr[ki];
       }
@@ -131,13 +123,13 @@ void StructFact::computeRhok(const ParticleSet& P)
       for (int ki = 0; ki < nk; ki++)
       {
         RealType s, c;
-        qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], pos), &s, &c);
+        qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], pos), &s, &c);
         rhok_r_ptr[ki] += c;
         rhok_i_ptr[ki] += s;
       }
 #else
       for (int ki = 0; ki < nk; ki++)
-        phiV[ki] = dot(k_lists_->kpts_cart[ki], pos);
+        phiV[ki] = dot(k_lists_.kpts_cart[ki], pos);
       eval_e2iphi(nk, phiV.data(), eikr_r_temp.data(), eikr_i_temp.data());
       for (int ki = 0; ki < nk; ki++)
       {
@@ -155,9 +147,9 @@ void StructFact::computeRhok(const ParticleSet& P)
     RealType s, c; //get sin and cos
     ComplexType* restrict eikr_ref = eikr[i];
     ComplexType* restrict rhok_ref = rhok[P.getGroupID(i)];
-    for (int ki = 0; ki < k_lists_->numk; ki++)
+    for (int ki = 0; ki < k_lists_.numk; ki++)
     {
-      qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], pos), &s, &c);
+      qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], pos), &s, &c);
       eikr_ref[ki] = ComplexType(c, s);
       rhok_ref[ki] += eikr_ref[ki];
     }
@@ -170,13 +162,13 @@ void StructFact::makeMove(int active, const PosType& pos)
 {
 #if defined(USE_REAL_STRUCT_FACTOR)
 #pragma omp simd
-  for (int ki = 0; ki < k_lists_->numk; ki++)
-    qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], pos), &eikr_i_temp[ki], &eikr_r_temp[ki]);
+  for (int ki = 0; ki < k_lists_.numk; ki++)
+    qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], pos), &eikr_i_temp[ki], &eikr_r_temp[ki]);
 #else
   RealType s, c; //get sin and cos
-  for (int ki = 0; ki < k_lists_->numk; ++ki)
+  for (int ki = 0; ki < k_lists_.numk; ++ki)
   {
-    qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], pos), &s, &c);
+    qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], pos), &s, &c);
     eikr_temp[ki] = ComplexType(c, s);
   }
 #endif
@@ -191,7 +183,7 @@ void StructFact::acceptMove(int active, int gid, const PosType& rold)
     RealType* restrict eikr_ptr_i = eikr_i[active];
     RealType* restrict rhok_ptr_r(rhok_r[gid]);
     RealType* restrict rhok_ptr_i(rhok_i[gid]);
-    for (int ki = 0; ki < k_lists_->numk; ++ki)
+    for (int ki = 0; ki < k_lists_.numk; ++ki)
     {
       rhok_ptr_r[ki] += (eikr_r_temp[ki] - eikr_ptr_r[ki]);
       rhok_ptr_i[ki] += (eikr_i_temp[ki] - eikr_ptr_i[ki]);
@@ -206,10 +198,10 @@ void StructFact::acceptMove(int active, int gid, const PosType& rold)
 
 // add the new value and subtract the old value
 #pragma omp simd
-    for (int ki = 0; ki < k_lists_->numk; ++ki)
+    for (int ki = 0; ki < k_lists_.numk; ++ki)
     {
       RealType s, c;
-      qmcplusplus::sincos(dot(k_lists_->kpts_cart[ki], rold), &s, &c);
+      qmcplusplus::sincos(dot(k_lists_.kpts_cart[ki], rold), &s, &c);
       rhok_ptr_r[ki] += eikr_r_temp[ki] - c;
       rhok_ptr_i[ki] += eikr_i_temp[ki] - s;
     }
@@ -217,7 +209,7 @@ void StructFact::acceptMove(int active, int gid, const PosType& rold)
 #else
   ComplexType* restrict eikr_ptr = eikr[active];
   ComplexType* restrict rhok_ptr(rhok[gid]);
-  for (int ki = 0; ki < k_lists_->numk; ++ki)
+  for (int ki = 0; ki < k_lists_.numk; ++ki)
   {
     rhok_ptr[ki] += (eikr_temp[ki] - eikr_ptr[ki]);
     eikr_ptr[ki] = eikr_temp[ki];
@@ -237,8 +229,8 @@ void StructFact::turnOnStorePerParticle(const ParticleSet& P)
   {
     StorePerParticle = true;
     const int nptcl  = P.getTotalNum();
-    eikr_r.resize(nptcl, k_lists_->numk);
-    eikr_i.resize(nptcl, k_lists_->numk);
+    eikr_r.resize(nptcl, k_lists_.numk);
+    eikr_i.resize(nptcl, k_lists_.numk);
     computeRhok(P);
   }
 #endif

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -17,12 +17,13 @@
 //#define USE_REAL_STRUCT_FACTOR
 #include "ParticleSet.h"
 #include "DynamicCoordinates.h"
-#include "LongRange/KContainer.h"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 
 namespace qmcplusplus
 {
+
+class KContainer;
 /** @ingroup longrange
  *\brief Calculates the structure-factor for a particle set
  *
@@ -68,14 +69,10 @@ public:
    * @param lattice long range box
    * @param kc cutoff for k
    */
-  StructFact(int nptcls, int ns, const ParticleLayout& lattice, RealType kc);
+  StructFact(int nptcls, int ns, const ParticleLayout& lattice, const KContainer& k_lists);
   /// desructor
   ~StructFact();
 
-  /** Recompute Rhok if lattice changed
-   * @param kc cut-off K
-   */
-  void updateNewCell(const ParticleLayout& lattice, RealType kc);
   /**  Update Rhok if all particles moved
    */
   void updateAllPart(const ParticleSet& P);
@@ -109,9 +106,6 @@ public:
   /// accessor of StorePerParticle
   bool isStorePerParticle() const { return StorePerParticle; }
 
-  /// access k_lists_ read only
-  const KContainer& getKLists() const { return *k_lists_; }
-
 private:
   /// Compute all rhok elements from the start
   void computeRhok(const ParticleSet& P);
@@ -123,7 +117,7 @@ private:
   void resize(int nkpts);
 
   /// K-Vector List.
-  const std::shared_ptr<KContainer> k_lists_;
+  const KContainer& k_lists_;
   /// number of particles
   const size_t num_ptcls;
   /// number of species

--- a/src/Particle/LongRange/TwoDEwaldHandler.cpp
+++ b/src/Particle/LongRange/TwoDEwaldHandler.cpp
@@ -29,7 +29,7 @@ void TwoDEwaldHandler::initBreakup(ParticleSet& ref)
   Sigma /= LR_rc;
   app_log() << "  Sigma=" << Sigma << std::endl;
   Volume = ref.Lattice.Volume;
-  fillFk(ref.getSK().getKLists());
+  fillFk(ref.getSimulationCell().getKLists());
 }
 
 TwoDEwaldHandler::TwoDEwaldHandler(const TwoDEwaldHandler& aLR, ParticleSet& ref)

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -30,12 +30,13 @@ TEST_CASE("StructFact", "[lrhandler]")
   Lattice.reset();
   REQUIRE(Approx(Lattice.Volume) == 125);
   Lattice.SetLRCutoffs(Lattice.Rv);
-  //Lattice.printCutoffs(app_log());
+  Lattice.printCutoffs(app_log());
   REQUIRE(Approx(Lattice.LR_rc) == 2.5);
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
+  Lattice.LR_dim_cutoff = 125;
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
 
   SpeciesSet& tspecies = ref.getSpeciesSet();
   int upIdx            = tspecies.addSpecies("u");
@@ -47,8 +48,8 @@ TEST_CASE("StructFact", "[lrhandler]")
   ref.R[2] = {0.3, 4.0, 1.4};
   ref.R[3] = {3.2, 4.7, 0.7};
 
-  StructFact sk(tspecies.size(), ref.getTotalNum(), ref.getLRBox(), 50);
-  REQUIRE(sk.getKLists().numk == 263786);
+  REQUIRE(simulation_cell.getKLists().numk == 263786);
+  StructFact sk(tspecies.size(), ref.getTotalNum(), ref.getLRBox(), simulation_cell.getKLists());
   sk.updateAllPart(ref);
 
   std::vector<std::complex<double>> rhok_sum_ref{-125.80618630936, 68.199075127271};
@@ -56,7 +57,7 @@ TEST_CASE("StructFact", "[lrhandler]")
   for (int i = 0; i < ref.groups(); i++)
   {
     std::complex<QMCTraits::RealType> rhok_sum, rhok_even_sum;
-    for (int ik = 0; ik < sk.getKLists().numk; ik++)
+    for (int ik = 0; ik < simulation_cell.getKLists().numk; ik++)
       rhok_sum += std::complex<QMCTraits::RealType>(sk.rhok_r[i][ik], sk.rhok_i[i][ik]);
 
     //std::cout << std::setprecision(14) << rhok_sum << std::endl;

--- a/src/Particle/LongRange/tests/test_ewald3d.cpp
+++ b/src/Particle/LongRange/tests/test_ewald3d.cpp
@@ -36,7 +36,7 @@ TEST_CASE("ewald3d", "[lrhandler]")
   REQUIRE(Lattice.LR_kc == Approx(12));
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   EwaldHandler3D handler(ref, Lattice.LR_kc);
 
@@ -83,7 +83,7 @@ TEST_CASE("ewald3d df", "[lrhandler]")
   REQUIRE(Lattice.LR_kc == Approx(12));
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   EwaldHandler3D handler(ref, Lattice.LR_kc);
 

--- a/src/Particle/LongRange/tests/test_lrhandler.cpp
+++ b/src/Particle/LongRange/tests/test_lrhandler.cpp
@@ -41,7 +41,7 @@ TEST_CASE("dummy", "[lrhandler]")
   REQUIRE(Lattice.LR_kc == Approx(12));
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   DummyLRHandler<CoulombF2> handler(Lattice.LR_kc);
 
@@ -60,8 +60,8 @@ TEST_CASE("dummy", "[lrhandler]")
   //  the full Coulomb potential should be retained in kspace
   for (int ish = 0; ish < handler.MaxKshell; ish++)
   {
-    int ik           = ref.getSK().getKLists().kshell[ish];
-    double k2        = ref.getSK().getKLists().ksq[ik];
+    int ik           = ref.getSimulationCell().getKLists().kshell[ish];
+    double k2        = ref.getSimulationCell().getKLists().ksq[ik];
     double fk_expect = fk(k2);
     REQUIRE(handler.Fk_symm[ish] == Approx(norm * fk_expect));
   }

--- a/src/Particle/LongRange/tests/test_srcoul.cpp
+++ b/src/Particle/LongRange/tests/test_srcoul.cpp
@@ -47,7 +47,7 @@ TEST_CASE("srcoul", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 
@@ -89,7 +89,7 @@ TEST_CASE("srcoul df", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerSRCoulomb<EslerCoulomb3D_ForSRCOUL, LPQHISRCoulombBasis> handler(ref);
 

--- a/src/Particle/LongRange/tests/test_temp.cpp
+++ b/src/Particle/LongRange/tests/test_temp.cpp
@@ -48,7 +48,7 @@ TEST_CASE("temp3d", "[lrhandler]")
   REQUIRE(Approx(Lattice.LR_kc) == 12);
 
   const SimulationCell simulation_cell(Lattice);
-  ParticleSet ref(simulation_cell);       // handler needs ref.SK.getKLists()
+  ParticleSet ref(simulation_cell);       // handler needs ref.getSimulationCell().getKLists()
   ref.createSK();
   LRHandlerTemp<EslerCoulomb3D, LPQHIBasis> handler(ref);
 

--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -383,7 +383,7 @@ void MCWalkerConfiguration::allocateGPU(size_t buffersize)
   int N    = WalkerList[0]->R.size();
   int Numk = 0;
   if (structure_factor_)
-    Numk = structure_factor_->getKLists().numk;
+    Numk = simulation_cell_.getKLists().numk;
   int NumSpecies = getSpeciesSet().TotalNum;
   for (int iw = 0; iw < WalkerList.size(); iw++)
   {

--- a/src/Particle/ParticleSet.BC.cpp
+++ b/src/Particle/ParticleSet.BC.cpp
@@ -39,7 +39,7 @@ void ParticleSet::createSK()
   if (Lattice.SuperCellEnum != SUPERCELL_OPEN)
   {
     app_log() << "\n  Creating Structure Factor for periodic systems " << LRBox.LR_kc << std::endl;
-    structure_factor_ = std::make_unique<StructFact>(my_species_.size(), TotalNum, LRBox, LRBox.LR_kc);
+    structure_factor_ = std::make_unique<StructFact>(my_species_.size(), TotalNum, LRBox, simulation_cell_.getKLists());
   }
 
   //set the mass array

--- a/src/Particle/SimulationCell.cpp
+++ b/src/Particle/SimulationCell.cpp
@@ -58,6 +58,8 @@ void SimulationCell::resetLRBox()
       LRBox_.print(app_log());
       app_log() << "--------------------------------------- " << std::endl;
     }
+
+    k_lists_.updateKLists(LRBox_, LRBox_.LR_kc);
   }
 }
 }

--- a/src/Particle/SimulationCell.h
+++ b/src/Particle/SimulationCell.h
@@ -14,6 +14,7 @@
 #define QMCPLUSPLUS_SIMULATIONCELL_H
 
 #include "Configuration.h"
+#include "LongRange/KContainer.h"
 
 namespace qmcplusplus
 {
@@ -33,6 +34,9 @@ public:
 
   void resetLRBox();
 
+  /// access k_lists_ read only
+  const KContainer& getKLists() const { return k_lists_; }
+
 private:
   ///simulation cell lattice
   Lattice lattice_;
@@ -40,6 +44,9 @@ private:
   Lattice primative_lattice_;
   ///long-range box
   Lattice LRBox_;
+
+  /// K-Vector List.
+  KContainer k_lists_;
 
   friend class ParticleSetPool;
 };

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -233,10 +233,10 @@ CoulombPBCAA::Return_t CoulombPBCAA::evaluate_sp(ParticleSet& P)
         {
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += z * Zspec[s] *
-              AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[s], PtclRhoK.rhok_i[s], PtclRhoK.eikr_r[i],
+              AA->evaluate(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok_r[s], PtclRhoK.rhok_i[s], PtclRhoK.eikr_r[i],
                            PtclRhoK.eikr_i[i]);
 #else
-          v1 += z * Zspec[s] * AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[s], PtclRhoK.eikr[i]);
+          v1 += z * Zspec[s] * AA->evaluate(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok[s], PtclRhoK.eikr[i]);
 #endif
         }
         V_samp(i) += v1;
@@ -485,7 +485,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
       for (int jat = 0; jat < iat; ++jat)
         u += Zat[jat] *
             AA->evaluate_slab(-d_slab[jat], //JK: Could be wrong. Check the SIGN
-                              PtclRhoK.getKLists().kshell, PtclRhoK.eikr[iat], PtclRhoK.eikr[jat]);
+                              P.getSimulationCell().getKLists().kshell, PtclRhoK.eikr[iat], PtclRhoK.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }
@@ -498,10 +498,10 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
       for (int spec2 = spec1; spec2 < NumSpecies; spec2++)
       {
 #if defined(USE_REAL_STRUCT_FACTOR)
-        mRealType temp = AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
+        mRealType temp = AA->evaluate(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
                                       PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
 #else
-        mRealType temp = AA->evaluate(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
+        mRealType temp = AA->evaluate(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
 #endif
         if (spec2 == spec1)
           temp *= 0.5;

--- a/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA_CUDA.cpp
@@ -69,12 +69,11 @@ void CoulombPBCAA_CUDA::setupLongRangeGPU(ParticleSet& P)
 {
   if (is_active)
   {
-    const auto& SK = P.getSK();
-    Numk           = SK.getKLists().numk;
+    Numk           = P.getSimulationCell().getKLists().numk;
     gpu::host_vector<CUDA_PRECISION_FULL> kpointsHost(OHMMS_DIM * Numk);
     for (int ik = 0; ik < Numk; ik++)
       for (int dim = 0; dim < OHMMS_DIM; dim++)
-        kpointsHost[ik * OHMMS_DIM + dim] = SK.getKLists().kpts_cart[ik][dim];
+        kpointsHost[ik * OHMMS_DIM + dim] = P.getSimulationCell().getKLists().kpts_cart[ik][dim];
     kpointsGPU = kpointsHost;
     gpu::host_vector<CUDA_PRECISION_FULL> FkHost(Numk);
     for (int ik = 0; ik < Numk; ik++)

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -181,10 +181,10 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesA; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Zspec[s] * q *
-              AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i],
+              AB->evaluate(PtclA.getSimulationCell().getKLists().kshell, RhoKA.rhok_r[s], RhoKA.rhok_i[s], RhoKB.eikr_r[i],
                            RhoKB.eikr_i[i]);
 #else
-          v1 += Zspec[s] * q * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
+          v1 += Zspec[s] * q * AB->evaluate(PtclA.getSimulationCell().getKLists().kshell, RhoKA.rhok[s], RhoKB.eikr[i]);
 #endif
         Ve_samp(i) += v1;
         Vlr += v1;
@@ -196,10 +196,10 @@ CoulombPBCAB::Return_t CoulombPBCAB::evaluate_sp(ParticleSet& P)
         for (int s = 0; s < NumSpeciesB; s++)
 #if defined(USE_REAL_STRUCT_FACTOR)
           v1 += Qspec[s] * q *
-              AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i],
+              AB->evaluate(P.getSimulationCell().getKLists().kshell, RhoKB.rhok_r[s], RhoKB.rhok_i[s], RhoKA.eikr_r[i],
                            RhoKA.eikr_i[i]);
 #else
-          v1 += Qspec[s] * q * AB->evaluate(RhoKB.getKLists().kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
+          v1 += Qspec[s] * q * AB->evaluate(P.getSimulationCell().getKLists().kshell, RhoKB.rhok[s], RhoKA.eikr[i]);
 #endif
         Vi_samp(i) += v1;
         Vlr += v1;
@@ -334,7 +334,7 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
       const int slab_dir = OHMMS_DIM - 1;
       for (int nn = d_ab.M[iat], jat = 0; nn < d_ab.M[iat + 1]; ++nn, ++jat)
         u += Qat[jat] *
-            AB->evaluate_slab(d_ab.dr(nn)[slab_dir], RhoKA.getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
+            AB->evaluate_slab(d_ab.dr(nn)[slab_dir], PtclA.getSimulationCell().getKLists().kshell, RhoKA.eikr[iat], RhoKB.eikr[jat]);
 #endif
       res += Zat[iat] * u;
     }
@@ -348,9 +348,9 @@ CoulombPBCAB::Return_t CoulombPBCAB::evalLR(ParticleSet& P)
       {
 #if defined(USE_REAL_STRUCT_FACTOR)
         esum += Qspec[j] *
-            AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
+            AB->evaluate(PtclA.getSimulationCell().getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j], RhoKB.rhok_i[j]);
 #else
-        esum += Qspec[j] * AB->evaluate(RhoKA.getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
+        esum += Qspec[j] * AB->evaluate(PtclA.getSimulationCell().getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
 #endif
       } //speceln
       res += Zspec[i] * esum;

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.cpp
@@ -102,12 +102,12 @@ void CoulombPBCAB_CUDA::add(int groupID, std::unique_ptr<RadFunctorType>&& ppot)
 
 void CoulombPBCAB_CUDA::setupLongRangeGPU()
 {
-  const auto& SK = ElecRef.getSK();
-  Numk           = SK.getKLists().numk;
+  const auto& klists = ElecRef.getSimulationCell().getKLists();
+  Numk               = klists.numk;
   gpu::host_vector<CUDA_PRECISION_FULL> kpointsHost(OHMMS_DIM * Numk);
   for (int ik = 0; ik < Numk; ik++)
     for (int dim = 0; dim < OHMMS_DIM; dim++)
-      kpointsHost[ik * OHMMS_DIM + dim] = SK.getKLists().kpts_cart[ik][dim];
+      kpointsHost[ik * OHMMS_DIM + dim] = klists.kpts_cart[ik][dim];
   kpointsGPU = kpointsHost;
   gpu::host_vector<CUDA_PRECISION_FULL> FkHost(Numk);
   for (int ik = 0; ik < Numk; ik++)
@@ -120,7 +120,7 @@ void CoulombPBCAB_CUDA::setupLongRangeGPU()
   {
     for (int ik = 0; ik < Numk; ik++)
     {
-      PosType k                 = SK.getKLists().kpts_cart[ik];
+      PosType k                 = klists.kpts_cart[ik];
       RhokIons_host[2 * ik + 0] = 0.0;
       RhokIons_host[2 * ik + 1] = 0.0;
       for (int ion = IonFirst[sp]; ion <= IonLast[sp]; ion++)

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -31,9 +31,9 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   NumIonSpecies = ions->getSpeciesSet().getTotalNum();
   update_mode_.set(COLLECTABLE, 1);
 
-  NumK      = source.getSK().getKLists().numk;
+  NumK      = source.getSimulationCell().getKLists().numk;
   OneOverN  = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell    = source.getSK().getKLists().kshell;
+  Kshell    = source.getSimulationCell().getKLists().kshell;
   MaxKshell = Kshell.size() - 1;
 
 #if defined(USE_REAL_STRUCT_FACTOR)
@@ -50,7 +50,7 @@ SkAllEstimator::SkAllEstimator(ParticleSet& source, ParticleSet& target)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.getSK().getKLists().ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.getSimulationCell().getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
   hdf5_out = false;
@@ -75,7 +75,7 @@ void SkAllEstimator::evaluateIonIon()
 
   for (int k = 0; k < NumK; k++)
   {
-    PosType kvec = ions->getSK().getKLists().kpts_cart[k];
+    PosType kvec = ions->getSimulationCell().getKLists().kpts_cart[k];
 
     filebuffer << kvec;
     for (int i = 0; i < NumIonSpecies; i++)
@@ -279,7 +279,7 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
     h5desc.emplace_back("kpoints");
     auto& ohKPoints = h5desc.back();
     ohKPoints.open(sgid); // add to SkAll hdf group
-    ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->getSK().getKLists().kpts_cart), "value");
+    ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->getSimulationCell().getKLists().kpts_cart), "value");
 
     // Add electron-electron S(k)
     std::vector<int> ng(1);

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -25,9 +25,9 @@ SkEstimator::SkEstimator(ParticleSet& source)
   sourcePtcl = &source;
   update_mode_.set(COLLECTABLE, 1);
   NumSpecies = source.getSpeciesSet().getTotalNum();
-  NumK       = source.getSK().getKLists().numk;
+  NumK       = source.getSimulationCell().getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell     = source.getSK().getKLists().kshell;
+  Kshell     = source.getSimulationCell().getKLists().kshell;
   MaxKshell  = Kshell.size() - 1;
 #if defined(USE_REAL_STRUCT_FACTOR)
   RhokTot_r.resize(NumK);
@@ -40,7 +40,7 @@ SkEstimator::SkEstimator(ParticleSet& source)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.getSK().getKLists().ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.getSimulationCell().getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
   hdf5_out = true;
@@ -154,7 +154,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
     hid_t k_set       = H5Dcreate(gid, kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);
-    auto* ptr         = &(sourcePtcl->getSK().getKLists().kpts_cart[0][0]);
+    auto* ptr         = &(sourcePtcl->getSimulationCell().getKLists().kpts_cart[0][0]);
     herr_t ret        = H5Dwrite(k_set, H5T_NATIVE_DOUBLE, mem_space, k_space, H5P_DEFAULT, ptr);
     H5Dclose(k_set);
     H5Sclose(mem_space);

--- a/src/QMCHamiltonians/SkPot.cpp
+++ b/src/QMCHamiltonians/SkPot.cpp
@@ -22,9 +22,9 @@ SkPot::SkPot(ParticleSet& source)
 {
   sourcePtcl = &source;
   NumSpecies = source.getSpeciesSet().getTotalNum();
-  NumK       = source.getSK().getKLists().numk;
+  NumK       = source.getSimulationCell().getKLists().numk;
   OneOverN   = 1.0 / static_cast<RealType>(source.getTotalNum());
-  Kshell     = source.getSK().getKLists().kshell;
+  Kshell     = source.getSimulationCell().getKLists().kshell;
   MaxKshell  = Kshell.size() - 1;
   RhokTot.resize(NumK);
   Fk.resize(NumK);
@@ -32,7 +32,7 @@ SkPot::SkPot(ParticleSet& source)
   OneOverDnk.resize(MaxKshell);
   for (int ks = 0; ks < MaxKshell; ks++)
   {
-    Kmag[ks]       = std::sqrt(source.getSK().getKLists().ksq[Kshell[ks]]);
+    Kmag[ks]       = std::sqrt(source.getSimulationCell().getKLists().ksq[Kshell[ks]]);
     OneOverDnk[ks] = 1.0 / static_cast<RealType>(Kshell[ks + 1] - Kshell[ks]);
   }
 }

--- a/src/QMCHamiltonians/SkPot.h
+++ b/src/QMCHamiltonians/SkPot.h
@@ -41,7 +41,7 @@ public:
   {
     for (int ki = 0; ki < NumK; ki++)
     {
-      RealType k = dot(sourcePtcl->getSK().getKLists().kpts_cart[ki], sourcePtcl->getSK().getKLists().kpts_cart[ki]);
+      RealType k = dot(sourcePtcl->getSimulationCell().getKLists().kpts_cart[ki], sourcePtcl->getSimulationCell().getKLists().kpts_cart[ki]);
       k          = std::sqrt(k) - K_0;
       Fk[ki]     = OneOverN * V_0 * std::exp(-k * k);
       //         app_log()<<ki<<": "<<Fk[ki] << std::endl;

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -54,7 +54,7 @@ bool StaticStructureFactor::put(xmlNodePtr cur)
 {
   using std::sqrt;
   reset();
-  const k2_t& k2_init = Pinit.getSK().getKLists().ksq;
+  const k2_t& k2_init = Pinit.getSimulationCell().getKLists().ksq;
 
   std::string write_report = "no";
   OhmmsAttributeSet attrib;
@@ -113,7 +113,7 @@ void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& 
   h5desc.emplace_back("kpoints");
   auto& oh = h5desc.back();
   oh.open(sgid); // add to SkAll hdf group
-  oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.getSK().getKLists().kpts_cart), "value");
+  oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.getSimulationCell().getKLists().kpts_cart), "value");
 
   std::vector<int> ng(2);
   ng[0] = 2;

--- a/src/QMCHamiltonians/StressPBC.cpp
+++ b/src/QMCHamiltonians/StressPBC.cpp
@@ -106,10 +106,10 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AB(ParticleSet& 
     {
 #if defined(USE_REAL_STRUCT_FACTOR)
       esum += Qspec[j] *
-          AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j],
+          AA->evaluateStress(P.getSimulationCell().getKLists().kshell, RhoKA.rhok_r[i], RhoKA.rhok_i[i], RhoKB.rhok_r[j],
                              RhoKB.rhok_i[j]);
 #else
-      esum += Qspec[j] * AA->evaluateStress(RhoKA.getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
+      esum += Qspec[j] * AA->evaluateStress(P.getSimulationCell().getKLists().kshell, RhoKA.rhok[i], RhoKB.rhok[j]);
 
 #endif
     }
@@ -184,10 +184,10 @@ SymTensor<StressPBC::RealType, OHMMS_DIM> StressPBC::evaluateLR_AA(ParticleSet& 
     {
 #if !defined(USE_REAL_STRUCT_FACTOR)
       SymTensor<RealType, OHMMS_DIM> temp =
-          AA->evaluateStress(PtclRhoK.getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
+          AA->evaluateStress(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok[spec1], PtclRhoK.rhok[spec2]);
 #else
       SymTensor<RealType, OHMMS_DIM> temp =
-          AA->evaluateStress(PtclRhoK.getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
+          AA->evaluateStress(P.getSimulationCell().getKLists().kshell, PtclRhoK.rhok_r[spec1], PtclRhoK.rhok_i[spec1],
                              PtclRhoK.rhok_r[spec2], PtclRhoK.rhok_i[spec2]);
 #endif
       if (spec2 == spec1)

--- a/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/tests/test_SkAllEstimator.cpp
@@ -208,7 +208,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   // In order to compare to analytic result, need the list
   // of k-vectors in cartesian coordinates.
   // Luckily, ParticleSet stores that in SK->getKLists().kpts_cart
-  int nkpts = elec->getSK().getKLists().numk;
+  int nkpts = elec->getSimulationCell().getKLists().numk;
   std::cout << "\n";
   std::cout << "SkAll results:\n";
   std::cout << std::fixed;
@@ -229,7 +229,7 @@ TEST_CASE("SkAll", "[hamiltonian]")
   std::cout << std::setprecision(5);
   for (int k = 0; k < nkpts; k++)
   {
-    auto kvec      = elec->getSK().getKLists().kpts_cart[k];
+    auto kvec      = elec->getSimulationCell().getKLists().kpts_cart[k];
     RealType kx    = kvec[0];
     RealType ky    = kvec[1];
     RealType kz    = kvec[2];

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -359,7 +359,7 @@ void QMCFiniteSize::initialize()
   Vol   = P->getLattice().Volume;
   rs    = std::pow(3.0 / (4 * M_PI) * Vol / RealType(Ne), 1.0 / 3.0);
   rho   = RealType(Ne) / Vol;
-  Klist = P->getSK().getKLists();
+  Klist = P->getSimulationCell().getKLists();
   kpts  = Klist.kpts; //These are in reduced coordinates.
                       //Easier to spline, but will have to convert
                       //for real space integration.

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -413,8 +413,8 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addRPA(xmlNodePtr cur)
       Rs = 100.0;
     }
   }
-  int indx        = targetPtcl.getSK().getKLists().ksq.size() - 1;
-  RealType Kc_max = std::pow(targetPtcl.getSK().getKLists().ksq[indx], 0.5);
+  int indx        = targetPtcl.getSimulationCell().getKLists().ksq.size() - 1;
+  RealType Kc_max = std::pow(targetPtcl.getSimulationCell().getKLists().ksq[indx], 0.5);
   if (Kc < 0)
   {
     Kc = 2.0 * std::pow(2.25 * M_PI, 1.0 / 3.0) / tlen;
@@ -569,7 +569,7 @@ void BackflowBuilder::makeLongRange_twoBody(xmlNodePtr cur, Backflow_ee_kSpace* 
         fout << "# Backflow longrange  \n";
         for (int i = 0; i < tbfks->NumKShells; i++)
         {
-          fout << std::pow(targetPtcl.getSK().getKLists().ksq[targetPtcl.getSK().getKLists().kshell[i]], 0.5) << " " << yk[i]
+          fout << std::pow(targetPtcl.getSimulationCell().getKLists().ksq[targetPtcl.getSimulationCell().getKLists().kshell[i]], 0.5) << " " << yk[i]
                << std::endl;
         }
         fout.close();

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee_kSpace.h
@@ -66,7 +66,7 @@ public:
   {
     NumKShells = yk.size();
     Fk         = yk;
-    NumKVecs   = P.getSK().getKLists().kshell[NumKShells + 1];
+    NumKVecs   = P.getSimulationCell().getKLists().kshell[NumKShells + 1];
     Rhok.resize(NumKVecs);
     if (Optimize)
       numParams = NumKShells;
@@ -263,8 +263,8 @@ public:
     copy(P.getSK().rhok[0], P.getSK().rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.getSK().rhok[spec1], P.getSK().rhok[spec1] + NumKVecs, Rhok.data());
-    const auto& Kcart(P.getSK().getKLists().kpts_cart);
-    std::vector<int>& kshell(P.getSK().getKLists().kshell);
+    const auto& Kcart(P.getSimulationCell().getKLists().kpts_cart);
+    std::vector<int>& kshell(P.getSimulationCell().getKLists().kshell);
     for (int iel = 0; iel < NumTargets; iel++)
     {
       const ComplexType* restrict eikr_ptr(P.getSK().eikr[iel]);
@@ -301,15 +301,15 @@ public:
     copy(P.getSK().rhok[0], P.getSK().rhok[0] + NumKVecs, Rhok.data());
     for (int spec1 = 1; spec1 < NumGroups; spec1++)
       accumulate_elements(P.getSK().rhok[spec1], P.getSK().rhok[spec1] + NumKVecs, Rhok.data());
-    const auto& Kcart(P.getSK().getKLists().kpts_cart);
-    std::vector<int>& kshell(P.getSK().getKLists().kshell);
+    const auto& Kcart(P.getSimulationCell().getKLists().kpts_cart);
+    std::vector<int>& kshell(P.getSimulationCell().getKLists().kshell);
     GradType fact;
     HessType kakb;
     for (int iel = 0; iel < NumTargets; iel++)
     {
       const ComplexType* restrict eikr_ptr(P.getSK().eikr[iel]);
       const ComplexType* restrict rhok_ptr(Rhok.data());
-      const RealType* restrict ksq_ptr(P.getSK().getKLists().ksq.data());
+      const RealType* restrict ksq_ptr(P.getSimulationCell().getKLists().ksq.data());
       int ki = 0;
       for (int ks = 0; ks < NumKShells; ks++, ksq_ptr++)
       {

--- a/src/QMCWaveFunctions/Jastrow/J2KECorrection.h
+++ b/src/QMCWaveFunctions/Jastrow/J2KECorrection.h
@@ -46,7 +46,7 @@ public:
       num_elec_in_groups_.push_back(targetPtcl.last(i) - targetPtcl.first(i));
 
     if (SK_enabled)
-      G0mag = std::sqrt(targetPtcl.getSK().getKLists().ksq[0]);
+      G0mag = std::sqrt(targetPtcl.getSimulationCell().getKLists().ksq[0]);
   }
 
   RT computeKEcorr()

--- a/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RPAJastrow.cpp
@@ -99,8 +99,8 @@ void RPAJastrow::buildOrbital(const std::string& name,
       Rs = 100.0;
     }
   }
-  int indx      = targetPtcl.getSK().getKLists().ksq.size() - 1;
-  double Kc_max = std::pow(targetPtcl.getSK().getKLists().ksq[indx], 0.5);
+  int indx      = targetPtcl.getSimulationCell().getKLists().ksq.size() - 1;
+  double Kc_max = std::pow(targetPtcl.getSimulationCell().getKLists().ksq[indx], 0.5);
   if (Kc < 0)
   {
     Kc = 2.0 * std::pow(2.25 * M_PI, 1.0 / 3.0) / tlen;

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -294,9 +294,9 @@ void RadialJastrowBuilder::computeJ2uk(const std::vector<RadFuncType*>& functors
     sprintf(fname, "uk.%s.g%03d.dat", NameOpt.c_str(), getGroupID());
     fout = fopen(fname, "w");
   }
-  for (int iG = 0; iG < targetPtcl.getSK().getKLists().ksq.size(); iG++)
+  for (int iG = 0; iG < targetPtcl.getSimulationCell().getKLists().ksq.size(); iG++)
   {
-    RealType Gmag = std::sqrt(targetPtcl.getSK().getKLists().ksq[iG]);
+    RealType Gmag = std::sqrt(targetPtcl.getSimulationCell().getKLists().ksq[iG]);
     RealType sum  = 0.0;
     RealType uk   = 0.0;
     for (int i = 0; i < targetPtcl.groups(); i++)


### PR DESCRIPTION
## Proposed changes
Since the KLists is associated to the SimulationCell, it is more suitable to move it there.
Earlier, I changed KLists to shared_ptr and I explained that was temporary. This time, it is moved to the final destination.

StructFactor still keeps a private reference for internal use but it should not be asked from outside.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'