### PR TITLE
Implement evaluateDerivRatios in J1 and J2

### DIFF
--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -197,23 +197,6 @@ public:
       dt_list[iw].finalizePbyP(p_list[iw]);
   }
 
-  /** build a compact list of a neighbor for the iat source
-   * @param iat source particle id
-   * @param rcut cutoff radius
-   * @param jid compressed index
-   * @param dist compressed distance
-   * @param displ compressed displacement
-   * @return number of target particles within rcut
-   */
-  virtual size_t get_neighbors(int iat,
-                               RealType rcut,
-                               int* restrict jid,
-                               RealType* restrict dist,
-                               PosType* restrict displ) const
-  {
-    return 0;
-  }
-
   /** find the first nearest neighbor
    * @param iat source particle id
    * @param r distance

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -102,28 +102,6 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
       std::copy_n(temp_dr_.data(idim), num_sources_, displacements_[iat].data(idim));
   }
 
-  size_t get_neighbors(int iat,
-                       RealType rcut,
-                       int* restrict jid,
-                       RealType* restrict dist,
-                       PosType* restrict displ) const override
-  {
-    constexpr T cminus(-1);
-    size_t nn = 0;
-    for (int jat = 0; jat < num_targets_; ++jat)
-    {
-      const RealType rij = distances_[jat][iat];
-      if (rij < rcut)
-      { //make the compact list
-        jid[nn]   = jat;
-        dist[nn]  = rij;
-        displ[nn] = cminus * displacements_[jat][iat];
-        nn++;
-      }
-    }
-    return nn;
-  }
-
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
     RealType min_dist = std::numeric_limits<RealType>::max();
@@ -158,21 +136,6 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
     }
     assert(index >= 0 && index < num_sources_);
     return index;
-  }
-
-  size_t get_neighbors(int iat, RealType rcut, RealType* restrict dist) const
-  {
-    size_t nn = 0;
-    for (int jat = 0; jat < num_targets_; ++jat)
-    {
-      const RealType rij = distances_[jat][iat];
-      if (rij < rcut)
-      { //make the compact list
-        dist[nn] = rij;
-        nn++;
-      }
-    }
-    return nn;
   }
 
 private:

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -377,28 +377,6 @@ public:
       std::copy_n(temp_dr_.data(idim), num_sources_, displacements_[iat].data(idim));
   }
 
-  size_t get_neighbors(int iat,
-                       RealType rcut,
-                       int* restrict jid,
-                       RealType* restrict dist,
-                       PosType* restrict displ) const override
-  {
-    constexpr T cminus(-1);
-    size_t nn = 0;
-    for (int jat = 0; jat < num_targets_; ++jat)
-    {
-      const RealType rij = distances_[jat][iat];
-      if (rij < rcut)
-      { //make the compact list
-        jid[nn]   = jat;
-        dist[nn]  = rij;
-        displ[nn] = cminus * displacements_[jat][iat];
-        nn++;
-      }
-    }
-    return nn;
-  }
-
   int get_first_neighbor(IndexType iat, RealType& r, PosType& dr, bool newpos) const override
   {
     RealType min_dist = std::numeric_limits<RealType>::max();
@@ -433,21 +411,6 @@ public:
     }
     assert(index >= 0 && index < num_sources_);
     return index;
-  }
-
-  size_t get_neighbors(int iat, RealType rcut, RealType* restrict dist) const
-  {
-    size_t nn = 0;
-    for (int jat = 0; jat < num_targets_; ++jat)
-    {
-      const RealType rij = distances_[jat][iat];
-      if (rij < rcut)
-      { //make the compact list
-        dist[nn] = rij;
-        nn++;
-      }
-    }
-    return nn;
   }
 
 private:

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -75,9 +75,7 @@ void NonLocalECPComponent::resize_warrays(int n, int m, int l)
   vrad.resize(m);
   dvrad.resize(m);
   vgrad.resize(m);
-  wvec.resize(m);
-  Amat.resize(n * m);
-  dAmat.resize(n * m);
+  wvec.resize(n);
   lpol.resize(l + 1, 1.0);
   dlpol.resize(l + 1, 0.0);
   rrotsgrid_m.resize(n);

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -61,7 +61,7 @@ private:
   ///weight of the spherical grid
   std::vector<RealType> sgridweight_m;
   ///Working arrays
-  std::vector<ValueType> wvec, Amat, dAmat;
+  std::vector<ValueType> wvec;
 
   //Position delta for virtual moves.
   std::vector<PosType> deltaV;

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -127,24 +127,24 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
   ValueType pairpot;
   if (nchannel == 1)
   {
-    pairpot = vrad[0] * BLAS::dot(nknot, &Amat[0], &psiratio[0]);
+    pairpot = vrad[0] * BLAS::dot(nknot, Amat.data(), psiratio.data());
     for (int v = 0; v < dhpsioverpsi.size(); ++v)
     {
       for (int j = 0; j < nknot; ++j)
         dratio(v, j) = psiratio[j] * dratio(v, j);
-      dhpsioverpsi[v] += vrad[0] * BLAS::dot(nknot, &Amat[0], dratio[v]);
+      dhpsioverpsi[v] += vrad[0] * BLAS::dot(nknot, Amat.data(), dratio[v]);
     }
   }
   else
   {
-    BLAS::gemv(nknot, nchannel, &Amat[0], &psiratio[0], &wvec[0]);
-    pairpot = BLAS::dot(nchannel, &vrad[0], &wvec[0]);
+    BLAS::gemv(nknot, nchannel, Amat.data(), psiratio.data(), wvec.data());
+    pairpot = BLAS::dot(nchannel, vrad.data(), wvec.data());
     for (int v = 0; v < dhpsioverpsi.size(); ++v)
     {
       for (int j = 0; j < nknot; ++j)
         dratio(v, j) = psiratio[j] * dratio(v, j);
-      BLAS::gemv(nknot, nchannel, &Amat[0], dratio[v], &wvec[0]);
-      dhpsioverpsi[v] += BLAS::dot(nchannel, &vrad[0], &wvec[0]);
+      BLAS::gemv(nknot, nchannel, Amat.data(), dratio[v], wvec.data());
+      dhpsioverpsi[v] += BLAS::dot(nchannel, vrad.data(), wvec.data());
     }
   }
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -315,10 +315,10 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   };
 
   {
-    test_evaluateOne();
     nlpp->initVirtualParticle(elec);
     test_evaluateOne();
     nlpp->deleteVirtualParticle();
+    test_evaluateOne();
   }
 
   opt_variables_type optvars;
@@ -367,10 +367,10 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   };
 
   {
-    test_evaluateValueAndDerivatives();
     nlpp->initVirtualParticle(elec);
     test_evaluateValueAndDerivatives();
     nlpp->deleteVirtualParticle();
+    test_evaluateValueAndDerivatives();
   }
 
   double Value2(0.0);

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -674,7 +674,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
     return true;
   }
 
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
   {
     if (r >= cutoff_radius)
       return false;

--- a/src/QMCWaveFunctions/Jastrow/FakeFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/FakeFunctor.h
@@ -125,10 +125,8 @@ struct FakeFunctor : public OptimizableFunctorBase
   }
 
 
-  // inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
-
   /// compute derivatives with respect to variational parameters
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) { return true; }
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override { return true; }
 
   bool put(xmlNodePtr cur) override { return true; }
 

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -626,7 +626,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
     {
       const size_t NumVars = myVars.size();
       const auto& d_table  = VP.getDistTableAB(myTableID);
-      std::vector<TinyVector<RealType, 3>> derivs(NumVars);
+      std::vector<RealType> derivs_ref(NumVars);
+      std::vector<RealType> derivs(NumVars);
 
       const size_t ns = d_table.sources();
       const size_t nt = VP.getTotalNum();
@@ -646,8 +647,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
             recalcFunc = true;
         if (recalcFunc)
         {
-          std::vector<TinyVector<RealType, 3>> derivs_ref(NumVars);
           //first calculate the old derivatives VP.refPctl.
+          std::fill(derivs_ref.begin(), derivs_ref.end(), 0);
           func->evaluateDerivatives(dist_ref[i], derivs_ref);
           for (size_t j = 0; j < nt; ++j)
           {
@@ -656,7 +657,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
             func->evaluateDerivatives(VP.getDistTableAB(myTableID).getDistRow(j)[i], derivs);
             //compute the new derivatives - old derivatives
             for (int ip = 0, p = func->myVars.Index.front(); ip < func->myVars.Index.size(); ++ip, ++p)
-              dratios[j][p] += derivs_ref[ip][0] - derivs[ip][0];
+              dratios[j][p] += derivs_ref[ip] - derivs[ip];
           }
         }
       }

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -285,20 +285,19 @@ struct J1OrbitalSoA : public WaveFunctionComponent
             recalcFunc = true;
         if (recalcFunc)
         {
-          size_t nn = d_table.get_neighbors(i, func->cutoff_radius, iadj.data(), dist.data(), displ.data());
-          for (size_t nj = 0; nj < nn; ++nj)
+          for (size_t j = 0; j < nt; ++j)
           {
             std::fill(derivs.begin(), derivs.end(), 0);
-            if (!func->evaluateDerivatives(dist[nj], derivs))
+            auto dist = P.getDistTableAB(myTableID).getDistRow(j)[i];
+            if (!func->evaluateDerivatives(dist, derivs))
               continue;
-            int j = iadj[nj];
-            RealType rinv(cone / dist[nj]);
-            PosType& dr = displ[nj];
+            RealType rinv(cone / dist);
+            const PosType& dr = P.getDistTableAB(myTableID).getDisplRow(j)[i];;
             for (int p = first, ip = 0; p < last; ++p, ++ip)
             {
               dLogPsi[p] -= derivs[ip][0];
               RealType dudr(rinv * derivs[ip][1]);
-              gradLogPsi[p][j] -= dudr * dr;
+              gradLogPsi[p][j] += dudr * dr;
               lapLogPsi[p][j] -= derivs[ip][2] + lapfac * dudr;
             }
           }

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -657,7 +657,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
             func->evaluateDerivatives(VP.getDistTableAB(myTableID).getDistRow(j)[i], derivs);
             //compute the new derivatives - old derivatives
             for (int ip = 0, p = func->myVars.Index.front(); ip < func->myVars.Index.size(); ++ip, ++p)
-              dratios[p][j] += derivs_ref[ip][0] - derivs[ip][0];
+              dratios[j][p] += derivs_ref[ip][0] - derivs[ip][0];
           }
         }
       }

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.cpp
@@ -956,6 +956,76 @@ void J2OMPTarget<FT>::evaluateDerivativesWF(ParticleSet& P,
   }
 }
 
+template<typename FT>
+void J2OMPTarget<FT>::evaluateDerivRatios(const VirtualParticleSet& VP,
+                                          const opt_variables_type& optvars,
+                                          std::vector<ValueType>& ratios,
+                                          Matrix<ValueType>& dratios)
+{
+  evaluateRatios(VP, ratios);
+  if (myVars.size() == 0)
+    return;
+
+  bool recalculate(false);
+  std::vector<bool> rcsingles(myVars.size(), false);
+  for (int k = 0; k < myVars.size(); ++k)
+  {
+    int kk = myVars.where(k);
+    if (kk < 0)
+      continue;
+    if (optvars.recompute(kk))
+      recalculate = true;
+    rcsingles[k] = true;
+  }
+
+  if (recalculate)
+  {
+    ///precomputed recalculation switch
+    std::vector<bool> RecalcSwitch(F.size(), false);
+    for (int i = 0; i < F.size(); ++i)
+    {
+      if (OffSet[i].first < 0)
+      {
+        // nothing to optimize
+        RecalcSwitch[i] = false;
+      }
+      else
+      {
+        bool recalcFunc(false);
+        for (int rcs = OffSet[i].first; rcs < OffSet[i].second; rcs++)
+          if (rcsingles[rcs] == true)
+            recalcFunc = true;
+        RecalcSwitch[i] = recalcFunc;
+      }
+    }
+    const size_t NumVars = myVars.size();
+    std::vector<RealType> derivs_ref(NumVars);
+    std::vector<RealType> derivs(NumVars);
+    const auto& d_table = VP.getDistTableAB(my_table_ID_);
+    const size_t n      = d_table.sources();
+    const size_t nt     = VP.getTotalNum();
+    for (size_t i = 0; i < n; ++i)
+    {
+      if (i == VP.refPtcl)
+        continue;
+      const size_t ptype = VP.refPS.GroupID[i] * VP.refPS.groups() + VP.refPS.GroupID[VP.refPtcl];
+      if (!RecalcSwitch[ptype])
+        continue;
+      const auto dist_ref = i < VP.refPtcl ? VP.refPS.getDistTableAA(my_table_ID_).getDistRow(VP.refPtcl)[i]
+                                           : VP.refPS.getDistTableAA(my_table_ID_).getDistRow(i)[VP.refPtcl];
+      //first calculate the old derivatives VP.refPtcl.
+      std::fill(derivs_ref.begin(), derivs_ref.end(), 0.0);
+      F[ptype]->evaluateDerivatives(dist_ref, derivs_ref);
+      for (size_t j = 0; j < nt; ++j)
+      {
+        std::fill(derivs.begin(), derivs.end(), 0.0);
+        F[ptype]->evaluateDerivatives(d_table.getDistRow(j)[i], derivs);
+        for (int ip = 0, p = F[ptype]->myVars.Index.front(); ip < F[ptype]->myVars.Index.size(); ++ip, ++p)
+          dratios[j][p] += derivs_ref[ip] - derivs[ip];
+      }
+    }
+  }
+}
 
 template class J2OMPTarget<BsplineFunctor<QMCTraits::RealType>>;
 template class J2OMPTarget<PadeFunctor<QMCTraits::RealType>>;

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
@@ -247,6 +247,11 @@ public:
   void evaluateDerivativesWF(ParticleSet& P,
                              const opt_variables_type& active,
                              std::vector<ValueType>& dlogpsi) override;
+
+  void evaluateDerivRatios(const VirtualParticleSet& VP,
+                           const opt_variables_type& optvars,
+                           std::vector<ValueType>& ratios,
+                           Matrix<ValueType>& dratios) override;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -724,7 +724,7 @@ void J2OrbitalSoA<FT>::evaluateDerivRatios(const VirtualParticleSet& VP,
         std::fill(derivs.begin(), derivs.end(), 0.0);
         F[ptype]->evaluateDerivatives(d_table.getDistRow(j)[i], derivs);
         for (int ip = 0, p = F[ptype]->myVars.Index.front(); ip < F[ptype]->myVars.Index.size(); ++ip, ++p)
-          dratios[p][j] += derivs_ref[ip][0] - derivs[ip][0];
+          dratios[j][p] += derivs_ref[ip][0] - derivs[ip][0];
       }
     }
   }

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -703,7 +703,8 @@ void J2OrbitalSoA<FT>::evaluateDerivRatios(const VirtualParticleSet& VP,
       }
     }
     const size_t NumVars = myVars.size();
-    std::vector<TinyVector<RealType, 3>> derivs(NumVars);
+    std::vector<RealType> derivs_ref(NumVars);
+    std::vector<RealType> derivs(NumVars);
     const auto& d_table = VP.getDistTableAB(my_table_ID_);
     const size_t n      = d_table.sources();
     const size_t nt     = VP.getTotalNum();
@@ -714,17 +715,17 @@ void J2OrbitalSoA<FT>::evaluateDerivRatios(const VirtualParticleSet& VP,
       const size_t ptype = VP.refPS.GroupID[i] * VP.refPS.groups() + VP.refPS.GroupID[VP.refPtcl];
       if (!RecalcSwitch[ptype])
         continue;
-      std::vector<TinyVector<RealType, 3>> derivs_ref(NumVars);
       const auto dist_ref = i < VP.refPtcl ? VP.refPS.getDistTableAA(my_table_ID_).getDistRow(VP.refPtcl)[i]
                                            : VP.refPS.getDistTableAA(my_table_ID_).getDistRow(i)[VP.refPtcl];
       //first calculate the old derivatives VP.refPtcl.
+      std::fill(derivs_ref.begin(), derivs_ref.end(), 0.0);
       F[ptype]->evaluateDerivatives(dist_ref, derivs_ref);
       for (size_t j = 0; j < nt; ++j)
       {
         std::fill(derivs.begin(), derivs.end(), 0.0);
         F[ptype]->evaluateDerivatives(d_table.getDistRow(j)[i], derivs);
         for (int ip = 0, p = F[ptype]->myVars.Index.front(); ip < F[ptype]->myVars.Index.size(); ++ip, ++p)
-          dratios[j][p] += derivs_ref[ip][0] - derivs[ip][0];
+          dratios[j][p] += derivs_ref[ip] - derivs[ip];
       }
     }
   }

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -203,6 +203,11 @@ public:
   void evaluateDerivativesWF(ParticleSet& P,
                              const opt_variables_type& active,
                              std::vector<ValueType>& dlogpsi) override;
+
+  void evaluateDerivRatios(const VirtualParticleSet& VP,
+                           const opt_variables_type& optvars,
+                           std::vector<ValueType>& ratios,
+                           Matrix<ValueType>& dratios) override;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
+++ b/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
@@ -223,7 +223,7 @@ struct PadeFunctor : public OptimizableFunctorBase
   }
 
   /// compute derivatives with respect to A and B
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
   {
     int i       = 0;
     real_type u = 1.0 / (1.0 + B * r);
@@ -461,7 +461,7 @@ struct Pade2ndOrderFunctor : public OptimizableFunctorBase
   }
 
 
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
   {
     real_type u = 1.0 / (1.0 + B * r);
     int i       = 0;

--- a/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
@@ -358,7 +358,7 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
   }
 
   /// compute derivatives of U(r) with respect to the variational parameters
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
   {
 
     // get the ratio of the distance and the soft cutoff distance

--- a/src/QMCWaveFunctions/Jastrow/UserFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/UserFunctor.h
@@ -236,10 +236,8 @@ struct UserFunctor : public OptimizableFunctorBase
   }
 
 
-  // inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
-
   /// compute derivatives with respect to variational parameters
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
   {
     int i = 0;
 

--- a/src/QMCWaveFunctions/OptimizableFunctorBase.h
+++ b/src/QMCWaveFunctions/OptimizableFunctorBase.h
@@ -112,6 +112,11 @@ struct OptimizableFunctorBase
     return false;
   }
 
+  virtual inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs)
+  {
+    return false;
+  }
+
   // mmorales: don't know how to solve a template problem for cusp correction,
   //           so for now I do this
   virtual void setGridManager(bool willmanage) {}

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1119,7 +1119,7 @@ void TrialWaveFunction::mw_evaluateRatios(const RefVectorWithLeader<TrialWaveFun
     }
 }
 
-void TrialWaveFunction::evaluateDerivRatios(VirtualParticleSet& VP,
+void TrialWaveFunction::evaluateDerivRatios(const VirtualParticleSet& VP,
                                             const opt_variables_type& optvars,
                                             std::vector<ValueType>& ratios,
                                             Matrix<ValueType>& dratio)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1124,10 +1124,8 @@ void TrialWaveFunction::evaluateDerivRatios(VirtualParticleSet& VP,
                                             std::vector<ValueType>& ratios,
                                             Matrix<ValueType>& dratio)
 {
-#if defined(QMC_COMPLEX)
-  APP_ABORT("TrialWaveFunction::evaluateDerivRatios not available for complex wavefunctions");
-#else
   std::fill(ratios.begin(), ratios.end(), 1.0);
+  std::fill(dratio.begin(), dratio.end(), 0.0);
   std::vector<ValueType> t(ratios.size());
   for (int i = 0; i < Z.size(); ++i)
   {
@@ -1135,7 +1133,6 @@ void TrialWaveFunction::evaluateDerivRatios(VirtualParticleSet& VP,
     for (int j = 0; j < ratios.size(); ++j)
       ratios[j] *= t[j];
   }
-#endif
 }
 
 bool TrialWaveFunction::put(xmlNodePtr cur) { return true; }

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -310,7 +310,7 @@ public:
                                 ComputeType ct = ComputeType::ALL);
 
   /** compute both ratios and deriatives of ratio with respect to the optimizables*/
-  void evaluateDerivRatios(VirtualParticleSet& P,
+  void evaluateDerivRatios(const VirtualParticleSet& P,
                            const opt_variables_type& optvars,
                            std::vector<ValueType>& ratios,
                            Matrix<ValueType>& dratio);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -203,7 +203,7 @@ void WaveFunctionComponent::mw_evaluateRatios(const RefVectorWithLeader<WaveFunc
     wfc_list[iw].evaluateRatios(vp_list[iw], ratios[iw]);
 }
 
-void WaveFunctionComponent::evaluateDerivRatios(VirtualParticleSet& VP,
+void WaveFunctionComponent::evaluateDerivRatios(const VirtualParticleSet& VP,
                                                 const opt_variables_type& optvars,
                                                 std::vector<ValueType>& ratios,
                                                 Matrix<ValueType>& dratios)

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -568,7 +568,7 @@ public:
    * @param ratios ratios with new positions VP.R[k] the VP.refPtcl
    * @param dratios \f$\partial_{\alpha}(\ln \Psi ({\bf R}^{\prime}) - \ln \Psi ({\bf R})) \f$
    */
-  virtual void evaluateDerivRatios(VirtualParticleSet& VP,
+  virtual void evaluateDerivRatios(const VirtualParticleSet& VP,
                                    const opt_variables_type& optvars,
                                    std::vector<ValueType>& ratios,
                                    Matrix<ValueType>& dratios);

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -566,7 +566,7 @@ public:
   /** evaluate ratios to evaluate the non-local PP
    * @param VP VirtualParticleSet
    * @param ratios ratios with new positions VP.R[k] the VP.refPtcl
-   * @param dratios \f$\partial_{\alpha}(\ln \Psi ({\bf R}^{\prime}) - \ln \Psi ({\bf R})) \f$
+   * @param dratios Nq x Num_param matrix. \f$\partial_{\alpha}(\ln \Psi ({\bf R}^{\prime}) - \ln \Psi ({\bf R})) \f$
    */
   virtual void evaluateDerivRatios(const VirtualParticleSet& VP,
                                    const opt_variables_type& optvars,


### PR DESCRIPTION
## Proposed changes
Implement J1 and J2. JeeI will be next.
Remove unnecessary get_neighbours in DT.

Running on diamondC_1x1x1
"use_nonlocalpp_deriv" is cheap to run now.
From "gradient_test"
```
# use_nonlocalpp_deriv = no
Param_Name  Value    Numeric            Analytic       Percent
eC_0 -2.0322e-01  5.8930e-03  5.8919e-03  1.9518e-02
eC_1 -1.6256e-01  -1.5658e-03  -1.5656e-03  1.6832e-02
...
eC_6 -4.4453e-02  1.1006e-03  1.0739e-03  2.4258e+00
eC_7 -2.1351e-02  -1.5482e-01  -1.5449e-01  2.1335e-01
uu_0 2.7977e-01  -3.6705e-05  -1.0604e-04  -1.8889e+02
uu_1 2.1726e-01  7.1735e-03  6.6674e-03  7.0540e+00
...
uu_6 2.9160e-02  -3.9518e-02  -3.5624e-02  9.8537e+00
uu_7 1.2240e-02  1.6430e-01  1.6897e-01  -2.8403e+00
...
ud_6 4.1459e-02  -5.6726e-02  -5.5265e-02  2.5760e+00
ud_7 1.6906e-02  5.9920e-02  5.5935e-02  6.6501e+00

  Execution time = 6.5431e+01
```
develop branch
```
# use_nonlocalpp_deriv = yes
Param_Name  Value    Numeric            Analytic       Percent
eC_0 -2.0322e-01  5.8930e-03  5.8919e-03  1.9524e-02
eC_1 -1.6256e-01  -1.5658e-03  -1.5656e-03  1.6872e-02
...
eC_6 -4.4453e-02  1.1006e-03  1.1006e-03  -3.6409e-03
eC_7 -2.1351e-02  -1.5482e-01  -1.5482e-01  1.4062e-05
uu_0 2.7977e-01  -3.6705e-05  -3.3317e-05  9.2291e+00
uu_1 2.1726e-01  7.1735e-03  7.1750e-03  -2.1123e-02
...
uu_6 2.9160e-02  -3.9518e-02  -3.9518e-02  5.7571e-05
uu_7 1.2240e-02  1.6430e-01  1.6430e-01  -9.4842e-06
ud_0 4.6311e-01  -3.0363e-04  -3.0126e-04  7.7817e-01
ud_1 3.5640e-01  2.4801e-02  2.4800e-02  2.3507e-03
...
ud_6 4.1459e-02  -5.6726e-02  -5.6726e-02  -1.3851e-05
ud_7 1.6906e-02  5.9920e-02  5.9920e-02  -3.2892e-05

  Execution time = 2.4349e+02
```
this PR
```
# use_nonlocalpp_deriv = yes
Param_Name  Value    Numeric            Analytic       Percent
eC_0 -2.0322e-01  5.8930e-03  5.8919e-03  1.9518e-02
eC_1 -1.6256e-01  -1.5658e-03  -1.5656e-03  1.6832e-02
...
eC_6 -4.4453e-02  1.1006e-03  1.1006e-03  -3.6651e-03
eC_7 -2.1351e-02  -1.5482e-01  -1.5482e-01  1.4176e-05
uu_0 2.7977e-01  -3.6705e-05  -3.3317e-05  9.2298e+00
uu_1 2.1726e-01  7.1735e-03  7.1750e-03  -2.1132e-02
...
uu_6 2.9160e-02  -3.9518e-02  -3.9518e-02  5.6447e-05
uu_7 1.2240e-02  1.6430e-01  1.6430e-01  -9.4301e-06
ud_0 4.6311e-01  -3.0363e-04  -3.0126e-04  7.7797e-01
ud_1 3.5640e-01  2.4801e-02  2.4800e-02  2.3539e-03
...
ud_6 4.1459e-02  -5.6726e-02  -5.6726e-02  -1.3694e-05
ud_7 1.6906e-02  5.9920e-02  5.9920e-02  -3.2447e-05

  Execution time = 4.7143e+01
```
use_nonlocalpp_deriv significantly reduces the difference between Numeric and Analytic.
New code path is much faster.

## What type(s) of changes does this code introduce?
- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'