### PR TITLE
Make the inter std::map of pools access from outside as const

### DIFF
--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -253,10 +253,9 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto& pset_target = *(particle_pool.getParticleSet("e"));
-  auto& species_set = pset_target.getSpeciesSet();
-  auto& wf_factory  = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& pset_target      = *(particle_pool.getParticleSet("e"));
+  auto& species_set      = pset_target.getSpeciesSet();
+  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
 
   auto samplingCaseRunner = [&pset_target, &species_set, &wf_factory](Inputs test_case) {
     Libxml2Document doc;
@@ -296,10 +295,9 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto& pset_target = *(particle_pool.getParticleSet("e"));
-  auto& species_set = pset_target.getSpeciesSet();
-  auto& wf_factory  = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& pset_target      = *(particle_pool.getParticleSet("e"));
+  auto& species_set      = pset_target.getSpeciesSet();
+  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(valid_one_body_density_matrices_input_sections[Inputs::valid_obdm_input]);
@@ -334,10 +332,9 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto& pset_target = *(particle_pool.getParticleSet("e"));
-  auto& pset_source = *(particle_pool.getParticleSet("ion"));
-  auto& species_set = pset_target.getSpeciesSet();
+  auto& pset_target      = *(particle_pool.getParticleSet("e"));
+  auto& pset_source      = *(particle_pool.getParticleSet("ion"));
+  auto& species_set      = pset_target.getSpeciesSet();
   OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
 
   std::vector<MCPWalker> walkers;
@@ -435,9 +432,8 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
     auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
     auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
     auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
-    wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-    auto& pset_target = *(particle_pool.getParticleSet("e"));
-    auto& species_set = pset_target.getSpeciesSet();
+    auto& pset_target      = *(particle_pool.getParticleSet("e"));
+    auto& species_set      = pset_target.getSpeciesSet();
     OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
     auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
 

--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -89,7 +89,7 @@ public:
 
   /** get the Pool object
    */
-  inline PoolType& getPool() { return myPool; }
+  inline const PoolType& getPool() const { return myPool; }
 
   /// get simulation cell
   const auto& getSimulationCell() const { return *simulation_cell_; }

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -202,11 +202,10 @@ void WaveFunctionTester::runCloneTest()
 void WaveFunctionTester::printEloc()
 {
   app_log() << " ===== printEloc =====\n";
-  ParticleSetPool::PoolType::iterator p;
-  for (p = PtclPool.getPool().begin(); p != PtclPool.getPool().end(); p++)
-    app_log() << "ParticelSet = " << p->first << std::endl;
+  for (auto& [key, value] : PtclPool.getPool())
+    app_log() << "ParticelSet = " << key << std::endl;
   // Find source ParticleSet
-  ParticleSetPool::PoolType::iterator pit(PtclPool.getPool().find(sourceName));
+  auto pit(PtclPool.getPool().find(sourceName));
   if (pit == PtclPool.getPool().end())
     APP_ABORT("Unknown source \"" + sourceName + "\" in printEloc in WaveFunctionTester.");
   ParticleSet& source = *((*pit).second);
@@ -1413,11 +1412,10 @@ void WaveFunctionTester::runRatioV()
 void WaveFunctionTester::runGradSourceTest()
 {
   app_log() << " ===== runGradSourceTest =====\n";
-  ParticleSetPool::PoolType::iterator p;
-  for (p = PtclPool.getPool().begin(); p != PtclPool.getPool().end(); p++)
-    app_log() << "ParticelSet = " << p->first << std::endl;
+  for (auto& [key, value] : PtclPool.getPool())
+    app_log() << "ParticelSet = " << key << std::endl;
   // Find source ParticleSet
-  ParticleSetPool::PoolType::iterator pit(PtclPool.getPool().find(sourceName));
+  auto pit(PtclPool.getPool().find(sourceName));
   app_log() << pit->first << std::endl;
   // if(pit == PtclPool.getPool().end())
   //   APP_ABORT("Unknown source \"" + sourceName + "\" WaveFunctionTester.");
@@ -1564,11 +1562,10 @@ void WaveFunctionTester::runGradSourceTest()
 void WaveFunctionTester::runZeroVarianceTest()
 {
   app_log() << " ===== runZeroVarianceTest =====\n";
-  ParticleSetPool::PoolType::iterator p;
-  for (p = PtclPool.getPool().begin(); p != PtclPool.getPool().end(); p++)
-    app_log() << "ParticelSet = " << p->first << std::endl;
+  for (auto& [key, value] : PtclPool.getPool())
+    app_log() << "ParticelSet = " << key << std::endl;
   // Find source ParticleSet
-  ParticleSetPool::PoolType::iterator pit(PtclPool.getPool().find(sourceName));
+  auto pit(PtclPool.getPool().find(sourceName));
   app_log() << pit->first << std::endl;
   // if(pit == PtclPool.getPool().end())
   //   APP_ABORT("Unknown source \"" + sourceName + "\" WaveFunctionTester.");

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -64,7 +64,6 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
   dmcdriver_input.readXML(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   SampleStack samples;

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -28,9 +28,8 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto wf_factory       = wavefunction_pool.getWaveFunctionFactory("wavefunction");
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto wf_factory        = wavefunction_pool.getWaveFunctionFactory("wavefunction");
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   TrialWaveFunction twf;
   WalkerConfigurations walker_confs;
 
@@ -64,9 +63,8 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  auto wf_factory       = wavefunction_pool.getWaveFunctionFactory("wavefunction");
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto wf_factory        = wavefunction_pool.getWaveFunctionFactory("wavefunction");
   WalkerConfigurations walker_confs;
   MCPopulation population(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                           wavefunction_pool.getPrimary(), wf_factory, hamiltonian_pool.getPrimary());

--- a/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverFactory.cpp
@@ -48,8 +48,7 @@ TEST_CASE("QMCDriverFactory create VMC Driver", "[qmcapp]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
@@ -78,8 +77,7 @@ TEST_CASE("QMCDriverFactory create VMCBatched driver", "[qmcapp]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
@@ -107,8 +105,7 @@ TEST_CASE("QMCDriverFactory create DMC driver", "[qmcapp]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 
@@ -136,8 +133,7 @@ TEST_CASE("QMCDriverFactory create DMCBatched driver", "[qmcapp]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   std::string target("e");
   MCWalkerConfiguration* qmc_system = particle_pool.getWalkerSet(target);
 

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -41,7 +41,6 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   qmcdriver_input.readXML(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   SampleStack samples;
@@ -88,7 +87,6 @@ TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
   qmcdriver_input.readXML(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
@@ -129,7 +127,6 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
   qmcdriver_input.readXML(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 

--- a/src/QMCDrivers/tests/test_VMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_VMCBatched.cpp
@@ -53,8 +53,7 @@ public:
 
     auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
     auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-    wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-    auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+    auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   }
 
 private:

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -94,7 +94,7 @@ void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
   if (sourceInp != targetPtcl.getName())
   {
     //renameProperty(sourceInp);
-    PtclPoolType::iterator pit(ptclPool.find(sourceInp));
+    auto pit(ptclPool.find(sourceInp));
     if (pit == ptclPool.end())
     {
       ERRORMSG("Missing source ParticleSet" << sourceInp);
@@ -175,7 +175,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   bool quantum = (a == targetPtcl.getName());
 
   renameProperty(a);
-  PtclPoolType::iterator pit(ptclPool.find(a));
+  auto pit(ptclPool.find(a));
   if (pit == ptclPool.end())
   {
     ERRORMSG("Missing source ParticleSet" << a)
@@ -214,7 +214,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
   else if (mode == "acforce")
   {
     app_log() << "Adding Assaraf-Caffarel total force.\n";
-    PsiPoolType::iterator psi_it(psiPool.find(PsiName));
+    auto psi_it(psiPool.find(PsiName));
     if (psi_it == psiPool.end())
     {
       APP_ABORT("Unknown psi \"" + PsiName + "\" for zero-variance force.");
@@ -247,14 +247,14 @@ void HamiltonianFactory::addPseudoPotential(xmlNodePtr cur)
   }
   renameProperty(src);
   renameProperty(wfname);
-  PtclPoolType::iterator pit(ptclPool.find(src));
+  auto pit(ptclPool.find(src));
   if (pit == ptclPool.end())
   {
     ERRORMSG("Missing source ParticleSet" << src)
     return;
   }
   ParticleSet* ion = (*pit).second;
-  PsiPoolType::iterator oit(psiPool.find(wfname));
+  auto oit(psiPool.find(wfname));
   TrialWaveFunction* psi = 0;
   if (oit == psiPool.end())
   {

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -23,7 +23,7 @@
 
 namespace qmcplusplus
 {
-EnergyDensityEstimator::EnergyDensityEstimator(PSPool& PSP, const std::string& defaultKE)
+EnergyDensityEstimator::EnergyDensityEstimator(const PSPool& PSP, const std::string& defaultKE)
     : psetpool(PSP), Pdynamic(0), Pstatic(0), w_trace(0), Td_trace(0), Vd_trace(0), Vs_trace(0)
 {
   update_mode_.set(COLLECTABLE, 1);
@@ -194,12 +194,13 @@ void EnergyDensityEstimator::unset_ptcl()
 
 ParticleSet* EnergyDensityEstimator::get_particleset(std::string& psname)
 {
-  if (psetpool.find(psname) == psetpool.end())
+  auto pit(psetpool.find(psname));
+  if (pit == psetpool.end())
   {
     app_log() << "  ParticleSet " << psname << " does not exist" << std::endl;
     APP_ABORT("EnergyDensityEstimator::put");
   }
-  return psetpool[psname];
+  return pit->second;
 }
 
 

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -28,7 +28,7 @@ public:
   using Point  = ReferencePoints::Point;
   using PSPool = std::map<std::string, ParticleSet*>;
 
-  EnergyDensityEstimator(PSPool& PSP, const std::string& defaultKE);
+  EnergyDensityEstimator(const PSPool& PSP, const std::string& defaultKE);
   ~EnergyDensityEstimator() override;
 
   void resetTargetParticleSet(ParticleSet& P) override;
@@ -54,7 +54,7 @@ private:
   xmlNodePtr input_xml;
   //system information
   std::string defKE;
-  PSPool& psetpool;
+  const PSPool& psetpool;
   ParticleSet* Pdynamic;
   ParticleSet* Pstatic;
   ParticleSet* get_particleset(std::string& psname);

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -60,8 +60,8 @@ namespace qmcplusplus
 {
 HamiltonianFactory::HamiltonianFactory(const std::string& hName,
                                        ParticleSet& qp,
-                                       PtclPoolType& pset,
-                                       PsiPoolType& oset,
+                                       const PtclPoolType& pset,
+                                       const PsiPoolType& oset,
                                        Communicate* c)
     : MPIObjectBase(c),
       targetH(std::make_unique<QMCHamiltonian>(hName)),
@@ -129,7 +129,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       attach2Node = true;
     }
   }
-  PsiPoolType::iterator psi_it(psiPool.find(psiName));
+  auto psi_it(psiPool.find(psiName));
   if (psi_it == psiPool.end())
     APP_ABORT("Unknown psi \"" + psiName + "\" for target Psi");
   TrialWaveFunction* targetPsi = psi_it->second->getTWF();
@@ -216,7 +216,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       else if (potType == "latticedeviation")
       {
         // find target particle set
-        PtclPoolType::iterator pit(ptclPool.find(targetInp));
+        auto pit(ptclPool.find(targetInp));
         if (pit == ptclPool.end())
         {
           APP_ABORT("Unknown target \"" + targetInp + "\" for LatticeDeviation.");
@@ -224,7 +224,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         ParticleSet* target_particle_set = (*pit).second;
 
         // find source particle set
-        PtclPoolType::iterator spit(ptclPool.find(sourceInp));
+        auto spit(ptclPool.find(sourceInp));
         if (spit == ptclPool.end())
         {
           APP_ABORT("Unknown source \"" + sourceInp + "\" for LatticeDeviation.");
@@ -300,7 +300,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         OhmmsAttributeSet attrib;
         attrib.add(source, "source");
         attrib.put(cur);
-        PtclPoolType::iterator pit(ptclPool.find(source));
+        auto pit(ptclPool.find(source));
         ParticleSet* Pc = nullptr;
         if (source == "")
           Pc = nullptr;
@@ -339,13 +339,13 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         hAttrib.add(PsiName, "psi");
         hAttrib.add(SourceName, "source");
         hAttrib.put(cur);
-        PtclPoolType::iterator pit(ptclPool.find(SourceName));
+        auto pit(ptclPool.find(SourceName));
         if (pit == ptclPool.end())
         {
           APP_ABORT("Unknown source \"" + SourceName + "\" for Chiesa correction.");
         }
         ParticleSet& source = *pit->second;
-        PsiPoolType::iterator psi_it(psiPool.find(PsiName));
+        auto psi_it(psiPool.find(PsiName));
         if (psi_it == psiPool.end())
         {
           APP_ABORT("Unknown psi \"" + PsiName + "\" for Chiesa correction.");
@@ -361,7 +361,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         attrib.add(SourceName, "source");
         attrib.put(cur);
 
-        PtclPoolType::iterator pit(ptclPool.find(SourceName));
+        auto pit(ptclPool.find(SourceName));
         if (pit == ptclPool.end())
         {
           APP_ABORT("Unknown source \"" + SourceName + "\" for SkAll.");
@@ -399,7 +399,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         OhmmsAttributeSet hAttrib;
         hAttrib.add(PsiName, "wavefunction");
         hAttrib.put(cur);
-        PsiPoolType::iterator psi_it(psiPool.find(PsiName));
+        auto psi_it(psiPool.find(PsiName));
         if (psi_it == psiPool.end())
         {
           APP_ABORT("Unknown psi \"" + PsiName + "\" for momentum.");

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -33,7 +33,7 @@ public:
   using PsiPoolType  = std::map<std::string, WaveFunctionFactory*>;
 
   ///constructor
-  HamiltonianFactory(const std::string& hName, ParticleSet& qp, PtclPoolType& pset, PsiPoolType& oset, Communicate* c);
+  HamiltonianFactory(const std::string& hName, ParticleSet& qp, const PtclPoolType& pset, const PsiPoolType& oset, Communicate* c);
 
   ///read from xmlNode
   bool put(xmlNodePtr cur);
@@ -71,9 +71,9 @@ private:
   ///target ParticleSet
   ParticleSet& targetPtcl;
   ///reference to the PtclPoolType
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ///reference to the WaveFunctionFactory Pool
-  PsiPoolType& psiPool;
+  const PsiPoolType& psiPool;
   ///input node for a many-body wavefunction
   xmlNodePtr myNode;
 

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-OrbitalImages::OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory)
+OrbitalImages::OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory)
     : psetpool(PSP), wf_factory_(factory)
 {
   //keep the electron particle to get the cell later, if necessary
@@ -197,11 +197,12 @@ bool OrbitalImages::put(xmlNodePtr cur)
   }
 
   //get the ion particleset
-  if (psetpool.find(ion_psname) == psetpool.end())
+  if (auto pit = psetpool.find(ion_psname); pit == psetpool.end())
   {
     APP_ABORT("OrbitalImages::put  ParticleSet " + ion_psname + " does not exist");
   }
-  Pion = psetpool[ion_psname];
+  else
+    Pion = pit->second;
 
   app_log() << "  getting sposets" << std::endl;
 

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -143,7 +143,7 @@ public:
   };
 
   ///at put() ion particleset is obtained from ParticleSetPool
-  PSPool& psetpool;
+  const PSPool& psetpool;
 
   ///electron particleset
   ParticleSet* Peln;
@@ -216,7 +216,7 @@ public:
   std::vector<ValueType> orbital;
 
   //constructors
-  OrbitalImages(ParticleSet& P, PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory);
+  OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory);
   OrbitalImages(const OrbitalImages& other);
 
   //standard interface

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -26,8 +26,7 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
   TrialWaveFunction twf;
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -53,8 +53,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
   WaveFunctionPool wfp(pp, c);
 
   WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *pp.getPool()["e"], pp.getPool(), c);
-  wfp.getPool()["psi0"] = wf_factory;
-  wfp.setPrimary(wf_factory->getTWF());
+  wfp.addFactory(wf_factory, true);
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,7 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
 
   WaveFunctionPool wfp(pp, c);
 
-  WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *pp.getPool()["e"], pp.getPool(), c);
+  WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *pp.getParticleSet("e"), pp.getPool(), c);
   wfp.addFactory(wf_factory, true);
 
   HamiltonianPool hpool(pp, wfp, c);

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.cpp
@@ -22,7 +22,7 @@
 
 namespace qmcplusplus
 {
-AGPDeterminantBuilder::AGPDeterminantBuilder(Communicate* comm, ParticleSet& els, PtclPoolType& pset)
+AGPDeterminantBuilder::AGPDeterminantBuilder(Communicate* comm, ParticleSet& els, const PtclPoolType& pset)
     : WaveFunctionComponentBuilder(comm, els), ptclPool(pset)
 {}
 

--- a/src/QMCWaveFunctions/AGPDeterminantBuilder.h
+++ b/src/QMCWaveFunctions/AGPDeterminantBuilder.h
@@ -31,14 +31,14 @@ namespace qmcplusplus
 class AGPDeterminantBuilder : public WaveFunctionComponentBuilder
 {
 public:
-  AGPDeterminantBuilder(Communicate* comm, ParticleSet& els, PtclPoolType& pset);
+  AGPDeterminantBuilder(Communicate* comm, ParticleSet& els, const PtclPoolType& pset);
 
   /// process a xml node at cur
   std::unique_ptr<WaveFunctionComponent> buildComponent(xmlNodePtr cur) override;
 
 protected:
   ///reference to a PtclPoolType
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ///basiset Factory
   std::unique_ptr<SPOSetBuilderFactory> mySPOSetBuilderFactory;
   ///AGPDeterminant

--- a/src/QMCWaveFunctions/ExampleHeBuilder.cpp
+++ b/src/QMCWaveFunctions/ExampleHeBuilder.cpp
@@ -20,7 +20,7 @@
 
 namespace qmcplusplus
 {
-ExampleHeBuilder::ExampleHeBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets)
+ExampleHeBuilder::ExampleHeBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets)
     : WaveFunctionComponentBuilder(comm, p), ptclPool(psets), els(p)
 {}
 

--- a/src/QMCWaveFunctions/ExampleHeBuilder.h
+++ b/src/QMCWaveFunctions/ExampleHeBuilder.h
@@ -27,12 +27,12 @@ namespace qmcplusplus
 class ExampleHeBuilder : public WaveFunctionComponentBuilder
 {
 public:
-  ExampleHeBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets);
+  ExampleHeBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets);
 
   std::unique_ptr<WaveFunctionComponent> buildComponent(xmlNodePtr cur) override;
 
 private:
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ParticleSet& els;
 };
 

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.cpp
@@ -38,7 +38,7 @@
 
 namespace qmcplusplus
 {
-BackflowBuilder::BackflowBuilder(ParticleSet& els, PtclPoolType& pool) : cutOff(1.0), targetPtcl(els), ptclPool(pool) {}
+BackflowBuilder::BackflowBuilder(ParticleSet& els, const PtclPoolType& pool) : cutOff(1.0), targetPtcl(els), ptclPool(pool) {}
 
 std::unique_ptr<BackflowTransformation> BackflowBuilder::buildBackflowTransformation(xmlNodePtr cur)
 {
@@ -105,7 +105,7 @@ std::unique_ptr<BackflowFunctionBase> BackflowBuilder::addOneBody(xmlNodePtr cur
   spoAttrib.add(spin, "spin");
   spoAttrib.put(cur);
   ParticleSet* ions = 0;
-  PtclPoolType::iterator pit(ptclPool.find(source));
+  auto pit(ptclPool.find(source));
   if (pit == ptclPool.end())
   {
     APP_ABORT("Missing backflow/@source.");

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.h
@@ -39,7 +39,7 @@ class BackflowBuilder
   using PtclPoolType = std::map<std::string, ParticleSet*>;
 
 public:
-  BackflowBuilder(ParticleSet& p, PtclPoolType& pool);
+  BackflowBuilder(ParticleSet& p, const PtclPoolType& pool);
 
   std::unique_ptr<BackflowTransformation> buildBackflowTransformation(xmlNodePtr cur);
 
@@ -47,7 +47,7 @@ public:
 
 private:
   ParticleSet& targetPtcl;
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   bool IgnoreSpin;
   RealType Rs;
   RealType Kc;

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -46,7 +46,7 @@ SlaterDetBuilder::SlaterDetBuilder(Communicate* comm,
                                    SPOSetBuilderFactory& factory,
                                    ParticleSet& els,
                                    TrialWaveFunction& psi,
-                                   PtclPoolType& psets)
+                                   const PtclPoolType& psets)
     : WaveFunctionComponentBuilder(comm, els), sposet_builder_factory_(factory), targetPsi(psi), ptclPool(psets)
 {
   ClassName = "SlaterDetBuilder";

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -46,7 +46,7 @@ public:
                    SPOSetBuilderFactory& factory,
                    ParticleSet& els,
                    TrialWaveFunction& psi,
-                   PtclPoolType& psets);
+                   const PtclPoolType& psets);
 
   /** initialize the Antisymmetric wave function for electrons
    *@param cur the current xml node
@@ -60,7 +60,7 @@ private:
   ///reference to TrialWaveFunction, should go away as the CUDA code.
   TrialWaveFunction& targetPsi;
   ///reference to a PtclPoolType
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
 
   /** process a determinant element
    * @param cur xml node

--- a/src/QMCWaveFunctions/Jastrow/JastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/JastrowBuilder.cpp
@@ -26,7 +26,7 @@
 
 namespace qmcplusplus
 {
-JastrowBuilder::JastrowBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets)
+JastrowBuilder::JastrowBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets)
     : WaveFunctionComponentBuilder(comm, p), ptclPool(psets)
 {
   resetOptions();
@@ -88,7 +88,7 @@ std::unique_ptr<WaveFunctionComponent> JastrowBuilder::buildCounting(xmlNodePtr 
 {
   ReportEngine PRE(ClassName, "addCounting(xmlNodePtr)");
   std::unique_ptr<CountingJastrowBuilder> cjb;
-  std::map<std::string, ParticleSet*>::iterator pa_it(ptclPool.find(sourceOpt));
+  auto pa_it(ptclPool.find(sourceOpt));
   if (pa_it != ptclPool.end() && sourceOpt != targetPtcl.getName()) // source is not target
   {
     ParticleSet* sourcePtcl = (*pa_it).second;
@@ -102,7 +102,7 @@ std::unique_ptr<WaveFunctionComponent> JastrowBuilder::buildCounting(xmlNodePtr 
 std::unique_ptr<WaveFunctionComponent> JastrowBuilder::buildkSpace(xmlNodePtr cur)
 {
   app_log() << "  JastrowBuilder::buildkSpace(xmlNodePtr)" << std::endl;
-  std::map<std::string, ParticleSet*>::iterator pa_it(ptclPool.find(sourceOpt));
+  auto pa_it(ptclPool.find(sourceOpt));
   if (pa_it == ptclPool.end())
   {
     app_warning() << "  JastrowBuilder::buildkSpace failed. " << sourceOpt << " does not exist" << std::endl;
@@ -123,7 +123,7 @@ std::unique_ptr<WaveFunctionComponent> JastrowBuilder::buildOneBody(xmlNodePtr c
               "\nExit JastrowBuilder::buildOneBody.\n");
     return nullptr;
   }
-  std::map<std::string, ParticleSet*>::iterator pa_it(ptclPool.find(sourceOpt));
+  auto pa_it(ptclPool.find(sourceOpt));
   if (pa_it == ptclPool.end())
   {
     PRE.error("JastrowBuilder::buildOneBody failed. " + sourceOpt + " does not exist.");
@@ -139,7 +139,7 @@ std::unique_ptr<WaveFunctionComponent> JastrowBuilder::build_eeI(xmlNodePtr cur)
 {
 #if OHMMS_DIM == 3
   ReportEngine PRE(ClassName, "add_eeI(xmlNodePtr)");
-  PtclPoolType::iterator pit(ptclPool.find(sourceOpt));
+  auto pit(ptclPool.find(sourceOpt));
   if (pit == ptclPool.end())
   {
     app_error() << "     JastrowBuilder::build_eeI requires a source attribute. " << sourceOpt << " is invalid "

--- a/src/QMCWaveFunctions/Jastrow/JastrowBuilder.h
+++ b/src/QMCWaveFunctions/Jastrow/JastrowBuilder.h
@@ -26,13 +26,13 @@ class OrbitalConstraintsBase;
 class JastrowBuilder : public WaveFunctionComponentBuilder
 {
 public:
-  JastrowBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets);
+  JastrowBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets);
 
   std::unique_ptr<WaveFunctionComponent> buildComponent(xmlNodePtr cur) override;
 
 private:
   ///particleset pool to get ParticleSet other than the target
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ///index for the jastrow type: 1, 2, 3
   int JastrowType;
   /// \xmla{jastrow,name}

--- a/src/QMCWaveFunctions/LatticeGaussianProductBuilder.cpp
+++ b/src/QMCWaveFunctions/LatticeGaussianProductBuilder.cpp
@@ -18,7 +18,7 @@
 
 namespace qmcplusplus
 {
-LatticeGaussianProductBuilder::LatticeGaussianProductBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets)
+LatticeGaussianProductBuilder::LatticeGaussianProductBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets)
     : WaveFunctionComponentBuilder(comm, p), ptclPool(psets)
 {}
 
@@ -36,7 +36,8 @@ std::unique_ptr<WaveFunctionComponent> LatticeGaussianProductBuilder::buildCompo
   {
     app_warning() << "  LatticeGaussianProductBuilder::put does not have name " << std::endl;
   }
-  std::map<std::string, ParticleSet*>::iterator pa_it(ptclPool.find(sourceOpt));
+
+  auto pa_it(ptclPool.find(sourceOpt));
   if (pa_it == ptclPool.end())
   {
     app_error() << "Could not file source ParticleSet " << sourceOpt << " for ion wave function.\n";

--- a/src/QMCWaveFunctions/LatticeGaussianProductBuilder.h
+++ b/src/QMCWaveFunctions/LatticeGaussianProductBuilder.h
@@ -23,13 +23,13 @@ namespace qmcplusplus
 class LatticeGaussianProductBuilder : public WaveFunctionComponentBuilder
 {
 public:
-  LatticeGaussianProductBuilder(Communicate* comm, ParticleSet& p, PtclPoolType& psets);
+  LatticeGaussianProductBuilder(Communicate* comm, ParticleSet& p, const PtclPoolType& psets);
 
   std::unique_ptr<WaveFunctionComponent> buildComponent(xmlNodePtr cur) override;
 
 private:
   ///particleset pool to get ParticleSet other than the target
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ///index for the jastrow type: 1, 2, 3
   int LatticeGaussianProductType;
   ///name

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -28,7 +28,7 @@
 
 namespace qmcplusplus
 {
-PWOrbitalBuilder::PWOrbitalBuilder(Communicate* comm, ParticleSet& els, PtclPoolType& psets)
+PWOrbitalBuilder::PWOrbitalBuilder(Communicate* comm, ParticleSet& els, const PtclPoolType& psets)
     : WaveFunctionComponentBuilder(comm, els), ptclPool(psets), hfileID(-1), rootNode(NULL)
 {
   myParam = new PWParameterSet(myComm);

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.h
@@ -40,7 +40,7 @@ private:
 #endif
 
   std::map<std::string, SPOSetPtr> spomap;
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
 
   ///Read routine for HDF wavefunction file version 0.10
   void ReadHDFWavefunction(hid_t hfile);
@@ -59,7 +59,7 @@ private:
   //std::map<std::string,SPOSetPtr> PWOSet;
 public:
   ///constructor
-  PWOrbitalBuilder(Communicate* comm, ParticleSet& els, PtclPoolType& psets);
+  PWOrbitalBuilder(Communicate* comm, ParticleSet& els, const PtclPoolType& psets);
   ~PWOrbitalBuilder() override;
 
   ///implement vritual function

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -94,7 +94,7 @@ SPOSetBuilder& SPOSetBuilderFactory::getLastBuilder()
  * \param psi reference to the wavefunction
  * \param ions reference to the ions
  */
-SPOSetBuilderFactory::SPOSetBuilderFactory(Communicate* comm, ParticleSet& els, PtclPoolType& psets)
+SPOSetBuilderFactory::SPOSetBuilderFactory(Communicate* comm, ParticleSet& els, const PtclPoolType& psets)
     : MPIObjectBase(comm), targetPtcl(els), ptclPool(psets)
 {
   ClassName = "SPOSetBuilderFactory";

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -32,7 +32,7 @@ public:
    * \param els reference to the electrons
    * \param ions reference to the ions
    */
-  SPOSetBuilderFactory(Communicate* comm, ParticleSet& els, PtclPoolType& psets);
+  SPOSetBuilderFactory(Communicate* comm, ParticleSet& els, const PtclPoolType& psets);
 
   ~SPOSetBuilderFactory();
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -43,7 +43,7 @@ namespace qmcplusplus
 {
 WaveFunctionFactory::WaveFunctionFactory(const std::string& psiName,
                                          ParticleSet& qp,
-                                         PtclPoolType& pset,
+                                         const PtclPoolType& pset,
                                          Communicate* c,
                                          bool tasking)
     : MPIObjectBase(c),

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -41,7 +41,7 @@ public:
    */
   WaveFunctionFactory(const std::string& psiName,
                       ParticleSet& qp,
-                      PtclPoolType& pset,
+                      const PtclPoolType& pset,
                       Communicate* c,
                       bool tasking = false);
 
@@ -77,7 +77,7 @@ private:
   ///target ParticleSet
   ParticleSet& targetPtcl;
   ///reference to the PtclPoolType
-  PtclPoolType& ptclPool;
+  const PtclPoolType& ptclPool;
   ///input node for a many-body wavefunction
   xmlNodePtr myNode;
   ///builder tree

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -40,10 +40,10 @@ public:
   using PoolType = std::map<std::string, WaveFunctionFactory*>;
 
   WaveFunctionPool(ParticleSetPool& pset_pool, Communicate* c, const char* aname = "wavefunction");
-  WaveFunctionPool(const WaveFunctionPool&) = delete;
+  WaveFunctionPool(const WaveFunctionPool&)            = delete;
   WaveFunctionPool& operator=(const WaveFunctionPool&) = delete;
   WaveFunctionPool(WaveFunctionPool&&)                 = default;
-  WaveFunctionPool& operator=(WaveFunctionPool&&) = delete;
+  WaveFunctionPool& operator=(WaveFunctionPool&&)      = delete;
 
   ~WaveFunctionPool();
 
@@ -53,12 +53,9 @@ public:
 
   TrialWaveFunction* getPrimary() { return primary_psi_; }
 
-  void setPrimary(TrialWaveFunction* psi) { primary_psi_ = psi; }
-
   TrialWaveFunction* getWaveFunction(const std::string& pname)
   {
-    std::map<std::string, WaveFunctionFactory*>::iterator pit(myPool.find(pname));
-    if (pit == myPool.end())
+    if (auto pit(myPool.find(pname)); pit == myPool.end())
     {
       if (myPool.empty())
         return nullptr;
@@ -71,8 +68,7 @@ public:
 
   WaveFunctionFactory* getWaveFunctionFactory(const std::string& pname)
   {
-    std::map<std::string, WaveFunctionFactory*>::iterator pit(myPool.find(pname));
-    if (pit == myPool.end())
+    if (auto pit(myPool.find(pname)); pit == myPool.end())
     {
       if (myPool.empty())
         return nullptr;
@@ -96,7 +92,7 @@ public:
 
   /** add a WaveFunctionFactory* to myPool
    */
-  void addFactory(WaveFunctionFactory* psifac);
+  void addFactory(WaveFunctionFactory* psifac, bool primary);
 
 private:
   /// pointer to the primary TrialWaveFunction

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -88,7 +88,7 @@ public:
 
   /** get the Pool object
    */
-  inline PoolType& getPool() { return myPool; }
+  inline const PoolType& getPool() const { return myPool; }
 
   /** add a WaveFunctionFactory* to myPool
    */

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -29,9 +29,8 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  wavefunction_pool.setPrimary(wavefunction_pool.getWaveFunction("psi0"));
-  auto& pset       = *particle_pool.getParticleSet("e");
-  auto& wf_factory = *wavefunction_pool.getWaveFunctionFactory("wavefunction");
+  auto& pset             = *particle_pool.getParticleSet("e");
+  auto& wf_factory       = *wavefunction_pool.getWaveFunctionFactory("wavefunction");
 
   CompositeSPOSet comp_sposet;
 


### PR DESCRIPTION
## Proposed changes
Make the inter std::map of PaticleSetPool, WaveFuncttionPool const when being accessed from outside.
Also in WaveFunctionPool remove setPrimary. This is handled via addFactory function.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'