### PR TITLE
intel/offload: Update cmake for intel compiler for GPU offloading

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -23,6 +23,8 @@ if(QMC_OMP)
           "spir64"
           CACHE STRING "Offload target architecture")
       set(OPENMP_OFFLOAD_COMPILE_OPTIONS "-fopenmp-targets=${OFFLOAD_TARGET}")
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g -O2")
     endif(ENABLE_OFFLOAD)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fiopenmp")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fiopenmp")


### PR DESCRIPTION
The Intel compiler requires debug flags '-g -O0' to be explicetly
specified via CMake flags 'CMAKE_CXX_FLAGS_<target>' when offloading
code to GPU. If those flags are not specified, offloaded code/kernels
may be optimized and debugging experience may differ from what is
expected by users.

## Proposed changes

The Intel compiler requires 'CMAKE_CXX_FLAGS_DEBUG' and 'CMAKE_CXX_FLAGS_RELWITHDEBINFO' to contain debug flags in order to enable debugging of GPU offloaded code. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Build related changes
### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
