### PR TITLE
Suppress QMCPACK printout in unit tests by default.

### DIFF
--- a/docs/unit_testing.rst
+++ b/docs/unit_testing.rst
@@ -32,9 +32,11 @@ Some of the tests reference input files. The unit test CMake setup places those 
 
 Command line options are available on the unit test executables.  Some of the more useful ones are
 
--  List command line options.
+-  ``-h`` List command line options.
 
--  List all the tests in the executable.
+-  ``-l`` List all the tests in the executable.
+
+-  ``--turn-on-printout`` See all the QMCPACK printouts which are suppressed by default in unit tests.
 
 A test name can be given on the command line to execute just that test.  This is useful when iterating
 on a particular test or when running in the debugger.   Test names often contain spaces, so most command line environments require enclosing the test name in single or double quotes.

--- a/src/Message/catch_main.cpp
+++ b/src/Message/catch_main.cpp
@@ -17,9 +17,13 @@
 #ifdef CATCH_MAIN_HAVE_MPI
 #include "Message/Communicate.h"
 #endif
+#include "Host/OutputManager.h"
 
 // Replacement unit test main function to ensure that MPI is finalized once
 // (and only once) at the end of the unit test.
+
+// turn on QMCPACK printout
+bool turn_on_output = false;
 
 // AFQMC specific unit test arguments.
 std::string UTEST_HAMIL, UTEST_WFN;
@@ -31,10 +35,17 @@ int main(int argc, char* argv[])
   // Build command line parser.
   auto cli = session.cli() |
       Opt(UTEST_HAMIL, "UTEST_HAMIL")["--hamil"]("Hamiltonian file to be used by unit test if applicable.") |
-      Opt(UTEST_WFN, "UTEST_WFN")["--wfn"]("Wavefunction file to be used by unit test if applicable.");
+      Opt(UTEST_WFN, "UTEST_WFN")["--wfn"]("Wavefunction file to be used by unit test if applicable.") |
+      Opt(turn_on_output)["--turn-on-printout"]("Turn on QMCPACK output manager printout");
   session.cli(cli);
   // Parse arguments.
   int parser_err = session.applyCommandLine(argc, argv);
+  if (!turn_on_output)
+  {
+    qmcplusplus::app_log() << "QMCPACK printout is suppressed. Use --turn-on-printout to see all the printout."
+                           << std::endl;
+    outputManager.shutOff();
+  }
 #ifdef CATCH_MAIN_HAVE_MPI
   mpi3::environment env(argc, argv);
   OHMMS::Controller->initialize(env);

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -25,12 +25,16 @@ add_executable(
   test_infostream.cpp
   test_project_data.cpp
   test_rng_control.cpp
-  test_output_manager.cpp
   test_ModernStringUtils.cpp
   test_StlPrettyPrint.cpp
   test_StdRandom.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcutil)
 
 add_unit_test(${UTEST_NAME} 1 1 $<TARGET_FILE:${UTEST_EXE}>)
+
+set(UTEST_EXE test_utilities_output_manager)
+add_executable(${UTEST_EXE} test_output_manager.cpp)
+target_link_libraries(${UTEST_EXE} catch_main qmcutil)
+add_unit_test(deterministic-unit_${UTEST_EXE} 1 1 $<TARGET_FILE:${UTEST_EXE}> --turn-on-printout)
 
 subdirs(for_testing)


### PR DESCRIPTION
## Proposed changes
Failing unit test was not able to report all output to cdash.
"The rest of the test output was removed since it exceeds the threshold of 100000 bytes."
https://cdash.qmcpack.org/CDash/testDetails.php?test=19984254&build=325108
So it is better to suppress output by default.
Option "--turn-on-printout" added to make the printout through if needed.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'