### PR TITLE
Modernize ROCm includes

### DIFF
--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -19,9 +19,9 @@
 #include "AFQMC/Memory/device_pointers.hpp"
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include "hipsparse.h"
-#include "rocsolver.h"
+#include <rocsolver/rocsolver.h>
 #include "rocrand/rocrand.h"
 
 namespace arch

--- a/src/AFQMC/Memory/HIP/hip_arch.cpp
+++ b/src/AFQMC/Memory/HIP/hip_arch.cpp
@@ -20,9 +20,9 @@
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
 #include <hipblas/hipblas.h>
-#include "hipsparse.h"
+#include <hipsparse/hipsparse.h>
 #include <rocsolver/rocsolver.h>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 namespace arch
 {

--- a/src/AFQMC/Memory/HIP/hip_arch.h
+++ b/src/AFQMC/Memory/HIP/hip_arch.h
@@ -20,9 +20,9 @@
 #include "hip_init.h"
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include "hipsparse.h"
-#include "rocsolver.h"
+#include <rocsolver/rocsolver.h>
 #include "rocrand/rocrand.h"
 
 

--- a/src/AFQMC/Memory/HIP/hip_arch.h
+++ b/src/AFQMC/Memory/HIP/hip_arch.h
@@ -21,9 +21,9 @@
 #include "mpi3/communicator.hpp"
 #include "mpi3/shared_communicator.hpp"
 #include <hipblas/hipblas.h>
-#include "hipsparse.h"
+#include <hipsparse/hipsparse.h>
 #include <rocsolver/rocsolver.h>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 
 namespace arch

--- a/src/AFQMC/Memory/HIP/hip_utilities.cpp
+++ b/src/AFQMC/Memory/HIP/hip_utilities.cpp
@@ -15,9 +15,9 @@
 #include <cstdlib>
 #include <stdexcept>
 #include <hip/hip_runtime.h>
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include "hipsparse.h"
-#include "rocsolver.h"
+#include <rocsolver/rocsolver.h>
 #include "rocrand/rocrand.h"
 #include "hip_utilities.h"
 

--- a/src/AFQMC/Memory/HIP/hip_utilities.cpp
+++ b/src/AFQMC/Memory/HIP/hip_utilities.cpp
@@ -16,9 +16,9 @@
 #include <stdexcept>
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
-#include "hipsparse.h"
+#include <hipsparse/hipsparse.h>
 #include <rocsolver/rocsolver.h>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 #include "hip_utilities.h"
 
 #include "multi/array.hpp"

--- a/src/AFQMC/Memory/HIP/hip_utilities.h
+++ b/src/AFQMC/Memory/HIP/hip_utilities.h
@@ -18,9 +18,9 @@
 #include <stdexcept>
 #include <vector>
 #include <hip/hip_runtime.h>
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include "hipsparse.h"
-#include "rocsolver.h"
+#include <rocsolver/rocsolver.h>
 #include "rocrand/rocrand.h"
 
 namespace qmc_hip

--- a/src/AFQMC/Memory/HIP/hip_utilities.h
+++ b/src/AFQMC/Memory/HIP/hip_utilities.h
@@ -19,9 +19,9 @@
 #include <vector>
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
-#include "hipsparse.h"
+#include <hipsparse/hipsparse.h>
 #include <rocsolver/rocsolver.h>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 namespace qmc_hip
 {

--- a/src/AFQMC/Numerics/detail/HIP/Kernels/sampleGaussianRNG.hip.cpp
+++ b/src/AFQMC/Numerics/detail/HIP/Kernels/sampleGaussianRNG.hip.cpp
@@ -12,7 +12,7 @@
 #include <cassert>
 #include <complex>
 #include <hip/hip_runtime.h>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 #include "AFQMC/Numerics/detail/HIP/Kernels/hip_settings.h"
 #include "AFQMC/Numerics/detail/HIP/Kernels/zero_complex_part.hip.h"
 #include "AFQMC/Numerics/detail/HIP/hip_kernel_utils.h"

--- a/src/AFQMC/Numerics/detail/HIP/Kernels/sampleGaussianRNG.hip.h
+++ b/src/AFQMC/Numerics/detail/HIP/Kernels/sampleGaussianRNG.hip.h
@@ -14,7 +14,7 @@
 
 #include <cassert>
 #include <complex>
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 namespace kernels
 {

--- a/src/AFQMC/Numerics/detail/HIP/hip_kernel_utils.cpp
+++ b/src/AFQMC/Numerics/detail/HIP/hip_kernel_utils.cpp
@@ -14,7 +14,7 @@
 #include <hip/hip_runtime.h>
 
 #include "hip_kernel_utils.h"
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 namespace qmc_hip
 {

--- a/src/AFQMC/Numerics/detail/HIP/hip_kernel_utils.h
+++ b/src/AFQMC/Numerics/detail/HIP/hip_kernel_utils.h
@@ -16,7 +16,7 @@
 #include <hip/hip_runtime.h>
 
 #include "hip_kernel_utils.h"
-#include "rocrand/rocrand.h"
+#include <rocrand/rocrand.h>
 
 namespace qmc_hip
 {

--- a/src/AFQMC/Numerics/detail/HIP/hipblas_wrapper.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/hipblas_wrapper.hpp
@@ -14,8 +14,8 @@
 
 #include <cassert>
 #include <hip/hip_runtime.h>
-#include "hipblas.h"
-#include "rocsolver.h"
+#include <hipblas/hipblas.h>
+#include <rocsolver/rocsolver.h>
 #include "AFQMC/Memory/HIP/hip_utilities.h"
 
 namespace hipblas

--- a/src/AFQMC/Numerics/detail/HIP/hipsparse_wrapper.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/hipsparse_wrapper.hpp
@@ -14,7 +14,7 @@
 
 #include <cassert>
 #include <hip/hip_runtime.h>
-#include "hipsparse.h"
+#include <hipsparse/hipsparse.h>
 #include "AFQMC/Memory/HIP/hip_utilities.h"
 
 namespace hipsparse

--- a/src/AFQMC/Numerics/detail/HIP/rocsolver_wrapper.hpp
+++ b/src/AFQMC/Numerics/detail/HIP/rocsolver_wrapper.hpp
@@ -14,7 +14,7 @@
 
 #include <cassert>
 #include <hip/hip_runtime.h>
-#include "rocsolver.h"
+#include <rocsolver/rocsolver.h>
 #include "AFQMC/Memory/HIP/hip_utilities.h"
 #include "AFQMC/Numerics/detail/CPU/lapack_cpu.hpp"
 

--- a/src/Platforms/CUDA/cuBLAS.hpp
+++ b/src/Platforms/CUDA/cuBLAS.hpp
@@ -22,7 +22,7 @@
 #include <cublas_v2.h>
 #define castNativeType castCUDAType
 #else
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include "Platforms/ROCm/cuda2hip.h"
 #include "Platforms/ROCm/hipBLAS.hpp"
 #include "Platforms/ROCm/hipblasTypeMapping.hpp"

--- a/src/Platforms/CUDA_legacy/cuda_inverse.cu
+++ b/src/Platforms/CUDA_legacy/cuda_inverse.cu
@@ -45,7 +45,7 @@
 #include <cuComplex.h>
 #else
 #include <hip/hip_runtime.h>
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_complex.h>
 #include "Platforms/ROCm/cuda2hip.h"
 #include "Platforms/ROCm/hipBLAS.hpp"

--- a/src/Platforms/CUDA_legacy/gpu_misc.h
+++ b/src/Platforms/CUDA_legacy/gpu_misc.h
@@ -28,7 +28,7 @@
 #include <cublas_v2.h>
 #else
 #include <hip/hip_runtime.h>
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include "Platforms/ROCm/cuda2hip.h"
 #endif
 

--- a/src/Platforms/ROCm/hipBLAS.hip.cpp
+++ b/src/Platforms/ROCm/hipBLAS.hip.cpp
@@ -13,7 +13,7 @@
 
 
 #include "hipBLAS.hpp"
-#include <rocsolver.h>
+#include <rocsolver/rocsolver.h>
 
 //------------------------------------------------------------------------------
 hipblasStatus_t

--- a/src/Platforms/ROCm/hipBLAS.hpp
+++ b/src/Platforms/ROCm/hipBLAS.hpp
@@ -15,7 +15,7 @@
 #ifndef HIPBLAS_HPP
 #define HIPBLAS_HPP
 
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_complex.h>
 
 //------------------------------------------------------------------------------

--- a/src/Platforms/ROCm/hipblasTypeMapping.hpp
+++ b/src/Platforms/ROCm/hipblasTypeMapping.hpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 #include "type_traits/type_mapping.hpp"
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 
 namespace qmcplusplus
 {

--- a/src/Platforms/ROCm/rocsolver.hpp
+++ b/src/Platforms/ROCm/rocsolver.hpp
@@ -16,7 +16,7 @@
 // Interface to rocSOLVER linear algebra library.
 // File copied and modified from CUDA/cusolver.hpp
 
-#include <rocsolver.h>
+#include <rocsolver/rocsolver.h>
 #include <complex>
 #include <iostream>
 #include <string>

--- a/src/QMCWaveFunctions/detail/CUDA/cuBLAS_LU.hpp
+++ b/src/QMCWaveFunctions/detail/CUDA/cuBLAS_LU.hpp
@@ -20,7 +20,7 @@
 #include <cublas_v2.h>
 #include <cuComplex.h>
 #else
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_complex.h>
 #include <ROCm/hipBLAS.hpp>
 #endif

--- a/src/QMCWaveFunctions/detail/CUDA_legacy/delayed_update.cu
+++ b/src/QMCWaveFunctions/detail/CUDA_legacy/delayed_update.cu
@@ -24,7 +24,7 @@
 #include <cublas_v2.h>
 #include <cuComplex.h>
 #else
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include <hip/hip_complex.h>
 #include "Platforms/ROCm/cuda2hip.h"
 #include "Platforms/ROCm/hipBLAS.hpp"

--- a/src/QMCWaveFunctions/detail/CUDA_legacy/delayed_update.h
+++ b/src/QMCWaveFunctions/detail/CUDA_legacy/delayed_update.h
@@ -18,7 +18,7 @@
 #ifndef QMC_CUDA2HIP
 #include <cublas_v2.h>
 #else
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include "Platforms/ROCm/cuda2hip.h"
 #endif
 


### PR DESCRIPTION
## Proposed changes

Use the modern, non-deprecated include style for hipblas and rocsolver. This fixes the current build warnings.

## What type(s) of changes does this code introduce?

- New feature

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen, Radeon VII, ROCm 5.3.0

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
