### PR TITLE
add twist_info.dat files to results dir

### DIFF
--- a/nexus/lib/qmcpack_input.py
+++ b/nexus/lib/qmcpack_input.py
@@ -4216,6 +4216,8 @@ class BundledQmcpackInput(SimulationInput):
             outfile= infile.rsplit('.',1)[0]+'.g'+str(index).zfill(3)+'.qmc'
             outfiles.append(infile)
             outfiles.append(outfile)
+            twfile = infile.rsplit('.',3)[0]+'.twist_info.dat'
+            outfiles.append(twfile)
             for outf in outfs:
                 prefix,rest = outf.split('.',1)
                 outfiles.append(prefix+'.g'+str(index).zfill(3)+'.'+rest)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Adds twist_info files to be copied to the results directory. This is useful in order to do weighted twist averaging with qmca (which reads the weights from these files) from the nexus results directory if it isn't the same as the 'runs' directory.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
