### PR TITLE
emphasize update() in developer manual

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -780,6 +780,29 @@ needs to be transferred to the structure-of-arrays (SoA) storage in
 ``RSoA``. This is done by the ``update`` method. In the future the
 interface may change to use functions to set and retrieve positions so
 the SoA transformation of the particle data can happen automatically.
+For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)`` to populate ``RSoA``. Otherwise, the distance tables associated with ``R`` will be uninitialized or out-of-date.
+
+::
+  const SimulationCell sc;
+  ParticleSet elec(sc), ions(sc);
+  elec.setName("e");
+  ions.setName("ion0");
+
+  // initialize ions
+  ions.create(2);
+  ions.R[0] = {0.0, 0.0, 0.0};
+  ions.R[1] = {0.5, 0.5, 0.5};
+  ions.setCoordinates(ions.R); // transfer to RSoA
+
+  // initialize elec
+  elec.create(2);
+  elec.R[0] = {0.0, 0.0, 0.0};
+  elec.R[1] = {0.0, 0.25, 0.0};
+  const int itab = elec.addTable(ions);
+  elec.update(); // update RSoA and distance tables
+
+  const auto& d_table = elec.getDistTableAB(itab);
+  // d_table is an electron-ion distance table
 
 A particular distance table is retrieved with ``getDistTable``. Use
 ``addTable`` to add a ``ParticleSet`` and return the index of the

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -780,7 +780,7 @@ needs to be transferred to the structure-of-arrays (SoA) storage in
 ``RSoA``. This is done by the ``update`` method. In the future the
 interface may change to use functions to set and retrieve positions so
 the SoA transformation of the particle data can happen automatically.
-For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)`` to populate ``RSoA``. Otherwise, the distance tables associated with ``R`` will be uninitialized or out-of-date.
+For now, it is crucial to call ``P.update()`` to populate ``RSoA`` anytime ``P.R`` is changed. Otherwise, the distance tables associated with ``R`` will be uninitialized or out-of-date.
 
 ::
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -783,6 +783,7 @@ the SoA transformation of the particle data can happen automatically.
 For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)`` to populate ``RSoA``. Otherwise, the distance tables associated with ``R`` will be uninitialized or out-of-date.
 
 ::
+
   const SimulationCell sc;
   ParticleSet elec(sc), ions(sc);
   elec.setName("e");
@@ -793,7 +794,6 @@ For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)
   ions.R[0] = {0.0, 0.0, 0.0};
   ions.R[1] = {0.5, 0.5, 0.5};
   ions.update(); // transfer to RSoA
-  //ions.setCoordinates(ions.R); // avoid public API with internal data
 
   // initialize elec
   elec.create(2);
@@ -802,8 +802,8 @@ For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)
   const int itab = elec.addTable(ions);
   elec.update(); // update RSoA and distance tables
 
-  const auto& d_table = elec.getDistTableAB(itab);
   // d_table is an electron-ion distance table
+  const auto& d_table = elec.getDistTableAB(itab);
 
 A particular distance table is retrieved with ``getDistTable``. Use
 ``addTable`` to add a ``ParticleSet`` and return the index of the

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -792,7 +792,8 @@ For now, it is crucial to call either ``P.update()``, or ``P.setCoordinates(P.R)
   ions.create(2);
   ions.R[0] = {0.0, 0.0, 0.0};
   ions.R[1] = {0.5, 0.5, 0.5};
-  ions.setCoordinates(ions.R); // transfer to RSoA
+  ions.update(); // transfer to RSoA
+  //ions.setCoordinates(ions.R); // avoid public API with internal data
 
   // initialize elec
   elec.create(2);


### PR DESCRIPTION
## Proposed changes

Emphasize the need to call `ParticleSet::update()` in the developer manual.
The coexistence of `R` and `RSoA` did not sink in for me until now.
I spent many hours trying to figure out why my unit test distance tables are garbage...
Just want to add some emphasis in the manual to help the next unfortunate soul.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
