### PR TITLE
Reapprove PR after Auto Rebase Completes

### DIFF
--- a/.github/workflows/ci-github-action-auto-rebase.yaml
+++ b/.github/workflows/ci-github-action-auto-rebase.yaml
@@ -32,6 +32,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}
+        QMCPACK_BOT_GPG_SIGNING_KEY: ${{ secrets.QMCPACK_BOT_GPG_SIGNING_KEY }}
 
   trigger-rebase:
     if: github.event_name == 'push'
@@ -48,3 +49,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}
+        QMCPACK_BOT_GPG_SIGNING_KEY: ${{ secrets.QMCPACK_BOT_GPG_SIGNING_KEY }}

--- a/.github/workflows/ci-github-action-auto-rebase.yaml
+++ b/.github/workflows/ci-github-action-auto-rebase.yaml
@@ -2,6 +2,7 @@ on:
   pull_request_target:
     types: [edited, auto_merge_enabled]
     branches:
+      - github_actions_automatic_rebase
       - develop
       - main
   push:
@@ -30,6 +31,7 @@ jobs:
       run: tests/test_automation/github-actions/ci/run_step.sh rebase
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}
 
   trigger-rebase:
     if: github.event_name == 'push'
@@ -45,3 +47,4 @@ jobs:
       run: tests/test_automation/github-actions/ci/run_step.sh pull-rebase
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}

--- a/external_codes/github_actions/auto-rebase.sh
+++ b/external_codes/github_actions/auto-rebase.sh
@@ -111,8 +111,9 @@ UNTRIMMED_COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
 COMMITTER_TOKEN="$(echo -e "${UNTRIMMED_COMMITTER_TOKEN}" | tr -d '[:space:]')"
 
 git remote set-url origin https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git
-git config --global user.email "$USER_EMAIL"
-git config --global user.name "$USER_NAME"
+# CHANGED FROM ORIGNAL: use bot credentials
+git config --global user.email "QMCPACKbot@gmail.com"
+git config --global user.name "QMCPACK-Bot"
 
 git remote add fork https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REPO.git
 
@@ -128,6 +129,11 @@ git rebase origin/$BASE_BRANCH
 
 # push back
 git push --force-with-lease fork fork/$HEAD_BRANCH:$HEAD_BRANCH
+
+# CHANGE FROM ORIGINAL: add empty commit signed by bot 
+git config --global user.signingkey "$QMCPACK_BOT_GPG_KEY"  
+git commit --allow-empty -S -m "Rebased Signed Off by QMCPACK-Bot"
+git push fork HEAD
 
 COMMIT_SHA=$(git rev-parse --verify HEAD)
 

--- a/external_codes/github_actions/auto-rebase.sh
+++ b/external_codes/github_actions/auto-rebase.sh
@@ -128,3 +128,16 @@ git rebase origin/$BASE_BRANCH
 
 # push back
 git push --force-with-lease fork fork/$HEAD_BRANCH:$HEAD_BRANCH
+
+COMMIT_SHA=$(git rev-parse --verify HEAD)
+
+# EDIT TO ORIGINAL SCRIPT:  Reapprove PR after push
+# NOTE: Submits a review appoving the SHA it just sent, 
+# so if someone tried to commit something on top and "steal" this review,
+# it shouldn't work because it would have a different SHA
+REVIEW_URI="${URI}/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews"
+UPDATE_PARAMETERS='{"commit_id" : "' + "${COMMIT_SHA}" + '", "body":"AUTOMATED REVIEW: Reapprove after rebase", "event":"APPROVE"}'
+
+RESULT=$(curl -X POST -H "${AUTH_HEADER}" -H "${API_HEADER}" \
+            -d "${UPDATE_PARAMETERS}" \
+            "${REVIEW_URI}")

--- a/external_codes/github_actions/auto-rebase.sh
+++ b/external_codes/github_actions/auto-rebase.sh
@@ -138,7 +138,7 @@ COMMIT_SHA=$(git rev-parse --verify HEAD)
 REVIEW_URI="${URI}/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews"
 UPDATE_PARAMETERS=$(jq --null-input \
             --arg commit_sha "${COMMIT_SHA}" \
-            '{"commit_id" : "$commit_sha", "body":"AUTOMATED REVIEW: Reapprove after rebase", "event":"APPROVE"}')
+            '{"commit_id" : $commit_sha, "body":"AUTOMATED REVIEW: Reapprove after rebase", "event":"APPROVE"}')
 
 
 RESULT=$(curl -X POST -H "${AUTH_HEADER}" -H "${API_HEADER}" \

--- a/external_codes/github_actions/auto-rebase.sh
+++ b/external_codes/github_actions/auto-rebase.sh
@@ -136,7 +136,10 @@ COMMIT_SHA=$(git rev-parse --verify HEAD)
 # so if someone tried to commit something on top and "steal" this review,
 # it shouldn't work because it would have a different SHA
 REVIEW_URI="${URI}/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews"
-UPDATE_PARAMETERS='{"commit_id" : "' + "${COMMIT_SHA}" + '", "body":"AUTOMATED REVIEW: Reapprove after rebase", "event":"APPROVE"}'
+UPDATE_PARAMETERS=$(jq --null-input \
+            --arg commit_sha "${COMMIT_SHA}" \
+            '{"commit_id" : "$commit_sha", "body":"AUTOMATED REVIEW: Reapprove after rebase", "event":"APPROVE"}')
+
 
 RESULT=$(curl -X POST -H "${AUTH_HEADER}" -H "${API_HEADER}" \
             -d "${UPDATE_PARAMETERS}" \

--- a/external_codes/github_actions/auto-rebase.sh
+++ b/external_codes/github_actions/auto-rebase.sh
@@ -130,10 +130,13 @@ git rebase origin/$BASE_BRANCH
 # push back
 git push --force-with-lease fork fork/$HEAD_BRANCH:$HEAD_BRANCH
 
-# CHANGE FROM ORIGINAL: add empty commit signed by bot 
-git config --global user.signingkey "$QMCPACK_BOT_GPG_KEY"  
+# CHANGE FROM ORIGINAL: add empty commit signed by bot
+echo "$QMCPACK_BOT_GPG_KEY" >> import.key
+gpg --import import.key
+rm import.key
+git config --global user.signingkey "$QMCPACK_BOT_GPG_SIGNING_KEY"  
 git commit --allow-empty -S -m "Rebased Signed Off by QMCPACK-Bot"
-git push fork HEAD
+git push fork fork/$HEAD_BRANCH:$HEAD_BRANCH
 
 COMMIT_SHA=$(git rev-parse --verify HEAD)
 


### PR DESCRIPTION
## Proposed changes
In reference to issue: https://github.com/QMCPACK/qmcpack/issues/3862
Continuation of this PR: https://github.com/QMCPACK/qmcpack/pull/3994

Allows the rebase action to reapprove pr after autorebase is complete.  It approves specifically the SHA it pushes, so there shouldnt be an accidental approval.

## What type(s) of changes does this code introduce?

- Other (please describe): Github Actions Pipeline Changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

remote github runners

Tested on this PR: https://github.com/walshmm/qmcpack/pull/11
You can follow its listed history to see it was rebased and reapproved via bot before being automerged.

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
