### PR TITLE
Orbital rotation initializes parameter only once, fixes for legacy driver with threads

### DIFF
--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -30,7 +30,12 @@ LCAOrbitalSet::LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize)
 }
 
 LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
-    : SPOSet(in), myBasisSet(in.myBasisSet->makeClone()), C(in.C), BasisSetSize(in.BasisSetSize), Identity(in.Identity)
+    : SPOSet(in),
+      myBasisSet(in.myBasisSet->makeClone()),
+      C(in.C),
+      BasisSetSize(in.BasisSetSize),
+      C_copy(in.C_copy),
+      Identity(in.Identity)
 {
   Temp.resize(BasisSetSize);
   Temph.resize(BasisSetSize);

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -69,8 +69,11 @@ void RotatedSPOs::buildOptVariables(const size_t nel)
   /* Only rebuild optimized variables if more after-rotation orbitals are needed
    * Consider ROHF, there is only one set of SPO for both spin up and down Nup > Ndown.
    * nel_major_ will be set Nup.
+   *
+   * Use the size of myVars as a flag to avoid building the rotation parameters again
+   * when a clone is made (the DiracDeterminant constructor calls buildOptVariables)
    */
-  if (nel > nel_major_)
+  if (nel > nel_major_ && myVars.size() == 0)
   {
     nel_major_ = nel;
 

--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -103,6 +103,24 @@ if(NOT QMC_CUDA)
     SCALAR_VALUES
     HE_ORB_ROT_PARAM)
 
+  qmc_run_and_check_custom_scalar(
+    BASE_NAME
+    He_orb_rot_param_grad_legacy
+    BASE_DIR
+    "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+    PREFIX
+    He_orb_rot_param_grad_legacy.param
+    INPUT_FILE
+    He_orb_rot_param_grad_legacy.xml
+    PROCS
+    1
+    THREADS
+    16
+    SERIES
+    0
+    SCALAR_VALUES
+    HE_ORB_ROT_PARAM)
+
 
   else()
     message(VERBOSE "Skipping He_param tests because parameter output is not supported by mixed precison build (QMC_MIXED_PRECISION=1)")

--- a/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
+++ b/tests/molecules/He_param/He_orb_rot_param_grad_legacy.xml
@@ -90,7 +90,7 @@
       <parameter name="steps"> 10 </parameter>
       <parameter name="substeps"> 20 </parameter>
       <parameter name="timestep"> 0.5 </parameter>
-      <parameter name="samples"> 1000 </parameter>
+      <parameter name="samplesperthread"> 1000 </parameter>
       <cost name="energy">                   1.0 </cost>
       <cost name="reweightedvariance">       0.00 </cost>
     </qmc>


### PR DESCRIPTION
See #4083, #3977, and #4076 for previous attempts.

This is the minimal change to get the added test to pass (parameter derivative for the legacy driver when multiple threads are used).

As a result of investigations from the comment in https://github.com/QMCPACK/qmcpack/pull/4083#pullrequestreview-1036223817 , calling buildOptVariables multiple times is the culprit in resetting the global indexing in myVars.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
