### PR TITLE
Set offload mandatory in ctest

### DIFF
--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -183,15 +183,7 @@ function(
     endif()
   endif()
 
-  if(TEST_ADDED_TEMP
-     AND (QMC_CUDA
-          OR ENABLE_CUDA
-          OR ENABLE_ROCM
-          OR ENABLE_OFFLOAD
-         ))
-    set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
-  endif()
-
+  # set additional test properties when the test gets added
   set(TEST_LABELS_TEMP "")
   if(TEST_ADDED_TEMP)
     add_test_labels(${TESTNAME} TEST_LABELS_TEMP)
@@ -199,6 +191,21 @@ function(
       TEST ${TESTNAME}
       APPEND
       PROPERTY LABELS "QMCPACK")
+
+    if(QMC_CUDA
+          OR ENABLE_CUDA
+          OR ENABLE_ROCM
+          OR ENABLE_OFFLOAD
+       )
+      set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
+    endif()
+
+    if(ENABLE_OFFLOAD)
+      set_property(
+      TEST ${TESTNAME}
+      APPEND
+      PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
+    endif()
   endif()
   set(${TEST_ADDED}
       ${TEST_ADDED_TEMP}

--- a/CMake/macros.cmake
+++ b/CMake/macros.cmake
@@ -76,10 +76,10 @@ function(COPY_DIRECTORY_USING_SYMLINK_LIMITED SRC_DIR DST_DIR ${ARGN})
   symlink_list_of_files("${FILE_FOLDER_NAMES}" "${DST_DIR}")
   list(TRANSFORM ARGN PREPEND "${SRC_DIR}/")
   symlink_list_of_files("${ARGN}" "${DST_DIR}")
-# Special handling for .txt input files; assumed to be an ensemble run. Link referenced ensemble inputs
-  if ( ${ARGN} MATCHES ".txt")
+  # Special handling for .txt input files; assumed to be an ensemble run. Link referenced ensemble inputs
+  if(${ARGN} MATCHES ".txt")
     file(STRINGS ${ARGN} ENSEMBLE_INPUTS)
-    list(TRANSFORM ENSEMBLE_INPUTS PREPEND "${SRC_DIR}/")   
+    list(TRANSFORM ENSEMBLE_INPUTS PREPEND "${SRC_DIR}/")
     symlink_list_of_files("${ENSEMBLE_INPUTS}" "${DST_DIR}")
   endif()
 endfunction()
@@ -193,18 +193,14 @@ function(
       PROPERTY LABELS "QMCPACK")
 
     if(QMC_CUDA
-          OR ENABLE_CUDA
-          OR ENABLE_ROCM
-          OR ENABLE_OFFLOAD
-       )
+       OR ENABLE_CUDA
+       OR ENABLE_ROCM
+       OR ENABLE_OFFLOAD)
       set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
     endif()
 
     if(ENABLE_OFFLOAD)
-      set_property(
-      TEST ${TESTNAME}
-      APPEND
-      PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
+      set_property(TEST ${TESTNAME} APPEND PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
     endif()
   endif()
   set(${TEST_ADDED}
@@ -672,7 +668,7 @@ function(add_test_check_file_existence TEST_DEP_IN FILE_NAME SHOULD_SUCCEED)
     get_test_property(${TEST_DEP_IN} WORKING_DIRECTORY TEST_DEP_IN_WORK_DIR)
     set(TESTNAME ${TEST_DEP_IN}-exists-${FILE_NAME})
     add_test(NAME ${TESTNAME} COMMAND ls ${TEST_DEP_IN_WORK_DIR}/${FILE_NAME})
-    if (NOT SHOULD_SUCCEED)
+    if(NOT SHOULD_SUCCEED)
       set_property(TEST ${TESTNAME} PROPERTY WILL_FAIL TRUE)
     endif()
     set_tests_properties(${TESTNAME} PROPERTIES DEPENDS ${TEST_DEP_IN})

--- a/CMake/unit_test.cmake
+++ b/CMake/unit_test.cmake
@@ -30,18 +30,15 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
 
     if(ENABLE_OFFLOAD)
       set_property(
-      TEST ${TESTNAME}
-      APPEND
-      PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
+        TEST ${TESTNAME}
+        APPEND
+        PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
     endif()
   endif()
 
   set(TEST_LABELS_TEMP "")
   add_test_labels(${TESTNAME} TEST_LABELS_TEMP)
-  set_property(
-    TEST ${TESTNAME}
-    APPEND
-    PROPERTY LABELS "unit")
+  set_property(TEST ${TESTNAME} APPEND PROPERTY LABELS "unit")
 endfunction()
 
 # Add a test to see if the target output exists in the desired location in the build directory.

--- a/CMake/unit_test.cmake
+++ b/CMake/unit_test.cmake
@@ -27,6 +27,13 @@ function(ADD_UNIT_TEST TESTNAME PROCS THREADS TEST_BINARY)
        OR ENABLE_OFFLOAD)
       set_tests_properties(${TESTNAME} PROPERTIES RESOURCE_LOCK exclusively_owned_gpus)
     endif()
+
+    if(ENABLE_OFFLOAD)
+      set_property(
+      TEST ${TESTNAME}
+      APPEND
+      PROPERTY ENVIRONMENT "OMP_TARGET_OFFLOAD=mandatory")
+    endif()
   endif()
 
   set(TEST_LABELS_TEMP "")

--- a/src/QMCTools/ppconvert/src/common/IOASCII.cc
+++ b/src/QMCTools/ppconvert/src/common/IOASCII.cc
@@ -273,7 +273,7 @@ namespace IO {
 	}
       }
     }
-    buffer.resizeAndPreserve(Array<char,1>::sizes_type({bufferLoc}));
+    buffer.resizeAndPreserve(Array<char,1>::sizes_type(bufferLoc));
     infile2.close();
     return (true);
   }


### PR DESCRIPTION
## Proposed changes
OpenMP may offload to CPU when GPUs are not available. Set `OMP_TARGET_OFFLOAD=mandatory` to stop false positive test results.

## What type(s) of changes does this code introduce?
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora
## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted