### PR TITLE
Add documentation for MAX_ATOMS variable for the performance test

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1728,6 +1728,10 @@ in the hundreds of electrons up to low thousands of electrons are representative
 research runs performed in 2017. The largest runs target
 future machines and require very large memory.
 
+All system sizes in the table below will be tested as a default, but you will be able to define the maximum size of
+the system by setting ``-DQMC_PERFORMANCE_NIO_MAX_ATOMS = NUMBER_OF_ATOMS`` in order to run the test only
+the systems possessing number of atoms below ``NUMBER_OF_ATOMS``.
+
 .. table:: System sizes and names for NiO performance tests. GPU performance
     tests are named similarly but have different walker counts.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1716,9 +1716,8 @@ The NiO tests are for bulk supercells of varying size. The QMC runs consist of s
 without drift (2) VMC with drift term included, and (3) DMC with
 constant population. The tests use spline wavefunctions that must be
 downloaded as described in the README file because of their large size. You
-will need to set ``-DQMC_DATA=YOUR_DATA_FOLDER``
-when running CMake as
-described in the README file.
+will need to set ``-DQMC_DATA=<full path to your data folder>``
+when running CMake as described in the README file.
 
 Two sets of wavefunction are tested: spline orbitals with one- and
 two-body Jastrow functions and a more complex form with an additional
@@ -1728,9 +1727,9 @@ in the hundreds of electrons up to low thousands of electrons are representative
 research runs performed in 2017. The largest runs target
 future machines and require very large memory.
 
-All system sizes in the table below will be tested as a default, but you will be able to define the maximum size of
-the system by setting ``-DQMC_PERFORMANCE_NIO_MAX_ATOMS = NUMBER_OF_ATOMS`` in order to run the test only
-the systems possessing number of atoms below ``NUMBER_OF_ATOMS``.
+All system sizes in the table below will be tested as long as the corresponding h5 files are available in the data folder.
+You may limit the maximal system size of tests by an atom count via ``-DQMC_PERFORMANCE_NIO_MAX_ATOMS=<number of atoms>``.
+Only tests with their atom counts below and equal to ``<number of atoms>`` are added to the performance tests.
 
 .. table:: System sizes and names for NiO performance tests. GPU performance
     tests are named similarly but have different walker counts.

--- a/tests/performance/NiO/README
+++ b/tests/performance/NiO/README
@@ -142,9 +142,9 @@ affinity, please read the next section.
 To activate the ctest route, add the following option in your cmake
 command line before building your binary:
 
--DQMC_DATA=YOUR_DATA_FOLDER
+-DQMC_DATA=<full path to your data folder>
 
-All the h5 files must be placed in a subdirectory YOUR_DATA_FOLDER/NiO.
+All the h5 files must be placed in a subdirectory <full path to your data folder>/NiO.
 Run tests with command "ctest -R performance-NiO" after building
 QMCPACK. Add "-VV" to capture the QMCPACK output. Enabling the timers
 is not essential, but activates fine grained timers and counters useful for


### PR DESCRIPTION
## Proposed changes

Add documentation for variable -DQMC_PERFORMANCE_NIO_MAX_ATOMS for the performance test. This variable is to define the maximum size of the system for the performance test.

## What type(s) of changes does this code introduce?

- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Intel Xeon

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
