### PR TITLE
[ppconvert] avoid use of tuple in the interface in Blitz interface

### DIFF
--- a/src/QMCTools/ppconvert/src/common/Blitz.h
+++ b/src/QMCTools/ppconvert/src/common/Blitz.h
@@ -74,7 +74,7 @@ struct Array : base_type{
 	void resize(sizes_type sizes){resizeAndPreserve(sizes);}
 	void resizeAndPreserve(sizes_type sizes){base_type::reextent(sizes);}
 	template<class... Ints>
-	void resize(Ints... ns){base_type::reextent(std::make_tuple(ns...));}
+	void resize(Ints... ns){base_type::reextent({ns...});}
 	typename base_type::element_ptr       data()      {return base_type::data_elements();}
 	typename base_type::element_const_ptr data() const{return base_type::data_elements();}
 };
@@ -108,7 +108,7 @@ struct Array<T, 1, base_type> : base_type{
 		return 0;
 	}
 	template<class... Ints>
-	void resize(Ints... ns){base_type::reextent(std::make_tuple(ns...));}
+	void resize(Ints... ns){base_type::reextent({ns...});}
 	friend Array operator*(T const& t, Array const& a){
 		Array ret(a.extensions());
 		std::transform(a.begin(), a.end(), ret.begin(), [&](auto const& e){return t*e;});


### PR DESCRIPTION
## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 21.10

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
