### PR TITLE
Fix -DQMC_SYMLINK_TEST_FILES=OFF 

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -98,7 +98,7 @@ function(MAYBE_SYMLINK SRC_DIR DST_DIR)
   if(QMC_SYMLINK_TEST_FILES)
     file(CREATE_LINK ${SRC_DIR} ${DST_DIR} SYMBOLIC)
   else()
-    file(COPY ${SRC_DIR} DESTINATION ${DST_DIR})
+    configure_file(${SRC_DIR} ${DST_DIR} COPYONLY)
   endif()
 endfunction()
 

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -94,11 +94,11 @@ function(COPY_DIRECTORY_MAYBE_USING_SYMLINK SRC_DIR DST_DIR ${ARGN})
 endfunction()
 
 # Symlink or copy an individual file
-function(MAYBE_SYMLINK SRC_DIR DST_DIR)
+function(MAYBE_SYMLINK SRC_FILE DST_FILE)
   if(QMC_SYMLINK_TEST_FILES)
-    file(CREATE_LINK ${SRC_DIR} ${DST_DIR} SYMBOLIC)
+    file(CREATE_LINK ${SRC_FILE} ${DST_FILE} SYMBOLIC)
   else()
-    configure_file(${SRC_DIR} ${DST_DIR} COPYONLY)
+    configure_file(${SRC_FILE} ${DST_FILE} COPYONLY)
   endif()
 endfunction()
 

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -98,6 +98,10 @@ function(MAYBE_SYMLINK SRC_FILE DST_FILE)
   if(QMC_SYMLINK_TEST_FILES)
     file(CREATE_LINK ${SRC_FILE} ${DST_FILE} SYMBOLIC)
   else()
+    # file(COPY ...) takes a destination directory and doesn't rename the file.
+    # cmake_path requires CMake v3.20 and file(COPY_FILE ...) requires CMake v3.21.
+    # Instead we use configure_file, which takes an input and output filename and
+    # updates files that change in the source directory or qmc_dir.
     configure_file(${SRC_FILE} ${DST_FILE} COPYONLY)
   endif()
 endfunction()


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

At the Crusher Hackathon I ran into trouble using `-DQMC_SYMLINK_TEST_FILES=OFF`. Files were being placed inside an additional directory and not where they were expected to be located.

I believe the issue is that [file(COPY ...)]( https://cmake.org/cmake/help/latest/command/file.html#copy) asks for a destination directory and therefore has different behavior than `cmake -E copy...`. Instead of going back to execute_process, I think [configure_file](https://cmake.org/cmake/help/latest/command/configure_file.html) should give the same behavior as `cmake -E copy ...` with the added benefit of updating files that change in the source directory or qmc_dir.

To test:

1. build qmcpack with `-DQMC_SYMLINK_TEST_FILES=OFF`
2. run `cmake -R deterministic-unit_test_wavefunction_trialwf`. This test should fail in develop and pass in this branch.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

local workstation

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
