### PR TITLE
Fix printing style issue.

### DIFF
--- a/src/QMCHamiltonians/HamiltonianPool.cpp
+++ b/src/QMCHamiltonians/HamiltonianPool.cpp
@@ -85,13 +85,10 @@ bool HamiltonianPool::put(xmlNodePtr cur)
 
 bool HamiltonianPool::get(std::ostream& os) const
 {
-  PoolType::const_iterator it(myPool.begin()), it_end(myPool.end());
-  while (it != it_end)
+  for(auto& [name, factory] : myPool)
   {
-    os << "  Hamiltonian " << (*it).first << std::endl;
-    ;
-    (*it).second->getH()->get(os);
-    ++it;
+    os << "  Hamiltonian " << name << std::endl;
+    factory->getH()->get(os);
   }
   os << std::endl;
   return true;

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -69,8 +69,7 @@ bool QMCHamiltonian::get(std::ostream& os) const
 {
   for (int i = 0; i < H.size(); i++)
   {
-    os.setf(std::ios::left);
-    os << "  " << std::setw(16) << H[i]->getName();
+    os << "  " << std::setw(16) << std::left << H[i]->getName();
     H[i]->get(os);
     os << "\n";
   }


### PR DESCRIPTION
## Proposed changes
bad, since https://github.com/QMCPACK/qmcpack/pull/4130
```
  Hamiltonian h0
           KineticKinetic energy
          ElecElecCoulombPBCAA potential: e_e
            IonIonCoulombPBCAA potential: ion0_ion0
          LocalECPCoulombPBCAB potential source: ion0
       NonLocalECPNonLocalECPotential: ion0
```
good.
```
  Hamiltonian h0
  Kinetic         Kinetic energy
  ElecElec        CoulombPBCAA potential: e_e
  IonIon          CoulombPBCAA potential: ion0_ion0
  LocalECP        CoulombPBCAB potential source: ion0
  NonLocalECP     NonLocalECPotential: ion0
```

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'