### PR TITLE
Remove includes of obsolete hdf5 headers.

### DIFF
--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -28,7 +28,6 @@
 #include "Estimators/ScalarEstimatorBase.h"
 #include "Particle/Walker.h"
 #include "OhmmsPETE/OhmmsVector.h"
-#include "OhmmsData/HDFAttribIO.h"
 #include <bitset>
 
 namespace qmcplusplus

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -22,7 +22,6 @@
 #include "Estimators/EstimatorManagerNew.h"
 #include "Particle/Walker.h"
 #include "OhmmsPETE/OhmmsVector.h"
-#include "OhmmsData/HDFAttribIO.h"
 
 namespace qmcplusplus
 {

--- a/src/Estimators/EstimatorManagerNew.h
+++ b/src/Estimators/EstimatorManagerNew.h
@@ -22,7 +22,6 @@
 #include "OperatorEstBase.h"
 #include "Particle/Walker.h"
 #include "OhmmsPETE/OhmmsVector.h"
-#include "OhmmsData/HDFAttribIO.h"
 #include "type_traits/template_types.hpp"
 #include "EstimatorManagerInput.h"
 #include <bitset>

--- a/src/Estimators/ScalarEstimatorBase.h
+++ b/src/Estimators/ScalarEstimatorBase.h
@@ -18,7 +18,6 @@
 #define QMCPLUSPLUS_SCALAR_ESTIMATORBASE_H
 #include "Particle/MCWalkerConfiguration.h"
 #include "OhmmsData/RecordProperty.h"
-#include "OhmmsData/HDFAttribIO.h"
 #include "Estimators/accumulators.h"
 #include "Particle/Walker.h"
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCTools/QMCGaussianParserBase.cpp
+++ b/src/QMCTools/QMCGaussianParserBase.cpp
@@ -26,7 +26,6 @@
 #include <bitset>
 #include <iomanip>
 #include "ParticleIO/XMLParticleIO.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "ModernStringUtils.hpp"
 
 //std::vector<std::string> QMCGaussianParserBase::IonName;

--- a/src/QMCTools/QMCGaussianParserBase.h
+++ b/src/QMCTools/QMCGaussianParserBase.h
@@ -26,7 +26,6 @@
 #include "OhmmsData/OhmmsElementBase.h"
 #include "Utilities/SimpleParser.h"
 #include "Particle/ParticleSet.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "hdf/hdf_archive.h"
 
 using namespace qmcplusplus;

--- a/src/QMCWaveFunctions/EinsplineSetBuilder.h
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder.h
@@ -26,7 +26,6 @@
 #include "QMCWaveFunctions/SPOSetBuilder.h"
 #include "QMCWaveFunctions/BandInfo.h"
 #include "QMCWaveFunctions/AtomicOrbital.h"
-#include "Numerics/HDFNumericAttrib.h"
 #include <filesystem>
 #include <map>
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -19,7 +19,6 @@
 #include "Utilities/Timer.h"
 #include "Message/Communicate.h"
 #include "Message/CommOperators.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Utilities/qmc_common.h"
 

--- a/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilder_createSPOs.cpp
@@ -24,7 +24,6 @@
 #include "OhmmsData/AttributeSet.h"
 #include "Message/CommOperators.h"
 #include "Utilities/Timer.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "ParticleBase/RandomSeqGenerator.h"
 #include "Particle/DistanceTable.h"
 #include <fftw3.h>

--- a/src/QMCWaveFunctions/PlaneWave/PWBasis.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWBasis.cpp
@@ -17,11 +17,10 @@
  * @brief Definition of member functions of Plane-wave basis set
  */
 #include "PWBasis.h"
-#include "Numerics/HDFSTLAttrib.h"
 
 namespace qmcplusplus
 {
-int PWBasis::readbasis(hid_t h5basisgroup,
+int PWBasis::readbasis(hdf_archive& h5basisgroup,
                        RealType ecutoff,
                        const ParticleLayout& lat,
                        const std::string& pwname,
@@ -32,8 +31,7 @@ int PWBasis::readbasis(hid_t h5basisgroup,
   Lattice = lat;
   ecut    = ecutoff;
   app_log() << "  PWBasis::" << pwmultname << " is found " << std::endl;
-  HDFAttribIO<std::vector<GIndex_t>> hdfvtv(gvecs);
-  hdfvtv.read(h5basisgroup, "/electrons/kpoint_0/gvectors");
+  h5basisgroup.read(gvecs, "/electrons/kpoint_0/gvectors");
   NumPlaneWaves = std::max(gvecs.size(), kplusgvecs_cart.size());
   if (NumPlaneWaves == 0)
   {

--- a/src/QMCWaveFunctions/PlaneWave/PWBasis.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWBasis.h
@@ -20,9 +20,9 @@
 
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "Message/Communicate.h"
 #include "CPU/e2iphi.h"
+#include "hdf/hdf_archive.h"
 
 /** If defined, use recursive method to build the basis set for each position
  *
@@ -134,7 +134,7 @@ public:
    * @param resizeContainer if true, resize internal storage.
    * @return the number of plane waves
    */
-  int readbasis(hid_t h5basisgroup,
+  int readbasis(hdf_archive& h5basisgroup,
                 RealType ecutoff,
                 const ParticleLayout& lat,
                 const std::string& pwname     = "planewaves",

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -22,7 +22,6 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "OhmmsData/ParameterSet.h"
 #include "OhmmsData/AttributeSet.h"
-#include "Numerics/HDFSTLAttrib.h"
 #include "Message/Communicate.h"
 
 namespace qmcplusplus
@@ -184,8 +183,7 @@ bool PWOrbitalBuilder::createPWBasis(xmlNodePtr cur)
   //return the ecut to be used by the basis set
   RealType real_ecut = myParam->getEcut(ecut);
   //create at least one basis set but do resize the containers
-  int nh5gvecs =
-      myBasisSet->readbasis(hfile.getFileID(), real_ecut, targetPtcl.getLattice(), myParam->pwTag, myParam->pwMultTag);
+  int nh5gvecs = myBasisSet->readbasis(hfile, real_ecut, targetPtcl.getLattice(), myParam->pwTag, myParam->pwMultTag);
   app_log() << "  num_twist = " << nkpts << std::endl;
   app_log() << "  twist angle = " << TwistAngle << std::endl;
   app_log() << "  num_bands = " << nbands << std::endl;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

I removed `HDFNumericAttrib.h`, `HDFSTLAttrib.h`, and `HDFAttribIO.h` until the build failed. Then I refactored PWBasis to use hdf_archive.

This is part of https://github.com/QMCPACK/qmcpack/issues/4156.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
