### PR TITLE
Disable offload explicitly in GCC

### DIFF
--- a/CMake/GNUCompilers.cmake
+++ b/CMake/GNUCompilers.cmake
@@ -50,6 +50,8 @@ if(QMC_OMP)
         message(WARNING "We don't know how to handle OFFLOAD_ARCH=${OFFLOAD_ARCH} for OFFLOAD_TARGET=${OFFLOAD_TARGET}. Got ignored.")
       endif()
     endif()
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -foffload=disable")
   endif()
 endif(QMC_OMP)
 


### PR DESCRIPTION
## Proposed changes

When GCC is built with OpenMP offload support. GCC turns on offload by default. This is undesired.
So turn off offload explicitly. Tested that `-foffload=disable` exists in GCC 7.0 (minimal requirement), 8,9,10,11.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'