### PR TITLE
Fix warnings, small c++ updates

### DIFF
--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -1057,7 +1057,7 @@ std::vector<int> QMCHamiltonian::mw_makeNonLocalMoves(const RefVectorWithLeader<
 
 void QMCHamiltonian::createResource(ResourceCollection& collection) const
 {
-  auto resource_index = collection.addResource(std::move(std::make_unique<QMCHamiltonianMultiWalkerResource>()));
+  auto resource_index = collection.addResource(std::make_unique<QMCHamiltonianMultiWalkerResource>());
   for (int i = 0; i < H.size(); ++i)
     H[i]->createResource(collection);
 }

--- a/src/QMCTools/ppconvert/src/common/IO.cc
+++ b/src/QMCTools/ppconvert/src/common/IO.cc
@@ -130,7 +130,7 @@ namespace IO
 
   bool IOSectionClass::OpenSection (std::string name, int num)
   {
-    IOTreeClass *newSection;
+    IOTreeClass *newSection = NULL;
     bool success;
     success = CurrentSection->FindSection(name, newSection, num);
     if (success)

--- a/src/formic/utils/matrix.h
+++ b/src/formic/utils/matrix.h
@@ -39,11 +39,16 @@ namespace formic {
   /// \brief  An iterator used for iterating over the elements of a matrix row.
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> class RowConstIterator : public std::iterator<std::bidirectional_iterator_tag, const S> {
+  template<class S> class RowConstIterator {
     private:
       const S * m_x;
       size_t m_n;
     public:
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = S;
+      using difference_type = S;
+      using pointer = S*;
+      using reference = S&;
       RowConstIterator(const S * x, size_t n) : m_x(x), m_n(n) {}
       const S & operator*() const { return *m_x; }
       const S * operator->() const { return m_x; }
@@ -59,11 +64,16 @@ namespace formic {
   /// \brief  An iterator used for iterating over the elements of a matrix row.
   ///
   ///////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class S> class RowIterator : public std::iterator<std::bidirectional_iterator_tag, S> {
+  template<class S> class RowIterator {
     private:
       S * m_x;
       size_t m_n;
     public:
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = S;
+      using difference_type = S;
+      using pointer = S*;
+      using reference = S&;
       RowIterator(S * x, size_t n) : m_x(x), m_n(n) {}
       S & operator*() { return *m_x; }
       S * operator->() { return m_x; }


### PR DESCRIPTION
## Proposed changes

Cleanup for fewer warnings from gcc12, llvm15

IO.cc: fix the false warning from GCC12 about possible use of unitialized newSection
matrix.h: do not use deprecated std::iterator
QMCHamiltonian: remove warned about and seemingly not-needed std::move 

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2, nightly gcc12 and llvm15 config

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
