### PR TITLE
Remove broken putCommunicator and parallel setting from QMCMainState

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -454,11 +454,7 @@ bool QMCMain::validateXML()
   {
     std::string cname((const char*)cur->name);
     bool inputnode = true;
-    if (cname == "parallel")
-    {
-      putCommunicator(cur);
-    }
-    else if (cname == "particleset")
+    if (cname == "particleset")
     {
       ptclPool->put(cur);
     }

--- a/src/QMCApp/QMCMainState.cpp
+++ b/src/QMCApp/QMCMainState.cpp
@@ -51,21 +51,4 @@ QMCMainState::QMCMainState(Communicate* c) : MPIObjectBase(c), curRunType(QMCRun
 
 QMCMainState::~QMCMainState() = default;
 
-void QMCMainState::putCommunicator(xmlNodePtr cur)
-{
-  //BROKEN: myComm is ALWAYS initialized by the constructor
-  if (myComm)
-    return;
-  ParameterSet params;
-  int nparts = 1;
-  params.add(nparts, "groups");
-  params.add(nparts, "twistAngles");
-  params.put(cur);
-  if (nparts > 1)
-  {
-    app_log() << "  Communiator groups = " << nparts << std::endl;
-    myComm = new Communicate(*OHMMS::Controller, nparts);
-  }
-}
-
 } // namespace qmcplusplus

--- a/src/QMCApp/QMCMainState.h
+++ b/src/QMCApp/QMCMainState.h
@@ -69,9 +69,6 @@ struct QMCMainState : public MPIObjectBase
   /** default constructor **/
   QMCMainState(Communicate* c);
 
-  /** set the active qmcDriver */
-  void putCommunicator(xmlNodePtr cur);
-
   ///Global estimators defined outside of <qmc> nodes
   std::optional<EstimatorManagerInput> estimator_manager_input_;
 


### PR DESCRIPTION
## Proposed changes

Remove labelled as broken and unused undocumented code. How to specify or automatically determine the parallelization in the input will need a future rethink. e.g. If we wish to bundle over twists.

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Sulfur, nightly gcc new mpi config

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
