### PR TITLE
Reorder unique determinants by excitation level

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -104,16 +104,13 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
   }
   assert(det_idx_order.size() == nci);
 
-  // make reverse mapping (old to new)
-  for (size_t i = 0; i < nci; i++)
-    det_idx_reverse[det_idx_order[i]] = i;
-
-  // reorder confgList by exc. lvl.
+  // make reverse mapping (old to new) and reorder confgList by exc. lvl.
   std::shared_ptr<std::vector<ci_configuration2>> tmp_confgList = std::make_shared<std::vector<ci_configuration2>>(nci);
-  for (int i = 0; i < nci; i++)
+  for (size_t i = 0; i < nci; i++)
   {
-    (*tmp_confgList)[i] = confgList[det_idx_order[i]];
-    sign[i]             = tmp_sign[det_idx_order[i]];
+    det_idx_reverse[det_idx_order[i]] = i;
+    (*tmp_confgList)[i]               = confgList[det_idx_order[i]];
+    sign[i]                           = tmp_sign[det_idx_order[i]];
   }
   tmp_confgList.swap(ciConfigList);
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -49,8 +49,8 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
 {
   const auto& confgList = *ciConfigList;
 
-  size_t nci     = confgList.size(), nex;
-  size_t nex_max = 0;
+  const size_t nci = confgList.size();
+  size_t nex_max   = 0;
   std::vector<size_t> pos(NumPtcls);
   std::vector<size_t> ocp(NumPtcls);
   std::vector<size_t> uno(NumPtcls);
@@ -63,6 +63,7 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
   pairs.clear();
   for (size_t i = 0; i < nci; i++)
   {
+    size_t nex;
     tmp_sign[i] = ref.calculateExcitations(confgList[i], nex, pos, ocp, uno);
     nex_max     = std::max(nex, nex_max);
     dataMap[nex].push_back(nex);
@@ -94,10 +95,8 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
 
   // populate data, ordered by exc. lvl.
   // make mapping from new to old det idx
-  for (std::map<int, std::vector<int>>::const_iterator iter = sortMap.begin(); iter != sortMap.end(); ++iter)
+  for (const auto& [nex, det_idx_old] : sortMap)
   {
-    nex                          = iter->first;
-    std::vector<int> det_idx_old = iter->second;
     data.insert(data.end(), dataMap[nex].begin(), dataMap[nex].end());
     det_idx_order.insert(det_idx_order.end(), det_idx_old.begin(), det_idx_old.end());
     (*ndet_per_exc_lvl)[nex] = det_idx_old.size();
@@ -105,7 +104,7 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
   assert(det_idx_order.size() == nci);
 
   // make reverse mapping (old to new) and reorder confgList by exc. lvl.
-  std::shared_ptr<std::vector<ci_configuration2>> tmp_confgList = std::make_shared<std::vector<ci_configuration2>>(nci);
+  auto tmp_confgList = std::make_shared<std::vector<ci_configuration2>>(nci);
   for (size_t i = 0; i < nci; i++)
   {
     det_idx_reverse[det_idx_order[i]] = i;
@@ -129,11 +128,6 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
          std::cout <<pairs[i].first <<"   " <<pairs[i].second << std::endl;
   */
 }
-
-//erase
-void out1(int n, std::string str = "NULL") {}
-//{ std::cout <<"MDD: " <<str <<"  " <<n << std::endl; std::cout.flush(); }
-
 
 void MultiDiracDeterminant::evaluateForWalkerMove(const ParticleSet& P, bool fromScratch)
 {

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -87,8 +87,8 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
       }
   }
   app_log() << "Number of terms in pairs array: " << pairs.size() << std::endl;
-  (*ndet_per_exc_lvl).clear();
-  (*ndet_per_exc_lvl).resize(nex_max + 1, 0);
+  (*ndets_per_excitation_level).clear();
+  (*ndets_per_excitation_level).resize(nex_max + 1, 0);
   //reorder configs and det data
   std::vector<size_t> det_idx_order;           // old indices in new order
   std::vector<size_t> det_idx_reverse(nci, 0); // new indices in old order
@@ -99,7 +99,7 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
   {
     data.insert(data.end(), dataMap[nex].begin(), dataMap[nex].end());
     det_idx_order.insert(det_idx_order.end(), det_idx_old.begin(), det_idx_old.end());
-    (*ndet_per_exc_lvl)[nex] = det_idx_old.size();
+    (*ndets_per_excitation_level)[nex] = det_idx_old.size();
   }
   assert(det_idx_order.size() == nci);
 
@@ -444,7 +444,7 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
       detData(s.detData),
       uniquePairs(s.uniquePairs),
       DetSigns(s.DetSigns),
-      ndet_per_exc_lvl(s.ndet_per_exc_lvl)
+      ndets_per_excitation_level(s.ndets_per_excitation_level)
 {
   Optimizable = s.Optimizable;
 
@@ -487,11 +487,11 @@ MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, boo
 {
   (Phi->isOptimizable() == true) ? Optimizable = true : Optimizable = false;
 
-  ciConfigList     = std::make_shared<std::vector<ci_configuration2>>();
-  detData          = std::make_shared<std::vector<int>>();
-  uniquePairs      = std::make_shared<std::vector<std::pair<int, int>>>();
-  DetSigns         = std::make_shared<std::vector<RealType>>();
-  ndet_per_exc_lvl = std::make_shared<std::vector<int>>();
+  ciConfigList               = std::make_shared<std::vector<ci_configuration2>>();
+  detData                    = std::make_shared<std::vector<int>>();
+  uniquePairs                = std::make_shared<std::vector<std::pair<int, int>>>();
+  DetSigns                   = std::make_shared<std::vector<RealType>>();
+  ndets_per_excitation_level = std::make_shared<std::vector<int>>();
 
   registerTimers();
 }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -49,7 +49,7 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
 {
   const auto& confgList = *ciConfigList;
 
-  size_t nci = confgList.size(), nex;
+  size_t nci     = confgList.size(), nex;
   size_t nex_max = 0;
   std::vector<size_t> pos(NumPtcls);
   std::vector<size_t> ocp(NumPtcls);
@@ -496,10 +496,10 @@ MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, boo
 {
   (Phi->isOptimizable() == true) ? Optimizable = true : Optimizable = false;
 
-  ciConfigList = std::make_shared<std::vector<ci_configuration2>>();
-  detData      = std::make_shared<std::vector<int>>();
-  uniquePairs  = std::make_shared<std::vector<std::pair<int, int>>>();
-  DetSigns     = std::make_shared<std::vector<RealType>>();
+  ciConfigList     = std::make_shared<std::vector<ci_configuration2>>();
+  detData          = std::make_shared<std::vector<int>>();
+  uniquePairs      = std::make_shared<std::vector<std::pair<int, int>>>();
+  DetSigns         = std::make_shared<std::vector<RealType>>();
   ndet_per_exc_lvl = std::make_shared<std::vector<int>>();
 
   registerTimers();

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -592,8 +592,8 @@ private:
   std::shared_ptr<std::vector<int>> detData;
   std::shared_ptr<std::vector<std::pair<int, int>>> uniquePairs;
   std::shared_ptr<std::vector<RealType>> DetSigns;
-  /* number of unique determinants at each excitation level (relative to reference)
-   * {1, n_singles, n_doubles, n_triples, ...}
+  /** number of unique determinants at each excitation level (relative to reference)
+   *  {1, n_singles, n_doubles, n_triples, ...}
    */
   std::shared_ptr<std::vector<int>> ndet_per_exc_lvl;
   MultiDiracDeterminantCalculator<ValueType> DetCalculator;

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -80,6 +80,7 @@ public:
    *@param first index of first particle
    *@param nel number of particles in the determinant
    *@param ref_det_id id of the reference determinant
+   *@param C2nodes_ptcl mapping from overall det index to unique det index for this particle group
    *
    * Note: ciConfigList should have been populated when calling this function
    */
@@ -222,8 +223,17 @@ public:
    * END END END
    ***************************************************************************/
 
-  // create necessary structures used in the evaluation of the determinants
-  // this works with confgList, which shouldn't change during a simulation
+  /** create necessary structures used in the evaluation of the determinants
+   * sort confgList by excitation level
+   * confgList shouldn't change during a simulation after it is sorted here
+   *
+   *@param ref reference configuration
+   *@param data data structure holding information about excitation holes/particles (*this->detData)
+   *@param pairs all hole/particle pairs needed to construct excitation matrices for table method (*this->uniquePairs)
+   *@param sign sign of each excitation (parity of permutation of orbital indices) (*this->DetSigns)
+   *@param C2nodes_ptcl mapping from overall det index to unique det index for this particle group
+   *
+   */
   void createDetData(const ci_configuration2& ref,
                      std::vector<int>& data,
                      std::vector<std::pair<int, int>>& pairs,
@@ -582,6 +592,9 @@ private:
   std::shared_ptr<std::vector<int>> detData;
   std::shared_ptr<std::vector<std::pair<int, int>>> uniquePairs;
   std::shared_ptr<std::vector<RealType>> DetSigns;
+  /* number of unique determinants at each excitation level (relative to reference)
+   * {1, n_singles, n_doubles, n_triples, ...}
+   */
   std::shared_ptr<std::vector<int>> ndet_per_exc_lvl;
   MultiDiracDeterminantCalculator<ValueType> DetCalculator;
 };

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -595,7 +595,7 @@ private:
   /** number of unique determinants at each excitation level (relative to reference)
    *  {1, n_singles, n_doubles, n_triples, ...}
    */
-  std::shared_ptr<std::vector<int>> ndet_per_exc_lvl;
+  std::shared_ptr<std::vector<int>> ndets_per_excitation_level;
   MultiDiracDeterminantCalculator<ValueType> DetCalculator;
 };
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -83,7 +83,7 @@ public:
    *
    * Note: ciConfigList should have been populated when calling this function
    */
-  void set(int first, int nel, int ref_det_id);
+  void set(int first, int nel, int ref_det_id, std::vector<size_t>& C2nodes_ptcl);
 
   ///optimizations  are disabled
   inline void checkInVariables(opt_variables_type& active) override { Phi->checkInVariables(active); }
@@ -227,7 +227,8 @@ public:
   void createDetData(const ci_configuration2& ref,
                      std::vector<int>& data,
                      std::vector<std::pair<int, int>>& pairs,
-                     std::vector<RealType>& sign);
+                     std::vector<RealType>& sign,
+                     std::vector<size_t>& C2nodes_ptcl);
 
   template<typename ITER>
   inline ValueType CalculateRatioFromMatrixElements(int n, ValueMatrix& dotProducts, ITER it)
@@ -581,6 +582,7 @@ private:
   std::shared_ptr<std::vector<int>> detData;
   std::shared_ptr<std::vector<std::pair<int, int>>> uniquePairs;
   std::shared_ptr<std::vector<RealType>> DetSigns;
+  std::shared_ptr<std::vector<int>> ndet_per_exc_lvl;
   MultiDiracDeterminantCalculator<ValueType> DetCalculator;
 };
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -512,7 +512,7 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
   if (!success)
     return false;
 
-  const auto maxloc = std::max_element(C.begin(), C.end(), [](ValueType const& lhs, ValueType const& rhs) {
+  const auto maxloc   = std::max_element(C.begin(), C.end(), [](ValueType const& lhs, ValueType const& rhs) {
     return std::norm(lhs) < std::norm(rhs);
   });
   const int refdet_id = std::distance(C.begin(), maxloc);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -512,10 +512,10 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
   if (!success)
     return false;
 
-  std::vector<ValueType>::iterator maxloc =
-      std::max_element(C.begin(), C.end(),
-                       [](ValueType const& lhs, ValueType const& rhs) { return std::abs(lhs) < std::abs(rhs); });
-  int refdet_id = std::distance(C.begin(), maxloc);
+  const auto maxloc = std::max_element(C.begin(), C.end(), [](ValueType const& lhs, ValueType const& rhs) {
+    return std::norm(lhs) < std::norm(rhs);
+  });
+  const int refdet_id = std::distance(C.begin(), maxloc);
   app_log() << "max CI coeff at det number " << refdet_id << " with value " << std::abs(C[refdet_id]) << std::endl;
   for (int grp = 0; grp < nGroups; grp++)
   {

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -512,6 +512,11 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
   if (!success)
     return false;
 
+  std::vector<ValueType>::iterator maxloc =
+      std::max_element(C.begin(), C.end(),
+                       [](ValueType const& lhs, ValueType const& rhs) { return std::abs(lhs) < std::abs(rhs); });
+  int refdet_id = std::distance(C.begin(), maxloc);
+  app_log() << "max CI coeff at det number " << refdet_id << " with value " << std::abs(C[refdet_id]) << std::endl;
   for (int grp = 0; grp < nGroups; grp++)
   {
     std::vector<ci_configuration2>& list = Dets[grp]->getCIConfigList();
@@ -530,7 +535,7 @@ bool SlaterDetBuilder::createMSDFast(std::vector<std::unique_ptr<MultiDiracDeter
       }
     }
     // you should choose the det with highest weight for reference. for now choosing 0
-    Dets[grp]->set(targetPtcl.first(grp), nptcls[grp], 0);
+    Dets[grp]->set(targetPtcl.first(grp), nptcls[grp], refdet_id, C2nodes[grp]);
   }
 
   if (CSFcoeff.size() == 1)


### PR DESCRIPTION
## Proposed changes

This reorders the unique determinants of each particle type by excitation level.
It also identifies the reference SlaterDeterminant as the one with the largest coefficient (in magnitude) (was previously always set to the first det in the list).
For each particle group, the reference DiracDeterminant is the one that appears in the reference SlaterDeterminant.
There is also a new data member of MultiDiracDeterminant that holds the number of unique dets at each excitation level

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
unix workstation (gcc 10.3.0; amd zen)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
