### PR TITLE
Add minimal ensemble test

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -76,6 +76,13 @@ function(COPY_DIRECTORY_USING_SYMLINK_LIMITED SRC_DIR DST_DIR ${ARGN})
   symlink_list_of_files("${FILE_FOLDER_NAMES}" "${DST_DIR}")
   list(TRANSFORM ARGN PREPEND "${SRC_DIR}/")
   symlink_list_of_files("${ARGN}" "${DST_DIR}")
+# Special handling for .txt input files; assumed to be an ensemble run. Link referenced ensemble inputs
+  if ( ${ARGN} MATCHES ".txt")
+    message(STATUS "PKDEBUG Ensemble")
+    file(STRINGS ${ARGN} ENSEMBLE_INPUTS)
+    list(TRANSFORM ENSEMBLE_INPUTS PREPEND "${SRC_DIR}/")   
+    symlink_list_of_files("${ENSEMBLE_INPUTS}" "${DST_DIR}")
+  endif()
 endfunction()
 
 # Control copy vs. symlink with top-level variable

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -78,7 +78,6 @@ function(COPY_DIRECTORY_USING_SYMLINK_LIMITED SRC_DIR DST_DIR ${ARGN})
   symlink_list_of_files("${ARGN}" "${DST_DIR}")
 # Special handling for .txt input files; assumed to be an ensemble run. Link referenced ensemble inputs
   if ( ${ARGN} MATCHES ".txt")
-    message(STATUS "PKDEBUG Ensemble")
     file(STRINGS ${ARGN} ENSEMBLE_INPUTS)
     list(TRANSFORM ENSEMBLE_INPUTS PREPEND "${SRC_DIR}/")   
     symlink_list_of_files("${ENSEMBLE_INPUTS}" "${DST_DIR}")

--- a/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
@@ -272,3 +272,37 @@ qmc_run_and_check(
   0
   DET_LIH_GAMMA_SCALARS # VMC
 )
+
+# Minimal test of ensemble run
+# No check on results yet
+# Arrange for "imbalanced" ensemble and assume will crash or hang/timeout on major error
+# Should abort if number of MPI taks is not an integer multiple of number of inputs in ensemble
+qmc_run_and_check(
+  deterministic-ensemble_blocks_LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
+  "${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+  det_ensemble_blocks_hf_vmc_LiH-gamma
+  det_ensemble_blocks_hf_vmc_LiH-gamma.txt
+  4
+  1
+  TRUE
+ )
+
+qmc_run_and_check(
+  deterministic-ensemble_blocks_LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
+  "${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+  det_ensemble_blocks_hf_vmc_LiH-gamma
+  det_ensemble_blocks_hf_vmc_LiH-gamma.txt
+  3
+  1
+  FALSE
+ )
+
+qmc_run_and_check(
+  deterministic-ensemble_blocks_LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
+  "${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"
+  det_ensemble_blocks_hf_vmc_LiH-gamma
+  det_ensemble_blocks_hf_vmc_LiH-gamma.txt
+  5
+  1
+  TRUE
+ )

--- a/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
+++ b/tests/solids/LiH_solid_1x1x1_pp/CMakeLists.txt
@@ -274,9 +274,9 @@ qmc_run_and_check(
 )
 
 # Minimal test of ensemble run
-# No check on results yet
+# No check on results
 # Arrange for "imbalanced" ensemble and assume will crash or hang/timeout on major error
-# Should abort if number of MPI taks is not an integer multiple of number of inputs in ensemble
+# Should abort if number of MPI tasks is smaller than ensemble
 qmc_run_and_check(
   deterministic-ensemble_blocks_LiH_solid_1x1x1_pp-gamma-vmc_hf_noj
   "${qmcpack_SOURCE_DIR}/tests/solids/LiH_solid_1x1x1_pp"

--- a/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma.txt
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma.txt
@@ -1,0 +1,4 @@
+det_ensemble_blocks_hf_vmc_LiH-gamma_0.xml
+det_ensemble_blocks_hf_vmc_LiH-gamma_1.xml
+det_ensemble_blocks_hf_vmc_LiH-gamma_2.xml
+det_ensemble_blocks_hf_vmc_LiH-gamma_3.xml

--- a/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_0.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_0.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_ensemble_blocks_hf_vmc_LiH-gamma" series="0">
+  </project>
+  <random seed="77"/>
+
+  <qmcsystem>
+    <simulationcell>
+       <parameter name="lattice" units="bohr">
+        -3.550000  0.000000  3.550000
+         0.000000  3.550000  3.550000
+        -3.550000  3.550000  0.000000
+       </parameter>
+       <parameter name="bconds">
+          p p p
+       </parameter>
+       <parameter name="LR_dim_cutoff"       >    10                 </parameter>
+    </simulationcell>
+    <particleset name="e" random="yes" random_source="i">
+       <group name="u" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+       <group name="d" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+    </particleset>
+    <particleset name="i" size="2">
+       <group name="Li">
+          <parameter name="charge"              >    3                     </parameter>
+          <parameter name="valence"             >    3                     </parameter>
+          <parameter name="atomicnumber"        >    3                     </parameter>
+          <parameter name="mass"                >    12753.131164          </parameter>
+       </group>
+       <group name="H">
+          <parameter name="charge"              >    1                     </parameter>
+          <parameter name="valence"             >    1                     </parameter>
+          <parameter name="atomicnumber"        >    1                     </parameter>
+          <parameter name="mass"                >    1837.36221934            </parameter>
+       </group>
+       <attrib name="position" datatype="posArray" condition="0">
+                0.00000000        0.00000000        0.00000000
+                3.55000000        3.55000000        3.55000000
+       </attrib>
+       <attrib name="ionid" datatype="stringArray">
+         Li H
+       </attrib>
+    </particleset>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+  <qmc method="vmc" move="pbyp" gpu="yes">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    1 </parameter>
+    <parameter name="substeps">  2 </parameter>
+    <parameter name="warmupSteps">  3 </parameter>
+    <parameter name="steps">  3 </parameter>
+    <parameter name="blocks">  3 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_1.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_1.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_ensemble_blocks_hf_vmc_LiH-gamma" series="0">
+  </project>
+  <random seed="77"/>
+
+  <qmcsystem>
+    <simulationcell>
+       <parameter name="lattice" units="bohr">
+        -3.550000  0.000000  3.550000
+         0.000000  3.550000  3.550000
+        -3.550000  3.550000  0.000000
+       </parameter>
+       <parameter name="bconds">
+          p p p
+       </parameter>
+       <parameter name="LR_dim_cutoff"       >    10                 </parameter>
+    </simulationcell>
+    <particleset name="e" random="yes" random_source="i">
+       <group name="u" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+       <group name="d" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+    </particleset>
+    <particleset name="i" size="2">
+       <group name="Li">
+          <parameter name="charge"              >    3                     </parameter>
+          <parameter name="valence"             >    3                     </parameter>
+          <parameter name="atomicnumber"        >    3                     </parameter>
+          <parameter name="mass"                >    12753.131164          </parameter>
+       </group>
+       <group name="H">
+          <parameter name="charge"              >    1                     </parameter>
+          <parameter name="valence"             >    1                     </parameter>
+          <parameter name="atomicnumber"        >    1                     </parameter>
+          <parameter name="mass"                >    1837.36221934            </parameter>
+       </group>
+       <attrib name="position" datatype="posArray" condition="0">
+                0.00000000        0.00000000        0.00000000
+                3.55000000        3.55000000        3.55000000
+       </attrib>
+       <attrib name="ionid" datatype="stringArray">
+         Li H
+       </attrib>
+    </particleset>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+  <qmc method="vmc" move="pbyp" gpu="yes">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    1 </parameter>
+    <parameter name="substeps">  2 </parameter>
+    <parameter name="warmupSteps">  3 </parameter>
+    <parameter name="steps">  3 </parameter>
+    <parameter name="blocks">  6 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_2.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_2.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_ensemble_blocks_hf_vmc_LiH-gamma" series="0">
+  </project>
+  <random seed="77"/>
+
+  <qmcsystem>
+    <simulationcell>
+       <parameter name="lattice" units="bohr">
+        -3.550000  0.000000  3.550000
+         0.000000  3.550000  3.550000
+        -3.550000  3.550000  0.000000
+       </parameter>
+       <parameter name="bconds">
+          p p p
+       </parameter>
+       <parameter name="LR_dim_cutoff"       >    10                 </parameter>
+    </simulationcell>
+    <particleset name="e" random="yes" random_source="i">
+       <group name="u" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+       <group name="d" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+    </particleset>
+    <particleset name="i" size="2">
+       <group name="Li">
+          <parameter name="charge"              >    3                     </parameter>
+          <parameter name="valence"             >    3                     </parameter>
+          <parameter name="atomicnumber"        >    3                     </parameter>
+          <parameter name="mass"                >    12753.131164          </parameter>
+       </group>
+       <group name="H">
+          <parameter name="charge"              >    1                     </parameter>
+          <parameter name="valence"             >    1                     </parameter>
+          <parameter name="atomicnumber"        >    1                     </parameter>
+          <parameter name="mass"                >    1837.36221934            </parameter>
+       </group>
+       <attrib name="position" datatype="posArray" condition="0">
+                0.00000000        0.00000000        0.00000000
+                3.55000000        3.55000000        3.55000000
+       </attrib>
+       <attrib name="ionid" datatype="stringArray">
+         Li H
+       </attrib>
+    </particleset>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+  <qmc method="vmc" move="pbyp" gpu="yes">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    1 </parameter>
+    <parameter name="substeps">  2 </parameter>
+    <parameter name="warmupSteps">  3 </parameter>
+    <parameter name="steps">  3 </parameter>
+    <parameter name="blocks">  12 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+</simulation>

--- a/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_3.xml
+++ b/tests/solids/LiH_solid_1x1x1_pp/det_ensemble_blocks_hf_vmc_LiH-gamma_3.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="det_ensemble_blocks_hf_vmc_LiH-gamma" series="0">
+  </project>
+  <random seed="77"/>
+
+  <qmcsystem>
+    <simulationcell>
+       <parameter name="lattice" units="bohr">
+        -3.550000  0.000000  3.550000
+         0.000000  3.550000  3.550000
+        -3.550000  3.550000  0.000000
+       </parameter>
+       <parameter name="bconds">
+          p p p
+       </parameter>
+       <parameter name="LR_dim_cutoff"       >    10                 </parameter>
+    </simulationcell>
+    <particleset name="e" random="yes" random_source="i">
+       <group name="u" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+       <group name="d" size="2" mass="1.0">
+          <parameter name="charge"              >    -1                    </parameter>
+          <parameter name="mass"                >    1.0                   </parameter>
+       </group>
+    </particleset>
+    <particleset name="i" size="2">
+       <group name="Li">
+          <parameter name="charge"              >    3                     </parameter>
+          <parameter name="valence"             >    3                     </parameter>
+          <parameter name="atomicnumber"        >    3                     </parameter>
+          <parameter name="mass"                >    12753.131164          </parameter>
+       </group>
+       <group name="H">
+          <parameter name="charge"              >    1                     </parameter>
+          <parameter name="valence"             >    1                     </parameter>
+          <parameter name="atomicnumber"        >    1                     </parameter>
+          <parameter name="mass"                >    1837.36221934            </parameter>
+       </group>
+       <attrib name="position" datatype="posArray" condition="0">
+                0.00000000        0.00000000        0.00000000
+                3.55000000        3.55000000        3.55000000
+       </attrib>
+       <attrib name="ionid" datatype="stringArray">
+         Li H
+       </attrib>
+    </particleset>
+   <wavefunction name="psi0" target="e">
+     <determinantset type="einspline" href="LiH-gamma.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="-1" meshfactor="1.0" source="i"  precision="double" twist="0  0  0">
+       <slaterdeterminant>
+         <determinant id="updet" size="2" ref="updet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+         <determinant id="downdet" size="2" ref="downdet">
+           <occupation mode="ground" spindataset="0">
+           </occupation>
+         </determinant>
+       </slaterdeterminant>
+     </determinantset>
+   </wavefunction>
+  </qmcsystem>
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml">
+      <pseudo elementType="Li" href="Li.xml"/>
+      <pseudo elementType="H" href="H.xml"/>
+    </pairpot>
+    <constant name="IonIon" type="coulomb" source="i" target="i"/>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <estimator type="flux" name="Flux"/>
+  </hamiltonian>
+
+  <qmc method="vmc" move="pbyp" gpu="yes">
+    <estimator name="LocalEnergy" hdf5="no"/>
+    <parameter name="walkers">    1 </parameter>
+    <parameter name="substeps">  2 </parameter>
+    <parameter name="warmupSteps">  3 </parameter>
+    <parameter name="steps">  3 </parameter>
+    <parameter name="blocks">  24 </parameter>
+    <parameter name="timestep">  1.0 </parameter>
+    <parameter name="usedrift">   no </parameter>
+  </qmc>
+
+</simulation>


### PR DESCRIPTION
## Proposed changes

Add minimal test of ensemble functionality. Each run in the ensemble has a different number of blocks to catch basic MPI errors. Standard CMake macro adapted to recognize *.txt files when specified as input and treat them as ensemble inputs. Statistical output is currently unchecked. Further changes and a possibly different approach may be needed if/when simulation output is checked. While deterministic, ensemble output currently differs from non-ensemble case.
 
## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Sulfur. gcc mpi new config.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
