### PR TITLE
SpinorSet offload VGLandDetGradRatios

### DIFF
--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -20,6 +20,9 @@ struct SpinorSet::SpinorSetMultiWalkerResource : public Resource
   SpinorSetMultiWalkerResource() : Resource("SpinorSet") {}
   SpinorSetMultiWalkerResource(const SpinorSetMultiWalkerResource&) : SpinorSetMultiWalkerResource() {}
   Resource* makeClone() const override { return new SpinorSetMultiWalkerResource(*this); }
+  OffloadMWVGLArray up_phi_vgl_v, dn_phi_vgl_v;
+  std::vector<ValueType> up_ratios, dn_ratios;
+  std::vector<GradType> up_grads, dn_grads;
 };
 
 SpinorSet::SpinorSet(const std::string& my_name) : SPOSet(my_name), spo_up(nullptr), spo_dn(nullptr) {}
@@ -229,11 +232,20 @@ void SpinorSet::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader
   const size_t nw             = spo_list.size();
   const size_t norb_requested = phi_vgl_v.size(2);
 
-  OffloadMWVGLArray up_phi_vgl_v, dn_phi_vgl_v;
+  auto& mw_res       = *spo_leader.mw_res_;
+  auto& up_phi_vgl_v = mw_res.up_phi_vgl_v;
+  auto& dn_phi_vgl_v = mw_res.dn_phi_vgl_v;
+  auto& up_ratios    = mw_res.up_ratios;
+  auto& dn_ratios    = mw_res.dn_ratios;
+  auto& up_grads     = mw_res.up_grads;
+  auto& dn_grads     = mw_res.dn_grads;
+
   up_phi_vgl_v.resize(DIM_VGL, nw, norb_requested);
   dn_phi_vgl_v.resize(DIM_VGL, nw, norb_requested);
-  std::vector<ValueType> up_ratios(nw), dn_ratios(nw);
-  std::vector<GradType> up_grads(nw), dn_grads(nw);
+  up_ratios.resize(nw);
+  dn_ratios.resize(nw);
+  up_grads.resize(nw);
+  dn_grads.resize(nw);
 
   auto [up_spo_list, dn_spo_list] = extractSpinComponentRefList(spo_list);
   auto& up_spo_leader             = up_spo_list.getLeader();

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -280,13 +280,13 @@ void SpinorSet::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader
   auto* phi_vgl_ptr    = phi_vgl_v.data();
   auto* up_phi_vgl_ptr = up_phi_vgl_v.data();
   auto* dn_phi_vgl_ptr = dn_phi_vgl_v.data();
-  PRAGMA_OFFLOAD("omp target teams distribute map(to:spins_ptr[0:nw])");
+  PRAGMA_OFFLOAD("omp target teams distribute map(to:spins_ptr[0:nw])")
   for (int iw = 0; iw < nw; iw++)
   {
     RealType c, s;
     omptarget::sincos(spins_ptr[iw], &s, &c);
     ValueType eis(c, s), emis(c, -s);
-    PRAGMA_OFFLOAD("omp parallel for collapse(2)");
+    PRAGMA_OFFLOAD("omp parallel for collapse(2)")
     for (int idim = 0; idim < DIM_VGL; idim++)
       for (int iorb = 0; iorb < norb_requested; iorb++)
       {

--- a/src/QMCWaveFunctions/SpinorSet.cpp
+++ b/src/QMCWaveFunctions/SpinorSet.cpp
@@ -147,13 +147,10 @@ void SpinorSet::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_li
   auto& P_leader   = P_list.getLeader();
   assert(this == &spo_leader);
 
-  IndexType nw          = spo_list.size();
-  SPOSet& up_spo_leader = *(spo_leader.spo_up);
-  SPOSet& dn_spo_leader = *(spo_leader.spo_dn);
-  RefVectorWithLeader<SPOSet> up_spo_list(up_spo_leader);
-  RefVectorWithLeader<SPOSet> dn_spo_list(dn_spo_leader);
-  up_spo_list.reserve(nw);
-  dn_spo_list.reserve(nw);
+  IndexType nw                    = spo_list.size();
+  auto [up_spo_list, dn_spo_list] = extractSpinComponentRefList(spo_list);
+  auto& up_spo_leader             = up_spo_list.getLeader();
+  auto& dn_spo_leader             = dn_spo_list.getLeader();
 
   std::vector<ValueVector> mw_up_psi_work, mw_dn_psi_work;
   std::vector<GradVector> mw_up_dpsi_work, mw_dn_dpsi_work;
@@ -179,10 +176,6 @@ void SpinorSet::mw_evaluateVGLWithSpin(const RefVectorWithLeader<SPOSet>& spo_li
   GradVector tmp_grad_vec(OrbitalSetSize);
   for (int iw = 0; iw < nw; iw++)
   {
-    SpinorSet& spinor = spo_list.getCastedElement<SpinorSet>(iw);
-    up_spo_list.emplace_back(*(spinor.spo_up));
-    dn_spo_list.emplace_back(*(spinor.spo_dn));
-
     mw_up_psi_work.emplace_back(tmp_val_vec);
     up_psi_v_list.emplace_back(mw_up_psi_work.back());
     mw_dn_psi_work.emplace_back(tmp_val_vec);
@@ -242,19 +235,9 @@ void SpinorSet::mw_evaluateVGLandDetRatioGradsWithSpin(const RefVectorWithLeader
   std::vector<ValueType> up_ratios(nw), dn_ratios(nw);
   std::vector<GradType> up_grads(nw), dn_grads(nw);
 
-  SPOSet& up_spo_leader = *(spo_leader.spo_up);
-  SPOSet& dn_spo_leader = *(spo_leader.spo_dn);
-  RefVectorWithLeader<SPOSet> up_spo_list(up_spo_leader);
-  RefVectorWithLeader<SPOSet> dn_spo_list(dn_spo_leader);
-  up_spo_list.reserve(nw);
-  dn_spo_list.reserve(nw);
-
-  for (int iw = 0; iw < nw; iw++)
-  {
-    SpinorSet& spinor = spo_list.getCastedElement<SpinorSet>(iw);
-    up_spo_list.emplace_back(*(spinor.spo_up));
-    dn_spo_list.emplace_back(*(spinor.spo_dn));
-  }
+  auto [up_spo_list, dn_spo_list] = extractSpinComponentRefList(spo_list);
+  auto& up_spo_leader             = up_spo_list.getLeader();
+  auto& dn_spo_leader             = dn_spo_list.getLeader();
 
   up_spo_leader.mw_evaluateVGLandDetRatioGrads(up_spo_list, P_list, iat, invRow_ptr_list, up_phi_vgl_v, up_ratios,
                                                up_grads);
@@ -356,12 +339,9 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   IndexType nw    = spo_list.size();
   IndexType nelec = P_leader.getTotalNum();
 
-  SPOSet& up_spo_leader = *(spo_leader.spo_up);
-  SPOSet& dn_spo_leader = *(spo_leader.spo_dn);
-  RefVectorWithLeader<SPOSet> up_spo_list(up_spo_leader);
-  RefVectorWithLeader<SPOSet> dn_spo_list(dn_spo_leader);
-  up_spo_list.reserve(nw);
-  dn_spo_list.reserve(nw);
+  auto [up_spo_list, dn_spo_list] = extractSpinComponentRefList(spo_list);
+  auto& up_spo_leader             = up_spo_list.getLeader();
+  auto& dn_spo_leader             = dn_spo_list.getLeader();
 
   std::vector<ValueMatrix> mw_up_logdet, mw_dn_logdet;
   std::vector<GradMatrix> mw_up_dlogdet, mw_dn_dlogdet;
@@ -387,10 +367,6 @@ void SpinorSet::mw_evaluate_notranspose(const RefVectorWithLeader<SPOSet>& spo_l
   GradMatrix tmp_grad_mat(nelec, OrbitalSetSize);
   for (int iw = 0; iw < nw; iw++)
   {
-    SpinorSet& spinor = spo_list.getCastedElement<SpinorSet>(iw);
-    up_spo_list.emplace_back(*(spinor.spo_up));
-    dn_spo_list.emplace_back(*(spinor.spo_dn));
-
     mw_up_logdet.emplace_back(tmp_val_mat);
     up_logdet_list.emplace_back(mw_up_logdet.back());
     mw_dn_logdet.emplace_back(tmp_val_mat);

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -180,6 +180,9 @@ private:
   struct SpinorSetMultiWalkerResource;
   std::unique_ptr<SpinorSetMultiWalkerResource> mw_res_;
 
+  std::pair<RefVectorWithLeader<SPOSet>, RefVectorWithLeader<SPOSet>> extractSpinComponentRefList(
+      const RefVectorWithLeader<SPOSet>& spo_list) const;
+
   //Sposet for the up and down channels of our spinors.
   std::unique_ptr<SPOSet> spo_up;
   std::unique_ptr<SPOSet> spo_dn;


### PR DESCRIPTION
## Proposed changes

This PR optimizes the existing mw_evaluateVGLandDetRatiosGrad implemented in #4208 so that we remove the data transfers to the host and instead update the spinor data on the device. 

This also adds an extractSpinComponentRefList API reduce repeated code for getting the up/down spo reference vectors. I updated a few other functions which had repeated code to use the new API

Note that there is a unit test for this API already in place. However, the problem is that the existing unit tests don't utilize splines which are the only SPOSets that are currently offloaded. 

## What type(s) of changes does this code introduce?

- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
