### PR TITLE
QMCHamiltonian with Listener support

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -131,8 +131,8 @@ struct CoulombPBCAA : public OperatorBase, public ForceBase
 
   std::unique_ptr<OperatorBase> makeClone(ParticleSet& qp, TrialWaveFunction& psi) override;
 
-  /** Call to inform objects associated with this operator of per particle listeners.
-   *  should be called before createResources
+  /** Inform objects associated with this operator of per particle listeners.
+   *  i.e. turnOnPerParticleSK of particleset qp.
    */
   void informOfPerParticleListener() override;
 

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -60,20 +60,26 @@ private:
 };
 
 /** Convenience container for common optional element to mw_eval.._impl.
- *  This can allow the per_particle and reduced mw_eval to share the same
+ *  This allows the per_particle and reduced mw_eval_... to share the same
  *  implementation method.
  *
+ *  member naming is such that on usage:
+ *       ListenerOption listeners
+ *       ...
+ *       if (listeners)
+ *         for (const ListenerVector<Real>& listener : listeners->electron_values)
+ *           listener.report(iw, O_leader.getName(), ve_sample);
+ *
  *  see NonLocalECPotential for example of usage.
- *  I anticipate it could be used elsewhere.
  */
 template<typename T>
 struct ListenerOption
 {
   ListenerOption(const std::vector<ListenerVector<T>>& le, const std::vector<ListenerVector<T>>& li)
-      : electrons(le), ions(li)
+      : electron_values(le), ion_values(li)
   {}
-  const std::vector<ListenerVector<T>>& electrons;
-  const std::vector<ListenerVector<T>>& ions;
+  const std::vector<ListenerVector<T>>& electron_values;
+  const std::vector<ListenerVector<T>>& ion_values;
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/Listener.hpp
+++ b/src/QMCHamiltonians/Listener.hpp
@@ -69,14 +69,12 @@ private:
 template<typename T>
 struct ListenerOption
 {
-    ListenerOption(const std::vector<ListenerVector<T>>& le, const std::vector<ListenerVector<T>>& li)
-        : electrons(le), ions(li)
-    {}
-    const std::vector<ListenerVector<T>>& electrons;
-    const std::vector<ListenerVector<T>>& ions;
+  ListenerOption(const std::vector<ListenerVector<T>>& le, const std::vector<ListenerVector<T>>& li)
+      : electrons(le), ions(li)
+  {}
+  const std::vector<ListenerVector<T>>& electrons;
+  const std::vector<ListenerVector<T>>& ions;
 };
-
-
 
 } // namespace qmcplusplus
 

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -441,9 +441,9 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
     {
       Vector<Real> ve_sample(ve_samples.begin(iw), num_electrons);
       Vector<Real> vi_sample(vi_samples.begin(iw), O_leader.NumIons);
-      for (const ListenerVector<Real>& listener : listeners->electrons)
+      for (const ListenerVector<Real>& listener : listeners->electron_values)
         listener.report(iw, O_leader.getName(), ve_sample);
-      for (const ListenerVector<Real>& listener : listeners->ions)
+      for (const ListenerVector<Real>& listener : listeners->ion_values)
         listener.report(iw, O_leader.getName(), vi_sample);
     }
     ve_samples = 0.0;

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -291,13 +291,6 @@ void QMCHamiltonian::informOperatorsOfListener() {
     H[i]->informOfPerParticleListener();
 }
 
-void QMCHamiltonian::checkQuantityAvailable(std::string_view var_tag)
-{
-  if (std::none_of(available_quantities_.begin(), available_quantities_.end(),
-                   [var_tag](std::string_view avail) { return lowerCase(var_tag) == lowerCase(avail); }))
-    throw std::runtime_error("Listener requires value that isn't available from the QMCHamiltonian");
-}
-
 #if !defined(REMOVE_TRACEMANAGER)
 void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
 {

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -280,13 +280,15 @@ void QMCHamiltonian::mw_registerLocalPotentialListener(const QMCHamiltonian& lea
   leader.mw_res_->potential_listeners_.push_back(listener);
 }
 
-void QMCHamiltonian::mw_registerLocalIonPotentialListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)
+void QMCHamiltonian::mw_registerLocalIonPotentialListener(const QMCHamiltonian& leader,
+                                                          ListenerVector<RealType> listener)
 {
   // This creates a state replication burder of unknown scope when operators are cloned.
   leader.mw_res_->ion_potential_listeners_.push_back(listener);
 }
 
-void QMCHamiltonian::informOperatorsOfListener() {
+void QMCHamiltonian::informOperatorsOfListener()
+{
   for (int i = 0; i < H.size(); ++i)
     H[i]->informOfPerParticleListener();
 }
@@ -600,19 +602,21 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
   const int num_ham_operators = ham_leader.H.size();
 
   // It is an invariant of the class that H[0] be the kinetic energy operator.
-  // This is enforced by HamiltonianFactory's constuctor and not QMCHamiltonians 
+  // This is enforced by HamiltonianFactory's constuctor and not QMCHamiltonians
   int kinetic_index = 0;
   {
     ScopedTimer h_timer(ham_leader.my_timers_[kinetic_index]);
     const auto HC_list(extract_HC_list(ham_list, kinetic_index));
-    if(ham_leader.mw_res_->kinetic_listeners_.size() > 0)
-      ham_leader.H[kinetic_index]->mw_evaluatePerParticle(HC_list, wf_list, p_list, ham_leader.mw_res_->kinetic_listeners_, ham_leader.mw_res_->ion_kinetic_listeners_);
+    if (ham_leader.mw_res_->kinetic_listeners_.size() > 0)
+      ham_leader.H[kinetic_index]->mw_evaluatePerParticle(HC_list, wf_list, p_list,
+                                                          ham_leader.mw_res_->kinetic_listeners_,
+                                                          ham_leader.mw_res_->ion_kinetic_listeners_);
     else
       ham_leader.H[kinetic_index]->mw_evaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
-  
+
   for (int i_ham_op = 1; i_ham_op < num_ham_operators; ++i_ham_op)
   {
     ScopedTimer h_timer(ham_leader.my_timers_[i_ham_op]);
@@ -633,8 +637,9 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     //   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
     // };
 
-    if(ham_leader.mw_res_->potential_listeners_.size() > 0)
-      ham_leader.H[i_ham_op]->mw_evaluatePerParticle(HC_list, wf_list, p_list, ham_leader.mw_res_->potential_listeners_, ham_leader.mw_res_->ion_potential_listeners_);
+    if (ham_leader.mw_res_->potential_listeners_.size() > 0)
+      ham_leader.H[i_ham_op]->mw_evaluatePerParticle(HC_list, wf_list, p_list, ham_leader.mw_res_->potential_listeners_,
+                                                     ham_leader.mw_res_->ion_potential_listeners_);
     else
       ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
@@ -844,20 +849,24 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
   {
     ScopedTimer h_timer(ham_leader.my_timers_[kinetic_index]);
     const auto HC_list(extract_HC_list(ham_list, kinetic_index));
-    if(ham_leader.mw_res_->kinetic_listeners_.size() > 0)
-      ham_leader.H[kinetic_index]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list, ham_leader.mw_res_->kinetic_listeners_, ham_leader.mw_res_->ion_kinetic_listeners_);
+    if (ham_leader.mw_res_->kinetic_listeners_.size() > 0)
+      ham_leader.H[kinetic_index]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list,
+                                                                       ham_leader.mw_res_->kinetic_listeners_,
+                                                                       ham_leader.mw_res_->ion_kinetic_listeners_);
     else
       ham_leader.H[kinetic_index]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
-  
+
   for (int i_ham_op = 1; i_ham_op < num_ham_operators; ++i_ham_op)
   {
     ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
-    if(ham_leader.mw_res_->potential_listeners_.size() > 0)
-      ham_leader.H[i_ham_op]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list, ham_leader.mw_res_->potential_listeners_, ham_leader.mw_res_->ion_potential_listeners_);
+    if (ham_leader.mw_res_->potential_listeners_.size() > 0)
+      ham_leader.H[i_ham_op]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list,
+                                                                  ham_leader.mw_res_->potential_listeners_,
+                                                                  ham_leader.mw_res_->ion_potential_listeners_);
     else
       ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); ++iw)
@@ -1050,7 +1059,7 @@ std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<
 
 void QMCHamiltonian::createResource(ResourceCollection& collection) const
 {
-  auto new_res = std::make_unique<QMCHamiltonianMultiWalkerResource>();
+  auto new_res        = std::make_unique<QMCHamiltonianMultiWalkerResource>();
   auto resource_index = collection.addResource(std::move(new_res));
   for (int i = 0; i < H.size(); ++i)
     H[i]->createResource(collection);
@@ -1060,7 +1069,8 @@ void QMCHamiltonian::acquireResource(ResourceCollection& collection,
                                      const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
   auto& ham_leader = ham_list.getLeader();
-  ham_leader.mw_res_.reset(dynamic_cast<typename decltype(ham_leader.mw_res_)::pointer>(collection.lendResource().release()));
+  ham_leader.mw_res_.reset(
+      dynamic_cast<typename decltype(ham_leader.mw_res_)::pointer>(collection.lendResource().release()));
   if (!ham_leader.mw_res_)
     throw std::runtime_error("QMCHamilonian::acquireResource dynamic_cast failed");
   for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
@@ -1215,7 +1225,7 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivsDeterministicF
   std::vector<std::vector<ValueMatrix>> dM_gs_;
   std::vector<std::vector<ValueMatrix>> dB_;
   std::vector<std::vector<ValueMatrix>> dB_gs_;
-  
+
   {
     //  ScopedTimer resizetimer(*timer_manager.createTimer("NEW::Resize"));
     M_.resize(ngroups);

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Bryan Clark, bclark@Princeton.edu, Princeton University
 //                    Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
@@ -12,6 +12,7 @@
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -259,6 +260,43 @@ void QMCHamiltonian::registerCollectables(std::vector<ObservableHelper>& h5desc,
     auxH[i]->registerCollectables(h5desc, gid);
 }
 
+void QMCHamiltonian::mw_registerKineticListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)
+{
+  // This creates a state replication burder of unknown scope when operators are cloned.
+  leader.mw_res_->kinetic_listeners_.push_back(listener);
+}
+
+void QMCHamiltonian::mw_registerLocalEnergyListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)
+{
+  // This creates a state replication burder of unknown scope when operators are cloned.
+  // A local energy listener listens to both the kinetic operator and all involved in the potential.
+  leader.mw_res_->kinetic_listeners_.push_back(listener);
+  leader.mw_res_->potential_listeners_.push_back(listener);
+}
+
+void QMCHamiltonian::mw_registerLocalPotentialListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)
+{
+  // This creates a state replication burder of unknown scope when operators are cloned.
+  leader.mw_res_->potential_listeners_.push_back(listener);
+}
+
+void QMCHamiltonian::mw_registerLocalIonPotentialListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)
+{
+  // This creates a state replication burder of unknown scope when operators are cloned.
+  leader.mw_res_->ion_potential_listeners_.push_back(listener);
+}
+
+void QMCHamiltonian::informOperatorsOfListener() {
+  for (int i = 0; i < H.size(); ++i)
+    H[i]->informOfPerParticleListener();
+}
+
+void QMCHamiltonian::checkQuantityAvailable(std::string_view var_tag)
+{
+  if (std::none_of(available_quantities_.begin(), available_quantities_.end(),
+                   [var_tag](std::string_view avail) { return lowerCase(var_tag) == lowerCase(avail); }))
+    throw std::runtime_error("Listener requires value that isn't available from the QMCHamiltonian");
+}
 
 #if !defined(REMOVE_TRACEMANAGER)
 void QMCHamiltonian::initialize_traces(TraceManager& tm, ParticleSet& P)
@@ -567,11 +605,27 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     ham.LocalEnergy = 0.0;
 
   const int num_ham_operators = ham_leader.H.size();
-  for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
+
+  // It is an invariant of the class that H[0] be the kinetic energy operator.
+  // This is enforced by HamiltonianFactory's constuctor and not QMCHamiltonians 
+  int kinetic_index = 0;
+  {
+    ScopedTimer h_timer(ham_leader.my_timers_[kinetic_index]);
+    const auto HC_list(extract_HC_list(ham_list, kinetic_index));
+    if(ham_leader.mw_res_->kinetic_listeners_.size() > 0)
+      ham_leader.H[kinetic_index]->mw_evaluatePerParticle(HC_list, wf_list, p_list, ham_leader.mw_res_->kinetic_listeners_, ham_leader.mw_res_->ion_kinetic_listeners_);
+    else
+      ham_leader.H[kinetic_index]->mw_evaluate(HC_list, wf_list, p_list);
+    for (int iw = 0; iw < ham_list.size(); iw++)
+      updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
+  }
+  
+  for (int i_ham_op = 1; i_ham_op < num_ham_operators; ++i_ham_op)
   {
     ScopedTimer h_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
 
+    // This comment badly breaks the 1st rule of comments..
     // // This lambda accomplishes two things
     // // 1. It makes clear T& and not std::reference_wrapper<T> is desired removing need for gets.
     // // 2. [] captures nothing insuring that we know these updates only depend on the three object involved.
@@ -585,7 +639,11 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
     //   op.setObservables(ham.Observables);
     //   op.setParticlePropertyList(pset.PropertyList, ham.myIndex);
     // };
-    ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
+
+    if(ham_leader.mw_res_->potential_listeners_.size() > 0)
+      ham_leader.H[i_ham_op]->mw_evaluatePerParticle(HC_list, wf_list, p_list, ham_leader.mw_res_->potential_listeners_, ham_leader.mw_res_->ion_potential_listeners_);
+    else
+      ham_leader.H[i_ham_op]->mw_evaluate(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); iw++)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -595,10 +653,9 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
   //   pset.PropertyList[WP::LOCALENERGY]    = ham.LocalEnergy;
   //   pset.PropertyList[LOCALPOTENTIAL] = ham.LocalEnergy - ham.KineticEnergy;
   // };
-
+  const auto HC_list(extract_HC_list(ham_list, 0));
   for (int iw = 0; iw < ham_list.size(); iw++)
   {
-    const auto HC_list(extract_HC_list(ham_list, 0));
     updateKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
 
@@ -789,12 +846,27 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
 
   auto& ham_leader            = ham_list.getLeader();
   const int num_ham_operators = ham_leader.H.size();
-  for (int i_ham_op = 0; i_ham_op < num_ham_operators; ++i_ham_op)
+
+  int kinetic_index = 0;
+  {
+    ScopedTimer h_timer(ham_leader.my_timers_[kinetic_index]);
+    const auto HC_list(extract_HC_list(ham_list, kinetic_index));
+    if(ham_leader.mw_res_->kinetic_listeners_.size() > 0)
+      ham_leader.H[kinetic_index]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list, ham_leader.mw_res_->kinetic_listeners_, ham_leader.mw_res_->ion_kinetic_listeners_);
+    else
+      ham_leader.H[kinetic_index]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
+    for (int iw = 0; iw < ham_list.size(); iw++)
+      updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
+  }
+  
+  for (int i_ham_op = 1; i_ham_op < num_ham_operators; ++i_ham_op)
   {
     ScopedTimer local_timer(ham_leader.my_timers_[i_ham_op]);
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
-
-    ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
+    if(ham_leader.mw_res_->potential_listeners_.size() > 0)
+      ham_leader.H[i_ham_op]->mw_evaluatePerParticleWithToperator(HC_list, wf_list, p_list, ham_leader.mw_res_->potential_listeners_, ham_leader.mw_res_->ion_potential_listeners_);
+    else
+      ham_leader.H[i_ham_op]->mw_evaluateWithToperator(HC_list, wf_list, p_list);
     for (int iw = 0; iw < ham_list.size(); ++iw)
       updateNonKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
   }
@@ -985,6 +1057,8 @@ std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<
 
 void QMCHamiltonian::createResource(ResourceCollection& collection) const
 {
+  auto new_res = std::make_unique<QMCHamiltonianMultiWalkerResource>();
+  auto resource_index = collection.addResource(std::move(new_res));
   for (int i = 0; i < H.size(); ++i)
     H[i]->createResource(collection);
 }
@@ -993,6 +1067,9 @@ void QMCHamiltonian::acquireResource(ResourceCollection& collection,
                                      const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
   auto& ham_leader = ham_list.getLeader();
+  ham_leader.mw_res_.reset(dynamic_cast<typename decltype(ham_leader.mw_res_)::pointer>(collection.lendResource().release()));
+  if (!ham_leader.mw_res_)
+    throw std::runtime_error("QMCHamilonian::acquireResource dynamic_cast failed");
   for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
   {
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
@@ -1004,6 +1081,7 @@ void QMCHamiltonian::releaseResource(ResourceCollection& collection,
                                      const RefVectorWithLeader<QMCHamiltonian>& ham_list)
 {
   auto& ham_leader = ham_list.getLeader();
+  collection.takebackResource(std::move(ham_leader.mw_res_));
   for (int i_ham_op = 0; i_ham_op < ham_leader.H.size(); ++i_ham_op)
   {
     const auto HC_list(extract_HC_list(ham_list, i_ham_op));
@@ -1011,7 +1089,7 @@ void QMCHamiltonian::releaseResource(ResourceCollection& collection,
   }
 }
 
-std::unique_ptr<QMCHamiltonian> QMCHamiltonian::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
+std::unique_ptr<QMCHamiltonian> QMCHamiltonian::makeClone(ParticleSet& qp, TrialWaveFunction& psi) const
 {
   auto myclone = std::make_unique<QMCHamiltonian>(myName);
   for (int i = 0; i < H.size(); ++i)

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -653,9 +653,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluate(
   // };
   const auto HC_list(extract_HC_list(ham_list, 0));
   for (int iw = 0; iw < ham_list.size(); iw++)
-  {
     updateKinetic(HC_list[iw], ham_list[iw], p_list[iw]);
-  }
 
   std::vector<FullPrecRealType> local_energies(ham_list.size(), 0.0);
   for (int iw = 0; iw < ham_list.size(); ++iw)
@@ -845,7 +843,7 @@ std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::mw_evaluateWithTop
   auto& ham_leader            = ham_list.getLeader();
   const int num_ham_operators = ham_leader.H.size();
 
-  int kinetic_index = 0;
+  const int kinetic_index = 0;
   {
     ScopedTimer h_timer(ham_leader.my_timers_[kinetic_index]);
     const auto HC_list(extract_HC_list(ham_list, kinetic_index));
@@ -1059,8 +1057,7 @@ std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<
 
 void QMCHamiltonian::createResource(ResourceCollection& collection) const
 {
-  auto new_res        = std::make_unique<QMCHamiltonianMultiWalkerResource>();
-  auto resource_index = collection.addResource(std::move(new_res));
+  auto resource_index = collection.addResource(std::move(std::make_unique<QMCHamiltonianMultiWalkerResource>()));
   for (int i = 0; i < H.size(); ++i)
     H[i]->createResource(collection);
 }

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -153,8 +153,6 @@ public:
   
   void informOperatorsOfListener();
   
-  void checkQuantityAvailable(std::string_view var_tag);
-  
   ///retrun the starting index
   inline int startIndex() const { return myIndex; }
   ///return the size of observables

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -150,9 +150,9 @@ public:
   static void mw_registerLocalEnergyListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
   static void mw_registerLocalPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
   static void mw_registerLocalIonPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
-  
+
   void informOperatorsOfListener();
-  
+
   ///retrun the starting index
   inline int startIndex() const { return myIndex; }
   ///return the size of observables
@@ -452,15 +452,17 @@ public:
                 std::vector<RealType>& energyVector,
                 std::vector<std::vector<NonLocalData>>& Txy);
 
-private:  
+private:
   /////////////////////
   // Vectorized data //
   /////////////////////
   std::vector<QMCHamiltonian::FullPrecRealType> LocalEnergyVector, AuxEnergyVector;
 #endif
 private:
-  static constexpr std::array<std::string_view, 8> available_quantities_{"weight", "LocalEnergy","LocalPotential","Vq","Vc","Vqq","Vqc","Vcc"};
-  
+  static constexpr std::array<std::string_view, 8> available_quantities_{"weight", "LocalEnergy", "LocalPotential",
+                                                                         "Vq",     "Vc",          "Vqq",
+                                                                         "Vqc",    "Vcc"};
+
   ///starting index
   int myIndex;
   ///starting index
@@ -529,7 +531,6 @@ private:
 
   /// multiwalker shared resource
   ResourceHandle<QMCHamiltonianMultiWalkerResource> mw_res_;
-
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -151,6 +151,15 @@ public:
   static void mw_registerLocalPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
   static void mw_registerLocalIonPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
 
+  /** Some Hamiltonian components need to be informed that they are in a per particle reporting
+   *  situation so additional state can be added either to them or the objects they are strongly coupled with.
+   *
+   *  This includes evalation of hamiltonian components constants on a per particle basis and informing a components
+   *  attached particle set that it needs to store per particle values for StructFact. This is a reason that the
+   *  coupling between Hamiltonian components and particle sets can strong and must be correct.
+   *
+   *  This is not desirable and hopefully this state transformation message can be removed.
+   */
   void informOperatorsOfListener();
 
   ///retrun the starting index
@@ -209,12 +218,6 @@ public:
   void auxHevaluate(ParticleSet& P, Walker_t& ThisWalker);
   void auxHevaluate(ParticleSet& P, Walker_t& ThisWalker, bool do_properties, bool do_collectables);
   void rejectedMove(ParticleSet& P, Walker_t& ThisWalker);
-  ///** set Tau for each Hamiltonian
-  // */
-  //inline void setTau(RealType tau)
-  //{
-  //  for(int i=0; i< H.size();i++)H[i]->setTau(tau);
-  //}
 
   /** set PRIMARY bit of all the components
    */
@@ -223,25 +226,6 @@ public:
     for (int i = 0; i < H.size(); i++)
       H[i]->getUpdateMode().set(OperatorBase::PRIMARY, primary);
   }
-
-  /////Set Tau inside each of the Hamiltonian elements
-  //void setTau(Return_t tau)
-  //{
-  //  for(int i=0; i<H.size(); i++) H[i]->setTau(tau);
-  //  for(int i=0; i<auxH.size(); i++) auxH[i]->setTau(tau);
-  //}
-
-  ///** return if WaveFunction Ratio needs to be evaluated
-  // *
-  // * This is added to handle orbital-dependent OperatorBase during
-  // * orbital optimizations.
-  // */
-  //inline bool needRatio() {
-  //  bool dependOnOrbital=false;
-  //  for(int i=0; i< H.size();i++)
-  //    if(H[i]->UpdateMode[OperatorBase::RATIOUPDATE]) dependOnOrbital=true;
-  //  return dependOnOrbital;
-  //}
 
   /** evaluate Local Energy
    * @param P ParticleSet

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -2,13 +2,14 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jaron T. Krogel, krogeljt@ornl.gov, Oak Ridge National Laboratory
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
+//                    Peter W. Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -19,6 +20,11 @@
  */
 #ifndef QMCPLUSPLUS_HAMILTONIAN_H
 #define QMCPLUSPLUS_HAMILTONIAN_H
+
+#include <string_view>
+
+#include <ResourceHandle.h>
+
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "QMCHamiltonians/L2Potential.h"
 #include "Configuration.h"
@@ -136,6 +142,19 @@ public:
    * Add observable_helper information for the data stored in ParticleSet::mcObservables.
    */
   void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+
+  /** Listener Registration
+   *  This must be called on a QMCHamiltonian that has acquired multiwalker resources
+   */
+  static void mw_registerKineticListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalEnergyListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalIonPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  
+  void informOperatorsOfListener();
+  
+  void checkQuantityAvailable(std::string_view var_tag);
+  
   ///retrun the starting index
   inline int startIndex() const { return myIndex; }
   ///return the size of observables
@@ -412,7 +431,6 @@ public:
   static void updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
   static void updateKinetic(OperatorBase& op, QMCHamiltonian& ham, ParticleSet& pset);
 
-
   /// initialize a shared resource and hand it to a collection
   void createResource(ResourceCollection& collection) const;
   /** acquire external resource
@@ -425,7 +443,7 @@ public:
   static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<QMCHamiltonian>& ham_list);
 
   /** return a clone */
-  std::unique_ptr<QMCHamiltonian> makeClone(ParticleSet& qp, TrialWaveFunction& psi);
+  std::unique_ptr<QMCHamiltonian> makeClone(ParticleSet& qp, TrialWaveFunction& psi) const;
 
 #ifdef QMC_CUDA
   ////////////////////////////////////////////
@@ -436,14 +454,15 @@ public:
                 std::vector<RealType>& energyVector,
                 std::vector<std::vector<NonLocalData>>& Txy);
 
-private:
+private:  
   /////////////////////
   // Vectorized data //
   /////////////////////
   std::vector<QMCHamiltonian::FullPrecRealType> LocalEnergyVector, AuxEnergyVector;
 #endif
-
 private:
+  static constexpr std::array<std::string_view, 8> available_quantities_{"weight", "LocalEnergy","LocalPotential","Vq","Vc","Vqq","Vqc","Vcc"};
+  
   ///starting index
   int myIndex;
   ///starting index
@@ -480,6 +499,7 @@ private:
    */
   void resetObservables(int start, int ncollects);
 
+  void reportToListeners();
   // helper function for extracting a list of Hamiltonian components from a list of QMCHamiltonian::H.
   static RefVectorWithLeader<OperatorBase> extract_HC_list(const RefVectorWithLeader<QMCHamiltonian>& ham_list, int id);
 
@@ -496,6 +516,22 @@ private:
   Array<TraceReal, 1>* weight_sample;
   Array<TraceReal, 2>* position_sample;
 #endif
+
+  struct QMCHamiltonianMultiWalkerResource : public Resource
+  {
+    QMCHamiltonianMultiWalkerResource() : Resource("QMCHamiltonian") {}
+    // the listeners represet the connection of a particular crowds estimators to the crowds lead QMCHamiltonian.
+    // So you can not clone them.
+    Resource* makeClone() const override { return new QMCHamiltonianMultiWalkerResource(*this); }
+    std::vector<ListenerVector<RealType>> kinetic_listeners_;
+    std::vector<ListenerVector<RealType>> potential_listeners_;
+    std::vector<ListenerVector<RealType>> ion_kinetic_listeners_;
+    std::vector<ListenerVector<RealType>> ion_potential_listeners_;
+  };
+
+  /// multiwalker shared resource
+  ResourceHandle<QMCHamiltonianMultiWalkerResource> mw_res_;
+
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/tests/MinimalHamiltonianPool.h
+++ b/src/QMCHamiltonians/tests/MinimalHamiltonianPool.h
@@ -28,6 +28,13 @@ class MinimalHamiltonianPool
 </hamiltonian>
   )";
 
+    static constexpr const char* const hamiltonian_eeei_xml = R"(
+<hamiltonian name="h0" type="generic" target="e"> 
+  <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+  <pairpot type="coulomb" name="ElecIon" source="ion" target="e"/> 
+</hamiltonian>
+  )";
+
 public:
   static HamiltonianPool make_hamWithEE(Communicate* comm,
                                         ParticleSetPool& particle_pool,
@@ -42,6 +49,21 @@ public:
 
     return hpool;
   }
+
+  static HamiltonianPool makeHamWithEEEI(Communicate* comm,
+                                        ParticleSetPool& particle_pool,
+                                        WaveFunctionPool& wavefunction_pool)
+  {
+    HamiltonianPool hpool(particle_pool, wavefunction_pool, comm);
+    Libxml2Document doc;
+    doc.parseFromString(hamiltonian_eeei_xml);
+
+    xmlNodePtr root = doc.getRoot();
+    hpool.put(root);
+
+    return hpool;
+  }
+
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/MinimalHamiltonianPool.h
+++ b/src/QMCHamiltonians/tests/MinimalHamiltonianPool.h
@@ -28,7 +28,7 @@ class MinimalHamiltonianPool
 </hamiltonian>
   )";
 
-    static constexpr const char* const hamiltonian_eeei_xml = R"(
+  static constexpr const char* const hamiltonian_eeei_xml = R"(
 <hamiltonian name="h0" type="generic" target="e"> 
   <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
   <pairpot type="coulomb" name="ElecIon" source="ion" target="e"/> 
@@ -51,8 +51,8 @@ public:
   }
 
   static HamiltonianPool makeHamWithEEEI(Communicate* comm,
-                                        ParticleSetPool& particle_pool,
-                                        WaveFunctionPool& wavefunction_pool)
+                                         ParticleSetPool& particle_pool,
+                                         WaveFunctionPool& wavefunction_pool)
   {
     HamiltonianPool hpool(particle_pool, wavefunction_pool, comm);
     Libxml2Document doc;
@@ -63,7 +63,6 @@ public:
 
     return hpool;
   }
-
 };
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/TestListenerFunction.h
+++ b/src/QMCHamiltonians/tests/TestListenerFunction.h
@@ -27,6 +27,17 @@ auto getParticularListener(Matrix<T>& local_pots)
   };
 }
 
+template<typename T>
+auto getSummingListener(Matrix<T>& local_pots)
+{
+  return [&local_pots](const int walker_index, const std::string& name, const Vector<T>& inputV) {
+    assert(local_pots.cols() >= inputV.size());
+    assert(walker_index < local_pots.rows());
+    std::transform(inputV.begin(), inputV.end(), local_pots[walker_index], local_pots[walker_index], std::plus<>{} );
+  };
+}
+
+  
 } // namespace testing
 } // namespace qmcplusplus
 

--- a/src/QMCHamiltonians/tests/test_Listener.cpp
+++ b/src/QMCHamiltonians/tests/test_Listener.cpp
@@ -25,14 +25,18 @@ using Real = QMCT::RealType;
 namespace testing
 {
 
-class Talker
+/** Mock class that collects ListnerVectors as QMCHamiltonian does
+ *   and reports ListenerVectors Hamiltonian operators do when they report per particle values.
+ */
+class MockQMCHamiltonianAndReporter
 {
 private:
   std::vector<ListenerVector<Real>> listener_vectors_;
   const std::string name_{"Talker"};
 
 public:
-  void registerVector(ListenerVector<Real>&& listener_vector) { listener_vectors_.push_back(listener_vector); }
+  /** why move or not move */
+  void registerVector(ListenerVector<Real>&& listener_vector) { listener_vectors_.push_back(std::move(listener_vector)); }
   void reportVector()
   {
     Vector<Real> vec_part(4);
@@ -42,7 +46,7 @@ public:
   }
 };
 
-class TestReceiver
+class MockPerParticleEstimator
 {
 public:
   /** Return listener frunction that has captured an object data member.
@@ -64,14 +68,14 @@ public:
 
 TEST_CASE("ListenerVector", "[hamiltonian]")
 {
-  Talker talker;
-  TestReceiver test_receiver;
+  MockQMCHamiltonianAndReporter mock_ham_report;
+  MockPerParticleEstimator mock_estimator;
 
-  talker.registerVector(test_receiver.makeListener());
+  mock_ham_report.registerVector(mock_estimator.makeListener());
 
-  talker.reportVector();
-  CHECK(test_receiver.receiver_vector_[0] == 0);
-  CHECK(test_receiver.receiver_vector_[3] == 3);
+  mock_ham_report.reportVector();
+  CHECK(mock_estimator.receiver_vector_[0] == 0);
+  CHECK(mock_estimator.receiver_vector_[3] == 3);
 }
 
 } // namespace testing

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -33,8 +33,6 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
   Communicate* comm;
   comm = OHMMS::Controller;
 
-  outputManager.pause();
-
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
   auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
@@ -53,7 +51,6 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
   //std::vector<QMCHamiltonian::RealType> local_energies(QMCHamiltonian::flex_evaluate(makeRefVector<QMCHamiltonian>(hamiltonians), makeRefVector<ParticleSet>(elecs)));
 
   //TODO: Would be nice to check some values but I think the system needs a little more setup
-  outputManager.resume();
 }
 
 #ifndef QMC_CUDA
@@ -62,10 +59,7 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
  */
 TEST_CASE("integrateListeners", "[hamiltonian]")
 {
-  Communicate* comm;
-  comm = OHMMS::Controller;
-
-  outputManager.pause();
+  Communicate* comm = OHMMS::Controller;
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
@@ -269,7 +263,6 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
     auto sum_local_nrg  = std::accumulate(local_nrg.begin(), local_nrg.end(), 0.0);
     CHECK(sum_local_nrg == Approx(sum_local_pots + sum_kinetic));
   }
-  outputManager.resume();
 }
 #endif
 

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -56,6 +56,8 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
   outputManager.resume();
 }
 
+#ifndef QMC_CUDA
+
 /** QMCHamiltonian + Hamiltonians with listeners integration test
  */
 TEST_CASE("integrateListeners", "[hamiltonian]")
@@ -263,10 +265,12 @@ TEST_CASE("integrateListeners", "[hamiltonian]")
     // When only EE and EI coulomb potentials the local energy is just the sum of
     // the local_pots and kinetic
     auto sum_local_pots = std::accumulate(local_pots.begin(), local_pots.end(), 0.0);
-    auto sum_kinetic   = std::accumulate(kinetic.begin(), kinetic.end(), 0.0);
-    auto sum_local_nrg = std::accumulate(local_nrg.begin(), local_nrg.end(), 0.0);
+    auto sum_kinetic    = std::accumulate(kinetic.begin(), kinetic.end(), 0.0);
+    auto sum_local_nrg  = std::accumulate(local_nrg.begin(), local_nrg.end(), 0.0);
     CHECK(sum_local_nrg == Approx(sum_local_pots + sum_kinetic));
   }
   outputManager.resume();
 }
+#endif
+
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -64,10 +64,10 @@ TEST_CASE("QMCHamiltonian-registerListeners", "[hamiltonian]")
 
   outputManager.pause();
 
-  auto particle_pool       = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool   = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
-  auto hamiltonian_pool    = MinimalHamiltonianPool::makeHamWithEEEI(comm, particle_pool, wavefunction_pool);
-  auto& pset_target        = *(particle_pool.getParticleSet("e"));
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::makeHamWithEEEI(comm, particle_pool, wavefunction_pool);
+  auto& pset_target      = *(particle_pool.getParticleSet("e"));
   //auto& species_set        = pset_target.getSpeciesSet();
   //auto& spo_map            = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
   auto& trial_wavefunction = *(wavefunction_pool.getPrimary());

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2019 QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
 //
@@ -17,12 +17,23 @@
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
+#include "TestListenerFunction.h"
+#include "Utilities/StlPrettyPrint.hpp"
+#include "Utilities/for_testing/NativeInitializerPrint.hpp"
+
 namespace qmcplusplus
 {
+using QMCT = QMCTraits;
+using Real = QMCT::RealType;
+
+constexpr bool generate_test_data = false;
+
 TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
 {
   Communicate* comm;
   comm = OHMMS::Controller;
+
+  outputManager.pause();
 
   auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
@@ -42,6 +53,186 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
   //std::vector<QMCHamiltonian::RealType> local_energies(QMCHamiltonian::flex_evaluate(makeRefVector<QMCHamiltonian>(hamiltonians), makeRefVector<ParticleSet>(elecs)));
 
   //TODO: Would be nice to check some values but I think the system needs a little more setup
+  outputManager.resume();
 }
 
+TEST_CASE("QMCHamiltonian-registerListeners", "[hamiltonian]")
+{
+  using testing::getParticularListener;
+  Communicate* comm;
+  comm = OHMMS::Controller;
+
+  outputManager.pause();
+
+  auto particle_pool       = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool   = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
+  auto hamiltonian_pool    = MinimalHamiltonianPool::makeHamWithEEEI(comm, particle_pool, wavefunction_pool);
+  auto& pset_target        = *(particle_pool.getParticleSet("e"));
+  //auto& species_set        = pset_target.getSpeciesSet();
+  //auto& spo_map            = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
+  auto& trial_wavefunction = *(wavefunction_pool.getPrimary());
+
+  UPtrVector<QMCHamiltonian> hams;
+  UPtrVector<TrialWaveFunction> twfs;
+  std::vector<ParticleSet> psets;
+
+  // This must be done before clones otherwise the clone particle sets do not have the correct state.
+  hamiltonian_pool.getPrimary()->informOperatorsOfListener();
+
+
+  int num_walkers   = 4;
+  int num_electrons = 8;
+  for (int iw = 0; iw < num_walkers; ++iw)
+  {
+    psets.emplace_back(pset_target);
+    psets.back().randomizeFromSource(*particle_pool.getParticleSet("ion"));
+    twfs.emplace_back(trial_wavefunction.makeClone(psets.back()));
+    hams.emplace_back(hamiltonian_pool.getPrimary()->makeClone(psets.back(), *twfs.back()));
+  }
+
+  RefVector<QMCHamiltonian> ham_refs = convertUPtrToRefVector(hams);
+  RefVectorWithLeader<QMCHamiltonian> ham_list{ham_refs[0], ham_refs};
+
+  ResourceCollection ham_res("test_ham_res");
+  ham_list.getLeader().createResource(ham_res);
+  ResourceCollectionTeamLock<QMCHamiltonian> ham_lock(ham_res, ham_list);
+
+  Matrix<Real> kinetic(num_walkers, num_electrons);
+  Matrix<Real> local_pots(num_walkers, num_electrons);
+
+  ListenerVector<Real> listener_kinetic("kinetic", getParticularListener(kinetic));
+  QMCHamiltonian::mw_registerKineticListener(ham_list.getLeader(), listener_kinetic);
+  ListenerVector<Real> listener_potential("kinetic", getParticularListener(local_pots));
+  QMCHamiltonian::mw_registerLocalPotentialListener(ham_list.getLeader(), listener_potential);
+
+  auto p_refs = makeRefVector<ParticleSet>(psets);
+  RefVectorWithLeader<ParticleSet> p_list{p_refs[0], p_refs};
+
+  ResourceCollection pset_res("test_pset_res");
+  p_list.getLeader().createResource(pset_res);
+  ResourceCollectionTeamLock<ParticleSet> pset_lock(pset_res, p_list);
+
+  auto twf_refs = convertUPtrToRefVector(twfs);
+  RefVectorWithLeader<TrialWaveFunction> twf_list{twf_refs[0], twf_refs};
+
+
+  ResourceCollection wfc_res("test_wfc_res");
+  twf_list.getLeader().createResource(wfc_res);
+  ResourceCollectionTeamLock<TrialWaveFunction> mw_wfc_lock(wfc_res, twf_list);
+
+  // Otherwise we'll get no kinetic energy values
+  p_refs[0].get().L[0] = 1.0;
+  p_refs[1].get().L[1] = 1.0;
+  p_refs[2].get().L[2] = 1.0;
+  p_refs[3].get().L[3] = 1.0;
+
+  if constexpr (generate_test_data)
+  {
+    std::cout << "QMCHamiltonian-registerListeners initialize psets with:\n{";
+
+    for (int iw = 0; iw < num_walkers; ++iw)
+    {
+      //psets.emplace_back(pset_target);
+      std::cout << "{";
+      for (auto r : p_refs[iw].get().R)
+        std::cout << NativePrint(r) << ",";
+      std::cout << "},\n";
+    }
+    std::cout << "}\n";
+  }
+  else
+  {
+    std::vector<ParticleSet::ParticlePos> deterministic_rs = {
+        {
+            {0.515677886, 0.9486072745, -1.17423246},
+            {-0.3166678423, 1.376550506, 1.445290031},
+            {1.96071365, 2.47265689, 1.051449486},
+            {0.745853269, 0.5551359072, 4.080774681},
+            {-0.3515016103, -0.5192222523, 0.9941510909},
+            {-0.8354426872, 0.7071638258, -0.3409843552},
+            {0.4386044751, 1.237378731, 2.331874152},
+            {2.125850717, 0.3221067321, 0.5825731561},
+        },
+        {
+            {-0.4633736785, 0.06318772224, -0.8580153742},
+            {-1.174926354, -0.6276503679, 0.07458759314},
+            {1.327618206, 2.085829379, 1.415749862},
+            {0.9114727103, 0.1789183931, -0.08135540251},
+            {-2.267908723, 0.802928773, 0.9522812957},
+            {1.502715257, -1.84493529, 0.2805620469},
+            {3.168934617, 0.1348337978, 1.371092768},
+            {0.8310229518, 1.070827168, 1.18016733},
+        },
+        {
+            {-0.04847732172, -1.201739871, -1.700527771},
+            {0.1589259538, -0.3096047065, -2.066626415},
+            {2.255976232, 1.629132391, -0.8024446773},
+            {2.534792993, 3.121092901, 1.609780703},
+            {-0.2892376071, -0.152022511, -2.727613712},
+            {0.2477154804, 0.5039232765, 2.995702733},
+            {3.679345099, 3.037770313, 2.808899306},
+            {0.6418578532, 1.935944544, 1.515637954},
+        },
+        {
+            {0.91126951, 0.0234699242, 1.442297821},
+            {-0.9240061217, -0.1014997844, 0.9081020061},
+            {1.887794866, 2.210192703, 2.209118551},
+            {2.758945014, -1.21140421, 1.3337907},
+            {0.376540703, 0.3485486555, 0.9056881595},
+            {-0.3512770187, -0.4056820917, -2.068499576},
+            {0.5358460986, 2.720153363, 1.41999706},
+            {2.284020089, 1.173071915, 1.044597715},
+        },
+    };
+    for (int iw = 0; iw < num_walkers; ++iw)
+    {
+      p_refs[iw].get().R = deterministic_rs[iw];
+    }
+  }
+
+  ParticleSet::mw_update(p_list);
+
+  QMCHamiltonian::mw_evaluate(ham_list, twf_list, p_list);
+
+
+  if constexpr (generate_test_data)
+  {
+    std::vector<Real> vector_kinetic;
+    std::copy(kinetic.begin(), kinetic.end(), std::back_inserter(vector_kinetic));
+    std::cout << " size kinetic: " << vector_kinetic.size() << '\n';
+    std::cout << " std::vector<Real> kinetic_ref_vector = " << NativePrint(vector_kinetic) << ";\n";
+
+    std::vector<Real> vector_pots;
+    std::copy(local_pots.begin(), local_pots.end(), std::back_inserter(vector_pots));
+    std::cout << " size potentials: " << vector_pots.size() << '\n';
+    std::cout << " std::vector<Real> potential_ref_vector = " << NativePrint(vector_pots) << ";\n";
+  }
+  else
+  {
+    std::vector<Real> kinetic_ref_vector = {
+        -0.5, -0, -0,   -0, -0, -0, -0, -0, -0, -0.5, -0, -0,   -0, -0, -0, -0,
+        -0,   -0, -0.5, -0, -0, -0, -0, -0, -0, -0,   -0, -0.5, -0, -0, -0, -0,
+    };
+    std::vector<Real> potential_ref_vector = {
+        0.1902921988,  0.3051115892,  -0.4795567016, 0.4963486852,  -0.3115299199, -0.3619893752, 0.09889832988,
+        0.2794993746,  -0.5591061164, -0.1018774556, -1.758163533,  -0.6303051358, 0.4878929502,  0.3358202323,
+        0.3278906128,  -0.3592569681, 0.2308181408,  0.3380463886,  0.4502142541,  0.09129681648, 0.5120332571,
+        0.4968745532,  0.52070839,    -0.3453223967, 0.1190383566,  -0.1566598479, -1.061808709,  0.4489104638,
+        -0.4774404557, 0.3925164499,  0.1283951706,  -0.4368348731,
+    };
+    std::size_t num_data = num_electrons * num_walkers;
+    for (std::size_t id = 0; id < num_data; ++id)
+    {
+      INFO("id : " << id);
+      CHECK(kinetic_ref_vector[id] == Approx(kinetic(id)));
+    }
+
+    for (std::size_t id = 0; id < num_data; ++id)
+    {
+      INFO("id : " << id);
+      CHECK(potential_ref_vector[id] == Approx(local_pots(id)));
+    }
+  }
+  outputManager.resume();
+}
 } // namespace qmcplusplus


### PR DESCRIPTION
## Proposed changes

API changes and additions to QMCHamiltonian to support per particle Listerners from Estimators.
Next PR will add an estimator that logs per particle values to illustrate the API's use.

## What type(s) of changes does this code introduce?

- New feature
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
