### PR TITLE
Compute logarithm of rotation matrix

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -119,7 +119,7 @@ void RotatedSPOs::buildOptVariables(const RotationIndices& rotations)
   app_log() << "nparams_active: " << nparams_active << " params2.size(): " << params.size() << std::endl;
   if (params_supplied)
     if (nparams_active != params.size())
-      APP_ABORT("The number of supplied orbital rotation parameters does not match number prdouced by the slater "
+      throw std::runtime_error("The number of supplied orbital rotation parameters does not match number prdouced by the slater "
                 "expansion. \n");
 
   myVars.clear();
@@ -219,9 +219,8 @@ void RotatedSPOs::exponentiate_antisym_matrix(ValueMatrix& mat)
   if (info != 0)
   {
     std::ostringstream msg;
-    msg << "heev failed with info = " << info << " in MultiSlaterDetTableMethod::exponentiate_antisym_matrix";
-    app_log() << msg.str() << std::endl;
-    APP_ABORT(msg.str());
+    msg << "heev failed with info = " << info << " in RotatedSPOs::exponentiate_antisym_matrix";
+    throw std::runtime_error(msg.str());
   }
   // iterate through diagonal matrix, exponentiate terms
   for (int i = 0; i < n; ++i)
@@ -278,9 +277,8 @@ void RotatedSPOs::log_antisym_matrix(ValueMatrix& mat)
   if (info != 0)
   {
     std::ostringstream msg;
-    msg << "heev failed with info = " << info << " in MultiSlaterDetTableMethod::exponentiate_antisym_matrix";
-    app_log() << msg.str() << std::endl;
-    APP_ABORT(msg.str());
+    msg << "heev failed with info = " << info << " in RotatedSPOs::log_antisym_matrix";
+    throw std::runtime_error(msg.str());
   }
 
   // iterate through diagonal matrix, take log

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -290,7 +290,7 @@ void RotatedSPOs::log_antisym_matrix(ValueMatrix& mat)
     {
       auto tmp = (i == j) ? std::log(std::complex<RealType>(eval_r[i], eval_i[i])) : std::complex<RealType>(0.0, 0.0);
       mat_cd[i + j * n] = tmp;
-      //std::cout << "mat_cd " << i << " " << j <<  "  " << mat_cd[i + n*j] << std::endl;
+
       if (eval_i[j] > 0.0)
       {
         mat_cl[i + j * n]       = std::complex<RealType>(mat_l[i + j * n], mat_l[i + (j + 1) * n]);

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -314,7 +314,7 @@ void RotatedSPOs::log_antisym_matrix(ValueMatrix& mat)
     {
       if (mat_cd[i + n * j].imag() > 1e-12)
       {
-        app_log() << "warning: large imaginary value in orbital rotation matrix: (i,j) = (" << i << "," << j
+        app_log() << "warning: large imaginary value in antisymmetric matrix: (i,j) = (" << i << "," << j
                   << "), im = " << mat_cd[i + n * j].imag() << std::endl;
       }
       mat[i][j] = mat_cd[i + n * j].real();

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -62,6 +62,20 @@ void RotatedSPOs::constructAntiSymmetricMatrix(const RotationIndices& rot_indice
   }
 }
 
+void RotatedSPOs::extractParamsFromAntiSymmetricMatrix(const RotationIndices& rot_indices,
+                                                       const ValueMatrix& rot_mat,
+                                                       std::vector<ValueType>& param)
+{
+  assert(rot_indices.size() == param.size());
+  // Assumes rot_mat is of the correct size and initialized to zero upon entry
+
+  for (int i = 0; i < rot_indices.size(); i++)
+  {
+    const int p = rot_indices[i].first;
+    const int q = rot_indices[i].second;
+    param[i]    = rot_mat[q][p];
+  }
+}
 
 void RotatedSPOs::buildOptVariables(const size_t nel)
 {
@@ -232,6 +246,78 @@ void RotatedSPOs::exponentiate_antisym_matrix(ValueMatrix& mat)
                   << "), im = " << mat_d[i + n * j].imag() << std::endl;
       }
       mat[j][i] = mat_d[i + n * j].real();
+    }
+}
+
+void RotatedSPOs::log_antisym_matrix(ValueMatrix& mat)
+{
+  const int n = mat.rows();
+  std::vector<RealType> mat_h(n * n, 0);
+  std::vector<RealType> eval_r(n, 0);
+  std::vector<RealType> eval_i(n, 0);
+  std::vector<RealType> mat_l(n * n, 0);
+  std::vector<RealType> work(4 * n, 0);
+
+  std::vector<std::complex<RealType>> mat_cd(n * n, 0);
+  std::vector<std::complex<RealType>> mat_cl(n * n, 0);
+  std::vector<std::complex<RealType>> mat_ch(n * n, 0);
+
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      mat_h[i + n * j] = mat[i][j];
+
+  // diagonalize the matrix
+  char JOBL('V');
+  char JOBR('N');
+  int N(n);
+  int LDA(n);
+  int LWORK(4 * n);
+  int info = 0;
+  LAPACK::geev(&JOBL, &JOBR, &N, &mat_h.at(0), &LDA, &eval_r.at(0), &eval_i.at(0), &mat_l.at(0), &LDA, nullptr, &LDA,
+               &work.at(0), &LWORK, &info);
+  if (info != 0)
+  {
+    std::ostringstream msg;
+    msg << "heev failed with info = " << info << " in MultiSlaterDetTableMethod::exponentiate_antisym_matrix";
+    app_log() << msg.str() << std::endl;
+    APP_ABORT(msg.str());
+  }
+
+  // iterate through diagonal matrix, take log
+  for (int i = 0; i < n; ++i)
+  {
+    for (int j = 0; j < n; ++j)
+    {
+      auto tmp = (i == j) ? std::log(std::complex<RealType>(eval_r[i], eval_i[i])) : std::complex<RealType>(0.0, 0.0);
+      mat_cd[i + j * n] = tmp;
+      //std::cout << "mat_cd " << i << " " << j <<  "  " << mat_cd[i + n*j] << std::endl;
+      if (eval_i[j] > 0.0)
+      {
+        mat_cl[i + j * n]       = std::complex<RealType>(mat_l[i + j * n], mat_l[i + (j + 1) * n]);
+        mat_cl[i + (j + 1) * n] = std::complex<RealType>(mat_l[i + j * n], -mat_l[i + (j + 1) * n]);
+      }
+      else if (!(eval_i[j] < 0.0))
+      {
+        mat_cl[i + j * n] = std::complex<RealType>(mat_l[i + j * n], 0.0);
+      }
+    }
+  }
+
+  RealType one(1.0);
+  RealType zero(0.0);
+  BLAS::gemm('N', 'N', n, n, n, one, &mat_cl.at(0), n, &mat_cd.at(0), n, zero, &mat_ch.at(0), n);
+  BLAS::gemm('N', 'C', n, n, n, one, &mat_ch.at(0), n, &mat_cl.at(0), n, zero, &mat_cd.at(0), n);
+
+
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+    {
+      if (mat_cd[i + n * j].imag() > 1e-12)
+      {
+        app_log() << "warning: large imaginary value in orbital rotation matrix: (i,j) = (" << i << "," << j
+                  << "), im = " << mat_cd[i + n * j].imag() << std::endl;
+      }
+      mat[i][j] = mat_cd[i + n * j].real();
     }
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -45,6 +45,7 @@ public:
                                            ValueMatrix& rot_mat);
 
   // Extract the list of rotation parameters from the entries in an antisymmetric matrix
+  // This function expects rot_indices and param are the same length.
   static void extractParamsFromAntiSymmetricMatrix(const RotationIndices& rot_indices,
                                                    const ValueMatrix& rot_mat,
                                                    std::vector<ValueType>& param);

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -37,19 +37,26 @@ public:
   // Only core->active rotations are created.
   static void createRotationIndices(int nel, int nmo, RotationIndices& rot_indices);
 
-  // Fill in anti-symmetric matrix from the list of rotation parameter indices
+  // Fill in antisymmetric matrix from the list of rotation parameter indices
   // and a list of parameter values.
   // This function assumes rot_mat is properly sized upon input and is set to zero.
   static void constructAntiSymmetricMatrix(const RotationIndices& rot_indices,
                                            const std::vector<ValueType>& param,
                                            ValueMatrix& rot_mat);
 
+  // Extract the list of rotation parameters from the entries in an antisymmetric matrix
+  static void extractParamsFromAntiSymmetricMatrix(const RotationIndices& rot_indices,
+                                                   const ValueMatrix& rot_mat,
+                                                   std::vector<ValueType>& param);
 
   //function to perform orbital rotations
   void apply_rotation(const std::vector<RealType>& param, bool use_stored_copy);
 
   // Compute matrix exponential of an antisymmetric matrix (result is rotation matrix)
   static void exponentiate_antisym_matrix(ValueMatrix& mat);
+
+  // Compute matrix log of rotation matrix to produce antisymmetric matrix
+  static void log_antisym_matrix(ValueMatrix& mat);
 
   //A particular SPOSet used for Orbitals
   std::unique_ptr<SPOSet> Phi;


### PR DESCRIPTION
Add functions to compute the matrix log of a rotation matrix and extract the entries of the resulting antisymmetric matrix to a list of parameters.

This should allow us to recover rotation parameters from a rotation matrix.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
