### PR TITLE
Do not print initial memory availability for every MPI task

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -87,17 +87,6 @@ void Communicate::initialize(const mpi3::environment& env)
   d_ncontexts = comm.size();
   d_groupid   = 0;
   d_ngroups   = 1;
-#ifdef __linux__
-  for (int proc = 0; proc < OHMMS::Controller->size(); proc++)
-  {
-    if (OHMMS::Controller->rank() == proc)
-    {
-      fprintf(stderr, "Rank = %4d  Free Memory = %5zu MB\n", proc, (freemem() >> 20));
-    }
-    comm.barrier();
-  }
-  comm.barrier();
-#endif
   std::string when = "qmc." + getDateAndTime("%Y%m%d_%H%M");
 }
 


### PR DESCRIPTION
## Proposed changes

Increase output readability in MPI jobs by not printing free memory for every single MPI task. Rely on #4130 instead. If problems ever occur we could expand the #4130 report to include max and min values.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen, nightly gcc 12 mpi configuration

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
