### PR TITLE
[WIP] Prototype for orbital rotation using global rotation

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -57,7 +57,8 @@ QMCCostFunctionBase::QMCCostFunctionBase(ParticleSet& w,
       m_wfPtr(NULL),
       m_doc_out(NULL),
       includeNonlocalH("no"),
-      debug_stream(0)
+      debug_stream(0),
+      do_override_output(true)
 {
   GEVType = "mixed";
   //paramList.resize(10);
@@ -316,7 +317,7 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
 {
   std::string writeXmlPerStep("no");
   std::string computeNLPPderiv;
-  std::string output_override_str("no");
+  std::string output_override_str("yes");
   ParameterSet m_param;
   m_param.add(writeXmlPerStep, "dumpXML");
   m_param.add(MinNumWalkers, "minwalkers");
@@ -327,14 +328,14 @@ bool QMCCostFunctionBase::put(xmlNodePtr q)
   m_param.add(GEVType, "GEVMethod");
   m_param.add(targetExcitedStr, "targetExcited");
   m_param.add(omega_shift, "omega");
-  m_param.add(output_override_str, "output_vp_override", {"no", "yes"});
+  m_param.add(output_override_str, "output_vp_override", {"yes", "no"});
   m_param.put(q);
 
   targetExcitedStr = lowerCase(targetExcitedStr);
   targetExcited    = (targetExcitedStr == "yes");
 
-  if (output_override_str == "yes")
-    do_override_output = true;
+  if (output_override_str == "no")
+    do_override_output = false;
 
   if (includeNonlocalH == "yes")
     includeNonlocalH = "NonLocalECP";

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -219,7 +219,9 @@ void QMCCostFunctionBase::reportParameters()
   {
     std::ostringstream vp_filename;
     vp_filename << RootName << ".vp.h5";
-    OptVariables.saveAsHDF(vp_filename.str());
+    hdf_archive hout;
+    OptVariables.saveAsHDF(vp_filename.str(), hout);
+    Psi.saveExtraParameters(hout);
 
     char newxml[128];
     sprintf(newxml, "%s.opt.xml", RootName.c_str());

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -80,6 +80,9 @@ public:
 
   void resetParameters(const opt_variables_type& active) override { Phi->resetParameters(active); }
 
+  void saveExtraParameters(hdf_archive& hout, int id) { Phi->saveExtraParameters(hout, id); }
+  void readExtraParameters(hdf_archive& hin, int id) { Phi->readExtraParameters(hin, id); }
+
   inline void reportStatus(std::ostream& os) final {}
 
   virtual void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.cpp
@@ -75,6 +75,21 @@ void SlaterDet::resetParameters(const opt_variables_type& active)
       Dets[i]->resetParameters(active);
 }
 
+void SlaterDet::saveExtraParameters(hdf_archive& hout)
+{
+  if (Optimizable)
+    for (int i = 0; i < Dets.size(); i++)
+      Dets[i]->saveExtraParameters(hout, i);
+}
+
+void SlaterDet::readExtraParameters(hdf_archive& hin)
+{
+  if (Optimizable)
+    for (int i = 0; i < Dets.size(); i++)
+      Dets[i]->readExtraParameters(hin, i);
+}
+
+
 void SlaterDet::reportStatus(std::ostream& os) {}
 
 PsiValueType SlaterDet::ratioGrad(ParticleSet& P, int iat, GradType& grad_iat)

--- a/src/QMCWaveFunctions/Fermion/SlaterDet.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDet.h
@@ -55,6 +55,10 @@ public:
   ///reset all the Dirac determinants, Optimizable is true
   void resetParameters(const opt_variables_type& optVariables) override;
 
+  void saveExtraParameters(hdf_archive& hout) override;
+  void readExtraParameters(hdf_archive& hin) override;
+
+
   void reportStatus(std::ostream& os) override;
 
   void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override;

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -68,6 +68,11 @@ public:
   //function to perform orbital rotations
   void apply_rotation(const std::vector<RealType>& param, bool use_stored_copy);
 
+  void apply_full_rotation(const std::vector<RealType>& full_param, bool use_stored_copy);
+
+  // Apply the list of rotations in the history.  Used for initializing from a file.
+  void apply_rotation_history();
+
   // Compute matrix exponential of an antisymmetric matrix (result is rotation matrix)
   static void exponentiate_antisym_matrix(ValueMatrix& mat);
 
@@ -222,6 +227,10 @@ public:
 
   ///reset
   void resetParameters(const opt_variables_type& active) override;
+
+  void saveExtraParameters(hdf_archive& hout, int id) override;
+  void readExtraParameters(hdf_archive& hin, int id) override;
+
 
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -119,6 +119,9 @@ public:
   /// reset parameters to the values from optimizer
   virtual void resetParameters(const opt_variables_type& optVariables) {}
 
+  virtual void saveExtraParameters(hdf_archive& hout, int id) {}
+  virtual void readExtraParameters(hdf_archive& hin, int id) {}
+
   /** check in parameters to the global list of parameters used by the optimizer.
    * This is a query function and should never be implemented as a feature blocker.
    * If an SPOSet derived class doesn't support optimization, use the base class fallback.

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -95,6 +95,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
     app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";
     abort();
 #else
+    sposet->storeParamsBeforeRotation();
     // create sposet with rotation
     auto& sposet_ref = *sposet;
     auto rot_spo     = std::make_unique<RotatedSPOs>(std::move(sposet));

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -893,6 +893,19 @@ void TrialWaveFunction::resetParameters(const opt_variables_type& active)
 {
   for (int i = 0; i < Z.size(); i++)
     Z[i]->resetParameters(active);
+
+}
+
+void TrialWaveFunction::saveExtraParameters(hdf_archive& hout)
+{
+  for (int i = 0; i < Z.size(); i++)
+    Z[i]->saveExtraParameters(hout);
+}
+
+void TrialWaveFunction::readExtraParameters(hdf_archive& hin)
+{
+  for (int i = 0; i < Z.size(); i++)
+    Z[i]->readExtraParameters(hin);
 }
 
 void TrialWaveFunction::reportStatus(std::ostream& os)

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -40,6 +40,8 @@
 
 namespace qmcplusplus
 {
+
+class hdf_archive;
 /** @ingroup MBWfs
  * @brief Class to represent a many-body trial wave function
  *
@@ -166,6 +168,10 @@ public:
    */
   void resetParameters(const opt_variables_type& active);
 
+  // Save and restore extra variational parameter data
+
+  void saveExtraParameters(hdf_archive &hout);
+  void readExtraParameters(hdf_archive &hout);
 
   /** print out state of the trial wavefunction
    */

--- a/src/QMCWaveFunctions/VariableSet.cpp
+++ b/src/QMCWaveFunctions/VariableSet.cpp
@@ -287,11 +287,11 @@ void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader) c
   }
 }
 
-void VariableSet::saveAsHDF(const std::string& filename) const
+void VariableSet::saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const
 {
-  qmcplusplus::hdf_archive hout;
+  //qmcplusplus::hdf_archive hout;
   hout.create(filename);
-  std::vector<int> vp_file_version{1, 0, 0};
+  std::vector<int> vp_file_version{1, 1, 0};
   hout.write(vp_file_version, "version");
 
   std::string timestamp(getDateAndTime("%Y-%m-%d %H:%M:%S %Z"));
@@ -312,9 +312,9 @@ void VariableSet::saveAsHDF(const std::string& filename) const
   hout.pop();
 }
 
-void VariableSet::readFromHDF(const std::string& filename)
+void VariableSet::readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hin)
 {
-  qmcplusplus::hdf_archive hin;
+  //qmcplusplus::hdf_archive hin;
   if (!hin.open(filename, H5F_ACC_RDONLY))
   {
     std::ostringstream err_msg;
@@ -344,6 +344,7 @@ void VariableSet::readFromHDF(const std::string& filename)
     if (find(vp_name) != end())
       (*this)[vp_name] = param_values[i];
   }
+  hin.pop();
 }
 
 

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -22,6 +22,11 @@
 #include <complex>
 #include "Configuration.h"
 
+namespace qmcplusplus
+{
+  class hdf_archive;
+}
+
 namespace optimize
 {
 /** An enum useful for determining the type of parameter is being optimized.
@@ -358,11 +363,11 @@ struct VariableSet
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
 
   // Save variational parameters to an HDF file
-  void saveAsHDF(const std::string& filename) const;
+  void saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const;
 
   /// Read variational parameters from an HDF file.
   /// This assumes VariableSet is already set up.
-  void readFromHDF(const std::string& filename);
+  void readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hout);
 };
 } // namespace optimize
 

--- a/src/QMCWaveFunctions/WaveFunctionComponent.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponent.h
@@ -51,6 +51,7 @@ struct NLjob
 class WaveFunctionComponent;
 class ResourceCollection;
 class TWFFastDerivWrapper;
+class hdf_archive;
 /**@defgroup WaveFunctionComponent group
  * @brief Classes which constitute a many-body trial wave function
  *
@@ -158,6 +159,9 @@ public:
   /** reset the parameters during optimizations
    */
   virtual void resetParameters(const opt_variables_type& active) = 0;
+
+  virtual void saveExtraParameters(hdf_archive& hout) {}
+  virtual void readExtraParameters(hdf_archive& hin) {}
 
   /** print the state, e.g., optimizables */
   virtual void reportStatus(std::ostream& os) = 0;

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -162,7 +162,12 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur)
   if (!vp_file_to_load.empty())
   {
     app_log() << "  Reading variational parameters from " << vp_file_to_load << std::endl;
-    dummy.readFromHDF(vp_file_to_load);
+    hdf_archive hin;
+    dummy.readFromHDF(vp_file_to_load, hin);
+    targetPsi->readExtraParameters(hin);
+    // Get the latest values of the parameters for dummy so the following resetParameters doesn't mess up the
+    // rotation
+    targetPsi->checkInVariables(dummy);
   }
 
   targetPsi->resetParameters(dummy);

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -12,6 +12,7 @@
 
 #include "catch.hpp"
 #include "complex_approx.hpp"
+#include "io/hdf/hdf_archive.h"
 
 #include "VariableSet.h"
 
@@ -120,12 +121,14 @@ TEST_CASE("VariableSet HDF output and input", "[optimize]")
   vs.insert("s", first_val);
   vs.insert("second", second_val);
   vs.insert("really_really_really_long_name", third_val);
-  vs.saveAsHDF("vp.h5");
+  qmcplusplus::hdf_archive hout;
+  vs.saveAsHDF("vp.h5", hout);
 
   VariableSet vs2;
   vs2.insert("s", 0.0);
   vs2.insert("second", 0.0);
-  vs2.readFromHDF("vp.h5");
+  qmcplusplus::hdf_archive hin;
+  vs2.readFromHDF("vp.h5", hin);
   CHECK(vs2.find("s")->second == ValueApprox(first_val));
   CHECK(vs2.find("second")->second == ValueApprox(second_val));
   // This value as in the file, but not in the VariableSet that loaded the file,


### PR DESCRIPTION
This implements option 3 in https://github.com/QMCPACK/qmcpack/issues/3983#issuecomment-1197380631
It maintains global rotation parameters instead of a history list.

The call to resetParameters does
1. Compute the change in parameters from the old ones in myVars and the new ones in 'active'.
2. Compute rotation matrices corresponding the old and delta parameters
3. Multiply rotation matrices
4. Apply rotation to stored MO coefficients
5. Extract the rotation parameters from the new rotation matrix and set those the new parameters.

One subtle point is we need to track all the rotation parameters, not just the subset of parameters being optimized.

This code does store a copy of the coefficient matrix to compute rotated parameters, so it will only work with LCAO.

This uses the same infrastructure to save and restore the extra parameter info as in #4146.

The PR is not intended to be checked in.  The intent to make this option visible and available for testing.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
