### PR TITLE
Extract run_qmc to separate module

### DIFF
--- a/src/QMCWaveFunctions/tests/run_qmc.py
+++ b/src/QMCWaveFunctions/tests/run_qmc.py
@@ -1,0 +1,107 @@
+
+# Minimal QMC loop for validation
+
+# Uses automatic differentiation via the autograd package to
+#  compute spatial and parameter derivatives.
+# The autodiff is performed in the wavefunction class
+from stats import averager
+import autograd.numpy as np
+
+# Parameters for run_qmc
+# r - numpy array of shape (number of electrons, 3)
+# wf - class implementing a wavefunction.
+#   It should implement the functions:
+#        psi(self, r, VP)
+#        dpsi(self, r, VP) - derivative of psi wrt to VP
+#        local_energy(self, r, VP)
+#        dlocal_energy(self, r, VP) - derivative of local_energy wrt VP
+# VP - numpy array of the variational parameters
+# nblock - Loop for statistics
+# nstep - Loop to gather data
+# nsubstep - Loop for decorrelation
+
+def run_qmc(r, wf, VP, nblock=20, nstep=10, nsubstep=10):
+    nelectron = r.shape[0]
+
+    # Step size for trial move
+    delta = 1.2
+
+    r_old = np.zeros(3)
+    r_trial = np.zeros(3)
+
+    block_dp_ave = averager()
+    total_en_ave = averager()
+
+    # Outer loop for statistics
+    for nb in range(nblock):
+
+        naccept = 0
+        en_ave = averager()
+        dpsi_ave = averager()
+        deloc_ave = averager()
+        eloc_dpsi_ave = averager()
+
+        # Loop to gather data
+        for ns in range(nstep):
+            # Loop for decorrelation
+            for nss in range(nsubstep):
+                # Loop over electrons
+                for ne in range(nelectron):
+
+                    wf_old = wf.psi(r, VP)
+                    r_old[:] = r[ne,:]
+
+                    change = delta*(np.random.rand(3)-0.5)
+
+                    r_trial[:] = r_old[:] + change
+                    r[ne,:] = r_trial[:]
+
+                    wf_new = wf.psi(r, VP)
+
+                    wf_ratio = (wf_new/wf_old)**2
+
+                    if wf_ratio > np.random.random():
+                        naccept += 1
+                    else:
+                        r[ne,:] = r_old[:]
+
+            eloc = wf.local_energy(r, VP)
+            en_ave.add_value(eloc)
+
+            psi_val = wf.psi(r, VP)
+            dpsi_val = wf.dpsi(r, VP)
+            dpsi_ave.add_value(dpsi_val/psi_val)
+
+            deloc_val = wf.dlocal_energy(r, VP)
+            deloc_ave.add_value(deloc_val)
+
+            eloc_dpsi_ave.add_value(eloc * dpsi_val/psi_val)
+
+
+        en = en_ave.average()
+        en_err = en_ave.error()
+        ar = naccept/(nstep*nsubstep*nelectron)
+        print('block = ',nb, ' energy = ',en,en_err,' acceptance ratio = ',ar, flush=True)
+
+
+        dp = dpsi_ave.average()
+        dp_err = dpsi_ave.error()
+
+        deloc = deloc_ave.average()
+        deloc_err = deloc_ave.error()
+
+        eloc_dpsi = eloc_dpsi_ave.average()
+        eloc_dpsi_err = eloc_dpsi_ave.error()
+
+        # For the parameter derivative formula, see
+        # https://github.com/QMCPACK/qmc_algorithms/blob/master/Variational/Parameter_Optimization.ipynb
+
+        dg = deloc + 2*eloc_dpsi - 2*en*dp
+        block_dp_ave.add_value(dg)
+
+    dg = block_dp_ave.average()
+    dg_err = block_dp_ave.error()
+    print('parameter values = ',VP)
+    print('parameter derivatives = ',dg)
+    print('parameter derivative errors = ',dg_err)
+


### PR DESCRIPTION
Generalize the run_qmc function to an arbitrary number of electrons and extract it to a separate module.
Future validation code will use different wavefunctions and we want to reuse the run_qmc function.

The implementation of psi in the wavefunction needs to be split into two parts.  For generality, calling from run_qmc uses an array for all the electron positions.  Autograd is easier to use if each position is a separate argument.  The solution is to make psi a wrapper that extracts individual positions and calls the internal implementation.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
