### PR TITLE
Remove ParticleSet::setCoordinates(R)

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -411,7 +411,7 @@ void ParticleSet::mw_update(const RefVectorWithLeader<ParticleSet>& p_list, bool
   ScopedTimer update_scope(p_leader.myTimers[PS_update]);
 
   for (ParticleSet& pset : p_list)
-    pset.setCoordinates(pset.R);
+    pset.coordinates_->setAllParticlePos(pset.R);
 
   auto& dts = p_leader.DistTables;
   for (int i = 0; i < dts.size(); ++i)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -240,10 +240,8 @@ public:
   }
 
   inline const DynamicCoordinates& getCoordinates() const { return *coordinates_; }
-  inline void setCoordinates(const ParticlePos& R) { return coordinates_->setAllParticlePos(R); }
 
   void resetGroups();
-
 
   const auto& getSimulationCell() const { return simulation_cell_; }
   const auto& getLattice() const { return simulation_cell_.getLattice(); }

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -59,8 +59,7 @@ TEST_CASE("PolynomialFunctor3D Jastrow", "[wavefunction]")
   ions_.R[1][2] = 0.0;
   SpeciesSet& source_species(ions_.getSpeciesSet());
   source_species.addSpecies("O");
-  ions_.setCoordinates(ions_.R);
-  //ions_.resetGroups();
+  ions_.update();
 
   elec_.setName("elec");
   std::vector<int> ud(2);

--- a/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_rpa_jastrow.cpp
@@ -71,8 +71,7 @@ TEST_CASE("RPA Jastrow", "[wavefunction]")
   ions_.R[1][2] = 0.0;
   SpeciesSet& source_species(ions_.getSpeciesSet());
   source_species.addSpecies("O");
-  ions_.setCoordinates(ions_.R);
-  //ions_.resetGroups();
+  ions_.update();
 
   elec_.setName("elec");
   std::vector<int> ud(2);

--- a/src/Sandbox/diff_distancetables.cpp
+++ b/src/Sandbox/diff_distancetables.cpp
@@ -92,8 +92,9 @@ int main(int argc, char** argv)
   ParticleSet ions(super_lattice), els(super_lattice);
 
   ions.setName("ion0");
+  els.setName("e");
   tile_cell(ions, tmat);
-  ions.setCoordinates(ions.R); //this needs to be handled internally
+  ions.update();
 
   const int nions = ions.getTotalNum();
   const int nels  = count_electrons(ions);
@@ -107,8 +108,7 @@ int main(int argc, char** argv)
     els.R.InUnit = PosUnit::Lattice;
     std::generate(&els.R[0][0], &els.R[0][0] + nels3, random_th);
     els.convert2Cart(els.R);   // convert to Cartiesian
-    els.setCoordinates(els.R); //this needs to be handled internally
-    els.setName("e");
+    els.update();
   }
 
   constexpr RealType eps = numeric_limits<float>::epsilon();

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
       els.R.InUnit = PosUnit::Lattice;
       std::generate(&els.R[0][0], &els.R[0][0] + nels3, random_th);
       els.convert2Cart(els.R); // convert to Cartiesian
-      els.setCoordinates(els.R);
+      els.update();
     }
 
     if (!ip)


### PR DESCRIPTION
## Proposed changes
This function is neither needed nor safe-to-use (breaks encapsulation).
Thus removal is the best option to avoid confusion like #3808

## What type(s) of changes does this code introduce?
- Other (please describe): Cleaning

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'