### PR TITLE
Make type conversion explicit.

### DIFF
--- a/src/Containers/OhmmsPETE/TinyVector.h
+++ b/src/Containers/OhmmsPETE/TinyVector.h
@@ -160,13 +160,15 @@ struct TinyVector
   template<class T1>
   inline TinyVector<T, D>& operator=(const TinyVector<T1, D>& rhs)
   {
-    OTAssign<TinyVector<T, D>, TinyVector<T1, D>, OpAssign>::apply(*this, rhs, OpAssign());
+    for (size_t d = 0; d < D; ++d)
+      X[d] = rhs[d];
     return *this;
   }
 
   inline TinyVector<T, D>& operator=(const T& rhs)
   {
-    OTAssign<TinyVector<T, D>, T, OpAssign>::apply(*this, rhs, OpAssign());
+    for (size_t d = 0; d < D; ++d)
+      X[d] = rhs;
     return *this;
   }
 

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -508,7 +508,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   //This is going to be slow an painful for now.
   for (size_t jat = 0; jat < ions.getTotalNum(); jat++)
   {
-    pulay_ref[jat] = psi.evalGradSource(W, ions, jat);
+    convertToReal(psi.evalGradSource(W, ions, jat), pulay_ref[jat]);
     gradpotterm_   = 0;
     for (size_t j = 0; j < nknot; j++)
     {
@@ -524,10 +524,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
 
       iongradtmp_ = psi.evalGradSource(W, ions, jat);
       iongradtmp_ *= psiratio[j];
-#ifdef QMC_COMPLEX
       convertToReal(iongradtmp_, pulay_quad[j][jat]);
-#endif
-      pulay_quad[j][jat] = iongradtmp_;
       //And move the particle back.
       deltaV[j] = dr - r * rrotsgrid_m[j];
 


### PR DESCRIPTION
## Proposed changes
Current TinyVector assign operator allow implicit complex to real conversion which is error-prone. Disallow that.
Fixed NLPP accordingly.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'