### PR TITLE
Update Dockerfile CI images

### DIFF
--- a/config/docker/dependencies/ubuntu/clang-latest/Dockerfile
+++ b/config/docker/dependencies/ubuntu/clang-latest/Dockerfile
@@ -1,36 +1,40 @@
 FROM ubuntu:20.04
-MAINTAINER William F Godoy williamfgc@yahoo.com
+LABEL maintainer="williamfgc@yahoo.com"
 
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get update -y &&\
-    apt-get upgrade -y apt-utils
+    apt-get upgrade -y apt-utils &&\
+    apt-get install -y gpg wget
 
 # Dependencies
+RUN wget https://apt.kitware.com/kitware-archive.sh &&\
+    sh kitware-archive.sh
+
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc g++ \ 
-                    python3 \
-                    cmake \
-                    ninja-build \
-                    libboost-all-dev \
-                    git \
-                    libhdf5-serial-dev \
-                    hdf5-tools \
-                    libfftw3-dev \
-                    libopenblas-openmp-dev \
-                    libxml2-dev \
-                    sudo \
-                    curl \
-                    rsync \
-                    wget \
-                    software-properties-common \
-                    vim \
-                    -y
+    python3 \
+    cmake \
+    ninja-build \
+    libboost-all-dev \
+    git \
+    libhdf5-serial-dev \
+    hdf5-tools \
+    libfftw3-dev \
+    libopenblas-openmp-dev \
+    libxml2-dev \
+    sudo \
+    curl \
+    rsync \
+    wget \
+    software-properties-common \
+    vim \
+    -y
 
 # add the latest clang development
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - &&\
     apt-add-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
 RUN apt-get update -y &&\     
-    apt-get install clang-12 clang-tools-12 -y
+    apt-get install clang-12 clang-tools-12 libomp-12-dev -y
 
 # must add a user different from root 
 # to run MPI executables

--- a/config/docker/dependencies/ubuntu/openmpi/Dockerfile
+++ b/config/docker/dependencies/ubuntu/openmpi/Dockerfile
@@ -4,9 +4,13 @@ LABEL maintainer="williamfgc@yahoo.com"
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get clean &&\
     apt-get update -y &&\
-    apt-get upgrade -y apt-utils
+    apt-get upgrade -y apt-utils &&\
+    apt-get install -y gpg wget
 
 # Dependencies
+RUN wget https://apt.kitware.com/kitware-archive.sh &&\
+    sh kitware-archive.sh
+
 RUN export DEBIAN_FRONTEND=noninteractive &&\
     apt-get install gcc g++ \ 
     clang \

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -322,6 +322,7 @@ case "$1" in
     then
        echo "Adding /usr/lib/llvm-12/lib/ to LD_LIBRARY_PATH to enable libomptarget.so"
        export LD_LIBRARY_PATH=/usr/lib/llvm-12/lib/:${LD_LIBRARY_PATH}
+       export KMP_TEAMS_THREAD_LIMIT=1
        # Run only unit tests (reasonable for CI)
        TEST_LABEL="-L unit"
     fi


### PR DESCRIPTION
## Proposed changes

Bump CMake version using Kitware apt repo as a quick fix to PR #3997
Add `libomp-12-dev` to `clang-12` dependencies
Images already built and pushed to DockerHub

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Local docker image, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
