### PR TITLE
Add missing dependency in CMake.

### DIFF
--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -163,8 +163,8 @@ else(USE_OBJECT_TARGET)
 endif(USE_OBJECT_TARGET)
 
 target_include_directories(qmcwfs PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime)
-target_link_libraries(qmcwfs PRIVATE einspline platform_LA Math::FFTW3)
+target_link_libraries(qmcwfs PUBLIC qmcutil qmcparticle platform_runtime platform_LA)
+target_link_libraries(qmcwfs PRIVATE einspline Math::FFTW3)
 
 if(USE_OBJECT_TARGET)
   add_library(qmcwfs_omptarget OBJECT ${JASTROW_OMPTARGET_SRCS} ${FERMION_OMPTARGET_SRCS})
@@ -173,7 +173,7 @@ else(USE_OBJECT_TARGET)
 endif(USE_OBJECT_TARGET)
 
 target_include_directories(qmcwfs_omptarget PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers)
+target_link_libraries(qmcwfs_omptarget PUBLIC qmcutil qmcparticle containers platform_LA)
 
 target_compile_options(qmcwfs_omptarget PRIVATE "$<$<BOOL:${ENABLE_OFFLOAD_CLANG_DEBUG_O3}>:$<$<CONFIG:DEBUG>:-O3>>")
 


### PR DESCRIPTION
## Proposed changes
qmcwfs_omptarget needs platform_LA
platform_LA also needs to be PUBLIC due to exposure via header files.

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'