### PR TITLE
Fix legacy CUDA compilation issue on Bora

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -33,13 +33,6 @@ namespace qmcplusplus
 {
 using WP = WalkerProperties::Indexes;
 
-//using namespace particle_info;
-
-#ifdef QMC_CUDA
-template<>
-int ParticleSet::Walker_t::cuda_DataSize = 0;
-#endif
-
 enum PSetTimers
 {
   PS_newpos,

--- a/src/Particle/Walker.h
+++ b/src/Particle/Walker.h
@@ -154,7 +154,7 @@ public:
 
   /// Data for GPU-vectorized versions
 #ifdef QMC_CUDA
-  static inline int cuda_DataSize;
+  static inline int cuda_DataSize = 0;
   using cuda_Buffer_t = gpu::device_vector<CTS::ValueType>;
   cuda_Buffer_t cuda_DataSet;
   // Note that R_GPU has size N+1.  The last element contains the


### PR DESCRIPTION
## Proposed changes
Got some issue on bora
```
/scratch2/QMCPACK_CI_BUILDS_DO_NOT_REMOVE/qmcpack-develop/src/Particle/ParticleSet.cpp(40): error: member "qmcplusplus::Walker<t_traits, p_traits>::cuda_DataSize [with t_traits=qmcplusplus::QMCTraits, p_traits=qmcplusplus::PtclOnLatticeTraits]" has already been defined
  int ParticleSet::Walker_t::cuda_DataSize = 0;
                             ^
```

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'