### PR TITLE
Minor CI and CMake maintenance

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -9,8 +9,7 @@ jobs:
     if: |
       github.repository_owner == 'QMCPACK' &&
       github.event.issue.pull_request &&
-      ( startsWith(github.event.comment.body, 'Test this please') || 
-        startsWith(github.event.comment.body, 'Start testing in-house') )
+      startsWith(github.event.comment.body, 'Test this please')
 
     runs-on: [self-hosted, Linux, X64, ornl-sulfur-1]
 
@@ -43,7 +42,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.1.0
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -72,7 +71,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
@@ -145,7 +144,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.1.0
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -174,7 +173,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
@@ -241,7 +240,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.1.0
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -270,7 +269,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
@@ -336,7 +335,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.1.0
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -365,7 +364,7 @@ jobs:
 
       - name: Checkout PR branch
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}

--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout Action
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Configure
         run: tests/test_automation/github-actions/ci/run_step.sh configure
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout Action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,8 +724,8 @@ if(QMC_CUDA OR ENABLE_CUDA)
     if(NOT TARGET CUDA::cublas)
       message(
         FATAL_ERROR
-          "Found an incomplete CUDA toolkit installation. "
-          "This often happens when CMake failed in recognizing the NVHPC internal CUDA toolkit. "
+          "Found an incomplete CUDA toolkit installation, target CUDA::cublas not found. "
+          "This often happens when CMake failed in recognizing the NVHPC internal CUDA toolkit with libcublas. "
           "Set CMAKE_CUDA_COMPILER to the full path of nvcc from a complete CUDA toolkit installation.")
     endif()
     # Automatically set the default NVCC flags


### PR DESCRIPTION
## Proposed changes

Bump GitHub Actions versions from Marketplace (permissions updated in repo).
Remove "Start testing in-house" to trigger self-hosted CI in PR comments.
Friendly CMake error message as it happens on Summit with nvhpc and cublas
Related to #3963 

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
