### PR TITLE
Refactor Factory functions to return std::unique ptr

### DIFF
--- a/src/QMCDrivers/DMC/DMCFactory.cpp
+++ b/src/QMCDrivers/DMC/DMCFactory.cpp
@@ -24,17 +24,17 @@
 //#define PETA_DMC_TEST
 namespace qmcplusplus
 {
-QMCDriver* DMCFactory::create(MCWalkerConfiguration& w,
-                              TrialWaveFunction& psi,
-                              QMCHamiltonian& h,
-                              Communicate* comm,
-                              bool enable_profiling)
+std::unique_ptr<QMCDriver> DMCFactory::create(MCWalkerConfiguration& w,
+                                              TrialWaveFunction& psi,
+                                              QMCHamiltonian& h,
+                                              Communicate* comm,
+                                              bool enable_profiling)
 {
 #ifdef QMC_CUDA
   if (GPU)
-    return new DMCcuda(w, psi, h, comm, enable_profiling);
+    return std::make_unique<DMCcuda>(w, psi, h, comm, enable_profiling);
 #endif
-  QMCDriver* qmc = new DMC(w, psi, h, comm, enable_profiling);
+  auto qmc = std::make_unique<DMC>(w, psi, h, comm, enable_profiling);
   qmc->setUpdateMode(PbyPUpdate);
   return qmc;
 }

--- a/src/QMCDrivers/DMC/DMCFactory.h
+++ b/src/QMCDrivers/DMC/DMCFactory.h
@@ -28,11 +28,11 @@ private:
 public:
   DMCFactory(bool pbyp, bool gpu, xmlNodePtr cur) : PbyPUpdate(pbyp), GPU(gpu), myNode(cur) {}
 
-  QMCDriver* create(MCWalkerConfiguration& w,
-                    TrialWaveFunction& psi,
-                    QMCHamiltonian& h,
-                    Communicate* comm,
-                    bool enable_profiling);
+  std::unique_ptr<QMCDriver> create(MCWalkerConfiguration& w,
+                                    TrialWaveFunction& psi,
+                                    QMCHamiltonian& h,
+                                    Communicate* comm,
+                                    bool enable_profiling);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/DMC/DMCFactoryNew.cpp
+++ b/src/QMCDrivers/DMC/DMCFactoryNew.cpp
@@ -16,11 +16,11 @@
 
 namespace qmcplusplus
 {
-QMCDriverInterface* DMCFactoryNew::create(const ProjectData& project_data,
-                                          const std::optional<EstimatorManagerInput> global_emi,
-                                          WalkerConfigurations& wc,
-                                          MCPopulation&& pop,
-                                          Communicate* comm)
+std::unique_ptr<QMCDriverInterface> DMCFactoryNew::create(const ProjectData& project_data,
+                                                          const std::optional<EstimatorManagerInput> global_emi,
+                                                          WalkerConfigurations& wc,
+                                                          MCPopulation&& pop,
+                                                          Communicate* comm)
 {
 #if defined(QMC_CUDA)
   comm->barrier_and_abort("DMC batched driver is not supported by legacy CUDA builds.");
@@ -35,8 +35,8 @@ QMCDriverInterface* DMCFactoryNew::create(const ProjectData& project_data,
   qmcdriver_input.readXML(input_node_);
   DMCDriverInput dmcdriver_input;
   dmcdriver_input.readXML(input_node_);
-  QMCDriverInterface* qmc = new DMCBatched(project_data, std::move(qmcdriver_input), global_emi,
-                                           std::move(dmcdriver_input), wc, std::move(pop), comm);
+  auto qmc = std::make_unique<DMCBatched>(project_data, std::move(qmcdriver_input), global_emi,
+                                          std::move(dmcdriver_input), wc, std::move(pop), comm);
   // This can probably be eliminated completely since we only support PbyP
   qmc->setUpdateMode(dmc_mode_ & 1);
   return qmc;

--- a/src/QMCDrivers/DMC/DMCFactoryNew.h
+++ b/src/QMCDrivers/DMC/DMCFactoryNew.h
@@ -37,11 +37,11 @@ public:
    *  \param[in]   global_emi     optional global estimator manager input passed by value to insure copy,
    *                              a global input should not be consumed by driver.
    */
-  QMCDriverInterface* create(const ProjectData& project_data,
-                             const std::optional<EstimatorManagerInput> global_emi,
-                             WalkerConfigurations& wc,
-                             MCPopulation&& pop,
-                             Communicate* comm);
+  std::unique_ptr<QMCDriverInterface> create(const ProjectData& project_data,
+                                             const std::optional<EstimatorManagerInput> global_emi,
+                                             WalkerConfigurations& wc,
+                                             MCPopulation&& pop,
+                                             Communicate* comm);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -232,7 +232,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     //VMCFactory fac(curQmcModeBits[UPDATE_MODE],cur);
     VMCFactory fac(das.what_to_do.to_ulong(), cur);
-    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling));
+    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
     //TESTING CLONE
     //TrialWaveFunction* psiclone=primaryPsi->makeClone(qmc_system);
     //qmcDriver = fac.create(qmc_system,*psiclone,*primaryH,particle_pool,hamiltonian_pool);
@@ -240,25 +240,25 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   else if (das.new_run_type == QMCRunType::VMC_BATCH)
   {
     VMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE]);
-    new_driver.reset(fac.create(project_data_, emi, qmc_system,
-                                MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
-                                qmc_system.getSampleStack(), comm));
+    new_driver = fac.create(project_data_, emi, qmc_system,
+                            MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
+                            qmc_system.getSampleStack(), comm);
   }
   else if (das.new_run_type == QMCRunType::DMC)
   {
     DMCFactory fac(das.what_to_do[UPDATE_MODE], das.what_to_do[GPU_MODE], cur);
-    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling));
+    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
   }
   else if (das.new_run_type == QMCRunType::DMC_BATCH)
   {
     DMCFactoryNew fac(cur, das.what_to_do[UPDATE_MODE]);
-    new_driver.reset(fac.create(project_data_, emi, qmc_system,
-                                MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH), comm));
+    new_driver = fac.create(project_data_, emi, qmc_system,
+                            MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH), comm);
   }
   else if (das.new_run_type == QMCRunType::RMC)
   {
     RMCFactory fac(das.what_to_do[UPDATE_MODE], cur);
-    new_driver.reset(fac.create(qmc_system, *primaryPsi, *primaryH, comm));
+    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm);
   }
   else if (das.new_run_type == QMCRunType::LINEAR_OPTIMIZE)
   {
@@ -277,12 +277,11 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
     APP_ABORT("QMCDriverFactory::createQMCDriver : method=\"linear_batch\" is not safe with CPU mixed precision. "
               "Please use full precision build instead.");
 #endif
-    QMCFixedSampleLinearOptimizeBatched* opt =
-        QMCWFOptLinearFactoryNew(cur, project_data_, emi, qmc_system,
-                                 MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
-                                 qmc_system.getSampleStack(), comm);
+    auto opt = QMCWFOptLinearFactoryNew(cur, project_data_, emi, qmc_system,
+                                        MCPopulation(comm->size(), comm->rank(), &qmc_system, primaryPsi, primaryH),
+                                        qmc_system.getSampleStack(), comm);
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
-    new_driver.reset(opt);
+    new_driver = std::move(opt);
   }
   else if (das.new_run_type == QMCRunType::WF_TEST)
   {

--- a/src/QMCDrivers/RMC/RMCFactory.cpp
+++ b/src/QMCDrivers/RMC/RMCFactory.cpp
@@ -17,43 +17,20 @@
 
 namespace qmcplusplus
 {
-QMCDriver* RMCFactory::create(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm)
+std::unique_ptr<QMCDriver> RMCFactory::create(MCWalkerConfiguration& w,
+                                              TrialWaveFunction& psi,
+                                              QMCHamiltonian& h,
+                                              Communicate* comm)
 {
-  int np = omp_get_max_threads();
-  //(SPACEWARP_MODE,MULTIPE_MODE,UPDATE_MODE)
-  QMCDriver* qmc = 0;
+  std::unique_ptr<QMCDriver> qmc;
 #ifdef QMC_CUDA
   APP_ABORT("RMCFactory::create. RMC is not supported on GPU.\n");
 #endif
 
   if (RMCMode == 0 || RMCMode == 1) //(0,0,0) (0,0,1) pbyp and all electron
   {
-    qmc = new RMC(w, psi, h, comm);
+    qmc = std::make_unique<RMC>(w, psi, h, comm);
   }
-#if defined(QMC_BUILD_COMPLETE)
-//else if(RMCMode == 2) //(0,1,0)
-//{
-//  qmc = new RMCMultiple(w,psi,h);
-//}
-//else if(RMCMode == 3) //(0,1,1)
-//{
-//  qmc = new RMCPbyPMultiple(w,psi,h);
-//}
-// else if(RMCMode ==2 || RMCMode ==3)
-// {
-//   qmc = new CSRMC(w,psi,h);
-// }
-// #if !defined(QMC_COMPLEX)
-// else if(RMCMode == 6) //(1,1,0)
-// {
-//   qmc = new RMCMultipleWarp(w,psi,h, ptclpool);
-// }
-// else if(RMCMode == 7) //(1,1,1)
-// {
-//   qmc = new RMCPbyPMultiWarp(w,psi,h, ptclpool);
-// }
-// #endif
-#endif
   qmc->setUpdateMode(RMCMode & 1);
   return qmc;
 }

--- a/src/QMCDrivers/RMC/RMCFactory.h
+++ b/src/QMCDrivers/RMC/RMCFactory.h
@@ -29,10 +29,10 @@ private:
 public:
   RMCFactory(int vmode, xmlNodePtr cur) : RMCMode(vmode), myNode(cur) {}
 
-  QMCDriver* create(MCWalkerConfiguration& w,
-                    TrialWaveFunction& psi,
-                    QMCHamiltonian& h,
-                    Communicate* comm);
+  std::unique_ptr<QMCDriver> create(MCWalkerConfiguration& w,
+                                    TrialWaveFunction& psi,
+                                    QMCHamiltonian& h,
+                                    Communicate* comm);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/VMC/VMCFactory.cpp
+++ b/src/QMCDrivers/VMC/VMCFactory.cpp
@@ -33,50 +33,27 @@
 
 namespace qmcplusplus
 {
-QMCDriverInterface* VMCFactory::create(MCWalkerConfiguration& w,
-                                       TrialWaveFunction& psi,
-                                       QMCHamiltonian& h,
-                                       Communicate* comm,
-                                       bool enable_profiling)
+std::unique_ptr<QMCDriverInterface> VMCFactory::create(MCWalkerConfiguration& w,
+                                                       TrialWaveFunction& psi,
+                                                       QMCHamiltonian& h,
+                                                       Communicate* comm,
+                                                       bool enable_profiling)
 {
-  int np = omp_get_max_threads();
   //(SPACEWARP_MODE,MULTIPE_MODE,UPDATE_MODE)
-  QMCDriverInterface* qmc = nullptr;
+  std::unique_ptr<QMCDriverInterface> qmc;
 #ifdef QMC_CUDA
   if (VMCMode & 16)
-    qmc = new VMCcuda(w, psi, h, comm, enable_profiling);
+    qmc = std::make_unique<VMCcuda>(w, psi, h, comm, enable_profiling);
   else
 #endif
       if (VMCMode == 0 || VMCMode == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMC(w, psi, h, comm, enable_profiling);
+    qmc = std::make_unique<VMC>(w, psi, h, comm, enable_profiling);
   }
-  //else if(VMCMode == 2) //(0,1,0)
-  //{
-  //  qmc = new VMCMultiple(w,psi,h);
-  //}
-  //else if(VMCMode == 3) //(0,1,1)
-  //{
-  //  qmc = new VMCPbyPMultiple(w,psi,h);
-  //}
   else if (VMCMode == 2 || VMCMode == 3)
   {
-    qmc = new CSVMC(w, psi, h, comm);
+    qmc = std::make_unique<CSVMC>(w, psi, h, comm);
   }
-  //#if !defined(QMC_COMPLEX)
-  //    else if(VMCMode == 6) //(1,1,0)
-  //    {
-  //      qmc = new VMCMultipleWarp(w,psi,h, ptclpool);
-  //    }
-  //    else if(VMCMode == 7) //(1,1,1)
-  //    {
-  //      qmc = new VMCPbyPMultiWarp(w,psi,h, ptclpool);
-  //    }
-  //#endif
-  //     else if(VMCMode == 8) //(only possible for WFMC run)
-  //     {
-  //       qmc = new WFMCSingleOMP(w,psi,h,hpool,ppool);
-  //     }
   qmc->setUpdateMode(VMCMode & 1);
   return qmc;
 }

--- a/src/QMCDrivers/VMC/VMCFactory.h
+++ b/src/QMCDrivers/VMC/VMCFactory.h
@@ -29,11 +29,11 @@ private:
 public:
   VMCFactory(unsigned long vmode, xmlNodePtr cur) : VMCMode(vmode), myNode(cur) {}
 
-  QMCDriverInterface* create(MCWalkerConfiguration& w,
-                             TrialWaveFunction& psi,
-                             QMCHamiltonian& h,
-                             Communicate* comm,
-                             bool enable_profiling);
+  std::unique_ptr<QMCDriverInterface> create(MCWalkerConfiguration& w,
+                                             TrialWaveFunction& psi,
+                                             QMCHamiltonian& h,
+                                             Communicate* comm,
+                                             bool enable_profiling);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/VMC/VMCFactoryNew.cpp
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.cpp
@@ -20,12 +20,12 @@
 
 namespace qmcplusplus
 {
-QMCDriverInterface* VMCFactoryNew::create(const ProjectData& project_data,
-                                          const std::optional<EstimatorManagerInput>& global_emi,
-                                          WalkerConfigurations& wc,
-                                          MCPopulation&& pop,
-                                          SampleStack& samples,
-                                          Communicate* comm)
+std::unique_ptr<QMCDriverInterface> VMCFactoryNew::create(const ProjectData& project_data,
+                                                          const std::optional<EstimatorManagerInput>& global_emi,
+                                                          WalkerConfigurations& wc,
+                                                          MCPopulation&& pop,
+                                                          SampleStack& samples,
+                                                          Communicate* comm)
 {
 #if defined(QMC_CUDA)
   comm->barrier_and_abort("VMC batched driver is not supported by legacy CUDA builds.");
@@ -40,12 +40,12 @@ QMCDriverInterface* VMCFactoryNew::create(const ProjectData& project_data,
   qmcdriver_input.readXML(input_node_);
   VMCDriverInput vmcdriver_input;
   vmcdriver_input.readXML(input_node_);
-  QMCDriverInterface* qmc = nullptr;
+  std::unique_ptr<QMCDriverInterface> qmc;
 
   if (vmc_mode_ == 0 || vmc_mode_ == 1) //(0,0,0) (0,0,1)
   {
-    qmc = new VMCBatched(project_data, std::move(qmcdriver_input), global_emi, std::move(vmcdriver_input), wc,
-                         std::move(pop), samples, comm);
+    qmc = std::make_unique<VMCBatched>(project_data, std::move(qmcdriver_input), global_emi, std::move(vmcdriver_input),
+                                       wc, std::move(pop), samples, comm);
   }
   else
   {

--- a/src/QMCDrivers/VMC/VMCFactoryNew.h
+++ b/src/QMCDrivers/VMC/VMCFactoryNew.h
@@ -42,12 +42,12 @@ public:
    *  \param[in]   global_emi     optional global estimator manager input passed by value to insure copy,
    *                              a global input should not be consumed by driver.
    */
-  QMCDriverInterface* create(const ProjectData& project_data,
-                             const std::optional<EstimatorManagerInput>& global_emi,
-                             WalkerConfigurations& wc,
-                             MCPopulation&& pop,
-                             SampleStack& samples,
-                             Communicate* comm);
+  std::unique_ptr<QMCDriverInterface> create(const ProjectData& project_data,
+                                             const std::optional<EstimatorManagerInput>& global_emi,
+                                             WalkerConfigurations& wc,
+                                             MCPopulation&& pop,
+                                             SampleStack& samples,
+                                             Communicate* comm);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.cpp
+++ b/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.cpp
@@ -7,14 +7,14 @@
 
 namespace qmcplusplus
 {
-
-QMCFixedSampleLinearOptimizeBatched* QMCWFOptLinearFactoryNew(xmlNodePtr cur,
-                                                              const ProjectData& project_data,
-                                                              const std::optional<EstimatorManagerInput>& global_emi,
-                                                              WalkerConfigurations& wc,
-                                                              MCPopulation&& pop,
-                                                              SampleStack& samples,
-                                                              Communicate* comm)
+std::unique_ptr<QMCFixedSampleLinearOptimizeBatched> QMCWFOptLinearFactoryNew(
+    xmlNodePtr cur,
+    const ProjectData& project_data,
+    const std::optional<EstimatorManagerInput>& global_emi,
+    WalkerConfigurations& wc,
+    MCPopulation&& pop,
+    SampleStack& samples,
+    Communicate* comm)
 {
   app_summary() << "\n========================================"
                    "\n  Reading WFOpt driver XML input section"
@@ -26,9 +26,9 @@ QMCFixedSampleLinearOptimizeBatched* QMCWFOptLinearFactoryNew(xmlNodePtr cur,
   VMCDriverInput vmcdriver_input;
   vmcdriver_input.readXML(cur);
 
-  QMCFixedSampleLinearOptimizeBatched* opt =
-      new QMCFixedSampleLinearOptimizeBatched(project_data, std::move(qmcdriver_input), global_emi,
-                                              std::move(vmcdriver_input), wc, std::move(pop), samples, comm);
+  auto opt = std::make_unique<QMCFixedSampleLinearOptimizeBatched>(project_data, std::move(qmcdriver_input), global_emi,
+                                                                   std::move(vmcdriver_input), wc, std::move(pop),
+                                                                   samples, comm);
   return opt;
 }
 

--- a/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.h
+++ b/src/QMCDrivers/WFOpt/QMCWFOptFactoryNew.h
@@ -26,13 +26,14 @@ class SampleStack;
 class QMCFixedSampleLinearOptimizeBatched;
 class ProjectData;
 
-QMCFixedSampleLinearOptimizeBatched* QMCWFOptLinearFactoryNew(xmlNodePtr cur,
-                                                              const ProjectData& project_data,
-                                                              const std::optional<EstimatorManagerInput>& global_emi,
-                                                              WalkerConfigurations& wc,
-                                                              MCPopulation&& pop,
-                                                              SampleStack& samples,
-                                                              Communicate* comm);
+std::unique_ptr<QMCFixedSampleLinearOptimizeBatched> QMCWFOptLinearFactoryNew(
+    xmlNodePtr cur,
+    const ProjectData& project_data,
+    const std::optional<EstimatorManagerInput>& global_emi,
+    WalkerConfigurations& wc,
+    MCPopulation&& pop,
+    SampleStack& samples,
+    Communicate* comm);
 } // namespace qmcplusplus
 
 #endif


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

As suggested in #4125, this updates various factory functions to return `std::unique_ptr<T>`.

~I also moved construction of `wOut` to be earlier in the construction of` QMCDriverNew`.~

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

local workstation: Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
