### PR TITLE
Test more orbital rotation scenarios

### DIFF
--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Rotated LCAO WF1", "[qmcapp]")
 }
 
 // No Jastrow, rotation angle of 0
-TEST_CASE("Rotated LCAO WF zero angle", "[qmcapp]")
+TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
 {
   Communicate* c;
   c = OHMMS::Controller;
@@ -267,7 +267,7 @@ TEST_CASE("Rotated LCAO WF zero angle", "[qmcapp]")
 }
 
 // Rotation angle of 0 and add Jastrow factory
-TEST_CASE("Rotated LCAO WF with jastrow", "[qmcapp]")
+TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
 {
   Communicate* c;
   c = OHMMS::Controller;
@@ -364,9 +364,9 @@ TEST_CASE("Rotated LCAO WF with jastrow", "[qmcapp]")
 
 // Test the case where the rotation has already been applied to
 // the MO coefficients in the input file.
-// Should give the same results as the "Rotated LCAO WF zero angle" test case
+// Should give the same results as the "Rotated LCAO WF1 zero angle" test case
 
-TEST_CASE("Rotated LCAO WF, MO coeff rotated, zero angle", "[qmcapp]")
+TEST_CASE("Rotated LCAO WF1, MO coeff rotated, zero angle", "[qmcapp]")
 {
   Communicate* c;
   c = OHMMS::Controller;
@@ -455,9 +455,9 @@ TEST_CASE("Rotated LCAO WF, MO coeff rotated, zero angle", "[qmcapp]")
 // Test the case where half the rotation has already been applied to
 // the MO coefficients in the input file and half the rotation is
 // applied through the input.
-// Should give the same results as the "Rotated LCAO WF zero angle" test case
+// Should give the same results as the "Rotated LCAO WF1 zero angle" test case
 
-TEST_CASE("Rotated LCAO WF, MO coeff rotated, half angle", "[qmcapp]")
+TEST_CASE("Rotated LCAO WF1 MO coeff rotated, half angle", "[qmcapp]")
 {
   Communicate* c;
   c = OHMMS::Controller;


### PR DESCRIPTION
### Preliminary discussion
From conversations with Ye, it may be the case the mathematics of RotatedSPOs::evaluateDerivatives assumes the current rotation angle is zero. See some of the discussion in #4083 on parameter derivatives with respect to the total rotation or delta rotation.

The equation of orbital rotation is:
C_1 = exp(X) * C_0
where C_0 is the original MO coefficient matrix, X is the skew-symmetric matrix containing the rotation parameters, exp(X) is the rotation matrix, and C_1 is the MO coefficient matrix after the rotations have been applied.
The question is whether the derivatives are computed as
 * exp(0) * C_1 ( This is delta rotation )
or 
* exp(X) * C_0 ( This is total rotation )

(where the "0" in exp(0) means a matrix where all the rotation parameters are set to zero.  The resulting rotation matrix will be the identity matrix, but the derivatives with respect to those parameters may be non-zero)

Rotation matrices have the property that exp(X +Y) = exp(X)exp(Y). So the value of the wavefunction doesn't depend on how the rotation is applied, and will be the same in both schemes.
It's not clear the derivatives have the same property (or at least not as implemented in RotatedSPOs::evaluateDerivatives.)

The added tests check total and delta rotation scenarios, and they pass.
However, these cases only cover a 2x2 rotation matrix, which may very well be a special case. 

### Description of the actual PR code:

Add cases where the rotation has already been applied to the MO coefficients in the input block.

Existing case:
* No rotation in MO coeff (identity matrix), rotation in input parameters (0.1, 0.2)

Added cases:
* All the rotation in the MO coeff (0.1, 0.2), zero rotation in input parameters
* Half the rotation in the MO coeff (0.05, 0.1), half the rotation in the input parameters (0.05, 0.1)



Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
