### PR TITLE
Nexus: Pass PYTHONPATH recorded at cmake step to nxs-test.

### DIFF
--- a/nexus/bin/nxs-test
+++ b/nexus/bin/nxs-test
@@ -1821,7 +1821,7 @@ def user_examples(label):
     #end if
     for script in einfo['scripts']:
         # run the example script
-        command = './'+script+' --generate_only --sleep=0.01'
+        command = sys.executable+' ./'+script+' --generate_only --sleep=0.01'
         out,err,rc = nexus_testing.execute(command)
     #end for
     os.chdir(cwd)
@@ -2124,7 +2124,7 @@ def regenerate_reference(update=False):
             if not os.path.exists('./'+script):
                 nerror('script file {} does not exist'.format(script),n=2)
             #end if
-            command = './'+script+' --generate_only --sleep=0.1'
+            command =  sys.executable+' ./'+script+' --generate_only --sleep=0.1'
             nlog('executing command: '+command,n=2)
             out,err,rc = execute(command)
             if rc>0:

--- a/nexus/tests/CMakeLists.txt
+++ b/nexus/tests/CMakeLists.txt
@@ -8,17 +8,23 @@ if(ADD_TEST)
   message("Adding Nexus tests")
   file(TIMESTAMP ${qmcpack_SOURCE_DIR}/nexus/bin/nxs-test NEXUS_TESTLIST_TIMESTAMP)
   if(NOT "${NEXUS_TESTLIST_TIMESTAMP}" STREQUAL "${CACHE_NEXUS_TESTLIST_TIMESTAMP}")
-    execute_process(COMMAND ${qmcpack_SOURCE_DIR}/nexus/bin/nxs-test --ctestlist OUTPUT_VARIABLE NEXUS_TESTLIST)
-    set(CACHE_NEXUS_TESTLIST ${NEXUS_TESTLIST} CACHE INTERNAL "NEXUS_TESTLIST cache variable" FORCE)
-    set(CACHE_NEXUS_TESTLIST_TIMESTAMP ${NEXUS_TESTLIST_TIMESTAMP} CACHE INTERNAL "Timestamp used to validate NEXUS_TESTLIST cache variables" FORCE)
+    execute_process(COMMAND ${Python3_EXECUTABLE} ${qmcpack_SOURCE_DIR}/nexus/bin/nxs-test --ctestlist
+                    OUTPUT_VARIABLE NEXUS_TESTLIST)
+    set(CACHE_NEXUS_TESTLIST
+        ${NEXUS_TESTLIST}
+        CACHE INTERNAL "NEXUS_TESTLIST cache variable" FORCE)
+    set(CACHE_NEXUS_TESTLIST_TIMESTAMP
+        ${NEXUS_TESTLIST_TIMESTAMP}
+        CACHE INTERNAL "Timestamp used to validate NEXUS_TESTLIST cache variables" FORCE)
   else()
     set(NEXUS_TESTLIST ${CACHE_NEXUS_TESTLIST})
   endif()
   foreach(TESTNAME ${NEXUS_TESTLIST})
     #message("Adding test ntest_nexus_${TESTNAME}")
     set(NTEST "${qmcpack_SOURCE_DIR}/nexus/bin/nxs-test")
-    add_test(NAME ntest_nexus_${TESTNAME} COMMAND ${NTEST} -R ${TESTNAME}\$ --ctest
-                                                  --pythonpath=${PROJECT_SOURCE_DIR}/nexus/lib)
+    add_test(NAME ntest_nexus_${TESTNAME} COMMAND ${Python3_EXECUTABLE} ${NTEST} -R ${TESTNAME}\$ --ctest
+                                                  --pythonpath=${PROJECT_SOURCE_DIR}/nexus/lib:$ENV{PYTHONPATH})
+    set_tests_properties(ntest_nexus_${TESTNAME} PROPERTIES ENVIRONMENT PYTHONPATH=$ENV{PYTHONPATH})
     set_property(
       TEST ntest_nexus_${TESTNAME}
       APPEND
@@ -26,7 +32,7 @@ if(ADD_TEST)
     set(TEST_LABELS "")
     add_test_labels(ntest_nexus_${TESTNAME} TEST_LABELS)
     # Use a resource lock to avoid potential race condition in copying example inputs
-    if (${TESTNAME} MATCHES ".*example.*")
+    if(${TESTNAME} MATCHES ".*example.*")
       set_tests_properties(ntest_nexus_${TESTNAME} PROPERTIES RESOURCE_LOCK nexus_examples_resource)
     endif()
   endforeach()

--- a/nexus/tests/unit/test_nxs_sim.py
+++ b/nexus/tests/unit/test_nxs_sim.py
@@ -1,4 +1,5 @@
 
+import sys
 import testing
 from testing import divert_nexus,restore_nexus,clear_all_sims
 from testing import execute,text_eq
@@ -28,7 +29,7 @@ def test_sim():
 
 
     # initial simulation state
-    command = '{} show {}'.format(exe,simp_path)
+    command = sys.executable+' {} show {}'.format(exe,simp_path)
 
     out,err,rc = execute(command)
 
@@ -47,10 +48,10 @@ def test_sim():
 
 
     # final simulation state
-    command = '{} complete {}'.format(exe,simp_path)
+    command = sys.executable+' {} complete {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
-    command = '{} show {}'.format(exe,simp_path)
+    command = sys.executable+' {} show {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -68,13 +69,13 @@ def test_sim():
 
 
     # intermediate simulation state 1
-    command = '{} reset {}'.format(exe,simp_path)
+    command = sys.executable+' {} reset {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
-    command = '{} set setup sent_files submitted {}'.format(exe,simp_path)
+    command = sys.executable+' {} set setup sent_files submitted {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
-    command = '{} show {}'.format(exe,simp_path)
+    command = sys.executable+' {} show {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -90,13 +91,13 @@ def test_sim():
 
 
     # intermediate simulation state 2
-    command = '{} complete {}'.format(exe,simp_path)
+    command = sys.executable+' {} complete {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
-    command = '{} unset got_output analyzed {}'.format(exe,simp_path)
+    command = sys.executable+' {} unset got_output analyzed {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
-    command = '{} show {}'.format(exe,simp_path)
+    command = sys.executable+' {} show {}'.format(exe,simp_path)
     out,err,rc = execute(command)
 
     out_ref = '''

--- a/nexus/tests/unit/test_qmca.py
+++ b/nexus/tests/unit/test_qmca.py
@@ -1,4 +1,5 @@
 
+import sys
 import testing
 from testing import execute,text_eq
 
@@ -76,11 +77,11 @@ def test_help():
 
     help_text = 'Usage: qmca'
 
-    command = '{}'.format(exe)
+    command = sys.executable+' {}'.format(exe)
     out,err,rc = execute(command)
     assert(help_text in out)
 
-    command = '{} -h'.format(exe)
+    command = sys.executable+' {} -h'.format(exe)
     out,err,rc = execute(command)
     assert(help_text in out)
 #end def test_help
@@ -92,7 +93,7 @@ def test_examples():
 
     example_text = 'QMCA examples'
 
-    command = '{} -x'.format(exe)
+    command = sys.executable+' {} -x'.format(exe)
     out,err,rc = execute(command)
     assert(example_text in out)
 #end def test_examples
@@ -104,7 +105,7 @@ def test_unit_conversion():
 
     enter('vmc')
 
-    command = '{} -e 5 -q e -u eV --fp=16.8f *scalar*'.format(exe)
+    command = sys.executable+' {} -e 5 -q e -u eV --fp=16.8f *scalar*'.format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -123,7 +124,7 @@ def test_selected_quantities():
 
     enter('vmc')
 
-    command = "{} -e 5 -q 'e k p' --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -e 5 -q 'e k p' --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -145,7 +146,7 @@ def test_all_quantities():
 
     enter('vmc')
 
-    command = "{} -e 5 --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -e 5 --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -182,7 +183,7 @@ def test_energy_variance():
 
     enter('opt')
 
-    command = "{} -e 5 -q ev --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -e 5 -q ev --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -207,7 +208,7 @@ def test_multiple_equilibration():
 
     enter('dmc')
 
-    command = "{} -e '5 10 15 20' -q ev --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -e '5 10 15 20' -q ev --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -230,7 +231,7 @@ def test_join():
 
     enter('dmc')
 
-    command = "{} -e 5 -j '1 3' -q ev --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -e 5 -j '1 3' -q ev --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -251,7 +252,7 @@ def test_multiple_directories():
 
     enter('multi')
 
-    command = "{} -e 5 -q ev --fp=16.8f */*scalar*".format(exe)
+    command = sys.executable+" {} -e 5 -q ev --fp=16.8f */*scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -283,7 +284,7 @@ def test_twist_average():
 
     enter('vmc_twist')
 
-    command = "{} -a -e 5 -q ev --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -a -e 5 -q ev --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''
@@ -303,7 +304,7 @@ def test_weighted_twist_average():
 
     enter('vmc_twist')
 
-    command = "{} -a -w '1 3 3 1' -e 5 -q ev --fp=16.8f *scalar*".format(exe)
+    command = sys.executable+" {} -a -w '1 3 3 1' -e 5 -q ev --fp=16.8f *scalar*".format(exe)
     out,err,rc = execute(command)
 
     out_ref = '''


### PR DESCRIPTION
## Proposed changes
I can reproduce nxs-test issue of sulfur on my workstation.
Both python interpreter and PYTHONPATH must be properly propagated to all the cmake to python and python internal calls.
Previous issues
1. `nxs-test --pythonpath` wipes out necessary PYTHONPATH
2. All nexus internal calls to python scripts doesn't enforce parent python interpreter. There might be more fixes needed. I only found those covered by ctest.

With this PR, at the CMake step, recorded python environment will be used for ctest. Even the environment is changed after cmake, ctest runs in the recorded environment. Updating test environment requires rerun cmake.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
