### PR TITLE
Adjust block sizes in offload kernels

### DIFF
--- a/config/build_olcf_summit_Clang.sh
+++ b/config/build_olcf_summit_Clang.sh
@@ -25,7 +25,7 @@ if [[ ! -d /ccs/proj/mat151/opt/modules ]] ; then
   exit 1
 fi
 module use /ccs/proj/mat151/opt/modules
-module load llvm/main-20220304-cuda11.0
+module load llvm/main-20220317-cuda11.0
 
 TYPE=Release
 Compiler=Clang

--- a/src/Particle/SoaDistanceTableAAOMPTarget.h
+++ b/src/Particle/SoaDistanceTableAAOMPTarget.h
@@ -211,7 +211,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
     const auto num_padded        = dt_leader.num_targets_padded_;
     mw_mem.mw_distances_subset.resize(nw * subset_size * num_padded);
 
-    const int ChunkSizePerTeam = 256;
+    const int ChunkSizePerTeam = 512;
     const size_t num_teams     = (num_sources_local + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
     auto& coordinates_leader = static_cast<const RealSpacePositionsOMPTarget&>(pset_leader.getCoordinates());
@@ -320,7 +320,7 @@ struct SoaDistanceTableAAOMPTarget : public DTD_BConds<T, D, SC>, public Distanc
       auto& coordinates_soa = static_cast<const RealSpacePositionsOMPTarget&>(p_list[iw].getCoordinates());
     }
 
-    const int ChunkSizePerTeam = 256;
+    const int ChunkSizePerTeam = 512;
     const size_t num_teams     = (num_targets_ + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
     auto& coordinates_leader = static_cast<const RealSpacePositionsOMPTarget&>(pset_leader.getCoordinates());

--- a/src/Particle/SoaDistanceTableABOMPTarget.h
+++ b/src/Particle/SoaDistanceTableABOMPTarget.h
@@ -201,7 +201,7 @@ public:
     assert(distances_[0].data() + num_padded == displacements_[0].data());
 
     // To maximize thread usage, the loop over electrons is chunked. Each chunk is sent to an OpenMP offload thread team.
-    const int ChunkSizePerTeam = 256;
+    const int ChunkSizePerTeam = 512;
     const size_t num_teams     = (num_sources_ + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
     const size_t stride_size   = getPerTargetPctlStrideSize();
 
@@ -301,7 +301,7 @@ public:
     }
 
     // To maximize thread usage, the loop over electrons is chunked. Each chunk is sent to an OpenMP offload thread team.
-    const int ChunkSizePerTeam = 256;
+    const int ChunkSizePerTeam = 512;
     const size_t num_teams     = (num_sources_ + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
     auto* r_dr_ptr              = mw_r_dr.data();

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -230,7 +230,7 @@ void SplineC2COMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
     pos_scratch[iat * 6 + 5] = ru[2];
   }
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   ratios_private.resize(nVP, NumTeams);
   const auto padded_size = myV.size();
@@ -350,7 +350,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
     }
   }
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   mw_ratios_private.resize(mw_nVP, NumTeams);
   const auto padded_size = myV.size();
@@ -497,7 +497,7 @@ void SplineC2COMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   const PointType& r = P.activeR(iat);
   PointType ru(PrimLattice.toUnit_floor(r));
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
   const auto padded_size = myV.size();
@@ -572,7 +572,7 @@ void SplineC2COMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
                                                  const RefVector<ValueVector>& d2psi_v_list) const
 {
   const size_t num_pos          = psi_v_list.size();
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   const auto padded_size        = myV.size();
   // for V(1)G(3)H(6) intermediate result
@@ -732,7 +732,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   }
 
   const size_t num_pos          = nwalkers;
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   const auto padded_size        = myV.size();
   // for V(1)G(3)H(6) intermediate result

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -238,7 +238,7 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
   }
   else
   {
-    const size_t ChunkSizePerTeam = 128;
+    const size_t ChunkSizePerTeam = 512;
     const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
     const auto padded_size = myV.size();
@@ -310,7 +310,7 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
     pos_scratch[iat * 6 + 5] = ru[2];
   }
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   ratios_private.resize(nVP, NumTeams);
   const auto padded_size = myV.size();
@@ -433,7 +433,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
     }
   }
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   mw_ratios_private.resize(mw_nVP, NumTeams);
   const auto padded_size = myV.size();
@@ -639,7 +639,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   const PointType& r = P.activeR(iat);
   PointType ru(PrimLattice.toUnit_floor(r));
 
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
   const auto padded_size = myV.size();
@@ -715,7 +715,7 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
                                                  const RefVector<ValueVector>& d2psi_v_list) const
 {
   const size_t num_pos          = psi_v_list.size();
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   const auto padded_size        = myV.size();
   // for V(1)G(3)H(6) intermediate result
@@ -876,7 +876,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   }
 
   const size_t num_pos          = nwalkers;
-  const size_t ChunkSizePerTeam = 128;
+  const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   const auto padded_size        = myV.size();
   // for V(1)G(3)H(6) intermediate result


### PR DESCRIPTION
## Proposed changes
The full loop iterations space is spliced into sizes of ChunkSizePerTeam to increase the number of  CUDA blocks/ workgroups on GPU.

Larger block sizes allow more resident computation and thus more efficient but lose time to solution when the number of blocks. For small problem sizes, the number of blocks is not an issue and efficiency matters more. I noticed much closer kernel performance between legacy CUDA and OpenMP offload.

A larger block size only affects iterations space larger than the block size, namely when the number of blocks changes.
The increase from 128 to 512 actually improve kernel efficiency a lot for small to medium problem sizes with smaller CUDA grid sizes. For example NiO a32 has 288 splines, so need 3 blocks of size 128, 2 blocks of 256, and 1 blocks of 512. 512 should be good for both NVIDIA and AMD, 64 CUDA cores per SM and 64 Stream processors per CU.
With 128, 256, 512, I saw kernel time dropping but 1024 stays the same as 512 accross all problem sizes.

For large problem sizes, the number of walkers drop and thus keeping more blocks makes better use of the device.  So I think 512 is a sweat spot.

## What type(s) of changes does this code introduce?
- Other (please describe): Performance tuning.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
