### PR TITLE
Remove macro HAVE_LIBHDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,8 +652,6 @@ endif()
 find_package(HDF5 COMPONENTS C)
 
 if(HDF5_FOUND)
-  set(HAVE_LIBHDF5 1)
-
   if(HDF5_IS_PARALLEL)
     message(STATUS "Parallel HDF5 library found")
     option(ENABLE_PHDF5 "Enable code paths using parallel HDF5" ON)
@@ -692,7 +690,7 @@ if(HDF5_FOUND)
 
   add_library(IO::HDF5 INTERFACE IMPORTED)
   target_include_directories(IO::HDF5 INTERFACE "${HDF5_INCLUDE_DIR}")
-  target_compile_definitions(IO::HDF5 INTERFACE "HAVE_LIBHDF5;H5_USE_16_API")
+  target_compile_definitions(IO::HDF5 INTERFACE "H5_USE_16_API")
   target_link_libraries(IO::HDF5 INTERFACE "${HDF5_LIBRARIES}")
   if(ENABLE_PHDF5)
     target_compile_definitions(IO::HDF5 INTERFACE "ENABLE_PHDF5")

--- a/doxygen/config.h
+++ b/doxygen/config.h
@@ -36,9 +36,6 @@
 /* Enable OpenMP parallelization. */
 #define QMC_OMP 1
 
-/* Define to 1 if you have the `hdf5' library (-lhdf5). */
-#define HAVE_LIBHDF5 1
-
 /* Define to 1 if you want to use parallel hdf5 for frequent output */
 /* #undef ENABLE_PHDF5 */
 

--- a/src/Particle/HDFWalkerInputManager.cpp
+++ b/src/Particle/HDFWalkerInputManager.cpp
@@ -16,9 +16,7 @@
 
 #include "HDFWalkerInputManager.h"
 #include "OhmmsData/AttributeSet.h"
-#if defined(HAVE_LIBHDF5)
 #include "Particle/HDFWalkerInput_0_4.h"
-#endif
 #include "Message/Communicate.h"
 #include "hdf/HDFVersion.h"
 
@@ -28,7 +26,6 @@ HDFWalkerInputManager::HDFWalkerInputManager(WalkerConfigurations& wc_list, size
 
 HDFWalkerInputManager::~HDFWalkerInputManager() {}
 
-#if defined(HAVE_LIBHDF5)
 bool HDFWalkerInputManager::put(xmlNodePtr cur)
 {
   //reference revision number
@@ -60,14 +57,5 @@ bool HDFWalkerInputManager::put(xmlNodePtr cur)
   if (success)
     CurrentFileRoot = cfile;
   return success;
-}
-#else
-bool HDFWalkerInputManager::put(xmlNodePtr cur) { return false; }
-#endif
-
-void HDFWalkerInputManager::rewind(const std::string& h5root, int blocks)
-{
-  //   HDFWalkerInputCollect WO(h5root);
-  //   WO.rewind(wc_list_,blocks);
 }
 } // namespace qmcplusplus

--- a/src/Particle/HDFWalkerInputManager.h
+++ b/src/Particle/HDFWalkerInputManager.h
@@ -37,8 +37,6 @@ public:
   //bool put(std::vector<xmlNodePtr>& mset, int pid);
   //bool put(std::vector<xmlNodePtr>& mset, Communicate* comm);
   std::string getFileRoot() { return CurrentFileRoot; }
-
-  void rewind(const std::string& h5root, int blocks);
 };
 } // namespace qmcplusplus
 

--- a/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOSpinorBuilder.cpp
@@ -117,7 +117,6 @@ bool LCAOSpinorBuilder::loadMO(LCAOrbitalSet& up, LCAOrbitalSet& dn, xmlNodePtr 
 bool LCAOSpinorBuilder::putFromH5(LCAOrbitalSet& up, LCAOrbitalSet& dn, xmlNodePtr occ_ptr)
 {
 #ifdef QMC_COMPLEX
-#if defined(HAVE_LIBHDF5)
   if (up.getBasisSetSize() == 0 || dn.getBasisSetSize() == 0)
   {
     myComm->barrier_and_abort("LCASpinorBuilder::loadMO  detected ZERO BasisSetSize");
@@ -196,10 +195,6 @@ bool LCAOSpinorBuilder::putFromH5(LCAOrbitalSet& up, LCAOrbitalSet& dn, xmlNodeP
 #ifdef HAVE_MPI
   myComm->comm.broadcast_n(up.C->data(), up.C->size());
   myComm->comm.broadcast_n(dn.C->data(), dn.C->size());
-#endif
-
-#else
-  myComm->barrier_and_abort("LCAOSpinorBuilder::putFromH5 HDF5 is disabled");
 #endif
 
 #else

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -661,7 +661,6 @@ bool LCAOrbitalBuilder::putFromXML(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
    */
 bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
 {
-#if defined(HAVE_LIBHDF5)
   int neigs  = spo.getBasisSetSize();
   int setVal = -1;
   std::string setname;
@@ -723,9 +722,6 @@ bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
     }
   }
   myComm->bcast(spo.C->data(), spo.C->size());
-#else
-  APP_ABORT("LCAOrbitalBuilder::putFromH5 HDF5 is disabled.")
-#endif
   return true;
 }
 
@@ -736,7 +732,6 @@ bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
    */
 bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
 {
-#if defined(HAVE_LIBHDF5)
   ReportEngine PRE("LCAOrbitalBuilder", "LCAOrbitalBuilder::putPBCFromH5");
   int norbs      = spo.getOrbitalSetSize();
   int neigs      = spo.getBasisSetSize();
@@ -821,10 +816,6 @@ bool LCAOrbitalBuilder::putPBCFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
   }
 #ifdef HAVE_MPI
   myComm->comm.broadcast_n(spo.C->data(), spo.C->size());
-#endif
-
-#else
-  APP_ABORT("LCAOrbitalBuilder::putFromH5 HDF5 is disabled.")
 #endif
   return true;
 }

--- a/src/io/OhmmsData/HDFAttribIO.h
+++ b/src/io/OhmmsData/HDFAttribIO.h
@@ -17,14 +17,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#if defined(HAVE_LIBHDF5)
 #include "hdf5.h"
-#else
-using hid_t           = int;
-using hsize_t         = std::size_t;
-const int H5P_DEFAULT = 0;
-#endif
-
 #include <string>
 
 

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -18,12 +18,9 @@
 #include "hdf_datatype.h"
 #include "hdf_dataspace.h"
 #include "hdf_dataproxy.h"
-#if defined(HAVE_LIBHDF5)
 #include "hdf_pete.h"
 #include "hdf_stl.h"
 #include "hdf_hyperslab.h"
-//#include "hdf_double_hyperslab.h"
-#endif
 #include <stack>
 #include <bitset>
 #ifdef HAVE_MPI

--- a/src/io/hdf/hdf_datatype.h
+++ b/src/io/hdf/hdf_datatype.h
@@ -14,13 +14,10 @@
 #define QMCPLUSPLUS_H5DATATYPE_DEFINE_H
 
 #include <type_traits>
-#if defined(HAVE_LIBHDF5)
 #include <hdf5.h>
-#endif
 
 namespace qmcplusplus
 {
-#if defined(HAVE_LIBHDF5)
 /** map C types to hdf5 native types
  * bool is explicit removed due to the fact that it is implementation-dependant
  */
@@ -44,24 +41,8 @@ BOOSTSUB_H5_DATATYPE(unsigned short, H5T_NATIVE_USHORT);
 BOOSTSUB_H5_DATATYPE(unsigned int, H5T_NATIVE_UINT);
 BOOSTSUB_H5_DATATYPE(unsigned long, H5T_NATIVE_ULONG);
 BOOSTSUB_H5_DATATYPE(unsigned long long, H5T_NATIVE_ULLONG);
-//BOOSTSUB_H5_DATATYPE(uint32_t, H5T_NATIVE_UINT32);
-//BOOSTSUB_H5_DATATYPE(uint64_t, H5T_NATIVE_UINT64);
 BOOSTSUB_H5_DATATYPE(float, H5T_NATIVE_FLOAT);
 BOOSTSUB_H5_DATATYPE(double, H5T_NATIVE_DOUBLE);
 
-#else
-using hid_t           = int;
-using herr_t          = int;
-using hsize_t         = std::size_t;
-const int H5P_DEFAULT = 0;
-
-//return a non-sense integer
-template<typename T>
-inline hid_t get_h5_datatype(const T&)
-{
-  return 0;
-}
-
-#endif
 } // namespace qmcplusplus
 #endif


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Removes the macro HAVE_LIBHDF5 which is always true.

Fixes #4155

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
