### PR TITLE
Enable clang gcov

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -142,7 +142,7 @@ endif(QMC_BUILD_STATIC)
 
 # Coverage
 if(ENABLE_GCOV)
-  set(GCOV_COVERAGE TRUE)
+  set(GCOV_SUPPORTED TRUE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")

--- a/config/docker/dependencies/ubuntu22/Dockerfile
+++ b/config/docker/dependencies/ubuntu22/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:jammy-20220130
+LABEL maintainer="williamfgc@yahoo.com"
+
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get update -y &&\
+    apt-get upgrade -y apt-utils
+
+# Dependencies
+RUN export DEBIAN_FRONTEND=noninteractive &&\
+    apt-get install gcc g++ \ 
+    gcovr \
+    python3 \
+    cmake \
+    ninja-build \
+    libboost-all-dev \
+    git \
+    libhdf5-serial-dev \
+    hdf5-tools \
+    libfftw3-dev \
+    libopenblas-openmp-dev \
+    libxml2-dev \
+    sudo \
+    curl \
+    rsync \
+    wget \
+    software-properties-common \
+    vim \
+    -y
+
+
+# add gcc-12 repo
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+
+# add clang-13 repo
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - &&\
+    apt-add-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+
+RUN apt-get update -y &&\     
+    apt-get install gcc-12 g++-12 clang-13 clang-tools-13 libomp-13-dev -y
+
+# must add a user different from root 
+# to run MPI executables
+RUN useradd -ms /bin/bash user
+# allow in sudoers to install packages
+RUN adduser user sudo
+RUN echo "user:user" | chpasswd
+
+USER user
+WORKDIR /home/user
+


### PR DESCRIPTION
## Proposed changes

This PR is part of the efforts to enable clang+gcov for offload cases
- Fix typo in clang gcov configuration
- Add Dockerfile to test gcov with latest compilers: gcc-12 and clang-13 supporting offload. Container hosted in [Dockerhub](https://hub.docker.com/layers/193595951/williamfgc/qmcpack-ci/ubuntu22-gcc12-clang13/images/sha256-983b5ee621349102ad7920dc7ad6bc685d4a117965c92c58ff01a5d24715a626?context=repo)
Related to #3834 

## What type(s) of changes does this code introduce?

- Bugfix
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20.04

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
