### PR TITLE
Remove twistnum in bspline SPO XML attribute

### DIFF
--- a/docs/hamiltonianobservable.rst
+++ b/docs/hamiltonianobservable.rst
@@ -1682,7 +1682,7 @@ Additional information:
   :caption: Example ``sposet`` initialization for density matrix use.  Occupied and virtual orbital sets are created separately, then joined (``basis="spo_u spo_uv"``).
   :name: Listing 39
 
-  <sposet_builder type="bspline" href="../dft/pwscf_output/pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" gpu="no" precision="single">
+  <sposet_builder type="bspline" href="../dft/pwscf_output/pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" gpu="no" precision="single">
     <sposet type="bspline" name="spo_u"  group="0" size="4"/>
     <sposet type="bspline" name="spo_d"  group="0" size="2"/>
     <sposet type="bspline" name="spo_uv" group="0" index_min="4" index_max="10"/>
@@ -1692,7 +1692,7 @@ Additional information:
   :caption: Example ``sposet`` initialization for density matrix use. Density matrix orbital basis created separately (``basis="dm_basis"``).
   :name: Listing 40
 
-  <sposet_builder type="bspline" href="../dft/pwscf_output/pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" gpu="no" precision="single">
+  <sposet_builder type="bspline" href="../dft/pwscf_output/pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" gpu="no" precision="single">
     <sposet type="bspline" name="spo_u"  group="0" size="4"/>
     <sposet type="bspline" name="spo_d"  group="0" size="2"/>
     <sposet type="bspline" name="dm_basis" size="50" spindataset="0"/>

--- a/docs/intro_wavefunction.rst
+++ b/docs/intro_wavefunction.rst
@@ -124,7 +124,7 @@ determinants.
   :caption: Deprecated input style.
   :name: spo.singledet.old.xml
 
-  <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+  <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
      <slaterdeterminant>
         <determinant id="updet" size="8">
            <occupation mode="ground" spindataset="0"/>
@@ -142,7 +142,7 @@ After updating the input style.
   :name: spo.singledet.xml
 
   <!-- all the attributes are moved from determinantset.-->
-  <sposet_collection type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+  <sposet_collection type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
     <!-- all the attributes and contents are moved from determinant.  Change 'id' tag to 'name' tag.
          Need only one sposet for unpolarized calculation.-->
     <sposet name="spo-ud" size="8">
@@ -221,7 +221,7 @@ The input xml block for the spline SPOs is given in :ref:`spline.spo.xml`. A lis
   :name: spline.spo.xml
 
   <sposet_collection type="bspline" source="i" href="pwscf.h5"
-                  tilematrix="1 1 3 1 2 -1 -2 1 0" twistnum="-1" gpu="yes" meshfactor="0.8"
+                  tilematrix="1 1 3 1 2 -1 -2 1 0" gpu="yes" meshfactor="0.8"
                   twist="0  0  0" precision="double">
     <sposet name="spo-up" size="208">
       <occupation mode="ground" spindataset="0"/>
@@ -255,9 +255,7 @@ attribute:
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
 | ``tilematrix``              | 9 integers |                          |         | Tiling matrix used to expand supercell.   |
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
-| ``twistnum``                | Integer    |                          |         | Index of the super twist.                 |
-+-----------------------------+------------+--------------------------+---------+-------------------------------------------+
-| ``twist``                   | 3 floats   |                          |         | Super twist.                              |
+| ``twist``                   | 3 floats   |                          | [0,0,0] | Super twist.                              |
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
 | ``meshfactor``              | Float      | :math:`\le 1.0`          |         | Grid spacing ratio.                       |
 +-----------------------------+------------+--------------------------+---------+-------------------------------------------+
@@ -295,11 +293,6 @@ Additional information:
     A smaller meshfactor saves memory use but reduces accuracy. The
     effects are similar to reducing plane wave cutoff in DFT
     calculations. Use with caution!
-
-- twistnum
-    If positive, it is the index. We recommend not taking
-    this way since the indexing might show some uncertainty. If negative,
-    the super twist is referred by ``twist``.
 
 - save_coefs
     If yes, dump the real-space B-spline coefficient
@@ -637,7 +630,7 @@ To enable hybrid orbital representation, the input XML needs to see the tag ``hy
   :name: Listing 6
 
   <sposet_collection type="bspline" source="i" href="pwscf.h5"
-                tilematrix="1 1 3 1 2 -1 -2 1 0" twistnum="-1" gpu="yes" meshfactor="0.8"
+                tilematrix="1 1 3 1 2 -1 -2 1 0" gpu="yes" meshfactor="0.8"
                 twist="0  0  0" precision="single" hybridrep="yes">
     ...
   </sposet_collection>

--- a/docs/spin_orbit.rst
+++ b/docs/spin_orbit.rst
@@ -58,7 +58,7 @@ where we now utilize determinants of spinors, as opposed to the usual product of
   <?xml version="1.0"?>
   <qmcsystem>
     <wavefunction name="psi0" target="e">
-      <sposet_builder name="spo_builder" type="bspline" href="eshdf.h5" tilematrix="100010001" twistnum="0" source="ion0" size="10">
+      <sposet_builder name="spo_builder" type="bspline" href="eshdf.h5" tilematrix="100010001" source="ion0" size="10">
         <sposet type="bspline" name="myspo" size="10">
           <occupation mode="ground"/>
         </sposet>

--- a/examples/solids/simple-LiH.xml
+++ b/examples/solids/simple-LiH.xml
@@ -46,7 +46,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="LiH.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" twist="0.0 0.0 0.0" gpu="yes" meshfactor="1.0" source="i"  precision="single">
+    <determinantset type="einspline" href="LiH.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" source="i"  precision="single">
       <slaterdeterminant>
         <determinant id="updet" size="2" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -30,7 +30,7 @@ namespace qmcplusplus
  *  TO USE THIS YOU NEED TO KNOW THE NAME OF THE SPOSET(S)!!!
  *    For example, using sposet_builder the names are prominently displayed:
  * 
- *      <sposet_builder type="bspline" href="pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10">
+ *      <sposet_builder type="bspline" href="pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10">
  *         <sposet type="bspline" name="spo_ud" size="2" spindataset="0"/>
  *      </sposet_builder>
  * 

--- a/src/QMCTools/PyscfToQmcpack_Spline.py
+++ b/src/QMCTools/PyscfToQmcpack_Spline.py
@@ -735,7 +735,6 @@ class InputXml:
                                                            "href":"{}".format(h5_path),
                                                            "source":"ion0",
                                                            "tilematrix":"{}".format(tilematrix),
-                                                           "twistnum":"0",
                                                            "meshfactor":"1.0"})
     basisset_node = etree.Element('basisset')
     determinantset_node.append(basisset_node)

--- a/src/QMCTools/RMGParser.cpp
+++ b/src/QMCTools/RMGParser.cpp
@@ -87,7 +87,6 @@ void RMGParser::dumpPBC(const std::string& psi_tag, const std::string& ion_tag)
       // this just reproduces the behavior of pw2qmcpack
       xmlNewProp(detsetPtr, (const xmlChar*)"sort", (const xmlChar*)"1");
       xmlNewProp(detsetPtr, (const xmlChar*)"tilematrix", (const xmlChar*)"1 0 0 0 1 0 0 0 1");
-      xmlNewProp(detsetPtr, (const xmlChar*)"twistnum", (const xmlChar*)"0");
       xmlNewProp(detsetPtr, (const xmlChar*)"version", (const xmlChar*)"0.10");
       {
         std::ostringstream up_size, down_size;

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -62,9 +62,6 @@ public:
   /// The "Twist" variables are in reduced coords, i.e. from 0 to1.
   /// The "k" variables are in Cartesian coordinates.
   PosType TwistVector, kVector;
-  /// This stores which "true" twist vector this clone is using.
-  /// "True" indicates the physical twist angle after untiling
-  int TwistNum;
   /// metric tensor to handle generic unitcell
   Tensor<RealType, OHMMS_DIM> GGt;
 
@@ -76,7 +73,7 @@ public:
   void resetSourceParticleSet(ParticleSet& ions);
   void setOrbitalSetSize(int norbs) override;
   inline std::string Type() { return "EinsplineSet"; }
-  EinsplineSet() : TwistNum(0), NumValenceOrbs(0) { className = "EinsplineSet"; }
+  EinsplineSet() : NumValenceOrbs(0) { className = "EinsplineSet"; }
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -135,7 +135,7 @@ public:
 
   ///This is true if we have the orbital derivatives w.r.t. the ion positions
   bool HaveOrbDerivs;
-  ///root XML node with href, sort, tilematrix, twistnum, source, precision,truncate,version
+  ///root XML node with href, sort, tilematrix, source, precision,truncate,version
   xmlNodePtr XMLRoot;
 
   std::map<H5OrbSet, SPOSet*, H5OrbSet> SPOSetMap;
@@ -154,7 +154,7 @@ public:
   /** a specific but clean code path in createSPOSetFromXML, for PBC, double, ESHDF
    * @param cur the current xml node
    */
-  void set_metadata(int numOrbs, int TwistNum_inp, bool skipChecks = false);
+  void set_metadata(int numOrbs, bool skipChecks = false);
 
   /** initialize with the existing SPOSet */
   std::unique_ptr<SPOSet> createSPOSet(xmlNodePtr cur, SPOSetInputInfo& input_info) override;
@@ -218,9 +218,10 @@ public:
   /////////////////////////////
   // Twist angle information //
   /////////////////////////////
-  // This stores which "true" twist number I am using
-  int TwistNum;
+  // captured XML input twist attribute. Default [0.0, 0.0, 0.0]
   TinyVector<double, OHMMS_DIM> givenTwist;
+  // The index of twist selected from h5 based on givenTwist;
+  int TwistNum;
   std::vector<TinyVector<double, OHMMS_DIM>> TwistAngles;
   //     integer index of sym operation from the irreducible brillion zone
   std::vector<int> TwistSymmetry;

--- a/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderCommon.cpp
@@ -48,7 +48,7 @@ EinsplineSetBuilder::EinsplineSetBuilder(ParticleSet& p, const PtclPoolType& pse
       NumCoreStates(0),
       MeshFactor(1.0),
       MeshSize(0, 0, 0),
-      TwistNum(0),
+      TwistNum(-1),
       TileFactor(1, 1, 1),
       NumMuffinTins(0),
       LastSpinSet(-1),
@@ -466,6 +466,8 @@ void EinsplineSetBuilder::AnalyzeTwists2()
     }
     //        fprintf (stderr, "Number in irredicible twist grid: %d \n", n_tot_irred);
   }
+
+  // TwistNum has not been selected, find it in SuperTwists
   if (TwistNum < 0)
   {
     PosType gtFrac = FracPart(givenTwist);

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -38,7 +38,7 @@
 
 namespace qmcplusplus
 {
-void EinsplineSetBuilder::set_metadata(int numOrbs, int TwistNum_inp, bool skipChecks)
+void EinsplineSetBuilder::set_metadata(int numOrbs, bool skipChecks)
 {
   // 1. set a lot of internal parameters in the EinsplineSetBuilder class
   //  e.g. TileMatrix, use_real_splines_, DistinctTwists, MakeTwoCopies.
@@ -99,7 +99,6 @@ void EinsplineSetBuilder::set_metadata(int numOrbs, int TwistNum_inp, bool skipC
     AtomicOrbitals[iat].Lattice.set(Lattice);
 
   // Now, analyze the k-point mesh to figure out the what k-points  are needed
-  TwistNum = TwistNum_inp;
   AnalyzeTwists2();
 }
 
@@ -108,9 +107,8 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   //use 2 bohr as the default when truncated orbitals are used based on the extend of the ions
   int numOrbs = 0;
   int sortBands(1);
-  int spinSet      = 0;
-  int TwistNum_inp = 0;
-  bool skipChecks  = false;
+  int spinSet     = 0;
+  bool skipChecks = false;
 
   std::string sourceName;
   std::string spo_prec("double");
@@ -133,7 +131,6 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
     a.add(TileFactor, "tile");
     a.add(sortBands, "sort");
     a.add(TileMatrix, "tilematrix");
-    a.add(TwistNum_inp, "twistnum");
     a.add(givenTwist, "twist");
     a.add(sourceName, "source");
     a.add(MeshFactor, "meshfactor");
@@ -248,7 +245,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 
   // set the internal parameters
   if (spinSet == 0)
-    set_metadata(numOrbs, TwistNum_inp, skipChecks);
+    set_metadata(numOrbs, skipChecks);
   //if (use_complex_orb == "yes") use_real_splines_ = false; // override given user input
 
   // look for <backflow>, would be a lot easier with xpath, but I cannot get it to work

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
@@ -21,6 +21,7 @@
 #include "QMCWaveFunctions/SpinorSet.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
+#include <Message/UniformCommunicateError.h>
 #include "Utilities/Timer.h"
 #include "QMCWaveFunctions/einspline_helper.hpp"
 #include "QMCWaveFunctions/BsplineFactory/BsplineReaderBase.h"
@@ -32,8 +33,9 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
 {
   int numOrbs = 0;
   int sortBands(1);
-  int spinSet  = 0;
-  int spinSet2 = 1;
+  int spinSet      = 0;
+  int spinSet2     = 1;
+  int twistnum_inp = -1;
 
   //There have to be two "spin states"...  one for the up channel and one for the down channel.
   // We force this for spinors and manually resize states and FullBands.
@@ -55,6 +57,8 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(TileFactor, "tile");
     a.add(sortBands, "sort");
     a.add(TileMatrix, "tilematrix");
+    // twistnum input support has been removed. Still read it for adding a trap for risky old input
+    a.add(twistnum_inp, "twistnum", {}, TagStatus::DEPRECATED);
     a.add(givenTwist, "twist");
     a.add(sourceName, "source");
     a.add(MeshFactor, "meshfactor");
@@ -70,6 +74,10 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(spinSet, "group");
     a.put(cur);
   }
+
+  // only assume -1 case may safely run
+  if (twistnum_inp != -1)
+    throw UniformCommunicateError("The support of 'twistnum' attribute has been removed. Use 'twist' instead.");
 
   auto pit(ParticleSets.find(sourceName));
   if (pit == ParticleSets.end())

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
@@ -32,9 +32,8 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
 {
   int numOrbs = 0;
   int sortBands(1);
-  int spinSet      = 0;
-  int spinSet2     = 1;
-  int TwistNum_inp = 0;
+  int spinSet  = 0;
+  int spinSet2 = 1;
 
   //There have to be two "spin states"...  one for the up channel and one for the down channel.
   // We force this for spinors and manually resize states and FullBands.
@@ -56,7 +55,6 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
     a.add(TileFactor, "tile");
     a.add(sortBands, "sort");
     a.add(TileMatrix, "tilematrix");
-    a.add(TwistNum_inp, "twistnum");
     a.add(givenTwist, "twist");
     a.add(sourceName, "source");
     a.add(MeshFactor, "meshfactor");
@@ -144,7 +142,7 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   //than Einspline on what the data means...
   bool skipChecks = true;
 
-  set_metadata(numOrbs, TwistNum_inp, skipChecks);
+  set_metadata(numOrbs, skipChecks);
 
   //////////////////////////////////
   // Create the OrbitalSet object
@@ -159,7 +157,8 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
 
   // safeguard for a removed feature
   if (truncate == "yes")
-    myComm->barrier_and_abort("The 'truncate' feature of spline SPO has been removed. Please use hybrid orbital representation.");
+    myComm->barrier_and_abort(
+        "The 'truncate' feature of spline SPO has been removed. Please use hybrid orbital representation.");
 
   std::string useGPU("no");
 #if !defined(QMC_COMPLEX)
@@ -192,12 +191,12 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   MixedSplineReader->setRotate(false);
 
   //Make the up spin set.
-  HasCoreOrbs = bcastSortBands(spinSet, NumDistinctOrbitals, myComm->rank() == 0);
+  HasCoreOrbs       = bcastSortBands(spinSet, NumDistinctOrbitals, myComm->rank() == 0);
   auto bspline_zd_u = MixedSplineReader->create_spline_set(spinSet, spo_cur);
 
   //Make the down spin set.
   OccupyBands(spinSet2, sortBands, numOrbs, skipChecks);
-  HasCoreOrbs = bcastSortBands(spinSet2, NumDistinctOrbitals, myComm->rank() == 0);
+  HasCoreOrbs       = bcastSortBands(spinSet2, NumDistinctOrbitals, myComm->rank() == 0);
   auto bspline_zd_d = MixedSplineReader->create_spline_set(spinSet2, spo_cur);
 
   //register with spin set and we're off to the races.

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -14,6 +14,7 @@
 
 #include "SPOSetBuilder.h"
 #include "OhmmsData/AttributeSet.h"
+#include <Message/UniformCommunicateError.h>
 
 #if !defined(QMC_COMPLEX)
 #include "QMCWaveFunctions/RotatedSPOs.h"
@@ -72,10 +73,18 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   // process general sposet construction requests
   //   and preserve legacy interface
   std::unique_ptr<SPOSet> sposet;
-  if (legacy && input_info.legacy_request)
-    sposet = createSPOSetFromXML(cur);
-  else
-    sposet = createSPOSet(cur, input_info);
+
+  try
+  {
+    if (legacy && input_info.legacy_request)
+      sposet = createSPOSetFromXML(cur);
+    else
+      sposet = createSPOSet(cur, input_info);
+  }
+  catch (const UniformCommunicateError& ue)
+  {
+    myComm->barrier_and_abort(ue.what());
+  }
 
   if (!sposet)
     myComm->barrier_and_abort("SPOSetBuilder::createSPOSet sposet creation failed");
@@ -88,8 +97,8 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
 #else
     // create sposet with rotation
     auto& sposet_ref = *sposet;
-    auto rot_spo    = std::make_unique<RotatedSPOs>(std::move(sposet));
-    xmlNodePtr tcur = cur->xmlChildrenNode;
+    auto rot_spo     = std::make_unique<RotatedSPOs>(std::move(sposet));
+    xmlNodePtr tcur  = cur->xmlChildrenNode;
     while (tcur != NULL)
     {
       std::string cname((const char*)(tcur->name));

--- a/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
+++ b/src/QMCWaveFunctions/tests/MinimalWaveFunctionPool.h
@@ -23,10 +23,10 @@ class MinimalWaveFunctionPool
 {
   static constexpr const char* const wf_input = R"(
 <wavefunction target='e'>
-  <sposet_collection type="bspline" source="ion" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="0.8" twist="0 0 0" precision="double">
+  <sposet_collection type="bspline" source="ion" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="0.8" twist="0 0 0" precision="double">
     <sposet name="spo_for_dets" size="4" spindataset="0"/>
   </sposet_collection>
-  <sposet_collection type="bspline" source="ion" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="no" meshfactor="0.8" twist="0 0 0" precision="double">
+  <sposet_collection type="bspline" source="ion" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="no" meshfactor="0.8" twist="0 0 0" precision="double">
     <sposet name="spo_ud" size="4" spindataset="0"/>
     <sposet name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
   </sposet_collection>

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -99,7 +99,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   //diamondC_1x1x1
   const char* spo_xml = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"2\"/> \
+<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"2\"/> \
 </tmp> \
 ";
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -125,7 +125,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   //diamondC_1x1x1
   std::string spo_xml = "<tmp> \
-               <determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.5\" precision=\"float\" size=\"2\"/> \
+               <determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.5\" precision=\"float\" size=\"2\"/> \
                </tmp> \
                ";
 #ifndef MIXED_PRECISION

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\"/> \
+<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\"/> \
 </tmp> \
 ";
 
@@ -293,7 +293,7 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
 
   //diamondC_2x1x1
   const char* particles = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\"/> \
+<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\"/> \
 </tmp> \
 ";
 

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 
 
   const char* particles = "<tmp> \
-   <sposet_builder name=\"A\" type=\"einspline\" href=\"o2_45deg_spins.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" size=\"3\" precision=\"float\" meshfactor=\"4.0\"> \
+   <sposet_builder name=\"A\" type=\"einspline\" href=\"o2_45deg_spins.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\" size=\"3\" precision=\"float\" meshfactor=\"4.0\"> \
      <sposet name=\"myspo\" size=\"3\"> \
        <occupation mode=\"ground\"/> \
      </sposet> \

--- a/src/QMCWaveFunctions/tests/test_hybridrep.cpp
+++ b/src/QMCWaveFunctions/tests/test_hybridrep.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_1x1x1", "[wavefunction]")
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\" hybridrep=\"yes\"/> \
+<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\" hybridrep=\"yes\"/> \
 </tmp> \
 ";
 
@@ -220,7 +220,7 @@ TEST_CASE("Hybridrep SPO from HDF diamond_2x1x1", "[wavefunction]")
 
   //diamondC_2x1x1
   const char* particles = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\" hybridrep=\"yes\"/> \
+<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"4\" hybridrep=\"yes\"/> \
 </tmp> \
 ";
 

--- a/src/QMCWaveFunctions/tests/test_pw.cpp
+++ b/src/QMCWaveFunctions/tests/test_pw.cpp
@@ -91,7 +91,7 @@ TEST_CASE("PlaneWave SPO from HDF for BCC H", "[wavefunction]")
 
   //BCC H
   const char* particles = "<tmp> \
-<determinantset type=\"PW\" href=\"bccH.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\"> \
+<determinantset type=\"PW\" href=\"bccH.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\"> \
    <slaterdeterminant> \
      <determinant id=\"updet\" size=\"1\"> \
       <occupation mode=\"ground\" spindataset=\"0\"/> \
@@ -236,7 +236,7 @@ TEST_CASE("PlaneWave SPO from HDF for LiH arb", "[wavefunction]")
 
   //diamondC_1x1x1
   const char* particles = "<tmp> \
-<determinantset type=\"PW\" href=\"LiH-arb.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\"> \
+<determinantset type=\"PW\" href=\"LiH-arb.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" source=\"ion\"> \
    <slaterdeterminant> \
      <determinant id=\"updet\" size=\"2\"> \
       <occupation mode=\"ground\" spindataset=\"0\"/> \

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -145,7 +145,7 @@ TEST_CASE("SPO input spline from HDF diamond_2x1x1", "[wavefunction]")
   app_log() << "diamondC_2x1x1 input style 1 using sposet_collection" << std::endl;
   app_log() << "-------------------------------------------------------------" << std::endl;
   const char* spo_xml_string1 = "<wavefunction name=\"psi0\" target=\"elec\">\
-<sposet_collection name=\"einspline_diamond_size4\" type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
+<sposet_collection name=\"einspline_diamond_size4\" type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
   <sposet name=\"spo\" size=\"4\" spindataset=\"0\"/> \
 </sposet_collection> \
 </wavefunction> \
@@ -156,7 +156,7 @@ TEST_CASE("SPO input spline from HDF diamond_2x1x1", "[wavefunction]")
   app_log() << "diamondC_2x1x1 input style 2 sposet inside determinantset" << std::endl;
   app_log() << "-------------------------------------------------------------" << std::endl;
   const char* spo_xml_string2 = "<wavefunction name=\"psi0\" target=\"elec\">\
-<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
+<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
   <sposet name=\"spo\" size=\"4\" spindataset=\"0\"/> \
   <slaterdeterminant> \
     <determinant name=\"det\" sposet=\"spo\"/> \
@@ -170,7 +170,7 @@ TEST_CASE("SPO input spline from HDF diamond_2x1x1", "[wavefunction]")
   app_log() << "diamondC_2x1x1 input style 3 sposet inside determinantset" << std::endl;
   app_log() << "-------------------------------------------------------------" << std::endl;
   const char* spo_xml_string3 = "<wavefunction name=\"psi0\" target=\"elec\">\
-<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
+<determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\"> \
   <slaterdeterminant> \
     <determinant name=\"spo\" size=\"4\" spindataset=\"0\"/> \
   </slaterdeterminant> \

--- a/src/QMCWaveFunctions/tests/test_wavefunction_pool.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_pool.cpp
@@ -93,7 +93,7 @@ TEST_CASE("WaveFunctionPool", "[qmcapp]")
 
 
   const char* wf_input = "<wavefunction target='e'>\
-     <determinantset type='einspline' href='diamondC_1x1x1.pwscf.h5' tilematrix='1 0 0 0 1 0 0 0 1' twistnum='0' source='ion' meshfactor='1.0' precision='float'> \
+     <determinantset type='einspline' href='diamondC_1x1x1.pwscf.h5' tilematrix='1 0 0 0 1 0 0 0 1' source='ion' meshfactor='1.0' precision='float'> \
          <slaterdeterminant> \
             <determinant id='updet' size='4'> \
               <occupation mode='ground' spindataset='0'/>\

--- a/tests/converter/test_O_rmg/gold.wfnoj.xml
+++ b/tests/converter/test_O_rmg/gold.wfnoj.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-    <determinantset type="bspline" href="o.h5" source="ion0" sort="1" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" version="0.10">
+    <determinantset type="bspline" href="o.h5" source="ion0" sort="1" tilematrix="1 0 0 0 1 0 0 0 1" version="0.10">
       <slaterdeterminant>
         <determinant id="updet" size="4">
           <occupation mode="ground" spindataset="0"/>

--- a/tests/converter/test_diamond2_rmg/gold.wfnoj.xml
+++ b/tests/converter/test_diamond2_rmg/gold.wfnoj.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-    <determinantset type="bspline" href="diamond2.h5" source="ion0" sort="1" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" version="0.10">
+    <determinantset type="bspline" href="diamond2.h5" source="ion0" sort="1" tilematrix="1 0 0 0 1 0 0 0 1" version="0.10">
       <slaterdeterminant>
         <determinant id="updet" size="4">
           <occupation mode="ground" spindataset="0"/>

--- a/tests/estimator/latdev/vmc.xml
+++ b/tests/estimator/latdev/vmc.xml
@@ -45,7 +45,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-        <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+        <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/estimator/skinetic/vmc.xml
+++ b/tests/estimator/skinetic/vmc.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/estimator/sofk/allp_dat-h5.xml
+++ b/tests/estimator/sofk/allp_dat-h5.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/estimator/sofk/pbyp_dat-h5.xml
+++ b/tests/estimator/sofk/pbyp_dat-h5.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/io/restart/qmc_short.in.xml
+++ b/tests/io/restart/qmc_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/io/restart/qmc_short.restart.xml
+++ b/tests/io/restart/qmc_short.restart.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/io/save_coefs/qmc_short.in.xml
+++ b/tests/io/save_coefs/qmc_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float" save_coefs="yes">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float" save_coefs="yes">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/io/save_coefs/qmc_short.restart.xml
+++ b/tests/io/save_coefs/qmc_short.restart.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S256-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a64-e256-cpu/C-graphite-S256-dmc.xml
@@ -105,7 +105,7 @@
   </particleset>
   <wavefunction name="psi0" target="e">
     <determinantset type="bspline" href="../lda.pwscf.h5" sort="1"
-      tilematrix="4 0 0 0 4 0 0 0 1" twistnum="2" source="ion0"
+      tilematrix="4 0 0 0 4 0 0 0 1" twist="0.0 0.0 0.5" source="ion0"
       version="0.10" gpu="yes" LR_dim_cutoff="10" precision="single">
       <slaterdeterminant>
         <determinant id="updet" size="128">

--- a/tests/performance/C-graphite/sample/dmc-a64-e256-gpu/C-graphite-S256-dmc.xml
+++ b/tests/performance/C-graphite/sample/dmc-a64-e256-gpu/C-graphite-S256-dmc.xml
@@ -105,7 +105,7 @@
   </particleset>
   <wavefunction name="psi0" target="e">
     <determinantset type="bspline" href="../lda.pwscf.h5" sort="1"
-      tilematrix="4 0 0 0 4 0 0 0 1" twistnum="2" source="ion0"
+      tilematrix="4 0 0 0 4 0 0 0 1" twist="0.0 0.0 0.5" source="ion0"
       version="0.10" gpu="yes" LR_dim_cutoff="10" precision="single">
       <slaterdeterminant>
         <determinant id="updet" size="128">

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu-J3/NiO-fcc-S256-dmc.xml
@@ -1194,7 +1194,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S256.h5" meshfactor="0.9" precision="single" source="i" tilematrix="3 7 -1 -2 4 2 -2 3 -8" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S256.h5" meshfactor="0.9" precision="single" source="i" tilematrix="3 7 -1 -2 4 2 -2 3 -8" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="6144">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-cpu/NiO-fcc-S256-dmc.xml
@@ -1195,7 +1195,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S256.h5" tilematrix="3 7 -1 -2 4 2 -2 3 -8" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S256.h5" tilematrix="3 7 -1 -2 4 2 -2 3 -8" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="6144" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a1024-e12288-gpu/NiO-fcc-S256-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a1024-e12288-gpu/NiO-fcc-S256-dmc.xml
@@ -1194,7 +1194,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S256.h5" meshfactor="0.9" precision="single" source="i" tilematrix="3 7 -1 -2 4 2 -2 3 -8" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S256.h5" meshfactor="0.9" precision="single" source="i" tilematrix="3 7 -1 -2 4 2 -2 3 -8" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="6144">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu-J3/NiO-fcc-S32-dmc.xml
@@ -186,7 +186,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S32.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -1 1 0 1 3 1 4 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S32.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -1 1 0 1 3 1 4 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="768">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-cpu/NiO-fcc-S32-dmc.xml
@@ -187,7 +187,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S32.h5" tilematrix="2 -1 1 0 1 3 1 4 -2" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S32.h5" tilematrix="2 -1 1 0 1 3 1 4 -2" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="768" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a128-e1536-gpu/NiO-fcc-S32-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a128-e1536-gpu/NiO-fcc-S32-dmc.xml
@@ -186,7 +186,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S32.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -1 1 0 1 3 1 4 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S32.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -1 1 0 1 3 1 4 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="768">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu-J3/NiO-fcc-S4-dmc.xml
@@ -60,7 +60,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S4.h5" meshfactor="0.9" precision="float" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S4.h5" meshfactor="0.9" precision="float" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="96">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a16-e192-cpu/NiO-fcc-S4-dmc.xml
@@ -61,7 +61,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S4.h5" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" twistnum="-1" gpu="yes" meshfactor="0.9" precision="float" twist="0  0  0">
+    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S4.h5" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" gpu="yes" meshfactor="0.9" precision="float" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="96" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a16-e192-gpu/NiO-fcc-S4-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a16-e192-gpu/NiO-fcc-S4-dmc.xml
@@ -60,7 +60,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S4.h5" meshfactor="0.9" precision="float" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S4.h5" meshfactor="0.9" precision="float" source="i" tilematrix="1 0 0 0 1 1 0 2 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="96">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu-J3/NiO-fcc-S48-dmc.xml
@@ -258,7 +258,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S48.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -4 2 2 1 3 1 2 -4" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S48.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -4 2 2 1 3 1 2 -4" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="1152">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-cpu/NiO-fcc-S48-dmc.xml
@@ -259,7 +259,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S48.h5" tilematrix="1 -4 2 2 1 3 1 2 -4" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S48.h5" tilematrix="1 -4 2 2 1 3 1 2 -4" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="1152" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a192-e2304-gpu/NiO-fcc-S48-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a192-e2304-gpu/NiO-fcc-S48-dmc.xml
@@ -258,7 +258,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S48.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -4 2 2 1 3 1 2 -4" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S48.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -4 2 2 1 3 1 2 -4" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="1152">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu-J3/NiO-fcc-S64-dmc.xml
@@ -330,7 +330,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S64.h5" meshfactor="0.9" precision="single" source="i" tilematrix="0 -5 1 2 0 4 2 3 -3" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S64.h5" meshfactor="0.9" precision="single" source="i" tilematrix="0 -5 1 2 0 4 2 3 -3" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="1536">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-cpu/NiO-fcc-S64-dmc.xml
@@ -331,7 +331,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S64.h5" tilematrix="0 -5 1 2 0 4 2 3 -3" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S64.h5" tilematrix="0 -5 1 2 0 4 2 3 -3" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="1536" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a256-e3072-gpu/NiO-fcc-S64-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a256-e3072-gpu/NiO-fcc-S64-dmc.xml
@@ -330,7 +330,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S64.h5" meshfactor="0.9" precision="single" source="i" tilematrix="0 -5 1 2 0 4 2 3 -3" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S64.h5" meshfactor="0.9" precision="single" source="i" tilematrix="0 -5 1 2 0 4 2 3 -3" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="1536">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu-J3/NiO-fcc-S8-dmc.xml
@@ -78,7 +78,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S8.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 1 1 0 2 -2 1 -1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S8.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 1 1 0 2 -2 1 -1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="192">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a32-e384-cpu/NiO-fcc-S8-dmc.xml
@@ -79,7 +79,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S8.h5" tilematrix="1 1 1 0 2 -2 1 -1 -1" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S8.h5" tilematrix="1 1 1 0 2 -2 1 -1 -1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="192" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a32-e384-gpu/NiO-fcc-S8-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a32-e384-gpu/NiO-fcc-S8-dmc.xml
@@ -78,7 +78,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S8.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 1 1 0 2 -2 1 -1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S8.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 1 1 0 2 -2 1 -1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="192">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu-J3/NiO-fcc-S1-dmc.xml
@@ -47,7 +47,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S1.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S1.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="24">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a4-e48-cpu/NiO-fcc-S1-dmc.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a4-e48-gpu/NiO-fcc-S1-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a4-e48-gpu/NiO-fcc-S1-dmc.xml
@@ -47,7 +47,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S1.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S1.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="24">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu-J3/NiO-fcc-S128-dmc.xml
@@ -618,7 +618,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S128.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -2 6 2 6 -2 2 -2 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S128.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -2 6 2 6 -2 2 -2 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="3072">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-cpu/NiO-fcc-S128-dmc.xml
@@ -619,7 +619,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S128.h5" tilematrix="2 -2 6 2 6 -2 2 -2 -2" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S128.h5" tilematrix="2 -2 6 2 6 -2 2 -2 -2" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="3072" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a512-e6144-gpu/NiO-fcc-S128-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a512-e6144-gpu/NiO-fcc-S128-dmc.xml
@@ -618,7 +618,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S128.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -2 6 2 6 -2 2 -2 -2" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S128.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 -2 6 2 6 -2 2 -2 -2" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="3072">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu-J3/NiO-fcc-S16-dmc.xml
@@ -114,7 +114,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S16.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -1 3 1 3 -1 1 -1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S16.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -1 3 1 3 -1 1 -1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="384">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a64-e768-cpu/NiO-fcc-S16-dmc.xml
@@ -115,7 +115,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S16.h5" tilematrix="1 -1 3 1 3 -1 1 -1 -1" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S16.h5" tilematrix="1 -1 3 1 3 -1 1 -1 -1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="384" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a64-e768-gpu/NiO-fcc-S16-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a64-e768-gpu/NiO-fcc-S16-dmc.xml
@@ -114,7 +114,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S16.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -1 3 1 3 -1 1 -1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S16.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 -1 3 1 3 -1 1 -1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="384">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu-J3/NiO-fcc-S2-dmc.xml
@@ -51,7 +51,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S2.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S2.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="48">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a8-e96-cpu/NiO-fcc-S2-dmc.xml
@@ -52,7 +52,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S2.h5" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S2.h5" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="48" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a8-e96-gpu/NiO-fcc-S2-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a8-e96-gpu/NiO-fcc-S2-dmc.xml
@@ -51,7 +51,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S2.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S2.h5" meshfactor="0.9" precision="single" source="i" tilematrix="1 0 0 0 1 1 0 1 -1" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="48">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu-J3/NiO-fcc-S24-dmc.xml
@@ -150,7 +150,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S24.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 0 1 1 3 1 1 3 -3" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S24.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 0 1 1 3 1 1 3 -3" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="576">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-cpu/NiO-fcc-S24-dmc.xml
@@ -151,7 +151,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S24.h5" tilematrix="2 0 1 1 3 1 1 3 -3" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" source="i" href="../NiO-fcc-supertwist111-supershift000-S24.h5" tilematrix="2 0 1 1 3 1 1 3 -3" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="576" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/performance/NiO/sample/dmc-a96-e1152-gpu/NiO-fcc-S24-dmc.xml
+++ b/tests/performance/NiO/sample/dmc-a96-e1152-gpu/NiO-fcc-S24-dmc.xml
@@ -150,7 +150,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S24.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 0 1 1 3 1 1 3 -3" twist="0  0  0" twistnum="-1" type="einspline">
+    <determinantset gpu="yes" href="../NiO-fcc-supertwist111-supershift000-S24.h5" meshfactor="0.9" precision="single" source="i" tilematrix="2 0 1 1 3 1 1 3 -3" twist="0  0  0" type="einspline">
       <slaterdeterminant>
         <determinant id="updet" ref="updet" size="576">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/det_hf_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_hf_vmc_LiH-gamma.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/fake_nspin2/hf_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/fake_nspin2/hf_vmc_LiH-gamma.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/fake_nspin2/hf_vmc_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/fake_nspin2/hf_vmc_LiH-x.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb-drift.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twist="-0.1 -0.2 -0.3" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-arb.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twist="-0.1 -0.2 -0.3" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma-drift.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-gamma.xml
@@ -47,7 +47,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x-drift.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x.xml
@@ -47,7 +47,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x_hybridrep.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_LiH-x_hybridrep.xml
@@ -56,7 +56,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0" hybridrep="yes">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="single"  twist="0.5  0  0" hybridrep="yes">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-arb.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twist="-0.1 -0.2 -0.3" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-gamma.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmc_short_LiH-x.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-arb.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twist="-0.1 -0.2 -0.3" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-gamma.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/hf_vmc_dmcnl_short_LiH-x.xml
@@ -48,7 +48,7 @@
        </attrib>
     </particleset>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/md_cc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/md_cc_vmc_LiH-gamma.xml
@@ -53,7 +53,7 @@ H
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" source="i"  precision="single">
+    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" source="i"  precision="single">
 
       <sposet type="einspline" name="spo-up" size="4" source="i" group="0" optimizable="no" />
       <sposet type="einspline" name="spo-dn" size="4" source="i" group="0" optimizable="no" />

--- a/tests/solids/LiH_solid_1x1x1_pp/md_rc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/md_rc_vmc_LiH-gamma.xml
@@ -53,7 +53,7 @@ H
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" source="i"  precision="single">
+    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" source="i"  precision="single">
 
       <sposet type="einspline" name="spo-up" size="4" source="i" group="0" optimizable="no" />
       <sposet type="einspline" name="spo-dn" size="4" source="i" group="0" optimizable="no" />

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-arb.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-gamma.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmc_ref_LiH-x.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-arb.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" source="i"  precision="double">
+     <determinantset type="einspline" href="LiH-arb.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-gamma.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/hf_vmc_dmcnl_ref_LiH-x.xml
@@ -6,7 +6,7 @@
 
   <qmcsystem>
    <wavefunction name="psi0" target="e">
-     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
+     <determinantset type="einspline" href="LiH-x.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" source="i"  precision="double" twist="0.5  0  0">
        <slaterdeterminant>
          <determinant id="updet" size="2" ref="updet">
            <occupation mode="ground" spindataset="0">

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/md_cc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/md_cc_vmc_LiH-gamma.xml
@@ -53,7 +53,7 @@ H
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" source="i"  precision="single">
+    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" source="i"  precision="single">
 
       <sposet type="einspline" name="spo-up" size="4" source="i" group="0" optimizable="no" />
       <sposet type="einspline" name="spo-dn" size="4" source="i" group="0" optimizable="no" />

--- a/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/md_rc_vmc_LiH-gamma.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/qmc-ref/md_rc_vmc_LiH-gamma.xml
@@ -53,7 +53,7 @@ H
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" source="i"  precision="single">
+    <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" source="i"  precision="single">
 
       <sposet type="einspline" name="spo-up" size="4" source="i" group="0" optimizable="no" />
       <sposet type="einspline" name="spo-dn" size="4" source="i" group="0" optimizable="no" />

--- a/tests/solids/NiO_a4_e48_pp/NiO-L2-long.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-L2-long.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-L2-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-L2-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-delayedupdate-vmc-dmc-TMv1v3-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-delayedupdate-vmc-dmc-TMv1v3-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant delay_rank="7">
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-delayedupdate-vmc-dmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-delayedupdate-vmc-dmc-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant delay_rank="7">
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-hybridrep-j3-batched-vmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-hybridrep-j3-batched-vmc-short.in.xml
@@ -52,7 +52,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0" hybridrep="yes">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0" hybridrep="yes">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-hybridrep-j3-vmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-hybridrep-j3-vmc-short.in.xml
@@ -52,7 +52,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0" hybridrep="yes">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0" hybridrep="yes">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-j3-batched-vmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-j3-batched-vmc-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-j3-vmc-long.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-j3-vmc-long.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-j3-vmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-j3-vmc-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-vmc-dmc-TMv1v3-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-vmc-dmc-TMv1v3-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-vmc-dmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-vmc-dmc-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-vmc-long.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-vmc-long.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/NiO-vmc-short.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/NiO-vmc-short.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/det_NiO-batched-vmc.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/det_NiO-batched-vmc.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/det_NiO-vmc.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/det_NiO-vmc.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-L2-ref.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-L2-ref.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-j3-vmc-ref.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-j3-vmc-ref.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-vmc-dmc-ref.xml
+++ b/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-vmc-dmc-ref.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-vmc-ref.in.xml
+++ b/tests/solids/NiO_a4_e48_pp/qmc-ref/NiO-vmc-ref.in.xml
@@ -48,7 +48,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" twistnum="-1" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
+    <determinantset type="einspline" href="../NiO-fcc-supertwist111-supershift000-S1.h5" source="i" tilematrix="1 0 0 1 0 1 1 1 0" gpu="yes" meshfactor="0.9" precision="single" twist="0  0  0">
       <slaterdeterminant>
         <determinant id="updet" size="24" ref="updet">
           <occupation mode="ground" spindataset="0">

--- a/tests/solids/atomO_pp/qmc_short.in.xml
+++ b/tests/solids/atomO_pp/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="atomO.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="atomO.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/atomO_pp/qmc_short_noj.in.xml
+++ b/tests/solids/atomO_pp/qmc_short_noj.in.xml
@@ -37,7 +37,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="atomO.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="atomO.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_long.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_long_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_ref_vmc_dmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_ref_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_all.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_all.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_all_nodrift.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_all_nodrift.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_pbyp_nodrift.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_csvmc_pbyp_nodrift.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc-ref/qmc_short_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_cpu_limit_rmc.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_cpu_limit_rmc.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_long.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_rmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_long_vmc_rmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_all.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_all.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_all_nodrift.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_all_nodrift.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_pbyp_nodrift.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_csvmc_pbyp_nodrift.in.xml
@@ -55,7 +55,7 @@
       </particleset>
   </qmcsystem>
       <wavefunction name="psi0" target="e">
-        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
       </sposet_builder>
@@ -83,7 +83,7 @@
          </jastrow>
       </wavefunction>
       <wavefunction name="psi1" target="e" source="ion1">
-        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
         <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
         <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
       </sposet_builder>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_pw.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_pw.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="pw" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="pw" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_all.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_all.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_all_nodrift.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_all_nodrift.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_dmc_all.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_dmc_all.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_rmc.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/qmc_short_vmc_rmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/bccH_2x2x2_ae/deriv.xml
+++ b/tests/solids/bccH_2x2x2_ae/deriv.xml
@@ -50,7 +50,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/det_qmc-bf-opt.in.xml
+++ b/tests/solids/bccH_2x2x2_ae/det_qmc-bf-opt.in.xml
@@ -51,7 +51,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/gamma_deriv.xml
+++ b/tests/solids/bccH_2x2x2_ae/gamma_deriv.xml
@@ -50,7 +50,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/grad_lap.xml
+++ b/tests/solids/bccH_2x2x2_ae/grad_lap.xml
@@ -50,7 +50,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_det_qmc-bf-opt_comp.s001.opt.xml
+++ b/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_det_qmc-bf-opt_comp.s001.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_det_qmc-bf-opt_real.s001.opt.xml
+++ b/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_det_qmc-bf-opt_real.s001.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_qmc-bf.in.xml
+++ b/tests/solids/bccH_2x2x2_ae/qmc-ref/ref_qmc-bf.in.xml
@@ -51,7 +51,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_2x2x2_ae/qmc-short-bf.in.xml
+++ b/tests/solids/bccH_2x2x2_ae/qmc-short-bf.in.xml
@@ -50,7 +50,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 2 0 0 0 2" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="8" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_3x3x3_ae/deriv.xml
+++ b/tests/solids/bccH_3x3x3_ae/deriv.xml
@@ -90,7 +90,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="3 0 0 0 3 0 0 0 3" twistnum="0" source="ion0" size="27">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="3 0 0 0 3 0 0 0 3" source="ion0" size="27">
            <sposet type="bspline" name="spo_ud" size="27" spindataset="0"/> 
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_3x3x3_ae/gamma_deriv.xml
+++ b/tests/solids/bccH_3x3x3_ae/gamma_deriv.xml
@@ -90,7 +90,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" size="27">
+         <sposet_builder type="bspline" href="gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" size="27">
            <sposet type="bspline" name="spo_ud" size="27" spindataset="0"/> 
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_3x3x3_ae/grad_lap.xml
+++ b/tests/solids/bccH_3x3x3_ae/grad_lap.xml
@@ -90,7 +90,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="3 0 0 0 3 0 0 0 3" twistnum="0" source="ion0" size="27">
+         <sposet_builder type="bspline" href="pwscf.pwscf.h5" tilematrix="3 0 0 0 3 0 0 0 3" source="ion0" size="27">
            <sposet type="bspline" name="spo_ud" size="27" spindataset="0"/> 
          </sposet_builder>
          <determinantset>

--- a/tests/solids/bccH_3x3x3_ae/not-orth_deriv.xml
+++ b/tests/solids/bccH_3x3x3_ae/not-orth_deriv.xml
@@ -60,7 +60,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="not-orth.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0">
+         <sposet_builder type="bspline" href="not-orth.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0">
             <sposet type="bspline" name="spo_ud" size="12" spindataset="0"/>
          </sposet_builder>
          <determinantset>

--- a/tests/solids/diamondC_1x1x1-Gaussian_pp/C_Diamond.wfj-Twist0-Bspline.xml
+++ b/tests/solids/diamondC_1x1x1-Gaussian_pp/C_Diamond.wfj-Twist0-Bspline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-    <determinantset check_orb_norm="no" href="C_Diamond-Bspline.h5" meshfactor="1.0" source="ion0" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" type="einspline">
+    <determinantset check_orb_norm="no" href="C_Diamond-Bspline.h5" meshfactor="1.0" source="ion0" tilematrix="1 0 0 0 1 0 0 0 1" type="einspline">
       <basisset/>
       <slaterdeterminant>
         <determinant id="updet" size="4" ref="updet">

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_J2_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_J2_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_noJ_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_noJ_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_1rdm_short_vmc_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short_mw.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short_mw.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_dens_short_vmc_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_momentum_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_momentum_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_momentum_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_momentum_short_vmc_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short-meshf.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short-meshf.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="4.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="4.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_excited.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_kspace.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_excited.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_lg_ts.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_lg_ts.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_mwalkers.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_mwalkers.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_mwalkers_with_checks.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_dmc_mwalkers_with_checks.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_multi_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_short_vmc_multi_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_mw.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_mw.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_vmc_dmc.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_vmcbatched.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_spindens_short_vmcbatched.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_vmc_dmc_tm.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_vmc_dmc_tm.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_vmc_dmc_tm_gpu.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_vmc_dmc_tm_gpu.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_vmcbatch_dmcbatch_tm.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_vmcbatch_dmcbatch_tm.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s001.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s001.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s002.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s002.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s003.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s003.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s004.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s004.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s005.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s005.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s006.opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short.s006.opt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <qmcsystem>
   <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short_opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short_opt.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_1rdm_J2.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_1rdm_J2.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_1rdm_noJ.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_1rdm_noJ.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_dens.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_dens.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_dens_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_dens_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_cell.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_cell.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_cell_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_cell_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_vor.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_edens_vor.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_kspace.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_long_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_ref_vmc_dmc_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_short_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_spindens.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_spindens.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_spindens_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/qmc_spindens_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_J2_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_J2_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_J2_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_J2_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_noJ_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_noJ_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_noJ_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_1rdm_noJ_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+         <sposet_builder type="bspline" href="./pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
             <sposet type="bspline" name="spo_ud" size="4" spindataset="0"/>
             <sposet type="bspline" name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
          </sposet_builder>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_dmc.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_dmc.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_vmc.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_cpu_limit_vmc.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_dmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_dmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_dmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_dmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_long_gpu.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_long_gpu.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_dens_short_gpu.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_dens_short_gpu.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_dmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_dmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_dmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_dmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_cell_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_vor_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_vor_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_edens_vor_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_edens_vor_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long-meshf.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long-meshf.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="4.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="4.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_kspace.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_allp.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_long_vmc_dmc_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc_onebodydensitymatrices_vmcbatch_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_onebodydensitymatrices_vmcbatch_short.in.xml
@@ -38,10 +38,10 @@
          </group>
       </particleset>
 <wavefunction name="psi0" target='e'>
-  <sposet_collection type="bspline" source="ion0" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" meshfactor="1.0" twist="0 0 0" precision="float" truncate="no">
+  <sposet_collection type="bspline" source="ion0" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" meshfactor="1.0" twist="0 0 0" precision="float" truncate="no">
     <sposet name="spo_for_dets" size="4" spindataset="0"/>
   </sposet_collection>
-  <sposet_collection type="bspline" source="ion0" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="no" meshfactor="1.0" twist="0 0 0" precision="float" truncate="no">
+  <sposet_collection type="bspline" source="ion0" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" gpu="no" meshfactor="1.0" twist="0 0 0" precision="float" truncate="no">
     <sposet name="spo_ud" size="4" spindataset="0"/>
     <sposet name="spo_dm" index_min="4" index_max="8" spindataset="0"/>
   </sposet_collection>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short-meshf.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short-meshf.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="4.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="4.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_hybridrep.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_hybridrep.in.xml
@@ -42,7 +42,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float" hybridrep="yes">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float" hybridrep="yes">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace_4_4.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_kspace_4_4.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_opt.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_opt.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_allp.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_coverage.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_coverage.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_vmc_dmc_excited.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_dmc_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_dmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_dmc_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_dmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_long.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_long_gpu.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_long_gpu.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_short_gpu.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_short_gpu.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_spindens_vmcbatch_short.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_spindens_vmcbatch_short.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_trace_scalars.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_trace_scalars.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_trace_scalars_selective.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_trace_scalars_selective.in.xml
@@ -39,7 +39,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="4">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_delayedupdate.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_delayedupdate.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant delay_rank="5">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_excited.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes" matrix_inverter="gpu">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers_inverter_host.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers_inverter_host.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes" matrix_inverter="host">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers_with_checks.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_dmcbatch_mwalkers_with_checks.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_sdbatch_vmcbatch_mwalkers.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmc_dmc.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmc_dmc_excited.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_excited.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no" matrix_inverter="gpu">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers_inverter_host.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers_inverter_host.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no" matrix_inverter="host">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers_serialized.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_dmcbatch_mwalkers_serialized.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_mwalkers.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch_mwalkers.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_vmc_dmc_pw.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_vmc_dmc_pw.in.xml
@@ -41,7 +41,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="pw" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="pw" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_long.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_long.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_long_vmc_dmc.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_ref_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_ref_vmc_dmc.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_short.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_short.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc-ref/qmc_short_vmc_dmc.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_excited.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_dla.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_dla.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_excited.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_reconf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_long_vmc_dmc_reconf.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_delayedupdate.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_delayedupdate.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant delay_rank="5">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_excited.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_hybridrep.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_hybridrep.in.xml
@@ -42,7 +42,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double" hybridrep="yes">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double" hybridrep="yes">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_4b.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_4b.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_dmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_sdbatch_vmcbatch_dmcbatch.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="yes">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_4r.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_4r.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_dla.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_dla.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_excited.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_excited.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="excited" spindataset="0">

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_reconf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmc_dmc_reconf.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b_asynctwf.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_4b_asynctwf.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e" tasking="yes">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant batch="no">
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch_4r.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/qmc_short_vmcbatch_dmcbatch_4r.in.xml
@@ -40,7 +40,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="double">
             <slaterdeterminant>
                <determinant id="updet" size="8">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/grapheneC_1x1_pp/det_qmc_short_z10.in.xml
+++ b/tests/solids/grapheneC_1x1_pp/det_qmc_short_z10.in.xml
@@ -42,7 +42,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="Gr.pwscf_10.h5" source="i" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" precision="double">
+    <determinantset type="einspline" href="Gr.pwscf_10.h5" source="i" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" precision="double">
       <basisset/>
       <slaterdeterminant>
         <determinant id="updet" size="4" ref="updet">

--- a/tests/solids/grapheneC_1x1_pp/det_qmc_short_z30.in.xml
+++ b/tests/solids/grapheneC_1x1_pp/det_qmc_short_z30.in.xml
@@ -42,7 +42,7 @@
     </group>
   </particleset>
   <wavefunction name="psi0" target="e">
-    <determinantset type="einspline" href="Gr.pwscf_30.h5" source="i" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" gpu="yes" meshfactor="1.0" precision="double">
+    <determinantset type="einspline" href="Gr.pwscf_30.h5" source="i" tilematrix="1 0 0 0 1 0 0 0 1" gpu="yes" meshfactor="1.0" precision="double">
       <basisset/>
       <slaterdeterminant>
         <determinant id="updet" size="4" ref="updet">

--- a/tests/solids/hcpBe_1x1x1_pp/qmc-ref/qmc_long.in.xml
+++ b/tests/solids/hcpBe_1x1x1_pp/qmc-ref/qmc_long.in.xml
@@ -37,7 +37,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/hcpBe_1x1x1_pp/qmc-ref/qmc_short.in.xml
+++ b/tests/solids/hcpBe_1x1x1_pp/qmc-ref/qmc_short.in.xml
@@ -37,7 +37,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/hcpBe_1x1x1_pp/qmc_long.in.xml
+++ b/tests/solids/hcpBe_1x1x1_pp/qmc_long.in.xml
@@ -37,7 +37,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/hcpBe_1x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/hcpBe_1x1x1_pp/qmc_short.in.xml
@@ -37,7 +37,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="1">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc-ref/qmc_long.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc-ref/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc-ref/qmc_short.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc-ref/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc_j3_long.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_j3_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc_j3_short.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_j3_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc_long.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_long.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_1x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/monoO_1x1x1_pp/qmc_short.in.xml
@@ -38,7 +38,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="float">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" meshfactor="1.0" precision="float">
             <slaterdeterminant>
                <determinant id="updet" size="6">
                   <occupation mode="ground" spindataset="0"/>

--- a/tests/solids/monoO_noncollinear_1x1x1_pp/qmc_short.in.xml
+++ b/tests/solids/monoO_noncollinear_1x1x1_pp/qmc_short.in.xml
@@ -63,7 +63,7 @@
          </group>
       </particleset>
       <wavefunction name="psi0" target="e">
-   <sposet_builder name="A" type="einspline" href="o2_45deg_spins.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" size="12"> 
+   <sposet_builder name="A" type="einspline" href="o2_45deg_spins.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" source="ion0" size="12"> 
      <sposet name="myspo" size="12"> 
        <occupation mode="ground"/> 
      </sposet> 


### PR DESCRIPTION
## Proposed changes
The existing documentation clearly says avoid using twistnum and I just made one more step by removing it.
Use twist="x.x y.y z.z" input to indicate the exact twist. From now on, all twistnum input will be ignored.
Massive changes are due to updating input files.
I explicit tested complex build.

## What type(s) of changes does this code introduce?
- Other (please describe): Simply input tags.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'