### PR TITLE
Workaround for Debug, since omptarget requires -03 to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-#####################################################################
+######################################################################
 # CMake version and policies
 ######################################################################
 cmake_minimum_required(VERSION 3.17.0)
@@ -486,17 +486,17 @@ endif()
 
 
 #--------------------------------------------------------------
-# Workaround for breakage of OMP Target kernels at -O0
+# Workaround for breakage of OMP Target kernels at -O0 by Clang
 #--------------------------------------------------------------
-# Workaround for failing OMP Target compilation when -O0 in
-# clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619
+# When the build type is Debug, default -O0 compilation is broken by
+# Clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619.
 # Previous compilers are not suggested for clang offload builds.
 #
 # You can set this option to false on the command line to check
 # if this problem has been fixed.
 
 if((${COMPILER} MATCHES "Clang") AND ENABLE_OFFLOAD)
-  set(ENABLE_OFFLOAD_CLANG_DEBUG_O3 TRUE CACHE BOOL "build OMP target kernels with -O3 in debug")
+  option(ENABLE_OFFLOAD_CLANG_DEBUG_O3 "build OMP target kernels with -O3 in the build type Debug" ON)
 endif()
 mark_as_advanced(ENABLE_OFFLOAD_CLANG_DEBUG_O3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-######################################################################
+#####################################################################
 # CMake version and policies
 ######################################################################
 cmake_minimum_required(VERSION 3.17.0)
@@ -483,6 +483,23 @@ if(NOT TEST_CXX_COMPILE_MAIN)
   message(FATAL_ERROR "Failed in compiling a main() function likely due to incorrect compile options. "
                       "Check error in \"${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CMakeError.log\".")
 endif()
+
+
+#--------------------------------------------------------------
+# Workaround for breakage of OMP Target kernels at -O0
+#--------------------------------------------------------------
+# Workaround for failing OMP Target compilation when -O0 in
+# clang 15 as of 5d2ce7663b10c107328a4ae0c678165209e64619
+# Previous compilers are not suggested for clang offload builds.
+#
+# You can set this option to false on the command line to check
+# if this problem has been fixed.
+
+if((${COMPILER} MATCHES "Clang") AND ENABLE_OFFLOAD)
+  set(ENABLE_OFFLOAD_CLANG_DEBUG_O3 TRUE CACHE BOOL "build OMP target kernels with -O3 in debug")
+endif()
+mark_as_advanced(ENABLE_OFFLOAD_CLANG_DEBUG_O3)
+
 
 ######################################################################
 # Check external libraries.

--- a/src/Estimators/tests/CMakeLists.txt
+++ b/src/Estimators/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ if(USE_OBJECT_TARGET)
     qmcham_unit
     qmcwfs
     qmcparticle
+    qmcwfs_omptarget
+    qmcparticle_omptarget
     qmcutil
     platform_omptarget_LA
     utilities_for_test)
@@ -74,6 +76,8 @@ if(HAVE_MPI)
       qmcdriver_unit
       qmcwfs
       qmcparticle
+      qmcwfs_omptarget
+      qmcparticle_omptarget
       qmcutil
       platform_omptarget_LA
       utilities_for_test)

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -51,8 +51,8 @@ target_include_directories(qmcparticle PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle PRIVATE platform_cpu_LA)
 target_link_libraries(qmcparticle PUBLIC qmcnumerics qmcutil platform_runtime)
 
-# Workaround for broken OMP Target debug in clang as of 5d, main is more broken so
-# perhaps this problem is fixed.
+# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
+# but clang 15 main is completely broken for our omptarget code,
 #
 # In the meantime we need to make a new target for just the omp target tainted files
 # so we don't have broken debug for all of ParticleSet.

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -28,8 +28,6 @@ set(PARTICLE
     SampleStack.cpp
     createDistanceTableAA.cpp
     createDistanceTableAB.cpp
-    createDistanceTableAAOMPTarget.cpp
-    createDistanceTableABOMPTarget.cpp
     HDFWalkerInputManager.cpp
     LongRange/KContainer.cpp
     LongRange/StructFact.cpp
@@ -52,6 +50,34 @@ endif(USE_OBJECT_TARGET)
 target_include_directories(qmcparticle PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle PRIVATE platform_cpu_LA)
 target_link_libraries(qmcparticle PUBLIC qmcnumerics qmcutil platform_runtime)
+
+# Workaround for broken OMP Target debug in clang as of 5d, main is more broken so
+# perhaps this problem is fixed.
+#
+# In the meantime we need to make a new target for just the omp target tainted files
+# so we don't have broken debug for all of ParticleSet.
+
+# this can be put back into qmcparticle when omp target isn't broken.
+set(PARTICLEOMPTARGET
+    createDistanceTableAAOMPTarget.cpp
+    createDistanceTableABOMPTarget.cpp)
+
+if(USE_OBJECT_TARGET)
+  add_library(qmcparticle_omptarget OBJECT ${PARTICLEOMPTARGET})
+else(USE_OBJECT_TARGET)
+  add_library(qmcparticle_omptarget ${PARTICLEOMPTARGET})
+endif(USE_OBJECT_TARGET)
+
+target_include_directories(qmcparticle_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(qmcparticle_omptarget PUBLIC qmcutil containers)
+
+if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
+    target_compile_options(qmcparticle_omptarget PRIVATE $<$<CONFIG:DEBUG>:-O3>)
+endif()
+
+target_link_libraries(qmcparticle PUBLIC qmcparticle_omptarget)
+
+# workaround end
 
 if(QMC_CUDA)
   if(NOT QMC_CUDA2HIP)

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -50,30 +50,20 @@ endif(USE_OBJECT_TARGET)
 target_include_directories(qmcparticle PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle PRIVATE platform_cpu_LA)
 target_link_libraries(qmcparticle PUBLIC qmcnumerics qmcutil platform_runtime)
-
-# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
-# but clang 15 main is completely broken for our omptarget code,
-#
-# In the meantime we need to make a new target for just the omp target tainted files
-# so we don't have broken debug for all of ParticleSet.
-
-# this can be put back into qmcparticle when omp target isn't broken.
-set(PARTICLEOMPTARGET
+set(PARTICLE_OMPTARGET_SRCS
     createDistanceTableAAOMPTarget.cpp
     createDistanceTableABOMPTarget.cpp)
 
 if(USE_OBJECT_TARGET)
-  add_library(qmcparticle_omptarget OBJECT ${PARTICLEOMPTARGET})
+  add_library(qmcparticle_omptarget OBJECT ${PARTICLE_OMPTARGET_SRCS})
 else(USE_OBJECT_TARGET)
-  add_library(qmcparticle_omptarget ${PARTICLEOMPTARGET})
+  add_library(qmcparticle_omptarget ${PARTICLE_OMPTARGET_SRCS})
 endif(USE_OBJECT_TARGET)
 
 target_include_directories(qmcparticle_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcparticle_omptarget PUBLIC qmcutil containers)
 
-if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
-    target_compile_options(qmcparticle_omptarget PRIVATE $<$<CONFIG:DEBUG>:-O3>)
-endif()
+target_compile_options(qmcparticle_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 
 target_link_libraries(qmcparticle PUBLIC qmcparticle_omptarget)
 

--- a/src/Particle/CMakeLists.txt
+++ b/src/Particle/CMakeLists.txt
@@ -67,8 +67,6 @@ target_compile_options(qmcparticle_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_
 
 target_link_libraries(qmcparticle PUBLIC qmcparticle_omptarget)
 
-# workaround end
-
 if(QMC_CUDA)
   if(NOT QMC_CUDA2HIP)
     add_library(qmcparticle_cuda accept_kernel.cu)

--- a/src/Particle/LongRange/tests/CMakeLists.txt
+++ b/src/Particle/LongRange/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 add_executable(${UTEST_EXE} test_lrhandler.cpp test_ewald3d.cpp test_temp.cpp test_srcoul.cpp test_StructFact.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(${UTEST_EXE} qmcutil)
+  target_link_libraries(${UTEST_EXE} qmcutil qmcparticle_omptarget)
 endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Particle/ParticleBase/tests/CMakeLists.txt
+++ b/src/Particle/ParticleBase/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(${UTEST_EXE} test_particle_attrib.cpp test_random_seq.cpp test_at
 use_fake_rng(${UTEST_EXE})
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(${UTEST_EXE} qmcutil)
+  target_link_libraries(${UTEST_EXE} qmcutil qmcparticle_omptarget)
 endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Particle/ParticleIO/tests/CMakeLists.txt
+++ b/src/Particle/ParticleIO/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 add_executable(${UTEST_EXE} test_xml_io.cpp test_lattice_parser.cpp test_xml_mass.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(${UTEST_EXE} qmcutil)
+  target_link_libraries(${UTEST_EXE} qmcutil qmcparticle_omptarget)
 endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Particle/tests/CMakeLists.txt
+++ b/src/Particle/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(
   test_MCCoords.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcparticle)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(${UTEST_EXE} qmcutil)
+  target_link_libraries(${UTEST_EXE} qmcutil qmcparticle_omptarget)
 endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -20,11 +20,7 @@ else()
 endif()
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
-# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
-# but clang 15 main is completely broken for our omptarget code,
-if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
-    target_compile_options(platform_omptarget_LA PRIVATE $<$<CONFIG:DEBUG>:-O3>)
-endif()
+target_compile_options(platform_omptarget_LA PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 
 if(ENABLE_CUDA AND QMC_OFFLOAD_MEM_ASSOCIATED)
   target_link_libraries(platform_omptarget_runtime PUBLIC platform_cuda_runtime)

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -20,6 +20,8 @@ else()
 endif()
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
+# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
+# but clang 15 main is completely broken for our omptarget code,
 if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
     target_compile_options(platform_omptarget_LA PRIVATE $<$<CONFIG:DEBUG>:-O3>)
 endif()

--- a/src/Platforms/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/OMPTarget/CMakeLists.txt
@@ -20,6 +20,10 @@ else()
 endif()
 target_link_libraries(platform_omptarget_LA PUBLIC platform_omptarget_runtime)
 
+if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
+    target_compile_options(platform_omptarget_LA PRIVATE $<$<CONFIG:DEBUG>:-O3>)
+endif()
+
 if(ENABLE_CUDA AND QMC_OFFLOAD_MEM_ASSOCIATED)
   target_link_libraries(platform_omptarget_runtime PUBLIC platform_cuda_runtime)
 endif()

--- a/src/QMCApp/CMakeLists.txt
+++ b/src/QMCApp/CMakeLists.txt
@@ -52,6 +52,8 @@ if(USE_OBJECT_TARGET)
     qmcham
     qmcwfs
     qmcparticle
+    qmcwfs_omptarget
+    qmcparticle_omptarget
     qmcutil
     platform_omptarget_LA)
 endif()

--- a/src/QMCDrivers/tests/CMakeLists.txt
+++ b/src/QMCDrivers/tests/CMakeLists.txt
@@ -55,6 +55,8 @@ if(USE_OBJECT_TARGET)
     qmcham_unit
     qmcwfs
     qmcparticle
+    qmcwfs_omptarget
+    qmcparticle_omptarget
     qmcutil
     platform_omptarget_LA)
 endif()
@@ -97,6 +99,8 @@ if(NOT QMC_CUDA)
       qmcham_unit
       qmcwfs
       qmcparticle
+      qmcwfs_omptarget
+      qmcparticle_omptarget
       qmcutil
       platform_omptarget_LA)
   endif()
@@ -119,6 +123,8 @@ if(NOT QMC_CUDA)
         qmcham_unit
         qmcwfs
         qmcparticle
+	qmcwfs_omptarget
+	qmcparticle_omptarget
         qmcutil
         platform_omptarget_LA)
     endif()

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(CATEGORY coulomb force ham ewald2d)
 
   target_link_libraries(${UTEST_EXE} catch_main qmcham)
   if(USE_OBJECT_TARGET)
-    target_link_libraries(${UTEST_EXE} qmcwfs qmcparticle qmcutil platform_omptarget_LA)
+    target_link_libraries(${UTEST_EXE} qmcwfs qmcparticle qmcwfs_omptarget qmcparticle_omptarget qmcutil platform_omptarget_LA)
   endif()
 
   add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/QMCTools/CMakeLists.txt
+++ b/src/QMCTools/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(
 
 target_link_libraries(convert4qmc PUBLIC qmcparticle)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(convert4qmc PUBLIC qmcutil)
+  target_link_libraries(convert4qmc PUBLIC qmcutil qmcparticle_omptarget)
 endif()
 
 add_executable(qmc-extract-eshdf-kvectors qmc-extract-eshdf-kvectors.cpp)
@@ -55,7 +55,7 @@ target_link_libraries(fstool PUBLIC qmc qmcparticle qmcwfs)
 add_executable(qmcfinitesize qmcfinitesize.cpp)
 target_link_libraries(qmcfinitesize fstool)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(qmcfinitesize qmcparticle qmcutil)
+  target_link_libraries(qmcfinitesize qmcparticle qmcparticle_omptarget qmcutil)
 endif()
 
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/gpaw4qmcpack.py ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gpaw4qmcpack.py SYMBOLIC)

--- a/src/QMCTools/tests/CMakeLists.txt
+++ b/src/QMCTools/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/si
 add_executable(${UTEST_EXE} ${SRCS})
 target_link_libraries(${UTEST_EXE} catch_main fstool)
 if(USE_OBJECT_TARGET)
-  target_link_libraries(${UTEST_EXE} qmcparticle qmcutil)
+  target_link_libraries(${UTEST_EXE} qmcparticle qmcparticle_omptarget qmcutil)
 endif()
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -61,8 +61,8 @@ set(JASTROW_SRCS
     LatticeGaussianProduct.cpp
     LatticeGaussianProductBuilder.cpp)
 set(JASTROW_OMPTARGET_SRCS
-    Jastrow/J2OMPTarget.cpp)
-
+    Jastrow/J2OMPTarget.cpp
+    Jastrow/BsplineFunctor.cpp)
 if(QMC_COMPLEX)
   set(FERMION_SRCS ${FERMION_SRCS} ElectronGas/ElectronGasComplexOrbitalBuilder.cpp)
 else(QMC_COMPLEX)
@@ -102,13 +102,14 @@ if(OHMMS_DIM MATCHES 3)
         BsplineFactory/HybridRepCenterOrbitals.cpp
         BandInfo.cpp
         BsplineFactory/BsplineReaderBase.cpp)
+      set(FERMION_OMPTARGET_SRCS Fermion/DiracDeterminantBatched.cpp)
     if(QMC_COMPLEX)
       set(FERMION_SRCS ${FERMION_SRCS} EinsplineSpinorSetBuilder.cpp BsplineFactory/SplineC2C.cpp)
-      set(FERMION_OMPTARGET_SRCS BsplineFactory/SplineC2COMPTarget.cpp)
+      set(FERMION_OMPTARGET_SRCS ${FERMION_OMPTARGET_SRCS} BsplineFactory/SplineC2COMPTarget.cpp)
     else(QMC_COMPLEX)
       set(FERMION_SRCS ${FERMION_SRCS} BsplineFactory/createRealSingle.cpp BsplineFactory/createRealDouble.cpp
         BsplineFactory/SplineC2R.cpp BsplineFactory/SplineR2R.cpp)
-      set(FERMION_OMPTARGET_SRCS BsplineFactory/SplineC2ROMPTarget.cpp)
+      set(FERMION_OMPTARGET_SRCS ${FERMION_OMPTARGET_SRCS} BsplineFactory/SplineC2ROMPTarget.cpp)
     endif(QMC_COMPLEX)
 
   endif(HAVE_EINSPLINE)
@@ -130,12 +131,10 @@ endif(OHMMS_DIM MATCHES 3)
 set(FERMION_SRCS
     ${FERMION_SRCS}
     Fermion/DiracDeterminant.cpp
-    Fermion/DiracDeterminantBatched.cpp
-    Fermion/SlaterDet.cpp
-    Fermion/SlaterDetBuilder.cpp
-    Fermion/MultiSlaterDetTableMethod.cpp
     Fermion/MultiDiracDeterminant.cpp
     Fermion/MultiDiracDeterminant.2.cpp
+    Fermion/SlaterDet.cpp
+    Fermion/SlaterDetBuilder.cpp
     Fermion/BackflowBuilder.cpp
     Fermion/BackflowTransformation.cpp
     Fermion/DiracDeterminantWithBackflow.cpp
@@ -146,6 +145,7 @@ set(FERMION_SRCS
     TWFFastDerivWrapper.cpp
     TWFGrads.cpp
     WaveFunctionFactory.cpp)
+set(FERMION_OMPTARGET_SRCS ${FERMION_OMPTARGET_SRCS} Fermion/MultiSlaterDetTableMethod.cpp)
 
 if(QMC_CUDA)
   set(FERMION_SRCS ${FERMION_SRCS} EinsplineSetCuda.cpp Fermion/DiracDeterminantCUDA.cpp Fermion/SlaterDetCUDA.cpp
@@ -185,6 +185,9 @@ target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)
 if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
     target_compile_options(qmcwfs_omptarget PRIVATE $<$<CONFIG:DEBUG>:-O3>)
 endif()
+#target_compile_options(qmcwfs_omptarget PUBLIC ${OPENMP_OFFLOAD_COMPILE_OPTIONS})
+
+
 
 target_link_libraries(qmcwfs PUBLIC qmcwfs_omptarget)
 # end omp target workaround

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -58,9 +58,10 @@ set(JASTROW_SRCS
     Jastrow/RPAJastrow.cpp
     Jastrow/J1OrbitalSoA.cpp
     Jastrow/J2OrbitalSoA.cpp
-    Jastrow/J2OMPTarget.cpp
     LatticeGaussianProduct.cpp
     LatticeGaussianProductBuilder.cpp)
+set(JASTROW_OMPTARGET_SRCS
+    Jastrow/J2OMPTarget.cpp)
 
 if(QMC_COMPLEX)
   set(FERMION_SRCS ${FERMION_SRCS} ElectronGas/ElectronGasComplexOrbitalBuilder.cpp)
@@ -102,11 +103,12 @@ if(OHMMS_DIM MATCHES 3)
         BandInfo.cpp
         BsplineFactory/BsplineReaderBase.cpp)
     if(QMC_COMPLEX)
-      set(FERMION_SRCS ${FERMION_SRCS} EinsplineSpinorSetBuilder.cpp BsplineFactory/SplineC2C.cpp
-                       BsplineFactory/SplineC2COMPTarget.cpp)
+      set(FERMION_SRCS ${FERMION_SRCS} EinsplineSpinorSetBuilder.cpp BsplineFactory/SplineC2C.cpp)
+      set(FERMION_OMPTARGET_SRCS BsplineFactory/SplineC2COMPTarget.cpp)
     else(QMC_COMPLEX)
       set(FERMION_SRCS ${FERMION_SRCS} BsplineFactory/createRealSingle.cpp BsplineFactory/createRealDouble.cpp
-                       BsplineFactory/SplineC2R.cpp BsplineFactory/SplineR2R.cpp BsplineFactory/SplineC2ROMPTarget.cpp)
+        BsplineFactory/SplineC2R.cpp BsplineFactory/SplineR2R.cpp)
+      set(FERMION_OMPTARGET_SRCS BsplineFactory/SplineC2ROMPTarget.cpp)
     endif(QMC_COMPLEX)
 
   endif(HAVE_EINSPLINE)
@@ -163,6 +165,29 @@ endif(USE_OBJECT_TARGET)
 target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime)
 target_link_libraries(qmcwfs PRIVATE einspline platform_LA Math::FFTW3)
+
+# Workaround for broken OMP Target debug in clang as of 5d, main is more broken so
+# perhaps this problem is fixed.
+#
+# In the meantime we need to make a new target for just the omp target tainted files
+# so we don't have broken debug for all of QMCWavefunctions
+
+if(USE_OBJECT_TARGET)
+  add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
+else(USE_OBJECT_TARGET)
+  add_library(qmcwfs_omptarget ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
+endif(USE_OBJECT_TARGET)
+# the srcs can be put back into qmcwfs when clang omp target isn't broken.
+
+target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)
+
+if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
+    target_compile_options(qmcwfs_omptarget PRIVATE $<$<CONFIG:DEBUG>:-O3>)
+endif()
+
+target_link_libraries(qmcwfs PUBLIC qmcwfs_omptarget)
+# end omp target workaround
 
 if(ENABLE_CUDA)
   target_link_libraries(qmcwfs PRIVATE qmcwfs_cuda)

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -182,12 +182,7 @@ endif(USE_OBJECT_TARGET)
 target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)
 
-if(ENABLE_OFFLOAD AND ${COMPILER} MATCHES "Clang")
-    target_compile_options(qmcwfs_omptarget PRIVATE $<$<CONFIG:DEBUG>:-O3>)
-endif()
-#target_compile_options(qmcwfs_omptarget PUBLIC ${OPENMP_OFFLOAD_COMPILE_OPTIONS})
-
-
+target_compile_options(qmcwfs_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 
 target_link_libraries(qmcwfs PUBLIC qmcwfs_omptarget)
 # end omp target workaround

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -185,7 +185,6 @@ target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)
 target_compile_options(qmcwfs_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 
 target_link_libraries(qmcwfs PUBLIC qmcwfs_omptarget)
-# end omp target workaround
 
 if(ENABLE_CUDA)
   target_link_libraries(qmcwfs PRIVATE qmcwfs_cuda)

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -166,8 +166,8 @@ target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime)
 target_link_libraries(qmcwfs PRIVATE einspline platform_LA Math::FFTW3)
 
-# Workaround for broken OMP Target debug in clang as of 5d, main is more broken so
-# perhaps this problem is fixed.
+# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
+# but clang 15 main is completely broken for our omptarget code,
 #
 # In the meantime we need to make a new target for just the omp target tainted files
 # so we don't have broken debug for all of QMCWavefunctions

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -166,18 +166,11 @@ target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime)
 target_link_libraries(qmcwfs PRIVATE einspline platform_LA Math::FFTW3)
 
-# Workaround for broken OMP Target debug in clang as of 5d2ce7663b10c107328a4ae0c678165209e64619
-# but clang 15 main is completely broken for our omptarget code,
-#
-# In the meantime we need to make a new target for just the omp target tainted files
-# so we don't have broken debug for all of QMCWavefunctions
-
 if(USE_OBJECT_TARGET)
   add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
 else(USE_OBJECT_TARGET)
   add_library(qmcwfs_omptarget ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
 endif(USE_OBJECT_TARGET)
-# the srcs can be put back into qmcwfs when clang omp target isn't broken.
 
 target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -202,9 +202,9 @@ public:
   void restore(int iat) override;
 
   static void mw_accept_rejectMove(const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list,
-                                                 const RefVectorWithLeader<ParticleSet>& p_list,
-                                                 int iat,
-                                                 const std::vector<bool>& isAccepted);
+                                   const RefVectorWithLeader<ParticleSet>& p_list,
+                                   int iat,
+                                   const std::vector<bool>& isAccepted);
 
   void createResource(ResourceCollection& collection) const override;
   void acquireResource(ResourceCollection& collection,

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -670,10 +670,10 @@ void MultiSlaterDetTableMethod::restore(int iat)
 }
 
 void MultiSlaterDetTableMethod::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list,
-                          int iat,
-                          const std::vector<bool>& isAccepted,
-                          bool safe_to_delay) const
+                                                     const RefVectorWithLeader<ParticleSet>& p_list,
+                                                     int iat,
+                                                     const std::vector<bool>& isAccepted,
+                                                     bool safe_to_delay) const
 {
   ScopedTimer local_timer(AccRejTimer);
   for (size_t iw = 0; iw < isAccepted.size(); iw++)

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
@@ -22,18 +22,18 @@
 
 namespace qmcplusplus
 {
-template<typename REAL>
-void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
-                                          const int num_groups,
-                                          const BsplineFunctor* const functors[],
-                                          const int n_src,
-                                          const int* grp_ids,
-                                          const int nw,
-                                          REAL* mw_vgl, // [nw][DIM+2]
-                                          const int n_padded,
-                                          const REAL* mw_dist, // [nw][DIM+1][n_padded]
-                                          REAL* mw_cur_allu,   // [nw][3][n_padded]
-                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename MWREAL>
+void BsplineFunctor<MWREAL>::mw_evaluateVGL(const int iat,
+                                            const int num_groups,
+                                            const BsplineFunctor* const functors[],
+                                            const int n_src,
+                                            const int* grp_ids,
+                                            const int nw,
+                                            MWREAL* mw_vgl, // [nw][DIM+2]
+                                            const int n_padded,
+                                            const MWREAL* mw_dist, // [nw][DIM+1][n_padded]
+                                            MWREAL* mw_cur_allu,   // [nw][3][n_padded]
+                                            Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
@@ -43,10 +43,10 @@ void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
      * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T) and cutoff_radius sizeof(T)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
-  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
-  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
-  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
+  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
+  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
+  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   for (int ig = 0; ig < num_groups; ig++)
   {
     mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
@@ -63,41 +63,41 @@ void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
                     map(always, from: mw_vgl[:(DIM+2)*nw])")
   for (int ip = 0; ip < nw; ip++)
   {
-    REAL val_sum(0);
-    REAL grad_x(0);
-    REAL grad_y(0);
-    REAL grad_z(0);
-    REAL lapl(0);
+    MWREAL val_sum(0);
+    MWREAL grad_x(0);
+    MWREAL grad_y(0);
+    MWREAL grad_z(0);
+    MWREAL lapl(0);
 
-    const REAL* dist   = mw_dist + ip * dist_stride;
-    const REAL* dipl_x = dist + n_padded;
-    const REAL* dipl_y = dist + n_padded * 2;
-    const REAL* dipl_z = dist + n_padded * 3;
+    const MWREAL* dist   = mw_dist + ip * dist_stride;
+    const MWREAL* dipl_x = dist + n_padded;
+    const MWREAL* dipl_y = dist + n_padded * 2;
+    const MWREAL* dipl_z = dist + n_padded * 3;
 
-    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
-    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
-    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
+    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
+    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
 
-    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+    MWREAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
     PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
     for (int j = 0; j < n_src; j++)
     {
       if (j == iat)
         continue;
-      const int ig       = grp_ids[j];
-      const REAL* coefs  = mw_coefs[ig];
-      REAL DeltaRInv     = mw_DeltaRInv[ig];
-      REAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig         = grp_ids[j];
+      const MWREAL* coefs  = mw_coefs[ig];
+      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
+      MWREAL cutoff_radius = mw_cutoff_radius[ig];
 
-      REAL r = dist[j];
-      REAL u(0);
-      REAL dudr(0);
-      REAL d2udr2(0);
+      MWREAL r = dist[j];
+      MWREAL u(0);
+      MWREAL dudr(0);
+      MWREAL d2udr2(0);
       if (r < cutoff_radius)
       {
         u = evaluate_impl(dist[j], coefs, DeltaRInv, dudr, d2udr2);
-        dudr *= REAL(1) / r;
+        dudr *= MWREAL(1) / r;
       }
       // save u, dudr/r and d2udr2 to cur_allu
       cur_allu[j]                = u;
@@ -110,35 +110,35 @@ void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
       grad_z += dudr * dipl_z[j];
     }
 
-    REAL* vgl = mw_vgl + ip * (DIM + 2);
-    vgl[0]    = val_sum;
-    vgl[1]    = grad_x;
-    vgl[2]    = grad_y;
-    vgl[3]    = grad_z;
-    vgl[4]    = -lapl;
+    MWREAL* vgl = mw_vgl + ip * (DIM + 2);
+    vgl[0]      = val_sum;
+    vgl[1]      = grad_x;
+    vgl[2]      = grad_y;
+    vgl[3]      = grad_z;
+    vgl[4]      = -lapl;
   }
 }
 
-template<typename REAL>
-void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
-                                        const BsplineFunctor<REAL>* const functors[],
-                                        const int n_src,
-                                        const int* grp_ids,
-                                        const int num_pairs,
-                                        const int* ref_at,
-                                        const REAL* mw_dist,
-                                        const int dist_stride,
-                                        REAL* mw_vals,
-                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename MWREAL>
+void BsplineFunctor<MWREAL>::mw_evaluateV(const int num_groups,
+                                          const BsplineFunctor<MWREAL>* const functors[],
+                                          const int n_src,
+                                          const int* grp_ids,
+                                          const int num_pairs,
+                                          const int* ref_at,
+                                          const MWREAL* mw_dist,
+                                          const int dist_stride,
+                                          MWREAL* mw_vals,
+                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
+     * Bspline coefs device pointer sizeof(MWREAL*), DeltaRInv sizeof(MWREAL), cutoff_radius sizeof(MWREAL)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
-  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
-  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
-  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
+  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
+  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
+  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   for (int ig = 0; ig < num_groups; ig++)
   {
     mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
@@ -154,26 +154,26 @@ void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
                     map(always, from:mw_vals[:num_pairs])")
   for (int ip = 0; ip < num_pairs; ip++)
   {
-    REAL sum               = 0;
-    const REAL* dist       = mw_dist + ip * dist_stride;
-    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
-    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
-    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    MWREAL sum               = 0;
+    const MWREAL* dist       = mw_dist + ip * dist_stride;
+    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
+    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
+    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
     PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
     for (int j = 0; j < n_src; j++)
     {
-      const int ig       = grp_ids[j];
-      const REAL* coefs  = mw_coefs[ig];
-      REAL DeltaRInv     = mw_DeltaRInv[ig];
-      REAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig         = grp_ids[j];
+      const MWREAL* coefs  = mw_coefs[ig];
+      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
+      MWREAL cutoff_radius = mw_cutoff_radius[ig];
 
-      REAL r = dist[j];
+      MWREAL r = dist[j];
       if (j != ref_at[ip] && r < cutoff_radius)
       {
         r *= DeltaRInv;
-        REAL ipart;
-        const REAL t = std::modf(r, &ipart);
-        const int i  = (int)ipart;
+        MWREAL ipart;
+        const MWREAL t = std::modf(r, &ipart);
+        const int i    = (int)ipart;
         sum += coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3) + coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7) +
             coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11) +
             coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
@@ -183,36 +183,36 @@ void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
   }
 }
 
-template<typename REAL>
-void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
-                                        const std::vector<bool>& isAccepted,
-                                        const int num_groups,
-                                        const BsplineFunctor* const functors[],
-                                        const int n_src,
-                                        const int* grp_ids,
-                                        const int nw,
-                                        REAL* mw_vgl, // [nw][DIM+2]
-                                        const int n_padded,
-                                        const REAL* mw_dist, // [nw][DIM+1][n_padded]
-                                        REAL* mw_allUat,     // [nw][DIM+2][n_padded]
-                                        REAL* mw_cur_allu,   // [nw][3][n_padded]
-                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename MWREAL>
+void BsplineFunctor<MWREAL>::mw_updateVGL(const int iat,
+                                          const std::vector<bool>& isAccepted,
+                                          const int num_groups,
+                                          const BsplineFunctor* const functors[],
+                                          const int n_src,
+                                          const int* grp_ids,
+                                          const int nw,
+                                          MWREAL* mw_vgl, // [nw][DIM+2]
+                                          const int n_padded,
+                                          const MWREAL* mw_dist, // [nw][DIM+1][n_padded]
+                                          MWREAL* mw_allUat,     // [nw][DIM+2][n_padded]
+                                          MWREAL* mw_cur_allu,   // [nw][3][n_padded]
+                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
   const size_t dist_stride = n_padded * (DIM + 1);
 
   /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
+     * Bspline coefs device pointer sizeof(MWREAL*), DeltaRInv sizeof(MWREAL), cutoff_radius sizeof(MWREAL)
      * and packed accept list at most nw * sizeof(int)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups + nw * sizeof(int));
-  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
-  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
-  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups + nw * sizeof(int));
+  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
+  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
+  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   int* accepted_indices =
-      reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+      reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
 
   for (int ig = 0; ig < num_groups; ig++)
   {
@@ -235,62 +235,62 @@ void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
                     map(always, from: mw_allUat[:nw * n_padded * (DIM + 2)])")
   for (int iw = 0; iw < nw_accepted; iw++)
   {
-    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
-    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
-    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
+    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
+    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
     int* accepted_indices =
-        reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+        reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
     const int ip = accepted_indices[iw];
 
-    const REAL* dist_new   = mw_dist + ip * dist_stride;
-    const REAL* dipl_x_new = dist_new + n_padded;
-    const REAL* dipl_y_new = dist_new + n_padded * 2;
-    const REAL* dipl_z_new = dist_new + n_padded * 3;
+    const MWREAL* dist_new   = mw_dist + ip * dist_stride;
+    const MWREAL* dipl_x_new = dist_new + n_padded;
+    const MWREAL* dipl_y_new = dist_new + n_padded * 2;
+    const MWREAL* dipl_z_new = dist_new + n_padded * 3;
 
-    const REAL* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
-    const REAL* dipl_x_old = dist_old + n_padded;
-    const REAL* dipl_y_old = dist_old + n_padded * 2;
-    const REAL* dipl_z_old = dist_old + n_padded * 3;
+    const MWREAL* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
+    const MWREAL* dipl_x_old = dist_old + n_padded;
+    const MWREAL* dipl_y_old = dist_old + n_padded * 2;
+    const MWREAL* dipl_z_old = dist_old + n_padded * 3;
 
-    REAL* Uat    = mw_allUat + ip * n_padded;
-    REAL* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
-    REAL* dUat_y = dUat_x + n_padded;
-    REAL* dUat_z = dUat_y + n_padded;
-    REAL* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
+    MWREAL* Uat    = mw_allUat + ip * n_padded;
+    MWREAL* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
+    MWREAL* dUat_y = dUat_x + n_padded;
+    MWREAL* dUat_z = dUat_y + n_padded;
+    MWREAL* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
 
-    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+    MWREAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
     PRAGMA_OFFLOAD("omp parallel for")
     for (int j = 0; j < n_src; j++)
     {
       if (j == iat)
         continue;
-      const int ig       = grp_ids[j];
-      const REAL* coefs  = mw_coefs[ig];
-      REAL DeltaRInv     = mw_DeltaRInv[ig];
-      REAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig         = grp_ids[j];
+      const MWREAL* coefs  = mw_coefs[ig];
+      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
+      MWREAL cutoff_radius = mw_cutoff_radius[ig];
 
-      REAL r = dist_old[j];
-      REAL u(0);
-      REAL dudr(0);
-      REAL d2udr2(0);
+      MWREAL r = dist_old[j];
+      MWREAL u(0);
+      MWREAL dudr(0);
+      MWREAL d2udr2(0);
       if (r < cutoff_radius)
       {
         u = evaluate_impl(dist_old[j], coefs, DeltaRInv, dudr, d2udr2);
-        dudr *= REAL(1) / r;
+        dudr *= MWREAL(1) / r;
       }
       // update Uat, dUat, d2Uat
-      REAL cur_u      = cur_allu[j];
-      REAL cur_dudr   = cur_allu[j + n_padded];
-      REAL cur_d2udr2 = cur_allu[j + n_padded * 2];
+      MWREAL cur_u      = cur_allu[j];
+      MWREAL cur_dudr   = cur_allu[j + n_padded];
+      MWREAL cur_d2udr2 = cur_allu[j + n_padded * 2];
       Uat[j] += cur_u - u;
       dUat_x[j] -= dipl_x_new[j] * cur_dudr - dipl_x_old[j] * dudr;
       dUat_y[j] -= dipl_y_new[j] * cur_dudr - dipl_y_old[j] * dudr;
       dUat_z[j] -= dipl_z_new[j] * cur_dudr - dipl_z_old[j] * dudr;
-      constexpr REAL lapfac(DIM - 1);
+      constexpr MWREAL lapfac(DIM - 1);
       d2Uat[j] -= cur_d2udr2 + lapfac * cur_dudr - (d2udr2 + lapfac * dudr);
     }
-    REAL* vgl   = mw_vgl + ip * (DIM + 2);
+    MWREAL* vgl = mw_vgl + ip * (DIM + 2);
     Uat[iat]    = vgl[0];
     dUat_x[iat] = vgl[1];
     dUat_y[iat] = vgl[2];

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
@@ -24,16 +24,16 @@ namespace qmcplusplus
 {
 template<typename REAL>
 void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
-                                       const int num_groups,
-                                       const BsplineFunctor* const functors[],
-                                       const int n_src,
-                                       const int* grp_ids,
-                                       const int nw,
-                                       REAL* mw_vgl, // [nw][DIM+2]
-                                       const int n_padded,
-                                       const REAL* mw_dist, // [nw][DIM+1][n_padded]
-                                       REAL* mw_cur_allu,   // [nw][3][n_padded]
-                                       Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+                                          const int num_groups,
+                                          const BsplineFunctor* const functors[],
+                                          const int n_src,
+                                          const int* grp_ids,
+                                          const int nw,
+                                          REAL* mw_vgl, // [nw][DIM+2]
+                                          const int n_padded,
+                                          const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                          REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
@@ -85,7 +85,7 @@ void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
     {
       if (j == iat)
         continue;
-      const int ig    = grp_ids[j];
+      const int ig       = grp_ids[j];
       const REAL* coefs  = mw_coefs[ig];
       REAL DeltaRInv     = mw_DeltaRInv[ig];
       REAL cutoff_radius = mw_cutoff_radius[ig];
@@ -111,25 +111,25 @@ void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
     }
 
     REAL* vgl = mw_vgl + ip * (DIM + 2);
-    vgl[0] = val_sum;
-    vgl[1] = grad_x;
-    vgl[2] = grad_y;
-    vgl[3] = grad_z;
-    vgl[4] = -lapl;
+    vgl[0]    = val_sum;
+    vgl[1]    = grad_x;
+    vgl[2]    = grad_y;
+    vgl[3]    = grad_z;
+    vgl[4]    = -lapl;
   }
 }
 
 template<typename REAL>
 void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
-                                     const BsplineFunctor<REAL>* const functors[],
-                                     const int n_src,
-                                     const int* grp_ids,
-                                     const int num_pairs,
-                                     const int* ref_at,
-                                     const REAL* mw_dist,
-                                     const int dist_stride,
-                                     REAL* mw_vals,
-                                     Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+                                        const BsplineFunctor<REAL>* const functors[],
+                                        const int n_src,
+                                        const int* grp_ids,
+                                        const int num_pairs,
+                                        const int* ref_at,
+                                        const REAL* mw_dist,
+                                        const int dist_stride,
+                                        REAL* mw_vals,
+                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   /* transfer buffer used for
      * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
@@ -162,7 +162,7 @@ void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
     PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
     for (int j = 0; j < n_src; j++)
     {
-      const int ig    = grp_ids[j];
+      const int ig       = grp_ids[j];
       const REAL* coefs  = mw_coefs[ig];
       REAL DeltaRInv     = mw_DeltaRInv[ig];
       REAL cutoff_radius = mw_cutoff_radius[ig];
@@ -172,8 +172,8 @@ void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
       {
         r *= DeltaRInv;
         REAL ipart;
-        const REAL t   = std::modf(r, &ipart);
-        const int i = (int)ipart;
+        const REAL t = std::modf(r, &ipart);
+        const int i  = (int)ipart;
         sum += coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3) + coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7) +
             coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11) +
             coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
@@ -185,18 +185,18 @@ void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
 
 template<typename REAL>
 void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
-                                     const std::vector<bool>& isAccepted,
-                                     const int num_groups,
-                                     const BsplineFunctor* const functors[],
-                                     const int n_src,
-                                     const int* grp_ids,
-                                     const int nw,
-                                     REAL* mw_vgl, // [nw][DIM+2]
-                                     const int n_padded,
-                                     const REAL* mw_dist, // [nw][DIM+1][n_padded]
-                                     REAL* mw_allUat,     // [nw][DIM+2][n_padded]
-                                     REAL* mw_cur_allu,   // [nw][3][n_padded]
-                                     Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+                                        const std::vector<bool>& isAccepted,
+                                        const int num_groups,
+                                        const BsplineFunctor* const functors[],
+                                        const int n_src,
+                                        const int* grp_ids,
+                                        const int nw,
+                                        REAL* mw_vgl, // [nw][DIM+2]
+                                        const int n_padded,
+                                        const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                        REAL* mw_allUat,     // [nw][DIM+2][n_padded]
+                                        REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
@@ -211,7 +211,8 @@ void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
   REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
   REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
   REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
-  int* accepted_indices   = reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+  int* accepted_indices =
+      reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
 
   for (int ig = 0; ig < num_groups; ig++)
   {
@@ -234,11 +235,12 @@ void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
                     map(always, from: mw_allUat[:nw * n_padded * (DIM + 2)])")
   for (int iw = 0; iw < nw_accepted; iw++)
   {
-    REAL** mw_coefs          = reinterpret_cast<REAL**>(transfer_buffer_ptr);
-    REAL* mw_DeltaRInv       = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
-    REAL* mw_cutoff_radius   = mw_DeltaRInv + num_groups;
-    int* accepted_indices = reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
-    const int ip          = accepted_indices[iw];
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    int* accepted_indices =
+        reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+    const int ip = accepted_indices[iw];
 
     const REAL* dist_new   = mw_dist + ip * dist_stride;
     const REAL* dipl_x_new = dist_new + n_padded;
@@ -263,7 +265,7 @@ void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
     {
       if (j == iat)
         continue;
-      const int ig    = grp_ids[j];
+      const int ig       = grp_ids[j];
       const REAL* coefs  = mw_coefs[ig];
       REAL DeltaRInv     = mw_DeltaRInv[ig];
       REAL cutoff_radius = mw_cutoff_radius[ig];
@@ -288,7 +290,7 @@ void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
       constexpr REAL lapfac(DIM - 1);
       d2Uat[j] -= cur_d2udr2 + lapfac * cur_dudr - (d2udr2 + lapfac * dudr);
     }
-    REAL* vgl      = mw_vgl + ip * (DIM + 2);
+    REAL* vgl   = mw_vgl + ip * (DIM + 2);
     Uat[iat]    = vgl[0];
     dUat_x[iat] = vgl[1];
     dUat_y[iat] = vgl[2];

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
@@ -22,18 +22,18 @@
 
 namespace qmcplusplus
 {
-template<typename MWREAL>
-void BsplineFunctor<MWREAL>::mw_evaluateVGL(const int iat,
-                                            const int num_groups,
-                                            const BsplineFunctor* const functors[],
-                                            const int n_src,
-                                            const int* grp_ids,
-                                            const int nw,
-                                            MWREAL* mw_vgl, // [nw][DIM+2]
-                                            const int n_padded,
-                                            const MWREAL* mw_dist, // [nw][DIM+1][n_padded]
-                                            MWREAL* mw_cur_allu,   // [nw][3][n_padded]
-                                            Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
+                                          const int num_groups,
+                                          const BsplineFunctor* const functors[],
+                                          const int n_src,
+                                          const int* grp_ids,
+                                          const int nw,
+                                          REAL* mw_vgl, // [nw][DIM+2]
+                                          const int n_padded,
+                                          const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                          REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
@@ -43,10 +43,10 @@ void BsplineFunctor<MWREAL>::mw_evaluateVGL(const int iat,
      * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T) and cutoff_radius sizeof(T)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
-  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
-  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
-  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   for (int ig = 0; ig < num_groups; ig++)
   {
     mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
@@ -63,41 +63,41 @@ void BsplineFunctor<MWREAL>::mw_evaluateVGL(const int iat,
                     map(always, from: mw_vgl[:(DIM+2)*nw])")
   for (int ip = 0; ip < nw; ip++)
   {
-    MWREAL val_sum(0);
-    MWREAL grad_x(0);
-    MWREAL grad_y(0);
-    MWREAL grad_z(0);
-    MWREAL lapl(0);
+    REAL val_sum(0);
+    REAL grad_x(0);
+    REAL grad_y(0);
+    REAL grad_z(0);
+    REAL lapl(0);
 
-    const MWREAL* dist   = mw_dist + ip * dist_stride;
-    const MWREAL* dipl_x = dist + n_padded;
-    const MWREAL* dipl_y = dist + n_padded * 2;
-    const MWREAL* dipl_z = dist + n_padded * 3;
+    const REAL* dist   = mw_dist + ip * dist_stride;
+    const REAL* dipl_x = dist + n_padded;
+    const REAL* dipl_y = dist + n_padded * 2;
+    const REAL* dipl_z = dist + n_padded * 3;
 
-    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
-    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
-    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
 
-    MWREAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
     PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
     for (int j = 0; j < n_src; j++)
     {
       if (j == iat)
         continue;
-      const int ig         = grp_ids[j];
-      const MWREAL* coefs  = mw_coefs[ig];
-      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
-      MWREAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig       = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
 
-      MWREAL r = dist[j];
-      MWREAL u(0);
-      MWREAL dudr(0);
-      MWREAL d2udr2(0);
+      REAL r = dist[j];
+      REAL u(0);
+      REAL dudr(0);
+      REAL d2udr2(0);
       if (r < cutoff_radius)
       {
         u = evaluate_impl(dist[j], coefs, DeltaRInv, dudr, d2udr2);
-        dudr *= MWREAL(1) / r;
+        dudr *= REAL(1) / r;
       }
       // save u, dudr/r and d2udr2 to cur_allu
       cur_allu[j]                = u;
@@ -110,35 +110,35 @@ void BsplineFunctor<MWREAL>::mw_evaluateVGL(const int iat,
       grad_z += dudr * dipl_z[j];
     }
 
-    MWREAL* vgl = mw_vgl + ip * (DIM + 2);
-    vgl[0]      = val_sum;
-    vgl[1]      = grad_x;
-    vgl[2]      = grad_y;
-    vgl[3]      = grad_z;
-    vgl[4]      = -lapl;
+    REAL* vgl = mw_vgl + ip * (DIM + 2);
+    vgl[0]    = val_sum;
+    vgl[1]    = grad_x;
+    vgl[2]    = grad_y;
+    vgl[3]    = grad_z;
+    vgl[4]    = -lapl;
   }
 }
 
-template<typename MWREAL>
-void BsplineFunctor<MWREAL>::mw_evaluateV(const int num_groups,
-                                          const BsplineFunctor<MWREAL>* const functors[],
-                                          const int n_src,
-                                          const int* grp_ids,
-                                          const int num_pairs,
-                                          const int* ref_at,
-                                          const MWREAL* mw_dist,
-                                          const int dist_stride,
-                                          MWREAL* mw_vals,
-                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
+                                        const BsplineFunctor<REAL>* const functors[],
+                                        const int n_src,
+                                        const int* grp_ids,
+                                        const int num_pairs,
+                                        const int* ref_at,
+                                        const REAL* mw_dist,
+                                        const int dist_stride,
+                                        REAL* mw_vals,
+                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(MWREAL*), DeltaRInv sizeof(MWREAL), cutoff_radius sizeof(MWREAL)
+     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
-  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
-  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
-  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   for (int ig = 0; ig < num_groups; ig++)
   {
     mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
@@ -154,26 +154,26 @@ void BsplineFunctor<MWREAL>::mw_evaluateV(const int num_groups,
                     map(always, from:mw_vals[:num_pairs])")
   for (int ip = 0; ip < num_pairs; ip++)
   {
-    MWREAL sum               = 0;
-    const MWREAL* dist       = mw_dist + ip * dist_stride;
-    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
-    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
-    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    REAL sum               = 0;
+    const REAL* dist       = mw_dist + ip * dist_stride;
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
     PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
     for (int j = 0; j < n_src; j++)
     {
-      const int ig         = grp_ids[j];
-      const MWREAL* coefs  = mw_coefs[ig];
-      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
-      MWREAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig       = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
 
-      MWREAL r = dist[j];
+      REAL r = dist[j];
       if (j != ref_at[ip] && r < cutoff_radius)
       {
         r *= DeltaRInv;
-        MWREAL ipart;
-        const MWREAL t = std::modf(r, &ipart);
-        const int i    = (int)ipart;
+        REAL ipart;
+        const REAL t = std::modf(r, &ipart);
+        const int i  = (int)ipart;
         sum += coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3) + coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7) +
             coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11) +
             coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
@@ -183,36 +183,36 @@ void BsplineFunctor<MWREAL>::mw_evaluateV(const int num_groups,
   }
 }
 
-template<typename MWREAL>
-void BsplineFunctor<MWREAL>::mw_updateVGL(const int iat,
-                                          const std::vector<bool>& isAccepted,
-                                          const int num_groups,
-                                          const BsplineFunctor* const functors[],
-                                          const int n_src,
-                                          const int* grp_ids,
-                                          const int nw,
-                                          MWREAL* mw_vgl, // [nw][DIM+2]
-                                          const int n_padded,
-                                          const MWREAL* mw_dist, // [nw][DIM+1][n_padded]
-                                          MWREAL* mw_allUat,     // [nw][DIM+2][n_padded]
-                                          MWREAL* mw_cur_allu,   // [nw][3][n_padded]
-                                          Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
+                                        const std::vector<bool>& isAccepted,
+                                        const int num_groups,
+                                        const BsplineFunctor* const functors[],
+                                        const int n_src,
+                                        const int* grp_ids,
+                                        const int nw,
+                                        REAL* mw_vgl, // [nw][DIM+2]
+                                        const int n_padded,
+                                        const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                        REAL* mw_allUat,     // [nw][DIM+2][n_padded]
+                                        REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                        Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
 {
   constexpr unsigned DIM = OHMMS_DIM;
   static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
   const size_t dist_stride = n_padded * (DIM + 1);
 
   /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(MWREAL*), DeltaRInv sizeof(MWREAL), cutoff_radius sizeof(MWREAL)
+     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
      * and packed accept list at most nw * sizeof(int)
      * these contents change based on the group of the target particle, so it is prepared per call.
      */
-  transfer_buffer.resize((sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups + nw * sizeof(int));
-  MWREAL** mw_coefs_ptr        = reinterpret_cast<MWREAL**>(transfer_buffer.data());
-  MWREAL* mw_DeltaRInv_ptr     = reinterpret_cast<MWREAL*>(transfer_buffer.data() + sizeof(MWREAL*) * num_groups);
-  MWREAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups + nw * sizeof(int));
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
   int* accepted_indices =
-      reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
+      reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
 
   for (int ig = 0; ig < num_groups; ig++)
   {
@@ -235,62 +235,62 @@ void BsplineFunctor<MWREAL>::mw_updateVGL(const int iat,
                     map(always, from: mw_allUat[:nw * n_padded * (DIM + 2)])")
   for (int iw = 0; iw < nw_accepted; iw++)
   {
-    MWREAL** mw_coefs        = reinterpret_cast<MWREAL**>(transfer_buffer_ptr);
-    MWREAL* mw_DeltaRInv     = reinterpret_cast<MWREAL*>(transfer_buffer_ptr + sizeof(MWREAL*) * num_groups);
-    MWREAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
     int* accepted_indices =
-        reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(MWREAL*) + sizeof(MWREAL) * 2) * num_groups);
+        reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
     const int ip = accepted_indices[iw];
 
-    const MWREAL* dist_new   = mw_dist + ip * dist_stride;
-    const MWREAL* dipl_x_new = dist_new + n_padded;
-    const MWREAL* dipl_y_new = dist_new + n_padded * 2;
-    const MWREAL* dipl_z_new = dist_new + n_padded * 3;
+    const REAL* dist_new   = mw_dist + ip * dist_stride;
+    const REAL* dipl_x_new = dist_new + n_padded;
+    const REAL* dipl_y_new = dist_new + n_padded * 2;
+    const REAL* dipl_z_new = dist_new + n_padded * 3;
 
-    const MWREAL* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
-    const MWREAL* dipl_x_old = dist_old + n_padded;
-    const MWREAL* dipl_y_old = dist_old + n_padded * 2;
-    const MWREAL* dipl_z_old = dist_old + n_padded * 3;
+    const REAL* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
+    const REAL* dipl_x_old = dist_old + n_padded;
+    const REAL* dipl_y_old = dist_old + n_padded * 2;
+    const REAL* dipl_z_old = dist_old + n_padded * 3;
 
-    MWREAL* Uat    = mw_allUat + ip * n_padded;
-    MWREAL* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
-    MWREAL* dUat_y = dUat_x + n_padded;
-    MWREAL* dUat_z = dUat_y + n_padded;
-    MWREAL* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
+    REAL* Uat    = mw_allUat + ip * n_padded;
+    REAL* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
+    REAL* dUat_y = dUat_x + n_padded;
+    REAL* dUat_z = dUat_y + n_padded;
+    REAL* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
 
-    MWREAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
 
     PRAGMA_OFFLOAD("omp parallel for")
     for (int j = 0; j < n_src; j++)
     {
       if (j == iat)
         continue;
-      const int ig         = grp_ids[j];
-      const MWREAL* coefs  = mw_coefs[ig];
-      MWREAL DeltaRInv     = mw_DeltaRInv[ig];
-      MWREAL cutoff_radius = mw_cutoff_radius[ig];
+      const int ig       = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
 
-      MWREAL r = dist_old[j];
-      MWREAL u(0);
-      MWREAL dudr(0);
-      MWREAL d2udr2(0);
+      REAL r = dist_old[j];
+      REAL u(0);
+      REAL dudr(0);
+      REAL d2udr2(0);
       if (r < cutoff_radius)
       {
         u = evaluate_impl(dist_old[j], coefs, DeltaRInv, dudr, d2udr2);
-        dudr *= MWREAL(1) / r;
+        dudr *= REAL(1) / r;
       }
       // update Uat, dUat, d2Uat
-      MWREAL cur_u      = cur_allu[j];
-      MWREAL cur_dudr   = cur_allu[j + n_padded];
-      MWREAL cur_d2udr2 = cur_allu[j + n_padded * 2];
+      REAL cur_u      = cur_allu[j];
+      REAL cur_dudr   = cur_allu[j + n_padded];
+      REAL cur_d2udr2 = cur_allu[j + n_padded * 2];
       Uat[j] += cur_u - u;
       dUat_x[j] -= dipl_x_new[j] * cur_dudr - dipl_x_old[j] * dudr;
       dUat_y[j] -= dipl_y_new[j] * cur_dudr - dipl_y_old[j] * dudr;
       dUat_z[j] -= dipl_z_new[j] * cur_dudr - dipl_z_old[j] * dudr;
-      constexpr MWREAL lapfac(DIM - 1);
+      constexpr REAL lapfac(DIM - 1);
       d2Uat[j] -= cur_d2udr2 + lapfac * cur_dudr - (d2udr2 + lapfac * dudr);
     }
-    MWREAL* vgl = mw_vgl + ip * (DIM + 2);
+    REAL* vgl   = mw_vgl + ip * (DIM + 2);
     Uat[iat]    = vgl[0];
     dUat_x[iat] = vgl[1];
     dUat_y[iat] = vgl[2];

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.cpp
@@ -1,0 +1,302 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: John R. Gergely,  University of Illinois at Urbana-Champaign
+//                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//                    Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
+//                    Raymond Clay III, j.k.rofling@gmail.com, Lawrence Livermore National Laboratory
+//                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
+//                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Amrita Mathuriya, amrita.mathuriya@intel.com, Intel Corp.
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "BsplineFunctor.h"
+
+namespace qmcplusplus
+{
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_evaluateVGL(const int iat,
+                                       const int num_groups,
+                                       const BsplineFunctor* const functors[],
+                                       const int n_src,
+                                       const int* grp_ids,
+                                       const int nw,
+                                       REAL* mw_vgl, // [nw][DIM+2]
+                                       const int n_padded,
+                                       const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                       REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                       Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+{
+  constexpr unsigned DIM = OHMMS_DIM;
+  static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
+  const size_t dist_stride = n_padded * (DIM + 1);
+
+  /* transfer buffer used for
+     * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T) and cutoff_radius sizeof(T)
+     * these contents change based on the group of the target particle, so it is prepared per call.
+     */
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  for (int ig = 0; ig < num_groups; ig++)
+  {
+    mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
+    mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
+    mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
+  }
+
+  auto* transfer_buffer_ptr = transfer_buffer.data();
+
+  PRAGMA_OFFLOAD("omp target teams distribute map(always, to: transfer_buffer_ptr[:transfer_buffer.size()]) \
+                    map(to: grp_ids[:n_src]) \
+                    map(to: mw_dist[:dist_stride*nw]) \
+                    map(from: mw_cur_allu[:n_padded*3*nw]) \
+                    map(always, from: mw_vgl[:(DIM+2)*nw])")
+  for (int ip = 0; ip < nw; ip++)
+  {
+    REAL val_sum(0);
+    REAL grad_x(0);
+    REAL grad_y(0);
+    REAL grad_z(0);
+    REAL lapl(0);
+
+    const REAL* dist   = mw_dist + ip * dist_stride;
+    const REAL* dipl_x = dist + n_padded;
+    const REAL* dipl_y = dist + n_padded * 2;
+    const REAL* dipl_z = dist + n_padded * 3;
+
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+
+    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+
+    PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
+    for (int j = 0; j < n_src; j++)
+    {
+      if (j == iat)
+        continue;
+      const int ig    = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
+
+      REAL r = dist[j];
+      REAL u(0);
+      REAL dudr(0);
+      REAL d2udr2(0);
+      if (r < cutoff_radius)
+      {
+        u = evaluate_impl(dist[j], coefs, DeltaRInv, dudr, d2udr2);
+        dudr *= REAL(1) / r;
+      }
+      // save u, dudr/r and d2udr2 to cur_allu
+      cur_allu[j]                = u;
+      cur_allu[j + n_padded]     = dudr;
+      cur_allu[j + n_padded * 2] = d2udr2;
+      val_sum += u;
+      lapl += d2udr2 + (DIM - 1) * dudr;
+      grad_x += dudr * dipl_x[j];
+      grad_y += dudr * dipl_y[j];
+      grad_z += dudr * dipl_z[j];
+    }
+
+    REAL* vgl = mw_vgl + ip * (DIM + 2);
+    vgl[0] = val_sum;
+    vgl[1] = grad_x;
+    vgl[2] = grad_y;
+    vgl[3] = grad_z;
+    vgl[4] = -lapl;
+  }
+}
+
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_evaluateV(const int num_groups,
+                                     const BsplineFunctor<REAL>* const functors[],
+                                     const int n_src,
+                                     const int* grp_ids,
+                                     const int num_pairs,
+                                     const int* ref_at,
+                                     const REAL* mw_dist,
+                                     const int dist_stride,
+                                     REAL* mw_vals,
+                                     Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+{
+  /* transfer buffer used for
+     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
+     * these contents change based on the group of the target particle, so it is prepared per call.
+     */
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  for (int ig = 0; ig < num_groups; ig++)
+  {
+    mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
+    mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
+    mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
+  }
+
+  auto* transfer_buffer_ptr = transfer_buffer.data();
+
+  PRAGMA_OFFLOAD("omp target teams distribute map(always, to:transfer_buffer_ptr[:transfer_buffer.size()]) \
+                    map(to: grp_ids[:n_src]) \
+                    map(to:ref_at[:num_pairs], mw_dist[:dist_stride*num_pairs]) \
+                    map(always, from:mw_vals[:num_pairs])")
+  for (int ip = 0; ip < num_pairs; ip++)
+  {
+    REAL sum               = 0;
+    const REAL* dist       = mw_dist + ip * dist_stride;
+    REAL** mw_coefs        = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv     = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius = mw_DeltaRInv + num_groups;
+    PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
+    for (int j = 0; j < n_src; j++)
+    {
+      const int ig    = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
+
+      REAL r = dist[j];
+      if (j != ref_at[ip] && r < cutoff_radius)
+      {
+        r *= DeltaRInv;
+        REAL ipart;
+        const REAL t   = std::modf(r, &ipart);
+        const int i = (int)ipart;
+        sum += coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3) + coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7) +
+            coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11) +
+            coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
+      }
+    }
+    mw_vals[ip] = sum;
+  }
+}
+
+template<typename REAL>
+void BsplineFunctor<REAL>::mw_updateVGL(const int iat,
+                                     const std::vector<bool>& isAccepted,
+                                     const int num_groups,
+                                     const BsplineFunctor* const functors[],
+                                     const int n_src,
+                                     const int* grp_ids,
+                                     const int nw,
+                                     REAL* mw_vgl, // [nw][DIM+2]
+                                     const int n_padded,
+                                     const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                                     REAL* mw_allUat,     // [nw][DIM+2][n_padded]
+                                     REAL* mw_cur_allu,   // [nw][3][n_padded]
+                                     Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
+{
+  constexpr unsigned DIM = OHMMS_DIM;
+  static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
+  const size_t dist_stride = n_padded * (DIM + 1);
+
+  /* transfer buffer used for
+     * Bspline coefs device pointer sizeof(REAL*), DeltaRInv sizeof(REAL), cutoff_radius sizeof(REAL)
+     * and packed accept list at most nw * sizeof(int)
+     * these contents change based on the group of the target particle, so it is prepared per call.
+     */
+  transfer_buffer.resize((sizeof(REAL*) + sizeof(REAL) * 2) * num_groups + nw * sizeof(int));
+  REAL** mw_coefs_ptr        = reinterpret_cast<REAL**>(transfer_buffer.data());
+  REAL* mw_DeltaRInv_ptr     = reinterpret_cast<REAL*>(transfer_buffer.data() + sizeof(REAL*) * num_groups);
+  REAL* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
+  int* accepted_indices   = reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+
+  for (int ig = 0; ig < num_groups; ig++)
+  {
+    mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
+    mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
+    mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
+  }
+
+  int nw_accepted = 0;
+  for (int iw = 0; iw < nw; iw++)
+    if (isAccepted[iw])
+      accepted_indices[nw_accepted++] = iw;
+
+  auto* transfer_buffer_ptr = transfer_buffer.data();
+
+  PRAGMA_OFFLOAD("omp target teams distribute map(always, to: transfer_buffer_ptr[:transfer_buffer.size()]) \
+                    map(to: grp_ids[:n_src]) \
+                    map(to: mw_dist[:dist_stride*nw]) \
+                    map(to: mw_vgl[:(DIM+2)*nw]) \
+                    map(always, from: mw_allUat[:nw * n_padded * (DIM + 2)])")
+  for (int iw = 0; iw < nw_accepted; iw++)
+  {
+    REAL** mw_coefs          = reinterpret_cast<REAL**>(transfer_buffer_ptr);
+    REAL* mw_DeltaRInv       = reinterpret_cast<REAL*>(transfer_buffer_ptr + sizeof(REAL*) * num_groups);
+    REAL* mw_cutoff_radius   = mw_DeltaRInv + num_groups;
+    int* accepted_indices = reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(REAL*) + sizeof(REAL) * 2) * num_groups);
+    const int ip          = accepted_indices[iw];
+
+    const REAL* dist_new   = mw_dist + ip * dist_stride;
+    const REAL* dipl_x_new = dist_new + n_padded;
+    const REAL* dipl_y_new = dist_new + n_padded * 2;
+    const REAL* dipl_z_new = dist_new + n_padded * 3;
+
+    const REAL* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
+    const REAL* dipl_x_old = dist_old + n_padded;
+    const REAL* dipl_y_old = dist_old + n_padded * 2;
+    const REAL* dipl_z_old = dist_old + n_padded * 3;
+
+    REAL* Uat    = mw_allUat + ip * n_padded;
+    REAL* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
+    REAL* dUat_y = dUat_x + n_padded;
+    REAL* dUat_z = dUat_y + n_padded;
+    REAL* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
+
+    REAL* cur_allu = mw_cur_allu + ip * n_padded * 3;
+
+    PRAGMA_OFFLOAD("omp parallel for")
+    for (int j = 0; j < n_src; j++)
+    {
+      if (j == iat)
+        continue;
+      const int ig    = grp_ids[j];
+      const REAL* coefs  = mw_coefs[ig];
+      REAL DeltaRInv     = mw_DeltaRInv[ig];
+      REAL cutoff_radius = mw_cutoff_radius[ig];
+
+      REAL r = dist_old[j];
+      REAL u(0);
+      REAL dudr(0);
+      REAL d2udr2(0);
+      if (r < cutoff_radius)
+      {
+        u = evaluate_impl(dist_old[j], coefs, DeltaRInv, dudr, d2udr2);
+        dudr *= REAL(1) / r;
+      }
+      // update Uat, dUat, d2Uat
+      REAL cur_u      = cur_allu[j];
+      REAL cur_dudr   = cur_allu[j + n_padded];
+      REAL cur_d2udr2 = cur_allu[j + n_padded * 2];
+      Uat[j] += cur_u - u;
+      dUat_x[j] -= dipl_x_new[j] * cur_dudr - dipl_x_old[j] * dudr;
+      dUat_y[j] -= dipl_y_new[j] * cur_dudr - dipl_y_old[j] * dudr;
+      dUat_z[j] -= dipl_z_new[j] * cur_dudr - dipl_z_old[j] * dudr;
+      constexpr REAL lapfac(DIM - 1);
+      d2Uat[j] -= cur_d2udr2 + lapfac * cur_dudr - (d2udr2 + lapfac * dudr);
+    }
+    REAL* vgl      = mw_vgl + ip * (DIM + 2);
+    Uat[iat]    = vgl[0];
+    dUat_x[iat] = vgl[1];
+    dUat_y[iat] = vgl[2];
+    dUat_z[iat] = vgl[3];
+    d2Uat[iat]  = vgl[4];
+  }
+}
+
+template struct BsplineFunctor<QMCTraits::RealType>;
+
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: John R. Gergely,  University of Illinois at Urbana-Champaign
 //                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
@@ -13,6 +13,7 @@
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
 //                    Amrita Mathuriya, amrita.mathuriya@intel.com, Intel Corp.
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Lab
 //
 // File created by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -30,44 +31,43 @@
 #include "Numerics/LinearFit.h"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 
-
 namespace qmcplusplus
 {
-template<class T>
+template<typename REAL>
 struct BsplineFunctor : public OptimizableFunctorBase
 {
-  using value_type = real_type;
+  using Value = REAL; // while there is a value type referenced it was set to real
+  using Real = REAL;
+  static constexpr Real A0 = -1.0 / 6.0, A1 = 3.0 / 6.0, A2 = -3.0 / 6.0, A3 = 1.0 / 6.0;
+  static constexpr Real A4 = 3.0 / 6.0, A5 = -6.0 / 6.0, A6 = 0.0 / 6.0, A7 = 4.0 / 6.0;
+  static constexpr Real A8 = -3.0 / 6.0, A9 = 3.0 / 6.0, A10 = 3.0 / 6.0, A11 = 1.0 / 6.0;
+  static constexpr Real A12 = 1.0 / 6.0, A13 = 0.0 / 6.0, A14 = 0.0 / 6.0, A15 = 0.0 / 6.0;
 
-  static constexpr real_type A0 = -1.0 / 6.0, A1 = 3.0 / 6.0, A2 = -3.0 / 6.0, A3 = 1.0 / 6.0;
-  static constexpr real_type A4 = 3.0 / 6.0, A5 = -6.0 / 6.0, A6 = 0.0 / 6.0, A7 = 4.0 / 6.0;
-  static constexpr real_type A8 = -3.0 / 6.0, A9 = 3.0 / 6.0, A10 = 3.0 / 6.0, A11 = 1.0 / 6.0;
-  static constexpr real_type A12 = 1.0 / 6.0, A13 = 0.0 / 6.0, A14 = 0.0 / 6.0, A15 = 0.0 / 6.0;
+  static constexpr Real dA0 = 0.0, dA1 = -0.5, dA2 = 1.0, dA3 = -0.5;
+  static constexpr Real dA4 = 0.0, dA5 = 1.5, dA6 = -2.0, dA7 = 0.0;
+  static constexpr Real dA8 = 0.0, dA9 = -1.5, dA10 = 1.0, dA11 = 0.5;
+  static constexpr Real dA12 = 0.0, dA13 = 0.5, dA14 = 0.0, dA15 = 0.0;
 
-  static constexpr real_type dA0 = 0.0, dA1 = -0.5, dA2 = 1.0, dA3 = -0.5;
-  static constexpr real_type dA4 = 0.0, dA5 = 1.5, dA6 = -2.0, dA7 = 0.0;
-  static constexpr real_type dA8 = 0.0, dA9 = -1.5, dA10 = 1.0, dA11 = 0.5;
-  static constexpr real_type dA12 = 0.0, dA13 = 0.5, dA14 = 0.0, dA15 = 0.0;
+  static constexpr Real d2A0 = 0.0, d2A1 = 0.0, d2A2 = -1.0, d2A3 = 1.0;
+  static constexpr Real d2A4 = 0.0, d2A5 = 0.0, d2A6 = 3.0, d2A7 = -2.0;
+  static constexpr Real d2A8 = 0.0, d2A9 = 0.0, d2A10 = -3.0, d2A11 = 1.0;
+  static constexpr Real d2A12 = 0.0, d2A13 = 0.0, d2A14 = 1.0, d2A15 = 0.0;
 
-  static constexpr real_type d2A0 = 0.0, d2A1 = 0.0, d2A2 = -1.0, d2A3 = 1.0;
-  static constexpr real_type d2A4 = 0.0, d2A5 = 0.0, d2A6 = 3.0, d2A7 = -2.0;
-  static constexpr real_type d2A8 = 0.0, d2A9 = 0.0, d2A10 = -3.0, d2A11 = 1.0;
-  static constexpr real_type d2A12 = 0.0, d2A13 = 0.0, d2A14 = 1.0, d2A15 = 0.0;
+  static constexpr Real d3A0 = 0.0, d3A1 = 0.0, d3A2 = 0.0, d3A3 = -1.0;
+  static constexpr Real d3A4 = 0.0, d3A5 = 0.0, d3A6 = 0.0, d3A7 = 3.0;
+  static constexpr Real d3A8 = 0.0, d3A9 = 0.0, d3A10 = 0.0, d3A11 = -3.0;
+  static constexpr Real d3A12 = 0.0, d3A13 = 0.0, d3A14 = 0.0, d3A15 = 1.0;
 
-  static constexpr real_type d3A0 = 0.0, d3A1 = 0.0, d3A2 = 0.0, d3A3 = -1.0;
-  static constexpr real_type d3A4 = 0.0, d3A5 = 0.0, d3A6 = 0.0, d3A7 = 3.0;
-  static constexpr real_type d3A8 = 0.0, d3A9 = 0.0, d3A10 = 0.0, d3A11 = -3.0;
-  static constexpr real_type d3A12 = 0.0, d3A13 = 0.0, d3A14 = 0.0, d3A15 = 1.0;
-
-  std::shared_ptr<Vector<real_type, OffloadAllocator<value_type>>> spline_coefs_;
+  std::shared_ptr<Vector<Real, OffloadAllocator<Real>>> spline_coefs_;
 
   int NumParams;
-  real_type DeltaR, DeltaRInv;
-  real_type CuspValue;
-  real_type Y, dY, d2Y;
+  Real DeltaR, DeltaRInv;
+  Real CuspValue;
+  Real Y, dY, d2Y;
   // Stores the derivatives w.r.t. coefs
   // of the u, du/dr, and d2u/dr2
-  std::vector<TinyVector<real_type, 3>> SplineDerivs;
-  std::vector<real_type> Parameters;
+  std::vector<TinyVector<Real, 3>> SplineDerivs;
+  std::vector<Real> Parameters;
   std::vector<std::string> ParameterNames;
   std::string elementType, pairType;
   std::string fileName;
@@ -76,14 +76,14 @@ struct BsplineFunctor : public OptimizableFunctorBase
   bool periodic;
 
   ///constructor
-  BsplineFunctor(real_type cusp = 0.0) : NumParams(0), CuspValue(cusp), notOpt(false), periodic(true)
+  BsplineFunctor(Real cusp = 0.0) : NumParams(0), CuspValue(cusp), notOpt(false), periodic(true)
   {
     cutoff_radius = 0.0;
   }
 
   OptimizableFunctorBase* makeClone() const override { return new BsplineFunctor(*this); }
 
-  void setCusp(real_type c) override { CuspValue = c; }
+  void setCusp(Real c) override { CuspValue = c; }
 
   void setPeriodic(bool p) override { periodic = p; }
 
@@ -92,10 +92,10 @@ struct BsplineFunctor : public OptimizableFunctorBase
     NumParams    = n;
     int numCoefs = NumParams + 4;
     int numKnots = numCoefs - 2;
-    DeltaR       = cutoff_radius / (real_type)(numKnots - 1);
+    DeltaR       = cutoff_radius / (Real)(numKnots - 1);
     DeltaRInv    = 1.0 / DeltaR;
     Parameters.resize(n);
-    spline_coefs_ = std::make_shared<Vector<real_type, OffloadAllocator<value_type>>>(numCoefs);
+    spline_coefs_ = std::make_shared<Vector<Real, OffloadAllocator<Real>>>(numCoefs);
     SplineDerivs.resize(numCoefs);
   }
 
@@ -105,7 +105,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
   {
     const int numCoefs = NumParams + 4;
     const int numKnots = numCoefs - 2;
-    DeltaR             = cutoff_radius / (real_type)(numKnots - 1);
+    DeltaR             = cutoff_radius / (Real)(numKnots - 1);
     DeltaRInv          = 1.0 / DeltaR;
     auto& coefs        = *spline_coefs_;
     for (int i = 0; i < coefs.size(); i++)
@@ -133,11 +133,11 @@ struct BsplineFunctor : public OptimizableFunctorBase
   void evaluateVGL(const int iat,
                    const int iStart,
                    const int iEnd,
-                   const T* _distArray,
-                   T* restrict _valArray,
-                   T* restrict _gradArray,
-                   T* restrict _laplArray,
-                   T* restrict distArrayCompressed,
+                   const REAL* _distArray,
+                   REAL* restrict _valArray,
+                   REAL* restrict _gradArray,
+                   REAL* restrict _laplArray,
+                   REAL* restrict distArrayCompressed,
                    int* restrict distIndices) const;
 
   /** compute value, gradient and laplacian for target particles
@@ -164,94 +164,11 @@ struct BsplineFunctor : public OptimizableFunctorBase
                              const int n_src,
                              const int* grp_ids,
                              const int nw,
-                             T* mw_vgl, // [nw][DIM+2]
+                             REAL* mw_vgl, // [nw][DIM+2]
                              const int n_padded,
-                             const T* mw_dist, // [nw][DIM+1][n_padded]
-                             T* mw_cur_allu,   // [nw][3][n_padded]
-                             Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
-  {
-    constexpr unsigned DIM = OHMMS_DIM;
-    static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
-    const size_t dist_stride = n_padded * (DIM + 1);
-
-    /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T) and cutoff_radius sizeof(T)
-     * these contents change based on the group of the target particle, so it is prepared per call.
-     */
-    transfer_buffer.resize((sizeof(T*) + sizeof(T) * 2) * num_groups);
-    T** mw_coefs_ptr        = reinterpret_cast<T**>(transfer_buffer.data());
-    T* mw_DeltaRInv_ptr     = reinterpret_cast<T*>(transfer_buffer.data() + sizeof(T*) * num_groups);
-    T* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
-    for (int ig = 0; ig < num_groups; ig++)
-    {
-      mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
-      mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
-      mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
-    }
-
-    auto* transfer_buffer_ptr = transfer_buffer.data();
-
-    PRAGMA_OFFLOAD("omp target teams distribute map(always, to: transfer_buffer_ptr[:transfer_buffer.size()]) \
-                    map(to: grp_ids[:n_src]) \
-                    map(to: mw_dist[:dist_stride*nw]) \
-                    map(from: mw_cur_allu[:n_padded*3*nw]) \
-                    map(always, from: mw_vgl[:(DIM+2)*nw])")
-    for (int ip = 0; ip < nw; ip++)
-    {
-      T val_sum(0);
-      T grad_x(0);
-      T grad_y(0);
-      T grad_z(0);
-      T lapl(0);
-
-      const T* dist   = mw_dist + ip * dist_stride;
-      const T* dipl_x = dist + n_padded;
-      const T* dipl_y = dist + n_padded * 2;
-      const T* dipl_z = dist + n_padded * 3;
-
-      T** mw_coefs        = reinterpret_cast<T**>(transfer_buffer_ptr);
-      T* mw_DeltaRInv     = reinterpret_cast<T*>(transfer_buffer_ptr + sizeof(T*) * num_groups);
-      T* mw_cutoff_radius = mw_DeltaRInv + num_groups;
-
-      T* cur_allu = mw_cur_allu + ip * n_padded * 3;
-
-      PRAGMA_OFFLOAD("omp parallel for reduction(+: val_sum, grad_x, grad_y, grad_z, lapl)")
-      for (int j = 0; j < n_src; j++)
-      {
-        if (j == iat) continue;
-        const int ig    = grp_ids[j];
-        const T* coefs  = mw_coefs[ig];
-        T DeltaRInv     = mw_DeltaRInv[ig];
-        T cutoff_radius = mw_cutoff_radius[ig];
-
-        T r = dist[j];
-        T u(0);
-        T dudr(0);
-        T d2udr2(0);
-        if (r < cutoff_radius)
-        {
-          u = evaluate_impl(dist[j], coefs, DeltaRInv, dudr, d2udr2);
-          dudr *= T(1) / r;
-        }
-        // save u, dudr/r and d2udr2 to cur_allu
-        cur_allu[j]                = u;
-        cur_allu[j + n_padded]     = dudr;
-        cur_allu[j + n_padded * 2] = d2udr2;
-        val_sum += u;
-        lapl += d2udr2 + (DIM - 1) * dudr;
-        grad_x += dudr * dipl_x[j];
-        grad_y += dudr * dipl_y[j];
-        grad_z += dudr * dipl_z[j];
-      }
-
-      T* vgl = mw_vgl + ip * (DIM + 2);
-      vgl[0] = val_sum;
-      vgl[1] = grad_x;
-      vgl[2] = grad_y;
-      vgl[3] = grad_z;
-      vgl[4] = -lapl;
-    }
-  }
+                             const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                             REAL* mw_cur_allu,   // [nw][3][n_padded]
+                             Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer);
 
   /** evaluate sum of the pair potentials for [iStart,iEnd)
    * @param iat dummy
@@ -261,11 +178,11 @@ struct BsplineFunctor : public OptimizableFunctorBase
    * @param distArrayCompressed temp storage to filter r_j < cutoff_radius
    * @return \f$\sum u(r_j)\f$ for r_j < cutoff_radius
    */
-  T evaluateV(const int iat,
+  REAL evaluateV(const int iat,
               const int iStart,
               const int iEnd,
-              const T* restrict _distArray,
-              T* restrict distArrayCompressed) const;
+              const REAL* restrict _distArray,
+              REAL* restrict distArrayCompressed) const;
 
   /** compute value for target-source particle pair potentials
    * This more than just a batched call of evaluateV
@@ -288,107 +205,54 @@ struct BsplineFunctor : public OptimizableFunctorBase
                            const int* grp_ids,
                            const int num_pairs,
                            const int* ref_at,
-                           const T* mw_dist,
+                           const REAL* mw_dist,
                            const int dist_stride,
-                           T* mw_vals,
-                           Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
-  {
-    /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T), cutoff_radius sizeof(T)
-     * these contents change based on the group of the target particle, so it is prepared per call.
-     */
-    transfer_buffer.resize((sizeof(T*) + sizeof(T) * 2) * num_groups);
-    T** mw_coefs_ptr        = reinterpret_cast<T**>(transfer_buffer.data());
-    T* mw_DeltaRInv_ptr     = reinterpret_cast<T*>(transfer_buffer.data() + sizeof(T*) * num_groups);
-    T* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
-    for (int ig = 0; ig < num_groups; ig++)
-    {
-      mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
-      mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
-      mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
-    }
+                           REAL* mw_vals,
+                           Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer);
 
-    auto* transfer_buffer_ptr = transfer_buffer.data();
-
-    PRAGMA_OFFLOAD("omp target teams distribute map(always, to:transfer_buffer_ptr[:transfer_buffer.size()]) \
-                    map(to: grp_ids[:n_src]) \
-                    map(to:ref_at[:num_pairs], mw_dist[:dist_stride*num_pairs]) \
-                    map(always, from:mw_vals[:num_pairs])")
-    for (int ip = 0; ip < num_pairs; ip++)
-    {
-      T sum               = 0;
-      const T* dist       = mw_dist + ip * dist_stride;
-      T** mw_coefs        = reinterpret_cast<T**>(transfer_buffer_ptr);
-      T* mw_DeltaRInv     = reinterpret_cast<T*>(transfer_buffer_ptr + sizeof(T*) * num_groups);
-      T* mw_cutoff_radius = mw_DeltaRInv + num_groups;
-      PRAGMA_OFFLOAD("omp parallel for reduction(+: sum)")
-      for (int j = 0; j < n_src; j++)
-      {
-        const int ig    = grp_ids[j];
-        const T* coefs  = mw_coefs[ig];
-        T DeltaRInv     = mw_DeltaRInv[ig];
-        T cutoff_radius = mw_cutoff_radius[ig];
-
-        T r = dist[j];
-        if (j != ref_at[ip] && r < cutoff_radius)
-        {
-          r *= DeltaRInv;
-          T ipart;
-          const T t   = std::modf(r, &ipart);
-          const int i = (int)ipart;
-          sum += coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3) +
-              coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7) +
-              coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11) +
-              coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
-        }
-      }
-      mw_vals[ip] = sum;
-    }
-  }
-
-  inline static real_type evaluate_impl(real_type r, const real_type* coefs, const real_type DeltaRInv)
+  inline static Real evaluate_impl(Real r, const Real* coefs, const Real DeltaRInv)
   {
     r *= DeltaRInv;
-    T ipart;
-    const T t   = std::modf(r, &ipart);
+    REAL ipart;
+    const REAL t   = std::modf(r, &ipart);
     const int i = (int)ipart;
 
-    real_type sCoef0 = coefs[i + 0];
-    real_type sCoef1 = coefs[i + 1];
-    real_type sCoef2 = coefs[i + 2];
-    real_type sCoef3 = coefs[i + 3];
+    Real sCoef0 = coefs[i + 0];
+    Real sCoef1 = coefs[i + 1];
+    Real sCoef2 = coefs[i + 2];
+    Real sCoef3 = coefs[i + 3];
 
     return (sCoef0 * (((A0 * t + A1) * t + A2) * t + A3) + sCoef1 * (((A4 * t + A5) * t + A6) * t + A7) +
             sCoef2 * (((A8 * t + A9) * t + A10) * t + A11) + sCoef3 * (((A12 * t + A13) * t + A14) * t + A15));
   }
 
-  inline real_type evaluate(real_type r) const
+  inline Real evaluate(Real r) const
   {
-    real_type u(0);
+    Real u(0);
     if (r < cutoff_radius)
       u = evaluate_impl(r, spline_coefs_->data(), DeltaRInv);
     return u;
   }
 
-  inline real_type evaluate(real_type r, real_type rinv) { return Y = evaluate(r, dY, d2Y); }
+  inline Real evaluate(Real r, Real rinv) { return Y = evaluate(r, dY, d2Y); }
 
-  inline void evaluateAll(real_type r, real_type rinv) { Y = evaluate(r, dY, d2Y); }
+  inline void evaluateAll(Real r, Real rinv) { Y = evaluate(r, dY, d2Y); }
 
-  inline static real_type evaluate_impl(real_type r,
-                                        const real_type* coefs,
-                                        const real_type DeltaRInv,
-                                        real_type& dudr,
-                                        real_type& d2udr2)
+  inline static Real evaluate_impl(Real r,
+                                        const Real* coefs,
+                                        const Real DeltaRInv,
+                                        Real& dudr,
+                                        Real& d2udr2)
   {
     r *= DeltaRInv;
-    T ipart;
-    const T t   = std::modf(r, &ipart);
+    REAL ipart;
+    const REAL t   = std::modf(r, &ipart);
     const int i = (int)ipart;
 
-    real_type sCoef0 = coefs[i + 0];
-    real_type sCoef1 = coefs[i + 1];
-    real_type sCoef2 = coefs[i + 2];
-    real_type sCoef3 = coefs[i + 3];
+    Real sCoef0 = coefs[i + 0];
+    Real sCoef1 = coefs[i + 1];
+    Real sCoef2 = coefs[i + 2];
+    Real sCoef3 = coefs[i + 3];
 
     d2udr2 = DeltaRInv * DeltaRInv *
         (sCoef0 * (d2A2 * t + d2A3) + sCoef1 * (d2A6 * t + d2A7) + sCoef2 * (d2A10 * t + d2A11) +
@@ -398,16 +262,16 @@ struct BsplineFunctor : public OptimizableFunctorBase
         (sCoef0 * ((dA1 * t + dA2) * t + dA3) + sCoef1 * ((dA5 * t + dA6) * t + dA7) +
          sCoef2 * ((dA9 * t + dA10) * t + dA11) + sCoef3 * ((dA13 * t + dA14) * t + dA15));
 
-    real_type u = (sCoef0 * (((A0 * t + A1) * t + A2) * t + A3) + sCoef1 * (((A4 * t + A5) * t + A6) * t + A7) +
+    Real u = (sCoef0 * (((A0 * t + A1) * t + A2) * t + A3) + sCoef1 * (((A4 * t + A5) * t + A6) * t + A7) +
                    sCoef2 * (((A8 * t + A9) * t + A10) * t + A11) + sCoef3 * (((A12 * t + A13) * t + A14) * t + A15));
     return u;
   }
 
-  inline real_type evaluate(real_type r, real_type& dudr, real_type& d2udr2)
+  inline Real evaluate(Real r, Real& dudr, Real& d2udr2)
   {
-    real_type u(0);
-    dudr   = real_type(0);
-    d2udr2 = real_type(0);
+    Real u(0);
+    dudr   = Real(0);
+    d2udr2 = Real(0);
 
     if (r < cutoff_radius)
       u = evaluate_impl(r, spline_coefs_->data(), DeltaRInv, dudr, d2udr2);
@@ -415,25 +279,25 @@ struct BsplineFunctor : public OptimizableFunctorBase
   }
 
 
-  inline real_type evaluate(real_type r, real_type& dudr, real_type& d2udr2, real_type& d3udr3)
+  inline Real evaluate(Real r, Real& dudr, Real& d2udr2, Real& d3udr3)
   {
     if (r >= cutoff_radius)
     {
       dudr = d2udr2 = d3udr3 = 0.0;
       return 0.0;
     }
-    // real_type eps = 1.0e-5;
-    //       real_type dudr_FD = (evaluate(r+eps)-evaluate(r-eps))/(2.0*eps);
-    //       real_type d2udr2_FD = (evaluate(r+eps)+evaluate(r-eps)-2.0*evaluate(r))/(eps*eps);
-    // real_type d3udr3_FD = (-1.0*evaluate(r+1.0*eps)
+    // Real eps = 1.0e-5;
+    //       Real dudr_FD = (evaluate(r+eps)-evaluate(r-eps))/(2.0*eps);
+    //       Real d2udr2_FD = (evaluate(r+eps)+evaluate(r-eps)-2.0*evaluate(r))/(eps*eps);
+    // Real d3udr3_FD = (-1.0*evaluate(r+1.0*eps)
     //         +2.0*evaluate(r+0.5*eps)
     //         -2.0*evaluate(r-0.5*eps)
     //         +1.0*evaluate(r-1.0*eps))/(eps*eps*eps);
     r *= DeltaRInv;
-    real_type ipart, t;
+    Real ipart, t;
     t     = std::modf(r, &ipart);
     int i = (int)ipart;
-    real_type tp[4];
+    Real tp[4];
     tp[0]       = t * t * t;
     tp[1]       = t * t;
     tp[2]       = t;
@@ -495,128 +359,29 @@ struct BsplineFunctor : public OptimizableFunctorBase
                            const int n_src,
                            const int* grp_ids,
                            const int nw,
-                           T* mw_vgl, // [nw][DIM+2]
+                           REAL* mw_vgl, // [nw][DIM+2]
                            const int n_padded,
-                           const T* mw_dist, // [nw][DIM+1][n_padded]
-                           T* mw_allUat,     // [nw][DIM+2][n_padded]
-                           T* mw_cur_allu,   // [nw][3][n_padded]
-                           Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer)
-  {
-    constexpr unsigned DIM = OHMMS_DIM;
-    static_assert(DIM == 3, "only support 3D due to explicit x,y,z coded.");
-    const size_t dist_stride = n_padded * (DIM + 1);
+                           const REAL* mw_dist, // [nw][DIM+1][n_padded]
+                           REAL* mw_allUat,     // [nw][DIM+2][n_padded]
+                           REAL* mw_cur_allu,   // [nw][3][n_padded]
+                           Vector<char, OffloadPinnedAllocator<char>>& transfer_buffer);
 
-    /* transfer buffer used for
-     * Bspline coefs device pointer sizeof(T*), DeltaRInv sizeof(T), cutoff_radius sizeof(T)
-     * and packed accept list at most nw * sizeof(int)
-     * these contents change based on the group of the target particle, so it is prepared per call.
-     */
-    transfer_buffer.resize((sizeof(T*) + sizeof(T) * 2) * num_groups + nw * sizeof(int));
-    T** mw_coefs_ptr        = reinterpret_cast<T**>(transfer_buffer.data());
-    T* mw_DeltaRInv_ptr     = reinterpret_cast<T*>(transfer_buffer.data() + sizeof(T*) * num_groups);
-    T* mw_cutoff_radius_ptr = mw_DeltaRInv_ptr + num_groups;
-    int* accepted_indices = reinterpret_cast<int*>(transfer_buffer.data() + (sizeof(T*) + sizeof(T) * 2) * num_groups);
-
-    for (int ig = 0; ig < num_groups; ig++)
-    {
-      mw_coefs_ptr[ig]         = functors[ig]->spline_coefs_->device_data();
-      mw_DeltaRInv_ptr[ig]     = functors[ig]->DeltaRInv;
-      mw_cutoff_radius_ptr[ig] = functors[ig]->cutoff_radius;
-    }
-
-    int nw_accepted = 0;
-    for (int iw = 0; iw < nw; iw++)
-      if (isAccepted[iw])
-        accepted_indices[nw_accepted++] = iw;
-
-    auto* transfer_buffer_ptr = transfer_buffer.data();
-
-    PRAGMA_OFFLOAD("omp target teams distribute map(always, to: transfer_buffer_ptr[:transfer_buffer.size()]) \
-                    map(to: grp_ids[:n_src]) \
-                    map(to: mw_dist[:dist_stride*nw]) \
-                    map(to: mw_vgl[:(DIM+2)*nw]) \
-                    map(always, from: mw_allUat[:nw * n_padded * (DIM + 2)])")
-    for (int iw = 0; iw < nw_accepted; iw++)
-    {
-      T** mw_coefs          = reinterpret_cast<T**>(transfer_buffer_ptr);
-      T* mw_DeltaRInv       = reinterpret_cast<T*>(transfer_buffer_ptr + sizeof(T*) * num_groups);
-      T* mw_cutoff_radius   = mw_DeltaRInv + num_groups;
-      int* accepted_indices = reinterpret_cast<int*>(transfer_buffer_ptr + (sizeof(T*) + sizeof(T) * 2) * num_groups);
-      const int ip          = accepted_indices[iw];
-
-      const T* dist_new   = mw_dist + ip * dist_stride;
-      const T* dipl_x_new = dist_new + n_padded;
-      const T* dipl_y_new = dist_new + n_padded * 2;
-      const T* dipl_z_new = dist_new + n_padded * 3;
-
-      const T* dist_old   = mw_dist + ip * dist_stride + dist_stride * nw;
-      const T* dipl_x_old = dist_old + n_padded;
-      const T* dipl_y_old = dist_old + n_padded * 2;
-      const T* dipl_z_old = dist_old + n_padded * 3;
-
-      T* Uat    = mw_allUat + ip * n_padded;
-      T* dUat_x = mw_allUat + n_padded * nw + ip * n_padded * DIM;
-      T* dUat_y = dUat_x + n_padded;
-      T* dUat_z = dUat_y + n_padded;
-      T* d2Uat  = mw_allUat + n_padded * (DIM + 1) * nw + ip * n_padded;
-
-      T* cur_allu = mw_cur_allu + ip * n_padded * 3;
-
-      PRAGMA_OFFLOAD("omp parallel for")
-      for (int j = 0; j < n_src; j++)
-      {
-        if (j == iat) continue;
-        const int ig    = grp_ids[j];
-        const T* coefs  = mw_coefs[ig];
-        T DeltaRInv     = mw_DeltaRInv[ig];
-        T cutoff_radius = mw_cutoff_radius[ig];
-
-        T r = dist_old[j];
-        T u(0);
-        T dudr(0);
-        T d2udr2(0);
-        if (r < cutoff_radius)
-        {
-          u = evaluate_impl(dist_old[j], coefs, DeltaRInv, dudr, d2udr2);
-          dudr *= T(1) / r;
-        }
-        // update Uat, dUat, d2Uat
-        T cur_u      = cur_allu[j];
-        T cur_dudr   = cur_allu[j + n_padded];
-        T cur_d2udr2 = cur_allu[j + n_padded * 2];
-        Uat[j] += cur_u - u;
-        dUat_x[j] -= dipl_x_new[j] * cur_dudr - dipl_x_old[j] * dudr;
-        dUat_y[j] -= dipl_y_new[j] * cur_dudr - dipl_y_old[j] * dudr;
-        dUat_z[j] -= dipl_z_new[j] * cur_dudr - dipl_z_old[j] * dudr;
-        constexpr T lapfac(DIM - 1);
-        d2Uat[j] -= cur_d2udr2 + lapfac * cur_dudr - (d2udr2 + lapfac * dudr);
-      }
-      T* vgl      = mw_vgl + ip * (DIM + 2);
-      Uat[iat]    = vgl[0];
-      dUat_x[iat] = vgl[1];
-      dUat_y[iat] = vgl[2];
-      dUat_z[iat] = vgl[3];
-      d2Uat[iat]  = vgl[4];
-    }
-  }
-
-
-  inline bool evaluateDerivatives(real_type r, std::vector<TinyVector<real_type, 3>>& derivs) override
+  inline bool evaluateDerivatives(Real r, std::vector<TinyVector<Real, 3>>& derivs) override
   {
     if (r >= cutoff_radius)
       return false;
     r *= DeltaRInv;
-    real_type ipart, t;
+    Real ipart, t;
     t     = std::modf(r, &ipart);
     int i = (int)ipart;
-    real_type tp[4];
+    Real tp[4];
     tp[0] = t * t * t;
     tp[1] = t * t;
     tp[2] = t;
     tp[3] = 1.0;
 
     auto& coefs     = *spline_coefs_;
-    SplineDerivs[0] = TinyVector<real_type, 3>(0.0);
+    SplineDerivs[0] = TinyVector<Real, 3>(0.0);
     // d/dp_i u(r)
     SplineDerivs[i + 0][0] = A0 * tp[0] + A1 * tp[1] + A2 * tp[2] + A3 * tp[3];
     SplineDerivs[i + 1][0] = A4 * tp[0] + A5 * tp[1] + A6 * tp[2] + A7 * tp[3];
@@ -639,7 +404,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
       derivs[n - 1] = SplineDerivs[n];
     derivs[1] += SplineDerivs[0];
 
-    //real_type v[4],dv[4],d2v[4];
+    //Real v[4],dv[4],d2v[4];
     //v[0] = A[ 0]*tp[0] + A[ 1]*tp[1] + A[ 2]*tp[2] + A[ 3]*tp[3];
     //v[1] = A[ 4]*tp[0] + A[ 5]*tp[1] + A[ 6]*tp[2] + A[ 7]*tp[3];
     //v[2] = A[ 8]*tp[0] + A[ 9]*tp[1] + A10*tp[2] + A11*tp[3];
@@ -660,19 +425,19 @@ struct BsplineFunctor : public OptimizableFunctorBase
     //int n=imin-1, j=imin-i;
     //while(n<imax && j<4)
     //{
-    //  derivs[n] = TinyVector<real_type,3>(v[j],dv[j],d2v[j]);
+    //  derivs[n] = TinyVector<Real,3>(v[j],dv[j],d2v[j]);
     //  n++; j++;
     //}
-    //if(i==0) derivs[1]+= TinyVector<real_type,3>(v[0],dv[0],d2v[0]);
+    //if(i==0) derivs[1]+= TinyVector<Real,3>(v[0],dv[0],d2v[0]);
 
     return true;
   }
 
-  inline bool evaluateDerivatives(real_type r, std::vector<real_type>& derivs) override
+  inline bool evaluateDerivatives(Real r, std::vector<Real>& derivs) override
   {
     if (r >= cutoff_radius)
       return false;
-    real_type tp[4], v[4], ipart, t;
+    Real tp[4], v[4], ipart, t;
     t        = std::modf(r * DeltaRInv, &ipart);
     tp[0]    = t * t * t;
     tp[1]    = t * t;
@@ -697,17 +462,17 @@ struct BsplineFunctor : public OptimizableFunctorBase
     return true;
   }
 
-  inline real_type f(real_type r) override
+  inline Real f(Real r) override
   {
     if (r >= cutoff_radius)
       return 0.0;
     return evaluate(r);
   }
-  inline real_type df(real_type r) override
+  inline Real df(Real r) override
   {
     if (r >= cutoff_radius)
       return 0.0;
-    real_type du, d2u;
+    Real du, d2u;
     evaluate(r, du, d2u);
     return du;
   }
@@ -720,7 +485,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
     NumParams = 0;
     //cutoff_radius = 0.0;
     OhmmsAttributeSet rAttrib;
-    real_type radius = -1.0;
+    Real radius = -1.0;
     rAttrib.add(NumParams, "size");
     rAttrib.add(radius, "rcut");
     rAttrib.add(radius, "cutoff");
@@ -776,7 +541,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
           PRE.error("Unknown correlation type " + type + " in BsplineFunctor." + "Resetting to \"Array\"");
           xmlNewProp(xmlCoefs, (const xmlChar*)"type", (const xmlChar*)"Array");
         }
-        std::vector<real_type> params;
+        std::vector<Real> params;
         putContent(params, xmlCoefs);
         if (params.size() == NumParams)
           Parameters = params;
@@ -786,17 +551,17 @@ struct BsplineFunctor : public OptimizableFunctorBase
                     << ".  Performing fit:\n";
           // Fit function to new number of parameters
           const int numPoints = 500;
-          BsplineFunctor<T> tmp_func(CuspValue);
+          BsplineFunctor<REAL> tmp_func(CuspValue);
           tmp_func.cutoff_radius = cutoff_radius;
           tmp_func.resize(params.size());
           tmp_func.Parameters = params;
           tmp_func.reset();
-          std::vector<real_type> y(numPoints);
-          Matrix<real_type> basis(numPoints, NumParams);
-          std::vector<TinyVector<real_type, 3>> derivs(NumParams);
+          std::vector<Real> y(numPoints);
+          Matrix<Real> basis(numPoints, NumParams);
+          std::vector<TinyVector<Real, 3>> derivs(NumParams);
           for (int i = 0; i < numPoints; i++)
           {
-            real_type r = (real_type)i / (real_type)numPoints * cutoff_radius;
+            Real r = (Real)i / (Real)numPoints * cutoff_radius;
             y[i]        = tmp_func.evaluate(r);
             evaluateDerivatives(r, derivs);
             for (int j = 0; j < NumParams; j++)
@@ -820,7 +585,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
         {
           std::stringstream sstr;
           sstr << id << "_" << i;
-          myVars.insert(sstr.str(), (value_type)Parameters[i], !notOpt, optimize::LOGLINEAR_P);
+          myVars.insert(sstr.str(), (Real)Parameters[i], !notOpt, optimize::LOGLINEAR_P);
         }
         int left_pad_space = 5;
         app_log() << std::endl;
@@ -829,17 +594,17 @@ struct BsplineFunctor : public OptimizableFunctorBase
       xmlCoefs = xmlCoefs->next;
     }
     reset();
-    real_type zeros = 0;
+    Real zeros = 0;
     for (int i = 0; i < NumParams; i++)
       zeros += Parameters[i] * Parameters[i];
     return zeros > 1.0e-12; //true if Parameters are not zero
   }
 
   void initialize(int numPoints,
-                  std::vector<real_type>& x,
-                  std::vector<real_type>& y,
-                  real_type cusp,
-                  real_type rcut,
+                  std::vector<Real>& x,
+                  std::vector<Real>& y,
+                  REAL cusp,
+                  REAL rcut,
                   std::string& id,
                   std::string& optimize)
   {
@@ -857,11 +622,11 @@ struct BsplineFunctor : public OptimizableFunctorBase
     app_log() << " rcut = " << cutoff_radius << std::endl;
     resize(NumParams);
     int npts = x.size();
-    Matrix<real_type> basis(npts, NumParams);
-    std::vector<TinyVector<real_type, 3>> derivs(NumParams);
+    Matrix<Real> basis(npts, NumParams);
+    std::vector<TinyVector<Real, 3>> derivs(NumParams);
     for (int i = 0; i < npts; i++)
     {
-      real_type r = x[i];
+      Real r = x[i];
       if (r > cutoff_radius)
       {
         PRE.error("Error in BsplineFunctor::initialize: r > cutoff_radius.", true);
@@ -883,7 +648,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
       {
         std::stringstream sstr;
         sstr << id << "_" << i;
-        myVars.insert(sstr.str(), (value_type)Parameters[i], true, optimize::LOGLINEAR_P);
+        myVars.insert(sstr.str(), (Real)Parameters[i], true, optimize::LOGLINEAR_P);
       }
       myVars.print(app_log());
     }
@@ -945,14 +710,14 @@ struct BsplineFunctor : public OptimizableFunctorBase
   }
 };
 
-template<typename T>
-inline T BsplineFunctor<T>::evaluateV(const int iat,
+template<typename REAL>
+inline REAL BsplineFunctor<REAL>::evaluateV(const int iat,
                                       const int iStart,
                                       const int iEnd,
-                                      const T* restrict _distArray,
-                                      T* restrict distArrayCompressed) const
+                                      const REAL* restrict _distArray,
+                                      REAL* restrict distArrayCompressed) const
 {
-  const real_type* restrict distArray = _distArray + iStart;
+  const Real* restrict distArray = _distArray + iStart;
 
   ASSUME_ALIGNED(distArrayCompressed);
   int iCount       = 0;
@@ -961,43 +726,43 @@ inline T BsplineFunctor<T>::evaluateV(const int iat,
 #pragma vector always
   for (int jat = 0; jat < iLimit; jat++)
   {
-    real_type r = distArray[jat];
+    Real r = distArray[jat];
     // pick the distances smaller than the cutoff and avoid the reference atom
     if (r < cutoff_radius && iStart + jat != iat)
       distArrayCompressed[iCount++] = distArray[jat];
   }
 
-  real_type d = 0.0;
+  Real d = 0.0;
   auto& coefs = *spline_coefs_;
 #pragma omp simd reduction(+ : d)
   for (int jat = 0; jat < iCount; jat++)
   {
-    real_type r = distArrayCompressed[jat];
+    Real r = distArrayCompressed[jat];
     r *= DeltaRInv;
     const int i       = (int)r;
-    const real_type t = r - real_type(i);
-    real_type d1      = coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3);
-    real_type d2      = coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7);
-    real_type d3      = coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11);
-    real_type d4      = coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
+    const Real t = r - Real(i);
+    Real d1      = coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3);
+    Real d2      = coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7);
+    Real d3      = coefs[i + 2] * (((A8 * t + A9) * t + A10) * t + A11);
+    Real d4      = coefs[i + 3] * (((A12 * t + A13) * t + A14) * t + A15);
     d += (d1 + d2 + d3 + d4);
   }
   return d;
 }
 
-template<typename T>
-inline void BsplineFunctor<T>::evaluateVGL(const int iat,
+template<typename REAL>
+inline void BsplineFunctor<REAL>::evaluateVGL(const int iat,
                                            const int iStart,
                                            const int iEnd,
-                                           const T* _distArray,
-                                           T* restrict _valArray,
-                                           T* restrict _gradArray,
-                                           T* restrict _laplArray,
-                                           T* restrict distArrayCompressed,
+                                           const REAL* _distArray,
+                                           REAL* restrict _valArray,
+                                           REAL* restrict _gradArray,
+                                           REAL* restrict _laplArray,
+                                           REAL* restrict distArrayCompressed,
                                            int* restrict distIndices) const
 {
-  real_type dSquareDeltaRinv = DeltaRInv * DeltaRInv;
-  constexpr real_type cOne(1);
+  Real dSquareDeltaRinv = DeltaRInv * DeltaRInv;
+  constexpr Real cOne(1);
 
   //    START_MARK_FIRST();
 
@@ -1005,15 +770,15 @@ inline void BsplineFunctor<T>::evaluateVGL(const int iat,
   ASSUME_ALIGNED(distArrayCompressed);
   int iCount                 = 0;
   int iLimit                 = iEnd - iStart;
-  const real_type* distArray = _distArray + iStart;
-  real_type* valArray        = _valArray + iStart;
-  real_type* gradArray       = _gradArray + iStart;
-  real_type* laplArray       = _laplArray + iStart;
+  const REAL* distArray = _distArray + iStart;
+  REAL* valArray        = _valArray + iStart;
+  REAL* gradArray       = _gradArray + iStart;
+  REAL* laplArray       = _laplArray + iStart;
 
 #pragma vector always
   for (int jat = 0; jat < iLimit; jat++)
   {
-    real_type r = distArray[jat];
+    Real r = distArray[jat];
     if (r < cutoff_radius && iStart + jat != iat)
     {
       distIndices[iCount]         = jat;
@@ -1026,17 +791,17 @@ inline void BsplineFunctor<T>::evaluateVGL(const int iat,
 #pragma omp simd
   for (int j = 0; j < iCount; j++)
   {
-    real_type r    = distArrayCompressed[j];
+    Real r    = distArrayCompressed[j];
     int iScatter   = distIndices[j];
-    real_type rinv = cOne / r;
+    Real rinv = cOne / r;
     r *= DeltaRInv;
     const int iGather = (int)r;
-    const real_type t = r - real_type(iGather);
+    const Real t = r - Real(iGather);
 
-    real_type sCoef0 = coefs[iGather + 0];
-    real_type sCoef1 = coefs[iGather + 1];
-    real_type sCoef2 = coefs[iGather + 2];
-    real_type sCoef3 = coefs[iGather + 3];
+    Real sCoef0 = coefs[iGather + 0];
+    Real sCoef1 = coefs[iGather + 1];
+    Real sCoef2 = coefs[iGather + 2];
+    Real sCoef3 = coefs[iGather + 3];
 
     laplArray[iScatter] = dSquareDeltaRinv *
         (sCoef0 * (d2A2 * t + d2A3) + sCoef1 * (d2A6 * t + d2A7) + sCoef2 * (d2A10 * t + d2A11) +
@@ -1051,5 +816,8 @@ inline void BsplineFunctor<T>::evaluateVGL(const int iat,
          sCoef2 * (((A8 * t + A9) * t + A10) * t + A11) + sCoef3 * (((A12 * t + A13) * t + A14) * t + A15));
   }
 }
+
+extern template struct BsplineFunctor<QMCTraits::RealType>;
+
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -35,9 +35,9 @@ namespace qmcplusplus
 {
 
 /**BsplineFunctor class for the Jastrows
- * MWREAL is the real type used by offload target (and hopefully the mw_resource that should own all that.)
- * It is used to coerce/implicitly convert the Real type inherited OptimizableFunctorBase into the buffer
- * type used by target offload or if offload is off the mercilessly complicated CPU reference code.
+ * MWREAL is the real type used by offload target, it is the correct type for the mw data pointers
+ * and is also used to coerce/implicitly convert the Real type inherited OptimizableFunctorBase into that buffer
+ * if offload is off this happens too but is just an implementation quirk.
  */
 template<typename MWREAL>
 struct BsplineFunctor : public OptimizableFunctorBase

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -36,8 +36,8 @@ namespace qmcplusplus
 template<typename REAL>
 struct BsplineFunctor : public OptimizableFunctorBase
 {
-  using Value = REAL; // while there is a value type referenced it was set to real
-  using Real = REAL;
+  using Value              = REAL; // while there is a value type referenced it was set to real
+  using Real               = REAL;
   static constexpr Real A0 = -1.0 / 6.0, A1 = 3.0 / 6.0, A2 = -3.0 / 6.0, A3 = 1.0 / 6.0;
   static constexpr Real A4 = 3.0 / 6.0, A5 = -6.0 / 6.0, A6 = 0.0 / 6.0, A7 = 4.0 / 6.0;
   static constexpr Real A8 = -3.0 / 6.0, A9 = 3.0 / 6.0, A10 = 3.0 / 6.0, A11 = 1.0 / 6.0;
@@ -179,10 +179,10 @@ struct BsplineFunctor : public OptimizableFunctorBase
    * @return \f$\sum u(r_j)\f$ for r_j < cutoff_radius
    */
   REAL evaluateV(const int iat,
-              const int iStart,
-              const int iEnd,
-              const REAL* restrict _distArray,
-              REAL* restrict distArrayCompressed) const;
+                 const int iStart,
+                 const int iEnd,
+                 const REAL* restrict _distArray,
+                 REAL* restrict distArrayCompressed) const;
 
   /** compute value for target-source particle pair potentials
    * This more than just a batched call of evaluateV
@@ -214,8 +214,8 @@ struct BsplineFunctor : public OptimizableFunctorBase
   {
     r *= DeltaRInv;
     REAL ipart;
-    const REAL t   = std::modf(r, &ipart);
-    const int i = (int)ipart;
+    const REAL t = std::modf(r, &ipart);
+    const int i  = (int)ipart;
 
     Real sCoef0 = coefs[i + 0];
     Real sCoef1 = coefs[i + 1];
@@ -238,16 +238,12 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
   inline void evaluateAll(Real r, Real rinv) { Y = evaluate(r, dY, d2Y); }
 
-  inline static Real evaluate_impl(Real r,
-                                        const Real* coefs,
-                                        const Real DeltaRInv,
-                                        Real& dudr,
-                                        Real& d2udr2)
+  inline static Real evaluate_impl(Real r, const Real* coefs, const Real DeltaRInv, Real& dudr, Real& d2udr2)
   {
     r *= DeltaRInv;
     REAL ipart;
-    const REAL t   = std::modf(r, &ipart);
-    const int i = (int)ipart;
+    const REAL t = std::modf(r, &ipart);
+    const int i  = (int)ipart;
 
     Real sCoef0 = coefs[i + 0];
     Real sCoef1 = coefs[i + 1];
@@ -263,7 +259,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
          sCoef2 * ((dA9 * t + dA10) * t + dA11) + sCoef3 * ((dA13 * t + dA14) * t + dA15));
 
     Real u = (sCoef0 * (((A0 * t + A1) * t + A2) * t + A3) + sCoef1 * (((A4 * t + A5) * t + A6) * t + A7) +
-                   sCoef2 * (((A8 * t + A9) * t + A10) * t + A11) + sCoef3 * (((A12 * t + A13) * t + A14) * t + A15));
+              sCoef2 * (((A8 * t + A9) * t + A10) * t + A11) + sCoef3 * (((A12 * t + A13) * t + A14) * t + A15));
     return u;
   }
 
@@ -562,7 +558,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
           for (int i = 0; i < numPoints; i++)
           {
             Real r = (Real)i / (Real)numPoints * cutoff_radius;
-            y[i]        = tmp_func.evaluate(r);
+            y[i]   = tmp_func.evaluate(r);
             evaluateDerivatives(r, derivs);
             for (int j = 0; j < NumParams; j++)
               basis(i, j) = derivs[j][0];
@@ -712,10 +708,10 @@ struct BsplineFunctor : public OptimizableFunctorBase
 
 template<typename REAL>
 inline REAL BsplineFunctor<REAL>::evaluateV(const int iat,
-                                      const int iStart,
-                                      const int iEnd,
-                                      const REAL* restrict _distArray,
-                                      REAL* restrict distArrayCompressed) const
+                                            const int iStart,
+                                            const int iEnd,
+                                            const REAL* restrict _distArray,
+                                            REAL* restrict distArrayCompressed) const
 {
   const Real* restrict distArray = _distArray + iStart;
 
@@ -732,14 +728,14 @@ inline REAL BsplineFunctor<REAL>::evaluateV(const int iat,
       distArrayCompressed[iCount++] = distArray[jat];
   }
 
-  Real d = 0.0;
+  Real d      = 0.0;
   auto& coefs = *spline_coefs_;
 #pragma omp simd reduction(+ : d)
   for (int jat = 0; jat < iCount; jat++)
   {
     Real r = distArrayCompressed[jat];
     r *= DeltaRInv;
-    const int i       = (int)r;
+    const int i  = (int)r;
     const Real t = r - Real(i);
     Real d1      = coefs[i + 0] * (((A0 * t + A1) * t + A2) * t + A3);
     Real d2      = coefs[i + 1] * (((A4 * t + A5) * t + A6) * t + A7);
@@ -752,14 +748,14 @@ inline REAL BsplineFunctor<REAL>::evaluateV(const int iat,
 
 template<typename REAL>
 inline void BsplineFunctor<REAL>::evaluateVGL(const int iat,
-                                           const int iStart,
-                                           const int iEnd,
-                                           const REAL* _distArray,
-                                           REAL* restrict _valArray,
-                                           REAL* restrict _gradArray,
-                                           REAL* restrict _laplArray,
-                                           REAL* restrict distArrayCompressed,
-                                           int* restrict distIndices) const
+                                              const int iStart,
+                                              const int iEnd,
+                                              const REAL* _distArray,
+                                              REAL* restrict _valArray,
+                                              REAL* restrict _gradArray,
+                                              REAL* restrict _laplArray,
+                                              REAL* restrict distArrayCompressed,
+                                              int* restrict distIndices) const
 {
   Real dSquareDeltaRinv = DeltaRInv * DeltaRInv;
   constexpr Real cOne(1);
@@ -768,8 +764,8 @@ inline void BsplineFunctor<REAL>::evaluateVGL(const int iat,
 
   ASSUME_ALIGNED(distIndices);
   ASSUME_ALIGNED(distArrayCompressed);
-  int iCount                 = 0;
-  int iLimit                 = iEnd - iStart;
+  int iCount            = 0;
+  int iLimit            = iEnd - iStart;
   const REAL* distArray = _distArray + iStart;
   REAL* valArray        = _valArray + iStart;
   REAL* gradArray       = _gradArray + iStart;
@@ -791,12 +787,12 @@ inline void BsplineFunctor<REAL>::evaluateVGL(const int iat,
 #pragma omp simd
   for (int j = 0; j < iCount; j++)
   {
-    Real r    = distArrayCompressed[j];
-    int iScatter   = distIndices[j];
-    Real rinv = cOne / r;
+    Real r       = distArrayCompressed[j];
+    int iScatter = distIndices[j];
+    Real rinv    = cOne / r;
     r *= DeltaRInv;
     const int iGather = (int)r;
-    const Real t = r - Real(iGather);
+    const Real t      = r - Real(iGather);
 
     Real sCoef0 = coefs[iGather + 0];
     Real sCoef1 = coefs[iGather + 1];

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -147,7 +147,7 @@ foreach(CATEGORY common trialwf sposet jastrow determinant)
     utilities_for_test
     container_testing)
   if(USE_OBJECT_TARGET)
-    target_link_libraries(${UTEST_EXE} qmcparticle qmcutil platform_omptarget_LA)
+    target_link_libraries(${UTEST_EXE} qmcparticle qmcparticle_omptarget qmcwfs_omptarget qmcutil platform_omptarget_LA)
   endif()
 
   add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)
@@ -173,7 +173,7 @@ if(ENABLE_CUDA AND BUILD_MICRO_BENCHMARKS)
     utilities_for_test
     container_testing)
   if(USE_OBJECT_TARGET)
-    target_link_libraries(${UTEST_EXE} qmcutil qmcparticle platform_omptarget_LA)
+    target_link_libraries(${UTEST_EXE} qmcutil qmcparticle qmcparticle_omptarget qmcwfs_omptarget platform_omptarget_LA)
   endif()
   #  target_include_directories(${UTEST_EXE} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../..")
   target_include_directories(${UTEST_EXE} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -142,6 +142,8 @@ foreach(CATEGORY common trialwf sposet jastrow determinant)
     ${UTEST_EXE}
     catch_main
     qmcwfs
+    qmcwfs_omptarget
+    qmcparticle_omptarget
     platform_LA
     platform_runtime
     utilities_for_test

--- a/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
@@ -38,6 +38,8 @@ using PsiValueType = WaveFunctionComponent::PsiValueType;
 
 TEST_CASE("BSpline functor zero", "[wavefunction]")
 {
+  // What is being tested here is different depending on QMC_MIXED_PRECISION
+  // double with either match the real_type of the OptimizableFunctorBase or not
   BsplineFunctor<double> bf;
 
   double r = 1.2;


### PR DESCRIPTION
## Proposed changes

I've added a build workaround required by the current functional clang 15 offload compiler which cannot build offload target kernels with -O0. This breaks out the omptarget files in ParticleSet and QMCWavefunctions as separate targets. If you actually use a debugger and have experienced using it on -O3 code you'll realize there is no way we want all of ParticleSet and QMCWavefunctions compiled with -O3 in debug.

This also required refactoring BsplineFunctor.h which contained omp target and was ending up in many compilation units.  I also couldn't stand the extremely sloppy template parameter and typedef use in the class and cleaned that up.  While it looked as if T could be any scalar it in fact could only be the QMCTraits::RealType.  There were a few value_type typedefs but they were set at the top of the header using value_type = real_type. 

## What type(s) of changes does this code introduce?

- Bugfix
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Build related changes
- Other (please describe):

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
