### PR TITLE
Update cmake in NERSC Cori build script

### DIFF
--- a/config/build_nersc_cori.sh
+++ b/config/build_nersc_cori.sh
@@ -17,7 +17,7 @@ export CRAYPE_LINK_TYPE=dynamic
 module unload cray-libsci
 module load boost/1.70.0
 module load cray-hdf5-parallel
-module load cmake/3.14.4
+module load cmake
 module load gcc/7.3.0 # Make C++ 14 standard library available to the Intel compiler
 module list
 

--- a/config/build_nersc_cori.sh
+++ b/config/build_nersc_cori.sh
@@ -23,11 +23,16 @@ module list
 
 # module files resulting from module imports above:
 #Currently Loaded Modulefiles:
-#  1) modules/3.2.11.4                                  6) craype/2.6.2                                     11) gni-headers/5.0.12.0-7.0.1.1_6.43__g3b1768f.ari  16) rca/2.2.20-7.0.1.1_4.65__g8e3fb5b.ari            21) craype-hugepages2M
-#  2) altd/2.0                                          7) udreg/2.3.2-7.0.1.1_3.52__g8175d3d.ari           12) xpmem/2.2.20-7.0.1.1_4.23__g0475745.ari          17) atp/2.1.3                                        22) boost/1.70.0
-#  3) darshan/3.2.1                                     8) ugni/6.0.14.0-7.0.1.1_7.54__ge78e5b0.ari         13) job/2.2.4-7.0.1.1_3.50__g36b56f4.ari             18) PrgEnv-intel/6.0.5                               23) cray-hdf5-parallel/1.10.5.2
-#  4) craype-network-aries                              9) pmi/5.0.14                                       14) dvs/2.12_2.2.167-7.0.1.1_17.6__ge473d3a2         19) craype-haswell                                   24) cmake/3.14.4
-#  5) intel/19.0.3.199                                 10) dmapp/7.1.1-7.0.1.1_4.64__g38cf134.ari           15) alps/6.6.58-7.0.1.1_6.22__g437d88db.ari          20) cray-mpich/7.7.10                                25) gcc/7.3.0
+#  1) modules/3.2.11.4                                 10) dmapp/7.1.1-7.0.1.1_4.72__g38cf134.ari           19) craype-haswell
+#  2) altd/2.0                                         11) gni-headers/5.0.12.0-7.0.1.1_6.46__g3b1768f.ari  20) cray-mpich/7.7.10
+#  3) darshan/3.2.1                                    12) xpmem/2.2.20-7.0.1.1_4.28__g0475745.ari          21) craype-hugepages2M
+#  4) craype-network-aries                             13) job/2.2.4-7.0.1.1_3.55__g36b56f4.ari             22) boost/1.70.0
+#  5) intel/19.0.3.199                                 14) dvs/2.12_2.2.167-7.0.1.1_17.11__ge473d3a2        23) cray-hdf5-parallel/1.10.5.2
+#  6) craype/2.6.2                                     15) alps/6.6.58-7.0.1.1_6.30__g437d88db.ari          24) cmake/3.21.3
+#  7) udreg/2.3.2-7.0.1.1_3.61__g8175d3d.ari           16) rca/2.2.20-7.0.1.1_4.74__g8e3fb5b.ari            25) gcc/7.3.0
+#  8) ugni/6.0.14.0-7.0.1.1_7.63__ge78e5b0.ari         17) atp/2.1.3
+#  9) pmi/5.0.14                                       18) PrgEnv-intel/6.0.5
+
 
 # Haswell CPU Complex
 mkdir build_nersc_cori_hsw_cmplx

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -186,7 +186,7 @@ Building with CMake
 The build system for QMCPACK is based on CMake. It will autoconfigure
 based on the detected compilers and libraries. The most recent version
 of CMake has the best detection for the greatest variety of systems. The
-minimum required version of CMake is 3.14.0. Most
+minimum required version of CMake is 3.15.0. Most
 computer installations have a sufficiently recent CMake, though it might
 not be the default.
 


### PR DESCRIPTION

## Proposed changes

The version of cmake (3.14.4) in `config/build_nersc_cori.sh` is not sufficient for QMCPACK 3.12.0. This PR resolves this by loading an updated cmake version (3.21.3)

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No. Verified that the build executes correctly on NERSC Cori

## What systems has this change been tested on?

NERSC Cori

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
