### PR TITLE
Nexus: update to current batched driver style

### DIFF
--- a/nexus/bin/qdens
+++ b/nexus/bin/qdens
@@ -64,7 +64,6 @@ try:
     qmcpack_input = import_nexus_module('qmcpack_input')
     QmcpackInput    = qmcpack_input.QmcpackInput
     spindensity_xml = qmcpack_input.spindensity
-    spindensity_new_xml = qmcpack_input.spindensity_new  # temporary
     density_xml = qmcpack_input.density  # temporary
     del qmcpack_input
 except:
@@ -78,7 +77,6 @@ except:
     from numerics import simplestats,simstats
     from qmcpack_input import QmcpackInput
     from qmcpack_input import spindensity as spindensity_xml
-    from qmcpack_input import spindensity_new as spindensity_new_xml # temporary
     from qmcpack_input import density as density_xml
 #end try
 
@@ -1042,12 +1040,10 @@ class QMCDensityProcessor(QDBase):
                     # the if statement below is a nasty hack to temporarily support 
                     # the name mismatch between the input file and stat.h5 currently 
                     # enforced by the (new) batched spin denisity class in qmcpack
-                    if isinstance(xml,spindensity_new_xml):
-                        name = 'SpinDensity' # override all user input, just like qmcpack
-                    elif isinstance(xml,density_xml):
+                    if isinstance(xml,density_xml):
                         name = 'Density' # override all user input, just like qmcpack
                     #end if
-                    if name not in grids and isinstance(xml,(spindensity_xml,spindensity_new_xml)):
+                    if name not in grids and isinstance(xml,spindensity_xml):
                         sd = xml
                         if 'grid' in sd:
                             grids[name] = sd.grid

--- a/nexus/examples/qmcpack/rsqmc_quantum_espresso/01_diamond_dft_vmc/diamond_lda_vmc_batched_estimators.py
+++ b/nexus/examples/qmcpack/rsqmc_quantum_espresso/01_diamond_dft_vmc/diamond_lda_vmc_batched_estimators.py
@@ -95,14 +95,14 @@ opt = generate_qmcpack(
 estimators = [
     spindensity(grid=(8,8,8)),
     momentumdistribution(samples=20,kmax=4),
-    #onebodydensitymatrices(
-    #    basis         = sposet(type='bspline',size=32),
-    #    reuse         = True,
-    #    integrator    = 'uniform_grid',
-    #    points        = 6,
-    #    center        = (0,0,0),
-    #    check_overlap = False,
-    #    ),
+    onebodydensitymatrices(
+        basis         = sposet(type='bspline',size=16),
+        reuse         = True,
+        integrator    = 'uniform_grid',
+        points        = 6,
+        center        = (0,0,0),
+        check_overlap = False,
+        ),
     ]
 
 qmc = generate_qmcpack(

--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -1763,7 +1763,7 @@ class simulation(QIxml):
 
 class project(QIxml):
     attributes = ['id','series']
-    parameters = ['maxcpusecs','max_seconds']
+    parameters = ['driver_version','maxcpusecs','max_seconds']
     elements   = ['application','host','date','user']
 #end class project
 
@@ -2214,14 +2214,6 @@ class neighbor_trace(QIxml):
     identifier = 'neighbors','centers'
 #end class neighbor_trace
 
-class dm1b(QIxml):
-    tag         = 'estimator'
-    identifier  = 'type'
-    attributes  = ['type','name','reuse']#reuse is a temporary dummy keyword
-    parameters  = ['energy_matrix','basis_size','integrator','points','scale','basis','evaluator','center','check_overlap','check_derivatives','acceptance_ratio','rstats','normalized','volume_normed']
-    write_types = obj(energy_matrix=yesno,check_overlap=yesno,check_derivatives=yesno,acceptance_ratio=yesno,rstats=yesno,normalized=yesno,volume_normed=yesno)
-#end class dm1b
-
 class spindensity(QIxml):
     tag = 'estimator'
     attributes  = ['type','name','report']
@@ -2229,14 +2221,6 @@ class spindensity(QIxml):
     write_types = obj(report=yesno)
     identifier  = 'name'
 #end class spindensity
-
-class spindensity_new(QIxml): # temporary
-    tag = 'estimator'
-    attributes  = ['type','name','report','save_memory']
-    parameters  = ['dr','grid','cell','center','corner','voronoi','test_moves']
-    write_types = obj(report=yesno,save_memory=yesno)
-    identifier  = 'name'
-#end class spindensity_new
 
 class structurefactor(QIxml):
     tag = 'estimator'
@@ -2313,12 +2297,36 @@ class flux(QIxml):
     identifier = 'name'
 #end class flux
 
-class momentum(QIxml):
+class momentum(QIxml): # legacy
     tag = 'estimator'
     attributes = ['type','name','grid','samples','hdf5','wavefunction','kmax','kmax0','kmax1','kmax2']
     identifier = 'name'
     write_types = obj(hdf5=yesno)
 #end class momentum
+
+class momentumdistribution(QIxml): # batched
+    tag = 'estimator'
+    attributes = ['type','name','grid','samples','hdf5','wavefunction','kmax','kmax0','kmax1','kmax2']
+    identifier = 'name'
+    write_types = obj(hdf5=yesno)
+#end class momentumdistribution
+
+class dm1b(QIxml): # legacy
+    tag         = 'estimator'
+    identifier  = 'type'
+    attributes  = ['type','name','reuse']#reuse is a temporary dummy keyword
+    parameters  = ['energy_matrix','basis_size','integrator','points','scale','basis','evaluator','center','check_overlap','check_derivatives','acceptance_ratio','rstats','normalized','volume_normed']
+    write_types = obj(energy_matrix=yesno,check_overlap=yesno,check_derivatives=yesno,acceptance_ratio=yesno,rstats=yesno,normalized=yesno,volume_normed=yesno)
+#end class dm1b
+
+class onebodydensitymatrices(QIxml): # batched
+    tag         = 'estimator'
+    identifier  = 'type'
+    attributes  = ['type','name','reuse']#reuse is a temporary dummy keyword
+    parameters  = ['energy_matrix','basis_size','integrator','points','scale','basis','evaluator','center','check_overlap','check_derivatives','acceptance_ratio','rstats','normalized','volume_normed']
+    write_types = obj(energy_matrix=yesno,check_overlap=yesno,check_derivatives=yesno,acceptance_ratio=yesno,rstats=yesno,normalized=yesno,volume_normed=yesno)
+#end class onebodydensitymatrices
+
 
 # afqmc estimators
 class back_propagation(QIxml):
@@ -2331,28 +2339,29 @@ class back_propagation(QIxml):
 
 estimator = QIxmlFactory(
     name  = 'estimator',
-    types = dict(localenergy         = localenergy,
-                 energydensity       = energydensity,
-                 chiesa              = chiesa,
-                 density             = density,
-                 nearestneighbors    = nearestneighbors,
-                 dm1b                = dm1b,
-                 spindensity         = spindensity,
-                 spindensity_new     = spindensity_new, # temporary
-                 structurefactor     = structurefactor,
-                 force               = force,
-                 forwardwalking      = forwardwalking,
-                 pressure            = pressure,
-                 dmccorrection       = dmccorrection,
-                 nofk                = nofk,
-                 mpc                 = mpc_est,
-                 sk                  = sk,
-                 skall               = skall,
-                 gofr                = gofr,
-                 flux                = flux,
-                 momentum            = momentum,
-                 # afqmc estimators
-                 back_propagation    = back_propagation,
+    types = dict(localenergy            = localenergy,
+                 energydensity          = energydensity,
+                 chiesa                 = chiesa,
+                 density                = density,
+                 nearestneighbors       = nearestneighbors,
+                 dm1b                   = dm1b,
+                 spindensity            = spindensity,
+                 structurefactor        = structurefactor,
+                 force                  = force,
+                 forwardwalking         = forwardwalking,
+                 pressure               = pressure,
+                 dmccorrection          = dmccorrection,
+                 nofk                   = nofk,
+                 mpc                    = mpc_est,
+                 sk                     = sk,
+                 skall                  = skall,
+                 gofr                   = gofr,
+                 flux                   = flux,
+                 momentum               = momentum,
+                 momentumdistribution   = momentumdistribution,
+                 onebodydensitymatrices = onebodydensitymatrices,
+                 # afqmc estimators   
+                 back_propagation       = back_propagation,
                  ),
     typekey  = 'type',
     typekey2 = 'name'
@@ -2475,9 +2484,11 @@ class optimize_qmc(QIxml):
 class linear(QIxml):
     collection_id = 'qmc'
     tag = 'qmc'
-    attributes = ['method','move','checkpoint','gpu','trace']
+    attributes = ['method','move','profiling','kdelay', # batched
+                  'checkpoint','gpu','trace']           # legacy - batched
     elements   = ['estimator']
-    parameters = ['walkers','warmupsteps','blocks','steps','substeps','timestep',
+    parameters = ['total_walkers','walkers_per_rank','crowds','opt_num_crowds',   # batched
+                  'walkers','warmupsteps','blocks','steps','substeps','timestep', # who knows
                   'usedrift','stepsbetweensamples','samples','minmethod',
                   'minwalkers','maxweight','nonlocalpp','use_nonlocalpp_deriv',
                   'usebuffer','alloweddifference','gevmethod','beta','exp0',
@@ -2512,19 +2523,46 @@ class cslinear(QIxml):
 class vmc(QIxml):
     collection_id = 'qmc'
     tag = 'qmc'
-    attributes = ['method','multiple','warp','move','gpu','checkpoint','trace','target','completed','id']
-    elements   = ['estimator','record']
-    parameters = ['walkers','warmupsteps','blocks','steps','substeps','timestep','usedrift','stepsbetweensamples','samples','samplesperthread','nonlocalpp','tau','walkersperthread','reconfiguration','dmcwalkersperthread','current','ratio','firststep','minimumtargetwalkers','max_seconds']
-    write_types = obj(gpu=yesno,usedrift=yesno,nonlocalpp=yesno,reconfiguration=yesno,ratio=yesno,completed=yesno)
+    attributes = ['method','move','profiling','kdelay',         # batched
+                  'multiple','warp','gpu','checkpoint','trace', # legacy - batched
+                  'target','completed','id'] 
+    elements   = ['estimator', # batched
+                  'record']    # legacy - batched
+    parameters = ['total_walkers','walkers_per_rank','crowds','warmupsteps',         # batched
+                  'blocks','steps','substeps','timestep','maxcpusecs','rewind',
+                  'storeconfigs','checkproperties','recordconfigs','current',
+                  'stepsbetweensamples','samplesperthread','samples','usedrift',
+                  'walkers','nonlocalpp','tau','walkersperthread','reconfiguration', # legacy - batched
+                  'dmcwalkersperthread','current','ratio','firststep',
+                  'minimumtargetwalkers','max_seconds']
+    write_types = obj(usedrift=yesno,profiling=yesno,                   # batched
+                      gpu=yesno,nonlocalpp=yesno,reconfiguration=yesno, # legacy - batched
+                      ratio=yesno,completed=yesno)
 #end class vmc
 
 class dmc(QIxml):
     collection_id = 'qmc'
     tag = 'qmc'
-    attributes = ['method','move','gpu','multiple','warp','checkpoint','trace','target','completed','id','continue']
+    attributes = ['method','move','profiling','kdelay',         # batched
+                  'gpu','multiple','warp','checkpoint','trace', # legacy - batched
+                  'target','completed','id','continue']
     elements   = ['estimator']
-    parameters = ['walkers','warmupsteps','blocks','steps','timestep','nonlocalmove','nonlocalmoves','pop_control','reconfiguration','targetwalkers','minimumtargetwalkers','sigmabound','energybound','feedback','recordwalkers','fastgrad','popcontrol','branchinterval','usedrift','storeconfigs','en_ref','tau','alpha','gamma','stepsbetweensamples','max_branch','killnode','swap_walkers','swap_trigger','branching_cutoff_scheme','l2_diffusion','maxage','max_seconds']
-    write_types = obj(gpu=yesno,nonlocalmoves=yesnostr,reconfiguration=yesno,fastgrad=yesno,completed=yesno,killnode=yesno,swap_walkers=yesno,l2_diffusion=yesno)
+    parameters = ['total_walkers','walkers_per_rank','crowds','warmupsteps',            # batched
+                  'blocks','steps','substeps','timestep','maxcpusecs','rewind',
+                  'storeconfigs','checkproperties','recordconfigs','current',
+                  'stepsbetweensamples','samplesperthread','samples','reconfiguration',
+                  'nonlocalmoves','maxage','alpha','gamma','reserve','use_nonblocking',
+                  'branching_cutoff_scheme','feedback','sigmabound',
+                  'walkers','nonlocalmove','pop_control','targetwalkers',               # legacy - batched
+                  'minimumtargetwalkers','energybound','feedback','recordwalkers',
+                  'fastgrad','popcontrol','branchinterval','usedrift','storeconfigs',
+                  'en_ref','tau','alpha','gamma','max_branch','killnode','swap_walkers',
+                  'swap_trigger','branching_cutoff_scheme','l2_diffusion','maxage',
+                  'max_seconds']
+    write_types = obj(usedrift=yesno,profiling=yesno,reconfiguration=yesno,    # batched
+                      nonlocalmoves=yesnostr,use_nonblocking=yesno,
+                      gpu=yesno,fastgrad=yesno,completed=yesno,killnode=yesno, # legacy - batched
+                      swap_walkers=yesno,l2_diffusion=yesno)
 #end class dmc
 
 class rmc(QIxml):
@@ -2544,7 +2582,7 @@ class vmc_batch(QIxml):
     tag = 'qmc'
     attributes = ['method','move','profiling','kdelay']
     elements   = ['estimator']
-    parameters = ['total_walkers','walkers_per_rank','warmupsteps','blocks','steps','substeps','timestep','maxcpusecs','rewind','storeconfigs','checkproperties','recordconfigs','current','crowds','stepsbetweensamples','samplesperthread','samples','usedrift']
+    parameters = ['total_walkers','walkers_per_rank','crowds','warmupsteps','blocks','steps','substeps','timestep','maxcpusecs','rewind','storeconfigs','checkproperties','recordconfigs','current','stepsbetweensamples','samplesperthread','samples','usedrift']
     write_types = obj(usedrift=yesno,profiling=yesno)
 #end class vmc_batch
 
@@ -2556,7 +2594,7 @@ class dmc_batch(QIxml):
     tag = 'qmc'
     attributes = ['method','move','profiling','kdelay']
     elements   = ['estimator']
-    parameters = ['total_walkers','walkers_per_rank','warmupsteps','blocks','steps','substeps','timestep','maxcpusecs','rewind','storeconfigs','checkproperties','recordconfigs','current','crowds','stepsbetweensamples','samplesperthread','samples','reconfiguration','nonlocalmoves','maxage','alpha','gamma','reserve','use_nonblocking','branching_cutoff_scheme','feedback','sigmabound']
+    parameters = ['total_walkers','walkers_per_rank','crowds','warmupsteps','blocks','steps','substeps','timestep','maxcpusecs','rewind','storeconfigs','checkproperties','recordconfigs','current','stepsbetweensamples','samplesperthread','samples','reconfiguration','nonlocalmoves','maxage','alpha','gamma','reserve','use_nonblocking','branching_cutoff_scheme','feedback','sigmabound']
     write_types = obj(usedrift=yesno,profiling=yesno,reconfiguration=yesno,nonlocalmoves=yesnostr,use_nonblocking=yesno)
 #end class dmc_batch
 
@@ -2665,7 +2703,6 @@ classes = [   #standard classes
     atomicbasisset,basisgroup,init,var,traces,scalar_traces,particle_traces,array_traces,
     reference_points,nearestneighbors,neighbor_trace,dm1b,
     coefficient,radfunc,spindensity,structurefactor,
-    spindensity_new, # temporary
     sposet,bspline_builder,composite_builder,heg_builder,include,
     multideterminant,detlist,ci,mcwalkerset,csf,det,
     optimize,cg_optimizer,flex_optimizer,optimize_qmc,wftest,kspace_jastrow,
@@ -2673,6 +2710,7 @@ classes = [   #standard classes
     nofk,mpc_est,flux,distancetable,cpp,element,spline,setparams,
     backflow,transformation,cubicgrid,molecular_orbital_builder,cmc,sk,skall,gofr,
     host,date,user,rpa_jastrow,momentum,override_variational_parameters,
+    momentumdistribution,onebodydensitymatrices,
     # afqmc classes
     afqmcinfo,walkerset,propagator,execute,back_propagation,onerdm
     ]
@@ -2863,9 +2901,6 @@ localenergy.defaults.set(
 #spacegrid.defaults.set(
 #    coord='voronoi'
 #    )
-dm1b.defaults.set(
-    type = 'dm1b',name='DensityMatrices'
-    )
 density.defaults.set(
     type='density',name='Density'
     )
@@ -2884,8 +2919,16 @@ pressure.defaults.set(
 momentum.defaults.set(
     type='momentum'
     )
-spindensity_new.defaults.set( # temporary
-    type='spindensity_new',name='SpinDensityNew'
+momentumdistribution.defaults.set(
+    type='MomentumDistribution',name='nofk'
+    )
+dm1b.defaults.set(
+    type = 'dm1b',name='DensityMatrices',energy_matrix=False,
+    evaluator='matrix',
+    )
+onebodydensitymatrices.defaults.set(
+    type = 'OneBodyDensityMatrices',name='DensityMatrices',energy_matrix=False,
+    evaluator='matrix',
     )
 
 
@@ -5212,7 +5255,7 @@ def generate_hamiltonian(name         = 'h0',
     #end if
 
     ests = []
-    if estimators!=None:
+    if estimators is not None:
         for estimator in estimators:
             if isinstance(estimator,QIxml):
                 estimator = estimator.copy()
@@ -5248,89 +5291,7 @@ def generate_hamiltonian(name         = 'h0',
                     static  = iname,
                     )
             elif isinstance(estimator,dm1b):
-                dm = estimator
-                reuse = False
-                if 'reuse' in dm:
-                    reuse = bool(dm.reuse)
-                    del dm.reuse
-                #end if
-                basis = []
-                builder = None
-                maxed = False
-                if reuse and 'basis' in dm and isinstance(dm.basis,sposet):
-                    spo = dm.basis
-                    # get sposet size
-                    if 'size' in dm.basis:
-                        size = spo.size
-                        del spo.size
-                    elif 'index_max' in dm.basis:
-                        size = spo.index_max
-                        del spo.index_max
-                    else:
-                        QmcpackInput.class_error('cannot generate estimator dm1b\n  basis sposet provided does not have a "size" attribute')
-                    #end if
-                    try:
-                        # get sposet from wavefunction
-                        wf = QIcollections.get('wavefunctions',wfname)
-                        dets = wf.get('determinant')
-                        det  = dets.get_single()
-                        if 'sposet' in det:
-                            rsponame = det.sposet
-                        else:
-                            rsponame = det.id
-                        #end if
-                        builders = QIcollections.get('sposet_builders')
-                        rspo = None
-                        for bld in builders:
-                            if rsponame in bld.sposets:
-                                builder = bld
-                                rspo    = bld.sposets[rsponame]
-                                break
-                            #end if
-                        #end for
-                        basis.append(rsponame)
-                        # adjust current sposet
-                        spo.index_min = rspo.size
-                        spo.index_max = size
-                        maxed = rspo.size>=size
-                    except Exception as e:
-                        msg = 'cannot generate estimator dm1b\n  '
-                        if wf is None:
-                            QmcpackInput.class_error(msg+'wavefunction {0} not found'.format(wfname))
-                        elif dets is None or det is None:
-                            QmcpackInput.class_error(msg+'determinant not found')
-                        elif builders is None:
-                            QmcpackInput.class_error(msg+'sposet_builders not found')
-                        elif rspo is None:
-                            QmcpackInput.class_error(msg+'sposet {0} not found'.format(rsponame))
-                        else:
-                            QmcpackInput.class_error(msg+'cause of failure could not be determined\n  see the following error message:\n{0}'.format(e))
-
-                        #end if
-                    #end if
-                #end if
-                # put the basis sposet in the appropriate builder
-                if isinstance(dm.basis,sposet) and not maxed:
-                    spo = dm.basis
-                    del dm.basis
-                    if not 'type' in spo:
-                        QmcpackInput.class_error('cannot generate estimator dm1b\n  basis sposet provided does not have a "type" attribute')
-                    #end if
-                    if not 'name' in spo:
-                        spo.name = 'spo_dm'
-                    #end if
-                    builders = QIcollections.get('sposet_builders')
-                    if not spo.type in builders:
-                        bld = generate_sposet_builder(spo.type,sposets=[spo])
-                        builders.add(bld)
-                    else:
-                        bld = builders[spo.type]
-                        bld.sposets.add(spo)
-                    #end if
-                    basis.append(spo.name)
-                #end if
-                dm.basis = basis
-                dm.incorporate_defaults(elements=False,overwrite=False,propagate=False)
+                est = process_dm1b_estimator(estimator,wfname)
             #end if
             if est!=None:
                 ests.append(est)
@@ -5355,6 +5316,133 @@ def generate_hamiltonian(name         = 'h0',
 
     return hmltn
 #end def generate_hamiltonian
+
+
+def generate_estimators_batched(estimators,
+                                electrons    = 'e',
+                                ions         = 'ion0',
+                                wavefunction = 'psi0',
+                                ):
+    assert len(estimators)>0
+    ename  = electrons
+    iname  = ions
+    wfname = wavefunction
+    del electrons
+    del ions
+
+    ests = []
+    for estimator in estimators:
+        if isinstance(estimator,QIxml):
+            estimator = estimator.copy()
+        #end if
+        est = estimator
+        if isinstance(estimator,str):
+            estname = estimator.lower().replace(' ','_').replace('-','_').replace('__','_')
+            #if estname=='chiesa':
+            #    est = chiesa(name='KEcorr',type='chiesa',source=ename,psi=wfname)
+            #else:
+            QmcpackInput.class_error('estimator '+estimator+' has not yet been enabled in generate_estimators')
+            ##end if
+        elif not isinstance(estimator,QIxml):
+                QmcpackInput.class_error('generate_estimators received an invalid estimator\n  an estimator must either be a name or a QIxml object\n  inputted estimator type: {0}\n  inputted estimator contents: {1}'.format(estimator.__class__.__name__,estimator))
+        elif isinstance(estimator,momentum):
+            estimator.type = 'MomentumDistribution'
+        elif isinstance(estimator,onebodydensitymatrices):
+            est = process_dm1b_estimator(estimator,wfname)
+        #end if
+        if est is not None:
+            ests.append(est)
+        #end if
+    #end for
+    estimators = make_collection(ests)
+    return estimators
+#end def generate_estimators_batched
+
+
+def process_dm1b_estimator(dm,wfname):
+    reuse = False
+    if 'reuse' in dm:
+        reuse = bool(dm.reuse)
+        del dm.reuse
+    #end if
+    basis = []
+    builder = None
+    maxed = False
+    if reuse and 'basis' in dm and isinstance(dm.basis,sposet):
+        spo = dm.basis
+        # get sposet size
+        if 'size' in dm.basis:
+            size = spo.size
+            del spo.size
+        elif 'index_max' in dm.basis:
+            size = spo.index_max
+            del spo.index_max
+        else:
+            QmcpackInput.class_error('cannot generate estimator dm1b\n  basis sposet provided does not have a "size" attribute')
+        #end if
+        try:
+            # get sposet from wavefunction
+            wf = QIcollections.get('wavefunctions',wfname)
+            dets = wf.get('determinant')
+            det  = dets.get_single()
+            if 'sposet' in det:
+                rsponame = det.sposet
+            else:
+                rsponame = det.id
+            #end if
+            builders = QIcollections.get('sposet_builders')
+            rspo = None
+            for bld in builders:
+                if rsponame in bld.sposets:
+                    builder = bld
+                    rspo    = bld.sposets[rsponame]
+                    break
+                #end if
+            #end for
+            basis.append(rsponame)
+            # adjust current sposet
+            spo.index_min = rspo.size
+            spo.index_max = size
+            maxed = rspo.size>=size
+        except Exception as e:
+            msg = 'cannot generate estimator dm1b\n  '
+            if wf is None:
+                QmcpackInput.class_error(msg+'wavefunction {0} not found'.format(wfname))
+            elif dets is None or det is None:
+                QmcpackInput.class_error(msg+'determinant not found')
+            elif builders is None:
+                QmcpackInput.class_error(msg+'sposet_builders not found')
+            elif rspo is None:
+                QmcpackInput.class_error(msg+'sposet {0} not found'.format(rsponame))
+            else:
+                QmcpackInput.class_error(msg+'cause of failure could not be determined\n  see the following error message:\n{0}'.format(e))
+            #end if
+        #end if
+    #end if
+    # put the basis sposet in the appropriate builder
+    if isinstance(dm.basis,sposet) and not maxed:
+        spo = dm.basis
+        del dm.basis
+        if not 'type' in spo:
+            QmcpackInput.class_error('cannot generate estimator dm1b\n  basis sposet provided does not have a "type" attribute')
+        #end if
+        if not 'name' in spo:
+            spo.name = 'spo_dm'
+        #end if
+        builders = QIcollections.get('sposet_builders')
+        if not spo.type in builders:
+            bld = generate_sposet_builder(spo.type,sposets=[spo])
+            builders.add(bld)
+        else:
+            bld = builders[spo.type]
+            bld.sposets.add(spo)
+        #end if
+        basis.append(spo.name)
+    #end if
+    dm.basis = basis
+    dm.incorporate_defaults(elements=False,overwrite=False,propagate=False)
+    return dm
+#end def process_dm1b_estimator
 
 
 
@@ -6794,7 +6882,7 @@ def generate_batched_opt_calculations(
     **opt_inputs
     ):
 
-    methods = obj(linear=linear,cslinear=cslinear)
+    methods = obj(linear=linear)
     if method not in methods:
         error('invalid optimization method requested\ninvalid method: {0}\nvalid options are: {1}'.format(method,sorted(methods.keys())),loc)
     #end if
@@ -6902,7 +6990,7 @@ def generate_batched_vmc_calculations(
         #end if
     #end for
 
-    vmc_calcs = [vmc_batch(**vmc_inputs)]
+    vmc_calcs = [vmc(**vmc_inputs)]
 
     return vmc_calcs
 #end def generate_batched_vmc_calculations
@@ -6969,12 +7057,12 @@ def generate_batched_dmc_calculations(
         #end if
     #end for
 
-    vmc_calc = vmc_batch(**vmc_inputs)
+    vmc_calc = vmc(**vmc_inputs)
 
     dmc_calcs = [vmc_calc]
     if eq_dmc:
         dmc_calcs.append(
-            dmc_batch(
+            dmc(
                 warmupsteps   = eq_warmupsteps,
                 blocks        = eq_blocks,
                 steps         = eq_steps,
@@ -6987,7 +7075,7 @@ def generate_batched_dmc_calculations(
     for n in range(ntimesteps):
         sfac = 1.0/tfac
         dmc_calcs.append(
-            dmc_batch(
+            dmc(
                 warmupsteps   = int(sfac*warmupsteps),
                 blocks        = blocks,
                 steps         = int(sfac*steps),
@@ -7011,7 +7099,7 @@ def generate_batched_dmc_calculations(
         sigmabound              = sigmabound,
         )
     for calc in dmc_calcs:
-        if isinstance(calc,dmc_batch):
+        if isinstance(calc,dmc):
             for name,value in optional_dmc_inputs.items():
                 if value is not None:
                     calc[name] = value
@@ -7159,7 +7247,11 @@ def generate_basic_input(**kwargs):
         #end if
     #end if
     if kw.corrections=='default' and tuple(kw.bconds)==tuple('ppp'):
-        kw.corrections = ['mpc','chiesa']
+        if not batched:
+            kw.corrections = ['mpc','chiesa']
+        else:
+            kw.corrections = ['mpc']
+        #end if
     elif isinstance(kw.corrections,(list,tuple)):
         None
     else:
@@ -7189,9 +7281,10 @@ def generate_basic_input(**kwargs):
     metadata = QmcpackInput.default_metadata.copy()
 
     proj = project(
-        id          = kw.id,
-        series      = kw.series,
-        application = application(),
+        id             = kw.id,
+        series         = kw.series,
+        application    = application(),
+        driver_version = kw.driver,
         )
     if batched:
         if kw.maxcpusecs is not None:
@@ -7317,12 +7410,28 @@ def generate_basic_input(**kwargs):
         wfn.jastrows = generate_jastrows(kw.jastrows,kw.system,check_ions=True)
     #end if
 
+    h_estimators = kw.estimators
+    d_estimators = None
+    if batched:
+        h_estimators = []
+        d_estimators = []
+        if isinstance(kw.estimators,list):
+            for est in kw.estimators:
+                if isinstance(est,str) and est.lower()=='mpc':
+                    h_estimators.append(est)
+                else:
+                    d_estimators.append(est)
+                #end if
+            #end for
+        #end if
+    #end if
+
     hmltn = generate_hamiltonian(
         system       = kw.system,
         pseudos      = kw.pseudos,
         dla          = kw.dla,
         interactions = kw.interactions,
-        estimators   = kw.estimators,
+        estimators   = h_estimators,
         )
 
     if spobuilders is not None:
@@ -7362,28 +7471,15 @@ def generate_basic_input(**kwargs):
             kw.calculations = generate_dmc_calculations(**qmc_inputs)
         #end if
     #end if
-    for calculation in kw.calculations:
-        if isinstance(calculation,loop):
-            calc = calculation.qmc
-        else:
-            calc = calculation
-        #end if
-        has_localenergy = False
-        has_estimators = 'estimators' in calc
-        if has_estimators:
-            estimators = calc.estimators
-            if not isinstance(estimators,collection):
-                estimators = make_collection(estimators)
+    if batched and d_estimators is not None and len(d_estimators)>0:
+        estimators = generate_estimators_batched(d_estimators)
+        for calc in kw.calculations:
+            if isinstance(calc,loop):
+                calc = calc.qmc
             #end if
-            has_localenergy = 'localenergy' in estimators or 'LocalEnergy' in estimators
-        else:
-            estimators = collection()
-        #end if
-        #if not has_localenergy:
-        #    estimators.localenergy = localenergy(name='LocalEnergy')
-        #    calc.estimators = estimators
-        ##end if
-    #end for
+            calc.estimators = estimators.copy()
+        #end for
+    #end if
     sim.calculations = make_collection(kw.calculations).copy()
 
     qi = QmcpackInput(metadata,sim)

--- a/nexus/lib/testing.py
+++ b/nexus/lib/testing.py
@@ -217,8 +217,10 @@ def print_diff(o1,o2,atol=def_atol,rtol=def_rtol,int_as_float=False,text=False,b
     d1 = obj(diff1)
     d2 = obj(diff2)
     print(hline.format('left diff'))
+    print(list(sorted(d1.keys())))
     print(d1)
     print(hline.format('right diff'))
+    print(list(sorted(d2.keys())))
     print(d2)
 #end def print_diff
 

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/H2O/runs/dmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/H2O/runs/dmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="dmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/H2O/runs/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/H2O/runs/opt.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="opt" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/LiH/runs/dmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/LiH/runs/dmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="dmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/LiH/runs/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/LiH/runs/opt.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="opt" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/opt/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/opt/opt.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="opt" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/qmc/qmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/c20/runs/c20/qmc/qmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="qmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/diamond/runs/diamond/vmc/vmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/diamond/runs/diamond/vmc/vmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="vmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/opt/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/opt/opt.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="opt" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/qmc/qmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/graphene/runs/graphene/qmc/qmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="qmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/oxygen_dimer/scale_1.0/opt.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/oxygen_dimer/scale_1.0/opt.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="opt" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>

--- a/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/oxygen_dimer/scale_1.0/qmc.in.xml
+++ b/nexus/tests/reference/user_examples/qmcpack/rsqmc_misc/oxygen_dimer/scale_1.0/qmc.in.xml
@@ -2,6 +2,7 @@
 <simulation>
    <project id="qmc" series="0">
       <application name="qmcpack" role="molecu" class="serial" version="1.0"/>
+      <parameter name="driver_version"> legacy </parameter>
    </project>
    <qmcsystem>
       <simulationcell>


### PR DESCRIPTION
## Proposed changes

Support `driver_version` and also currently working estimators for the batched drivers.  The sole Nexus example for the batched drivers has been updated (also including Jastrow optimization) and another has been added that includes all currently working estimators: MPC, spin density, and the momentum distribution.


## What type(s) of changes does this code introduce?

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Laptop

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'



