### PR TITLE
Sulfur CI upgrade to LLVM 15 rc3

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -119,10 +119,10 @@ jobs:
             GCC8-NoMPI-Legacy-CUDA-Complex-Mixed,
             GCC8-NoMPI-Legacy-CUDA-Real, # full precision
             GCC8-NoMPI-Legacy-CUDA-Complex,
-            Clang14-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload requires llvm14
-            Clang14-MPI-CUDA-AFQMC-Offload-Real,
-            Clang14-MPI-CUDA-AFQMC-Offload-Complex-Mixed,
-            Clang14-MPI-CUDA-AFQMC-Offload-Complex,
+            Clang15-MPI-CUDA-AFQMC-Offload-Real-Mixed, # auxiliary field, offload requires llvm14
+            Clang15-MPI-CUDA-AFQMC-Offload-Real,
+            Clang15-MPI-CUDA-AFQMC-Offload-Complex-Mixed,
+            Clang15-MPI-CUDA-AFQMC-Offload-Complex,
             Intel19-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
             Intel19-MPI-CUDA-AFQMC-Complex-Mixed,
             Intel19-MPI-CUDA-AFQMC-Real,

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -162,19 +162,20 @@ case "$1" in
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ${GITHUB_WORKSPACE}
       ;;
-      *"Clang14-MPI-CUDA-AFQMC-Offload"*)
+      *"Clang15-MPI-CUDA-AFQMC-Offload"*)
         echo "Configure for building with ENABLE_CUDA and AFQMC using OpenMP offload on x86_64 " \
               "with latest llvm, need built-from-source OpenBLAS due to bug in rpm"
 
-        export OMPI_CC=/opt/llvm/14.0.1/bin/clang
-        export OMPI_CXX=/opt/llvm/14.0.1/bin/clang++
+        # todo: update to llvm 15 release, currently using release candidate
+        export OMPI_CC=/opt/llvm/15.0.0-rc3/bin/clang
+        export OMPI_CXX=/opt/llvm/15.0.0-rc3/bin/clang++
         
         # Make current environment variables available to subsequent steps
-        echo "OMPI_CC=/opt/llvm/14.0.1/bin/clang" >> $GITHUB_ENV
-        echo "OMPI_CXX=/opt/llvm/14.0.1/bin/clang++" >> $GITHUB_ENV
+        echo "OMPI_CC=/opt/llvm/15.0.0-rc3/bin/clang" >> $GITHUB_ENV
+        echo "OMPI_CXX=/opt/llvm/15.0.0-rc3/bin/clang++" >> $GITHUB_ENV
 
         # Confirm that cuda 11.2 gets picked up by the compiler
-        /opt/llvm/14.0.1/bin/clang++ -v
+        /opt/llvm/15.0.0-rc3/bin/clang++ -v
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
@@ -183,7 +184,6 @@ case "$1" in
               -DBUILD_AFQMC=ON \
               -DENABLE_CUDA=ON \
               -DENABLE_OFFLOAD=ON \
-              -DUSE_OBJECT_TARGET=ON \
               -DCMAKE_PREFIX_PATH="/opt/OpenBLAS/0.3.18" \
               -DQMC_COMPLEX=$IS_COMPLEX \
               -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \


### PR DESCRIPTION
## Proposed changes
Upgrade from LLVM 14 to LLVM 15-rc3 on sulfur and migrate CI
Remove USE_OBJECT_TARGET option
Needs to be merged to execute the new CI workflow
Related to #4128 
Closes #4211

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
