### PR TITLE
Use macos-11 image until macos-latest has xcode >= 14.1

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -135,7 +135,7 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       GH_JOBNAME: ${{ matrix.jobname }}
       GH_OS: macOS


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

MacOS build is failing with the following error:

```
FAILED: src/io/OhmmsData/tests/test_io_ohmmsdata 
: && /usr/local/bin/g++-11 -fopenmp -foffload=disable -finline-limit=1000 -fstrict-aliasing -funroll-all-loops -Wno-deprecated -Wvla -Wcomment -Wmisleading-indentation -Wmaybe-uninitialized -Wuninitialized -Wreorder -Wno-unknown-pragmas -Wno-sign-compare -Wsuggest-override -ffast-math -march=native -O2 -g -DNDEBUG -isysroot /Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  src/io/OhmmsData/tests/CMakeFiles/test_io_ohmmsdata.dir/test_xml.cpp.o src/io/OhmmsData/tests/CMakeFiles/test_io_ohmmsdata.dir/test_AttributeSet.cpp.o src/io/OhmmsData/tests/CMakeFiles/test_io_ohmmsdata.dir/test_ParameterSet.cpp.o -o src/io/OhmmsData/tests/test_io_ohmmsdata  src/Message/libcatch_main.a  src/Utilities/libqmcutil.a  src/io/OhmmsData/libqmcio_xml.a  src/io/OhmmsData/libqmcio_xml.a  src/Utilities/libcxx_helpers.a  src/io/hdf/libqmcio_hdf.a  src/Message/libmessage.a  src/Containers/libcontainers.a  src/Platforms/libplatform_runtime.a  src/Platforms/Host/libplatform_host_runtime.a  src/Platforms/OMPTarget/libplatform_omptarget_runtime.a  /usr/local/Cellar/hdf5/1.12.2_2/lib/libhdf5.dylib  /usr/local/opt/libaec/lib/libsz.dylib  /Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/lib/libz.tbd  /Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/lib/libdl.tbd  /Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/lib/libm.tbd  src/Utilities/libqmcrng.a  /Applications/Xcode_14.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/lib/libxml2.tbd && :
0  0x106548ffa  __assert_rtn + 139
1  0x10637c28d  mach_o::relocatable::Parser<x86_64>::parse(mach_o::relocatable::ParserOptions const&) + 4989
2  0x10636cf8f  mach_o::relocatable::Parser<x86_64>::parse(unsigned char const*, unsigned long long, char const*, long, ld::File::Ordinal, mach_o::relocatable::ParserOptions const&) + 207
3  0x1063ba404  archive::File<x86_64>::makeObjectFileForMember(archive::File<x86_64>::Entry const*) const + 1268
4  0x1063b9a8b  archive::File<x86_64>::File(unsigned char const*, unsigned long long, char const*, long, ld::File::Ordinal, archive::ParserOptions const&) + 1035
5  0x1063b8c72  archive::parse(unsigned char const*, unsigned long long, char const*, long, ld::File::Ordinal, archive::ParserOptions const&) + 146
6  0x1063e3c8e  ld::tool::InputFiles::makeFile(Options::FileInfo const&, bool) + 2734
7  0x1063e6fa0  ___ZN2ld4tool10InputFilesC2ER7Options_block_invoke + 48
8  0x7ff81709734a  _dispatch_client_callout2 + 8
9  0x7ff8170a88f5  _dispatch_apply_invoke + 213
10  0x7ff817097317  _dispatch_client_callout + 8
11  0x7ff8170a6c0c  _dispatch_root_queue_drain + 673
12  0x7ff8170a725c  _dispatch_worker_thread2 + 160
13  0x7ff81724af8a  _pthread_wqthread + 256
A linker snapshot was created at:
	/tmp/test_io_ohmmsdata-2022-11-21-173944.ld-snapshot
ld: Assertion failed: (_file->_atomsArrayCount == computedAtomCount && "more atoms allocated than expected"), function parse, file macho_relocatable_file.cpp, line 2061.
collect2: error: ld returned 1 exit status
[155/757] Building CXX object src/Utilities/tests/CMakeFiles/test_utilities.dir/test_prime_set.cpp.o
[156/757] Building CXX object src/Utilities/tests/CMakeFiles/test_utilities.dir/test_parser.cpp.o
[157/757] Building CXX object src/Utilities/tests/CMakeFiles/test_utilities.dir/test_partition.cpp.o
[158/757] Building CXX object src/Utilities/tests/CMakeFiles/test_utilities.dir/test_timer.cpp.o
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```
It appears to be an issue with XCode 14.0 and fixed in 14.1.
https://stackoverflow.com/questions/73714336/xcode-update-to-version-2395-ld-compile-problem-occurs-computedatomcount-m

For now, the easiest fix is to use macos-11 which comes with XCode 13.4

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'