### PR TITLE
Jastrows skip recompute in evaluateGL.

### DIFF
--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -147,7 +147,8 @@ struct J1OrbitalSoA : public WaveFunctionComponent
                            ParticleSet::ParticleGradient& G,
                            ParticleSet::ParticleLaplacian& L) override
   {
-    return evaluateGL(P, G, L, true);
+    recompute(P);
+    return log_value_ = computeGL(G, L);
   }
 
   void evaluateHessian(ParticleSet& P, HessVector& grad_grad_psi) override
@@ -330,19 +331,23 @@ struct J1OrbitalSoA : public WaveFunctionComponent
       ratios[i] = std::exp(Vat[i] - curAt);
   }
 
+  /// compute G and L from internally stored data
+  inline QTFull::RealType computeGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L) const
+  {
+    for (size_t iat = 0; iat < Nelec; ++iat)
+    {
+      G[iat] += Grad[iat];
+      L[iat] -= Lap[iat];
+    }
+    return -simd::accumulate_n(Vat.data(), Nelec, QTFull::RealType());
+  }
+
   inline LogValueType evaluateGL(const ParticleSet& P,
                                  ParticleSet::ParticleGradient& G,
                                  ParticleSet::ParticleLaplacian& L,
                                  bool fromscratch = false) override
   {
-    if (fromscratch)
-      recompute(P);
-
-    for (size_t iat = 0; iat < Nelec; ++iat)
-      G[iat] += Grad[iat];
-    for (size_t iat = 0; iat < Nelec; ++iat)
-      L[iat] -= Lap[iat];
-    return log_value_ = -simd::accumulate_n(Vat.data(), Nelec, valT());
+    return log_value_ = computeGL(G, L);
   }
 
   /** compute gradient and lap
@@ -452,7 +457,7 @@ struct J1OrbitalSoA : public WaveFunctionComponent
 
   inline LogValueType updateBuffer(ParticleSet& P, WFBufferType& buf, bool fromscratch = false) override
   {
-    evaluateGL(P, P.G, P.L, false);
+    log_value_ = computeGL(P.G, P.L);
     buf.forward(Bytes_in_WFBuffer);
     return log_value_;
   }

--- a/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OMPTarget.h
@@ -115,6 +115,9 @@ private:
     lapLogPsi.resize(myVars.size(), ValueDerivVec(N));
   }
 
+  /// compute G and L from internally stored data
+  QTFull::RealType computeGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L) const;
+
 public:
   J2OMPTarget(const std::string& obj_name, ParticleSet& p);
   J2OMPTarget(const J2OMPTarget& rhs) = delete;
@@ -236,8 +239,6 @@ public:
   inline RealType KECorrection() override { return KEcorr; }
 
   const std::vector<FT*>& getPairFunctions() const { return F; }
-
-  QTFull::RealType computeGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L) const;
 
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& active,

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -105,6 +105,9 @@ protected:
     lapLogPsi.resize(myVars.size(), ValueDerivVec(N));
   }
 
+  /// compute G and L from internally stored data
+  QTFull::RealType computeGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L) const;
+
 public:
   J2OrbitalSoA(const std::string& obj_name, ParticleSet& p);
   J2OrbitalSoA(const J2OrbitalSoA& rhs) = delete;

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -414,7 +414,8 @@ public:
    * @param P particle set
    * @param G Gradients, \f$\nabla\ln\Psi\f$
    * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
-   * @param fromscratch if true, all the internal data are recomputed from scratch
+   * @param fromscratch if true and this WFC is sensitive to numeical error accumulation,
+   *        all the internal data are recomputed from scratch.
    * @return log(psi)
    */
   virtual LogValueType evaluateGL(const ParticleSet& P,
@@ -427,7 +428,8 @@ public:
    * @param p_list the list of ParticleSet pointers in a walker batch
    * @param G_list the list of Gradients pointers in a walker batch, \f$\nabla\ln\Psi\f$
    * @param L_list the list of Laplacians pointers in a walker batch, \f$\nabla^2\ln\Psi\f$
-   * @param fromscratch if true, all the internal data are recomputed from scratch
+   * @param fromscratch if true and this WFC is sensitive to numeical error accumulation,
+   *        all the internal data are recomputed from scratch.
    */
   virtual void mw_evaluateGL(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                              const RefVectorWithLeader<ParticleSet>& p_list,


### PR DESCRIPTION
## Proposed changes
Unlike determinants, Jastrow factors don't suffer from numerical error accumulation and thus recomputing is not needed.
This is consistent with the old choice of evaluateGL being called from updateBuffer by classic drivers.
evaluateLog = recompute() + computeGL;
evaluateGL = computeGL in Jastrow factors. recompute is always skipped.

## What type(s) of changes does this code introduce?
- Other (please describe): 

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'