### PR TITLE
Reorganize self-hosted runners

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted-nitrogen.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted-nitrogen.yaml
@@ -1,0 +1,197 @@
+name: ornl-nitrogen CI
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  gpu-rocm-nitrogen:
+    if: |
+      github.repository_owner == 'QMCPACK' &&
+      github.event.issue.pull_request &&
+      ( startsWith(github.event.comment.body, 'Test this please') || 
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    runs-on: [self-hosted, Linux, X64, ornl-nitrogen]
+
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname:
+          [
+            ROCm-Clang13-NoMPI-CUDA2HIP-Real-Mixed,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Real,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Complex-Mixed,
+            ROCm-Clang13-NoMPI-CUDA2HIP-Complex,
+          ]
+
+    steps:
+      - name: Verify actor
+        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
+        # this is in-line with the current workflow
+        env:
+          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
+        id: check
+        run: |
+          echo "::set-output name=triggered::true"
+
+      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
+      - name: GitHub API Request
+        if: steps.check.outputs.triggered == 'true'
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{github.event.issue.pull_request.url}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Create a separate PR status pointing at GitHub Actions tab URL
+      # just like any other third-party service
+      - name: Create PR status
+        if: steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-nitrogen CI ${{matrix.jobname}}"
+          state: "pending"
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Get PR information
+        if: steps.check.outputs.triggered == 'true'
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+          ref: ${{steps.pr_data.outputs.branch}}
+
+      - name: Configure
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+      - name: Build
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh build
+
+      - name: Test
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh test
+
+      - name: Report PR status
+        if: always() && steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-nitrogen CI ${{matrix.jobname}}"
+          state: ${{job.status}}
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+  gpu-cuda-nitrogen:
+    if: |
+      github.repository_owner == 'QMCPACK' &&
+      github.event.issue.pull_request &&
+      ( startsWith(github.event.comment.body, 'Test this please') || 
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    runs-on: [self-hosted, Linux, X64, ornl-nitrogen]
+
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname: [
+            GCC8-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
+            GCC8-MPI-CUDA-AFQMC-Complex-Mixed,
+            GCC8-MPI-CUDA-AFQMC-Real,
+            GCC8-MPI-CUDA-AFQMC-Complex,
+          ]
+
+    steps:
+      - name: Verify actor
+        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
+        # this is in-line with the current workflow
+        env:
+          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
+        id: check
+        run: |
+          echo "::set-output name=triggered::true"
+
+      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
+      - name: GitHub API Request
+        if: steps.check.outputs.triggered == 'true'
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{github.event.issue.pull_request.url}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Create a separate PR status pointing at GitHub Actions tab URL
+      # just like any other third-party service
+      - name: Create PR status
+        if: steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-nitrogen CI ${{matrix.jobname}}"
+          state: "pending"
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Get PR information
+        if: steps.check.outputs.triggered == 'true'
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+          ref: ${{steps.pr_data.outputs.branch}}
+
+      - name: Configure
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+      - name: Build
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh build
+
+      - name: Test
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh test
+
+      - name: Report PR status
+        if: always() && steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-nitrogen CI ${{matrix.jobname}}"
+          state: ${{job.status}}
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/ci-github-actions-self-hosted-sulfur.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted-sulfur.yaml
@@ -1,0 +1,201 @@
+name: ornl-sulfur CI
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  cpu-intel64-sulfur:
+    if: |
+      github.repository_owner == 'QMCPACK' &&
+      github.event.issue.pull_request &&
+      ( startsWith(github.event.comment.body, 'Test this please') || 
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    runs-on: [self-hosted, Linux, X64, ornl-sulfur]
+
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname: [
+            GCC8-NoMPI-MKL-Real-Mixed, # mixed precision
+            GCC8-NoMPI-MKL-Complex-Mixed,
+            GCC8-NoMPI-MKL-Real, # full precision
+            GCC8-NoMPI-MKL-Complex,
+          ]
+
+    steps:
+      - name: Verify actor
+        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
+        # this is in-line with the current workflow
+        env:
+          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
+        id: check
+        run: |
+          echo "::set-output name=triggered::true"
+
+      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
+      - name: GitHub API Request
+        if: steps.check.outputs.triggered == 'true'
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{github.event.issue.pull_request.url}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Create a separate PR status pointing at GitHub Actions tab URL
+      # just like any other third-party service
+      - name: Create PR status
+        if: steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-sulfur CI ${{ matrix.jobname }}"
+          state: "pending"
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Get PR information
+        if: steps.check.outputs.triggered == 'true'
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+          ref: ${{steps.pr_data.outputs.branch}}
+
+      - name: Configure
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+      - name: Build
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh build
+
+      - name: Test
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh test
+
+      - name: Report PR status
+        if: always() && steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-sulfur CI ${{matrix.jobname}}"
+          state: ${{job.status}}
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+  gpu-cuda-sulfur:
+    if: |
+      github.repository_owner == 'QMCPACK' &&
+      github.event.issue.pull_request &&
+      ( startsWith(github.event.comment.body, 'Test this please') || 
+        startsWith(github.event.comment.body, 'Start testing in-house') )
+
+    runs-on: [self-hosted, Linux, X64, ornl-sulfur]
+
+    env:
+      GH_JOBNAME: ${{matrix.jobname}}
+      GH_OS: Linux
+    strategy:
+      fail-fast: false
+      matrix:
+        jobname: [
+            GCC8-NoMPI-Legacy-CUDA-Real-Mixed, # mixed precision
+            GCC8-NoMPI-Legacy-CUDA-Complex-Mixed,
+            GCC8-NoMPI-Legacy-CUDA-Real, # full precision
+            GCC8-NoMPI-Legacy-CUDA-Complex,
+            Clang14Dev-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload requires development llvm14
+            Clang14Dev-MPI-CUDA-AFQMC-Offload-Real,
+            Intel19-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
+            Intel19-MPI-CUDA-AFQMC-Complex-Mixed,
+            Intel19-MPI-CUDA-AFQMC-Real,
+          ]
+
+    steps:
+      - name: Verify actor
+        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
+        # this is in-line with the current workflow
+        env:
+          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
+          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
+        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
+        id: check
+        run: |
+          echo "::set-output name=triggered::true"
+
+      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
+      - name: GitHub API Request
+        if: steps.check.outputs.triggered == 'true'
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{github.event.issue.pull_request.url}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      # Create a separate PR status pointing at GitHub Actions tab URL
+      # just like any other third-party service
+      - name: Create PR status
+        if: steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-sulfur CI ${{ matrix.jobname }}"
+          state: "pending"
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Get PR information
+        if: steps.check.outputs.triggered == 'true'
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
+          ref: ${{steps.pr_data.outputs.branch}}
+
+      - name: Configure
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh configure
+
+      - name: Build
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh build
+
+      - name: Test
+        if: steps.check.outputs.triggered == 'true'
+        run: tests/test_automation/github-actions/ci/run_step.sh test
+
+      - name: Report PR status
+        if: always() && steps.check.outputs.triggered == 'true'
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "ornl-sulfur CI ${{matrix.jobname}}"
+          state: ${{job.status}}
+          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
+          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
## Proposed changes

Refactor self-hosted CI runner jobs on sulfur and nitrogen
Allow for simulataneous runs
Move CUDA jobs from sulfur to nitrogen


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
