### PR TITLE
Adjust RecordArray to direct storage.

### DIFF
--- a/src/Containers/MinimalContainers/RecordArray.hpp
+++ b/src/Containers/MinimalContainers/RecordArray.hpp
@@ -30,25 +30,16 @@ public:
   RecordArray() {}
 
   /// Constructor specifying the number of parameters and entries
-  RecordArray(size_t nentries, size_t nparams) : Base(nentries, nparams), num_entries_(nentries), num_params_(nparams) {}
+  RecordArray(size_t nentries, size_t nparams) : Base(nentries, nparams) {}
 
   /// Change the size
   void resize(size_t nentries, size_t nparams)
   {
-    num_entries_ = nentries;
-    num_params_  = nparams;
     Base::resize(nentries, nparams);
   }
 
-  int getNumOfParams() const { return num_params_; }
-
-  int getNumOfEntries() const { return num_entries_; }
-
-private:
-  // Number of entries (rows)
-  size_t num_entries_ = 0;
-  // Number of parameters (columns)
-  size_t num_params_ = 0;
+  int getNumOfEntries() const { return Base::rows(); }
+  int getNumOfParams() const { return Base::cols(); }
 };
 } // namespace qmcplusplus
 

--- a/src/Containers/MinimalContainers/RecordArray.hpp
+++ b/src/Containers/MinimalContainers/RecordArray.hpp
@@ -30,15 +30,14 @@ public:
   RecordArray() {}
 
   /// Constructor specifying the number of parameters and entries
-
-  RecordArray(int nparam, int nentry) : Base(nentry, nparam), num_entries_(nentry), num_params_(nparam) {}
+  RecordArray(size_t nentries, size_t nparams) : Base(nentries, nparams), num_entries_(nentries), num_params_(nparams) {}
 
   /// Change the size
-  void resize(int nparam, int nentry)
+  void resize(size_t nentries, size_t nparams)
   {
-    num_entries_ = nentry;
-    num_params_  = nparam;
-    Base::resize(nentry, nparam);
+    num_entries_ = nentries;
+    num_params_  = nparams;
+    Base::resize(nentries, nparams);
   }
 
   int getNumOfParams() const { return num_params_; }
@@ -47,9 +46,9 @@ public:
 
 private:
   // Number of entries (rows)
-  int num_entries_ = 0;
+  size_t num_entries_ = 0;
   // Number of parameters (columns)
-  int num_params_ = 0;
+  size_t num_params_ = 0;
 };
 } // namespace qmcplusplus
 

--- a/src/Containers/MinimalContainers/RecordArray.hpp
+++ b/src/Containers/MinimalContainers/RecordArray.hpp
@@ -2,9 +2,10 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//                    Ye Luo, yeluo@anl.gov, Argonne National Laboratory
 //
 // File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
 //////////////////////////////////////////////////////////////////////////////////////
@@ -12,81 +13,43 @@
 #ifndef QMCPLUSPLUS_RECORDARRAY_H
 #define QMCPLUSPLUS_RECORDARRAY_H
 
-#include <vector>
+#include "OhmmsPETE/OhmmsMatrix.h"
 
-// This is a data structure with two indices.  The data is a list of samples,
+// This is a data structure with two indices. The data is a list of samples,
 // and each sample has an entry for multiple parameters.
 // Think of a spreadsheet where the samples are the rows and the parameters are the columns.
-// This could be implemented with nested vectors (std::vector<std::vector<T>> records),
-// but that requires specifying the order of access everywhere it is used.  Any
-// changes to the storage or indexing order require changes everywhere.  This data
-// structure is an indirection between the specification of the access and the
-// underlying storage.
 //
-// In principle the underlying data could be switched from AoS (record-oriented)
-// to SoA (column-oriented), but the performance of accessing this structure is
-// unlikely to matter enough to warrant such functionality.
-//
-// The calls to setValue and getValue use the parameter index first, and the
-// sample entry index second.  It would nice to create different types for these
-// indices so the correct ordering could be enforced by the compiler.
-//
-
 namespace qmcplusplus
 {
 template<typename T>
-class RecordArray
+class RecordArray : public Matrix<T>
 {
 public:
-  void setValue(int param_idx, int entry_idx, T value)
-  {
-    storage_[param_idx * param_dim_ + entry_idx * nparam_] = value;
-  }
+  using Base = Matrix<T>;
 
-  T getValue(int param_idx, int entry_idx) const
-  {
-    return storage_[param_idx * param_dim_ + entry_idx * entry_dim_];
-  }
-
-  RecordArray() : nparam_(0), nentry_(0) {}
+  RecordArray() {}
 
   /// Constructor specifying the number of parameters and entries
 
-  RecordArray(int nparam, int nentry) : nparam_(nparam), nentry_(nentry)
-  {
-    storage_.resize(nparam_ * nentry_);
-    // AoS (or record-oriented) - param is fastest varying
-    param_dim_ = 1;
-    entry_dim_ = nparam_;
-  }
+  RecordArray(int nparam, int nentry) : Base(nentry, nparam), num_entries_(nentry), num_params_(nparam) {}
 
   /// Change the size
   void resize(int nparam, int nentry)
   {
-    nparam_ = nparam;
-    nentry_ = nentry;
-
-    param_dim_ = 1;
-    entry_dim_ = nparam_;
-
-    storage_.resize(nparam_ * nentry_);
+    num_entries_ = nentry;
+    num_params_  = nparam;
+    Base::resize(nentry, nparam);
   }
 
-  int nparam() const { return nparam_;}
+  int getNumOfParams() const { return num_params_; }
 
-  int nentry() const { return nentry_;}
+  int getNumOfEntries() const { return num_entries_; }
 
 private:
-  // Number of parameters (columns)
-  int nparam_;
   // Number of entries (rows)
-  int nentry_;
-
-  // These control the ordering of the storage
-  int param_dim_;
-  int entry_dim_;
-
-  std::vector<T> storage_;
+  int num_entries_ = 0;
+  // Number of parameters (columns)
+  int num_params_ = 0;
 };
 } // namespace qmcplusplus
 

--- a/src/Containers/MinimalContainers/tests/test_RecordArray.cpp
+++ b/src/Containers/MinimalContainers/tests/test_RecordArray.cpp
@@ -23,7 +23,7 @@ TEST_CASE("RecordArray basics", "[containers]")
 
   int nentry = 1;
   int nparam = 2;
-  records.resize(nparam, nentry);
+  records.resize(nentry, nparam);
 
   records[0][0] = 1.1;
   records[0][1] = 1.2;

--- a/src/Containers/MinimalContainers/tests/test_RecordArray.cpp
+++ b/src/Containers/MinimalContainers/tests/test_RecordArray.cpp
@@ -25,14 +25,14 @@ TEST_CASE("RecordArray basics", "[containers]")
   int nparam = 2;
   records.resize(nparam, nentry);
 
-  records.setValue(0, 0, 1.1);
-  records.setValue(1, 0, 1.2);
+  records[0][0] = 1.1;
+  records[0][1] = 1.2;
 
-  REQUIRE(records.nparam() == 2);
-  REQUIRE(records.nentry() == 1);
+  REQUIRE(records.getNumOfParams() == 2);
+  REQUIRE(records.getNumOfEntries() == 1);
 
-  REQUIRE(records.getValue(0, 0) == Approx(1.1));
-  REQUIRE(records.getValue(1, 0) == Approx(1.2));
+  REQUIRE(records[0][0] == Approx(1.1));
+  REQUIRE(records[0][1] == Approx(1.2));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/EngineHandle.h
+++ b/src/QMCDrivers/WFOpt/EngineHandle.h
@@ -96,7 +96,7 @@ public:
                   const RecordArray<Value>& dhpsioverpsi_array,
                   int base_sample_index) override
   {
-    int current_batch_size = dlogpsi_array.nentry();
+    const int current_batch_size = dlogpsi_array.getNumOfEntries();
     for (int local_index = 0; local_index < current_batch_size; local_index++)
     {
       der_rat_samp[0] = 1.0;
@@ -105,9 +105,9 @@ public:
       int num_params = der_rat_samp.size() - 1;
       for (int j = 0; j < num_params; j++)
       {
-        der_rat_samp[j + 1] = static_cast<FullPrecValue>(dlogpsi_array.getValue(j, local_index));
-        le_der_samp[j + 1]  = static_cast<FullPrecValue>(dhpsioverpsi_array.getValue(j, local_index)) +
-            le_der_samp[0] * static_cast<FullPrecValue>(dlogpsi_array.getValue(j, local_index));
+        der_rat_samp[j + 1] = static_cast<FullPrecValue>(dlogpsi_array[local_index][j]);
+        le_der_samp[j + 1]  = static_cast<FullPrecValue>(dhpsioverpsi_array[local_index][j]) +
+            le_der_samp[0] * static_cast<FullPrecValue>(dlogpsi_array[local_index][j]);
       }
       //FIXME it should respect base_sample_index and avoid relying on threads.
       int ip = omp_get_thread_num();
@@ -141,7 +141,7 @@ public:
                   const RecordArray<Value>& dhpsioverpsi_array,
                   int base_sample_index) override
   {
-    int current_batch_size = dlogpsi_array.nentry();
+    int current_batch_size = dlogpsi_array.getNumOfEntries();
     for (int local_index = 0; local_index < current_batch_size; local_index++)
     {
       const int sample_index = base_sample_index + local_index;
@@ -151,9 +151,9 @@ public:
       int num_params = der_rat_samp.size() - 1;
       for (int j = 0; j < num_params; j++)
       {
-        der_rat_samp[j + 1] = static_cast<FullPrecValue>(dlogpsi_array.getValue(j, local_index));
-        le_der_samp[j + 1]  = static_cast<FullPrecValue>(dhpsioverpsi_array.getValue(j, local_index)) +
-            le_der_samp[0] * static_cast<FullPrecValue>(dlogpsi_array.getValue(j, local_index));
+        der_rat_samp[j + 1] = static_cast<FullPrecValue>(dlogpsi_array[local_index][j]);
+        le_der_samp[j + 1]  = static_cast<FullPrecValue>(dhpsioverpsi_array[local_index][j]) +
+            le_der_samp[0] * static_cast<FullPrecValue>(dlogpsi_array[local_index][j]);
       }
 
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -344,8 +344,8 @@ void QMCCostFunctionBatched::checkConfigurations(EngineHandle& handle)
           const int is = base_sample_index + ib;
           for (int j = 0; j < nparam; j++)
           {
-            DerivRecords[is][j]  = std::real(dlogpsi_array.getValue(j, ib));
-            HDerivRecords[is][j] = std::real(dhpsioverpsi_array.getValue(j, ib));
+            DerivRecords[is][j]  = std::real(dlogpsi_array[ib][j]);
+            HDerivRecords[is][j] = std::real(dhpsioverpsi_array[ib][j]);
           }
           RecordsOnNode[is][LOGPSI_FIXED] = opt_data.get_log_psi_fixed()[ib];
           RecordsOnNode[is][LOGPSI_FREE]  = opt_data.get_log_psi_opt()[ib];
@@ -577,8 +577,8 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
               {
                 if (optVars.recompute(j))
                 {
-                  DerivRecords[is][j]  = std::real(dlogpsi_array.getValue(j, ib));
-                  HDerivRecords[is][j] = std::real(dhpsioverpsi_array.getValue(j, ib));
+                  DerivRecords[is][j]  = std::real(dlogpsi_array[ib][j]);
+                  HDerivRecords[is][j] = std::real(dhpsioverpsi_array[ib][j]);
                 }
               }
             }

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -330,9 +330,9 @@ void QMCCostFunctionBatched::checkConfigurations(EngineHandle& handle)
       if (needGrads)
       {
         // Compute parameter derivatives of the wavefunction
-        int nparam = optVars.size();
-        RecordArray<Return_t> dlogpsi_array(nparam, current_batch_size);
-        RecordArray<Return_t> dhpsioverpsi_array(nparam, current_batch_size);
+        const size_t nparams = optVars.size();
+        RecordArray<Return_t> dlogpsi_array(current_batch_size, nparams);
+        RecordArray<Return_t> dhpsioverpsi_array(current_batch_size, nparams);
 
         energy_list = QMCHamiltonian::mw_evaluateValueAndDerivatives(h_list, wf_list, p_list, optVars, dlogpsi_array,
                                                                      dhpsioverpsi_array);
@@ -342,7 +342,7 @@ void QMCCostFunctionBatched::checkConfigurations(EngineHandle& handle)
         for (int ib = 0; ib < current_batch_size; ib++)
         {
           const int is = base_sample_index + ib;
-          for (int j = 0; j < nparam; j++)
+          for (int j = 0; j < nparams; j++)
           {
             DerivRecords[is][j]  = std::real(dlogpsi_array[ib][j]);
             HDerivRecords[is][j] = std::real(dhpsioverpsi_array[ib][j]);
@@ -560,9 +560,9 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
           if (needGrad)
           {
             // Parameter derivatives
-            int nparam = optVars.size();
-            RecordArray<Return_t> dlogpsi_array(nparam, current_batch_size);
-            RecordArray<Return_t> dhpsioverpsi_array(nparam, current_batch_size);
+            const size_t nparams = optVars.size();
+            RecordArray<Return_t> dlogpsi_array(current_batch_size, nparams);
+            RecordArray<Return_t> dhpsioverpsi_array(current_batch_size, nparams);
 
             // Energy
             auto energy_list = QMCHamiltonian::mw_evaluateValueAndDerivatives(h0_list, wf_list, p_list, optVars,
@@ -573,7 +573,7 @@ QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampli
               const int is                  = base_sample_index + ib;
               auto etmp                     = energy_list[ib];
               RecordsOnNode[is][ENERGY_NEW] = etmp + RecordsOnNode[is][ENERGY_FIXED];
-              for (int j = 0; j < nparam; j++)
+              for (int j = 0; j < nparams; j++)
               {
                 if (optVars.recompute(j))
                 {

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -129,22 +129,13 @@ void OperatorBase::mw_evaluateWithParameterDerivatives(const RefVectorWithLeader
                                                        const RecordArray<ValueType>& dlogpsi,
                                                        RecordArray<ValueType>& dhpsioverpsi) const
 {
-  const int nparam = dlogpsi.nparam();
-  Vector<ValueType> tmp_dlogpsi(nparam);
-  Vector<ValueType> tmp_dhpsioverpsi(nparam);
+  const int nparam = dlogpsi.getNumOfParams();
   for (int iw = 0; iw < o_list.size(); iw++)
   {
-    for (int j = 0; j < nparam; j++)
-    {
-      tmp_dlogpsi[j] = dlogpsi.getValue(j, iw);
-    }
+    const Vector<ValueType> dlogpsi_record_view(const_cast<ValueType*>(dlogpsi[iw]), nparam);
+    Vector<ValueType> dhpsioverpsi_record_view(dhpsioverpsi[iw], nparam);
 
-    o_list[iw].evaluateValueAndDerivatives(p_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
-
-    for (int j = 0; j < nparam; j++)
-    {
-      dhpsioverpsi.setValue(j, iw, dhpsioverpsi.getValue(j, iw) + tmp_dhpsioverpsi[j]);
-    }
+    o_list[iw].evaluateValueAndDerivatives(p_list[iw], optvars, dlogpsi_record_view, dhpsioverpsi_record_view);
   }
 }
 

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -894,7 +894,7 @@ void TrialWaveFunction::reportStatus(std::ostream& os)
 {
   auto opt_obj_refs = extractOptimizableObjectRefs();
   for (OptimizableObject& obj : opt_obj_refs)
-      obj.reportStatus(os);
+    obj.reportStatus(os);
 }
 
 void TrialWaveFunction::getLogs(std::vector<RealType>& lvals)
@@ -1095,20 +1095,13 @@ void TrialWaveFunction::mw_evaluateParameterDerivatives(const RefVectorWithLeade
                                                         RecordArray<ValueType>& dlogpsi,
                                                         RecordArray<ValueType>& dhpsioverpsi)
 {
-  const int nparam = dlogpsi.nparam();
+  const int nparam = dlogpsi.getNumOfParams();
   for (int iw = 0; iw < wf_list.size(); iw++)
   {
-    Vector<ValueType> tmp_dlogpsi(nparam);
-    Vector<ValueType> tmp_dhpsioverpsi(nparam);
+    Vector<ValueType> dlogpsi_record_view(dlogpsi[iw], nparam);
+    Vector<ValueType> dhpsioverpsi_record_view(dhpsioverpsi[iw], nparam);
 
-    wf_list[iw].evaluateDerivatives(p_list[iw], optvars, tmp_dlogpsi, tmp_dhpsioverpsi);
-
-    for (int i = 0; i < nparam; i++)
-    {
-      dlogpsi.setValue(i, iw, tmp_dlogpsi[i]);
-      //orbitals do not know about mass of particle.
-      dhpsioverpsi.setValue(i, iw, tmp_dhpsioverpsi[i]);
-    }
+    wf_list[iw].evaluateDerivatives(p_list[iw], optvars, dlogpsi_record_view, dhpsioverpsi_record_view);
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -227,10 +227,10 @@ TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
 
   TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, opt_vars, dlogpsi_list, dhpsi_over_psi_list);
 
-  CHECK(dlogpsi_list.getValue(0, 0) == ValueApprox(32.2062050179872));
-  CHECK(dlogpsi_list.getValue(1, 0) == ValueApprox(5.87482925187464));
-  CHECK(dhpsi_over_psi_list.getValue(0, 0) == ValueApprox(46.0088643114103));
-  CHECK(dhpsi_over_psi_list.getValue(1, 0) == ValueApprox(7.84119772047731));
+  CHECK(dlogpsi_list[0][0] == ValueApprox(32.2062050179872));
+  CHECK(dlogpsi_list[0][1] == ValueApprox(5.87482925187464));
+  CHECK(dhpsi_over_psi_list[0][0] == ValueApprox(46.0088643114103));
+  CHECK(dhpsi_over_psi_list[0][1] == ValueApprox(7.84119772047731));
 }
 
 // No Jastrow, rotation angle theta1=0.1 and theta2=0.2 from idenity coefficients

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -222,8 +222,8 @@ TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
 
   int nparam = 2;
   int nentry = 1;
-  RecordArray<ValueType> dlogpsi_list(nparam, nentry);
-  RecordArray<ValueType> dhpsi_over_psi_list(nparam, nentry);
+  RecordArray<ValueType> dlogpsi_list(nentry, nparam);
+  RecordArray<ValueType> dhpsi_over_psi_list(nentry, nparam);
 
   TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, opt_vars, dlogpsi_list, dhpsi_over_psi_list);
 

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -163,8 +163,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   // Test list with one wavefunction
 
   int nentry = 1;
-  RecordArray<ValueType> dlogpsi_list(nparam, nentry);
-  RecordArray<ValueType> dhpsi_over_psi_list(nparam, nentry);
+  RecordArray<ValueType> dlogpsi_list(nentry, nparam);
+  RecordArray<ValueType> dhpsi_over_psi_list(nentry, nparam);
 
   TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
 
@@ -174,8 +174,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
   // Test list with two wavefunctions
 
   nentry = 2;
-  dlogpsi_list.resize(nparam, nentry);
-  dhpsi_over_psi_list.resize(nparam, nentry);
+  dlogpsi_list.resize(nentry, nparam);
+  dhpsi_over_psi_list.resize(nentry, nparam);
 
   ParticleSet elec2(elec);
   elec2.R[0][0] = 0.9;

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -27,9 +27,9 @@
 namespace qmcplusplus
 {
 std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
-                           ParticleSet& elec,
-                           ParticleSet& ions,
-                           const WaveFunctionFactory::PSetMap& particle_set_map)
+                                                         ParticleSet& elec,
+                                                         ParticleSet& ions,
+                                                         const WaveFunctionFactory::PSetMap& particle_set_map)
 {
   std::vector<int> agroup(2);
   int nelec = 2;
@@ -106,7 +106,7 @@ std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  auto twf_ptr = wff.buildTWF(root);
+  auto twf_ptr    = wff.buildTWF(root);
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 2);
@@ -168,8 +168,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
 
   TrialWaveFunction::mw_evaluateParameterDerivatives(wf_list, p_list, var_param, dlogpsi_list, dhpsi_over_psi_list);
 
-  CHECK(dlogpsi[0] == ValueApprox(dlogpsi_list.getValue(0, 0)));
-  CHECK(dhpsioverpsi[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 0)));
+  CHECK(dlogpsi[0] == ValueApprox(dlogpsi_list[0][0]));
+  CHECK(dhpsioverpsi[0] == ValueApprox(dhpsi_over_psi_list[0][0]));
 
   // Test list with two wavefunctions
 
@@ -192,11 +192,11 @@ TEST_CASE("TrialWaveFunction flex_evaluateParameterDerivatives", "[wavefunction]
 
   psi.evaluateDerivatives(elec2, var_param, dlogpsi2, dhpsioverpsi2);
 
-  CHECK(dlogpsi[0] == ValueApprox(dlogpsi_list.getValue(0, 0)));
-  CHECK(dhpsioverpsi[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 0)));
+  CHECK(dlogpsi[0] == ValueApprox(dlogpsi_list[0][0]));
+  CHECK(dhpsioverpsi[0] == ValueApprox(dhpsi_over_psi_list[0][0]));
 
-  CHECK(dlogpsi2[0] == ValueApprox(dlogpsi_list.getValue(0, 1)));
-  CHECK(dhpsioverpsi2[0] == ValueApprox(dhpsi_over_psi_list.getValue(0, 1)));
+  CHECK(dlogpsi2[0] == ValueApprox(dlogpsi_list[1][0]));
+  CHECK(dhpsioverpsi2[0] == ValueApprox(dhpsi_over_psi_list[1][0]));
 }
 
 


### PR DESCRIPTION
## Proposed changes
Switch from indirect access to direct access. More convenient to use views.
@markdewing I kept the RecordArray as a specialized type of Matrix.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'