### PR TITLE
Use optimizer crowd settings from VMC

### DIFF
--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -309,15 +309,17 @@ void VMCBatched::runVMCStep(int crowd_id,
                                     accumulate_this_step);
 }
 
-void VMCBatched::process(xmlNodePtr node)
+void VMCBatched::process(xmlNodePtr node) { process1(node); }
+
+QMCDriverNew::AdjustedWalkerCounts VMCBatched::process1(xmlNodePtr node)
 {
   print_mem("VMCBatched before initialization", app_log());
   // \todo get total walkers should be coming from VMCDriverInpu
+  QMCDriverNew::AdjustedWalkerCounts awc;
   try
   {
-    QMCDriverNew::AdjustedWalkerCounts awc =
-        adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
-                                qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
+    awc = adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
+                                  qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
     Base::startup(node, awc);
   }
@@ -325,6 +327,8 @@ void VMCBatched::process(xmlNodePtr node)
   {
     myComm->barrier_and_abort(ue.what());
   }
+
+  return awc;
 }
 
 int VMCBatched::compute_samples_per_rank(const QMCDriverInput& qmcdriver_input, const IndexType local_walkers)

--- a/src/QMCDrivers/VMC/VMCBatched.h
+++ b/src/QMCDrivers/VMC/VMCBatched.h
@@ -73,6 +73,9 @@ public:
 
   void process(xmlNodePtr node) override;
 
+  /// Process xml input and return adjusted walker counts
+  AdjustedWalkerCounts process1(xmlNodePtr node);
+
   bool run() override;
 
   /** Refactor of VMCUpdatePbyP in crowd context

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -72,7 +72,7 @@ public:
   ///preprocess xml node
   void process(xmlNodePtr cur) override;
   ///process xml node value (parameters for both VMC and OPT) for the actual optimization
-  bool processOptXML(xmlNodePtr cur, const std::string& vmcMove, bool reportH5, bool useGPU);
+  AdjustedWalkerCounts processOptXML(xmlNodePtr cur, const std::string& vmcMove, bool reportH5, bool useGPU);
 
   RealType costFunc(RealType dl);
 


### PR DESCRIPTION
Addresses #3849 

Use the optimizer settings from the VMC driver for the number of crowds and the walkers per crowd as defaults.  The parameters are still available (`opt_num_crowds` and `opt_crowd_size`) to set these values explicitly.


Output for the crowd-related optimizer settings is
```
  Optimizer settings that affect performance
    Number of crowds (threads) : 2
    Crowd size (items processed in one batch - important for GPU offload) : 24
```

For the implementation, add a version of `VMCBatched::process` (`process1`) that returns the adjusted walker counts. Then the calculated values can be reused in the optimization driver.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
