### PR TITLE
Prepare MSD for offload

### DIFF
--- a/config/build_olcf_summit_Clang.sh
+++ b/config/build_olcf_summit_Clang.sh
@@ -25,7 +25,7 @@ if [[ ! -d /ccs/proj/mat151/opt/modules ]] ; then
   exit 1
 fi
 module use /ccs/proj/mat151/opt/modules
-module load llvm/main-20220119-cuda11.0
+module load llvm/main-20220304-cuda11.0
 
 TYPE=Release
 Compiler=Clang

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -53,7 +53,6 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
   for (size_t count = 0; count < nitems; ++count)
   {
     const size_t n = *it2;
-    //ratios[count]=(count!=ref)?sign[count]*det0*CustomizedMatrixDet(n,dotProducts,it2+1):det0;
     if (count != ref)
       ratios[count] = sign[count] * det0 *
           (n > MaxSmallDet ? det_calculator_.evaluate(dotProducts, it2 + 1, n) : calcSmallDeterminant(n, dotProducts, it2 + 1));
@@ -91,8 +90,9 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
       const int J                      = p[i].second;
       dotProducts_list[iw].get()(I, J) = simd::dot(psiinv_list[iw].get()[I], psi_list[iw].get()[J], num);
     }
-    ratios_list[iw].get()[0] = det0_list[iw];
     dotProducts_list[iw].get().updateTo();
+    // reference determinant
+    ratios_list[iw].get()[0] = det0_list[iw];
   }
 
   const int max_ext_level = ndets_per_excitation_level_->size() - 1;

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -47,7 +47,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
   dotProducts.updateTo();
   buildTableTimer.stop();
   readMatTimer.start();
-  std::vector<int>::const_iterator it2 = data.begin();
+  const int* it2 = data.data();
   const size_t nitems                  = sign.size();
   // explore Inclusive Scan for OpenMP
   for (size_t count = 0; count < nitems; ++count)
@@ -55,7 +55,8 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
     const size_t n = *it2;
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
-      ratios[count] = sign[count] * det0 * calculateDeterminant(DetCalculator, n, dotProducts, &(*(it2 + 1)) );
+      ratios[count] = sign[count] * det0 * 
+                      (n > 5 ? DetCalculator.evaluate(dotProducts, it2 + 1, n ) : calcSmallDeterminant(n, dotProducts, it2 + 1));
     it2 += 3 * n + 1;
   }
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -101,7 +101,6 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
   std::vector<size_t> sum_ndets_per_excitation_level;
   std::vector<size_t> sum_with_shift_ndets_per_excitation_level;
 
-  // Ugly but working
   {
     size_t count_0          = 1;
     size_t it_shift         = 1;
@@ -112,23 +111,38 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
         sum_with_shift_ndets_per_excitation_level.push_back(it_shift);
     }
   }
-
-  for (size_t ext_level = 1; ext_level <= max_ext_level; ext_level++)
+  // Can replaced by variadic template at some point if needed
+  // Can put break to short-circuit
+  if (max_ext_level <= 0)
+    update_ratios_list<0>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+  if ( max_ext_level <= 1 )
+    update_ratios_list<1>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+  if ( max_ext_level <= 2)
+    update_ratios_list<2>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+  if (max_ext_level <= 3)
+    update_ratios_list<3>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+  if (max_ext_level <= 4)
+    update_ratios_list<4>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+  if (max_ext_level <= 5)
+    update_ratios_list<5>(nw, ratios_list,
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
+    
+  for (size_t ext_level = 6; ext_level <= max_ext_level; ext_level++)
   {
-    size_t count_0 = sum_ndets_per_excitation_level[ext_level];
-    size_t it_shift = sum_with_shift_ndets_per_excitation_level.push_back[ext_level];
-
-    for (size_t iw = 0; iw < nw; iw++)
-    {
-      std::vector<int>::const_iterator it2 = data.begin() + it_shift;
-      for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[ext_level]; ++count_1)
-      {
-        size_t count                 = count_0 + count_1;
-        ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            CalculateRatioFromMatrixElements(ext_level, dotProducts_list[iw].get(),
-                                             &(*(it2 + 1 + count_1 * (3 * ext_level + 1))));
-      }
-    }
+    update_ratios_list(ext_level, nw, ratios_list, 
+                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
+                       data, sign, det0_list, dotProducts_list);
   }
 
   for (size_t iw = 0; iw < nw; iw++)

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -105,10 +105,10 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
     size_t count_0          = 1;
     size_t it_shift         = 1;
     for (size_t ext_level = 1; ext_level <= max_ext_level; ext_level++) {
-        count_0 += (*ndets_per_excitation_level_)[ext_level];
-        it_shift += (*ndets_per_excitation_level_)[ext_level] * (3 * ext_level + 1);
         sum_ndets_per_excitation_level.push_back(count_0);
         sum_with_shift_ndets_per_excitation_level.push_back(it_shift);
+        count_0 += (*ndets_per_excitation_level_)[ext_level];
+        it_shift += (*ndets_per_excitation_level_)[ext_level] * (3 * ext_level + 1);
     }
   }
   // Can replaced by variadic template at some point if needed

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -47,16 +47,16 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
   dotProducts.updateTo();
   buildTableTimer.stop();
   readMatTimer.start();
-  const int* it2 = data.data();
-  const size_t nitems                  = sign.size();
+  const int* it2      = data.data();
+  const size_t nitems = sign.size();
   // explore Inclusive Scan for OpenMP
   for (size_t count = 0; count < nitems; ++count)
   {
     const size_t n = *it2;
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
-      ratios[count] = sign[count] * det0 * 
-                      (n > 5 ? det_calculator_.evaluate(dotProducts, it2 + 1, n ) : calcSmallDeterminant(n, dotProducts, it2 + 1));
+      ratios[count] = sign[count] * det0 *
+          (n > 5 ? det_calculator_.evaluate(dotProducts, it2 + 1, n) : calcSmallDeterminant(n, dotProducts, it2 + 1));
     it2 += 3 * n + 1;
   }
 
@@ -103,43 +103,38 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
   std::vector<size_t> sum_with_shift_ndets_per_excitation_level;
 
   {
-    size_t count_0          = 0;
-    size_t it_shift         = 0;
-    for (size_t ext_level = 0; ext_level <= max_ext_level; ext_level++) {
-        sum_ndets_per_excitation_level.push_back(count_0);
-        sum_with_shift_ndets_per_excitation_level.push_back(it_shift);
-        count_0 += (*ndets_per_excitation_level_)[ext_level];
-        it_shift += (*ndets_per_excitation_level_)[ext_level] * (3 * ext_level + 1);
+    size_t count_0  = 0;
+    size_t it_shift = 0;
+    for (size_t ext_level = 0; ext_level <= max_ext_level; ext_level++)
+    {
+      sum_ndets_per_excitation_level.push_back(count_0);
+      sum_with_shift_ndets_per_excitation_level.push_back(it_shift);
+      count_0 += (*ndets_per_excitation_level_)[ext_level];
+      it_shift += (*ndets_per_excitation_level_)[ext_level] * (3 * ext_level + 1);
     }
   }
   // Can replaced by variadic template at some point if needed
   // Can put break to short-circuit
-  if ( max_ext_level >= 1 )
-    mw_updateRatios<1>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
-  if ( max_ext_level >= 2)
-    mw_updateRatios<2>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
+  if (max_ext_level >= 1)
+    mw_updateRatios<1>(nw, ratios_list, sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level, data,
+                       sign, det0_list, dotProducts_list);
+  if (max_ext_level >= 2)
+    mw_updateRatios<2>(nw, ratios_list, sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level, data,
+                       sign, det0_list, dotProducts_list);
   if (max_ext_level >= 3)
-    mw_updateRatios<3>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
+    mw_updateRatios<3>(nw, ratios_list, sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level, data,
+                       sign, det0_list, dotProducts_list);
   if (max_ext_level >= 4)
-    mw_updateRatios<4>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
+    mw_updateRatios<4>(nw, ratios_list, sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level, data,
+                       sign, det0_list, dotProducts_list);
   if (max_ext_level >= 5)
-    mw_updateRatios<5>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
-    
+    mw_updateRatios<5>(nw, ratios_list, sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level, data,
+                       sign, det0_list, dotProducts_list);
+
   for (size_t ext_level = 6; ext_level <= max_ext_level; ext_level++)
   {
-    mw_updateRatios(ext_level, nw, ratios_list, 
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
+    mw_updateRatios(ext_level, nw, ratios_list, sum_ndets_per_excitation_level,
+                    sum_with_shift_ndets_per_excitation_level, data, sign, det0_list, dotProducts_list);
   }
 
   for (size_t iw = 0; iw < nw; iw++)
@@ -857,58 +852,57 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
   }
 }
 
-  void MultiDiracDeterminant::mw_updateRatios(int ext_level,
-                          int nw,
-                          const RefVector<OffloadVector<ValueType>>& ratios_list,
-                          const std::vector<size_t>& sum_ndets_per_excitation_level,
-                          const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                          const std::vector<int>& data,
-                          const std::vector<RealType>& sign,
-                          const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list)
-   {
-    size_t count_0 = sum_ndets_per_excitation_level[ext_level];
-    size_t it_shift = sum_with_shift_ndets_per_excitation_level[ext_level];
+void MultiDiracDeterminant::mw_updateRatios(int ext_level,
+                                            int nw,
+                                            const RefVector<OffloadVector<ValueType>>& ratios_list,
+                                            const std::vector<size_t>& sum_ndets_per_excitation_level,
+                                            const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
+                                            const std::vector<int>& data,
+                                            const std::vector<RealType>& sign,
+                                            const std::vector<ValueType>& det0_list,
+                                            const RefVector<OffloadMatrix<ValueType>>& dotProducts_list)
+{
+  size_t count_0  = sum_ndets_per_excitation_level[ext_level];
+  size_t it_shift = sum_with_shift_ndets_per_excitation_level[ext_level];
 
-    for (size_t iw = 0; iw < nw; iw++)
+  for (size_t iw = 0; iw < nw; iw++)
+  {
+    std::vector<int>::const_iterator it2 = data.begin() + it_shift;
+    for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[ext_level]; ++count_1)
     {
-      std::vector<int>::const_iterator it2 = data.begin() + it_shift;
-      for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[ext_level]; ++count_1)
-      {
-        size_t count                 = count_0 + count_1;
+      size_t count = count_0 + count_1;
 
-        ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            det_calculator_.evaluate(dotProducts_list[iw].get(),
-                                   it2 + 1 + count_1 * (3 * ext_level + 1), ext_level);
-      }
+      ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
+          det_calculator_.evaluate(dotProducts_list[iw].get(), it2 + 1 + count_1 * (3 * ext_level + 1), ext_level);
     }
   }
+}
 
-  template<unsigned NEXCITED>
-  void MultiDiracDeterminant::mw_updateRatios(int nw,
-                          const RefVector<OffloadVector<ValueType>>& ratios_list,
-                          const std::vector<size_t>& sum_ndets_per_excitation_level,
-                          const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                          const std::vector<int>& data,
-                          const std::vector<RealType>& sign,
-                          const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const
-   {
-    size_t count_0 = sum_ndets_per_excitation_level[NEXCITED];
-    size_t it_shift = sum_with_shift_ndets_per_excitation_level[NEXCITED];
+template<unsigned NEXCITED>
+void MultiDiracDeterminant::mw_updateRatios(int nw,
+                                            const RefVector<OffloadVector<ValueType>>& ratios_list,
+                                            const std::vector<size_t>& sum_ndets_per_excitation_level,
+                                            const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
+                                            const std::vector<int>& data,
+                                            const std::vector<RealType>& sign,
+                                            const std::vector<ValueType>& det0_list,
+                                            const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const
+{
+  size_t count_0  = sum_ndets_per_excitation_level[NEXCITED];
+  size_t it_shift = sum_with_shift_ndets_per_excitation_level[NEXCITED];
 
-    for (size_t iw = 0; iw < nw; iw++)
+  for (size_t iw = 0; iw < nw; iw++)
+  {
+    const int* it2 = data.data() + it_shift;
+    for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[NEXCITED]; ++count_1)
     {
-      const int* it2 = data.data() + it_shift;
-      for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[NEXCITED]; ++count_1)
-      {
-        size_t count                 = count_0 + count_1;
+      size_t count = count_0 + count_1;
 
-        ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            CalculateRatioFromMatrixElements<NEXCITED>::evaluate(dotProducts_list[iw].get(),
-                                             it2 + 1 + count_1 * (3 * NEXCITED + 1));
-      }
+      ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
+          CalculateRatioFromMatrixElements<NEXCITED>::evaluate(dotProducts_list[iw].get(),
+                                                               it2 + 1 + count_1 * (3 * NEXCITED + 1));
     }
   }
+}
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -56,7 +56,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
       ratios[count] = sign[count] * det0 *
-          (n > 5 ? det_calculator_.evaluate(dotProducts, it2 + 1, n) : calcSmallDeterminant(n, dotProducts, it2 + 1));
+          (n > MaxSmallDet ? det_calculator_.evaluate(dotProducts, it2 + 1, n) : calcSmallDeterminant(n, dotProducts, it2 + 1));
     it2 += 3 * n + 1;
   }
 
@@ -99,8 +99,8 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
 
   const int max_ext_level = ndets_per_excitation_level_->size() - 1;
 
-  // Can replaced by variadic template at some point if needed
-  // Can put break to short-circuit
+  // Compute workload changes drastically as the excitation level increases.
+  // this may need different parallelization strategy.
   size_t det_offset  = 1;
   size_t data_offset = 1;
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -53,7 +53,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
   for (size_t count = 0; count < nitems; ++count)
   {
     const size_t n = *it2;
-    //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
+    //ratios[count]=(count!=ref)?sign[count]*det0*CustomizedMatrixDet(n,dotProducts,it2+1):det0;
     if (count != ref)
       ratios[count] = sign[count] * det0 *
           (n > MaxSmallDet ? det_calculator_.evaluate(dotProducts, it2 + 1, n) : calcSmallDeterminant(n, dotProducts, it2 + 1));
@@ -259,7 +259,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatiosValueMatrixOnePart
         count++;
         continue;
       }
-      ratios(count,iat) = sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1);
+      ratios(count,iat) = sign[count]*det0*CustomizedMatrixDet(n,dotProducts,it2+1);
       count++;
       it2+=3*n+1;
     }
@@ -890,7 +890,7 @@ void MultiDiracDeterminant::mw_updateRatios(int nw,
     {
       size_t det_id                 = det_offset + count;
       ratios_list[iw].get()[det_id] = sign[det_id] * det0_list[iw] *
-          CalculateRatioFromMatrixElements<NEXCITED>::evaluate(dotProducts_list[iw].get(),
+          CustomizedMatrixDet<NEXCITED>::evaluate(dotProducts_list[iw].get(),
                                                                it2 + 1 + count * (3 * NEXCITED + 1));
     }
 }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -55,7 +55,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
     const size_t n = *it2;
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
-      ratios[count] = sign[count] * det0 * CalculateRatioFromMatrixElements(n, dotProducts, &(*(it2 + 1)) );
+      ratios[count] = sign[count] * det0 * calculateDeterminant(DetCalculator, n, dotProducts, &(*(it2 + 1)) );
     it2 += 3 * n + 1;
   }
 
@@ -102,9 +102,9 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
   std::vector<size_t> sum_with_shift_ndets_per_excitation_level;
 
   {
-    size_t count_0          = 1;
-    size_t it_shift         = 1;
-    for (size_t ext_level = 1; ext_level <= max_ext_level; ext_level++) {
+    size_t count_0          = 0;
+    size_t it_shift         = 0;
+    for (size_t ext_level = 0; ext_level <= max_ext_level; ext_level++) {
         sum_ndets_per_excitation_level.push_back(count_0);
         sum_with_shift_ndets_per_excitation_level.push_back(it_shift);
         count_0 += (*ndets_per_excitation_level_)[ext_level];
@@ -113,23 +113,23 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
   }
   // Can replaced by variadic template at some point if needed
   // Can put break to short-circuit
-  if ( max_ext_level <= 1 )
+  if ( max_ext_level >= 1 )
     mw_updateRatios<1>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
-  if ( max_ext_level <= 2)
+  if ( max_ext_level >= 2)
     mw_updateRatios<2>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
-  if (max_ext_level <= 3)
+  if (max_ext_level >= 3)
     mw_updateRatios<3>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
-  if (max_ext_level <= 4)
+  if (max_ext_level >= 4)
     mw_updateRatios<4>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
-  if (max_ext_level <= 5)
+  if (max_ext_level >= 5)
     mw_updateRatios<5>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -113,34 +113,30 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
   }
   // Can replaced by variadic template at some point if needed
   // Can put break to short-circuit
-  if (max_ext_level <= 0)
-    update_ratios_list<0>(nw, ratios_list,
-                       sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
-                       data, sign, det0_list, dotProducts_list);
   if ( max_ext_level <= 1 )
-    update_ratios_list<1>(nw, ratios_list,
+    mw_updateRatios<1>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
   if ( max_ext_level <= 2)
-    update_ratios_list<2>(nw, ratios_list,
+    mw_updateRatios<2>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
   if (max_ext_level <= 3)
-    update_ratios_list<3>(nw, ratios_list,
+    mw_updateRatios<3>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
   if (max_ext_level <= 4)
-    update_ratios_list<4>(nw, ratios_list,
+    mw_updateRatios<4>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
   if (max_ext_level <= 5)
-    update_ratios_list<5>(nw, ratios_list,
+    mw_updateRatios<5>(nw, ratios_list,
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
     
   for (size_t ext_level = 6; ext_level <= max_ext_level; ext_level++)
   {
-    update_ratios_list(ext_level, nw, ratios_list, 
+    mw_updateRatios(ext_level, nw, ratios_list, 
                        sum_ndets_per_excitation_level, sum_with_shift_ndets_per_excitation_level,
                        data, sign, det0_list, dotProducts_list);
   }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -56,7 +56,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
       ratios[count] = sign[count] * det0 * 
-                      (n > 5 ? DetCalculator.evaluate(dotProducts, it2 + 1, n ) : calcSmallDeterminant(n, dotProducts, it2 + 1));
+                      (n > 5 ? det_calculator_.evaluate(dotProducts, it2 + 1, n ) : calcSmallDeterminant(n, dotProducts, it2 + 1));
     it2 += 3 * n + 1;
   }
 
@@ -878,7 +878,7 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
         size_t count                 = count_0 + count_1;
 
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            DetCalculator.evaluate(dotProducts_list[iw].get(),
+            det_calculator_.evaluate(dotProducts_list[iw].get(),
                                    it2 + 1 + count_1 * (3 * ext_level + 1), ext_level);
       }
     }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -55,7 +55,7 @@ void MultiDiracDeterminant::BuildDotProductsAndCalculateRatios_impl(int ref,
     const size_t n = *it2;
     //ratios[count]=(count!=ref)?sign[count]*det0*CalculateRatioFromMatrixElements(n,dotProducts,it2+1):det0;
     if (count != ref)
-      ratios[count] = sign[count] * det0 * CalculateRatioFromMatrixElements(n, dotProducts, it2 + 1);
+      ratios[count] = sign[count] * det0 * CalculateRatioFromMatrixElements(n, dotProducts, &(*(it2 + 1)) );
     it2 += 3 * n + 1;
   }
 
@@ -113,7 +113,7 @@ void MultiDiracDeterminant::mw_BuildDotProductsAndCalculateRatios_impl(
         size_t count                 = count_0 + count_1;
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
             CalculateRatioFromMatrixElements(ext_level, dotProducts_list[iw].get(),
-                                             it2 + 1 + count_1 * (3 * ext_level + 1));
+                                             &(*(it2 + 1 + count_1 * (3 * ext_level + 1))));
       }
     }
     count_0 += (*ndets_per_excitation_level_)[ext_level];

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -583,7 +583,7 @@ void MultiDiracDeterminant::resize()
   lapls.resize(NumDets, nel);
   new_lapls.resize(NumDets, nel);
   dotProducts.resize(NumOrbitals, NumOrbitals);
-  DetCalculator.resize(nel);
+  det_calculator_.resize(nel);
 
   if (is_spinor_)
   {

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -216,7 +216,7 @@ public:
                        const std::vector<ValueType>& det0_list,
                        const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const;
 
-  /** Function to calculate the ratio of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
+  /** Function to calculate the ratio of the excited determinant to the reference determinant in CustomizedMatrixDet following the paper by Clark et al. JCP 135(24), 244105
    *@param nw Number of walkers in the batch
    *@param ref ID of the reference determinant
    *@param det0_list takes lists of ValueType(1) for the value or RatioGrad/curRatio for the gradients
@@ -239,7 +239,7 @@ public:
                                                   const RefVector<OffloadMatrix<ValueType>>& dotProducts_list,
                                                   const RefVector<OffloadVector<ValueType>>& ratios_list);
 
-  /** Function to calculate the ratio of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
+  /** Function to calculate the ratio of the excited determinant to the reference determinant in CustomizedMatrixDet following the paper by Clark et al. JCP 135(24), 244105
    *@param ref ID of the reference determinant
    *@param det0 take ValueType(1) for the value or RatioGrad/curRatio for the gradients
    *@param ratios returned computed ratios
@@ -283,7 +283,7 @@ public:
                                              const RefVector<OffloadMatrix<ValueType>>& dotProducts_list,
                                              const RefVector<OffloadVector<ValueType>>& ratios_list);
 
-  /** Function to calculate the ratio of the gradients of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
+  /** Function to calculate the ratio of the gradients of the excited determinant to the reference determinant in CustomizedMatrixDet following the paper by Clark et al. JCP 135(24), 244105
    *@param ref ID of the reference determinant
    *@param psiinv
    *@param psi
@@ -308,7 +308,7 @@ public:
                                                int iat,
                                                OffloadMatrix<GradType>& grads);
 
-  /** Function to calculate the ratio of the gradients of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
+  /** Function to calculate the ratio of the gradients of the excited determinant to the reference determinant in CustomizedMatrixDet following the paper by Clark et al. JCP 135(24), 244105
    *@param nw Number of walkers in the batch
    *@param ref ID of the reference determinant
    *@param iat atom ID 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -191,106 +191,6 @@ public:
                      const std::vector<size_t>& C2nodes_unsorted,
                      std::vector<size_t>& C2nodes_sorted);
 
-  template<int N>
-  ValueType CalculateRatioFromMatrixElements(OffloadMatrix<ValueType>& dotProducts, const int *it);
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<0>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-    return 1.0;
-  }
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<1>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-    return dotProducts(*it, *(it + 1));
-  }
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<2>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-      const int i = *it;
-      const int j = *(it + 1);
-      const int a = *(it + 2);
-      const int b = *(it + 3);
-      return  MultiDiracDeterminantCalculator<ValueType>::evaluate( dotProducts(i, a), dotProducts(j, b), dotProducts(i, b), dotProducts(j, a));
-  }
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<3>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-      const int i1 = *it;
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int a1 = *(it + 3);
-      const int a2 = *(it + 4);
-      const int a3 = *(it + 5);
-      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
-                                    dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
-                                    dotProducts(i3, a3));
-  }
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<4>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-      const int i1 = *it;
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int i4 = *(it + 3);
-      const int a1 = *(it + 4);
-      const int a2 = *(it + 5);
-      const int a3 = *(it + 6);
-      const int a4 = *(it + 7);
-      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
-                                    dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
-                                    dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
-                                    dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
-  }
-
-  template<>
-  inline ValueType CalculateRatioFromMatrixElements<5>(OffloadMatrix<ValueType>& dotProducts, const int *it)
-  {
-      const int i1 = *it;
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int i4 = *(it + 3);
-      const int i5 = *(it + 4);
-      const int a1 = *(it + 5);
-      const int a2 = *(it + 6);
-      const int a3 = *(it + 7);
-      const int a4 = *(it + 8);
-      const int a5 = *(it + 9);
-      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
-                                    dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
-                                    dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
-                                    dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),
-                                    dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4), dotProducts(i4, a5),
-                                    dotProducts(i5, a1), dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
-                                    dotProducts(i5, a5));
-  }
-
-  inline ValueType CalculateRatioFromMatrixElements(int n, OffloadMatrix<ValueType>& dotProducts, const int* it)
-  {
-    switch (n)
-    {
-    case 0:
-      return CalculateRatioFromMatrixElements<0>(dotProducts, it);
-    case 1:
-      return CalculateRatioFromMatrixElements<1>(dotProducts, it);
-    case 2:
-      return CalculateRatioFromMatrixElements<2>(dotProducts, it);
-    case 3:
-      return CalculateRatioFromMatrixElements<3>(dotProducts, it);
-    case 4:
-      return CalculateRatioFromMatrixElements<4>(dotProducts, it);
-    case 5:
-      return CalculateRatioFromMatrixElements<5>(dotProducts, it);
-    default:
-      return DetCalculator.evaluate(dotProducts, it, n);
-    }
-    return 0.0;
-  }
-
   // Anouar explain what does kevin did
   //
   // Do not offlaod this one
@@ -316,7 +216,7 @@ public:
         size_t count                 = count_0 + count_1;
 
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            CalculateRatioFromMatrixElements(ext_level, dotProducts_list[iw].get(),
+            calculateDeterminant(DetCalculator, ext_level, dotProducts_list[iw].get(),
                                              &(*(it2 + 1 + count_1 * (3 * ext_level + 1))));
       }
     }
@@ -346,7 +246,7 @@ public:
         size_t count                 = count_0 + count_1;
 
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            CalculateRatioFromMatrixElements<Ext_level>(dotProducts_list[iw].get(),
+            CalculateRatioFromMatrixElements<Ext_level>::evaluate(dotProducts_list[iw].get(),
                                              &(*(it2 + 1 + count_1 * (3 * Ext_level + 1))));
       }
     }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -195,26 +195,26 @@ public:
   //
   // Do not offlaod this one
   void mw_updateRatios(int ext_level,
-                          int nw,
-                          const RefVector<OffloadVector<ValueType>>& ratios_list,
-                          const std::vector<size_t>& sum_ndets_per_excitation_level,
-                          const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                          const std::vector<int>& data,
-                          const std::vector<RealType>& sign,
-                          const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list);
+                       int nw,
+                       const RefVector<OffloadVector<ValueType>>& ratios_list,
+                       const std::vector<size_t>& sum_ndets_per_excitation_level,
+                       const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
+                       const std::vector<int>& data,
+                       const std::vector<RealType>& sign,
+                       const std::vector<ValueType>& det0_list,
+                       const RefVector<OffloadMatrix<ValueType>>& dotProducts_list);
 
   // Anouar explain what does kevin did
   // This one should be offloaded
   template<unsigned NEXCITED>
   void mw_updateRatios(int nw,
-                          const RefVector<OffloadVector<ValueType>>& ratios_list,
-                          const std::vector<size_t>& sum_ndets_per_excitation_level,
-                          const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                          const std::vector<int>& data,
-                          const std::vector<RealType>& sign,
-                          const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const;
+                       const RefVector<OffloadVector<ValueType>>& ratios_list,
+                       const std::vector<size_t>& sum_ndets_per_excitation_level,
+                       const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
+                       const std::vector<int>& data,
+                       const std::vector<RealType>& sign,
+                       const std::vector<ValueType>& det0_list,
+                       const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const;
 
   /** Function to calculate the ratio of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
    *@param nw Number of walkers in the batch

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -191,34 +191,48 @@ public:
                      const std::vector<size_t>& C2nodes_unsorted,
                      std::vector<size_t>& C2nodes_sorted);
 
-  template<typename ITER>
-  inline ValueType CalculateRatioFromMatrixElements(int n, OffloadMatrix<ValueType>& dotProducts, ITER it)
+  template<int N>
+  ValueType CalculateRatioFromMatrixElements(OffloadMatrix<ValueType>& dotProducts, const int *it);
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<0>(OffloadMatrix<ValueType>& dotProducts, const int *it)
   {
-    switch (n)
-    {
-    case 0:
-      return 1.0;
-    case 1:
-      return dotProducts(*it, *(it + 1));
-    case 2: {
+    return 1.0;
+  }
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<1>(OffloadMatrix<ValueType>& dotProducts, const int *it)
+  {
+    return dotProducts(*it, *(it + 1));
+  }
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<2>(OffloadMatrix<ValueType>& dotProducts, const int *it)
+  {
       const int i = *it;
       const int j = *(it + 1);
       const int a = *(it + 2);
       const int b = *(it + 3);
-      return dotProducts(i, a) * dotProducts(j, b) - dotProducts(i, b) * dotProducts(j, a);
-    }
-    case 3: {
+      return  MultiDiracDeterminantCalculator<ValueType>::evaluate( dotProducts(i, a), dotProducts(j, b), dotProducts(i, b), dotProducts(j, a));
+  }
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<3>(OffloadMatrix<ValueType>& dotProducts, const int *it)
+  {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
       const int a1 = *(it + 3);
       const int a2 = *(it + 4);
       const int a3 = *(it + 5);
-      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
+      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
                                     dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
                                     dotProducts(i3, a3));
-    }
-    case 4: {
+  }
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<4>(OffloadMatrix<ValueType>& dotProducts, const int *it)
+  {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
@@ -227,12 +241,15 @@ public:
       const int a2 = *(it + 5);
       const int a3 = *(it + 6);
       const int a4 = *(it + 7);
-      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
                                     dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
                                     dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
                                     dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
-    }
-    case 5: {
+  }
+
+  template<>
+  inline ValueType CalculateRatioFromMatrixElements<5>(OffloadMatrix<ValueType>& dotProducts, const int *it)
+  {
       const int i1 = *it;
       const int i2 = *(it + 1);
       const int i3 = *(it + 2);
@@ -243,14 +260,33 @@ public:
       const int a3 = *(it + 7);
       const int a4 = *(it + 8);
       const int a5 = *(it + 9);
-      return DetCalculator.evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+      return MultiDiracDeterminantCalculator<ValueType>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
                                     dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
                                     dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
                                     dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),
                                     dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4), dotProducts(i4, a5),
                                     dotProducts(i5, a1), dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
                                     dotProducts(i5, a5));
-    }
+  }
+
+
+  //template<typename ITER>
+  inline ValueType CalculateRatioFromMatrixElements(int n, OffloadMatrix<ValueType>& dotProducts, const int* it)
+  {
+    switch (n)
+    {
+    case 0:
+      return CalculateRatioFromMatrixElements<0>(dotProducts, it);  
+    case 1:
+      return CalculateRatioFromMatrixElements<1>(dotProducts, it);
+    case 2: 
+      return CalculateRatioFromMatrixElements<2>(dotProducts, it);    
+    case 3:
+      return CalculateRatioFromMatrixElements<3>(dotProducts, it);
+    case 4:
+      return CalculateRatioFromMatrixElements<4>(dotProducts, it); 
+    case 5: 
+      return CalculateRatioFromMatrixElements<5>(dotProducts, it);
     default:
       return DetCalculator.evaluate(dotProducts, it, n);
     }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -194,23 +194,23 @@ public:
   // Anouar explain what does kevin did
   //
   // Do not offlaod this one
-  void mw_updateRatios(int ext_level,
-                       int nw,
-                       const RefVector<OffloadVector<ValueType>>& ratios_list,
-                       const std::vector<size_t>& sum_ndets_per_excitation_level,
-                       const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                       const std::vector<int>& data,
-                       const std::vector<RealType>& sign,
-                       const std::vector<ValueType>& det0_list,
-                       const RefVector<OffloadMatrix<ValueType>>& dotProducts_list);
+  void mw_updateRatios_generic(const int ext_level,
+                               const int nw,
+                               const size_t det_offset,
+                               const size_t data_offset,
+                               const RefVector<OffloadVector<ValueType>>& ratios_list,
+                               const std::vector<int>& data,
+                               const std::vector<RealType>& sign,
+                               const std::vector<ValueType>& det0_list,
+                               const RefVector<OffloadMatrix<ValueType>>& dotProducts_list);
 
   // Anouar explain what does kevin did
   // This one should be offloaded
   template<unsigned NEXCITED>
-  void mw_updateRatios(int nw,
+  void mw_updateRatios(const int nw,
+                       const size_t det_offset,
+                       const size_t data_offset,
                        const RefVector<OffloadVector<ValueType>>& ratios_list,
-                       const std::vector<size_t>& sum_ndets_per_excitation_level,
-                       const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
                        const std::vector<int>& data,
                        const std::vector<RealType>& sign,
                        const std::vector<ValueType>& det0_list,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -216,8 +216,8 @@ public:
         size_t count                 = count_0 + count_1;
 
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            calculateDeterminant(DetCalculator, ext_level, dotProducts_list[iw].get(),
-                                             &(*(it2 + 1 + count_1 * (3 * ext_level + 1))));
+            DetCalculator.evaluate(dotProducts_list[iw].get(),
+                                   it2 + 1 + count_1 * (3 * ext_level + 1), ext_level);
       }
     }
   }
@@ -240,14 +240,14 @@ public:
 
     for (size_t iw = 0; iw < nw; iw++)
     {
-      std::vector<int>::const_iterator it2 = data.begin() + it_shift;
+      const int* it2 = data.data() + it_shift;
       for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[Ext_level]; ++count_1)
       {
         size_t count                 = count_0 + count_1;
 
         ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
             CalculateRatioFromMatrixElements<Ext_level>::evaluate(dotProducts_list[iw].get(),
-                                             &(*(it2 + 1 + count_1 * (3 * Ext_level + 1))));
+                                             it2 + 1 + count_1 * (3 * Ext_level + 1));
       }
     }
   }

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -352,20 +352,6 @@ public:
     }
   }
 
-  void  update_ratios_list_for_all_ext_level(
-                          int max_ext_level,
-                          int nw,
-                          const RefVector<OffloadVector<ValueType>>& ratios_list,
-                          const std::vector<size_t>& sum_ndets_per_excitation_level,
-                          const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,
-                          const std::vector<int>& data,
-                          const std::vector<RealType>& sign,
-                          const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list)
-{
-  constexpr auto seq = std::make_index_sequence<5>();
-
-} 
 
   /** Function to calculate the ratio of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
    *@param nw Number of walkers in the batch

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -294,7 +294,7 @@ public:
   // Anouar explain what does kevin did
   //
   // Do not offlaod this one
-  void update_ratios_list(int ext_level,
+  void mw_updateRatios(int ext_level,
                           int nw,
                           const RefVector<OffloadVector<ValueType>>& ratios_list,
                           const std::vector<size_t>& sum_ndets_per_excitation_level,
@@ -325,7 +325,7 @@ public:
   // Anouar explain what does kevin did
   // This one should be offloaded
   template<int Ext_level>
-  void update_ratios_list(int nw,
+  void mw_updateRatios(int nw,
                           const RefVector<OffloadVector<ValueType>>& ratios_list,
                           const std::vector<size_t>& sum_ndets_per_excitation_level,
                           const std::vector<size_t>& sum_with_shift_ndets_per_excitation_level,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -202,29 +202,11 @@ public:
                           const std::vector<int>& data,
                           const std::vector<RealType>& sign,
                           const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list)
-
-   {
-    size_t count_0 = sum_ndets_per_excitation_level[ext_level];
-    size_t it_shift = sum_with_shift_ndets_per_excitation_level[ext_level];
-
-    for (size_t iw = 0; iw < nw; iw++)
-    {
-      std::vector<int>::const_iterator it2 = data.begin() + it_shift;
-      for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[ext_level]; ++count_1)
-      {
-        size_t count                 = count_0 + count_1;
-
-        ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            DetCalculator.evaluate(dotProducts_list[iw].get(),
-                                   it2 + 1 + count_1 * (3 * ext_level + 1), ext_level);
-      }
-    }
-  }
+                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list);
 
   // Anouar explain what does kevin did
   // This one should be offloaded
-  template<int Ext_level>
+  template<unsigned NEXCITED>
   void mw_updateRatios(int nw,
                           const RefVector<OffloadVector<ValueType>>& ratios_list,
                           const std::vector<size_t>& sum_ndets_per_excitation_level,
@@ -232,26 +214,7 @@ public:
                           const std::vector<int>& data,
                           const std::vector<RealType>& sign,
                           const std::vector<ValueType>& det0_list,
-                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list)
-                         
-   {
-    size_t count_0 = sum_ndets_per_excitation_level[Ext_level];
-    size_t it_shift = sum_with_shift_ndets_per_excitation_level[Ext_level];
-
-    for (size_t iw = 0; iw < nw; iw++)
-    {
-      const int* it2 = data.data() + it_shift;
-      for (size_t count_1 = 0; count_1 < (*ndets_per_excitation_level_)[Ext_level]; ++count_1)
-      {
-        size_t count                 = count_0 + count_1;
-
-        ratios_list[iw].get()[count] = sign[count] * det0_list[iw] *
-            CalculateRatioFromMatrixElements<Ext_level>::evaluate(dotProducts_list[iw].get(),
-                                             it2 + 1 + count_1 * (3 * Ext_level + 1));
-      }
-    }
-  }
-
+                          const RefVector<OffloadMatrix<ValueType>>& dotProducts_list) const;
 
   /** Function to calculate the ratio of the excited determinant to the reference determinant in CalculateRatioFromMatrixElements following the paper by Clark et al. JCP 135(24), 244105
    *@param nw Number of walkers in the batch

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -507,6 +507,9 @@ private:
    */
   std::shared_ptr<std::vector<int>> ndets_per_excitation_level_;
   SmallMatrixDetCalculator<ValueType> det_calculator_;
+
+  /// for matrices with leading dimensions <= MaxSmallDet, compute determinant with direct expansion.
+  static constexpr size_t MaxSmallDet = 5;
 };
 
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -22,7 +22,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/SPOSet.h"
 #include "QMCWaveFunctions/Fermion/ci_configuration2.h"
-#include "QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h"
+#include "QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h"
 #include "Message/Communicate.h"
 #include "Numerics/DeterminantOperators.h"
 //#include "CPU/BLAS.hpp"
@@ -506,7 +506,7 @@ private:
    *  {1, n_singles, n_doubles, n_triples, ...}
    */
   std::shared_ptr<std::vector<int>> ndets_per_excitation_level_;
-  MultiDiracDeterminantCalculator<ValueType> DetCalculator;
+  SmallMatrixDetCalculator<ValueType> det_calculator_;
 };
 
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
@@ -147,5 +147,136 @@ struct MultiDiracDeterminantCalculator
   }
 };
 
+  template<unsigned NEXCITED>
+  class CalculateRatioFromMatrixElements;
+
+  template<>
+  class CalculateRatioFromMatrixElements<0>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+    return 1.0;
+  }
+  };
+
+  template<>
+  class CalculateRatioFromMatrixElements<1>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+    return dotProducts(*it, *(it + 1));
+  }
+  };
+
+  template<>
+class CalculateRatioFromMatrixElements<2>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+      const int i = *it; 
+      const int j = *(it + 1);
+      const int a = *(it + 2);
+      const int b = *(it + 3);
+      return  MultiDiracDeterminantCalculator<VALUE>::evaluate( dotProducts(i, a), dotProducts(i, b), dotProducts(j, a), dotProducts(j, b));
+  }
+  };
+
+  template<>
+class CalculateRatioFromMatrixElements<3>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+      const int i1 = *it; 
+      const int i2 = *(it + 1);
+      const int i3 = *(it + 2);
+      const int a1 = *(it + 3);
+      const int a2 = *(it + 4);
+      const int a3 = *(it + 5);
+      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
+                                    dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
+                                    dotProducts(i3, a3));
+  }
+  };
+
+  template<>
+class CalculateRatioFromMatrixElements<4>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+      const int i1 = *it; 
+      const int i2 = *(it + 1);
+      const int i3 = *(it + 2);
+      const int i4 = *(it + 3);
+      const int a1 = *(it + 4);
+      const int a2 = *(it + 5);
+      const int a3 = *(it + 6);
+      const int a4 = *(it + 7);
+      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+                                    dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
+                                    dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
+                                    dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
+  }
+  };
+
+  template<>
+class CalculateRatioFromMatrixElements<5>
+  {
+public:
+    template<typename VALUE>
+    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  {
+      const int i1 = *it;
+      const int i2 = *(it + 1);
+      const int i3 = *(it + 2);
+      const int i4 = *(it + 3);
+      const int i5 = *(it + 4);
+      const int a1 = *(it + 5);
+      const int a2 = *(it + 6);
+      const int a3 = *(it + 7);
+      const int a4 = *(it + 8);
+      const int a5 = *(it + 9);
+      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+                                    dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
+                                    dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
+                                    dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),
+                                    dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4), dotProducts(i4, a5),
+                                    dotProducts(i5, a1), dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
+                                    dotProducts(i5, a5));
+  }
+  };
+
+    template<class DETCALCULATOR, typename VALUE>
+  inline VALUE calculateDeterminant(DETCALCULATOR& DetCalculator, size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
+  {
+    switch (n)
+    {
+    case 0:
+      return CalculateRatioFromMatrixElements<0>::evaluate(dotProducts, it);
+    case 1:
+      return CalculateRatioFromMatrixElements<1>::evaluate(dotProducts, it);
+    case 2:
+      return CalculateRatioFromMatrixElements<2>::evaluate(dotProducts, it);
+    case 3:
+      return CalculateRatioFromMatrixElements<3>::evaluate(dotProducts, it);
+    case 4:
+      return CalculateRatioFromMatrixElements<4>::evaluate(dotProducts, it);
+    case 5:
+      return CalculateRatioFromMatrixElements<5>::evaluate(dotProducts, it);
+    default:
+      return DetCalculator.evaluate(dotProducts, it, n);
+    }
+    return 0.0;
+  }
+
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
@@ -41,14 +41,14 @@ struct MultiDiracDeterminantCalculator
     Pivot.resize(n);
   }
 
-  inline T evaluate(T a11, T a12, T a21, T a22) { return a11 * a22 - a21 * a12; }
+  static T evaluate(T a11, T a12, T a21, T a22) { return a11 * a22 - a21 * a12; }
 
-  inline T evaluate(T a11, T a12, T a13, T a21, T a22, T a23, T a31, T a32, T a33)
+  static T evaluate(T a11, T a12, T a13, T a21, T a22, T a23, T a31, T a32, T a33)
   {
     return (a11 * (a22 * a33 - a32 * a23) - a21 * (a12 * a33 - a32 * a13) + a31 * (a12 * a23 - a22 * a13));
   }
 
-  inline T evaluate(T a11,
+  static T evaluate(T a11,
                     T a12,
                     T a13,
                     T a14,
@@ -71,7 +71,7 @@ struct MultiDiracDeterminantCalculator
             a41 * (a12 * (a23 * a34 - a33 * a24) - a22 * (a13 * a34 - a33 * a14) + a32 * (a13 * a24 - a23 * a14)));
   }
 
-  inline T evaluate(T a11,
+  static T evaluate(T a11,
                     T a12,
                     T a13,
                     T a14,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminantCalculator.h
@@ -255,8 +255,8 @@ public:
   }
   };
 
-    template<class DETCALCULATOR, typename VALUE>
-  inline VALUE calculateDeterminant(DETCALCULATOR& DetCalculator, size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
+    template<typename VALUE>
+  inline VALUE calcSmallDeterminant(size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     switch (n)
     {
@@ -273,7 +273,7 @@ public:
     case 5:
       return CalculateRatioFromMatrixElements<5>::evaluate(dotProducts, it);
     default:
-      return DetCalculator.evaluate(dotProducts, it, n);
+      throw std::runtime_error("calculateSmallDeterminant only handles the number of excitations <= 5.");
     }
     return 0.0;
   }

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -30,7 +30,7 @@ namespace qmcplusplus
  *  includes manual expansions for smaller evaluations
  */
 template<typename T>
-struct MultiDiracDeterminantCalculator
+struct SmallMatrixDetCalculator
 {
   std::vector<T> M;
   std::vector<int> Pivot;
@@ -183,7 +183,7 @@ public:
       const int j = *(it + 1);
       const int a = *(it + 2);
       const int b = *(it + 3);
-      return  MultiDiracDeterminantCalculator<VALUE>::evaluate( dotProducts(i, a), dotProducts(i, b), dotProducts(j, a), dotProducts(j, b));
+      return  SmallMatrixDetCalculator<VALUE>::evaluate( dotProducts(i, a), dotProducts(i, b), dotProducts(j, a), dotProducts(j, b));
   }
   };
 
@@ -200,7 +200,7 @@ public:
       const int a1 = *(it + 3);
       const int a2 = *(it + 4);
       const int a3 = *(it + 5);
-      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
+      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
                                     dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
                                     dotProducts(i3, a3));
   }
@@ -221,7 +221,7 @@ public:
       const int a2 = *(it + 5);
       const int a3 = *(it + 6);
       const int a4 = *(it + 7);
-      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
                                     dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
                                     dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
                                     dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
@@ -245,7 +245,7 @@ public:
       const int a3 = *(it + 7);
       const int a4 = *(it + 8);
       const int a5 = *(it + 9);
-      return MultiDiracDeterminantCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
+      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
                                     dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
                                     dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
                                     dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -261,7 +261,7 @@ public:
 };
 
 template<typename VALUE>
-inline VALUE calcSmallDeterminant(size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
+inline VALUE calcSmallDeterminant(size_t n, const OffloadMatrix<VALUE>& dotProducts, const int* it)
 {
   switch (n)
   {

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -134,7 +134,7 @@ struct SmallMatrixDetCalculator
   template<typename DT>
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
   template<typename ITER>
-  inline T evaluate(OffloadMatrix<T>& dots, ITER it, int n)
+  inline T evaluate(const OffloadMatrix<T>& dots, ITER it, int n)
   {
     typename std::vector<T>::iterator d = M.begin();
     for (int i = 0; i < n; i++)
@@ -155,7 +155,7 @@ class CalculateRatioFromMatrixElements<0>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     return 1.0;
   }
@@ -166,7 +166,7 @@ class CalculateRatioFromMatrixElements<1>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     return dotProducts(*it, *(it + 1));
   }
@@ -177,7 +177,7 @@ class CalculateRatioFromMatrixElements<2>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     const int i = *it;
     const int j = *(it + 1);
@@ -193,7 +193,7 @@ class CalculateRatioFromMatrixElements<3>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     const int i1 = *it;
     const int i2 = *(it + 1);
@@ -212,7 +212,7 @@ class CalculateRatioFromMatrixElements<4>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     const int i1 = *it;
     const int i2 = *(it + 1);
@@ -236,7 +236,7 @@ class CalculateRatioFromMatrixElements<5>
 {
 public:
   template<typename VALUE>
-  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
+  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     const int i1 = *it;
     const int i2 = *(it + 1);

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -125,7 +125,7 @@ struct SmallMatrixDetCalculator
              a42 * (a13 * (a24 * a35 - a34 * a25) - a23 * (a14 * a35 - a34 * a15) + a33 * (a14 * a25 - a24 * a15))));
   }
 
-  /** default implementation of MultiDiracDeterminant::CalculateRatioFromMatrixElements
+  /** default implementation of MultiDiracDeterminant::CustomizedMatrixDet
    *  If you don't have a perfect square below 25 of dots this is what you hit
    *  dots must be a 2n by 2n Matrix
    *  iter must be size n^2
@@ -148,10 +148,10 @@ struct SmallMatrixDetCalculator
 };
 
 template<unsigned NEXCITED>
-class CalculateRatioFromMatrixElements;
+class CustomizedMatrixDet;
 
 template<>
-class CalculateRatioFromMatrixElements<0>
+class CustomizedMatrixDet<0>
 {
 public:
   template<typename VALUE>
@@ -162,7 +162,7 @@ public:
 };
 
 template<>
-class CalculateRatioFromMatrixElements<1>
+class CustomizedMatrixDet<1>
 {
 public:
   template<typename VALUE>
@@ -173,7 +173,7 @@ public:
 };
 
 template<>
-class CalculateRatioFromMatrixElements<2>
+class CustomizedMatrixDet<2>
 {
 public:
   template<typename VALUE>
@@ -189,7 +189,7 @@ public:
 };
 
 template<>
-class CalculateRatioFromMatrixElements<3>
+class CustomizedMatrixDet<3>
 {
 public:
   template<typename VALUE>
@@ -208,7 +208,7 @@ public:
 };
 
 template<>
-class CalculateRatioFromMatrixElements<4>
+class CustomizedMatrixDet<4>
 {
 public:
   template<typename VALUE>
@@ -232,7 +232,7 @@ public:
 };
 
 template<>
-class CalculateRatioFromMatrixElements<5>
+class CustomizedMatrixDet<5>
 {
 public:
   template<typename VALUE>
@@ -266,17 +266,17 @@ inline VALUE calcSmallDeterminant(size_t n, OffloadMatrix<VALUE>& dotProducts, c
   switch (n)
   {
   case 0:
-    return CalculateRatioFromMatrixElements<0>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<0>::evaluate(dotProducts, it);
   case 1:
-    return CalculateRatioFromMatrixElements<1>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<1>::evaluate(dotProducts, it);
   case 2:
-    return CalculateRatioFromMatrixElements<2>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<2>::evaluate(dotProducts, it);
   case 3:
-    return CalculateRatioFromMatrixElements<3>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<3>::evaluate(dotProducts, it);
   case 4:
-    return CalculateRatioFromMatrixElements<4>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<4>::evaluate(dotProducts, it);
   case 5:
-    return CalculateRatioFromMatrixElements<5>::evaluate(dotProducts, it);
+    return CustomizedMatrixDet<5>::evaluate(dotProducts, it);
   default:
     throw std::runtime_error("calculateSmallDeterminant only handles the number of excitations <= 5.");
   }

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -151,17 +151,6 @@ template<unsigned NEXCITED>
 class CustomizedMatrixDet;
 
 template<>
-class CustomizedMatrixDet<0>
-{
-public:
-  template<typename VALUE>
-  static VALUE evaluate(const OffloadMatrix<VALUE>& dotProducts, const int* it)
-  {
-    return 1.0;
-  }
-};
-
-template<>
 class CustomizedMatrixDet<1>
 {
 public:
@@ -265,8 +254,6 @@ inline VALUE calcSmallDeterminant(size_t n, const OffloadMatrix<VALUE>& dotProdu
 {
   switch (n)
   {
-  case 0:
-    return CustomizedMatrixDet<0>::evaluate(dotProducts, it);
   case 1:
     return CustomizedMatrixDet<1>::evaluate(dotProducts, it);
   case 2:

--- a/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
+++ b/src/QMCWaveFunctions/Fermion/SmallMatrixDetCalculator.h
@@ -147,136 +147,141 @@ struct SmallMatrixDetCalculator
   }
 };
 
-  template<unsigned NEXCITED>
-  class CalculateRatioFromMatrixElements;
+template<unsigned NEXCITED>
+class CalculateRatioFromMatrixElements;
 
-  template<>
-  class CalculateRatioFromMatrixElements<0>
-  {
+template<>
+class CalculateRatioFromMatrixElements<0>
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     return 1.0;
   }
-  };
+};
 
-  template<>
-  class CalculateRatioFromMatrixElements<1>
-  {
+template<>
+class CalculateRatioFromMatrixElements<1>
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
     return dotProducts(*it, *(it + 1));
   }
-  };
+};
 
-  template<>
+template<>
 class CalculateRatioFromMatrixElements<2>
-  {
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
-      const int i = *it; 
-      const int j = *(it + 1);
-      const int a = *(it + 2);
-      const int b = *(it + 3);
-      return  SmallMatrixDetCalculator<VALUE>::evaluate( dotProducts(i, a), dotProducts(i, b), dotProducts(j, a), dotProducts(j, b));
+    const int i = *it;
+    const int j = *(it + 1);
+    const int a = *(it + 2);
+    const int b = *(it + 3);
+    return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i, a), dotProducts(i, b), dotProducts(j, a),
+                                                     dotProducts(j, b));
   }
-  };
+};
 
-  template<>
+template<>
 class CalculateRatioFromMatrixElements<3>
-  {
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
-      const int i1 = *it; 
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int a1 = *(it + 3);
-      const int a2 = *(it + 4);
-      const int a3 = *(it + 5);
-      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i2, a1),
-                                    dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i3, a1), dotProducts(i3, a2),
-                                    dotProducts(i3, a3));
+    const int i1 = *it;
+    const int i2 = *(it + 1);
+    const int i3 = *(it + 2);
+    const int a1 = *(it + 3);
+    const int a2 = *(it + 4);
+    const int a3 = *(it + 5);
+    return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3),
+                                                     dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
+                                                     dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3));
   }
-  };
+};
 
-  template<>
+template<>
 class CalculateRatioFromMatrixElements<4>
-  {
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
-      const int i1 = *it; 
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int i4 = *(it + 3);
-      const int a1 = *(it + 4);
-      const int a2 = *(it + 5);
-      const int a3 = *(it + 6);
-      const int a4 = *(it + 7);
-      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
-                                    dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
-                                    dotProducts(i3, a1), dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
-                                    dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4));
+    const int i1 = *it;
+    const int i2 = *(it + 1);
+    const int i3 = *(it + 2);
+    const int i4 = *(it + 3);
+    const int a1 = *(it + 4);
+    const int a2 = *(it + 5);
+    const int a3 = *(it + 6);
+    const int a4 = *(it + 7);
+    return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3),
+                                                     dotProducts(i1, a4), dotProducts(i2, a1), dotProducts(i2, a2),
+                                                     dotProducts(i2, a3), dotProducts(i2, a4), dotProducts(i3, a1),
+                                                     dotProducts(i3, a2), dotProducts(i3, a3), dotProducts(i3, a4),
+                                                     dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3),
+                                                     dotProducts(i4, a4));
   }
-  };
+};
 
-  template<>
+template<>
 class CalculateRatioFromMatrixElements<5>
-  {
+{
 public:
-    template<typename VALUE>
-    static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int *it)
+  template<typename VALUE>
+  static VALUE evaluate(OffloadMatrix<VALUE>& dotProducts, const int* it)
   {
-      const int i1 = *it;
-      const int i2 = *(it + 1);
-      const int i3 = *(it + 2);
-      const int i4 = *(it + 3);
-      const int i5 = *(it + 4);
-      const int a1 = *(it + 5);
-      const int a2 = *(it + 6);
-      const int a3 = *(it + 7);
-      const int a4 = *(it + 8);
-      const int a5 = *(it + 9);
-      return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3), dotProducts(i1, a4),
-                                    dotProducts(i1, a5), dotProducts(i2, a1), dotProducts(i2, a2), dotProducts(i2, a3),
-                                    dotProducts(i2, a4), dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
-                                    dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5), dotProducts(i4, a1),
-                                    dotProducts(i4, a2), dotProducts(i4, a3), dotProducts(i4, a4), dotProducts(i4, a5),
-                                    dotProducts(i5, a1), dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
-                                    dotProducts(i5, a5));
+    const int i1 = *it;
+    const int i2 = *(it + 1);
+    const int i3 = *(it + 2);
+    const int i4 = *(it + 3);
+    const int i5 = *(it + 4);
+    const int a1 = *(it + 5);
+    const int a2 = *(it + 6);
+    const int a3 = *(it + 7);
+    const int a4 = *(it + 8);
+    const int a5 = *(it + 9);
+    return SmallMatrixDetCalculator<VALUE>::evaluate(dotProducts(i1, a1), dotProducts(i1, a2), dotProducts(i1, a3),
+                                                     dotProducts(i1, a4), dotProducts(i1, a5), dotProducts(i2, a1),
+                                                     dotProducts(i2, a2), dotProducts(i2, a3), dotProducts(i2, a4),
+                                                     dotProducts(i2, a5), dotProducts(i3, a1), dotProducts(i3, a2),
+                                                     dotProducts(i3, a3), dotProducts(i3, a4), dotProducts(i3, a5),
+                                                     dotProducts(i4, a1), dotProducts(i4, a2), dotProducts(i4, a3),
+                                                     dotProducts(i4, a4), dotProducts(i4, a5), dotProducts(i5, a1),
+                                                     dotProducts(i5, a2), dotProducts(i5, a3), dotProducts(i5, a4),
+                                                     dotProducts(i5, a5));
   }
-  };
+};
 
-    template<typename VALUE>
-  inline VALUE calcSmallDeterminant(size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
+template<typename VALUE>
+inline VALUE calcSmallDeterminant(size_t n, OffloadMatrix<VALUE>& dotProducts, const int* it)
+{
+  switch (n)
   {
-    switch (n)
-    {
-    case 0:
-      return CalculateRatioFromMatrixElements<0>::evaluate(dotProducts, it);
-    case 1:
-      return CalculateRatioFromMatrixElements<1>::evaluate(dotProducts, it);
-    case 2:
-      return CalculateRatioFromMatrixElements<2>::evaluate(dotProducts, it);
-    case 3:
-      return CalculateRatioFromMatrixElements<3>::evaluate(dotProducts, it);
-    case 4:
-      return CalculateRatioFromMatrixElements<4>::evaluate(dotProducts, it);
-    case 5:
-      return CalculateRatioFromMatrixElements<5>::evaluate(dotProducts, it);
-    default:
-      throw std::runtime_error("calculateSmallDeterminant only handles the number of excitations <= 5.");
-    }
-    return 0.0;
+  case 0:
+    return CalculateRatioFromMatrixElements<0>::evaluate(dotProducts, it);
+  case 1:
+    return CalculateRatioFromMatrixElements<1>::evaluate(dotProducts, it);
+  case 2:
+    return CalculateRatioFromMatrixElements<2>::evaluate(dotProducts, it);
+  case 3:
+    return CalculateRatioFromMatrixElements<3>::evaluate(dotProducts, it);
+  case 4:
+    return CalculateRatioFromMatrixElements<4>::evaluate(dotProducts, it);
+  case 5:
+    return CalculateRatioFromMatrixElements<5>::evaluate(dotProducts, it);
+  default:
+    throw std::runtime_error("calculateSmallDeterminant only handles the number of excitations <= 5.");
   }
+  return 0.0;
+}
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/tests/test_multi_dirac_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_dirac_determinant.cpp
@@ -26,35 +26,50 @@ namespace qmcplusplus
 template<class T>
 class TestSmallMatrixDetCalculator
 {
-public:
   template<typename DT>
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
-  T default_evaluate(int power_of_two)
+
+  SmallMatrixDetCalculator<double> MDDC;
+  OffloadMatrix<double> dots;
+  std::vector<int> it_things;
+
+public:
+  void build_interal_data(int dim_size)
   {
-    SmallMatrixDetCalculator<double> MDDC;
-    int power2 = std::pow(2, power_of_two);
-    MDDC.resize(power2);
-    OffloadMatrix<double> dots(2 * power2); //This is an 2n by 2n matrix if you don't reduce pairs
+    MDDC.resize(dim_size);
+    dots.resize(dim_size, dim_size);
+    it_things.resize(2 * dim_size);
+
     double n = 0.0;
     int i    = 0;
     //Just making some non trivial data
     for (auto& m : dots)
     {
       if (++i % 2 != 0)
-        m = -n / (T)power2;
+        m = -n / (T)dim_size;
       else
-        m = n / (T)power2;
-      if (n > (T)power2 - 0.5)
+        m = n / (T)dim_size;
+      if (n > (T)dim_size - 0.5)
         n = 0.0;
       else
         n += 1.0;
     }
-    std::vector<int> it_things(power2 * power2);
-    i = 0;
-    for (auto& itt : it_things)
-      itt = i++;
-    std::vector<int>::const_iterator it = it_things.begin();
-    return MDDC.evaluate(dots, it, power2);
+
+    for (size_t i = 0; i < dim_size; i++)
+      it_things[i] = it_things[i + dim_size] = i;
+  }
+
+  T generic_evaluate(int dim_size)
+  {
+    build_interal_data(dim_size);
+    return MDDC.evaluate(dots, it_things.data(), dim_size);
+  }
+
+  template<unsigned EXT_LEVEL>
+  T customized_evaluate()
+  {
+    build_interal_data(EXT_LEVEL);
+    return calcSmallDeterminant(EXT_LEVEL, dots, it_things.data());
   }
 };
 
@@ -63,12 +78,21 @@ public:
 TEST_CASE("SmallMatrixDetCalculator::evaluate-Small", "[wavefunction][fermion][multidet]")
 {
   TestSmallMatrixDetCalculator<double> double_test;
-  double det_value_expect = -1.1086723208;
-  REQUIRE(double_test.default_evaluate(3) == Approx(det_value_expect));
-  det_value_expect = -1.3432116824;
-  REQUIRE(double_test.default_evaluate(7) == Approx(det_value_expect));
-  det_value_expect = -1.3586431786;
-  REQUIRE(double_test.default_evaluate(12) == Approx(det_value_expect));
+  CHECK(double_test.generic_evaluate(1) == Approx(0.0));
+  CHECK(double_test.generic_evaluate(2) == Approx(0.5));
+  CHECK(double_test.generic_evaluate(3) == Approx(-0.7407407407));
+  CHECK(double_test.generic_evaluate(4) == Approx(-0.87890625));
+  CHECK(double_test.generic_evaluate(5) == Approx(-0.96768));
+
+  CHECK(double_test.customized_evaluate<1>() == Approx(0.0));
+  CHECK(double_test.customized_evaluate<2>() == Approx(0.5));
+  CHECK(double_test.customized_evaluate<3>() == Approx(-0.7407407407));
+  CHECK(double_test.customized_evaluate<4>() == Approx(-0.87890625));
+  CHECK(double_test.customized_evaluate<5>() == Approx(-0.96768));
+
+  CHECK(double_test.generic_evaluate(1<<3) == Approx(-1.1086723208));
+  CHECK(double_test.generic_evaluate(1<<7) == Approx(-1.3432116824));
+  CHECK(double_test.generic_evaluate(1<<12) == Approx(-1.3586431786));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_multi_dirac_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_dirac_determinant.cpp
@@ -24,14 +24,14 @@ using std::string;
 namespace qmcplusplus
 {
 template<class T>
-class TestMultiDiracDeterminantCalculator
+class TestSmallMatrixDetCalculator
 {
 public:
   template<typename DT>
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
   T default_evaluate(int power_of_two)
   {
-    MultiDiracDeterminantCalculator<double> MDDC;
+    SmallMatrixDetCalculator<double> MDDC;
     int power2 = std::pow(2, power_of_two);
     MDDC.resize(power2);
     OffloadMatrix<double> dots(2 * power2); //This is an 2n by 2n matrix if you don't reduce pairs
@@ -60,9 +60,9 @@ public:
 
 /** Simple synthetic test case will trip on changes in this method.
  */
-TEST_CASE("MultiDiracDeterminantCalculator::evaluate-Small", "[wavefunction][fermion][multidet]")
+TEST_CASE("SmallMatrixDetCalculator::evaluate-Small", "[wavefunction][fermion][multidet]")
 {
-  TestMultiDiracDeterminantCalculator<double> double_test;
+  TestSmallMatrixDetCalculator<double> double_test;
   double det_value_expect = -1.1086723208;
   REQUIRE(double_test.default_evaluate(3) == Approx(det_value_expect));
   det_value_expect = -1.3432116824;


### PR DESCRIPTION
## Proposed changes
After sorting all the unique determinants, we can dispatch the computation by excitation level.
Before offloading to GPU, we make more functions static (callable inside kernel).
@TApplencourt made the initial change.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'