### PR TITLE
Simplify StructFact resize logic and fix a bug

### DIFF
--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -23,7 +23,7 @@
 namespace qmcplusplus
 {
 //Constructor - pass arguments to k_lists_' constructor
-StructFact::StructFact(int nptcls, int ns, const ParticleLayout& lattice, const KContainer& k_lists)
+StructFact::StructFact(int ns, int nptcls, const ParticleLayout& lattice, const KContainer& k_lists)
     : SuperCellEnum(SUPERCELL_BULK),
       k_lists_(k_lists),
       num_ptcls(nptcls),
@@ -36,8 +36,6 @@ StructFact::StructFact(int nptcls, int ns, const ParticleLayout& lattice, const 
     app_log() << "  Setting StructFact::SuperCellEnum=SUPERCELL_SLAB " << std::endl;
     SuperCellEnum = SUPERCELL_SLAB;
   }
-
-  resize(k_lists_.numk);
 }
 
 //Destructor
@@ -75,10 +73,11 @@ void StructFact::mw_updateAllPart(const RefVectorWithLeader<StructFact>& sk_list
  */
 void StructFact::computeRhok(const ParticleSet& P)
 {
-  int npart = P.getTotalNum();
+  resize(k_lists_.numk);
+
   rhok_r = 0.0;
   rhok_i = 0.0;
-  //algorithmA
+  const int npart = P.getTotalNum();
   const int nk = k_lists_.numk;
   if (StorePerParticle)
   {
@@ -145,9 +144,6 @@ void StructFact::turnOnStorePerParticle(const ParticleSet& P)
   if (!StorePerParticle)
   {
     StorePerParticle = true;
-    const int nptcl  = P.getTotalNum();
-    eikr_r.resize(nptcl, k_lists_.numk);
-    eikr_i.resize(nptcl, k_lists_.numk);
     computeRhok(P);
   }
 }

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -41,12 +41,9 @@ public:
    * Allow overwriting lattice::SuperCellEnum to use D-dim k-point sets with mixed BC
    */
   int SuperCellEnum;
-  ///1-D container for the phase
-  Vector<RealType> phiV;
   ///2-D container for the phase
   Matrix<RealType> rhok_r, rhok_i;
   Matrix<RealType> eikr_r, eikr_i;
-  Vector<RealType> eikr_r_temp, eikr_i_temp;
   /** Constructor - copy ParticleSet and init. k-shells
    * @param nptcls number of particles
    * @param ns number of species

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -45,12 +45,12 @@ public:
   Matrix<RealType> rhok_r, rhok_i;
   Matrix<RealType> eikr_r, eikr_i;
   /** Constructor - copy ParticleSet and init. k-shells
-   * @param nptcls number of particles
    * @param ns number of species
+   * @param nptcls number of particles
    * @param lattice long range box
    * @param kc cutoff for k
    */
-  StructFact(int nptcls, int ns, const ParticleLayout& lattice, const KContainer& k_lists);
+  StructFact(int ns, int nptcls, const ParticleLayout& lattice, const KContainer& k_lists);
   /// desructor
   ~StructFact();
 

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -45,12 +45,10 @@ public:
   Matrix<RealType> rhok_r, rhok_i;
   Matrix<RealType> eikr_r, eikr_i;
   /** Constructor - copy ParticleSet and init. k-shells
-   * @param ns number of species
-   * @param nptcls number of particles
    * @param lattice long range box
    * @param kc cutoff for k
    */
-  StructFact(int ns, int nptcls, const ParticleLayout& lattice, const KContainer& k_lists);
+  StructFact(const ParticleLayout& lattice, const KContainer& k_lists);
   /// desructor
   ~StructFact();
 
@@ -75,15 +73,13 @@ private:
   void computeRhok(const ParticleSet& P);
   /** resize the internal data
    * @param nkpts
+   * @param num_species number of species
+   * @param num_ptcls number of particles
    */
-  void resize(int nkpts);
+  void resize(int nkpts, int num_species, int num_ptcls);
 
   /// K-Vector List.
   const KContainer& k_lists_;
-  /// number of particles
-  const size_t num_ptcls;
-  /// number of species
-  const size_t num_species;
   /** Whether intermediate data is stored per particle. default false
    * storing data per particle needs significant amount of memory but some calculation may request it.
    * storing data per particle specie is more cost-effective

--- a/src/Particle/LongRange/tests/test_StructFact.cpp
+++ b/src/Particle/LongRange/tests/test_StructFact.cpp
@@ -49,8 +49,13 @@ TEST_CASE("StructFact", "[lrhandler]")
   ref.R[3] = {3.2, 4.7, 0.7};
 
   REQUIRE(simulation_cell.getKLists().numk == 263786);
-  StructFact sk(tspecies.size(), ref.getTotalNum(), ref.getLRBox(), simulation_cell.getKLists());
+  StructFact sk(ref.getLRBox(), simulation_cell.getKLists());
   sk.updateAllPart(ref);
+
+  CHECK(sk.rhok_r.rows() == ref.groups());
+  CHECK(sk.rhok_i.rows() == ref.groups());
+  CHECK(sk.rhok_r.cols() == simulation_cell.getKLists().numk);
+  CHECK(sk.rhok_i.cols() == simulation_cell.getKLists().numk);
 
   std::vector<std::complex<double>> rhok_sum_ref{-125.80618630936, 68.199075127271};
 

--- a/src/Particle/ParticleSet.BC.cpp
+++ b/src/Particle/ParticleSet.BC.cpp
@@ -39,7 +39,7 @@ void ParticleSet::createSK()
   if (Lattice.SuperCellEnum != SUPERCELL_OPEN)
   {
     app_log() << "\n  Creating Structure Factor for periodic systems " << LRBox.LR_kc << std::endl;
-    structure_factor_ = std::make_unique<StructFact>(my_species_.size(), TotalNum, LRBox, simulation_cell_.getKLists());
+    structure_factor_ = std::make_unique<StructFact>(LRBox, simulation_cell_.getKLists());
   }
 
   //set the mass array


### PR DESCRIPTION
## Proposed changes
Bug: the constructor takes first the number of particles and second number of species. But #3359 makes calls with these two parameters swapped. Since the number of particles is only used by StorePerParticle is turned on and turnOnStorePerParticle  actually ignores the internal num_ptlcs. Runs are just fine fine. When StorePerParticle is false, only num_species is used, since the number of particles is always larger than species, it only increases memory usage without any run failure.

When I I worked on moving StructFact::resize, one of the unit test fails and this bug got surfaced. Since I moved the resize anyway, I just get rid of StructFact internal num_ptlcs and num_species fully. Since the resize is moved into the evaluation function, the number K is up-to-date and thus the vulnerability of StructFact to cell change is resolved.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'