### PR TITLE
Print memory usage when QMCPACK starts

### DIFF
--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -44,6 +44,7 @@
 #include "hdf/HDFVersion.h"
 #include "OhmmsData/AttributeSet.h"
 #include "Utilities/qmc_common.h"
+#include "MemoryUsage.h"
 #ifdef BUILD_AFQMC
 #include "AFQMC/AFQMCFactory.h"
 #endif
@@ -154,7 +155,9 @@ QMCMain::QMCMain(Communicate* c)
                 << timer_manager.get_timer_threshold_string() << std::endl;
 #endif
   app_summary() << std::endl;
-  app_summary().flush();
+
+  print_mem("when QMCPACK starts", app_summary());
+  app_summary() << std::endl;
 }
 
 ///destructor


### PR DESCRIPTION
## Proposed changes
Closes #4119
Report memory info when QMCPACK starts.
Please ignore `106:` which is from ctest runs.

```
106: =====================================================
106:                     QMCPACK 3.14.9
106: 
106:        (c) Copyright 2003-  QMCPACK developers
106: 
106:                     Please cite:
106:  J. Kim et al. J. Phys. Cond. Mat. 30 195901 (2018)
106:       https://doi.org/10.1088/1361-648X/aab9c3
106: 
106:   Git branch: print-mem
106:   Last git commit: 5c9a98318306951107dc084d7ff7aa8fca181699-dirty
106:   Last git commit date: Mon Jul 25 16:08:29 2022 -0500
106:   Last git commit subject: Print memory when main starts.
106: =====================================================
106:   Global options 
106: 
106:   Total number of MPI ranks = 8
106:   Number of MPI groups      = 1
106:   MPI group ID              = 0
106:   Number of ranks in group  = 8
106:   MPI ranks per node        = 8
106:   Accelerators per node     = 1
106:   OMP 1st level threads     = 2
106:   OMP nested threading disabled or only 1 thread on the 2nd level
106: 
106:   Precision used in this calculation, see definitions in the manual:
106:   Base precision      = float
106:   Full precision      = double
106: 
106:   OpenMP target offload to accelerators build option is enabled
106:   CUDA acceleration build option is enabled
106:   Timer build option is enabled. Current timer level is coarse
106: 
106: =================================================
106: --- Memory usage report : when QMCPACK starts ---
106: =================================================
106: Available memory on node 0, free + buffers :   29592 MiB
106: Memory footprint by rank 0 on node 0       :     239 MiB
106: Device memory allocated via CUDA allocator :       0 MiB
106: Free memory available on default device    :    6768 MiB
106: Device memory allocated via OpenMP offload :       0 MiB
106: =================================================
```

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'