### PR TITLE
Add UHF/UKS support in Pyscf converter

### DIFF
--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -38,12 +38,12 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
      Python2=True
  
 
-  val=str(mf)
+  val=str(mf.dump_flags)
   ComputeMode= re.split('[. ]',val)
 
   SizeMode=len(ComputeMode)
   for i in range(SizeMode):
-     if ComputeMode[i] in ("UHF","KUHF","UKS"):
+     if ComputeMode[i] in ("UHF","KUHF","UKS","SymAdaptedUHF","SymAdaptedUKS"):
            Restricted=False
      if ComputeMode[i]=="pbc":
            PBC=True


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Fixes #3958
I tested the changes on the F atom and the SCF vs VMC/NoJ energies agree for UHF:
```
SCF: -23.942446 Ha
VMC: -23.9427(2) Ha
```

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

OLCF/Andes
