### PR TITLE
remove spurious assignment

### DIFF
--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -54,6 +54,12 @@ Communicate::Communicate(mpi3::communicator& in_comm) : d_groupid(0), d_ngroups(
   d_ncontexts = comm.size();
 }
 
+Communicate::Communicate(mpi3::communicator&& in_comm) : d_groupid(0), d_ngroups(1), comm{std::move(in_comm)}
+{
+  myMPI       = comm.get();
+  d_mycontext = comm.rank();
+  d_ncontexts = comm.size();
+}
 
 Communicate::Communicate(const Communicate& in_comm, int nparts)
 {

--- a/src/Message/Communicate.cpp
+++ b/src/Message/Communicate.cpp
@@ -46,10 +46,9 @@ Communicate::~Communicate() = default;
 //exclusive:  MPI or Serial
 #ifdef HAVE_MPI
 
-Communicate::Communicate(mpi3::communicator& in_comm) : d_groupid(0), d_ngroups(1)
-{
   // in_comm needs to be mutable to be duplicated
-  comm        = in_comm.duplicate();
+Communicate::Communicate(mpi3::communicator& in_comm) : d_groupid(0), d_ngroups(1), comm{in_comm.duplicate()}
+{
   myMPI       = comm.get();
   d_mycontext = comm.rank();
   d_ncontexts = comm.size();

--- a/src/Message/Communicate.h
+++ b/src/Message/Communicate.h
@@ -77,6 +77,7 @@ public:
 
   ///constructor with communicator
   Communicate(mpi3::communicator& in_comm);
+  Communicate(mpi3::communicator&& in_comm);
 #endif
 
   /** constructor that splits in_comm


### PR DESCRIPTION
## Proposed changes

Remove spurious assignments that can be easily replaced by copy- (actually duplicate-) constructor.
The exact meaning of (re)assignment in BMPI3 communicator can change in the near future, so it is better to avoid it.
As well as two-phase construction in general.

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
