### PR TITLE
DiracDeterminantBatched xxxWithSpin APIs

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBase.h
@@ -161,12 +161,12 @@ public:
 
   PsiValueType ratioGradWithSpin(ParticleSet& P, int iat, GradType& grad_iat, ComplexType& spingrad) override
   {
-    APP_ABORT("  DiracDeterminantBase::ratioGradWithSpins():  Implementation required\n");
+    APP_ABORT("  DiracDeterminantBase::ratioGradWithSpin():  Implementation required\n");
     return 0.0;
   }
   GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) override
   {
-    APP_ABORT("  DiracDeterminantBase::evalGradWithSpins():  Implementation required\n");
+    APP_ABORT("  DiracDeterminantBase::evalGradWithSpin():  Implementation required\n");
     return GradType();
   }
   /** cloning function

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -137,6 +137,8 @@ public:
                    int iat,
                    std::vector<Grad>& grad_now) const override;
 
+  Grad evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) final;
+
   /** \todo would be great to have docs.
    *  Note: Can result in substantial CPU memory allocation on first call.
    *  31 * n^2 * sizeof(Value) bytes per DDB
@@ -267,6 +269,8 @@ public:
   Vector<Grad> dpsiV_host_view;
   DualVector<Value> d2psiV;
   Vector<Value> d2psiV_host_view;
+  DualVector<Value> dspin_psiV;
+  Vector<Value> dspin_psiV_host_view;
 
   /// psi(r')/psi(r) during a PbyP move
   PsiValue curRatio;

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -130,6 +130,8 @@ public:
                     std::vector<PsiValue>& ratios,
                     std::vector<Grad>& grad_new) const override;
 
+  PsiValue ratioGradWithSpin(ParticleSet& P, int iat, Grad& grad_iat, ComplexType& spingrad) override;
+
   Grad evalGrad(ParticleSet& P, int iat) override;
 
   void mw_evalGrad(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
@@ -137,7 +139,7 @@ public:
                    int iat,
                    std::vector<Grad>& grad_now) const override;
 
-  Grad evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) final;
+  Grad evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad) override;
 
   /** \todo would be great to have docs.
    *  Note: Can result in substantial CPU memory allocation on first call.

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -18,6 +18,8 @@
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #include "QMCWaveFunctions/Fermion/DiracDeterminantBatched.h"
 #include "QMCWaveFunctions/tests/FakeSPO.h"
+#include "QMCWaveFunctions/SpinorSet.h"
+#include "QMCWaveFunctions/ElectronGas/FreeOrbital.h"
 #include "checkMatrix.hpp"
 #include <ResourceCollection.h>
 
@@ -25,6 +27,7 @@ namespace qmcplusplus
 {
 using RealType     = QMCTraits::RealType;
 using ValueType    = QMCTraits::ValueType;
+using ComplexType  = QMCTraits::ComplexType;
 using PosType      = QMCTraits::PosType;
 using GradType     = QMCTraits::GradType;
 using LogValueType = std::complex<QMCTraits::QTFull::RealType>;
@@ -480,4 +483,236 @@ TEST_CASE("DiracDeterminantBatched_delayed_update", "[wavefunction][fermion]")
   test_DiracDeterminantBatched_delayed_update<
       MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(2, DetMatInvertor::HOST);
 }
+
+
+#ifdef QMC_COMPLEX
+template<class DET_ENGINE>
+void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInvertor matrix_inverter_kind)
+{
+
+  std::cout << "Hello from test" << std::endl;
+  using ParticlePos       = ParticleSet::ParticlePos;
+  using ParticleGradient  = ParticleSet::ParticleGradient;
+  using ParticleLaplacian = ParticleSet::ParticleLaplacian;
+
+  // O2 test example from pwscf non-collinear calculation.
+  ParticleSet::ParticleLayout lattice;
+  lattice.R(0, 0) = 5.10509515;
+  lattice.R(0, 1) = -3.23993545;
+  lattice.R(0, 2) = 0.00000000;
+  lattice.R(1, 0) = 5.10509515;
+  lattice.R(1, 1) = 3.23993545;
+  lattice.R(1, 2) = 0.00000000;
+  lattice.R(2, 0) = -6.49690625;
+  lattice.R(2, 1) = 0.00000000;
+  lattice.R(2, 2) = 7.08268015;
+
+  //Shamelessly stealing this from test_einset.cpp.  3 particles though.
+  const SimulationCell simulation_cell(lattice);
+  ParticleSet ions_(simulation_cell);
+  ParticleSet elec_(simulation_cell);
+  ions_.setName("ion");
+  ions_.create({2});
+
+  ions_.R[0][0] = 0.00000000;
+  ions_.R[0][1] = 0.00000000;
+  ions_.R[0][2] = 1.08659253;
+  ions_.R[1][0] = 0.00000000;
+  ions_.R[1][1] = 0.00000000;
+  ions_.R[1][2] = -1.08659253;
+
+  elec_.setName("elec");
+  elec_.create({3});
+  elec_.R[0][0] = 0.1;
+  elec_.R[0][1] = -0.3;
+  elec_.R[0][2] = 1.0;
+  elec_.R[1][0] = -0.1;
+  elec_.R[1][1] = 0.3;
+  elec_.R[1][2] = 1.0;
+  elec_.R[2][0] = 0.1;
+  elec_.R[2][1] = 0.2;
+  elec_.R[2][2] = 0.3;
+
+  elec_.spins[0] = 0.0;
+  elec_.spins[1] = 0.2;
+  elec_.spins[2] = 0.4;
+  elec_.setSpinor(true);
+
+  SpeciesSet& tspecies       = elec_.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  tspecies(chargeIdx, upIdx) = -1;
+
+  elec_.addTable(ions_);
+  elec_.resetGroups();
+  elec_.update();
+  // </steal>
+
+
+  const auto nelec = elec_.R.size();
+  //Our test case is going to be three electron gas orbitals distinguished by 3 different kpoints.
+  //Independent SPO's for the up and down channels.
+  //
+  std::vector<PosType> kup, kdn;
+  std::vector<RealType> k2up, k2dn;
+
+
+  kup.resize(nelec);
+  kup[0] = PosType(0, 0, 0);
+  kup[1] = PosType(0.1, 0.2, 0.3);
+  kup[2] = PosType(0.4, 0.5, 0.6);
+
+  kdn.resize(nelec);
+  kdn[0] = PosType(0, 0, 0);
+  kdn[1] = PosType(-0.1, 0.2, -0.3);
+  kdn[2] = PosType(0.4, -0.5, 0.6);
+
+  auto spo_up = std::make_unique<FreeOrbital>("free_orb_up", kup);
+  auto spo_dn = std::make_unique<FreeOrbital>("free_orb_up", kdn);
+
+  auto spinor_set = std::make_unique<SpinorSet>("free_orb_spinor");
+  spinor_set->set_spos(std::move(spo_up), std::move(spo_dn));
+
+  using DetType  = DiracDeterminantBatched<DET_ENGINE>;
+  DetType dd(std::move(spinor_set), 0, nelec, delay_rank, matrix_inverter_kind);
+  app_log() << " nelec=" << nelec << std::endl;
+
+  ParticleGradient G;
+  ParticleLaplacian L;
+  ParticleAttrib<ComplexType> SG;
+
+  G.resize(nelec);
+  L.resize(nelec);
+  SG.resize(nelec);
+
+  G  = 0.0;
+  L  = 0.0;
+  SG = 0.0;
+
+  PosType dr(0.1, -0.05, 0.2);
+  RealType ds = 0.3;
+
+  app_log() << " BEFORE\n";
+  app_log() << " R = " << elec_.R << std::endl;
+  app_log() << " s = " << elec_.spins << std::endl;
+
+  //In this section, we're going to test that values and various derivatives come out
+  //correctly at the reference configuration.
+
+  LogValueType logref = dd.evaluateLog(elec_, G, L);
+
+  REQUIRE(logref == ComplexApprox(ValueType(-1.1619939279564413, 0.8794794652468605)));
+  REQUIRE(G[0][0] == ComplexApprox(ValueType(0.13416635, 0.2468612)));
+  REQUIRE(G[0][1] == ComplexApprox(ValueType(-1.1165475, 0.71497753)));
+  REQUIRE(G[0][2] == ComplexApprox(ValueType(0.0178403, 0.08212244)));
+  REQUIRE(G[1][0] == ComplexApprox(ValueType(1.00240841, 0.12371593)));
+  REQUIRE(G[1][1] == ComplexApprox(ValueType(1.62679698, -0.41080777)));
+  REQUIRE(G[1][2] == ComplexApprox(ValueType(1.81324632, 0.78589013)));
+  REQUIRE(G[2][0] == ComplexApprox(ValueType(-1.10994555, 0.15525902)));
+  REQUIRE(G[2][1] == ComplexApprox(ValueType(-0.46335602, -0.50809713)));
+  REQUIRE(G[2][2] == ComplexApprox(ValueType(-1.751199, 0.10949589)));
+  REQUIRE(L[0] == ComplexApprox(ValueType(-2.06554158, 1.18145239)));
+  REQUIRE(L[1] == ComplexApprox(ValueType(-5.06340536, 0.82126749)));
+  REQUIRE(L[2] == ComplexApprox(ValueType(-4.82375261, -1.97943258)));
+
+  //This is a workaround for the fact that I haven't implemented
+  // evaluateLogWithSpin().  Shouldn't be needed unless we do drifted all-electron moves...
+  for (int iat = 0; iat < nelec; iat++)
+    dd.evalGradWithSpin(elec_, iat, SG[iat]);
+
+  REQUIRE(SG[0] == ComplexApprox(ValueType(-1.05686704, -2.01802154)));
+  REQUIRE(SG[1] == ComplexApprox(ValueType(1.18922259, 2.80414598)));
+  REQUIRE(SG[2] == ComplexApprox(ValueType(-0.62617675, -0.51093984)));
+
+  GradType g_singleeval(0.0);
+  g_singleeval = dd.evalGrad(elec_, 1);
+
+  REQUIRE(g_singleeval[0] == ComplexApprox(G[1][0]));
+  REQUIRE(g_singleeval[1] == ComplexApprox(G[1][1]));
+  REQUIRE(g_singleeval[2] == ComplexApprox(G[1][2]));
+
+
+  //And now we're going to propose a trial spin+particle move and check the ratio and gradients at the
+  //new location.
+  //
+  elec_.makeMoveAndCheckWithSpin(1, dr, ds);
+
+  ValueType ratio_new;
+  ValueType spingrad_new;
+  GradType grad_new;
+
+  //This tests ratio only evaluation.  Indirectly a call to evaluate(P,iat)
+  ratio_new = dd.ratio(elec_, 1);
+  REQUIRE(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
+
+  ratio_new = dd.ratioGrad(elec_, 1, grad_new);
+  REQUIRE(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
+  REQUIRE(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
+  REQUIRE(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
+  REQUIRE(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+
+  grad_new     = 0;
+  spingrad_new = 0;
+  ratio_new    = dd.ratioGradWithSpin(elec_, 1, grad_new, spingrad_new);
+  REQUIRE(ratio_new == ComplexApprox(ValueType(1.7472917722050971, 1.1900872950904169)));
+  REQUIRE(grad_new[0] == ComplexApprox(ValueType(0.5496675534224996, -0.07968022499097227)));
+  REQUIRE(grad_new[1] == ComplexApprox(ValueType(0.4927399293808675, -0.29971549854643653)));
+  REQUIRE(grad_new[2] == ComplexApprox(ValueType(1.2792642963632226, 0.12110307514989149)));
+  REQUIRE(spingrad_new == ComplexApprox(ValueType(1.164708841479661, 0.9576425115390172)));
+
+
+  //Cool.  Now we test the transition between rejecting a move and accepting a move.
+  //Reject the move first.  We want to see if everything stays the same.  evalGrad and evalSpinGrad for ease of use.
+
+  elec_.rejectMove(1);
+  //Going to check evalGrad and evalGradWithSpin for simplicity.
+  g_singleeval = dd.evalGrad(elec_, 1);
+  REQUIRE(g_singleeval[0] == ComplexApprox(G[1][0]));
+  REQUIRE(g_singleeval[1] == ComplexApprox(G[1][1]));
+  REQUIRE(g_singleeval[2] == ComplexApprox(G[1][2]));
+
+  ValueType spingrad_old_test;
+  g_singleeval = dd.evalGradWithSpin(elec_, 1, spingrad_old_test);
+
+  REQUIRE(spingrad_old_test == ComplexApprox(SG[1]));
+  REQUIRE(g_singleeval[0] == ComplexApprox(G[1][0]));
+  REQUIRE(g_singleeval[1] == ComplexApprox(G[1][1]));
+  REQUIRE(g_singleeval[2] == ComplexApprox(G[1][2]));
+
+  //Now we test what happens if we accept a move...
+  elec_.makeMoveAndCheckWithSpin(1, dr, ds);
+  elec_.acceptMove(1);
+
+  LogValueType lognew(0.0);
+  G      = 0.0; //evalauteLog += onto the G and L arguments.  So we zero them out.
+  L      = 0.0;
+  SG     = 0.0;
+  lognew = dd.evaluateLog(elec_, G, L);
+
+  for (int iat = 0; iat < nelec; iat++)
+    dd.evalGradWithSpin(elec_, iat, SG[iat]);
+  //logval for the new configuration has been computed with python.
+  //The others reference values are computed earlier in this section.  New values equal the previous
+  // "new values" associated with the previous trial moves.
+  REQUIRE(lognew == ComplexApprox(ValueType(-0.41337396772929913, 1.4774106123071726)));
+  REQUIRE(G[1][0] == ComplexApprox(grad_new[0]));
+  REQUIRE(G[1][1] == ComplexApprox(grad_new[1]));
+  REQUIRE(G[1][2] == ComplexApprox(grad_new[2]));
+  REQUIRE(SG[1] == ComplexApprox(spingrad_new));
+}
+
+TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")
+{
+#if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
+  test_DiracDeterminantBatched_spinor_update<
+      MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::ACCEL);
+  test_DiracDeterminantBatched_spinor_update<
+      MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::HOST);
+#endif
+  test_DiracDeterminantBatched_spinor_update<
+      MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::ACCEL);
+  test_DiracDeterminantBatched_spinor_update<
+      MatrixUpdateOMPTarget<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::HOST);
+}
+#endif
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -490,7 +490,6 @@ template<class DET_ENGINE>
 void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInvertor matrix_inverter_kind)
 {
 
-  std::cout << "Hello from test" << std::endl;
   using ParticlePos       = ParticleSet::ParticlePos;
   using ParticleGradient  = ParticleSet::ParticleGradient;
   using ParticleLaplacian = ParticleSet::ParticleLaplacian;
@@ -699,6 +698,8 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   REQUIRE(G[1][1] == ComplexApprox(grad_new[1]));
   REQUIRE(G[1][2] == ComplexApprox(grad_new[2]));
   REQUIRE(SG[1] == ComplexApprox(spingrad_new));
+
+  //TODO: add batched APIs and test
 }
 
 TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -513,24 +513,14 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   ions_.setName("ion");
   ions_.create({2});
 
-  ions_.R[0][0] = 0.00000000;
-  ions_.R[0][1] = 0.00000000;
-  ions_.R[0][2] = 1.08659253;
-  ions_.R[1][0] = 0.00000000;
-  ions_.R[1][1] = 0.00000000;
-  ions_.R[1][2] = -1.08659253;
+  ions_.R[0] = {0.00000000, 0.00000000, 1.08659253};
+  ions_.R[1] = {0.00000000, 0.00000000, -1.08659253};
 
   elec_.setName("elec");
   elec_.create({3});
-  elec_.R[0][0] = 0.1;
-  elec_.R[0][1] = -0.3;
-  elec_.R[0][2] = 1.0;
-  elec_.R[1][0] = -0.1;
-  elec_.R[1][1] = 0.3;
-  elec_.R[1][2] = 1.0;
-  elec_.R[2][0] = 0.1;
-  elec_.R[2][1] = 0.2;
-  elec_.R[2][2] = 0.3;
+  elec_.R[0] = {0.1, -0.3, 1.0};
+  elec_.R[1] = {-0.1, 0.3, 1.0};
+  elec_.R[2] = {0.1, 0.2, 0.3;
 
   elec_.spins[0] = 0.0;
   elec_.spins[1] = 0.2;

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -520,7 +520,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
   elec_.create({3});
   elec_.R[0] = {0.1, -0.3, 1.0};
   elec_.R[1] = {-0.1, 0.3, 1.0};
-  elec_.R[2] = {0.1, 0.2, 0.3;
+  elec_.R[2] = {0.1, 0.2, 0.3};
 
   elec_.spins[0] = 0.0;
   elec_.spins[1] = 0.2;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
 Part of #3712, this adds a unit test for DiracDeterminantBatched for the spinor orbital case. Essentially, it uses the same values from the DiracDeterminant unit test. For now, I have only added the single walker APIs for evalGradWithSpin and ratioGradWithSpin. Will add the actual mw_ APIs in a separate PR
 
## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
MacBook Pro, M1 Pro chip
## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
