### PR TITLE
Set ucx layer for ornl runners

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -276,11 +276,8 @@ case "$1" in
       echo "Enabling OpenMPI oversubscription"
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export OMPI_MCA_hwloc_base_binding_policy=none
-      if [[ "$HOST_NAME" =~ (sulfur) ]]
-      then
-        echo "Set the management layer to ucx"
-        export OMPI_MCA_pml=ucx
-      fi
+      echo "Set the management layer to ucx"
+      export OMPI_MCA_pml=ucx
     fi 
     
     if [[ "${GH_JOBNAME}" =~ (Clang12-NoMPI-Offload) ]]


### PR DESCRIPTION
## Proposed changes

Enable ucx MPI p2p management layer for nitrogen, similar to sulfur
Converter tests are failing.
Similar to #3659 

## What type(s) of changes does this code introduce?

- Bugfix


### Does this introduce a breaking change?

- Yes


## What systems has this change been tested on?
sulfur, must work on nitrogen

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
