### PR TITLE
ParticleSetPool: Don't assume single element has the correct key

### DIFF
--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -56,16 +56,12 @@ ParticleSet* ParticleSetPool::getParticleSet(const std::string& pname)
 
 MCWalkerConfiguration* ParticleSetPool::getWalkerSet(const std::string& pname)
 {
-  ParticleSet* mc = 0;
-  if (myPool.size() == 1)
-    mc = myPool.begin()->second.get();
-  else
-    mc = getParticleSet(pname);
-  if (mc == 0)
+  auto mc = dynamic_cast<MCWalkerConfiguration*>(getParticleSet(pname));
+  if (mc == nullptr)
   {
     throw std::runtime_error("ParticleSePool::getWalkerSet missing " + pname);
   }
-  return dynamic_cast<MCWalkerConfiguration*>(mc);
+  return mc;
 }
 
 void ParticleSetPool::addParticleSet(std::unique_ptr<ParticleSet>&& p)

--- a/src/Particle/tests/test_particle_pool.cpp
+++ b/src/Particle/tests/test_particle_pool.cpp
@@ -57,8 +57,10 @@ TEST_CASE("ParticleSetPool", "[qmcapp]")
   ParticleSet* not_here = pp.getParticleSet("does_not_exist");
   REQUIRE(not_here == NULL);
 
-  ParticleSet* ws = pp.getWalkerSet("ion0");
+  MCWalkerConfiguration* ws = pp.getWalkerSet("ion0");
   REQUIRE(ws != NULL);
+
+  REQUIRE_THROWS_AS(pp.getWalkerSet("does_not_exist"), std::runtime_error);
 
   auto ps2 = std::make_unique<ParticleSet>(pp.getSimulationCell());
   ps2->setName("particle_set_2");


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

`ParticleSetPool::getWalkerSet` doesn't check `pname` if `myPool.size() == 1`. This removes the if statement and adds a test for this corner case.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
