### PR TITLE
Fix hybrid method for legacy driver

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -548,6 +548,8 @@ bool QMCFixedSampleLinearOptimize::put(xmlNodePtr q)
     if (!hybridEngineObj)
       hybridEngineObj = std::make_unique<HybridEngine>(myComm, q);
 
+    hybridEngineObj->incrementStepCounter();
+
     return processOptXML(hybridEngineObj->getSelectedXML(), vmcMove, ReportToH5 == "yes", useGPU == "yes");
   }
   else


### PR DESCRIPTION

## Proposed changes

This is a small fix to a problem @ye-luo found with PR #4075. With this change, the hybrid method should work with the legacy driver again and pass the tests.

## What type(s) of changes does this code introduce?


- Bugfix



### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
Lawrencium computing cluster

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
