### PR TITLE
fix Madelung constant in CoulombPBCAA

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -434,9 +434,7 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalConsts(bool report)
     Consts += v1;
   }
   if (report)
-  {
     app_log() << "   PBCAA total constant " << Consts << std::endl;
-  }
   return Consts;
 }
 

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -98,7 +98,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces)
   app_log() << "  Maximum K shell " << AA->MaxKshell << std::endl;
   app_log() << "  Number of k vectors " << AA->Fk.size() << std::endl;
   app_log() << "  Fixed Coulomb potential for " << ref.getName();
-  app_log() << "\n    e-e Madelung Const. =" << MC0 << "\n    Vtot     =" << value_ << std::endl;
+  app_log() << "\n    e-e Madelung Const. =" << std::setprecision(8) << MC0 << "\n    Vtot     =" << value_ << std::endl;
 }
 
 CoulombPBCAA::~CoulombPBCAA() = default;
@@ -415,13 +415,13 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalConsts(bool report)
   }
   if (report)
     app_log() << "   PBCAA self-interaction term " << Consts << std::endl;
-  //Compute Madelung constant: this is not correct for general cases
+  //Neutraling background term
+  mRealType vs_k0 = AA->evaluateSR_k0(); //v_s(k=0)
+  //Compute Madelung constant
   MC0 = 0.0;
   for (int i = 0; i < AA->Fk.size(); i++)
     MC0 += AA->Fk[i];
-  MC0 = 0.5 * (MC0 - vl_r0);
-  //Neutraling background term
-  mRealType vs_k0 = AA->evaluateSR_k0(); //v_s(k=0)
+  MC0 = 0.5 * (MC0 - vl_r0 - vs_k0);
   for (int ipart = 0; ipart < NumCenters; ipart++)
   {
     v1 = 0.0;
@@ -434,8 +434,9 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalConsts(bool report)
     Consts += v1;
   }
   if (report)
+  {
     app_log() << "   PBCAA total constant " << Consts << std::endl;
-  //app_log() << "   MC0 of PBCAA " << MC0 << std::endl;
+  }
   return Consts;
 }
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -57,15 +57,15 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 
   // Background charge term
   double consts = caa.evalConsts();
-  REQUIRE(consts == Approx(-3.1151210154));
+  CHECK(consts == Approx(-3.1151210154));
 
   double val = caa.evaluate(ions);
   //std::cout << "val = " << val << std::endl;
-  REQUIRE(val == Approx(vmad_sc));
+  CHECK(val == Approx(vmad_sc));
 
   // supercell Madelung energy
   val = caa.MC0;
-  REQUIRE(val == Approx(vmad_sc));
+  CHECK(val == Approx(vmad_sc));
 }
 
 TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
@@ -105,14 +105,14 @@ TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
 
   // Background charge term
   double consts = caa.evalConsts();
-  REQUIRE(consts == Approx(-1.675229452)); // not validated
+  CHECK(consts == Approx(-1.675229452)); // not validated
 
   double val = caa.evaluate(elec);
-  REQUIRE(val == Approx(-0.9628996199)); // not validated
+  CHECK(val == Approx(-0.9628996199)); // not validated
 
   // supercell Madelung energy
   val = caa.MC0;
-  REQUIRE(val == Approx(vmad_sc));
+  CHECK(val == Approx(vmad_sc));
 }
 
 TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
@@ -150,10 +150,10 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 
   // Self-energy correction, no background charge for e-e interaction
   double consts = caa.evalConsts();
-  REQUIRE(consts == Approx(-3.1151210154));
+  CHECK(consts == Approx(-3.1151210154));
 
   double val = caa.evaluate(elec);
-  REQUIRE(val == Approx(-1.418648723)); // not validated
+  CHECK(val == Approx(-1.418648723)); // not validated
 }
 
 TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
@@ -193,10 +193,10 @@ TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
   CoulombPBCAA caa = CoulombPBCAA(elec, false);
 
   double val = caa.evaluate(elec);
-  REQUIRE(val == Approx(vmad_bcc));
+  CHECK(val == Approx(vmad_bcc));
 
   val = caa.MC0;
-  REQUIRE(val == Approx(vmad_bcc));
+  CHECK(val == Approx(vmad_bcc));
 }
 
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 {
-  const double vmad_sc = -1.4186487397403098;
+  const double vmad_sc               = -1.4186487397403098;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
@@ -70,8 +70,8 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
 {
-  const double alat = 3.77945227;
-  const double vmad_sc = -1.4186487397403098/alat;
+  const double alat                  = 3.77945227;
+  const double vmad_sc               = -1.4186487397403098 / alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
@@ -133,14 +133,14 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
   elec.R[0][1] = 0.5;
   elec.R[0][2] = 0.0;
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  int pMembersizeIdx           = tspecies.addAttribute("membersize");
-  tspecies(pMembersizeIdx, upIdx)   = 1;
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies            = elec.getSpeciesSet();
+  int upIdx                       = tspecies.addSpecies("u");
+  int chargeIdx                   = tspecies.addAttribute("charge");
+  int massIdx                     = tspecies.addAttribute("mass");
+  int pMembersizeIdx              = tspecies.addAttribute("membersize");
+  tspecies(pMembersizeIdx, upIdx) = 1;
+  tspecies(chargeIdx, upIdx)      = -1;
+  tspecies(massIdx, upIdx)        = 1.0;
 
   elec.createSK();
   elec.update();
@@ -158,16 +158,16 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
 {
-  const double alat = 1.0;
-  const double vmad_bcc = -1.819616724754322/alat;
+  const double alat                  = 1.0;
+  const double vmad_bcc              = -1.819616724754322 / alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
   lattice.BoxBConds = true; // periodic
-  lattice.R = 0.5*alat;
-  lattice.R(0, 0) = -0.5*alat;
-  lattice.R(1, 1) = -0.5*alat;
-  lattice.R(2, 2) = -0.5*alat;
+  lattice.R         = 0.5 * alat;
+  lattice.R(0, 0)   = -0.5 * alat;
+  lattice.R(1, 1)   = -0.5 * alat;
+  lattice.R(2, 2)   = -0.5 * alat;
   lattice.reset();
 
   const SimulationCell simulation_cell(lattice);

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -27,7 +27,7 @@ namespace qmcplusplus
 {
 TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 {
-  double vmad_sc = -1.4186487397403098;
+  const double vmad_sc = -1.4186487397403098;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
@@ -70,8 +70,8 @@ TEST_CASE("Coulomb PBC A-A", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
 {
-  double alat = 3.77945227;
-  double vmad_sc = -1.4186487397403098/alat;
+  const double alat = 3.77945227;
+  const double vmad_sc = -1.4186487397403098/alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
@@ -108,7 +108,6 @@ TEST_CASE("Coulomb PBC A-A BCC H", "[hamiltonian]")
   REQUIRE(consts == Approx(-1.675229452)); // not validated
 
   double val = caa.evaluate(elec);
-  //std::cout << "BCC H val = " << val << std::endl;
   REQUIRE(val == Approx(-0.9628996199)); // not validated
 
   // supercell Madelung energy
@@ -159,8 +158,8 @@ TEST_CASE("Coulomb PBC A-A elec", "[hamiltonian]")
 
 TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
 {
-  double alat = 1.0;
-  double vmad_bcc = -1.819616724754322/alat;
+  const double alat = 1.0;
+  const double vmad_bcc = -1.819616724754322/alat;
   LRCoulombSingleton::CoulombHandler = 0;
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
@@ -176,18 +175,16 @@ TEST_CASE("Coulomb PBC A-A BCC", "[hamiltonian]")
 
   elec.setName("elec");
   elec.create(1);
-  elec.R[0][0] = 0.0;
-  elec.R[0][1] = 0.0;
-  elec.R[0][2] = 0.0;
+  elec.R[0] = {0.0, 0.0, 0.0};
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  int pMembersizeIdx           = tspecies.addAttribute("membersize");
-  tspecies(pMembersizeIdx, upIdx)   = 1;
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies            = elec.getSpeciesSet();
+  int upIdx                       = tspecies.addSpecies("u");
+  int chargeIdx                   = tspecies.addAttribute("charge");
+  int massIdx                     = tspecies.addAttribute("mass");
+  int pMembersizeIdx              = tspecies.addAttribute("membersize");
+  tspecies(pMembersizeIdx, upIdx) = 1;
+  tspecies(chargeIdx, upIdx)      = -1;
+  tspecies(massIdx, upIdx)        = 1.0;
 
   elec.createSK();
   elec.update();


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Add the missing background term (`vs_k0`) into the Madelung constant.
This makes it correct for simple cubic and body center cubic crystals as shown by the unit tests.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
