### PR TITLE
Fix h5o_info_t usage

### DIFF
--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -164,9 +164,12 @@ bool hdf_archive::is_group(const std::string& aname)
 
   if (H5Lexists(p, aname.c_str(), H5P_DEFAULT) > 0)
   {
+#if H5_VERSION_GE(1, 12, 0)
+    H5O_info2_t oinfo;
+#else
     H5O_info_t oinfo;
+#endif
     oinfo.type = H5O_TYPE_UNKNOWN;
-
 #if H5_VERSION_GE(1, 12, 0)
     H5Oget_info_by_name3(p, aname.c_str(), &oinfo, H5O_INFO_BASIC, H5P_DEFAULT);
 #else
@@ -190,7 +193,11 @@ hid_t hdf_archive::push(const std::string& gname, bool createit)
     return is_closed;
   hid_t p = group_id.empty() ? file_id : group_id.top();
 
+#if H5_VERSION_GE(1, 12, 0)
+  H5O_info2_t oinfo;
+#else
   H5O_info_t oinfo;
+#endif
   oinfo.type = H5O_TYPE_UNKNOWN;
   if (H5Lexists(p, gname.c_str(), H5P_DEFAULT) > 0)
   {


### PR DESCRIPTION
## Proposed changes

Update type for 1.12.0 API usage. Breaks build on some systems (discovered with macports), where the compiler will not convert between the old and new info types.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

mac laptop, sulfur (full deterministic tests)

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
