### PR TITLE
Refactor EstimatorManagerBase. Use hdf_archive in tests.

### DIFF
--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -28,6 +28,7 @@
 #include "Estimators/ScalarEstimatorBase.h"
 #include "Particle/Walker.h"
 #include "OhmmsPETE/OhmmsVector.h"
+#include "io/hdf/hdf_archive.h"
 #include <bitset>
 
 namespace qmcplusplus
@@ -202,13 +203,15 @@ protected:
   ///index for the acceptance rate PropertyCache(acceptInd)
   int acceptInd;
   ///hdf5 handler
-  hid_t h_file;
+  hdf_archive h_file;
   ///total weight accumulated in a block
   RealType BlockWeight;
   ///file handler to write data
-  std::ofstream* Archive;
+  std::unique_ptr<std::ofstream> Archive;
+#if defined(DEBUG_ESTIMATOR_ARCHIVE)
   ///file handler to write data for debugging
-  std::ofstream* DebugArchive;
+  std::unique_ptr<std::ofstream> DebugArchive;
+#endif
   ///communicator to handle communication
   Communicate* myComm;
   /** pointer to the primary ScalarEstimatorBase

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -209,9 +209,9 @@ void EstimatorManagerNew::startDriverRun()
 #endif
   if (my_comm_->rank() == 0)
   {
-    std::string fname(my_comm_->getName());
-    fname.append(".scalar.dat");
-    Archive = std::make_unique<std::ofstream>(fname.c_str());
+    std::filesystem::path fname(my_comm_->getName());
+    fname.concat(".scalar.dat");
+    Archive = std::make_unique<std::ofstream>(fname);
     addHeader(*Archive);
     if (h5desc.size())
     {
@@ -346,7 +346,7 @@ void EstimatorManagerNew::writeScalarH5()
     for (int o = 0; o < h5desc.size(); ++o)
       // cheating here, remove SquaredAverageCache from API
       h5desc[o].write(AverageCache.data(), AverageCache.data());
-    H5Fflush(h_file->getFileID(), H5F_SCOPE_LOCAL);
+    h_file->flush();
   }
 
   if (Archive)
@@ -412,7 +412,7 @@ void EstimatorManagerNew::writeOperatorEstimators()
     {
       for (auto& op_est : operator_ests_)
         op_est->write();
-      H5Fflush(h_file->getFileID(), H5F_SCOPE_LOCAL);
+      h_file->flush();
     }
   }
 }

--- a/src/Estimators/tests/test_local_energy_est.cpp
+++ b/src/Estimators/tests/test_local_energy_est.cpp
@@ -19,6 +19,7 @@
 #include "Estimators/LocalEnergyEstimator.h"
 #include "Estimators/LocalEnergyOnlyEstimator.h"
 #include "QMCDrivers/WalkerProperties.h"
+#include "io/hdf/hdf_archive.h"
 
 #include <stdio.h>
 #include <sstream>
@@ -89,10 +90,14 @@ TEST_CASE("LocalEnergy with hdf5", "[estimators]")
 
   std::vector<ObservableHelper> h5desc;
 
-  hid_t h_file = H5Fcreate("tmp_obs.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  le_est.registerObservables(h5desc, h_file);
-  H5Fclose(h_file);
-  // Should make sure h5 file was created?  Check contents?
+  std::filesystem::path filename("tmp_obs.h5");
+  hdf_archive h_file;
+  h_file.create(filename);
+  le_est.registerObservables(h5desc, h_file.getFileID());
+  h_file.close();
+  REQUIRE(std::filesystem::exists(filename));
+  // Check contents?
+  REQUIRE(std::filesystem::remove(filename));
 
   LocalEnergyEstimator::RecordListType record;
   le_est.add2Record(record);

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -229,16 +229,19 @@ void CSVMC::resetRun()
 
   if (Movers.empty())
   {
-    CSMovers.resize(NumThreads, 0);
-    estimatorClones.resize(NumThreads, 0);
-    traceClones.resize(NumThreads, 0);
+    CSMovers.resize(NumThreads, nullptr);
+    estimatorClones.resize(NumThreads, nullptr);
+    traceClones.resize(NumThreads, nullptr);
     Rng.resize(NumThreads);
+
+    // hdf_archive::hdf_archive() is not thread-safe
+    for (int ip = 0; ip < NumThreads; ++ip)
+      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
 
 #pragma omp parallel for
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCDrivers/DMC/DMC.cpp
+++ b/src/QMCDrivers/DMC/DMC.cpp
@@ -88,10 +88,10 @@ void DMC::resetUpdateEngines()
       setWalkerOffsets();
     }
     //if(qmc_driver_mode[QMC_UPDATE_MODE]) W.clearAuxDataSet();
-    Movers.resize(NumThreads, 0);
+    Movers.resize(NumThreads, nullptr);
     Rng.resize(NumThreads);
-    estimatorClones.resize(NumThreads, 0);
-    traceClones.resize(NumThreads, 0);
+    estimatorClones.resize(NumThreads, nullptr);
+    traceClones.resize(NumThreads, nullptr);
     FairDivideLow(W.getActiveWalkers(), NumThreads, wPerRank);
 
     {
@@ -117,10 +117,14 @@ void DMC::resetUpdateEngines()
         o << "\n  DMC moves are rejected when a node crossing is detected";
       app_log() << o.str() << std::endl;
     }
+
+    // hdf_archive::hdf_archive() is not thread-safe
+    for (int ip = 0; ip < NumThreads; ++ip)
+      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
+
 #pragma omp parallel for
     for (int ip = 0; ip < NumThreads; ++ip)
     {
-      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)
       traceClones[ip] = Traces->makeClone();

--- a/src/QMCDrivers/RMC/RMC.cpp
+++ b/src/QMCDrivers/RMC/RMC.cpp
@@ -209,16 +209,20 @@ void RMC::resetRun()
 
   if (Movers.empty())
   {
-    Movers.resize(NumThreads, 0);
-    estimatorClones.resize(NumThreads, 0);
-    traceClones.resize(NumThreads, 0);
+    Movers.resize(NumThreads, nullptr);
+    estimatorClones.resize(NumThreads, nullptr);
+    traceClones.resize(NumThreads, nullptr);
     Rng.resize(NumThreads);
     branchEngine->initReptile(W);
+
+    // hdf_archive::hdf_archive() is not thread-safe
+    for (int ip = 0; ip < NumThreads; ++ip)
+      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
+
 #pragma omp parallel for
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip] = new EstimatorManagerBase(*Estimators); //,*hClones[ip]);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
       Rng[ip] = std::make_unique<RandomGenerator>(*RandomNumberControl::Children[ip]);

--- a/src/QMCDrivers/VMC/VMC.cpp
+++ b/src/QMCDrivers/VMC/VMC.cpp
@@ -165,15 +165,19 @@ void VMC::resetRun()
   if (Movers.empty())
   {
     movers_created = true;
-    Movers.resize(NumThreads, 0);
-    estimatorClones.resize(NumThreads, 0);
-    traceClones.resize(NumThreads, 0);
+    Movers.resize(NumThreads, nullptr);
+    estimatorClones.resize(NumThreads, nullptr);
+    traceClones.resize(NumThreads, nullptr);
     Rng.resize(NumThreads);
+
+    // hdf_archive::hdf_archive() is not thread-safe
+    for (int ip = 0; ip < NumThreads; ++ip)
+      estimatorClones[ip] = new EstimatorManagerBase(*Estimators);
+
 #pragma omp parallel for
     for (int ip = 0; ip < NumThreads; ++ip)
     {
       std::ostringstream os;
-      estimatorClones[ip] = new EstimatorManagerBase(*Estimators); //,*hClones[ip]);
       estimatorClones[ip]->resetTargetParticleSet(*wClones[ip]);
       estimatorClones[ip]->setCollectionMode(false);
 #if !defined(REMOVE_TRACEMANAGER)

--- a/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
+++ b/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
@@ -13,6 +13,9 @@
 #include "catch.hpp"
 
 #include "QMCHamiltonians/ObservableHelper.h"
+#include "io/hdf/hdf_archive.h"
+
+#include <filesystem>
 
 /*
   -- 05/07/2021 --
@@ -38,10 +41,12 @@ TEST_CASE("ObservableHelper::ObservableHelper(const std::string&)", "[hamiltonia
 
 TEST_CASE("ObservableHelper::ObservableHelper(ObservableHelper&&)", "[hamiltonian]")
 {
-  hid_t hFile = H5Fcreate("tmp_ObservableHelper1.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  std::filesystem::path filename("tmp_ObservableHelper1.h5");
+  hdf_archive hFile;
+  hFile.create(filename);
 
   ObservableHelper ohIn("u");
-  ohIn.open(hFile);
+  ohIn.open(hFile.getFileID());
   CHECK(ohIn.isOpened() == true);
   {
     ObservableHelper oh(std::move(ohIn));
@@ -50,7 +55,9 @@ TEST_CASE("ObservableHelper::ObservableHelper(ObservableHelper&&)", "[hamiltonia
   }
   CHECK(ohIn.isOpened() == false);
 
-  H5Fclose(hFile);
+  hFile.close();
+  REQUIRE(std::filesystem::exists(filename));
+  REQUIRE(std::filesystem::remove(filename));
 }
 
 TEST_CASE("ObservableHelper::set_dimensions", "[hamiltonian]")
@@ -69,10 +76,12 @@ TEST_CASE("ObservableHelper::set_dimensions", "[hamiltonian]")
 
 TEST_CASE("ObservableHelper::ObservableHelper()", "[hamiltonian]")
 {
-  hid_t hFile = H5Fcreate("tmp_ObservableHelper2.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  std::filesystem::path filename("tmp_ObservableHelper2.h5");
+  hdf_archive hFile;
+  hFile.create(filename);
 
   ObservableHelper oh("u");
-  oh.open(hFile);
+  oh.open(hFile.getFileID());
   std::vector<int> dims = {10, 10};
   float propertyFloat   = 10.f;
   oh.addProperty(propertyFloat, "propertyFloat");
@@ -92,7 +101,9 @@ TEST_CASE("ObservableHelper::ObservableHelper()", "[hamiltonian]")
   std::vector<TinyVector<float, OHMMS_DIM>> propertyVectorTinyVector;
   oh.addProperty(propertyVectorTinyVector, "propertyVectorTinyVector");
 
-  H5Fclose(hFile);
+  hFile.close();
+  REQUIRE(std::filesystem::exists(filename));
+  REQUIRE(std::filesystem::remove(filename));
 }
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWOrbitalBuilder.cpp
@@ -262,7 +262,7 @@ SPOSet* PWOrbitalBuilder::createPW(xmlNodePtr cur, int spinIndex)
   }
   //going to take care of occ
   psi->resize(new PWBasis(*myBasisSet), nb, true);
-  if (myParam->hasComplexData(hfile.getFileID())) //input is complex
+  if (myParam->hasComplexData(hfile)) //input is complex
   {
     //app_log() << "  PW coefficients are complex." << std::endl;
     using TempVecType    = std::vector<std::complex<RealType>>;

--- a/src/QMCWaveFunctions/PlaneWave/PWParameterSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWParameterSet.cpp
@@ -85,7 +85,7 @@ bool PWParameterSet::getEigVectorType(hid_t h)
   return rank == 4;
 }
 
-bool PWParameterSet::hasComplexData(hid_t h_file)
+bool PWParameterSet::hasComplexData(hdf_archive& h_file)
 {
   int iscomplex = 0;
   // Should be the tag "/electrons/psi_r_is_complex", but the test HDF files
@@ -95,8 +95,7 @@ bool PWParameterSet::hasComplexData(hid_t h_file)
   {
     std::ostringstream oss;
     oss << paramTag << "/complex_coefficients";
-    HDFAttribIO<int> creader(iscomplex);
-    creader.read(h_file,oss.str().c_str());
+    h_file.read(iscomplex, oss.str());
   }
 #endif
   myComm->bcast(iscomplex);

--- a/src/QMCWaveFunctions/PlaneWave/PWParameterSet.h
+++ b/src/QMCWaveFunctions/PlaneWave/PWParameterSet.h
@@ -80,7 +80,7 @@ struct PWParameterSet : public MPIObjectBase
    */
   bool getEigVectorType(hid_t h);
 
-  bool hasComplexData(hid_t h);
+  bool hasComplexData(hdf_archive& h);
 
   std::string getTwistAngleName();
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

I refactored EstimatorManagerBase to use hdf_archive. I also tried replacing H5Fcreate and H5Fflush with hdf_archive::open and hdf_archive::flush, respectively.

This is part of #4156.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
