### PR TITLE
Introduce PlatformSelector to allow both direct and indrect selection and enable offload codepath in non-offload builds.

### DIFF
--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -28,6 +28,8 @@ set(PARTICLE
     SampleStack.cpp
     createDistanceTableAA.cpp
     createDistanceTableAB.cpp
+    createDistanceTableAAOMPTarget.cpp
+    createDistanceTableABOMPTarget.cpp
     HDFWalkerInputManager.cpp
     LongRange/KContainer.cpp
     LongRange/StructFact.cpp
@@ -36,10 +38,6 @@ set(PARTICLE
     LongRange/EwaldHandlerQuasi2D.cpp
     LongRange/EwaldHandler3D.cpp
     LongRange/LRCoulombSingleton.cpp)
-
-if(ENABLE_OFFLOAD)
-  set(PARTICLE ${PARTICLE} createDistanceTableAAOMPTarget.cpp createDistanceTableABOMPTarget.cpp)
-endif(ENABLE_OFFLOAD)
 
 set(PARTICLEIO
     ParticleTags.cpp

--- a/src/Particle/DynamicCoordinatesBuilder.cpp
+++ b/src/Particle/DynamicCoordinatesBuilder.cpp
@@ -22,12 +22,8 @@ std::unique_ptr<DynamicCoordinates> createDynamicCoordinates(const DynamicCoordi
 {
   if (kind == DynamicCoordinateKind::DC_POS)
     return std::make_unique<RealSpacePositions>();
-#if defined(ENABLE_OFFLOAD)
   else if (kind == DynamicCoordinateKind::DC_POS_OFFLOAD)
     return std::make_unique<RealSpacePositionsOMPTarget>();
-#endif
-  else
-    throw std::runtime_error("DynamicCoordinatesBuilder::createDynamicCoordinates unknown DynamicCoordinateKind");
   // dummy return
   return std::unique_ptr<RealSpacePositions>();
 }

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -26,6 +26,7 @@
 #include "Particle/InitMolecularSystem.h"
 #include "LongRange/LRCoulombSingleton.h"
 #include <Message/UniformCommunicateError.h>
+#include <PlatformSelector.hpp>
 
 namespace qmcplusplus
 {
@@ -124,9 +125,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   pAttrib.add(randomsrc, "randomsrc");
   pAttrib.add(randomsrc, "random_source");
   pAttrib.add(spinor, "spinor", {"no", "yes"});
-#if defined(ENABLE_OFFLOAD)
-  pAttrib.add(useGPU, "gpu", {"yes", "no"});
-#endif
+  pAttrib.add(useGPU, "gpu", OMPTargetSelector::candidate_values);
   pAttrib.put(cur);
   //backward compatibility
   if (id == "e" && role == "none")
@@ -134,14 +133,15 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   ParticleSet* pTemp = getParticleSet(id);
   if (pTemp == 0)
   {
+    const bool use_offload = OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET;
     app_summary() << std::endl;
     app_summary() << " Particle Set" << std::endl;
     app_summary() << " ------------" << std::endl;
-    app_summary() << "  Name: " << id << "   Offload : " << useGPU << std::endl;
+    app_summary() << "  Name: " << id << "   Offload : " << (use_offload ? "yes" : "no") << std::endl;
     app_summary() << std::endl;
 
     // select OpenMP offload implementation in ParticleSet.
-    if (useGPU == "yes")
+    if (use_offload)
       pTemp = new MCWalkerConfiguration(*simulation_cell_, DynamicCoordinateKind::DC_POS_OFFLOAD);
     else
       pTemp = new MCWalkerConfiguration(*simulation_cell_, DynamicCoordinateKind::DC_POS);

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -125,7 +125,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   pAttrib.add(randomsrc, "randomsrc");
   pAttrib.add(randomsrc, "random_source");
   pAttrib.add(spinor, "spinor", {"no", "yes"});
-  pAttrib.add(useGPU, "gpu", OMPTargetSelector::candidate_values);
+  pAttrib.add(useGPU, "gpu", CPUOMPTargetSelector::candidate_values);
   pAttrib.put(cur);
   //backward compatibility
   if (id == "e" && role == "none")
@@ -133,7 +133,7 @@ bool ParticleSetPool::put(xmlNodePtr cur)
   ParticleSet* pTemp = getParticleSet(id);
   if (pTemp == 0)
   {
-    const bool use_offload = OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET;
+    const bool use_offload = CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET;
     app_summary() << std::endl;
     app_summary() << " Particle Set" << std::endl;
     app_summary() << " ------------" << std::endl;

--- a/src/Particle/createDistanceTable.h
+++ b/src/Particle/createDistanceTable.h
@@ -45,11 +45,9 @@ inline std::unique_ptr<DistanceTable> createDistanceTable(ParticleSet& s, std::o
   // during P-by-P move, the cost of single particle evaluation of distance tables
   // is determined by the number of source particles.
   // Thus the implementation selection is determined by the source particle set.
-#if defined(ENABLE_OFFLOAD)
   if (s.getCoordinates().getKind() == DynamicCoordinateKind::DC_POS_OFFLOAD)
     return createDistanceTableAAOMPTarget(s, description);
   else
-#endif
     return createDistanceTableAA(s, description);
 }
 
@@ -66,11 +64,9 @@ inline std::unique_ptr<DistanceTable> createDistanceTable(const ParticleSet& s,
   // during P-by-P move, the cost of single particle evaluation of distance tables
   // is determined by the number of source particles.
   // Thus the implementation selection is determined by the source particle set.
-#if defined(ENABLE_OFFLOAD)
   if (s.getCoordinates().getKind() == DynamicCoordinateKind::DC_POS_OFFLOAD)
     return createDistanceTableABOMPTarget(s, t, description);
   else
-#endif
     return createDistanceTableAB(s, t, description);
 }
 

--- a/src/Particle/tests/test_distance_table.cpp
+++ b/src/Particle/tests/test_distance_table.cpp
@@ -579,9 +579,7 @@ void test_distance_pbc_z_batched_APIs(DynamicCoordinateKind test_kind)
 TEST_CASE("distance_pbc_z batched APIs", "[distance_table][xml]")
 {
   test_distance_pbc_z_batched_APIs(DynamicCoordinateKind::DC_POS);
-#if defined(ENABLE_OFFLOAD)
   test_distance_pbc_z_batched_APIs(DynamicCoordinateKind::DC_POS_OFFLOAD);
-#endif
 }
 
 void test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinateKind test_kind)
@@ -649,9 +647,7 @@ void test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinat
 TEST_CASE("distance_pbc_z batched APIs ee NEED_TEMP_DATA_ON_HOST", "[distance_table][xml]")
 {
   test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinateKind::DC_POS);
-#if defined(ENABLE_OFFLOAD)
   test_distance_pbc_z_batched_APIs_ee_NEED_TEMP_DATA_ON_HOST(DynamicCoordinateKind::DC_POS_OFFLOAD);
-#endif
 }
 
 TEST_CASE("test_distance_pbc_diamond", "[distance_table][xml]")

--- a/src/Platforms/CMakeLists.txt
+++ b/src/Platforms/CMakeLists.txt
@@ -17,7 +17,7 @@
 # platform_runtime is for host and programming model runtime systems which inclues
 # Device management: device assignement, memory management. Note: CPU is a device
 # Math functions: scalar and vector math functions from OS or vendors
-set(DEVICE_SRCS MemoryUsage.cpp DualAllocator.cpp DeviceManager.cpp)
+set(DEVICE_SRCS MemoryUsage.cpp DualAllocator.cpp DeviceManager.cpp PlatformSelector.cpp)
 add_library(platform_runtime ${DEVICE_SRCS})
 target_link_libraries(platform_runtime PUBLIC platform_host_runtime)
 target_include_directories(platform_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/Platforms/PlatformSelector.cpp
+++ b/src/Platforms/PlatformSelector.cpp
@@ -1,0 +1,33 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "PlatformSelector.hpp"
+#include <config.h>
+
+namespace qmcplusplus
+{
+
+const std::vector<std::string> PlatformSelector<SelectorKind::OMPTARGET>::candidate_values{"", "yes", "no", "omptarget", "cpu"};
+
+PlatformKind PlatformSelector<SelectorKind::OMPTARGET>::convertToPlatform(std::string_view value)
+  {
+#if defined(ENABLE_OFFLOAD)
+    if (value.empty() || value == "yes" || value == "omptarget" )
+#else
+    if (value == "omptarget")
+#endif
+      return PlatformKind::OMPTARGET;
+    else
+      return PlatformKind::CPU;
+  }
+
+}

--- a/src/Platforms/PlatformSelector.cpp
+++ b/src/Platforms/PlatformSelector.cpp
@@ -12,6 +12,7 @@
 
 #include "PlatformSelector.hpp"
 #include <config.h>
+#include <stdexcept>
 
 namespace qmcplusplus
 {
@@ -25,6 +26,30 @@ PlatformKind PlatformSelector<SelectorKind::CPU_OMPTARGET>::selectPlatform(std::
   if (value.empty() || value == "yes" || value == "omptarget")
 #else
   if (value == "omptarget")
+#endif
+    return PlatformKind::OMPTARGET;
+  else
+    return PlatformKind::CPU;
+}
+
+const std::vector<std::string> PlatformSelector<SelectorKind::CPU_OMPTARGET_CUDA>::candidate_values{"",          "yes",
+                                                                                                    "no",        "cuda",
+                                                                                                    "omptarget", "cpu"};
+
+PlatformKind PlatformSelector<SelectorKind::CPU_OMPTARGET_CUDA>::selectPlatform(std::string_view value)
+{
+#if defined(ENABLE_CUDA)
+  if (value.empty() || value == "yes" || value == "cuda")
+    return PlatformKind::CUDA;
+  else if (value == "omptarget")
+#else
+  if (value == "cuda")
+    throw std::runtime_error("Cannot access CUDA code path. Executables are built with ENABLE_CUDA=OFF.");
+#if defined(ENABLE_OFFLOAD)
+  if (value.empty() || value == "yes" || value == "omptarget")
+#else
+  if (value == "omptarget")
+#endif
 #endif
     return PlatformKind::OMPTARGET;
   else

--- a/src/Platforms/PlatformSelector.cpp
+++ b/src/Platforms/PlatformSelector.cpp
@@ -16,18 +16,19 @@
 namespace qmcplusplus
 {
 
-const std::vector<std::string> PlatformSelector<SelectorKind::OMPTARGET>::candidate_values{"", "yes", "no", "omptarget", "cpu"};
+const std::vector<std::string> PlatformSelector<SelectorKind::CPU_OMPTARGET>::candidate_values{"", "yes", "no",
+                                                                                               "omptarget", "cpu"};
 
-PlatformKind PlatformSelector<SelectorKind::OMPTARGET>::convertToPlatform(std::string_view value)
-  {
+PlatformKind PlatformSelector<SelectorKind::CPU_OMPTARGET>::selectPlatform(std::string_view value)
+{
 #if defined(ENABLE_OFFLOAD)
-    if (value.empty() || value == "yes" || value == "omptarget" )
+  if (value.empty() || value == "yes" || value == "omptarget")
 #else
-    if (value == "omptarget")
+  if (value == "omptarget")
 #endif
-      return PlatformKind::OMPTARGET;
-    else
-      return PlatformKind::CPU;
-  }
-
+    return PlatformKind::OMPTARGET;
+  else
+    return PlatformKind::CPU;
 }
+
+} // namespace qmcplusplus

--- a/src/Platforms/PlatformSelector.hpp
+++ b/src/Platforms/PlatformSelector.hpp
@@ -44,5 +44,15 @@ public:
 };
 
 using CPUOMPTargetSelector = PlatformSelector<SelectorKind::CPU_OMPTARGET>;
+
+template<>
+class PlatformSelector<SelectorKind::CPU_OMPTARGET_CUDA>
+{
+public:
+  static const std::vector<std::string> candidate_values;
+  static PlatformKind selectPlatform(std::string_view value);
+};
+
+using CPUOMPTargetCUDASelector = PlatformSelector<SelectorKind::CPU_OMPTARGET_CUDA>;
 } // namespace qmcplusplus
 #endif

--- a/src/Platforms/PlatformSelector.hpp
+++ b/src/Platforms/PlatformSelector.hpp
@@ -19,28 +19,30 @@
 namespace qmcplusplus
 {
 
-enum class PlatformKind {
+enum class PlatformKind
+{
   CPU,
   OMPTARGET,
   CUDA
 };
 
-enum class SelectorKind {
-  OMPTARGET,
-  OMPTARGET_AND_CUDA
+enum class SelectorKind
+{
+  CPU_OMPTARGET,
+  CPU_OMPTARGET_CUDA
 };
 
 template<SelectorKind KIND>
 class PlatformSelector;
 
 template<>
-class PlatformSelector<SelectorKind::OMPTARGET>
+class PlatformSelector<SelectorKind::CPU_OMPTARGET>
 {
 public:
   static const std::vector<std::string> candidate_values;
-  static PlatformKind convertToPlatform(std::string_view value);
+  static PlatformKind selectPlatform(std::string_view value);
 };
 
-using OMPTargetSelector = PlatformSelector<SelectorKind::OMPTARGET>;
-}
+using CPUOMPTargetSelector = PlatformSelector<SelectorKind::CPU_OMPTARGET>;
+} // namespace qmcplusplus
 #endif

--- a/src/Platforms/PlatformSelector.hpp
+++ b/src/Platforms/PlatformSelector.hpp
@@ -1,0 +1,46 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_PLATFORM_SELECTOR_H
+#define QMCPLUSPLUS_PLATFORM_SELECTOR_H
+
+#include <vector>
+#include <string>
+
+namespace qmcplusplus
+{
+
+enum class PlatformKind {
+  CPU,
+  OMPTARGET,
+  CUDA
+};
+
+enum class SelectorKind {
+  OMPTARGET,
+  OMPTARGET_AND_CUDA
+};
+
+template<SelectorKind KIND>
+class PlatformSelector;
+
+template<>
+class PlatformSelector<SelectorKind::OMPTARGET>
+{
+public:
+  static const std::vector<std::string> candidate_values;
+  static PlatformKind convertToPlatform(std::string_view value);
+};
+
+using OMPTargetSelector = PlatformSelector<SelectorKind::OMPTARGET>;
+}
+#endif

--- a/src/Platforms/tests/CMakeLists.txt
+++ b/src/Platforms/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 #// This file is distributed under the University of Illinois/NCSA Open Source License.
 #// See LICENSE file in top directory for details.
 #//
-#// Copyright (c) 2021 QMCPACK developers.
+#// Copyright (c) 2022 QMCPACK developers.
 #//
 #// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 #//
@@ -19,3 +19,11 @@ endif()
 if(ENABLE_OFFLOAD)
   add_subdirectory(OMPTarget)
 endif(ENABLE_OFFLOAD)
+
+set(UTEST_EXE test_platforms)
+set(UTEST_NAME deterministic-unit_${UTEST_EXE})
+
+add_executable(${UTEST_EXE} test_PlatformSelector.cpp)
+target_link_libraries(${UTEST_EXE} platform_runtime catch_main)
+
+add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Platforms/tests/test_PlatformSelector.cpp
+++ b/src/Platforms/tests/test_PlatformSelector.cpp
@@ -18,15 +18,36 @@ namespace qmcplusplus
 {
 TEST_CASE("PlatformSelector", "[platform]")
 {
+  SECTION("CPU_OMPTARGET")
+  {
 #if defined(ENABLE_OFFLOAD)
-  CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::OMPTARGET);
-  CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::OMPTARGET);
+    CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::OMPTARGET);
+    CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::OMPTARGET);
 #else
-  CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::CPU);
-  CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::CPU);
 #endif
-  CHECK(CPUOMPTargetSelector::selectPlatform("omptarget") == PlatformKind::OMPTARGET);
-  CHECK(CPUOMPTargetSelector::selectPlatform("cpu") == PlatformKind::CPU);
-  CHECK(CPUOMPTargetSelector::selectPlatform("no") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetSelector::selectPlatform("omptarget") == PlatformKind::OMPTARGET);
+    CHECK(CPUOMPTargetSelector::selectPlatform("cpu") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetSelector::selectPlatform("no") == PlatformKind::CPU);
+  }
+
+  SECTION("CPU_OMPTARGET_CUDA")
+  {
+#if defined(ENABLE_CUDA)
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("yes") == PlatformKind::CUDA);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("") == PlatformKind::CUDA);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("cuda") == PlatformKind::CUDA);
+#elif defined(ENABLE_OFFLOAD)
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("yes") == PlatformKind::OMPTARGET);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("") == PlatformKind::OMPTARGET);
+#else
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("yes") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("") == PlatformKind::CPU);
+#endif
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("omptarget") == PlatformKind::OMPTARGET);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("cpu") == PlatformKind::CPU);
+    CHECK(CPUOMPTargetCUDASelector::selectPlatform("no") == PlatformKind::CPU);
+  }
 }
 } // namespace qmcplusplus

--- a/src/Platforms/tests/test_PlatformSelector.cpp
+++ b/src/Platforms/tests/test_PlatformSelector.cpp
@@ -19,14 +19,14 @@ namespace qmcplusplus
 TEST_CASE("PlatformSelector", "[platform]")
 {
 #if defined(ENABLE_OFFLOAD)
-  CHECK(OMPTargetSelector::convertToPlatform("yes") == PlatformKind::OMPTARGET);
-  CHECK(OMPTargetSelector::convertToPlatform("") == PlatformKind::OMPTARGET);
+  CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::OMPTARGET);
+  CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::OMPTARGET);
 #else
-  CHECK(OMPTargetSelector::convertToPlatform("yes") == PlatformKind::CPU);
-  CHECK(OMPTargetSelector::convertToPlatform("") == PlatformKind::CPU);
+  CHECK(CPUOMPTargetSelector::selectPlatform("yes") == PlatformKind::CPU);
+  CHECK(CPUOMPTargetSelector::selectPlatform("") == PlatformKind::CPU);
 #endif
-  CHECK(OMPTargetSelector::convertToPlatform("omptarget") == PlatformKind::OMPTARGET);
-  CHECK(OMPTargetSelector::convertToPlatform("cpu") == PlatformKind::CPU);
-  CHECK(OMPTargetSelector::convertToPlatform("no") == PlatformKind::CPU);
+  CHECK(CPUOMPTargetSelector::selectPlatform("omptarget") == PlatformKind::OMPTARGET);
+  CHECK(CPUOMPTargetSelector::selectPlatform("cpu") == PlatformKind::CPU);
+  CHECK(CPUOMPTargetSelector::selectPlatform("no") == PlatformKind::CPU);
 }
-}
+} // namespace qmcplusplus

--- a/src/Platforms/tests/test_PlatformSelector.cpp
+++ b/src/Platforms/tests/test_PlatformSelector.cpp
@@ -1,0 +1,32 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "PlatformSelector.hpp"
+#include <config.h>
+
+namespace qmcplusplus
+{
+TEST_CASE("PlatformSelector", "[platform]")
+{
+#if defined(ENABLE_OFFLOAD)
+  CHECK(OMPTargetSelector::convertToPlatform("yes") == PlatformKind::OMPTARGET);
+  CHECK(OMPTargetSelector::convertToPlatform("") == PlatformKind::OMPTARGET);
+#else
+  CHECK(OMPTargetSelector::convertToPlatform("yes") == PlatformKind::CPU);
+  CHECK(OMPTargetSelector::convertToPlatform("") == PlatformKind::CPU);
+#endif
+  CHECK(OMPTargetSelector::convertToPlatform("omptarget") == PlatformKind::OMPTARGET);
+  CHECK(OMPTargetSelector::convertToPlatform("cpu") == PlatformKind::CPU);
+  CHECK(OMPTargetSelector::convertToPlatform("no") == PlatformKind::CPU);
+}
+}

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -210,7 +210,7 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   ParticleSet elec(simulation_cell, kind);
 
   elec.setName("elec");
-  elec.create({1,2});
+  elec.create({1, 2});
   elec.R[0] = {0.0, 0.0, 0.0};
   elec.R[1] = {0.1, 0.2, 0.3};
   elec.R[2] = {0.3, 0.1, 0.2};
@@ -261,8 +261,6 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
 TEST_CASE("Coulomb PBC A-A BCC 3 particles", "[hamiltonian]")
 {
   test_CoulombPBCAA_3p(DynamicCoordinateKind::DC_POS);
-#if defined(ENABLE_OFFLOAD)
   test_CoulombPBCAA_3p(DynamicCoordinateKind::DC_POS_OFFLOAD);
-#endif
 }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/BsplineFactory/createComplexDouble.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createComplexDouble.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
 
 #if defined(QMC_COMPLEX)
   app_summary() << "    Using complex valued spline SPOs with complex double precision storage (C2C)." << std::endl;
-  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -67,7 +67,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
   }
 #else //QMC_COMPLEX
   app_summary() << "    Using real valued spline SPOs with complex double precision storage (C2R)." << std::endl;
-  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {

--- a/src/QMCWaveFunctions/BsplineFactory/createComplexDouble.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createComplexDouble.cpp
@@ -11,6 +11,7 @@
 
 
 #include "QMCWaveFunctions/BsplineFactory/createBsplineReader.h"
+#include <PlatformSelector.hpp>
 #include "CPU/e2iphi.h"
 #include "CPU/SIMD/vmath.hpp"
 #include "Utilities/ProgressReportEngine.h"
@@ -18,10 +19,8 @@
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2R.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2C.h"
-#if defined(ENABLE_OFFLOAD)
 #include "QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h"
-#endif
 #include "QMCWaveFunctions/BsplineFactory/HybridRepCplx.h"
 #include <fftw3.h>
 #include "QMCWaveFunctions/einspline_helper.hpp"
@@ -40,8 +39,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
 
 #if defined(QMC_COMPLEX)
   app_summary() << "    Using complex valued spline SPOs with complex double precision storage (C2C)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -57,7 +55,6 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
     }
   }
   else
-#endif
   {
     app_summary() << "    Running on CPU." << std::endl;
     if (hybrid_rep)
@@ -70,8 +67,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
   }
 #else //QMC_COMPLEX
   app_summary() << "    Using real valued spline SPOs with complex double precision storage (C2R)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -87,7 +83,6 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexDouble(EinsplineSetBuilde
     }
   }
   else
-#endif
   {
     app_summary() << "    Running on CPU." << std::endl;
     if (hybrid_rep)

--- a/src/QMCWaveFunctions/BsplineFactory/createComplexSingle.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createComplexSingle.cpp
@@ -11,6 +11,7 @@
 
 
 #include "QMCWaveFunctions/BsplineFactory/createBsplineReader.h"
+#include <PlatformSelector.hpp>
 #include "CPU/e2iphi.h"
 #include "CPU/SIMD/vmath.hpp"
 #include "Utilities/ProgressReportEngine.h"
@@ -18,10 +19,8 @@
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2R.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2C.h"
-#if defined(ENABLE_OFFLOAD)
 #include "QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h"
 #include "QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h"
-#endif
 #include "QMCWaveFunctions/BsplineFactory/HybridRepCplx.h"
 #include <fftw3.h>
 #include "QMCWaveFunctions/einspline_helper.hpp"
@@ -40,8 +39,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
 
 #if defined(QMC_COMPLEX)
   app_summary() << "    Using complex valued spline SPOs with complex single precision storage (C2C)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -57,7 +55,6 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
     }
   }
   else
-#endif
   {
     app_summary() << "    Running on CPU." << std::endl;
     if (hybrid_rep)
@@ -70,8 +67,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
   }
 #else //QMC_COMPLEX
   app_summary() << "    Using real valued spline SPOs with complex single precision storage (C2R)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -87,7 +83,6 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
     }
   }
   else
-#endif
   {
     app_summary() << "    Running on CPU." << std::endl;
     if (hybrid_rep)

--- a/src/QMCWaveFunctions/BsplineFactory/createComplexSingle.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createComplexSingle.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
 
 #if defined(QMC_COMPLEX)
   app_summary() << "    Using complex valued spline SPOs with complex single precision storage (C2C)." << std::endl;
-  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {
@@ -67,7 +67,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineComplexSingle(EinsplineSetBuilde
   }
 #else //QMC_COMPLEX
   app_summary() << "    Using real valued spline SPOs with complex single precision storage (C2R)." << std::endl;
-  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
   {
     if (hybrid_rep)
     {

--- a/src/QMCWaveFunctions/BsplineFactory/createRealDouble.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createRealDouble.cpp
@@ -11,6 +11,7 @@
 
 
 #include "QMCWaveFunctions/BsplineFactory/createBsplineReader.h"
+#include <PlatformSelector.hpp>
 #include "Utilities/ProgressReportEngine.h"
 #include "QMCWaveFunctions/EinsplineSetBuilder.h"
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"
@@ -29,11 +30,9 @@ std::unique_ptr<BsplineReaderBase> createBsplineRealDouble(EinsplineSetBuilder* 
                                                            const std::string& useGPU)
 {
   app_summary() << "    Using real valued spline SPOs with real double precision storage (R2R)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
     app_summary() << "OpenMP offload has not been implemented to support real valued spline SPOs with real storage!"
                   << std::endl;
-#endif
   app_summary() << "    Running on CPU." << std::endl;
 
   std::unique_ptr<BsplineReaderBase> aReader;

--- a/src/QMCWaveFunctions/BsplineFactory/createRealDouble.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createRealDouble.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<BsplineReaderBase> createBsplineRealDouble(EinsplineSetBuilder* 
                                                            const std::string& useGPU)
 {
   app_summary() << "    Using real valued spline SPOs with real double precision storage (R2R)." << std::endl;
-  if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
     app_summary() << "OpenMP offload has not been implemented to support real valued spline SPOs with real storage!"
                   << std::endl;
   app_summary() << "    Running on CPU." << std::endl;

--- a/src/QMCWaveFunctions/BsplineFactory/createRealSingle.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createRealSingle.cpp
@@ -11,6 +11,7 @@
 
 
 #include "QMCWaveFunctions/BsplineFactory/createBsplineReader.h"
+#include <PlatformSelector.hpp>
 #include "Utilities/ProgressReportEngine.h"
 #include "QMCWaveFunctions/EinsplineSetBuilder.h"
 #include "QMCWaveFunctions/BsplineFactory/BsplineSet.h"

--- a/src/QMCWaveFunctions/BsplineFactory/createRealSingle.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/createRealSingle.cpp
@@ -30,11 +30,9 @@ std::unique_ptr<BsplineReaderBase> createBsplineRealSingle(EinsplineSetBuilder* 
                                                            const std::string& useGPU)
 {
   app_summary() << "    Using real valued spline SPOs with real single precision storage (R2R)." << std::endl;
-#if defined(ENABLE_OFFLOAD)
-  if (useGPU == "yes")
+  if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
     app_summary() << "OpenMP offload has not been implemented to support real valued spline SPOs with real storage!"
                   << std::endl;
-#endif
   app_summary() << "    Running on CPU." << std::endl;
 
   std::unique_ptr<BsplineReaderBase> aReader;

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -55,12 +55,9 @@ set(JASTROW_SRCS
     Jastrow/CountingJastrowBuilder.cpp
     Jastrow/RPAJastrow.cpp
     Jastrow/J2OrbitalSoA.cpp
+    Jastrow/J2OMPTarget.cpp
     LatticeGaussianProduct.cpp
     LatticeGaussianProductBuilder.cpp)
-
-if(ENABLE_OFFLOAD)
-  set(JASTROW_SRCS ${JASTROW_SRCS} Jastrow/J2OMPTarget.cpp)
-endif()
 
 if(QMC_COMPLEX)
   set(FERMION_SRCS ${FERMION_SRCS} ElectronGas/ElectronGasComplexOrbitalBuilder.cpp)
@@ -120,16 +117,11 @@ if(OHMMS_DIM MATCHES 3)
         BandInfo.cpp
         BsplineFactory/BsplineReaderBase.cpp)
     if(QMC_COMPLEX)
-      set(FERMION_SRCS ${FERMION_SRCS} EinsplineSpinorSetBuilder.cpp BsplineFactory/SplineC2C.cpp)
-      if(ENABLE_OFFLOAD)
-        set(FERMION_SRCS ${FERMION_SRCS} BsplineFactory/SplineC2COMPTarget.cpp)
-      endif(ENABLE_OFFLOAD)
+      set(FERMION_SRCS ${FERMION_SRCS} EinsplineSpinorSetBuilder.cpp
+          BsplineFactory/SplineC2C.cpp BsplineFactory/SplineC2COMPTarget.cpp)
     else(QMC_COMPLEX)
       set(FERMION_SRCS ${FERMION_SRCS} BsplineFactory/createRealSingle.cpp BsplineFactory/createRealDouble.cpp
-                       BsplineFactory/SplineC2R.cpp BsplineFactory/SplineR2R.cpp)
-      if(ENABLE_OFFLOAD)
-        set(FERMION_SRCS ${FERMION_SRCS} BsplineFactory/SplineC2ROMPTarget.cpp)
-      endif(ENABLE_OFFLOAD)
+                       BsplineFactory/SplineC2R.cpp BsplineFactory/SplineR2R.cpp BsplineFactory/SplineC2ROMPTarget.cpp)
     endif(QMC_COMPLEX)
 
   endif(HAVE_EINSPLINE)

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
 #if defined(QMC_CUDA)
     useGPU = "yes";
 #else
-    a.add(useGPU, "gpu", OMPTargetSelector::candidate_values);
+    a.add(useGPU, "gpu", CPUOMPTargetSelector::candidate_values);
 #endif
     a.add(GPUsharing, "gpusharing"); // split spline across GPUs visible per rank
     a.add(spo_prec, "precision");
@@ -347,12 +347,12 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       else
 #endif
         temp_OrbitalSet = std::make_unique<EinsplineSetExtended<double>>();
-      temp_OrbitalSet->MultiSpline              = MixedSplineReader->export_MultiSplineDouble().release();
+      temp_OrbitalSet->MultiSpline = MixedSplineReader->export_MultiSplineDouble().release();
       temp_OrbitalSet->MultiSpline->num_splines = NumDistinctOrbitals;
       temp_OrbitalSet->resizeStorage(NumDistinctOrbitals, NumValenceOrbs);
       //set the flags for anti periodic boundary conditions
       temp_OrbitalSet->HalfG = dynamic_cast<BsplineSet&>(*OrbitalSet).getHalfG();
-      new_OrbitalSet         = std::move(temp_OrbitalSet);
+      new_OrbitalSet = std::move(temp_OrbitalSet);
     }
     else
     {
@@ -363,13 +363,13 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       else
 #endif
         temp_OrbitalSet = std::make_unique<EinsplineSetExtended<std::complex<double>>>();
-      temp_OrbitalSet->MultiSpline              = MixedSplineReader->export_MultiSplineComplexDouble().release();
+      temp_OrbitalSet->MultiSpline = MixedSplineReader->export_MultiSplineComplexDouble().release();
       temp_OrbitalSet->MultiSpline->num_splines = NumDistinctOrbitals;
       temp_OrbitalSet->resizeStorage(NumDistinctOrbitals, NumValenceOrbs);
       for (int iorb = 0, num = 0; iorb < NumDistinctOrbitals; iorb++)
       {
-        int ti                               = (*FullBands[spinSet])[iorb].TwistIndex;
-        temp_OrbitalSet->kPoints[iorb]       = PrimCell.k_cart(-TwistAngles[ti]);
+        int ti = (*FullBands[spinSet])[iorb].TwistIndex;
+        temp_OrbitalSet->kPoints[iorb] = PrimCell.k_cart(-TwistAngles[ti]);
         temp_OrbitalSet->MakeTwoCopies[iorb] = (num < (numOrbs - 1)) && (*FullBands[spinSet])[iorb].MakeTwoCopies;
         num += temp_OrbitalSet->MakeTwoCopies[iorb] ? 2 : 1;
       }

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -151,13 +151,13 @@ template<class RadFuncType, unsigned Implementation>
 std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ2(xmlNodePtr cur)
 {
   ReportEngine PRE(ClassName, "createJ2(xmlNodePtr)");
-  using Real       = typename RadFuncType::real_type;
-  using J2Type     = typename JastrowTypeHelper<RadFuncType, Implementation>::J2Type;
+  using Real   = typename RadFuncType::real_type;
+  using J2Type = typename JastrowTypeHelper<RadFuncType, Implementation>::J2Type;
 
   std::string input_name(getXMLAttributeValue(cur, "name"));
   std::string j2name = input_name.empty() ? "J2_" + Jastfunction : input_name;
   SpeciesSet& species(targetPtcl.getSpeciesSet());
-  auto J2  = std::make_unique<J2Type>(j2name, targetPtcl);
+  auto J2 = std::make_unique<J2Type>(j2name, targetPtcl);
 
   std::string init_mode("0");
   {
@@ -501,12 +501,12 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::buildComponent(xmlN
   aAttrib.add(TypeOpt, "type");
   aAttrib.add(Jastfunction, "function");
   aAttrib.add(SpinOpt, "spin", {"no", "yes"});
-  aAttrib.add(useGPU, "gpu", OMPTargetSelector::candidate_values);
+  aAttrib.add(useGPU, "gpu", CPUOMPTargetSelector::candidate_values);
   aAttrib.put(cur);
-  NameOpt = lowerCase(NameOpt);
-  TypeOpt = lowerCase(TypeOpt);
+  NameOpt      = lowerCase(NameOpt);
+  TypeOpt      = lowerCase(TypeOpt);
   Jastfunction = lowerCase(Jastfunction);
-  SpinOpt = lowerCase(SpinOpt);
+  SpinOpt      = lowerCase(SpinOpt);
 
   SpeciesSet& species(targetPtcl.getSpeciesSet());
   int chargeInd = species.addAttribute("charge");
@@ -519,7 +519,8 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::buildComponent(xmlN
       if (SpinOpt == "yes")
       {
 #if defined(QMC_CUDA)
-        myComm->barrier_and_abort("RadialJastrowBuilder::buildComponent spin resolved bspline Jastrow is not supported in legacy CUDA build.");
+        myComm->barrier_and_abort("RadialJastrowBuilder::buildComponent spin resolved bspline Jastrow is not supported "
+                                  "in legacy CUDA build.");
 #else
         return createJ1<BsplineFunctor<RealType>, true>(cur);
 #endif
@@ -581,7 +582,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::buildComponent(xmlN
 #if defined(QMC_CUDA)
       return createJ2<BsplineFunctor<RealType>, detail::CUDA_LEGACY>(cur);
 #else
-      if (OMPTargetSelector::convertToPlatform(useGPU) == PlatformKind::OMPTARGET)
+      if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
       {
         static_assert(std::is_same<JastrowTypeHelper<BsplineFunctor<RealType>, OMPTARGET>::J2Type,
                                    J2OMPTarget<BsplineFunctor<RealType>>>::value,

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -582,6 +582,9 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::buildComponent(xmlN
 #if defined(QMC_CUDA)
       return createJ2<BsplineFunctor<RealType>, detail::CUDA_LEGACY>(cur);
 #else
+      if (useGPU.empty())
+        useGPU = targetPtcl.getCoordinates().getKind() == DynamicCoordinateKind::DC_POS_OFFLOAD ? "yes" : "no";
+
       if (CPUOMPTargetSelector::selectPlatform(useGPU) == PlatformKind::OMPTARGET)
       {
         static_assert(std::is_same<JastrowTypeHelper<BsplineFunctor<RealType>, OMPTARGET>::J2Type,

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -44,7 +44,7 @@ struct float_tag
  *  used and a constexpr based on DeterminantTypes that actually depend on legacy cuda.
  */
 template<class DiracDet, class SPO_precision>
-void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
+void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_jas)
 {
 #if defined(MIXED_PRECISION)
   const double grad_precision  = 1.3e-4;
@@ -56,11 +56,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   OHMMS::Controller->initialize(0, NULL);
   Communicate* c = OHMMS::Controller;
 
-#if defined(ENABLE_OFFLOAD)
-  const DynamicCoordinateKind kind_selected = DynamicCoordinateKind::DC_POS_OFFLOAD;
-#else
-  const DynamicCoordinateKind kind_selected = DynamicCoordinateKind::DC_POS;
-#endif
+  const DynamicCoordinateKind kind_selected = offload_jas ? DynamicCoordinateKind::DC_POS_OFFLOAD : DynamicCoordinateKind::DC_POS;
+
   // diamondC_2x1x1
   ParticleSet::ParticleLayout lattice;
   lattice.R(0, 0)   = 6.7463223;
@@ -123,10 +120,9 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   ParticleSet elec_clone(elec_);
 
   //diamondC_1x1x1
-  std::string spo_xml = "<tmp> \
-               <determinantset type=\"einspline\" href=\"diamondC_2x1x1.pwscf.h5\" tilematrix=\"2 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.5\" precision=\"float\" size=\"2\"/> \
-               </tmp> \
-               ";
+  std::string spo_xml = R"XML(<tmp> \
+               <determinantset type="einspline" href="diamondC_2x1x1.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.5" precision="float" size="2"/> \
+               </tmp>)XML";
 #ifndef MIXED_PRECISION
   if (std::is_same<SPO_precision, double_tag>::value)
   {
@@ -155,16 +151,24 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay)
   TrialWaveFunction psi;
   psi.addComponent(std::move(slater_det));
 
-  const char* jas_input = "<tmp> \
-<jastrow name=\"J2\" type=\"Two-Body\" function=\"Bspline\" print=\"yes\"> \
-   <correlation size=\"10\" speciesA=\"u\" speciesB=\"u\"> \
-      <coefficients id=\"uu\" type=\"Array\"> 0.02904699284 -0.1004179 -0.1752703883 -0.2232576505 -0.2728029201 -0.3253286875 -0.3624525145 -0.3958223107 -0.4268582166 -0.4394531176</coefficients> \
+  const char* jas_input = R"XML(<tmp> \
+<jastrow name="J2" type="Two-Body" function="Bspline" print="yes" gpu="no"> \
+   <correlation size="10" speciesA="u" speciesB="u"> \
+      <coefficients id="uu" type="Array"> 0.02904699284 -0.1004179 -0.1752703883 -0.2232576505 -0.2728029201 -0.3253286875 -0.3624525145 -0.3958223107 -0.4268582166 -0.4394531176</coefficients> \
    </correlation> \
 </jastrow> \
-</tmp> \
-";
+</tmp>)XML";
+
+  const char* jas_omp_input = R"XML(<tmp> \
+<jastrow name="J2" type="Two-Body" function="Bspline" print="yes" gpu="omptarget"> \
+   <correlation size="10" speciesA="u" speciesB="u"> \
+      <coefficients id="uu" type="Array"> 0.02904699284 -0.1004179 -0.1752703883 -0.2232576505 -0.2728029201 -0.3253286875 -0.3624525145 -0.3958223107 -0.4268582166 -0.4394531176</coefficients> \
+   </correlation> \
+</jastrow> \
+</tmp>)XML";
+
   Libxml2Document doc_jas;
-  okay = doc.parseFromString(jas_input);
+  okay = doc.parseFromString(offload_jas ? jas_omp_input : jas_input);
   REQUIRE(okay);
 
   xmlNodePtr jas_root = doc.getRoot();
@@ -574,25 +578,25 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
 #if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1, true);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2, true);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1, true);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2, true);
   }
 #endif
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1, true);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2, false);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1, false);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2, false);
   }
   SECTION("DiracDeterminant<DelayedUpdate>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1, false);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2, false);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1, false);
+    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2, false);
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -38,25 +38,32 @@ struct double_tag
 struct float_tag
 {};
 
+struct OffloadSwitches
+{
+  bool spo;
+  bool jas;
+};
+
 /** Templated test of TrialWF with different DiracDet flavors.
  *  If QMC_CUDA there is no testing converage beyond setup.
  *  \todo at the very least the prepocessor define QMC_CUDA shouldn't be 
  *  used and a constexpr based on DeterminantTypes that actually depend on legacy cuda.
  */
 template<class DiracDet, class SPO_precision>
-void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_spo, const bool offload_jas)
+void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitches& offload_switches)
 {
 #if defined(MIXED_PRECISION)
   const double grad_precision  = 1.3e-4;
   const double ratio_precision = 2e-4;
 #else
-  const double grad_precision               = std::is_same<SPO_precision, float_tag>::value ? 1.3e-4 : 1e-8;
-  const double ratio_precision              = std::is_same<SPO_precision, float_tag>::value ? 2e-4 : 1e-5;
+  const double grad_precision  = std::is_same<SPO_precision, float_tag>::value ? 1.3e-4 : 1e-8;
+  const double ratio_precision = std::is_same<SPO_precision, float_tag>::value ? 2e-4 : 1e-5;
 #endif
   OHMMS::Controller->initialize(0, NULL);
   Communicate* c = OHMMS::Controller;
 
-  const DynamicCoordinateKind kind_selected = offload_jas ? DynamicCoordinateKind::DC_POS_OFFLOAD : DynamicCoordinateKind::DC_POS;
+  const DynamicCoordinateKind kind_selected =
+      offload_switches.jas ? DynamicCoordinateKind::DC_POS_OFFLOAD : DynamicCoordinateKind::DC_POS;
 
   // diamondC_2x1x1
   ParticleSet::ParticleLayout lattice;
@@ -120,7 +127,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
   ParticleSet elec_clone(elec_);
 
   //diamondC_1x1x1
-  std::string spo_xml = R"XML(<tmp> \
+  std::string spo_xml     = R"XML(<tmp> \
                <determinantset type="einspline" href="diamondC_2x1x1.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.5" precision="float" size="2" gpu="no"/> \
                </tmp>)XML";
   std::string spo_omp_xml = R"XML(<tmp> \
@@ -129,12 +136,12 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
 #ifndef MIXED_PRECISION
   if (std::is_same<SPO_precision, double_tag>::value)
   {
-    spo_xml = std::regex_replace(spo_xml, std::regex("float"), "double");
+    spo_xml     = std::regex_replace(spo_xml, std::regex("float"), "double");
     spo_omp_xml = std::regex_replace(spo_omp_xml, std::regex("float"), "double");
   }
 #endif
   Libxml2Document doc;
-  bool okay = doc.parseFromString(offload_spo ? spo_omp_xml : spo_xml);
+  bool okay = doc.parseFromString(offload_switches.spo ? spo_omp_xml : spo_xml);
   REQUIRE(okay);
 
   xmlNodePtr spo_root = doc.getRoot();
@@ -172,7 +179,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
 </tmp>)XML";
 
   Libxml2Document doc_jas;
-  okay = doc.parseFromString(offload_jas ? jas_omp_input : jas_input);
+  okay = doc.parseFromString(offload_switches.jas ? jas_omp_input : jas_input);
   REQUIRE(okay);
 
   xmlNodePtr jas_root = doc.getRoot();
@@ -364,13 +371,17 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)).epsilon(5e-5));
 #if defined(MIXED_PRECISION)
-  CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)).epsilon(2e-5));
+  CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)).epsilon(5e-5));
 #else
   CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)));
 #endif
 #else
   CHECK(ratios[0] == Approx(1).epsilon(5e-5));
+#if defined(MIXED_PRECISION)
+  CHECK(ratios[1] == Approx(0.12487384604697).epsilon(5e-5));
+#else
   CHECK(ratios[1] == Approx(0.12487384604697));
+#endif
 #endif
 
   std::fill(ratios.begin(), ratios.end(), 0);
@@ -401,7 +412,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
         ComplexApprox(ValueType(713.71203320654, 0.020838031944677)).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[0][2] ==
         ComplexApprox(ValueType(-768.42842826889, -0.020838032035842)).epsilon(grad_precision));
-  CHECK(ratios[1] == ComplexApprox(ValueType(0.12487384604679, 0)));
+  CHECK(ratios[1] == ComplexApprox(ValueType(0.12487384604679, 0)).epsilon(5e-5));
   CHECK(grad_new.grads_positions[1][0] ==
         ComplexApprox(ValueType(713.71203320656, 0.020838031892613)).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[1][1] ==
@@ -413,7 +424,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const bool offload_s
   CHECK(grad_new.grads_positions[0][0] == Approx(713.69119517463).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[0][1] == Approx(713.69119517463).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[0][2] == Approx(-768.40759023689).epsilon(grad_precision));
-  CHECK(ratios[1] == Approx(0.12487384604697));
+  CHECK(ratios[1] == Approx(0.12487384604697).epsilon(5e-5));
   CHECK(grad_new.grads_positions[1][0] == Approx(713.69119517467).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[1][1] == Approx(713.69119517468).epsilon(grad_precision));
   CHECK(grad_new.grads_positions[1][2] == Approx(-768.40759023695).epsilon(grad_precision));
@@ -582,92 +593,104 @@ TEST_CASE("TrialWaveFunction_diamondC_2x1x1", "[wavefunction]")
 #if defined(ENABLE_CUDA) && defined(ENABLE_OFFLOAD)
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2, false, false);
+    using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, false});
   }
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>_offload_spo")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2, true, false);
+    using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, false});
   }
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>_offload_jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2, false, true);
+    using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, true});
   }
   SECTION("DiracDeterminantBatched<MatrixDelayedUpdateCUDA>_offload_spo_jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, float_tag>(2, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>, double_tag>(2, true, true);
+    using Det = DiracDeterminantBatched<MatrixDelayedUpdateCUDA<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, true});
   }
 #endif
 
   // DiracDeterminantBatched<MatrixUpdateOMPTarget>
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2, false, false);
+    using Det = DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, false});
   }
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>_offload_spo")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2, true, false);
+    using Det = DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, false});
   }
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>_offload_jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2, false, true);
+    using Det = DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, true});
   }
   SECTION("DiracDeterminantBatched<MatrixUpdateOMPTarget>_offload_spo_jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, float_tag>(2, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>, double_tag>(2, true, true);
+    using Det = DiracDeterminantBatched<MatrixUpdateOMPTarget<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, true});
   }
 
   // DiracDeterminant<DelayedUpdate>
   SECTION("DiracDeterminant<DelayedUpdate>")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1, false, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2, false, false);
+    using Det = DiracDeterminant<DelayedUpdate<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, false});
   }
   SECTION("DiracDeterminant<DelayedUpdate>_offload_spo")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1, true, false);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2, true, false);
+    using Det = DiracDeterminant<DelayedUpdate<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, false});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, false});
   }
   SECTION("DiracDeterminant<DelayedUpdate>_offload_Jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1, false, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2, false, true);
+    using Det = DiracDeterminant<DelayedUpdate<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{false, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{false, true});
   }
   SECTION("DiracDeterminant<DelayedUpdate>_offload_spo_jas")
   {
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, float_tag>(2, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(1, true, true);
-    testTrialWaveFunction_diamondC_2x1x1<DiracDeterminant<DelayedUpdate<VT, FPVT>>, double_tag>(2, true, true);
+    using Det = DiracDeterminant<DelayedUpdate<VT, FPVT>>;
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, float_tag>(2, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(1, OffloadSwitches{true, true});
+    testTrialWaveFunction_diamondC_2x1x1<Det, double_tag>(2, OffloadSwitches{true, true});
   }
 }
 

--- a/src/io/OhmmsData/AttributeSet.h
+++ b/src/io/OhmmsData/AttributeSet.h
@@ -41,7 +41,7 @@ struct OhmmsAttributeSet
   template<class PDT>
   void add(PDT& aparam,
            const std::string& aname,
-           std::vector<PDT>&& candidate_values = {},
+           std::vector<PDT> candidate_values = {},
            TagStatus status                    = TagStatus::OPTIONAL)
   {
     if (auto it = m_param.find(aname); it == m_param.end())

--- a/src/io/OhmmsData/ParameterSet.cpp
+++ b/src/io/OhmmsData/ParameterSet.cpp
@@ -55,7 +55,7 @@ bool ParameterSet::put(xmlNodePtr cur)
 }
 
 template<class PDT>
-void ParameterSet::add(PDT& aparam, const std::string& aname_in, std::vector<PDT>&& candidate_values, TagStatus status)
+void ParameterSet::add(PDT& aparam, const std::string& aname_in, std::vector<PDT> candidate_values, TagStatus status)
 {
   using namespace qmcplusplus;
   std::string aname(lowerCase(aname_in));
@@ -76,23 +76,23 @@ void ParameterSet::setValue(const std::string& aname_in, PDT aval)
   }
 }
 
-template void ParameterSet::add(std::string&, const std::string&, std::vector<std::string>&&, TagStatus);
-template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>&&, TagStatus);
-template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>&&, TagStatus);
-template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>&&, TagStatus);
-template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>&&, TagStatus);
+template void ParameterSet::add(std::string&, const std::string&, std::vector<std::string>, TagStatus);
+template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>, TagStatus);
+template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>, TagStatus);
+template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>, TagStatus);
+template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>, TagStatus);
 template void ParameterSet::add<std::complex<double>>(std::complex<double>&,
                                                       const std::string&,
-                                                      std::vector<std::complex<double>>&&,
+                                                      std::vector<std::complex<double>>,
                                                       TagStatus);
 template void ParameterSet::add<std::complex<float>>(std::complex<float>&,
                                                      const std::string&,
-                                                     std::vector<std::complex<float>>&&,
+                                                     std::vector<std::complex<float>>,
                                                      TagStatus);
 
 template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(qmcplusplus::TinyVector<int, 3u>&,
                                                                   const std::string&,
-                                                                  std::vector<qmcplusplus::TinyVector<int, 3u>>&&,
+                                                                  std::vector<qmcplusplus::TinyVector<int, 3u>>,
                                                                   TagStatus);
 
 template void ParameterSet::setValue<int>(const std::string& aname_in, int aval);

--- a/src/io/OhmmsData/ParameterSet.h
+++ b/src/io/OhmmsData/ParameterSet.h
@@ -63,7 +63,7 @@ struct ParameterSet : public OhmmsElementBase
   template<class PDT>
   void add(PDT& aparam,
            const std::string& aname_in,
-           std::vector<PDT>&& candidate_values = {},
+           std::vector<PDT> candidate_values = {},
            TagStatus status                    = TagStatus::OPTIONAL);
 
   template<class PDT>
@@ -72,24 +72,24 @@ struct ParameterSet : public OhmmsElementBase
 
 extern template void ParameterSet::add<std::string>(std::string&,
                                                     const std::string&,
-                                                    std::vector<std::string>&&,
+                                                    std::vector<std::string>,
                                                     TagStatus);
-extern template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>&&, TagStatus);
-extern template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>&&, TagStatus);
-extern template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>&&, TagStatus);
-extern template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>&&, TagStatus);
+extern template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>, TagStatus);
+extern template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>, TagStatus);
+extern template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>, TagStatus);
+extern template void ParameterSet::add<float>(float&, const std::string&, std::vector<float>, TagStatus);
 extern template void ParameterSet::add<std::complex<double>>(std::complex<double>&,
                                                              const std::string&,
-                                                             std::vector<std::complex<double>>&&,
+                                                             std::vector<std::complex<double>>,
                                                              TagStatus);
 extern template void ParameterSet::add<std::complex<float>>(std::complex<float>&,
                                                             const std::string&,
-                                                            std::vector<std::complex<float>>&&,
+                                                            std::vector<std::complex<float>>,
                                                             TagStatus);
 extern template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(
     qmcplusplus::TinyVector<int, 3u>&,
     const std::string&,
-    std::vector<qmcplusplus::TinyVector<int, 3u>>&&,
+    std::vector<qmcplusplus::TinyVector<int, 3u>>,
     TagStatus);
 
 extern template void ParameterSet::setValue<int>(const std::string& aname_in, int aval);


### PR DESCRIPTION
## Proposed changes
As described in #2451, we need a way to select the exact implementation and being able map yes/no based on the build. So introduce PlatformSelector<CPU_OMPTARGET>.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
