### PR TITLE
Fix incorrect reference determinant id.

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -35,8 +35,6 @@ void MultiDiracDeterminant::createDetData(const int ref_det_id,
                                           const std::vector<size_t>& C2nodes_unsorted,
                                           std::vector<size_t>& C2nodes_sorted)
 {
-  ReferenceDeterminant = ref_det_id;
-
   auto& ref                        = configlist_unsorted[ref_det_id];
   auto& configlist_sorted          = *ciConfigList;
   auto& data                       = *detData;
@@ -463,7 +461,6 @@ MultiDiracDeterminant::MultiDiracDeterminant(const MultiDiracDeterminant& s)
       NumPtcls(s.NumPtcls),
       LastIndex(s.LastIndex),
       ciConfigList(s.ciConfigList),
-      ReferenceDeterminant(s.ReferenceDeterminant),
       is_spinor_(s.is_spinor_),
       detData(s.detData),
       uniquePairs(s.uniquePairs),
@@ -508,7 +505,6 @@ MultiDiracDeterminant::MultiDiracDeterminant(std::unique_ptr<SPOSet>&& spos, boo
       FirstIndex(first),
       NumPtcls(nel),
       LastIndex(first + nel),
-      ReferenceDeterminant(0),
       is_spinor_(spinor)
 {
   (Phi->isOptimizable() == true) ? Optimizable = true : Optimizable = false;

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -181,7 +181,7 @@ public:
    * sort configlist_unsorted by excitation level abd store the results in ciConfigList (class member)
    * ciConfigList shouldn't change during a simulation after it is sorted here
    *
-   * @param ref_det_id id of the reference determinant
+   * @param ref_det_id id of the reference determinant before sorting
    * @param configlist_unsorted config list to be loaded.
    * @param C2nodes_unsorted mapping from overall det index to unique det (configlist_unsorted) index
    * @param C2nodes_sorted mapping from overall det index to unique det (ciConfigList) index

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -446,10 +446,8 @@ private:
   const int LastIndex;
   ///use shared_ptr
   std::shared_ptr<std::vector<ci_configuration2>> ciConfigList;
-  // the reference determinant never changes, so there is no need to store it.
-  // if its value is zero, then use a data from backup, but always use this one
-  // by default
-  int ReferenceDeterminant;
+  /// all the unique determinants are sorted, the id of the reference det id is always 0
+  static constexpr int ReferenceDeterminant = 0;
   // flag to determine if spin arrays need to be resized and used. Set by ParticleSet::is_spinor_ in SlaterDetBuilder
   const bool is_spinor_;
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -538,7 +538,8 @@ std::unique_ptr<MultiSlaterDetTableMethod> SlaterDetBuilder::createMSDFast(
                   << grp << ", problems with ci configuration list. \n");
       }
     }
-    dets[grp]->createDetData(refdet_id, list, C2nodes[grp], C2nodes_sorted[grp]);
+    // reorder unique determinants for a given spin based on the selected reference determinant
+    dets[grp]->createDetData(C2nodes[grp][refdet_id], list, C2nodes[grp], C2nodes_sorted[grp]);
   }
 
   if (csf_data_ptr && csf_data_ptr->coeffs.size() == 1)


### PR DESCRIPTION
## Proposed changes
@shivupa reported to me this bug. Once determinants are reordered #3874.
`ReferenceDeterminant = ref_det_id;` is wrong.
The reference one should be always id 0.
I had some difficulty to add unit test.
1) reference det is chosen with the maximal weight. It is not exposed in input file.
2) current construction of MSD relies on the builder, namely the input file.

To make a test, refactoring certain code will be needed but it is better to do that after pending MSD PRs.
I did some tests by forcing refdet_id directly in SlaterDetBuilder.cpp. No failure so far.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'