### PR TITLE
WaveFunctionPool owns a map of TrialWaveFunction

### DIFF
--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -401,7 +401,7 @@ bool EstimatorManagerNew::put(QMCHamiltonian& H,
         // happens once insures golden particle set is not abused.
         ParticleSet pset_target(pset);
         operator_ests_.emplace_back(std::make_unique<OneBodyDensityMatrices>(std::move(obdmi), pset.getLattice(),
-                                                                             pset.getSpeciesSet(), twf,
+                                                                             pset.getSpeciesSet(), twf.getSPOMap(),
                                                                              pset_target));
       }
       else

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -333,7 +333,6 @@ EstimatorManagerNew::EstimatorType* EstimatorManagerNew::getEstimator(const std:
 bool EstimatorManagerNew::put(QMCHamiltonian& H,
                               const ParticleSet& pset,
                               const TrialWaveFunction& twf,
-                              const WaveFunctionFactory& wf_factory,
                               xmlNodePtr cur)
 {
   std::vector<std::string> extra_types;
@@ -402,7 +401,7 @@ bool EstimatorManagerNew::put(QMCHamiltonian& H,
         // happens once insures golden particle set is not abused.
         ParticleSet pset_target(pset);
         operator_ests_.emplace_back(std::make_unique<OneBodyDensityMatrices>(std::move(obdmi), pset.getLattice(),
-                                                                             pset.getSpeciesSet(), wf_factory,
+                                                                             pset.getSpeciesSet(), twf,
                                                                              pset_target));
       }
       else

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -79,7 +79,6 @@ public:
   bool put(QMCHamiltonian& H,
            const ParticleSet& pset,
            const TrialWaveFunction& twf,
-           const WaveFunctionFactory& wf_factory,
            xmlNodePtr cur);
 
   /** Start the manager at the beginning of a driver run().

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -29,7 +29,6 @@
 namespace qmcplusplus
 {
 class QMCHamiltonian;
-class WaveFunctionFactory;
 class CollectablesEstimator;
 class hdf_archive;
 

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -30,7 +30,7 @@ using MatrixOperators::product_AtB;
 OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                                                const Lattice& lattice,
                                                const SpeciesSet& species,
-                                               const WaveFunctionFactory& wf_factory,
+                                               const TrialWaveFunction& psi,
                                                ParticleSet& pset_target)
     : OperatorEstBase(DataLocality::crowd),
       input_(obdmi),
@@ -86,13 +86,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
   auto& sposets = input_.get_basis_sets();
 
   for (int i = 0; i < sposets.size(); ++i)
-  {
-    SPOSet* sposet = wf_factory.getSPOSet(sposets[i]);
-    if (sposet == 0)
-      throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices sposet " + sposets[i] +
-                                    " does not exist");
-    basis_functions_.add(sposet->makeClone());
-  }
+    basis_functions_.add(psi.getSPOSet(sposets[i]).makeClone());
   basis_size_ = basis_functions_.size();
 
   if (basis_size_ < 1)

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -18,7 +18,6 @@
 #include "Numerics/MatrixOperators.h"
 #include "Utilities/IteratorUtility.h"
 #include "Utilities/string_utils.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "type_traits/complex_help.hpp"
 
 namespace qmcplusplus

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -30,7 +30,7 @@ using MatrixOperators::product_AtB;
 OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                                                const Lattice& lattice,
                                                const SpeciesSet& species,
-                                               const TrialWaveFunction& psi,
+                                               const SPOMap& spomap,
                                                ParticleSet& pset_target)
     : OperatorEstBase(DataLocality::crowd),
       input_(obdmi),
@@ -86,7 +86,13 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
   auto& sposets = input_.get_basis_sets();
 
   for (int i = 0; i < sposets.size(); ++i)
-    basis_functions_.add(psi.getSPOSet(sposets[i]).makeClone());
+  {
+    auto spo_it = spomap.find(sposets[i]);
+    if (spo_it == spomap.end())
+      throw UniformCommunicateError("OneBodyDensityMatrices::OneBodyDensityMatrices sposet " + sposets[i] +
+                                    " does not exist.");
+    basis_functions_.add(spo_it->second->makeClone());
+  }
   basis_size_ = basis_functions_.size();
 
   if (basis_size_ < 1)

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -151,7 +151,7 @@ public:
   OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                          const Lattice& lattice,
                          const SpeciesSet& species,
-                         const WaveFunctionFactory& wf_factory,
+                         const TrialWaveFunction& psi,
                          ParticleSet& pset_target);
 
   /** Constructor used when spawing crowd clones

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -56,6 +56,8 @@ public:
   using Evaluator  = OneBodyDensityMatricesInput::Evaluator;
   using Integrator = OneBodyDensityMatricesInput::Integrator;
 
+  using SPOMap = TrialWaveFunction::SPOMap;
+
   enum class Sampling
   {
     VOLUME_BASED,
@@ -151,7 +153,7 @@ public:
   OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obdmi,
                          const Lattice& lattice,
                          const SpeciesSet& species,
-                         const TrialWaveFunction& psi,
+                         const SPOMap& spomap,
                          ParticleSet& pset_target);
 
   /** Constructor used when spawing crowd clones

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -19,7 +19,6 @@
 #include "type_traits/complex_help.hpp"
 #include "QMCWaveFunctions/CompositeSPOSet.h"
 #include "ParticleBase/RandomSeqGenerator.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "OneBodyDensityMatricesInput.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include <SpeciesSet.h>
@@ -56,7 +55,7 @@ public:
   using Evaluator  = OneBodyDensityMatricesInput::Evaluator;
   using Integrator = OneBodyDensityMatricesInput::Integrator;
 
-  using SPOMap = TrialWaveFunction::SPOMap;
+  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
 
   enum class Sampling
   {

--- a/src/Estimators/tests/test_MomentumDistribution.cpp
+++ b/src/Estimators/tests/test_MomentumDistribution.cpp
@@ -80,7 +80,6 @@ TEST_CASE("MomentumDistribution::MomentumDistribution", "[estimators]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset             = *(particle_pool.getParticleSet("e"));
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
   DataLocality dl        = DataLocality::crowd;
 
   // Build from input
@@ -131,7 +130,6 @@ TEST_CASE("MomentumDistribution::accumulate", "[estimators]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset             = *(particle_pool.getParticleSet("e"));
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
   DataLocality dl        = DataLocality::crowd;
 
   // Setup particleset

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -223,10 +223,10 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
-  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
+  auto& spomap           = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
 
   // Good constructor
-  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, twf.getSPOMap(), pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, spomap, pset_target);
   // make sure there is something in obdm's data
   OEBAccessor oeba(obdm);
   oeba[0] = 1.0;
@@ -234,7 +234,7 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   obdmt.testCopyConstructor(obdm);
 
   species_set = testing::makeSpeciesSet(SpeciesCases::NO_MEMBERSIZE);
-  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, twf.getSPOMap(), pset_target),
+  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, spomap, pset_target),
                   UniformCommunicateError);
 
   outputManager.resume();
@@ -255,9 +255,9 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& species_set      = pset_target.getSpeciesSet();
-  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
+  auto& spomap           = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
 
-  auto samplingCaseRunner = [&pset_target, &species_set, &twf](Inputs test_case) {
+  auto samplingCaseRunner = [&pset_target, &species_set, &spomap](Inputs test_case) {
     Libxml2Document doc;
 
     bool okay = doc.parseFromString(valid_one_body_density_matrices_input_sections[test_case]);
@@ -266,7 +266,7 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
     xmlNodePtr node = doc.getRoot();
     OneBodyDensityMatricesInput obdmi(node);
 
-    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
+    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
 
     OneBodyDensityMatricesTests<double> obdmt;
     //Get control over which rng is used.
@@ -297,7 +297,7 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& species_set      = pset_target.getSpeciesSet();
-  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
+  auto& spomap           = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(valid_one_body_density_matrices_input_sections[Inputs::valid_obdm_input]);
@@ -306,7 +306,7 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
   xmlNodePtr node = doc.getRoot();
   OneBodyDensityMatricesInput obdmi(node);
 
-  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
+  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
   auto clone = original.spawnCrowdClone();
   REQUIRE(clone != nullptr);
   REQUIRE(clone.get() != &original);
@@ -331,11 +331,11 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   OneBodyDensityMatricesInput obdmi(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
+  auto& spomap           = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& pset_source      = *(particle_pool.getParticleSet("ion"));
   auto& species_set      = pset_target.getSpeciesSet();
-  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
 
   std::vector<MCPWalker> walkers;
   int nwalkers = 3;
@@ -431,10 +431,10 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
 
     auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
     auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-    auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
+    auto& spomap           = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
     auto& pset_target      = *(particle_pool.getParticleSet("e"));
     auto& species_set      = pset_target.getSpeciesSet();
-    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
+    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, spomap, pset_target);
     auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
 
     // Because we can't control or consistent know the global random state we must initialize particle positions to known values.

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -223,10 +223,10 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
 
   // Good constructor
-  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, wf_factory, pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, twf, pset_target);
   // make sure there is something in obdm's data
   OEBAccessor oeba(obdm);
   oeba[0] = 1.0;
@@ -234,7 +234,7 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   obdmt.testCopyConstructor(obdm);
 
   species_set = testing::makeSpeciesSet(SpeciesCases::NO_MEMBERSIZE);
-  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, wf_factory, pset_target),
+  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, twf, pset_target),
                   UniformCommunicateError);
 
   outputManager.resume();
@@ -255,9 +255,9 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& species_set      = pset_target.getSpeciesSet();
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
 
-  auto samplingCaseRunner = [&pset_target, &species_set, &wf_factory](Inputs test_case) {
+  auto samplingCaseRunner = [&pset_target, &species_set, &twf](Inputs test_case) {
     Libxml2Document doc;
 
     bool okay = doc.parseFromString(valid_one_body_density_matrices_input_sections[test_case]);
@@ -266,7 +266,7 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
     xmlNodePtr node = doc.getRoot();
     OneBodyDensityMatricesInput obdmi(node);
 
-    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
+    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
 
     OneBodyDensityMatricesTests<double> obdmt;
     //Get control over which rng is used.
@@ -297,7 +297,7 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& species_set      = pset_target.getSpeciesSet();
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(valid_one_body_density_matrices_input_sections[Inputs::valid_obdm_input]);
@@ -306,7 +306,7 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
   xmlNodePtr node = doc.getRoot();
   OneBodyDensityMatricesInput obdmi(node);
 
-  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
+  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
   auto clone = original.spawnCrowdClone();
   REQUIRE(clone != nullptr);
   REQUIRE(clone.get() != &original);
@@ -331,11 +331,11 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   OneBodyDensityMatricesInput obdmi(node);
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+  auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& pset_source      = *(particle_pool.getParticleSet("ion"));
   auto& species_set      = pset_target.getSpeciesSet();
-  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
 
   std::vector<MCPWalker> walkers;
   int nwalkers = 3;
@@ -431,10 +431,10 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
 
     auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
     auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-    auto& wf_factory       = *(wavefunction_pool.getWaveFunctionFactory("wavefunction"));
+    auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
     auto& pset_target      = *(particle_pool.getParticleSet("e"));
     auto& species_set      = pset_target.getSpeciesSet();
-    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, wf_factory, pset_target);
+    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
     auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
 
     // Because we can't control or consistent know the global random state we must initialize particle positions to known values.

--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -226,7 +226,7 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
 
   // Good constructor
-  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, twf, pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), lattice, species_set, twf.getSPOMap(), pset_target);
   // make sure there is something in obdm's data
   OEBAccessor oeba(obdm);
   oeba[0] = 1.0;
@@ -234,7 +234,7 @@ TEST_CASE("OneBodyDensityMatrices::OneBodyDensityMatrices", "[estimators]")
   obdmt.testCopyConstructor(obdm);
 
   species_set = testing::makeSpeciesSet(SpeciesCases::NO_MEMBERSIZE);
-  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, twf, pset_target),
+  CHECK_THROWS_AS(OneBodyDensityMatrices(std::move(obdmi), lattice, species_set, twf.getSPOMap(), pset_target),
                   UniformCommunicateError);
 
   outputManager.resume();
@@ -266,7 +266,7 @@ TEST_CASE("OneBodyDensityMatrices::generateSamples", "[estimators]")
     xmlNodePtr node = doc.getRoot();
     OneBodyDensityMatricesInput obdmi(node);
 
-    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
+    OneBodyDensityMatrices obDenMat(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
 
     OneBodyDensityMatricesTests<double> obdmt;
     //Get control over which rng is used.
@@ -306,7 +306,7 @@ TEST_CASE("OneBodyDensityMatrices::spawnCrowdClone()", "[estimators]")
   xmlNodePtr node = doc.getRoot();
   OneBodyDensityMatricesInput obdmi(node);
 
-  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
+  OneBodyDensityMatrices original(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
   auto clone = original.spawnCrowdClone();
   REQUIRE(clone != nullptr);
   REQUIRE(clone.get() != &original);
@@ -335,7 +335,7 @@ TEST_CASE("OneBodyDensityMatrices::accumulate", "[estimators]")
   auto& pset_target      = *(particle_pool.getParticleSet("e"));
   auto& pset_source      = *(particle_pool.getParticleSet("ion"));
   auto& species_set      = pset_target.getSpeciesSet();
-  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
+  OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
 
   std::vector<MCPWalker> walkers;
   int nwalkers = 3;
@@ -434,7 +434,7 @@ TEST_CASE("OneBodyDensityMatrices::evaluateMatrix", "[estimators]")
     auto& twf       = *(wavefunction_pool.getWaveFunction("wavefunction"));
     auto& pset_target      = *(particle_pool.getParticleSet("e"));
     auto& species_set      = pset_target.getSpeciesSet();
-    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf, pset_target);
+    OneBodyDensityMatrices obdm(std::move(obdmi), pset_target.getLattice(), species_set, twf.getSPOMap(), pset_target);
     auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
 
     // Because we can't control or consistent know the global random state we must initialize particle positions to known values.

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -25,12 +25,10 @@ MCPopulation::MCPopulation(int num_ranks,
                            WalkerConfigurations& mcwc,
                            ParticleSet* elecs,
                            TrialWaveFunction* trial_wf,
-                           WaveFunctionFactory* wf_factory,
                            QMCHamiltonian* hamiltonian)
     : trial_wf_(trial_wf),
       elec_particle_set_(elecs),
       hamiltonian_(hamiltonian),
-      wf_factory_(wf_factory),
       num_ranks_(num_ranks),
       rank_(this_rank),
       walker_configs_ref_(mcwc)

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -22,7 +22,6 @@
 #include "ParticleBase/ParticleAttrib.h"
 #include "Particle/Walker.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCDrivers/WalkerElementsRef.h"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "Utilities/FairDivide.h"

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -74,7 +74,6 @@ private:
   TrialWaveFunction* trial_wf_;
   ParticleSet* elec_particle_set_;
   QMCHamiltonian* hamiltonian_;
-  WaveFunctionFactory* wf_factory_;
   // At the moment these are "clones" but I think this design pattern smells.
   UPtrVector<ParticleSet> walker_elec_particle_sets_;
   UPtrVector<TrialWaveFunction> walker_trial_wavefunctions_;
@@ -103,7 +102,6 @@ public:
                WalkerConfigurations& mcwc,
                ParticleSet* elecs,
                TrialWaveFunction* trial_wf,
-               WaveFunctionFactory* wf_factory,
                QMCHamiltonian* hamiltonian_);
 
   ~MCPopulation();
@@ -187,7 +185,6 @@ public:
   TrialWaveFunction& get_golden_twf() { return *trial_wf_; }
   // TODO: the fact this is needed is sad remove need for its existence.
   QMCHamiltonian& get_golden_hamiltonian() { return *hamiltonian_; }
-  WaveFunctionFactory& get_wf_factory() { return *wf_factory_; }
   
   void set_num_global_walkers(IndexType num_global_walkers) { num_global_walkers_ = num_global_walkers; }
   void set_num_local_walkers(IndexType num_local_walkers) { num_local_walkers_ = num_local_walkers; }

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -173,7 +173,6 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   std::queue<QMCHamiltonian*> targetH;      //FIFO
   xmlNodePtr tcur = cur->children;
   std::unique_ptr<QMCDriverInterface> new_driver;
-  auto wf_factory = wavefunction_pool.getWaveFunctionFactory("wavefunction");
   while (tcur != NULL)
   {
     if (xmlStrEqual(tcur->name, (const xmlChar*)"qmcsystem"))
@@ -241,7 +240,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     VMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE]);
     new_driver.reset(fac.create(project_data_,
-                                MCPopulation(comm->size(), comm->rank(), qmc_system, &qmc_system, primaryPsi, wf_factory, primaryH),
+                                MCPopulation(comm->size(), comm->rank(), qmc_system, &qmc_system, primaryPsi, primaryH),
                                 qmc_system.getSampleStack(), comm));
   }
   else if (das.new_run_type == QMCRunType::DMC)
@@ -253,7 +252,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     DMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE]);
     new_driver.reset(fac.create(project_data_,
-                                MCPopulation(comm->size(), comm->rank(), qmc_system, &qmc_system, primaryPsi, wf_factory, primaryH),
+                                MCPopulation(comm->size(), comm->rank(), qmc_system, &qmc_system, primaryPsi, primaryH),
                                 comm));
   }
   else if (das.new_run_type == QMCRunType::RMC)
@@ -282,7 +281,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
     QMCFixedSampleLinearOptimizeBatched* opt =
         QMCWFOptLinearFactoryNew(cur, project_data_, qmc_system,
                                  MCPopulation(comm->size(), comm->rank(), qmc_system, 
-                                              &qmc_system, primaryPsi, wf_factory, primaryH),
+                                              &qmc_system, primaryPsi, primaryH),
                                  qmc_system.getSampleStack(), comm);
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
     new_driver.reset(opt);

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -135,7 +135,7 @@ void QMCDriverNew::startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCou
   makeLocalWalkers(awc.walkers_per_rank[myComm->rank()], awc.reserve_walkers);
 
   estimator_manager_->put(population_.get_golden_hamiltonian(), *population_.get_golden_electrons(),
-                          population_.get_golden_twf(), population_.get_wf_factory(), cur);
+                          population_.get_golden_twf(), cur);
 
   if (dispatchers_.are_walkers_batched())
   {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -738,7 +738,7 @@ bool QMCFixedSampleLinearOptimizeBatched::processOptXML(xmlNodePtr opt_xml,
       std::make_unique<VMCBatched>(project_data_, std::move(qmcdriver_input_copy), std::move(vmcdriver_input_copy),
                                    MCPopulation(myComm->size(), myComm->rank(), population_.getWalkerConfigsRef(),
                                                 population_.get_golden_electrons(), &population_.get_golden_twf(),
-                                                &population_.get_wf_factory(), &population_.get_golden_hamiltonian()),
+                                                &population_.get_golden_hamiltonian()),
                                    samples_, myComm);
 
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');

--- a/src/QMCDrivers/tests/SetupDMCTest.h
+++ b/src/QMCDrivers/tests/SetupDMCTest.h
@@ -47,7 +47,7 @@ public:
     DMCDriverInput dmc_input_copy(dmcdrv_input);
     return {test_project, std::move(qmc_input_copy), std::move(dmc_input_copy),
             MCPopulation(comm->size(), comm->rank(), walker_confs, particle_pool->getParticleSet("e"),
-                         wavefunction_pool->getPrimary(), wavefunction_pool->getWaveFunctionFactory("wavefunction"),
+                         wavefunction_pool->getPrimary(),
                          hamiltonian_pool->getPrimary()),
             comm};
   }

--- a/src/QMCDrivers/tests/test_DMCBatched.cpp
+++ b/src/QMCDrivers/tests/test_DMCBatched.cpp
@@ -72,7 +72,6 @@ TEST_CASE("DMCDriver+QMCDriverNew integration", "[drivers]")
   DMCBatched dmcdriver(test_project, std::move(qmcdriver_input), std::move(dmcdriver_input),
                        MCPopulation(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                                     wavefunction_pool.getPrimary(),
-                                    wavefunction_pool.getWaveFunctionFactory("wavefunction"),
                                     hamiltonian_pool.getPrimary()),
                        comm);
 

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -28,12 +28,11 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  auto wf_factory        = wavefunction_pool.getWaveFunctionFactory("wavefunction");
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   TrialWaveFunction twf;
   WalkerConfigurations walker_confs;
 
-  MCPopulation population(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"), &twf, wf_factory,
+  MCPopulation population(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"), &twf,
                           hamiltonian_pool.getPrimary());
 
   population.createWalkers(8, 2.0);
@@ -64,10 +63,9 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  auto wf_factory        = wavefunction_pool.getWaveFunctionFactory("wavefunction");
   WalkerConfigurations walker_confs;
   MCPopulation population(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
-                          wavefunction_pool.getPrimary(), wf_factory, hamiltonian_pool.getPrimary());
+                          wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary());
 
   population.createWalkers(8);
   REQUIRE(population.get_walkers().size() == 8);

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -48,7 +48,6 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   QMCDriverNewTestWrapper qmcdriver(std::move(qmcdriver_input),
                                     MCPopulation(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(),
-                                                 wavefunction_pool.getWaveFunctionFactory("wavefunction"),
                                                  hamiltonian_pool.getPrimary()),
                                     samples, comm);
 
@@ -103,7 +102,6 @@ TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
   QMCDriverNewTestWrapper qmc_batched(std::move(qmcdriver_copy),
                                       MCPopulation(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(),
-                                                   wavefunction_pool.getWaveFunctionFactory("wavefunction"),
                                                    hamiltonian_pool.getPrimary()),
                                       samples, comm);
   QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<ParallelExecutor<>> testNumCrowds;
@@ -144,7 +142,6 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
   QMCDriverNewTestWrapper qmc_batched(std::move(qmcdriver_copy),
                                       MCPopulation(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(),
-                                                   wavefunction_pool.getWaveFunctionFactory("wavefunction"),
                                                    hamiltonian_pool.getPrimary()),
                                       samples, comm);
 
@@ -175,7 +172,6 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
   QMCDriverNewTestWrapper qmcdriver(std::move(qmcdriver_input),
                                     MCPopulation(1, comm->rank(), walker_confs, particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(),
-                                                 wavefunction_pool.getWaveFunctionFactory("wavefunction"),
                                                  hamiltonian_pool.getPrimary()),
                                     samples, comm);
 

--- a/src/QMCDrivers/tests/test_SFNBranch.cpp
+++ b/src/QMCDrivers/tests/test_SFNBranch.cpp
@@ -48,10 +48,9 @@ public:
 
   std::unique_ptr<SFNBranch> operator()(ParticleSet& pset,
                                         TrialWaveFunction& twf,
-                                        WaveFunctionFactory& wf_factory,
                                         QMCHamiltonian& ham)
   {
-    pop_ = std::make_unique<MCPopulation>(1, comm_->rank(), walker_confs_, &pset, &twf, &wf_factory, &ham);
+    pop_ = std::make_unique<MCPopulation>(1, comm_->rank(), walker_confs_, &pset, &twf, &ham);
     // MCPopulation owns it walkers it cannot just take refs so we just create and then update its walkers.
     pop_->createWalkers(2);
 
@@ -96,7 +95,6 @@ TEST_CASE("SFNBranch::branch(MCPopulation...)", "[drivers]")
   SetupSFNBranch setup_sfnb(pools.comm);
   std::unique_ptr<SFNBranch> sfnb =
       setup_sfnb(*pools.particle_pool->getParticleSet("e"), *pools.wavefunction_pool->getPrimary(),
-                 *pools.wavefunction_pool->getWaveFunctionFactory("wavefunction"),
                  *pools.hamiltonian_pool->getPrimary());
 }
 

--- a/src/QMCDrivers/tests/test_WalkerControl.cpp
+++ b/src/QMCDrivers/tests/test_WalkerControl.cpp
@@ -39,7 +39,6 @@ UnifiedDriverWalkerControlMPITest::UnifiedDriverWalkerControlMPITest() : wc_(dpo
   pop_ = std::make_unique<MCPopulation>(num_ranks, dpools_.comm->rank(), walker_confs,
                                         dpools_.particle_pool->getParticleSet("e"),
                                         dpools_.wavefunction_pool->getPrimary(),
-                                        dpools_.wavefunction_pool->getWaveFunctionFactory("wavefunction"),
                                         dpools_.hamiltonian_pool->getPrimary());
 
   pop_->createWalkers(1);

--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -220,7 +220,7 @@ void HamiltonianFactory::addForceHam(xmlNodePtr cur)
     {
       APP_ABORT("Unknown psi \"" + PsiName + "\" for zero-variance force.");
     }
-    TrialWaveFunction& psi           = *psi_it->second->getTWF();
+    TrialWaveFunction& psi           = *psi_it->second;
     std::unique_ptr<ACForce> acforce = std::make_unique<ACForce>(*source, *target, psi, *targetH);
     acforce->put(cur);
     targetH->addOperator(std::move(acforce), title, false);
@@ -263,11 +263,11 @@ void HamiltonianFactory::addPseudoPotential(xmlNodePtr cur)
       return;
     app_error() << "  Cannot find " << wfname << " in the Wavefunction pool. Using the first wavefunction."
                 << std::endl;
-    psi = (*(psiPool.begin())).second->getTWF();
+    psi = psiPool.begin()->second.get();
   }
   else
   {
-    psi = (*oit).second->getTWF();
+    psi = (*oit).second.get();
   }
   //remember the TrialWaveFunction used by this pseudopotential
   psiName = wfname;

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -233,14 +233,14 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     metric     = 1.0 / samples;
   }
   else
-    APP_ABORT("DensityMatrices1B::set_state  invalid integrator\n  valid options are: uniform_grid, uniform, density");
+    throw std::runtime_error("DensityMatrices1B::set_state  invalid integrator\n  valid options are: uniform_grid, uniform, density");
 
   if (evstr == "loop")
     evaluator = loop;
   else if (evstr == "matrix")
     evaluator = matrix;
   else
-    APP_ABORT("DensityMatrices1B::set_state  invalid evaluator\n  valid options are: loop, matrix");
+    throw std::runtime_error("DensityMatrices1B::set_state  invalid evaluator\n  valid options are: loop, matrix");
 
   normalized             = nmstr == "yes";
   volume_normed          = vnstr == "yes";
@@ -253,14 +253,20 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
 
   // get the sposets that form the basis
   if (sposets.size() == 0)
-    APP_ABORT("DensityMatrices1B::put  basis must have at least one sposet");
+    throw std::runtime_error("DensityMatrices1B::put  basis must have at least one sposet");
 
   for (int i = 0; i < sposets.size(); ++i)
-    basis_functions.add(Psi.getSPOSet(sposets[i]).makeClone());
+  {
+    auto& spomap = Psi.getSPOMap();
+    auto spo_it = spomap.find(sposets[i]);
+    if (spo_it == spomap.end())
+      throw std::runtime_error("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist.");
+    basis_functions.add(spo_it->second->makeClone());
+  }
   basis_size = basis_functions.size();
 
   if (basis_size < 1)
-    APP_ABORT("DensityMatrices1B::put  basis_size must be greater than one");
+    throw std::runtime_error("DensityMatrices1B::put  basis_size must be greater than one");
 }
 
 

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -29,9 +29,8 @@ using MatrixOperators::product_AtB;
 
 DensityMatrices1B::DensityMatrices1B(ParticleSet& P,
                                      TrialWaveFunction& psi,
-                                     ParticleSet* Pcl,
-                                     const WaveFunctionFactory& factory)
-    : lattice_(P.getLattice()), Psi(psi), Pq(P), Pc(Pcl), wf_factory_(factory)
+                                     ParticleSet* Pcl)
+    : lattice_(P.getLattice()), Psi(psi), Pq(P), Pc(Pcl)
 {
   reset();
 }
@@ -43,8 +42,7 @@ DensityMatrices1B::DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, 
       lattice_(P.getLattice()),
       Psi(psi),
       Pq(P),
-      Pc(master.Pc),
-      wf_factory_(master.wf_factory_)
+      Pc(master.Pc)
 {
   reset();
   set_state(master);
@@ -258,12 +256,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     APP_ABORT("DensityMatrices1B::put  basis must have at least one sposet");
 
   for (int i = 0; i < sposets.size(); ++i)
-  {
-    SPOSet* sposet = wf_factory_.getSPOSet(sposets[i]);
-    if (sposet == 0)
-      APP_ABORT("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist");
-    basis_functions.add(sposet->makeClone());
-  }
+    basis_functions.add(Psi.getSPOSet(sposets[i]).makeClone());
   basis_size = basis_functions.size();
 
   if (basis_size < 1)

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -17,7 +17,6 @@
 #include "Numerics/MatrixOperators.h"
 #include "Utilities/IteratorUtility.h"
 #include "Utilities/string_utils.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 
 namespace qmcplusplus

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -156,7 +156,7 @@ public:
 
 
   //constructor/destructor
-  DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl, const WaveFunctionFactory& factory);
+  DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl);
   DensityMatrices1B(DensityMatrices1B& master, ParticleSet& P, TrialWaveFunction& psi);
   ~DensityMatrices1B() override;
 
@@ -230,8 +230,6 @@ public:
   void compare(const std::string& name, Matrix_t& m1, Matrix_t& m2, bool write = false, bool diff_only = true);
 
 private:
-  /// reference to the sposet_builder_factory
-  const WaveFunctionFactory& wf_factory_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -17,7 +17,6 @@
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCWaveFunctions/CompositeSPOSet.h"
 #include "ParticleBase/RandomSeqGenerator.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -278,7 +278,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       {
         app_log() << "  Adding OrbitalImages" << std::endl;
         std::unique_ptr<OrbitalImages> apot =
-            std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, *targetPsi);
+            std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, targetPsi->getSPOMap());
         apot->put(cur);
         targetH->addOperator(std::move(apot), potName, false);
       }

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -132,7 +132,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
   auto psi_it(psiPool.find(psiName));
   if (psi_it == psiPool.end())
     APP_ABORT("Unknown psi \"" + psiName + "\" for target Psi");
-  TrialWaveFunction* targetPsi = psi_it->second->getTWF();
+  TrialWaveFunction* targetPsi = psi_it->second.get();
   xmlNodePtr cur_saved(cur);
   cur = cur->children;
   while (cur != NULL)
@@ -278,7 +278,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       {
         app_log() << "  Adding OrbitalImages" << std::endl;
         std::unique_ptr<OrbitalImages> apot =
-            std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, *psi_it->second);
+            std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, *targetPsi);
         apot->put(cur);
         targetH->addOperator(std::move(apot), potName, false);
       }
@@ -308,7 +308,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
           APP_ABORT("Unknown source \"" + source + "\" for DensityMatrices1B");
         }
         std::unique_ptr<DensityMatrices1B> apot =
-            std::make_unique<DensityMatrices1B>(targetPtcl, *targetPsi, Pc, *psi_it->second);
+            std::make_unique<DensityMatrices1B>(targetPtcl, *targetPsi, Pc);
         apot->put(cur);
         targetH->addOperator(std::move(apot), potName, false);
       }
@@ -347,7 +347,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         {
           APP_ABORT("Unknown psi \"" + PsiName + "\" for Chiesa correction.");
         }
-        const TrialWaveFunction& psi             = *psi_it->second->getTWF();
+        const TrialWaveFunction& psi             = *psi_it->second;
         std::unique_ptr<ChiesaCorrection> chiesa = std::make_unique<ChiesaCorrection>(source, psi);
         targetH->addOperator(std::move(chiesa), "KEcorr", false);
       }
@@ -400,8 +400,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         {
           APP_ABORT("Unknown psi \"" + PsiName + "\" for momentum.");
         }
-        TrialWaveFunction* psi                = (*psi_it).second->getTWF();
-        std::unique_ptr<MomentumEstimator> ME = std::make_unique<MomentumEstimator>(targetPtcl, *psi);
+        std::unique_ptr<MomentumEstimator> ME = std::make_unique<MomentumEstimator>(targetPtcl, *psi_it->second);
         bool rt(myComm->rank() == 0);
         ME->putSpecial(cur, targetPtcl, rt);
         targetH->addOperator(std::move(ME), "MomentumEstimator", false);

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -29,7 +29,7 @@ class HamiltonianFactory : public MPIObjectBase
 {
 public:
   using PSetMap     = std::map<std::string, std::unique_ptr<ParticleSet>>;
-  using PsiPoolType = std::map<std::string, std::unique_ptr<TrialWaveFunction>>;
+  using PsiPoolType = std::map<std::string, const std::unique_ptr<TrialWaveFunction>>;
 
   ///constructor
   HamiltonianFactory(const std::string& hName,

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -75,7 +75,7 @@ private:
   ParticleSet& targetPtcl;
   ///reference to the PSetMap
   const PSetMap& ptclPool;
-  ///reference to the WaveFunctionFactory Pool
+  ///reference to the TrialWaveFunction Pool
   const PsiPoolType& psiPool;
   ///input node for a many-body wavefunction
   xmlNodePtr myNode;

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -21,7 +21,6 @@
 #define QMCPLUSPLUS_HAMILTONIAN_FACTORY_H
 
 #include "QMCHamiltonians/QMCHamiltonian.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 namespace qmcplusplus
 {
 /** Factory class to build a many-body wavefunction
@@ -30,7 +29,7 @@ class HamiltonianFactory : public MPIObjectBase
 {
 public:
   using PSetMap     = std::map<std::string, std::unique_ptr<ParticleSet>>;
-  using PsiPoolType = std::map<std::string, WaveFunctionFactory*>;
+  using PsiPoolType = std::map<std::string, std::unique_ptr<TrialWaveFunction>>;
 
   ///constructor
   HamiltonianFactory(const std::string& hName,

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -78,6 +78,9 @@ public:
   ///typedef for the ParticleScalar
   using ParticleScalar = ParticleSet::Scalar_t;
 
+  ///typedef for SPOMap
+  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+
   ///enum to denote energy domain of operators
   enum EnergyDomains
   {

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -22,8 +22,8 @@ namespace qmcplusplus
 OrbitalImages::OrbitalImages(ParticleSet& P,
                              const PSPool& PSP,
                              Communicate* mpicomm,
-                             const WaveFunctionFactory& factory)
-    : psetpool(PSP), wf_factory_(factory)
+                             const TrialWaveFunction& psi)
+    : psetpool(PSP), psi_(psi)
 {
   //keep the electron particle to get the cell later, if necessary
   Peln = &P;
@@ -57,7 +57,7 @@ OrbitalImages::OrbitalImages(const OrbitalImages& other)
       batch_gradients(other.batch_gradients),
       batch_laplacians(other.batch_laplacians),
       orbital(other.orbital),
-      wf_factory_(other.wf_factory_)
+      psi_(other.psi_)
 {
   for (auto& element : other.sposets)
     sposets.push_back(element->makeClone());
@@ -214,10 +214,8 @@ bool OrbitalImages::put(xmlNodePtr cur)
     APP_ABORT("OrbitalImages::put  must have at least one sposet");
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    SPOSet* sposet = wf_factory_.getSPOSet(sposet_names[i]);
-    if (sposet == 0)
-      APP_ABORT("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist");
-    sposets.push_back(sposet->makeClone());
+    sposets.push_back(psi_.getSPOSet(sposet_names[i]).makeClone());
+    auto& sposet = sposets.back();
     std::vector<int>& sposet_inds = (*sposet_indices)[i];
     if (sposet_inds.size() == 0)
       for (int n = 0; n < sposet->size(); ++n)

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -22,8 +22,8 @@ namespace qmcplusplus
 OrbitalImages::OrbitalImages(ParticleSet& P,
                              const PSPool& PSP,
                              Communicate* mpicomm,
-                             const TrialWaveFunction& psi)
-    : psetpool(PSP), psi_(psi)
+                             const SPOMap& spomap)
+    : psetpool(PSP), spomap_(spomap)
 {
   //keep the electron particle to get the cell later, if necessary
   Peln = &P;
@@ -57,7 +57,7 @@ OrbitalImages::OrbitalImages(const OrbitalImages& other)
       batch_gradients(other.batch_gradients),
       batch_laplacians(other.batch_laplacians),
       orbital(other.orbital),
-      psi_(other.psi_)
+      spomap_(other.spomap_)
 {
   for (auto& element : other.sposets)
     sposets.push_back(element->makeClone());
@@ -214,7 +214,11 @@ bool OrbitalImages::put(xmlNodePtr cur)
     APP_ABORT("OrbitalImages::put  must have at least one sposet");
   for (int i = 0; i < sposet_names.size(); ++i)
   {
-    sposets.push_back(psi_.getSPOSet(sposet_names[i]).makeClone());
+    auto spo_it = spomap_.find(sposet_names[i]);
+    if (spo_it == spomap_.end())
+      throw std::runtime_error("OrbitalImages::put  sposet " + sposet_names[i] + " does not exist.");
+
+    sposets.push_back(spo_it->second->makeClone());
     auto& sposet = sposets.back();
     std::vector<int>& sposet_inds = (*sposet_indices)[i];
     if (sposet_inds.size() == 0)

--- a/src/QMCHamiltonians/OrbitalImages.cpp
+++ b/src/QMCHamiltonians/OrbitalImages.cpp
@@ -13,7 +13,6 @@
 
 #include "OrbitalImages.h"
 #include "OhmmsData/AttributeSet.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "Utilities/unit_conversion.h"
 
 

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -116,7 +116,7 @@ public:
   using GradVector  = SPOSet::GradVector;
   using Lattice_t   = ParticleSet::ParticleLayout;
   using PSPool      = std::map<std::string, std::unique_ptr<ParticleSet>>;
-
+  using SPOMap      = TrialWaveFunction::SPOMap;
 
   ///derivative types
   enum derivative_types_enum
@@ -216,7 +216,7 @@ public:
   std::vector<ValueType> orbital;
 
   //constructors
-  OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const TrialWaveFunction& psi);
+  OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const SPOMap& spomap);
   OrbitalImages(const OrbitalImages& other);
 
   //standard interface
@@ -271,7 +271,7 @@ public:
 
 private:
   /// reference to the sposet_builder_factory
-  const TrialWaveFunction& psi_;
+  const SPOMap& spomap_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -16,7 +16,6 @@
 
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCWaveFunctions/SPOSet.h"
-#include "QMCWaveFunctions/WaveFunctionFactory.h"
 
 namespace qmcplusplus
 {
@@ -116,7 +115,6 @@ public:
   using GradVector  = SPOSet::GradVector;
   using Lattice_t   = ParticleSet::ParticleLayout;
   using PSPool      = std::map<std::string, std::unique_ptr<ParticleSet>>;
-  using SPOMap      = TrialWaveFunction::SPOMap;
 
   ///derivative types
   enum derivative_types_enum
@@ -170,7 +168,7 @@ public:
   ///indices of orbitals within each sposet to evaluate
   const std::shared_ptr<std::vector<std::vector<int>>> sposet_indices;
 
-  ///sposets obtained by name from WaveFunctionFactory
+  ///sposets obtained by name from SPOMap
   std::vector<std::unique_ptr<SPOSet>> sposets;
 
   ///evaluate points at grid cell centers instead of edges

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -216,7 +216,7 @@ public:
   std::vector<ValueType> orbital;
 
   //constructors
-  OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const WaveFunctionFactory& factory);
+  OrbitalImages(ParticleSet& P, const PSPool& PSP, Communicate* mpicomm, const TrialWaveFunction& psi);
   OrbitalImages(const OrbitalImages& other);
 
   //standard interface
@@ -271,7 +271,7 @@ public:
 
 private:
   /// reference to the sposet_builder_factory
-  const WaveFunctionFactory& wf_factory_;
+  const TrialWaveFunction& psi_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -58,7 +58,7 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = WaveFunctionFactory::buildEmptyTWFForTesting();
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting("psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
@@ -110,7 +110,7 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = WaveFunctionFactory::buildEmptyTWFForTesting();
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting("psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -15,6 +15,7 @@
 #include "Configuration.h"
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
+#include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCHamiltonians/HamiltonianFactory.h"
 
 namespace qmcplusplus
@@ -56,10 +57,8 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
-
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
+  psi_map["psi0"] = WaveFunctionFactory::buildEmptyTWFForTesting();
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
@@ -110,10 +109,8 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
-
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
+  psi_map["psi0"] = WaveFunctionFactory::buildEmptyTWFForTesting();
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,8 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
 
   WaveFunctionPool wfp(pp, c);
 
-  WaveFunctionFactory* wf_factory = new WaveFunctionFactory("psi0", *pp.getParticleSet("e"), pp.getPool(), c);
-  wfp.addFactory(wf_factory, true);
+  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(), true);
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,7 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
 
   WaveFunctionPool wfp(pp, c);
 
-  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(), true);
+  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting("psi0"), true);
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
 
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = wff.buildTWF(wfroot);
+  psi_map.emplace("psi0", wff.buildTWF(wfroot));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -308,7 +308,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
 
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = wff.buildTWF(wfroot);
+  psi_map.emplace("psi0", wff.buildTWF(wfroot));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -475,7 +475,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
 
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = wff.buildTWF(wfroot);
+  psi_map.emplace("psi0", wff.buildTWF(wfroot));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -613,7 +613,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
 
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = wff.buildTWF(wfroot);
+  psi_map.emplace("psi0", wff.buildTWF(wfroot));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -755,7 +755,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
 
   WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = wff.buildTWF(root2);
+  psi_map.emplace("psi0", wff.buildTWF(root2));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -132,21 +132,20 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  HamiltonianFactory::PsiPoolType psi_map;
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
-
   WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
-  psi_map["psi0"] = &wff;
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.wfnoj.xml");
   REQUIRE(wfokay);
 
   xmlNodePtr wfroot = wfdoc.getRoot();
-  wff.put(wfroot);
+  HamiltonianFactory::PsiPoolType psi_map;
+  psi_map["psi0"] = wff.buildTWF(wfroot);
 
-  TrialWaveFunction* psi = wff.getTWF();
+  TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
+
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
   //Output of WFTester Eloc test for this ion/electron configuration.
   //Logpsi: (-1.4233853149e+01,0.0000000000e+00)
@@ -302,20 +301,19 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
   WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
-  HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
-
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.wfj.xml");
   REQUIRE(wfokay);
 
   xmlNodePtr wfroot = wfdoc.getRoot();
-  wff.put(wfroot);
+  HamiltonianFactory::PsiPoolType psi_map;
+  psi_map["psi0"] = wff.buildTWF(wfroot);
 
-  TrialWaveFunction* psi = wff.getTWF();
+  TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
+
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
   //Output of WFTester Eloc test for this ion/electron configuration.
   //  Logpsi: (-8.945509461103977600e+00,0.000000000000000000e+00)
@@ -471,20 +469,18 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
 
   WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
 
-  HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
-
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
-
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.msd-wfnoj.xml");
   REQUIRE(wfokay);
 
   xmlNodePtr wfroot = wfdoc.getRoot();
-  wff.put(wfroot);
+  HamiltonianFactory::PsiPoolType psi_map;
+  psi_map["psi0"] = wff.buildTWF(wfroot);
 
-  TrialWaveFunction* psi = wff.getTWF();
+  TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
+
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
   //Output of WFTester Eloc test for this ion/electron configuration.
   //Logpsi: (-1.411499619826623686e+01,0.000000000000000000e+00)
@@ -611,20 +607,18 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
 
   WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
 
-  HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
-
-  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
-
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.msd-wfj.xml");
   REQUIRE(wfokay);
 
   xmlNodePtr wfroot = wfdoc.getRoot();
-  wff.put(wfroot);
+  HamiltonianFactory::PsiPoolType psi_map;
+  psi_map["psi0"] = wff.buildTWF(wfroot);
 
-  TrialWaveFunction* psi = wff.getTWF();
+  TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
+
+  HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
   //Output of WFTester Eloc test for this ion/electron configuration.
   //Logpsi: (-8.693299948465634586e+00,0.000000000000000000e+00)
@@ -760,13 +754,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
   WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
-
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map["psi0"] = &wff;
+  psi_map["psi0"] = wff.buildTWF(root2);
 
-  wff.put(root2);
-
-  TrialWaveFunction* psi = wff.getTWF();
+  TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
   //end incantation
 

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -132,7 +132,7 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.wfnoj.xml");
@@ -300,7 +300,7 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.wfj.xml");
@@ -467,7 +467,7 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.msd-wfnoj.xml");
@@ -605,7 +605,7 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   Libxml2Document wfdoc;
   bool wfokay = wfdoc.parse("cn.msd-wfj.xml");
@@ -753,7 +753,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
   psi_map["psi0"] = wff.buildTWF(root2);
 
@@ -1007,7 +1007,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
   psi_map["psi0"] = &wff;
 
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
@@ -1192,7 +1192,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
   psi_map["psi0"] = &wff;
 
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \
@@ -1347,7 +1347,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
   psi_map["psi0"] = &wff;
 
   const char* hamiltonian_xml = "<hamiltonian name=\"h0\" type=\"generic\" target=\"e\"> \

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -197,7 +197,7 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
   auto spo_now = std::make_unique<CompositeSPOSet>();
   for (int i = 0; i < spolist.size(); ++i)
   {
-    SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
+    const SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);
     if (spo)
       spo_now->add(spo->makeClone());
   }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -196,7 +196,7 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
 
       for (int grp = 0; grp < nGroups; grp++)
       {
-        SPOSetPtr spo_tmp = sposet_builder_factory_.getSPOSet(spoNames[grp]);
+        const SPOSet* spo_tmp = sposet_builder_factory_.getSPOSet(spoNames[grp]);
         if (spo_tmp == nullptr)
         {
           std::stringstream err_msg;
@@ -346,7 +346,7 @@ std::unique_ptr<DiracDeterminantBase> SlaterDetBuilder::putDeterminant(
                 << std::endl;
   app_summary() << std::endl;
 
-  SPOSetPtr psi = sposet_builder_factory_.getSPOSet(sposet_name);
+  const SPOSet* psi = sposet_builder_factory_.getSPOSet(sposet_name);
   //check if the named sposet exists
   if (psi == 0)
   {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.cpp
@@ -42,7 +42,7 @@
 
 namespace qmcplusplus
 {
-SPOSet* SPOSetBuilderFactory::getSPOSet(const std::string& name) const
+const SPOSet* SPOSetBuilderFactory::getSPOSet(const std::string& name) const
 {
   if (auto spoit = sposets.find(name); spoit == sposets.end())
   {

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -43,7 +43,7 @@ public:
    *  only use in serial portion of execution
    *  ie during initialization prior to threaded code
    */
-  SPOSet* getSPOSet(const std::string& name) const;
+  const SPOSet* getSPOSet(const std::string& name) const;
 
   void buildSPOSetCollection(xmlNodePtr cur);
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -25,6 +25,7 @@ namespace qmcplusplus
 class SPOSetBuilderFactory : public MPIObjectBase
 {
 public:
+  using SPOMap = std::map<std::string, std::unique_ptr<SPOSet>>;
   using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
 
   /** constructor
@@ -53,6 +54,8 @@ public:
    */
   void addSPOSet(std::unique_ptr<SPOSet>);
 
+  SPOMap&& exportSPOSets() { return std::move(sposets); }
+
 private:
   ///reference to the target particle
   ParticleSet& targetPtcl;
@@ -61,7 +64,7 @@ private:
   const PSetMap& ptclPool;
 
   /// list of all sposets created by the builders of this factory
-  std::map<std::string, std::unique_ptr<SPOSet>> sposets;
+  SPOMap sposets;
 
   static std::string basisset_tag;
 };

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -25,7 +25,7 @@ namespace qmcplusplus
 class SPOSetBuilderFactory : public MPIObjectBase
 {
 public:
-  using SPOMap = std::map<std::string, std::unique_ptr<SPOSet>>;
+  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
   using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
 
   /** constructor

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -26,7 +26,7 @@ class SPOSetScanner
 {
 public:
   using PtclPool    = std::map<std::string, std::unique_ptr<ParticleSet>>;
-  using SPOSetMap   = std::map<std::string, std::unique_ptr<SPOSet>>;
+  using SPOSetMap   = std::map<std::string, const std::unique_ptr<const SPOSet>>;
   using RealType    = QMCTraits::RealType;
   using ValueType   = QMCTraits::ValueType;
   using ValueVector = OrbitalSetTraits<ValueType>::ValueVector;
@@ -89,7 +89,8 @@ public:
         {
           app_log() << "    Scanning a " << cname << " called " << trace_name << " and writing to "
                     << prefix + "_v/g/l/report.dat" << std::endl;
-          scan_path(cur, *sposet, prefix);
+          auto spo = sposet->makeClone();
+          scan_path(cur, *spo, prefix);
         }
         else
         {

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -42,8 +42,10 @@ typedef enum
 static const std::vector<std::string> suffixes{"V",         "VGL",    "accept", "NLratio",
                                                "recompute", "buffer", "derivs", "preparegroup"};
 
-TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, bool create_local_resource)
-    : myName(aname),
+TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking)
+    : myNode_(NULL),
+      spomap_(std::make_shared<SPOMap>()),
+      myName(aname),
       BufferCursor(0),
       BufferCursor_scalar(0),
       PhaseValue(0.0),
@@ -67,7 +69,11 @@ TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking, boo
 *@warning Have not decided whether Z is cleaned up by TrialWaveFunction
 *  or not. It will depend on I/O implementation.
 */
-TrialWaveFunction::~TrialWaveFunction() {}
+TrialWaveFunction::~TrialWaveFunction()
+{
+  if (myNode_ != NULL)
+    xmlFreeNode(myNode_);
+}
 
 void TrialWaveFunction::startOptimization()
 {
@@ -101,6 +107,13 @@ void TrialWaveFunction::addComponent(std::unique_ptr<WaveFunctionComponent>&& at
   Z.emplace_back(std::move(aterm));
 }
 
+SPOSet& TrialWaveFunction::getSPOSet(const std::string& name) const
+{
+  auto spoit = spomap_->find(name);
+  if (spoit == spomap_->end())
+    throw std::runtime_error("SPOSet " + name + " cannot be found!");
+  return *spoit->second;
+}
 
 /** return log(|psi|)
 *
@@ -1166,7 +1179,7 @@ void TrialWaveFunction::reset() {}
 
 std::unique_ptr<TrialWaveFunction> TrialWaveFunction::makeClone(ParticleSet& tqp) const
 {
-  auto myclone                 = std::make_unique<TrialWaveFunction>(myName, use_tasking_, false);
+  auto myclone                 = std::make_unique<TrialWaveFunction>(myName, use_tasking_);
   myclone->BufferCursor        = BufferCursor;
   myclone->BufferCursor_scalar = BufferCursor_scalar;
   for (int i = 0; i < Z.size(); ++i)

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -107,7 +107,7 @@ void TrialWaveFunction::addComponent(std::unique_ptr<WaveFunctionComponent>&& at
   Z.emplace_back(std::move(aterm));
 }
 
-SPOSet& TrialWaveFunction::getSPOSet(const std::string& name) const
+const SPOSet& TrialWaveFunction::getSPOSet(const std::string& name) const
 {
   auto spoit = spomap_->find(name);
   if (spoit == spomap_->end())

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -42,7 +42,7 @@ typedef enum
 static const std::vector<std::string> suffixes{"V",         "VGL",    "accept", "NLratio",
                                                "recompute", "buffer", "derivs", "preparegroup"};
 
-TrialWaveFunction::TrialWaveFunction(const std::string& aname, bool tasking)
+TrialWaveFunction::TrialWaveFunction(const std::string_view aname, bool tasking)
     : myNode_(NULL),
       spomap_(std::make_shared<SPOMap>()),
       myName(aname),

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -543,9 +543,14 @@ public:
 
   xmlNodePtr getNode() const { return myNode_; }
 
+  /// store an SPOSet map
   void storeSPOMap(SPOMap&& spomap) { *spomap_ = std::move(spomap); }
 
+  /// look up SPOSet named 'name', if not found, throw exception.
   const SPOSet& getSPOSet(const std::string& name) const;
+
+  /// spomap_ reference accessor
+  const SPOMap& getSPOMap() const { return *spomap_; }
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -74,6 +74,8 @@ public:
   using LogValueType     = WaveFunctionComponent::LogValueType;
   using PsiValueType     = WaveFunctionComponent::PsiValueType;
 
+  using SPOMap = std::map<std::string, std::unique_ptr<SPOSet>>;
+
 #ifdef QMC_CUDA
   using CTS          = CUDAGlobalTypes;
   using RealMatrix_t = WaveFunctionComponent::RealMatrix_t;
@@ -95,7 +97,7 @@ public:
   ///differential laplacians
   ParticleSet::ParticleLaplacian L;
 
-  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false, bool create_local_resource = true);
+  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false);
 
   // delete copy constructor
   TrialWaveFunction(const TrialWaveFunction&) = delete;
@@ -537,8 +539,22 @@ public:
 
   bool use_tasking() const { return use_tasking_; }
 
+  void storeXMLNode(xmlNodePtr node) { myNode_ = xmlCopyNode(node, 1); }
+
+  xmlNodePtr getNode() const { return myNode_; }
+
+  void storeSPOMap(SPOMap&& spomap) { *spomap_ = std::move(spomap); }
+
+  SPOSet& getSPOSet(const std::string& name) const;
+
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
+
+  ///input node for a many-body wavefunction
+  xmlNodePtr myNode_;
+
+  ///Owned SPOSets
+  const std::shared_ptr<SPOMap> spomap_;
 
   ///getName is in the way
   const std::string myName;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -74,7 +74,7 @@ public:
   using LogValueType     = WaveFunctionComponent::LogValueType;
   using PsiValueType     = WaveFunctionComponent::PsiValueType;
 
-  using SPOMap = std::map<std::string, std::unique_ptr<SPOSet>>;
+  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
 
 #ifdef QMC_CUDA
   using CTS          = CUDAGlobalTypes;
@@ -97,7 +97,7 @@ public:
   ///differential laplacians
   ParticleSet::ParticleLaplacian L;
 
-  TrialWaveFunction(const std::string& aname = "psi0", bool tasking = false);
+  TrialWaveFunction(const std::string_view aname = "psi0", bool tasking = false);
 
   // delete copy constructor
   TrialWaveFunction(const TrialWaveFunction&) = delete;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -545,15 +545,18 @@ public:
 
   void storeSPOMap(SPOMap&& spomap) { *spomap_ = std::move(spomap); }
 
-  SPOSet& getSPOSet(const std::string& name) const;
+  const SPOSet& getSPOSet(const std::string& name) const;
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
 
-  ///input node for a many-body wavefunction
+  /** XML input node for a many-body wavefunction. Copied from the original one.
+   * WFOpt driver needs to look it up and make its own copies.
+   * YL: updating parameters in an XML file is extremely messy. Better to make WFOpt using h5 only.
+   */
   xmlNodePtr myNode_;
 
-  ///Owned SPOSets
+  /// Owned SPOSets. Once a TWF is fully built, SPOSet lookup should be done via TWF.
   const std::shared_ptr<SPOMap> spomap_;
 
   ///getName is in the way

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -49,19 +49,14 @@ public:
   ~WaveFunctionFactory();
 
   ///read from xmlNode
-  bool put(xmlNodePtr cur);
+  std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur);
+
+  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting() { return std::make_unique<TrialWaveFunction>("psi0"); }
+
   ///get xmlNode
   xmlNodePtr getNode() const { return myNode; }
-  ///get targetPsi
-  TrialWaveFunction* getTWF() const { return targetPsi.get(); }
-  ///get SPOSet
-  SPOSet* getSPOSet(const std::string& name) const { return sposet_builder_factory_.getSPOSet(name); }
 
 private:
-  /** process xmlNode to populate targetPsi
-   */
-  bool build(xmlNodePtr cur, bool buildtree = true);
-
   /** add Fermion wavefunction term */
   bool addFermionTerm(xmlNodePtr cur);
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -39,11 +39,9 @@ public:
    * @param c  communicator
    * @param c  using tasking inside TWF
    */
-  WaveFunctionFactory(const std::string& psiName,
-                      ParticleSet& qp,
+  WaveFunctionFactory(ParticleSet& qp,
                       const PSetMap& pset,
-                      Communicate* c,
-                      bool tasking = false);
+                      Communicate* c);
 
   ///destructor
   ~WaveFunctionFactory();
@@ -51,35 +49,18 @@ public:
   ///read from xmlNode
   std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur);
 
+  /// create an empty TrialWaveFunction for testing use.
   std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting() { return std::make_unique<TrialWaveFunction>("psi0"); }
-
-  ///get xmlNode
-  xmlNodePtr getNode() const { return myNode; }
 
 private:
   /** add Fermion wavefunction term */
-  bool addFermionTerm(xmlNodePtr cur);
-
-  /** add an OrbitalBuilder and the matching xml node
-   * @param b WaveFunctionComponentBuilder*
-   * @oaram cur xmlNode for b
-   * @return true if successful
-   */
-  bool addNode(std::unique_ptr<WaveFunctionComponentBuilder> b, xmlNodePtr cur);
+  bool addFermionTerm(TrialWaveFunction& psi, SPOSetBuilderFactory& spo_factory, xmlNodePtr cur);
 
   ///many-body wavefunction object
-  std::unique_ptr<TrialWaveFunction> targetPsi;
   ///target ParticleSet
   ParticleSet& targetPtcl;
   ///reference to the PSetMap
   const PSetMap& ptclPool;
-  ///input node for a many-body wavefunction
-  xmlNodePtr myNode;
-  ///builder tree
-  UPtrVector<WaveFunctionComponentBuilder> psiBuilder;
-
-  /// factory for all the sposet builders in this WF
-  SPOSetBuilderFactory sposet_builder_factory_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -39,9 +39,7 @@ public:
    * @param c  communicator
    * @param c  using tasking inside TWF
    */
-  WaveFunctionFactory(ParticleSet& qp,
-                      const PSetMap& pset,
-                      Communicate* c);
+  WaveFunctionFactory(ParticleSet& qp, const PSetMap& pset, Communicate* c);
 
   ///destructor
   ~WaveFunctionFactory();
@@ -50,7 +48,10 @@ public:
   std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur);
 
   /// create an empty TrialWaveFunction for testing use.
-  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting() { return std::make_unique<TrialWaveFunction>("psi0"); }
+  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting(const std::string_view name)
+  {
+    return std::make_unique<TrialWaveFunction>(name);
+  }
 
 private:
   /** add Fermion wavefunction term */

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -60,7 +60,7 @@ void WaveFunctionPool::addFactory(std::unique_ptr<TrialWaveFunction> psi, bool p
 
   if (primary)
     primary_psi_ = psi.get();
-  myPool[psi->getName()] = std::move(psi);
+  myPool.emplace(psi->getName(), std::move(psi));
 }
 
 xmlNodePtr WaveFunctionPool::getWaveFunctionNode(const std::string& id)

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -33,13 +33,10 @@ WaveFunctionPool::~WaveFunctionPool() = default;
 
 bool WaveFunctionPool::put(xmlNodePtr cur)
 {
-  std::string id("psi0"), target("e"), role("extra"), tasking;
+  std::string target("e"), role("extra");
   OhmmsAttributeSet pAttrib;
-  pAttrib.add(id, "id");
-  pAttrib.add(id, "name");
   pAttrib.add(target, "target");
   pAttrib.add(target, "ref");
-  pAttrib.add(tasking, "tasking", {"no", "yes"});
   pAttrib.add(role, "role");
   pAttrib.put(cur);
 
@@ -48,7 +45,7 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
   if (qp == nullptr)
     myComm->barrier_and_abort("target particle set named '" + target + "' not found");
 
-  WaveFunctionFactory psiFactory(id, *qp, ptcl_pool_.getPool(), myComm, tasking == "yes");
+  WaveFunctionFactory psiFactory(*qp, ptcl_pool_.getPool(), myComm);
   auto psi = psiFactory.buildTWF(cur);
   addFactory(std::move(psi), myPool.empty() || role == "primary");
   return true;

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -37,7 +37,7 @@ class ParticleSet;
 class WaveFunctionPool : public MPIObjectBase
 {
 public:
-  using PoolType = std::map<std::string, WaveFunctionFactory*>;
+  using PoolType = std::map<std::string, std::unique_ptr<TrialWaveFunction>>;
 
   WaveFunctionPool(ParticleSetPool& pset_pool, Communicate* c, const char* aname = "wavefunction");
   WaveFunctionPool(const WaveFunctionPool&)            = delete;
@@ -60,12 +60,13 @@ public:
       if (myPool.empty())
         return nullptr;
       else
-        return (*(myPool.begin())).second->getTWF();
+        return myPool.begin()->second.get();
     }
     else
-      return (*pit).second->getTWF();
+      return pit->second.get();
   }
 
+/*
   WaveFunctionFactory* getWaveFunctionFactory(const std::string& pname)
   {
     if (auto pit(myPool.find(pname)); pit == myPool.end())
@@ -78,6 +79,7 @@ public:
     else
       return (*pit).second;
   }
+*/
 
   /** return a xmlNode containing Jastrow
    * @param id name of the wave function
@@ -90,9 +92,9 @@ public:
    */
   inline const PoolType& getPool() const { return myPool; }
 
-  /** add a WaveFunctionFactory* to myPool
+  /** add a TrialWaveFunction* to myPool
    */
-  void addFactory(WaveFunctionFactory* psifac, bool primary);
+  void addFactory(std::unique_ptr<TrialWaveFunction> psi, bool primary);
 
 private:
   /// pointer to the primary TrialWaveFunction

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -66,21 +66,6 @@ public:
       return pit->second.get();
   }
 
-/*
-  WaveFunctionFactory* getWaveFunctionFactory(const std::string& pname)
-  {
-    if (auto pit(myPool.find(pname)); pit == myPool.end())
-    {
-      if (myPool.empty())
-        return nullptr;
-      else
-        return (*(myPool.begin())).second;
-    }
-    else
-      return (*pit).second;
-  }
-*/
-
   /** return a xmlNode containing Jastrow
    * @param id name of the wave function
    *

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -37,7 +37,7 @@ class ParticleSet;
 class WaveFunctionPool : public MPIObjectBase
 {
 public:
-  using PoolType = std::map<std::string, std::unique_ptr<TrialWaveFunction>>;
+  using PoolType = std::map<std::string, const std::unique_ptr<TrialWaveFunction>>;
 
   WaveFunctionPool(ParticleSetPool& pset_pool, Communicate* c, const char* aname = "wavefunction");
   WaveFunctionPool(const WaveFunctionPool&)            = delete;

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -30,17 +30,15 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto& pset             = *particle_pool.getParticleSet("e");
-  auto& wf_factory       = *wavefunction_pool.getWaveFunctionFactory("wavefunction");
+  auto& twf              = *wavefunction_pool.getWaveFunction("wavefunction");
 
   CompositeSPOSet comp_sposet;
 
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
   for (auto sposet_str : sposets)
   {
-    SPOSet* sposet = wf_factory.getSPOSet(sposet_str);
-    if (sposet == 0)
-      throw std::runtime_error("MinimalWaveFunctionPool sposet " + sposet_str + " does not exist");
-    comp_sposet.add(sposet->makeClone());
+    auto& sposet = twf.getSPOSet(sposet_str);
+    comp_sposet.add(sposet.makeClone());
   }
   CHECK(comp_sposet.size() == 8);
 

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -79,7 +79,7 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
@@ -179,7 +179,7 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
@@ -276,7 +276,7 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow"
 
   // update all distance tables
   elec_.update();
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -80,8 +80,8 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(jas1);
-  auto& twf(*wf_factory.getTWF());
+  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
@@ -180,8 +180,8 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(jas1);
-  auto& twf(*wf_factory.getTWF());
+  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);
@@ -277,8 +277,8 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow"
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(jas1);
-  auto& twf(*wf_factory.getTWF());
+  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -81,8 +81,8 @@ TEST_CASE("J1 spin evaluate derivatives Jastrow", "[wavefunction]")
   REQUIRE(okay);
   xmlNodePtr jas1 = doc.getRoot();
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(jas1);
-  auto& twf(*wf_factory.getTWF());
+  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   auto& twf_component_list = twf.getOrbitals();
   auto cloned_j1spin       = twf_component_list[0]->makeClone(elec_);

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -80,7 +80,7 @@ TEST_CASE("J1 spin evaluate derivatives Jastrow", "[wavefunction]")
   bool okay = doc.parseFromString(jasxml);
   REQUIRE(okay);
   xmlNodePtr jas1 = doc.getRoot();
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
 
   elec.addTable(ions);
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   const char* wavefunction_xml = "<wavefunction name=\"psi0\" target=\"e\">  \
      <jastrow name=\"Jee\" type=\"Two-Body\" function=\"pade\"> \

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -26,10 +26,9 @@
 
 namespace qmcplusplus
 {
-void setup_He_wavefunction(Communicate* c,
+std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
                            ParticleSet& elec,
                            ParticleSet& ions,
-                           std::unique_ptr<WaveFunctionFactory>& wff,
                            const WaveFunctionFactory::PSetMap& particle_set_map)
 {
   std::vector<int> agroup(2);
@@ -70,7 +69,7 @@ void setup_He_wavefunction(Communicate* c,
 
   elec.addTable(ions);
 
-  wff = std::make_unique<WaveFunctionFactory>("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
 
   const char* wavefunction_xml = "<wavefunction name=\"psi0\" target=\"e\">  \
      <jastrow name=\"Jee\" type=\"Two-Body\" function=\"pade\"> \
@@ -107,10 +106,12 @@ void setup_He_wavefunction(Communicate* c,
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  wff->put(root);
+  auto twf_ptr = wff.buildTWF(root);
 
-  REQUIRE(wff->getTWF() != nullptr);
-  REQUIRE(wff->getTWF()->size() == 2);
+  REQUIRE(twf_ptr != nullptr);
+  REQUIRE(twf_ptr->size() == 2);
+
+  return twf_ptr;
 }
 
 #ifndef QMC_CUDA
@@ -131,10 +132,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
-  std::unique_ptr<WaveFunctionFactory> wff;
-
-  setup_He_wavefunction(c, elec, ions, wff, particle_set_map);
-  TrialWaveFunction& psi(*wff->getTWF());
+  auto psi_ptr = setup_He_wavefunction(c, elec, ions, particle_set_map);
+  TrialWaveFunction& psi(*psi_ptr);
 
   ions.update();
   elec.update();
@@ -237,12 +236,11 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec1_ptr->getName(), std::move(elec1_ptr));
 
-  std::unique_ptr<WaveFunctionFactory> wff;
   // This He wavefunction has two components
   // The orbitals are fixed and have not optimizable parameters.
   // The Jastrow factor does have an optimizable parameter.
-  setup_He_wavefunction(c, elec1, ions, wff, particle_set_map);
-  TrialWaveFunction& psi(*wff->getTWF());
+  auto psi_ptr = setup_He_wavefunction(c, elec1, ions, particle_set_map);
+  TrialWaveFunction& psi(*psi_ptr);
   ions.update();
   elec1.update();
 

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -85,12 +85,12 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  wff.put(root);
+  auto twf_ptr = wff.buildTWF(root);
 
-  REQUIRE(wff.getTWF() != nullptr);
-  REQUIRE(wff.getTWF()->size() == 1);
+  REQUIRE(twf_ptr != nullptr);
+  REQUIRE(twf_ptr->size() == 1);
 
-  auto& base_example_he = wff.getTWF()->getOrbitals()[0];
+  auto& base_example_he = twf_ptr->getOrbitals()[0];
   REQUIRE(base_example_he != nullptr);
 
   ExampleHeComponent* example_he = dynamic_cast<ExampleHeComponent*>(base_example_he.get());
@@ -106,7 +106,6 @@ TEST_CASE("ExampleHe", "[wavefunction]")
 
   // Set the base expectations for wavefunction value and derivatives
   LogValueType logpsi = example_he->evaluateLog(elec, all_grad, all_lap);
-
 
   // Comparisons are performed at a single set of electron coordinates.  This should be expanded.
 

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -73,7 +73,7 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
 
-  WaveFunctionFactory wff("psi0", elec, particle_set_map, c);
+  WaveFunctionFactory wff(elec, particle_set_map, c);
 
   const char* wavefunction_xml = "<wavefunction> \
   <example_he name=\"mine\" source=\"ion0\"> \

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -80,7 +80,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);
@@ -371,7 +371,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -81,17 +81,16 @@ void test_LiH_msd(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet(check_sponame));
-  REQUIRE(spo_ptr != nullptr);
-  CHECK(spo_ptr->getOrbitalSetSize() == check_spo_size);
-  CHECK(spo_ptr->getBasisSetSize() == check_basisset_size);
+  auto& spo = twf_ptr->getSPOSet(check_sponame);
+  CHECK(spo.getOrbitalSetSize() == check_spo_size);
+  CHECK(spo.getBasisSetSize() == check_basisset_size);
 
   ions_.update();
   elec_.update();
 
-  auto& twf(*wf_factory.getTWF());
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 
@@ -373,17 +372,16 @@ void test_Bi_msd(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet(check_sponame));
-  REQUIRE(spo_ptr != nullptr);
-  CHECK(spo_ptr->getOrbitalSetSize() == check_spo_size);
-  CHECK(spo_ptr->getBasisSetSize() == check_basisset_size);
+  auto& spo = twf_ptr->getSPOSet(check_sponame);
+  CHECK(spo.getOrbitalSetSize() == check_spo_size);
+  CHECK(spo.getBasisSetSize() == check_basisset_size);
 
   ions_.update();
   elec_.update();
 
-  auto& twf(*wf_factory.getTWF());
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 

--- a/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
@@ -183,8 +183,8 @@ TEST_CASE("Pade2 Jastrow", "[wavefunction]")
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(jas1);
-  auto& twf(*wf_factory.getTWF());
+  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
   twf.prepareGroup(elec_, 0);

--- a/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
@@ -182,7 +182,7 @@ TEST_CASE("Pade2 Jastrow", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(jas1);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -65,7 +65,7 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   std::unique_ptr<SPOSet> sposet(twf_ptr->getSPOSet("spo").makeClone());

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -66,11 +66,9 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet("spo"));
-  REQUIRE(spo_ptr);
-  std::unique_ptr<SPOSet> sposet(spo_ptr->makeClone());
+  std::unique_ptr<SPOSet> sposet(twf_ptr->getSPOSet("spo").makeClone());
 
   SPOSet::ValueVector values;
   SPOSet::GradVector dpsi;

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -69,7 +69,7 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);
@@ -247,7 +247,7 @@ void test_LiH_msd_xml_input_with_positron(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -70,12 +70,11 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet(check_sponame));
-  REQUIRE(spo_ptr != nullptr);
-  REQUIRE(spo_ptr->getOrbitalSetSize() == check_spo_size);
-  REQUIRE(spo_ptr->getBasisSetSize() == check_basisset_size);
+  auto& spo = twf_ptr->getSPOSet(check_sponame);
+  REQUIRE(spo.getOrbitalSetSize() == check_spo_size);
+  REQUIRE(spo.getBasisSetSize() == check_basisset_size);
 }
 
 TEST_CASE("SPO input spline from xml LiH_msd", "[wavefunction]")
@@ -249,12 +248,11 @@ void test_LiH_msd_xml_input_with_positron(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet(check_sponame));
-  REQUIRE(spo_ptr != nullptr);
-  REQUIRE(spo_ptr->getOrbitalSetSize() == check_spo_size);
-  REQUIRE(spo_ptr->getBasisSetSize() == check_basisset_size);
+  auto& spo = twf_ptr->getSPOSet(check_sponame);
+  REQUIRE(spo.getOrbitalSetSize() == check_spo_size);
+  REQUIRE(spo.getBasisSetSize() == check_basisset_size);
 }
 
 TEST_CASE("SPO input spline from xml LiH_msd arbitrary species", "[wavefunction]")

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -87,7 +87,7 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
+  WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
   auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
   std::unique_ptr<SPOSet> spo(twf_ptr->getSPOSet("spo").makeClone());

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -88,11 +88,9 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory("psi0", elec_, ptcl.getPool(), c);
-  wf_factory.put(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml);
 
-  SPOSet* spo_ptr(wf_factory.getSPOSet("spo"));
-  REQUIRE(spo_ptr);
-  std::unique_ptr<SPOSet> spo(spo_ptr->makeClone());
+  std::unique_ptr<SPOSet> spo(twf_ptr->getSPOSet("spo").makeClone());
 
   // for vgl
   SPOSet::ValueMatrix psiM(elec_.R.size(), spo->getOrbitalSetSize());

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -43,7 +43,7 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   WaveFunctionFactory::PSetMap particle_set_map;
   particle_set_map.emplace("e", std::move(qp));
 
-  WaveFunctionFactory wff("psi0", *particle_set_map["e"], particle_set_map, c);
+  WaveFunctionFactory wff(*particle_set_map["e"], particle_set_map, c);
 
   const char* wavefunction_xml = "<wavefunction> \
          <jastrow type=\"Two-Body\" name=\"J2\" function=\"bspline\" print=\"yes\" gpu=\"no\"> \

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -60,12 +60,12 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  wff.put(root);
+  auto twf_ptr = wff.buildTWF(root);
 
-  REQUIRE(wff.getTWF() != nullptr);
-  REQUIRE(wff.getTWF()->size() == 1);
+  REQUIRE(twf_ptr != nullptr);
+  REQUIRE(twf_ptr->size() == 1);
 
-  auto& j2_base = wff.getTWF()->getOrbitals()[0];
+  auto& j2_base = twf_ptr->getOrbitals()[0];
   REQUIRE(j2_base != nullptr);
 }
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes
Previously. `WaveFunctionPool` holds a map of `WaveFunctionFactory*`, I think the reason to keep WaveFunctionFactory around was to keep SPOSetBuilderFactory around to access SPOSets. This is over complicated.
This PR changes WaveFunctionPool to own a map of `TrialWaveFunction*` and `WaveFunctionFactory` is only short-lived to build `TrialWaveFunction*`. Once the constructions finishes, All the SPOs will be transferred to TrialWaveFunction before WaveFunctionFactory got destroyed. In the current code, SPOSet are TWF specific and cannot be shared across two TWFs. For this reason, makes sense for TWF to own the map of pre-built SPOSets.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'