### PR TITLE
Fix LCAOrbitalSet::evaluateDetRatios and clean up Numerics/MatrixOperators.h

### DIFF
--- a/src/Numerics/MatrixOperators.h
+++ b/src/Numerics/MatrixOperators.h
@@ -26,15 +26,6 @@
 
 namespace qmcplusplus
 {
-template<typename T>
-inline T TESTDOT(const T* restrict f, const T* restrict l, const T* restrict b)
-{
-  T s = 0;
-  while (f != l)
-    s += (*f++) * (*b++);
-  return s;
-}
-
 namespace MatrixOperators
 {
 /** static function to perform C=AB for real matrices
@@ -173,45 +164,23 @@ inline void product(const Matrix<double>& A, const Matrix<std::complex<double>>&
 /** static function to perform y=Ax for generic matrix and vector
    */
 template<typename T>
-inline void product(const Matrix<T>& A, const Vector<T>& x, T* restrict yptr)
+inline void product(const Matrix<T>& A, const Vector<T>& x, Vector<T>& y)
 {
   const char transa = 'T';
   const T one       = 1.0;
   const T zero      = 0.0;
-  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), x.data(), 1, zero, yptr, 1);
+  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), x.data(), 1, zero, y.data(), 1);
 }
 
 /** static function to perform y = A^t x for generic matrix and vector
    */
 template<typename T>
-inline void product_Atx(const Matrix<T>& A, const Vector<T>& x, T* restrict yptr)
+inline void product_Atx(const Matrix<T>& A, const Vector<T>& x, Vector<T>& y)
 {
   const char transa = 'N';
   const T one       = 1.0;
   const T zero      = 0.0;
-  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), x.data(), 1, zero, yptr, 1);
-}
-
-/** static function to perform y=Ax for generic matrix and vector
-   */
-template<typename T>
-inline void product(const Matrix<T>& A, const T* restrict xptr, T* restrict yptr)
-{
-  const char transa = 'T';
-  const T one       = 1.0;
-  const T zero      = 0.0;
-  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), xptr, 1, zero, yptr, 1);
-}
-
-/** static function to perform y = A^t x for generic matrix and vector
-   */
-template<typename T>
-inline void product_Atx(const Matrix<T>& A, const T* restrict xptr, T* restrict yptr)
-{
-  const char transa = 'N';
-  const T one       = 1.0;
-  const T zero      = 0.0;
-  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), xptr, 1, zero, yptr, 1);
+  BLAS::gemv(transa, A.cols(), A.rows(), one, A.data(), A.cols(), x.data(), 1, zero, y.data(), 1);
 }
 
 /** static function to perform y=Ax for generic matrix and vector
@@ -294,73 +263,7 @@ inline void product(const Matrix<std::complex<double>>& A, const Vector<double>&
   }
 }
 
-inline void product(const Matrix<std::complex<double>>& A,
-                    const std::complex<double>* restrict x,
-                    std::complex<double>* restrict yptr)
-{
-  const char transa = 'T';
-  const std::complex<double> zone(1.0, 0.0);
-  const std::complex<double> zero(0.0, 0.0);
-  zgemv(transa, A.cols(), A.rows(), zone, A.data(), A.cols(), x, 1, zero, yptr, 1);
-}
-
-/** static function to perform y=Ax for generic matrix and vector
-   */
-inline void product(const Matrix<double>& A, const Vector<std::complex<double>>& x, double* restrict yptr)
-{
-  std::cerr << " Undefined C=AB with real A and complex x " << std::endl;
-}
-
-template<typename T>
-inline void product(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, std::vector<int>& offset)
-{
-  int nr = C.rows();
-  int nb = offset.size() - 1;
-  for (int i = 0; i < nr; i++)
-  {
-    for (int b = 0; b < nb; b++)
-    {
-      int firstK               = offset[b];
-      int lastK                = offset[b + 1];
-      const T* restrict firstY = A[i] + firstK;
-      const T* restrict lastY  = A[i] + lastK;
-      for (int k = firstK; k < lastK; k++)
-      {
-        C(i, k) = TESTDOT(firstY, lastY, B[k] + firstK);
-      }
-    }
-  }
-}
-
-//    template<typename T>
-//      inline statis void product(const Matrix<T>& A, const T* restrict x, T* restrict y)
-//      {
-//        GEMV<T,0>::apply(A.data(),x,y,A.rows(),A.cols());
-//      }
 } // namespace MatrixOperators
-
-/** API to handle gemv */
-namespace simd
-{
-template<typename T>
-inline void gemv(const Matrix<T>& a, const T* restrict v, T* restrict b)
-{
-  MatrixOperators::product(a, v, b);
-}
-
-template<typename T, unsigned D>
-inline void gemv(const Matrix<T>& a, const TinyVector<T, D>* restrict v, TinyVector<T, D>* restrict b)
-{
-  MatrixOperators::product(a, v, b);
-}
-
-template<typename T, unsigned D>
-inline void gemv(const Matrix<T>& a, const Tensor<T, D>* restrict v, Tensor<T, D>* restrict b)
-{
-  MatrixOperators::product(a, v, b);
-}
-
-} // namespace simd
 
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/ForceCeperley.cpp
+++ b/src/QMCHamiltonians/ForceCeperley.cpp
@@ -76,7 +76,7 @@ void ForceCeperley::InitMatrix()
   // in Numerics/DeterminantOperators.h
   invert_matrix(Sinv, false);
   // in Numerics/MatrixOperators.h
-  MatrixOperators::product(Sinv, h.data(), c.data());
+  MatrixOperators::product(Sinv, h, c);
 }
 
 ForceCeperley::Return_t ForceCeperley::evaluate(ParticleSet& P)

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.cpp
@@ -68,7 +68,7 @@ void ForceChiesaPBCAA::InitMatrix()
   // in Numerics/DeterminantOperators.h
   invert_matrix(Sinv, false);
   // in Numerics/MatrixOperators.h
-  MatrixOperators::product(Sinv, h.data(), c.data());
+  MatrixOperators::product(Sinv, h, c);
 }
 
 void ForceChiesaPBCAA::initBreakup(ParticleSet& P)

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -461,7 +461,8 @@ void DiracDeterminant<DU_TYPE>::evaluateRatiosAlltoOne(ParticleSet& P, std::vect
 {
   ScopedTimer local_timer(SPOVTimer);
   Phi->evaluateValue(P, -1, psiV);
-  MatrixOperators::product(psiM, psiV.data(), &ratios[FirstIndex]);
+  Vector<ValueType> ratios_this_det(ratios.data() + FirstIndex, NumPtcls);
+  MatrixOperators::product(psiM, psiV, ratios_this_det);
 }
 
 

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -98,7 +98,7 @@ void LCAOrbitalSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& ps
     myBasisSet->evaluateV(P, iat, vTemp.data());
     assert(psi.size() <= OrbitalSetSize);
     ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
-    simd::gemv(C_partial_view, vTemp.data(), psi.data());
+    MatrixOperators::product(C_partial_view, vTemp, psi);
   }
 }
 
@@ -354,7 +354,9 @@ void LCAOrbitalSet::evaluateDetRatios(const VirtualParticleSet& VP,
   Vector<ValueType> vTemp(Temp.data(0), BasisSetSize);
   Vector<ValueType> invTemp(Temp.data(1), BasisSetSize);
 
-  MatrixOperators::product_Atx(*C, psiinv, invTemp.data());
+  // when only a subset of orbitals is used, extract limited rows of C.
+  Matrix<ValueType> C_occupied(C->data(), psiinv.size(), BasisSetSize);
+  MatrixOperators::product_Atx(C_occupied, psiinv, invTemp);
 
   for (size_t j = 0; j < VP.getTotalNum(); j++)
   {

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalSet.cpp
@@ -89,7 +89,7 @@ void PWOrbitalSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi
   //Evaluate the basis-set at these coordinates:
   //myBasisSet->evaluate(P,iat);
   myBasisSet->evaluate(P.activeR(iat));
-  MatrixOperators::product(*C, myBasisSet->Zv, &psi[0]);
+  MatrixOperators::product(*C, myBasisSet->Zv, psi);
 }
 
 void PWOrbitalSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi, GradVector& dpsi, ValueVector& d2psi)

--- a/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWRealOrbitalSet.cpp
@@ -90,7 +90,7 @@ void PWRealOrbitalSet::addVector(const std::vector<ComplexType>& coefs, int jorb
 void PWRealOrbitalSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& psi)
 {
   myBasisSet->evaluate(P.activeR(iat));
-  MatrixOperators::product(CC, myBasisSet->Zv, tempPsi.data());
+  MatrixOperators::product(CC, myBasisSet->Zv, tempPsi);
   for (int j = 0; j < OrbitalSetSize; j++)
     psi[j] = tempPsi[j].real();
 }

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -211,12 +211,13 @@ void test_Ne(bool transform)
 
     //std::cout << "basis set size = " << sposet->getBasisSetSize() << std::endl;
 
+    const int norbs = 5;
     SPOSet::ValueVector values;
     SPOSet::GradVector dpsi;
     SPOSet::ValueVector d2psi;
-    values.resize(5);
-    dpsi.resize(5);
-    d2psi.resize(5);
+    values.resize(norbs);
+    dpsi.resize(norbs);
+    d2psi.resize(norbs);
 
     ParticleSet::SingleParticlePos newpos(0.00001, 0.0, 0.0);
     elec.makeMove(0, newpos);
@@ -253,6 +254,19 @@ void test_Ne(bool transform)
     REQUIRE(dpsi[0][1] == Approx(0));
     REQUIRE(dpsi[0][2] == Approx(0));
     REQUIRE(d2psi[0] == Approx(-0.01551755818));
+
+    // when a determinant only contains a single particle.
+    SPOSet::ValueVector phi(1), phiinv(1);
+    phiinv[0] = 100;
+    VirtualParticleSet VP(elec, 2);
+    std::vector<ParticleSet::SingleParticlePos> newpos2(2);
+    std::vector<SPOSet::ValueType> ratios2(2);
+    newpos2[0] = disp;
+    newpos2[1] = -disp;
+    VP.makeMoves(0, elec.R[0], newpos2);
+    sposet->evaluateDetRatios(VP, phi, phiinv, ratios2);
+    CHECK(ratios2[0] == Approx(-0.504163137)); // values[0] * phiinv[0]
+    CHECK(ratios2[1] == Approx(-0.504163137)); // symmetric move
   }
 }
 


### PR DESCRIPTION
## Proposed changes
A bug found in LCAOrbitalSet::evaluateDetRatios.
Also removed many not necessary APIs in Numerics/MatrixOperators.h

## What type(s) of changes does this code introduce?
- Bugfix
- Build related changes
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'