### PR TITLE
Improve gradient test

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -1274,7 +1274,7 @@ Parameter gradients
 ~~~~~~~~~~~~~~~~~~~
 The gradients of the energy with respect to the variational parameters can be checked and optionally written to a file.
 The check compares the analytic derivatives with a finite difference approximation.
-These are activated by giving a ``gradient_test`` method in and ``optimize`` block, as follows:
+These are activated by giving a ``gradient_test`` method in an ``optimize`` block, as follows:
 
 ::
 
@@ -1294,6 +1294,8 @@ It contains one line per loop iteration, to allow using existing tools to comput
   +=======================+==============+=============+=============+============================================+
   | ``output_param_file`` | text         | yes, no     | no          |  Output parameter gradients to a file      |
   +-----------------------+--------------+-------------+-------------+--------------------------------------------+
+  | ``finite_diff_delta`` | double       | :math:`> 0` | 1e-5        |  Finite difference delta                   |
+  +-----------------------+--------------+-------------+-------------+--------------------------------------------+
 
 The input would look like the following:
 
@@ -1305,6 +1307,21 @@ The input would look like the following:
       </optimize>
       ... rest of optimizer input ...
 
+
+The output has columns for the parameter name, value, analytic gradient, numeric gradient, and relative difference (in percent). Following the relative difference, there may be exclamation marks which highlight large differences that likely indicate a problem.
+
+Sample output looks like:
+
+::
+
+ Param_Name                         Value             Numeric            Analytic        Percent
+ updet_orb_rot_0000_0002      0.000000e+00   -1.8622037512e-02    4.6904958207e-02      3.52e+02 !!!
+ updet_orb_rot_0001_0002      0.000000e+00    1.6733860519e-03    3.9023863136e-03     -1.33e+02 !!!
+ downdet_orb_rot_0000_0002    0.000000e+00   -9.3267917833e-03   -8.0747281231e-03      1.34e+01 !!!
+ downdet_orb_rot_0001_0002    0.000000e+00   -4.3276838557e-03    2.6684235669e-02      7.17e+02 !!!
+ uu_0                         0.000000e+00   -1.2724910770e-02   -1.2724906671e-02      3.22e-05
+ uu_1                         0.000000e+00    2.0305884219e-02    2.0305883999e-02      1.08e-06
+ uu_2                         0.000000e+00   -1.1644597731e-03   -1.1644591818e-03      5.08e-05
 
 
 Output of intermediate values

--- a/src/QMCDrivers/WFOpt/GradientTest.cpp
+++ b/src/QMCDrivers/WFOpt/GradientTest.cpp
@@ -47,8 +47,7 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
   }
 
   // Numerical gradient
-  double finite_diff_delta = 1e-5;
-  costFunc.GradCost(numeric_grad, params, finite_diff_delta);
+  costFunc.GradCost(numeric_grad, params, input_.finite_diff_delta());
 
   // Analytic gradient
   costFunc.GradCost(analytic_grad, params);
@@ -60,19 +59,61 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
     param_deriv_index_++;
   }
 
-  app_log() << "Param_Name  Value    Numeric            Analytic       Percent" << std::endl;
+  size_t max_name_len = std::string("Param_Name").size();
   for (int k = 0; k < num_params; k++)
   {
     std::string vname = costFunc.getParamName(k);
+    max_name_len      = std::max(vname.size(), max_name_len);
+  }
+  max_name_len += 2; // add some padding
+
+  // clang-format off
+  app_log() << std::setw(max_name_len) << std::left << "Param_Name"
+            << std::setw(14) << std::right << " Value "
+            << std::setw(20) << std::right << " Numeric "
+            << std::setw(20) << std::right << " Analytic "
+            << std::setw(14) << " Percent" << std::endl;
+  // clang-format on
+
+  for (int k = 0; k < num_params; k++)
+  {
+    std::string vname = costFunc.getParamName(k);
+    std::ostringstream rel_diff_str;
+    std::string over_threshold;
     if (numeric_grad[k] != 0)
-      app_log() << vname << " " << params[k] << "  " << numeric_grad[k] << "  " << analytic_grad[k] << "  "
-                << 100 * (numeric_grad[k] - analytic_grad[k]) / numeric_grad[k] << std::endl;
+    {
+      double rel_diff_percent = 100 * (numeric_grad[k] - analytic_grad[k]) / numeric_grad[k];
+      rel_diff_str << std::scientific << std::setprecision(2) << rel_diff_percent;
+      // Highlight problematic differences
+      // The thresholds are arbitrary.
+      if (std::abs(rel_diff_percent) > 1e-3)
+        over_threshold = " !";
+      if (std::abs(rel_diff_percent) > 1e-2)
+        over_threshold = " !!";
+      if (std::abs(rel_diff_percent) > 1e-1)
+        over_threshold = " !!!";
+    }
     else
-      app_log() << vname << " " << params[k] << "  " << numeric_grad[k] << "  " << analytic_grad[k] << "   inf"
-                << std::endl;
+    {
+      rel_diff_str << "inf";
+      over_threshold = " !!!";
+    }
+
+
+    // clang-format off
+    app_log() << std::setw(max_name_len) << std::left << vname
+              << std::setprecision(6)  << std::setw(14) << std::right << params[k]
+              << std::setprecision(10) << std::setw(20) << std::right << numeric_grad[k]
+              << std::setw(20) << std::right << analytic_grad[k]
+              << std::setw(14) << std::right << rel_diff_str.str() << over_threshold << std::endl;
+    // clang-format off
+
     if (input_.do_param_output())
       param_deriv_file_ << std::setprecision(10) << analytic_grad[k] << " ";
   }
+
+  // Reset precision to the default
+  app_log() << std::setprecision(6);
 
   if (input_.do_param_output())
     param_deriv_file_ << std::endl;

--- a/src/QMCDrivers/WFOpt/GradientTest.cpp
+++ b/src/QMCDrivers/WFOpt/GradientTest.cpp
@@ -47,7 +47,7 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
   }
 
   // Numerical gradient
-  costFunc.GradCost(numeric_grad, params, input_.finite_diff_delta());
+  costFunc.GradCost(numeric_grad, params, input_.get_finite_diff_delta());
 
   // Analytic gradient
   costFunc.GradCost(analytic_grad, params);

--- a/src/QMCDrivers/WFOpt/GradientTest.cpp
+++ b/src/QMCDrivers/WFOpt/GradientTest.cpp
@@ -59,7 +59,8 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
     param_deriv_index_++;
   }
 
-  size_t max_name_len = std::string("Param_Name").size();
+  std::string_view param_name_header("Param_Name");
+  size_t max_name_len = param_name_header.size();
   for (int k = 0; k < num_params; k++)
   {
     std::string vname = costFunc.getParamName(k);
@@ -68,7 +69,7 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
   max_name_len += 2; // add some padding
 
   // clang-format off
-  app_log() << std::setw(max_name_len) << std::left << "Param_Name"
+  app_log() << std::setw(max_name_len) << std::left << param_name_header
             << std::setw(14) << std::right << " Value "
             << std::setw(20) << std::right << " Numeric "
             << std::setw(20) << std::right << " Analytic "

--- a/src/QMCDrivers/WFOpt/GradientTest.cpp
+++ b/src/QMCDrivers/WFOpt/GradientTest.cpp
@@ -106,7 +106,7 @@ void GradientTest::run(QMCCostFunctionBase& costFunc, const std::string& root_na
               << std::setprecision(10) << std::setw(20) << std::right << numeric_grad[k]
               << std::setw(20) << std::right << analytic_grad[k]
               << std::setw(14) << std::right << rel_diff_str.str() << over_threshold << std::endl;
-    // clang-format off
+    // clang-format on
 
     if (input_.do_param_output())
       param_deriv_file_ << std::setprecision(10) << analytic_grad[k] << " ";

--- a/src/QMCDrivers/WFOpt/GradientTestInput.cpp
+++ b/src/QMCDrivers/WFOpt/GradientTestInput.cpp
@@ -17,11 +17,9 @@ namespace qmcplusplus
 void GradientTestInput::readXML(xmlNodePtr xml_input)
 {
   ParameterSet param;
-  std::string do_output_file = "no";
-  param.add(do_output_file, "output_param_file");
+  param.add(do_param_output_, "output_param_file", {false});
+  param.add(finite_diff_delta_, "finite_diff_delta");
   param.put(xml_input);
-
-  do_param_output_ = (do_output_file != "no");
 }
 
 

--- a/src/QMCDrivers/WFOpt/GradientTestInput.h
+++ b/src/QMCDrivers/WFOpt/GradientTestInput.h
@@ -25,9 +25,11 @@ public:
 
 protected:
   bool do_param_output_ = false;
+  double finite_diff_delta_ = 1e-5;
 
 public:
   bool do_param_output() { return do_param_output_; }
+  double finite_diff_delta() { return finite_diff_delta_; }
 };
 
 } // namespace qmcplusplus

--- a/src/QMCDrivers/WFOpt/GradientTestInput.h
+++ b/src/QMCDrivers/WFOpt/GradientTestInput.h
@@ -28,8 +28,8 @@ protected:
   double finite_diff_delta_ = 1e-5;
 
 public:
-  bool do_param_output() { return do_param_output_; }
-  double finite_diff_delta() { return finite_diff_delta_; }
+  bool do_param_output() const { return do_param_output_; }
+  double get_finite_diff_delta() const { return finite_diff_delta_; }
 };
 
 } // namespace qmcplusplus


### PR DESCRIPTION
Allow specifying the finite difference delta from the input file. Motivation for this addition comes from checking the orbital rotation gradients for Bspline SPOs.  The Bspline SPOs can be used with a precision of float or double.  The orbital rotation gradients with float precision were giving a large relative difference, and it turned out the default finite difference delta of 1e-5 was too small.  As the value of delta increased, the relative error decreased, which indicated it was in the numerical noise region.  As an alternate check, the precision of the SPOs was switched to double, and then the relative differences from the default delta were fine.

For improvements in the output formatting, the columns and headers are aligned, as requested in #3793.  The precision of the gradients was increased.  The precision of the relative difference was decreased (pretty much only the exponent matters.).
Making the format of the relative difference more uniform makes it harder to quickly scan for problematic values.  A simple threshold scheme was added that prints !, !!, or !!! after the relative difference to highlight problematic values. The thresholds are set to 10^-3, 10^-2, and 10^-1.  

The documentation now includes sample output.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
