### PR TITLE
Fix DelayedUpdateCUDA::initializeInv H2D must be synchronized

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateCUDA.h
@@ -135,7 +135,8 @@ public:
                                    hstream),
                    "cudaMemcpyAsync failed!");
     clearDelayCount();
-    // no need to wait because : For transfers from device memory to pageable host memory, the function will return only once the copy has completed.
+    // H2D transfer must be synchronized regardless of host memory being pinned or not.
+    cudaErrorCheck(cudaStreamSynchronize(hstream), "cudaStreamSynchronize failed!");
   }
 
   inline int getDelayCount() const { return delay_count; }


### PR DESCRIPTION
## Proposed changes
Saw this bug when reading the code. The old assumption is only valid for D2H not H2D.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'