### PR TITLE
Make communicator member mutable

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
@@ -11,6 +11,7 @@
 //                    Cynthia Gu, zg1@ornl.gov, Oak Ridge National Laboratory
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//                    Alfredo A. Correa, correaa@llnl.gov, Lawrence Livermore National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -45,10 +46,10 @@ Communicate::~Communicate() = default;
 //exclusive:  MPI or Serial
 #ifdef HAVE_MPI
 
-Communicate::Communicate(const mpi3::communicator& in_comm) : d_groupid(0), d_ngroups(1)
+Communicate::Communicate(mpi3::communicator& in_comm) : d_groupid(0), d_ngroups(1)
 {
-  // const_cast is used to enable non-const call to duplicate()
-  comm        = const_cast<mpi3::communicator&>(in_comm).duplicate();
+  // in_comm needs to be mutable to be duplicated
+  comm        = in_comm.duplicate();
   myMPI       = comm.get();
   d_mycontext = comm.rank();
   d_ncontexts = comm.size();
@@ -59,8 +60,8 @@ Communicate::Communicate(const Communicate& in_comm, int nparts)
 {
   std::vector<int> nplist(nparts + 1);
   int p = FairDivideLow(in_comm.rank(), in_comm.size(), nparts, nplist); //group
-  // const_cast is used to enable non-const call to split()
-  comm  = const_cast<mpi3::communicator&>(in_comm.comm).split(p, in_comm.rank());
+  // comm is mutable member
+  comm  = in_comm.comm.split(p, in_comm.rank());
   myMPI = comm.get();
   // TODO: mpi3 needs to define comm
   d_mycontext = comm.rank();
@@ -93,8 +94,8 @@ void Communicate::initialize(int argc, char** argv) {}
 
 void Communicate::initializeAsNodeComm(const Communicate& parent)
 {
-  // const_cast is used to enable non-const call to split_shared()
-  comm        = const_cast<mpi3::communicator&>(parent.comm).split_shared();
+  // comm is mutable member
+  comm        = parent.comm.split_shared();
   myMPI       = comm.get();
   d_mycontext = comm.rank();
   d_ncontexts = comm.size();

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -231,7 +231,7 @@ public:
 
 #ifdef HAVE_MPI
   /// mpi3 communicator wrapper
-  mpi3::communicator comm;
+  mutable mpi3::communicator comm;
 #endif
 };
 

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2020 QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Ken Esler, kpesler@gmail.com, University of Illinois at Urbana-Champaign
 //                    Miguel Morales, moralessilva2@llnl.gov, Lawrence Livermore National Laboratory
@@ -11,6 +11,7 @@
 //                    Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
 //                    Mark A. Berrill, berrillma@ornl.gov, Oak Ridge National Laboratory
 //                    Peter Doak, doakpw@ornl.gov, Oak Ridge National Laboratory
+//                    Alfredo A. Correa, correaa@llnl.gov, Lawrence Livermore National Laboratory
 //
 // File created by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +76,7 @@ public:
   Communicate(const mpi3::environment& env);
 
   ///constructor with communicator
-  Communicate(const mpi3::communicator& in_comm);
+  Communicate(mpi3::communicator& in_comm);
 #endif
 
   /** constructor that splits in_comm


### PR DESCRIPTION
## Proposed changes

Remove const_cast, replace by a single mutable tag.
In modern C++ an unprotected mutable member is a good indication of the context in which a class can be used. (Not usable when shared across threads).

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
