### PR TITLE
Propagate ProjectData in QMCDrivers

### DIFF
--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -34,8 +34,12 @@ using TraceManager = int;
 namespace qmcplusplus
 {
 /// Constructor.
-CSVMC::CSVMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "CSVMC"), UseDrift("yes"), multiEstimator(0), Mover(0)
+CSVMC::CSVMC(const ProjectData& project_data,
+             MCWalkerConfiguration& w,
+             TrialWaveFunction& psi,
+             QMCHamiltonian& h,
+             Communicate* comm)
+    : QMCDriver(project_data, w, psi, h, comm, "CSVMC"), UseDrift("yes"), multiEstimator(0), Mover(0)
 {
   RootName = "csvmc";
   m_param.add(UseDrift, "useDrift");

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.h
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.h
@@ -35,7 +35,8 @@ class CSVMC : public QMCDriver, public CloneManager
 {
 public:
   /// Constructor.
-  CSVMC(MCWalkerConfiguration& w,
+  CSVMC(const ProjectData& project_data,
+        MCWalkerConfiguration& w,
         TrialWaveFunction& psi,
         QMCHamiltonian& h,
         Communicate* comm);

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -41,8 +41,13 @@ using TraceManager = int;
 namespace qmcplusplus
 {
 /// Constructor.
-DMC::DMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling)
-    : QMCDriver(w, psi, h, comm, "DMC", enable_profiling),
+DMC::DMC(const ProjectData& project_data,
+         MCWalkerConfiguration& w,
+         TrialWaveFunction& psi,
+         QMCHamiltonian& h,
+         Communicate* comm,
+         bool enable_profiling)
+    : QMCDriver(project_data, w, psi, h, comm, "DMC", enable_profiling),
       KillNodeCrossing(0),
       BranchInterval(-1),
       L2("no"),

--- a/src/QMCDrivers/DMC/DMC.h
+++ b/src/QMCDrivers/DMC/DMC.h
@@ -31,7 +31,12 @@ class DMC : public QMCDriver, public CloneManager
 {
 public:
   /// Constructor.
-  DMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling);
+  DMC(const ProjectData& project_data,
+      MCWalkerConfiguration& w,
+      TrialWaveFunction& psi,
+      QMCHamiltonian& h,
+      Communicate* comm,
+      bool enable_profiling);
 
   bool run() override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCDrivers/DMC/DMCFactory.cpp
+++ b/src/QMCDrivers/DMC/DMCFactory.cpp
@@ -24,7 +24,8 @@
 //#define PETA_DMC_TEST
 namespace qmcplusplus
 {
-std::unique_ptr<QMCDriver> DMCFactory::create(MCWalkerConfiguration& w,
+std::unique_ptr<QMCDriver> DMCFactory::create(const ProjectData& project_data,
+                                              MCWalkerConfiguration& w,
                                               TrialWaveFunction& psi,
                                               QMCHamiltonian& h,
                                               Communicate* comm,
@@ -32,9 +33,9 @@ std::unique_ptr<QMCDriver> DMCFactory::create(MCWalkerConfiguration& w,
 {
 #ifdef QMC_CUDA
   if (GPU)
-    return std::make_unique<DMCcuda>(w, psi, h, comm, enable_profiling);
+    return std::make_unique<DMCcuda>(project_data, w, psi, h, comm, enable_profiling);
 #endif
-  auto qmc = std::make_unique<DMC>(w, psi, h, comm, enable_profiling);
+  auto qmc = std::make_unique<DMC>(project_data, w, psi, h, comm, enable_profiling);
   qmc->setUpdateMode(PbyPUpdate);
   return qmc;
 }

--- a/src/QMCDrivers/DMC/DMCFactory.h
+++ b/src/QMCDrivers/DMC/DMCFactory.h
@@ -28,7 +28,8 @@ private:
 public:
   DMCFactory(bool pbyp, bool gpu, xmlNodePtr cur) : PbyPUpdate(pbyp), GPU(gpu), myNode(cur) {}
 
-  std::unique_ptr<QMCDriver> create(MCWalkerConfiguration& w,
+  std::unique_ptr<QMCDriver> create(const ProjectData& project_data,
+                                    MCWalkerConfiguration& w,
                                     TrialWaveFunction& psi,
                                     QMCHamiltonian& h,
                                     Communicate* comm,

--- a/src/QMCDrivers/DMC/DMC_CUDA.cpp
+++ b/src/QMCDrivers/DMC/DMC_CUDA.cpp
@@ -33,12 +33,13 @@ namespace qmcplusplus
 using WP = WalkerProperties::Indexes;
 
 /// Constructor.
-DMCcuda::DMCcuda(MCWalkerConfiguration& w,
+DMCcuda::DMCcuda(const ProjectData& project_data,
+                 MCWalkerConfiguration& w,
                  TrialWaveFunction& psi,
                  QMCHamiltonian& h,
                  Communicate* comm,
                  bool enable_profiling)
-    : QMCDriver(w, psi, h, comm, "DMCcuda", enable_profiling),
+    : QMCDriver(project_data, w, psi, h, comm, "DMCcuda", enable_profiling),
       myWarmupSteps(0),
       Mover(0),
       ResizeTimer(*timer_manager.createTimer("DMCcuda::resize")),
@@ -81,11 +82,11 @@ bool DMCcuda::run()
   if (scaleweight)
     app_log() << "  Scaling weight per Umrigar/Nightingale.\n";
   resetRun();
-  Mover->MaxAge        = 1;
-  IndexType block      = 0;
-  bool update_now      = false;
-  int nat              = W.getTotalNum();
-  int nw               = W.getActiveWalkers();
+  Mover->MaxAge   = 1;
+  IndexType block = 0;
+  bool update_now = false;
+  int nat         = W.getTotalNum();
+  int nw          = W.getActiveWalkers();
   std::vector<RealType> LocalEnergy(nw), LocalEnergyOld(nw);
   std::vector<PosType> delpos(nw);
   std::vector<PosType> newpos(nw);

--- a/src/QMCDrivers/DMC/DMC_CUDA.h
+++ b/src/QMCDrivers/DMC/DMC_CUDA.h
@@ -31,7 +31,8 @@ class DMCcuda : public QMCDriver
 {
 public:
   /// Constructor.
-  DMCcuda(MCWalkerConfiguration& w,
+  DMCcuda(const ProjectData& project_data,
+          MCWalkerConfiguration& w,
           TrialWaveFunction& psi,
           QMCHamiltonian& h,
           Communicate* comm,

--- a/src/QMCDrivers/QMCDriver.cpp
+++ b/src/QMCDrivers/QMCDriver.cpp
@@ -42,13 +42,15 @@ using TraceManager = int;
 
 namespace qmcplusplus
 {
-QMCDriver::QMCDriver(MCWalkerConfiguration& w,
+QMCDriver::QMCDriver(const ProjectData& project_data,
+                     MCWalkerConfiguration& w,
                      TrialWaveFunction& psi,
                      QMCHamiltonian& h,
                      Communicate* comm,
                      const std::string& QMC_driver_type,
                      bool enable_profiling)
     : MPIObjectBase(comm),
+      project_data_(project_data),
       DriftModifier(0),
       qmcNode(NULL),
       QMCType(QMC_driver_type),

--- a/src/QMCDrivers/QMCDriver.h
+++ b/src/QMCDrivers/QMCDriver.h
@@ -26,6 +26,7 @@
 #include "Pools/PooledData.h"
 #include "Utilities/TimerManager.h"
 #include "Utilities/ScopedProfiler.h"
+#include "Utilities/ProjectData.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/WaveFunctionPool.h"
 #include "QMCHamiltonians/QMCHamiltonian.h"
@@ -94,17 +95,13 @@ public:
   xmlNodePtr traces_xml;
 
   /// Constructor.
-  QMCDriver(MCWalkerConfiguration& w,
+  QMCDriver(const ProjectData& project_data,
+            MCWalkerConfiguration& w,
             TrialWaveFunction& psi,
             QMCHamiltonian& h,
             Communicate* comm,
             const std::string& QMC_driver_type,
             bool enable_profiling = false);
-
-  ///Copy Constructor (disabled).
-  QMCDriver(const QMCDriver&) = delete;
-  ///Copy operator (disabled).
-  QMCDriver& operator=(const QMCDriver&) = delete;
 
   ~QMCDriver() override;
 
@@ -200,6 +197,8 @@ public:
   unsigned long getDriverMode() override { return qmc_driver_mode.to_ulong(); }
 
 protected:
+  /// @brief top-level project data information
+  const ProjectData& project_data_;
   ///branch engine
   std::unique_ptr<BranchEngineType> branchEngine;
   ///drift modifer

--- a/src/QMCDrivers/QMCDriverFactory.cpp
+++ b/src/QMCDrivers/QMCDriverFactory.cpp
@@ -232,7 +232,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   {
     //VMCFactory fac(curQmcModeBits[UPDATE_MODE],cur);
     VMCFactory fac(das.what_to_do.to_ulong(), cur);
-    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
+    new_driver = fac.create(project_data_, qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
     //TESTING CLONE
     //TrialWaveFunction* psiclone=primaryPsi->makeClone(qmc_system);
     //qmcDriver = fac.create(qmc_system,*psiclone,*primaryH,particle_pool,hamiltonian_pool);
@@ -247,7 +247,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   else if (das.new_run_type == QMCRunType::DMC)
   {
     DMCFactory fac(das.what_to_do[UPDATE_MODE], das.what_to_do[GPU_MODE], cur);
-    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
+    new_driver = fac.create(project_data_, qmc_system, *primaryPsi, *primaryH, comm, das.enable_profiling);
   }
   else if (das.new_run_type == QMCRunType::DMC_BATCH)
   {
@@ -258,7 +258,7 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   else if (das.new_run_type == QMCRunType::RMC)
   {
     RMCFactory fac(das.what_to_do[UPDATE_MODE], cur);
-    new_driver = fac.create(qmc_system, *primaryPsi, *primaryH, comm);
+    new_driver = fac.create(project_data_, qmc_system, *primaryPsi, *primaryH, comm);
   }
   else if (das.new_run_type == QMCRunType::LINEAR_OPTIMIZE)
   {
@@ -266,7 +266,8 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
     APP_ABORT("QMCDriverFactory::createQMCDriver : method=\"linear\" is not safe with CPU mixed precision. Please use "
               "full precision build instead.");
 #endif
-    QMCFixedSampleLinearOptimize* opt = new QMCFixedSampleLinearOptimize(qmc_system, *primaryPsi, *primaryH, comm);
+    QMCFixedSampleLinearOptimize* opt =
+        new QMCFixedSampleLinearOptimize(project_data_, qmc_system, *primaryPsi, *primaryH, comm);
     //ZeroVarianceOptimize *opt = new ZeroVarianceOptimize(qmc_system,*primaryPsi,*primaryH );
     opt->setWaveFunctionNode(wavefunction_pool.getWaveFunctionNode("psi0"));
     new_driver.reset(opt);
@@ -286,7 +287,8 @@ std::unique_ptr<QMCDriverInterface> QMCDriverFactory::createQMCDriver(xmlNodePtr
   else if (das.new_run_type == QMCRunType::WF_TEST)
   {
     app_log() << "Testing wavefunctions." << std::endl;
-    QMCDriverInterface* temp_ptr = new WaveFunctionTester(qmc_system, *primaryPsi, *primaryH, particle_pool, comm);
+    QMCDriverInterface* temp_ptr =
+        new WaveFunctionTester(project_data_, qmc_system, *primaryPsi, *primaryH, particle_pool, comm);
     new_driver.reset(temp_ptr);
   }
   else

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -35,8 +35,17 @@ using TraceManager = int;
 namespace qmcplusplus
 {
 /// Constructor.
-RMC::RMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "RMC"), prestepsVMC(-1), rescaleDrift("no"), beta(-1), beads(-1), fromScratch(true)
+RMC::RMC(const ProjectData& project_data,
+         MCWalkerConfiguration& w,
+         TrialWaveFunction& psi,
+         QMCHamiltonian& h,
+         Communicate* comm)
+    : QMCDriver(project_data, w, psi, h, comm, "RMC"),
+      prestepsVMC(-1),
+      rescaleDrift("no"),
+      beta(-1),
+      beads(-1),
+      fromScratch(true)
 {
   RootName = "rmc";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);

--- a/src/QMCDrivers/RMC/RMC.h
+++ b/src/QMCDrivers/RMC/RMC.h
@@ -29,7 +29,11 @@ public:
   using ParticlePos     = ParticleSet::ParticlePos;
   using ReptileConfig_t = Reptile::ReptileConfig_t;
 
-  RMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
+  RMC(const ProjectData& project_data,
+      MCWalkerConfiguration& w,
+      TrialWaveFunction& psi,
+      QMCHamiltonian& h,
+      Communicate* comm);
   bool run() override;
   bool put(xmlNodePtr cur) override;
   //inline std::vector<RandomGenerator*>& getRng() { return Rng;}

--- a/src/QMCDrivers/RMC/RMCFactory.cpp
+++ b/src/QMCDrivers/RMC/RMCFactory.cpp
@@ -17,7 +17,8 @@
 
 namespace qmcplusplus
 {
-std::unique_ptr<QMCDriver> RMCFactory::create(MCWalkerConfiguration& w,
+std::unique_ptr<QMCDriver> RMCFactory::create(const ProjectData& project_data,
+                                              MCWalkerConfiguration& w,
                                               TrialWaveFunction& psi,
                                               QMCHamiltonian& h,
                                               Communicate* comm)
@@ -29,7 +30,7 @@ std::unique_ptr<QMCDriver> RMCFactory::create(MCWalkerConfiguration& w,
 
   if (RMCMode == 0 || RMCMode == 1) //(0,0,0) (0,0,1) pbyp and all electron
   {
-    qmc = std::make_unique<RMC>(w, psi, h, comm);
+    qmc = std::make_unique<RMC>(project_data, w, psi, h, comm);
   }
   qmc->setUpdateMode(RMCMode & 1);
   return qmc;

--- a/src/QMCDrivers/RMC/RMCFactory.h
+++ b/src/QMCDrivers/RMC/RMCFactory.h
@@ -29,7 +29,8 @@ private:
 public:
   RMCFactory(int vmode, xmlNodePtr cur) : RMCMode(vmode), myNode(cur) {}
 
-  std::unique_ptr<QMCDriver> create(MCWalkerConfiguration& w,
+  std::unique_ptr<QMCDriver> create(const ProjectData& project_data,
+                                    MCWalkerConfiguration& w,
                                     TrialWaveFunction& psi,
                                     QMCHamiltonian& h,
                                     Communicate* comm);

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -37,8 +37,13 @@ using TraceManager = int;
 namespace qmcplusplus
 {
 /// Constructor.
-VMC::VMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling)
-    : QMCDriver(w, psi, h, comm, "VMC", enable_profiling), UseDrift("yes")
+VMC::VMC(const ProjectData& project_data,
+         MCWalkerConfiguration& w,
+         TrialWaveFunction& psi,
+         QMCHamiltonian& h,
+         Communicate* comm,
+         bool enable_profiling)
+    : QMCDriver(project_data, w, psi, h, comm, "VMC", enable_profiling), UseDrift("yes")
 {
   RootName = "vmc";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);

--- a/src/QMCDrivers/VMC/VMC.h
+++ b/src/QMCDrivers/VMC/VMC.h
@@ -25,7 +25,12 @@ class VMC : public QMCDriver, public CloneManager
 {
 public:
   /// Constructor.
-  VMC(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm, bool enable_profiling);
+  VMC(const ProjectData& project_data_,
+      MCWalkerConfiguration& w,
+      TrialWaveFunction& psi,
+      QMCHamiltonian& h,
+      Communicate* comm,
+      bool enable_profiling);
   bool run() override;
   bool put(xmlNodePtr cur) override;
   QMCRunType getRunType() override { return QMCRunType::VMC; }

--- a/src/QMCDrivers/VMC/VMCFactory.cpp
+++ b/src/QMCDrivers/VMC/VMCFactory.cpp
@@ -33,7 +33,8 @@
 
 namespace qmcplusplus
 {
-std::unique_ptr<QMCDriverInterface> VMCFactory::create(MCWalkerConfiguration& w,
+std::unique_ptr<QMCDriverInterface> VMCFactory::create(const ProjectData& project_data,
+                                                       MCWalkerConfiguration& w,
                                                        TrialWaveFunction& psi,
                                                        QMCHamiltonian& h,
                                                        Communicate* comm,
@@ -43,16 +44,16 @@ std::unique_ptr<QMCDriverInterface> VMCFactory::create(MCWalkerConfiguration& w,
   std::unique_ptr<QMCDriverInterface> qmc;
 #ifdef QMC_CUDA
   if (VMCMode & 16)
-    qmc = std::make_unique<VMCcuda>(w, psi, h, comm, enable_profiling);
+    qmc = std::make_unique<VMCcuda>(project_data, w, psi, h, comm, enable_profiling);
   else
 #endif
       if (VMCMode == 0 || VMCMode == 1) //(0,0,0) (0,0,1)
   {
-    qmc = std::make_unique<VMC>(w, psi, h, comm, enable_profiling);
+    qmc = std::make_unique<VMC>(project_data, w, psi, h, comm, enable_profiling);
   }
   else if (VMCMode == 2 || VMCMode == 3)
   {
-    qmc = std::make_unique<CSVMC>(w, psi, h, comm);
+    qmc = std::make_unique<CSVMC>(project_data, w, psi, h, comm);
   }
   qmc->setUpdateMode(VMCMode & 1);
   return qmc;

--- a/src/QMCDrivers/VMC/VMCFactory.h
+++ b/src/QMCDrivers/VMC/VMCFactory.h
@@ -29,7 +29,8 @@ private:
 public:
   VMCFactory(unsigned long vmode, xmlNodePtr cur) : VMCMode(vmode), myNode(cur) {}
 
-  std::unique_ptr<QMCDriverInterface> create(MCWalkerConfiguration& w,
+  std::unique_ptr<QMCDriverInterface> create(const ProjectData& project_data,
+                                             MCWalkerConfiguration& w,
                                              TrialWaveFunction& psi,
                                              QMCHamiltonian& h,
                                              Communicate* comm,

--- a/src/QMCDrivers/VMC/VMC_CUDA.cpp
+++ b/src/QMCDrivers/VMC/VMC_CUDA.cpp
@@ -29,14 +29,13 @@
 namespace qmcplusplus
 {
 /// Constructor.
-VMCcuda::VMCcuda(MCWalkerConfiguration& w,
+VMCcuda::VMCcuda(const ProjectData& project_data,
+                 MCWalkerConfiguration& w,
                  TrialWaveFunction& psi,
                  QMCHamiltonian& h,
                  Communicate* comm,
                  bool enable_profiling)
-    : QMCDriver(w, psi, h, comm, "VMCcuda", enable_profiling),
-      UseDrift("yes"),
-      myPeriod4WalkerDump(0)
+    : QMCDriver(project_data, w, psi, h, comm, "VMCcuda", enable_profiling), UseDrift("yes"), myPeriod4WalkerDump(0)
 {
   RootName = "vmc";
   qmc_driver_mode.set(QMC_UPDATE_MODE, 1);

--- a/src/QMCDrivers/VMC/VMC_CUDA.h
+++ b/src/QMCDrivers/VMC/VMC_CUDA.h
@@ -29,7 +29,8 @@ class VMCcuda : public QMCDriver
 {
 public:
   /// Constructor.
-  VMCcuda(MCWalkerConfiguration& w,
+  VMCcuda(const ProjectData& project_data,
+          MCWalkerConfiguration& w,
           TrialWaveFunction& psi,
           QMCHamiltonian& h,
           Communicate* comm,

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.cpp
@@ -44,11 +44,12 @@ namespace qmcplusplus
 using MatrixOperators::product;
 
 
-QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(MCWalkerConfiguration& w,
+QMCFixedSampleLinearOptimize::QMCFixedSampleLinearOptimize(const ProjectData& project_data,
+                                                           MCWalkerConfiguration& w,
                                                            TrialWaveFunction& psi,
                                                            QMCHamiltonian& h,
                                                            Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "QMCFixedSampleLinearOptimize"),
+    : QMCDriver(project_data, w, psi, h, comm, "QMCFixedSampleLinearOptimize"),
 #ifdef HAVE_LMY_ENGINE
       vdeps(1, std::vector<double>()),
 #endif
@@ -652,7 +653,7 @@ bool QMCFixedSampleLinearOptimize::processOptXML(xmlNodePtr opt_xml,
 
   // Destroy old object to stop timer to correctly order timer with object lifetime scope
   vmcEngine.reset(nullptr);
-  vmcEngine = std::make_unique<VMC>(W, Psi, H, myComm, false);
+  vmcEngine = std::make_unique<VMC>(project_data_, W, Psi, H, myComm, false);
   vmcEngine->setUpdateMode(vmcMove[0] == 'p');
 
 

--- a/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
+++ b/src/QMCDrivers/WFOpt/QMCFixedSampleLinearOptimize.h
@@ -44,7 +44,11 @@ class QMCFixedSampleLinearOptimize : public QMCDriver, public LinearMethod, priv
 {
 public:
   ///Constructor.
-  QMCFixedSampleLinearOptimize(MCWalkerConfiguration& w, TrialWaveFunction& psi, QMCHamiltonian& h, Communicate* comm);
+  QMCFixedSampleLinearOptimize(const ProjectData& project_data,
+                               MCWalkerConfiguration& w,
+                               TrialWaveFunction& psi,
+                               QMCHamiltonian& h,
+                               Communicate*);
 
   ///Destructor
   ~QMCFixedSampleLinearOptimize() override;

--- a/src/QMCDrivers/WaveFunctionTester.cpp
+++ b/src/QMCDrivers/WaveFunctionTester.cpp
@@ -35,12 +35,13 @@ namespace qmcplusplus
 {
 using WP = WalkerProperties::Indexes;
 
-WaveFunctionTester::WaveFunctionTester(MCWalkerConfiguration& w,
+WaveFunctionTester::WaveFunctionTester(const ProjectData& project_data,
+                                       MCWalkerConfiguration& w,
                                        TrialWaveFunction& psi,
                                        QMCHamiltonian& h,
                                        ParticleSetPool& ptclPool,
                                        Communicate* comm)
-    : QMCDriver(w, psi, h, comm, "WaveFunctionTester"),
+    : QMCDriver(project_data, w, psi, h, comm, "WaveFunctionTester"),
       PtclPool(ptclPool),
       checkRatio("no"),
       checkClone("no"),

--- a/src/QMCDrivers/WaveFunctionTester.h
+++ b/src/QMCDrivers/WaveFunctionTester.h
@@ -46,7 +46,8 @@ public:
   using LogValueType = WaveFunctionComponent::LogValueType;
 
   /// Constructor.
-  WaveFunctionTester(MCWalkerConfiguration& w,
+  WaveFunctionTester(const ProjectData& project_data,
+                     MCWalkerConfiguration& w,
                      TrialWaveFunction& psi,
                      QMCHamiltonian& h,
                      ParticleSetPool& ptclPool,

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -13,6 +13,7 @@
 #include "catch.hpp"
 
 
+#include "Utilities/ProjectData.h"
 #include "Utilities/RandomGenerator.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
@@ -40,6 +41,7 @@ namespace qmcplusplus
 {
 TEST_CASE("DMC", "[drivers][dmc]")
 {
+  ProjectData project_data;
   Communicate* c = OHMMS::Controller;
 
   const SimulationCell simulation_cell;
@@ -90,7 +92,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(elec, psi, h, c, false);
+  DMC dmc_omp(project_data, elec, psi, h, c, false);
 
   const char* dmc_input = "<qmc method=\"dmc\"> \
    <parameter name=\"steps\">1</parameter> \
@@ -126,6 +128,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
 TEST_CASE("SODMC", "[drivers][dmc]")
 {
+  ProjectData project_data;
   Communicate* c = OHMMS::Controller;
 
   const SimulationCell simulation_cell;
@@ -175,7 +178,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  DMC dmc_omp(elec, psi, h, c, false);
+  DMC dmc_omp(project_data, elec, psi, h, c, false);
 
   const char* dmc_input = "<qmc method=\"dmc\"> \
    <parameter name=\"steps\">1</parameter> \

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -13,6 +13,7 @@
 #include "catch.hpp"
 
 
+#include "Utilities/ProjectData.h"
 #include "Utilities/RandomGenerator.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
@@ -40,6 +41,7 @@ namespace qmcplusplus
 {
 TEST_CASE("VMC", "[drivers][vmc]")
 {
+  ProjectData project_data;
   Communicate* c = OHMMS::Controller;
   c->setName("test");
   const SimulationCell simulation_cell;
@@ -82,7 +84,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, c, false);
 
   const char* vmc_input = "<qmc method=\"vmc\" move=\"pbyp\"> \
    <parameter name=\"substeps\">1</parameter> \
@@ -120,6 +122,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
 TEST_CASE("SOVMC", "[drivers][vmc]")
 {
+  ProjectData project_data;
   Communicate* c = OHMMS::Controller;
   c->setName("test");
   const SimulationCell simulation_cell;
@@ -163,7 +166,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, c, false);
 
   const char* vmc_input = "<qmc method=\"vmc\" move=\"pbyp\"> \
    <parameter name=\"substeps\">1</parameter> \
@@ -206,6 +209,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
 TEST_CASE("SOVMC-alle", "[drivers][vmc]")
 {
+  ProjectData project_data;
   Communicate* c = OHMMS::Controller;
   c->setName("test");
   const SimulationCell simulation_cell;
@@ -249,7 +253,7 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
 
   elec.resetWalkerProperty(); // get memory corruption w/o this
 
-  VMC vmc_omp(elec, psi, h, c, false);
+  VMC vmc_omp(project_data, elec, psi, h, c, false);
 
   const char* vmc_input = "<qmc method=\"vmc\" move=\"alle\"> \
    <parameter name=\"substeps\">1</parameter> \


### PR DESCRIPTION
## Proposed changes

Enable propagating ProjectData members to:
1. derived QMCDriver classes
2. factory classes `create` functions 

Similar pattern to QMCDriversNew
Related to #3411 and #4099


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 22.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
