### PR TITLE
Add per particle listener support to CoulombPBCAB

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -120,8 +120,9 @@ public:
   Array<TraceReal, 1> Ve_const;
   Array<TraceReal, 1> Vi_const;
 #endif
-  // FIXME: Coulomb class is walker agnositic, it should not record a particular electron particle set.
-  // kept for the trace manager.
+  // \todo Coulomb class is walker agnositic, it should not record a particular electron particle set.
+  // kept for the trace manager. Delete this particle set reference when support for TraceManager is permanently
+  // removed which should coincide with the removal of the legacy drivers.
   ParticleSet& Peln;
 
   CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeForces = false);
@@ -214,6 +215,9 @@ public:
    */
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
+  /** Call to inform objects associated with this operator of per particle listeners.
+   *  should be called before createResources
+   */
   void informOfPerParticleListener() override;
 
 private:

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -220,6 +220,13 @@ public:
    */
   void informOfPerParticleListener() override;
 
+protected:
+  /** Creates the long-range handlers, then splines and stores it by particle and species for quick evaluation.
+   *  this is just constructor code factored out.
+   *  It is called by the derived class CoulombPBCAB_CUDA
+   */
+  void initBreakup(ParticleSet& P);
+
 private:
   ///source particle set
   ParticleSet& pset_ions_;
@@ -246,11 +253,6 @@ private:
    *  \param[out]  pp_consts_trg   constant values for the target particles aka electrons aka B
    */
   void evalPerParticleConsts(Vector<RealType>& pp_consts_src, Vector<RealType>& pp_consts_trg) const;
-
-  /** Creates the long-range handlers, then splines and stores it by particle and species for quick evaluation.
-   *  this is just constructor code factored out
-   */
-  void initBreakup(ParticleSet& P);
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -2,20 +2,22 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef QMCPLUSPLUS_COULOMBPBCAB_TEMP_H
-#define QMCPLUSPLUS_COULOMBPBCAB_TEMP_H
+#ifndef QMCPLUSPLUS_COULOMBPBCAB_H
+#define QMCPLUSPLUS_COULOMBPBCAB_H
+#include <ResourceHandle.h>
 #include "QMCHamiltonians/OperatorBase.h"
 #include "QMCHamiltonians/ForceBase.h"
 #include "LongRange/LRCoulombSingleton.h"
@@ -24,6 +26,7 @@
 #include "Numerics/OneDimCubicSpline.h"
 #include "OhmmsSoA/VectorSoaContainer.h"
 #include "Particle/DistanceTable.h"
+
 namespace qmcplusplus
 {
 /** @ingroup hamiltonian
@@ -32,15 +35,14 @@ namespace qmcplusplus
  * Functionally identical to CoulombPBCAB but uses a templated version of
  * LRHandler.
  */
-struct CoulombPBCAB : public OperatorBase, public ForceBase
+class CoulombPBCAB : public OperatorBase, public ForceBase
 {
+public:
   using LRHandlerType  = LRCoulombSingleton::LRHandlerType;
   using GridType       = LRCoulombSingleton::GridType;
   using RadFunctorType = LRCoulombSingleton::RadFunctorType;
   using mRealType      = LRHandlerType::mRealType;
 
-  ///source particle set
-  ParticleSet& PtclA;
   ///long-range Handler. Should be const LRHandlerType eventually
   std::shared_ptr<LRHandlerType> AB;
   ///long-range derivative handler
@@ -118,7 +120,6 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
   Array<TraceReal, 1> Ve_const;
   Array<TraceReal, 1> Vi_const;
 #endif
-  ParticleSet& Pion;
   // FIXME: Coulomb class is walker agnositic, it should not record a particular electron particle set.
   // kept for the trace manager.
   ParticleSet& Peln;
@@ -142,6 +143,17 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
 
 
   Return_t evaluate(ParticleSet& P) override;
+
+  /** Evaluate the contribution of this component of multiple walkers per particle reporting
+   *  to registered listeners from Estimators.
+   */
+  void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              const std::vector<ListenerVector<RealType>>& listeners,
+                              const std::vector<ListenerVector<RealType>>& ion_listeners) const override;
+
+
   Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
                                  TrialWaveFunction& psi,
@@ -153,14 +165,11 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
 
   bool get(std::ostream& os) const override
   {
-    os << "CoulombPBCAB potential source: " << PtclA.getName();
+    os << "CoulombPBCAB potential source: " << pset_ions_.getName();
     return true;
   }
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
-
-  ///Creates the long-range handlers, then splines and stores it by particle and species for quick evaluation.
-  void initBreakup(ParticleSet& P);
 
   ///Computes the short-range contribution to the coulomb energy.
   Return_t evalSR(ParticleSet& P);
@@ -190,6 +199,54 @@ struct CoulombPBCAB : public OperatorBase, public ForceBase
     if (ComputeForces)
       setParticleSetF(plist, offset);
   }
+
+  const ParticleSet& getSourcePSet() const { return pset_ions_; }
+
+  /** initialize a shared resource and hand it to a collection
+   */
+  void createResource(ResourceCollection& collection) const override;
+
+  /** acquire a shared resource from a collection
+   */
+  void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
+  /** return a shared resource to a collection
+   */
+  void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
+
+  void informOfPerParticleListener() override;
+
+private:
+  ///source particle set
+  ParticleSet& pset_ions_;
+
+  struct CoulombPBCABMultiWalkerResource : public Resource
+  {
+    CoulombPBCABMultiWalkerResource() : Resource("CoulombPBCAB") {}
+    Resource* makeClone() const override { return new CoulombPBCABMultiWalkerResource(*this); }
+
+    /// a walkers worth of per ion AB potential values
+    Vector<RealType> pp_samples_src;
+    /// a walkers worth of per electron AB potential values
+    Vector<RealType> pp_samples_trg;
+    /// constant values for the source particles aka ions aka A
+    Vector<RealType> pp_consts_src;
+    /// constant values for the target particles aka electrons aka B
+    Vector<RealType> pp_consts_trg;
+  };
+
+  ResourceHandle<CoulombPBCABMultiWalkerResource> mw_res_;
+
+  /** Compute the const part of the per particle coulomb AB potential.
+   *  \param[out]  pp_consts_src   constant values for the source particles aka ions aka A   
+   *  \param[out]  pp_consts_trg   constant values for the target particles aka electrons aka B
+   */
+  void evalPerParticleConsts(Vector<RealType>& pp_consts_src, Vector<RealType>& pp_consts_trg) const;
+
+  /** Creates the long-range handlers, then splines and stores it by particle and species for quick evaluation.
+   *  this is just constructor code factored out
+   */
+  void initBreakup(ParticleSet& P);
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
+++ b/src/QMCHamiltonians/CoulombPBCAB_CUDA.h
@@ -22,8 +22,9 @@
 
 namespace qmcplusplus
 {
-struct CoulombPBCAB_CUDA : public CoulombPBCAB
+class CoulombPBCAB_CUDA : public CoulombPBCAB
 {
+private:
   //////////////////////////////////
   // Vectorized evaluation on GPU //
   //////////////////////////////////
@@ -57,15 +58,12 @@ struct CoulombPBCAB_CUDA : public CoulombPBCAB
   std::vector<gpu::device_vector<CUDA_PRECISION_FULL>> RhokIonsGPU;
   void setupLongRangeGPU();
 
-  void add(int groupID, std::unique_ptr<RadFunctorType>&& ppot);
-
   void initBreakup(ParticleSet& P);
-
-  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
-
-  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
-
+public:
   CoulombPBCAB_CUDA(ParticleSet& ions, ParticleSet& elns, bool cloning = false);
+  void add(int groupID, std::unique_ptr<RadFunctorType>&& ppot);
+  void addEnergy(MCWalkerConfiguration& W, std::vector<RealType>& LocalEnergy) override;
+  std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) final;
 };
 } // namespace qmcplusplus
 

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -12,12 +13,14 @@
 
 #include "catch.hpp"
 
+#include <ResourceCollection.h>
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
 #include "QMCHamiltonians/CoulombPBCAB.h"
 #include "QMCHamiltonians/CoulombPBCAA.h"
-
+#include "QMCWaveFunctions/TrialWaveFunction.h"
+#include "TestListenerFunction.h"
 
 #include <stdio.h>
 #include <string>
@@ -26,6 +29,10 @@ using std::string;
 
 namespace qmcplusplus
 {
+
+using QMCT = QMCTraits;
+using Real = QMCT::RealType;
+
 TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
 {
   LRCoulombSingleton::CoulombHandler = 0;
@@ -75,17 +82,16 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   CoulombPBCAB cab(ions, elec);
 
   // Self energy plus Background charge term
-  double consts = cab.evalConsts(elec);
-  REQUIRE(consts == Approx(2 * 0.0506238028)); // not validated
+  REQUIRE(cab.myConst == Approx(2 * 0.0506238028)); // not validated
 
   double val_ei = cab.evaluate(elec);
   REQUIRE(val_ei == Approx(-0.005314032183 + 2 * 0.0506238028)); // not validated
 
   CoulombPBCAA caa_elec(elec, true, false, false);
-  CoulombPBCAA caa_ion (ions, false, false, false);
-  double val_ee         = caa_elec.evaluate(elec);
-  double val_ii         = caa_ion.evaluate(ions);
-  double sum            = val_ee + val_ii + val_ei;
+  CoulombPBCAA caa_ion(ions, false, false, false);
+  double val_ee = caa_elec.evaluate(elec);
+  double val_ii = caa_ion.evaluate(ions);
+  double sum    = val_ee + val_ii + val_ei;
   REQUIRE(sum == Approx(-2.741363553)); // Can be validated via Ewald summation elsewhere
                                         // -2.74136517454081
 }
@@ -153,11 +159,132 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
 
   CoulombPBCAA caa_elec(elec, false, false, false);
   CoulombPBCAA caa_ion(ions, false, false, false);
-  double val_ee         = caa_elec.evaluate(elec);
-  double val_ii         = caa_ion.evaluate(ions);
-  double sum            = val_ee + val_ii + val_ei;
+  double val_ee = caa_elec.evaluate(elec);
+  double val_ii = caa_ion.evaluate(ions);
+  double sum    = val_ee + val_ii + val_ei;
   REQUIRE(sum == Approx(-3.143491064)); // Can be validated via Ewald summation elsewhere
                                         // -3.14349127313640
 }
+
+TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
+{
+  using testing::getParticularListener;
+
+  LRCoulombSingleton::CoulombHandler = 0;
+
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  lattice.BoxBConds = true; // periodic
+  lattice.R.diagonal(3.77945227);
+  lattice.reset();
+
+  const SimulationCell simulation_cell(lattice);
+
+  ParticleSet ions(simulation_cell);
+
+  ions.setName("ion");
+  ions.create({2});
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+  ions.R[1][0] = 1.88972614;
+  ions.R[1][1] = 1.88972614;
+  ions.R[1][2] = 1.88972614;
+
+  SpeciesSet& ion_species       = ions.getSpeciesSet();
+  int pIdx                      = ion_species.addSpecies("H");
+  int pChargeIdx                = ion_species.addAttribute("charge");
+  ion_species(pChargeIdx, pIdx) = 1;
+  ions.createSK();
+  ions.update();
+  ions.turnOnPerParticleSK();
+
+  ParticleSet ions2(ions);
+  ions2.update();
+
+  ParticleSet elec(simulation_cell);
+
+  elec.setName("elec");
+  elec.create({2});
+  elec.R[0][0] = 0.0;
+  elec.R[0][1] = 0.5;
+  elec.R[0][2] = 0.0;
+  elec.R[1][0] = 0.0;
+  elec.R[1][1] = 0.5;
+  elec.R[1][2] = 0.0;
+
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
+
+  elec.createSK();
+  elec.update();
+  elec.turnOnPerParticleSK();
+
+  ParticleSet elec2(elec);
+
+  elec2.R[0][0] = 0.0;
+  elec2.R[0][1] = 0.5;
+  elec2.R[0][2] = 0.1;
+  elec2.R[1][0] = 0.6;
+  elec2.R[1][1] = 0.05;
+  elec2.R[1][2] = -0.1;
+  elec2.update();
+
+  CoulombPBCAB cab(ions, elec, false);
+  CoulombPBCAB cab2(ions2, elec2, false);
+  RefVector<OperatorBase> cabs{cab, cab2};
+  RefVectorWithLeader<OperatorBase> o_list(cab, cabs);
+  // Self-energy correction, no background charge for e-e interaction
+  double consts = cab.evalConsts(elec);
+  CHECK(consts == Approx(0.0267892759 * 4));
+  RefVector<ParticleSet> ptcls{elec, elec2};
+  RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);
+
+  RefVector<ParticleSet> ion_ptcls{ions, ions2};
+  RefVectorWithLeader<ParticleSet> ion_p_list(ions, ion_ptcls);
+
+  TrialWaveFunction psi, psi_clone;
+  RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
+
+  Matrix<Real> local_pots(2);
+  Matrix<Real> local_pots2(2);
+
+  ResourceCollection cab_res("test_cab_res");
+  cab.createResource(cab_res);
+  ResourceCollectionTeamLock<OperatorBase> cab_lock(cab_res, o_list);
+
+  ResourceCollection pset_res("test_pset_res");
+  elec.createResource(pset_res);
+  ResourceCollectionTeamLock<ParticleSet> pset_lock(pset_res, p_list);
+
+  std::vector<ListenerVector<Real>> listeners;
+  listeners.emplace_back("localpotential", getParticularListener(local_pots));
+  listeners.emplace_back("localpotential", getParticularListener(local_pots2));
+
+  Matrix<Real> ion_pots(2);
+  Matrix<Real> ion_pots2(2);
+
+  std::vector<ListenerVector<Real>> ion_listeners;
+  ion_listeners.emplace_back("localpotential", getParticularListener(ion_pots));
+  ion_listeners.emplace_back("localpotential", getParticularListener(ion_pots2));
+
+  ParticleSet::mw_update(p_list);
+  cab.mw_evaluatePerParticle(o_list, twf_list, p_list, listeners, ion_listeners);
+  CHECK(cab.getValue() == Approx(-2.219665062 + 0.0267892759 * 4));
+  CHECK(cab2.getValue() == Approx(-1.7222343352));
+  // Check that the sum of the particle energies == the total
+  Real elec_ion_sum = std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0);
+  CHECK( elec_ion_sum ==
+	 Approx(-1.0562537047));
+  CHECK( elec_ion_sum + std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) ==
+        Approx(-2.219665062 + 0.0267892759 * 4));
+  elec_ion_sum = std::accumulate(local_pots[1], local_pots[1] + local_pots.cols(), 0.0);
+  CHECK(elec_ion_sum == Approx(-0.8611171676));
+  CHECK(elec_ion_sum + std::accumulate(ion_pots[1], ion_pots[1] + ion_pots.cols(), 0.0) == Approx(-1.7222343352));
+}
+
 
 } // namespace qmcplusplus

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -15,7 +15,6 @@
 #include <string>
 #include <memory>
 #include <cstddef>
-#include <cassert>
 #include <vector>
 #include "Resource.h"
 #include "type_traits/RefVectorWithLeader.h"

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <memory>
 #include <cstddef>
+#include <cassert>
 #include <vector>
 #include "Resource.h"
 #include "type_traits/RefVectorWithLeader.h"

--- a/src/type_traits/RefVectorWithLeader.h
+++ b/src/type_traits/RefVectorWithLeader.h
@@ -13,6 +13,7 @@
 #ifndef QMCPLUSPLUS_REFVECTORWITHLEADER_H
 #define QMCPLUSPLUS_REFVECTORWITHLEADER_H
 
+#include <cassert>
 #include <vector>
 #include <memory>
 
@@ -38,9 +39,7 @@ public:
   CASTTYPE& getCastedLeader() const
   {
     static_assert(std::is_const<T>::value == std::is_const<CASTTYPE>::value, "Unmatched const type qualifier!");
-#ifndef NDEBUG
     assert(dynamic_cast<CASTTYPE*>(&leader_.get()) != nullptr);
-#endif
     return static_cast<CASTTYPE&>(leader_.get());
   }
 
@@ -48,9 +47,7 @@ public:
   CASTTYPE& getCastedElement(size_t i) const
   {
     static_assert(std::is_const<T>::value == std::is_const<CASTTYPE>::value, "Unmatched const type qualifier!");
-#ifndef NDEBUG
     assert(dynamic_cast<CASTTYPE*>(&(*this)[i]) != nullptr);
-#endif
     return static_cast<CASTTYPE&>((*this)[i]);
   }
 


### PR DESCRIPTION
## Proposed changes

This contains changes to CoulombPBCAB to support per particle Listeners and a corresponding test. Documentation is partial here but should make sense when the changes to QMCHamiltonian are PR'd. That can't really be done until all the lower level changes go in.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Code style update (formatting, renaming)
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
