### PR TITLE
Only create gridded Jastrow and pseudopotential files at debug level verbosity

### DIFF
--- a/src/QMCHamiltonians/ECPComponentBuilder.cpp
+++ b/src/QMCHamiltonians/ECPComponentBuilder.cpp
@@ -21,6 +21,7 @@
 #include "Utilities/IteratorUtility.h"
 #include "Utilities/SimpleParser.h"
 #include "Message/CommOperators.h"
+#include "Platforms/Host/OutputManager.h"
 #include <cmath>
 #include "Utilities/qmc_common.h"
 
@@ -223,7 +224,8 @@ void ECPComponentBuilder::printECPTable()
 {
   if (!qmc_common.io_node || qmc_common.mpi_groups > 1)
     return;
-
+  if (!outputManager.isActive(Verbosity::DEBUG))
+    return;
   char fname[12];
   sprintf(fname, "%s.pp.dat", Species.c_str());
   std::ofstream fout(fname);

--- a/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
+++ b/src/QMCWaveFunctions/Jastrow/RadialJastrowBuilder.cpp
@@ -33,6 +33,7 @@
 #include "QMCWaveFunctions/Jastrow/PadeFunctors.h"
 #include "QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h"
 #include "QMCWaveFunctions/Jastrow/UserFunctor.h"
+#include "Platforms/Host/OutputManager.h"
 #include <iostream>
 
 
@@ -242,7 +243,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ2(xmlNodePtr
 
       app_summary() << std::endl;
 
-      if (is_manager())
+      if (is_manager() && outputManager.isActive(Verbosity::DEBUG))
       {
         char fname[32];
         sprintf(fname, "J2.%s.%s.g%03d.dat", NameOpt.c_str(), pairType.c_str(), getGroupID());
@@ -274,7 +275,7 @@ void RadialJastrowBuilder::computeJ2uk(const std::vector<RadFuncType*>& functors
   RealType vol        = targetPtcl.getLattice().Volume;
   int nsp             = targetPtcl.groups();
   FILE* fout          = 0;
-  if (is_manager())
+  if (is_manager() && outputManager.isActive(Verbosity::DEBUG))
   {
     char fname[16];
     sprintf(fname, "uk.%s.g%03d.dat", NameOpt.c_str(), getGroupID());
@@ -404,7 +405,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
                     << (speciesB.empty() ? targetPtcl.getName() : speciesB) << std::endl;
       functor->put(kids);
       app_summary() << std::endl;
-      if (is_manager())
+      if (is_manager() && outputManager.isActive(Verbosity::DEBUG))
       {
         char fname[128];
         if (speciesB.size())
@@ -417,7 +418,7 @@ std::unique_ptr<WaveFunctionComponent> RadialJastrowBuilder::createJ1(xmlNodePtr
             std::is_same<RadFuncType, Pade2ndOrderFunctor<RealType>>::value)
         {
           double plotextent = 10.0;
-          print(*functor.get(), os, plotextent);
+          print(*functor.get(), os, plotextent);  
         }
         else
         {


### PR DESCRIPTION
## Proposed changes

Change the defaults to only create *.pp.dat, J1.*, J2.*, uk.* files when verbosity is set to the debug level.

i.e. After this change, `qmcpack input.xml` will result in a much cleaner run directory by default while `qmcpack -verbosity=debug input.xml` will restore historical behavior. 

In previous discussions, these files are rarely used and only in debugging type situations. They are also not mentioned in the manual.

Note that the einspline.tile_* files are still created since these are mentioned in the manual and the excitations tutorial. 

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- Yes

Someone relying on these files will have to specify -verbosity=debug.

## What systems has this change been tested on?

Sulfur, nightly gcc12 mpi config

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
