### PR TITLE
Replace vector of SPOSetBuilder with map of SPOSet

### DIFF
--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -27,6 +27,7 @@ class TrialWaveFunction;
 class BackflowTransformation;
 class DiracDeterminantBase;
 class MultiDiracDeterminant;
+class SPOSetBuilder;
 class SPOSetBuilderFactory;
 struct ci_configuration;
 
@@ -64,12 +65,15 @@ private:
 
   /** process a determinant element
    * @param cur xml node
-   * @param firstIndex index of the determinant
-   * @return firstIndex+number of orbitals
+   * @param spin_group the spin group of the created determinant
+   * @return legacy_input_sposet_builder an sposet builder to handle legacy input
+   * @return BFTrans backflow transformations
    */
-  std::unique_ptr<DiracDeterminantBase> putDeterminant(xmlNodePtr cur,
-                                                       int spin_group,
-                                                       const std::unique_ptr<BackflowTransformation>& BFTrans);
+  std::unique_ptr<DiracDeterminantBase> putDeterminant(
+      xmlNodePtr cur,
+      int spin_group,
+      const std::unique_ptr<SPOSetBuilder>& legacy_input_sposet_builder,
+      const std::unique_ptr<BackflowTransformation>& BFTrans);
 
   bool createMSDFast(std::vector<std::unique_ptr<MultiDiracDeterminant>>& Dets,
                      std::vector<std::vector<size_t>>& C2node,

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputI
 }
 
 
-SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
+std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
 {
   std::string spo_object_name;
   std::string optimize("no");
@@ -133,9 +133,7 @@ SPOSet* SPOSetBuilder::createSPOSet(xmlNodePtr cur)
                   << "   object name: " << sposet->getName() << std::endl;
 
   sposet->checkObject();
-  // builder owns created sposets
-  sposets.push_back(std::move(sposet));
-  return sposets.back().get();
+  return sposet;
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/SPOSetBuilder.h
+++ b/src/QMCWaveFunctions/SPOSetBuilder.h
@@ -57,9 +57,6 @@ public:
   /// state info of all possible states available in the basis
   std::vector<std::unique_ptr<SPOSetInfo>> states;
 
-  /// list of all sposets created by this builder
-  std::vector<std::unique_ptr<SPOSet>> sposets;
-
   SPOSetBuilder(const std::string& type_name, Communicate* comm);
   virtual ~SPOSetBuilder() {}
 
@@ -73,7 +70,7 @@ public:
   inline void clear_states(int index = 0) { states[index]->clear(); }
 
   /// create an sposet from xml and save the resulting SPOSet
-  SPOSet* createSPOSet(xmlNodePtr cur);
+  std::unique_ptr<SPOSet> createSPOSet(xmlNodePtr cur);
 
   const std::string& getTypeName() const { return type_name_; }
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -36,7 +36,7 @@ public:
 
   ~SPOSetBuilderFactory();
 
-  SPOSetBuilder& createSPOSetBuilder(xmlNodePtr rootNode);
+  std::unique_ptr<SPOSetBuilder> createSPOSetBuilder(xmlNodePtr rootNode);
 
   /** returns a named sposet from the pool
    *  only use in serial portion of execution
@@ -44,24 +44,24 @@ public:
    */
   SPOSet* getSPOSet(const std::string& name) const;
 
-  SPOSetBuilder& getLastBuilder();
-
   void buildSPOSetCollection(xmlNodePtr cur);
 
-  bool empty() const { return sposet_builders_.size() == 0; }
+  bool empty() const { return sposets.empty(); }
+
+  /** add an SPOSet to sposets map.
+   * This is only used to handle legacy SPOSet input styles without using sposet_collection
+   */
+  void addSPOSet(std::unique_ptr<SPOSet>);
 
 private:
-  ///writes info about contained sposets to stdout
-  void write_sposet_builders_(const std::string& pad = "") const;
-
-  ///set of basis set builders resolved by type
-  UPtrVector<SPOSetBuilder> sposet_builders_;
-
   ///reference to the target particle
   ParticleSet& targetPtcl;
 
   ///reference to the particle pool
   const PtclPoolType& ptclPool;
+
+  /// list of all sposets created by the builders of this factory
+  std::map<std::string, std::unique_ptr<SPOSet>> sposets;
 
   static std::string basisset_tag;
 };

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -25,12 +25,13 @@ namespace qmcplusplus
 class SPOSetScanner
 {
 public:
-  using PtclPoolType = std::map<std::string, ParticleSet*>;
-  using RealType     = QMCTraits::RealType;
-  using ValueType    = QMCTraits::ValueType;
-  using ValueVector  = OrbitalSetTraits<ValueType>::ValueVector;
-  using GradVector   = OrbitalSetTraits<ValueType>::GradVector;
-  using HessVector   = OrbitalSetTraits<ValueType>::HessVector;
+  using PtclPool    = std::map<std::string, ParticleSet*>;
+  using SPOSetMap   = std::map<std::string, std::unique_ptr<SPOSet>>;
+  using RealType    = QMCTraits::RealType;
+  using ValueType   = QMCTraits::ValueType;
+  using ValueVector = OrbitalSetTraits<ValueType>::ValueVector;
+  using GradVector  = OrbitalSetTraits<ValueType>::GradVector;
+  using HessVector  = OrbitalSetTraits<ValueType>::HessVector;
 
   RealType myfabs(RealType s) { return std::fabs(s); }
   template<typename T>
@@ -44,14 +45,14 @@ public:
     return TinyVector<T, OHMMS_DIM>(myfabs(s[0]), myfabs(s[1]), myfabs(s[2]));
   }
 
-  std::vector<std::unique_ptr<SPOSet>>& sposets;
+  const SPOSetMap& sposets;
   ParticleSet& target;
-  const PtclPoolType& PtclPool;
+  const PtclPool& ptcl_pool_;
   ParticleSet* ions;
 
   // construction/destruction
-  SPOSetScanner(std::vector<std::unique_ptr<SPOSet>>& sposets_in, ParticleSet& targetPtcl, const PtclPoolType& psets)
-      : sposets(sposets_in), target(targetPtcl), PtclPool(psets), ions(0){};
+  SPOSetScanner(const SPOSetMap& sposets_in, ParticleSet& targetPtcl, const PtclPool& psets)
+      : sposets(sposets_in), target(targetPtcl), ptcl_pool_(psets), ions(0){};
   //~SPOSetScanner(){};
 
   // processing scanning
@@ -63,15 +64,15 @@ public:
     OhmmsAttributeSet aAttrib;
     aAttrib.add(sourcePtcl, "source");
     aAttrib.put(cur);
-    auto pit(PtclPool.find(sourcePtcl));
-    if (pit == PtclPool.end())
+    auto pit(ptcl_pool_.find(sourcePtcl));
+    if (pit == ptcl_pool_.end())
       app_log() << "Source particle set not found. Can not be used as reference point." << std::endl;
     else
       ions = (*pit).second;
 
     // scanning the SPO sets
     xmlNodePtr cur_save = cur;
-    for (auto& sposet : sposets)
+    for (const auto& [name, sposet] : sposets)
     {
       app_log() << "  Processing SPO " << sposet->getName() << std::endl;
       // scanning the paths

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -84,10 +84,11 @@ void test_He(bool transform)
       xmlSetProp(MO_base[0], (const xmlChar*)"key", (const xmlChar*)"GTO");
     }
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb(*bb_ptr);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
     //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
@@ -201,10 +202,11 @@ void test_Ne(bool transform)
       xmlSetProp(MO_base[0], (const xmlChar*)"key", (const xmlChar*)"GTO");
     }
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb(*bb_ptr);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
     //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
@@ -323,10 +325,11 @@ void test_HCN(bool transform)
       xmlSetProp(MO_base[0], (const xmlChar*)"key", (const xmlChar*)"GTO");
     }
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb(*bb_ptr);
 
     OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
 
     SPOSet::ValueVector values;

--- a/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO_spinor.cpp
@@ -83,10 +83,11 @@ void test_lcao_spinor()
 
   xmlNodePtr bnode = xmlFirstElementChild(root);
   SPOSetBuilderFactory fac(c, elec_, ptcl.getPool());
-  auto& bb = fac.createSPOSetBuilder(bnode);
+  const auto spo_builder_ptr = fac.createSPOSetBuilder(bnode);
+  auto& bb                   = *spo_builder_ptr;
 
   // only pick up the last sposet
-  SPOSet* spo = nullptr;
+  std::unique_ptr<SPOSet> spo;
   processChildren(bnode, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "sposet")
       spo = bb.createSPOSet(element);
@@ -276,7 +277,7 @@ void test_lcao_spinor()
   {
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {dR[iat], dR[iat]};
-    displs.spins = {dS[iat], dS[iat]};
+    displs.spins     = {dS[iat], dS[iat]};
     elec_.mw_makeMove(p_list, iat, displs);
     std::vector<bool> accept = {true, true};
     elec_.mw_accept_rejectMove<CoordsType::POS_SPIN>(p_list, iat, accept);
@@ -304,10 +305,10 @@ void test_lcao_spinor()
     dpsi_work_2  = 0.0;
     d2psi_work_2 = 0.0;
     dspsi_work_2 = 0.0;
-    
+
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {-dR[iat], -dR[iat]};
-    displs.spins = {-dS[iat], -dS[iat]};
+    displs.spins     = {-dS[iat], -dS[iat]};
     elec_.mw_makeMove(p_list, iat, displs);
     spo->mw_evaluateVGLWithSpin(spo_list, p_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, dspsi_v_list);
     //walker 0
@@ -395,10 +396,11 @@ void test_lcao_spinor_excited()
 
   xmlNodePtr bnode = xmlFirstElementChild(root);
   SPOSetBuilderFactory fac(c, elec_, ptcl.getPool());
-  auto& bb = fac.createSPOSetBuilder(bnode);
+  const auto sposet_builder_ptr = fac.createSPOSetBuilder(bnode);
+  auto& bb                      = *sposet_builder_ptr;
 
   // only pick up the last sposet
-  SPOSet* spo = nullptr;
+  std::unique_ptr<SPOSet> spo;
   processChildren(bnode, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "sposet")
       spo = bb.createSPOSet(element);
@@ -589,7 +591,7 @@ void test_lcao_spinor_excited()
   {
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {dR[iat], dR[iat]};
-    displs.spins = {dS[iat], dS[iat]};
+    displs.spins     = {dS[iat], dS[iat]};
     elec_.mw_makeMove(p_list, iat, displs);
     std::vector<bool> accept = {true, true};
     elec_.mw_accept_rejectMove<CoordsType::POS_SPIN>(p_list, iat, accept);
@@ -620,7 +622,7 @@ void test_lcao_spinor_excited()
 
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {-dR[iat], -dR[iat]};
-    displs.spins = {-dS[iat], -dS[iat]};
+    displs.spins     = {-dS[iat], -dS[iat]};
     elec_.mw_makeMove(p_list, iat, displs);
     spo->mw_evaluateVGLWithSpin(spo_list, p_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, dspsi_v_list);
     //walker 0

--- a/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
+++ b/src/QMCWaveFunctions/tests/test_cartesian_ao.cpp
@@ -70,10 +70,11 @@ void test_cartesian_ao()
     OhmmsXPathObject MO_base("//determinantset", doc.getXPathContext());
     REQUIRE(MO_base.size() == 1);
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb(*bb_ptr);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector values;
     values.resize(1);
@@ -137,10 +138,11 @@ void test_dirac_ao()
     OhmmsXPathObject MO_base("//determinantset", doc.getXPathContext());
     REQUIRE(MO_base.size() == 1);
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb(*bb_ptr);
 
     OhmmsXPathObject slater_base("//determinant", doc.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector values;
     values.resize(1);

--- a/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_spinor.cpp
@@ -116,9 +116,10 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   xmlNodePtr ein1 = xmlFirstElementChild(root);
 
   SPOSetBuilderFactory fac(c, elec_, ptcl.getPool());
-  auto& builder = fac.createSPOSetBuilder(ein1);
+  const auto spo_builder_ptr = fac.createSPOSetBuilder(ein1);
+  auto& builder              = *spo_builder_ptr;
 
-  SPOSet* spo = builder.createSPOSet(ein1);
+  auto spo = builder.createSPOSet(ein1);
   CHECK(spo);
 
   SPOSet::ValueMatrix psiM(elec_.R.size(), spo->getOrbitalSetSize());
@@ -534,7 +535,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
   {
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {dR[iat], dR[iat]};
-    displs.spins = {dS[iat], dS[iat]};
+    displs.spins     = {dS[iat], dS[iat]};
 
     elec_.mw_makeMove(p_list, iat, displs);
     std::vector<bool> accept = {true, true};
@@ -566,7 +567,7 @@ TEST_CASE("Einspline SpinorSet from HDF", "[wavefunction]")
 
     MCCoords<CoordsType::POS_SPIN> displs;
     displs.positions = {-dR[iat], -dR[iat]};
-    displs.spins = {-dS[iat], -dS[iat]};
+    displs.spins     = {-dS[iat], -dS[iat]};
 
     elec_.mw_makeMove(p_list, iat, displs);
     spo->mw_evaluateVGLWithSpin(spo_list, p_list, iat, psi_v_list, dpsi_v_list, d2psi_v_list, dspsi_v_list);

--- a/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_pyscf_complex_MO.cpp
@@ -96,10 +96,11 @@ void test_C_diamond()
     OhmmsXPathObject MO_base("//determinantset", doc2.getXPathContext());
     REQUIRE(MO_base.size() == 1);
 
-    auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+    const auto sposet_builder_ptr = bf.createSPOSetBuilder(MO_base[0]);
+    auto& bb                      = *sposet_builder_ptr;
 
     OhmmsXPathObject slater_base("//sposet", doc2.getXPathContext());
-    SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+    auto sposet = bb.createSPOSet(slater_base[0]);
 
     SPOSet::ValueVector values;
     values.resize(26);

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -110,23 +110,22 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
   OhmmsXPathObject MO_base("//determinantset", doc2.getXPathContext());
   REQUIRE(MO_base.size() == 1);
 
-  auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+  const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+  auto& bb(*bb_ptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+  auto sposet = bb.createSPOSet(slater_base[0]);
 
-  LCAOrbitalSet* lcob = dynamic_cast<LCAOrbitalSet*>(sposet);
-  REQUIRE(lcob != nullptr);
+  LCAOrbitalSet& lcob = dynamic_cast<LCAOrbitalSet&>(*sposet);
 
+  LCAOrbitalSet phi(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()), lcob.isOptimizable());
+  phi.setOrbitalSetSize(lcob.getOrbitalSetSize());
 
-  LCAOrbitalSet phi(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob->myBasisSet->makeClone()), lcob->isOptimizable());
-  phi.setOrbitalSetSize(lcob->getOrbitalSetSize());
+  LCAOrbitalSet eta(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()), lcob.isOptimizable());
+  eta.setOrbitalSetSize(lcob.getOrbitalSetSize());
 
-  LCAOrbitalSet eta(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob->myBasisSet->makeClone()), lcob->isOptimizable());
-  eta.setOrbitalSetSize(lcob->getOrbitalSetSize());
-
-  *(eta.C) = *(lcob->C);
-  *(phi.C) = *(lcob->C);
+  *(eta.C) = *(lcob.C);
+  *(phi.C) = *(lcob.C);
 
 
   int num_center = 3;
@@ -195,8 +194,8 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
 
   // Reset the MO matrices for another center
 
-  *(eta.C) = *(lcob->C);
-  *(phi.C) = *(lcob->C);
+  *(eta.C) = *(lcob.C);
+  *(phi.C) = *(lcob.C);
 
 
   // C is second atom
@@ -223,12 +222,12 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
   REQUIRE(rad_orb[9] == Approx(0.0010837868)); // x = 0.12
 
 
-  removeSTypeOrbitals(corrCenter, *lcob);
+  removeSTypeOrbitals(corrCenter, lcob);
 
-  CHECK((*lcob->C)(0, 0) == Approx(0.0));
-  CHECK((*lcob->C)(0, 1) == Approx(0.0));
-  CHECK((*lcob->C)(0, 2) == Approx(0.0));
-  CHECK((*lcob->C)(0, 3) != 0.0);
+  CHECK((*lcob.C)(0, 0) == Approx(0.0));
+  CHECK((*lcob.C)(0, 1) == Approx(0.0));
+  CHECK((*lcob.C)(0, 2) == Approx(0.0));
+  CHECK((*lcob.C)(0, 3) != 0.0);
 }
 
 TEST_CASE("HCN MO with cusp", "[wavefunction]")
@@ -281,10 +280,11 @@ TEST_CASE("HCN MO with cusp", "[wavefunction]")
 
   xmlSetProp(MO_base[0], (const xmlChar*)"cuspCorrection", (const xmlChar*)"yes");
 
-  auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+  const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+  auto& bb(*bb_ptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+  auto sposet = bb.createSPOSet(slater_base[0]);
 
   SPOSet::ValueVector values;
   SPOSet::GradVector dpsi;
@@ -453,10 +453,11 @@ TEST_CASE("Ethanol MO with cusp", "[wavefunction]")
 
   xmlSetProp(MO_base[0], (const xmlChar*)"cuspCorrection", (const xmlChar*)"yes");
 
-  auto& bb = bf.createSPOSetBuilder(MO_base[0]);
+  const auto bb_ptr = bf.createSPOSetBuilder(MO_base[0]);
+  auto& bb(*bb_ptr);
 
   OhmmsXPathObject slater_base("//determinant", doc2.getXPathContext());
-  SPOSet* sposet = bb.createSPOSet(slater_base[0]);
+  auto sposet = bb.createSPOSet(slater_base[0]);
 
   SPOSet::ValueVector values;
   SPOSet::GradVector dpsi;


### PR DESCRIPTION
## Proposed changes
SPOSetBuilderFactory keeps an array of SPOSetBuilder pointers and each SPOSetBuilder contains a map of SPOSet. To make all the SPOSets available for lookup later, SPOSetBuilderFactory is persist and thus all the builders are persistent thought out the the whole run. This PR makes SPOSetBuilder short-lived. Once all the SPOSets from a collection are processed by a SPOSetBuilder, there is no need to keep the builder. Thus the map of SPOSets are directly kept in SPOSetBuilderFactory class.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
