### PR TITLE
spherical harmonic wrapper

### DIFF
--- a/src/Numerics/Ylm.h
+++ b/src/Numerics/Ylm.h
@@ -139,5 +139,32 @@ inline std::complex<T> sphericalHarmonic(const int l, const int m, const TinyVec
   return Ylm(l, m, unit);
 }
 
+// get cartesian derivatives of spherical Harmonics. This takes a arbitrary position vector (x,y,z) and returns (d/dx, d/dy, d/dz)Ylm
+template<typename T>
+inline void sphericalHarmonicGrad(const int l,
+                                  const int m,
+                                  const TinyVector<T, 3>& r,
+                                  TinyVector<std::complex<T>, 3>& grad)
+{
+  TinyVector<T, 3> unit;
+  T norm  = std::sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+  unit[0] = r[2] / norm;
+  unit[1] = r[0] / norm;
+  unit[2] = r[1] / norm;
+  std::complex<T> dth, dph;
+  derivYlmSpherical(l, m, unit, dth, dph, false);
+
+  T dth_dx = r[0] * r[2] / (norm * norm * std::sqrt(r[0] * r[0] + r[1] * r[1]));
+  T dph_dx = -r[1] / (r[0] * r[0] + r[1] * r[1]);
+  T dth_dy = r[1] * r[2] / (norm * norm * std::sqrt(r[0] * r[0] + r[1] * r[1]));
+  T dph_dy = r[0] / (r[0] * r[0] + r[1] * r[1]);
+  T dth_dz = -std::sqrt(r[0] * r[0] + r[1] * r[1]) / (norm * norm);
+  T dph_dz = 0;
+
+  grad[0] = dth * dth_dx + dph * dph_dx;
+  grad[1] = dth * dth_dy + dph * dph_dy;
+  grad[2] = dth * dth_dz + dph * dph_dz;
+}
+
 } // namespace qmcplusplus
 #endif

--- a/src/Numerics/Ylm.h
+++ b/src/Numerics/Ylm.h
@@ -127,5 +127,17 @@ inline void derivYlmSpherical(const int l,
   }
 }
 
+// wrapper for Ylm, which doesn't require a unit vector and is in the normal order (x,y,z)
+template<typename T>
+inline std::complex<T> sphericalHarmonic(const int l, const int m, const TinyVector<T, 3>& r)
+{
+  TinyVector<T, 3> unit;
+  T norm  = std::sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+  unit[0] = r[2] / norm;
+  unit[1] = r[0] / norm;
+  unit[2] = r[1] / norm;
+  return Ylm(l, m, unit);
+}
+
 } // namespace qmcplusplus
 #endif

--- a/src/Numerics/Ylm.h
+++ b/src/Numerics/Ylm.h
@@ -80,6 +80,11 @@ inline T LegendrePlm(int l, int m, T x)
   }
 }
 
+/** calculates Ylm
+ * param[in] l angular momentum
+ * param[in] m magnetic quantum number
+ * param[in] r position vector. Note: This must be a unit vector and in the order [z,x,y] to be correct
+ */
 template<typename T>
 inline std::complex<T> Ylm(int l, int m, const TinyVector<T, 3>& r)
 {
@@ -127,7 +132,11 @@ inline void derivYlmSpherical(const int l,
   }
 }
 
-// wrapper for Ylm, which doesn't require a unit vector and is in the normal order (x,y,z)
+/** wrapper for Ylm, which can take any normal position vector as an argument
+ * param[in] l angular momentum
+ * param[in] m magnetic quantum number
+ * param[in] r is a position vector. This does not have to be normalized and is in the standard ordering [x,y,z]
+ */
 template<typename T>
 inline std::complex<T> sphericalHarmonic(const int l, const int m, const TinyVector<T, 3>& r)
 {
@@ -139,7 +148,12 @@ inline std::complex<T> sphericalHarmonic(const int l, const int m, const TinyVec
   return Ylm(l, m, unit);
 }
 
-// get cartesian derivatives of spherical Harmonics. This takes a arbitrary position vector (x,y,z) and returns (d/dx, d/dy, d/dz)Ylm
+/** get cartesian derivatives of spherical Harmonics. This takes a arbitrary position vector (x,y,z) and returns (d/dx, d/dy, d/dz)Ylm
+ * param[in] l angular momentum 
+ * param[in] m magnetic quantum number
+ * param[in] r position vector. This does not have to be normalized and is in the standard ordering [x,y,z]
+ * param[out] grad (d/dx, d/dy, d/dz) of Ylm
+ */
 template<typename T>
 inline void sphericalHarmonicGrad(const int l,
                                   const int m,

--- a/src/Numerics/tests/test_ylm.cpp
+++ b/src/Numerics/tests/test_ylm.cpp
@@ -209,4 +209,62 @@ TEST_CASE("Spherical Harmonics Wrapper", "[numerics]")
   }
 }
 
+TEST_CASE("Cartesian derivatives of Spherical Harmonics", "[numerics]")
+{
+  struct Point
+  {
+    double x;
+    double y;
+    double z;
+  };
+
+  struct YlmDerivValue
+  {
+    Point p;
+    int l;
+    int m;
+    double dx_re;
+    double dx_im;
+    double dy_re;
+    double dy_im;
+    double dz_re;
+    double dz_im;
+  };
+
+  //reference values from sympy
+  //d/dtheta Ylm and d/dphi Ylm
+  const int N = 10;
+  YlmDerivValue Vals[N] =
+      {{{0.587785, 0, 0.809017}, 1, -1, 0.2261289, 0.0, 0.0, -0.3454942, -0.1642922, 0.0},
+       {{2.938925, 0, 4.045085}, 1, 0, -0.0464689, 0.0, 0.0, 0.0, 0.0337616, 0.0},
+       {{4.755285, 0, 1.545085}, 1, 1, -0.0065983, 0.0, 0.0, -0.0690987, 0.020307, 0.0},
+       {{0.587785, 0, 0.809017}, 2, -2, 0.2972075, 0.0, 0.0, -0.4540925, -0.2159337, 0.0},
+       {{1.469465, 4.52254, 1.545085}, 2, -1, 0.0394982, 0.0253845, -0.0253846, 0.0303795, 0.0367369, -0.1130644},
+       {{0.587785, 0, -0.809017}, 2, 0, -0.7280067, 0.0, 0.0, 0.0, -0.5289276, 0.0},
+       {{0.293893, 0.904508, -0.309017}, 2, 1, 0.1974909, -0.1269229, -0.1269229, -0.1518973, -0.183685, -0.5653221},
+       {{1.469465, 4.52254, 1.545085}, 2, 2, 0.0786382, 0.1156131, -0.0374877, -0.0288926, 0.0349388, -0.0253846},
+       {{-0.475528, -0.345492, -0.809017}, 3, -3, 0.1709827, -0.2963218, -0.3841394, -0.0501111, 0.0635463, 0.1955735},
+       {{-2.37764, -1.72746, 4.045085}, 4, 4, 0.0059594, -0.0565636, 0.0565635, 0.0307981, 0.0276584, -0.0200945}};
+
+  using vec_t = TinyVector<double, 3>;
+  for (int i = 0; i < N; i++)
+  {
+    YlmDerivValue& v = Vals[i];
+    vec_t w;
+    w[0] = v.p.x; // first component appears to be aligned along the z-axis
+    w[1] = v.p.y;
+    w[2] = v.p.z;
+
+    TinyVector<std::complex<double>, 3> grad;
+    sphericalHarmonicGrad(v.l, v.m, w, grad);
+    //printf("%d %d  expected %g %g %g %g  actual %g %g %g %g\n",v.l,v.m,v.th_re,v.th_im, v.ph_re, v.ph_im, theta.real(), theta.imag(), phi.real(), phi.imag());
+    CHECK(std::real(grad[0]) == Approx(v.dx_re));
+    CHECK(std::imag(grad[0]) == Approx(v.dx_im));
+    CHECK(std::real(grad[1]) == Approx(v.dy_re));
+    CHECK(std::imag(grad[1]) == Approx(v.dy_im));
+    CHECK(std::real(grad[2]) == Approx(v.dz_re));
+    CHECK(std::imag(grad[2]) == Approx(v.dz_im));
+  }
+}
+
 } // namespace qmcplusplus

--- a/src/Numerics/tests/test_ylm.cpp
+++ b/src/Numerics/tests/test_ylm.cpp
@@ -232,7 +232,7 @@ TEST_CASE("Cartesian derivatives of Spherical Harmonics", "[numerics]")
   };
 
   //reference values from sympy
-  //d/dtheta Ylm and d/dphi Ylm
+  // (d/dx, d/dy, d/dz)Ylm
   const int N = 10;
   YlmDerivValue Vals[N] =
       {{{0.587785, 0, 0.809017}, 1, -1, 0.2261289, 0.0, 0.0, -0.3454942, -0.1642922, 0.0},

--- a/src/Numerics/tests/test_ylm.cpp
+++ b/src/Numerics/tests/test_ylm.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Derivatives of Spherical Harmonics", "[numerics]")
 
   //reference values from sympy
   //d/dtheta Ylm and d/dphi Ylm
-  const int N      = 10;
+  const int N           = 10;
   YlmDerivValue Vals[N] = {
       {{0.587785, 0, 0.809017}, 1, -1, 0.27951007, 0.0, 0.0, -0.2030763},
       {{0.587785, 0, 0.809017}, 1, 0, -0.2871933, 0.0, 0.0, 0.0},
@@ -157,7 +157,56 @@ TEST_CASE("Derivatives of Spherical Harmonics", "[numerics]")
     REQUIRE(std::real(phi) == Approx(v.ph_re));
     REQUIRE(std::imag(phi) == Approx(v.ph_im));
   }
+}
 
+TEST_CASE("Spherical Harmonics Wrapper", "[numerics]")
+{
+  struct Point
+  {
+    double x;
+    double y;
+    double z;
+  };
+
+  struct YlmValue
+  {
+    Point p;
+    int l;
+    int m;
+    double y_re;
+    double y_im;
+  };
+
+  // Test a small subset of values, same test as Spherical Harmonics except some are scaled to not be unit vectors
+  const int N      = 11;
+  YlmValue Vals[N] = {
+      {{0, 0, 5}, 1, -1, 0, 0},
+      {{2.938925, 0, 4.045085}, 1, -1, 0.203076, 0},
+      {{2.938925, 0, 4.045085}, 1, 0, 0.395288, 0},
+      {{0.951057, 0, 0.309017}, 1, 1, -0.328584, 0},
+      {{0.587785, 0, 0.809017}, 2, -2, 0.133454, 0},
+      {{1.469465, 4.52254, 1.545085}, 2, -1, 0.0701612, -0.215934},
+      {{0.587785, 0, -0.809017}, 2, 0, 0.303888, 0},
+      {{0.293893, 0.904508, -0.309017}, 2, 1, 0.0701612, 0.215934},
+      {{1.469465, 4.52254, 1.545085}, 2, 2, -0.282661, 0.205365},
+      {{-0.475528, -0.345492, -0.809017}, 3, -3, 0.0261823, 0.0805808},
+      {{-2.37764, -1.72746, 4.045085}, 4, 4, -0.0427344, 0.0310484},
+  };
+
+  using vec_t = TinyVector<double, 3>;
+  for (int i = 0; i < N; i++)
+  {
+    YlmValue& v = Vals[i];
+    vec_t w;
+    w[0] = v.p.x;
+    w[1] = v.p.y;
+    w[2] = v.p.z;
+
+    std::complex<double> out = sphericalHarmonic(v.l, v.m, w);
+    //printf("%d %d  expected %g %g   actual %g %g\n",v.l,v.m,v.y_re,v.y_im, out.real(), out.imag());
+    REQUIRE(v.y_re == Approx(out.real()));
+    REQUIRE(v.y_im == Approx(out.imag()));
+  }
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -144,18 +144,8 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
           ComplexType ldots(0.0);
           for (int d = 0; d < 3; d++)
             ldots += lmMatrixElements(l, m1, m2, d) * sMatrixElements(sold, snew, d);
-          //Seemingly Numerics/Ylm takes unit vector with order z,x,y...why
-          RealType rmag = std::sqrt(dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2]);
-          PosType rr    = dr / rmag;
-          PosType tmp;
-          tmp[0]         = rr[2];
-          tmp[1]         = rr[0];
-          tmp[2]         = rr[1];
-          ComplexType Y  = Ylm(l, m1, tmp);
-          tmp[0]         = rrotsgrid_m[j][2];
-          tmp[1]         = rrotsgrid_m[j][0];
-          tmp[2]         = rrotsgrid_m[j][1];
-          ComplexType cY = std::conj(Ylm(l, m2, tmp));
+          ComplexType Y  = sphericalHarmonic(l, m1, dr);
+          ComplexType cY = std::conj(sphericalHarmonic(l, m2, rrotsgrid_m[j]));
           msums += Y * cY * ldots;
         }
       }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

I use the Ylm's in Numerics for the spin-orbit ECP, and will need cartesian derivatives of these for ionic derivatives. The Ylm's in Numerics require cartesian vectors as input...except they **must**  unit vectors and must be in the format [z,x,y] instead of the standard ordering. 

This just adds a sphericalHarmonic wrapper which takes in any cartesian vector so the user can simply provide whatever position they want. Internally, it calculates the unit vector and reorders it to be [z,x,y] and then calls the Ylm implementation we already have. This allows me to clean up the SOECP for better readability.

I also introduce a sphericalHarmonicGrad, which calculates (d/dx, d/dy, d/dz)Ylm. This will be need for ionic derivatives of the SOECP.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
