### PR TITLE
Orbital rotation test with hcp Be

### DIFF
--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UTEST_HDF_INPUT7 ${qmcpack_SOURCE_DIR}/tests/molecules/LiH_ae_MSD/LiH.orbs.h
 set(UTEST_HDF_INPUT8 ${qmcpack_SOURCE_DIR}/tests/molecules/LiH_ae_MSD/LiH.Multidet.h5)
 set(UTEST_HDF_INPUT9 ${qmcpack_SOURCE_DIR}/tests/converter/test_Bi_dirac/gold.orbs.h5)
 set(UTEST_HDF_INPUT10 ${qmcpack_SOURCE_DIR}/src/QMCWaveFunctions/tests/lcao_spinor_molecule.h5)
+set(UTEST_HDF_INPUT11 ${qmcpack_SOURCE_DIR}/tests/solids/hcpBe_1x1x1_pp/pwscf.pwscf.h5)
 
 maybe_symlink(${UTEST_HDF_INPUT0} ${UTEST_DIR}/diamondC_1x1x1.pwscf.h5)
 maybe_symlink(${UTEST_HDF_INPUT1} ${UTEST_DIR}/diamondC_2x1x1.pwscf.h5)
@@ -36,6 +37,7 @@ maybe_symlink(${UTEST_HDF_INPUT7} ${UTEST_DIR}/LiH.orbs.h5)
 maybe_symlink(${UTEST_HDF_INPUT8} ${UTEST_DIR}/LiH.Multidet.h5)
 maybe_symlink(${UTEST_HDF_INPUT9} ${UTEST_DIR}/Bi.orbs.h5)
 maybe_symlink(${UTEST_HDF_INPUT10} ${UTEST_DIR}/lcao_spinor_molecule.h5)
+maybe_symlink(${UTEST_HDF_INPUT11} ${UTEST_DIR}/hcpBe.pwscf.h5)
 
 set(FILES_TO_COPY
     he_sto3g.wfj.xml

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -506,25 +506,23 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   ions.setName("ion");
   ptcl.addParticleSet(std::move(ions_uptr));
   ions.create({1});
-  ions.R[0][0] = 0.0;
-  ions.R[0][1] = 0.0;
-  ions.R[0][2] = 0.0;
+  ions.R[0] = {0.0, 0.0, 0.0};
 
   elec.setName("elec");
   ptcl.addParticleSet(std::move(elec_uptr));
   elec.create({1});
-  elec.R[0][0] = 0.0;
-  elec.R[0][1] = 0.0;
-  elec.R[0][2] = 0.0;
+  elec.R[0] = {0.0, 0.0, 0.0};
 
   SpeciesSet& tspecies       = elec.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");
   int chargeIdx              = tspecies.addAttribute("charge");
   tspecies(chargeIdx, upIdx) = -1;
 
+  // Add the attribute save_coefs="yes" to the sposet_builder tag to generate the
+  // spline file for use in eval_bspline_spo.py
 
   const char* particles = R"(<tmp>
-<sposet_builder type="bspline" href="hcpBe.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="double" save_coefs="yes" size="2">
+<sposet_builder type="bspline" href="hcpBe.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="double" size="2">
     <sposet type="bspline" name="spo_ud" size="2" spindataset="0" optimize="yes"/>
 </sposet_builder>
 </tmp>)";

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -480,5 +480,116 @@ TEST_CASE("RotatedSPOs exp-log matrix", "[wavefunction]")
   }
 }
 
+TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
+{
+  using RealType = QMCTraits::RealType;
+  Communicate* c = OHMMS::Controller;
+
+  ParticleSet::ParticleLayout lattice;
+  lattice.R(0, 0) = 4.32747284;
+  lattice.R(0, 1) = 0.00000000;
+  lattice.R(0, 2) = 0.00000000;
+  lattice.R(1, 0) = -2.16373642;
+  lattice.R(1, 1) = 3.74770142;
+  lattice.R(1, 2) = 0.00000000;
+  lattice.R(2, 0) = 0.00000000;
+  lattice.R(2, 1) = 0.00000000;
+  lattice.R(2, 2) = 6.78114995;
+
+  ParticleSetPool ptcl = ParticleSetPool(c);
+  ptcl.setSimulationCell(lattice);
+  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  ParticleSet& ions(*ions_uptr);
+  ParticleSet& elec(*elec_uptr);
+
+  ions.setName("ion");
+  ptcl.addParticleSet(std::move(ions_uptr));
+  ions.create({1});
+  ions.R[0][0] = 0.0;
+  ions.R[0][1] = 0.0;
+  ions.R[0][2] = 0.0;
+
+  elec.setName("elec");
+  ptcl.addParticleSet(std::move(elec_uptr));
+  elec.create({1});
+  elec.R[0][0] = 0.0;
+  elec.R[0][1] = 0.0;
+  elec.R[0][2] = 0.0;
+
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  tspecies(chargeIdx, upIdx) = -1;
+
+
+  const char* particles = R"(<tmp>
+<sposet_builder type="bspline" href="hcpBe.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="double" save_coefs="yes" size="2">
+    <sposet type="bspline" name="spo_ud" size="2" spindataset="0" optimize="yes"/>
+</sposet_builder>
+</tmp>)";
+
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(particles);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  xmlNodePtr ein1 = xmlFirstElementChild(root);
+
+  EinsplineSetBuilder einSet(elec, ptcl.getPool(), c, ein1);
+  auto spo = einSet.createSPOSetFromXML(ein1);
+  REQUIRE(spo);
+
+  auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
+
+  // Sanity check for orbs. Expect 1 electron, 2 orbitals
+  const auto orbitalsetsize = rot_spo->getOrbitalSetSize();
+  REQUIRE(orbitalsetsize == 2);
+
+  rot_spo->buildOptVariables(elec.R.size());
+
+  SPOSet::ValueMatrix psiM_bare(elec.R.size(), orbitalsetsize);
+  SPOSet::GradMatrix dpsiM_bare(elec.R.size(), orbitalsetsize);
+  SPOSet::ValueMatrix d2psiM_bare(elec.R.size(), orbitalsetsize);
+  rot_spo->evaluate_notranspose(elec, 0, elec.R.size(), psiM_bare, dpsiM_bare, d2psiM_bare);
+
+  // Values generated from eval_bspline_spo.py, the generate_point_values_hcpBe function
+  CHECK(std::real(psiM_bare[0][0]) == Approx(0.210221765375514));
+  CHECK(std::real(psiM_bare[0][1]) == Approx(-2.984345024542937e-06));
+
+  CHECK(std::real(d2psiM_bare[0][0]) == Approx(5.303848362116568));
+
+  opt_variables_type opt_vars;
+  rot_spo->checkInVariablesExclusive(opt_vars);
+  opt_vars.resetIndex();
+  rot_spo->checkOutVariables(opt_vars);
+  rot_spo->resetParametersExclusive(opt_vars);
+
+  using ValueType = QMCTraits::ValueType;
+  Vector<ValueType> dlogpsi(1);
+  Vector<ValueType> dhpsioverpsi(1);
+  rot_spo->evaluateDerivatives(elec, opt_vars, dlogpsi, dhpsioverpsi, 0, 1);
+
+  CHECK(dlogpsi[0] == ValueApprox(-1.41961753e-05));
+  CHECK(dhpsioverpsi[0] == ValueApprox(-0.00060853));
+
+  std::vector<RealType> params = {0.1};
+  rot_spo->apply_rotation(params, false);
+
+  rot_spo->evaluate_notranspose(elec, 0, elec.R.size(), psiM_bare, dpsiM_bare, d2psiM_bare);
+  CHECK(std::real(psiM_bare[0][0]) == Approx(0.20917123424337608));
+  CHECK(std::real(psiM_bare[0][1]) == Approx(-0.02099012652669549));
+
+  CHECK(std::real(d2psiM_bare[0][0]) == Approx(5.277362065087747));
+
+  dlogpsi[0]      = 0.0;
+  dhpsioverpsi[0] = 0.0;
+
+  rot_spo->evaluateDerivatives(elec, opt_vars, dlogpsi, dhpsioverpsi, 0, 1);
+  CHECK(dlogpsi[0] == ValueApprox(-0.10034901119468914));
+  CHECK(dhpsioverpsi[0] == ValueApprox(32.96939041498753));
+}
+
 
 } // namespace qmcplusplus


### PR DESCRIPTION
The hcpBe test is the solid system with the fewest electrons (2), making it useful for validating orbital rotation with a 2x2 rotation matrix.
The test adds some point values for the system with unrotated and rotated orbitals.
The validation script adds support for this system, along with a wavefunction class usable with run_qmc.  (Eventually there will be tests using the output of run_qmc)

The convertPos function was simplified and corrected (the if-tests in the C++ code were only for a narrow special case, not a general less-than-zero case)


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
