### PR TITLE
Update generated folder and name of NiO peformance tests

### DIFF
--- a/tests/performance/NiO/CMakeLists.txt
+++ b/tests/performance/NiO/CMakeLists.txt
@@ -156,8 +156,8 @@ else()
       if(NOT QMC_CUDA)
         # CPU driver
         set(DRIVER_TYPE cpu_driver)
-        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-w${WALKER_COUNT}-SM1)
-        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE})
+        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-SM1-${DRIVER_TYPE}-w${WALKER_COUNT})
+        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-SM1-${DRIVER_TYPE})
         add_nio_test(
           ${PERF_TEST}
           1
@@ -169,8 +169,8 @@ else()
           "${ADJUST_INPUT} -w ${WALKER_COUNT} -d 1")
         ## delayed update
         list(GET DELAY_RANKS ${INDEX} NDELAY)
-        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-w${WALKER_COUNT}-DU${NDELAY})
-        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-DU${NDELAY})
+        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-${DRIVER_TYPE}-w${WALKER_COUNT})
+        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-${DRIVER_TYPE})
         add_nio_test(
           ${PERF_TEST}
           1
@@ -181,8 +181,8 @@ else()
           ${H5_FILE}
           "${ADJUST_INPUT} -w ${WALKER_COUNT} -d ${NDELAY}")
         ## J3
-        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-w${WALKER_COUNT}-J3)
-        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-J3)
+        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-J3-${DRIVER_TYPE}-w${WALKER_COUNT})
+        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-J3-${DRIVER_TYPE})
         add_nio_test(
           ${PERF_TEST}
           1
@@ -191,13 +191,13 @@ else()
           ${TEST_SOURCE_DIR}
           ${INPUT_FILE}
           ${H5_FILE}
-          "${ADJUST_INPUT} -w ${WALKER_COUNT} -j ${TEST_DIR}/J123.xml")
+          "${ADJUST_INPUT} -w ${WALKER_COUNT} -d ${NDELAY} -j ${TEST_DIR}/J123.xml")
 
         # Batched driver
         set(DRIVER_TYPE batched_driver)
         ## delayed update
-        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-w${WALKER_COUNT}-DU${NDELAY})
-        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-${DRIVER_TYPE}-DU${NDELAY})
+        set(PERF_TEST performance-NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-${DRIVER_TYPE}-w${WALKER_COUNT})
+        set(TEST_DIR dmc-a${ATOM_COUNT}-e${ELECTRON_COUNT}-DU${NDELAY}-${DRIVER_TYPE})
         add_nio_test(
           ${PERF_TEST}
           1


### PR DESCRIPTION
## Proposed changes

Current folder and test names put tags in different orders.
old:
test name : `performance-NiO-a8-e96-cpu_driver-w512-DU16-1-16`
test work folder is at `tests/performance/NiO/dmc-a8-e96-cpu_driver-DU16`

It was painful to locate the test work directory.
Rename them to be closer.

Now
test name : `performance-NiO-a8-e96-DU16-cpu_driver-w512-1-16`
test work folder is at `tests/performance/NiO/dmc-a8-e96-DU16-cpu_driver`

Another notable change, all the J3 tests have delayed updated. Not useful to benchmark the slow code path. There are SM1 case already although without J3.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'