### PR TITLE
Remove ROCM/AOMP workaround.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,6 @@ message(STATUS "ENABLE_OMP_TASKLOOP is set to ${ENABLE_OMP_TASKLOOP}")
 # Set up OpenMP offload compile options
 #---------------------------------------------------------
 set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT OFF)
-set(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT OFF)
 if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
   message(STATUS "OpenMP offload CXX flags: ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_OFFLOAD_COMPILE_OPTIONS}")
@@ -372,26 +371,11 @@ if(ENABLE_OFFLOAD AND DEFINED OPENMP_OFFLOAD_COMPILE_OPTIONS)
     # when using OpenMP offload to AMD GPU together with HIP.
     set(QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT ON)
   endif()
-  if(${COMPILER} MATCHES "Clang" AND OPENMP_OFFLOAD_COMPILE_OPTIONS MATCHES "amdgcn")
-    # As of 11/2021, QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON is needed for
-    # ROCM/AOMP compilers when using OpenMP offload to AMD GPU.
-    set(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT ON)
-  endif()
 endif()
 # Some OpenMP offload runtime libraries have composibility issue with a vendor native runtime.
 # A workaround is making the vendor native runtime responsible for memory allocations and OpenMP associate/disassocate them.
 cmake_dependent_option(QMC_OFFLOAD_MEM_ASSOCIATED "Manage OpenMP memory allocations via the vendor runtime"
                        ${QMC_OFFLOAD_MEM_ASSOCIATED_DEFAULT} "ENABLE_OFFLOAD;ENABLE_CUDA" OFF)
-cmake_dependent_option(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL "ROCM compiler offload bug workaround"
-                       ${QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL_DEFAULT} "ENABLE_OFFLOAD" OFF)
-
-if(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
-  message(
-    WARNING "QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON hurts performance. "
-            "As of 11/2021, QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL=ON is needed for "
-            "ROCM/AOMP compilers when using OpenMP offload to AMD GPU. See bug report "
-            "https://github.com/ROCm-Developer-Tools/aomp/issues/255")
-endif()
 
 #-------------------------------------------------------------------------------------
 # consider making this always on if OpenMP is no longer UB with Thread Support Library

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -215,9 +215,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
       T* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
-#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
-#endif
       for (int j = 0; j < n_src; j++)
       {
         if (j == iat) continue;
@@ -323,9 +321,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
       T** mw_coefs        = reinterpret_cast<T**>(transfer_buffer_ptr);
       T* mw_DeltaRInv     = reinterpret_cast<T*>(transfer_buffer_ptr + sizeof(T*) * num_groups);
       T* mw_cutoff_radius = mw_DeltaRInv + num_groups;
-#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
-#endif
       for (int j = 0; j < n_src; j++)
       {
         const int ig    = grp_ids[j];
@@ -566,9 +562,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
       T* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
-#if !defined(QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL)
       PRAGMA_OFFLOAD("omp parallel for")
-#endif
       for (int j = 0; j < n_src; j++)
       {
         if (j == iat) continue;

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -53,9 +53,6 @@
 /* Manage memory allocations via vendor APIs and associate them with the OpenMP runtime */
 #cmakedefine QMC_OFFLOAD_MEM_ASSOCIATED @QMC_OFFLOAD_MEM_ASSOCIATED@
 
-/* Workaround offload bug when branching happens in parallel */
-#cmakedefine QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL @QMC_OFFLOAD_ROCM_WORKAROUND_BRANCH_IN_PARALLEL@
-
 /* Define to 1 if you have MPI library */
 #cmakedefine HAVE_MPI @HAVE_MPI@
 


### PR DESCRIPTION
## Proposed changes

No more needed since ROCm 5.0 and AOMP 14.0-2

## What type(s) of changes does this code introduce?
- Other (please describe): Cleaning

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'