### PR TITLE
Orbital rotation fixes for legacy driver and threads, again.

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -168,7 +168,13 @@ void QMCCostFunction::GradCost(std::vector<Return_rt>& PGradient,
 
 void QMCCostFunction::getConfigurations(const std::string& aroot)
 {
-  //makeClones(W,Psi,H);
+  // Set all the myVars indices in the wavefunction clones.
+  // If not set, the parameter derivative pieces in evaluateDerivatives
+  // end up in the wrong indices in dlogpsi and dhpsioverpsi.
+  for (int i = 0; i < psiClones.size(); i++)
+    psiClones[i]->checkOutVariables(OptVariablesForPsi);
+
+
   if (H_KE_Node.empty())
   {
     app_log() << "  QMCCostFunction is created with " << NumThreads << " threads." << std::endl;

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -30,7 +30,12 @@ LCAOrbitalSet::LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize)
 }
 
 LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
-    : SPOSet(in), myBasisSet(in.myBasisSet->makeClone()), C(in.C), BasisSetSize(in.BasisSetSize), Identity(in.Identity)
+    : SPOSet(in),
+      myBasisSet(in.myBasisSet->makeClone()),
+      C(in.C),
+      BasisSetSize(in.BasisSetSize),
+      C_copy(in.C_copy),
+      Identity(in.Identity)
 {
   Temp.resize(BasisSetSize);
   Temph.resize(BasisSetSize);

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -113,7 +113,7 @@ void RotatedSPOs::buildOptVariables(const std::vector<std::pair<int, int>>& rota
   std::vector<RealType> param(m_act_rot_inds.size());
   for (int i = 0; i < m_act_rot_inds.size(); i++)
     param[i] = myVars[i];
-  apply_rotation(param, false);
+  apply_rotation(param, true);
 
   if (!Optimizable)
   {

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -165,15 +165,10 @@ public:
 
   void checkInVariables(opt_variables_type& active) override
   {
-    //reset parameters to zero after coefficient matrix has been updated
-    for (int k = 0; k < myVars.size(); ++k)
-      myVars[k] = 0.0;
-
     if (Optimizable)
     {
       if (myVars.size())
         active.insertFrom(myVars);
-      Phi->storeParamsBeforeRotation();
     }
   }
 

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -95,6 +95,10 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
     app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";
     abort();
 #else
+    // At this point in the code we know that orbital rotation is used, so the target SPO
+    // can make a copy of the coefficient matrix.
+    sposet->storeParamsBeforeRotation();
+
     // create sposet with rotation
     auto& sposet_ref = *sposet;
     auto rot_spo     = std::make_unique<RotatedSPOs>(std::move(sposet));

--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -103,6 +103,24 @@ if(NOT QMC_CUDA)
     SCALAR_VALUES
     HE_ORB_ROT_PARAM)
 
+  qmc_run_and_check_custom_scalar(
+    BASE_NAME
+    He_orb_rot_param_grad_legacy
+    BASE_DIR
+    "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+    PREFIX
+    He_orb_rot_param_grad_legacy.param
+    INPUT_FILE
+    He_orb_rot_param_grad_legacy.xml
+    PROCS
+    1
+    THREADS
+    16
+    SERIES
+    0
+    SCALAR_VALUES
+    HE_ORB_ROT_PARAM)
+
 
   else()
     message(VERBOSE "Skipping He_param tests because parameter output is not supported by mixed precison build (QMC_MIXED_PRECISION=1)")

--- a/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
+++ b/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
@@ -90,7 +90,7 @@
       <parameter name="steps"> 10 </parameter>
       <parameter name="substeps"> 20 </parameter>
       <parameter name="timestep"> 0.5 </parameter>
-      <parameter name="samples"> 1000 </parameter>
+      <parameter name="samplesperthread"> 1000 </parameter>
       <cost name="energy">                   1.0 </cost>
       <cost name="reweightedvariance">       0.00 </cost>
     </qmc>


### PR DESCRIPTION
So #3977 and #4076 have failed to be an acceptable move forward in fixing orbital rotation.
Trying again...
The trick this time is to instruct the SPOSet to store the orbital rotations at setup time, after we know that orbital rotations are being used in the code, but before any cloning is done.
The copy constructor on the LCAOrbitalSet class is fixed so the pristine copy of the coefficient matrix gets propagated through all the subsequent clones. And the tricky state management goes away.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
