### PR TITLE
Allow ConstantSizeMatrix to increase along a dimension

### DIFF
--- a/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
+++ b/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
@@ -160,13 +160,26 @@ public:
 
   void resize(size_t m, size_t n)
   {
-    if (n > n_max_ || m > m_max_)
+    if (n * m > n_max_ * m_max_)
     {
       std::ostringstream error;
       error << "You cannot resize a constant size matrix beyond its initial max dimensions ( " << m << "," << n << " > "
             << m_max_ << "," << n_max_ << " )\n";
       throw std::domain_error(error.str());
     }
+
+    size_t capacity = n_max_ * m_max_;
+    if (n > n_max_)
+    {
+      n_max_ = n;
+      m_max_ = capacity / n_max_;
+    }
+    if (m > m_max_)
+    {
+      m_max_ = m;
+      n_max_ = capacity / m_max_;
+    }
+
     n_ = n;
     m_ = m;
   }
@@ -182,8 +195,6 @@ private:
   size_t m_max_;
   size_t n_max_;
   std::vector<T, ALLOC> data_;
-
-
 };
 
 extern template class ConstantSizeMatrix<float>;

--- a/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
+++ b/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
@@ -24,14 +24,14 @@ class ConstantSizeMatrix
 {
 public:
   ConstantSizeMatrix(size_t m, size_t n, size_t m_max, size_t n_max, T val = T())
-      : m_(m), n_(n), m_max_(m_max), n_max_(n_max), data_(n_max * m_max, val)
+      : m_(m), n_(n), m_max_(m_max), n_max_(n_max), capacity_(n_max * m_max), data_(n_max * m_max, val)
   {
     if (n_max <= 0 || n > n_max || m_max <= 0 || m > m_max)
       throw std::runtime_error("Cannot construct ConstantSizeMatrix with an invalid size");
   }
 
   ConstantSizeMatrix(const ConstantSizeMatrix& csm)
-      : m_(csm.m_), n_(csm.n_), m_max_(csm.m_max_), n_max_(csm.n_max_), data_(csm.n_max_ * csm.m_max_)
+      : m_(csm.m_), n_(csm.n_), m_max_(csm.m_max_), n_max_(csm.n_max_), capacity_(csm.capacity_), data_(csm.capacity_)
   {
     //I don't just do an = here because of the posible semantics of allocator propagation.
     data_.assign(csm.begin(), csm.end());
@@ -151,7 +151,7 @@ public:
   T* data() { return data_.data(); }
   const T* data() const { return data_.data(); }
 
-  size_t capacity() { return n_max_ * m_max_; }
+  size_t capacity() { return capacity_; }
   size_t n_capacity() { return n_max_; }
 
   size_t size() const { return n_ * m_; }
@@ -160,9 +160,7 @@ public:
 
   void resize(size_t m, size_t n)
   {
-    size_t max_capacity = capacity();
-
-    if (n * m > max_capacity)
+    if (n * m > capacity())
     {
       std::ostringstream error;
       error << "You cannot resize a constant size matrix beyond its initial max dimensions ( " << m << "," << n << " > "
@@ -173,12 +171,13 @@ public:
     if (n > n_max_)
     {
       n_max_ = n;
-      m_max_ = max_capacity / n_max_;
+      m_max_ = capacity() / n_max_;
     }
+
     if (m > m_max_)
     {
       m_max_ = m;
-      n_max_ = max_capacity / m_max_;
+      n_max_ = capacity() / m_max_;
     }
 
     n_ = n;
@@ -195,6 +194,7 @@ private:
   size_t n_;
   size_t m_max_;
   size_t n_max_;
+  size_t capacity_;
   std::vector<T, ALLOC> data_;
 };
 

--- a/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
+++ b/src/Containers/MinimalContainers/ConstantSizeMatrix.hpp
@@ -160,7 +160,9 @@ public:
 
   void resize(size_t m, size_t n)
   {
-    if (n * m > n_max_ * m_max_)
+    size_t max_capacity = capacity();
+
+    if (n * m > max_capacity)
     {
       std::ostringstream error;
       error << "You cannot resize a constant size matrix beyond its initial max dimensions ( " << m << "," << n << " > "
@@ -168,16 +170,15 @@ public:
       throw std::domain_error(error.str());
     }
 
-    size_t capacity = n_max_ * m_max_;
     if (n > n_max_)
     {
       n_max_ = n;
-      m_max_ = capacity / n_max_;
+      m_max_ = max_capacity / n_max_;
     }
     if (m > m_max_)
     {
       m_max_ = m;
-      n_max_ = capacity / m_max_;
+      n_max_ = max_capacity / m_max_;
     }
 
     n_ = n;

--- a/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
+++ b/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
@@ -29,7 +29,14 @@ TEST_CASE("ConstantSizeMatrix basics", "[containers]")
 
   CHECK_THROWS(cmat.resize(1, 33));
 
-  CHECK_THROWS(cmat.resize(2, 9));
+  CHECK_NOTHROW(cmat.resize(2, 9));
+  CHECK(cmat.capacity() == 32);
+
+  // If the new dimensions are not commensurable with the old ones,
+  // the capacity could decrease, even though the size of the underlying
+  // storage does not decrease.
+  CHECK_NOTHROW(cmat.resize(3, 9));
+  CHECK(cmat.capacity() == 30);
 
   //note the odd OhmmsMatrix style access operator semantics
   //If these break you probably breaking other weird QMCPACK code.

--- a/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
+++ b/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
@@ -37,7 +37,7 @@ TEST_CASE("ConstantSizeMatrix basics", "[containers]")
   // the capacity could decrease, even though the size of the underlying
   // storage does not decrease.
   CHECK_NOTHROW(cmat.resize(3, 9));
-  CHECK(cmat.capacity() == 30);
+  CHECK(cmat.capacity() == 32);
 
   //note the odd OhmmsMatrix style access operator semantics
   //If these break you probably breaking other weird QMCPACK code.

--- a/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
+++ b/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
@@ -28,6 +28,7 @@ TEST_CASE("ConstantSizeMatrix basics", "[containers]")
   CHECK(cmat.capacity() == 32);
 
   CHECK_THROWS(cmat.resize(1, 33));
+  CHECK_THROWS(cmat.resize(34, 2));
 
   CHECK_NOTHROW(cmat.resize(2, 9));
   CHECK(cmat.capacity() == 32);
@@ -55,6 +56,15 @@ TEST_CASE("ConstantSizeMatrix basics", "[containers]")
   CHECK(*(cmat2[0]) == Approx(1.0));
   CHECK(*(cmat2[0] + 1) == Approx(1.0));
   CHECK(*(cmat2[1]) == Approx(2.0));
+
+  ConstantSizeMatrix<double> cmat3(4, 32, 4, 32, 0.0);
+  CHECK_NOTHROW(cmat3.resize(2, 64));
+  CHECK(cmat3.size() == 128);
+  CHECK(cmat3.capacity() == 128);
+
+  CHECK_NOTHROW(cmat3.resize(8, 16));
+  CHECK(cmat3.size() == 128);
+  CHECK(cmat3.capacity() == 128);
 }
 
 TEST_CASE("ConstantSizeMatrix Ohmms integration", "[containers]")

--- a/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
+++ b/src/Containers/MinimalContainers/tests/test_ConstantSizeMatrix.cpp
@@ -33,9 +33,6 @@ TEST_CASE("ConstantSizeMatrix basics", "[containers]")
   CHECK_NOTHROW(cmat.resize(2, 9));
   CHECK(cmat.capacity() == 32);
 
-  // If the new dimensions are not commensurable with the old ones,
-  // the capacity could decrease, even though the size of the underlying
-  // storage does not decrease.
   CHECK_NOTHROW(cmat.resize(3, 9));
   CHECK(cmat.capacity() == 32);
 

--- a/src/QMCDrivers/CloneManager.cpp
+++ b/src/QMCDrivers/CloneManager.cpp
@@ -80,7 +80,6 @@ CloneManager::CloneManager() : NumThreads(omp_get_max_threads()) { wPerRank.resi
 ///cleanup non-static data members
 CloneManager::~CloneManager()
 {
-  // delete_iter(CSMovers.begin(),CSMovers.end());
   delete_iter(Movers.begin(), Movers.end());
   delete_iter(estimatorClones.begin(), estimatorClones.end());
 

--- a/src/QMCDrivers/CloneManager.h
+++ b/src/QMCDrivers/CloneManager.h
@@ -83,7 +83,7 @@ protected:
   static std::vector<std::vector<TrialWaveFunction*>> PsiPoolClones;
   static std::vector<UPtrVector<QMCHamiltonian>> HPoolClones_uptr;
   static std::vector<std::vector<QMCHamiltonian*>> HPoolClones;
-  std::vector<CSUpdateBase*> CSMovers;
+  UPtrVector<CSUpdateBase> CSMovers;
 
   ///Walkers per MPI rank
   std::vector<int> wPerRank;

--- a/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
+++ b/src/QMCDrivers/CorrelatedSampling/CSVMC.cpp
@@ -229,7 +229,7 @@ void CSVMC::resetRun()
 
   if (Movers.empty())
   {
-    CSMovers.resize(NumThreads, nullptr);
+    CSMovers.resize(NumThreads);
     estimatorClones.resize(NumThreads, nullptr);
     traceClones.resize(NumThreads, nullptr);
     Rng.resize(NumThreads);
@@ -253,12 +253,12 @@ void CSVMC::resetRun()
         if (UseDrift == "yes")
         {
           os << "  Using particle-by-particle update with drift " << std::endl;
-          CSMovers[ip] = new CSVMCUpdatePbyPWithDriftFast(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
+          CSMovers[ip] = std::make_unique<CSVMCUpdatePbyPWithDriftFast>(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
         }
         else
         {
           os << "  Using particle-by-particle update with no drift" << std::endl;
-          CSMovers[ip] = new CSVMCUpdatePbyP(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
+          CSMovers[ip] = std::make_unique<CSVMCUpdatePbyP>(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
         }
       }
       else
@@ -266,12 +266,12 @@ void CSVMC::resetRun()
         if (UseDrift == "yes")
         {
           os << "  Using walker-by-walker update with Drift " << std::endl;
-          CSMovers[ip] = new CSVMCUpdateAllWithDrift(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
+          CSMovers[ip] = std::make_unique<CSVMCUpdateAllWithDrift>(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
         }
         else
         {
           os << "  Using walker-by-walker update " << std::endl;
-          CSMovers[ip] = new CSVMCUpdateAll(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
+          CSMovers[ip] = std::make_unique<CSVMCUpdateAll>(*wClones[ip], PsiPoolClones[ip], HPoolClones[ip], *Rng[ip]);
         }
       }
       if (ip == 0)

--- a/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
+++ b/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
@@ -80,6 +80,26 @@ if(NOT QMC_CUDA)
     BCC_H_DMC_SCALARS # DMC
   )
 
+  # Deterministic correlated sampling test
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "totenergy_A"   "-1.5879406376 0.00001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "totenergy_B"   "-1.5845690797 0.00001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "dtotenergy_AB" "-0.0033713724 0.00001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "ionion_A"      "-0.9628996202 0.0000001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "ionion_B"      "-0.9581655983 0.0000001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "dionion_AB"    "-0.0047340219 0.0000001")
+
+  qmc_run_and_check(
+    deterministic-bccH_1x1x1_ae-csvmc-all_sdj
+    "${qmcpack_SOURCE_DIR}/tests/solids/bccH_1x1x1_ae"
+    det_qmc_short_csvmc_all
+    det_qmc_short_csvmc_all.in.xml
+    1
+    1
+    TRUE
+    0
+    DET_BCC_H_CSVMC_SCALARS # VMC
+  )
+
   #Now for the correlated sampling tests
   list(APPEND BCC_H_CSVMC_SCALARS "totenergy_A" "-1.83428 0.00013")
   list(APPEND BCC_H_CSVMC_SCALARS "totenergy_B" "-1.83390 0.00012")

--- a/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
+++ b/tests/solids/bccH_1x1x1_ae/CMakeLists.txt
@@ -82,7 +82,7 @@ if(NOT QMC_CUDA)
 
   # Deterministic correlated sampling test
   list(APPEND DET_BCC_H_CSVMC_SCALARS "totenergy_A"   "-1.5879406376 0.00001")
-  list(APPEND DET_BCC_H_CSVMC_SCALARS "totenergy_B"   "-1.5845690797 0.00001")
+  list(APPEND DET_BCC_H_CSVMC_SCALARS "totenergy_B"   "-1.5845867400 0.00001")
   list(APPEND DET_BCC_H_CSVMC_SCALARS "dtotenergy_AB" "-0.0033713724 0.00001")
   list(APPEND DET_BCC_H_CSVMC_SCALARS "ionion_A"      "-0.9628996202 0.0000001")
   list(APPEND DET_BCC_H_CSVMC_SCALARS "ionion_B"      "-0.9581655983 0.0000001")

--- a/tests/solids/bccH_1x1x1_ae/det_qmc_short_csvmc_all.in.xml
+++ b/tests/solids/bccH_1x1x1_ae/det_qmc_short_csvmc_all.in.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<simulation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.mcc.uiuc.edu/qmc/schema/molecu.xsd">
+  <project id="det_qmc_short_csvmc_all" series="0">
+    <driver_version>legacy</driver_version>
+    <application name="qmcapp" role="molecu" class="serial" version="0.2">
+      Correlated Sampling VMC on BCCH. Perturb ion 2 by (0.2,0.2,0.2)
+    </application>
+  </project>
+
+  <random seed="1"/>
+<qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.77945227        0.00000000        0.00000000
+                 -0.00000000        3.77945227        0.00000000
+                 -0.00000000       -0.00000000        3.77945227
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="1" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="H" size="2" mass="1837.36221934">
+            <parameter name="charge"              >    1                     </parameter>
+            <parameter name="valence"             >    1                     </parameter>
+            <parameter name="atomicnumber"        >    1                     </parameter>
+            <parameter name="mass"                >    1837.36221934            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.88972614        1.88972614        1.88972614
+            </attrib>
+         </group>
+      </particleset>
+      <particleset name="ion1">
+         <group name="H" size="2" mass="1837.36221934">
+            <parameter name="charge"              >    1                     </parameter>
+            <parameter name="valence"             >    1                     </parameter>
+            <parameter name="atomicnumber"        >    1                     </parameter>
+            <parameter name="mass"                >    1837.36221934            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     2.08972614        2.08972614        2.08972614
+            </attrib>
+         </group>
+      </particleset>
+  </qmcsystem>
+      <wavefunction name="psi0" target="e">
+        <sposet_builder name="A" type="bspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet type="bspline" name="spoA_u" size="1" spindataset="0"/>
+        <sposet type="bspline" name="spoA_d" size="1" spindataset="0"/>
+      </sposet_builder>
+      <determinantset>
+        <slaterdeterminant>
+          <determinant id="updetA" group="u" sposet="spoA_u" size="1"/>
+          <determinant id="downdetA" group="d" sposet="spoA_d" size="1"/>
+        </slaterdeterminant>
+      </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="H" size="8" cusp="1.0">
+               <coefficients id="eH" type="Array">                  
+0.00206602038 -0.002841926986 0.0036266191 -0.001913930279 8.457152991e-06 
+0.0007380321824 3.635172529e-05 0.0001299635851
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.5954603818 0.5062051797 0.3746940461 0.2521010502 0.1440163317 0.07796688253 
+0.03804420551 0.01449320872
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <wavefunction name="psi1" target="e" source="ion1">
+        <sposet_builder name="B" type="bspline" href="pwscf_dR.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion1" version="0.10" meshfactor="1.0" precision="float" truncate="no">
+        <sposet type="bspline" name="spoB_u" size="1" spindataset="0"/>
+        <sposet type="bspline" name="spoB_d" size="1" spindataset="0"/>
+      </sposet_builder>
+      <determinantset>
+        <slaterdeterminant>
+          <determinant id="updetB" group="u" sposet="spoB_u" size="1"/>
+          <determinant id="downdetB" group="d" sposet="spoB_d" size="1"/>
+        </slaterdeterminant>
+      </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion1" print="yes">
+            <correlation elementType="H" size="8" cusp="1.0">
+               <coefficients id="eH" type="Array">                  
+0.00206602038 -0.002841926986 0.0036266191 -0.001913930279 8.457152991e-06 
+0.0007380321824 3.635172529e-05 0.0001299635851
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.5954603818 0.5062051797 0.3746940461 0.2521010502 0.1440163317 0.07796688253 
+0.03804420551 0.01449320872
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="coulomb" name="ElecIon" source="ion0" target="e"/>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+      <hamiltonian name="h1" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion1" target="ion1"/>
+         <pairpot type="coulomb" name="ElecIon" source="ion1" target="e"/>
+         <estimator type="flux" name="Flux"/>
+      </hamiltonian>
+
+  <qmc method="csvmc" multiple="yes" move="alle" checkpoint="-1" gpu="no">
+    <qmcsystem wavefunction="psi0" hamiltonian="h0" source="ion0"/>
+    <qmcsystem wavefunction="psi1" hamiltonian="h1" source="ion1"/>
+    <estimator name="CSLocalEnergy" nPsi="2" />
+    <parameter name="substeps">  2 </parameter>
+    <parameter name="warmupSteps">  1 </parameter>
+    <parameter name="steps">  3 </parameter>
+    <parameter name="blocks">  3 </parameter>
+    <parameter name="timestep">  1.00 </parameter>
+    <parameter name="usedrift">   yes </parameter>
+  </qmc>
+</simulation>


### PR DESCRIPTION
Allow increasing one dimension in ConstantSizeMatrix, as long the other dimension decreases to compensate and the new capacity is less than or equal to the existing capacity.

This fixes the WALKER_MAX_PROPERTIES error in the csvmc tests (#2509 and #2709).
(I got annoyed seeing the csvmc failures on cdash in the nightly tests.)
 
## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
