### PR TITLE
Connect CoulombPBCAA to multi walker resource

### DIFF
--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.cpp
@@ -21,7 +21,7 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
                                              QMCHamiltonian& H,
                                              std::vector<std::string>& H_KE_node_names,
                                              RandomGenerator& Rng)
-    : e0_(0.0), e2_(0.0), wgt_(0.0), wgt2_(0.0)
+    : h0_res_("h0 resource"), e0_(0.0), e2_(0.0), wgt_(0.0), wgt2_(0.0)
 {
   P.createResource(driverwalker_resource_collection_.pset_res);
   Psi.createResource(driverwalker_resource_collection_.twf_res);
@@ -42,6 +42,7 @@ CostFunctionCrowdData::CostFunctionCrowdData(int crowd_size,
   QMCHamiltonian H_KE;
   for (const std::string& node_name : H_KE_node_names)
     H_KE.addOperator(H.getHamiltonian(node_name)->makeClone(P, Psi), node_name);
+  H_KE.createResource(h0_res_);
 
   for (int ib = 0; ib < crowd_size; ib++)
   {

--- a/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
+++ b/src/QMCDrivers/WFOpt/CostFunctionCrowdData.h
@@ -61,6 +61,7 @@ public:
   Return_rt& get_wgt2() { return wgt2_; }
 
   DriverWalkerResourceCollection& getSharedResource() { return driverwalker_resource_collection_; }
+  ResourceCollection& get_h0_res() { return h0_res_; }
 
 private:
   // Temporary vectors for the call to flex_evaluateDeltaLogSetup
@@ -76,6 +77,9 @@ private:
 
   // proivides multi walker resource
   DriverWalkerResourceCollection driverwalker_resource_collection_;
+
+  /// resource collection corresponding to h0
+  ResourceCollection h0_res_;
 
   // Saved RNG state to reset to before correlated sampling
   std::unique_ptr<RandomGenerator> rng_save_ptr_;

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -550,7 +550,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
 
       ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(opt_data.getSharedResource().pset_res, p_list);
       ResourceCollectionTeamLock<TrialWaveFunction> twfs_res_lock(opt_data.getSharedResource().twf_res, wf_list);
-      ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(opt_data.getSharedResource().ham_res, h0_list);
+      ResourceCollectionTeamLock<QMCHamiltonian> hams_res_lock(opt_data.get_h0_res(), h0_list);
 
       // Load this batch of samples into the crowd data
       for (int ib = 0; ib < current_batch_size; ib++)

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -19,6 +19,7 @@
 #include "EwaldRef.h"
 #include "Particle/DistanceTable.h"
 #include "Utilities/ProgressReportEngine.h"
+#include <ResourceCollection.h>
 #include "Numerics/OneDimCubicSplineLinearGrid.h"
 
 namespace qmcplusplus
@@ -505,11 +506,8 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
                                                                     const RefVectorWithLeader<ParticleSet>& p_list)
 {
   const size_t nw = o_list.size();
-  std::vector<Return_t> values(nw);
-  Vector<Return_t, OffloadPinnedAllocator<Return_t>> values_offload(nw);
   auto& p_leader   = p_list.getLeader();
   auto& caa_leader = o_list.getCastedLeader<CoulombPBCAA>();
-
   ScopedTimer local_timer(caa_leader.evalSR_timer_);
 
   RefVectorWithLeader<DistanceTable> dt_list(p_leader.getDistTable(caa_leader.d_aa_ID));
@@ -523,6 +521,7 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
   if (chunk_size == 0)
     throw std::runtime_error("bug dtaa_leader.get_num_particls_stored() == 0");
 
+  auto& values_offload = caa_leader.mw_res_->values_offload;
   const size_t total_num      = p_leader.getTotalNum();
   const size_t total_num_half = (total_num + 1) / 2;
   const size_t num_padded     = getAlignedSize<RealType>(total_num);
@@ -538,9 +537,10 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
   const auto delta_inv   = caa_leader.rVs_offload->get_delta_inv();
   const auto Zat         = caa_leader.Zat_offload->data();
 
-  auto value_ptr = values_offload.data();
-
   {
+    values_offload.resize(nw);
+    std::fill_n(values_offload.data(), nw, 0);
+    auto value_ptr = values_offload.data();
     values_offload.updateTo();
     for (size_t ichunk = 0; ichunk < num_chunks; ichunk++)
     {
@@ -575,9 +575,10 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
     }
 
     values_offload.updateFrom();
-    for (int iw = 0; iw < nw; iw++)
-      values[iw] = values_offload[iw];
   }
+  std::vector<Return_t> values(nw);
+  for (int iw = 0; iw < nw; iw++)
+    values[iw] = values_offload[iw];
   return values;
 }
 
@@ -606,6 +607,29 @@ CoulombPBCAA::Return_t CoulombPBCAA::evalLR(ParticleSet& P)
     }   //spec1
   }
   return res;
+}
+
+void CoulombPBCAA::createResource(ResourceCollection& collection) const
+{
+  auto new_res = std::make_unique<CoulombPBCAAMultiWalkerResource>();
+  auto resource_index = collection.addResource(std::move(new_res));
+}
+
+void CoulombPBCAA::acquireResource(ResourceCollection& collection,
+                                          const RefVectorWithLeader<OperatorBase>& o_list) const
+{
+  auto& O_leader = o_list.getCastedLeader<CoulombPBCAA>();
+  auto res_ptr   = dynamic_cast<CoulombPBCAAMultiWalkerResource*>(collection.lendResource().release());
+  if (!res_ptr)
+    throw std::runtime_error("CoulombPBCAA::acquireResource dynamic_cast failed");
+  O_leader.mw_res_.reset(res_ptr);
+}
+
+void CoulombPBCAA::releaseResource(ResourceCollection& collection,
+                                          const RefVectorWithLeader<OperatorBase>& o_list) const
+{
+  auto& O_leader = o_list.getCastedLeader<CoulombPBCAA>();
+  collection.takebackResource(std::move(O_leader.mw_res_));
 }
 
 std::unique_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -20,6 +20,7 @@
 #include "QMCHamiltonians/ForceBase.h"
 #include "LongRange/LRCoulombSingleton.h"
 #include "Particle/DistanceTable.h"
+#include <ResourceHandle.h>
 
 namespace qmcplusplus
 {
@@ -151,6 +152,18 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
       setParticleSetF(plist, offset);
   }
 
+  /** initialize a shared resource and hand it to a collection
+   */
+  void createResource(ResourceCollection& collection) const override;
+
+  /** acquire a shared resource from a collection
+   */
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
+  /** return a shared resource to a collection
+   */
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
 private:
   /// if true use offload
   const bool use_offload_;
@@ -162,6 +175,18 @@ private:
   NewTimer& evalSR_timer_;
   /// Timer for offload part
   NewTimer& offload_timer_;
+
+struct CoulombPBCAAMultiWalkerResource : public Resource
+{
+  CoulombPBCAAMultiWalkerResource() : Resource("CoulombPBCAA") {}
+
+  Resource* makeClone() const override { return new CoulombPBCAAMultiWalkerResource(*this); }
+
+  Vector<CoulombPBCAA::Return_t, OffloadPinnedAllocator<CoulombPBCAA::Return_t>> values_offload;
+};
+
+  /// multiwalker shared resource
+  ResourceHandle<CoulombPBCAAMultiWalkerResource> mw_res_;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -236,7 +236,9 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
 
   // testing batched interfaces
   ResourceCollection pset_res("test_pset_res");
+  ResourceCollection caa_res("test_caa_res");
   elec.createResource(pset_res);
+  caa.createResource(caa_res);
 
   // testing batched interfaces
   RefVectorWithLeader<ParticleSet> p_ref_list(elec, {elec, elec_clone});
@@ -247,6 +249,7 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   RefVectorWithLeader<TrialWaveFunction> psi_ref_list(psi, {psi, psi_clone});
 
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
+  ResourceCollectionTeamLock<OperatorBase> mw_caa_lock(caa_res, caa_ref_list);
 
   ParticleSet::mw_update(p_ref_list);
   caa.mw_evaluate(caa_ref_list, psi_ref_list, p_ref_list);


### PR DESCRIPTION
Need #3951
## Proposed changes
1. Connect CoulombPBCAA to multi walker resource. This change reduces allocation/de-allocation of value_offload but due to its low call count, performance gain is negligible. Anyway, reducing noise to the runtime is beneficial.
2. When we have two resources from coulomb and NLPP. WFOpt shows a bug of using the same resource collection for two hamiltonians. In CostFunction, h and h_0 have different components and thus cannot use the same resource collection.

## What type(s) of changes does this code introduce?
- Bugfix
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'