### PR TITLE
Add hdf_error_suppression class

### DIFF
--- a/src/Message/CMakeLists.txt
+++ b/src/Message/CMakeLists.txt
@@ -21,14 +21,14 @@ endif()
 
 add_library(catch_main catch_main.cpp)
 target_compile_definitions(catch_main PUBLIC "CATCH_CONFIG_ENABLE_BENCHMARKING")
-target_link_libraries(catch_main PUBLIC qmc_external_catch2)
+target_link_libraries(catch_main PUBLIC qmc_external_catch2 qmcio_hdf)
 target_link_libraries(catch_main PRIVATE message platform_runtime)
 if(HAVE_MPI)
   target_compile_definitions(catch_main PRIVATE "CATCH_MAIN_HAVE_MPI")
 endif()
 
 add_library(catch_main_no_mpi catch_main.cpp)
-target_link_libraries(catch_main_no_mpi PUBLIC qmc_external_catch2)
+target_link_libraries(catch_main_no_mpi PUBLIC qmc_external_catch2 qmcio_hdf)
 target_link_libraries(catch_main_no_mpi PRIVATE platform_runtime)
 
 if(BUILD_UNIT_TESTS)

--- a/src/Message/catch_main.cpp
+++ b/src/Message/catch_main.cpp
@@ -19,6 +19,7 @@
 #endif
 #include "Host/OutputManager.h"
 #include "MemoryUsage.h"
+#include "io/hdf/hdf_error_suppression.h"
 
 // Replacement unit test main function to ensure that MPI is finalized once
 // (and only once) at the end of the unit test.
@@ -31,6 +32,8 @@ std::string UTEST_HAMIL, UTEST_WFN;
 
 int main(int argc, char* argv[])
 {
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
   Catch::Session session;
   using namespace Catch::clara;
   // Build command line parser.

--- a/src/QMCApp/QMCAppBase.cpp
+++ b/src/QMCApp/QMCAppBase.cpp
@@ -17,7 +17,7 @@
 
 namespace qmcplusplus
 {
-QMCAppBase::QMCAppBase() {}
+QMCAppBase::QMCAppBase() = default;
 
 QMCAppBase::~QMCAppBase()
 {

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -23,6 +23,7 @@
 #include "QMCApp/QMCMainState.h"
 #include "QMCApp/QMCAppBase.h"
 #include "QMCDrivers/SimpleFixedNodeBranch.h"
+#include "hdf/hdf_error_suppression.h"
 
 namespace qmcplusplus
 {
@@ -47,12 +48,13 @@ public:
 private:
   ///flag to indicate that a qmc is the first QMC
   bool FirstQMC;
-
   /// the last driver object. Should be in a loop only.
   std::unique_ptr<QMCDriverInterface> last_driver;
   /// last branch engine used by legacy drivers
   std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver;
 
+  /// Suppress HDF5 warning and error messages.
+  hdf_error_suppression hide_hdf_errors;
   ///xml mcwalkerset elements for output
   std::vector<xmlNodePtr> m_walkerset;
   ///xml mcwalkerset read-in elements

--- a/src/QMCTools/convert4qmc.cpp
+++ b/src/QMCTools/convert4qmc.cpp
@@ -33,6 +33,8 @@ int main(int argc, char** argv)
   mpi3::environment env(argc, argv);
   OHMMS::Controller->initialize(env);
 #endif
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
   if (argc < 2)
   {
     std::cout << "Usage: convert [-gaussian|-gamess|-orbitals|-dirac|-rmg] filename " << std::endl;

--- a/src/QMCTools/convertpw4qmc.cpp
+++ b/src/QMCTools/convertpw4qmc.cpp
@@ -46,6 +46,9 @@ int main(int argc, char* argv[])
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 #endif
 
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
+
   vector<string> vecParams;
   convertToVecStrings(argc, argv, vecParams);
   string fname;

--- a/src/QMCTools/qmc-extract-eshdf-kvectors.cpp
+++ b/src/QMCTools/qmc-extract-eshdf-kvectors.cpp
@@ -30,6 +30,8 @@ int main(int argc, char* argv[])
     std::cout << "Program must take as an argument a single input eshdf file to parse" << std::endl;
     return 1;
   }
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
   std::string fname(argv[1]);
   //cout << "Input file is: " << fname << std::endl;
   hdf_archive hin;

--- a/src/QMCTools/qmcfinitesize.cpp
+++ b/src/QMCTools/qmcfinitesize.cpp
@@ -56,6 +56,9 @@ int main(int argc, char** argv)
   std::cout.setf(std::ios::right, std::ios::adjustfield);
   std::cout.precision(12);
 
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
+
   std::unique_ptr<SkParserBase> skparser(nullptr);
 
   bool show_usage = false;

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -49,6 +49,9 @@ int main(int argc, char** argv)
   mpi3::environment env(argc, argv);
   OHMMS::Controller->initialize(env);
 #endif
+  // Suppress HDF5 warning and error messages.
+  qmcplusplus::hdf_error_suppression hide_hdf_errors;
+
   Communicate* myComm = OHMMS::Controller;
   myComm->setName("restart");
   myComm->barrier();

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -28,7 +28,6 @@ hdf_archive::~hdf_archive()
     H5Pclose(access_id);
 #endif
   close();
-  H5Eset_auto2(H5E_DEFAULT, err_func, client_data);
 }
 
 void hdf_archive::close()

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -22,7 +22,6 @@
 #include "hdf_pete.h"
 #include "hdf_stl.h"
 #include "hdf_hyperslab.h"
-#include "OutputManager.h"
 
 #include <bitset>
 #include <filesystem>
@@ -88,14 +87,14 @@ public:
   hdf_archive(Comm c, bool request_pio = false) : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
     if (!hdf_error_suppression::enabled)
-      app_warning() << "HDF5 library warnings and errors may appear in output.\n";
+      throw std::runtime_error("HDF5 library warnings and errors not suppressed from output.\n");
     set_access_plist(c, request_pio);
   }
 
   hdf_archive() : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
     if (!hdf_error_suppression::enabled)
-      app_warning() << "HDF5 library warnings and errors may appear in output.\n";
+      throw std::runtime_error("HDF5 library warnings and errors not suppressed from output.\n");
     set_access_plist();
   }
   ///destructor

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -18,9 +18,11 @@
 #include "hdf_datatype.h"
 #include "hdf_dataspace.h"
 #include "hdf_dataproxy.h"
+#include "hdf_error_suppression.h"
 #include "hdf_pete.h"
 #include "hdf_stl.h"
 #include "hdf_hyperslab.h"
+#include "OutputManager.h"
 
 #include <bitset>
 #include <filesystem>
@@ -64,10 +66,6 @@ private:
   hid_t access_id;
   ///transfer property
   hid_t xfer_plist;
-  ///error type
-  H5E_auto2_t err_func;
-  ///error handling
-  void* client_data;
   ///FILO to handle H5Group
   std::stack<hid_t> group_id;
 
@@ -89,15 +87,15 @@ public:
   template<class Comm = Communicate*>
   hdf_archive(Comm c, bool request_pio = false) : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
-    H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
-    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    if (!hdf_error_suppression::enabled)
+      app_warning() << "HDF5 library warnings and errors may appear in output.\n";
     set_access_plist(c, request_pio);
   }
 
   hdf_archive() : file_id(is_closed), access_id(H5P_DEFAULT), xfer_plist(H5P_DEFAULT)
   {
-    H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
-    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    if (!hdf_error_suppression::enabled)
+      app_warning() << "HDF5 library warnings and errors may appear in output.\n";
     set_access_plist();
   }
   ///destructor

--- a/src/io/hdf/hdf_error_suppression.h
+++ b/src/io/hdf/hdf_error_suppression.h
@@ -51,3 +51,4 @@ private:
 
 } // namespace qmcplusplus
 #endif //QMCPLUSPLUS_HDF5_ERROR_SUPPRESSION_H
+

--- a/src/io/hdf/hdf_error_suppression.h
+++ b/src/io/hdf/hdf_error_suppression.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
+//                    Luke Shulenburger, lshulen@sandia.gov, Sandia National Laboratories
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef QMCPLUSPLUS_HDF5_ERROR_SUPPRESSION_H
+#define QMCPLUSPLUS_HDF5_ERROR_SUPPRESSION_H
+
+#include "hdf5.h"
+
+namespace qmcplusplus
+{
+/// class suppressing warnings from the HDF5 library
+class hdf_error_suppression
+{
+public:
+  /// constructor
+  hdf_error_suppression()
+  {
+    H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
+    H5Eset_auto2(H5E_DEFAULT, nullptr, nullptr);
+    enabled = true;
+  }
+  /// We don't want more than one instance at a time.
+  hdf_error_suppression(const hdf_error_suppression&) = delete;
+  hdf_error_suppression& operator=(const hdf_error_suppression&) = delete;
+  /// destructor reset HDF5 error handling
+  ~hdf_error_suppression()
+  {
+    H5Eset_auto2(H5E_DEFAULT, err_func, client_data);
+    enabled = false;
+  }
+
+  /// status of hdf_error_suppression. An instance of this class changes enabled to true.
+  static inline bool enabled{false};
+
+private:
+  ///error type
+  H5E_auto2_t err_func;
+  ///error handling
+  void* client_data{nullptr};
+};
+
+} // namespace qmcplusplus
+#endif //QMCPLUSPLUS_HDF5_ERROR_SUPPRESSION_H

--- a/src/io/hdf/tests/CMakeLists.txt
+++ b/src/io/hdf/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UTEST_NAME deterministic-unit_test_${SRC_DIR})
 # Directory where input file is copied to, and working directory for unit test
 set(UTEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-set(UTEST_SRC test_hdf_archive.cpp test_hdf_parallel.cpp test_hdf_reshape.cpp test_hdf_hyperslab.cpp)
+set(UTEST_SRC test_hdf_archive.cpp test_hdf_error_suppression.cpp test_hdf_parallel.cpp test_hdf_reshape.cpp test_hdf_hyperslab.cpp)
 
 add_executable(${UTEST_EXE} ${UTEST_SRC})
 target_link_libraries(${UTEST_EXE} catch_main qmcio)

--- a/src/io/hdf/tests/test_hdf_error_suppression.cpp
+++ b/src/io/hdf/tests/test_hdf_error_suppression.cpp
@@ -1,0 +1,26 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+#include "hdf/hdf_error_suppression.h"
+
+using namespace qmcplusplus;
+
+TEST_CASE("hdf_error_suppression", "[hdf]")
+{
+  H5E_auto2_t err_func{};
+  void* client_data{nullptr};
+  // catch main already contains an instance of hdf_error_suppression.
+  REQUIRE(hdf_error_suppression::enabled == true);
+  H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
+  REQUIRE(client_data == nullptr);
+}

--- a/src/io/hdf/tests/test_hdf_error_suppression.cpp
+++ b/src/io/hdf/tests/test_hdf_error_suppression.cpp
@@ -24,3 +24,4 @@ TEST_CASE("hdf_error_suppression", "[hdf]")
   H5Eget_auto2(H5E_DEFAULT, &err_func, &client_data);
   REQUIRE(client_data == nullptr);
 }
+


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Moving error handling changes from `hdf_archive` to a separate `hdf_error_suppression` class. It suppresses HDF5 warnings throughout the lifetime of `QMCMain`.

I'd appreciate your input on this approach and any other required functionality before going further.

This fixes #4283.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
