### PR TITLE
Rewrite loop to workaround NVHPC bugs

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixUpdateOMPTarget.h
@@ -222,13 +222,15 @@ public:
       success = ompBLAS::gemv(dummy_handle, 'T', norb, norb, cone, Ainv_ptr, lda, phiV_ptr, 1, czero, temp_ptr, 1);
       if (success != 0)
         throw std::runtime_error("ompBLAS::gemv failed.");
-      PRAGMA_OFFLOAD("omp target is_device_ptr(Ainv_ptr, temp_ptr, rcopy_ptr)")
+
+      PRAGMA_OFFLOAD("omp target parallel for simd is_device_ptr(Ainv_ptr, temp_ptr, rcopy_ptr)")
+      for (int i = 0; i < norb; i++)
       {
-        temp_ptr[rowchanged] -= cone;
-        PRAGMA_OFFLOAD("omp parallel for simd")
-        for (int i = 0; i < norb; i++)
-          rcopy_ptr[i] = Ainv_ptr[rowchanged * lda + i];
+        rcopy_ptr[i] = Ainv_ptr[rowchanged * lda + i];
+        if (i == 0)
+          temp_ptr[rowchanged] -= cone;
       }
+
       success = ompBLAS::ger(dummy_handle, norb, norb, static_cast<Value>(-1.0 / c_ratio_in), rcopy_ptr, 1, temp_ptr, 1,
                              Ainv_ptr, lda);
       if (success != 0)


### PR DESCRIPTION
## Proposed changes
NVHPC 22.5 recompiled two of the offload regions can caused crazy weights and blow up the calculation. In some scenarios, DMC hangs. With this PR, DMC in performance tests seems stable.

Tested also with Clang on NVIDIA and AOMP on AMD GPUs.

## What type(s) of changes does this code introduce?
- Other (please describe): Compiler workaround.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
