### PR TITLE
Early return to avoid undefined behavior.

### DIFF
--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -139,6 +139,10 @@ public:
         num_accepted++;
       }
 
+    // early return to avoid OpenMP runtime mishandling of size 0 in transfer/compute.
+    if (num_accepted == 0)
+      return;
+
     //offload to GPU
     auto* restrict mw_pos_ptr  = mw_new_pos.data();
     auto* restrict mw_rosa_ptr = mw_rsoa_ptrs.data();


### PR DESCRIPTION
## Proposed changes
This was discovered when offloading to AMD GPUs with LLVM/AOMP. libomptarget tries to make a data transfer of size 0. https://github.com/llvm/llvm-project/issues/53803

## What type(s) of changes does this code introduce?
- Workaround

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
