### PR TITLE
Fix trialwf unit test failures with clang14+openblas complex builds

### DIFF
--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -368,7 +368,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   std::cout << "mixed move calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
 
 #if defined(QMC_COMPLEX)
-  CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)).epsilon(5e-5));
+  CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)).epsilon(5e-4));
 #if defined(MIXED_PRECISION)
   CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)).epsilon(5e-5));
 #else


### PR DESCRIPTION
## Proposed changes

Fix the Clang14-Complex and Clang14-Complex-Mixed failures at
https://cdash.qmcpack.org/CDash/testSummary.php?project=1&name=deterministic-unit_test_wavefunction_trialwf&date=2022-05-31

This is a numerical check failure, but I do wonder if the complex builds are losing precision faster than they should.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen, same as nightlies

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
