### PR TITLE
Directly set c++17 for nvcc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,10 +731,16 @@ if(QMC_CUDA OR ENABLE_CUDA)
     endif()
     set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
     set(CMAKE_CUDA_EXTENSIONS OFF)
+    # CMAKE_CUDA_STANDARD doesn't affect nvcc detection and using unsupported compilers may choke the detection.
+    # This happens when Clang default to C++17. Setting CMAKE_CUDA_FLAGS directly works around the issue.
+    # but CUDA_FLAGS in flags.make may contain -std=c++17 twice with no harm.
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -std=c++${CMAKE_CUDA_STANDARD}")
+
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "nvcc host compiler passed via -ccbin")
     if(NOT CMAKE_CUDA_FLAGS MATCHES "allow-unsupported-compiler")
       set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --allow-unsupported-compiler")
     endif()
+
     enable_language(CUDA)
     if(QMC_CUDA)
       include(TestCUDAHostCompatibility)


### PR DESCRIPTION
## Proposed changes
Current clang develop caused nvcc detection failure in CMake. Explicitly instructing the C++ standard used by nvcc works around the issue. See discussion in https://gitlab.kitware.com/cmake/cmake/-/issues/23971

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'