### PR TITLE
Set CMake CMP0127 Policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.17.0)
 # All policies known to the running version of CMake and introduced in
 # cmake_minimum_required version or earlier will be set to use NEW behavior
 
+cmake_policy(SET CMP0127 NEW) # Condition evaluation v3.22+ https://cmake.org/cmake/help/latest/policy/CMP0127.html
+
 ######################################################################
 # QMCPACK project
 ######################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.17.0)
 # All policies known to the running version of CMake and introduced in
 # cmake_minimum_required version or earlier will be set to use NEW behavior
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22.0)
+if (POLICY CMP0127)
   cmake_policy(SET CMP0127 NEW) # Condition evaluation v3.22+ https://cmake.org/cmake/help/latest/policy/CMP0127.html
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ cmake_minimum_required(VERSION 3.17.0)
 # All policies known to the running version of CMake and introduced in
 # cmake_minimum_required version or earlier will be set to use NEW behavior
 
-cmake_policy(SET CMP0127 NEW) # Condition evaluation v3.22+ https://cmake.org/cmake/help/latest/policy/CMP0127.html
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22.0)
+  cmake_policy(SET CMP0127 NEW) # Condition evaluation v3.22+ https://cmake.org/cmake/help/latest/policy/CMP0127.html
+endif()
 
 ######################################################################
 # QMCPACK project


### PR DESCRIPTION
## Proposed changes

Avoids CMake warnings of unset policy for CMake 3.22 onwards

## What type(s) of changes does this code introduce?

_Delete the items that do not apply_

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

macports / cmake 3.22.4 / llvm 13 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
