### PR TITLE
Add orbital rotation test with legacy driver

### DIFF
--- a/src/QMCWaveFunctions/tests/stats.py
+++ b/src/QMCWaveFunctions/tests/stats.py
@@ -1,0 +1,43 @@
+
+import math
+import numpy as np
+
+class averager:
+  """Compute average, variance, and standard error for a set of data"""
+  def __init__(self):
+    self.sum = 0.0
+    self.sum_sq = 0.0
+    self.norm = 0
+
+  def add_value(self,v):
+    self.sum += v
+    self.sum_sq += v*v
+    self.norm += 1
+
+  def average(self):
+    if (self.norm == 0):
+      return 0.0
+    else:
+      return self.sum/self.norm
+
+  def variance(self):
+    var = 0.0
+    if (self.norm != 0):
+      var = (self.sum_sq - self.sum*self.sum/self.norm)/self.norm
+    return var
+
+  def std_dev(self):
+    return math.sqrt(self.variance())
+
+  def error(self):
+    err = 0.0
+    if (self.norm > 1):
+      var = self.variance()
+      err = np.sqrt(var/(self.norm-1))
+    return err
+
+  def merge(self, other):
+      self.sum += other.sum
+      self.sum_sq += other.sum_sq
+      self.norm += other.norm
+

--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -78,6 +78,32 @@ if(NOT QMC_CUDA)
   endif()
 
 
+  # Orbital Rotation
+
+  # Two atomic orbitals, no jastrow
+
+  list(APPEND HE_ORB_ROT_PARAM spo-up_orb_rot_0000_0001  -0.218  0.01) # scalar name, value, error
+  list(APPEND HE_ORB_ROT_PARAM spo-down_orb_rot_0000_0001  -0.218  0.01) # scalar name, value, error
+
+  qmc_run_and_check_custom_scalar(
+    BASE_NAME
+    He_orb_rot_param_grad_legacy
+    BASE_DIR
+    "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+    PREFIX
+    He_orb_rot_param_grad_legacy.param
+    INPUT_FILE
+    He_orb_rot_param_grad_legacy.xml
+    PROCS
+    1
+    THREADS
+    1
+    SERIES
+    0
+    SCALAR_VALUES
+    HE_ORB_ROT_PARAM)
+
+
   else()
     message(VERBOSE "Skipping He_param tests because parameter output is not supported by mixed precison build (QMC_MIXED_PRECISION=1)")
   endif()

--- a/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
+++ b/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="He_orb_rot_param_grad_legacy" series="0">
+         <parameter name="driver_version">legacy</parameter>
+  </project>
+
+  <!-- Location of atoms -->
+
+  <particleset name="ion0" size="1">
+    <group name="He">
+      <parameter name="charge">2</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+      0.0 0.0 0.0
+    </attrib>
+  </particleset>
+
+  <!-- Randomly create electrons around the atomic position -->
+
+  <particleset name="e" random="yes" randomsrc="ion0">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+
+  <!-- Trial wavefunction - use Slater determinant multiplied by a Jastrow factor -->
+
+  <wavefunction name="psi0" target="e">
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="downdetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="1"/>
+      </slaterdeterminant>
+    </determinantset>
+
+
+  </wavefunction>
+
+  <!-- Hamiltonian - the energy of interactions between particles -->
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <!-- Electon-electron -->
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e"/>
+    <!-- Electon-ion -->
+    <pairpot name="Coulomb" type="coulomb" source="ion0" target="e"/>
+    <!-- Ion-ion (not needed for a single atom) -->
+    <!--<constant name="IonIon" type="coulomb" source="ion0" target="ion0"/>-->
+  </hamiltonian>
+
+  <!-- QMC method(s) to run -->
+
+  <loop max="10">
+    <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
+      <optimize method="gradient_test">
+        <parameter name="output_param_file">yes</parameter>
+      </optimize>
+      <parameter name="blocks">     100  </parameter>
+
+      <parameter name="warmupsteps"> 25 </parameter>
+      <parameter name="steps"> 10 </parameter>
+      <parameter name="substeps"> 20 </parameter>
+      <parameter name="timestep"> 0.5 </parameter>
+      <parameter name="samples"> 1000 </parameter>
+      <cost name="energy">                   1.0 </cost>
+      <cost name="reweightedvariance">       0.00 </cost>
+    </qmc>
+  </loop>
+
+
+</simulation>


### PR DESCRIPTION
The gen_rotated_lcao_wf.py file is extended to generate QMC averages for the parameter gradients.

A test for the legacy driver using one thread is introduced.  The same rotation is used for both up and down electrons to check the parameter gradients are the same.

The cost parameters in the input file are important (energy to 1.0 and reweightedvariance to 0.0) because the code defaults to an energy fraction of 0.9 and a reweightedvariance fraction of 0.1.  If these are left at the default, the rotation parameter gradients are around -0.29.

The error bars on the reference values were taken from a QMCPACK run 100x longer (and divided by 10).

This is an attempt to define one point where we know the code works and has a validated answer.

The test uses the legacy driver and only one thread.  It will fail with multiple threads. The batched driver fails.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
