### PR TITLE
Remove unused Collectables from new Estimator code.

### DIFF
--- a/src/Estimators/EstimatorManagerCrowd.cpp
+++ b/src/Estimators/EstimatorManagerCrowd.cpp
@@ -10,14 +10,12 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 #include "EstimatorManagerCrowd.h"
-#include "Estimators/CollectablesEstimator.h"
 
 namespace qmcplusplus
 {
 EstimatorManagerCrowd::EstimatorManagerCrowd(EstimatorManagerNew& em)
 {
   // For now I'm going to try to refactor away the clone pattern only at the manager level.
-  // i.e. not continue into the scalar_estimators and collectables
   for (const auto& est : em.Estimators)
     scalar_estimators_.emplace_back(est->clone());
   for (const auto& upeb : em.operator_ests_)
@@ -50,7 +48,7 @@ void EstimatorManagerCrowd::startBlock(int steps)
 
 void EstimatorManagerCrowd::stopBlock()
 {
-  // the main estimator does it some more inside of here.
+  // the main estimator does more here.
 }
 
 

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -28,7 +28,6 @@ namespace qmcplusplus
 {
 class MCWalkerConifugration;
 class QMCHamiltonian;
-class CollectablesEstimator;
 
 /** Thread local estimator container/accumulator
  *

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
@@ -29,7 +29,6 @@
 namespace qmcplusplus
 {
 class QMCHamiltonian;
-class CollectablesEstimator;
 class hdf_archive;
 
 namespace testing
@@ -196,11 +195,6 @@ private:
   std::unique_ptr<std::ofstream> DebugArchive;
   ///communicator to handle communication
   Communicate* my_comm_;
-  /** pointer to the CollectablesEstimator
-   *
-   * Do not need to clone: owned by the master thread
-   */
-  CollectablesEstimator* Collectables;
   /** accumulator for the energy
    *
    * @todo expand it for all the scalar observables to report the final results

--- a/src/Estimators/ScalarEstimatorBase.h
+++ b/src/Estimators/ScalarEstimatorBase.h
@@ -104,7 +104,7 @@ struct ScalarEstimatorBase
     {
       *first++    = scalars[i].mean();
       *first_sq++ = scalars[i].mean2();
-      // For mixed precision I believe this is where Collectables data goes from Actual QMCT::RealType
+      // For mixed precision this is where data goes from Actual QMCT::RealType
       // to the local RealType which is hard coded to QMCTFullPrecRealType.
       // I think it is a bad idea to have RealType to have a changing meaning,
       // I also feel like having the floating point expension needed to write always to


### PR DESCRIPTION
## Proposed changes

This drops Collectibles from the "new" Estimator code.  It isn't used and it won't be.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
