### PR TITLE
Orbital rotation fixes for legacy driver with threads

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -168,7 +168,12 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
 
 void QMCCostFunction::getConfigurations(const std::string& aroot)
 {
-  //makeClones(W,Psi,H);
+  // Set all the myVars indices in the wavefunction clones
+  for (int i = 0; i < psiClones.size(); ++i)
+  {
+    psiClones[i]->checkOutVariables(OptVariablesForPsi);
+  }
+
   if (H_KE_Node.empty())
   {
     app_log() << "  QMCCostFunction is created with " << NumThreads << " threads." << std::endl;
@@ -331,7 +336,7 @@ void QMCCostFunction::checkConfigurations()
   app_log().flush();
   setTargetEnergy(Etarget);
   ReportCounter = 0;
-  IsValid = true;
+  IsValid       = true;
   //collect SumValue for computedCost
   SumValue[SUM_WGT]       = etemp[1];
   SumValue[SUM_WGTSQ]     = etemp[1];
@@ -521,7 +526,10 @@ void QMCCostFunction::resetPsi(bool final_reset)
   //cout << "-------------------------------------- " << std::endl;
   Psi.resetParameters(OptVariablesForPsi);
   for (int i = 0; i < psiClones.size(); ++i)
+  {
+    psiClones[i]->checkOutVariables(OptVariablesForPsi);
     psiClones[i]->resetParameters(OptVariablesForPsi);
+  }
 }
 
 QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGrad)

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -57,7 +57,8 @@ QMCCostFunctionBase::QMCCostFunctionBase(MCWalkerConfiguration& w,
       m_wfPtr(NULL),
       m_doc_out(NULL),
       includeNonlocalH("no"),
-      debug_stream(0)
+      debug_stream(0),
+      do_override_output(false)
 {
   GEVType = "mixed";
   //paramList.resize(10);

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -30,7 +30,12 @@ LCAOrbitalSet::LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize)
 }
 
 LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
-    : SPOSet(in), myBasisSet(in.myBasisSet->makeClone()), C(in.C), BasisSetSize(in.BasisSetSize), Identity(in.Identity)
+    : SPOSet(in),
+      myBasisSet(in.myBasisSet->makeClone()),
+      C(in.C),
+      BasisSetSize(in.BasisSetSize),
+      C_copy(in.C_copy),
+      Identity(in.Identity)
 {
   Temp.resize(BasisSetSize);
   Temph.resize(BasisSetSize);

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -22,7 +22,7 @@ class RotatedSPOs : public SPOSet
 {
 public:
   //constructor
-  RotatedSPOs(std::unique_ptr<SPOSet>&& spos);
+  RotatedSPOs(std::unique_ptr<SPOSet>&& spos, bool creatingCopy = false);
   //destructor
   ~RotatedSPOs() override;
 
@@ -165,15 +165,10 @@ public:
 
   void checkInVariables(opt_variables_type& active) override
   {
-    //reset parameters to zero after coefficient matrix has been updated
-    for (int k = 0; k < myVars.size(); ++k)
-      myVars[k] = 0.0;
-
     if (Optimizable)
     {
       if (myVars.size())
         active.insertFrom(myVars);
-      Phi->storeParamsBeforeRotation();
     }
   }
 

--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -103,6 +103,24 @@ if(NOT QMC_CUDA)
     SCALAR_VALUES
     HE_ORB_ROT_PARAM)
 
+  qmc_run_and_check_custom_scalar(
+    BASE_NAME
+    He_orb_rot_param_grad_legacy
+    BASE_DIR
+    "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+    PREFIX
+    He_orb_rot_param_grad_legacy.param
+    INPUT_FILE
+    He_orb_rot_param_grad_legacy.xml
+    PROCS
+    1
+    THREADS
+    16
+    SERIES
+    0
+    SCALAR_VALUES
+    HE_ORB_ROT_PARAM)
+
 
   else()
     message(VERBOSE "Skipping He_param tests because parameter output is not supported by mixed precison build (QMC_MIXED_PRECISION=1)")

--- a/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
+++ b/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
@@ -90,7 +90,7 @@
       <parameter name="steps"> 10 </parameter>
       <parameter name="substeps"> 20 </parameter>
       <parameter name="timestep"> 0.5 </parameter>
-      <parameter name="samples"> 1000 </parameter>
+      <parameter name="samplesperthread"> 1000 </parameter>
       <cost name="energy">                   1.0 </cost>
       <cost name="reweightedvariance">       0.00 </cost>
     </qmc>


### PR DESCRIPTION
These are fixes for orbital rotation with the legacy driver and multiple threads.

See #3983 for an overarching issue, and #3977 for a previous attempt (this PR is similar).  The use_stored_copy flag is no longer used, but I avoided removing it to keep the PR simple.

The change in QMCCostFunctionBase.cpp is unrelated, but small (setting the default value of do_override_output) (I know, violating my own rule about keep PR's focused on a single change.  But it is small.)

A multi-threaded version of the test was added.  The input was changed to use samplesperthread because otherwise there were too few samples per thread, and it could trigger the variance check.

The core issue is how, when, and where to keep a copy of the original coefficient matrix ("SPO internal state") for subsequent application of rotations.

### Design space
PR #3977 has some discussion about the design.
@PDoakORNL mentioned keeping a copy of the SPOSet in https://github.com/QMCPACK/qmcpack/pull/3977#issuecomment-1110289861
However, the coefficient matrix is kept in a shared pointer.  Copying the object only copies the pointer (which saves memory when copying the object), but is not the behavior we want to keep a clean copy of the coefficient matrix.   Four possible solutions:
1. An API so the SPO keeps it's own copy of the SPO internal state (this is the existing API)
2. Implement deep copy in the SPO.
3. An API that the SPO can hand over a copy the SPO internal state, and create the SPO using that state.
4. Separate object for the SPO internal state that gets set up initially, and the SPO gets created later in the process.


With 1-3, there is a further problem, related to the sequence of creation, set up, and copying.
We need to pick some point at which to save the SPO internal state, and we need to make sure we're not getting the state from a modified SPO.
Essentially, we want to get to the same object state regardless of path (creation + set up or copying a fully set-up object). (Somewhat like making an object idempotent to certain operations)

Reducing the code to a single path to get the object state is option 4. The downside of 4 is it requires a lot of changes to the initialization code.

### Rationale for choices in this PR
1. Adding a state variable to the RotatedSPO class is perhaps not the ideal choice.  However, it does seem like the best local fix for now.  
2. Given there are multiple changes necessary, it would be nice to get **something** working along with tests.  That makes it easier to change in the future.

### Other changes
- stop setting the parameters to zero in checkInVariables
- set the myVars local-to-global mapping indices on wavefunction clones via checkOutVariables. If not set correctly, the parameter derivatives in RotatedSPOs::evaluateDerivatives do not get written to the correct indices in dlogpsi and dhpsioverpsi near the end of the function. myVars does get copied via cloning, but the original doesn't get checkOutVariables called on it before the cloning happens.  So we need to make sure it does get set.  Note that if it's only set in resetParameters, the code fails on the first round of the optimizer.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
