### PR TITLE
Fix LCAO AO MO mismatch due to particle reordering.

### DIFF
--- a/src/Particle/ParticleIO/XMLParticleIO.cpp
+++ b/src/Particle/ParticleIO/XMLParticleIO.cpp
@@ -199,8 +199,9 @@ bool XMLParticleParser::readXML(xmlNodePtr cur)
         {
           std::ostringstream msg;
           msg << "The total number of particles deterimined previously was " << nat
-              << " but the 'size' atttribute found on the '" << ParticleTags::attrib_tag << "' XML element nodes named '"
-              << sname << "' is " << size_att << ". Please check the 'particleset' XML element node!" << std::endl;
+              << " but the 'size' atttribute found on the '" << ParticleTags::attrib_tag
+              << "' XML element nodes named '" << sname << "' is " << size_att
+              << ". Please check the 'particleset' XML element node!" << std::endl;
           throw UniformCommunicateError(msg.str());
         }
 
@@ -264,6 +265,8 @@ bool XMLParticleParser::readXML(xmlNodePtr cur)
 
     checkGrouping(nat, nat_group);
     ref_.create(nat_group);
+    // save map_storage_to_input
+    ref_.setMapStorageToInput(map_storage_to_input);
 
     for (int iat = 0; iat < nat; iat++)
     {

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -547,6 +547,9 @@ public:
     AttribList.add(Z);
   }
 
+  inline void setMapStorageToInput(const std::vector<int>& mapping) { map_storage_to_input_ = mapping; }
+  inline const std::vector<int>& get_map_storage_to_input() const { return map_storage_to_input_; }
+
   inline int getNumDistTables() const { return DistTables.size(); }
 
   /// initialize a shared resource and hand it to a collection
@@ -583,6 +586,14 @@ protected:
   SingleParticlePos active_pos_;
   ///the proposed spin of active_ptcl_ during particle-by-particle moves
   Scalar_t active_spin_val_;
+
+  /** Map storage index to the input index.
+   * If not empty, particles were reordered by groups when being loaded from XML input.
+   * When other input data are affected by reordering, its builder should query this mapping.
+   * map_storage_to_input_[5] = 2 means the index 5(6th) particle in this ParticleSet was read from
+   * the index 2(3th) particle in the XML input
+   */
+  std::vector<int> map_storage_to_input_;
 
   ///SpeciesSet of particles
   SpeciesSet my_species_;

--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.h
@@ -57,9 +57,8 @@ public:
   PosType SuperTwist;
 
 
-  /** container to store the offsets of the basis functions
-   *
-   * the number of basis states for center J is BasisOffset[J+1]-Basis[J]
+  /** container to store the offsets of the basis functions for each center
+   * Due to potential reordering of ions, offsets can be in any order.
    */
   std::vector<size_t> BasisOffset;
 


### PR DESCRIPTION
## Proposed changes
Fixes #3820

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted