### PR TITLE
Set CMake CUDACXX in CUDA CI runners

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -31,6 +31,15 @@ case "$1" in
       ;; 
     esac
 
+    if [[ "${GH_JOBNAME}" =~ (-CUDA) ]]
+    then
+      echo "Set CUDACXX CMake environment variable to nvcc standard location"
+      export CUDACXX=/usr/local/cuda/bin/nvcc
+        
+      # Make current environment variables available to subsequent steps
+      echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
+    fi 
+
     # Sanitizer
     case "${GH_JOBNAME}" in
       *"ASan"*)


### PR DESCRIPTION
## Proposed changes

Set CMake `CUDACXX` environment variable, docs [here](https://cmake.org/cmake/help/latest/envvar/CUDACXX.html) to standard nvcc location in CI runners. 

## What type(s) of changes does this code introduce?

- Bugfix for nitrogen-cuda CI

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass CI on nitrogen-cuda


## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
