### PR TITLE
[WIP] Orbital rotation optimization prototype

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -57,7 +57,8 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w,
       m_wfPtr(NULL),
       m_doc_out(NULL),
       includeNonlocalH("no"),
-      debug_stream(0)
+      debug_stream(0),
+      do_override_output(true)
 {
   GEVType = "mixed";
   //paramList.resize(10);
@@ -316,7 +317,7 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
 {
   std::string writeXmlPerStep("no");
   std::string computeNLPPderiv;
-  std::string output_override_str("no");
+  std::string output_override_str("yes");
   ParameterSet m_param;
   m_param.add(writeXmlPerStep, "dumpXML");
   m_param.add(MinNumWalkers, "minwalkers");
@@ -327,14 +328,14 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
   m_param.add(GEVType, "GEVMethod");
   m_param.add(targetExcitedStr, "targetExcited");
   m_param.add(omega_shift, "omega");
-  m_param.add(output_override_str, "output_vp_override", {"no", "yes"});
+  m_param.add(output_override_str, "output_vp_override", {"yes", "no"});
   m_param.put(q);
 
   targetExcitedStr = lowerCase(targetExcitedStr);
   targetExcited    = (targetExcitedStr == "yes");
 
-  if (output_override_str == "yes")
-    do_override_output = true;
+  if (output_override_str == "no")
+    do_override_output = false;
 
   if (includeNonlocalH == "yes")
     includeNonlocalH = "NonLocalECP";

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -219,7 +219,9 @@ void QMCCostFunctionBase::reportParameters()
   {
     std::ostringstream vp_filename;
     vp_filename << RootName << ".vp.h5";
-    OptVariables.saveAsHDF(vp_filename.str());
+    hdf_archive hout;
+    OptVariables.saveAsHDF(vp_filename.str(), hout);
+    Psi.saveExtraParameters(hout);
 
     char newxml[128];
     sprintf(newxml, "%s.opt.xml", RootName.c_str());

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -80,6 +80,9 @@ public:
 
   void resetParameters(const opt_variables_type& active) override { Phi->resetParameters(active); }
 
+  void saveExtraParameters(hdf_archive& hout, int id) { Phi->saveExtraParameters(hout, id); }
+  void readExtraParameters(hdf_archive& hin, int id) { Phi->readExtraParameters(hin, id); }
+
   inline void reportStatus(std::ostream& os) final {}
 
   virtual void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -75,6 +75,21 @@ void SlaterDet::resetParameters(const opt_variables_type& active)
       Dets[i]->resetParameters(active);
 }
 
+void SlaterDet::saveExtraParameters(hdf_archive& hout)
+{
+  if (Optimizable)
+    for (int i = 0; i < Dets.size(); i++)
+      Dets[i]->saveExtraParameters(hout, i);
+}
+
+void SlaterDet::readExtraParameters(hdf_archive& hin)
+{
+  if (Optimizable)
+    for (int i = 0; i < Dets.size(); i++)
+      Dets[i]->readExtraParameters(hin, i);
+}
+
+
 void SlaterDet::reportStatus(std::ostream& os) {}
 
 PsiValueType SlaterDet::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -55,6 +55,10 @@ public:
   ///reset all the Dirac determinants, Optimizable is true
   void resetParameters(const opt_variables_type& optVariables) override;
 
+  void saveExtraParameters(hdf_archive& hout) override;
+  void readExtraParameters(hdf_archive& hin) override;
+
+
   void reportStatus(std::ostream& os) override;
 
   void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override;

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1252,6 +1252,8 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   myclone->m_act_rot_inds  = this->m_act_rot_inds;
   myclone->myVars          = this->myVars;
   myclone->myName          = this->myName;
+  myclone->history_params_ = this->history_params_;
+  // use_this_copy_to_apply_rotation_ is not copied
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -190,15 +190,11 @@ public:
 
   void checkInVariables(opt_variables_type& active) override
   {
-    //reset parameters to zero after coefficient matrix has been updated
-    for (int k = 0; k < myVars.size(); ++k)
-      myVars[k] = 0.0;
-
+    use_this_copy_to_apply_rotation_ = true;
     if (Optimizable)
     {
       if (myVars.size())
         active.insertFrom(myVars);
-      Phi->storeParamsBeforeRotation();
     }
   }
 
@@ -211,19 +207,7 @@ public:
   }
 
   ///reset
-  void resetParameters(const opt_variables_type& active) override
-  {
-    if (Optimizable)
-    {
-      std::vector<RealType> param(m_act_rot_inds.size());
-      for (int i = 0; i < m_act_rot_inds.size(); i++)
-      {
-        int loc  = myVars.where(i);
-        param[i] = myVars[i] = active[loc];
-      }
-      apply_rotation(param, true);
-    }
-  }
+  void resetParameters(const opt_variables_type& active) override;
 
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions
@@ -335,6 +319,13 @@ private:
   bool params_supplied;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
+
+  // Flag for which copy to applies the rotation.
+  // Pick the one that has checkInVariables called on it
+  bool use_this_copy_to_apply_rotation_;
+
+
+  std::vector<std::vector<RealType>> history_params_;
 };
 
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -53,6 +53,9 @@ public:
   //function to perform orbital rotations
   void apply_rotation(const std::vector<RealType>& param, bool use_stored_copy);
 
+  // Apply the list of rotations in the history.  Used for initializing from a file.
+  void apply_rotation_history();
+
   // Compute matrix exponential of an antisymmetric matrix (result is rotation matrix)
   static void exponentiate_antisym_matrix(ValueMatrix& mat);
 
@@ -208,6 +211,10 @@ public:
 
   ///reset
   void resetParameters(const opt_variables_type& active) override;
+
+  void saveExtraParameters(hdf_archive& hout, int id) override;
+  void readExtraParameters(hdf_archive& hin, int id) override;
+
 
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -119,6 +119,9 @@ public:
   /// reset parameters to the values from optimizer
   virtual void resetParameters(const opt_variables_type& optVariables) {}
 
+  virtual void saveExtraParameters(hdf_archive& hout, int id) {}
+  virtual void readExtraParameters(hdf_archive& hin, int id) {}
+
   /** check in parameters to the global list of parameters used by the optimizer.
    * This is a query function and should never be implemented as a feature blocker.
    * If an SPOSet derived class doesn't support optimization, use the base class fallback.

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -895,6 +895,18 @@ void TrialWaveFunction::resetParameters(const opt_variables_type& active)
     Z[i]->resetParameters(active);
 }
 
+void TrialWaveFunction::saveExtraParameters(hdf_archive& hout)
+{
+  for (int i = 0; i < Z.size(); i++)
+    Z[i]->saveExtraParameters(hout);
+}
+
+void TrialWaveFunction::readExtraParameters(hdf_archive& hin)
+{
+  for (int i = 0; i < Z.size(); i++)
+    Z[i]->readExtraParameters(hin);
+}
+
 void TrialWaveFunction::reportStatus(std::ostream& os)
 {
   for (int i = 0; i < Z.size(); i++)
@@ -1238,7 +1250,7 @@ void TrialWaveFunction::initializeTWFFastDerivWrapper(const ParticleSet& P, TWFF
       //det->registerTWFFastDerivWrapper(P, twf);
       Z[i]->registerTWFFastDerivWrapper(P, twf);
     }
-    else 
+    else
       twf.addJastrow(Z[i].get());
   }
 }

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -895,12 +895,14 @@ void TrialWaveFunction::resetParameters(const opt_variables_type& active)
     Z[i]->resetParameters(active);
 }
 
+// The hdf_archive should be first passed to VariableSet::saveAsHDF to open the HDF file
 void TrialWaveFunction::saveExtraParameters(hdf_archive& hout)
 {
   for (int i = 0; i < Z.size(); i++)
     Z[i]->saveExtraParameters(hout);
 }
 
+// The hdf_archive should be first passed to VariableSet::readFromHDF to open the HDF file
 void TrialWaveFunction::readExtraParameters(hdf_archive& hin)
 {
   for (int i = 0; i < Z.size(); i++)

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -40,6 +40,8 @@
 
 namespace qmcplusplus
 {
+
+class hdf_archive;
 /** @ingroup MBWfs
  * @brief Class to represent a many-body trial wave function
  *
@@ -166,6 +168,10 @@ public:
    */
   void resetParameters(const opt_variables_type& active);
 
+  // Save and restore extra variational parameter data
+
+  void saveExtraParameters(hdf_archive& hout);
+  void readExtraParameters(hdf_archive& hout);
 
   /** print out state of the trial wavefunction
    */

--- a/src/QMCWaveFunctions/VariableSet.cpp
+++ b/src/QMCWaveFunctions/VariableSet.cpp
@@ -287,11 +287,11 @@ void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader) c
   }
 }
 
-void VariableSet::saveAsHDF(const std::string& filename) const
+void VariableSet::saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const
 {
-  qmcplusplus::hdf_archive hout;
+  //qmcplusplus::hdf_archive hout;
   hout.create(filename);
-  std::vector<int> vp_file_version{1, 0, 0};
+  std::vector<int> vp_file_version{1, 1, 0};
   hout.write(vp_file_version, "version");
 
   std::string timestamp(getDateAndTime("%Y-%m-%d %H:%M:%S %Z"));
@@ -312,9 +312,9 @@ void VariableSet::saveAsHDF(const std::string& filename) const
   hout.pop();
 }
 
-void VariableSet::readFromHDF(const std::string& filename)
+void VariableSet::readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hin)
 {
-  qmcplusplus::hdf_archive hin;
+  //qmcplusplus::hdf_archive hin;
   if (!hin.open(filename, H5F_ACC_RDONLY))
   {
     std::ostringstream err_msg;
@@ -344,6 +344,7 @@ void VariableSet::readFromHDF(const std::string& filename)
     if (find(vp_name) != end())
       (*this)[vp_name] = param_values[i];
   }
+  hin.pop();
 }
 
 

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -22,6 +22,11 @@
 #include <complex>
 #include "Configuration.h"
 
+namespace qmcplusplus
+{
+  class hdf_archive;
+}
+
 namespace optimize
 {
 /** An enum useful for determining the type of parameter is being optimized.
@@ -358,11 +363,11 @@ struct VariableSet
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
 
   // Save variational parameters to an HDF file
-  void saveAsHDF(const std::string& filename) const;
+  void saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const;
 
   /// Read variational parameters from an HDF file.
   /// This assumes VariableSet is already set up.
-  void readFromHDF(const std::string& filename);
+  void readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hout);
 };
 } // namespace optimize
 

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -24,7 +24,7 @@
 
 namespace qmcplusplus
 {
-  class hdf_archive;
+class hdf_archive;
 }
 
 namespace optimize

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -51,6 +51,7 @@ struct NLjob
 class WaveFunctionComponent;
 class ResourceCollection;
 class TWFFastDerivWrapper;
+class hdf_archive;
 /**@defgroup WaveFunctionComponent group
  * @brief Classes which constitute a many-body trial wave function
  *
@@ -158,6 +159,9 @@ public:
   /** reset the parameters during optimizations
    */
   virtual void resetParameters(const opt_variables_type& active) = 0;
+
+  virtual void saveExtraParameters(hdf_archive& hout) {}
+  virtual void readExtraParameters(hdf_archive& hin) {}
 
   /** print the state, e.g., optimizables */
   virtual void reportStatus(std::ostream& os) = 0;

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -162,7 +162,12 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur)
   if (!vp_file_to_load.empty())
   {
     app_log() << "  Reading variational parameters from " << vp_file_to_load << std::endl;
-    dummy.readFromHDF(vp_file_to_load);
+    hdf_archive hin;
+    dummy.readFromHDF(vp_file_to_load, hin);
+    targetPsi->readExtraParameters(hin);
+    // Get the latest values of the parameters for dummy so the following resetParameters doesn't mess up the
+    // rotation
+    targetPsi->checkInVariables(dummy);
   }
 
   targetPsi->resetParameters(dummy);

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -12,6 +12,7 @@
 
 #include "catch.hpp"
 #include "complex_approx.hpp"
+#include "io/hdf/hdf_archive.h"
 
 #include "VariableSet.h"
 
@@ -120,12 +121,14 @@ TEST_CASE("VariableSet HDF output and input", "[optimize]")
   vs.insert("s", first_val);
   vs.insert("second", second_val);
   vs.insert("really_really_really_long_name", third_val);
-  vs.saveAsHDF("vp.h5");
+  qmcplusplus::hdf_archive hout;
+  vs.saveAsHDF("vp.h5", hout);
 
   VariableSet vs2;
   vs2.insert("s", 0.0);
   vs2.insert("second", 0.0);
-  vs2.readFromHDF("vp.h5");
+  qmcplusplus::hdf_archive hin;
+  vs2.readFromHDF("vp.h5", hin);
   CHECK(vs2.find("s")->second == ValueApprox(first_val));
   CHECK(vs2.find("second")->second == ValueApprox(second_val));
   // This value as in the file, but not in the VariableSet that loaded the file,


### PR DESCRIPTION
This implements option 2 in https://github.com/QMCPACK/qmcpack/issues/3983#issuecomment-1197380631
It saves a history of applied rotations.

One purpose of this PR is allow others to test orbital rotation (@anbenali ).   Variational parameters can be saved and restored from the vp.h5 file, though this is still a prototype.  RHF wavefunctions, where the up and down coefficients should be constrained to the be the same is not implemented. For testing I've used separate coefficient matrices and let them vary separately.

The problem with previous code is that checkInVariables is used to signal the beginning of an optimization cycle.  This function does not get called on all the clones, so it is not a good choice for this signal.
    
The rotation code depends on two things in the call to checkInVariables:
1. Sets the parameters to zero in order to get the parameter change when resetParameters gets called.
2. Stores the rotated coefficient matrix for later use.
    
The new code addresses these as:
1. Computes the delta between old parameters (in myVars) and the new parameters (in active).  This also has the effect that calling resetParameters multiple times with the same parameters will have no effect.
2. Always applies the rotation from the existing coefficient matrix - no copy is saved.   This should work for both the LCAO and spline code. (The spline code doesn't implement saving the coefficient matrix - with this change it does not need to).
    
One problem that arises is the coefficient matrix is stored as a shared pointer, and is shared among the clones.  If multiple threads call resetParameters, the rotation gets applied multiple times.

The hack to fix this here is to use the fact that checkInVariables (the irony!) is only called on one clone, and use that clone to perform the rotation.  This should be changed to something better before going into the code.


The mechanism to save and restore extra parameter information in the HDF file is to add two new functions in TWF (saveExtraParameters/readExtraParameters) and various pieces in the wavefunction hierarchy.
The hdf_archive object is pulled out of saveAsHDF/readFromHDF so it can be passed to save/readExtraParameters.

The SPOSet version of save/readExtraParameters has an id parameter to distinguish between up and down electrons.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
