### PR TITLE
Update SPOSet WFopt related APIs

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -119,8 +119,6 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override = 0;
 
-  void resetParameters(const opt_variables_type& active) override {}
-
   void setOrbitalSetSize(int norbs) override { OrbitalSetSize = norbs; }
 
   void evaluate_notranspose(const ParticleSet& P,

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -62,9 +62,9 @@ public:
     APP_ABORT("CompositeSPOSet::" + method + " has not been implemented");
   }
 
+  void resetParameters(const opt_variables_type& optVariables) override;
 
   //methods to be implemented in the future (possibly)
-  void resetParameters(const opt_variables_type& optVariables) override;
 #ifdef QMC_CUDA
   void evaluate(const ParticleSet& P, PosType& r, ValueVector& psi) override;
 #endif

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -135,10 +135,6 @@ inline void EinsplineMultiEval(multi_UBspline_3d_z* restrict spline,
 }
 
 template<typename StorageType>
-void EinsplineSetExtended<StorageType>::resetParameters(const opt_variables_type& active)
-{}
-
-template<typename StorageType>
 void EinsplineSetExtended<StorageType>::setOrbitalSetSize(int norbs)
 {
   OrbitalSetSize = norbs;

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -72,7 +72,6 @@ public:
 
 public:
   UnitCellType GetLattice();
-  void resetParameters(const opt_variables_type& active) override {}
   void resetSourceParticleSet(ParticleSet& ions);
   void setOrbitalSetSize(int norbs) override;
   inline std::string Type() { return "EinsplineSet"; }
@@ -473,7 +472,6 @@ public:
 #endif
 #endif
 
-  void resetParameters(const opt_variables_type& active) override;
   void setOrbitalSetSize(int norbs) override;
   std::string Type();
 

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
@@ -60,7 +60,6 @@ public:
   void report(const std::string& pad) const override;
   // ---- begin required overrides
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<FreeOrbital>(*this); }
-  void resetParameters(const opt_variables_type& optVariables) override {} //called by BFTrans}
   void setOrbitalSetSize(int norbs) override { throw std::runtime_error("not implemented"); }
   // required overrides end ----
 private:

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
@@ -523,9 +523,6 @@ void SHOSet::test_overlap()
 }
 
 
-//methods to be implemented later
-void SHOSet::resetParameters(const opt_variables_type& optVariables) { not_implemented("resetParameters"); }
-
 void SHOSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
 {
   not_implemented("evaluateThirdDeriv(P,first,last,dddlogdet)");

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
@@ -110,7 +110,6 @@ struct SHOSet : public SPOSet
 
 
   //methods to be implemented in the future (possibly)
-  void resetParameters(const opt_variables_type& optVariables) override;
   void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& dddlogdet) override;
   void evaluate_notranspose(const ParticleSet& P,
                             int first,

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -53,22 +53,6 @@ public:
 
   void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
 
-  void checkInVariables(opt_variables_type& active) override
-  {
-    APP_ABORT("LCAOrbitalSet should not call checkInVariables");
-  }
-
-  void checkOutVariables(const opt_variables_type& active) override
-  {
-    APP_ABORT("LCAOrbitalSet should not call checkOutVariables");
-  }
-
-  ///reset
-  void resetParameters(const opt_variables_type& active) override
-  {
-    APP_ABORT("LCAOrbitalSet should not call resetParameters");
-  }
-
   /** set the OrbitalSetSize and Identity=false and initialize internal storages
     */
   void setOrbitalSetSize(int norbs) override;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -35,11 +35,6 @@ std::unique_ptr<SPOSet> PWOrbitalSet::makeClone() const
   return myclone;
 }
 
-void PWOrbitalSet::resetParameters(const opt_variables_type& optVariables)
-{
-  //DO NOTHING FOR NOW
-}
-
 void PWOrbitalSet::setOrbitalSetSize(int norbs) {}
 
 void PWOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -67,8 +67,6 @@ public:
   void addVector(const std::vector<ComplexType>& coefs, int jorb);
   void addVector(const std::vector<RealType>& coefs, int jorb);
 
-  void resetParameters(const opt_variables_type& optVariables) override;
-
   void setOrbitalSetSize(int norbs) override;
 
   inline ValueType evaluate(int ib, const PosType& pos)

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -38,12 +38,6 @@ std::unique_ptr<SPOSet> PWRealOrbitalSet::makeClone() const
   return myclone;
 }
 
-
-void PWRealOrbitalSet::resetParameters(const opt_variables_type& active)
-{
-  //DO NOTHING FOR NOW
-}
-
 void PWRealOrbitalSet::setOrbitalSetSize(int norbs) {}
 
 void PWRealOrbitalSet::resize(PWBasisPtr bset, int nbands, bool cleanup)

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -76,8 +76,6 @@ public:
    */
   void addVector(const std::vector<ComplexType>& coefs, int jorb);
 
-  void resetParameters(const opt_variables_type& optVariables) override;
-
   void setOrbitalSetSize(int norbs) override;
 
   inline ValueType evaluate(int ib, const PosType& pos)

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -119,8 +119,12 @@ public:
   /// reset parameters to the values from optimizer
   virtual void resetParameters(const opt_variables_type& optVariables) {}
 
-  /// check in/out parameters to the global list of parameters used by the optimizer
+  /** check in parameters to the global list of parameters used by the optimizer.
+   * This is a query function and should never be implemented as a feature blocker.
+   * If an SPOSet derived class doesn't support optimization, use the base class fallback.
+   */
   virtual void checkInVariables(opt_variables_type& active) {}
+  /// check out parameters to the global list of parameters used by the optimizer
   virtual void checkOutVariables(const opt_variables_type& active) {}
 
   virtual void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -117,7 +117,7 @@ public:
     APP_ABORT(o.str());
   }
   /// reset parameters to the values from optimizer
-  virtual void resetParameters(const opt_variables_type& optVariables) = 0;
+  virtual void resetParameters(const opt_variables_type& optVariables) {}
 
   /// check in/out parameters to the global list of parameters used by the optimizer
   virtual void checkInVariables(opt_variables_type& active) {}

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -40,8 +40,6 @@ void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&&
   d2psi_work_down.resize(OrbitalSetSize);
 }
 
-void SpinorSet::resetParameters(const opt_variables_type& optVariables){};
-
 void SpinorSet::setOrbitalSetSize(int norbs) { OrbitalSetSize = norbs; };
 
 

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -33,8 +33,6 @@ public:
   //This class is initialized by separately building the up and down channels of the spinor set and
   //then registering them.
   void set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn);
-  /// reset parameters to the values from optimizer
-  void resetParameters(const opt_variables_type& optVariables) override;
 
   /** set the OrbitalSetSize
    * @param norbs number of single-particle orbitals

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -1078,8 +1078,7 @@ std::unique_ptr<TrialWaveFunction> TrialWaveFunction::makeClone(ParticleSet& tqp
 void TrialWaveFunction::evaluateDerivatives(ParticleSet& P,
                                             const opt_variables_type& optvars,
                                             std::vector<ValueType>& dlogpsi,
-                                            std::vector<ValueType>& dhpsioverpsi,
-                                            bool project)
+                                            std::vector<ValueType>& dhpsioverpsi)
 {
   //     // First, zero out derivatives
   //  This should only be done for some variables.
@@ -1090,15 +1089,6 @@ void TrialWaveFunction::evaluateDerivatives(ParticleSet& P,
   //orbitals do not know about mass of particle.
   for (int i = 0; i < dhpsioverpsi.size(); i++)
     dhpsioverpsi[i] *= OneOverM;
-
-  if (project)
-  {
-    for (int i = 0; i < Z.size(); i++)
-      Z[i]->multiplyDerivsByOrbR(dlogpsi);
-    RealType psiValue = std::exp(-log_real_) * std::cos(PhaseValue);
-    for (int i = 0; i < dlogpsi.size(); i++)
-      dlogpsi[i] *= psiValue;
-  }
 }
 
 void TrialWaveFunction::mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -455,8 +455,7 @@ public:
   void evaluateDerivatives(ParticleSet& P,
                            const opt_variables_type& optvars,
                            std::vector<ValueType>& dlogpsi,
-                           std::vector<ValueType>& dhpsioverpsi,
-                           bool project = false);
+                           std::vector<ValueType>& dhpsioverpsi);
 
   static void mw_evaluateParameterDerivatives(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                               const RefVectorWithLeader<ParticleSet>& p_list,

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -505,16 +505,6 @@ public:
                                      const opt_variables_type& optvars,
                                      std::vector<ValueType>& dlogpsi);
 
-  virtual void multiplyDerivsByOrbR(std::vector<ValueType>& dlogpsi)
-  {
-    RealType myrat = std::real(LogToValue<PsiValueType>::convert(log_value_));
-    for (int j = 0; j < myVars.size(); j++)
-    {
-      int loc = myVars.where(j);
-      dlogpsi[loc] *= myrat;
-    }
-  }
-
   /** Calculates the derivatives of \f$ \nabla \textnormal{log} \psi_f \f$ with respect to
       the optimizable parameters, and the dot product of this is then
       performed with the passed-in G_in gradient vector. This object is then

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -33,7 +33,6 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override;
   virtual void report() {}
-  void resetParameters(const opt_variables_type& optVariables) override {}
   void setOrbitalSetSize(int norbs) override;
 
   void evaluateValue(const ParticleSet& P, int iat, ValueVector& psi) override;


### PR DESCRIPTION
## Proposed changes
Once TrialWF is built, it calls checkInVariables to query variational parameters under the TrialWF tree regardless of if running WFOpt or not. This the desired behavior.
Consequentially, checkInVariables cannot be implemented as a feature blocker. Update SPOSet and its derived classes.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'