### PR TITLE
[WIP]Prototype orbital rotation

### DIFF
--- a/src/QMCWaveFunctions/OptimizableObject.h
+++ b/src/QMCWaveFunctions/OptimizableObject.h
@@ -22,6 +22,7 @@
 namespace qmcplusplus
 {
 using opt_variables_type = optimize::VariableSet;
+class hdf_archive;
 
 class OptimizableObject
 {
@@ -72,6 +73,23 @@ public:
   virtual void reportStatus(std::ostream& os) {}
 
   void setOptimization(bool state) { is_optimized_ = state; }
+
+  /** save extra parameters for wavefunction state
+   *
+   *  The hdf archive is expected to be created in VariableSet::saveAsHDF
+   */
+  virtual void saveExtraParameters(hdf_archive& hout)
+  {
+  }
+
+  /** read extra parameters for wavefunction state
+   *
+   *  The hdf archive is expected to be opened in VariableSet::readFromHDF
+   */
+  virtual void readExtraParameters(hdf_archive& hin)
+  {
+  }
+
 };
 
 class UniqueOptObjRefs : public RefVector<OptimizableObject>

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -95,6 +95,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
     app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";
     abort();
 #else
+    sposet->storeParamsBeforeRotation();
     // create sposet with rotation
     auto& sposet_ref = *sposet;
     app_log() << "  SPOSet " << sposet_ref.getName() << " is optimizable\n";

--- a/src/QMCWaveFunctions/VariableSet.cpp
+++ b/src/QMCWaveFunctions/VariableSet.cpp
@@ -231,11 +231,10 @@ void VariableSet::print(std::ostream& os, int leftPadSpaces, bool printHeader) c
   }
 }
 
-void VariableSet::saveAsHDF(const std::string& filename) const
+void VariableSet::saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const
 {
-  qmcplusplus::hdf_archive hout;
   hout.create(filename);
-  std::vector<int> vp_file_version{1, 0, 0};
+  std::vector<int> vp_file_version{1, 1, 0};
   hout.write(vp_file_version, "version");
 
   std::string timestamp(getDateAndTime("%Y-%m-%d %H:%M:%S %Z"));
@@ -256,9 +255,8 @@ void VariableSet::saveAsHDF(const std::string& filename) const
   hout.pop();
 }
 
-void VariableSet::readFromHDF(const std::string& filename)
+void VariableSet::readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hin)
 {
-  qmcplusplus::hdf_archive hin;
   if (!hin.open(filename, H5F_ACC_RDONLY))
   {
     std::ostringstream err_msg;

--- a/src/QMCWaveFunctions/VariableSet.h
+++ b/src/QMCWaveFunctions/VariableSet.h
@@ -22,6 +22,11 @@
 #include <complex>
 #include "Configuration.h"
 
+namespace qmcplusplus
+{
+  class hdf_archive;
+}
+
 namespace optimize
 {
 /** An enum useful for determining the type of parameter is being optimized.
@@ -334,11 +339,11 @@ struct VariableSet
   void print(std::ostream& os, int leftPadSpaces = 0, bool printHeader = false) const;
 
   // Save variational parameters to an HDF file
-  void saveAsHDF(const std::string& filename) const;
+  void saveAsHDF(const std::string& filename, qmcplusplus::hdf_archive& hout) const;
 
   /// Read variational parameters from an HDF file.
   /// This assumes VariableSet is already set up.
-  void readFromHDF(const std::string& filename);
+  void readFromHDF(const std::string& filename, qmcplusplus::hdf_archive& hin);
 };
 } // namespace optimize
 

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -162,7 +162,16 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur)
   if (!vp_file_to_load.empty())
   {
     app_log() << "  Reading variational parameters from " << vp_file_to_load << std::endl;
-    dummy.readFromHDF(vp_file_to_load);
+    hdf_archive hin;
+    dummy.readFromHDF(vp_file_to_load, hin);
+    UniqueOptObjRefs opt_obj_refs = targetPsi->extractOptimizableObjectRefs();
+    for (auto opt_obj : opt_obj_refs)
+      opt_obj.get().readExtraParameters(hin);
+
+    // Get the latest values of the parameters for dummy so the following resetParameters
+    // doesn't mess up the rotation
+    targetPsi->checkInVariables(dummy);
+
   }
 
   targetPsi->resetParameters(dummy);

--- a/src/QMCWaveFunctions/tests/test_variable_set.cpp
+++ b/src/QMCWaveFunctions/tests/test_variable_set.cpp
@@ -14,6 +14,7 @@
 #include "complex_approx.hpp"
 
 #include "VariableSet.h"
+#include "io/hdf/hdf_archive.h"
 
 #include <stdio.h>
 #include <string>
@@ -120,12 +121,14 @@ TEST_CASE("VariableSet HDF output and input", "[optimize]")
   vs.insert("s", first_val);
   vs.insert("second", second_val);
   vs.insert("really_really_really_long_name", third_val);
-  vs.saveAsHDF("vp.h5");
+  qmcplusplus::hdf_archive hout;
+  vs.saveAsHDF("vp.h5", hout);
 
   VariableSet vs2;
   vs2.insert("s", 0.0);
   vs2.insert("second", 0.0);
-  vs2.readFromHDF("vp.h5");
+  qmcplusplus::hdf_archive hin;
+  vs2.readFromHDF("vp.h5", hin);
   CHECK(vs2.find("s")->second == ValueApprox(first_val));
   CHECK(vs2.find("second")->second == ValueApprox(second_val));
   // This value as in the file, but not in the VariableSet that loaded the file,


### PR DESCRIPTION
Replaces #4146 and #4147
Includes the changes in OptimizableObject and the wavefunction optimization API changes.
The PR isn't intended to be checked in. The intent to update the previous prototypes and make it visible for testing.

Implements options 2 and 3 in https://github.com/QMCPACK/qmcpack/issues/3983#issuecomment-1197380631

The options are switched by a flag (`use_global_rot_` in RotatedSPOs). There's no input option for it - the constructor needs to be changed in the source and recompiled.
* false - use the history list (like #4146)
* true - use global rotation (like #4147)

Loading a vp.h5 will restore the rotation state based on what type of data is stored in the file (history list or global rotation)

Status of various system types:
* LCAO
  * STO basis functions with single determinant - works
  * pp/ECP with GTO basis functions with single determinant  - work s(with the #4196 changes, which are included here)
  * GTO basis functions with cusp correction. Does not work. Probably will require recomputing the cusp correction after every rotation.
* B-splines
   * multideterminant  - doesn't crash, but the parameter gradients don't match in the gradient test
   * single determinant - crashes - will require fixes similar to #4196




## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
