### PR TITLE
Do not use cudaDeviceProp maxTexture1D in HIP

### DIFF
--- a/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.2.cpp
@@ -474,7 +474,7 @@ void ECPComponentBuilder::doBreakUp(const std::vector<int>& angList,
                                     RealType rmax,
                                     mRealType Vprefactor)
 {
-#ifdef QMC_CUDA
+#if defined(QMC_CUDA) && !defined(QMC_CUDA2HIP)
   int device;
   cudaCheck(cudaGetDevice(&device));
   cudaDeviceProp deviceProp;


### PR DESCRIPTION
## Proposed changes

Remove the check of maxTexture1D in HIP.
The texture API is deprecated (both CUDA and HIP).
HIP will return -1 when the texture API is no loger supported.
Therefore, adopting the same magic number as for CPUs (100,000).

## What type(s) of changes does this code introduce?

Removing reliance on deprecated API.

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

AMD Radeon 7

## Checklist

- Yes, this PR is up to date with current the current state of 'develop'
