### PR TITLE
Increase CI jobs on nitrogen and sulfur

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -390,7 +390,7 @@ case "$1" in
 
     if [[ "$HOST_NAME" =~ (sulfur) || "$HOST_NAME" =~ (nitrogen) ]]
     then
-      CTEST_JOBS="16"
+      CTEST_JOBS="32"
     fi
     
     ctest --output-on-failure $TEST_LABEL -j $CTEST_JOBS


### PR DESCRIPTION
## Proposed changes

Double the job count in CI for nitrogen and sulfur for hopefully improved throughput

nitrogen is dual 32 core and sulfur is dual 24 core, and both have HT enabled, so this change will still leave the machines usable for other tasks.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
