### PR TITLE
Update handling of array sizes in SplineR2R and SplineC2C for rotation cases

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
+++ b/src/QMCWaveFunctions/BsplineFactory/BsplineSet.h
@@ -129,9 +129,9 @@ public:
     using grad_type  = GradMatrix::value_type;
     for (int iat = first, i = 0; iat < last; ++iat, ++i)
     {
-      ValueVector v(logdet[i], OrbitalSetSize);
-      GradVector g(dlogdet[i], OrbitalSetSize);
-      ValueVector l(d2logdet[i], OrbitalSetSize);
+      ValueVector v(logdet[i], logdet.cols());
+      GradVector g(dlogdet[i], dlogdet.cols());
+      ValueVector l(d2logdet[i], d2logdet.cols());
       evaluateVGL(P, iat, v, g, l);
     }
   }
@@ -173,9 +173,9 @@ public:
 
       for (int iw = 0; iw < nw; iw++)
       {
-        mw_psi_v.emplace_back(logdet_list[iw].get()[i], OrbitalSetSize);
-        mw_dpsi_v.emplace_back(dlogdet_list[iw].get()[i], OrbitalSetSize);
-        mw_d2psi_v.emplace_back(d2logdet_list[iw].get()[i], OrbitalSetSize);
+        mw_psi_v.emplace_back(logdet_list[iw].get()[i], logdet_list[iw].get().cols());
+        mw_dpsi_v.emplace_back(dlogdet_list[iw].get()[i], dlogdet_list[iw].get().cols());
+        mw_d2psi_v.emplace_back(d2logdet_list[iw].get()[i], d2logdet_list[iw].get().cols());
         psi_v_list.push_back(mw_psi_v.back());
         dpsi_v_list.push_back(mw_dpsi_v.back());
         d2psi_v_list.push_back(mw_d2psi_v.back());
@@ -194,9 +194,9 @@ public:
   {
     for (int iat = first, i = 0; iat < last; ++iat, ++i)
     {
-      ValueVector v(logdet[i], OrbitalSetSize);
-      GradVector g(dlogdet[i], OrbitalSetSize);
-      HessVector h(grad_grad_logdet[i], OrbitalSetSize);
+      ValueVector v(logdet[i], logdet.cols());
+      GradVector g(dlogdet[i], dlogdet.cols());
+      HessVector h(grad_grad_logdet[i], grad_grad_logdet.cols());
       evaluateVGH(P, iat, v, g, h);
     }
   }
@@ -211,10 +211,10 @@ public:
   {
     for (int iat = first, i = 0; iat < last; ++iat, ++i)
     {
-      ValueVector v(logdet[i], OrbitalSetSize);
-      GradVector g(dlogdet[i], OrbitalSetSize);
-      HessVector h(grad_grad_logdet[i], OrbitalSetSize);
-      GGGVector gh(grad_grad_grad_logdet[i], OrbitalSetSize);
+      ValueVector v(logdet[i], logdet.cols());
+      GradVector g(dlogdet[i], dlogdet.cols());
+      HessVector h(grad_grad_logdet[i], grad_grad_logdet.cols());
+      GGGVector gh(grad_grad_grad_logdet[i], grad_grad_grad_logdet.cols());
       evaluateVGHGH(P, iat, v, g, h, gh);
     }
   }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -86,7 +86,7 @@ void SplineC2C<ST>::evaluateValue(const ParticleSet& P, const int iat, ValueVect
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d(SplineInst->getSplinePtr(), ru, myV, first, last);
     assign_v(r, myV, psi, first / 2, last / 2);
@@ -112,7 +112,7 @@ void SplineC2C<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
 #pragma omp barrier
     }
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), tid, first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), tid, first, last);
     const int first_cplx = first / 2;
     const int last_cplx  = kPoints.size() < last / 2 ? kPoints.size() : last / 2;
 
@@ -292,7 +292,7 @@ void SplineC2C<ST>::evaluateVGL(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
     assign_vgl(r, psi, dpsi, d2psi, first / 2, last / 2);
@@ -431,7 +431,7 @@ void SplineC2C<ST>::evaluateVGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
     assign_vgh(r, psi, dpsi, grad_grad_psi, first / 2, last / 2);
@@ -686,7 +686,7 @@ void SplineC2C<ST>::evaluateVGHGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vghgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, mygH, first, last);
     assign_vghgh(r, psi, dpsi, grad_grad_psi, grad_grad_grad_psi, first / 2, last / 2);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2C.cpp
@@ -86,6 +86,7 @@ void SplineC2C<ST>::evaluateValue(const ParticleSet& P, const int iat, ValueVect
 #pragma omp parallel
   {
     int first, last;
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
     FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d(SplineInst->getSplinePtr(), ru, myV, first, last);
@@ -112,6 +113,7 @@ void SplineC2C<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
 #pragma omp barrier
     }
     int first, last;
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
     FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), tid, first, last);
     const int first_cplx = first / 2;
     const int last_cplx  = kPoints.size() < last / 2 ? kPoints.size() : last / 2;
@@ -292,6 +294,7 @@ void SplineC2C<ST>::evaluateVGL(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
     FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
@@ -431,6 +434,7 @@ void SplineC2C<ST>::evaluateVGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
     FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
@@ -686,6 +690,7 @@ void SplineC2C<ST>::evaluateVGHGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
     FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vghgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, mygH, first, last);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -201,7 +201,8 @@ void SplineC2COMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d(SplineInst->getSplinePtr(), ru, myV, first, last);
     assign_v(r, myV, psi, first / 2, last / 2);
@@ -991,7 +992,8 @@ void SplineC2COMPTarget<ST>::evaluateVGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    // Factor of 2 because psi is complex and the spline storage and evaluation uses a real type
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
     assign_vgh(r, psi, dpsi, grad_grad_psi, first / 2, last / 2);
@@ -1246,7 +1248,7 @@ void SplineC2COMPTarget<ST>::evaluateVGHGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(2 * psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vghgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, mygH, first, last);
     assign_vghgh(r, psi, dpsi, grad_grad_psi, grad_grad_grad_psi, first / 2, last / 2);
@@ -1302,9 +1304,9 @@ void SplineC2COMPTarget<ST>::evaluate_notranspose(const ParticleSet& P,
       multi_pos_copy[ipos * 6 + 4] = ru[1];
       multi_pos_copy[ipos * 6 + 5] = ru[2];
 
-      multi_psi_v.emplace_back(logdet[i + ipos], OrbitalSetSize);
-      multi_dpsi_v.emplace_back(dlogdet[i + ipos], OrbitalSetSize);
-      multi_d2psi_v.emplace_back(d2logdet[i + ipos], OrbitalSetSize);
+      multi_psi_v.emplace_back(logdet[i + ipos], logdet.cols());
+      multi_dpsi_v.emplace_back(dlogdet[i + ipos], dlogdet.cols());
+      multi_d2psi_v.emplace_back(d2logdet[i + ipos], d2logdet.cols());
 
       psi_v_list.push_back(multi_psi_v[ipos]);
       dpsi_v_list.push_back(multi_dpsi_v[ipos]);

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -151,7 +151,7 @@ void SplineR2R<ST>::evaluateValue(const ParticleSet& P, const int iat, ValueVect
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d(SplineInst->getSplinePtr(), ru, myV, first, last);
     assign_v(bc_sign, myV, psi, first, last);
@@ -177,7 +177,7 @@ void SplineR2R<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
 #pragma omp barrier
     }
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), tid, first, last);
+    FairDivideAligned(psi.size(), getAlignment<ST>(), omp_get_num_threads(), tid, first, last);
     const int last_real = kPoints.size() < last ? kPoints.size() : last;
 
     for (int iat = 0; iat < VP.getTotalNum(); ++iat)
@@ -276,7 +276,7 @@ void SplineR2R<ST>::evaluateVGL(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
     assign_vgl(bc_sign, psi, dpsi, d2psi, first, last);
@@ -359,7 +359,7 @@ void SplineR2R<ST>::evaluateVGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, first, last);
     assign_vgh(bc_sign, psi, dpsi, grad_grad_psi, first, last);
@@ -537,7 +537,7 @@ void SplineR2R<ST>::evaluateVGHGH(const ParticleSet& P,
 #pragma omp parallel
   {
     int first, last;
-    FairDivideAligned(myV.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
+    FairDivideAligned(psi.size(), getAlignment<ST>(), omp_get_num_threads(), omp_get_thread_num(), first, last);
 
     spline2::evaluate3d_vghgh(SplineInst->getSplinePtr(), ru, myV, myG, myH, mygH, first, last);
     assign_vghgh(bc_sign, psi, dpsi, grad_grad_psi, grad_grad_grad_psi, first, last);

--- a/src/QMCWaveFunctions/EinsplineSet.cpp
+++ b/src/QMCWaveFunctions/EinsplineSet.cpp
@@ -1079,7 +1079,7 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
     EinsplineTimer.stop();
     //computePhaseFactors(r);
     std::complex<double> eye(0.0, 1.0);
-    for (int j = 0; j < OrbitalSetSize; j++)
+    for (int j = 0; j < psi.cols(); j++)
     {
       std::complex<double> u, laplu;
       TinyVector<std::complex<double>, OHMMS_DIM> gradu;
@@ -1212,7 +1212,14 @@ void EinsplineSetExtended<StorageType>::evaluate_notranspose(const ParticleSet& 
     }
     const std::complex<double> eye(0.0, 1.0);
     const std::complex<double> meye(0.0, -1.0);
-    for (int j = 0; j < NumValenceOrbs; j++)
+
+    // NumValenceOrbs appears to be the same as OrbitalSetSize in some code paths.
+    // In order to handle orbital rotation where OrbitalSetSize is not
+    // the same as the number of columns of psi, OrbitalSetSize was
+    // replaced with the columns of psi in other places.
+    // The minimum is used here just in case NumValenceOrbs might be smaller.
+    size_t loop_bound = NumValenceOrbs < psi.cols() ? NumValenceOrbs : psi.cols();
+    for (int j = 0; j < loop_bound; j++)
     {
       std::complex<double> u(storage_value_vector_[j]);
       TinyVector<std::complex<double>, OHMMS_DIM> gradu(storage_grad_vector_[j]);

--- a/src/QMCWaveFunctions/tests/eval_bspline_spo.py
+++ b/src/QMCWaveFunctions/tests/eval_bspline_spo.py
@@ -1,0 +1,181 @@
+# 3D B-splines
+# Python implementation of SPO spline evaluation
+# Reads spline coefficients from HDF file of saved coefficients
+
+import autograd.numpy as np
+from autograd import hessian,grad
+import h5py
+
+
+class Grid1D:
+  def __init__(self, num, start, stop):
+    self.num = num
+    self.start = start
+    self.stop = stop
+
+    self.delta = (stop-start)/num
+    self.delta_inv = 1.0/self.delta
+
+# Parameters for spline basis functions.
+Ad = np.array(
+  [ -1.0/6.0,  3.0/6.0, -3.0/6.0, 1.0/6.0,
+     3.0/6.0, -6.0/6.0,  0.0/6.0, 4.0/6.0,
+    -3.0/6.0,  3.0/6.0,  3.0/6.0, 1.0/6.0,
+     1.0/6.0,  0.0/6.0,  0.0/6.0, 0.0/6.0
+  ])
+
+class Spline3D:
+    def __init__(self, grids, coeffs, G):
+        self.grids = grids
+        self.coeffs = coeffs
+        self.G = G
+        self.evaluate_grad = grad(self.convert_and_evaluate_v, 0)
+        self.evaluate_hess = hessian(self.convert_and_evaluate_v, 0)
+
+    def convert_and_evaluate_v(self, x):
+        xu = convertPos(x, self.G)
+        return self.evaluate_v(xu)
+
+    def evaluate_v(self, x):
+
+        # Unrolled over dimensions to make autograd work
+        xx0 = x[0] - self.grids[0].start
+        u = xx0 * self.grids[0].delta_inv
+        t = u % 1
+        i = np.int64(u)
+        tp1 = np.array([t*t*t, t*t, t, 1.0])
+
+        xx1 = x[1] - self.grids[1].start
+        u1 = xx1 * self.grids[1].delta_inv
+        t = u1 % 1
+        j = np.int64(u1)
+        tp2 = np.array([t*t*t, t*t, t, 1.0])
+
+        xx2 = x[2] - self.grids[2].start
+        u2 = xx2 * self.grids[2].delta_inv
+        t = u2 % 1
+        k = np.int64(u2)
+        tp3 = np.array([t*t*t, t*t, t, 1.0])
+
+        a = np.array([np.dot(Ad[0:4], tp1),
+                      np.dot(Ad[4:8], tp1),
+                      np.dot(Ad[8:12], tp1),
+                      np.dot(Ad[12:16], tp1)])
+        b = np.array([np.dot(Ad[0:4], tp2),
+                      np.dot(Ad[4:8], tp2),
+                      np.dot(Ad[8:12], tp2),
+                      np.dot(Ad[12:16], tp2)])
+        c = np.array([np.dot(Ad[0:4], tp3),
+                      np.dot(Ad[4:8], tp3),
+                      np.dot(Ad[8:12], tp3),
+                      np.dot(Ad[12:16], tp3)])
+
+        val = 0.0
+        for idx in range(4):
+          for jdx in range(4):
+            pre00 = a[idx]*b[jdx]
+            sum00 = c[0]*self.coeffs[i+idx, j+jdx, k  ] + \
+                    c[1]*self.coeffs[i+idx, j+jdx, k+1] + \
+                    c[2]*self.coeffs[i+idx, j+jdx, k+2] + \
+                    c[3]*self.coeffs[i+idx, j+jdx, k+3]
+            val += pre00 * sum00
+
+        return val
+
+def convertPos(r, G):
+    # Compact form, but autograd doesn't like item assignment to arrays
+    # ru = np.dot(r, G)
+    # for i in range(3):
+    #     if ru[i] < 0.0:
+    #         img = np.floor(ru[i])
+    #         ru[i] -= img
+
+    ru = np.dot(r, G)
+    # Unroll loop over dimensions and avoid array assignment
+    if ru[0] < 0.0:
+        img = np.floor(ru[0])
+        x = ru[0] - img
+    else:
+        x = ru[0]
+
+    if ru[1] < 0.0:
+        img = np.floor(ru[1])
+        y = ru[1] - img
+    else:
+        y = ru[1]
+
+    if ru[2] < 0.0:
+        img = np.floor(ru[2])
+        z = ru[2] - img
+    else:
+        z = ru[2]
+
+    return np.array([x,y,z])
+
+
+
+def setup_splines():
+    # HDF file with system info
+    f2 = h5py.File("diamondC_1x1x1.pwscf.h5")
+    prim_vec = f2["supercell/primitive_vectors"]
+    G = np.linalg.inv(prim_vec)
+    print("primitive vectors = ",np.array(prim_vec))
+
+    # HDF file with spline coefficients.
+    # Generate by adding the attribute save_coefs="yes" to determinantset or
+    # sposet_builder tag in test_einset.cpp or a QMCPACK run.
+    f = h5py.File("einspline.tile_100010001.spin_0.tw_0.l0u8.g40x40x40.h5", "r")
+
+    a = 1.0
+    grid1 = Grid1D(40, 0.0, a)
+    grids = [grid1, grid1, grid1]
+
+    g = f["spline_0"]
+    coeffs1 = g[:,:,:,0]
+    coeffs2 = g[:,:,:,1]
+    print("coefficients shape = ", g.shape)
+
+    spline1 = Spline3D(grids, coeffs1, G)
+    spline2 = Spline3D(grids, coeffs2, G)
+
+    return spline1, spline2
+
+
+def generate_point_values():
+    spline1, spline2 = setup_splines()
+
+    r1 = np.array([0.0, 0.0, 0.0])
+    r2 = np.array([0.0, 1.0, 0.0])
+
+    o1 = spline1.convert_and_evaluate_v(r1)
+    print("orbital 1 for particle 1 = ", o1)
+
+    o2 = spline1.convert_and_evaluate_v(r2)
+    print("orbital 1 for particle 2 = ", o2)
+
+    o11 = spline2.convert_and_evaluate_v(r1)
+    print("orbital 2 for particle 1 = ", o11)
+
+    o21 = spline2.convert_and_evaluate_v(r2)
+    print("orbital 2 for particle 2 = ", o21)
+
+    go1 = spline1.evaluate_grad(r2)
+    print("gradient for robital 1, particle 2 = ", go1)
+
+    ho1 = spline1.evaluate_hess(r1)
+    lap = ho1[0,0] + ho1[1,1] + ho1[2,2]
+    print("laplacian for particle 1 = ", lap)
+
+    ho2 = spline1.evaluate_hess(r2)
+    lap = ho2[0,0] + ho2[1,1] + ho2[2,2]
+    print("lap for particle 2 = ", lap)
+    print("hessian for particle 2", ho2)
+
+    ho2 = spline2.evaluate_hess(r2)
+    lap = ho2[0,0] + ho2[1,1] + ho2[2,2]
+    print("lap for orbital 2, particle 2 = ", lap)
+    print("hessian for orbital 2, particle 2", ho2)
+
+
+if __name__ == "__main__":
+    generate_point_values()

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -91,10 +91,10 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   tspecies(chargeIdx, upIdx) = -1;
 
   //diamondC_1x1x1
-  const char* particles = "<tmp> \
-<determinantset type=\"einspline\" href=\"diamondC_1x1x1.pwscf.h5\" tilematrix=\"1 0 0 0 1 0 0 0 1\" twistnum=\"0\" source=\"ion\" meshfactor=\"1.0\" precision=\"float\" size=\"8\"/> \
-</tmp> \
-";
+  // add save_coefs="yes" to create an HDF file of spline coefficients for the eval_bspline_spo.py script
+  const char* particles = R"(<tmp>
+<determinantset type="einspline" href="diamondC_1x1x1.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="8"/>
+</tmp>)";
 
   Libxml2Document doc;
   bool okay = doc.parseFromString(particles);
@@ -110,31 +110,37 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 
 #if !defined(QMC_CUDA) || defined(QMC_COMPLEX)
   // due to the different ordering of bands skip the tests on CUDA+Real builds
-  // checking evaluations, reference values are not independently generated.
-  // for vgl
-  SPOSet::ValueMatrix psiM(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::GradMatrix dpsiM(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::ValueMatrix d2psiM(elec_.R.size(), spo->getOrbitalSetSize());
+  // checking evaluations
+  // Reference values can be checked using eval_bspline_spo.py
+
+  // Test the case where the number of psi values is not the orbital set size
+  // or the number of electrons/2
+  const int psi_size = 3;
+  SPOSet::ValueMatrix psiM(elec_.R.size(), psi_size);
+  SPOSet::GradMatrix dpsiM(elec_.R.size(), psi_size);
+  SPOSet::ValueMatrix d2psiM(elec_.R.size(), psi_size);
   spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, d2psiM);
 
   // value
-  REQUIRE(std::real(psiM[1][0]) == Approx(-0.8886948824));
-  REQUIRE(std::real(psiM[1][1]) == Approx(1.4194120169));
+  CHECK(std::real(psiM[0][0]) == Approx(-0.42546836868));
+  CHECK(std::real(psiM[0][1]) == Approx(0.0));
+  CHECK(std::real(psiM[1][0]) == Approx(-0.8886948824));
+  CHECK(std::real(psiM[1][1]) == Approx(1.419412370359));
   // grad
-  REQUIRE(std::real(dpsiM[1][0][0]) == Approx(-0.0000183403));
-  REQUIRE(std::real(dpsiM[1][0][1]) == Approx(0.1655139178));
-  REQUIRE(std::real(dpsiM[1][0][2]) == Approx(-0.0000193077));
-  REQUIRE(std::real(dpsiM[1][1][0]) == Approx(-1.3131694794));
-  REQUIRE(std::real(dpsiM[1][1][1]) == Approx(-1.1174004078));
-  REQUIRE(std::real(dpsiM[1][1][2]) == Approx(-0.8462534547));
+  CHECK(std::real(dpsiM[1][0][0]) == Approx(-0.0000183403));
+  CHECK(std::real(dpsiM[1][0][1]) == Approx(0.1655139178));
+  CHECK(std::real(dpsiM[1][0][2]) == Approx(-0.0000193077));
+  CHECK(std::real(dpsiM[1][1][0]) == Approx(-1.3131694794));
+  CHECK(std::real(dpsiM[1][1][1]) == Approx(-1.1174004078));
+  CHECK(std::real(dpsiM[1][1][2]) == Approx(-0.8462534547));
   // lapl
-  REQUIRE(std::real(d2psiM[1][0]) == Approx(1.3313053846));
-  REQUIRE(std::real(d2psiM[1][1]) == Approx(-4.712583065));
+  CHECK(std::real(d2psiM[1][0]) == Approx(1.3313053846));
+  CHECK(std::real(d2psiM[1][1]) == Approx(-4.712583065));
 
   // for vgh
-  SPOSet::ValueVector psiV(psiM[1], spo->getOrbitalSetSize());
-  SPOSet::GradVector dpsiV(dpsiM[1], spo->getOrbitalSetSize());
-  SPOSet::HessVector ddpsiV(spo->getOrbitalSetSize());
+  SPOSet::ValueVector psiV(psiM[1], psi_size);
+  SPOSet::GradVector dpsiV(dpsiM[1], psi_size);
+  SPOSet::HessVector ddpsiV(psi_size);
   spo->evaluateVGH(elec_, 1, psiV, dpsiV, ddpsiV);
 
   // Catch default is 100*(float epsilson)
@@ -150,8 +156,8 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   REQUIRE(std::real(ddpsiV[1](2, 1)) == Approx(0.5237969314));
   REQUIRE(std::real(ddpsiV[1](2, 2)) == Approx(-2.316497764));
 
-  SPOSet::HessMatrix hesspsiV(elec_.R.size(), spo->getOrbitalSetSize());
-  SPOSet::GGGMatrix d3psiV(elec_.R.size(), spo->getOrbitalSetSize());
+  SPOSet::HessMatrix hesspsiV(elec_.R.size(), psi_size);
+  SPOSet::GGGMatrix d3psiV(elec_.R.size(), psi_size);
   spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, hesspsiV, d3psiV);
 
   //The reference values for grad_grad_grad_psi.
@@ -202,6 +208,46 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   REQUIRE(std::real(d3psiV(1,1)[1][8] ) == Approx(5.5741839408));
   REQUIRE(std::real(d3psiV(1,1)[2][8] ) == Approx(3.1312348842));
 #endif
+
+  // Test the batched interface
+  ParticleSet elec_2(elec_);
+  // interchange positions
+  elec_2.R[0] = elec_.R[1];
+  elec_2.R[1] = elec_.R[0];
+  RefVectorWithLeader<ParticleSet> p_list(elec_);
+  p_list.push_back(elec_);
+  p_list.push_back(elec_2);
+
+  std::unique_ptr<SPOSet> spo_2(spo->makeClone());
+  RefVectorWithLeader<SPOSet> spo_list(*spo);
+  spo_list.push_back(*spo);
+  spo_list.push_back(*spo_2);
+
+  const int ne = elec_.R.size();
+  SPOSet::ValueMatrix psi(ne, psi_size);
+  SPOSet::GradMatrix dpsi(ne, psi_size);
+  SPOSet::ValueMatrix d2psi(ne, psi_size);
+  SPOSet::ValueMatrix psi_2(ne, psi_size);
+  SPOSet::GradMatrix dpsi_2(ne, psi_size);
+  SPOSet::ValueMatrix d2psi_2(ne, psi_size);
+
+  RefVector<SPOSet::ValueMatrix> psi_v_list;
+  RefVector<SPOSet::GradMatrix> dpsi_v_list;
+  RefVector<SPOSet::ValueMatrix> d2psi_v_list;
+
+  psi_v_list.push_back(psi);
+  psi_v_list.push_back(psi_2);
+  dpsi_v_list.push_back(dpsi);
+  dpsi_v_list.push_back(dpsi_2);
+  d2psi_v_list.push_back(d2psi);
+  d2psi_v_list.push_back(d2psi_2);
+  spo->mw_evaluate_notranspose(spo_list, p_list, 0, elec_.R.size(), psi_v_list, dpsi_v_list, d2psi_v_list);
+
+  CHECK(std::real(psi_v_list[0].get()[0][0]) == Approx(-0.42546836868));
+  CHECK(std::real(psi_v_list[0].get()[1][0]) == Approx(-0.8886948824));
+  // Second particle set had particle positions flipped
+  CHECK(std::real(psi_v_list[1].get()[0][0]) == Approx(-0.8886948824));
+  CHECK(std::real(psi_v_list[1].get()[1][0]) == Approx(-0.42546836868));
 
 #endif
 


### PR DESCRIPTION
In the case of orbital rotation, the orbital set size from the H5 file may not match the number of SPOs used, which may not match the number of occupied orbitals.

In BsplineSet.h, the slices of the matrices need to have a size consistent with the size of the matrix.

In SplineR2R.cpp, use the size of psi rather than myV.  In the call to evaluate3d it doesn't matter because all the inputs are sized the same as myV, but in the following call to assign_*, the size discrepancy can cause invalid accesses.

Add a Python script for evaluating SPOs given the HDF file of coefficients.  It uses autograd to evaluate the spatial derivatives.



## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
