### PR TITLE
Require named SPOSet

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -35,6 +35,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(OneBodyDensityMatricesInput&& obd
       input_(obdmi),
       lattice_(lattice),
       species_(species),
+      basis_functions_("OneBodyDensityMatrices::basis"),
       timers_("OneBodyDensityMatrix")
 {
   my_name_ = "OneBodyDensityMatrices";

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -26,10 +26,8 @@ using MatrixOperators::product;
 using MatrixOperators::product_AtB;
 
 
-DensityMatrices1B::DensityMatrices1B(ParticleSet& P,
-                                     TrialWaveFunction& psi,
-                                     ParticleSet* Pcl)
-    : lattice_(P.getLattice()), Psi(psi), Pq(P), Pc(Pcl)
+DensityMatrices1B::DensityMatrices1B(ParticleSet& P, TrialWaveFunction& psi, ParticleSet* Pcl)
+    : basis_functions("DensityMatrices1B::basis"), lattice_(P.getLattice()), Psi(psi), Pq(P), Pc(Pcl)
 {
   reset();
 }
@@ -232,7 +230,8 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
     metric     = 1.0 / samples;
   }
   else
-    throw std::runtime_error("DensityMatrices1B::set_state  invalid integrator\n  valid options are: uniform_grid, uniform, density");
+    throw std::runtime_error(
+        "DensityMatrices1B::set_state  invalid integrator\n  valid options are: uniform_grid, uniform, density");
 
   if (evstr == "loop")
     evaluator = loop;
@@ -257,7 +256,7 @@ void DensityMatrices1B::set_state(xmlNodePtr cur)
   for (int i = 0; i < sposets.size(); ++i)
   {
     auto& spomap = Psi.getSPOMap();
-    auto spo_it = spomap.find(sposets[i]);
+    auto spo_it  = spomap.find(sposets[i]);
     if (spo_it == spomap.end())
       throw std::runtime_error("DensityMatrices1B::put  sposet " + sposets[i] + " does not exist.");
     basis_functions.add(spo_it->second->makeClone());

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -503,10 +503,10 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   kdn.resize(nelec);
   kdn[0] = PosType(2, 2, 2);
 
-  auto spo_up = std::make_unique<FreeOrbital>(kup);
-  auto spo_dn = std::make_unique<FreeOrbital>(kdn);
+  auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
+  auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>();
+  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
   QMCTraits::IndexType norb = spinor_set->getOrbitalSetSize();
   REQUIRE(norb == 1);

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.cpp
@@ -102,8 +102,11 @@ void BsplineReaderBase::setCommon(xmlNodePtr cur)
 std::unique_ptr<SPOSet> BsplineReaderBase::create_spline_set(int spin, xmlNodePtr cur)
 {
   int ns(0);
+  std::string spo_object_name;
   OhmmsAttributeSet a;
   a.add(ns, "size");
+  a.add(spo_object_name, "name");
+  a.add(spo_object_name, "id");
   a.put(cur);
 
   if (ns == 0)
@@ -129,11 +132,17 @@ std::unique_ptr<SPOSet> BsplineReaderBase::create_spline_set(int spin, xmlNodePt
   vals.myName = make_bandgroup_name(mybuilder->getName(), spin, mybuilder->twist_num_, mybuilder->TileMatrix, 0, ns);
   vals.selectBands(fullband, 0, ns, false);
 
-  return create_spline_set(spin, vals);
+  return create_spline_set(spo_object_name, spin, vals);
 }
 
 std::unique_ptr<SPOSet> BsplineReaderBase::create_spline_set(int spin, xmlNodePtr cur, SPOSetInputInfo& input_info)
 {
+  std::string spo_object_name;
+  OhmmsAttributeSet a;
+  a.add(spo_object_name, "name");
+  a.add(spo_object_name, "id");
+  a.put(cur);
+
   if (spo2band.empty())
     spo2band.resize(mybuilder->states.size());
 
@@ -156,7 +165,7 @@ std::unique_ptr<SPOSet> BsplineReaderBase::create_spline_set(int spin, xmlNodePt
   vals.selectBands(fullband, spo2band[spin][input_info.min_index()], input_info.max_index() - input_info.min_index(),
                    false);
 
-  return create_spline_set(spin, vals);
+  return create_spline_set(spo_object_name, spin, vals);
 }
 
 /** build index tables to map a state to band with k-point folidng

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineReaderBase.h
@@ -122,7 +122,7 @@ struct BsplineReaderBase
 
     bspline->HalfG            = 0;
     TinyVector<int, 3> bconds = mybuilder->TargetPtcl.getLattice().BoxBConds;
-    if (!bspline->is_complex)
+    if (!bspline->isComplex())
     {
       //no k-point folding, single special k point (G, L ...)
       TinyVector<double, 3> twist0 = mybuilder->TwistAngles[bandgroup.TwistIndex];
@@ -165,7 +165,9 @@ struct BsplineReaderBase
 
   /** create the actual spline sets
    */
-  virtual std::unique_ptr<SPOSet> create_spline_set(int spin, const BandInfoGroup& bandgroup) = 0;
+  virtual std::unique_ptr<SPOSet> create_spline_set(const std::string& my_name,
+                                                    int spin,
+                                                    const BandInfoGroup& bandgroup) = 0;
 
   /** setting common parameters
    */

--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -35,8 +35,6 @@ class BsplineSet : public SPOSet
 {
 protected:
   static const int D = DIM;
-  ///true if the computed values are complex
-  bool is_complex;
   ///Index of this adoptor, when multiple adoptors are used for NUMA or distributed cases
   size_t MyIndex;
   ///first index of the SPOs this Spline handles
@@ -56,13 +54,12 @@ protected:
   aligned_vector<int> BandIndexMap;
   ///band offsets used for communication
   std::vector<int> offset;
-  ///keyword used to match hdf5
-  std::string KeyWord;
 
 public:
-  BsplineSet(bool use_OMP_offload = false, bool ion_deriv = false, bool optimizable = false)
-      : SPOSet(use_OMP_offload, ion_deriv, optimizable), is_complex(false), MyIndex(0), first_spo(0), last_spo(0)
-  {}
+  BsplineSet(const std::string& my_name) : SPOSet(my_name), MyIndex(0), first_spo(0), last_spo(0) {}
+
+  virtual bool isComplex() const         = 0;
+  virtual std::string getKeyword() const = 0;
 
   auto& getHalfG() const { return HalfG; }
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCplx.h
@@ -53,11 +53,10 @@ private:
   using SPLINEBASE::myV;
 
 public:
-  HybridRepCplx()
-  {
-    this->className = "Hybrid" + this->className;
-    this->KeyWord   = "Hybrid" + this->KeyWord;
-  }
+  HybridRepCplx(const std::string& my_name) : SPLINEBASE(my_name) {}
+
+  std::string getClassName() const final { return "Hybrid" + SPLINEBASE::getClassName(); }
+  std::string getKeyword() const final { return "Hybrid" + SPLINEBASE::getKeyword(); }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepCplx>(*this); }
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepReal.h
@@ -55,11 +55,10 @@ private:
   using SPLINEBASE::PrimLattice;
 
 public:
-  HybridRepReal()
-  {
-    this->className = "Hybrid" + this->className;
-    this->KeyWord   = "Hybrid" + this->KeyWord;
-  }
+  HybridRepReal(const std::string& my_name) : SPLINEBASE(my_name) {}
+
+  std::string getClassName() const final { return "Hybrid" + SPLINEBASE::getClassName(); }
+  std::string getKeyword() const final { return "Hybrid" + SPLINEBASE::getKeyword(); }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<HybridRepReal>(*this); }
 

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
@@ -540,7 +540,7 @@ public:
             splineData_r[ip] = all_vals[idx][ip][lm];
           atomic_spline_r = einspline::create(atomic_spline_r, 0.0, spline_radius, spline_npoints, splineData_r.data(),
                                               ((lm == 0) || (lm > 3)));
-          if (!bspline->is_complex)
+          if (!bspline->isComplex())
           {
             mycenter.set_spline(atomic_spline_r, lm, iorb);
             einspline::destroy(atomic_spline_r);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -21,6 +21,9 @@
 namespace qmcplusplus
 {
 template<typename ST>
+SplineC2C<ST>::SplineC2C(const SplineC2C& in) = default;
+
+template<typename ST>
 inline void SplineC2C<ST>::set_spline(SingleSplineType* spline_r,
                                       SingleSplineType* spline_i,
                                       int twist,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.h
@@ -78,12 +78,13 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2C()
-  {
-    is_complex = true;
-    className  = "SplineC2C";
-    KeyWord    = "SplineC2C";
-  }
+  SplineC2C(const std::string& my_name) : BsplineSet(my_name) {}
+
+  SplineC2C(const SplineC2C& in);
+  virtual std::string getClassName() const override { return "SplineC2C"; }
+  virtual std::string getKeyword() const override { return "SplineC2C"; }
+  bool isComplex() const override { return true; };
+
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2C>(*this); }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -19,6 +19,9 @@
 
 namespace qmcplusplus
 {
+template<typename ST>
+SplineC2COMPTarget<ST>::SplineC2COMPTarget(const SplineC2COMPTarget& in) = default;
+
 namespace C2C
 {
 template<typename ST, typename TT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -107,18 +107,19 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2COMPTarget()
-      : BsplineSet(true),
+  SplineC2COMPTarget(const std::string& my_name)
+      : BsplineSet(my_name),
         offload_timer_(*timer_manager.createTimer("SplineC2COMPTarget::offload", timer_level_fine)),
         GGt_offload(std::make_shared<OffloadVector<ST>>(9)),
         PrimLattice_G_offload(std::make_shared<OffloadVector<ST>>(9))
-  {
-    is_complex = true;
-    className  = "SplineC2COMPTarget";
-    KeyWord    = "SplineC2C";
-  }
+  {}
 
-  SplineC2COMPTarget(const SplineC2COMPTarget& in) = default;
+  SplineC2COMPTarget(const SplineC2COMPTarget& in);
+
+  virtual std::string getClassName() const override { return "SplineC2COMPTarget"; }
+  virtual std::string getKeyword() const override { return "SplineC2C"; }
+  bool isComplex() const override { return true; };
+  bool isOMPoffload() const override { return true; }
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.cpp
@@ -23,6 +23,9 @@
 namespace qmcplusplus
 {
 template<typename ST>
+SplineC2R<ST>::SplineC2R(const SplineC2R& in) = default;
+
+template<typename ST>
 inline void SplineC2R<ST>::set_spline(SingleSplineType* spline_r,
                                       SingleSplineType* spline_i,
                                       int twist,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -84,12 +84,12 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2R() : nComplexBands(0)
-  {
-    is_complex = true;
-    className  = "SplineC2R";
-    KeyWord    = "SplineC2R";
-  }
+  SplineC2R(const std::string& my_name) : BsplineSet(my_name), nComplexBands(0) {}
+
+  SplineC2R(const SplineC2R& in);
+  virtual std::string getClassName() const override { return "SplineC2R"; }
+  virtual std::string getKeyword() const override { return "SplineC2R"; }
+  bool isComplex() const override { return true; };
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2R>(*this); }
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -18,6 +18,9 @@
 
 namespace qmcplusplus
 {
+template<typename ST>
+SplineC2ROMPTarget<ST>::SplineC2ROMPTarget(const SplineC2ROMPTarget& in) = default;
+
 namespace C2R
 {
 template<typename ST, typename TT>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -111,19 +111,20 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineC2ROMPTarget()
-      : BsplineSet(true),
+  SplineC2ROMPTarget(const std::string& my_name)
+      : BsplineSet(my_name),
         offload_timer_(*timer_manager.createTimer("SplineC2ROMPTarget::offload", timer_level_fine)),
         nComplexBands(0),
         GGt_offload(std::make_shared<OffloadVector<ST>>(9)),
         PrimLattice_G_offload(std::make_shared<OffloadVector<ST>>(9))
-  {
-    is_complex = true;
-    className  = "SplineC2ROMPTarget";
-    KeyWord    = "SplineC2R";
-  }
+  {}
 
-  SplineC2ROMPTarget(const SplineC2ROMPTarget& in) = default;
+  SplineC2ROMPTarget(const SplineC2ROMPTarget& in);
+
+  virtual std::string getClassName() const override { return "SplineC2ROMPTarget"; }
+  virtual std::string getKeyword() const override { return "SplineC2R"; }
+  bool isComplex() const override { return true; };
+  bool isOMPoffload() const override { return true; }
 
   void createResource(ResourceCollection& collection) const override
   {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -21,6 +21,9 @@
 namespace qmcplusplus
 {
 template<typename ST>
+SplineR2R<ST>::SplineR2R(const SplineR2R& in) = default;
+
+template<typename ST>
 inline void SplineR2R<ST>::set_spline(SingleSplineType* spline_r,
                                       SingleSplineType* spline_i,
                                       int twist,

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -73,12 +73,12 @@ protected:
   ghContainer_type mygH;
 
 public:
-  SplineR2R()
-  {
-    is_complex = false;
-    className  = "SplineR2R";
-    KeyWord    = "SplineR2R";
-  }
+  SplineR2R(const std::string& my_name) : BsplineSet(my_name) {}
+
+  SplineR2R(const SplineR2R& in);
+  virtual std::string getClassName() const override { return "SplineR2R"; }
+  virtual std::string getKeyword() const override { return "SplineR2R"; }
+  bool isComplex() const override { return false; };
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineR2R>(*this); }
 

--- a/src/QMCWaveFunctions/CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/CompositeSPOSet.cpp
@@ -39,9 +39,8 @@ inline void insert_columns(const MAT1& small, MAT2& big, int offset_c)
 }
 } // namespace MatrixOperators
 
-CompositeSPOSet::CompositeSPOSet()
+CompositeSPOSet::CompositeSPOSet(const std::string& my_name) : SPOSet(my_name)
 {
-  className      = "CompositeSPOSet";
   OrbitalSetSize = 0;
   component_offsets.reserve(4);
 }
@@ -194,7 +193,7 @@ std::unique_ptr<SPOSet> CompositeSPOSetBuilder::createSPOSetFromXML(xmlNodePtr c
     return nullptr;
   }
 
-  auto spo_now = std::make_unique<CompositeSPOSet>();
+  auto spo_now = std::make_unique<CompositeSPOSet>(getXMLAttributeValue(cur, "name"));
   for (int i = 0; i < spolist.size(); ++i)
   {
     const SPOSet* spo = sposet_builder_factory_.getSPOSet(spolist[i]);

--- a/src/QMCWaveFunctions/CompositeSPOSet.h
+++ b/src/QMCWaveFunctions/CompositeSPOSet.h
@@ -36,9 +36,11 @@ public:
   ///store the precomputed offsets
   std::vector<int> component_offsets;
 
-  CompositeSPOSet();
+  CompositeSPOSet(const std::string& my_name);
   CompositeSPOSet(const CompositeSPOSet& other);
   ~CompositeSPOSet() override;
+
+  std::string getClassName() const override { return "CompositeSPOSet"; }
 
   ///add a sposet component to this composite sposet
   void add(std::unique_ptr<SPOSet> component);

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -446,7 +446,7 @@ void EinsplineSetExtended<StorageType>::evaluateGradSource(const ParticleSet& P,
                                                            int iat,
                                                            RealGradMatrix& dpsi)
 {
-  if (ionDerivs)
+  if (hasIonDerivs())
   {
     // Loop over dimensions
     for (int dim = 0; dim < OHMMS_DIM; dim++)
@@ -496,7 +496,7 @@ void EinsplineSetExtended<StorageType>::evaluateGradSource(const ParticleSet& P,
                                                            RealHessMatrix& dgrad_phi,
                                                            RealGradMatrix& dlapl_phi)
 {
-  if (ionDerivs)
+  if (hasIonDerivs())
   {
     std::complex<double> eye(0.0, 1.0);
     // Loop over dimensions
@@ -567,7 +567,7 @@ void EinsplineSetExtended<double>::evaluateGradSource(const ParticleSet& P,
                                                       RealHessMatrix& dgrad_phi,
                                                       RealGradMatrix& dlapl_phi)
 {
-  if (ionDerivs)
+  if (hasIonDerivs())
   {
     // Loop over dimensions
     for (int dim = 0; dim < OHMMS_DIM; dim++)
@@ -627,7 +627,7 @@ void EinsplineSetExtended<double>::evaluateGradSource(const ParticleSet& P,
                                                       int iat,
                                                       RealGradMatrix& dpsi)
 {
-  if (ionDerivs)
+  if (hasIonDerivs())
   {
     // Loop over dimensions
     for (int dim = 0; dim < OHMMS_DIM; dim++)
@@ -1309,17 +1309,17 @@ std::string EinsplineSetHybrid<std::complex<double>>::Type()
 }
 
 template<>
-EinsplineSetHybrid<double>::EinsplineSetHybrid() : CurrentWalkers(0)
+EinsplineSetHybrid<double>::EinsplineSetHybrid(const std::string& my_name)
+    : EinsplineSetExtended<double>(my_name), CurrentWalkers(0)
 {
-  className = "EinsplineSeHybrid";
   for (int i = 0; i < OHMMS_DIM; i++)
     HalfG[i] = 0;
 }
 
 template<>
-EinsplineSetHybrid<std::complex<double>>::EinsplineSetHybrid() : CurrentWalkers(0)
+EinsplineSetHybrid<std::complex<double>>::EinsplineSetHybrid(const std::string& my_name)
+    : EinsplineSetExtended<std::complex<double>>(my_name), CurrentWalkers(0)
 {
-  className = "EinsplineSeHybrid";
   for (int i = 0; i < OHMMS_DIM; i++)
     HalfG[i] = 0;
 }

--- a/src/QMCWaveFunctions/EinsplineSet.h
+++ b/src/QMCWaveFunctions/EinsplineSet.h
@@ -75,7 +75,9 @@ public:
   void resetSourceParticleSet(ParticleSet& ions);
   void setOrbitalSetSize(int norbs) override;
   inline std::string Type() { return "EinsplineSet"; }
-  EinsplineSet() : TwistNum(0), NumValenceOrbs(0) { className = "EinsplineSet"; }
+  EinsplineSet(const std::string& my_name) : SPOSet(my_name), TwistNum(0), NumValenceOrbs(0) {}
+
+  virtual std::string getClassName() const override { return "EinsplineSet"; }
 };
 
 ////////////////////////////////////////////////////////////////////
@@ -478,11 +480,14 @@ public:
   void registerTimers();
   PosType get_k(int orb) override { return kPoints[orb]; }
 
+  virtual std::string getClassName() const override { return "EinsplineSetExtended"; }
+  bool hasIonDerivs() const override { return true; }
 
   std::unique_ptr<SPOSet> makeClone() const override;
 
-  EinsplineSetExtended()
-      : MultiSpline(NULL),
+  EinsplineSetExtended(const std::string& my_name)
+      : EinsplineSet(my_name),
+        MultiSpline(NULL),
         ValueTimer(*timer_manager.createTimer("EinsplineSetExtended::ValueOnly")),
         VGLTimer(*timer_manager.createTimer("EinsplineSetExtended::VGL")),
         VGLMatTimer(*timer_manager.createTimer("EinsplineSetExtended::VGLMatrix")),
@@ -506,7 +511,6 @@ public:
         L_cuda("EinsplineSetExtended::L_cuda")
 #endif
   {
-    className = "EinsplineSetExtended";
     for (int i = 0; i < OHMMS_DIM; i++)
       HalfG[i] = 0;
   }
@@ -631,9 +635,11 @@ public:
 
   std::string Type();
 
+  std::string getClassName() const override { return "EinsplineSetHybrid"; }
+
   std::unique_ptr<SPOSet> makeClone() const override;
 
-  EinsplineSetHybrid();
+  EinsplineSetHybrid(const std::string& my_name) : EinsplineSetExtended<StorageType>(my_name) {}
 };
 
 #endif

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -125,6 +125,8 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       "no"); // use old spline library for high-order derivatives, e.g. needed for backflow optimization
   std::string useGPU;
   std::string GPUsharing = "no";
+  std::string spo_object_name;
+
   ScopedTimer spo_timer_scope(*timer_manager.createTimer("einspline::CreateSPOSetFromXML", timer_level_medium));
 
   {
@@ -183,6 +185,8 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   {
     OhmmsAttributeSet oAttrib;
     oAttrib.add(spinSet, "spindataset");
+    oAttrib.add(spo_object_name, "name");
+    oAttrib.add(spo_object_name, "id");
     oAttrib.put(cur);
   }
 
@@ -228,18 +232,13 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   spo_prec = "single"; //overwrite
 #endif
   H5OrbSet aset(H5FileName, spinSet, numOrbs);
-  std::map<H5OrbSet, SPOSet*, H5OrbSet>::iterator iter;
-  iter = SPOSetMap.find(aset);
+  const auto iter = SPOSetMap.find(aset);
   if ((iter != SPOSetMap.end()) && (!NewOcc))
-  {
-    app_log() << "SPOSet parameters match in EinsplineSetBuilder. cloning EinsplineSet object." << std::endl;
-    app_warning() << "!!!!!!! Deprecated input style: implicit sharing one SPOSet for spin-up and spin-down electrions "
-                     "has been deprecated. Create a single SPO set outside determinantset instead."
-                  << "Use sposet_collection to construct an explicit sposet for explicit sharing." << std::endl;
-    auto OrbitalSet = std::unique_ptr<SPOSet>(iter->second->makeClone());
-    OrbitalSet->setName("");
-    return OrbitalSet;
-  }
+    app_warning() << "!!!!!!! Identical SPOSet detected in EinsplineSetBuilder! "
+                     "Implicit sharing one SPOSet for spin-up and spin-down electrions has been removed. "
+                     "Create a single SPO set outside determinantset instead. "
+                     "Use sposet_collection to construct an explicit sposet for explicit sharing."
+                  << std::endl;
 
   if (FullBands[spinSet] == 0)
     FullBands[spinSet] = std::make_unique<std::vector<BandInfo>>();
@@ -342,10 +341,10 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       std::unique_ptr<EinsplineSetExtended<double>> temp_OrbitalSet;
 #if defined(QMC_CUDA)
       if (AtomicOrbitals.size() > 0)
-        temp_OrbitalSet = std::make_unique<EinsplineSetHybrid<double>>();
+        temp_OrbitalSet = std::make_unique<EinsplineSetHybrid<double>>(spo_object_name);
       else
 #endif
-        temp_OrbitalSet = std::make_unique<EinsplineSetExtended<double>>();
+        temp_OrbitalSet = std::make_unique<EinsplineSetExtended<double>>(spo_object_name);
       temp_OrbitalSet->MultiSpline = MixedSplineReader->export_MultiSplineDouble().release();
       temp_OrbitalSet->MultiSpline->num_splines = NumDistinctOrbitals;
       temp_OrbitalSet->resizeStorage(NumDistinctOrbitals, NumValenceOrbs);
@@ -358,10 +357,10 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
       std::unique_ptr<EinsplineSetExtended<std::complex<double>>> temp_OrbitalSet;
 #if defined(QMC_CUDA)
       if (AtomicOrbitals.size() > 0)
-        temp_OrbitalSet = std::make_unique<EinsplineSetHybrid<std::complex<double>>>();
+        temp_OrbitalSet = std::make_unique<EinsplineSetHybrid<std::complex<double>>>(spo_object_name);
       else
 #endif
-        temp_OrbitalSet = std::make_unique<EinsplineSetExtended<std::complex<double>>>();
+        temp_OrbitalSet = std::make_unique<EinsplineSetExtended<std::complex<double>>>(spo_object_name);
       temp_OrbitalSet->MultiSpline = MixedSplineReader->export_MultiSplineComplexDouble().release();
       temp_OrbitalSet->MultiSpline->num_splines = NumDistinctOrbitals;
       temp_OrbitalSet->resizeStorage(NumDistinctOrbitals, NumValenceOrbs);

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -234,10 +234,12 @@ std::unique_ptr<SPOSet> EinsplineSetBuilder::createSPOSetFromXML(xmlNodePtr cur)
   H5OrbSet aset(H5FileName, spinSet, numOrbs);
   const auto iter = SPOSetMap.find(aset);
   if ((iter != SPOSetMap.end()) && (!NewOcc))
-    app_warning() << "!!!!!!! Identical SPOSet detected in EinsplineSetBuilder! "
-                     "Implicit sharing one SPOSet for spin-up and spin-down electrions has been removed. "
-                     "Create a single SPO set outside determinantset instead. "
-                     "Use sposet_collection to construct an explicit sposet for explicit sharing."
+    app_warning() << "!!!!!!! Identical SPOSets are detected by EinsplineSetBuilder! "
+                     "Implicit sharing one SPOSet for spin-up and spin-down electrons has been removed. "
+                     "Each determinant creates its own SPOSet with dedicated memory for spline coefficients. "
+                     "To avoid increasing the memory footprint of spline coefficients, "
+                     "create a single SPOset outside the determinantset using 'sposet_collection' "
+                     "and reference it by name on the determinant line."
                   << std::endl;
 
   if (FullBands[spinSet] == 0)

--- a/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
+++ b/src/QMCWaveFunctions/EinsplineSpinorSetBuilder.cpp
@@ -132,10 +132,12 @@ std::unique_ptr<SPOSet> EinsplineSpinorSetBuilder::createSPOSetFromXML(xmlNodePt
   H5OrbSet aset(H5FileName, spinSet, numOrbs);
   const auto iter = SPOSetMap.find(aset);
   if ((iter != SPOSetMap.end()) && (!NewOcc))
-    app_warning() << "!!!!!!! Identical SPOSet detected in EinsplineSpinorSetBuilder! "
-                     "Implicit sharing one SPOSet for spin-up and spin-down electrions has been removed. "
-                     "Create a single SPO set outside determinantset instead. "
-                     "Use sposet_collection to construct an explicit sposet for explicit sharing."
+    app_warning() << "!!!!!!! Identical SPOSets are detected by EinsplineSpinorSetBuilder! "
+                     "Implicit sharing one SPOSet for spin-up and spin-down electrons has been removed. "
+                     "Each determinant creates its own SPOSet with dedicated memory for spline coefficients. "
+                     "To avoid increasing the memory footprint of spline coefficients, "
+                     "create a single SPOset outside the determinantset using 'sposet_collection' "
+                     "and reference it by name on the determinant line."
                   << std::endl;
 
   if (FullBands[spinSet] == 0)

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbital.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbital.cpp
@@ -2,8 +2,9 @@
 
 namespace qmcplusplus
 {
-FreeOrbital::FreeOrbital(const std::vector<PosType>& kpts_cart)
-    : kvecs(kpts_cart),
+FreeOrbital::FreeOrbital(const std::string& my_name, const std::vector<PosType>& kpts_cart)
+    : SPOSet(my_name),
+      kvecs(kpts_cart),
 #ifdef QMC_COMPLEX
       mink(0), // first k at twist may not be 0
 #else
@@ -200,16 +201,16 @@ void FreeOrbital::evaluate_notranspose(const ParticleSet& P,
       dp[j2]       = coskr * kvecs[ik];
       for (int la = 0; la < OHMMS_DIM; la++)
       {
-        hess[j1](la, la)      = -coskr * (kvecs[ik])[la] * (kvecs[ik])[la];
-        hess[j2](la, la)      = -sinkr * (kvecs[ik])[la] * (kvecs[ik])[la];
+        hess[j1](la, la)    = -coskr * (kvecs[ik])[la] * (kvecs[ik])[la];
+        hess[j2](la, la)    = -sinkr * (kvecs[ik])[la] * (kvecs[ik])[la];
         ggg[j1][la](la, la) = sinkr * (kvecs[ik])[la] * (kvecs[ik])[la] * (kvecs[ik])[la];
         ggg[j2][la](la, la) = -coskr * (kvecs[ik])[la] * (kvecs[ik])[la] * (kvecs[ik])[la];
         for (int lb = la + 1; lb < OHMMS_DIM; lb++)
         {
-          hess[j1](la, lb)      = -coskr * (kvecs[ik])[la] * (kvecs[ik])[lb];
-          hess[j2](la, lb)      = -sinkr * (kvecs[ik])[la] * (kvecs[ik])[lb];
-          hess[j1](lb, la)      = hess[j1](la, lb);
-          hess[j2](lb, la)      = hess[j2](la, lb);
+          hess[j1](la, lb)    = -coskr * (kvecs[ik])[la] * (kvecs[ik])[lb];
+          hess[j2](la, lb)    = -sinkr * (kvecs[ik])[la] * (kvecs[ik])[lb];
+          hess[j1](lb, la)    = hess[j1](la, lb);
+          hess[j2](lb, la)    = hess[j2](la, lb);
           ggg[j1][la](lb, la) = sinkr * (kvecs[ik])[la] * (kvecs[ik])[lb] * (kvecs[ik])[la];
           ggg[j2][la](lb, la) = -coskr * (kvecs[ik])[la] * (kvecs[ik])[lb] * (kvecs[ik])[la];
           ggg[j1][la](la, lb) = ggg[j1][la](lb, la);

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbital.h
@@ -24,8 +24,10 @@ namespace qmcplusplus
 class FreeOrbital : public SPOSet
 {
 public:
-  FreeOrbital(const std::vector<PosType>& kpts_cart);
+  FreeOrbital(const std::string& my_name, const std::vector<PosType>& kpts_cart);
   ~FreeOrbital();
+
+  std::string getClassName() const override { return "FreeOrbital"; }
 
   // phi[i][j] is phi_j(r_i), i.e. electron i in orbital j
   //  i \in [first, last)

--- a/src/QMCWaveFunctions/ElectronGas/FreeOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/ElectronGas/FreeOrbitalBuilder.cpp
@@ -13,10 +13,12 @@ FreeOrbitalBuilder::FreeOrbitalBuilder(ParticleSet& els, Communicate* comm, xmlN
 std::unique_ptr<SPOSet> FreeOrbitalBuilder::createSPOSetFromXML(xmlNodePtr cur)
 {
   int npw, norb;
+  std::string spo_object_name;
   PosType twist(0.0);
   OhmmsAttributeSet attrib;
   attrib.add(norb, "size");
   attrib.add(twist, "twist");
+  attrib.add(spo_object_name, "name");
   attrib.put(cur);
 
   auto lattice = targetPtcl.getLattice();
@@ -68,7 +70,7 @@ std::unique_ptr<SPOSet> FreeOrbitalBuilder::createSPOSetFromXML(xmlNodePtr cur)
       break;
   }
 #endif
-  auto sposet = std::make_unique<FreeOrbital>(kpts);
+  auto sposet = std::make_unique<FreeOrbital>(spo_object_name, kpts);
   sposet->report("  ");
   return sposet;
 }

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -73,9 +73,21 @@ public:
 #endif
 
   inline bool isOptimizable() const final { return Phi->isOptimizable(); }
-  inline void checkInVariables(opt_variables_type& active) final { Phi->checkInVariables(active); }
-  inline void checkOutVariables(const opt_variables_type& active) final { Phi->checkOutVariables(active); }
-  void resetParameters(const opt_variables_type& active) final { Phi->resetParameters(active); }
+  inline void checkInVariables(opt_variables_type& active) final
+  {
+    if (Phi->isOptimizable())
+      Phi->checkInVariables(active);
+  }
+  inline void checkOutVariables(const opt_variables_type& active) final
+  {
+    if (Phi->isOptimizable())
+      Phi->checkOutVariables(active);
+  }
+  void resetParameters(const opt_variables_type& active) final
+  {
+    if (Phi->isOptimizable())
+      Phi->resetParameters(active);
+  }
   inline void reportStatus(std::ostream& os) final {}
 
   virtual void registerTWFFastDerivWrapper(const ParticleSet& P, TWFFastDerivWrapper& twf) const override

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -147,9 +147,21 @@ public:
   SPOSetPtr getPhi() { return Phi.get(); };
 
   inline bool isOptimizable() const final { return Phi->isOptimizable(); }
-  inline void checkInVariables(opt_variables_type& active) override { Phi->checkInVariables(active); }
-  inline void checkOutVariables(const opt_variables_type& active) override { Phi->checkOutVariables(active); }
-  void resetParameters(const opt_variables_type& active) override { Phi->resetParameters(active); }
+  inline void checkInVariables(opt_variables_type& active) override
+  {
+    if (Phi->isOptimizable())
+      Phi->checkInVariables(active);
+  }
+  inline void checkOutVariables(const opt_variables_type& active) override
+  {
+    if (Phi->isOptimizable())
+      Phi->checkOutVariables(active);
+  }
+  void resetParameters(const opt_variables_type& active) override
+  {
+    if (Phi->isOptimizable())
+      Phi->resetParameters(active);
+  }
 
   /// create optimizable orbital rotation parameters
   void buildOptVariables(std::vector<size_t>& C2node);

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.cpp
@@ -16,7 +16,8 @@
 
 namespace qmcplusplus
 {
-SHOSet::SHOSet(RealType l, PosType c, const std::vector<SHOState*>& sho_states) : length(l), center(c)
+SHOSet::SHOSet(const std::string& my_name, RealType l, PosType c, const std::vector<SHOState*>& sho_states)
+    : SPOSet(my_name), length(l), center(c)
 {
   state_info.resize(sho_states.size());
   for (int s = 0; s < sho_states.size(); ++s)
@@ -28,8 +29,6 @@ SHOSet::SHOSet(RealType l, PosType c, const std::vector<SHOState*>& sho_states) 
 void SHOSet::initialize()
 {
   using std::sqrt;
-
-  className = "SHOSet";
 
   OrbitalSetSize = state_info.size();
 

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSet.h
@@ -64,12 +64,13 @@ struct SHOSet : public SPOSet
   Array<RealType, 2> d2_values;
 
   //construction/destruction
-  SHOSet(RealType l, PosType c, const std::vector<SHOState*>& sho_states);
+  SHOSet(const std::string& my_name, RealType l, PosType c, const std::vector<SHOState*>& sho_states);
 
   ~SHOSet() override;
 
-  void initialize();
+  std::string getClassName() const override { return "SHOSet"; }
 
+  void initialize();
 
   //SPOSet interface methods
   std::unique_ptr<SPOSet> makeClone() const override;

--- a/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/HarmonicOscillator/SHOSetBuilder.cpp
@@ -104,7 +104,7 @@ std::unique_ptr<SPOSet> SHOSetBuilder::createSPOSet(xmlNodePtr cur, SPOSetInputI
     sho_states.push_back(basis_states[indices[i]]);
 
   // make the sposet
-  auto sho = std::make_unique<SHOSet>(length, center, sho_states);
+  auto sho = std::make_unique<SHOSet>(spo_name, length, center, sho_states);
 
   sho->report("  ");
   //sho->test_derivatives();

--- a/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
+++ b/src/QMCWaveFunctions/LCAO/CuspCorrectionConstruction.cpp
@@ -34,10 +34,10 @@ void applyCuspCorrection(const Matrix<CuspCorrectionParameters>& info,
 
   ScopedTimer cuspApplyTimerWrapper(cuspApplyTimer);
 
-  LCAOrbitalSet phi(std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()), lcwc.isOptimizable());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()));
   phi.setOrbitalSetSize(lcwc.getOrbitalSetSize());
 
-  LCAOrbitalSet eta(std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()), lcwc.isOptimizable());
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()));
   eta.setOrbitalSetSize(lcwc.getOrbitalSetSize());
 
 
@@ -199,10 +199,10 @@ void generateCuspInfo(int orbital_set_size,
 
   ScopedTimer createCuspTimerWrapper(cuspCreateTimer);
 
-  LCAOrbitalSet phi(std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()), lcwc.isOptimizable());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()));
   phi.setOrbitalSetSize(lcwc.getOrbitalSetSize());
 
-  LCAOrbitalSet eta(std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()), lcwc.isOptimizable());
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcwc.myBasisSet->makeClone()));
   eta.setOrbitalSetSize(lcwc.getOrbitalSetSize());
 
 
@@ -229,12 +229,10 @@ void generateCuspInfo(int orbital_set_size,
       ParticleSet localTargetPtcl(targetPtcl);
       ParticleSet localSourcePtcl(sourcePtcl);
 
-      LCAOrbitalSet local_phi(std::unique_ptr<LCAOrbitalSet::basis_type>(phi.myBasisSet->makeClone()),
-                              phi.isOptimizable());
+      LCAOrbitalSet local_phi("local_phi", std::unique_ptr<LCAOrbitalSet::basis_type>(phi.myBasisSet->makeClone()));
       local_phi.setOrbitalSetSize(phi.getOrbitalSetSize());
 
-      LCAOrbitalSet local_eta(std::unique_ptr<LCAOrbitalSet::basis_type>(eta.myBasisSet->makeClone()),
-                              eta.isOptimizable());
+      LCAOrbitalSet local_eta("local_eta", std::unique_ptr<LCAOrbitalSet::basis_type>(eta.myBasisSet->makeClone()));
       local_eta.setOrbitalSetSize(eta.getOrbitalSetSize());
 
 #pragma omp critical

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
@@ -48,14 +48,14 @@ std::unique_ptr<SPOSet> LCAOSpinorBuilder::createSPOSetFromXML(xmlNodePtr cur)
     app_log() << "  SPOSet " << spo_name << " is optimizable\n";
 
   std::unique_ptr<LCAOrbitalSet> upspo =
-      std::make_unique<LCAOrbitalSet>(std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()), optimize == "yes");
+      std::make_unique<LCAOrbitalSet>(spo_name + "_up", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()));
   std::unique_ptr<LCAOrbitalSet> dnspo =
-      std::make_unique<LCAOrbitalSet>(std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()), optimize == "yes");
+      std::make_unique<LCAOrbitalSet>(spo_name + "_dn", std::unique_ptr<BasisSet_t>(myBasisSet->makeClone()));
 
   loadMO(*upspo, *dnspo, cur);
 
   //create spinor and register up/dn
-  auto spinor_set = std::make_unique<SpinorSet>();
+  auto spinor_set = std::make_unique<SpinorSet>(spo_name);
   spinor_set->set_spos(std::move(upspo), std::move(dnspo));
   return spinor_set;
 }

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -16,8 +16,8 @@
 
 namespace qmcplusplus
 {
-LCAOrbitalSet::LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize)
-    : SPOSet(false, true, optimize), BasisSetSize(bs ? bs->getBasisSetSize() : 0), Identity(true)
+LCAOrbitalSet::LCAOrbitalSet(const std::string& my_name, std::unique_ptr<basis_type>&& bs)
+    : SPOSet(my_name), BasisSetSize(bs ? bs->getBasisSetSize() : 0), Identity(true)
 {
   if (!bs)
     throw std::runtime_error("LCAOrbitalSet cannot take nullptr as its  basis set!");

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -43,9 +43,13 @@ public:
   /** constructor
      * @param bs pointer to the BasisSet
      */
-  LCAOrbitalSet(std::unique_ptr<basis_type>&& bs, bool optimize);
+  LCAOrbitalSet(const std::string& my_name, std::unique_ptr<basis_type>&& bs);
 
   LCAOrbitalSet(const LCAOrbitalSet& in);
+
+  virtual std::string getClassName() const override { return "LCAOrbitalSet"; }
+
+  bool hasIonDerivs() const override { return true; }
 
   std::unique_ptr<SPOSet> makeClone() const override;
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.cpp
@@ -14,11 +14,11 @@
 
 namespace qmcplusplus
 {
-LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(ParticleSet& ions,
+LCAOrbitalSetWithCorrection::LCAOrbitalSetWithCorrection(const std::string& my_name,
+                                                         ParticleSet& ions,
                                                          ParticleSet& els,
-                                                         std::unique_ptr<basis_type>&& bs,
-                                                         bool optimize)
-    : LCAOrbitalSet(std::move(bs), optimize), cusp(ions, els)
+                                                         std::unique_ptr<basis_type>&& bs)
+    : LCAOrbitalSet(my_name, std::move(bs)), cusp(ions, els)
 {}
 
 void LCAOrbitalSetWithCorrection::setOrbitalSetSize(int norbs)

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSetWithCorrection.h
@@ -33,9 +33,14 @@ public:
      * @param bs pointer to the BasisSet
      * @param rl report level
      */
-  LCAOrbitalSetWithCorrection(ParticleSet& ions, ParticleSet& els, std::unique_ptr<basis_type>&& bs, bool optimize);
+  LCAOrbitalSetWithCorrection(const std::string& my_name,
+                              ParticleSet& ions,
+                              ParticleSet& els,
+                              std::unique_ptr<basis_type>&& bs);
 
   LCAOrbitalSetWithCorrection(const LCAOrbitalSetWithCorrection& in) = default;
+
+  std::string getClassName() const override { return "LCAOrbitalSetWithCorrection"; }
 
   std::unique_ptr<SPOSet> makeClone() const override;
 

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -267,7 +267,7 @@ SPOSet* PWOrbitalBuilder::createPW(xmlNodePtr cur, int spinIndex)
   //hid_t twist_grp_id = H5Gopen2(es_grp_id,tname.c_str(), H5P_DEFAULT);
   hid_t twist_grp_id = H5Gopen2(es_grp_id, "kpoint_0", H5P_DEFAULT);
   //create a single-particle orbital set
-  SPOSetType* psi = new SPOSetType;
+  SPOSetType* psi = new SPOSetType(getXMLAttributeValue(cur, "name"));
   if (transform2grid)
   {
     nb = myParam->numBands;

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.h
@@ -43,10 +43,12 @@ public:
 
   /** default constructor
   */
-  PWOrbitalSet() : OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0), C(nullptr), IsCloned(false)
-  {
-    className = "PWOrbitalSet";
-  }
+  PWOrbitalSet(const std::string& my_name)
+      : SPOSet(my_name), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0), C(nullptr), IsCloned(false)
+  {}
+
+  std::string getClassName() const override { return "PWOrbitalSet"; }
+
 
   /** delete BasisSet only it owns this
    *

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.h
@@ -47,7 +47,11 @@ public:
 
   /** default constructor
   */
-  PWRealOrbitalSet() : OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0) { className = "PWRealOrbitalSet"; }
+  PWRealOrbitalSet(const std::string& my_name)
+      : SPOSet(my_name), OwnBasisSet(false), myBasisSet(nullptr), BasisSetSize(0)
+  {}
+
+  std::string getClassName() const override { return "PWRealOrbitalSet"; }
 
   /** delete BasisSet only it owns this
    *

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -22,9 +22,14 @@ class RotatedSPOs : public SPOSet
 {
 public:
   //constructor
-  RotatedSPOs(std::unique_ptr<SPOSet>&& spos);
+  RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos);
   //destructor
   ~RotatedSPOs() override;
+
+  std::string getClassName() const override { return "RotatedSPOs"; }
+  bool isOptimizable() const override { return true; }
+  bool isOMPoffload() const override { return Phi->isOMPoffload(); }
+  bool hasIonDerivs() const override { return Phi->hasIonDerivs(); }
 
   // Vector of rotation matrix indices
   using RotationIndices = std::vector<std::pair<int, int>>;
@@ -194,35 +199,23 @@ public:
     for (int k = 0; k < myVars.size(); ++k)
       myVars[k] = 0.0;
 
-    if (Optimizable)
-    {
-      if (myVars.size())
-        active.insertFrom(myVars);
-      Phi->storeParamsBeforeRotation();
-    }
+    if (myVars.size())
+      active.insertFrom(myVars);
+    Phi->storeParamsBeforeRotation();
   }
 
-  void checkOutVariables(const opt_variables_type& active) override
-  {
-    if (Optimizable)
-    {
-      myVars.getIndex(active);
-    }
-  }
+  void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
 
   ///reset
   void resetParameters(const opt_variables_type& active) override
   {
-    if (Optimizable)
+    std::vector<RealType> param(m_act_rot_inds.size());
+    for (int i = 0; i < m_act_rot_inds.size(); i++)
     {
-      std::vector<RealType> param(m_act_rot_inds.size());
-      for (int i = 0; i < m_act_rot_inds.size(); i++)
-      {
-        int loc  = myVars.where(i);
-        param[i] = myVars[i] = active[loc];
-      }
-      apply_rotation(param, true);
+      int loc  = myVars.where(i);
+      param[i] = myVars[i] = active[loc];
     }
+    apply_rotation(param, true);
   }
 
   //*********************************************************************************

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -26,7 +26,7 @@
 
 namespace qmcplusplus
 {
-SPOSet::SPOSet(const std::string& my_name) : my_name_(my_name), OrbitalSetSize(0) {}
+SPOSet::SPOSet(const std::string& my_name) : OptimizableObject(my_name), my_name_(my_name), OrbitalSetSize(0) {}
 
 void SPOSet::evaluateDetRatios(const VirtualParticleSet& VP,
                                ValueVector& psi,

--- a/src/QMCWaveFunctions/SPOSet.cpp
+++ b/src/QMCWaveFunctions/SPOSet.cpp
@@ -26,11 +26,7 @@
 
 namespace qmcplusplus
 {
-SPOSet::SPOSet(bool use_OMP_offload, bool ion_deriv, bool optimizable)
-    : useOMPoffload(use_OMP_offload), ionDerivs(ion_deriv), Optimizable(optimizable), OrbitalSetSize(0)
-{
-  className = "invalid";
-}
+SPOSet::SPOSet(const std::string& my_name) : my_name_(my_name), OrbitalSetSize(0) {}
 
 void SPOSet::evaluateDetRatios(const VirtualParticleSet& VP,
                                ValueVector& psi,
@@ -151,7 +147,7 @@ void SPOSet::evaluate_notranspose_spin(const ParticleSet& P,
                                        ValueMatrix& d2logdet,
                                        ValueMatrix& dspinlogdet)
 {
-  throw std::runtime_error("Need specialization of " + className +
+  throw std::runtime_error("Need specialization of " + getClassName() +
                            "::evaluate_notranspose_spin(P,iat,psi,dpsi,d2logdet, dspin_logdet) (vector quantities)\n");
 }
 
@@ -192,7 +188,7 @@ void SPOSet::evaluate_notranspose(const ParticleSet& P,
 
 std::unique_ptr<SPOSet> SPOSet::makeClone() const
 {
-  throw std::runtime_error("Missing  SPOSet::makeClone for " + className);
+  throw std::runtime_error("Missing  SPOSet::makeClone for " + getClassName());
 }
 
 void SPOSet::basic_report(const std::string& pad) const
@@ -205,7 +201,7 @@ void SPOSet::basic_report(const std::string& pad) const
 
 void SPOSet::evaluateVGH(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, HessVector& grad_grad_psi)
 {
-  throw std::runtime_error("Need specialization of " + className +
+  throw std::runtime_error("Need specialization of " + getClassName() +
                            "::evaluate(P,iat,psi,dpsi,dhpsi) (vector quantities)\n");
 }
 
@@ -216,7 +212,7 @@ void SPOSet::evaluateVGHGH(const ParticleSet& P,
                            HessVector& grad_grad_psi,
                            GGGVector& grad_grad_grad_psi)
 {
-  throw std::runtime_error("Need specialization of " + className +
+  throw std::runtime_error("Need specialization of " + getClassName() +
                            "::evaluate(P,iat,psi,dpsi,dhpsi,dghpsi) (vector quantities)\n");
 }
 
@@ -253,7 +249,7 @@ void SPOSet::evaluateGradSourceRow(const ParticleSet& P,
 
 void SPOSet::evaluate_spin(const ParticleSet& P, int iat, ValueVector& psi, ValueVector& dpsi)
 {
-  throw std::runtime_error("Need specialization of " + className +
+  throw std::runtime_error("Need specialization of " + getClassName() +
                            "::evaluate_spin(P,iat,psi,dpsi) (vector quantities)\n");
 }
 

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -61,23 +61,18 @@ public:
   using OffloadMWVGLArray = Array<ValueType, 3, OffloadPinnedAllocator<ValueType>>; // [VGL, walker, Orbs]
 
   /** constructor */
-  SPOSet(bool use_OMP_offload = false, bool ion_deriv = false, bool optimizable = false);
+  SPOSet(const std::string& my_name);
 
   /** destructor
    *
    * Derived class destructor needs to pay extra attention to freeing memory shared among clones of SPOSet.
    */
-  virtual ~SPOSet() {}
-
-  // accessor function to Optimizable
-  inline bool isOptimizable() const { return Optimizable; }
+  virtual ~SPOSet() = default;
 
   /** return the size of the orbital set
    * Ye: this needs to be replaced by getOrbitalSetSize();
    */
   inline int size() const { return OrbitalSetSize; }
-
-  inline const std::string& getClassName() const { return className; }
 
   /** print basic SPOSet information
    */
@@ -92,13 +87,15 @@ public:
    */
   inline int getOrbitalSetSize() const { return OrbitalSetSize; }
 
-  /** Query if this SPOSet uses OpenMP offload
-  */
-  inline bool isOMPoffload() const { return useOMPoffload; }
+  /// Query if this SPOSet is optimizable
+  virtual bool isOptimizable() const { return false; }
+
+  /// Query if this SPOSet uses OpenMP offload
+  virtual bool isOMPoffload() const { return false; }
 
   /** Query if this SPOSet has an explicit ion dependence. returns true if it does.
   */
-  inline bool hasIonDerivs() const { return ionDerivs; }
+  virtual bool hasIonDerivs() const { return false; }
 
   /// check a few key parameters before putting the SPO into a determinant
   virtual void checkObject() const {}
@@ -114,7 +111,7 @@ public:
   virtual void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy = false)
   {
     std::ostringstream o;
-    o << "SPOSet::applyRotation is not implemented by " << className << std::endl;
+    o << "SPOSet::applyRotation is not implemented by " << getClassName() << std::endl;
     APP_ABORT(o.str());
   }
   /// reset parameters to the values from optimizer
@@ -512,10 +509,11 @@ public:
    */
   virtual void finalizeConstruction() {}
 
-  /// set object name
-  void setName(const std::string& name) { myName = name; }
   /// return object name
-  const std::string& getName() const { return myName; }
+  const std::string& getName() const { return my_name_; }
+
+  /// return class name
+  virtual std::string getClassName() const = 0;
 
 #ifdef QMC_CUDA
   /** Evaluate the SPO value at an explicit position.
@@ -555,20 +553,12 @@ public:
 #endif
 
 protected:
-  ///true, if the derived class uses OpenMP offload and statisfies a few assumptions
-  const bool useOMPoffload;
-  ///true, if the derived class has non-zero ionic derivatives.
-  const bool ionDerivs;
-  ///true if SPO is optimizable
-  const bool Optimizable;
+  /// name of the object, unique identifier
+  const std::string my_name_;
   ///number of Single-particle orbitals
   IndexType OrbitalSetSize;
   /// Optimizable variables
   opt_variables_type myVars;
-  ///name of the class
-  std::string className;
-  /// name of the object, unique identifier
-  std::string myName;
 };
 
 using SPOSetPtr = SPOSet*;

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -39,7 +39,7 @@ class ResourceCollection;
  * SPOSet stands for S(ingle)P(article)O(rbital)Set which contains
  * a number of single-particle orbitals with capabilities of evaluating \f$ \psi_j({\bf r}_i)\f$
  */
-class SPOSet : public QMCTraits
+class SPOSet : public QMCTraits, public OptimizableObject
 {
 public:
   using IndexVector = OrbitalSetTraits<ValueType>::IndexVector;
@@ -114,16 +114,6 @@ public:
     o << "SPOSet::applyRotation is not implemented by " << getClassName() << std::endl;
     APP_ABORT(o.str());
   }
-  /// reset parameters to the values from optimizer
-  virtual void resetParameters(const opt_variables_type& optVariables) {}
-
-  /** check in parameters to the global list of parameters used by the optimizer.
-   * This is a query function and should never be implemented as a feature blocker.
-   * If an SPOSet derived class doesn't support optimization, use the base class fallback.
-   */
-  virtual void checkInVariables(opt_variables_type& active) {}
-  /// check out parameters to the global list of parameters used by the optimizer
-  virtual void checkOutVariables(const opt_variables_type& active) {}
 
   virtual void evaluateDerivatives(ParticleSet& P,
                                    const opt_variables_type& optvars,

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -97,8 +97,9 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
 #else
     // create sposet with rotation
     auto& sposet_ref = *sposet;
-    auto rot_spo     = std::make_unique<RotatedSPOs>(std::move(sposet));
-    xmlNodePtr tcur  = cur->xmlChildrenNode;
+    app_log() << "  SPOSet " << sposet_ref.getName() << " is optimizable\n";
+    auto rot_spo    = std::make_unique<RotatedSPOs>(sposet_ref.getName(), std::move(sposet));
+    xmlNodePtr tcur = cur->xmlChildrenNode;
     while (tcur != NULL)
     {
       std::string cname((const char*)(tcur->name));
@@ -110,23 +111,12 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
       }
       tcur = tcur->next;
     }
-
-    // pass sposet name and rename sposet before rotation
-    if (!sposet_ref.getName().empty())
-    {
-      rot_spo->setName(sposet_ref.getName());
-      sposet_ref.setName(sposet_ref.getName() + "_before_rotation");
-    }
-    if (sposet_ref.getName().empty())
-      sposet_ref.setName(spo_object_name + "_before_rotation");
-
-    // overwrite sposet
     sposet = std::move(rot_spo);
 #endif
   }
 
-  if (!spo_object_name.empty() && sposet->getName().empty())
-    sposet->setName(spo_object_name);
+  //if (!spo_object_name.empty() && sposet->getName().empty())
+  //sposet->setName(spo_object_name);
   if (sposet->getName().empty())
     app_warning() << "SPOSet object doesn't have a name." << std::endl;
   if (!spo_object_name.empty() && sposet->getName() != spo_object_name)

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -14,7 +14,8 @@
 
 namespace qmcplusplus
 {
-SpinorSet::SpinorSet() : SPOSet(), className("SpinorSet"), spo_up(nullptr), spo_dn(nullptr) {}
+SpinorSet::SpinorSet(const std::string& my_name) : SPOSet(my_name), spo_up(nullptr), spo_dn(nullptr) {}
+SpinorSet::~SpinorSet() = default;
 
 void SpinorSet::set_spos(std::unique_ptr<SPOSet>&& up, std::unique_ptr<SPOSet>&& dn)
 {
@@ -443,7 +444,7 @@ void SpinorSet::evaluateGradSource(const ParticleSet& P,
 
 std::unique_ptr<SPOSet> SpinorSet::makeClone() const
 {
-  auto myclone = std::make_unique<SpinorSet>();
+  auto myclone = std::make_unique<SpinorSet>(my_name_);
   std::unique_ptr<SPOSet> cloneup(spo_up->makeClone());
   std::unique_ptr<SPOSet> clonedn(spo_dn->makeClone());
   myclone->set_spos(std::move(cloneup), std::move(clonedn));

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -23,12 +23,14 @@ namespace qmcplusplus
 class SpinorSet : public SPOSet
 {
 public:
-  ///name of the class
-  std::string className;
-
   /** constructor */
-  SpinorSet();
-  ~SpinorSet() override = default;
+  SpinorSet(const std::string& my_name);
+  ~SpinorSet() override;
+
+  std::string getClassName() const override { return "SpinorSet"; }
+  bool isOptimizable() const override { return spo_up->isOptimizable() || spo_dn->isOptimizable(); }
+  bool isOMPoffload() const override { return spo_up->isOMPoffload() || spo_dn->isOMPoffload(); }
+  bool hasIonDerivs() const override { return spo_up->hasIonDerivs() || spo_dn->hasIonDerivs(); }
 
   //This class is initialized by separately building the up and down channels of the spinor set and
   //then registering them.

--- a/src/QMCWaveFunctions/tests/FakeSPO.cpp
+++ b/src/QMCWaveFunctions/tests/FakeSPO.cpp
@@ -15,9 +15,8 @@
 namespace qmcplusplus
 {
 
-FakeSPO::FakeSPO()
+FakeSPO::FakeSPO() : SPOSet("one_FakeSPO")
 {
-  className = "FakeSPO";
   a.resize(3, 3);
 
   a(0, 0) = 2.3;

--- a/src/QMCWaveFunctions/tests/FakeSPO.h
+++ b/src/QMCWaveFunctions/tests/FakeSPO.h
@@ -31,6 +31,8 @@ public:
   FakeSPO();
   ~FakeSPO() override {}
 
+  std::string getClassName() const override { return "FakeSPO"; }
+
   std::unique_ptr<SPOSet> makeClone() const override;
   virtual void report() {}
   void setOrbitalSetSize(int norbs) override;

--- a/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
+++ b/src/QMCWaveFunctions/tests/test_CompositeSPOSet.cpp
@@ -32,7 +32,7 @@ TEST_CASE("CompositeSPO::diamond_1x1x1", "[wavefunction")
   auto& pset             = *particle_pool.getParticleSet("e");
   auto& twf              = *wavefunction_pool.getWaveFunction("wavefunction");
 
-  CompositeSPOSet comp_sposet;
+  CompositeSPOSet comp_sposet("one_composite_set");
 
   std::vector<std::string> sposets{"spo_ud", "spo_dm"};
   for (auto sposet_str : sposets)

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -540,10 +540,10 @@ void test_DiracDeterminant_spinor_update(const DetMatInvertor inverter_kind)
   kdn[1] = PosType(-0.1, 0.2, -0.3);
   kdn[2] = PosType(0.4, -0.5, 0.6);
 
-  auto spo_up = std::make_unique<FreeOrbital>(kup);
-  auto spo_dn = std::make_unique<FreeOrbital>(kdn);
+  auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
+  auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
 
-  auto spinor_set = std::make_unique<SpinorSet>();
+  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
   spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
 
   DET dd(std::move(spinor_set), 0, nelec, 1, inverter_kind);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -120,7 +120,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
 #if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
 
   // 1.) Make a RotatedSPOs object so that we can use the rotation routines
-  auto rot_spo = std::make_unique<RotatedSPOs>(std::move(spo));
+  auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
 
   // Sanity check for orbs. Expect 2 electrons, 8 orbitals, & 79507 coefs/orb.
   const auto orbitalsetsize = rot_spo->getOrbitalSetSize();

--- a/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
+++ b/src/QMCWaveFunctions/tests/test_soa_cusp_corr.cpp
@@ -120,10 +120,10 @@ TEST_CASE("applyCuspInfo", "[wavefunction]")
 
   LCAOrbitalSet& lcob = dynamic_cast<LCAOrbitalSet&>(*sposet);
 
-  LCAOrbitalSet phi(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()), lcob.isOptimizable());
+  LCAOrbitalSet phi("phi", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()));
   phi.setOrbitalSetSize(lcob.getOrbitalSetSize());
 
-  LCAOrbitalSet eta(std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()), lcob.isOptimizable());
+  LCAOrbitalSet eta("eta", std::unique_ptr<LCAOrbitalSet::basis_type>(lcob.myBasisSet->makeClone()));
   eta.setOrbitalSetSize(lcob.getOrbitalSetSize());
 
   *(eta.C) = *(lcob.C);


### PR DESCRIPTION
Review can be done independent from  #4158 but need its fix of tests before merging.

## Proposed changes
The major change is in SPOSet.h
1. require it named
2. isOptimizable isOptimizable hasIonDerivs getClassName are virtual functions instead of relying on member variables.
3. make it inherited from OptimizableObject. This change will be soon reverted as OptimizableObject will be used in actual optimizable derived classes. The change will come with a later PR. 
4. in SPOSet builders, implicit sharing SPOSet for spin-up/down has been removed. Users may hit memory overhead if they are still using legacy input style instead of sposet_collection. I think it is time to phase out the legacy input style with SPOSet constructed inside determinants.

## What type(s) of changes does this code introduce?
- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
