### PR TITLE
Add convertStrToVec and astring support in ParameterSet

### DIFF
--- a/src/Estimators/EstimatorManagerInput.cpp
+++ b/src/Estimators/EstimatorManagerInput.cpp
@@ -15,6 +15,7 @@
 #include "MomentumDistributionInput.h"
 #include "OneBodyDensityMatricesInput.h"
 #include "SpinDensityInput.h"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/Estimators/InputSection.cpp
+++ b/src/Estimators/InputSection.cpp
@@ -11,7 +11,9 @@
 
 #include "InputSection.h"
 #include "Message/UniformCommunicateError.h"
+#include "ModernStringUtils.hpp"
 #include "Utilities/string_utils.h"
+
 namespace qmcplusplus
 {
 
@@ -51,8 +53,7 @@ void InputSection::readXML(xmlNodePtr cur)
       std::istringstream stream(XMLNodeString{element});
       setFromStream(name, stream);
     }
-    else if (isDelegate(ename))
-    {}
+    else if (isDelegate(ename)) {}
     element = element->next;
   }
 

--- a/src/Estimators/ScalarEstimatorInputs.cpp
+++ b/src/Estimators/ScalarEstimatorInputs.cpp
@@ -12,6 +12,7 @@
 #include "ScalarEstimatorInputs.h"
 #include "InputSection.h"
 #include "EstimatorInput.h"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/Estimators/tests/test_ScalarEstimatorInputs.cpp
+++ b/src/Estimators/tests/test_ScalarEstimatorInputs.cpp
@@ -15,6 +15,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "ScalarEstimatorInputs.h"
 #include "ValidScalarEstimatorInput.h"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -17,6 +17,7 @@
 #include "QMCDriverInput.h"
 #include "EstimatorInputDelegates.h"
 #include "Concurrency/Info.hpp"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {

--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -16,8 +16,6 @@
 
 
 #include "QMCGaussianParserBase.h"
-#include "ParticleIO/XMLParticleIO.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include <iterator>
 #include <algorithm>
 #include <numeric>
@@ -27,7 +25,9 @@
 #include <sstream>
 #include <bitset>
 #include <iomanip>
-
+#include "ParticleIO/XMLParticleIO.h"
+#include "Numerics/HDFSTLAttrib.h"
+#include "ModernStringUtils.hpp"
 
 //std::vector<std::string> QMCGaussianParserBase::IonName;
 const int OhmmsAsciiParser::bufferSize;

--- a/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
+++ b/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
@@ -17,6 +17,7 @@
 #include "Numerics/SlaterBasisSet.h"
 #include "Numerics/GaussianBasisSet.h"
 #include "Message/MPIObjectBase.h"
+#include "ModernStringUtils.hpp"
 #include "hdf/hdf_archive.h"
 
 namespace qmcplusplus

--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -32,7 +32,6 @@ namespace qmcplusplus
 std::string lowerCase(const std::string_view s);
 /** @} */
 
-
 } // namespace qmcplusplus
 
 #endif

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/qmc_common.h"
 #include "OhmmsData/ParameterSet.h"
 #include "Message/UniformCommunicateError.h"
+#include "ModernStringUtils.hpp"
 
 namespace qmcplusplus
 {
@@ -28,9 +29,15 @@ namespace qmcplusplus
 //----------------------------------------------------------------------------
 // constructors and destructors
 ProjectData::ProjectData(const std::string& atitle, ProjectData::DriverVersion driver_version)
-    : m_title(atitle), m_host("none"), m_date("none"), m_series(0), m_cur(NULL), max_cpu_secs_(360000), driver_version_(driver_version)
+    : m_title(atitle),
+      m_host("none"),
+      m_date("none"),
+      m_series(0),
+      m_cur(NULL),
+      max_cpu_secs_(360000),
+      driver_version_(driver_version)
 {
-  myComm  = OHMMS::Controller;
+  myComm = OHMMS::Controller;
   if (m_title.empty())
     m_title = getDateAndTime("%Y%m%dT%H%M");
 }

--- a/src/Utilities/string_utils.h
+++ b/src/Utilities/string_utils.h
@@ -187,10 +187,7 @@ inline std::ostream& operator<<(std::ostream& os, const astring& rhs)
   return os;
 }
 
-inline bool operator==(const astring& lhs, const astring& rhs)
-{
-  return lhs.s == rhs.s;
-}
+inline bool operator==(const astring& lhs, const astring& rhs) { return lhs.s == rhs.s; }
 } // namespace qmcplusplus
 
 #endif

--- a/src/Utilities/string_utils.h
+++ b/src/Utilities/string_utils.h
@@ -16,7 +16,10 @@
 
 
 #include <cstdio>
-#include <Configuration.h>
+#include <sstream>
+#include <typeinfo>
+#include <stdexcept>
+#include <vector>
 
 namespace qmcplusplus
 {
@@ -139,9 +142,28 @@ inline bool string2bool(const std::string& s)
   }
   else
   {
-    APP_ABORT("string2bool received non-boolean string: " + s);
+    throw std::runtime_error("string2bool received non-boolean string: " + s);
     return false;
   }
+}
+
+template<class T>
+inline std::vector<T> convertStrToVec(const std::string& s)
+{
+  std::istringstream stream(s);
+  std::vector<T> b;
+  while (!stream.eof())
+  {
+    if (T t; stream >> t)
+      b.push_back(t);
+    else if (!stream.eof() && stream.fail())
+    {
+      std::ostringstream msg;
+      msg << "Error parsing string '" << s << "' for type (type_info::name) " << typeid(T).name() << "." << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+  }
+  return b;
 }
 
 

--- a/src/Utilities/tests/CMakeLists.txt
+++ b/src/Utilities/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   test_project_data.cpp
   test_rng_control.cpp
   test_ModernStringUtils.cpp
+  test_string_utils.cpp
   test_StlPrettyPrint.cpp
   test_StdRandom.cpp)
 target_link_libraries(${UTEST_EXE} catch_main qmcutil)

--- a/src/Utilities/tests/test_string_utils.cpp
+++ b/src/Utilities/tests/test_string_utils.cpp
@@ -19,15 +19,29 @@ namespace qmcplusplus
 
 TEST_CASE("string_utils_streamToVec", "[utilities]")
 {
-  std::string test_string("abc def 123");
-  auto str_vec = convertStrToVec<std::string>(test_string);
-  REQUIRE(str_vec.size() == 3);
-  CHECK(str_vec[0] == "abc");
-  CHECK(str_vec[1] == "def");
-  CHECK(str_vec[2] == "123");
+  { // empty string
+    std::string test_string("");
+    auto str_vec = convertStrToVec<std::string>(test_string);
+    REQUIRE(str_vec.size() == 0);
+  }
 
-  // won't work with int
-  CHECK_THROWS_WITH(convertStrToVec<int>(test_string),
-                    Catch::Matchers::Contains("Error parsing string 'abc def 123' for type (type_info::name) i."));
+  { // whitespace string
+    std::string test_string("  ");
+    auto str_vec = convertStrToVec<std::string>(test_string);
+    REQUIRE(str_vec.size() == 0);
+  }
+
+  {
+    std::string test_string("abc def 123");
+    auto str_vec = convertStrToVec<std::string>(test_string);
+    REQUIRE(str_vec.size() == 3);
+    CHECK(str_vec[0] == "abc");
+    CHECK(str_vec[1] == "def");
+    CHECK(str_vec[2] == "123");
+
+    // won't work with int
+    CHECK_THROWS_WITH(convertStrToVec<int>(test_string),
+                      Catch::Matchers::Contains("Error parsing string 'abc def 123' for type (type_info::name) i."));
+  }
 }
 } // namespace qmcplusplus

--- a/src/Utilities/tests/test_string_utils.cpp
+++ b/src/Utilities/tests/test_string_utils.cpp
@@ -1,0 +1,33 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+#include "string_utils.h"
+
+/** \file
+ */
+namespace qmcplusplus
+{
+
+TEST_CASE("string_utils_streamToVec", "[utilities]")
+{
+  std::string test_string("abc def 123");
+  auto str_vec = convertStrToVec<std::string>(test_string);
+  REQUIRE(str_vec.size() == 3);
+  CHECK(str_vec[0] == "abc");
+  CHECK(str_vec[1] == "def");
+  CHECK(str_vec[2] == "123");
+
+  // won't work with int
+  CHECK_THROWS_WITH(convertStrToVec<int>(test_string),
+                    Catch::Matchers::Contains("Error parsing string 'abc def 123' for type (type_info::name) i."));
+}
+} // namespace qmcplusplus

--- a/src/io/OhmmsData/ParameterSet.cpp
+++ b/src/io/OhmmsData/ParameterSet.cpp
@@ -77,6 +77,10 @@ void ParameterSet::setValue(const std::string& aname_in, PDT aval)
 }
 
 template void ParameterSet::add(std::string&, const std::string&, std::vector<std::string>, TagStatus);
+template void ParameterSet::add(qmcplusplus::astring&,
+                                const std::string&,
+                                std::vector<qmcplusplus::astring>,
+                                TagStatus);
 template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>, TagStatus);
 template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>, TagStatus);
 template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>, TagStatus);

--- a/src/io/OhmmsData/ParameterSet.h
+++ b/src/io/OhmmsData/ParameterSet.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <complex>
 #include "OhmmsData/OhmmsParameter.h"
-#include "ModernStringUtils.hpp"
+#include "string_utils.h"
 #include "OhmmsPETE/TinyVector.h"
 
 /** class to handle a set of parameters
@@ -64,7 +64,7 @@ struct ParameterSet : public OhmmsElementBase
   void add(PDT& aparam,
            const std::string& aname_in,
            std::vector<PDT> candidate_values = {},
-           TagStatus status                    = TagStatus::OPTIONAL);
+           TagStatus status                  = TagStatus::OPTIONAL);
 
   template<class PDT>
   void setValue(const std::string& aname_in, PDT aval);
@@ -74,6 +74,10 @@ extern template void ParameterSet::add<std::string>(std::string&,
                                                     const std::string&,
                                                     std::vector<std::string>,
                                                     TagStatus);
+extern template void ParameterSet::add<qmcplusplus::astring>(qmcplusplus::astring&,
+                                                             const std::string&,
+                                                             std::vector<qmcplusplus::astring>,
+                                                             TagStatus);
 extern template void ParameterSet::add<bool>(bool&, const std::string&, std::vector<bool>, TagStatus);
 extern template void ParameterSet::add<int>(int&, const std::string&, std::vector<int>, TagStatus);
 extern template void ParameterSet::add<double>(double&, const std::string&, std::vector<double>, TagStatus);
@@ -86,11 +90,10 @@ extern template void ParameterSet::add<std::complex<float>>(std::complex<float>&
                                                             const std::string&,
                                                             std::vector<std::complex<float>>,
                                                             TagStatus);
-extern template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(
-    qmcplusplus::TinyVector<int, 3u>&,
-    const std::string&,
-    std::vector<qmcplusplus::TinyVector<int, 3u>>,
-    TagStatus);
+extern template void ParameterSet::add<qmcplusplus::TinyVector<int, 3u>>(qmcplusplus::TinyVector<int, 3u>&,
+                                                                         const std::string&,
+                                                                         std::vector<qmcplusplus::TinyVector<int, 3u>>,
+                                                                         TagStatus);
 
 extern template void ParameterSet::setValue<int>(const std::string& aname_in, int aval);
 

--- a/src/io/OhmmsData/libxmldefs.cpp
+++ b/src/io/OhmmsData/libxmldefs.cpp
@@ -1,3 +1,14 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2021 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
 #include "libxmldefs.h"
 #include "ModernStringUtils.hpp"
 

--- a/src/io/OhmmsData/libxmldefs.h
+++ b/src/io/OhmmsData/libxmldefs.h
@@ -23,9 +23,8 @@
 #include <string>
 #include <vector>
 #include <algorithm>
-#include <typeinfo>
 #include "XMLParsingString.h"
-#include "ModernStringUtils.hpp"
+#include "string_utils.h"
 
 /**\file libxmldefs.h
  *\brief A collection of put/get functions to read from or write to a xmlNode defined in libxml2.
@@ -143,21 +142,7 @@ inline bool putContent(std::vector<T>& a, const xmlNodePtr cur)
 {
   if (cur->children == NULL)
     return false;
-  std::istringstream stream(XMLNodeString{cur});
-  std::vector<T> b;
-  T t;
-  while (!stream.eof())
-  {
-    if (stream >> t)
-      b.push_back(t);
-    else if (!stream.eof() && stream.fail())
-    {
-      std::cerr << "Error parsing XML for type (type_info::name) " << typeid(T).name() << ", value " << t
-                << std::endl;
-      stream.clear();
-    }
-  }
-  a = b;
+  a = qmcplusplus::convertStrToVec<T>(XMLNodeString{cur});
   return true;
 }
 

--- a/src/io/OhmmsData/tests/test_xml.cpp
+++ b/src/io/OhmmsData/tests/test_xml.cpp
@@ -166,6 +166,7 @@ TEST_CASE("ParameterSet", "[xml]")
   const char* content = " \
 <simulation> \
    <parameter name=\"p1\">1</parameter> \
+   <parameter name=\"p4\"> -2 -3 </parameter> \
    <p2>2</p2> \
 </simulation>";
   Libxml2Document doc;
@@ -177,14 +178,21 @@ TEST_CASE("ParameterSet", "[xml]")
   int p1_val = 0;
   int p2_val = 0;
   int p3_val = 0;
+  qmcplusplus::astring p4_str;
   param.add(p1_val, "p1");
   param.add(p2_val, "p2");
   param.add(p3_val, "p3");
+  param.add(p4_str, "p4");
   param.put(root);
 
-  REQUIRE(p1_val == 1);
-  REQUIRE(p2_val == 2);
-  REQUIRE(p3_val == 0);
+  CHECK(p1_val == 1);
+  CHECK(p2_val == 2);
+  CHECK(p3_val == 0);
+
+  auto p4_vals = qmcplusplus::convertStrToVec<int>(p4_str.s);
+  REQUIRE(p4_vals.size() == 2);
+  CHECK(p4_vals[0] == -2);
+  CHECK(p4_vals[1] == -3);
 }
 
 TEST_CASE("write_file", "[xml]")


### PR DESCRIPTION
## Proposed changes
To load a vector of things, use astring to load the whole parameter content.
Then use convertStrToVec to generate the vector.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'