### PR TITLE
Fixed bug in handling of coefs array.

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -60,18 +60,19 @@ bool SplineR2R<ST>::write_splines(hdf_archive& h5f)
   spl_coefs has a complicated layout depending on dimensionality of splines. 
   Luckily, for our purposes, we can think of spl_coefs as pointing to a 
   matrix of size BasisSetSize x (OrbitalSetSize + padding), with the spline 
-  index adjacent in memory. NB: The orbital index is SIMD aligned and
-  therefore may include padding.
+  index adjacent in memory. The orbital index is SIMD aligned and therefore 
+  may include padding.
     
-  In other words, due to SIMD alignment, Nsplines may be larger than the 
-  actual number of splined orbitals, which means that in practice rot_mat 
-  may be smaller than the number of 'columns' in the coefs array. 
-  Therefore, we put rot_mat inside "tmpU". The padding of the splines 
-  is at the end, so if we put rot_mat at top left corner of tmpU, then 
-  we can apply tmpU to the coefs safely regardless of padding.   
+  As a result, due to SIMD alignment, Nsplines may be larger than the 
+  actual number of splined orbitals. This means that in practice rot_mat 
+  may be smaller than the number of 'columns' in the coefs array! 
+  To fix this problem, we put rot_mat inside "tmpU", which is guaranteed to have
+  the 'right' size to match spl_coefs. The padding of the splines is at the end, 
+  so if we put rot_mat at top left corner of tmpU, then we can apply tmpU to the 
+  coefs safely regardless of padding.   
   
-  Typically, BasisSetSize >> OrbitalSetSize, so the spl_coefs "matrix"
-  is very tall and skinny.
+  NB: For splines (typically) BasisSetSize >> OrbitalSetSize, so the spl_coefs 
+  "matrix" is very tall and skinny.
 */
 template<typename ST>
 void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
@@ -99,6 +100,7 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
   }
 
   // Apply rotation the dumb way b/c I can't get BLAS::gemm to work...
+  const auto new_coefs = new ValueType[coefs_tot_size];
   for (auto i = 0; i < BasisSetSize; i++)
   {
     for (auto j = 0; j < Nsplines; j++)
@@ -110,10 +112,18 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
         const auto index = i * Nsplines + k;
         newval += *(spl_coefs + index) * tmpU[k][j];
       }
-      *(spl_coefs + cur_elem) = newval;
+      *(new_coefs + cur_elem) = newval;
     }
   }
 
+  // Update the coefs, then delete the temporary array
+  for (auto i=0; i<coefs_tot_size; i++)
+    {
+      *(spl_coefs + i) = *(new_coefs + i);
+    }
+  
+  delete new_coefs;
+  
   /*
     // Here is my attempt to use gemm but it doesn't work...
     int smaller_BasisSetSize   = static_cast<int>(BasisSetSize);


### PR DESCRIPTION
## Proposed changes

In the current orbital rotation in SplineR2R, the spline coefs are overwritten in place, which is bad. This PR fixes this problem by creating a temporary copy of the coefs, applying the rotation, and then overwriting the coefs array with the correct updated coefs.

Describe what this PR changes and why.  If it closes an issue, link to it here
This PR changes the applyRotation method in SplineR2R

## What type(s) of changes does this code introduce?

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
RHEL8 Intel workstation

## Checklist

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
