### PR TITLE
InputNode and tests

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 add_subdirectory(hdf)
 add_subdirectory(OhmmsData)
-
+add_subdirectory(tests)
 # qmcio is intended to be an interface library servicing codes outside src/io.
 # header files inclusion from outside src/io needs to treat src/io being the root for
 # the header file inclusion.

--- a/src/io/InputNode.hpp
+++ b/src/io/InputNode.hpp
@@ -1,0 +1,35 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_INPUTNODE_HPP
+#define QMCPLUSPLUS_INPUTNODE_HPP
+
+#include <memory>
+
+namespace qmcplusplus
+{
+
+/** Interface to allow input nodes to be type erased for the purposes of ownership
+ */
+struct InputNode
+{
+  virtual ~InputNode(){};
+  template<typename T, typename VOWN, typename VINPUT, typename... Args>
+  static void append(VOWN& vown, VINPUT& vinput, Args&&... args) {
+    vown.push_back(std::make_unique<T>(std::forward<Args>(args)...));
+    vinput.push_back(static_cast<T&>(*vown.back()));
+  }
+};
+
+
+  
+} // namespace qmcplusplus
+#endif

--- a/src/io/InputNode.hpp
+++ b/src/io/InputNode.hpp
@@ -17,19 +17,20 @@
 namespace qmcplusplus
 {
 
-/** Interface to allow input nodes to be type erased for the purposes of ownership
+/** Interface to a class to be type erased for the purposes of ownership
+ *  To allow a vector of unique_ptr to InputNode to contain a heterolist of dynamic objects
  */
 struct InputNode
 {
   virtual ~InputNode(){};
   template<typename T, typename VOWN, typename VINPUT, typename... Args>
-  static void append(VOWN& vown, VINPUT& vinput, Args&&... args) {
+  static void append(VOWN& vown, VINPUT& vinput, Args&&... args)
+  {
     vown.push_back(std::make_unique<T>(std::forward<Args>(args)...));
     vinput.push_back(static_cast<T&>(*vown.back()));
   }
 };
 
 
-  
 } // namespace qmcplusplus
 #endif

--- a/src/io/tests/CMakeLists.txt
+++ b/src/io/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# //////////////////////////////////////////////////////////////////////////////////////
+# // This file is distributed under the University of Illinois/NCSA Open Source License.
+# // See LICENSE file in top directory for details.
+# //
+# // Copyright (c) 2022 QMCPACK developers
+# //
+# // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+# //
+# // File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+# //////////////////////////////////////////////////////////////////////////////////////
+
+set(SRC_DIR io)
+set(UTEST_EXE test_${SRC_DIR})
+set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
+
+# Directory where input file is copied to, and working directory for unit test
+set(UTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(${UTEST_EXE} test_InputNode.cpp)
+target_include_directories(${UTEST_EXE} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
+target_link_libraries(${UTEST_EXE} catch_main qmcutil)
+
+add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/io/tests/test_InputNode.cpp
+++ b/src/io/tests/test_InputNode.cpp
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include <variant>
+#include <string_view>
+#include "catch.hpp"
+#include "InputNode.hpp"
+#include "type_traits/template_types.hpp"
+#include "type_traits/variant_help.hpp"
+
+namespace qmcplusplus
+{
+
+struct InputA : public InputNode {
+  InputA() = default;
+  InputA(const std::string_view in_name, double in_dA, double in_dB, double in_dC, const std::string_view in_prop) : name(in_name), dA(in_dA), dB(in_dB), dC(in_dC), property(in_prop) {}
+  std::string name{"inputA"};
+  double dA{1.1};
+  double dB{1.2};
+  double dC{1.3};
+  std::string property{"some prop"};
+};
+
+struct InputB : public InputNode {
+  InputB() = default;
+  InputB(const std::string& in_name, short in_sA) : name(in_name), sA(in_sA) {}
+  std::string name{"inputB"};
+  short sA{1};
+};
+
+using ChildInput = std::variant<RefW<InputA>, RefW<InputB>>;
+
+TEST_CASE("InputNode_BasicUse", "[io]")
+{
+  UPtrVector<InputNode> input_ownership;
+  std::vector<ChildInput> inputs;
+  InputNode::append<InputA>(input_ownership, inputs, "my_input_a", 2.0, 3.0, 4.0, "my_prop");
+  InputNode::append<InputB>(input_ownership, inputs, "my_input_b", 2);
+  CHECK(has<InputA>(inputs[0]));
+  CHECK(!has<InputB>(inputs[0]));
+  CHECK(has<InputB>(inputs[1]));
+}
+
+}

--- a/src/io/tests/test_InputNode.cpp
+++ b/src/io/tests/test_InputNode.cpp
@@ -19,9 +19,12 @@
 namespace qmcplusplus
 {
 
-struct InputA : public InputNode {
+struct InputA : public InputNode
+{
   InputA() = default;
-  InputA(const std::string_view in_name, double in_dA, double in_dB, double in_dC, const std::string_view in_prop) : name(in_name), dA(in_dA), dB(in_dB), dC(in_dC), property(in_prop) {}
+  InputA(const std::string_view in_name, double in_dA, double in_dB, double in_dC, const std::string_view in_prop)
+      : name(in_name), dA(in_dA), dB(in_dB), dC(in_dC), property(in_prop)
+  {}
   std::string name{"inputA"};
   double dA{1.1};
   double dB{1.2};
@@ -29,7 +32,8 @@ struct InputA : public InputNode {
   std::string property{"some prop"};
 };
 
-struct InputB : public InputNode {
+struct InputB : public InputNode
+{
   InputB() = default;
   InputB(const std::string& in_name, short in_sA) : name(in_name), sA(in_sA) {}
   std::string name{"inputB"};
@@ -49,4 +53,4 @@ TEST_CASE("InputNode_BasicUse", "[io]")
   CHECK(has<InputB>(inputs[1]));
 }
 
-}
+} // namespace qmcplusplus

--- a/src/type_traits/template_types.hpp
+++ b/src/type_traits/template_types.hpp
@@ -13,10 +13,10 @@
 #ifndef QMCPLUSPLUS_TEMPLATE_TYPES_HPP
 #define QMCPLUSPLUS_TEMPLATE_TYPES_HPP
 
+#include <cassert>
 #include <vector>
 #include <functional>
 #include <memory>
-#include <cassert>
 #include "RefVectorWithLeader.h"
 
 namespace qmcplusplus
@@ -28,6 +28,10 @@ namespace qmcplusplus
  *  see: UPtrVector
  *  @{
  */
+
+template<typename T>
+using RefW = std::reference_wrapper<T>;
+
 template<typename T>
 using RefVector = std::vector<std::reference_wrapper<T>>;
 

--- a/src/type_traits/template_types.hpp
+++ b/src/type_traits/template_types.hpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers
+// Copyright (c) 2022 QMCPACK developers
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //

--- a/src/type_traits/variant_help.hpp
+++ b/src/type_traits/variant_help.hpp
@@ -1,0 +1,21 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+namespace qmcplusplus
+{
+
+template<class T, class R>
+constexpr bool has(const R& this_one)
+{
+  return std::holds_alternative<std::reference_wrapper<T>>(this_one);
+}
+
+}


### PR DESCRIPTION
## Proposed changes

Delegated Input classes will be owned by their managing input class. For purposes of access they will be accessed through a vector of variant<refwrapper<InputClassA>, refwrapper<InputClassB>,... in the managing class. Since input classes can potentially be quite large it seems better to separate ownership and access. For that reason the ownership of the input class is through a vector of UniquePointers to InputNode a mixin interface that provides a virtual destructor for the input classes.

## What type(s) of changes does this code introduce?
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte 

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
