### PR TITLE
Drop standalone-debug for offload builds

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -104,8 +104,16 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffast-math")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math")
 
 # Set extra debug flags
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fstandalone-debug")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fstandalone-debug")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
+
+# unfortunately this removes standalone-debug altogether for offload builds
+# but until we discover how to use the ${OPENMP_OFFLOAD_COMPILE_OPTIONS} more selectively
+# this is the only way to avoid a warning per compilation unit that contains an omp symbol.
+if (NOT OFFLOAD_TARGET MATCHES "nvptx64")
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fstandalone-debug")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstandalone-debug")
+endif()
 
 #--------------------------------------
 # Special architectural flags

--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -111,6 +111,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
 # but until we discover how to use the ${OPENMP_OFFLOAD_COMPILE_OPTIONS} more selectively
 # this is the only way to avoid a warning per compilation unit that contains an omp symbol.
 if (NOT OFFLOAD_TARGET MATCHES "nvptx64")
+  message(STATUS "QMCPACK adds -fstandalone-debug for Debug builds")
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fstandalone-debug")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstandalone-debug")
 endif()


### PR DESCRIPTION
This removes warnings that appear with almost every compilation unit. i.e. hundreds of times with the debug offload build.  Every useless long lived warning raises the chance a useful warning will be ignored.

This drops the debug info quality especially for CUDA kernels but it should be possible to get that back with
ENABLE_CUDA=1 and ENABLE_OFFLOAD=0. 

I'm not sure of what happens with this warning in the AMD environment. This PR doesn't change what will happen there at all.

## Proposed changes
Don't add the `-fstandalone-debug` for a platform that doesn't support it.

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Build related changes
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
