### PR TITLE
Workaroud OneAPI compiler bug.

### DIFF
--- a/src/spline2/MultiBsplineEval_helper.hpp
+++ b/src/spline2/MultiBsplineEval_helper.hpp
@@ -52,8 +52,13 @@ inline void getSplineBound(T x, TRESIDUAL& dx, int& ind, int nmax)
   }
   else
   {
+#if defined(__INTEL_LLVM_COMPILER) || defined(__INTEL_CLANG_COMPILER)
+    T ipart = std::floor(x);
+    dx = x - ipart;
+#else
     T ipart;
     dx  = std::modf(x, &ipart);
+#endif
     ind = static_cast<int>(ipart);
     // upper bound
     if (ind > nmax)


### PR DESCRIPTION
## Proposed changes
Add a workaround. Standalone reproducer is https://github.com/ye-luo/openmp-target/blob/master/tests/math/modf_team.cpp.
The current symptom is hang. So avoid adding the reproducer here.

## What type(s) of changes does this code introduce?
- Other (please describe): bug workaround

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'