### PR TITLE
Clang14 and CUDA11.2 in AFQMC-Offload CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -120,8 +120,10 @@ jobs:
             GCC8-NoMPI-Legacy-CUDA-Complex-Mixed,
             GCC8-NoMPI-Legacy-CUDA-Real, # full precision
             GCC8-NoMPI-Legacy-CUDA-Complex,
-            Clang14Dev-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload requires development llvm14
-            Clang14Dev-MPI-CUDA-AFQMC-Offload-Real,
+            Clang14-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload requires llvm14
+            Clang14-MPI-CUDA-AFQMC-Offload-Real,
+            Clang14-MPI-CUDA-AFQMC-Offload-Complex-Mixed,
+            Clang14-MPI-CUDA-AFQMC-Offload-Complex,
             Intel19-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
             Intel19-MPI-CUDA-AFQMC-Complex-Mixed,
             Intel19-MPI-CUDA-AFQMC-Real,

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -36,6 +36,8 @@ case "$1" in
       
       if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
       then
+        echo "Set PATH to cuda-11.2 to be associated with the C and C++ compilers"
+        export PATH=/usr/local/cuda-11.2/bin:$PATH
         echo "Set CUDACXX CMake environment variable to nvcc cuda 11.2 location due to a regression bug in 11.6"
         export CUDACXX=/usr/local/cuda-11.2/bin/nvcc
 
@@ -49,7 +51,7 @@ case "$1" in
         # Make current environment variables available to subsequent steps
         echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
       fi
-      
+
     fi 
 
     # Sanitizer
@@ -170,6 +172,9 @@ case "$1" in
         # Make current environment variables available to subsequent steps
         echo "OMPI_CC=/opt/llvm/14.0.1/bin/clang" >> $GITHUB_ENV
         echo "OMPI_CXX=/opt/llvm/14.0.1/bin/clang++" >> $GITHUB_ENV
+
+        # Confirm that cuda 11.2 gets picked up by the compiler
+        /opt/llvm/14.0.1/bin/clang++ -v
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
@@ -320,6 +325,8 @@ case "$1" in
     then
       if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
       then
+        # adding PATH to prevent default /usr/local/cuda to be associated with the compiler
+        export PATH=/usr/local/cuda-11.2/bin:$PATH
         export LD_LIBRARY_PATH=/usr/local/cuda-11.2/lib64:${LD_LIBRARY_PATH}
       else
         export LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -33,11 +33,23 @@ case "$1" in
 
     if [[ "${GH_JOBNAME}" =~ (-CUDA) ]]
     then
-      echo "Set CUDACXX CMake environment variable to nvcc standard location"
-      export CUDACXX=/usr/local/cuda/bin/nvcc
-        
-      # Make current environment variables available to subsequent steps
-      echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
+      
+      if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
+      then
+        echo "Set CUDACXX CMake environment variable to nvcc cuda 11.2 location due to a regression bug in 11.6"
+        export CUDACXX=/usr/local/cuda-11.2/bin/nvcc
+
+        # Make current environment variables available to subsequent steps
+        echo "CUDACXX=/usr/local/cuda-11.2/bin/nvcc" >> $GITHUB_ENV
+
+      else
+        echo "Set CUDACXX CMake environment variable to nvcc standard location"
+        export CUDACXX=/usr/local/cuda/bin/nvcc
+
+        # Make current environment variables available to subsequent steps
+        echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
+      fi
+      
     fi 
 
     # Sanitizer
@@ -148,17 +160,16 @@ case "$1" in
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ${GITHUB_WORKSPACE}
       ;;
-      *"Clang14Dev-MPI-CUDA-AFQMC-Offload"*)
+      *"Clang14-MPI-CUDA-AFQMC-Offload"*)
         echo "Configure for building with ENABLE_CUDA and AFQMC using OpenMP offload on x86_64 " \
-              "with llvm development commit bafb6f3e9cc7, need built-from-source OpenBLAS due to bug in rpm"
+              "with latest llvm, need built-from-source OpenBLAS due to bug in rpm"
 
-              # TODO: upgrade to llvm14 clang14 when available
-        export OMPI_CC=/opt/llvm/bafb6f3e9cc7/bin/clang
-        export OMPI_CXX=/opt/llvm/bafb6f3e9cc7/bin/clang++
+        export OMPI_CC=/opt/llvm/14.0.1/bin/clang
+        export OMPI_CXX=/opt/llvm/14.0.1/bin/clang++
         
         # Make current environment variables available to subsequent steps
-        echo "OMPI_CC=/opt/llvm/bafb6f3e9cc7/bin/clang" >> $GITHUB_ENV
-        echo "OMPI_CXX=/opt/llvm/bafb6f3e9cc7/bin/clang++" >> $GITHUB_ENV
+        echo "OMPI_CC=/opt/llvm/14.0.1/bin/clang" >> $GITHUB_ENV
+        echo "OMPI_CXX=/opt/llvm/14.0.1/bin/clang++" >> $GITHUB_ENV
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
@@ -307,7 +318,12 @@ case "$1" in
 
     if [[ "${GH_JOBNAME}" =~ (CUDA) ]]
     then
-       export LD_LIBRARY_PATH=/usr/local/cuda/lib/:/usr/local/cuda/lib64/:${LD_LIBRARY_PATH}
+      if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
+      then
+        export LD_LIBRARY_PATH=/usr/local/cuda-11.2/lib64:${LD_LIBRARY_PATH}
+      else
+        export LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+      fi
     fi
 
     if [[ "${GH_JOBNAME}" =~ (AFQMC) ]]
@@ -324,7 +340,7 @@ case "$1" in
 
     if [[ "${GH_JOBNAME}" =~ (AFQMC-Offload) ]]
     then
-       export LD_LIBRARY_PATH=/opt/llvm/bafb6f3e9cc7/lib:/usr/lib64/openmpi/lib/:${LD_LIBRARY_PATH}
+       export LD_LIBRARY_PATH=/opt/llvm/14.0.1/lib:/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH}
     fi
 
     if [[ "${GH_JOBNAME}" =~ (Intel19) ]]

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -33,8 +33,7 @@ case "$1" in
 
     if [[ "${GH_JOBNAME}" =~ (-CUDA) ]]
     then
-      
-      if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
+      if [[ "${GH_JOBNAME}" =~ (-Offload) ]]
       then
         echo "Set PATH to cuda-11.2 to be associated with the C and C++ compilers"
         export PATH=/usr/local/cuda-11.2/bin:$PATH
@@ -51,7 +50,6 @@ case "$1" in
         # Make current environment variables available to subsequent steps
         echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
       fi
-
     fi 
 
     # Sanitizer
@@ -323,13 +321,11 @@ case "$1" in
 
     if [[ "${GH_JOBNAME}" =~ (CUDA) ]]
     then
-      if [[ "${GH_JOBNAME}" =~ (-AFQMC-Offload-) ]]
+      if [[ "${GH_JOBNAME}" =~ (-Offload) ]]
       then
-        # adding PATH to prevent default /usr/local/cuda to be associated with the compiler
-        export PATH=/usr/local/cuda-11.2/bin:$PATH
         export LD_LIBRARY_PATH=/usr/local/cuda-11.2/lib64:${LD_LIBRARY_PATH}
       else
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
       fi
     fi
 


### PR DESCRIPTION
## Proposed changes

Bump to Clang14  in AFQMC-Offload CI test from using a non-release commit
Fixes #3960
Add Complex tests for CUDA 11.2. 
Fixes #3953 
Complex test are broken with CUDA 11.6
Must be merged to work

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
