### PR TITLE
Add tests for Rotated SPOs using LCAO

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ endforeach()
 
 if(NOT QMC_CUDA)
   if(NOT QMC_COMPLEX)
-    set(MO_SRCS test_MO.cpp test_multiquintic_spline.cpp test_cartesian_ao.cpp)
+    set(MO_SRCS test_MO.cpp test_multiquintic_spline.cpp test_cartesian_ao.cpp test_RotatedSPOs_LCAO.cpp)
     if(NOT QMC_MIXED_PRECISION)
       set(MO_SRCS ${MO_SRCS} test_soa_cusp_corr.cpp)
     endif()

--- a/src/QMCWaveFunctions/tests/gen_rotated_lcao_wf.py
+++ b/src/QMCWaveFunctions/tests/gen_rotated_lcao_wf.py
@@ -1,0 +1,191 @@
+
+# Helium atom with a combination of two orbitals and simple jastrow factor
+
+# Uses automatic differentiation via the autograd package to
+#  compute spatial and parameter derivatives
+import autograd.numpy as np
+from autograd import hessian,grad
+
+# Values used in test_RotatedSPOs_LCAO.cpp
+
+def mag(r):
+    return np.sqrt(r[0]*r[0] + r[1]*r[1] + r[2]*r[2])
+
+# normalized STO's correspond to the 'normalized="no"' part of the input
+#     <atomicBasisSet type="STO" elementType="He" normalized="no">
+
+
+def sto_norm1(zeta):
+  return 2*np.sqrt(zeta**3)
+
+def sto_norm2(zeta):
+  return 2*np.sqrt(3)*np.sqrt(zeta**5)/3
+
+
+def orb1(R):
+    r = mag(R)
+    Z = 2.0
+    y00 = 1/np.sqrt(4 * np.pi)
+    snorm1 = sto_norm1(Z)
+    return y00 * snorm1 * np.exp(-Z*r)
+
+def orb2(R):
+    r = mag(R)
+    zeta = 1.0
+    y00 = 1/np.sqrt(4*np.pi)
+    snorm2 = sto_norm2(zeta)
+    return snorm2* y00 * r* np.exp(-zeta*r)
+
+def rot_orb(R, theta):
+    return orb1(R) * np.cos(theta) + orb2(R) * np.sin(theta)
+
+
+def jastrow(r12, B):
+    A = 0.5
+    return np.exp(A*r12/(1.0 + B*r12) - A/B)
+
+def psi_no_jastrow(r1, r2, VP):
+    theta1 = VP[0]
+    theta2 = VP[1]
+    o1 = rot_orb(r1,theta1)
+    o2 = rot_orb(r2,theta2)
+    return o1*o2
+
+def psi_with_jastrow(r1, r2, VP):
+    theta1 = VP[0]
+    theta2 = VP[1]
+    B = VP[2]
+    o1 = rot_orb(r1,theta1)
+    o2 = rot_orb(r2,theta2)
+    r12 = r2 - r1
+    j = jastrow(r12, B)
+    return o1*o2*j
+
+def psi(r1, r2, VP):
+    global use_jastrow
+    theta1 = VP[0]
+    theta2 = VP[1]
+    j = 1.0
+    if use_jastrow:
+        B = VP[2]
+        r12 = mag(r2 - r1)
+        j = jastrow(r12, B)
+
+    o1 = rot_orb(r1,theta1)
+    o2 = rot_orb(r2,theta2)
+    return o1*o2*j
+
+def log_psi(r1, r2, B):
+    return np.log(psi(r1, r2, B))
+
+
+# Spatial derivatives
+hess0 = hessian(psi, 0)
+hess1 = hessian(psi, 1)
+
+
+hess_log_0 = hessian(log_psi, 0)
+hess_log_1 = hessian(log_psi, 1)
+
+grad0 = grad(psi, 0)
+grad1 = grad(psi, 1)
+
+# Derivative wrt parameters
+dpsi = grad(psi, 2)
+
+def lap0(r1, r2, VP):
+    h0 = np.sum(np.diag(hess_log_0(r1, r2, VP)))
+    return h0
+
+def lap1(r1, r2, VP):
+    h1 = np.sum(np.diag(hess_log_1(r1, r2, VP)))
+    return h1
+
+def lap(r1, r2, VP):
+    h0 = np.sum(np.diag(hess0(r1, r2, VP)))
+    h1 = np.sum(np.diag(hess1(r1, r2, VP)))
+    return h0 + h1
+
+def en_pot(r1, r2):
+    r1_mag = mag(r1)
+    r2_mag = mag(r2)
+    Z = 2.0
+    return -Z/r1_mag - Z/r2_mag
+
+def ee_pot(r1, r2):
+    r12 = r2 - r1
+    r12_mag = mag(r12)
+    return 1.0/r12_mag
+
+
+def local_energy(r1, r2, VP):
+    pot = en_pot(r1, r2) + ee_pot(r1, r2)
+    psi_val = psi(r1, r2, VP)
+    lapl = lap(r1, r2, VP)
+
+    h = -0.5*lapl/psi_val + pot
+    return h
+
+dlocal_energy = grad(local_energy, 2)
+
+
+
+def print_wf_values(theta1=0.0, theta2=0.0,  use_j=False, B=0.0):
+    global use_jastrow
+
+    # Adjust numpy output so arrays are printed with higher precision
+    float_formatter = "{:.15g}".format
+    np.set_printoptions(formatter={'float_kind':float_formatter})
+
+    if use_j:
+        use_jastrow = True
+        VP = np.array([theta1, theta2, B])
+        print("Values for theta = ",theta1,theta2," and jastrow B = ",B)
+    else:
+        use_jastrow = False
+        VP = np.array([theta1, theta2])
+        print("Values for theta = ",theta1,theta2," and no jastrow")
+
+
+
+    r1 = np.array([1.0, 2.0, 3.0])
+    r2 = np.array([0.0, 1.1, 2.2])
+
+    psi_val = psi(r1, r2, VP)
+    print("  wf = ",psi_val," log wf = ",np.log(np.abs(psi_val)))
+
+    g0 = grad0(r1, r2, VP)/psi_val
+    print("  grad/psi for particle 0 = ",g0[0],g0[1],g0[2])
+
+    # Using the laplacian of log psi to match internal QMCPACK values
+    lap_0 = lap0(r1, r2, VP)
+    print(" laplacian of log psi for particle 0 = ",lap_0)
+
+    lap_1 = lap1(r1, r2, VP)
+    print(" laplacian for log psi particle 1 = ",lap_1)
+
+    eloc = local_energy(r1, r2, VP)
+    print("  local energy = ",eloc)
+
+    dp = dpsi(r1, r2, VP)
+    print("  parameter derivative of log psi = ",dp / psi_val)
+
+    deloc = dlocal_energy(r1, r2, VP)
+    print("  parameter derivative of local energy = ",deloc)
+
+    print("")
+
+def print_point_values():
+    r1 = np.array([1.0, 2.0, 3.0])
+    r2 = np.array([0.0, 1.1, 2.2])
+
+    print_wf_values(theta1=0.1, theta2=0.2)
+
+    print_wf_values(theta1=0.0, theta2=0.0)
+
+    print_wf_values(theta1=0.0, theta2=0.0, use_j=True, B=0.1)
+
+
+if __name__=='__main__':
+    print_point_values()
+

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -1,0 +1,364 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+
+#include "Message/Communicate.h"
+#include "OhmmsData/Libxml2Doc.h"
+#include "Particle/ParticleSetPool.h"
+#include "QMCWaveFunctions/WaveFunctionPool.h"
+
+
+#include <stdio.h>
+#include <string>
+#include <sstream>
+
+
+// Reference values from gen_rotated_lcao_wf.py
+
+
+namespace qmcplusplus
+{
+void setupParticleSetPool(ParticleSetPool& pp)
+{
+  // See ParticleIO/tests/test_xml_io.cpp for particle parsing
+  const char* particles = R"(<tmp>
+  <particleset name="ion0" size="1">
+    <group name="He">
+      <parameter name="charge">2</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+      0.0 0.0 0.0
+    </attrib>
+  </particleset>
+
+  <particleset name="e" random="no">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+    <attrib name="position" datatype="posArray">
+      1.0 2.0 3.0
+    </attrib>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+    <attrib name="position" datatype="posArray">
+      0.0 1.1 2.2
+    </attrib>
+    </group>
+  </particleset>
+</tmp>)";
+  Libxml2Document doc;
+
+  bool okay = doc.parseFromString(particles);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  xmlNodePtr part_ion = xmlFirstElementChild(root);
+  pp.put(part_ion);
+  xmlNodePtr part_elec = xmlNextElementSibling(part_ion);
+  pp.put(part_elec);
+}
+
+
+// No Jastrow, rotation angle theta1=0.1 and theta2=0.2
+TEST_CASE("Rotated LCAO WF1", "[qmcapp]")
+{
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPool(pp);
+
+  WaveFunctionPool wp(pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+
+  const char* wf_input = R"(<wavefunction target='e'>
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+           <opt_vars>0.1</opt_vars>
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+           <opt_vars>0.2</opt_vars>
+          <coefficient id="downdetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="2"/>
+      </slaterdeterminant>
+    </determinantset>
+   </wavefunction>)";
+
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(wf_input);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(root);
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 1);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-9.26625670653773));
+
+  CHECK(elec->G[0][0] == ValueApprox(-0.2758747113720909));
+  CHECK(elec->L[0] == ValueApprox(-0.316459652026054));
+  CHECK(elec->L[1] == ValueApprox(-0.6035591598540904));
+
+  using ValueType = QMCTraits::ValueType;
+  std::vector<ValueType> dlogpsi(2);
+  std::vector<ValueType> dhpsioverpsi(2);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+
+  CHECK(dlogpsi[0] == ValueApprox(7.58753078998516));
+  CHECK(dlogpsi[1] == ValueApprox(2.58896036829191));
+  CHECK(dhpsioverpsi[0] == ValueApprox(2.59551625714144));
+  CHECK(dhpsioverpsi[1] == ValueApprox(1.70071425070404));
+}
+
+// No Jastrow, rotation angle of 0
+TEST_CASE("Rotated LCAO WF zero angle", "[qmcapp]")
+{
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPool(pp);
+
+  WaveFunctionPool wp(pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+
+  const char* wf_input = R"(<wavefunction target='e'>
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+          <coefficient id="downdetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="2"/>
+      </slaterdeterminant>
+    </determinantset>
+   </wavefunction>)";
+
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(wf_input);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(root);
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 1);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  opt_vars.resetIndex();
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-11.467952668216984));
+
+  CHECK(elec->G[0][0] == ValueApprox(-0.5345224838248487));
+  CHECK(elec->L[0] == ValueApprox(-1.0690449676496974));
+  CHECK(elec->L[1] == ValueApprox(-1.626231256363484));
+
+  using ValueType = QMCTraits::ValueType;
+  std::vector<ValueType> dlogpsi(2);
+  std::vector<ValueType> dhpsioverpsi(2);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(32.2062050179872));
+  CHECK(dlogpsi[1] == ValueApprox(5.87482925187464));
+  CHECK(dhpsioverpsi[0] == ValueApprox(46.0088643114103));
+  CHECK(dhpsioverpsi[1] == ValueApprox(7.84119772047731));
+
+  RefVectorWithLeader<TrialWaveFunction> wf_list(*psi, {*psi});
+  RefVectorWithLeader<ParticleSet> p_list(*elec, {*elec});
+
+  // Test list with one wavefunction
+
+  int nparam = 2;
+  int nentry = 1;
+  RecordArray<ValueType> dlogpsi_list(nparam, nentry);
+  RecordArray<ValueType> dhpsi_over_psi_list(nparam, nentry);
+
+  TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, opt_vars, dlogpsi_list, dhpsi_over_psi_list);
+
+  CHECK(dlogpsi_list.getValue(0, 0) == ValueApprox(32.2062050179872));
+  CHECK(dlogpsi_list.getValue(1, 0) == ValueApprox(5.87482925187464));
+  CHECK(dhpsi_over_psi_list.getValue(0, 0) == ValueApprox(46.0088643114103));
+  CHECK(dhpsi_over_psi_list.getValue(1, 0) == ValueApprox(7.84119772047731));
+}
+
+// Rotation angle of 0 and add Jastrow factory
+TEST_CASE("Rotated LCAO WF with jastrow", "[qmcapp]")
+{
+  Communicate* c;
+  c = OHMMS::Controller;
+
+  ParticleSetPool pp(c);
+  setupParticleSetPool(pp);
+
+  WaveFunctionPool wp(pp, c);
+
+  REQUIRE(wp.empty() == true);
+
+
+  const char* wf_input = R"(<wavefunction target='e'>
+
+     <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="2"/>
+      </slaterdeterminant>
+    </determinantset>
+    <jastrow name="Jee" type="Two-Body" function="pade">
+      <correlation speciesA="u" speciesB="d">
+        <var id="jud_b" name="B">0.1</var>
+      </correlation>
+    </jastrow>
+   </wavefunction>)";
+
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(wf_input);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  wp.put(root);
+
+  TrialWaveFunction* psi = wp.getWaveFunction("psi0");
+  REQUIRE(psi != nullptr);
+  REQUIRE(psi->getOrbitals().size() == 2);
+
+  opt_variables_type opt_vars;
+  psi->checkInVariables(opt_vars);
+  opt_vars.resetIndex();
+  psi->checkOutVariables(opt_vars);
+  psi->resetParameters(opt_vars);
+
+  ParticleSet* elec = pp.getParticleSet("e");
+  elec->update();
+
+
+  double logval = psi->evaluateLog(*elec);
+  CHECK(logval == Approx(-15.791249652199634));
+
+  CHECK(elec->G[0][0] == ValueApprox(-0.2956989647881321));
+  CHECK(elec->L[0] == ValueApprox(-0.6560429678274734));
+  CHECK(elec->L[1] == ValueApprox(-1.2132292565412577));
+
+  using ValueType = QMCTraits::ValueType;
+  std::vector<ValueType> dlogpsi(3);
+  std::vector<ValueType> dhpsioverpsi(3);
+  psi->evaluateDerivatives(*elec, opt_vars, dlogpsi, dhpsioverpsi);
+
+  CHECK(dlogpsi[0] == ValueApprox(32.206205017987166));
+  CHECK(dlogpsi[1] == ValueApprox(5.874829251874641));
+  CHECK(dlogpsi[2] == ValueApprox(49.08414605622605));
+  CHECK(dhpsioverpsi[0] == ValueApprox(32.462519534916666));
+  CHECK(dhpsioverpsi[1] == ValueApprox(10.047601212881027));
+  CHECK(dhpsioverpsi[2] == ValueApprox(2.0820644399551895));
+}
+} // namespace qmcplusplus


### PR DESCRIPTION
The test system is a helium atom with two orbitals and an optional Jastrow factor.

A python script is used to generate reference values for the values of the wavefunction and derivatives at one point in space.  The script uses automatic differentiation (via autograd) to make computing the spatial and parameter derivatives straightforward.

This is the starting point for some testing of orbital rotation that should make changes and fixes more reliable (see #3977 ). 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
