### PR TITLE
Update cmake in ORNL CADES build script

### DIFF
--- a/config/build_ornl_cades.sh
+++ b/config/build_ornl_cades.sh
@@ -7,13 +7,13 @@
 ## * Execute this script in trunk/                            ##
 ##   ./config/build_ornl_cades.sh                             ##
 ##                                                            ##
-## Last verified: Nov 12, 2020                                ##
+## Last verified: Jan 27, 2022                                ##
 ################################################################
 
 # module files resulting from module imports below:
 # Currently Loaded Modulefiles:
 #   1) python/3.6.3           3) openmpi/3.1.5          5) gcc/7.2.0              7) fftw/3.3.5             9) boost/1.70.0
-#   2) intel/19.0.3           4) PE-intel/3.0           6) hdf5-parallel/1.8.21   8) cmake/3.12.0          10) libxml2/2.9.9
+#   2) intel/19.0.3           4) PE-intel/3.0           6) hdf5-parallel/1.8.21   8) cmake/3.18.4          10) libxml2/2.9.9
 
 source $MODULESHOME/init/bash
 module purge
@@ -23,7 +23,7 @@ module swap intel intel/19.0.3
 module load gcc/7.2.0
 module load hdf5-parallel/1.8.21
 module load fftw/3.3.5
-module load cmake/3.12.0
+module load cmake/3.18.4
 module load boost/1.70.0
 module load libxml2/2.9.9
 module list


### PR DESCRIPTION
## Proposed changes

The version of cmake (3.12.0) in `config/build_ornl_cades.sh` is not sufficient for QMCPACK 3.12.0. This PR resolves this by loading an updated cmake version (3.18.4)

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No. Tested on ORNL CADES

## What systems has this change been tested on?

ORNL CADES

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
