### PR TITLE
Remove nonlocalpp and use_nonlocalpp_deriv in docs and tests

### DIFF
--- a/docs/lab_advanced_molecules.rst
+++ b/docs/lab_advanced_molecules.rst
@@ -880,7 +880,6 @@ Appendix C: Wavefunction optimization XML block
         <parameter name="bigchange">10.0</parameter>
         <estimator name="LocalEnergy" hdf5="no"/>
         <parameter name="usebuffer"> yes </parameter>
-        <parameter name="nonlocalpp"> yes </parameter>
         <parameter name="MinMethod">quartic</parameter>
         <parameter name="exp0">-6</parameter>
         <parameter name="alloweddifference"> 1.0e-5 </parameter>
@@ -894,8 +893,6 @@ Options:
 -  bigchange: (default 50.0) Largest parameter change allowed
 
 -  usebuffer: (default no) Save useful information during VMC
-
--  nonlocalpp: (default no) Include nonlocal energy on 1-D min
 
 -  MinMethod: (default quartic) Method to calculate magnitude of
    parameter change quartic: fit quartic polynomial to four values of

--- a/docs/lab_qmc_basics.rst
+++ b/docs/lab_qmc_basics.rst
@@ -347,8 +347,6 @@ The relevant portion of the input describing the linear optimization process is
       <parameter name="warmupSteps"    >  50       </parameter>
       <parameter name="blocks"         >  200      </parameter>
       <parameter name="subSteps"       >  1        </parameter>
-      <parameter name="nonlocalpp"     >  yes      </parameter>
-      <parameter name="useBuffer"      >  yes      </parameter>
       ...
     </qmc>
   </loop>
@@ -396,13 +394,6 @@ subSteps
    evaluation is expensive, so taking a few steps to decorrelate between
    measurements can be more efficient. Will be less efficient with many
    substeps.
-
-nonlocalpp,useBuffer
-   If ``nonlocalpp="no,"`` then the nonlocal part of the pseudopotential
-   is not included when computing the cost function. If
-   ``useBuffer="yes,"`` then temporary data is stored to speed up
-   nonlocal pseudopotential evaluation at the expense of memory
-   consumption.
 
 loop max
    Number of times to repeat the optimization. Using the resulting
@@ -962,8 +953,6 @@ Objects representing QMCPACK simulations are then constructed with the ``generat
                   warmupsteps          = 50,
                   blocks               = 200,
                   substeps             = 1,
-                  nonlocalpp           = True,
-                  usebuffer            = True,
                   walkers              = 1,
                   minwalkers           = 0.5,
                   maxweight            = 1e9,

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -519,9 +519,9 @@ The input parameters are listed in the following table.
   +--------------------------+--------------+-------------+-------------+--------------------------------------------------+
   | **Name**                 | **Datatype** | **Values**  | **Default** | **Description**                                  |
   +==========================+==============+=============+=============+==================================================+
-  | ``nonlocalpp``           | text         | yes, no     | no          | include non-local PP energy in the cost function |
+  | ``nonlocalpp``           | text         |             |             | No more effective. Will be removed.              |
   +--------------------------+--------------+-------------+-------------+--------------------------------------------------+
-  | ``use_nonlocalpp_deriv`` | text         | yes, no     | yes         | Add non-local PP energy derivative contribution  |
+  | ``use_nonlocalpp_deriv`` | text         |             |             | No more effective. Will be removed.              |
   +--------------------------+--------------+-------------+-------------+--------------------------------------------------+
   | ``minwalkers``           | real         | 0--1        | 0.3         | Lower bound of the effective weight              |
   +--------------------------+--------------+-------------+-------------+--------------------------------------------------+
@@ -532,13 +532,7 @@ Additional information:
 
 - ``maxWeight`` The default should be good.
 
-- ``nonlocalpp`` The ``nonlocalpp`` contribution to the local energy depends on the
-  wavefunction. When a new set of parameters is proposed, this
-  contribution needs to be updated if the cost function consists of local
-  energy. Fortunately, nonlocal contribution is chosen small when making a
-  PP for small locality error. We can ignore its change and avoid the
-  expensive computational cost. An implementation issue with legacy GPU code is
-  that a large amount of memory is consumed with this option.
+- ``nonlocalpp`` and ``use_nonlocalpp_deriv`` are obsolete and will be treated as invalid options (trigger application abort) in future releases. From this point forward, the code behaves as prior versions of qmcpack did when both were set to ``yes``.
 
 - ``minwalkers`` This is a ``critical`` parameter. When the ratio of effective samples to actual number of samples in a reweighting step goes lower than ``minwalkers``,
   the proposed set of parameters is invalid.

--- a/examples/molecules/He/he_bspline_jastrow.xml
+++ b/examples/molecules/He/he_bspline_jastrow.xml
@@ -86,7 +86,6 @@
       <parameter name="useDrift">  yes </parameter>
       <parameter name="bigchange">10.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">quartic</parameter>
       <parameter name="exp0">-6</parameter>
       <parameter name="alloweddifference"> 1.0e-5 </parameter>

--- a/examples/molecules/He/he_example_wf.xml
+++ b/examples/molecules/He/he_example_wf.xml
@@ -63,7 +63,6 @@
       <parameter name="useDrift">  yes </parameter>
       <parameter name="bigchange">10.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">quartic</parameter>
       <parameter name="exp0">-6</parameter>
       <parameter name="alloweddifference"> 1.0e-5 </parameter>

--- a/examples/molecules/He/he_from_gamess.xml
+++ b/examples/molecules/He/he_from_gamess.xml
@@ -2076,7 +2076,6 @@
       <parameter name="useDrift">  yes </parameter>
       <parameter name="bigchange">10.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">quartic</parameter>
       <parameter name="exp0">-6</parameter>
       <parameter name="alloweddifference"> 1.0e-5 </parameter>

--- a/examples/molecules/He/he_simple_opt.xml
+++ b/examples/molecules/He/he_simple_opt.xml
@@ -83,7 +83,6 @@
       <parameter name="useDrift">  yes </parameter>
       <parameter name="bigchange">10.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">quartic</parameter>
       <parameter name="exp0">-6</parameter>
       <parameter name="alloweddifference"> 1.0e-5 </parameter>

--- a/tests/molecules/C2_pp/opt_det_pp_msdj-H5-param-grad.xml
+++ b/tests/molecules/C2_pp/opt_det_pp_msdj-H5-param-grad.xml
@@ -31,8 +31,6 @@
     <parameter name="blocks">                 1 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="nonlocalpp">           yes </parameter>
-    <parameter name="use_nonlocalpp_deriv"> yes </parameter>
     <cost name="energy"> 1.0 </cost>
     <cost name="reweightedvariance"> 0.0 </cost>
   </qmc>

--- a/tests/molecules/H2_ae/h2_orb_opt.xml
+++ b/tests/molecules/H2_ae/h2_orb_opt.xml
@@ -25,7 +25,6 @@
       <parameter name="bigchange">15.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="usebuffer"> no </parameter>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">adaptive</parameter>
       <parameter name="shift_i"> 1.0 </parameter>
       <parameter name="shift_s"> 1.0 </parameter>

--- a/tests/molecules/H2_ae/h2_orb_opt_spindepjas.xml
+++ b/tests/molecules/H2_ae/h2_orb_opt_spindepjas.xml
@@ -25,7 +25,6 @@
       <parameter name="bigchange">15.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="usebuffer"> no </parameter>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">adaptive</parameter>
       <parameter name="shift_i"> 1.0 </parameter>
       <parameter name="shift_s"> 1.0 </parameter>

--- a/tests/molecules/H4_ae/H4_RHF_orb_opt.xml
+++ b/tests/molecules/H4_ae/H4_RHF_orb_opt.xml
@@ -25,7 +25,6 @@
       <parameter name="bigchange">15.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="usebuffer"> no </parameter>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">adaptive</parameter>
       <parameter name="shift_i"> 1.0 </parameter>
       <parameter name="shift_s"> 1.0 </parameter>

--- a/tests/molecules/H4_ae/H4_orb_opt.xml
+++ b/tests/molecules/H4_ae/H4_orb_opt.xml
@@ -25,7 +25,6 @@
       <parameter name="bigchange">15.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="usebuffer"> no </parameter>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">adaptive</parameter>
       <parameter name="shift_i"> 1.0 </parameter>
       <parameter name="shift_s"> 1.0 </parameter>

--- a/tests/molecules/H4_ae/H4_orb_opt_dmc.xml
+++ b/tests/molecules/H4_ae/H4_orb_opt_dmc.xml
@@ -25,7 +25,6 @@
       <parameter name="bigchange">15.0</parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="usebuffer"> no </parameter>
-      <parameter name="nonlocalpp"> yes </parameter>
       <parameter name="MinMethod">adaptive</parameter>
       <parameter name="shift_i"> 1.0 </parameter>
       <parameter name="shift_s"> 1.0 </parameter>

--- a/tests/molecules/H4_ae/batched-hybrid_ref/batched-hybrid_ref.xml
+++ b/tests/molecules/H4_ae/batched-hybrid_ref/batched-hybrid_ref.xml
@@ -28,12 +28,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.01</parameter>
        <parameter name="TJF_1Body_eta">.01</parameter>
        <parameter name="CI_eta">.01</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="Ramp_eta">no</parameter>
        <parameter name="Ramp_num">10</parameter>
@@ -47,8 +45,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/descent_target_ref/ref_descent.xml
+++ b/tests/molecules/H4_ae/descent_target_ref/ref_descent.xml
@@ -46,8 +46,6 @@
       <parameter name="omega"> -2.5 </parameter>
 
      <parameter name="useDrift">no</parameter>
-     <parameter name="nonlocalpp">no</parameter>
-     <parameter name="use_nonlocalpp_deriv">no</parameter>
      <parameter name="max_relative_cost_change">10.0</parameter>
      <parameter name="max_param_change">3</parameter>
      <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/hybrid_ref/hybrid_ref.xml
+++ b/tests/molecules/H4_ae/hybrid_ref/hybrid_ref.xml
@@ -26,12 +26,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.001</parameter>
        <parameter name="TJF_1Body_eta">.001</parameter>
        <parameter name="CI_eta">.001</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="Ramp_eta">no</parameter>
        <parameter name="Ramp_num">10</parameter>
@@ -45,8 +43,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/hybrid_target_ref/ref_hybrid.xml
+++ b/tests/molecules/H4_ae/hybrid_target_ref/ref_hybrid.xml
@@ -26,12 +26,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.001</parameter>
        <parameter name="TJF_1Body_eta">.001</parameter>
        <parameter name="CI_eta">.001</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="targetExcited"> yes </parameter>
        <parameter name="omega"> -2.5 </parameter>
@@ -48,8 +46,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/optm-OneShiftOnly-onlyjas.xml
+++ b/tests/molecules/H4_ae/optm-OneShiftOnly-onlyjas.xml
@@ -25,7 +25,6 @@
          <cost name="unreweightedvariance">     0.00 </cost>
          <cost name="reweightedvariance">       0.00 </cost>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">OneShiftOnly</parameter>
     <parameter name="variational_subset"> eH uu ud </parameter>
   </qmc>

--- a/tests/molecules/H4_ae/optm-OneShiftOnly-onlymsd.xml
+++ b/tests/molecules/H4_ae/optm-OneShiftOnly-onlymsd.xml
@@ -25,7 +25,6 @@
          <cost name="unreweightedvariance">     0.00 </cost>
          <cost name="reweightedvariance">       0.00 </cost>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">OneShiftOnly</parameter>
     <parameter name="variational_subset"> CI </parameter>
   </qmc>

--- a/tests/molecules/H4_ae/optm-OneShiftOnly.xml
+++ b/tests/molecules/H4_ae/optm-OneShiftOnly.xml
@@ -25,7 +25,6 @@
          <cost name="unreweightedvariance">     0.00 </cost>
          <cost name="reweightedvariance">       0.00 </cost>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">OneShiftOnly</parameter>
   </qmc>
 </loop>

--- a/tests/molecules/H4_ae/optm-adaptive.xml
+++ b/tests/molecules/H4_ae/optm-adaptive.xml
@@ -26,7 +26,6 @@
     <parameter name="useDrift">  yes </parameter>
     <parameter name="bigchange">15.0</parameter>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">adaptive</parameter>
     <parameter name="exp0">-6</parameter>
     <parameter name="alloweddifference"> 1.0e-4 </parameter>

--- a/tests/molecules/H4_ae/optm-batched-hybrid.xml
+++ b/tests/molecules/H4_ae/optm-batched-hybrid.xml
@@ -28,12 +28,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.01</parameter>
        <parameter name="TJF_1Body_eta">.01</parameter>
        <parameter name="CI_eta">.01</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="Ramp_eta">no</parameter>
        <parameter name="Ramp_num">10</parameter>
@@ -47,8 +45,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/optm-descent.xml
+++ b/tests/molecules/H4_ae/optm-descent.xml
@@ -45,8 +45,6 @@
 
 
      <parameter name="useDrift">no</parameter>
-     <parameter name="nonlocalpp">no</parameter>
-     <parameter name="use_nonlocalpp_deriv">no</parameter>
      <parameter name="max_relative_cost_change">10.0</parameter>
      <parameter name="max_param_change">3</parameter>
      <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/optm-hybrid.xml
+++ b/tests/molecules/H4_ae/optm-hybrid.xml
@@ -26,12 +26,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.001</parameter>
        <parameter name="TJF_1Body_eta">.001</parameter>
        <parameter name="CI_eta">.001</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="Ramp_eta">no</parameter>
        <parameter name="Ramp_num">10</parameter>
@@ -45,8 +43,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/optm-linear-linemin.xml
+++ b/tests/molecules/H4_ae/optm-linear-linemin.xml
@@ -26,7 +26,6 @@
     <parameter name="useDrift">  yes </parameter>
     <parameter name="bigchange">15.0</parameter>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">linemin</parameter>
     <parameter name="exp0">-6</parameter>
     <parameter name="alloweddifference"> 1.0e-4 </parameter>

--- a/tests/molecules/H4_ae/optm-linear-rescale.xml
+++ b/tests/molecules/H4_ae/optm-linear-rescale.xml
@@ -26,7 +26,6 @@
     <parameter name="useDrift">  yes </parameter>
     <parameter name="bigchange">15.0</parameter>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">rescale</parameter>
     <parameter name="exp0">-6</parameter>
     <parameter name="alloweddifference"> 1.0e-4 </parameter>

--- a/tests/molecules/H4_ae/optm-linear.xml
+++ b/tests/molecules/H4_ae/optm-linear.xml
@@ -26,7 +26,6 @@
     <parameter name="useDrift">  yes </parameter>
     <parameter name="bigchange">15.0</parameter>
     <estimator name="LocalEnergy" hdf5="no"/>
-    <parameter name="nonlocalpp"> yes </parameter>
     <parameter name="MinMethod">quartic</parameter>
     <parameter name="exp0">-6</parameter>
     <parameter name="alloweddifference"> 1.0e-4 </parameter>

--- a/tests/molecules/H4_ae/optm-target-descent.xml
+++ b/tests/molecules/H4_ae/optm-target-descent.xml
@@ -46,8 +46,6 @@
       <parameter name="omega"> -2.5 </parameter>
 
      <parameter name="useDrift">no</parameter>
-     <parameter name="nonlocalpp">no</parameter>
-     <parameter name="use_nonlocalpp_deriv">no</parameter>
      <parameter name="max_relative_cost_change">10.0</parameter>
      <parameter name="max_param_change">3</parameter>
      <parameter name="shift_i">0.01</parameter>

--- a/tests/molecules/H4_ae/optm-target-hybrid.xml
+++ b/tests/molecules/H4_ae/optm-target-hybrid.xml
@@ -26,12 +26,10 @@
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> descent </parameter>
        <parameter name="Stored_Vectors">1</parameter>
-       <parameter name="nonlocalpp">no</parameter>
        <parameter name="flavor">RMSprop</parameter>
        <parameter name="TJF_2Body_eta">.001</parameter>
        <parameter name="TJF_1Body_eta">.001</parameter>
        <parameter name="CI_eta">.001</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
 
        <parameter name="targetExcited"> yes </parameter>
        <parameter name="omega"> -2.5 </parameter>
@@ -48,8 +46,6 @@
        <parameter name="timestep">0.05</parameter>
        <estimator name="LocalEnergy" hdf5="no"/>
        <parameter name="Minmethod"> adaptive </parameter>
-       <parameter name="nonlocalpp">no</parameter>
-       <parameter name="use_nonlocalpp_deriv">no</parameter>
        <parameter name="max_relative_cost_change">10.0</parameter>
        <parameter name="max_param_change">3</parameter>
        <parameter name="shift_i">0.01</parameter>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad.xml
@@ -96,8 +96,6 @@
     <parameter name="blocks">                 1 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="nonlocalpp">           yes </parameter>
-    <parameter name="use_nonlocalpp_deriv"> yes </parameter>
     <cost name="energy"> 1.0 </cost>
     <cost name="reweightedvariance"> 0.0 </cost>
   </qmc>

--- a/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad_legacy_driver.xml
+++ b/tests/solids/diamondC_1x1x1_pp/det_qmc_param_grad_legacy_driver.xml
@@ -96,8 +96,6 @@
     <parameter name="blocks">                 1 </parameter>
     <parameter name="timestep">             1.0 </parameter>
     <parameter name="usedrift">             yes </parameter>
-    <parameter name="nonlocalpp">           yes </parameter>
-    <parameter name="use_nonlocalpp_deriv"> yes </parameter>
     <cost name="energy"> 1.0 </cost>
     <cost name="reweightedvariance"> 0.0 </cost>
   </qmc>

--- a/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short_opt.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc-ref/opt/qmc_short_opt.xml
@@ -100,7 +100,6 @@
       <parameter name="useDrift"            >    no              </parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="samples"             >    16384000          </parameter>
-      <parameter name="nonlocalpp"          >    no              </parameter>
       <parameter name="MinMethod"           >    OneShiftOnly </parameter>
          <cost name="energy">                   0.95 </cost>
          <cost name="unreweightedvariance">     0.00 </cost>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_opt.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_opt.in.xml
@@ -92,7 +92,6 @@
       <parameter name="useDrift"            >    no              </parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
       <parameter name="samples"             >    128000          </parameter>
-      <parameter name="nonlocalpp"          >    no              </parameter>
       <parameter name="MinMethod"           >    OneShiftOnly </parameter>
          <cost name="energy">                   0.95 </cost>
          <cost name="unreweightedvariance">     0.00 </cost>

--- a/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
+++ b/tests/solids/diamondC_1x1x1_pp/qmc_short_optbatch.in.xml
@@ -92,7 +92,6 @@
       <parameter name="warmupSteps"         >    50             </parameter>
       <parameter name="useDrift"            >    no              </parameter>
       <estimator name="LocalEnergy" hdf5="no"/>
-      <parameter name="nonlocalpp"          >    no              </parameter>
       <parameter name="MinMethod"           >    OneShiftOnly </parameter>
          <cost name="energy">                   0.95 </cost>
          <cost name="unreweightedvariance">     0.00 </cost>


### PR DESCRIPTION
## Proposed changes
doc/tests update following #4194

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'