### PR TITLE
Replace std::min inside target region

### DIFF
--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -98,7 +98,7 @@ void StructFact::mw_updateAllPart(const RefVectorWithLeader<StructFact>& sk_list
       for (int ib = 0; ib < num_kblocks; ib++)
       {
         const size_t offset          = ib * kblock_size;
-        const size_t this_block_size = std::min(kblock_size, nk - offset);
+        const size_t this_block_size = omptarget::min(kblock_size, nk - offset);
         const auto* rsoa_ptr         = mw_rsoa_ptr[iw];
 
         PRAGMA_OFFLOAD("omp parallel for")

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -284,7 +284,7 @@ bool ParticleSet::get(std::ostream& os) const
   if (auto& group_offsets(*group_offsets_); group_offsets.size() > 0)
     for (int i = 0; i < group_offsets.size() - 1; i++)
       os << " " << my_species_.speciesName[i] << "(" << group_offsets[i + 1] - group_offsets[i] << ")";
-  os << std::endl;
+  os << std::endl << std::endl;
 
   const size_t maxParticlesToPrint = 10;
   size_t numToPrint                = std::min(TotalNum, maxParticlesToPrint);

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -21,6 +21,7 @@
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"
 #include "ResourceCollection.h"
+#include "OMPTarget/OMPTargetMath.hpp"
 
 namespace qmcplusplus
 {
@@ -259,9 +260,8 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
         for (int team_id = 0; team_id < num_teams; team_id++)
         {
           auto* source_pos_ptr = rsoa_dev_list_ptr[iw];
-          const int first      = ChunkSizePerTeam * team_id;
-          const int last =
-              (first + ChunkSizePerTeam) > num_sources_local ? num_sources_local : first + ChunkSizePerTeam;
+          const size_t first   = ChunkSizePerTeam * team_id;
+          const size_t last    = omptarget::min(first + ChunkSizePerTeam, num_sources_local);
 
           { // temp
             auto* r_iw_ptr  = r_dr_ptr + iw * stride_size;

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -20,6 +20,7 @@
 #include "Platforms/PinnedAllocator.h"
 #include "Particle/RealSpacePositionsOMPTarget.h"
 #include "ResourceCollection.h"
+#include "OMPTarget/OMPTargetMath.hpp"
 
 namespace qmcplusplus
 {
@@ -214,8 +215,7 @@ public:
         for (int team_id = 0; team_id < num_teams; team_id++)
         {
           const int first = ChunkSizePerTeam * team_id;
-          const int last =
-              (first + ChunkSizePerTeam) > num_sources_local ? num_sources_local : first + ChunkSizePerTeam;
+          const int last  = omptarget::min(first + ChunkSizePerTeam, num_sources_local);
 
           T pos[D];
           for (int idim = 0; idim < D; idim++)
@@ -324,8 +324,7 @@ public:
           auto* dr_iat_ptr     = r_dr_ptr + iat * num_padded * (D + 1) + num_padded;
 
           const int first = ChunkSizePerTeam * team_id;
-          const int last =
-              (first + ChunkSizePerTeam) > num_sources_local ? num_sources_local : first + ChunkSizePerTeam;
+          const int last  = omptarget::min(first + ChunkSizePerTeam, num_sources_local);
 
           T pos[D];
           for (int idim = 0; idim < D; idim++)

--- a/src/Platforms/OMPTarget/OMPTargetMath.hpp
+++ b/src/Platforms/OMPTarget/OMPTargetMath.hpp
@@ -10,6 +10,10 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
+/**@file OMPTargetMath.hpp
+ *@brief handle math function mapping inside OpenMP offload regions.
+ */
+
 #ifndef OMPTARGET_MATH_H
 #define OMPTARGET_MATH_H
 
@@ -21,17 +25,17 @@
 namespace omptarget
 {
 #if defined(ENABLE_OFFLOAD)
-inline void sincos(double a, double* restrict s, double* restrict c)
-{
-  ::sincos(a,s,c);
-}
+inline void sincos(double a, double* restrict s, double* restrict c) { ::sincos(a, s, c); }
 
-inline void sincos(float a, float* restrict s, float* restrict c)
-{
-  ::sincosf(a,s,c);
-}
+inline void sincos(float a, float* restrict s, float* restrict c) { ::sincosf(a, s, c); }
 #else
 using namespace qmcplusplus;
 #endif
+
+template<typename T>
+T min(T a, T b)
+{
+  return a < b ? a : b;
 }
+} // namespace omptarget
 #endif


### PR DESCRIPTION
## Proposed changes
At a point NVHPC was having issue with std::min being used inside offload region. Let's just use a simple omptarget::min and move on.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
