### PR TITLE
Adjust tolerance for unit_test_estimators for One-body density matrices on mixed precision build

### DIFF
--- a/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
+++ b/src/Estimators/tests/test_OneBodyDensityMatrices.cpp
@@ -140,7 +140,7 @@ public:
       auto* test_data = reinterpret_cast<std::complex<Real>*>(test_in);
       for (size_t id = 0; id < size; id += 2)
 #if defined(MIXED_PRECISION)
-        CHECK(ref_data[id] == ComplexApprox(test_data[id]).epsilon(1e-4));
+        CHECK(ref_data[id] == ComplexApprox(test_data[id]).epsilon(6e-4));
 #else
         CHECK(ref_data[id] == ComplexApprox(test_data[id]));
 #endif


### PR DESCRIPTION
## Proposed changes

This PR is to make unit_test_estimators for one-body density matrices pass for mixed-precision build on sulfur.

https://cdash.qmcpack.org/CDash/testDetails.php?test=19584585&build=319954


## What type(s) of changes does this code introduce?

- Other (please describe): Add test

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
