### PR TITLE
Add ctest -j parallel jobs option to all CI

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -323,8 +323,22 @@ case "$1" in
     then 
        source /opt/intel2020/mkl/bin/mklvars.sh intel64
     fi
+
+    # Add ctest concurrent parallel jobs 
+    # Default for Linux GitHub Action runners
+    CTEST_JOBS="2"
+    # Default for macOS GitHub Action runners
+    if [[ "${GH_OS}" =~ (macOS) ]]
+    then
+      CTEST_JOBS="3"
+    fi
+
+    if [[ "$HOST_NAME" =~ (sulfur) || "$HOST_NAME" =~ (nitrogen) ]]
+    then
+      CTEST_JOBS="16"
+    fi
     
-    ctest --output-on-failure $TEST_LABEL
+    ctest --output-on-failure $TEST_LABEL -j $CTEST_JOBS
     ;;
   
   # Generate coverage reports


### PR DESCRIPTION
## Proposed changes

Add the -j option to ctest in CI for GitHub Actions (2 for Linux and 3 for macOS) and ornl-hosted (16) runners.
This option can be tested on this PR (no need to merge first).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
