### PR TITLE
[SYCL] Fix SYCL includes in SYCLDeviceManager

### DIFF
--- a/src/Platforms/SYCL/SYCLDeviceManager.cpp
+++ b/src/Platforms/SYCL/SYCLDeviceManager.cpp
@@ -21,9 +21,6 @@
 #include "determineDefaultDeviceNum.h"
 #if defined(_OPENMP)
 #include <omp.h>
-#include <CL/sycl/backend.hpp>
-#include <level_zero/ze_api.h>
-#include <CL/sycl/backend/level_zero.hpp>
 #endif
 
 namespace qmcplusplus


### PR DESCRIPTION
The includes 'CL/sycl/backend.hpp' and 'CL/sycl/backend/level_zero.hpp' are already included in 'CL/sycl.hpp' in 'SYCLDeviceManager.h' such that we can remove that here. 
Also, I could not find any calls to level_zero api such that I suggest to remove this include.

Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This commit removes non needed includes in SYCLDeviceManager.cpp to improve code quality. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

- Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
