### PR TITLE
Fix queryOrbitalsForSType due to reordering of ions.

### DIFF
--- a/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/SoaLocalizedBasisSet.cpp
@@ -99,9 +99,9 @@ void SoaLocalizedBasisSet<COT, ORBT>::queryOrbitalsForSType(const std::vector<bo
                                                             std::vector<bool>& is_s_orbital) const
 {
   const auto& IonID(ions_.GroupID);
-  int idx = 0;
   for (int c = 0; c < NumCenters; c++)
   {
+    int idx = BasisOffset[c];
     int bss = LOBasisSet[IonID[c]]->BasisSetSize;
     std::vector<bool> local_is_s_orbital(bss);
     LOBasisSet[IonID[c]]->queryOrbitalsForSType(local_is_s_orbital);


### PR DESCRIPTION
## Proposed changes
Fixes #4092. 3.13 and 3.14 releases are affected.
As @markdewing pointed out, it was caused by reordering and it seem I missed changing one function.
Still need a test, the current reproducer seems too heavy being used as a unit test.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'