### PR TITLE
Restore CSVMC access

### DIFF
--- a/src/Particle/DistanceTable.h
+++ b/src/Particle/DistanceTable.h
@@ -298,10 +298,10 @@ public:
     return nullptr;
   }
 
-  virtual const RealType* mw_evaluate_range(const RefVectorWithLeader<DistanceTable>& dt_list,
-                                            const RefVectorWithLeader<ParticleSet>& p_list,
-                                            size_t range_begin,
-                                            size_t range_end) const
+  virtual const RealType* mw_evalDistsInRange(const RefVectorWithLeader<DistanceTable>& dt_list,
+                                              const RefVectorWithLeader<ParticleSet>& p_list,
+                                              size_t range_begin,
+                                              size_t range_end) const
   {
     return nullptr;
   }

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -191,10 +191,10 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
    * half of the table due to the symmetry of AA table. See note of the output data object mw_distances_subset
    * To keep resident memory minimal on the device, range_end - range_begin < num_particls_stored is required.
    */
-  const RealType* mw_evaluate_range(const RefVectorWithLeader<DistanceTable>& dt_list,
-                                    const RefVectorWithLeader<ParticleSet>& p_list,
-                                    size_t range_begin,
-                                    size_t range_end) const override
+  const RealType* mw_evalDistsInRange(const RefVectorWithLeader<DistanceTable>& dt_list,
+                                      const RefVectorWithLeader<ParticleSet>& p_list,
+                                      size_t range_begin,
+                                      size_t range_end) const override
   {
     auto& dt_leader          = dt_list.getCastedLeader<SoaDistanceTableAAOMPTarget>();
     const size_t subset_size = range_end - range_begin;

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -70,7 +70,8 @@ QMCDriverFactory::DriverAssemblyState QMCDriverFactory::readSection(xmlNodePtr c
   std::string gpu_tag("no");
 #endif
   OhmmsAttributeSet aAttrib;
-  aAttrib.add(qmc_mode, "method", {"", "vmc", "vmc_batch", "dmc", "dmc_batch", "rmc", "linear", "linear_batch", "wftest"});
+  aAttrib.add(qmc_mode, "method",
+              {"", "vmc", "vmc_batch", "dmc", "dmc_batch", "csvmc", "rmc", "linear", "linear_batch", "wftest"});
   aAttrib.add(update_mode, "move");
   aAttrib.add(multi_tag, "multiple");
   aAttrib.add(warp_tag, "warp");
@@ -255,8 +256,8 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
 #endif
     QMCFixedSampleLinearOptimizeBatched* opt =
         QMCWFOptLinearFactoryNew(cur, project_data_, qmc_system,
-                                 MCPopulation(comm->size(), comm->rank(), qmc_system, 
-                                              &qmc_system, primaryPsi, primaryH),
+                                 MCPopulation(comm->size(), comm->rank(), qmc_system, &qmc_system, primaryPsi,
+                                              primaryH),
                                  qmc_system.getSampleStack(), comm);
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
     new_driver.reset(opt);

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -549,7 +549,7 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
       const size_t last            = std::min(first + chunk_size, total_num_half);
       const size_t this_chunk_size = last - first;
 
-      auto* mw_dist = dtaa_leader.mw_evaluate_range(dt_list, p_list, first, last);
+      auto* mw_dist = dtaa_leader.mw_evalDistsInRange(dt_list, p_list, first, last);
 
       ScopedTimer offload_scope(caa_leader.offload_timer_);
 


### PR DESCRIPTION
## Proposed changes
#3882 mistreated CSVMC. Fixed it.

I have a local renaming commit. mw_evaluate_range -> mw_evalDistsInRange. Would like to skip a separate PR.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted