### PR TITLE
Change -pyscf to -orbitals in some convert4qmc docs

### DIFF
--- a/docs/LCAO.rst
+++ b/docs/LCAO.rst
@@ -161,7 +161,7 @@ To generate QMCPACK input files, you will need to run ``convert4qmc`` exactly as
 
 ::
 
-  convert4qmc -pyscf C_diamond-tiled-cplx
+  convert4qmc -orbitals C_diamond-tiled-cplx
 
 This tool can be used with any option described in convert4qmc. Since
 the HDF5 contains all the information needed, there is no need to

--- a/src/QMCTools/PyscfToQmcpack.py
+++ b/src/QMCTools/PyscfToQmcpack.py
@@ -570,7 +570,7 @@ def savetoqmcpack(cell,mf,title="Default",kpts=[],kmesh=[],sp_twist=[],weight=1.
   H5_qmcpack.close()
 
   print ('Wavefunction successfully saved to QMCPACK HDF5 Format')
-  print ('Use: "convert4qmc -pyscf  {}.h5" to generate QMCPACK input files'.format(title))
+  print ('Use: "convert4qmc -orbitals  {}.h5" to generate QMCPACK input files'.format(title))
   # Close the file before exiting
 
 


### PR DESCRIPTION
The -pyscf option was removed in favor of the more general -orbitals in #2748.
Update a couple places the option was used in the documentation showing an example of converter use.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Documentation changes


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
