### PR TITLE
Fix test_structure divide by 0

### DIFF
--- a/nexus/tests/unit/test_structure.py
+++ b/nexus/tests/unit/test_structure.py
@@ -1372,7 +1372,9 @@ if versions.scipy_available:
         r = np.linalg.norm(dr,axis=1)
         dilation = 2*r*np.exp(-r)
         for i in range(npos):
-            gr.pos[i] += dilation[i]/r[i]*dr[i]
+            if r[i]>0:
+                gr.pos[i] += dilation[i]/r[i]*dr[i]
+            #end if
         #end for
 
         # Represent the unrelaxed large cell


### PR DESCRIPTION
## Proposed changes

Guard against divide by zero in the test_embed function of test_structure.py

This causes failures in the nightlies e.g. https://cdash.qmcpack.org/CDash/testDetails.php?test=19710670&build=322808

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Sulfur. Nightly gccnewmpi configuration.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
