### PR TITLE
Add MPI support to ROCm legacy CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -222,10 +222,10 @@ jobs:
             ROCm-Clang13-NoMPI-CUDA2HIP-Real,
             ROCm-Clang13-NoMPI-CUDA2HIP-Complex-Mixed,
             ROCm-Clang13-NoMPI-CUDA2HIP-Complex,
-            ROCm-Clang13-NoMPI-Legacy-CUDA2HIP-Real-Mixed,
-            ROCm-Clang13-NoMPI-Legacy-CUDA2HIP-Real,
-            ROCm-Clang13-NoMPI-Legacy-CUDA2HIP-Complex-Mixed,
-            ROCm-Clang13-NoMPI-Legacy-CUDA2HIP-Complex,
+            ROCm-Clang13-MPI-Legacy-CUDA2HIP-Real-Mixed,
+            ROCm-Clang13-MPI-Legacy-CUDA2HIP-Real,
+            ROCm-Clang13-MPI-Legacy-CUDA2HIP-Complex-Mixed,
+            ROCm-Clang13-MPI-Legacy-CUDA2HIP-Complex,
           ]
 
     steps:

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -231,13 +231,21 @@ case "$1" in
               -DQMC_DATA=$QMC_DATA_DIR \
               ${GITHUB_WORKSPACE}
       ;;
-      *"ROCm-Clang13-NoMPI-Legacy-CUDA2HIP"*)
+      *"ROCm-Clang13-MPI-Legacy-CUDA2HIP"*)
         echo 'Configure for building CUDA2HIP with clang compilers shipped with ROCM on AMD hardware'
+
+        export OMPI_CC=/opt/rocm/llvm/bin/clang
+        export OMPI_CXX=/opt/rocm/llvm/bin/clang++
+
+        # Make current environment variables available to subsequent steps
+        echo "OMPI_CC=/opt/rocm/llvm/bin/clang" >> $GITHUB_ENV
+        echo "OMPI_CXX=/opt/rocm/llvm/bin/clang++" >> $GITHUB_ENV
+
         cmake -GNinja \
-              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
-              -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+              -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
+              -DCMAKE_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx \
+              -DMPIEXEC_EXECUTABLE=/usr/lib64/openmpi/bin/mpirun \
               -DQMC_CUDA=1 \
-              -DQMC_MPI=0 \
               -DQMC_CUDA2HIP=ON \
               -DCMAKE_PREFIX_PATH="/opt/OpenBLAS/0.3.18" \
               -DQMC_COMPLEX=$IS_COMPLEX \


### PR DESCRIPTION
## Proposed changes

Add MPI configuration based on OpenMPI using ROCm clang compilers
For CI running on nitrogen
Must merge onto develop before changes take place.
Fixes #4048

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
nitrogen, must pass CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
