### PR TITLE
Adding batched per particle value reporting for NonLocalECPotential

### DIFF
--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -135,7 +135,9 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
     std::unique_ptr<NonLocalECPotential> apot =
         std::make_unique<NonLocalECPotential>(IonConfig, targetPtcl, targetPsi, doForces, use_DLA == "yes");
 #endif
+
     int nknot_max = 0;
+    // These are actually NonLocalECPComponents
     for (int i = 0; i < nonLocalPot.size(); i++)
     {
       if (nonLocalPot[i])

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -59,6 +59,17 @@ private:
   const std::string name_;
 };
 
+template<typename T>
+struct ListenerOption
+{
+    ListenerOption(const std::vector<ListenerVector<T>>& le, const std::vector<ListenerVector<T>>& li)
+        : electrons(le), ions(li)
+    {}
+    const std::vector<ListenerVector<T>>& electrons;
+    const std::vector<ListenerVector<T>>& ions;
+};
+
+
 
 } // namespace qmcplusplus
 

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -59,6 +59,13 @@ private:
   const std::string name_;
 };
 
+/** Convenience container for common optional element to mw_eval.._impl.
+ *  This can allow the per_particle and reduced mw_eval to share the same
+ *  implementation method.
+ *
+ *  see NonLocalECPotential for example of usage.
+ *  I anticipate it could be used elsewhere.
+ */
 template<typename T>
 struct ListenerOption
 {

--- a/src/QMCHamiltonians/NLPPJob.h
+++ b/src/QMCHamiltonians/NLPPJob.h
@@ -18,6 +18,9 @@
 namespace qmcplusplus
 {
 /** meta data for NLPP calculation of a pair of ion and electron
+    This is not just meta data.
+    elec pos ion_elec_dist etc.
+    This is an AoS data element.
    */
 template<typename T>
 struct NLPPJob
@@ -30,6 +33,10 @@ struct NLPPJob
   const RealType ion_elec_dist;
   const PosType ion_elec_displ;
 
+  /** This allows construction using emplace back
+   *  could be a way to pull it off with aggregate initialization
+   *  but it is nontrivial
+   */
   NLPPJob(const int ion_id_in,
           const int electron_id_in,
           const PosType& elec_pos_in,

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -243,7 +243,6 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
   else
   {
     // Compute ratios without VP. This is working but very slow code path.
-#pragma omp parallel for
     for (size_t i = 0; i < p_list.size(); i++)
     {
       NonLocalECPComponent& component(ecp_component_list[i]);

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -30,9 +30,9 @@ NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, 
     : NonLocalECPComponent(nl_ecpc)
 {
   for (int i = 0; i < nl_ecpc.nlpp_m.size(); ++i)
-    this->nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
+    nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
   if (nl_ecpc.VP)
-    this->VP = new VirtualParticleSet(pset, nknot);
+    VP = new VirtualParticleSet(pset, nknot);
 }
 
 NonLocalECPComponent::~NonLocalECPComponent()

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -24,22 +24,22 @@ namespace qmcplusplus
 {
 NonLocalECPComponent::NonLocalECPComponent() : lmax(0), nchannel(0), nknot(0), Rmax(-1), VP(nullptr) {}
 
+// unfortunately we continue the sloppy use of the default copy constructor followed by reassigning pointers.
+// This prevents use of smart pointers and concievably sets us up for trouble with double frees and the destructor.
+NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, const ParticleSet& pset) : NonLocalECPComponent(nl_ecpc)
+{
+  for (int i = 0; i < nl_ecpc.nlpp_m.size(); ++i)
+    this->nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
+  if (nl_ecpc.VP)
+    this->VP = new VirtualParticleSet(pset, nknot);
+}
+
 NonLocalECPComponent::~NonLocalECPComponent()
 {
   for (int ip = 0; ip < nlpp_m.size(); ip++)
     delete nlpp_m[ip];
   if (VP)
     delete VP;
-}
-
-NonLocalECPComponent* NonLocalECPComponent::makeClone(const ParticleSet& qp)
-{
-  NonLocalECPComponent* myclone = new NonLocalECPComponent(*this);
-  for (int i = 0; i < nlpp_m.size(); ++i)
-    myclone->nlpp_m[i] = nlpp_m[i]->makeClone();
-  if (VP)
-    myclone->VP = new VirtualParticleSet(qp, nknot);
-  return myclone;
 }
 
 void NonLocalECPComponent::initVirtualParticle(const ParticleSet& qp)

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -26,7 +26,8 @@ NonLocalECPComponent::NonLocalECPComponent() : lmax(0), nchannel(0), nknot(0), R
 
 // unfortunately we continue the sloppy use of the default copy constructor followed by reassigning pointers.
 // This prevents use of smart pointers and concievably sets us up for trouble with double frees and the destructor.
-NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, const ParticleSet& pset) : NonLocalECPComponent(nl_ecpc)
+NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, const ParticleSet& pset)
+    : NonLocalECPComponent(nl_ecpc)
 {
   for (int i = 0; i < nl_ecpc.nlpp_m.size(); ++i)
     this->nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
@@ -509,7 +510,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   for (size_t jat = 0; jat < ions.getTotalNum(); jat++)
   {
     convertToReal(psi.evalGradSource(W, ions, jat), pulay_ref[jat]);
-    gradpotterm_   = 0;
+    gradpotterm_ = 0;
     for (size_t j = 0; j < nknot; j++)
     {
       deltaV[j] = r * rrotsgrid_m[j] - dr;

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -27,6 +27,11 @@
 
 namespace qmcplusplus
 {
+namespace testing
+{
+class TestNonLocalECPotential;
+}
+
 /** Contains a set of radial grid potentials around a center.
 */
 class NonLocalECPComponent : public QMCTraits
@@ -115,14 +120,12 @@ private:
    */
   RealType calculateProjector(RealType r, const PosType& dr);
 
-  NonLocalECPComponent(const NonLocalECPComponent&) = default;
-  
 public:
   NonLocalECPComponent();
-  
+
   /// Make a copy but have it associated with pset instead of nl_ecpc's pset
   NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, const ParticleSet& pset);
-    
+
   ~NonLocalECPComponent();
 
   ///add a new Non Local component
@@ -310,7 +313,11 @@ public:
   friend struct ECPComponentBuilder;
   // a lazy temporal solution
   friend class NonLocalECPotential_CUDA;
-}; //end of RadialPotentialSet
+
+  // for testing
+  friend class testing::TestNonLocalECPotential;
+};
+
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/NonLocalECPComponent.h
+++ b/src/QMCHamiltonians/NonLocalECPComponent.h
@@ -115,13 +115,15 @@ private:
    */
   RealType calculateProjector(RealType r, const PosType& dr);
 
+  NonLocalECPComponent(const NonLocalECPComponent&) = default;
+  
 public:
   NonLocalECPComponent();
-
-  ///destructor
+  
+  /// Make a copy but have it associated with pset instead of nl_ecpc's pset
+  NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, const ParticleSet& pset);
+    
   ~NonLocalECPComponent();
-
-  NonLocalECPComponent* makeClone(const ParticleSet& qp);
 
   ///add a new Non Local component
   void add(int l, RadialPotentialType* pp);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -417,9 +417,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
           vi_samples(iw, batch_list[j].get().ion_id) += pairpots[j];
         }
 
-#ifndef DEBUG_NLPP_BATCHED
-        if (false)
-        { // code usefully for debugging, but bad for reading.
+#ifdef DEBUG_NLPP_BATCHED
           Real check_value =
               ecp_component_list[j].evaluateOne(pset_list[j], batch_list[j].get().ion_id, psi_list[j],
                                                 batch_list[j].get().electron_id, batch_list[j].get().ion_elec_dist,
@@ -427,7 +425,6 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
           if (std::abs(check_value - pairpots[j]) > 1e-5)
             std::cout << "check " << check_value << " wrong " << pairpots[j] << " diff "
                       << std::abs(check_value - pairpots[j]) << std::endl;
-        }
 #endif
       }
     }
@@ -449,9 +446,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         listener.report(iw, O_leader.getName(), ve_sample);
       }
       for (const ListenerVector<Real>& listener : listeners->ions)
-      {
         listener.report(iw, O_leader.getName(), vi_sample);
-      }
     }
     ve_samples = 0.0;
     vi_samples = 0.0;

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -235,6 +235,7 @@ void NonLocalECPotential::evaluateImpl(ParticleSet& P, bool Tmove, bool keep_gri
             Real pairpot = PP[iat]->evaluateOne(P, iat, Psi, jel, dist[iat], -displ[iat], use_DLA);
             if (Tmove)
               PP[iat]->contributeTxy(jel, tmove_xy_);
+
             value_ += pairpot;
             NeighborIons.push_back(iat);
             IonNeighborElecs.getNeighborList(iat).push_back(jel);
@@ -452,6 +453,8 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         listener.report(iw, O_leader.getName(), vi_sample);
       }
     }
+    ve_samples = 0.0;
+    vi_samples = 0.0;
   }
 }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -332,21 +332,6 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     O.value_ = 0.0;
   }
 
-  // make this class unit tests friendly without the need of setup resources.
-  if (!O_leader.mw_res_)
-  {
-    app_warning() << "NonLocalECPotential: This message should not be seen in production (performance bug) runs "
-                     "but only unit tests (expected)."
-                  << std::endl;
-    O_leader.mw_res_ = std::make_unique<NonLocalECPotentialMultiWalkerResource>();
-    for (int ig = 0; ig < O_leader.PPset.size(); ++ig)
-      if (O_leader.PPset[ig]->getVP())
-      {
-        O_leader.PPset[ig]->getVP()->createResource(O_leader.mw_res_->collection);
-        break;
-      }
-  }
-
   if (listeners)
   {
     auto& ve_samples = O_leader.mw_res_->ve_samples;

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -418,13 +418,13 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
         }
 
 #ifdef DEBUG_NLPP_BATCHED
-          Real check_value =
-              ecp_component_list[j].evaluateOne(pset_list[j], batch_list[j].get().ion_id, psi_list[j],
-                                                batch_list[j].get().electron_id, batch_list[j].get().ion_elec_dist,
-                                                batch_list[j].get().ion_elec_displ, O_leader.use_DLA);
-          if (std::abs(check_value - pairpots[j]) > 1e-5)
-            std::cout << "check " << check_value << " wrong " << pairpots[j] << " diff "
-                      << std::abs(check_value - pairpots[j]) << std::endl;
+        Real check_value =
+            ecp_component_list[j].evaluateOne(pset_list[j], batch_list[j].get().ion_id, psi_list[j],
+                                              batch_list[j].get().electron_id, batch_list[j].get().ion_elec_dist,
+                                              batch_list[j].get().ion_elec_displ, O_leader.use_DLA);
+        if (std::abs(check_value - pairpots[j]) > 1e-5)
+          std::cout << "check " << check_value << " wrong " << pairpots[j] << " diff "
+                    << std::abs(check_value - pairpots[j]) << std::endl;
 #endif
       }
     }
@@ -442,9 +442,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       Vector<Real> ve_sample(ve_samples.begin(iw), num_electrons);
       Vector<Real> vi_sample(vi_samples.begin(iw), O_leader.NumIons);
       for (const ListenerVector<Real>& listener : listeners->electrons)
-      {
         listener.report(iw, O_leader.getName(), ve_sample);
-      }
       for (const ListenerVector<Real>& listener : listeners->ions)
         listener.report(iw, O_leader.getName(), vi_sample);
     }

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -27,6 +27,11 @@ namespace qmcplusplus
 template<typename T>
 struct NLPPJob;
 
+namespace testing
+{
+class TestNonLocalECPotential;
+}
+
 /** @ingroup hamiltonian
  * \brief Evaluate the semi local potentials
  */
@@ -36,14 +41,16 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
 
   struct NonLocalECPotentialMultiWalkerResource : public Resource
   {
-    NonLocalECPotentialMultiWalkerResource();
+    NonLocalECPotentialMultiWalkerResource() : Resource("NonLocalECPotential") {}
+
     Resource* makeClone() const override;
 
-    ResourceCollection collection;
+    ResourceCollection collection{"NLPPcollection"};
 
-    /// a walkers worth of per particle nonlocal ecp potential values
-    Vector<RealType> ve_sample;
-    Vector<RealType> vi_sample;
+    int num_walker = 0;
+    /// a crowds worth of per particle nonlocal ecp potential values
+    Matrix<Real> ve_samples;
+    Matrix<Real> vi_samples;
   };
 
 public:
@@ -72,11 +79,17 @@ public:
                                 const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                 const RefVectorWithLeader<ParticleSet>& p_list) const override;
 
+  void mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              const std::vector<ListenerVector<Real>>& listeners,
+                              const std::vector<ListenerVector<Real>>& listeners_ions) const override;
+
   void mw_evaluatePerParticleWithToperator(const RefVectorWithLeader<OperatorBase>& o_list,
                                            const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                            const RefVectorWithLeader<ParticleSet>& p_list,
-                                           const std::vector<ListenerVector<RealType>>& listeners,
-                                           const std::vector<ListenerVector<RealType>>& listeners_ions) const override;
+                                           const std::vector<ListenerVector<Real>>& listeners,
+                                           const std::vector<ListenerVector<Real>>& listeners_ions) const override;
 
   Return_t evaluateWithIonDerivs(ParticleSet& P,
                                  ParticleSet& ions,
@@ -165,13 +178,28 @@ public:
    */
   inline void setComputeForces(bool val) override { ComputeForces = val; }
 
-  ///unique NonLocalECPComponent to remove
-  std::vector<std::unique_ptr<NonLocalECPComponent>> PPset;
 protected:
+  /** the actual implementation for batched walkers, used by mw_evaluate, mw_evaluateWithToperator
+   *  mw_evaluatePerPaticleWithToperator
+   * @param o_list     the list of NonLocalECPotential in a walker batch
+   * @param wf_list    the list of TrialWaveFunction in a walker batch
+   * @param p_list     the list of ParticleSet in a walker batch
+   * @param Tmove      whether Txy for Tmove is updated
+   * @param listeners  optional listeners which allow per particle and reduced to share impl
+   */
+  static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
+                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                              const RefVectorWithLeader<ParticleSet>& p_list,
+                              bool Tmove,
+                              std::optional<ListenerOption<Real>> listeners,
+			      bool keepGrid = false);
+
   ///random number generator
   RandomGenerator* myRNG;
   ///the set of local-potentials (one for each ion)
   std::vector<NonLocalECPComponent*> PP;
+  ///unique NonLocalECPComponent to remove
+  std::vector<std::unique_ptr<NonLocalECPComponent>> PPset;
   ///reference to the center ion
   ParticleSet& IonConfig;
   ///target TrialWaveFunction
@@ -204,11 +232,12 @@ private:
   std::vector<NonLocalData> tmove_xy_;
 #if !defined(REMOVE_TRACEMANAGER)
   ///single particle trace samples
+
   Array<TraceReal, 1>* Ve_sample;
   Array<TraceReal, 1>* Vi_sample;
 #endif
   ///NLPP job list of ion-electron pairs by spin group
-  std::vector<std::vector<NLPPJob<RealType>>> nlpp_jobs;
+  std::vector<std::vector<NLPPJob<Real>>> nlpp_jobs;
   /// mult walker shared resource
   std::unique_ptr<NonLocalECPotentialMultiWalkerResource> mw_res_;
 
@@ -218,23 +247,6 @@ private:
    * @param keepGrid.  If true, does not randomize the quadrature grid before evaluation.  
    */
   void evaluateImpl(ParticleSet& P, bool Tmove, bool keepGrid = false);
-
-  /** the actual implementation for batched walkers, used by mw_evaluate and mw_evaluateWithToperator
-   * @param o_list the list of NonLocalECPotential in a walker batch
-   * @param p_list the list of ParticleSet in a walker batch
-   * @param Tmove whether Txy for Tmove is updated
-   */
-  static void mw_evaluateImpl(const RefVectorWithLeader<OperatorBase>& o_list,
-                              const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                              const RefVectorWithLeader<ParticleSet>& p_list,
-                              bool Tmove);
-
-  static void mw_evaluatePerParticleImpl(const RefVectorWithLeader<OperatorBase>& o_list,
-                                         const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                         const RefVectorWithLeader<ParticleSet>& p_list,
-                                         const std::vector<ListenerVector<RealType>>& listeners,
-                                         const std::vector<ListenerVector<RealType>>& listeners_ions,
-                                         bool tmove);
 
   void evalIonDerivsImpl(ParticleSet& P,
                          ParticleSet& ions,
@@ -255,6 +267,8 @@ private:
    * Note this function should be called before acceptMove for a Tmove
    */
   void markAffectedElecs(const DistanceTableAB& myTable, int iel);
+
+  friend class testing::TestNonLocalECPotential;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -39,19 +39,7 @@ class NonLocalECPotential : public OperatorBase, public ForceBase
 {
   using Real = QMCTraits::RealType;
 
-  struct NonLocalECPotentialMultiWalkerResource : public Resource
-  {
-    NonLocalECPotentialMultiWalkerResource() : Resource("NonLocalECPotential") {}
-
-    Resource* makeClone() const override;
-
-    ResourceCollection collection{"NLPPcollection"};
-
-    int num_walker = 0;
-    /// a crowds worth of per particle nonlocal ecp potential values
-    Matrix<Real> ve_samples;
-    Matrix<Real> vi_samples;
-  };
+  struct NonLocalECPotentialMultiWalkerResource;
 
 public:
   NonLocalECPotential(ParticleSet& ions, ParticleSet& els, TrialWaveFunction& psi, bool computeForces, bool enable_DLA);
@@ -192,7 +180,7 @@ protected:
                               const RefVectorWithLeader<ParticleSet>& p_list,
                               bool Tmove,
                               std::optional<ListenerOption<Real>> listeners,
-			      bool keepGrid = false);
+                              bool keepGrid = false);
 
   ///random number generator
   RandomGenerator* myRNG;

--- a/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential_CUDA.cpp
@@ -48,7 +48,6 @@ NonLocalECPotential_CUDA::NonLocalECPotential_CUDA(ParticleSet& ions,
   setupCUDA(els);
 }
 
-
 std::unique_ptr<OperatorBase> NonLocalECPotential_CUDA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
 {
   std::unique_ptr<NonLocalECPotential_CUDA> myclone =
@@ -57,7 +56,7 @@ std::unique_ptr<OperatorBase> NonLocalECPotential_CUDA::makeClone(ParticleSet& q
   {
     if (PPset[ig])
     {
-      myclone->addComponent(ig, std::unique_ptr<NonLocalECPComponent>(PPset[ig]->makeClone(qp)));
+      myclone->addComponent(ig, std::make_unique<NonLocalECPComponent>(*PPset[ig], qp));
     }
   }
   return myclone;

--- a/src/QMCHamiltonians/tests/CMakeLists.txt
+++ b/src/QMCHamiltonians/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SRC_DIR hamiltonian)
 set(UTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 set(COULOMB_SRCS test_coulomb_pbcAB.cpp test_coulomb_pbcAB_ewald.cpp test_coulomb_pbcAA.cpp
-                 test_coulomb_pbcAA_ewald.cpp test_EwaldRef.cpp)
+                 test_coulomb_pbcAA_ewald.cpp test_EwaldRef.cpp test_NonLocalECPotential.cpp)
 set(EWALD2D_SRCS test_ewald2d.cpp test_ewald_quasi2d.cpp)
 set(FORCE_SRCS test_force.cpp test_force_ewald.cpp test_stress.cpp test_spacewarp.cpp)
 set(HAM_SRCS

--- a/src/QMCHamiltonians/tests/TestListenerFunction.h
+++ b/src/QMCHamiltonians/tests/TestListenerFunction.h
@@ -21,6 +21,8 @@ template<typename T>
 auto getParticularListener(Matrix<T>& local_pots)
 {
   return [&local_pots](const int walker_index, const std::string& name, const Vector<T>& inputV) {
+    assert(local_pots.cols() >= inputV.size());
+    assert(walker_index < local_pots.rows());
     std::copy_n(inputV.begin(), inputV.size(), local_pots[walker_index]);
   };
 }

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -93,12 +93,8 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   ParticleSet elec(simulation_cell);
   elec.setName("elec");
   elec.create({2, 1});
-  elec.R[0][0] = 0.4;
-  elec.R[0][1] = 0.0;
-  elec.R[0][2] = 0.0;
-  elec.R[1][0] = 1.0;
-  elec.R[1][1] = 0.0;
-  elec.R[1][2] = 0.0;
+  elec.R[0] = {0.4, 0.0, 0.0};
+  elec.R[1] = {1.0, 0.0, 0.0};
 
   SpeciesSet& tspecies       = elec.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");
@@ -198,9 +194,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
 
-  elec.R[0][0] = 0.5;
-  elec.R[0][1] = 0.0;
-  elec.R[0][2] = 2.0;
+  elec.R[0] = {0.5, 0.0, 2.0};
   elec.update();
 
   nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -71,12 +71,8 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   ions.setName("ion");
   ions.create({2});
-  ions.R[0][0] = 0.0;
-  ions.R[0][1] = 0.0;
-  ions.R[0][2] = 0.0;
-  ions.R[1][0] = 6.0;
-  ions.R[1][1] = 0.0;
-  ions.R[1][2] = 0.0;
+  ions.R[0] = {0.0, 0.0, 0.0};
+  ions.R[1] = {6.0, 0.0, 0.0};
 
   SpeciesSet& ion_species                         = ions.getSpeciesSet();
   int index_species                               = ion_species.addSpecies("Na");

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -48,6 +48,7 @@ public:
   {
     nl_ecp.mw_evaluateImpl(o_list, twf_list, p_list, Tmove, listener_opt, keep_grid);
   }
+
 };
 } // namespace testing
 
@@ -178,8 +179,6 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
   
-  //nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);
-
   ListenerOption<Real> listener_opt{listeners, ion_listeners};
   testing::TestNonLocalECPotential::mw_evaluateImpl(nl_ecp, o_list, twf_list, p_list, false, listener_opt, true);
 
@@ -196,20 +195,18 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   elec.R[0] = {0.5, 0.0, 2.0};
   elec.update();
+  testing::TestNonLocalECPotential::mw_evaluateImpl(nl_ecp, o_list, twf_list, p_list, true, listener_opt, true);
 
-  nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);
-  CHECK(testing::TestNonLocalECPotential::didGridChange(nl_ecp));
+  CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
   auto value2 = o_list[0].evaluateDeterministic(p_list[0]);
-  auto value3 = o_list[0].evaluate(p_list[0]);
   
   CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value2));
-  CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value3));
   CHECK(std::accumulate(local_pots2.begin(), local_pots2.begin() + local_pots2.cols(), 0.0) == Approx(value));
 
   // Randomizing grid does nothing for Na pp
-  nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);
-  CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value2));
-
+  testing::TestNonLocalECPotential::mw_evaluateImpl(nl_ecp, o_list, twf_list, p_list, true, listener_opt, false);
+  auto value3 = o_list[0].evaluateDeterministic(p_list[0]);
+  CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value3));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -1,0 +1,163 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "Configuration.h"
+#include "Numerics/Quadrature.h"
+#include "Particle/ParticleSet.h"
+#include "QMCHamiltonians/ECPComponentBuilder.h"
+#include "QMCHamiltonians/NonLocalECPotential.h"
+#include "TestListenerFunction.h"
+
+namespace qmcplusplus
+{
+
+TEST_CASE("NonLocalECPotential" "")
+{
+  using Real = QMCTraits::RealType;
+  using FullPrecReal = QMCTraits::FullPrecRealType;
+  using Position = QMCTraits::PosType;
+  using testing::getParticularListener;
+
+  CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
+  lattice.BoxBConds = true; // periodic
+  lattice.R.diagonal(1.0);
+  lattice.reset();
+
+  const SimulationCell simulation_cell(lattice);
+
+  ParticleSet ions(simulation_cell);
+
+  ions.setName("ion");
+  ions.create({1});
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  SpeciesSet& ion_species       = ions.getSpeciesSet();
+  int pIdx                      = ion_species.addSpecies("C");
+  int pChargeIdx                = ion_species.addAttribute("charge");
+  ion_species(pChargeIdx, pIdx) = 2;
+  ions.createSK();
+  ions.update();
+
+  ParticleSet ions2(ions);
+  ions2.update();
+
+  ParticleSet elec(simulation_cell);
+  elec.setName("elec");
+  elec.create({1,1});
+  elec.R[0][0] = 0.5;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
+
+  int dnIdx                  = tspecies.addSpecies("d");
+  chargeIdx              = tspecies.addAttribute("charge");
+  massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, dnIdx) = -1;
+  tspecies(massIdx, dnIdx)   = 1.0;
+
+  elec.resetGroups();
+  elec.createSK();
+  const int ei_table_index = elec.addTable(ions);
+  elec.update();
+
+  ParticleSet elec2(elec);
+
+  elec2.R[0][0] = 0.0;
+  elec2.R[0][1] = 0.5;
+  elec2.R[0][2] = 0.1;
+  elec2.R[1][0] = 0.6;
+  elec2.R[1][1] = 0.05;
+  elec2.R[1][2] = -0.1;
+  elec2.update();
+
+  RefVector<ParticleSet> ptcls{elec, elec2};
+  RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);
+  
+  TrialWaveFunction psi, psi2;
+  RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
+
+  bool doForces = false;
+  bool use_DLA = false;
+  
+  NonLocalECPotential nl_ecp(ions, elec, psi, doForces, use_DLA);
+
+  Matrix<Real> local_pots(2);
+  Matrix<Real> local_pots2(2);
+
+  ResourceCollection pset_res("test_pset_res");
+  elec.createResource(pset_res);
+  ResourceCollectionTeamLock<ParticleSet> pset_lock(pset_res, p_list);
+
+  std::vector<ListenerVector<Real>> listeners;
+  listeners.emplace_back("localpotential", getParticularListener(local_pots));
+  listeners.emplace_back("localpotential", getParticularListener(local_pots2));
+
+  Matrix<Real> ion_pots(2);
+  Matrix<Real> ion_pots2(2);
+
+  std::vector<ListenerVector<Real>> ion_listeners;
+  ion_listeners.emplace_back("localpotential", getParticularListener(ion_pots));
+  ion_listeners.emplace_back("localpotential", getParticularListener(ion_pots2));
+
+
+  // This took some time to sort out from the multistage mess of put and clones 
+  // but this accomplishes in a straight forward way what I interpret to be done by that code.
+  Communicate* comm = OHMMS::Controller;
+  ECPComponentBuilder ecp_comp_builder("test_read_ecp", comm, 4, 1);
+
+  bool okay = ecp_comp_builder.read_pp_file("C.BFD.xml");
+  REQUIRE(okay);
+  UPtr<NonLocalECPComponent> nl_ecp_comp = std::move(ecp_comp_builder.pp_nonloc);
+  nl_ecp_comp->initVirtualParticle(elec);
+  nl_ecp.addComponent(0, std::move(nl_ecp_comp));
+  UPtr<OperatorBase> nl_ecp2_ptr = nl_ecp.makeClone(elec2, psi2);
+  auto& nl_ecp2 = *nl_ecp2_ptr;
+
+  StdRandom<FullPrecReal> rng(10101);
+  StdRandom<FullPrecReal> rng2(10201);
+  nl_ecp.setRandomGenerator(&rng);
+  nl_ecp2.setRandomGenerator(&rng2);
+  
+  RefVector<OperatorBase> nl_ecps{nl_ecp, nl_ecp2};
+  RefVectorWithLeader<OperatorBase> o_list(nl_ecp, nl_ecps);
+  ResourceCollection nl_ecp_res("test_nl_ecp_res");
+  nl_ecp.createResource(nl_ecp_res);
+  ResourceCollectionTeamLock<OperatorBase> nl_ecp_lock(nl_ecp_res, o_list);
+  
+  nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);
+
+  CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(14.4822673798));
+  CHECK(std::accumulate(local_pots2.begin(), local_pots2.begin() + local_pots2.cols(), 0.0) == Approx(14.4822673798));
+  CHECK(std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) == Approx(14.4822673798));
+  CHECK(std::accumulate(ion_pots2.begin(), ion_pots2.begin() + ion_pots2.cols(), 0.0) == Approx(14.4822673798));
+
+  elec.R[0][0] = 0.5;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 2.0;
+  elec.update();
+  
+  nl_ecp.mw_evaluatePerParticleWithToperator(o_list, twf_list, p_list, listeners, ion_listeners);
+
+  CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(14.4822673798));
+
+}
+
+}

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -17,6 +17,7 @@
 #include "QMCHamiltonians/ECPComponentBuilder.h"
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "TestListenerFunction.h"
+#include "Utilities/StlPrettyPrint.hpp"
 
 namespace qmcplusplus
 {
@@ -48,7 +49,6 @@ public:
   {
     nl_ecp.mw_evaluateImpl(o_list, twf_list, p_list, Tmove, listener_opt, keep_grid);
   }
-
 };
 } // namespace testing
 
@@ -71,8 +71,8 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   ions.setName("ion");
   ions.create({2});
-  ions.R[0] = {0.0, 0.0, 0.0};
-  ions.R[1] = {6.0, 0.0, 0.0};
+  ions.R[0] = {0.0, 1.0, 0.0};
+  ions.R[1] = {0.0, -1.0, 0.0};
 
   SpeciesSet& ion_species                         = ions.getSpeciesSet();
   int index_species                               = ion_species.addSpecies("Na");
@@ -174,19 +174,24 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   testing::TestNonLocalECPotential::copyGridUnrotatedForTest(nl_ecp2);
 
   CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
-  
+
   ListenerOption<Real> listener_opt{listeners, ion_listeners};
   testing::TestNonLocalECPotential::mw_evaluateImpl(nl_ecp, o_list, twf_list, p_list, false, listener_opt, true);
 
+  std::cout << "ion_pots:" << ion_pots << '\n';
+  std::cout << "ion_pots.cols()" << ion_pots.cols() << '\n';
+  
   // I'd like to see this gone when legacy drivers are dropped but for now we'll check against
   // the single particle API
   auto value = o_list[0].evaluateDeterministic(p_list[0]);
-  
+
+  std::cout << "local_pots:" << local_pots << '\n';
+  std::cout << "local_pots.cols()" << local_pots.cols() << '\n';
   CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value));
   CHECK(std::accumulate(local_pots2.begin(), local_pots2.begin() + local_pots2.cols(), 0.0) == Approx(value));
-  CHECK(std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) == Approx(10.5313520432));
-  CHECK(std::accumulate(ion_pots2.begin(), ion_pots2.begin() + ion_pots2.cols(), 0.0) == Approx(10.5313520432));
-
+  CHECK(std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) == Approx(10.5313520));
+  CHECK(std::accumulate(ion_pots2.begin(), ion_pots2.begin() + ion_pots2.cols(), 0.0) == Approx(10.5313520));
+  
   CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
 
   elec.R[0] = {0.5, 0.0, 2.0};
@@ -195,7 +200,7 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
 
   CHECK(!testing::TestNonLocalECPotential::didGridChange(nl_ecp));
   auto value2 = o_list[0].evaluateDeterministic(p_list[0]);
-  
+
   CHECK(std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0) == Approx(value2));
   CHECK(std::accumulate(local_pots2.begin(), local_pots2.begin() + local_pots2.cols(), 0.0) == Approx(value));
 


### PR DESCRIPTION
## Proposed changes

This is another MS6.9 PR.  Now adding per particle energy reporting to the NonLocalECPotential.
I removed the makeClone method for NonLocalECPComponent which makes no sense since it is never type erased, now a proper constructor takes its place which allows use of std::make_unique which makes more sense.

There is some questionable raw pointer use in NonLocalECPComponent that should be addressed at some point. I don't think this makes it worse but it still carries the potential to create a double free if there is a problem during copy construction or cloning.

Rather than add to the misnamed and legacy only integration testing in `test_ecp.cpp`. I added a closer to actual unit test test.

It also shows a real lack of sensistivity to the randomization of the pp grid which should perhaps become an issue.

## What type(s) of changes does this code introduce?

- New feature
- Code style update (formatting, renaming)
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
