### PR TITLE
Use unversioned cuda in test script

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -35,14 +35,14 @@ case "$1" in
     then
       if [[ "${GH_JOBNAME}" =~ (-Offload) ]]
       then
-        echo "Set PATH to cuda-11.2 to be associated with the C and C++ compilers"
-        export PATH=/usr/local/cuda-11.2/bin:$PATH
-        echo "Set CUDACXX CMake environment variable to nvcc cuda 11.2 location due to a regression bug in 11.6"
-        export CUDACXX=/usr/local/cuda-11.2/bin/nvcc
+        echo "Set PATH to cuda to be associated with the C and C++ compilers"
+        export PATH=/usr/local/cuda/bin:$PATH
+        echo "Set CUDACXX CMake environment variable to nvcc cuda location"
+        export CUDACXX=/usr/local/cuda/bin/nvcc
 
         # Make current environment variables available to subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV
-        echo "CUDACXX=/usr/local/cuda-11.2/bin/nvcc" >> $GITHUB_ENV
+        echo "CUDACXX=/usr/local/cuda/bin/nvcc" >> $GITHUB_ENV
 
       else
         echo "Set CUDACXX CMake environment variable to nvcc standard location"
@@ -182,7 +182,7 @@ case "$1" in
         echo "OMPI_CC=/opt/llvm/15.0.0/bin/clang" >> $GITHUB_ENV
         echo "OMPI_CXX=/opt/llvm/15.0.0/bin/clang++" >> $GITHUB_ENV
 
-        # Confirm that cuda 11.2 gets picked up by the compiler
+        # Confirm cuda installation picked up by the compiler
         /opt/llvm/15.0.0/bin/clang++ -v
 
         cmake -GNinja \
@@ -370,7 +370,7 @@ case "$1" in
     then
       if [[ "${GH_JOBNAME}" =~ (-Offload) ]]
       then
-        export LD_LIBRARY_PATH=/usr/local/cuda-11.2/lib64:${LD_LIBRARY_PATH}
+        export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
       else
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
       fi


### PR DESCRIPTION
## Proposed changes

Use generic /cuda/ in script. Old CUDA versions no longer installed on test system. See if bug is fixed.

The relevant lines are kept in case future customization is needed.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
