### PR TITLE
Fix invalid workflow file message

### DIFF
--- a/.github/workflows/ci-github-action-auto-rebase.yaml
+++ b/.github/workflows/ci-github-action-auto-rebase.yaml
@@ -31,7 +31,7 @@ jobs:
       run: tests/test_automation/github-actions/ci/run_step.sh rebase
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}
+        QMCPACK_BOT_GPG_KEY: ${{ secrets.QMCPACK_BOT_GPG_KEY }}
         QMCPACK_BOT_GPG_SIGNING_KEY: ${{ secrets.QMCPACK_BOT_GPG_SIGNING_KEY }}
 
   trigger-rebase:
@@ -48,5 +48,5 @@ jobs:
       run: tests/test_automation/github-actions/ci/run_step.sh pull-rebase
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        QMCPACK_BOT_GPG_KEY: ${{ QMCPACK_BOT_GPG_KEY }}
+        QMCPACK_BOT_GPG_KEY: ${{ secrets.QMCPACK_BOT_GPG_KEY }}
         QMCPACK_BOT_GPG_SIGNING_KEY: ${{ secrets.QMCPACK_BOT_GPG_SIGNING_KEY }}


### PR DESCRIPTION
I get an error from github workflows:

**Invalid workflow file: .github/workflows/ci-github-action-auto-rebase.yaml#L34**
The workflow is not valid. .github/workflows/ci-github-action-auto-rebase.yaml (Line: 34, Col: 30): Unrecognized named-value: 'QMCPACK_BOT_GPG_KEY'. Located at position 1 within expression: QMCPACK_BOT_GPG_KEY .github/workflows/ci-github-action-auto-rebase.yaml (Line: 51, Col: 30): Unrecognized named-value: 'QMCPACK_BOT_GPG_KEY'. Located at position 1 within expression: QMCPACK_BOT_GPG_KEY

It looks like QMCPACK_BOT_GPG_KEY should be in the secrets context (I checked and it does exist as a secret for the repo)

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
None

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
