### PR TITLE
Add ResourceHandle

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -25,6 +25,7 @@
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
+#include <ResourceHandle.h>
 #include "SplineOMPTargetMultiWalkerMem.h"
 
 namespace qmcplusplus
@@ -77,7 +78,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  std::unique_ptr<SplineOMPTargetMultiWalkerMem<ST, ComplexT>> mw_mem_;
+  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, ComplexT>> mw_mem_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<ComplexT, OffloadPinnedAllocator<ComplexT>> ratios_private;
@@ -117,22 +118,7 @@ public:
     KeyWord    = "SplineC2C";
   }
 
-  SplineC2COMPTarget(const SplineC2COMPTarget& in)
-      : BsplineSet(in),
-        offload_timer_(in.offload_timer_),
-        PrimLattice(in.PrimLattice),
-        GGt(in.GGt),
-        SplineInst(in.SplineInst),
-        mKK(in.mKK),
-        myKcart(in.myKcart),
-        GGt_offload(in.GGt_offload),
-        PrimLattice_G_offload(in.PrimLattice_G_offload),
-        myV(in.myV),
-        myL(in.myL),
-        myG(in.myG),
-        myH(in.myH),
-        mygH(in.mygH)
-  {}
+  SplineC2COMPTarget(const SplineC2COMPTarget& in) = default;
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -25,6 +25,7 @@
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 #include "Utilities/FairDivide.h"
 #include "Utilities/TimerManager.h"
+#include <ResourceHandle.h>
 #include "SplineOMPTargetMultiWalkerMem.h"
 
 namespace qmcplusplus
@@ -81,7 +82,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  std::unique_ptr<SplineOMPTargetMultiWalkerMem<ST, TT>> mw_mem_;
+  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, TT>> mw_mem_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<TT, OffloadPinnedAllocator<TT>> ratios_private;
@@ -122,23 +123,7 @@ public:
     KeyWord    = "SplineC2R";
   }
 
-  SplineC2ROMPTarget(const SplineC2ROMPTarget& in)
-      : BsplineSet(in),
-        offload_timer_(in.offload_timer_),
-        PrimLattice(in.PrimLattice),
-        GGt(in.GGt),
-        nComplexBands(in.nComplexBands),
-        SplineInst(in.SplineInst),
-        mKK(in.mKK),
-        myKcart(in.myKcart),
-        GGt_offload(in.GGt_offload),
-        PrimLattice_G_offload(in.PrimLattice_G_offload),
-        myV(in.myV),
-        myL(in.myL),
-        myG(in.myG),
-        myH(in.myH),
-        mygH(in.mygH)
-  {}
+  SplineC2ROMPTarget(const SplineC2ROMPTarget& in) = default;
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/Utilities/ResourceHandle.h
+++ b/src/Utilities/ResourceHandle.h
@@ -1,0 +1,39 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RESOURCHANDLE_H
+#define QMCPLUSPLUS_RESOURCHANDLE_H
+
+#include <memory>
+
+namespace qmcplusplus
+{
+/** ResourceHandle manages the temporary owned resource obtained from a collection
+ *
+ * Resource copy should be handled at the collection. Individual handle cannot be copied.
+ * However, directly using unique_ptr prevents compiler generated copy constructor.
+ * For this reason, the ResourceHandle class adds a copy constructor as no-op to facilitate
+ * compiler generated copy constructor in classes owning ResourceHandle objects.
+ */
+template<class RS>
+class ResourceHandle : public std::unique_ptr<RS>
+{
+public:
+  ResourceHandle() = default;
+  ResourceHandle(const ResourceHandle&) {}
+  ResourceHandle(ResourceHandle&&) = default;
+  ResourceHandle& operator=(const ResourceHandle&) {};
+  ResourceHandle& operator=(ResourceHandle&&) = default;
+  using std::unique_ptr<RS>::operator=;
+};
+
+} // namespace qmcplusplus
+#endif


### PR DESCRIPTION
## Proposed changes
When using multiple-walker resource, the current scheme is to add a unique_ptr. This stops compiler auto-generated copy constructor and requires extra code. In the way of using resources, we never need exact copying of individual resources. We always copy by the collection. For this reason, this PR introduces ResourceHandle to implement copy as no-op.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'