### PR TITLE
Add listener "trait" and check if listening Estimators are instantiated, remove two sources of truth for walker serialization

### DIFF
--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -50,6 +50,12 @@ EstimatorManagerNew::EstimatorManagerNew(const QMCHamiltonian& ham, Communicate*
   addMainEstimator(std::make_unique<LocalEnergyEstimator>(ham, true));
 }
 
+bool EstimatorManagerNew::areThereListeners()
+{
+  return std::any_of(operator_ests_.begin(), operator_ests_.end(),
+                     [](auto& oper_est) { return oper_est->isListenerRequired(); });
+}
+  
 template<class EstInputType, typename... Args>
 bool EstimatorManagerNew::createEstimator(EstimatorInput& input, Args&&... args)
 {

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -50,7 +50,7 @@ EstimatorManagerNew::EstimatorManagerNew(const QMCHamiltonian& ham, Communicate*
   addMainEstimator(std::make_unique<LocalEnergyEstimator>(ham, true));
 }
 
-bool EstimatorManagerNew::areThereListeners()
+bool EstimatorManagerNew::areThereListeners() const
 {
   return std::any_of(operator_ests_.begin(), operator_ests_.end(),
                      [](auto& oper_est) { return oper_est->isListenerRequired(); });

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -146,6 +146,8 @@ public:
   std::size_t getNumEstimators() { return operator_ests_.size(); }
   std::size_t getNumScalarEstimators() { return scalar_ests_.size(); }
 
+  bool areThereListeners();
+
 private:
   /** Construct estimator of type matching the underlying EstimatorInput type Consumer
    *  and push its its unique_ptr onto operator_ests_

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -146,7 +146,10 @@ public:
   std::size_t getNumEstimators() { return operator_ests_.size(); }
   std::size_t getNumScalarEstimators() { return scalar_ests_.size(); }
 
-  bool areThereListeners();
+  /** Do any of the instantiated estimators in operator_ests_ listen to per particle hamiltonian values?
+   *  Listeners are lambda functions captured from crowd scope estimators and passed to QMCHamiltonian leaders.
+   */
+  bool areThereListeners() const;
 
 private:
   /** Construct estimator of type matching the underlying EstimatorInput type Consumer

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -130,6 +130,8 @@ public:
 
   const std::string& get_my_name() const { return my_name_; }
 
+  bool isListenerRequired() { return requires_listener_; }
+
 protected:
   ///name of this object -- only used for debugging and h5 output
   std::string my_name_;
@@ -140,6 +142,8 @@ protected:
   UPtrVector<ObservableHelper> h5desc_;
 
   Data data_;
+
+  bool requires_listener_ = false;
 
   friend testing::OEBAccessor;
 };

--- a/src/QMCDrivers/MultiWalkerDispatchers.h
+++ b/src/QMCDrivers/MultiWalkerDispatchers.h
@@ -29,8 +29,6 @@ public:
 
   MultiWalkerDispatchers(bool use_batch) : ps_dispatcher_(use_batch), twf_dispatcher_(use_batch), ham_dispatcher_(use_batch), use_batch_(use_batch) {}
 
-  bool are_walkers_batched() const { return use_batch_; }
-
   const PSdispatcher ps_dispatcher_;
   const TWFdispatcher twf_dispatcher_;
   const Hdispatcher ham_dispatcher_;

--- a/src/QMCDrivers/QMCDriverInput.h
+++ b/src/QMCDrivers/QMCDriverInput.h
@@ -138,7 +138,7 @@ public:
   const std::string& get_update_mode() const { return update_mode_; }
   DriverDebugChecks get_debug_checks() const { return debug_checks_; }
   bool get_scoped_profiling() const { return scoped_profiling_; }
-  bool are_walkers_serialized() const { return crowd_serialize_walkers_; }
+  bool areWalkersSerialized() const { return crowd_serialize_walkers_; }
   bool get_measure_imbalance() const { return measure_imbalance_; }
 
   const std::string get_drift_modifier() const { return drift_modifier_; }

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -55,7 +55,7 @@ QMCDriverNew::QMCDriverNew(const ProjectData& project_data,
       qmcdriver_input_(std::move(input)),
       QMCType(QMC_driver_type),
       population_(std::move(population)),
-      dispatchers_(!qmcdriver_input_.are_walkers_serialized()),
+      dispatchers_(!qmcdriver_input_.areWalkersSerialized()),
       estimator_manager_(nullptr),
       wOut(0),
       timers_(timer_prefix),
@@ -158,7 +158,12 @@ void QMCDriverNew::startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCou
 
   makeLocalWalkers(awc.walkers_per_rank[myComm->rank()], awc.reserve_walkers);
 
-  if (dispatchers_.are_walkers_batched())
+  if (qmcdriver_input_.areWalkersSerialized())
+  {
+    if(estimator_manager_->areThereListeners())
+      throw UniformCommunicateError("Serialized walkers ignore multiwalker API's and multiwalker resources and are incompatible with estimators requiring per particle listeners");
+  }
+  else
   {
     app_debug() << "Creating multi walker shared resources" << std::endl;
     population_.get_golden_electrons()->createResource(golden_resource_.pset_res);


### PR DESCRIPTION
## Proposed changes

In support of #4029 

The lighter weight replacement for per particle hamiltonian evaluation has crowd scope estimators register listener functions  with QMCHamiltonian. The hamiltonian operators use multi walker resources to manage the shared crowd level buffers on the operator side. It's necessary at runtime to be able to check this "trait" of the estimator and see if any have been added to the EstimatorManagerNew.

There is already a source of truth for walker serialization in QmcdriverInput which is strongly coupled to QMCDriverNew use that instead of adding an accessor to MultiWalkerDispatchers which is detail QMCDriverNew should know as little as possible about. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
