### PR TITLE
Fix incorrect use of DTModes

### DIFF
--- a/src/Particle/SoaDistanceTableAA.h
+++ b/src/Particle/SoaDistanceTableAA.h
@@ -30,7 +30,7 @@ struct SoaDistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableAA
 
   SoaDistanceTableAA(ParticleSet& target)
       : DTD_BConds<T, D, SC>(target.getLattice()),
-        DistanceTableAA(target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAA(target, DTModes::ALL_OFF),
         num_targets_padded_(getAlignedSize<T>(num_targets_)),
 #if !defined(NDEBUG)
         old_prepared_elec_id_(-1),

--- a/src/Particle/SoaDistanceTableAB.h
+++ b/src/Particle/SoaDistanceTableAB.h
@@ -27,7 +27,7 @@ struct SoaDistanceTableAB : public DTD_BConds<T, D, SC>, public DistanceTableAB
 {
   SoaDistanceTableAB(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.getLattice()),
-        DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAB(source, target, DTModes::ALL_OFF),
         evaluate_timer_(
             *timer_manager.createTimer(std::string("DTAB::evaluate_") + target.getName() + "_" + source.getName(),
                                        timer_level_fine)),

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -120,7 +120,7 @@ private:
 public:
   SoaDistanceTableABOMPTarget(const ParticleSet& source, ParticleSet& target)
       : DTD_BConds<T, D, SC>(source.getLattice()),
-        DistanceTableAB(source, target, DTModes::NEED_TEMP_DATA_ON_HOST),
+        DistanceTableAB(source, target, DTModes::ALL_OFF),
         offload_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::offload_") + name_, timer_level_fine)),
         evaluate_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::evaluate_") + name_, timer_level_fine)),
         move_timer_(*timer_manager.createTimer(std::string("DTABOMPTarget::move_") + name_, timer_level_fine)),

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -29,7 +29,7 @@ public:
   ExampleHeComponent(const ParticleSet& ions, ParticleSet& els)
       : WaveFunctionComponent("ExampleHeComponent"),
         ions_(ions),
-        my_table_ee_idx_(els.addTable(els)),
+        my_table_ee_idx_(els.addTable(els, DTModes::NEED_TEMP_DATA_ON_HOST | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
         my_table_ei_idx_(els.addTable(ions, DTModes::NEED_VP_FULL_TABLE_ON_HOST)){};
 
   using OptVariablesType = optimize::VariableSet;

--- a/src/QMCWaveFunctions/Fermion/Backflow_ee.h
+++ b/src/QMCWaveFunctions/Fermion/Backflow_ee.h
@@ -39,7 +39,9 @@ public:
   bool first;
 
   Backflow_ee(ParticleSet& ions, ParticleSet& els)
-      : BackflowFunctionBase(ions, els), myTableIndex_(els.addTable(els, DTModes::NEED_TEMP_DATA_ON_HOST)), first(true)
+      : BackflowFunctionBase(ions, els),
+        myTableIndex_(els.addTable(els, DTModes::NEED_TEMP_DATA_ON_HOST | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
+        first(true)
   {
     resize(NumTargets, NumTargets);
     NumGroups = els.groups();

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.cpp
@@ -176,7 +176,7 @@ typename J2OrbitalSoA<FT>::posT J2OrbitalSoA<FT>::accumulateG(const valT* restri
 template<typename FT>
 J2OrbitalSoA<FT>::J2OrbitalSoA(const std::string& obj_name, ParticleSet& p)
     : WaveFunctionComponent("J2OrbitalSoA", obj_name),
-      my_table_ID_(p.addTable(p, DTModes::NEED_TEMP_DATA_ON_HOST)),
+      my_table_ID_(p.addTable(p, DTModes::NEED_TEMP_DATA_ON_HOST | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
       j2_ke_corr_helper(p, F)
 {
   if (myName.empty())

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -147,7 +147,7 @@ public:
 
   JeeIOrbitalSoA(const std::string& obj_name, const ParticleSet& ions, ParticleSet& elecs, bool is_master = false)
       : WaveFunctionComponent("JeeIOrbitalSoA", obj_name),
-        ee_Table_ID_(elecs.addTable(elecs, DTModes::NEED_TEMP_DATA_ON_HOST)),
+        ee_Table_ID_(elecs.addTable(elecs, DTModes::NEED_TEMP_DATA_ON_HOST | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
         ei_Table_ID_(elecs.addTable(ions, DTModes::NEED_FULL_TABLE_ANYTIME | DTModes::NEED_VP_FULL_TABLE_ON_HOST)),
         Ions(ions)
   {


### PR DESCRIPTION
## Proposed changes
J3 in offload was broken by #3905 because virtual particle set data transfer no more depends on NEED_TEMP_DATA_ON_HOST.
This PR adds missing flags in AA table consumers who needs data on the host.
and removes implicit NEED_TEMP_DATA_ON_HOST always forced on AA, AB tables.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
