### PR TITLE
More const in ParticleSetPool.

### DIFF
--- a/src/Particle/ParticleSetPool.h
+++ b/src/Particle/ParticleSetPool.h
@@ -34,7 +34,7 @@ namespace qmcplusplus
 class ParticleSetPool : public MPIObjectBase
 {
 public:
-  using PoolType = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PoolType = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   /** constructor
    * @param aname xml tag

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -26,7 +26,7 @@ class EnergyDensityEstimator : public OperatorBase, public PtclOnLatticeTraits
 {
 public:
   using Point  = ReferencePoints::Point;
-  using PSPool = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSPool = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   EnergyDensityEstimator(const PSPool& PSP, const std::string& defaultKE);
   ~EnergyDensityEstimator() override;

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
 class HamiltonianFactory : public MPIObjectBase
 {
 public:
-  using PSetMap     = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap     = std::map<std::string, const std::unique_ptr<ParticleSet>>;
   using PsiPoolType = std::map<std::string, const std::unique_ptr<TrialWaveFunction>>;
 
   ///constructor

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -114,7 +114,7 @@ public:
   using ValueVector = SPOSet::ValueVector;
   using GradVector  = SPOSet::GradVector;
   using Lattice_t   = ParticleSet::ParticleLayout;
-  using PSPool      = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSPool      = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   ///derivative types
   enum derivative_types_enum

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -116,7 +116,7 @@ struct H5OrbSet
 class EinsplineSetBuilder : public SPOSetBuilder
 {
 public:
-  using PSetMap      = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap      = std::map<std::string, const std::unique_ptr<ParticleSet>>;
   using UnitCellType = CrystalLattice<ParticleSet::Scalar_t, DIM>;
 
   ///reference to the particleset pool

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.h
@@ -28,7 +28,7 @@ namespace qmcplusplus
 
 class EinsplineSpinorSetBuilder : public EinsplineSetBuilder
 {
-  using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
 public:
   ///constructor

--- a/src/QMCWaveFunctions/Fermion/BackflowBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowBuilder.h
@@ -36,7 +36,7 @@ class BackflowBuilder
   using RealType    = BackflowFunctionBase::RealType;
   using HandlerType = LRHandlerBase;
   using GridType    = LinearGrid<RealType>;
-  using PSetMap     = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap     = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
 public:
   BackflowBuilder(ParticleSet& p, const PSetMap& pool);

--- a/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
@@ -50,7 +50,7 @@ public:
 
   using HessArray = Array<HessType, 3>;
 
-  using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap = std::map<std::string, const std::unique_ptr<ParticleSet>>;
   //using GradArray_t = Array<GradType,3>      ;
   //using PosArray_t = Array<PosType,3>       ;
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -26,7 +26,7 @@ class SPOSetBuilderFactory : public MPIObjectBase
 {
 public:
   using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
-  using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   /** constructor
    * \param comm communicator

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -25,7 +25,7 @@ namespace qmcplusplus
 class SPOSetScanner
 {
 public:
-  using PtclPool    = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PtclPool    = std::map<std::string, const std::unique_ptr<ParticleSet>>;
   using SPOSetMap   = std::map<std::string, const std::unique_ptr<const SPOSet>>;
   using RealType    = QMCTraits::RealType;
   using ValueType   = QMCTraits::ValueType;

--- a/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBuilder.h
@@ -40,7 +40,7 @@ public:
   using ValueType = WaveFunctionComponent::ValueType;
   using PosType   = WaveFunctionComponent::PosType;
   using GradType  = WaveFunctionComponent::GradType;
-  using PSetMap   = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap   = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   /** \ingroup XMLTags
    *@{

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -30,7 +30,7 @@ namespace qmcplusplus
 class WaveFunctionFactory : public MPIObjectBase
 {
 public:
-  using PSetMap = std::map<std::string, std::unique_ptr<ParticleSet>>;
+  using PSetMap = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   /** constructor
    * @param psiName name for both the factory and psi

--- a/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
+++ b/src/QMCWaveFunctions/tests/test_lattice_gaussian.cpp
@@ -85,7 +85,7 @@ TEST_CASE("lattice gaussian", "[wavefunction]")
   elec.R[1][1] = 1.9679;
   elec.R[1][2] = -0.0128914;
 
-  std::map<string, std::unique_ptr<ParticleSet>> pp;
+  std::map<string, const std::unique_ptr<ParticleSet>> pp;
   pp.emplace(ions_ptr->getName(), std::move(ions_ptr));
   pp.emplace(elec_ptr->getName(), std::move(elec_ptr));
 


### PR DESCRIPTION
## Proposed changes
Pointers should be const once being added into the pool

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'