### PR TITLE
Fix MacOS build, h5py failing to build.

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -149,6 +149,11 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v3
 
+      - name: Set Python Version
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Setup Dependencies
         run: |
           brew install ninja hdf5 fftw boost


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

The MacOS runners on GitHub Actions updated to Python 3.11. One of our dependencies, h5py, does not currently have a Python 3.11 wheel and is not successfully building from source. A new release with a new wheel is anticipated in a few weeks. See https://github.com/h5py/h5py/pull/2165 for more information.

In the meantime, I updated GitHub Actions to use Python 3.10 on MacOS. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
