### PR TITLE
Disable configuration writing upon request in batched drivers 

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -654,3 +654,16 @@ function(
     set_property(TEST ${FULLNAME} APPEND PROPERTY PASS_REGULAR_EXPRESSION "Time limit reached for")
   endif()
 endfunction()
+
+# Add a test to see if a file exists in the desired location.
+function(add_test_check_file_existence TEST_DEP_IN FILE_NAME SHOULD_SUCCEED)
+  if(TEST ${TEST_DEP_IN})
+    get_test_property(${TEST_DEP_IN} WORKING_DIRECTORY TEST_DEP_IN_WORK_DIR)
+    set(TESTNAME ${TEST_DEP_IN}-exists-${FILE_NAME})
+    add_test(NAME ${TESTNAME} COMMAND ls ${TEST_DEP_IN_WORK_DIR}/${FILE_NAME})
+    if (NOT SHOULD_SUCCEED)
+      set_property(TEST ${TESTNAME} PROPERTY WILL_FAIL TRUE)
+    endif()
+    set_tests_properties(${TESTNAME} PROPERTIES DEPENDS ${TEST_DEP_IN})
+  endif()
+endfunction()

--- a/src/QMCDrivers/QMCDriverInput.cpp
+++ b/src/QMCDrivers/QMCDriverInput.cpp
@@ -39,6 +39,7 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   std::string serialize_walkers;
   std::string debug_checks_str;
   std::string measure_imbalance_str;
+  int Period4CheckPoint{-1};
 
   ParameterSet parameter_set;
   parameter_set.add(store_config_period_, "storeconfigs");
@@ -80,10 +81,15 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   aAttrib.add(qmc_method_, "method");
   aAttrib.add(update_mode_, "move");
   aAttrib.add(scoped_profiling_, "profiling");
-
+  aAttrib.add(Period4CheckPoint, "checkpoint");
   aAttrib.add(k_delay_, "kdelay");
   // This does all the parameter parsing setup in the constructor
   aAttrib.put(cur);
+
+  //set default to match legacy QMCDriver
+  check_point_period_.stride = Period4CheckPoint;
+  check_point_period_.period = Period4CheckPoint;
+
   if (cur != NULL)
   {
     //initialize the parameter set
@@ -156,7 +162,7 @@ void QMCDriverInput::readXML(xmlNodePtr cur)
   if (check_point_period_.period < 1)
     check_point_period_.period = max_blocks_;
 
-  dump_config_ = (check_point_period_.period >= 0);
+  dump_config_ = (Period4CheckPoint >= 0);
 }
 
 } // namespace qmcplusplus

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -107,6 +107,12 @@ if(NOT QMC_CUDA)
     2
     check.sh
     false)
+
+  add_test_check_file_existence(deterministic-restart_batch-8-2 qmc_short_batch.s000.config.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch-8-2 qmc_short_batch.s000.random.h5 TRUE)
+  add_test_check_file_existence(deterministic-restart_batch-8-2 qmc_short_batch.s001.config.h5 FALSE)
+  add_test_check_file_existence(deterministic-restart_batch-8-2 qmc_short_batch.s001.random.h5 FALSE)
+
   run_restart_and_check(
     deterministic-restart_batch
     "${qmcpack_SOURCE_DIR}/tests/io/restart_batch"


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Close #4195
The checkpoint attribute wasn't being read and therefore not being used to set `dumpconfig_`. This fixes that and tries to match the behavior of the legacy driver.

What changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- ? This PR adds tests to cover any new code, or to catch a bug that is being fixed
