### PR TITLE
Avoid creating driver scope walkers in the population object of WFOpt

### DIFF
--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -380,7 +380,7 @@ void DMCBatched::process(xmlNodePtr node)
                                 qmcdriver_input_.get_walkers_per_rank(), dmcdriver_input_.get_reserve(),
                                 qmcdriver_input_.get_num_crowds());
 
-    Base::startup(node, awc);
+    Base::startup(awc);
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/DMC/DMCBatched.cpp
+++ b/src/QMCDrivers/DMC/DMCBatched.cpp
@@ -380,7 +380,7 @@ void DMCBatched::process(xmlNodePtr node)
                                 qmcdriver_input_.get_walkers_per_rank(), dmcdriver_input_.get_reserve(),
                                 qmcdriver_input_.get_num_crowds());
 
-    Base::startup(awc);
+    Base::initializeQMC(awc);
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -257,14 +257,6 @@ void MCPopulation::measureGlobalEnergyVariance(Communicate& comm,
   variance = weight_energy_variance[2] / weight_energy_variance[0] - ener * ener;
 }
 
-void MCPopulation::set_variational_parameters(const opt_variables_type& active)
-{
-  for (auto it_twfs = walker_trial_wavefunctions_.begin(); it_twfs != walker_trial_wavefunctions_.end(); ++it_twfs)
-  {
-    (*it_twfs).get()->resetParameters(active);
-  }
-}
-
 void MCPopulation::checkIntegrity() const
 {
   // check active walkers

--- a/src/QMCDrivers/MCPopulation.h
+++ b/src/QMCDrivers/MCPopulation.h
@@ -226,10 +226,6 @@ public:
 
   /** }@ */
 
-
-  /// Set variational parameters for the per-walker copies of the wavefunction.
-  void set_variational_parameters(const opt_variables_type& active);
-
   /// check if all the internal vector contain consistent sizes;
   void checkIntegrity() const;
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -129,22 +129,7 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
   }
 }
 
-/** process a <qmc/> element
- * @param cur xmlNode with qmc tag
- *
- * This function is called before QMCDriverNew::run and following actions are taken:
- * - Initialize basic data to execute run function.
- * -- distance tables
- * -- resize deltaR and drift with the number of particles
- * -- assign cur to qmcNode
- * - process input file
- *   -- putQMCInfo: <parameter/> s for generic QMC
- *   -- put : extra data by derived classes
- * - initialize branchEngine to accumulate energies
- * - initialize Estimators
- * - initialize Walkers
- */
-void QMCDriverNew::startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCounts& awc)
+void QMCDriverNew::startup(const QMCDriverNew::AdjustedWalkerCounts& awc)
 {
   ScopedTimer local_timer(timers_.startup_timer);
 

--- a/src/QMCDrivers/QMCDriverNew.cpp
+++ b/src/QMCDrivers/QMCDriverNew.cpp
@@ -129,7 +129,7 @@ void QMCDriverNew::checkNumCrowdsLTNumThreads(const int num_crowds)
   }
 }
 
-void QMCDriverNew::startup(const QMCDriverNew::AdjustedWalkerCounts& awc)
+void QMCDriverNew::initializeQMC(const AdjustedWalkerCounts& awc)
 {
   ScopedTimer local_timer(timers_.startup_timer);
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -230,12 +230,9 @@ public:
 
   /** Do common section starting tasks
    *
-   *  \todo This should not take xmlNodePtr
-   *        It should either take BranchEngineInput and EstimatorInput
-   *        And these are the arguments to the branch_engine and estimator_manager
-   *        Constructors or these objects should be created elsewhere.
+   * set up population_, crowds_, rngs and step_contexts_
    */
-  void startup(xmlNodePtr cur, const QMCDriverNew::AdjustedWalkerCounts& awc);
+  void startup(const QMCDriverNew::AdjustedWalkerCounts& awc);
 
   static void initialLogEvaluation(int crowd_id, UPtrVector<Crowd>& crowds, UPtrVector<ContextForSteps>& step_context);
 

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -102,10 +102,6 @@ public:
   std::bitset<QMC_MODE_MAX> qmc_driver_mode_;
 
 protected:
-  /// inject additional barrier and measure load imbalance.
-  void measureImbalance(const std::string& tag) const;
-  /// end of a block operations. Aggregates statistics across all MPI ranks and write to disk.
-  void endBlock();
   /** This is a data structure strictly for QMCDriver and its derived classes
    *
    *  i.e. its nested in scope for a reason
@@ -117,6 +113,16 @@ protected:
     std::vector<IndexType> walkers_per_crowd;
     RealType reserve_walkers;
   };
+  /** Do common section starting tasks for VMC and DMC
+   *
+   * set up population_, crowds_, rngs and step_contexts_
+   */
+  void initializeQMC(const AdjustedWalkerCounts& awc);
+
+  /// inject additional barrier and measure load imbalance.
+  void measureImbalance(const std::string& tag) const;
+  /// end of a block operations. Aggregates statistics across all MPI ranks and write to disk.
+  void endBlock();
 
 public:
   /// Constructor.
@@ -227,12 +233,6 @@ public:
    *        this stage of driver initialization is hit.
    */
   void process(xmlNodePtr cur) override = 0;
-
-  /** Do common section starting tasks
-   *
-   * set up population_, crowds_, rngs and step_contexts_
-   */
-  void startup(const QMCDriverNew::AdjustedWalkerCounts& awc);
 
   static void initialLogEvaluation(int crowd_id, UPtrVector<Crowd>& crowds, UPtrVector<ContextForSteps>& step_context);
 

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -265,7 +265,7 @@ void VMCBatched::process(xmlNodePtr node)
         adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::startup(node, awc);
+    Base::startup(awc);
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/VMC/VMCBatched.cpp
+++ b/src/QMCDrivers/VMC/VMCBatched.cpp
@@ -265,7 +265,7 @@ void VMCBatched::process(xmlNodePtr node)
         adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::startup(awc);
+    Base::initializeQMC(awc);
   }
   catch (const UniformCommunicateError& ue)
   {

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimizeBatched.cpp
@@ -299,7 +299,6 @@ void QMCFixedSampleLinearOptimizeBatched::generateSamples()
   t1.restart();
   //     W.reset();
   samples_.resetSampleCount();
-  population_.set_variational_parameters(optTarget->getOptVariables());
 
   vmcEngine->run();
   app_log() << "  Execution time = " << std::setprecision(4) << t1.elapsed() << std::endl;
@@ -654,38 +653,11 @@ void QMCFixedSampleLinearOptimizeBatched::process(xmlNodePtr q)
 
     hybridEngineObj->incrementStepCounter();
 
-    //Overwrite sampling information with input from selected optimizer block of a hybrid run
-    QMCDriverInput qmcdriver_input_copy = qmcdriver_input_;
-    VMCDriverInput vmcdriver_input_copy = vmcdriver_input_;
-
-    qmcdriver_input_copy.readXML(hybridEngineObj->getSelectedXML());
-    vmcdriver_input_copy.readXML(hybridEngineObj->getSelectedXML());
-
-
     processOptXML(hybridEngineObj->getSelectedXML(), vmcMove, ReportToH5 == "yes", useGPU == "yes");
-
-
-    QMCDriverNew::AdjustedWalkerCounts awc =
-        adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_copy.get_total_walkers(),
-                                qmcdriver_input_copy.get_walkers_per_rank(), 1.0,
-                                qmcdriver_input_copy.get_num_crowds());
-    QMCDriverNew::startup(q, awc);
   }
   else
   {
-    //Also need to overwrite input information again in case this method was preceded by hybrid method optimization
-    QMCDriverInput qmcdriver_input_copy = qmcdriver_input_;
-    qmcdriver_input_copy.readXML(q);
-
     processOptXML(q, vmcMove, ReportToH5 == "yes", useGPU == "yes");
-
-    auto& qmcdriver_input = vmcEngine->getQMCDriverInput();
-    // This code is also called when setting up vmcEngine.  Would be nice to not duplicate the call.
-    QMCDriverNew::AdjustedWalkerCounts awc =
-        adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_copy.get_total_walkers(),
-                                qmcdriver_input_copy.get_walkers_per_rank(), 1.0,
-                                qmcdriver_input_copy.get_num_crowds());
-    QMCDriverNew::startup(q, awc);
   }
 }
 

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -56,7 +56,7 @@ public:
         adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::startup(node, awc);
+    Base::startup(awc);
   }
 
   void testAdjustGlobalWalkerCount()

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -56,7 +56,7 @@ public:
         adjustGlobalWalkerCount(myComm->size(), myComm->rank(), qmcdriver_input_.get_total_walkers(),
                                 qmcdriver_input_.get_walkers_per_rank(), 1.0, qmcdriver_input_.get_num_crowds());
 
-    Base::startup(awc);
+    Base::initializeQMC(awc);
   }
 
   void testAdjustGlobalWalkerCount()


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
pset, twf, ham objects are maintained in CostFunctionCrowdData.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'