### PR TITLE
Use std::chrono clock in profile timers

### DIFF
--- a/src/Utilities/Clock.cpp
+++ b/src/Utilities/Clock.cpp
@@ -14,6 +14,10 @@
 
 namespace qmcplusplus
 {
+
+FakeChronoClock::time_point FakeChronoClock::fake_chrono_clock_value = FakeChronoClock::time_point();
+FakeChronoClock::duration   FakeChronoClock::fake_chrono_clock_increment = std::chrono::seconds(1);
+
 double FakeCPUClock::fake_cpu_clock_value     = 0.0;
 double FakeCPUClock::fake_cpu_clock_increment = 1.0;
 } // namespace qmcplusplus

--- a/src/Utilities/Clock.h
+++ b/src/Utilities/Clock.h
@@ -19,9 +19,33 @@
 
 #include <sys/time.h>
 #include <stddef.h>
+#include <chrono>
 
 namespace qmcplusplus
 {
+
+
+// Implements a std::chrono clock
+// See https://github.com/korfuri/fake_clock
+
+class FakeChronoClock
+{
+public:
+  using duration   = std::chrono::nanoseconds;
+  using rep        = duration::rep;
+  using period     = duration::period;
+  using time_point = std::chrono::time_point<FakeChronoClock>;
+  static time_point now() noexcept
+  {
+    fake_chrono_clock_value += fake_chrono_clock_increment;
+    return fake_chrono_clock_value;
+  }
+
+  static time_point fake_chrono_clock_value;
+  static duration fake_chrono_clock_increment;
+};
+
+
 /** functor for fake clock
  * calling FakeCPUClock()() returns the clock value
  */

--- a/src/Utilities/NewTimer.cpp
+++ b/src/Utilities/NewTimer.cpp
@@ -72,10 +72,10 @@ void TimerType<CLOCK>::start()
 
         manager->push_timer(this);
       }
-      start_time = CLOCK()();
+      start_time = CLOCK::now();
     }
 #else
-    start_time     = CLOCK()();
+    start_time                            = CLOCK::now();
 #endif
   }
 }
@@ -101,19 +101,19 @@ void TimerType<CLOCK>::stop()
         is_true_master = false;
     if (is_true_master)
     {
-      double elapsed = CLOCK()() - start_time;
-      total_time += elapsed;
+      std::chrono::duration<double> elapsed = CLOCK::now() - start_time;
+      total_time += elapsed.count();
       num_calls++;
 
-      per_stack_total_time[current_stack_key] += elapsed;
+      per_stack_total_time[current_stack_key] += elapsed.count();
       per_stack_num_calls[current_stack_key] += 1;
 
       if (manager)
         manager->pop_timer(this);
     }
 #else
-    double elapsed = CLOCK()() - start_time;
-    total_time += elapsed;
+    std::chrono::duration<double> elapsed = CLOCK::now() - start_time;
+    total_time += elapsed.count();
     num_calls++;
 #endif
   }
@@ -129,7 +129,7 @@ void TimerType<CLOCK>::set_active_by_timer_threshold(const timer_levels threshol
     active = false;
 }
 
-template class TimerType<CPUClock>;
-template class TimerType<FakeCPUClock>;
+template class TimerType<std::chrono::system_clock>;
+template class TimerType<FakeChronoClock>;
 
 } // namespace qmcplusplus

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -136,7 +136,7 @@ class TimerType
 {
 protected:
   /// start time of the current measurement
-  double start_time;
+  typename CLOCK::time_point start_time;
   /// total time accumulated of all the calls
   double total_time;
   /// total call counts
@@ -231,10 +231,10 @@ public:
   friend void set_num_calls(TimerType<CLOCK1>* timer, long num_calls_input);
 };
 
-using NewTimer  = TimerType<CPUClock>;
-using FakeTimer = TimerType<FakeCPUClock>;
-extern template class TimerType<CPUClock>;
-extern template class TimerType<FakeCPUClock>;
+using NewTimer  = TimerType<std::chrono::system_clock>;
+using FakeTimer = TimerType<FakeChronoClock>;
+extern template class TimerType<std::chrono::system_clock>;
+extern template class TimerType<FakeChronoClock>;
 
 // Wrapper for timer that starts on construction and stops on destruction
 template<class TIMER = NewTimer>

--- a/src/Utilities/tests/test_runtime_manager.cpp
+++ b/src/Utilities/tests/test_runtime_manager.cpp
@@ -24,6 +24,7 @@ TEST_CASE("test_runtime_manager", "[utilities]")
   // Use a local version rather than the global timer_manager, otherwise
   //  changes will persist from test to test.
   RunTimeManager<FakeCPUClock> rm;
+  FakeCPUClock::fake_cpu_clock_increment = 1.0;
   double e = rm.elapsed();
   REQUIRE(e == Approx(1.0));
 }

--- a/src/Utilities/tests/test_timer.cpp
+++ b/src/Utilities/tests/test_timer.cpp
@@ -16,6 +16,8 @@
 #include <vector>
 #include "Utilities/TimerManager.h"
 
+using namespace std::chrono_literals;
+
 namespace qmcplusplus
 {
 using FakeTimerManager = TimerManager<FakeTimer>;
@@ -32,6 +34,19 @@ void set_num_calls(TimerType<CLOCK>* timer, long num_calls_input)
   timer->num_calls = num_calls_input;
 }
 
+// Convert duration input type to nanosecond duration
+template<typename T>
+FakeChronoClock::duration convert_to_ns(T in)
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(in);
+}
+
+// Convert duration input type to seconds as double precision type
+template<typename T>
+double convert_to_s(T in)
+{
+  return std::chrono::duration_cast<std::chrono::duration<double>>(in).count();
+}
 
 TEST_CASE("test_timer_stack", "[utilities]")
 {
@@ -99,10 +114,10 @@ TEST_CASE("test_timer_flat_profile_same_name", "[utilities]")
   FakeTimer* t2 = tm.createTimer("timer2");
   FakeTimer* t3 = tm.createTimer("timer1");
 
-  FakeCPUClock::fake_cpu_clock_increment = 1.1;
+  FakeChronoClock::fake_chrono_clock_increment = convert_to_ns(1.1s);
   t1->start();
   t1->stop();
-  FakeCPUClock::fake_cpu_clock_increment = 1.2;
+  FakeChronoClock::fake_chrono_clock_increment = convert_to_ns(1.2s);
   for (int i = 0; i < 3; i++)
   {
     t2->start();
@@ -139,7 +154,7 @@ TEST_CASE("test_timer_nested_profile", "[utilities]")
   FakeTimer* t1 = tm.createTimer("timer1");
   FakeTimer* t2 = tm.createTimer("timer2");
 
-  FakeCPUClock::fake_cpu_clock_increment = 1.1;
+  FakeChronoClock::fake_chrono_clock_increment = convert_to_ns(1.1s);
   t1->start();
   t2->start();
   t2->stop();
@@ -153,8 +168,8 @@ TEST_CASE("test_timer_nested_profile", "[utilities]")
   int idx1 = p.nameList.at("timer1");
   int idx2 = p.nameList.at("timer2");
   REQUIRE(p.timeList.size() == 2);
-  REQUIRE(p.timeList[idx1] == Approx(3 * FakeCPUClock::fake_cpu_clock_increment));
-  REQUIRE(p.timeList[idx2] == Approx(FakeCPUClock::fake_cpu_clock_increment));
+  CHECK(p.timeList[idx1] == Approx(3 * convert_to_s(FakeChronoClock::fake_chrono_clock_increment)));
+  CHECK(p.timeList[idx2] == Approx(convert_to_s(FakeChronoClock::fake_chrono_clock_increment)));
 #endif
 
   FakeTimerManager::StackProfileData p2;
@@ -166,12 +181,12 @@ TEST_CASE("test_timer_nested_profile", "[utilities]")
   idx2 = p2.nameList.at("timer1/timer2");
   REQUIRE(p2.timeList.size() == 2);
   REQUIRE(p2.timeExclList.size() == 2);
-  REQUIRE(p2.timeList[idx1] == Approx(3 * FakeCPUClock::fake_cpu_clock_increment));
-  REQUIRE(p2.timeList[idx2] == Approx(FakeCPUClock::fake_cpu_clock_increment));
+  CHECK(p2.timeList[idx1] == Approx(convert_to_s(3 * FakeChronoClock::fake_chrono_clock_increment)));
+  CHECK(p2.timeList[idx2] == Approx(convert_to_s(FakeChronoClock::fake_chrono_clock_increment)));
 
   // Time in t1 minus time inside t2
-  REQUIRE(p2.timeExclList[idx1] == Approx(2 * FakeCPUClock::fake_cpu_clock_increment));
-  REQUIRE(p2.timeExclList[idx2] == Approx(FakeCPUClock::fake_cpu_clock_increment));
+  CHECK(p2.timeExclList[idx1] == Approx(2 * convert_to_s(FakeChronoClock::fake_chrono_clock_increment)));
+  CHECK(p2.timeExclList[idx2] == Approx(convert_to_s(FakeChronoClock::fake_chrono_clock_increment)));
 #endif
 }
 
@@ -183,7 +198,7 @@ TEST_CASE("test_timer_nested_profile_two_children", "[utilities]")
   FakeTimer* t2 = tm.createTimer("timer2");
   FakeTimer* t3 = tm.createTimer("timer3");
 
-  FakeCPUClock::fake_cpu_clock_increment = 1.1;
+  FakeChronoClock::fake_chrono_clock_increment = convert_to_ns(1.1s);
   t1->start();
   t2->start();
   t2->stop();
@@ -385,10 +400,10 @@ TEST_CASE("test setup timers", "[utilities]")
 {
   FakeTimerManager tm;
   // Create  a list of timers and initialize it
-  std::vector<std::reference_wrapper<FakeTimer>>  Timers;
+  std::vector<std::reference_wrapper<FakeTimer>> Timers;
   setup_timers(Timers, TestTimerNames, timer_level_coarse, &tm);
 
-  FakeCPUClock::fake_cpu_clock_increment = 1.0;
+  FakeChronoClock::fake_chrono_clock_increment = convert_to_ns(1.0s);
   Timers[MyTimer1].get().start();
   Timers[MyTimer1].get().stop();
 


### PR DESCRIPTION
Replace timer based on gettimeofday with std::chrono timer (system_clock) in the profile timers.

Reasons:
1. I would like to add the event profile code, and it works better with std::chrono timers
2. Storing the start time as a double (since the epoch) loses precision - the elapsed time ends up being a small difference between large numbers.  This isn't as major an issue with aggregated profile data, but is noticeable in the event data.
3. Moves to a C++ standard API

The runtime manager was not switched in this PR, but could be changed in the future (and the the FakeCPUClock removed)

The test uses "chrono_literals" ( https://en.cppreference.com/w/cpp/header/chrono#Literals ), which uses C++ 11 user-defined literals ( https://en.cppreference.com/w/cpp/language/user_literal ).   The "1.1s" literal syntax can be a little disorienting if one has not encountered it before.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New implementation of existing functionality
- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Ye. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
