### PR TITLE
Communicator mutable

### DIFF
--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -231,7 +231,11 @@ public:
 
 #ifdef HAVE_MPI
   /// mpi3 communicator wrapper
-  mpi3::communicator comm;
+  // AAC: Communicate is escentially a 'mutable' wrapper of mpi3::communicator
+  //      Since this member doesn't have an access protector (mutex),
+  //      this makes the use of the class member non-thread compatible,
+  //      in other words Communicate cannot be used from difference threads
+  mutable mpi3::communicator comm;
 #endif
 };
 

--- a/src/QMCHamiltonians/tests/test_ewald2d.cpp
+++ b/src/QMCHamiltonians/tests/test_ewald2d.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D tri. in rect.", "[hamiltonian]")
   elec.setName("e");
   elec.create({2});
   elec.R[0] = {0.0, 0.0, 0.0};
-  elec.R[1] = {alat/2, std::sqrt(3)*alat/2, 0.0};
+  elec.R[1] = {alat/2, std::sqrt(3.0)*alat/2, 0.0};
 
   SpeciesSet& tspecies       = elec.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");

--- a/src/QMCHamiltonians/tests/test_ewald2d.cpp
+++ b/src/QMCHamiltonians/tests/test_ewald2d.cpp
@@ -186,7 +186,7 @@ TEST_CASE("Coulomb PBC A-A Ewald2D tri. in rect.", "[hamiltonian]")
   LRCoulombSingleton::CoulombHandler = 0; // !!!! crucial if not first test
   LRCoulombSingleton::this_lr_type = LRCoulombSingleton::STRICT2D;
   const double vmad_tri = -1.1061025865191676;
-  const double alat = std::sqrt(2.0*M_PI/std::sqrt(3));
+  const double alat = std::sqrt(2.0*M_PI/std::sqrt(3.0));
 
   CrystalLattice<OHMMS_PRECISION, OHMMS_DIM> lattice;
   lattice.BoxBConds = true; // periodic


### PR DESCRIPTION
## Proposed changes

Remove const_cast, replace by a single mutable tag.
In modern C++ an unprotected mutable member is a good indication of the context in which a class can be used. (Not usable when shared across threads).

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
