### PR TITLE
Adjust tolerance to make deterministic-unit_test_wavefunction_trialwf pass on AMD complex build

### DIFF
--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -227,9 +227,9 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update1, det_update1);
   PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
-  std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
+  app_log() << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
+  app_log() << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
   //double det_ratio1 = 0.178276269185;
 
@@ -244,9 +244,9 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
-  std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
+  app_log() << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
+  app_log() << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
   //double det_ratio2_val = 0.178276269185;
   REQUIRE(det_ratio2 == ValueApprox(det_ratio2_val));
@@ -260,9 +260,9 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
-  std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
+  app_log() << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
+  app_log() << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
   REQUIRE(det_ratio3 == ValueApprox(det_ratio3_val));
   //check_value(det_ratio3, det_ratio3_val);
@@ -273,10 +273,10 @@ void test_DiracDeterminant_second(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, orig_a, det_update3);
 
 #ifdef DUMP_INFO
-  std::cout << "original " << std::endl;
-  std::cout << orig_a << std::endl;
-  std::cout << "block update " << std::endl;
-  std::cout << ddb.psiM << std::endl;
+  app_log() << "original " << std::endl;
+  app_log() << orig_a << std::endl;
+  app_log() << "block update " << std::endl;
+  app_log() << ddb.psiM << std::endl;
 #endif
 
   check_matrix(orig_a, ddb.psiM);
@@ -370,9 +370,9 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update1, det_update1);
   PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
-  std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
+  app_log() << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
+  app_log() << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
   //double det_ratio1 = 0.178276269185;
 
@@ -394,9 +394,9 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
-  std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
+  app_log() << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
+  app_log() << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
   // check ratio computed directly and the one computed by ddc with no delay
   //double det_ratio2_val = 0.178276269185;
@@ -414,9 +414,9 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
-  std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
+  app_log() << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
+  app_log() << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
   // check ratio computed directly and the one computed by ddc with 1 delay
   REQUIRE(det_ratio3 == ValueApprox(det_ratio3_val));
@@ -431,10 +431,10 @@ void test_DiracDeterminant_delayed_update(const DetMatInvertor inverter_kind)
   dm.invert_transpose(scratchT, orig_a, det_update3);
 
 #ifdef DUMP_INFO
-  std::cout << "original " << std::endl;
-  std::cout << orig_a << std::endl;
-  std::cout << "delayed update " << std::endl;
-  std::cout << ddc.psiM << std::endl;
+  app_log() << "original " << std::endl;
+  app_log() << orig_a << std::endl;
+  app_log() << "delayed update " << std::endl;
+  app_log() << ddc.psiM << std::endl;
 #endif
 
   // compare all the elements of psiM in ddc and orig_a

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -204,9 +204,9 @@ void test_DiracDeterminantBatched_second()
   dm.invert_transpose(scratchT, a_update1, det_update1);
   PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddb.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
-  std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
+  app_log() << "det 0 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
+  app_log() << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
   //double det_ratio1 = 0.178276269185;
 
@@ -221,9 +221,9 @@ void test_DiracDeterminantBatched_second()
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
-  std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
+  app_log() << "det 1 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
+  app_log() << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
   //double det_ratio2_val = 0.178276269185;
   REQUIRE(det_ratio2 == ValueApprox(det_ratio2_val));
@@ -237,9 +237,9 @@ void test_DiracDeterminantBatched_second()
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
-  std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
-  std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
+  app_log() << "det 2 = " << std::exp(ddb.get_log_value()) << std::endl;
+  app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
+  app_log() << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
   REQUIRE(det_ratio3 == ValueApprox(det_ratio3_val));
   //check_value(det_ratio3, det_ratio3_val);
@@ -250,10 +250,10 @@ void test_DiracDeterminantBatched_second()
   dm.invert_transpose(scratchT, orig_a, det_update3);
 
 #ifdef DUMP_INFO
-  std::cout << "original " << std::endl;
-  std::cout << orig_a << std::endl;
-  std::cout << "block update " << std::endl;
-  std::cout << ddb.getPsiMinv() << std::endl;
+  app_log() << "original " << std::endl;
+  app_log() << orig_a << std::endl;
+  app_log() << "block update " << std::endl;
+  app_log() << ddb.getPsiMinv() << std::endl;
 #endif
 
   checkMatrix(ddb.get_det_engine().get_ref_psiMinv(), orig_a);
@@ -340,9 +340,9 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   dm.invert_transpose(scratchT, a_update1, det_update1);
   PsiValueType det_ratio1 = LogToValue<ValueType>::convert(det_update1 - ddc.get_log_value());
 #ifdef DUMP_INFO
-  std::cout << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 1 = " << std::exp(det_update1) << std::endl;
-  std::cout << "det ratio 1 = " << det_ratio1 << std::endl;
+  app_log() << "det 0 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 1 = " << std::exp(det_update1) << std::endl;
+  app_log() << "det ratio 1 = " << det_ratio1 << std::endl;
 #endif
   //double det_ratio1 = 0.178276269185;
 
@@ -364,9 +364,9 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   dm.invert_transpose(scratchT, a_update2, det_update2);
   PsiValueType det_ratio2_val = LogToValue<ValueType>::convert(det_update2 - det_update1);
 #ifdef DUMP_INFO
-  std::cout << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 2 = " << std::exp(det_update2) << std::endl;
-  std::cout << "det ratio 2 = " << det_ratio2 << std::endl;
+  app_log() << "det 1 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 2 = " << std::exp(det_update2) << std::endl;
+  app_log() << "det ratio 2 = " << det_ratio2 << std::endl;
 #endif
   // check ratio computed directly and the one computed by ddc with no delay
   //double det_ratio2_val = 0.178276269185;
@@ -384,9 +384,9 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   dm.invert_transpose(scratchT, a_update3, det_update3);
   PsiValueType det_ratio3_val = LogToValue<ValueType>::convert(det_update3 - det_update2);
 #ifdef DUMP_INFO
-  std::cout << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
-  std::cout << "det 3 = " << std::exp(det_update3) << std::endl;
-  std::cout << "det ratio 3 = " << det_ratio3 << std::endl;
+  app_log() << "det 2 = " << std::exp(ddc.get_log_value()) << std::endl;
+  app_log() << "det 3 = " << std::exp(det_update3) << std::endl;
+  app_log() << "det ratio 3 = " << det_ratio3 << std::endl;
 #endif
   // check ratio computed directly and the one computed by ddc with 1 delay
   REQUIRE(det_ratio3 == ValueApprox(det_ratio3_val));
@@ -401,10 +401,10 @@ void test_DiracDeterminantBatched_delayed_update(int delay_rank, DetMatInvertor 
   dm.invert_transpose(scratchT, orig_a, det_update3);
 
 #ifdef DUMP_INFO
-  std::cout << "original " << std::endl;
-  std::cout << orig_a << std::endl;
-  std::cout << "delayed update " << std::endl;
-  std::cout << ddc.getPsiMinv() << std::endl;
+  app_log() << "original " << std::endl;
+  app_log() << orig_a << std::endl;
+  app_log() << "delayed update " << std::endl;
+  app_log() << ddc.getPsiMinv() << std::endl;
 #endif
 
   // compare all the elements of get_ref_psiMinv() in ddc and orig_a

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -145,7 +145,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   elec_.update();
   double logpsi = psi.evaluateLog(elec_);
 
-  //std::cout << "debug before YYY " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()<< std::endl;
+  //app_log() << "debug before YYY " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()<< std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(logpsi == Approx(-0.1201465271523596));
 #else
@@ -176,9 +176,9 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   ValueType r_fermionic_val = psi.calcRatio(elec_, moved_elec_id, TrialWaveFunction::ComputeType::FERMIONIC);
   ValueType r_bosonic_val   = psi.calcRatio(elec_, moved_elec_id, TrialWaveFunction::ComputeType::NONFERMIONIC);
 
-  //std::cout << "debug YYY " << std::setprecision(16) << r_all_val << std::endl;
-  //std::cout << "debug YYY " << std::setprecision(16) << r_fermionic_val << std::endl;
-  //std::cout << "debug YYY " << std::setprecision(16) << r_bosonic_val << std::endl;
+  //app_log() << "debug YYY " << std::setprecision(16) << r_all_val << std::endl;
+  //app_log() << "debug YYY " << std::setprecision(16) << r_fermionic_val << std::endl;
+  //app_log() << "debug YYY " << std::setprecision(16) << r_bosonic_val << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(r_all_val == ComplexApprox(ValueType(1.653821746120792, 0.5484992491019633)));
   CHECK(r_fermionic_val == ComplexApprox(ValueType(1.804065087219802, 0.598328295048828)));
@@ -238,7 +238,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
   grad_old.grads_positions[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
   grad_old.grads_positions[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
-  std::cout << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+  app_log() << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
             << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
             << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
             << grad_old.grads_positions[1][2] << std::endl;
@@ -291,7 +291,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   std::vector<PsiValueType> ratios(2);
   TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
-  std::cout << "calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
+  app_log() << "calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)));
   CHECK(ratios[1] == ComplexApprox(PsiValueType(1.6538214581548, 0.54849918598717)));
@@ -308,7 +308,7 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
     ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new.grads_positions[0]);
     ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new.grads_positions[1]);
 
-    std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
+    app_log() << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
               << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
               << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
               << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -369,11 +369,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)).epsilon(5e-4));
-#if defined(MIXED_PRECISION)
   CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)).epsilon(5e-5));
-#else
-  CHECK(ratios[1] == ComplexApprox(PsiValueType(0.12487384604679, 0)));
-#endif
 #else
   CHECK(ratios[0] == Approx(1).epsilon(5e-5));
 #if defined(MIXED_PRECISION)

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -192,8 +192,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   elec_.update();
   double logpsi = psi.evaluateLog(elec_);
 
-  std::cout << "debug before YYY logpsi " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()
-            << std::endl;
+  app_log() << "debug before YYY logpsi " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()
+             << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(logpsi == Approx(-4.546410485374186));
 #else
@@ -238,9 +238,9 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   ValueType r_fermionic_val = psi.calcRatio(elec_, moved_elec_id, TrialWaveFunction::ComputeType::FERMIONIC);
   ValueType r_bosonic_val   = psi.calcRatio(elec_, moved_elec_id, TrialWaveFunction::ComputeType::NONFERMIONIC);
 
-  std::cout << "YYY r_all_val " << std::setprecision(16) << r_all_val << std::endl;
-  std::cout << "YYY r_fermionic_val " << std::setprecision(16) << r_fermionic_val << std::endl;
-  std::cout << "YYY r_bosonic_val " << std::setprecision(16) << r_bosonic_val << std::endl;
+  app_log() << "YYY r_all_val " << std::setprecision(16) << r_all_val << std::endl;
+  app_log() << "YYY r_fermionic_val " << std::setprecision(16) << r_fermionic_val << std::endl;
+  app_log() << "YYY r_bosonic_val " << std::setprecision(16) << r_bosonic_val << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(r_all_val == ComplexApprox(std::complex<RealType>(0.1248738460467855, 0)).epsilon(2e-5));
   CHECK(r_fermionic_val == ComplexApprox(std::complex<RealType>(0.1362181543980086, 0)).epsilon(2e-5));
@@ -252,8 +252,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   psi.acceptMove(elec_, moved_elec_id);
   elec_.acceptMove(moved_elec_id);
-  std::cout << "before YYY getLogPsi " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()
-            << std::endl;
+  app_log() << "before YYY getLogPsi " << std::setprecision(16) << psi.getLogPsi() << " " << psi.getPhase()
+             << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(psi.getLogPsi() == Approx(-6.626861768296886).epsilon(5e-5));
 #else
@@ -284,10 +284,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   ParticleSet::mw_update(p_ref_list);
   TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
-  std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
-            << wf_ref_list[0].getPhase() << std::endl;
-  std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
-            << wf_ref_list[1].getPhase() << std::endl;
+  app_log() << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
+             << wf_ref_list[0].getPhase() << std::endl;
+  app_log() << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
+             << wf_ref_list[1].getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082042)));
@@ -305,10 +305,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   grad_old.grads_positions[0] = wf_ref_list[0].evalGrad(p_ref_list[0], moved_elec_id);
   grad_old.grads_positions[1] = wf_ref_list[1].evalGrad(p_ref_list[1], moved_elec_id);
 
-  std::cout << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
-            << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
-            << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
-            << grad_old.grads_positions[1][2] << std::endl;
+  app_log() << "evalGrad " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+             << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
+             << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
+             << grad_old.grads_positions[1][2] << std::endl;
 
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id, grad_old);
 
@@ -342,8 +342,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
     ValueType r_0 = wf_ref_list[0].calcRatio(p_ref_list[0], moved_elec_id);
     GradType grad_temp;
     ValueType r_1 = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_temp);
-    std::cout << "calcRatio calcRatioGrad " << std::setprecision(14) << r_0 << " " << r_1 << " " << grad_temp[0] << " "
-              << grad_temp[1] << " " << grad_temp[2] << std::endl;
+    app_log() << "calcRatio calcRatioGrad " << std::setprecision(14) << r_0 << " " << r_1 << " " << grad_temp[0] << " "
+               << grad_temp[1] << " " << grad_temp[2] << std::endl;
 #if defined(QMC_COMPLEX)
     CHECK(r_0 == ComplexApprox(ValueType(253.71869245791, -0.00034808849808193)).epsilon(1e-4));
     CHECK(r_1 == ComplexApprox(ValueType(36.915636007059, -6.4240180082292e-05)).epsilon(1e-5));
@@ -365,7 +365,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   std::vector<PsiValueType> ratios(2);
   TrialWaveFunction::mw_calcRatio(wf_ref_list, p_ref_list, moved_elec_id, ratios);
-  std::cout << "mixed move calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
+  app_log() << "mixed move calcRatio " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl;
 
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(PsiValueType(1, 0)).epsilon(5e-4));
@@ -391,18 +391,18 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
     ratios[0] = wf_ref_list[0].calcRatioGrad(p_ref_list[0], moved_elec_id, grad_new.grads_positions[0]);
     ratios[1] = wf_ref_list[1].calcRatioGrad(p_ref_list[1], moved_elec_id, grad_new.grads_positions[1]);
 
-    std::cout << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-              << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
-              << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
-              << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
+    app_log() << "calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
+               << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
+               << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
+               << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
   }
   //Temporary as switch to std::reference_wrapper proceeds
   // testing batched interfaces
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id, ratios, grad_new);
-  std::cout << "flex_calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
-            << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
-            << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
-            << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
+  app_log() << "flex_calcRatioGrad " << std::setprecision(14) << ratios[0] << " " << ratios[1] << std::endl
+             << grad_new.grads_positions[0][0] << " " << grad_new.grads_positions[0][1] << " "
+             << grad_new.grads_positions[0][2] << " " << grad_new.grads_positions[1][0] << " "
+             << grad_new.grads_positions[1][1] << " " << grad_new.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(ratios[0] == ComplexApprox(ValueType(1, 0)).epsilon(5e-5));
   CHECK(grad_new.grads_positions[0][0] ==
@@ -431,10 +431,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   std::vector<bool> isAccepted(2, true);
   TrialWaveFunction::mw_accept_rejectMove(wf_ref_list, p_ref_list, moved_elec_id, isAccepted, true);
-  std::cout << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi()
-            << " " << wf_ref_list[0].getPhase() << std::endl;
-  std::cout << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi()
-            << " " << wf_ref_list[1].getPhase() << std::endl;
+  app_log() << "flex_acceptMove WF_list[0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi()
+             << " " << wf_ref_list[0].getPhase() << std::endl;
+  app_log() << "flex_acceptMove WF_list[1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi()
+             << " " << wf_ref_list[1].getPhase() << std::endl;
 #if defined(QMC_COMPLEX)
   REQUIRE(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-6.626861768296848, -3.141586279082065)));
@@ -451,10 +451,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   const int moved_elec_id_next = 1;
   TrialWaveFunction::mw_evalGrad(wf_ref_list, p_ref_list, moved_elec_id_next, grad_old);
-  std::cout << "evalGrad next electron " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
-            << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
-            << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
-            << grad_old.grads_positions[1][2] << std::endl;
+  app_log() << "evalGrad next electron " << std::setprecision(14) << grad_old.grads_positions[0][0] << " "
+             << grad_old.grads_positions[0][1] << " " << grad_old.grads_positions[0][2] << " "
+             << grad_old.grads_positions[1][0] << " " << grad_old.grads_positions[1][1] << " "
+             << grad_old.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(grad_old.grads_positions[0][0] ==
         ComplexApprox(ValueType(-114.82740072726, -7.605305979232e-05)).epsilon(grad_precision));
@@ -482,10 +482,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   ParticleSet::mw_makeMove(p_ref_list, moved_elec_id_next, displ);
   TrialWaveFunction::mw_calcRatioGrad(wf_ref_list, p_ref_list, moved_elec_id_next, ratios, grad_new);
-  std::cout << "ratioGrad next electron " << std::setprecision(14) << grad_new.grads_positions[0][0] << " "
-            << grad_new.grads_positions[0][1] << " " << grad_new.grads_positions[0][2] << " "
-            << grad_new.grads_positions[1][0] << " " << grad_new.grads_positions[1][1] << " "
-            << grad_new.grads_positions[1][2] << std::endl;
+  app_log() << "ratioGrad next electron " << std::setprecision(14) << grad_new.grads_positions[0][0] << " "
+             << grad_new.grads_positions[0][1] << " " << grad_new.grads_positions[0][2] << " "
+             << grad_new.grads_positions[1][0] << " " << grad_new.grads_positions[1][1] << " "
+             << grad_new.grads_positions[1][2] << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(grad_new.grads_positions[0][0] ==
         ComplexApprox(ValueType(9.6073058494562, -1.4375146770852e-05)).epsilon(8e-5));
@@ -516,9 +516,9 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   TrialWaveFunction::mw_completeUpdates(wf_ref_list);
   TrialWaveFunction::mw_evaluateGL(wf_ref_list, p_ref_list, false);
 #ifndef NDEBUG
-  std::cout << "invMat next electron " << std::setprecision(14) << det_up->getPsiMinv()[0][0] << " "
-            << det_up->getPsiMinv()[0][1] << " " << det_up->getPsiMinv()[1][0] << " " << det_up->getPsiMinv()[1][1]
-            << " " << std::endl;
+  app_log() << "invMat next electron " << std::setprecision(14) << det_up->getPsiMinv()[0][0] << " "
+             << det_up->getPsiMinv()[0][1] << " " << det_up->getPsiMinv()[1][0] << " " << det_up->getPsiMinv()[1][1]
+             << " " << std::endl;
 #if defined(QMC_COMPLEX)
   CHECK(det_up->getPsiMinv()[0][0] == ComplexApprox(ValueType(38.503358805635, -38.503358805645)).epsilon(1e-4));
   CHECK(det_up->getPsiMinv()[0][1] == ComplexApprox(ValueType(-31.465077529568, 31.465077529576)).epsilon(1e-4));

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -97,8 +97,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
 
-  std::cout << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-            << std::endl;
+  app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
+             << std::endl;
   CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
         LogComplexApprox(std::complex<double>(-7.646027846242066, 3.141592653589793)));
   CHECK(elec_.G[0][0] == ValueApprox(-2.181896934));
@@ -109,7 +109,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
   twf.prepareGroup(elec_, 0);
   auto grad_old = twf.evalGrad(elec_, 1);
-  std::cout << "twf.evalGrad grad_old " << std::setprecision(16) << grad_old << std::endl;
+  app_log() << "twf.evalGrad grad_old " << std::setprecision(16) << grad_old << std::endl;
   CHECK(grad_old[0] == ValueApprox(0.1204183219));
   CHECK(grad_old[1] == ValueApprox(0.120821033));
   CHECK(grad_old[2] == ValueApprox(2.05904174));
@@ -119,14 +119,14 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
   ParticleSet::GradType grad_new;
   auto ratio = twf.calcRatioGrad(elec_, 1, grad_new);
-  std::cout << "twf.calcRatioGrad ratio " << ratio << " grad_new " << grad_new << std::endl;
+  app_log() << "twf.calcRatioGrad ratio " << ratio << " grad_new " << grad_new << std::endl;
   CHECK(ratio == ValueApprox(1.374307585));
   CHECK(grad_new[0] == ValueApprox(0.05732804333));
   CHECK(grad_new[1] == ValueApprox(0.05747775029));
   CHECK(grad_new[2] == ValueApprox(1.126889742));
 
   ratio = twf.calcRatio(elec_, 1);
-  std::cout << "twf.calcRatio ratio " << ratio << std::endl;
+  app_log() << "twf.calcRatio ratio " << ratio << std::endl;
   CHECK(ratio == ValueApprox(1.374307585));
 
 
@@ -194,8 +194,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
     twf.evaluateLog(elec_);
 
-    std::cout << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-              << std::endl;
+    app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
+               << std::endl;
     CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
           LogComplexApprox(std::complex<double>(-7.803347327300154, 0.0)));
     CHECK(elec_.G[0][0] == ValueApprox(1.63020975849953));
@@ -233,10 +233,10 @@ void test_LiH_msd(const std::string& spo_xml_string,
 
     ParticleSet::mw_update(p_ref_list);
     TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
-    std::cout << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
-              << wf_ref_list[0].getPhase() << std::endl;
-    std::cout << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
-              << wf_ref_list[1].getPhase() << std::endl;
+    app_log() << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
+               << wf_ref_list[0].getPhase() << std::endl;
+    app_log() << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
+               << wf_ref_list[1].getPhase() << std::endl;
     CHECK(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-7.803347327300153, 0.0)));
     CHECK(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
@@ -439,15 +439,15 @@ void test_Bi_msd(const std::string& spo_xml_string,
 
   //Reference values from QWalk with SOC
 
-  std::cout << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-            << std::endl;
+  app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
+             << std::endl;
   CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
         LogComplexApprox(std::complex<double>(-9.653087, 3.311467)));
 
   twf.prepareGroup(elec_, 0);
   ParticleSet::ComplexType spingrad_old;
   auto grad_old = twf.evalGradWithSpin(elec_, 1, spingrad_old);
-  std::cout << "twf.evalGrad grad_old " << std::setprecision(16) << grad_old << std::endl;
+  app_log() << "twf.evalGrad grad_old " << std::setprecision(16) << grad_old << std::endl;
   CHECK(grad_old[0] == ComplexApprox(ValueType(0.060932, -0.285244)).epsilon(1e-4));
   CHECK(grad_old[1] == ComplexApprox(ValueType(-0.401769, 0.180544)).epsilon(1e-4));
   CHECK(grad_old[2] == ComplexApprox(ValueType(0.174010, 0.140642)).epsilon(1e-4));
@@ -459,14 +459,14 @@ void test_Bi_msd(const std::string& spo_xml_string,
   ParticleSet::GradType grad_new;
   ParticleSet::ComplexType spingrad_new;
   auto ratio = twf.calcRatioGradWithSpin(elec_, 0, grad_new, spingrad_new);
-  std::cout << "twf.calcRatioGrad ratio " << ratio << " grad_new " << grad_new << std::endl;
+  app_log() << "twf.calcRatioGrad ratio " << ratio << " grad_new " << grad_new << std::endl;
   CHECK(ValueType(std::abs(ratio)) == ValueApprox(0.991503).epsilon(1e-4));
   CHECK(grad_new[0] == ComplexApprox(ValueType(-0.631184, -0.136918)).epsilon(1e-4));
   CHECK(grad_new[1] == ComplexApprox(ValueType(0.074214, -0.080204)).epsilon(1e-4));
   CHECK(grad_new[2] == ComplexApprox(ValueType(-0.073180, -0.133539)).epsilon(1e-4));
 
   ratio = twf.calcRatio(elec_, 0);
-  std::cout << "twf.calcRatio ratio " << ratio << std::endl;
+  app_log() << "twf.calcRatio ratio " << ratio << std::endl;
   CHECK(ValueType(std::abs(ratio)) == ValueApprox(0.991503).epsilon(1e-4));
 }
 


### PR DESCRIPTION
## Proposed changes
Address https://cdash.qmcpack.org/CDash/testDetails.php?test=20251909&build=328253 failure by increasing tolerance.
Also suppress all the printout.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'