### PR TITLE
Safe default for blocks_between_recompute at full precision

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -401,10 +401,11 @@ Additional information:
 - ``storeconfigs`` If ``storeconfigs`` is set to a nonzero value, then electron configurations during the VMC run are saved to
   files.
 
-- ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction
-  from scratch: =1 by default when using mixed precision. =0 (no
-  recompute) by default when not using mixed precision. Recomputing
-  introduces a performance penalty dependent on system size.
+- ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction from scratch: =1 by
+  default when using mixed precision. =10 by default when not using mixed precision. 0 can be set for no recomputation
+  and higher performance, but numerical errors will accumulate over time. Recomputing introduces a performance penalty
+  dependent on system size, but protects against the accumulation of numerical error, particularly in the inverses of
+  the Slater determinants. These have a cubic-scaling cost to recompute.
 
 - ``debug_checks`` valid values are 'no', 'all', 'checkGL_after_load', 'checkGL_after_moves', 'checkGL_after_tmove'. If the build type is `debug`, the default value is 'all'. Otherwise, the default value is 'no'.
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -266,10 +266,11 @@ Additional information:
 - ``storeconfigs`` If ``storeconfigs`` is set to a nonzero value, then electron configurations during the VMC run are saved to
   files.
 
-- ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction
-  from scratch: =1 by default when using mixed precision. =0 (no
-  recompute) by default when not using mixed precision. Recomputing
-  introduces a performance penalty dependent on system size.
+- ``blocks_between_recompute`` Recompute the accuracy critical determinant part of the wavefunction from scratch: =1 by
+  default when using mixed precision. =10 by default when not using mixed precision. 0 can be set for no recomputation
+  and higher performance, but numerical errors will accumulate over time. Recomputing introduces a performance penalty
+  dependent on system size, but protects against the accumulation of numerical error, particularly in the inverses of
+  the Slater determinants. These have a cubic-scaling cost to recompute.
 
 - ``spinMass`` Optional parameter to allow the user to change the rate of spin sampling. If spin sampling is on using ``spinor`` == yes in the electron ParticleSet input,  the spin mass determines the rate
   of spin sampling, resulting in an effective spin timestep :math:`\tau_s = \frac{\tau}{\mu_s}`. The algorithm is described in detail in :cite:`Melton2016-1` and :cite:`Melton2016-2`.

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -138,7 +138,7 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
   else if (typeid(CTS::RealType) == typeid(double))
   {
     // gpu double precision
-    nBlocksBetweenRecompute = 0;
+    nBlocksBetweenRecompute = 10;
   }
 #else
 #ifdef MIXED_PRECISION
@@ -146,7 +146,7 @@ QMCDriver::QMCDriver(MCWalkerConfiguration& w,
   nBlocksBetweenRecompute = 1;
 #else
   // cpu double precision
-  nBlocksBetweenRecompute = 0;
+  nBlocksBetweenRecompute = 10;
 #endif
 #endif
   m_param.add(nBlocksBetweenRecompute, "blocks_between_recompute");

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short.in.xml
@@ -87,6 +87,7 @@
    <qmc method="vmc" move="pbyp">
       <parameter name="walkers"             >    1              </parameter>
       <parameter name="blocks"              >    3              </parameter>
+      <parameter name="blocks_between_recompute" > 2            </parameter>
       <parameter name="steps"               >    3              </parameter>
       <parameter name="subSteps"            >    2              </parameter>
       <parameter name="timestep"            >    0.3            </parameter>

--- a/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch.in.xml
+++ b/tests/solids/diamondC_2x1x1_pp/det_qmc_short_vmcbatch.in.xml
@@ -87,6 +87,7 @@
    <qmc method="vmc" move="pbyp">
       <parameter name="total_walkers"       >    1              </parameter>
       <parameter name="blocks"              >    3              </parameter>
+      <parameter name="blocks_between_recompute" > 2            </parameter>
       <parameter name="steps"               >    3              </parameter>
       <parameter name="subSteps"            >    2              </parameter>
       <parameter name="timestep"            >    0.3            </parameter>


### PR DESCRIPTION
## Proposed changes

Change the default number of blocks between computing the wavefunction (primarily the inverse Slater matrices) for non-mixed precision builds to 10 from the current value of zero (never). Set the input parameter in a couple of tests for coverage.

QMCPACK should not have unsafe defaults, and this removes one. Closes https://github.com/QMCPACK/qmcpack/issues/3056 . Currently if this input is not set, the results are guaranteed to be wrong after a sufficiently long run due to accumulation of numerical error. Unfortunately while the error clearly is larger in larger systems, how it accumulates is not obvious, particularly for different quality wavefunctions where e.g. occasional near electron coalescence presumably risks worsening the error. Potentially some of the reported problems with production runs could be due to this. While there are other more plausible reasons, this is an easy fix to one possibility. (Thanks to @jtkrogel for discussion on this issue.)

The new value of ten should be benign in terms of performance in nearly all circumstances while being numerically safe. 
Experts can set a larger value or zero if they wish. 

A future improvement could involve investigation of the error, checking the accumulated error in at least the inverses, or changing the default depending on electron count and steps per block. Ideally the code would check numerical consistency and restart a section or block if e.g. the local energy was too poor. The same analysis could be applied to mixed precision builds as well.

## What type(s) of changes does this code introduce?

- Bugfix
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

gcc 12 mpi, nightly sulfur config.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
