### PR TITLE
Make all MultiSlaterDetTableMethod data member private and clean up SlaterDetBuilder::createMSDFast

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -30,27 +30,24 @@
 
 namespace qmcplusplus
 {
-void MultiDiracDeterminant::set(int first, int nel, int ref_det_id, std::vector<size_t>& C2nodes_ptcl)
+void MultiDiracDeterminant::createDetData(const int ref_det_id,
+                                          const std::vector<ci_configuration2>& configlist_unsorted,
+                                          const std::vector<size_t>& C2nodes_unsorted,
+                                          std::vector<size_t>& C2nodes_sorted)
 {
-  assert(ciConfigList);
-  assert(ciConfigList->size() > 0);
-
-  FirstIndex           = first;
   ReferenceDeterminant = ref_det_id;
-  resize(nel);
-  createDetData((*ciConfigList)[ReferenceDeterminant], *detData, *uniquePairs, *DetSigns, C2nodes_ptcl);
-}
 
-void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
-                                          std::vector<int>& data,
-                                          std::vector<std::pair<int, int>>& pairs,
-                                          std::vector<RealType>& sign,
-                                          std::vector<size_t>& C2nodes_ptcl)
-{
-  const auto& confgList = *ciConfigList;
+  auto& ref                        = configlist_unsorted[ref_det_id];
+  auto& configlist_sorted          = *ciConfigList;
+  auto& data                       = *detData;
+  auto& pairs                      = *uniquePairs;
+  auto& sign                       = *DetSigns;
+  auto& ndets_per_excitation_level = *ndets_per_excitation_level_;
 
-  const size_t nci = confgList.size();
-  size_t nex_max   = 0;
+  const size_t nci = configlist_unsorted.size();
+
+  std::cout << "nci = " << nci << std::endl;
+  size_t nex_max = 0;
   std::vector<size_t> pos(NumPtcls);
   std::vector<size_t> ocp(NumPtcls);
   std::vector<size_t> uno(NumPtcls);
@@ -58,13 +55,11 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
   std::map<int, std::vector<int>> dataMap;
   std::map<int, std::vector<int>> sortMap;
   std::vector<RealType> tmp_sign(nci, 0);
-  data.clear();
-  sign.resize(nci);
   pairs.clear();
   for (size_t i = 0; i < nci; i++)
   {
     size_t nex;
-    tmp_sign[i] = ref.calculateExcitations(confgList[i], nex, pos, ocp, uno);
+    tmp_sign[i] = ref.calculateExcitations(configlist_unsorted[i], nex, pos, ocp, uno);
     nex_max     = std::max(nex, nex_max);
     dataMap[nex].push_back(nex);
     sortMap[nex].push_back(i);
@@ -87,35 +82,36 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
       }
   }
   app_log() << "Number of terms in pairs array: " << pairs.size() << std::endl;
-  (*ndets_per_excitation_level).clear();
-  (*ndets_per_excitation_level).resize(nex_max + 1, 0);
+  ndets_per_excitation_level.resize(nex_max + 1, 0);
   //reorder configs and det data
   std::vector<size_t> det_idx_order;           // old indices in new order
   std::vector<size_t> det_idx_reverse(nci, 0); // new indices in old order
 
   // populate data, ordered by exc. lvl.
   // make mapping from new to old det idx
+  data.clear();
   for (const auto& [nex, det_idx_old] : sortMap)
   {
     data.insert(data.end(), dataMap[nex].begin(), dataMap[nex].end());
     det_idx_order.insert(det_idx_order.end(), det_idx_old.begin(), det_idx_old.end());
-    (*ndets_per_excitation_level)[nex] = det_idx_old.size();
+    ndets_per_excitation_level[nex] = det_idx_old.size();
   }
   assert(det_idx_order.size() == nci);
 
   // make reverse mapping (old to new) and reorder confgList by exc. lvl.
-  auto tmp_confgList = std::make_shared<std::vector<ci_configuration2>>(nci);
+  configlist_sorted.resize(nci);
+  sign.resize(nci);
   for (size_t i = 0; i < nci; i++)
   {
     det_idx_reverse[det_idx_order[i]] = i;
-    (*tmp_confgList)[i]               = confgList[det_idx_order[i]];
+    configlist_sorted[i]              = configlist_unsorted[det_idx_order[i]];
     sign[i]                           = tmp_sign[det_idx_order[i]];
   }
-  tmp_confgList.swap(ciConfigList);
 
   // update C2nodes for new det ordering
-  for (int i = 0; i < C2nodes_ptcl.size(); i++)
-    C2nodes_ptcl[i] = det_idx_reverse[C2nodes_ptcl[i]];
+  C2nodes_sorted.resize(C2nodes_unsorted.size());
+  for (int i = 0; i < C2nodes_unsorted.size(); i++)
+    C2nodes_sorted[i] = det_idx_reverse[C2nodes_unsorted[i]];
 
   /*
        std::cout <<"ref: " <<ref << std::endl;
@@ -127,6 +123,9 @@ void MultiDiracDeterminant::createDetData(const ci_configuration2& ref,
        for(int i=0; i<pairs.size(); i++)
          std::cout <<pairs[i].first <<"   " <<pairs[i].second << std::endl;
   */
+
+  // make sure internal objects depending on the number of unique determinants are resized
+  resize();
 }
 
 void MultiDiracDeterminant::evaluateForWalkerMove(const ParticleSet& P, bool fromScratch)
@@ -438,18 +437,20 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
       Phi(s.Phi->makeClone()),
       NumOrbitals(Phi->getOrbitalSetSize()),
       FirstIndex(s.FirstIndex),
+      NumPtcls(s.NumPtcls),
+      LastIndex(s.LastIndex),
       ciConfigList(s.ciConfigList),
       ReferenceDeterminant(s.ReferenceDeterminant),
       is_spinor_(s.is_spinor_),
       detData(s.detData),
       uniquePairs(s.uniquePairs),
       DetSigns(s.DetSigns),
-      ndets_per_excitation_level(s.ndets_per_excitation_level)
+      ndets_per_excitation_level_(s.ndets_per_excitation_level_)
 {
   Optimizable = s.Optimizable;
 
+  resize();
   registerTimers();
-  resize(s.NumPtcls);
 }
 
 std::unique_ptr<SPOSet> MultiDiracDeterminant::clonePhi() const { return Phi->makeClone(); }
@@ -465,7 +466,7 @@ std::unique_ptr<WaveFunctionComponent> MultiDiracDeterminant::makeClone(Particle
  *@param first index of the first particle
  *@param spinor flag to determinane if spin arrays need to be resized and used
  */
-MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor)
+MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor, int first, int nel)
     : WaveFunctionComponent("MultiDiracDeterminant"),
       UpdateTimer(*timer_manager.createTimer(ClassName + "::update")),
       RatioTimer(*timer_manager.createTimer(ClassName + "::ratio")),
@@ -481,17 +482,19 @@ MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, boo
       ExtraStuffTimer(*timer_manager.createTimer(ClassName + "::RefDetInvUpdate")),
       Phi(std::move(spos)),
       NumOrbitals(Phi->getOrbitalSetSize()),
-      FirstIndex(-1),
+      FirstIndex(first),
+      NumPtcls(nel),
+      LastIndex(first + nel),
       ReferenceDeterminant(0),
       is_spinor_(spinor)
 {
   (Phi->isOptimizable() == true) ? Optimizable = true : Optimizable = false;
 
-  ciConfigList               = std::make_shared<std::vector<ci_configuration2>>();
-  detData                    = std::make_shared<std::vector<int>>();
-  uniquePairs                = std::make_shared<std::vector<std::pair<int, int>>>();
-  DetSigns                   = std::make_shared<std::vector<RealType>>();
-  ndets_per_excitation_level = std::make_shared<std::vector<int>>();
+  ciConfigList                = std::make_shared<std::vector<ci_configuration2>>();
+  detData                     = std::make_shared<std::vector<int>>();
+  uniquePairs                 = std::make_shared<std::vector<std::pair<int, int>>>();
+  DetSigns                    = std::make_shared<std::vector<RealType>>();
+  ndets_per_excitation_level_ = std::make_shared<std::vector<int>>();
 
   registerTimers();
 }
@@ -527,18 +530,13 @@ void MultiDiracDeterminant::registerData(ParticleSet& P, WFBufferType& buf)
 
 
 ///reset the size: with the number of particles and number of orbtials
-/// morb is the total number of orbitals, including virtual
-void MultiDiracDeterminant::resize(int nel)
+void MultiDiracDeterminant::resize()
 {
-  if (nel <= 0)
-  {
-    APP_ABORT(" ERROR: MultiDiracDeterminant::resize arguments equal to zero. \n");
-  }
-
+  const int nel = NumPtcls;
+  assert(NumPtcls > 0);
   const int NumDets = getNumDets();
+  assert(NumDets > 0);
 
-  NumPtcls  = nel;
-  LastIndex = FirstIndex + nel;
   psiV_temp.resize(nel);
   psiV.resize(NumOrbitals);
   dpsiV.resize(NumOrbitals);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -46,7 +46,6 @@ void MultiDiracDeterminant::createDetData(const int ref_det_id,
 
   const size_t nci = configlist_unsorted.size();
 
-  std::cout << "nci = " << nci << std::endl;
   size_t nex_max = 0;
   std::vector<size_t> pos(NumPtcls);
   std::vector<size_t> ocp(NumPtcls);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -76,16 +76,6 @@ public:
 
   SPOSetPtr getPhi() { return Phi.get(); };
 
-  /** set the index of the first particle in the determinant and reset the size of the determinant
-   *@param first index of first particle
-   *@param nel number of particles in the determinant
-   *@param ref_det_id id of the reference determinant
-   *@param C2nodes_ptcl mapping from overall det index to unique det index for this particle group
-   *
-   * Note: ciConfigList should have been populated when calling this function
-   */
-  //  void set(int first, int nel, int ref_det_id, std::vector<size_t>& C2nodes_ptcl);
-
   ///optimizations  are disabled
   inline void checkInVariables(opt_variables_type& active) override { Phi->checkInVariables(active); }
 
@@ -223,16 +213,14 @@ public:
    * END END END
    ***************************************************************************/
 
-  /** create necessary structures used in the evaluation of the determinants
-   * sort confgList by excitation level
-   * confgList shouldn't change during a simulation after it is sorted here
+  /** create necessary structures related to unique determinants
+   * sort configlist_unsorted by excitation level abd store the results in ciConfigList (class member)
+   * ciConfigList shouldn't change during a simulation after it is sorted here
    *
-   *@param ref reference configuration
-   *@param data data structure holding information about excitation holes/particles (*this->detData)
-   *@param pairs all hole/particle pairs needed to construct excitation matrices for table method (*this->uniquePairs)
-   *@param sign sign of each excitation (parity of permutation of orbital indices) (*this->DetSigns)
-   *@param C2nodes_ptcl mapping from overall det index to unique det index for this particle group
-   *
+   * @param ref_det_id id of the reference determinant
+   * @param configlist_unsorted config list to be loaded.
+   * @param C2nodes_unsorted mapping from overall det index to unique det (configlist_unsorted) index
+   * @param C2nodes_sorted mapping from overall det index to unique det (ciConfigList) index
    */
   void createDetData(const int ref_det_id,
                      const std::vector<ci_configuration2>& configlist_unsorted,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -55,7 +55,7 @@ public:
    *@param spos the single-particle orbital set
    *@param first index of the first particle
    */
-  MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor);
+  MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, bool spinor, int first, int nel);
 
   ///default destructor
   ~MultiDiracDeterminant() override;
@@ -84,7 +84,7 @@ public:
    *
    * Note: ciConfigList should have been populated when calling this function
    */
-  void set(int first, int nel, int ref_det_id, std::vector<size_t>& C2nodes_ptcl);
+  //  void set(int first, int nel, int ref_det_id, std::vector<size_t>& C2nodes_ptcl);
 
   ///optimizations  are disabled
   inline void checkInVariables(opt_variables_type& active) override { Phi->checkInVariables(active); }
@@ -234,11 +234,10 @@ public:
    *@param C2nodes_ptcl mapping from overall det index to unique det index for this particle group
    *
    */
-  void createDetData(const ci_configuration2& ref,
-                     std::vector<int>& data,
-                     std::vector<std::pair<int, int>>& pairs,
-                     std::vector<RealType>& sign,
-                     std::vector<size_t>& C2nodes_ptcl);
+  void createDetData(const int ref_det_id,
+                     const std::vector<ci_configuration2>& configlist_unsorted,
+                     const std::vector<size_t>& C2nodes_unsorted,
+                     std::vector<size_t>& C2nodes_sorted);
 
   template<typename ITER>
   inline ValueType CalculateRatioFromMatrixElements(int n, ValueMatrix& dotProducts, ITER it)
@@ -494,7 +493,6 @@ public:
   inline int getNumDets() const { return ciConfigList->size(); }
   inline int getNumPtcls() const { return NumPtcls; }
   inline int getFirstIndex() const { return FirstIndex; }
-  inline std::vector<ci_configuration2>& getCIConfigList() { return *ciConfigList; }
 
   const ValueVector& getRatiosToRefDet() const { return ratios_to_ref_; }
   const ValueVector& getNewRatiosToRefDet() const { return new_ratios_to_ref_; }
@@ -510,18 +508,18 @@ public:
 
 private:
   ///reset the size: with the number of particles
-  void resize(int nel);
+  void resize();
 
   ///a set of single-particle orbitals used to fill in the  values of the matrix
   const std::unique_ptr<SPOSet> Phi;
   ///number of single-particle orbitals which belong to this Dirac determinant
   const int NumOrbitals;
-  ///number of particles which belong to this Dirac determinant
-  int NumPtcls;
   ///index of the first particle with respect to the particle set
-  int FirstIndex;
+  const int FirstIndex;
+  ///number of particles which belong to this Dirac determinant
+  const int NumPtcls;
   ///index of the last particle with respect to the particle set
-  int LastIndex;
+  const int LastIndex;
   ///use shared_ptr
   std::shared_ptr<std::vector<ci_configuration2>> ciConfigList;
   // the reference determinant never changes, so there is no need to store it.
@@ -595,7 +593,7 @@ private:
   /** number of unique determinants at each excitation level (relative to reference)
    *  {1, n_singles, n_doubles, n_triples, ...}
    */
-  std::shared_ptr<std::vector<int>> ndets_per_excitation_level;
+  std::shared_ptr<std::vector<int>> ndets_per_excitation_level_;
   MultiDiracDeterminantCalculator<ValueType> DetCalculator;
 };
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -60,9 +60,7 @@ void MultiSlaterDetTableMethod::initialize()
 {
   C2node       = std::make_shared<std::vector<std::vector<size_t>>>(Dets.size());
   C            = std::make_shared<std::vector<ValueType>>();
-  CSFcoeff     = std::make_shared<std::vector<ValueType>>();
-  DetsPerCSF   = std::make_shared<std::vector<size_t>>();
-  CSFexpansion = std::make_shared<std::vector<RealType>>();
+  csf_data_    = std::make_shared<CSFData>();
   myVars       = std::make_shared<opt_variables_type>();
 }
 
@@ -76,21 +74,15 @@ std::unique_ptr<WaveFunctionComponent> MultiSlaterDetTableMethod::makeClone(Part
 
   auto clone = std::make_unique<MultiSlaterDetTableMethod>(tqp, std::move(dets_clone), use_pre_computing_);
 
+  clone->CI_Optimizable = CI_Optimizable;
   clone->C2node = C2node;
   clone->C      = C;
   clone->myVars = myVars;
 
   clone->Optimizable = Optimizable;
   clone->usingCSF    = usingCSF;
+  clone->csf_data_ = csf_data_;
 
-  clone->CI_Optimizable = CI_Optimizable;
-
-  if (usingCSF)
-  {
-    clone->CSFcoeff     = CSFcoeff;
-    clone->CSFexpansion = CSFexpansion;
-    clone->DetsPerCSF   = DetsPerCSF;
-  }
   return clone;
 }
 
@@ -780,8 +772,8 @@ void MultiSlaterDetTableMethod::resetParameters(const opt_variables_type& active
   {
     if (usingCSF)
     {
-      ValueType* restrict CSFcoeff_p = CSFcoeff->data();
-      for (int i = 0; i < CSFcoeff->size() - 1; i++)
+      ValueType* restrict CSFcoeff_p = csf_data_->coeffs.data();
+      for (int i = 0; i < csf_data_->coeffs.size() - 1; i++)
       {
         int loc = myVars->where(i);
         if (loc >= 0)
@@ -791,10 +783,10 @@ void MultiSlaterDetTableMethod::resetParameters(const opt_variables_type& active
       }
       int cnt                                 = 0;
       ValueType* restrict C_p                 = C->data();
-      const RealType* restrict CSFexpansion_p = CSFexpansion->data();
-      for (int i = 0; i < DetsPerCSF->size(); i++)
+      const RealType* restrict CSFexpansion_p = csf_data_->expansion.data();
+      for (int i = 0; i < csf_data_->dets_per_csf.size(); i++)
       {
-        for (int k = 0; k < (*DetsPerCSF)[i]; k++)
+        for (int k = 0; k < csf_data_->dets_per_csf[i]; k++)
         {
           C_p[cnt] = CSFcoeff_p[i] * CSFexpansion_p[cnt];
           cnt++;
@@ -881,23 +873,23 @@ void MultiSlaterDetTableMethod::evaluateDerivatives(ParticleSet& P,
 
       if (usingCSF)
       {
-        const int num = CSFcoeff->size() - 1;
+        const int num = csf_data_->coeffs.size() - 1;
         int cnt       = 0;
         //        this one is not optable
-        cnt += (*DetsPerCSF)[0];
+        cnt += csf_data_->dets_per_csf[0];
         int ip(1);
         for (int i = 0; i < num; i++, ip++)
         {
           int kk = myVars->where(i);
           if (kk < 0)
           {
-            cnt += (*DetsPerCSF)[ip];
+            cnt += csf_data_->dets_per_csf[ip];
             continue;
           }
           ValueType q0 = 0.0;
           std::vector<ValueType> v(Dets.size());
-          const RealType* restrict CSFexpansion_p = CSFexpansion->data();
-          for (int k = 0; k < (*DetsPerCSF)[ip]; k++)
+          const RealType* restrict CSFexpansion_p = csf_data_->expansion.data();
+          for (int k = 0; k < csf_data_->dets_per_csf[ip]; k++)
           {
             for (size_t id = 0; id < Dets.size(); id++)
             {
@@ -1016,22 +1008,22 @@ void MultiSlaterDetTableMethod::evaluateDerivativesWF(ParticleSet& P,
       {
         ValueType psiinv = static_cast<ValueType>(PsiValueType(1.0) / psi_ratio_to_ref_det_);
 
-        const int num = CSFcoeff->size() - 1;
+        const int num = csf_data_->coeffs.size() - 1;
         int cnt       = 0;
         //        this one is not optable
-        cnt += (*DetsPerCSF)[0];
+        cnt += csf_data_->dets_per_csf[0];
         int ip(1);
         for (int i = 0; i < num; i++, ip++)
         {
           int kk = myVars->where(i);
           if (kk < 0)
           {
-            cnt += (*DetsPerCSF)[ip];
+            cnt += csf_data_->dets_per_csf[ip];
             continue;
           }
           ValueType cdet                          = 0.0;
-          const RealType* restrict CSFexpansion_p = CSFexpansion->data();
-          for (int k = 0; k < (*DetsPerCSF)[ip]; k++)
+          const RealType* restrict CSFexpansion_p = csf_data_->expansion.data();
+          for (int k = 0; k < csf_data_->dets_per_csf[ip]; k++)
           {
             ValueType t = CSFexpansion_p[cnt] * psiinv;
             // assume that evaluateLog has been called in opt routine before

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -42,7 +42,6 @@ MultiSlaterDetTableMethod::MultiSlaterDetTableMethod(ParticleSet& targetPtcl,
   //Optimizable=true;
   Optimizable  = false;
   is_fermionic = true;
-  usingCSF     = false;
   Dets         = std::move(dets);
   C_otherDs.resize(Dets.size());
   int NP = targetPtcl.getTotalNum();
@@ -80,7 +79,6 @@ std::unique_ptr<WaveFunctionComponent> MultiSlaterDetTableMethod::makeClone(Part
   clone->myVars = myVars;
 
   clone->Optimizable = Optimizable;
-  clone->usingCSF    = usingCSF;
   clone->csf_data_ = csf_data_;
 
   return clone;
@@ -770,7 +768,7 @@ void MultiSlaterDetTableMethod::resetParameters(const opt_variables_type& active
 {
   if (CI_Optimizable)
   {
-    if (usingCSF)
+    if (csf_data_)
     {
       ValueType* restrict CSFcoeff_p = csf_data_->coeffs.data();
       for (int i = 0; i < csf_data_->coeffs.size() - 1; i++)
@@ -871,7 +869,7 @@ void MultiSlaterDetTableMethod::evaluateDerivatives(ParticleSet& P,
       for (size_t i = 0; i < P.getTotalNum(); i++)
         gg += dot(myG_temp[i], myG_temp[i]) - dot(P.G[i], myG_temp[i]);
 
-      if (usingCSF)
+      if (csf_data_)
       {
         const int num = csf_data_->coeffs.size() - 1;
         int cnt       = 0;
@@ -1004,7 +1002,7 @@ void MultiSlaterDetTableMethod::evaluateDerivativesWF(ParticleSet& P,
     // need to modify for CSF later on, right now assume Slater Det basis
     if (recalculate)
     {
-      if (usingCSF)
+      if (csf_data_)
       {
         ValueType psiinv = static_cast<ValueType>(PsiValueType(1.0) / psi_ratio_to_ref_det_);
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -55,12 +55,19 @@ MultiSlaterDetTableMethod::MultiSlaterDetTableMethod(ParticleSet& targetPtcl,
     Last[i] = targetPtcl.last(i) - 1;
 }
 
-void MultiSlaterDetTableMethod::initialize()
+void MultiSlaterDetTableMethod::initialize(std::unique_ptr<std::vector<std::vector<size_t>>> C2node_in,
+                                           std::unique_ptr<std::vector<ValueType>> C_in,
+                                           std::unique_ptr<opt_variables_type> myVars_in,
+                                           std::unique_ptr<CSFData> csf_data_in,
+                                           bool optimizable,
+                                           bool CI_optimizable)
 {
-  C2node       = std::make_shared<std::vector<std::vector<size_t>>>(Dets.size());
-  C            = std::make_shared<std::vector<ValueType>>();
-  csf_data_    = std::make_shared<CSFData>();
-  myVars       = std::make_shared<opt_variables_type>();
+  C2node         = std::move(C2node_in);
+  C              = std::move(C_in);
+  myVars         = std::move(myVars_in);
+  csf_data_      = std::move(csf_data_in);
+  Optimizable    = optimizable;
+  CI_Optimizable = CI_optimizable;
 }
 
 MultiSlaterDetTableMethod::~MultiSlaterDetTableMethod() = default;
@@ -74,12 +81,12 @@ std::unique_ptr<WaveFunctionComponent> MultiSlaterDetTableMethod::makeClone(Part
   auto clone = std::make_unique<MultiSlaterDetTableMethod>(tqp, std::move(dets_clone), use_pre_computing_);
 
   clone->CI_Optimizable = CI_Optimizable;
-  clone->C2node = C2node;
-  clone->C      = C;
-  clone->myVars = myVars;
+  clone->C2node         = C2node;
+  clone->C              = C;
+  clone->myVars         = myVars;
 
   clone->Optimizable = Optimizable;
-  clone->csf_data_ = csf_data_;
+  clone->csf_data_   = csf_data_;
 
   return clone;
 }

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -24,6 +24,20 @@
 
 namespace qmcplusplus
 {
+/// CSF related dataset
+struct CSFData
+{
+  using RealType  = WaveFunctionComponent::RealType;
+  using ValueType = WaveFunctionComponent::ValueType;
+
+  // coefficients of csfs, these are only used during optm
+  std::vector<ValueType> coeffs;
+  // number of dets per csf
+  std::vector<size_t> dets_per_csf;
+  // coefficient of csf expansion (smaller dimension)
+  std::vector<RealType> expansion;
+};
+
 /** @ingroup WaveFunctionComponent
  *  @brief An AntiSymmetric WaveFunctionComponent composed of a linear combination of SlaterDeterminants.
  *
@@ -167,17 +181,6 @@ public:
   std::shared_ptr<opt_variables_type> myVars;
 
   bool usingCSF;
-  /// CSF related dataset
-  struct CSFData
-  {
-    // coefficients of csfs, these are only used during optm
-    std::vector<ValueType> coeffs;
-    // number of dets per csf
-    std::vector<size_t> dets_per_csf;
-    // coefficient of csf expansion (smaller dimension)
-    std::vector<RealType> expansion;
-  };
-
   std::shared_ptr<CSFData> csf_data_;
 
 private:

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -164,24 +164,18 @@ public:
                              const opt_variables_type& optvars,
                              std::vector<ValueType>& dlogpsi) override;
 
-  void resize(int, int);
-  void initialize();
-
-  std::vector<std::unique_ptr<MultiDiracDeterminant>> Dets;
-
-  /** map determinant in linear combination to unique det list
-   * map global det id to unique det id. [spin, global det id] = unique det id
+  /** initialize a few objects and states by the builder
+   * YL: it should be part of the constructor. It cannot be added to the constructor
+   * because the constructor is used by makeClone. The right way of fix needs:
+   *  1. implement a copy constructor and reroute makeClone to it.
+   *  2. merge initialize() into the constructor.
    */
-  std::shared_ptr<std::vector<std::vector<size_t>>> C2node;
-  /// CI coefficients
-  std::shared_ptr<std::vector<ValueType>> C;
-  /// if true, the CI coefficients are optimized
-  bool CI_Optimizable;
-  //optimizable variable is shared with the clones
-  std::shared_ptr<opt_variables_type> myVars;
-
-  /// CSF data set. If nullptr, not using CSF
-  std::shared_ptr<CSFData> csf_data_;
+  void initialize(std::unique_ptr<std::vector<std::vector<size_t>>> C2node_in,
+                  std::unique_ptr<std::vector<ValueType>> C_in,
+                  std::unique_ptr<opt_variables_type> myVars_in,
+                  std::unique_ptr<CSFData> csf_data_in,
+                  bool optimizable,
+                  bool CI_optimizable);
 
 private:
   //get Det ID. It should be consistent with particle group id within the particle set.
@@ -230,6 +224,32 @@ private:
    */
   void precomputeC_otherDs(const ParticleSet& P, int ig);
 
+  void evaluateMultiDiracDeterminantDerivatives(ParticleSet& P,
+                                                const opt_variables_type& optvars,
+                                                std::vector<ValueType>& dlogpsi,
+                                                std::vector<ValueType>& dhpsioverpsi);
+
+  void evaluateMultiDiracDeterminantDerivativesWF(ParticleSet& P,
+                                                  const opt_variables_type& optvars,
+                                                  std::vector<ValueType>& dlogpsi);
+
+  /// determinant collection
+  std::vector<std::unique_ptr<MultiDiracDeterminant>> Dets;
+
+  /** map determinant in linear combination to unique det list
+   * map global det id to unique det id. [spin, global det id] = unique det id
+   */
+  std::shared_ptr<std::vector<std::vector<size_t>>> C2node;
+  /// CI coefficients
+  std::shared_ptr<std::vector<ValueType>> C;
+  /// if true, the CI coefficients are optimized
+  bool CI_Optimizable;
+  //optimizable variable is shared with the clones
+  std::shared_ptr<opt_variables_type> myVars;
+
+  /// CSF data set. If nullptr, not using CSF
+  std::shared_ptr<CSFData> csf_data_;
+
   ///the last particle of each group
   std::vector<int> Last;
   ///use pre-compute (fast) algorithm
@@ -239,15 +259,6 @@ private:
   PsiValueType psi_ratio_to_ref_det_;
   /// new psi over new ref single det when one particle is moved
   PsiValueType new_psi_ratio_to_new_ref_det_;
-
-  void evaluateMultiDiracDeterminantDerivatives(ParticleSet& P,
-                                                const opt_variables_type& optvars,
-                                                std::vector<ValueType>& dlogpsi,
-                                                std::vector<ValueType>& dhpsioverpsi);
-
-  void evaluateMultiDiracDeterminantDerivativesWF(ParticleSet& P,
-                                                  const opt_variables_type& optvars,
-                                                  std::vector<ValueType>& dlogpsi);
 
   size_t ActiveSpin;
   PsiValueType curRatio;

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -153,14 +153,7 @@ public:
   void resize(int, int);
   void initialize();
 
-  /// if true, the CI coefficients are optimized
-  bool CI_Optimizable;
-  size_t ActiveSpin;
-  bool usingCSF;
-  PsiValueType curRatio;
-
   std::vector<std::unique_ptr<MultiDiracDeterminant>> Dets;
-  std::map<std::string, size_t> SPOSetID;
 
   /** map determinant in linear combination to unique det list
    * map global det id to unique det id. [spin, global det id] = unique det id
@@ -168,29 +161,19 @@ public:
   std::shared_ptr<std::vector<std::vector<size_t>>> C2node;
   /// CI coefficients
   std::shared_ptr<std::vector<ValueType>> C;
-  /// C_n x D^1_n x D^2_n ... D^3_n with one D removed. Summed by group. [spin, unique det id]
-  std::vector<Vector<ValueType, OffloadPinnedAllocator<ValueType>>> C_otherDs;
-  /// a collection of device pointers of multiple walkers fused for fast H2D transfer.
-  Vector<const ValueType*, OffloadPinnedAllocator<const ValueType*>> C_otherDs_ptr_list;
-  Vector<const ValueType*, OffloadPinnedAllocator<const ValueType*>> det_value_ptr_list;
-
-  ParticleSet::ParticleGradient myG, myG_temp;
-  ParticleSet::ParticleLaplacian myL, myL_temp;
-  std::vector<ValueVector> laplSum;
-
   //optimizable variable is shared with the clones
   std::shared_ptr<opt_variables_type> myVars;
+
+  /// if true, the CI coefficients are optimized
+  bool CI_Optimizable;
+
+  bool usingCSF;
   // coefficients of csfs, these are only used during optm
   std::shared_ptr<std::vector<ValueType>> CSFcoeff;
   // number of dets per csf
   std::shared_ptr<std::vector<size_t>> DetsPerCSF;
   // coefficient of csf expansion (smaller dimension)
   std::shared_ptr<std::vector<RealType>> CSFexpansion;
-
-  // temporary storage for evaluateDerivatives
-  ParticleSet::ParticleGradient gmPG;
-  std::vector<Matrix<RealType>> dpsia, dLa;
-  std::vector<Array<GradType, OHMMS_DIM>> dGa;
 
 private:
   //get Det ID. It should be consistent with particle group id within the particle set.
@@ -257,6 +240,24 @@ private:
   void evaluateMultiDiracDeterminantDerivativesWF(ParticleSet& P,
                                                   const opt_variables_type& optvars,
                                                   std::vector<ValueType>& dlogpsi);
+
+  size_t ActiveSpin;
+  PsiValueType curRatio;
+
+  /// C_n x D^1_n x D^2_n ... D^3_n with one D removed. Summed by group. [spin, unique det id]
+  std::vector<Vector<ValueType, OffloadPinnedAllocator<ValueType>>> C_otherDs;
+  /// a collection of device pointers of multiple walkers fused for fast H2D transfer.
+  Vector<const ValueType*, OffloadPinnedAllocator<const ValueType*>> C_otherDs_ptr_list;
+  Vector<const ValueType*, OffloadPinnedAllocator<const ValueType*>> det_value_ptr_list;
+
+  ParticleSet::ParticleGradient myG, myG_temp;
+  ParticleSet::ParticleLaplacian myL, myL_temp;
+  std::vector<ValueVector> laplSum;
+
+  // temporary storage for evaluateDerivatives
+  ParticleSet::ParticleGradient gmPG;
+  std::vector<Matrix<RealType>> dpsia, dLa;
+  std::vector<Array<GradType, OHMMS_DIM>> dGa;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -161,19 +161,24 @@ public:
   std::shared_ptr<std::vector<std::vector<size_t>>> C2node;
   /// CI coefficients
   std::shared_ptr<std::vector<ValueType>> C;
+  /// if true, the CI coefficients are optimized
+  bool CI_Optimizable;
   //optimizable variable is shared with the clones
   std::shared_ptr<opt_variables_type> myVars;
 
-  /// if true, the CI coefficients are optimized
-  bool CI_Optimizable;
-
   bool usingCSF;
-  // coefficients of csfs, these are only used during optm
-  std::shared_ptr<std::vector<ValueType>> CSFcoeff;
-  // number of dets per csf
-  std::shared_ptr<std::vector<size_t>> DetsPerCSF;
-  // coefficient of csf expansion (smaller dimension)
-  std::shared_ptr<std::vector<RealType>> CSFexpansion;
+  /// CSF related dataset
+  struct CSFData
+  {
+    // coefficients of csfs, these are only used during optm
+    std::vector<ValueType> coeffs;
+    // number of dets per csf
+    std::vector<size_t> dets_per_csf;
+    // coefficient of csf expansion (smaller dimension)
+    std::vector<RealType> expansion;
+  };
+
+  std::shared_ptr<CSFData> csf_data_;
 
 private:
   //get Det ID. It should be consistent with particle group id within the particle set.

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -180,7 +180,7 @@ public:
   //optimizable variable is shared with the clones
   std::shared_ptr<opt_variables_type> myVars;
 
-  bool usingCSF;
+  /// CSF data set. If nullptr, not using CSF
   std::shared_ptr<CSFData> csf_data_;
 
 private:

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -597,16 +597,8 @@ std::unique_ptr<MultiSlaterDetTableMethod> SlaterDetBuilder::createMSDFast(
   }
 
   auto msd_fast = std::make_unique<MultiSlaterDetTableMethod>(targetPtcl, std::move(dets), use_precompute);
-  msd_fast->initialize();
-
-  msd_fast->C2node = std::move(C2nodes_sorted_ptr);
-  msd_fast->C      = std::move(C_ptr);
-  msd_fast->myVars = std::move(myVars_ptr);
-
-  msd_fast->csf_data_ = std::move(csf_data_ptr);
-
-  msd_fast->Optimizable    = Optimizable;
-  msd_fast->CI_Optimizable = CI_Optimizable;
+  msd_fast->initialize(std::move(C2nodes_sorted_ptr), std::move(C_ptr), std::move(myVars_ptr), std::move(csf_data_ptr),
+                       Optimizable, CI_Optimizable);
 
   return msd_fast;
 }

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -232,8 +232,8 @@ std::unique_ptr<WaveFunctionComponent> SlaterDetBuilder::buildComponent(xmlNodeP
       }
 
       msd_fast->initialize();
-      createMSDFast(msd_fast->Dets, *msd_fast->C2node, *msd_fast->C, *msd_fast->CSFcoeff, *msd_fast->DetsPerCSF,
-                    *msd_fast->CSFexpansion, msd_fast->usingCSF, *msd_fast->myVars, msd_fast->Optimizable,
+      createMSDFast(msd_fast->Dets, *msd_fast->C2node, *msd_fast->C, msd_fast->csf_data_->coeffs, msd_fast->csf_data_->dets_per_csf,
+                    msd_fast->csf_data_->expansion, msd_fast->usingCSF, *msd_fast->myVars, msd_fast->Optimizable,
                     msd_fast->CI_Optimizable, cur);
 
       // The primary purpose of this function is to create all the optimizable orbital rotation parameters.

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -27,6 +27,7 @@ class TrialWaveFunction;
 class BackflowTransformation;
 class DiracDeterminantBase;
 class MultiSlaterDetTableMethod;
+class CSFData;
 class SPOSet;
 class SPOSetBuilder;
 class SPOSetBuilderFactory;
@@ -90,10 +91,7 @@ private:
                    std::vector<ValueType>& coeff,
                    bool& optimizeCI,
                    std::vector<int>& nptcls,
-                   std::vector<ValueType>& CSFcoeff,
-                   std::vector<size_t>& DetsPerCSF,
-                   std::vector<RealType>& CSFexpansion,
-                   bool& usingCSF) const;
+                   std::unique_ptr<CSFData>& csf_data_ptr) const;
 
   bool readDetListH5(xmlNodePtr cur,
                      std::vector<std::vector<ci_configuration>>& uniqueConfgs,

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -26,7 +26,8 @@ namespace qmcplusplus
 class TrialWaveFunction;
 class BackflowTransformation;
 class DiracDeterminantBase;
-class MultiDiracDeterminant;
+class MultiSlaterDetTableMethod;
+class SPOSet;
 class SPOSetBuilder;
 class SPOSetBuilderFactory;
 struct ci_configuration;
@@ -75,17 +76,11 @@ private:
       const std::unique_ptr<SPOSetBuilder>& legacy_input_sposet_builder,
       const std::unique_ptr<BackflowTransformation>& BFTrans);
 
-  bool createMSDFast(std::vector<std::unique_ptr<MultiDiracDeterminant>>& Dets,
-                     std::vector<std::vector<size_t>>& C2node,
-                     std::vector<ValueType>& C,
-                     std::vector<ValueType>& CSFcoeff,
-                     std::vector<size_t>& DetsPerCSF,
-                     std::vector<RealType>& CSFexpansion,
-                     bool& usingCSF,
-                     opt_variables_type& myVars,
-                     bool& Optimizable,
-                     bool& CI_Optimizable,
-                     xmlNodePtr cur) const;
+  std::unique_ptr<MultiSlaterDetTableMethod> createMSDFast(xmlNodePtr cur,
+                                                           ParticleSet& target_ptcl,
+                                                           std::vector<std::unique_ptr<SPOSet>>&& spo_clones,
+                                                           const bool spinor,
+                                                           const bool use_precompute) const;
 
 
   bool readDetList(xmlNodePtr cur,


### PR DESCRIPTION
## Proposed changes
Refactor MultiSlaterDetTableMethod construction procedure, minimize the exposure of MultiSlaterDetTableMethod internal objects.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
