### PR TITLE
Reduce cmake_minimum_required to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################################
 # CMake version and policies
 ######################################################################
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.16.0)
 # Note that cmake_minimum_required affects policy defaults.
 # All policies known to the running version of CMake and introduced in
 # cmake_minimum_required version or earlier will be set to use NEW behavior


### PR DESCRIPTION
## Proposed changes

Cannot build on Ubuntu 20.04.4 LTS because of too high cmake_minimum_required. Reducing it to 3.16 fixes the problem.

## What type(s) of changes does this code introduce?

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 20.04, RHEL 8.5, SLES15 SP3

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
