### PR TITLE
Add CoordsType templates to WaveFunctionComponents

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -108,9 +108,7 @@ void DMCBatched::advanceWalkers(const StateForThread& sft,
 
   MCCoords<CT> drifts(num_walkers), drifts_reverse(num_walkers);
   MCCoords<CT> walker_deltas(num_walkers * num_particles), deltas(num_walkers);
-  TWFGrads<CT> grads_now, grads_new;
-  grads_now.resize(num_walkers);
-  grads_new.resize(num_walkers);
+  TWFGrads<CT> grads_now(num_walkers), grads_new(num_walkers);
 
   //This generates an entire steps worth of deltas.
   makeGaussRandomWithEngine(walker_deltas, step_context.get_random_gen());

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -85,9 +85,7 @@ void VMCBatched::advanceWalkers(const StateForThread& sft,
 
   MCCoords<CT> drifts(num_walkers), drifts_reverse(num_walkers);
   MCCoords<CT> walker_deltas(num_walkers * num_particles), deltas(num_walkers);
-  TWFGrads<CT> grads_now, grads_new;
-  grads_now.resize(num_walkers);
-  grads_new.resize(num_walkers);
+  TWFGrads<CT> grads_now(num_walkers), grads_new(num_walkers);
 
   for (int sub_step = 0; sub_step < sft.qmcdrv_input.get_sub_steps(); sub_step++)
   {

--- a/src/QMCWaveFunctions/TWFGrads.cpp
+++ b/src/QMCWaveFunctions/TWFGrads.cpp
@@ -14,14 +14,6 @@
 namespace qmcplusplus
 {
 
-void TWFGrads<CoordsType::POS>::resize(const std::size_t size) { grads_positions.resize(size); }
-
-void TWFGrads<CoordsType::POS_SPIN>::resize(const std::size_t size)
-{
-  grads_positions.resize(size);
-  grads_spins.resize(size);
-}
-
 template struct TWFGrads<CoordsType::POS>;
 template struct TWFGrads<CoordsType::POS_SPIN>;
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/TWFGrads.cpp
+++ b/src/QMCWaveFunctions/TWFGrads.cpp
@@ -14,6 +14,8 @@
 
 namespace qmcplusplus
 {
+TWFGrads<CoordsType::POS>::TWFGrads(const std::size_t size) : grads_positions(size) {}
+
 TWFGrads<CoordsType::POS>& TWFGrads<CoordsType::POS>::operator+=(const TWFGrads<CoordsType::POS>& rhs)
 {
   assert(grads_positions.size() == rhs.grads_positions.size());
@@ -21,6 +23,8 @@ TWFGrads<CoordsType::POS>& TWFGrads<CoordsType::POS>::operator+=(const TWFGrads<
                  [](const QMCTraits::GradType& x, const QMCTraits::GradType& y) { return x + y; });
   return *this;
 }
+
+TWFGrads<CoordsType::POS_SPIN>::TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size) {}
 
 TWFGrads<CoordsType::POS_SPIN>& TWFGrads<CoordsType::POS_SPIN>::operator+=(const TWFGrads<CoordsType::POS_SPIN>& rhs)
 {

--- a/src/QMCWaveFunctions/TWFGrads.cpp
+++ b/src/QMCWaveFunctions/TWFGrads.cpp
@@ -10,9 +10,27 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "TWFGrads.hpp"
+#include <algorithm>
 
 namespace qmcplusplus
 {
+TWFGrads<CoordsType::POS>& TWFGrads<CoordsType::POS>::operator+=(const TWFGrads<CoordsType::POS>& rhs)
+{
+  assert(grads_positions.size() == rhs.grads_positions.size());
+  std::transform(grads_positions.begin(), grads_positions.end(), rhs.grads_positions.begin(), grads_positions.begin(),
+                 [](const QMCTraits::GradType& x, const QMCTraits::GradType& y) { return x + y; });
+  return *this;
+}
+
+TWFGrads<CoordsType::POS_SPIN>& TWFGrads<CoordsType::POS_SPIN>::operator+=(const TWFGrads<CoordsType::POS_SPIN>& rhs)
+{
+  assert(grads_positions.size() == rhs.grads_positions.size());
+  std::transform(grads_positions.begin(), grads_positions.end(), rhs.grads_positions.begin(), grads_positions.begin(),
+                 [](const QMCTraits::GradType& x, const QMCTraits::GradType& y) { return x + y; });
+  std::transform(grads_spins.begin(), grads_spins.end(), rhs.grads_spins.begin(), grads_spins.begin(),
+                 [](const QMCTraits::ComplexType& x, const QMCTraits::ComplexType& y) { return x + y; });
+  return *this;
+}
 
 template struct TWFGrads<CoordsType::POS>;
 template struct TWFGrads<CoordsType::POS_SPIN>;

--- a/src/QMCWaveFunctions/TWFGrads.hpp
+++ b/src/QMCWaveFunctions/TWFGrads.hpp
@@ -24,7 +24,7 @@ struct TWFGrads;
 template<>
 struct TWFGrads<CoordsType::POS>
 {
-  TWFGrads(const std::size_t size) : grads_positions(size) {};
+  TWFGrads(const std::size_t size) : grads_positions(size){};
 
   TWFGrads& operator+=(const TWFGrads& rhs);
 
@@ -34,7 +34,7 @@ struct TWFGrads<CoordsType::POS>
 template<>
 struct TWFGrads<CoordsType::POS_SPIN>
 {
-  TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size) {};
+  TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size){};
 
   TWFGrads& operator+=(const TWFGrads& rhs);
 

--- a/src/QMCWaveFunctions/TWFGrads.hpp
+++ b/src/QMCWaveFunctions/TWFGrads.hpp
@@ -24,7 +24,7 @@ struct TWFGrads;
 template<>
 struct TWFGrads<CoordsType::POS>
 {
-  TWFGrads(const std::size_t size) : grads_positions(size){};
+  TWFGrads(const std::size_t size); 
 
   TWFGrads& operator+=(const TWFGrads& rhs);
 
@@ -34,7 +34,7 @@ struct TWFGrads<CoordsType::POS>
 template<>
 struct TWFGrads<CoordsType::POS_SPIN>
 {
-  TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size){};
+  TWFGrads(const std::size_t size);
 
   TWFGrads& operator+=(const TWFGrads& rhs);
 

--- a/src/QMCWaveFunctions/TWFGrads.hpp
+++ b/src/QMCWaveFunctions/TWFGrads.hpp
@@ -26,6 +26,8 @@ struct TWFGrads<CoordsType::POS>
 {
   TWFGrads(const std::size_t size) : grads_positions(size) {};
 
+  TWFGrads& operator+=(const TWFGrads& rhs);
+
   std::vector<QMCTraits::GradType> grads_positions;
 };
 
@@ -33,6 +35,8 @@ template<>
 struct TWFGrads<CoordsType::POS_SPIN>
 {
   TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size) {};
+
+  TWFGrads& operator+=(const TWFGrads& rhs);
 
   std::vector<QMCTraits::GradType> grads_positions;
   std::vector<QMCTraits::ComplexType> grads_spins;

--- a/src/QMCWaveFunctions/TWFGrads.hpp
+++ b/src/QMCWaveFunctions/TWFGrads.hpp
@@ -24,7 +24,7 @@ struct TWFGrads;
 template<>
 struct TWFGrads<CoordsType::POS>
 {
-  TWFGrads(const std::size_t size); 
+  TWFGrads(const std::size_t size);
 
   TWFGrads& operator+=(const TWFGrads& rhs);
 

--- a/src/QMCWaveFunctions/TWFGrads.hpp
+++ b/src/QMCWaveFunctions/TWFGrads.hpp
@@ -24,7 +24,7 @@ struct TWFGrads;
 template<>
 struct TWFGrads<CoordsType::POS>
 {
-  void resize(const std::size_t size);
+  TWFGrads(const std::size_t size) : grads_positions(size) {};
 
   std::vector<QMCTraits::GradType> grads_positions;
 };
@@ -32,7 +32,7 @@ struct TWFGrads<CoordsType::POS>
 template<>
 struct TWFGrads<CoordsType::POS_SPIN>
 {
-  void resize(const std::size_t size);
+  TWFGrads(const std::size_t size) : grads_positions(size), grads_spins(size) {};
 
   std::vector<QMCTraits::GradType> grads_positions;
   std::vector<QMCTraits::ComplexType> grads_spins;

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -84,7 +84,7 @@ void TWFdispatcher::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& 
   else
   {
     const int num_wf = wf_list.size();
-    grads.resize(num_wf);
+    assert(grads.grads_positions.size() == wf_list.size());
     for (size_t iw = 0; iw < num_wf; iw++)
       if constexpr (CT == CoordsType::POS_SPIN)
         grads.grads_positions[iw] = wf_list[iw].evalGradWithSpin(p_list[iw], iat, grads.grads_spins[iw]);
@@ -107,7 +107,7 @@ void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFuncti
   {
     const int num_wf = wf_list.size();
     ratios.resize(num_wf);
-    grads.resize(num_wf);
+    assert(wf_list.size() == grads.grads_positions.size());
     for (size_t iw = 0; iw < num_wf; iw++)
       if constexpr (CT == CoordsType::POS_SPIN)
         ratios[iw] = wf_list[iw].calcRatioGradWithSpin(p_list[iw], iat, grads.grads_positions[iw], grads.grads_spins[iw]);

--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -110,7 +110,8 @@ void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFuncti
     assert(wf_list.size() == grads.grads_positions.size());
     for (size_t iw = 0; iw < num_wf; iw++)
       if constexpr (CT == CoordsType::POS_SPIN)
-        ratios[iw] = wf_list[iw].calcRatioGradWithSpin(p_list[iw], iat, grads.grads_positions[iw], grads.grads_spins[iw]);
+        ratios[iw] =
+            wf_list[iw].calcRatioGradWithSpin(p_list[iw], iat, grads.grads_positions[iw], grads.grads_spins[iw]);
       else
         ratios[iw] = wf_list[iw].calcRatioGrad(p_list[iw], iat, grads.grads_positions[iw]);
   }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -547,12 +547,12 @@ void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>
                                     TWFGrads<CT>& grads)
 {
   const int num_wf = wf_list.size();
-  grads = TWFGrads<CT>(num_wf); //ensure elements are set to zero
+  grads            = TWFGrads<CT>(num_wf); //ensure elements are set to zero
 
   auto& wf_leader = wf_list.getLeader();
   ScopedTimer local_timer(wf_leader.TWF_timers_[VGL_TIMER]);
   // Right now mw_evalGrad can only be called through an concrete instance of a wavefunctioncomponent
-  const int num_wfc = wf_leader.Z.size();
+  const int num_wfc             = wf_leader.Z.size();
   auto& wavefunction_components = wf_leader.Z;
 
   TWFGrads<CT> grads_z(num_wf);
@@ -649,10 +649,10 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGradWithSpin(ParticleSe
 
 template<CoordsType CT>
 void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                                 const RefVectorWithLeader<ParticleSet>& p_list,
-                                                 int iat,
-                                                 std::vector<PsiValueType>& ratios,
-                                                 TWFGrads<CT>& grad_new)
+                                         const RefVectorWithLeader<ParticleSet>& p_list,
+                                         int iat,
+                                         std::vector<PsiValueType>& ratios,
+                                         TWFGrads<CT>& grad_new)
 {
   const int num_wf = wf_list.size();
   ratios.resize(num_wf);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -423,27 +423,6 @@ public:
                           int iat,
                           TWFGrads<CT>& grads);
 
-  /** batched version of evalGrad
-    *
-    * This is static because it should have no direct access
-    * to any TWF.
-    */
-  static void mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list,
-                          int iat,
-                          std::vector<GradType>& grad_now);
-
-  /** batched version of evalGradWithSpin
-    *
-    * This is static because it should have no direct access
-    * to any TWF.
-    */
-  static void mw_evalGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                  const RefVectorWithLeader<ParticleSet>& p_list,
-                                  int iat,
-                                  std::vector<GradType>& grad_now,
-                                  std::vector<ComplexType>& spingrad_now);
-
   void rejectMove(int iat);
 
   void acceptMove(ParticleSet& P, int iat, bool safe_to_delay = false);

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -363,27 +363,6 @@ public:
                                std::vector<PsiValueType>& ratios,
                                TWFGrads<CT>& grads);
 
-  /** batched version of ratioGrad
-   *
-   *  all vector sizes must match
-   */
-  static void mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                               const RefVectorWithLeader<ParticleSet>& p_list,
-                               int iat,
-                               std::vector<PsiValueType>& ratios,
-                               std::vector<GradType>& grad_new);
-
-  /** batched version of ratioGradWithSpin
-   *
-   *  all vector sizes must match
-   */
-  static void mw_calcRatioGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                       int iat,
-                                       std::vector<PsiValueType>& ratios,
-                                       std::vector<GradType>& grad_new,
-                                       std::vector<ComplexType>& spingrad_new);
-
   /** Prepare internal data for updating WFC correspond to a particle group
    *  Particle groups usually correspond to determinants of different spins.
    *  This call can be used to handle precomputation for PbyP moves.

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -119,6 +119,19 @@ PsiValueType WaveFunctionComponent::ratioGrad(ParticleSet& P, int iat, GradType&
   return ValueType();
 }
 
+template<CoordsType CT>
+void WaveFunctionComponent::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                         const RefVectorWithLeader<ParticleSet>& p_list,
+                                         int iat,
+                                         std::vector<PsiValueType>& ratios,
+                                         TWFGrads<CT>& grad_new) const
+{
+  if constexpr (CT == CoordsType::POS_SPIN)
+    mw_ratioGradWithSpin(wfc_list, p_list, iat, ratios, grad_new.grads_positions, grad_new.grads_spins);
+  else
+    mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new.grads_positions);
+}
+
 void WaveFunctionComponent::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list,
                                          int iat,
@@ -241,5 +254,17 @@ template void WaveFunctionComponent::mw_evalGrad<CoordsType::POS_SPIN>(
     const RefVectorWithLeader<ParticleSet>& p_list,
     int iat,
     TWFGrads<CoordsType::POS_SPIN>& grad_now) const;
+template void WaveFunctionComponent::mw_ratioGrad<CoordsType::POS>(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    std::vector<PsiValueType>& ratios,
+    TWFGrads<CoordsType::POS>& grad_new) const;
+template void WaveFunctionComponent::mw_ratioGrad<CoordsType::POS_SPIN>(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    std::vector<PsiValueType>& ratios,
+    TWFGrads<CoordsType::POS_SPIN>& grad_new) const;
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -78,6 +78,18 @@ void WaveFunctionComponent::mw_prepareGroup(const RefVectorWithLeader<WaveFuncti
     wfc_list[iw].prepareGroup(p_list[iw], ig);
 }
 
+template<CoordsType CT>
+void WaveFunctionComponent::mw_evalGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                        const RefVectorWithLeader<ParticleSet>& p_list,
+                                        const int iat,
+                                        TWFGrads<CT>& grad_now) const
+{
+  if constexpr (CT == CoordsType::POS_SPIN)
+    mw_evalGradWithSpin(wfc_list, p_list, iat, grad_now.grads_positions, grad_now.grads_spins);
+  else
+    mw_evalGrad(wfc_list, p_list, iat, grad_now.grads_positions);
+}
+
 void WaveFunctionComponent::mw_evalGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                         const RefVectorWithLeader<ParticleSet>& p_list,
                                         int iat,
@@ -218,5 +230,16 @@ void WaveFunctionComponent::registerTWFFastDerivWrapper(const ParticleSet& P, TW
   o << "WaveFunctionComponent::registerTWFFastDerivWrapper is not implemented by " << ClassName;
   APP_ABORT(o.str());
 }
+
+template void WaveFunctionComponent::mw_evalGrad<CoordsType::POS>(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    TWFGrads<CoordsType::POS>& grad_now) const;
+template void WaveFunctionComponent::mw_evalGrad<CoordsType::POS_SPIN>(
+    const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    TWFGrads<CoordsType::POS_SPIN>& grad_now) const;
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionComponent.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.cpp
@@ -101,6 +101,18 @@ void WaveFunctionComponent::mw_evalGrad(const RefVectorWithLeader<WaveFunctionCo
     grad_now[iw] = wfc_list[iw].evalGrad(p_list[iw], iat);
 }
 
+void WaveFunctionComponent::mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                const RefVectorWithLeader<ParticleSet>& p_list,
+                                                int iat,
+                                                std::vector<GradType>& grad_now,
+                                                std::vector<ComplexType>& spingrad_now) const
+{
+  assert(this == &wfc_list.getLeader());
+#pragma omp parallel for
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    grad_now[iw] = wfc_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+}
+
 void WaveFunctionComponent::mw_calcRatio(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                                          const RefVectorWithLeader<ParticleSet>& p_list,
                                          int iat,
@@ -142,6 +154,19 @@ void WaveFunctionComponent::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionC
 #pragma omp parallel for
   for (int iw = 0; iw < wfc_list.size(); iw++)
     ratios[iw] = wfc_list[iw].ratioGrad(p_list[iw], iat, grad_new[iw]);
+}
+
+void WaveFunctionComponent::mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                                 const RefVectorWithLeader<ParticleSet>& p_list,
+                                                 int iat,
+                                                 std::vector<PsiValueType>& ratios,
+                                                 std::vector<GradType>& grad_new,
+                                                 std::vector<ComplexType>& spingrad_new) const
+{
+  assert(this == &wfc_list.getLeader());
+#pragma omp parallel for
+  for (int iw = 0; iw < wfc_list.size(); iw++)
+    ratios[iw] = wfc_list[iw].ratioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
 }
 
 void WaveFunctionComponent::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -264,20 +264,6 @@ public:
                            int iat,
                            std::vector<GradType>& grad_now) const;
 
-  /** compute the current gradients and spin gradients for the iat-th particle of multiple walkers
-   * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch
-   * @param p_list the list of ParticleSet pointers in a walker batch
-   * @param iat particle index
-   * @param grad_now the list of gradients in a walker batch, \f$\nabla\ln\Psi\f$
-   * @param spingrad_now the list of spin gradients in a walker batch, \f$\nabla_s\ln\Psi\f$
-   *
-   */
-  virtual void mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                   const RefVectorWithLeader<ParticleSet>& p_list,
-                                   int iat,
-                                   std::vector<GradType>& grad_now,
-                                   std::vector<ComplexType>& spingrad_now) const;
-
   /** return the logarithmic gradient for the iat-th particle
    * of the source particleset
    * @param Pquantum particle set
@@ -349,20 +335,6 @@ public:
                             int iat,
                             std::vector<PsiValueType>& ratios,
                             std::vector<GradType>& grad_new) const;
-
-  /** compute the ratio of the new to old WaveFunctionComponent value and the new gradient/spingradient of multiple walkers
-   * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch
-   * @param p_list the list of ParticleSet pointers in a walker batch
-   * @param iat particle index
-   * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
-   * @param grad_now the list of new gradients in a walker batch, \f$\nabla\ln\Psi\f$
-   */
-  virtual void mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                                    const RefVectorWithLeader<ParticleSet>& p_list,
-                                    int iat,
-                                    std::vector<PsiValueType>& ratios,
-                                    std::vector<GradType>& grad_new,
-                                    std::vector<ComplexType>& spingrad_new) const;
 
   /** a move for iat-th particle is accepted. Update the current content.
    * @param P target ParticleSet
@@ -746,6 +718,35 @@ public:
               ".\n Required CUDA functionality not implemented. Contact developers.\n");
   }
 #endif
+
+private:
+  /** compute the current gradients and spin gradients for the iat-th particle of multiple walkers
+   * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch
+   * @param p_list the list of ParticleSet pointers in a walker batch
+   * @param iat particle index
+   * @param grad_now the list of gradients in a walker batch, \f$\nabla\ln\Psi\f$
+   * @param spingrad_now the list of spin gradients in a walker batch, \f$\nabla_s\ln\Psi\f$
+   *
+   */
+  virtual void mw_evalGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                   int iat,
+                                   std::vector<GradType>& grad_now,
+                                   std::vector<ComplexType>& spingrad_now) const;
+
+  /** compute the ratio of the new to old WaveFunctionComponent value and the new gradient/spingradient of multiple walkers
+   * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch
+   * @param p_list the list of ParticleSet pointers in a walker batch
+   * @param iat particle index
+   * @param ratios the list of WF ratios of a walker batch, \f$ \Psi( \{ {\bf R}^{'} \} )/ \Psi( \{ {\bf R}\})\f$
+   * @param grad_now the list of new gradients in a walker batch, \f$\nabla\ln\Psi\f$
+   */
+  virtual void mw_ratioGradWithSpin(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                                    const RefVectorWithLeader<ParticleSet>& p_list,
+                                    int iat,
+                                    std::vector<PsiValueType>& ratios,
+                                    std::vector<GradType>& grad_new,
+                                    std::vector<ComplexType>& spingrad_new) const;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -333,6 +333,13 @@ public:
     return ratioGrad(P, iat, grad_iat);
   }
 
+  template<CoordsType CT>
+  void mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                            const RefVectorWithLeader<ParticleSet>& p_list,
+                            int iat,
+                            std::vector<PsiValueType>& ratios,
+                            TWFGrads<CT>& grad_new) const;
+
   /** compute the ratio of the new to old WaveFunctionComponent value and the new gradient of multiple walkers
    * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch
    * @param p_list the list of ParticleSet pointers in a walker batch

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -332,10 +332,10 @@ public:
 
   template<CoordsType CT>
   void mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                            const RefVectorWithLeader<ParticleSet>& p_list,
-                            int iat,
-                            std::vector<PsiValueType>& ratios,
-                            TWFGrads<CT>& grad_new) const;
+                    const RefVectorWithLeader<ParticleSet>& p_list,
+                    int iat,
+                    std::vector<PsiValueType>& ratios,
+                    TWFGrads<CT>& grad_new) const;
 
   /** compute the ratio of the new to old WaveFunctionComponent value and the new gradient of multiple walkers
    * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -27,6 +27,7 @@
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
 #include "Particle/MCWalkerConfiguration.h"
 #include "type_traits/template_types.hpp"
+#include "TWFGrads.hpp"
 #ifdef QMC_CUDA
 #include "type_traits/CUDATypes.h"
 #endif
@@ -234,6 +235,7 @@ public:
     return GradType();
   }
 
+
   /** return the current spin gradient for the iat-th particle
    * Default implementation assumes that WaveFunctionComponent does not explicitly depend on Spin.
    * @param P quantum particle set
@@ -241,6 +243,15 @@ public:
    * @return the spin gradient of the iat-th particle
    */
   virtual GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) { return evalGrad(P, iat); }
+
+  /** compute the current gradients for the iat-th particle of multiple walkers
+   * @param[out] grad_now the list of gradients in a walker batch, \f$\nabla\ln\Psi\f$
+   */
+  template<CoordsType CT>
+  void mw_evalGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
+                   const RefVectorWithLeader<ParticleSet>& p_list,
+                   const int iat,
+                   TWFGrads<CT>& grads_now) const;
 
   /** compute the current gradients for the iat-th particle of multiple walkers
    * @param wfc_list the list of WaveFunctionComponent pointers of the same component in a walker batch

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -276,10 +276,7 @@ public:
                                    const RefVectorWithLeader<ParticleSet>& p_list,
                                    int iat,
                                    std::vector<GradType>& grad_now,
-                                   std::vector<ComplexType>& spingrad_now) const
-  {
-    mw_evalGrad(wfc_list, p_list, iat, grad_now);
-  };
+                                   std::vector<ComplexType>& spingrad_now) const;
 
   /** return the logarithmic gradient for the iat-th particle
    * of the source particleset
@@ -365,10 +362,7 @@ public:
                                     int iat,
                                     std::vector<PsiValueType>& ratios,
                                     std::vector<GradType>& grad_new,
-                                    std::vector<ComplexType>& spingrad_new) const
-  {
-    mw_ratioGrad(wfc_list, p_list, iat, ratios, grad_new);
-  }
+                                    std::vector<ComplexType>& spingrad_new) const;
 
   /** a move for iat-th particle is accepted. Update the current content.
    * @param P target ParticleSet

--- a/src/QMCWaveFunctions/tests/test_TWFGrads.cpp
+++ b/src/QMCWaveFunctions/tests/test_TWFGrads.cpp
@@ -14,19 +14,79 @@
 
 namespace qmcplusplus
 {
-
 TEST_CASE("TWFGrads", "[QMCWaveFunctions]")
 {
   {
     constexpr auto CT = CoordsType::POS;
-    auto grads        = TWFGrads<CT>(7);
-    REQUIRE(grads.grads_positions.size() == 7);
+    auto grads        = TWFGrads<CT>(3);
+    REQUIRE(grads.grads_positions.size() == 3);
+
+    grads.grads_positions[0] = QMCTraits::GradType({0.1, 0.2, 0.3});
+    grads.grads_positions[1] = QMCTraits::GradType({0.4, 0.5, 0.6});
+    grads.grads_positions[2] = QMCTraits::GradType({0.7, 0.8, 0.9});
+
+    auto shift               = TWFGrads<CT>(3);
+    shift.grads_positions[0] = QMCTraits::GradType({1.0, 1.0, 1.0});
+    shift.grads_positions[1] = QMCTraits::GradType({1.0, 1.0, 1.0});
+    shift.grads_positions[2] = QMCTraits::GradType({1.0, 1.0, 1.0});
+
+    grads += shift;
+#ifdef QMC_COMPLEX
+    CHECK(grads.grads_positions[0][0] == ComplexApprox(QMCTraits::ValueType(1.1, 0.0)));
+    CHECK(grads.grads_positions[0][1] == ComplexApprox(QMCTraits::ValueType(1.2, 0.0)));
+    CHECK(grads.grads_positions[0][2] == ComplexApprox(QMCTraits::ValueType(1.3, 0.0)));
+    CHECK(grads.grads_positions[1][0] == ComplexApprox(QMCTraits::ValueType(1.4, 0.0)));
+    CHECK(grads.grads_positions[1][1] == ComplexApprox(QMCTraits::ValueType(1.5, 0.0)));
+    CHECK(grads.grads_positions[1][2] == ComplexApprox(QMCTraits::ValueType(1.6, 0.0)));
+    CHECK(grads.grads_positions[2][0] == ComplexApprox(QMCTraits::ValueType(1.7, 0.0)));
+    CHECK(grads.grads_positions[2][1] == ComplexApprox(QMCTraits::ValueType(1.8, 0.0)));
+    CHECK(grads.grads_positions[2][2] == ComplexApprox(QMCTraits::ValueType(1.9, 0.0)));
+#else
+    CHECK(grads.grads_positions[0][0] == Approx(1.1));
+    CHECK(grads.grads_positions[0][1] == Approx(1.2));
+    CHECK(grads.grads_positions[0][2] == Approx(1.3));
+    CHECK(grads.grads_positions[1][0] == Approx(1.4));
+    CHECK(grads.grads_positions[1][1] == Approx(1.5));
+    CHECK(grads.grads_positions[1][2] == Approx(1.6));
+    CHECK(grads.grads_positions[2][0] == Approx(1.7));
+    CHECK(grads.grads_positions[2][1] == Approx(1.8));
+    CHECK(grads.grads_positions[2][2] == Approx(1.9));
+#endif
   }
   {
     constexpr auto CT = CoordsType::POS_SPIN;
-    auto grads    = TWFGrads<CT>(5);
-    REQUIRE(grads.grads_positions.size() == 5);
-    REQUIRE(grads.grads_spins.size() == 5);
+    auto grads        = TWFGrads<CT>(2);
+    REQUIRE(grads.grads_positions.size() == 2);
+    REQUIRE(grads.grads_spins.size() == 2);
+    grads.grads_positions[0] = QMCTraits::GradType({0.1, 0.2, 0.3});
+    grads.grads_positions[1] = QMCTraits::GradType({0.4, 0.5, 0.6});
+    grads.grads_spins[0]     = QMCTraits::ComplexType(0.7, 0.8);
+    grads.grads_spins[1]     = QMCTraits::ComplexType(0.9, 1.0);
+
+    auto shift               = TWFGrads<CT>(2);
+    shift.grads_positions[0] = QMCTraits::GradType({1.0, 1.0, 1.0});
+    shift.grads_positions[1] = QMCTraits::GradType({1.0, 1.0, 1.0});
+    shift.grads_spins[0]     = QMCTraits::ComplexType(1.0, 0.0);
+    shift.grads_spins[1]     = QMCTraits::ComplexType(1.0, 0.0);
+
+    grads += shift;
+#ifdef QMC_COMPLEX
+    CHECK(grads.grads_positions[0][0] == ComplexApprox(QMCTraits::ValueType(1.1, 0.0)));
+    CHECK(grads.grads_positions[0][1] == ComplexApprox(QMCTraits::ValueType(1.2, 0.0)));
+    CHECK(grads.grads_positions[0][2] == ComplexApprox(QMCTraits::ValueType(1.3, 0.0)));
+    CHECK(grads.grads_positions[1][0] == ComplexApprox(QMCTraits::ValueType(1.4, 0.0)));
+    CHECK(grads.grads_positions[1][1] == ComplexApprox(QMCTraits::ValueType(1.5, 0.0)));
+    CHECK(grads.grads_positions[1][2] == ComplexApprox(QMCTraits::ValueType(1.6, 0.0)));
+#else
+    CHECK(grads.grads_positions[0][0] == Approx(1.1));
+    CHECK(grads.grads_positions[0][1] == Approx(1.2));
+    CHECK(grads.grads_positions[0][2] == Approx(1.3));
+    CHECK(grads.grads_positions[1][0] == Approx(1.4));
+    CHECK(grads.grads_positions[1][1] == Approx(1.5));
+    CHECK(grads.grads_positions[1][2] == Approx(1.6));
+#endif
+    CHECK(grads.grads_spins[0] == ComplexApprox(QMCTraits::ComplexType(1.7, 0.8)));
+    CHECK(grads.grads_spins[1] == ComplexApprox(QMCTraits::ComplexType(1.9, 1.0)));
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_TWFGrads.cpp
+++ b/src/QMCWaveFunctions/tests/test_TWFGrads.cpp
@@ -19,17 +19,12 @@ TEST_CASE("TWFGrads", "[QMCWaveFunctions]")
 {
   {
     constexpr auto CT = CoordsType::POS;
-    auto grads        = TWFGrads<CT>();
-    REQUIRE(grads.grads_positions.size() == 0);
-    grads.resize(7);
+    auto grads        = TWFGrads<CT>(7);
     REQUIRE(grads.grads_positions.size() == 7);
   }
   {
     constexpr auto CT = CoordsType::POS_SPIN;
-    auto grads    = TWFGrads<CT>();
-    REQUIRE(grads.grads_positions.size() == 0);
-    REQUIRE(grads.grads_spins.size() == 0);
-    grads.resize(5);
+    auto grads    = TWFGrads<CT>(5);
     REQUIRE(grads.grads_positions.size() == 5);
     REQUIRE(grads.grads_spins.size() == 5);
   }

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -301,16 +301,17 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 #endif
 
   std::fill(ratios.begin(), ratios.end(), 0);
-  std::vector<GradType> grad_new(2);
+  TWFGrads<CoordsType::POS> grad_new(2);
 
   if (kind_selected != DynamicCoordinateKind::DC_POS_OFFLOAD)
   {
-    ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
-    ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
+    ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new.grads_positions[0]);
+    ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new.grads_positions[1]);
 
     std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-              << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
-              << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
+              << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
+              << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
+              << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
   }
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
@@ -318,22 +319,22 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(ValueType(1, 0)));
-  CHECK(grad_new[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
-  CHECK(grad_new[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
-  CHECK(grad_new[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
+  CHECK(grad_new.grads_positions[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
+  CHECK(grad_new.grads_positions[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
+  CHECK(grad_new.grads_positions[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
   CHECK(ratios[1] == ComplexApprox(ValueType(1.6538214581548, 0.54849918598717)));
-  CHECK(grad_new[1][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
-  CHECK(grad_new[1][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
-  CHECK(grad_new[1][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
+  CHECK(grad_new.grads_positions[1][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
+  CHECK(grad_new.grads_positions[1][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
+  CHECK(grad_new.grads_positions[1][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
 #else
   CHECK(ratios[0] == Approx(1));
-  CHECK(grad_new[0][0] == Approx(14.77249702264));
-  CHECK(grad_new[0][1] == Approx(-20.385235323777));
-  CHECK(grad_new[0][2] == Approx(4.8529516184558));
+  CHECK(grad_new.grads_positions[0][0] == Approx(14.77249702264));
+  CHECK(grad_new.grads_positions[0][1] == Approx(-20.385235323777));
+  CHECK(grad_new.grads_positions[0][2] == Approx(4.8529516184558));
   CHECK(ratios[1] == Approx(2.3055913093424));
-  CHECK(grad_new[1][0] == Approx(14.77249702264));
-  CHECK(grad_new[1][1] == Approx(-20.385235323777));
-  CHECK(grad_new[1][2] == Approx(4.8529516184558));
+  CHECK(grad_new.grads_positions[1][0] == Approx(14.77249702264));
+  CHECK(grad_new.grads_positions[1][1] == Approx(-20.385235323777));
+  CHECK(grad_new.grads_positions[1][2] == Approx(4.8529516184558));
 #endif
 
   std::vector<bool> isAccepted(2, true);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -21,6 +21,7 @@
 #include "QMCWaveFunctions/Fermion/DiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
+#include "TWFGrads.hpp"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -75,7 +76,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   elec_.setName("elec");
   ptcl.addParticleSet(std::move(elec_uptr));
-  elec_.create({2,2});
+  elec_.create({2, 2});
   elec_.R[0] = {0.0, 0.0, 0.0};
   elec_.R[1] = {0.0, 1.0, 1.0};
   elec_.R[2] = {1.0, 1.0, 0.0};
@@ -232,29 +233,31 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
           LogComplexApprox(std::complex<RealType>(-1.471840358291562, 3.141592653589793)));
 #endif
 
-  std::vector<GradType> grad_old(2);
+  TWFGrads<CoordsType::POS> grad_old(2);
 
-  grad_old[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
-  grad_old[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
+  grad_old.grads_positions[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
+  grad_old.grads_positions[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
-  std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
-            << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
+  std::cout << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+            << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
+            << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
+            << grad_old.grads_positions[1][2] << std::endl;
 
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
-  CHECK(grad_old[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
-  CHECK(grad_old[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
-  CHECK(grad_old[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
-  CHECK(grad_old[1][0] == ComplexApprox(ValueType(47.387717528888, -8.7703065253151e-06)));
-  CHECK(grad_old[1][1] == ComplexApprox(ValueType(-54.671696901113, -7.3126138879524)));
-  CHECK(grad_old[1][2] == ComplexApprox(ValueType(6.6288917088321, 7.3126230586018)));
+  CHECK(grad_old.grads_positions[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
+  CHECK(grad_old.grads_positions[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
+  CHECK(grad_old.grads_positions[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
+  CHECK(grad_old.grads_positions[1][0] == ComplexApprox(ValueType(47.387717528888, -8.7703065253151e-06)));
+  CHECK(grad_old.grads_positions[1][1] == ComplexApprox(ValueType(-54.671696901113, -7.3126138879524)));
+  CHECK(grad_old.grads_positions[1][2] == ComplexApprox(ValueType(6.6288917088321, 7.3126230586018)));
 #else
-  CHECK(grad_old[0][0] == Approx(14.77249702264));
-  CHECK(grad_old[0][1] == Approx(-20.385235323777));
-  CHECK(grad_old[0][2] == Approx(4.8529516184558));
-  CHECK(grad_old[1][0] == Approx(47.38770710732));
-  CHECK(grad_old[1][1] == Approx(-63.361119579044));
-  CHECK(grad_old[1][2] == Approx(15.318325284049));
+  CHECK(grad_old.grads_positions[0][0] == Approx(14.77249702264));
+  CHECK(grad_old.grads_positions[0][1] == Approx(-20.385235323777));
+  CHECK(grad_old.grads_positions[0][2] == Approx(4.8529516184558));
+  CHECK(grad_old.grads_positions[1][0] == Approx(47.38770710732));
+  CHECK(grad_old.grads_positions[1][1] == Approx(-63.361119579044));
+  CHECK(grad_old.grads_positions[1][2] == Approx(15.318325284049));
 #endif
 
   PosType delta_sign_changed(0.1, 0.1, -0.2);
@@ -349,19 +352,19 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 #if defined(QMC_COMPLEX)
-  CHECK(grad_old[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
-  CHECK(grad_old[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
-  CHECK(grad_old[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
-  CHECK(grad_old[1][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
-  CHECK(grad_old[1][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
-  CHECK(grad_old[1][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
+  CHECK(grad_old.grads_positions[0][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
+  CHECK(grad_old.grads_positions[0][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
+  CHECK(grad_old.grads_positions[0][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
+  CHECK(grad_old.grads_positions[1][0] == ComplexApprox(ValueType(18.817970466022, -6.5837500306076)));
+  CHECK(grad_old.grads_positions[1][1] == ComplexApprox(ValueType(-22.840838391977, 3.9963373883645)));
+  CHECK(grad_old.grads_positions[1][2] == ComplexApprox(ValueType(3.8805320617146, 1.5825508129169)));
 #else
-  CHECK(grad_old[0][0] == Approx(14.77249702264));
-  CHECK(grad_old[0][1] == Approx(-20.385235323777));
-  CHECK(grad_old[0][2] == Approx(4.8529516184558));
-  CHECK(grad_old[1][0] == Approx(14.77249702264));
-  CHECK(grad_old[1][1] == Approx(-20.385235323777));
-  CHECK(grad_old[1][2] == Approx(4.8529516184558));
+  CHECK(grad_old.grads_positions[0][0] == Approx(14.77249702264));
+  CHECK(grad_old.grads_positions[0][1] == Approx(-20.385235323777));
+  CHECK(grad_old.grads_positions[0][2] == Approx(4.8529516184558));
+  CHECK(grad_old.grads_positions[1][0] == Approx(14.77249702264));
+  CHECK(grad_old.grads_positions[1][1] == Approx(-20.385235323777));
+  CHECK(grad_old.grads_positions[1][2] == Approx(4.8529516184558));
 #endif
 
 #endif

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -366,41 +366,49 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 #endif
 
   std::fill(ratios.begin(), ratios.end(), 0);
-  std::vector<GradType> grad_new(2);
+  TWFGrads<CoordsType::POS> grad_new(2);
 
   if (kind_selected != DynamicCoordinateKind::DC_POS_OFFLOAD)
   {
-    ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new[0]);
-    ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new[1]);
+    ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new.grads_positions[0]);
+    ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new.grads_positions[1]);
 
     std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-              << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
-              << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
+              << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
+              << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
+              << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
   }
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
   std::cout << "flex_calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-            << grad_new[0][0] << " " << grad_new[0][1] << " " << grad_new[0][2] << " " << grad_new[1][0] << " "
-            << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
+            << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
+            << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
+            << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(ValueType(1, 0)).epsilon(5e-5));
-  CHECK(grad_new[0][0] == ComplexApprox(ValueType(713.71203320653, 0.020838031942702)).epsilon(grad_precision));
-  CHECK(grad_new[0][1] == ComplexApprox(ValueType(713.71203320654, 0.020838031944677)).epsilon(grad_precision));
-  CHECK(grad_new[0][2] == ComplexApprox(ValueType(-768.42842826889, -0.020838032035842)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][0] ==
+        ComplexApprox(ValueType(713.71203320653, 0.020838031942702)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][1] ==
+        ComplexApprox(ValueType(713.71203320654, 0.020838031944677)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][2] ==
+        ComplexApprox(ValueType(-768.42842826889, -0.020838032035842)).epsilon(grad_precision));
   CHECK(ratios[1] == ComplexApprox(ValueType(0.12487384604679, 0)));
-  CHECK(grad_new[1][0] == ComplexApprox(ValueType(713.71203320656, 0.020838031892613)).epsilon(grad_precision));
-  CHECK(grad_new[1][1] == ComplexApprox(ValueType(713.71203320657, 0.020838031894628)).epsilon(grad_precision));
-  CHECK(grad_new[1][2] == ComplexApprox(ValueType(-768.42842826892, -0.020838031981896)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][0] ==
+        ComplexApprox(ValueType(713.71203320656, 0.020838031892613)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][1] ==
+        ComplexApprox(ValueType(713.71203320657, 0.020838031894628)).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][2] ==
+        ComplexApprox(ValueType(-768.42842826892, -0.020838031981896)).epsilon(grad_precision));
 #else
   CHECK(ratios[0] == Approx(1).epsilon(5e-5));
-  CHECK(grad_new[0][0] == Approx(713.69119517463).epsilon(grad_precision));
-  CHECK(grad_new[0][1] == Approx(713.69119517463).epsilon(grad_precision));
-  CHECK(grad_new[0][2] == Approx(-768.40759023689).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][0] == Approx(713.69119517463).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][1] == Approx(713.69119517463).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[0][2] == Approx(-768.40759023689).epsilon(grad_precision));
   CHECK(ratios[1] == Approx(0.12487384604697));
-  CHECK(grad_new[1][0] == Approx(713.69119517467).epsilon(grad_precision));
-  CHECK(grad_new[1][1] == Approx(713.69119517468).epsilon(grad_precision));
-  CHECK(grad_new[1][2] == Approx(-768.40759023695).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][0] == Approx(713.69119517467).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][1] == Approx(713.69119517468).epsilon(grad_precision));
+  CHECK(grad_new.grads_positions[1][2] == Approx(-768.40759023695).epsilon(grad_precision));
 #endif
 
   std::vector<bool> isAccepted(2, true);
@@ -456,22 +464,30 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   ParticleSet::mw_makeMove(p_ref_list, moved_elec_id_next, displ);
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id_next, ratios, grad_new);
-  std::cout << "ratioGrad next electron " << std::setprecision(14) << grad_new[0][0] << " " << grad_new[0][1] << " "
-            << grad_new[0][2] << " " << grad_new[1][0] << " " << grad_new[1][1] << " " << grad_new[1][2] << std::endl;
+  std::cout << "ratioGrad next electron " << std::setprecision(14) << grad_new.grads_positions[0][0] << " "
+            << grad_new.grads_positions[0][1] << " " << grad_new.grads_positions[0][2] << " "
+            << grad_new.grads_positions[1][0] << " " << grad_new.grads_positions[1][1] << " "
+            << grad_new.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
-  CHECK(grad_new[0][0] == ComplexApprox(ValueType(9.6073058494562, -1.4375146770852e-05)).epsilon(8e-5));
-  CHECK(grad_new[0][1] == ComplexApprox(ValueType(6.3111018321898, -1.4375146510386e-05)).epsilon(8e-5));
-  CHECK(grad_new[0][2] == ComplexApprox(ValueType(-3.2027658046121, 1.4375146020225e-05)).epsilon(8e-5));
-  CHECK(grad_new[1][0] == ComplexApprox(ValueType(9.6073058494562, -1.4375146770852e-05)).epsilon(8e-5));
-  CHECK(grad_new[1][1] == ComplexApprox(ValueType(6.3111018321898, -1.4375146510386e-05)).epsilon(8e-5));
-  CHECK(grad_new[1][2] == ComplexApprox(ValueType(-3.2027658046121, 1.4375146020225e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[0][0] ==
+        ComplexApprox(ValueType(9.6073058494562, -1.4375146770852e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[0][1] ==
+        ComplexApprox(ValueType(6.3111018321898, -1.4375146510386e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[0][2] ==
+        ComplexApprox(ValueType(-3.2027658046121, 1.4375146020225e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[1][0] ==
+        ComplexApprox(ValueType(9.6073058494562, -1.4375146770852e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[1][1] ==
+        ComplexApprox(ValueType(6.3111018321898, -1.4375146510386e-05)).epsilon(8e-5));
+  CHECK(grad_new.grads_positions[1][2] ==
+        ComplexApprox(ValueType(-3.2027658046121, 1.4375146020225e-05)).epsilon(8e-5));
 #else
-  CHECK(grad_new[0][0] == Approx(9.607320224603).epsilon(1e-4));
-  CHECK(grad_new[0][1] == Approx(6.3111162073363).epsilon(1e-4));
-  CHECK(grad_new[0][2] == Approx(-3.2027801797581).epsilon(1e-4));
-  CHECK(grad_new[1][0] == Approx(9.607320224603).epsilon(1e-4));
-  CHECK(grad_new[1][1] == Approx(6.3111162073363).epsilon(1e-4));
-  CHECK(grad_new[1][2] == Approx(-3.2027801797581).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[0][0] == Approx(9.607320224603).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[0][1] == Approx(6.3111162073363).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[0][2] == Approx(-3.2027801797581).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[1][0] == Approx(9.607320224603).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[1][1] == Approx(6.3111162073363).epsilon(1e-4));
+  CHECK(grad_new.grads_positions[1][2] == Approx(-3.2027801797581).epsilon(1e-4));
 #endif
 
   isAccepted[0] = true;

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -24,6 +24,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCHamiltonians/NLPPJob.h"
+#include "TWFGrads.hpp"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -101,7 +102,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   elec_.setName("elec");
   ptcl.addParticleSet(std::move(elec_uptr));
-  elec_.create({2,2});
+  elec_.create({2, 2});
   elec_.R[0] = {0.0, 0.0, 0.0};
   elec_.R[1] = {0.0, 1.0, 1.0};
   elec_.R[2] = {1.0, 1.0, 0.0};
@@ -285,30 +286,38 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
           LogComplexApprox(std::complex<RealType>(-5.932711221043984, 6.283185307179586)));
 #endif
 
-  std::vector<GradType> grad_old(2);
+  TWFGrads<CoordsType::POS> grad_old(2);
 
-  grad_old[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
-  grad_old[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
+  grad_old.grads_positions[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
+  grad_old.grads_positions[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
-  std::cout << "evalGrad " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " " << grad_old[0][2]
-            << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
+  std::cout << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+            << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
+            << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
+            << grad_old.grads_positions[1][2] << std::endl;
 
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
 #if defined(QMC_COMPLEX)
-  CHECK(grad_old[0][0] == ComplexApprox(ValueType(713.71203320653, 0.020838031926441)).epsilon(grad_precision));
-  CHECK(grad_old[0][1] == ComplexApprox(ValueType(713.71203320654, 0.020838031928415)).epsilon(grad_precision));
-  CHECK(grad_old[0][2] == ComplexApprox(ValueType(-768.42842826889, -0.020838032018344)).epsilon(grad_precision));
-  CHECK(grad_old[1][0] == ComplexApprox(ValueType(118.02653358655, -0.0022419843505538)).epsilon(grad_precision));
-  CHECK(grad_old[1][1] == ComplexApprox(ValueType(118.02653358655, -0.0022419843498631)).epsilon(grad_precision));
-  CHECK(grad_old[1][2] == ComplexApprox(ValueType(-118.46325895634, 0.0022419843493758)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][0] ==
+        ComplexApprox(ValueType(713.71203320653, 0.020838031926441)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][1] ==
+        ComplexApprox(ValueType(713.71203320654, 0.020838031928415)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][2] ==
+        ComplexApprox(ValueType(-768.42842826889, -0.020838032018344)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][0] ==
+        ComplexApprox(ValueType(118.02653358655, -0.0022419843505538)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][1] ==
+        ComplexApprox(ValueType(118.02653358655, -0.0022419843498631)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][2] ==
+        ComplexApprox(ValueType(-118.46325895634, 0.0022419843493758)).epsilon(grad_precision));
 #else
-  CHECK(grad_old[0][0] == Approx(713.69119517454).epsilon(2. * grad_precision));
-  CHECK(grad_old[0][1] == Approx(713.69119517455).epsilon(2. * grad_precision));
-  CHECK(grad_old[0][2] == Approx(-768.40759023681).epsilon(2. * grad_precision));
-  CHECK(grad_old[1][0] == Approx(118.0287755709).epsilon(grad_precision));
-  CHECK(grad_old[1][1] == Approx(118.0287755709).epsilon(grad_precision));
-  CHECK(grad_old[1][2] == Approx(-118.46550094069).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][0] == Approx(713.69119517454).epsilon(2. * grad_precision));
+  CHECK(grad_old.grads_positions[0][1] == Approx(713.69119517455).epsilon(2. * grad_precision));
+  CHECK(grad_old.grads_positions[0][2] == Approx(-768.40759023681).epsilon(2. * grad_precision));
+  CHECK(grad_old.grads_positions[1][0] == Approx(118.0287755709).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][1] == Approx(118.0287755709).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][2] == Approx(-118.46550094069).epsilon(grad_precision));
 #endif
   PosType delta_sign_changed(0.1, 0.1, -0.2);
   std::vector<PosType> displs{delta_sign_changed, delta_sign_changed};
@@ -416,22 +425,30 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
 
   const int moved_elec_id_next = 1;
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
-  std::cout << "evalGrad next electron " << std::setprecision(14) << grad_old[0][0] << " " << grad_old[0][1] << " "
-            << grad_old[0][2] << " " << grad_old[1][0] << " " << grad_old[1][1] << " " << grad_old[1][2] << std::endl;
+  std::cout << "evalGrad next electron " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+            << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
+            << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
+            << grad_old.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
-  CHECK(grad_old[0][0] == ComplexApprox(ValueType(-114.82740072726, -7.605305979232e-05)).epsilon(grad_precision));
-  CHECK(grad_old[0][1] == ComplexApprox(ValueType(-93.980772428401, -7.605302517238e-05)).epsilon(grad_precision));
-  CHECK(grad_old[0][2] == ComplexApprox(ValueType(64.050803536571, 7.6052975324197e-05)).epsilon(grad_precision));
-  CHECK(grad_old[1][0] == ComplexApprox(ValueType(-114.82740072726, -7.605305979232e-05)).epsilon(grad_precision));
-  CHECK(grad_old[1][1] == ComplexApprox(ValueType(-93.980772428401, -7.605302517238e-05)).epsilon(grad_precision));
-  CHECK(grad_old[1][2] == ComplexApprox(ValueType(64.050803536571, 7.6052975324197e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][0] ==
+        ComplexApprox(ValueType(-114.82740072726, -7.605305979232e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][1] ==
+        ComplexApprox(ValueType(-93.980772428401, -7.605302517238e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][2] ==
+        ComplexApprox(ValueType(64.050803536571, 7.6052975324197e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][0] ==
+        ComplexApprox(ValueType(-114.82740072726, -7.605305979232e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][1] ==
+        ComplexApprox(ValueType(-93.980772428401, -7.605302517238e-05)).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][2] ==
+        ComplexApprox(ValueType(64.050803536571, 7.6052975324197e-05)).epsilon(grad_precision));
 #else
-  CHECK(grad_old[0][0] == Approx(-114.82732467419).epsilon(grad_precision));
-  CHECK(grad_old[0][1] == Approx(-93.98069637537).epsilon(grad_precision));
-  CHECK(grad_old[0][2] == Approx(64.050727483593).epsilon(grad_precision));
-  CHECK(grad_old[1][0] == Approx(-114.82732467419).epsilon(grad_precision));
-  CHECK(grad_old[1][1] == Approx(-93.98069637537).epsilon(grad_precision));
-  CHECK(grad_old[1][2] == Approx(64.050727483593).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][0] == Approx(-114.82732467419).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][1] == Approx(-93.98069637537).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[0][2] == Approx(64.050727483593).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][0] == Approx(-114.82732467419).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][1] == Approx(-93.98069637537).epsilon(grad_precision));
+  CHECK(grad_old.grads_positions[1][2] == Approx(64.050727483593).epsilon(grad_precision));
 #endif
 
   std::vector<PosType> displ(2);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -44,8 +44,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
   Communicate* c = OHMMS::Controller;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -331,8 +331,8 @@ void test_Bi_msd(const std::string& spo_xml_string,
   Communicate* c = OHMMS::Controller;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -17,6 +17,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "TWFGrads.hpp"
 
 #include <stdio.h>
 #include <string>
@@ -228,17 +229,17 @@ void test_LiH_msd(const std::string& spo_xml_string,
     CHECK(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-7.803347327300153, 0.0)));
 
-    std::vector<GradType> grad_old(2);
+    TWFGrads<CoordsType::POS> grad_old(2);
 
     const int moved_elec_id = 1;
     TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
-    CHECK(grad_old[0][0] == ValueApprox(-2.6785305398));
-    CHECK(grad_old[0][1] == ValueApprox(-1.7953759996));
-    CHECK(grad_old[0][2] == ValueApprox(-5.8209379274));
-    CHECK(grad_old[1][0] == ValueApprox(-2.6785305398));
-    CHECK(grad_old[1][1] == ValueApprox(-1.7953759996));
-    CHECK(grad_old[1][2] == ValueApprox(-5.8209379274));
+    CHECK(grad_old.grads_positions[0][0] == ValueApprox(-2.6785305398));
+    CHECK(grad_old.grads_positions[0][1] == ValueApprox(-1.7953759996));
+    CHECK(grad_old.grads_positions[0][2] == ValueApprox(-5.8209379274));
+    CHECK(grad_old.grads_positions[1][0] == ValueApprox(-2.6785305398));
+    CHECK(grad_old.grads_positions[1][1] == ValueApprox(-1.7953759996));
+    CHECK(grad_old.grads_positions[1][2] == ValueApprox(-5.8209379274));
 
     std::vector<GradType> grad_new(2);
     std::vector<PsiValueType> ratios(2);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -241,7 +241,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     CHECK(grad_old.grads_positions[1][1] == ValueApprox(-1.7953759996));
     CHECK(grad_old.grads_positions[1][2] == ValueApprox(-5.8209379274));
 
-    std::vector<GradType> grad_new(2);
+    TWFGrads<CoordsType::POS> grad_new(2);
     std::vector<PsiValueType> ratios(2);
 
     ParticleSet::mw_makeMove(p_ref_list, moved_elec_id, displ);
@@ -255,12 +255,12 @@ void test_LiH_msd(const std::string& spo_xml_string,
     CHECK(ratios[0] == ValueApprox(PsiValueType(-0.6181619459)));
     CHECK(ratios[1] == ValueApprox(PsiValueType(1.6186330488)));
 
-    CHECK(grad_new[0][0] == ValueApprox(1.2418467899));
-    CHECK(grad_new[0][1] == ValueApprox(1.2425653495));
-    CHECK(grad_new[0][2] == ValueApprox(4.4273237873));
-    CHECK(grad_new[1][0] == ValueApprox(-0.8633778143));
-    CHECK(grad_new[1][1] == ValueApprox(0.8245347691));
-    CHECK(grad_new[1][2] == ValueApprox(-5.1513380151));
+    CHECK(grad_new.grads_positions[0][0] == ValueApprox(1.2418467899));
+    CHECK(grad_new.grads_positions[0][1] == ValueApprox(1.2425653495));
+    CHECK(grad_new.grads_positions[0][2] == ValueApprox(4.4273237873));
+    CHECK(grad_new.grads_positions[1][0] == ValueApprox(-0.8633778143));
+    CHECK(grad_new.grads_positions[1][1] == ValueApprox(0.8245347691));
+    CHECK(grad_new.grads_positions[1][2] == ValueApprox(-5.1513380151));
   }
 }
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
This PR moves the CoordsType abstraction down into WFC. Currently, TrialWaveFunction had mw_evalGrad,  mw_evalGradWithSpin and a mw_evalGrad<CT> to decide which version to call. Same for mw_calcRatioGrad. 

This simplifies the TrialWaveFunction API to only have the one implementation and moves the selection down into WaveFunctionComponent. WFC now has mw_evalGrad, mw_evalGradWithSpin, and a mw_evalGrad<CT> (same for mw_calcRatioGrad) to choose which one to call based on CT

Eventually, we will want to only have mw_evalGrad<CT> in WaveFunctionComponent, but trying to keep things small and manageable for easier review.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOSX

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
