### PR TITLE
Minor fixes to the installation chapter

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -276,6 +276,8 @@ precedent over the environment and default variables.  To set them,
 add -D FLAG=VALUE to the configure line between the CMake command and
 the path to the source directory.
 
+.. highlight:: none
+
 - Key QMCPACK build options
 
   ::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -349,6 +349,7 @@ the path to the source directory.
 - Scalar and vector math functions
 
   ::
+
     QMC_MATH_VENDOR     Select a vendor optimized library for scalar and vector math functions.
                         Providers are GENERIC INTEL_VML IBM_MASS AMD_LIBM
 


### PR DESCRIPTION
Two changes
- make the highlighting language "none" in the literal blocks (otherwise the default highlighter colors apparently random words in the text.  Okay, they're not random - they're clearly programming keywords, but it looks random when highlighted in text and not code)
- Fix the QMC_MATH_VENDOR literal block

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Documentation changes


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
