### PR TITLE
Split walkers among crowds in optimizer to match VMC usage

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -294,7 +294,7 @@ void QMCCostFunctionBatched::checkConfigurations()
                           bool needGrads, bool compute_nlpp, const std::string& includeNonlocalH) {
     CostFunctionCrowdData& opt_data = *opt_crowds[crowd_id];
 
-    int local_samples = samples_per_crowd_offsets[crowd_id + 1] - samples_per_crowd_offsets[crowd_id];
+    const int local_samples = samples_per_crowd_offsets[crowd_id + 1] - samples_per_crowd_offsets[crowd_id];
     int num_batches;
     int final_batch_size;
 
@@ -306,7 +306,7 @@ void QMCCostFunctionBatched::checkConfigurations()
       if (inb == num_batches - 1)
         current_batch_size = final_batch_size;
 
-      int base_sample_index = inb * walkers_per_crowd[crowd_id] + samples_per_crowd_offsets[crowd_id];
+      const int base_sample_index = inb * walkers_per_crowd[crowd_id] + samples_per_crowd_offsets[crowd_id];
 
       auto wf_list_no_leader = opt_data.get_wf_list(current_batch_size);
       auto p_list_no_leader  = opt_data.get_p_list(current_batch_size);
@@ -365,7 +365,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
         for (int ib = 0; ib < current_batch_size; ib++)
         {
-          int is = base_sample_index + ib;
+          const int is = base_sample_index + ib;
           for (int j = 0; j < nparam; j++)
           {
             DerivRecords[is][j]  = std::real(dlogpsi_array.getValue(j, ib));
@@ -377,8 +377,8 @@ void QMCCostFunctionBatched::checkConfigurations()
 
         for (int ib = 0; ib < current_batch_size; ib++)
         {
-          int is    = base_sample_index + ib;
-          auto etmp = energy_list[ib];
+          const int is = base_sample_index + ib;
+          auto etmp    = energy_list[ib];
           opt_data.get_e0() += etmp;
           opt_data.get_e2() += etmp * etmp;
 
@@ -402,8 +402,8 @@ void QMCCostFunctionBatched::checkConfigurations()
 
         for (int ib = 0; ib < current_batch_size; ib++)
         {
-          int is    = base_sample_index + ib;
-          auto etmp = energy_list[ib];
+          const int is = base_sample_index + ib;
+          auto etmp    = energy_list[ib];
           opt_data.get_e0() += etmp;
           opt_data.get_e2() += etmp * etmp;
 
@@ -530,7 +530,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
     CostFunctionCrowdData& opt_data = *opt_crowds[crowd_id];
 
 
-    int local_samples = samples_per_crowd_offsets[crowd_id + 1] - samples_per_crowd_offsets[crowd_id];
+    const int local_samples = samples_per_crowd_offsets[crowd_id + 1] - samples_per_crowd_offsets[crowd_id];
 
     int num_batches;
     int final_batch_size;
@@ -544,7 +544,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
         current_batch_size = final_batch_size;
       }
 
-      int base_sample_index = inb * walkers_per_crowd[crowd_id] + samples_per_crowd_offsets[crowd_id];
+      const int base_sample_index = inb * walkers_per_crowd[crowd_id] + samples_per_crowd_offsets[crowd_id];
 
       auto p_list_no_leader  = opt_data.get_p_list(current_batch_size);
       auto wf_list_no_leader = opt_data.get_wf_list(current_batch_size);
@@ -597,7 +597,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
       for (int ib = 0; ib < current_batch_size; ib++)
       {
-        int is = base_sample_index + ib;
+        const int is = base_sample_index + ib;
         wf_list[ib].G += *gradPsi[is];
         wf_list[ib].L += *lapPsi[is];
         // This is needed to get the KE correct in QMCHamiltonian::mw_evaluate below
@@ -627,7 +627,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
         for (int ib = 0; ib < current_batch_size; ib++)
         {
-          int is                        = base_sample_index + ib;
+          const int is                  = base_sample_index + ib;
           auto etmp                     = energy_list[ib];
           RecordsOnNode[is][ENERGY_NEW] = etmp + RecordsOnNode[is][ENERGY_FIXED];
           for (int j = 0; j < nparam; j++)
@@ -646,7 +646,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
         auto energy_list = QMCHamiltonian::mw_evaluate(h0_list, wf_list, p_list);
         for (int ib = 0; ib < current_batch_size; ib++)
         {
-          int is                        = base_sample_index + ib;
+          const int is                  = base_sample_index + ib;
           auto etmp                     = energy_list[ib];
           RecordsOnNode[is][ENERGY_NEW] = etmp + RecordsOnNode[is][ENERGY_FIXED];
         }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -278,6 +278,9 @@ void QMCCostFunctionBatched::checkConfigurations()
   outputManager.resume();
 
 
+  // TODO - walkers per crowd may not be evenly divided, so the samples per crowd
+  //        might need to be divided differently for better load balancing.
+
   // Divide samples among the crowds
   std::vector<int> samples_per_crowd(opt_num_crowds + 1);
   FairDivide(rank_local_num_samples_, opt_num_crowds, samples_per_crowd);

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -31,7 +31,7 @@ QMCCostFunctionBatched::QMCCostFunctionBatched(MCWalkerConfiguration& w,
                                                TrialWaveFunction& psi,
                                                QMCHamiltonian& h,
                                                SampleStack& samples,
-                                               const std::vector<Index>& walkers_per_crowd,
+                                               const std::vector<int>& walkers_per_crowd,
                                                Communicate* comm)
     : QMCCostFunctionBase(w, psi, h, comm),
       samples_(samples),
@@ -284,7 +284,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   // lambda to execute on each crowd
   auto evalOptConfig = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
-                          std::vector<int>& samples_per_crowd, std::vector<Index>& walkers_per_crowd,
+                          std::vector<int>& samples_per_crowd, std::vector<int>& walkers_per_crowd,
                           std::vector<ParticleGradient*>& gradPsi, std::vector<ParticleLaplacian*>& lapPsi,
                           Matrix<Return_rt>& RecordsOnNode, Matrix<Return_rt>& DerivRecords,
                           Matrix<Return_rt>& HDerivRecords, const SampleStack& samples, opt_variables_type& optVars,
@@ -518,7 +518,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
   // lambda to execute on each crowd
   auto evalOptCorrelated = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
-                              const std::vector<int>& samples_per_crowd, std::vector<Index> walkers_per_crowd,
+                              const std::vector<int>& samples_per_crowd, std::vector<int> walkers_per_crowd,
                               std::vector<ParticleGradient*>& gradPsi, std::vector<ParticleLaplacian*>& lapPsi,
                               Matrix<Return_rt>& RecordsOnNode, Matrix<Return_rt>& DerivRecords,
                               Matrix<Return_rt>& HDerivRecords, const SampleStack& samples,

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -284,7 +284,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   // lambda to execute on each crowd
   auto evalOptConfig = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
-                          std::vector<int>& samples_per_crowd, std::vector<int>& walkers_per_crowd,
+                          const std::vector<int>& samples_per_crowd, const std::vector<int>& walkers_per_crowd,
                           std::vector<ParticleGradient*>& gradPsi, std::vector<ParticleLaplacian*>& lapPsi,
                           Matrix<Return_rt>& RecordsOnNode, Matrix<Return_rt>& DerivRecords,
                           Matrix<Return_rt>& HDerivRecords, const SampleStack& samples, opt_variables_type& optVars,
@@ -518,7 +518,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
 
   // lambda to execute on each crowd
   auto evalOptCorrelated = [](int crowd_id, UPtrVector<CostFunctionCrowdData>& opt_crowds,
-                              const std::vector<int>& samples_per_crowd, std::vector<int> walkers_per_crowd,
+                              const std::vector<int>& samples_per_crowd, const std::vector<int>& walkers_per_crowd,
                               std::vector<ParticleGradient*>& gradPsi, std::vector<ParticleLaplacian*>& lapPsi,
                               Matrix<Return_rt>& RecordsOnNode, Matrix<Return_rt>& DerivRecords,
                               Matrix<Return_rt>& HDerivRecords, const SampleStack& samples,

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -270,7 +270,7 @@ void QMCCostFunctionBatched::checkConfigurations()
 
   // Create crowd-local storage for evaluation
   outputManager.pause();
-  size_t opt_num_crowds = walkers_per_crowd_.size();
+  const size_t opt_num_crowds = walkers_per_crowd_.size();
   opt_eval_.resize(opt_num_crowds);
   for (int i = 0; i < opt_num_crowds; i++)
     opt_eval_[i] =
@@ -511,7 +511,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::correlatedSampling(boo
   bool compute_nlpp             = useNLPPDeriv && (includeNonlocalH != "no");
   bool compute_all_from_scratch = (includeNonlocalH != "no"); //true if we have nlpp
 
-  size_t opt_num_crowds = walkers_per_crowd_.size();
+  const size_t opt_num_crowds = walkers_per_crowd_.size();
   // Divide samples among crowds
   std::vector<int> samples_per_crowd(opt_num_crowds + 1);
   FairDivide(rank_local_num_samples_, opt_num_crowds, samples_per_crowd);

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -31,7 +31,7 @@ QMCCostFunctionBatched::QMCCostFunctionBatched(MCWalkerConfiguration& w,
                                                TrialWaveFunction& psi,
                                                QMCHamiltonian& h,
                                                SampleStack& samples,
-                                               std::vector<Index>& walkers_per_crowd,
+                                               const std::vector<Index>& walkers_per_crowd,
                                                Communicate* comm)
     : QMCCostFunctionBase(w, psi, h, comm),
       samples_(samples),

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -39,13 +39,13 @@ class LinearMethodTestSupport;
 class QMCCostFunctionBatched : public QMCCostFunctionBase, public QMCTraits
 {
 public:
+  using Index = QMCTraits::IndexType;
   ///Constructor.
   QMCCostFunctionBatched(MCWalkerConfiguration& w,
                          TrialWaveFunction& psi,
                          QMCHamiltonian& h,
                          SampleStack& samples,
-                         int opt_num_crowds,
-                         int crowd_size,
+                         std::vector<Index>& walkers_per_crowd,
                          Communicate* comm);
 
   ///Destructor
@@ -82,8 +82,7 @@ protected:
   // Number of samples local to each MPI rank
   int rank_local_num_samples_;
 
-  int opt_batch_size_;
-  int opt_num_crowds_;
+  std::vector<Index> walkers_per_crowd_;
 
   std::vector<std::unique_ptr<CostFunctionCrowdData>> opt_eval_;
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -45,7 +45,7 @@ public:
                          TrialWaveFunction& psi,
                          QMCHamiltonian& h,
                          SampleStack& samples,
-                         std::vector<Index>& walkers_per_crowd,
+                         const std::vector<Index>& walkers_per_crowd,
                          Communicate* comm);
 
   ///Destructor

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -82,6 +82,7 @@ protected:
   // Number of samples local to each MPI rank
   int rank_local_num_samples_;
 
+  // Number of walkers per crowd. Size of vector is number of crowds.
   std::vector<Index> walkers_per_crowd_;
 
   std::vector<std::unique_ptr<CostFunctionCrowdData>> opt_eval_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -39,13 +39,12 @@ class LinearMethodTestSupport;
 class QMCCostFunctionBatched : public QMCCostFunctionBase, public QMCTraits
 {
 public:
-  using Index = QMCTraits::IndexType;
   ///Constructor.
   QMCCostFunctionBatched(MCWalkerConfiguration& w,
                          TrialWaveFunction& psi,
                          QMCHamiltonian& h,
                          SampleStack& samples,
-                         const std::vector<Index>& walkers_per_crowd,
+                         const std::vector<int>& walkers_per_crowd,
                          Communicate* comm);
 
   ///Destructor
@@ -83,7 +82,7 @@ protected:
   int rank_local_num_samples_;
 
   // Number of walkers per crowd. Size of vector is number of crowds.
-  std::vector<Index> walkers_per_crowd_;
+  std::vector<int> walkers_per_crowd_;
 
   std::vector<std::unique_ptr<CostFunctionCrowdData>> opt_eval_;
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.h
@@ -235,10 +235,6 @@ private:
   bool block_third;
 
 
-  /// Number of walkers in each crowd to use to process samples during optimization
-  int crowd_size_;
-  /// Number of crowds to use to process samples during optimization
-  int opt_num_crowds_;
   //Variables for alternatives to linear method
 
   //name of the current optimization method, updated by processOptXML before run

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -56,7 +56,7 @@ public:
   TrialWaveFunction psi;
   QMCCostFunctionBatched costFn;
 
-  LinearMethodTestSupport(std::vector<Index> walkers_per_crowd, Communicate* comm)
+  LinearMethodTestSupport(const std::vector<Index>& walkers_per_crowd, Communicate* comm)
       : w(simulation_cell), costFn(w, psi, h, samples, walkers_per_crowd, comm)
   {}
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -46,6 +46,7 @@ namespace testing
 class LinearMethodTestSupport
 {
 public:
+  using Index = QMCTraits::IndexType;
   int numSamples;
   int numParam;
   SampleStack samples;
@@ -55,8 +56,8 @@ public:
   TrialWaveFunction psi;
   QMCCostFunctionBatched costFn;
 
-  LinearMethodTestSupport(int num_opt_crowds, int crowd_size, Communicate* comm)
-      : w(simulation_cell), costFn(w, psi, h, samples, num_opt_crowds, crowd_size, comm)
+  LinearMethodTestSupport(std::vector<Index> walkers_per_crowd, Communicate* comm)
+      : w(simulation_cell), costFn(w, psi, h, samples, walkers_per_crowd, comm)
   {}
 
   std::vector<QMCCostFunctionBase::Return_rt>& getSumValue() { return costFn.SumValue; }
@@ -89,14 +90,14 @@ public:
 
 TEST_CASE("fillOverlapAndHamiltonianMatrices", "[drivers]")
 {
-  int num_opt_crowds = 1;
-  int crowd_size     = 1;
+  using Index = QMCTraits::IndexType;
+  std::vector<Index> walkers_per_crowd{1};
 
   using Return_rt = qmcplusplus::QMCTraits::RealType;
 
   Communicate* comm = OHMMS::Controller;
 
-  testing::LinearMethodTestSupport lin(num_opt_crowds, crowd_size, comm);
+  testing::LinearMethodTestSupport lin(walkers_per_crowd, comm);
 
   int numSamples = 1;
   int numParam   = 1;
@@ -140,14 +141,14 @@ TEST_CASE("fillOverlapAndHamiltonianMatrices", "[drivers]")
 // the input/gold data (from a file created by convert_hdf_to_cpp.py)
 void fill_from_text(int num_opt_crowds, FillData& fd)
 {
-  // Not used in the function under test
-  int crowd_size = 1;
+  using Index = QMCTraits::IndexType;
+  std::vector<Index> walkers_per_crowd(num_opt_crowds, 1);
 
   using Return_rt = qmcplusplus::QMCTraits::RealType;
 
   Communicate* comm = OHMMS::Controller;
 
-  testing::LinearMethodTestSupport lin(num_opt_crowds, crowd_size, comm);
+  testing::LinearMethodTestSupport lin(walkers_per_crowd, comm);
 
   int numSamples = fd.numSamples;
   int numParam   = fd.numParam;

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -46,7 +46,6 @@ namespace testing
 class LinearMethodTestSupport
 {
 public:
-  using Index = QMCTraits::IndexType;
   int numSamples;
   int numParam;
   SampleStack samples;
@@ -56,7 +55,7 @@ public:
   TrialWaveFunction psi;
   QMCCostFunctionBatched costFn;
 
-  LinearMethodTestSupport(const std::vector<Index>& walkers_per_crowd, Communicate* comm)
+  LinearMethodTestSupport(const std::vector<int>& walkers_per_crowd, Communicate* comm)
       : w(simulation_cell), costFn(w, psi, h, samples, walkers_per_crowd, comm)
   {}
 
@@ -90,8 +89,7 @@ public:
 
 TEST_CASE("fillOverlapAndHamiltonianMatrices", "[drivers]")
 {
-  using Index = QMCTraits::IndexType;
-  std::vector<Index> walkers_per_crowd{1};
+  std::vector<int> walkers_per_crowd{1};
 
   using Return_rt = qmcplusplus::QMCTraits::RealType;
 
@@ -141,8 +139,7 @@ TEST_CASE("fillOverlapAndHamiltonianMatrices", "[drivers]")
 // the input/gold data (from a file created by convert_hdf_to_cpp.py)
 void fill_from_text(int num_opt_crowds, FillData& fd)
 {
-  using Index = QMCTraits::IndexType;
-  std::vector<Index> walkers_per_crowd(num_opt_crowds, 1);
+  std::vector<int> walkers_per_crowd(num_opt_crowds, 1);
 
   using Return_rt = qmcplusplus::QMCTraits::RealType;
 


### PR DESCRIPTION
Addresses #3849 

The code now uses walker_per_crowd computed the same way as VMC.

Previously the batched cost function code expected every crowd would have the same number walkers. Most of the changes come from updating the code to use different number of walkers per crowd.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop, Summit

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
