### PR TITLE
Fix slab (ppn)

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -185,6 +185,10 @@ function(
   set(TEST_LABELS_TEMP "")
   if(TEST_ADDED_TEMP)
     add_test_labels(${TESTNAME} TEST_LABELS_TEMP)
+    set_property(
+      TEST ${TESTNAME}
+      APPEND
+      PROPERTY LABELS "QMCPACK")
   endif()
   set(${TEST_ADDED}
       ${TEST_ADDED_TEMP}
@@ -353,12 +357,6 @@ else(QMC_NO_SLOW_CUSTOM_TESTING_COMMANDS)
       TEST_ADDED
       TEST_LABELS
       ${INPUT_FILE})
-    if(TEST_ADDED)
-      set_property(
-        TEST ${FULL_NAME}
-        APPEND
-        PROPERTY LABELS "QMCPACK")
-    endif()
 
     if(TEST_ADDED AND NOT SHOULD_SUCCEED)
       set_property(TEST ${FULL_NAME} APPEND PROPERTY WILL_FAIL TRUE)

--- a/docs/simulationcell.rst
+++ b/docs/simulationcell.rst
@@ -70,8 +70,8 @@ boundary conditions. The parameter expects a single string of three
 characters separated by spaces, *e.g.* “p p p” for purely periodic
 boundary conditions. These characters control the behavior of the
 :math:`x`, :math:`y`, and :math:`z`, axes, respectively. Non periodic
-directions must be placed after the periodic ones. Examples of valid
-include:
+directions must be placed after the periodic ones. The only supported
+combinations are:
 
 **“p p p”** Periodic boundary conditions. Corresponds to a 3D crystal.
 

--- a/src/Particle/LongRange/KContainer.cpp
+++ b/src/Particle/LongRange/KContainer.cpp
@@ -12,11 +12,12 @@
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#include "Message/Communicate.h"
 #include "KContainer.h"
-#include "Utilities/qmc_common.h"
 #include <map>
 #include <cstdint>
+#include "Message/Communicate.h"
+#include "LRCoulombSingleton.h"
+#include "Utilities/qmc_common.h"
 
 namespace qmcplusplus
 {
@@ -78,14 +79,12 @@ void KContainer::findApproxMMax(const ParticleLayout& lattice, unsigned ndim)
   for (int i = 0; i < DIM; i++)
     mmax[i] = static_cast<int>(std::floor(std::sqrt(dot(lattice.a(i), lattice.a(i))) * kcutoff / (2 * M_PI))) + 1;
 
-
-
   mmax[DIM] = mmax[0];
   for (int i = 1; i < DIM; ++i)
     mmax[DIM] = std::max(mmax[i], mmax[DIM]);
 
   //overwrite the non-periodic directon to be zero
-  if (lattice.SuperCellEnum == SUPERCELL_SLAB)
+  if (LRCoulombSingleton::isQuasi2D())
   {
     app_log() << "  No kspace sum perpendicular to slab " << std::endl;
     mmax[2] = 0;
@@ -95,7 +94,8 @@ void KContainer::findApproxMMax(const ParticleLayout& lattice, unsigned ndim)
     app_log() << "  No kspace sum along z " << std::endl;
     mmax[2] = 0;
   }
-  if (ndim < 2) mmax[1] = 0;
+  if (ndim < 2)
+    mmax[1] = 0;
 }
 
 void KContainer::BuildKLists(const ParticleLayout& lattice, bool useSphere)
@@ -215,11 +215,11 @@ void KContainer::BuildKLists(const ParticleLayout& lattice, bool useSphere)
     std::vector<int>::iterator vit((*it).second->begin());
     while (vit != (*it).second->end())
     {
-      int ik        = (*vit);
-      kpts[ok]      = kpts_tmp[ik];
-      kpts_cart[ok] = kpts_cart_tmp[ik];
+      int ik             = (*vit);
+      kpts[ok]           = kpts_tmp[ik];
+      kpts_cart[ok]      = kpts_cart_tmp[ik];
       kpts_cart_soa_(ok) = kpts_cart_tmp[ik];
-      ksq[ok]       = ksq_tmp[ik];
+      ksq[ok]            = ksq_tmp[ik];
       ++vit;
       ++ok;
     }

--- a/src/Particle/LongRange/LRCoulombSingleton.h
+++ b/src/Particle/LongRange/LRCoulombSingleton.h
@@ -54,6 +54,8 @@ struct LRCoulombSingleton
   static std::unique_ptr<LRHandlerType> getHandler(ParticleSet& ref);
   ///This returns a force/stress optimized LR handler.  If non existent, it creates one.
   static std::unique_ptr<LRHandlerType> getDerivHandler(ParticleSet& ref);
+  /// return true if quasi 2D is selected
+  static bool isQuasi2D() { return LRCoulombSingleton::this_lr_type == LRCoulombSingleton::QUASI2D; }
 
   //The following two helper functions are provided to spline the short-range component
   //of the coulomb potential and its derivative.  This is much faster than evaluating

--- a/src/Particle/LongRange/StructFact.cpp
+++ b/src/Particle/LongRange/StructFact.cpp
@@ -21,6 +21,7 @@
 #include "Utilities/qmc_common.h"
 #include "OMPTarget/OMPTargetMath.hpp"
 #include "RealSpacePositionsOMPTarget.h"
+#include "LRCoulombSingleton.h"
 
 namespace qmcplusplus
 {
@@ -31,7 +32,7 @@ StructFact::StructFact(const ParticleLayout& lattice, const KContainer& k_lists)
       StorePerParticle(false),
       update_all_timer_(*timer_manager.createTimer("StructFact::update_all_part", timer_level_fine))
 {
-  if (lattice.SuperCellEnum == SUPERCELL_SLAB)
+  if (LRCoulombSingleton::isQuasi2D())
   {
     app_log() << "  Setting StructFact::SuperCellEnum=SUPERCELL_SLAB " << std::endl;
     SuperCellEnum = SUPERCELL_SLAB;

--- a/src/Particle/ParticleIO/LatticeIO.cpp
+++ b/src/Particle/ParticleIO/LatticeIO.cpp
@@ -25,6 +25,7 @@
 #include "QMCWaveFunctions/ElectronGas/HEGGrid.h"
 #include "LongRange/LRCoulombSingleton.h"
 #include "ModernStringUtils.hpp"
+#include "Message/UniformCommunicateError.h"
 
 namespace qmcplusplus
 {
@@ -63,8 +64,10 @@ bool LatticeParser::put(xmlNodePtr cur)
         const std::string units_prop(getXMLAttributeValue(cur, "units"));
         if (!units_prop.empty() && units_prop != "bohr")
         {
-          APP_ABORT("LatticeParser::put. Only atomic units (bohr) supported for lattice units. Input file uses: "
-                    << units_prop);
+          std::ostringstream err_msg;
+          err_msg << "LatticeParser::put. Only atomic units (bohr) supported for lattice units. Input file uses: "
+                  << units_prop;
+          throw UniformCommunicateError(err_msg.str());
         }
 
         putContent(lattice_in, cur);
@@ -89,14 +92,20 @@ bool LatticeParser::put(xmlNodePtr cur)
           }
           else
           {
-            APP_ABORT("LatticeParser::put. Unknown label '" + bconds[idir] +
-                      "' used for periodicity. Only 'p', 'P', 'n' and 'N' are valid!");
+            std::ostringstream err_msg;
+            err_msg << "LatticeParser::put. Unknown label '" + bconds[idir] +
+                    "' used for periodicity. Only 'p', 'P', 'n' and 'N' are valid!";
+            throw UniformCommunicateError(err_msg.str());
           }
 
           // Protect BCs which are not implemented.
           if (idir > 0 && !ref_.BoxBConds[idir - 1] && ref_.BoxBConds[idir])
-            APP_ABORT(
-                "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic ones.");
+          {
+            std::ostringstream err_msg;
+            err_msg
+                << "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic ones.";
+            throw UniformCommunicateError(err_msg.str());
+          }
         }
       }
       else if (aname == "vacuum")
@@ -122,12 +131,12 @@ bool LatticeParser::put(xmlNodePtr cur)
         else if (handler_type == "ewald_strict2d")
         {
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::STRICT2D;
-          ref_.ndim = 2;
+          ref_.ndim                        = 2;
         }
         else if (handler_type == "ewald_quasi2d")
           LRCoulombSingleton::this_lr_type = LRCoulombSingleton::QUASI2D;
         else
-          APP_ABORT("\n  Long range breakup handler not recognized.\n");
+          throw UniformCommunicateError("LatticeParser::put. Long range breakup handler not recognized.");
       }
       else if (aname == "LR_tol")
       {
@@ -150,6 +159,7 @@ bool LatticeParser::put(xmlNodePtr cur)
     }
     cur = cur->next;
   }
+
   // checking boundary conditions
   if (lattice_defined)
   {
@@ -162,7 +172,8 @@ bool LatticeParser::put(xmlNodePtr cur)
   else if (boxsum == 0)
     app_log() << "  Lattice is not specified for the Open BC. Add a huge box." << std::endl;
   else
-    APP_ABORT(" LatticeParser::put \n   Mixed boundary is supported only when a lattice is specified!");
+    throw UniformCommunicateError("LatticeParser::put. Mixed boundary is supported only when a lattice is specified!");
+
   //special heg processing
   if (rs > 0.0)
   {
@@ -205,8 +216,13 @@ bool LatticeParser::put(xmlNodePtr cur)
     lattice_in *= a0;
     ref_.set(lattice_in);
   }
+
+  if (ref_.SuperCellEnum != SUPERCELL_SLAB && LRCoulombSingleton::isQuasi2D())
+    throw UniformCommunicateError("LatticeParser::put. Quasi 2D Ewald only works with boundary condition 'p p n'!");
+
   if (ref_.SuperCellEnum == SUPERCELL_OPEN)
     ref_.WignerSeitzRadius = ref_.SimulationCellRadius;
+
   std::string unit_name = "bohr";
   app_log() << std::fixed;
   app_log() << "  Simulation cell radius   = " << ref_.SimulationCellRadius << " " << unit_name << std::endl;

--- a/src/Particle/ParticleIO/tests/test_lattice_parser.cpp
+++ b/src/Particle/ParticleIO/tests/test_lattice_parser.cpp
@@ -27,32 +27,185 @@ namespace qmcplusplus
 {
 TEST_CASE("read_lattice_xml", "[particle_io][xml]")
 {
-  const char* particles = "<tmp> \
- <parameter name=\"lattice\" units=\"bohr\"> \
-                 3.80000000       0.00000000       0.00000000 \
-                 0.00000000       3.80000000       0.00000000 \
-                 0.00000000       0.00000000       3.80000000 \
-         </parameter> \
-         <parameter name=\"bconds\"> \
-            p p p \
-         </parameter> \
-         <parameter name=\"LR_dim_cutoff\">20</parameter> \
-</tmp> \
-";
-  Libxml2Document doc;
-  bool okay = doc.parseFromString(particles);
-  REQUIRE(okay);
+  SECTION("valid p p p input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000       3.80000000
+        </parameter>
+        <parameter name="bconds">
+          p p p
+        </parameter>
+        <parameter name="LR_dim_cutoff">20</parameter>
+      </tmp>
+    )";
 
-  xmlNodePtr root = doc.getRoot();
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
 
-  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
-  LatticeParser lp(uLattice);
-  lp.put(root);
+    xmlNodePtr root = doc.getRoot();
 
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_NOTHROW(lp.put(root));
 
-  REQUIRE(uLattice.R[0] == Approx(3.8));
-  REQUIRE(uLattice.Volume == Approx(3.8 * 3.8 * 3.8));
+    REQUIRE(uLattice.R[0] == Approx(3.8));
+    REQUIRE(uLattice.Volume == Approx(3.8 * 3.8 * 3.8));
 
-  REQUIRE(uLattice.LR_dim_cutoff == Approx(20));
+    REQUIRE(uLattice.LR_dim_cutoff == Approx(20));
+  }
+
+  SECTION("invalid n p p input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000       3.80000000
+        </parameter>
+        <parameter name="bconds">
+          n p p
+        </parameter>
+        <parameter name="LR_dim_cutoff">20</parameter>
+      </tmp>
+    )";
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_THROWS_WITH(lp.put(root),
+                        "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic "
+                        "ones.");
+  }
+
+  SECTION("invalid p n p input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000       3.80000000
+        </parameter>
+        <parameter name="bconds">
+          p n p
+        </parameter>
+        <parameter name="LR_dim_cutoff">20</parameter>
+      </tmp>
+    )";
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_THROWS_WITH(lp.put(root),
+                        "LatticeParser::put. In \"bconds\", non periodic directions must be placed after the periodic "
+                        "ones.");
+  }
+}
+
+TEST_CASE("read_lattice_xml_lrhandle", "[particle_io][xml]")
+{
+  SECTION("valid p p n input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000      10.00000000
+        </parameter>
+        <parameter name="bconds">
+          p p n
+        </parameter>
+        <parameter name="LR_dim_cutoff">30</parameter>
+        <parameter name="LR_handler"> opt_breakup </parameter>
+      </tmp>
+    )";
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_NOTHROW(lp.put(root));
+
+    REQUIRE(uLattice.R[8] == Approx(10.0));
+    REQUIRE(uLattice.LR_dim_cutoff == Approx(30));
+  }
+
+  SECTION("valid p p n ewald_quasi2d input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000      10.00000000
+        </parameter>
+        <parameter name="bconds">
+          p p n
+        </parameter>
+        <parameter name="LR_dim_cutoff">30</parameter>
+        <parameter name="LR_handler"> ewald_quasi2d </parameter>
+      </tmp>
+    )";
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_NOTHROW(lp.put(root));
+  }
+
+  SECTION("invalid p p p ewald_quasi2d input")
+  {
+    const char* const particles = R"(
+      <tmp>
+        <parameter name="lattice" units="bohr">
+          3.80000000       0.00000000       0.00000000
+          0.00000000       3.80000000       0.00000000
+          0.00000000       0.00000000      10.00000000
+        </parameter>
+        <parameter name="bconds">
+          p p p
+        </parameter>
+        <parameter name="LR_dim_cutoff">30</parameter>
+        <parameter name="LR_handler"> ewald_quasi2d </parameter>
+      </tmp>
+    )";
+
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(particles);
+    REQUIRE(okay);
+
+    xmlNodePtr root = doc.getRoot();
+
+    CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> uLattice;
+    LatticeParser lp(uLattice);
+    REQUIRE_THROWS_WITH(lp.put(root),
+                        "LatticeParser::put. Quasi 2D Ewald only works with boundary condition 'p p n'!");
+  }
 }
 } // namespace qmcplusplus

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -87,8 +87,17 @@ bool ParticleSetPool::readSimulationCellXML(xmlNodePtr cur)
 {
   ReportEngine PRE("ParticleSetPool", "putLattice");
 
-  LatticeParser a(simulation_cell_->lattice_);
-  bool lattice_defined = a.put(cur);
+  bool lattice_defined = false;
+  try
+  {
+    LatticeParser a(simulation_cell_->lattice_);
+    lattice_defined = a.put(cur);
+  }
+  catch (const UniformCommunicateError& ue)
+  {
+    myComm->barrier_and_abort(ue.what());
+  }
+
   if (lattice_defined)
   {
     app_log() << "  Overwriting global supercell " << std::endl;

--- a/tests/solids/CMakeLists.txt
+++ b/tests/solids/CMakeLists.txt
@@ -17,6 +17,8 @@ add_subdirectory("hcpBe_1x1x1_pp")
 add_subdirectory("monoO_1x1x1_pp")
 add_subdirectory("NiO_a4_e48_pp")
 add_subdirectory("grapheneC_1x1_pp")
+add_subdirectory("InSe_a4")
+
 if(QMC_COMPLEX)
   add_subdirectory("bccMo_2x1x1_SOREP")
   add_subdirectory("diamondC_1x1x1-Gaussian_pp_Tw_cplx")

--- a/tests/solids/InSe_a4/CMakeLists.txt
+++ b/tests/solids/InSe_a4/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(TEST_ADDED FALSE)
+set(TEST_LABELS "")
+
+run_qmc_app(
+  deterministic-InSe_a4_slab
+  "${qmcpack_SOURCE_DIR}/tests/solids/InSe_a4"
+  1
+  1
+  TEST_ADDED
+  TEST_LABELS
+  InSe-S1.xml)

--- a/tests/solids/InSe_a4/InSe-S1.xml
+++ b/tests/solids/InSe_a4/InSe-S1.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<simulation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.mcc.uiuc.edu/qmc/schema/molecu.xsd">
+  <project id="InSe-S1-dmc" series="1">
+	  <application name="qmcapp" role="molecu" class="serial" version="0.2"/>
+  </project>
+
+  <random seed="49154"/>
+  <qmcsystem>
+  <simulationcell>
+    <parameter name="lattice">
+      7.653390614   0   0
+      -3.826695307   6.628030697   0
+      0   0   31.993061563
+    </parameter>
+    <parameter name="bconds">p p n </parameter>
+    <parameter name="LR_dim_cutoff">30</parameter>
+    <parameter name="LR_handler"> opt_breakup </parameter>      
+  </simulationcell>
+  </qmcsystem>
+  <particleset name="i" size="4">
+    <group name="In">
+      <parameter name="charge">3</parameter>
+      <parameter name="valence">3</parameter>
+      <parameter name="atomicnumber">49</parameter>
+    </group>
+    <group name="Se">
+      <parameter name="charge">6.0000000000</parameter>
+      <parameter name="valence">6.0000000000</parameter>
+      <parameter name="atomicnumber">34</parameter>
+    </group>
+    <attrib name="position" datatype="posArray" condition="1">
+    0.333333343   0.666666687   0.407000005
+    0.333333343   0.666666687   0.592999995
+    0.666666627   0.333333313   0.648000002
+    0.666666627   0.333333313   0.351999998
+    </attrib>
+    <attrib name="ionid" datatype="stringArray">
+      In  In  Se  Se  
+    </attrib>
+  </particleset>
+  <particleset name="e" random="yes" randomsrc="i">
+    <group name="u" size="9">
+      <parameter name="charge">-1</parameter>
+    </group>
+    <group name="d" size="9">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+  <wavefunction name="psi0" target="e">
+  </wavefunction>
+  <hamiltonian name="h0" type="generic" target="e">
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+  </hamiltonian>
+</simulation>

--- a/tests/solids/InSe_a4/InSe-S1.xml
+++ b/tests/solids/InSe_a4/InSe-S1.xml
@@ -14,7 +14,7 @@
     </parameter>
     <parameter name="bconds">p p n </parameter>
     <parameter name="LR_dim_cutoff">30</parameter>
-    <parameter name="LR_handler"> opt_breakup </parameter>      
+    <parameter name="LR_handler"> opt_breakup </parameter>
   </simulationcell>
   </qmcsystem>
   <particleset name="i" size="4">
@@ -35,7 +35,7 @@
     0.666666627   0.333333313   0.351999998
     </attrib>
     <attrib name="ionid" datatype="stringArray">
-      In  In  Se  Se  
+      In  In  Se  Se
     </attrib>
   </particleset>
   <particleset name="e" random="yes" randomsrc="i">


### PR DESCRIPTION
## Proposed changes

Fixes #4051. Breakage happened in #3852 785ce12
In a slab calculation (ppn) with 3d ewald, `lattice.SuperCellEnum == SUPERCELL_SLAB` is true which cannot be used to select quasi2D code paths. Introduce `LRCoulombSingleton::isQuasi2D()` for this purpose.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
