### PR TITLE
Remove use_stored_copy flag in orbital rotation code

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -71,7 +71,7 @@ bool SplineR2R<ST>::write_splines(hdf_archive& h5f)
   is very tall and skinny.
 */
 template<typename ST>
-void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
+void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat)
 {
   // SplineInst is a MultiBspline. See src/spline2/MultiBspline.hpp
   const auto spline_ptr = SplineInst->getSplinePtr();

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -95,7 +95,7 @@ public:
      [2] Toulouse & Umrigar, JCP 126, (2007)
      [3] Townsend et al., PRB 102, (2020)
   */
-  void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
+  void applyRotation(const ValueMatrix& rot_mat) override;
 
   inline void resizeStorage(size_t n, size_t nvals)
   {

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -30,7 +30,12 @@ LCAOrbitalSet::LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize)
 }
 
 LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
-    : SPOSet(in), myBasisSet(in.myBasisSet->makeClone()), C(in.C), BasisSetSize(in.BasisSetSize), Identity(in.Identity)
+    : SPOSet(in),
+      myBasisSet(in.myBasisSet->makeClone()),
+      C(in.C),
+      BasisSetSize(in.BasisSetSize),
+      C_copy(in.C_copy),
+      Identity(in.Identity)
 {
   Temp.resize(BasisSetSize);
   Temph.resize(BasisSetSize);
@@ -680,10 +685,11 @@ void LCAOrbitalSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last
   APP_ABORT("LCAOrbitalSet::evaluateThirdDeriv(P,istart,istop,ggg_logdet) not implemented\n");
 }
 
-void LCAOrbitalSet::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
+void LCAOrbitalSet::applyRotation(const ValueMatrix& rot_mat)
 {
-  if (!use_stored_copy)
-    C_copy = *C;
+  if (C_copy.size() != C->size())
+    throw std::runtime_error("C_copy not set before applyRotation (storeParamsBeforeRotation was not called)");
+
   //gemm is out-of-place
   BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy.data(), BasisSetSize,
              rot_mat.data(), OrbitalSetSize, RealType(0.0), C->data(), BasisSetSize);

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -51,7 +51,7 @@ public:
 
   void storeParamsBeforeRotation() override { C_copy = *C; }
 
-  void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
+  void applyRotation(const ValueMatrix& rot_mat) override;
 
   void checkInVariables(opt_variables_type& active) override
   {

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -105,7 +105,8 @@ void RotatedSPOs::buildOptVariables(const std::vector<std::pair<int, int>>& rota
   std::vector<RealType> param(m_act_rot_inds.size());
   for (int i = 0; i < m_act_rot_inds.size(); i++)
     param[i] = myVars[i];
-  apply_rotation(param, false);
+  Phi->storeParamsBeforeRotation();
+  apply_rotation(param);
 
   if (!Optimizable)
   {
@@ -119,7 +120,7 @@ void RotatedSPOs::buildOptVariables(const std::vector<std::pair<int, int>>& rota
 #endif
 }
 
-void RotatedSPOs::apply_rotation(const std::vector<RealType>& param, bool use_stored_copy)
+void RotatedSPOs::apply_rotation(const std::vector<RealType>& param)
 {
   assert(param.size() == m_act_rot_inds.size());
 
@@ -144,7 +145,7 @@ void RotatedSPOs::apply_rotation(const std::vector<RealType>& param, bool use_st
     Finally, apply unitary matrix to orbs.
   */
   exponentiate_antisym_matrix(rot_mat);
-  Phi->applyRotation(rot_mat, use_stored_copy);
+  Phi->applyRotation(rot_mat);
 }
 
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -30,7 +30,7 @@ public:
   std::vector<std::pair<int, int>> m_act_rot_inds;
 
   //function to perform orbital rotations
-  void apply_rotation(const std::vector<RealType>& param, bool use_stored_copy);
+  void apply_rotation(const std::vector<RealType>& param);
 
   //helper function to apply_rotation
   void exponentiate_antisym_matrix(ValueMatrix& mat);
@@ -175,7 +175,6 @@ public:
     {
       if (myVars.size())
         active.insertFrom(myVars);
-      Phi->storeParamsBeforeRotation();
     }
   }
 
@@ -198,7 +197,7 @@ public:
         int loc  = myVars.where(i);
         param[i] = myVars[i] = active[loc];
       }
-      apply_rotation(param, true);
+      apply_rotation(param);
     }
   }
 

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -107,7 +107,7 @@ public:
   // store parameters before getting destroyed by rotation.
   virtual void storeParamsBeforeRotation() {}
   // apply rotation to all the orbitals
-  virtual void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy = false)
+  virtual void applyRotation(const ValueMatrix& rot_mat)
   {
     std::ostringstream o;
     o << "SPOSet::applyRotation is not implemented by " << className << std::endl;

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -162,7 +162,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
   {
     param[i] = 0.01 * static_cast<RealType>(i);
   }
-  rot_spo->apply_rotation(param, false); // Expect this to call SplineR2R::applyRotation()
+  rot_spo->apply_rotation(param); // Expect this to call SplineR2R::applyRotation()
 
   // 4.) Get data for rotated orbitals.
   SPOSet::ValueMatrix psiM_rot(elec_.R.size(), orbitalsetsize);

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -307,7 +307,7 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   rot_mat[7][7] = 0.99273;
 
   // Apply the rotation
-  spo->applyRotation(rot_mat, false);
+  spo->applyRotation(rot_mat);
 
   // Get data for rotated orbitals
   SPOSet::ValueMatrix psiM_rot(elec_.R.size(), orbitalsetsize);


### PR DESCRIPTION
Remove the 'use_stored_copy' flag from the functions that apply orbital rotations.

The LCAO orbital rotation stores a copy of the coefficient matrix (C is the matrix, C_copy is the copy). It multiplies the rotation matrix by C_copy and puts the result in C.
The stored copy is needed for parameter optimization.  When the rotation parameters change, they need to be reapplied to the original coefficient matrix.

Previously, use_stored_copy is false by default.  The logic in apply_rotation would perform the copy (and initialization) C_copy = *C if use_stored_copy is false (e.g., by default it uses the values in C to multiply by the rotation matrix.)
I find this logic hard to follow and would rather explicitly require initialization of C_copy via the storeParamsBeforeRotation function. (That function already exists and is already called in code prior to this PR so using it isn't adding complexity.)

One tricky part of the code path is to ensure storeParamsBeforeRotation doesn't get called after applyRotation has been called, otherwise the rotation will get applied multiple times.

This PR also adds the C_copy variable in the LCAOrbitalSet copy constructor, which is necessary because the changes in this PR don't copy/initialize C_copy as frequently.  The change may not be obvious because the clang formatting changes the layout.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
