### PR TITLE
Raise Intel classic compiler minimum version

### DIFF
--- a/CMake/IntelCompilers.cmake
+++ b/CMake/IntelCompilers.cmake
@@ -10,8 +10,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
 elseif(INTEL_ONEAPI_COMPILER_FOUND)
   # in this case, the version string reported based on Clang, not accurate enough. just skip check.
 else()
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.1.0)
-    message(FATAL_ERROR "Requires Intel classic compiler 19.1 or higher!")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.1.2)
+    message(FATAL_ERROR "Requires Intel classic compiler 19.1.2 or higher!")
   endif()
 endif()
 

--- a/config/build_alcf_polaris_Clang.sh
+++ b/config/build_alcf_polaris_Clang.sh
@@ -8,7 +8,7 @@
 # build_alcf_polaris_Clang.sh <source_dir> # build all the variants with a given source directory <source_dir>
 # build_alcf_polaris_Clang.sh <source_dir> <install_dir> # build all the variants with a given source directory <source_dir> and install to <install_dir>
 
-module load mpiwrappers/cray-mpich-llvm llvm/main-20220317
+module load mpiwrappers/cray-mpich-llvm llvm/release-15.0.0
 module load cudatoolkit-standalone/11.2.2
 module load cray-fftw/3.3.8.13
 module load cray-hdf5-parallel/1.12.1.3

--- a/config/build_alcf_theta.sh
+++ b/config/build_alcf_theta.sh
@@ -2,6 +2,7 @@ module unload cray-libsci
 module load cray-hdf5-parallel
 module load gcc/9.3.0
 module load cmake/3.20.4
+module load intel/19.1.2.254
 
 module list >& load_modules.txt
 


### PR DESCRIPTION
## Proposed changes
19.1.0 doesn't work on Theta. 19.1.2 works fine.

## What type(s) of changes does this code introduce?
- Build related changes

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Theta, Bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'