### PR TITLE
Pass reference to hdf_archive instead of gid. 

### DIFF
--- a/src/Estimators/CSEnergyEstimator.cpp
+++ b/src/Estimators/CSEnergyEstimator.cpp
@@ -110,7 +110,7 @@ void CSEnergyEstimator::add2Record(RecordNamedProperty<RealType>& record)
   //msg.add(d_data.begin(),d_data.end());
 }
 
-void CSEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid)
+void CSEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file)
 {
   //NEED TO IMPLEMENT for hdf5
 }

--- a/src/Estimators/CSEnergyEstimator.h
+++ b/src/Estimators/CSEnergyEstimator.h
@@ -86,7 +86,7 @@ struct CSEnergyEstimator : public ScalarEstimatorBase
    *@param record storage of scalar records (name,value)
    */
   void add2Record(RecordNamedProperty<RealType>& record) override;
-  void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override;
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& gid) override;
   CSEnergyEstimator* clone() override;
   const std::string& getSubTypeStr() const override { return input_.get_type(); }
   void evaluateDiff();

--- a/src/Estimators/CollectablesEstimator.cpp
+++ b/src/Estimators/CollectablesEstimator.cpp
@@ -23,10 +23,10 @@ CollectablesEstimator::CollectablesEstimator(QMCHamiltonian& h) : refH(h)
   scalars_saved.resize(h.sizeOfCollectables());
 }
 
-void CollectablesEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid)
+void CollectablesEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file)
 {
   int loc = h5desc.size();
-  refH.registerCollectables(h5desc, gid);
+  refH.registerCollectables(h5desc, file);
   for (int i = loc; i < h5desc.size(); ++i)
     h5desc[i].lower_bound += FirstIndex;
 }

--- a/src/Estimators/CollectablesEstimator.h
+++ b/src/Estimators/CollectablesEstimator.h
@@ -37,7 +37,7 @@ public:
   */
   CollectablesEstimator* clone() override;
 
-  void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override;
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) override;
   void add2Record(RecordListType& record) override;
   /** do nothing with accumulate */
   void accumulate(const MCWalkerConfiguration& W, WalkerIterator first, WalkerIterator last, RealType wgt) override {}

--- a/src/Estimators/EstimatorManagerBase.cpp
+++ b/src/Estimators/EstimatorManagerBase.cpp
@@ -201,9 +201,9 @@ void EstimatorManagerBase::start(int blocks, bool record)
     fname  = myComm->getName() + ".stat.h5";
     h_file.create(fname);
     for (int i = 0; i < Estimators.size(); i++)
-      Estimators[i]->registerObservables(h5desc, h_file.getFileID());
+      Estimators[i]->registerObservables(h5desc, h_file);
     if (Collectables)
-      Collectables->registerObservables(h5desc, h_file.getFileID());
+      Collectables->registerObservables(h5desc, h_file);
   }
 }
 

--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -220,11 +220,11 @@ void EstimatorManagerNew::startDriverRun()
     fname  = my_comm_->getName() + ".stat.h5";
     h_file = std::make_unique<hdf_archive>();
     h_file->create(fname);
-    main_estimator_->registerObservables(h5desc, h_file->getFileID());
+    main_estimator_->registerObservables(h5desc, *h_file);
     for (int i = 0; i < scalar_ests_.size(); i++)
-      scalar_ests_[i]->registerObservables(h5desc, h_file->getFileID());
+      scalar_ests_[i]->registerObservables(h5desc, *h_file);
     for (auto& uope : operator_ests_)
-      uope->registerOperatorEstimator(h_file->getFileID());
+      uope->registerOperatorEstimator(*h_file);
   }
 }
 

--- a/src/Estimators/LocalEnergyEstimator.cpp
+++ b/src/Estimators/LocalEnergyEstimator.cpp
@@ -35,7 +35,7 @@ LocalEnergyEstimator::LocalEnergyEstimator(LocalEnergyInput&& input, const QMCHa
  
 LocalEnergyEstimator* LocalEnergyEstimator::clone() { return new LocalEnergyEstimator(*this); }
 
-void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid)
+void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file)
 {
   if (!UseHDF5)
     return;
@@ -46,13 +46,13 @@ void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5
   h5desc.emplace_back("LocalPotential");
   std::vector<int> onedim(1, 1);
   h5desc[loc].set_dimensions(onedim, FirstIndex);
-  h5desc[loc++].open(gid);
+  h5desc[loc++].open(file);
   h5desc[loc].set_dimensions(onedim, FirstIndex + 1);
-  h5desc[loc++].open(gid);
+  h5desc[loc++].open(file);
   h5desc[loc].set_dimensions(onedim, FirstIndex + 2);
-  h5desc[loc++].open(gid);
+  h5desc[loc++].open(file);
   //hamiltonian adds more
-  refH.registerObservables(h5desc, gid);
+  refH.registerObservables(h5desc, file);
   int correction = FirstIndex + 3;
   for (int i = loc; i < h5desc.size(); ++i)
     h5desc[i].lower_bound += correction;

--- a/src/Estimators/LocalEnergyEstimator.h
+++ b/src/Estimators/LocalEnergyEstimator.h
@@ -82,7 +82,7 @@ public:
       accumulate(**first, wgt);
   }
   void add2Record(RecordListType& record) override;
-  void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) override;
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) override;
   LocalEnergyEstimator* clone() override;
   /*@}*/
 

--- a/src/Estimators/LocalEnergyOnlyEstimator.h
+++ b/src/Estimators/LocalEnergyOnlyEstimator.h
@@ -50,7 +50,7 @@ struct LocalEnergyOnlyEstimator : public ScalarEstimatorBase
     }
   }
 
-  void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override {}
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) override {}
 
   /**  add the local energy, variance and all the Hamiltonian components to the scalar record container
    * @param record storage of scalar records (name,value)

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -313,7 +313,7 @@ void MomentumDistribution::collect(const RefVector<OperatorEstBase>& type_erased
 }
 
 
-void MomentumDistribution::registerOperatorEstimator(hid_t gid)
+void MomentumDistribution::registerOperatorEstimator(hdf_archive& file)
 {
   //descriptor for the data, 1-D data
   std::vector<int> ng(1);
@@ -323,7 +323,7 @@ void MomentumDistribution::registerOperatorEstimator(hid_t gid)
   auto& h5o = h5desc_.back();
   //h5o.set_dimensions(ng, my_index_);
   h5o->set_dimensions(ng, 0); // JTK: doesn't seem right
-  h5o->open(gid);
+  h5o->open(file);
   h5o->addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints");
   h5o->addProperty(const_cast<std::vector<int>&>(kWeights), "kweights");
 }

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -121,7 +121,7 @@ public:
    *, needs to be unraveled and simplified the hdf5 output is another 
    *  big state big coupling design.
    */
-  void registerOperatorEstimator(hid_t gid) override;
+  void registerOperatorEstimator(hdf_archive& file) override;
 
 private:
   MomentumDistribution(const MomentumDistribution& md) = default;

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -599,8 +599,9 @@ inline void OneBodyDensityMatrices::normalizeBasis(ParticleSet& pset_target)
     basis_norms_[i] = 1.0 / std::sqrt(real(bnorms[i]));
 }
 
-void OneBodyDensityMatrices::registerOperatorEstimator(hid_t gid)
+void OneBodyDensityMatrices::registerOperatorEstimator(hdf_archive& file)
 {
+  auto gid   = file.getFileID();
   hid_t sgid = H5Gcreate2(gid, my_name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   std::vector<int> my_indexes(2, basis_size_);
   if constexpr (IsComplex_t<Value>::value)

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -176,7 +176,7 @@ public:
    * The default implementation does nothing. The derived classes which compute
    * big data, e.g. density, should overwrite this function.
    */
-  void registerOperatorEstimator(hid_t gid) override;
+  void registerOperatorEstimator(hdf_archive& file) override;
 
 private:
   /** Default copy constructor.

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -21,6 +21,7 @@
 #include "QMCHamiltonians/ObservableHelper.h"
 #include "QMCWaveFunctions/OrbitalSetTraits.h"
 #include "type_traits/DataLocality.h"
+#include "hdf/hdf_archive.h"
 #include <bitset>
 
 namespace qmcplusplus
@@ -109,7 +110,7 @@ public:
    * The default implementation does nothing. The derived classes which compute
    * big data, e.g. density, should overwrite this function.
    */
-  virtual void registerOperatorEstimator(hid_t gid) {}
+  virtual void registerOperatorEstimator(hdf_archive& file) {}
 
   virtual std::unique_ptr<OperatorEstBase> spawnCrowdClone() const = 0;
 

--- a/src/Estimators/RMCLocalEnergyEstimator.h
+++ b/src/Estimators/RMCLocalEnergyEstimator.h
@@ -148,7 +148,7 @@ public:
   }
 
   void add2Record(RecordListType& record) override;
-  void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override {}
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) override {}
   RMCLocalEnergyEstimator* clone() override;
   const std::string& getSubTypeStr() const override { return input_.get_type(); }
   /// RMCLocalEnergyEstimator is the main estimator type for RMC driver

--- a/src/Estimators/ScalarEstimatorBase.h
+++ b/src/Estimators/ScalarEstimatorBase.h
@@ -158,9 +158,9 @@ struct ScalarEstimatorBase
 
   /** add descriptors of observables to utilize hdf5
    * @param h5desc descriptor of a data stored in a h5 group
-   * @param gid h5 group to which each statistical data will be stored
+   * @param file file to which each statistical data will be stored
    */
-  virtual void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) = 0;
+  virtual void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) = 0;
 
   ///clone the object
   virtual ScalarEstimatorBase* clone() = 0;

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -12,6 +12,8 @@
 
 #include "SpinDensityNew.h"
 
+#include "hdf5.h"
+
 #include <iostream>
 #include <numeric>
 #include <SpeciesSet.h>
@@ -214,10 +216,10 @@ void SpinDensityNew::report(const std::string& pad)
   app_log() << pad << "end SpinDensity report" << std::endl;
 }
 
-void SpinDensityNew::registerOperatorEstimator(hid_t gid)
+void SpinDensityNew::registerOperatorEstimator(hdf_archive& file)
 {
   std::vector<size_t> my_indexes;
-  hid_t sgid = H5Gcreate2(gid, my_name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t sgid = H5Gcreate2(file.getFileID(), my_name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
   //vector<int> ng(DIM);
   //for(int d=0;d<DIM;++d)
@@ -228,7 +230,7 @@ void SpinDensityNew::registerOperatorEstimator(hid_t gid)
 
   for (int s = 0; s < species_.size(); ++s)
   {
-    h5desc_.emplace_back(std::make_unique<ObservableHelper>(species_.speciesName[s]));
+    h5desc_.push_back(std::make_unique<ObservableHelper>(species_.speciesName[s]));
     auto& oh = h5desc_.back();
     oh->set_dimensions(ng, 0);
     oh->open(sgid);

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -107,7 +107,7 @@ public:
    *, needs to be unraveled and simplified the hdf5 output is another 
    *  big state big coupling design.
    */
-  void registerOperatorEstimator(hid_t gid) override;
+  void registerOperatorEstimator(hdf_archive& file) override;
 
 private:
   SpinDensityNew(const SpinDensityNew& sdn) = default;

--- a/src/Estimators/tests/FakeEstimator.h
+++ b/src/Estimators/tests/FakeEstimator.h
@@ -25,7 +25,7 @@ public:
 
   void add2Record(RecordNamedProperty<RealType>& record) override {}
 
-  void registerObservables(std::vector<ObservableHelper>& h5dec, hid_t gid) override {}
+  void registerObservables(std::vector<ObservableHelper>& h5dec, hdf_archive& file) override {}
 
   FakeEstimator* clone() override { return new FakeEstimator; }
   

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -35,7 +35,7 @@ public:
                   RandomGenerator& rng) override
   {}
 
-  void registerOperatorEstimator(hid_t gid) override {}
+  void registerOperatorEstimator(hdf_archive& file) override {}
 
   void startBlock(int nsteps) override {}
 

--- a/src/Estimators/tests/test_local_energy_est.cpp
+++ b/src/Estimators/tests/test_local_energy_est.cpp
@@ -93,7 +93,7 @@ TEST_CASE("LocalEnergy with hdf5", "[estimators]")
   std::filesystem::path filename("tmp_obs.h5");
   hdf_archive h_file;
   h_file.create(filename);
-  le_est.registerObservables(h5desc, h_file.getFileID());
+  le_est.registerObservables(h5desc, h_file);
   h_file.close();
   REQUIRE(std::filesystem::exists(filename));
   // Check contents?

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -118,7 +118,7 @@ void DensityEstimator::addObservables(PropertySetType& plist, BufferType& collec
   //collectables.add(tmp2.begin(),tmp2.end());
 }
 
-void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   int loc = h5desc.size();
   std::vector<int> ng(OHMMS_DIM);
@@ -127,7 +127,7 @@ void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5des
   h5desc.emplace_back(name_);
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ng, my_index_);
-  h5o.open(gid);
+  h5o.open(file);
 }
 
 void DensityEstimator::setObservables(PropertySetType& plist)

--- a/src/QMCHamiltonians/DensityEstimator.h
+++ b/src/QMCHamiltonians/DensityEstimator.h
@@ -38,7 +38,7 @@ public:
 
   void addObservables(PropertySetType& plist) {}
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -524,7 +524,7 @@ void DensityMatrices1B::addObservables(PropertySetType& plist, BufferType& colle
 }
 
 
-void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
 #if defined(QMC_COMPLEX)
   std::vector<int> ng(3);
@@ -539,6 +539,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   int nentries = ng[0] * ng[1];
 #endif
 
+  auto gid          = file.getFileID();
   std::string dname = name_;
   hid_t dgid        = H5Gcreate2(gid, dname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/src/QMCHamiltonians/DensityMatrices1B.h
+++ b/src/QMCHamiltonians/DensityMatrices1B.h
@@ -172,7 +172,7 @@ public:
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
   void resetTargetParticleSet(ParticleSet& P) override {}

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -477,8 +477,9 @@ void EnergyDensityEstimator::addObservables(PropertySetType& plist, BufferType& 
 }
 
 
-void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
+  auto gid = file.getFileID();
   hid_t g = H5Gcreate2(gid, name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   h5desc.emplace_back("variables");
   auto& oh = h5desc.back();

--- a/src/QMCHamiltonians/EnergyDensityEstimator.h
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.h
@@ -36,7 +36,7 @@ public:
   Return_t evaluate(ParticleSet& P) override;
   void addObservables(PropertySetType& plist) {}
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -70,7 +70,7 @@ void ForceBase::addObservablesStress(QMCTraits::PropertySetType& plist)
     }
 }
 
-void ForceBase::registerObservablesF(std::vector<ObservableHelper>& h5list, hid_t gid) const
+void ForceBase::registerObservablesF(std::vector<ObservableHelper>& h5list, hdf_archive& file) const
 {
   std::vector<int> ndim(2);
   ndim[0] = Nnuc;
@@ -79,7 +79,7 @@ void ForceBase::registerObservablesF(std::vector<ObservableHelper>& h5list, hid_
   h5list.emplace_back(prefix);
   auto& h5o = h5list.back();
   h5o.set_dimensions(ndim, FirstForceIndex);
-  h5o.open(gid);
+  h5o.open(file);
 }
 
 void ForceBase::setObservablesF(QMCTraits::PropertySetType& plist)

--- a/src/QMCHamiltonians/ForceBase.h
+++ b/src/QMCHamiltonians/ForceBase.h
@@ -71,7 +71,7 @@ struct ForceBase
   ForceBase(ParticleSet& ions, ParticleSet& elns);
   virtual ~ForceBase() {}
 
-  void registerObservablesF(std::vector<ObservableHelper>& h5list, hid_t gid) const;
+  void registerObservablesF(std::vector<ObservableHelper>& h5list, hdf_archive& file) const;
 
   void addObservablesF(QMCTraits::PropertySetType& plist);
   void addObservablesStress(QMCTraits::PropertySetType& plist);
@@ -93,9 +93,9 @@ public:
 
   Return_t evaluate(ParticleSet& P) override;
 
-  void registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const override
+  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override
   {
-    registerObservablesF(h5list, gid);
+    registerObservablesF(h5list, file);
   }
 
   /** default implementation to add named values to  the property list

--- a/src/QMCHamiltonians/ForceCeperley.h
+++ b/src/QMCHamiltonians/ForceCeperley.h
@@ -47,9 +47,9 @@ public:
 
   void InitMatrix();
 
-  void registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const override
+  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override
   {
-    registerObservablesF(h5list, gid);
+    registerObservablesF(h5list, file);
   }
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override { addObservablesF(plist); }

--- a/src/QMCHamiltonians/ForceChiesaPBCAA.h
+++ b/src/QMCHamiltonians/ForceChiesaPBCAA.h
@@ -75,9 +75,9 @@ struct ForceChiesaPBCAA : public OperatorBase, public ForceBase
 
   Return_t g_filter(RealType r);
 
-  void registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const override
+  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override
   {
-    registerObservablesF(h5list, gid);
+    registerObservablesF(h5list, file);
   }
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override;

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -225,24 +225,24 @@ std::unique_ptr<OperatorBase> LatticeDeviationEstimator::makeClone(ParticleSet& 
   return myclone;
 }
 
-void LatticeDeviationEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void LatticeDeviationEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  if (hdf5_out)
-  {
-    // one scalar per lattice site (i.e. source particle)
-    std::vector<int> ndim(1, num_sites);
-    if (per_xyz)
-    {
-      // one scalar per lattice site per dimension
-      ndim[0] = num_sites * OHMMS_DIM;
-    }
+  if (!hdf5_out)
+    return;
 
-    // open hdf5 entry and resize
-    h5desc.emplace_back(name_);
-    auto& h5o = h5desc.back();
-    h5o.set_dimensions(ndim, h5_index);
-    h5o.open(gid);
+  // one scalar per lattice site (i.e. source particle)
+  std::vector<int> ndim(1, num_sites);
+  if (per_xyz)
+  {
+    // one scalar per lattice site per dimension
+    ndim[0] = num_sites * OHMMS_DIM;
   }
+
+  // open hdf5 entry and resize
+  h5desc.emplace_back(name_);
+  auto& h5o = h5desc.back();
+  h5o.set_dimensions(ndim, h5_index);
+  h5o.open(file);
 }
 
 

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.h
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.h
@@ -54,7 +54,7 @@ public:
   //void setParticlePropertyList(PropertySetType& plist, int offset); // is this method ever used?
 
   // make room in hdf5 observable registry
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   //void addObservables(PropertySetType& plist, BufferType& collectables); // also used for multiple scalars
 
   // pure virtual functions require overrider

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -94,7 +94,7 @@ MomentumEstimator::Return_t MomentumEstimator::evaluate(ParticleSet& P)
   return 0.0;
 }
 
-void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   if (hdf5_out)
   {
@@ -105,7 +105,7 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     h5desc.emplace_back("nofk");
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ng, my_index_);
-    h5o.open(gid);
+    h5o.open(file);
     h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints");
     h5o.addProperty(const_cast<std::vector<int>&>(kWeights), "kweights");
   }

--- a/src/QMCHamiltonians/MomentumEstimator.h
+++ b/src/QMCHamiltonians/MomentumEstimator.h
@@ -29,7 +29,7 @@ public:
 
   void addObservables(PropertySetType& plist) {}
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool putSpecial(xmlNodePtr cur, ParticleSet& elns, bool rootNode);

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -821,9 +821,9 @@ void NonLocalECPotential::addObservables(PropertySetType& plist, BufferType& col
   }
 }
 
-void NonLocalECPotential::registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const
+void NonLocalECPotential::registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const
 {
-  OperatorBase::registerObservables(h5list, gid);
+  OperatorBase::registerObservables(h5list, file);
   if (ComputeForces)
   {
     std::vector<int> ndim(2);
@@ -832,7 +832,7 @@ void NonLocalECPotential::registerObservables(std::vector<ObservableHelper>& h5l
     h5list.emplace_back("FNL");
     auto& h5o1 = h5list.back();
     h5o1.set_dimensions(ndim, FirstForceIndex);
-    h5o1.open(gid);
+    h5o1.open(file);
   }
 }
 

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -159,7 +159,7 @@ public:
 
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
 
-  void registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const override;
+  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override;
 
   /** Set the flag whether to compute forces or not.
    * @param val The boolean value for computing forces

--- a/src/QMCHamiltonians/ObservableHelper.cpp
+++ b/src/QMCHamiltonians/ObservableHelper.cpp
@@ -25,10 +25,10 @@ ObservableHelper::ObservableHelper(const std::string& title)
 {}
 
 ObservableHelper::ObservableHelper(ObservableHelper&& in) noexcept
-    : lower_bound(in.lower_bound),
-      data_id(in.data_id),
+    : data_id(in.data_id),
       space1_id(in.space1_id),
       value1_id(in.value1_id),
+      lower_bound(in.lower_bound),
       mydims(in.mydims),
       maxdims(in.maxdims),
       curdims(in.curdims),
@@ -84,11 +84,11 @@ void ObservableHelper::open(hid_t grp_id)
     }
     std::vector<value_type> zeros(nd, 0.0);
     hid_t p = H5Pcreate(H5P_DATASET_CREATE);
-    H5Pset_chunk(p, rank, &mydims[0]);
-    space1_id      = H5Screate_simple(rank, &mydims[0], &maxdims[0]);
+    H5Pset_chunk(p, rank, mydims.data());
+    space1_id      = H5Screate_simple(rank, mydims.data(), maxdims.data());
     value1_id      = H5Dcreate(data_id, "value", H5T_NATIVE_DOUBLE, space1_id, p);
-    hid_t memspace = H5Screate_simple(rank, &mydims[0], NULL);
-    herr_t ret     = H5Dwrite(value1_id, H5T_NATIVE_DOUBLE, memspace, space1_id, H5P_DEFAULT, &zeros[0]);
+    hid_t memspace = H5Screate_simple(rank, mydims.data(), NULL);
+    herr_t ret     = H5Dwrite(value1_id, H5T_NATIVE_DOUBLE, memspace, space1_id, H5P_DEFAULT, zeros.data());
     H5Sclose(memspace);
     H5Pclose(p);
   }

--- a/src/QMCHamiltonians/ObservableHelper.h
+++ b/src/QMCHamiltonians/ObservableHelper.h
@@ -20,6 +20,7 @@
 #define QMCPLUSPLUS_OBSERVABLEHELPER_H
 
 #include "Configuration.h"
+#include "hdf/hdf_archive.h"
 #include "OhmmsData/HDFAttribIO.h"
 #include "Numerics/HDFSTLAttrib.h"
 
@@ -35,15 +36,17 @@ using value_type = QMCTraits::FullPrecRealType;
  */
 class ObservableHelper
 {
-public:
-  ///starting index
-  hsize_t lower_bound = 0;
+private:
   ///id of this observable
   hid_t data_id = -1;
   ///dataspace for value
   hid_t space1_id = -1;
   ///id of the value dataset
   hid_t value1_id = -1;
+
+public:
+  ///starting index
+  hsize_t lower_bound = 0;
   ///my dimensions
   std::vector<hsize_t> mydims;
   ///maximum dimensions
@@ -89,8 +92,8 @@ public:
    * open a h5 group of this observable
    * Create a group for an observable and dataspace
    */
+  void open(hdf_archive& file) { open(file.top()); }
   void open(hid_t grp_id);
-
 
   /** add named property to describe the collectable this helper class handles
    * @param p any intrinsic datatype including vector, basic containers

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -55,7 +55,7 @@ TraceRequest& OperatorBase::getRequest() noexcept { return request_; }
 ////////  FUNCTIONS ////////////////
 void OperatorBase::addObservables(PropertySetType& plist, BufferType& collectables) { addValue(plist); }
 
-void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   const bool collect = update_mode_.test(COLLECTABLE);
   //exclude collectables
@@ -65,11 +65,11 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hi
     auto& oh = h5desc.back();
     std::vector<int> onedim(1, 1);
     oh.set_dimensions(onedim, my_index_);
-    oh.open(gid);
+    oh.open(file);
   }
 }
 
-void OperatorBase::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const {}
+void OperatorBase::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const {}
 
 void OperatorBase::setObservables(PropertySetType& plist) { plist[my_index_] = value_; }
 

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -203,7 +203,7 @@ public:
    * @param h5desc contains a set of hdf5 descriptors for a scalar observable
    * @param gid hdf5 group to which the observables belong
    */
-  virtual void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+  virtual void registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const;
 
   /*** 
    * @brief add to collectables descriptor for hdf5
@@ -213,7 +213,7 @@ public:
    * @param h5desc contains a set of hdf5 descriptors for a scalar observable
    * @param gid hdf5 group to which the observables belong
    */
-  virtual void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+  virtual void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const;
 
   /** 
    * @brief Set the values evaluated by this object to plist

--- a/src/QMCHamiltonians/OrbitalImages.h
+++ b/src/QMCHamiltonians/OrbitalImages.h
@@ -234,7 +234,7 @@ public:
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override {}
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override {}
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override {}
 
   //should be empty for Collectables interface
   void resetTargetParticleSet(ParticleSet& P) override {}

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -158,7 +158,7 @@ PairCorrEstimator::Return_t PairCorrEstimator::evaluate(ParticleSet& P)
   return 0.0;
 }
 
-void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5list, hid_t gid) const
+void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const
 {
   std::vector<int> onedim(1, NumBins);
   int offset = my_index_;
@@ -167,12 +167,9 @@ void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5li
     h5list.emplace_back(gof_r_prefix[i]);
     auto& h5o = h5list.back();
     h5o.set_dimensions(onedim, offset);
-    h5o.open(gid);
+    h5o.open(file);
     h5o.addProperty(const_cast<RealType&>(Delta), "delta");
     h5o.addProperty(const_cast<RealType&>(Dmax), "cutoff");
-    //       h5o->addProperty(const_cast<std::vector<RealType>&>(norm_factor),"norm_factor");
-    //       std::string blob("norm_factor[i]=1/r_m[i]^2 for r_m[i]=(r[i]+r[i+1])/2");
-    //       h5o->addProperty(blob,"dictionary");
     offset += NumBins;
   }
 }

--- a/src/QMCHamiltonians/PairCorrEstimator.h
+++ b/src/QMCHamiltonians/PairCorrEstimator.h
@@ -46,7 +46,7 @@ public:
 
   void addObservables(PropertySetType& plist) {}
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5list, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -245,19 +245,19 @@ void QMCHamiltonian::resetObservables(int start, int ncollects)
   numCollectables = ncollects;
 }
 
-void QMCHamiltonian::registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void QMCHamiltonian::registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   for (int i = 0; i < H.size(); ++i)
-    H[i]->registerObservables(h5desc, gid);
+    H[i]->registerObservables(h5desc, file);
   for (int i = 0; i < auxH.size(); ++i)
-    auxH[i]->registerObservables(h5desc, gid);
+    auxH[i]->registerObservables(h5desc, file);
 }
 
-void QMCHamiltonian::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void QMCHamiltonian::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   //The physical operators cannot add to collectables
   for (int i = 0; i < auxH.size(); ++i)
-    auxH[i]->registerCollectables(h5desc, gid);
+    auxH[i]->registerCollectables(h5desc, file);
 }
 
 void QMCHamiltonian::mw_registerKineticListener(const QMCHamiltonian& leader, ListenerVector<RealType> listener)

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -134,14 +134,14 @@ public:
    * @param h5desc has observable_helper for each h5 group
    * @param gid h5 group id to which the observable groups are added.
    */
-  void registerObservables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+  void registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const;
   /** register collectables so that their averages can be dumped to hdf5
    * @param h5desc has observable_helper for each h5 group
    * @param gid h5 group id to which the observable groups are added.
    *
    * Add observable_helper information for the data stored in ParticleSet::mcObservables.
    */
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive &file) const;
 
   /** Listener Registration
    *  This must be called on a QMCHamiltonian that has acquired multiwalker resources

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -221,38 +221,38 @@ void SkAllEstimator::setParticlePropertyList(PropertySetType& plist, int offset)
 }
 
 
-void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  if (hdf5_out)
-  {
-    // Create HDF group in stat.h5 with SkAllEstimator's name
-    hid_t sgid = H5Gcreate2(gid, name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  if (!hdf5_out)
+    return;
 
-    // Add k-point information
-    h5desc.emplace_back("kpoints");
-    auto& ohKPoints = h5desc.back();
-    ohKPoints.open(sgid); // add to SkAll hdf group
-    ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->getSimulationCell().getKLists().kpts_cart), "value");
+  // Create HDF group in stat.h5 with SkAllEstimator's name
+  hid_t sgid = file.push(name_, true);
 
-    // Add electron-electron S(k)
-    std::vector<int> ng(1);
-    ng[0] = NumK;
-    //  modulus
-    h5desc.emplace_back("rhok_e_e");
-    auto& ohRhoKEE = h5desc.back();
-    ohRhoKEE.set_dimensions(ng, my_index_);
-    ohRhoKEE.open(sgid); // add to SkAll hdf group
-    //  real part
-    h5desc.emplace_back("rhok_e_r");
-    auto& ohRhoKER = h5desc.back();
-    ohRhoKER.set_dimensions(ng, my_index_ + NumK);
-    ohRhoKER.open(sgid); // add to SkAll hdf group
-    //  imaginary part
-    h5desc.emplace_back("rhok_e_i");
-    auto& ohRhoKEI = h5desc.back();
-    ohRhoKEI.set_dimensions(ng, my_index_ + 2 * NumK);
-    ohRhoKEI.open(sgid); // add to SkAll hdf group
-  }
+  // Add k-point information
+  h5desc.emplace_back("kpoints");
+  auto& ohKPoints = h5desc.back();
+  ohKPoints.open(sgid); // add to SkAll hdf group
+  ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->getSimulationCell().getKLists().kpts_cart), "value");
+
+  // Add electron-electron S(k)
+  std::vector<int> ng(1);
+  ng[0] = NumK;
+  //  modulus
+  h5desc.emplace_back("rhok_e_e");
+  auto& ohRhoKEE = h5desc.back();
+  ohRhoKEE.set_dimensions(ng, my_index_);
+  ohRhoKEE.open(sgid); // add to SkAll hdf group
+  //  real part
+  h5desc.emplace_back("rhok_e_r");
+  auto& ohRhoKER = h5desc.back();
+  ohRhoKER.set_dimensions(ng, my_index_ + NumK);
+  ohRhoKER.open(sgid); // add to SkAll hdf group
+  //  imaginary part
+  h5desc.emplace_back("rhok_e_i");
+  auto& ohRhoKEI = h5desc.back();
+  ohRhoKEI.set_dimensions(ng, my_index_ + 2 * NumK);
+  ohRhoKEI.open(sgid); // add to SkAll hdf group
 }
 
 bool SkAllEstimator::put(xmlNodePtr cur)

--- a/src/QMCHamiltonians/SkAllEstimator.h
+++ b/src/QMCHamiltonians/SkAllEstimator.h
@@ -40,7 +40,7 @@ public:
 
   void addObservables(PropertySetType& plist);
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -114,7 +114,7 @@ void SkEstimator::setParticlePropertyList(PropertySetType& plist, int offset)
 }
 
 
-void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
   if (hdf5_out)
   {
@@ -122,21 +122,21 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hi
     h5desc.emplace_back(name_);
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, my_index_);
-    h5o.open(gid);
+    h5o.open(file);
 
     hsize_t kdims[2];
     kdims[0]          = NumK;
     kdims[1]          = OHMMS_DIM;
     std::string kpath = name_ + "/kpoints";
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
-    hid_t k_set       = H5Dcreate(gid, kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
+    hid_t k_set       = H5Dcreate(file.getFileID(), kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);
     auto* ptr         = &(sourcePtcl->getSimulationCell().getKLists().kpts_cart[0][0]);
     herr_t ret        = H5Dwrite(k_set, H5T_NATIVE_DOUBLE, mem_space, k_space, H5P_DEFAULT, ptr);
     H5Dclose(k_set);
     H5Sclose(mem_space);
     H5Sclose(k_space);
-    H5Fflush(gid, H5F_SCOPE_GLOBAL);
+    H5Fflush(file.getFileID(), H5F_SCOPE_GLOBAL);
   }
 }
 

--- a/src/QMCHamiltonians/SkEstimator.h
+++ b/src/QMCHamiltonians/SkEstimator.h
@@ -37,7 +37,7 @@ public:
 
   void addObservables(PropertySetType& plist);
   void addObservables(PropertySetType& plist, BufferType& collectables) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
   void setObservables(PropertySetType& plist) override;
   void setParticlePropertyList(PropertySetType& plist, int offset) override;
   bool put(xmlNodePtr cur) override;

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -79,16 +79,16 @@ void SpeciesKineticEnergy::addObservables(PropertySetType& plist, BufferType& co
   }
 }
 
-void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  if (hdf5_out)
-  {
-    std::vector<int> ndim(1, num_species);
-    h5desc.emplace_back(name_);
-    auto& h5o = h5desc.back();
-    h5o.set_dimensions(ndim, h5_index);
-    h5o.open(gid);
-  }
+  if (!hdf5_out)
+    return;
+
+  std::vector<int> ndim(1, num_species);
+  h5desc.emplace_back(name_);
+  auto& h5o = h5desc.back();
+  h5o.set_dimensions(ndim, h5_index);
+  h5o.open(file);
 }
 
 void SpeciesKineticEnergy::setObservables(PropertySetType& plist)

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.h
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.h
@@ -44,7 +44,7 @@ public:
   void setObservables(PropertySetType& plist) override;
 
   // allow h5 output
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
 private:
   ParticleSet& tpset; // reference to target particle set

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -187,9 +187,9 @@ void SpinDensity::addObservables(PropertySetType& plist, BufferType& collectable
 }
 
 
-void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  hid_t sgid = H5Gcreate2(gid, name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t sgid = H5Gcreate2(file.getFileID(), name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
   //vector<int> ng(DIM);
   //for(int d=0;d<DIM;++d)

--- a/src/QMCHamiltonians/SpinDensity.h
+++ b/src/QMCHamiltonians/SpinDensity.h
@@ -50,7 +50,7 @@ public:
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
   void resetTargetParticleSet(ParticleSet& P) override {}

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -104,9 +104,9 @@ void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& c
 }
 
 
-void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const
+void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  hid_t sgid = H5Gcreate2(gid, name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t sgid = H5Gcreate2(file.getFileID(), name_.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   h5desc.emplace_back("kpoints");
   auto& oh = h5desc.back();
   oh.open(sgid); // add to SkAll hdf group

--- a/src/QMCHamiltonians/StaticStructureFactor.h
+++ b/src/QMCHamiltonians/StaticStructureFactor.h
@@ -44,7 +44,7 @@ public:
 
   //required for Collectables interface
   void addObservables(PropertySetType& plist, BufferType& olist) override;
-  void registerCollectables(std::vector<ObservableHelper>& h5desc, hid_t gid) const override;
+  void registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const override;
 
   //should be empty for Collectables interface
   void resetTargetParticleSet(ParticleSet& P) override {}

--- a/src/QMCHamiltonians/StressPBC.h
+++ b/src/QMCHamiltonians/StressPBC.h
@@ -80,9 +80,9 @@ struct StressPBC : public OperatorBase, public ForceBase
 
   SymTensor<RealType, OHMMS_DIM> evaluateKineticSymTensor(ParticleSet& P);
 
-  void registerObservables(std::vector<ObservableHelper>& h5list, hid_t gid) const override
+  void registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const override
   {
-    registerObservablesF(h5list, gid);
+    registerObservablesF(h5list, file);
   }
 
   void addObservables(PropertySetType& plist, BufferType& collectables) override { addObservablesStress(plist); }

--- a/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
+++ b/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
@@ -28,9 +28,6 @@ TEST_CASE("ObservableHelper::ObservableHelper(const std::string&)", "[hamiltonia
 {
   ObservableHelper oh("u");
   CHECK(oh.lower_bound == 0);
-  CHECK(oh.data_id == -1);
-  CHECK(oh.space1_id == -1);
-  CHECK(oh.value1_id == -1);
   CHECK(oh.mydims == std::vector<hsize_t>());
   CHECK(oh.maxdims == std::vector<hsize_t>());
   CHECK(oh.curdims == std::vector<hsize_t>());
@@ -46,7 +43,7 @@ TEST_CASE("ObservableHelper::ObservableHelper(ObservableHelper&&)", "[hamiltonia
   hFile.create(filename);
 
   ObservableHelper ohIn("u");
-  ohIn.open(hFile.getFileID());
+  ohIn.open(hFile);
   CHECK(ohIn.isOpened() == true);
   {
     ObservableHelper oh(std::move(ohIn));
@@ -81,7 +78,7 @@ TEST_CASE("ObservableHelper::ObservableHelper()", "[hamiltonian]")
   hFile.create(filename);
 
   ObservableHelper oh("u");
-  oh.open(hFile.getFileID());
+  oh.open(hFile);
   std::vector<int> dims = {10, 10};
   float propertyFloat   = 10.f;
   oh.addProperty(propertyFloat, "propertyFloat");

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -144,7 +144,7 @@ public:
 
   /** return the top of the group stack
    */
-  inline hid_t top() const { return group_id.empty() ? is_closed : group_id.top(); }
+  inline hid_t top() const { return group_id.empty() ? file_id : group_id.top(); }
 
   /** check if any groups are open
    *  group stack will have entries if so


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

For `registerObservables` and `registerCollectables` member functions I changed the second argument from a hdf5 group id to a reference to hdf_archive. The number of changes grew quickly, so I'm making this a separate pull request. Next steps will be refactoring ObservableHelper to use hdf_archive to create, open and close groups and write data.

This is part of #4156.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

laptop, ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
