### PR TITLE
Refactor ProjectData and add runtime bool for complex/real runs

### DIFF
--- a/src/QMCApp/QMCAppBase.cpp
+++ b/src/QMCApp/QMCAppBase.cpp
@@ -71,7 +71,7 @@ void QMCAppBase::saveXml()
 {
   if (!XmlDocStack.empty())
   {
-    std::string newxml(myProject.CurrentMainRoot());
+    std::string newxml(myProject.currentMainRoot());
     newxml.append(".cont.xml");
     app_log() << "\n========================================================="
               << "\n  A new xml input file : " << newxml << std::endl;

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -307,7 +307,7 @@ bool QMCMain::execute()
     HDFVersion cur_version;
     v_str << cur_version[0] << " " << cur_version[1];
     xmlNodePtr newmcptr = xmlNewNode(NULL, (const xmlChar*)"mcwalkerset");
-    xmlNewProp(newmcptr, (const xmlChar*)"fileroot", (const xmlChar*)myProject.CurrentMainRoot().c_str());
+    xmlNewProp(newmcptr, (const xmlChar*)"fileroot", (const xmlChar*)myProject.currentMainRoot().c_str());
     xmlNewProp(newmcptr, (const xmlChar*)"node", (const xmlChar*)"-1");
     xmlNewProp(newmcptr, (const xmlChar*)"nprocs", (const xmlChar*)np_str.str().c_str());
     xmlNewProp(newmcptr, (const xmlChar*)"version", (const xmlChar*)v_str.str().c_str());
@@ -638,7 +638,7 @@ bool QMCMain::runQMC(xmlNodePtr cur, bool reuse)
     if (!FirstQMC && !append_run)
       myProject.advance();
 
-    qmc_driver->setStatus(myProject.CurrentMainRoot(), "", append_run);
+    qmc_driver->setStatus(myProject.currentMainRoot(), "", append_run);
     // PD:
     // Q: How does m_walkerset_in end up being non empty?
     // A: Anytime that we aren't doing a restart.

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -102,7 +102,7 @@ QMCDriverFactory::DriverAssemblyState QMCDriverFactory::readSection(xmlNodePtr c
   const int nchars = qmc_mode.size();
 
   using DV = ProjectData::DriverVersion;
-  switch (project_data_.get_driver_version())
+  switch (project_data_.getDriverVersion())
   {
   case DV::BATCH:
 #if defined(QMC_CUDA)

--- a/src/QMCDrivers/QMCDriverNew.h
+++ b/src/QMCDrivers/QMCDriverNew.h
@@ -308,7 +308,7 @@ protected:
   /// check logpsi and grad and lap against values computed from scratch
   static void checkLogAndGL(Crowd& crowd, const std::string_view location);
 
-  const std::string& get_root_name() const override { return project_data_.CurrentMainRoot(); }
+  const std::string& get_root_name() const override { return project_data_.currentMainRoot(); }
 
   /** The timers for the driver.
    *

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -30,13 +30,6 @@ const std::unordered_map<std::string, ProjectData::DriverVersion>
                                           {"batch", DriverVersion::BATCH},
                                           {"batched", DriverVersion::BATCH}};
 
-// This is temporary, the goal is to make decision at runtime so making it const not constexpr
-#ifdef QMC_COMPLEX
-const bool ProjectData::is_complex_ = true;
-#else
-const bool ProjectData::is_complex_ = false;
-#endif
-
 // PUBLIC
 
 ProjectData::ProjectData(const std::string& atitle, ProjectData::DriverVersion driver_version)
@@ -46,7 +39,12 @@ ProjectData::ProjectData(const std::string& atitle, ProjectData::DriverVersion d
       series_index_(0),
       m_cur_(NULL),
       max_cpu_secs_(360000),
-      driver_version_(driver_version)
+      driver_version_(driver_version),
+#ifdef QMC_COMPLEX
+      is_complex_(true)
+#else
+      is_complex_(false)
+#endif
 {
   my_comm_ = OHMMS::Controller;
   if (title_.empty())
@@ -251,7 +249,7 @@ int ProjectData::getMaxCPUSeconds() const noexcept { return max_cpu_secs_; }
 ProjectData::DriverVersion ProjectData::getDriverVersion() const noexcept { return driver_version_; }
 
 // STATIC PUBLIC
-bool ProjectData::isComplex() noexcept { return is_complex_; }
+bool ProjectData::isComplex() const noexcept { return is_complex_; }
 
 // PRIVATE
 ProjectData::DriverVersion ProjectData::lookupDriverVersion(const std::string& enum_value)

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -24,31 +24,40 @@
 
 namespace qmcplusplus
 {
-//----------------------------------------------------------------------------
-// ProjectData
-//----------------------------------------------------------------------------
-// constructors and destructors
+// static members
+const std::unordered_map<std::string, ProjectData::DriverVersion>
+    ProjectData::lookup_input_enum_value_{{"legacy", DriverVersion::LEGACY},
+                                          {"batch", DriverVersion::BATCH},
+                                          {"batched", DriverVersion::BATCH}};
+
+// This is temporary, the goal is to make decision at runtime so making it const not constexpr
+#ifdef QMC_COMPLEX
+const bool ProjectData::is_complex_ = true;
+#else
+const bool ProjectData::is_complex_ = false;
+#endif
+
+// PUBLIC
+
 ProjectData::ProjectData(const std::string& atitle, ProjectData::DriverVersion driver_version)
-    : m_title(atitle),
-      m_host("none"),
-      m_date("none"),
-      m_series(0),
-      m_cur(NULL),
+    : title_(atitle),
+      host_("none"),
+      date_("none"),
+      series_index_(0),
+      m_cur_(NULL),
       max_cpu_secs_(360000),
       driver_version_(driver_version)
 {
-  myComm = OHMMS::Controller;
-  if (m_title.empty())
-    m_title = getDateAndTime("%Y%m%dT%H%M");
+  my_comm_ = OHMMS::Controller;
+  if (title_.empty())
+    title_ = getDateAndTime("%Y%m%dT%H%M");
 }
-
-void ProjectData::setCommunicator(Communicate* c) { myComm = c; }
 
 bool ProjectData::get(std::ostream& os) const
 {
-  os << "  Project = " << m_title << "\n";
+  os << "  Project = " << title_ << "\n";
   os << "  date    = " << getDateAndTime("%Y-%m-%d %H:%M:%S %Z\n");
-  os << "  host    = " << m_host << "\n";
+  os << "  host    = " << host_ << "\n";
   return true;
 }
 
@@ -58,134 +67,28 @@ bool ProjectData::put(std::istream& is)
   while (!is.eof())
   {
     if (isdigit(t1[0]))
-      m_series = atoi(t1.c_str());
+      series_index_ = atoi(t1.c_str());
     is >> t1;
     if (t1 == "series")
-      is >> m_series;
+      is >> series_index_;
     else if (t1 == "host")
-      is >> m_host;
+      is >> host_;
     else if (t1 == "date")
-      is >> m_date;
+      is >> date_;
     else
-      m_title = t1;
+      title_ = t1;
   }
   reset();
   return true;
 }
 
-void ProjectData::advance()
-{
-  m_series++;
-  reset();
-}
-
-void ProjectData::rewind()
-{
-  if (m_series > 0)
-    m_series--;
-  reset();
-}
-
-/**\fn void ProjectData::reset()
- *\brief Construct the root name with m_title and m_series.
- */
-void ProjectData::reset()
-{
-  //int nproc_g = OHMMS::Controller->size();
-  int nproc   = myComm->size();
-  int nodeid  = myComm->rank();
-  int groupid = myComm->getGroupID();
-  char fileroot[256], nextroot[256];
-
-  bool no_gtag = (qmc_common.mpi_groups == 1);
-  int length{0};
-  if (no_gtag) //qnproc_g == nproc)
-    length = sprintf(fileroot, "%s.s%03d", m_title.c_str(), m_series);
-  else
-    length = sprintf(fileroot, "%s.g%03d.s%03d", m_title.c_str(), groupid, m_series);
-
-  m_projectmain = std::string(fileroot, length);
-  //set the communicator name
-  myComm->setName(fileroot);
-  if (no_gtag)
-  {
-    if (nproc > 1)
-    {
-      sprintf(fileroot, ".s%03d.p%03d", m_series, nodeid);
-      sprintf(nextroot, ".s%03d.p%03d", m_series + 1, nodeid);
-    }
-    else
-    {
-      sprintf(fileroot, ".s%03d", m_series);
-      sprintf(nextroot, ".s%03d", m_series + 1);
-    }
-  }
-  else
-  {
-    if (nproc > 1)
-    {
-      sprintf(fileroot, ".g%03d.s%03d.p%03d", groupid, m_series, nodeid);
-      sprintf(nextroot, ".g%03d.s%03d.p%03d", groupid, m_series + 1, nodeid);
-    }
-    else
-    {
-      sprintf(fileroot, ".g%03d.s%03d", groupid, m_series);
-      sprintf(nextroot, ".g%03d.s%03d", groupid, m_series + 1);
-    }
-  }
-  m_projectroot = m_title;
-  m_projectroot.append(fileroot);
-  m_nextroot = m_title;
-  m_nextroot.append(nextroot);
-  std::stringstream s;
-  s << m_series + 1;
-  if (m_cur)
-    xmlSetProp(m_cur, (const xmlChar*)"series", (const xmlChar*)(s.str().c_str()));
-}
-
-bool ProjectData::PreviousRoot(std::string& oldroot) const
-{
-  oldroot.erase(oldroot.begin(), oldroot.end());
-  if (m_series)
-  {
-    char fileroot[128];
-    //int nproc_g = OHMMS::Controller->size();
-    int nproc    = myComm->size();
-    int nodeid   = myComm->rank();
-    int groupid  = myComm->getGroupID();
-    bool no_gtag = (qmc_common.mpi_groups == 1);
-
-    if (no_gtag)
-    {
-      if (nproc > 1)
-        sprintf(fileroot, ".s%03d.p%03d", m_series - 1, nodeid);
-      else
-        sprintf(fileroot, ".s%03d", m_series - 1);
-    }
-    else
-    {
-      if (nproc > 1)
-        sprintf(fileroot, ".g%03d.s%03d.p%03d", groupid, m_series - 1, nodeid);
-      else
-        sprintf(fileroot, ".g%03d.s%03d", groupid, m_series - 1);
-    }
-    oldroot = m_title;
-    oldroot.append(fileroot);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-}
-
 bool ProjectData::put(xmlNodePtr cur)
 {
-  m_cur   = cur;
-  m_title = getXMLAttributeValue(cur, "id");
+  m_cur_ = cur;
+  title_ = getXMLAttributeValue(cur, "id");
   const std::string series_str(getXMLAttributeValue(cur, "series"));
   if (!series_str.empty())
-    m_series = std::stoi(series_str);
+    series_index_ = std::stoi(series_str);
 
   std::string driver_version_str;
   ParameterSet m_param;
@@ -207,39 +110,155 @@ bool ProjectData::put(xmlNodePtr cur)
     }
     if (cname == "host")
     {
-      m_host = getHostName();
-      const XMLNodeString node_string(m_host);
+      host_ = getHostName();
+      const XMLNodeString node_string(host_);
       node_string.setXMLNodeContent(cur);
     }
     if (cname == "date")
     {
-      m_date = getDateAndTime();
-      const XMLNodeString node_string(m_date);
+      date_ = getDateAndTime();
+      const XMLNodeString node_string(date_);
       node_string.setXMLNodeContent(cur);
     }
     cur = cur->next;
   }
   ///second, add xml nodes, if missing
-  if (m_host == "none")
+  if (host_ == "none")
   {
-    m_host = getHostName();
-    xmlNewChild(m_cur, m_cur->ns, (const xmlChar*)"host", (const xmlChar*)(m_host.c_str()));
+    host_ = getHostName();
+    xmlNewChild(m_cur_, m_cur_->ns, (const xmlChar*)"host", (const xmlChar*)(host_.c_str()));
   }
-  if (m_date == "none")
+  if (date_ == "none")
   {
-    m_date = getDateAndTime();
-    xmlNewChild(m_cur, m_cur->ns, (const xmlChar*)"date", (const xmlChar*)(m_date.c_str()));
+    date_ = getDateAndTime();
+    xmlNewChild(m_cur_, m_cur_->ns, (const xmlChar*)"date", (const xmlChar*)(date_.c_str()));
   }
   reset();
   return true;
 }
 
+void ProjectData::reset()
+{
+  int nproc   = my_comm_->size();
+  int nodeid  = my_comm_->rank();
+  int groupid = my_comm_->getGroupID();
+  char fileroot[256], nextroot[256];
+
+  bool no_gtag = (qmc_common.mpi_groups == 1);
+
+  const int length = no_gtag ? sprintf(fileroot, "%s.s%03d", title_.c_str(), series_index_)
+                             : sprintf(fileroot, "%s.g%03d.s%03d", title_.c_str(), groupid, series_index_);
+
+  project_main_ = std::string(fileroot, length);
+  //set the communicator name
+  my_comm_->setName(fileroot);
+  if (no_gtag)
+  {
+    if (nproc > 1)
+    {
+      sprintf(fileroot, ".s%03d.p%03d", series_index_, nodeid);
+      sprintf(nextroot, ".s%03d.p%03d", series_index_ + 1, nodeid);
+    }
+    else
+    {
+      sprintf(fileroot, ".s%03d", series_index_);
+      sprintf(nextroot, ".s%03d", series_index_ + 1);
+    }
+  }
+  else
+  {
+    if (nproc > 1)
+    {
+      sprintf(fileroot, ".g%03d.s%03d.p%03d", groupid, series_index_, nodeid);
+      sprintf(nextroot, ".g%03d.s%03d.p%03d", groupid, series_index_ + 1, nodeid);
+    }
+    else
+    {
+      sprintf(fileroot, ".g%03d.s%03d", groupid, series_index_);
+      sprintf(nextroot, ".g%03d.s%03d", groupid, series_index_ + 1);
+    }
+  }
+  project_root_ = title_;
+  project_root_.append(fileroot);
+  next_root_ = title_;
+  next_root_.append(nextroot);
+  std::stringstream s;
+  s << series_index_ + 1;
+  if (m_cur_)
+    xmlSetProp(m_cur_, (const xmlChar*)"series", (const xmlChar*)(s.str().c_str()));
+}
+
+void ProjectData::advance()
+{
+  series_index_++;
+  reset();
+}
+
+void ProjectData::rewind()
+{
+  if (series_index_ > 0)
+    series_index_--;
+  reset();
+}
+
+void ProjectData::setCommunicator(Communicate* c) noexcept { my_comm_ = c; }
+
+const std::string& ProjectData::getTitle() const noexcept { return title_; }
+
+const std::string& ProjectData::currentMainRoot() const noexcept { return project_main_; }
+
+const std::string& ProjectData::nextRoot() const noexcept { return next_root_; }
+
+bool ProjectData::previousRoot(std::string& oldroot) const
+{
+  oldroot.erase(oldroot.begin(), oldroot.end());
+  if (series_index_)
+  {
+    char fileroot[128];
+    const int nproc    = my_comm_->size();
+    int nodeid         = my_comm_->rank();
+    int groupid        = my_comm_->getGroupID();
+    const bool no_gtag = (qmc_common.mpi_groups == 1);
+
+    if (no_gtag)
+    {
+      if (nproc > 1)
+        sprintf(fileroot, ".s%03d.p%03d", series_index_ - 1, nodeid);
+      else
+        sprintf(fileroot, ".s%03d", series_index_ - 1);
+    }
+    else
+    {
+      if (nproc > 1)
+        sprintf(fileroot, ".g%03d.s%03d.p%03d", groupid, series_index_ - 1, nodeid);
+      else
+        sprintf(fileroot, ".g%03d.s%03d", groupid, series_index_ - 1);
+    }
+    oldroot = title_;
+    oldroot.append(fileroot);
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+int ProjectData::getSeriesIndex() const noexcept { return series_index_; }
+
+int ProjectData::getMaxCPUSeconds() const noexcept { return max_cpu_secs_; }
+
+ProjectData::DriverVersion ProjectData::getDriverVersion() const noexcept { return driver_version_; }
+
+bool ProjectData::isComplex() const noexcept { return is_complex_; }
+
+// PRIVATE
 ProjectData::DriverVersion ProjectData::lookupDriverVersion(const std::string& enum_value)
 {
   std::string enum_value_str(lowerCase(enum_value));
   try
   {
-    return lookup_input_enum_value.at(enum_value_str);
+    return lookup_input_enum_value_.at(enum_value_str);
   }
   catch (std::out_of_range& oor_exc)
   {

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -250,7 +250,8 @@ int ProjectData::getMaxCPUSeconds() const noexcept { return max_cpu_secs_; }
 
 ProjectData::DriverVersion ProjectData::getDriverVersion() const noexcept { return driver_version_; }
 
-bool ProjectData::isComplex() const noexcept { return is_complex_; }
+// STATIC PUBLIC
+bool ProjectData::isComplex() noexcept { return is_complex_; }
 
 // PRIVATE
 ProjectData::DriverVersion ProjectData::lookupDriverVersion(const std::string& enum_value)

--- a/src/Utilities/ProjectData.h
+++ b/src/Utilities/ProjectData.h
@@ -103,7 +103,7 @@ public:
    * true: complex run
    * false: real run (default)
    */
-  static bool isComplex() noexcept;
+  bool isComplex() const noexcept;
 
 private:
   static const std::unordered_map<std::string, DriverVersion> lookup_input_enum_value_;
@@ -147,7 +147,7 @@ private:
    * true: complex run
    * false: real run (default)
    */
-  static const bool is_complex_;
+  const bool is_complex_;
 
   static DriverVersion lookupDriverVersion(const std::string& enum_value);
 };

--- a/src/Utilities/ProjectData.h
+++ b/src/Utilities/ProjectData.h
@@ -23,41 +23,29 @@
 
 namespace qmcplusplus
 {
-/**class ProjectData
- *\brief Encapsulate data for a project
+/**
+ * @brief Encapsulate data for a project
  *
- * Default: m_title = getDateAndTime("%Y%m%dT%H%M")
+ * Default: m_title_ = getDateAndTime("%Y%m%dT%H%M")
  *
- * \todo This shouldn't contain MPI information it is only used to calculate the
+ * @todo This shouldn't contain MPI information it is only used to calculate the
  *       path information and the communication parameters should just be input params to that call.
  *       This reduce the internal state.
  */
 class ProjectData
 {
 public:
-
-/** Enum for global scope switch of design from legacy driver based to batch driver based.
- *  This effects more than just which drivers are used. Currently it just effects the meaning of
- *  qmc section vmc, dmc, linear name attributes.
- */
-enum class DriverVersion
-{
-  LEGACY,
-  BATCH
-};
-
-private:
-  inline static const std::unordered_map<std::string, DriverVersion> lookup_input_enum_value{{"legacy",
-                                                                                            DriverVersion::LEGACY},
-                                                                                           {"batch",
-                                                                                            DriverVersion::BATCH},
-                                                                                           {"batched",
-                                                                                            DriverVersion::BATCH}
-
+  /**
+   *  Enum for global scope switch of design from legacy driver based to batch driver based.
+   *  This effects more than just which drivers are used. Currently it just effects the meaning of
+   *  qmc section vmc, dmc, linear name attributes. 
+   **/
+  enum class DriverVersion
+  {
+    LEGACY,
+    BATCH
   };
 
-public:
-  /// constructor
   ProjectData(const std::string& atitle = "", DriverVersion de = DriverVersion::LEGACY);
 
   bool get(std::ostream& os) const;
@@ -65,76 +53,103 @@ public:
   bool put(xmlNodePtr cur);
   void reset();
 
-  ///increment a series number and reset m_projectroot
+  /**
+   * @brief increment a series number and reset project_root_
+   */
   void advance();
 
-  ///roll-back a series number and reset m_projectroot by one
+  /**
+   * @brief roll-back a series number and reset project_root_ by one
+   */
   void rewind();
 
-  void setCommunicator(Communicate* c);
+  void setCommunicator(Communicate* c) noexcept;
 
-  /** returns the title of the project
+  /** 
+   * @brief returns the title of the project
    * <project id="det_qmc_short_sdbatch_vmcbatch_mwalkers" series="0">
-   * translate to m_title = "det_qmc_short_sdbatch_vmcbatch_mwalkers"
+   * translate to m_title_ = "det_qmc_short_sdbatch_vmcbatch_mwalkers"
    */
-  inline const std::string& getTitle() const { return m_title; }
+  const std::string& getTitle() const noexcept;
 
-  /** returns the projectmain of the project, the series id is incremented at every QMC section
+  /** 
+   * @brief returns the projectmain of the project, the series id is incremented at every QMC section
    * <project id="det_qmc_short_sdbatch_vmcbatch_mwalkers" series="0">
-   * translate to m_projectmain = "det_qmc_short_sdbatch_vmcbatch_mwalkers.s000"
+   * translate to project_main_ = "det_qmc_short_sdbatch_vmcbatch_mwalkers.s000"
    */
-  inline const std::string& CurrentMainRoot() const { return m_projectmain; }
+  const std::string& currentMainRoot() const noexcept;
 
-  /** returns the nextroot of the project, the series id is incremented at every QMC section
+  /** 
+   * @brief returns the nextroot of the project, the series id is incremented at every QMC section
    * <project id="det_qmc_short_sdbatch_vmcbatch_mwalkers" series="0">
-   * translate to m_projectmain = "det_qmc_short_sdbatch_vmcbatch_mwalkers.s001"
+   * translate to project_main_ = "det_qmc_short_sdbatch_vmcbatch_mwalkers.s001"
    */
-  inline const std::string& NextRoot() const { return m_nextroot; }
+  const std::string& nextRoot() const noexcept;
 
-  /** return the root of the previous sequence
-   * @param oldroot is composed by the m_title and m_series
+  /** 
+   * @brief return the root of the previous sequence
+   * @param oldroot is composed by the m_title_ and series_index_
    */
-  bool PreviousRoot(std::string& oldroot) const;
+  bool previousRoot(std::string& oldroot) const;
 
-  int getSeriesIndex() const { return m_series; }
-  int getMaxCPUSeconds() const { return max_cpu_secs_; }
-  DriverVersion get_driver_version() const { return driver_version_; }
+  int getSeriesIndex() const noexcept;
+
+  int getMaxCPUSeconds() const noexcept;
+
+  DriverVersion getDriverVersion() const noexcept;
+
+  /**
+   * @brief Check if simulation run is real or complex
+   * true: complex run
+   * false: real run (default)
+   */
+  bool isComplex() const noexcept;
 
 private:
-  static DriverVersion lookupDriverVersion(const std::string& enum_value);
+  static const std::unordered_map<std::string, DriverVersion> lookup_input_enum_value_;
 
   ///title of the project
-  std::string m_title;
+  std::string title_;
 
   ///name of the host where the job is running
-  std::string m_host;
+  std::string host_;
 
   ///date when the job is executed
-  std::string m_date;
+  std::string date_;
 
   ///main root for all the output engines
-  std::string m_projectmain;
+  std::string project_main_;
 
   ///processor-dependent root for all the output engines
-  std::string m_projectroot;
+  std::string project_root_;
 
   ///root for the next run
-  std::string m_nextroot;
+  std::string next_root_;
 
   ///series index
-  int m_series;
+  int series_index_;
 
   ///communicator
-  Communicate* myComm;
+  Communicate* my_comm_;
 
   ///the xml node for <Project/>
-  xmlNodePtr m_cur;
+  xmlNodePtr m_cur_;
 
   ///max cpu seconds
   int max_cpu_secs_;
 
   // The driver version of the project
   DriverVersion driver_version_;
+
+  /**
+   * @brief runtime variable to track real or complex runs using a single compiled qmcpack executable
+   * @todo remove/rethink its "const" nature
+   * true: complex run
+   * false: real run (default)
+   */
+  static const bool is_complex_;
+
+  static DriverVersion lookupDriverVersion(const std::string& enum_value);
 };
 } // namespace qmcplusplus
 

--- a/src/Utilities/ProjectData.h
+++ b/src/Utilities/ProjectData.h
@@ -103,7 +103,7 @@ public:
    * true: complex run
    * false: real run (default)
    */
-  bool isComplex() const noexcept;
+  static bool isComplex() noexcept;
 
 private:
   static const std::unordered_map<std::string, DriverVersion> lookup_input_enum_value_;

--- a/src/Utilities/tests/test_project_data.cpp
+++ b/src/Utilities/tests/test_project_data.cpp
@@ -138,10 +138,11 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
 
 TEST_CASE("ProjectData::TestIsComplex", "[ohmmsapp]")
 {
+  ProjectData proj;
 #ifdef QMC_COMPLEX
-  REQUIRE(ProjectData::isComplex());
+  REQUIRE(proj.isComplex());
 #else
-  REQUIRE(!ProjectData::isComplex());
+  REQUIRE(!proj.isComplex());
 #endif
 }
 

--- a/src/Utilities/tests/test_project_data.cpp
+++ b/src/Utilities/tests/test_project_data.cpp
@@ -89,7 +89,8 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
   {
     ProjectData proj;
 
-    const char* xml_input = "<project id='test1' series='1'><parameter name='driver_version'>batch</parameter></project>";
+    const char* xml_input =
+        "<project id='test1' series='1'><parameter name='driver_version'>batch</parameter></project>";
     Libxml2Document doc;
     bool okay = doc.parseFromString(xml_input);
     REQUIRE(okay);
@@ -98,12 +99,12 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
 
     proj.put(root);
     REQUIRE(proj.getSeriesIndex() == 1);
-    REQUIRE(proj.get_driver_version() == DV::BATCH);
+    REQUIRE(proj.getDriverVersion() == DV::BATCH);
   }
   SECTION("driver version legacy")
   {
-      ProjectData proj;
-      REQUIRE(proj.get_driver_version() == DV::LEGACY);    
+    ProjectData proj;
+    REQUIRE(proj.getDriverVersion() == DV::LEGACY);
 
     const char* xml_input =
         "<project id='test1' series='1'><parameter name='driver_version'>legacy</parameter></project>";
@@ -115,7 +116,7 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
 
     proj.put(root);
     REQUIRE(proj.getSeriesIndex() == 1);
-    REQUIRE(proj.get_driver_version() == DV::LEGACY);    
+    REQUIRE(proj.getDriverVersion() == DV::LEGACY);
   }
   SECTION("driver version bad value")
   {

--- a/src/Utilities/tests/test_project_data.cpp
+++ b/src/Utilities/tests/test_project_data.cpp
@@ -136,5 +136,14 @@ TEST_CASE("ProjectData::TestDriverVersion", "[ohmmsapp]")
   // host and date nodes get added for output to the .cont.xml file
 }
 
+TEST_CASE("ProjectData::TestIsComplex", "[ohmmsapp]")
+{
+#ifdef QMC_COMPLEX
+  REQUIRE(ProjectData::isComplex());
+#else
+  REQUIRE(!ProjectData::isComplex());
+#endif
+}
+
 
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

- Refactor ProjectData class to meet coding standards
- Add `is_complex` static variable for start migration from compile-time `QMC_COMPLEX`
- Add unit test

Related to #4099 

## What type(s) of changes does this code introduce?

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 20, must pass CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
