### PR TITLE
Suppress NVHPC warning about unreachable statement

### DIFF
--- a/CMake/NVHPCCompilers.cmake
+++ b/CMake/NVHPCCompilers.cmake
@@ -38,7 +38,7 @@ add_definitions(-Drestrict=__restrict__)
 # 998 function "AA" is hidden by "BB" -- virtual function override intended?
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --display_error_number --diag_suppress 177 --diag_suppress 550")
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} --display_error_number --diag_suppress 177 --diag_suppress 550 --diag_suppress 612 --diag_suppress 998"
+    "${CMAKE_CXX_FLAGS} --display_error_number --diag_suppress 177 --diag_suppress 550 --diag_suppress 612 --diag_suppress 998 --diag_suppress 111"
 )
 
 # Set extra optimization specific flags


### PR DESCRIPTION
## Proposed changes
Not much I can do about this warning. GCC/Clang wants the return but NVHPC doesn't like the return.
Example
```
  virtual size_t getPerTargetPctlStrideSize() const
  {
    throw std::runtime_error(name_ + " getPerTargetPctlStrideSize not supported");
    return 0;
  }
  
"/home/yeluo/opt/cleanup/qmcpack/src/Particle/DistanceTable.h", line 371: warning #111-D: statement is unreachable
      return 0;
```
So suppress the warning of NVHPC.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'