### PR TITLE
Orbital rotation test for wavefunction with jastrow

### DIFF
--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -158,6 +158,48 @@ if(NOT QMC_CUDA)
       SCALAR_VALUES
       HE_ORB_ROT_PARAM)
 
+    # Two atomic orbitals, with jastrow
+
+    list(APPEND HE_ORB_ROT_JASTROW_PARAM spo-up_orb_rot_0000_0001    0.078  0.02)  # scalar name, value, error
+    list(APPEND HE_ORB_ROT_JASTROW_PARAM spo-down_orb_rot_0000_0001  0.078  0.02)
+    list(APPEND HE_ORB_ROT_JASTROW_PARAM jud_b                      -0.106  0.013)
+
+    qmc_run_and_check_custom_scalar(
+      BASE_NAME
+      short-He_orb_rot_jastrow_param_grad_legacy
+      BASE_DIR
+      "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+      PREFIX
+      He_orb_rot_jastrow_param_grad_legacy.param
+      INPUT_FILE
+      He_orb_rot_jastrow_param_grad_legacy.xml
+      PROCS
+      1
+      THREADS
+      16
+      SERIES
+      0
+      SCALAR_VALUES
+      HE_ORB_ROT_JASTROW_PARAM)
+
+    qmc_run_and_check_custom_scalar(
+      BASE_NAME
+      short-He_orb_rot_jastrow_param_grad_batch
+      BASE_DIR
+      "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+      PREFIX
+      He_orb_rot_jastrow_param_grad_batch.param
+      INPUT_FILE
+      He_orb_rot_jastrow_param_grad_batch.xml
+      PROCS
+      1
+      THREADS
+      16
+      SERIES
+      0
+      SCALAR_VALUES
+      HE_ORB_ROT_JASTROW_PARAM)
+
     else()
       message(VERBOSE "Skipping He_orb_rot_param_grad tests because orbital rotation optimization is not supported by complex build (QMC_COMPLEX=1)")
     endif()

--- a/tests/molecules/He_param/He_orb_rot_jastrow_param_grad_batch.xml
+++ b/tests/molecules/He_param/He_orb_rot_jastrow_param_grad_batch.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="He_orb_rot_jastrow_param_grad_batch" series="0">
+         <parameter name="driver_version">batch</parameter>
+  </project>
+
+  <!-- Location of atoms -->
+
+  <particleset name="ion0" size="1">
+    <group name="He">
+      <parameter name="charge">2</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+      0.0 0.0 0.0
+    </attrib>
+  </particleset>
+
+  <!-- Randomly create electrons around the atomic position -->
+
+  <particleset name="e" random="yes" randomsrc="ion0">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+
+  <!-- Trial wavefunction - use Slater determinant multiplied by a Jastrow factor -->
+
+  <wavefunction name="psi0" target="e">
+    <jastrow name="Jee" type="Two-Body" function="pade">
+      <correlation speciesA="u" speciesB="d">
+        <var id="jud_b" name="B">0.2</var>
+      </correlation>
+    </jastrow>
+
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="downdetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="1"/>
+      </slaterdeterminant>
+    </determinantset>
+
+
+  </wavefunction>
+
+  <!-- Hamiltonian - the energy of interactions between particles -->
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <!-- Electon-electron -->
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e"/>
+    <!-- Electon-ion -->
+    <pairpot name="Coulomb" type="coulomb" source="ion0" target="e"/>
+    <!-- Ion-ion (not needed for a single atom) -->
+    <!--<constant name="IonIon" type="coulomb" source="ion0" target="ion0"/>-->
+  </hamiltonian>
+
+  <!-- QMC method(s) to run -->
+
+  <loop max="10">
+    <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
+      <optimize method="gradient_test">
+        <parameter name="output_param_file">yes</parameter>
+      </optimize>
+      <parameter name="blocks">     100  </parameter>
+
+      <parameter name="warmupsteps"> 25 </parameter>
+      <parameter name="steps"> 10 </parameter>
+      <parameter name="substeps"> 20 </parameter>
+      <parameter name="timestep"> 0.5 </parameter>
+      <cost name="energy">                   1.0 </cost>
+      <cost name="reweightedvariance">       0.00 </cost>
+    </qmc>
+  </loop>
+
+
+</simulation>

--- a/tests/molecules/He_param/He_orb_rot_jastrow_param_grad_legacy.xml
+++ b/tests/molecules/He_param/He_orb_rot_jastrow_param_grad_legacy.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="He_orb_rot_jastrow_param_grad_legacy" series="0">
+         <parameter name="driver_version">legacy</parameter>
+  </project>
+
+  <!-- Location of atoms -->
+
+  <particleset name="ion0" size="1">
+    <group name="He">
+      <parameter name="charge">2</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+      0.0 0.0 0.0
+    </attrib>
+  </particleset>
+
+  <!-- Randomly create electrons around the atomic position -->
+
+  <particleset name="e" random="yes" randomsrc="ion0">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+
+  <!-- Trial wavefunction - use Slater determinant multiplied by a Jastrow factor -->
+
+  <wavefunction name="psi0" target="e">
+    <jastrow name="Jee" type="Two-Body" function="pade">
+      <correlation speciesA="u" speciesB="d">
+        <var id="jud_b" name="B">0.2</var>
+      </correlation>
+    </jastrow>
+
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+      <sposet basisset="LCAOBSet" name="spo-down" size="2" optimize="yes">
+          <opt_vars>0.1</opt_vars>
+          <coefficient id="downdetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-down" spin="-1" size="1"/>
+      </slaterdeterminant>
+    </determinantset>
+
+
+  </wavefunction>
+
+  <!-- Hamiltonian - the energy of interactions between particles -->
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <!-- Electon-electron -->
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e"/>
+    <!-- Electon-ion -->
+    <pairpot name="Coulomb" type="coulomb" source="ion0" target="e"/>
+    <!-- Ion-ion (not needed for a single atom) -->
+    <!--<constant name="IonIon" type="coulomb" source="ion0" target="ion0"/>-->
+  </hamiltonian>
+
+  <!-- QMC method(s) to run -->
+
+  <loop max="10">
+    <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
+      <optimize method="gradient_test">
+        <parameter name="output_param_file">yes</parameter>
+      </optimize>
+      <parameter name="blocks">     100  </parameter>
+
+      <parameter name="warmupsteps"> 25 </parameter>
+      <parameter name="steps"> 10 </parameter>
+      <parameter name="substeps"> 20 </parameter>
+      <parameter name="timestep"> 0.5 </parameter>
+      <parameter name="samplesperthread"> 1000 </parameter>
+      <cost name="energy">                   1.0 </cost>
+      <cost name="reweightedvariance">       0.00 </cost>
+    </qmc>
+  </loop>
+
+
+</simulation>


### PR DESCRIPTION
Add a test of the parameter gradient for a wavefunction that includes orbital rotation and a Jastrow factor.

Update the python script to more closely match how QMCPACK computes the derivatives.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
