### PR TITLE
Fix single quote printout 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,7 @@ if(QMC_MPI)
   if(NOT MPI_FOUND)
     message(
       FATAL_ERROR
-        "MPI support not found! Provide MPI compiler wrappers or build without MPI by passing '-DQMC_MPI=0' to cmake.")
+        "MPI support not found! Provide MPI compiler wrappers or build without MPI by passing '-DQMC_MPI=OFF' to cmake.")
   endif(NOT MPI_FOUND)
 
   if(${MPI_CXX_LIBRARY_VERSION_STRING} MATCHES "MVAPICH2")
@@ -462,7 +462,7 @@ if(QMC_MPI)
         "Building MPI version without using MPI compiler wrappers.\n"
         "This may not build qmcpack correctly. To ensure the correct version, specify the compiler wrappers to cmake.\n"
         "For example: cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++\n"
-        "To build without MPI, pass '-DQMC_MPI=0' to cmake")
+        "To build without MPI, pass '-DQMC_MPI=OFF' to cmake")
     message(WARNING ${MPI_WARNING_LIST})
   endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ if(IS_GIT_PROJECT)
     COMMAND ${GIT_EXECUTABLE} log -1 --format=%ad >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "#define GIT_COMMIT_SUBJECT_RAW \"" >> ${GITREV_TMP}
-    COMMAND ${GIT_EXECUTABLE} log -1 --format=%s | sed ${SED_FLAG} "s/\"/\\\\\"/g" | tr -d '\\n' >> ${GITREV_TMP}
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%s | sed ${SED_FLAG} "s/\"/\\\\\"/g" | tr -d "\\n" >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo_append "\"" >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E echo >> ${GITREV_TMP}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GITREV_TMP} ${GITREV_FILE}

--- a/tests/performance/NiO/README
+++ b/tests/performance/NiO/README
@@ -118,7 +118,7 @@ affinity, please read the next section.
 To activate the ctest route, add the following option in your cmake
 command line before building your binary:
 
--DQMC_DATA=YOUR_DATA_FOLDER -DENABLE_TIMERS=1
+-DQMC_DATA=YOUR_DATA_FOLDER
 
 YOUR_DATA_FOLDER contains a folder called NiO with the h5 files in it.
 Run tests with command "ctest -R performance-NiO" after building


### PR DESCRIPTION
## Proposed changes
Somehow single quote disappears by `tr -d '\\n'` and  `tr -d "\\n"` fixes the issue.
Also added some minor CMake change.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'