### PR TITLE
Remove unused OpenMP include from Clock.h

### DIFF
--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -11,7 +11,7 @@
 // File refactored from: QMCHamiltonians/DensityMatrices1B.cpp
 //////////////////////////////////////////////////////////////////////////////////////
 
-
+#include "Concurrency/OpenMP.h"
 #include "OneBodyDensityMatrices.h"
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -11,7 +11,6 @@
 // File refactored from: QMCHamiltonians/DensityMatrices1B.cpp
 //////////////////////////////////////////////////////////////////////////////////////
 
-#include "Concurrency/OpenMP.h"
 #include "OneBodyDensityMatrices.h"
 #include "OhmmsData/AttributeSet.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
@@ -19,6 +18,7 @@
 #include "Utilities/IteratorUtility.h"
 #include "Utilities/string_utils.h"
 #include "type_traits/complex_help.hpp"
+#include "Concurrency/OpenMP.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepSetReader.h
@@ -23,6 +23,7 @@
 #include "QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h"
 #include "OhmmsData/AttributeSet.h"
 #include "CPU/math.hpp"
+#include "Concurrency/OpenMP.h"
 
 //#include "QMCHamiltonians/Ylm.h"
 //#define PRINT_RADIAL

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -16,6 +16,7 @@
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "Platforms/OMPTarget/ompReductionComplex.hpp"
 #include "OMPTarget/OMPTargetMath.hpp"
+#include "Concurrency/OpenMP.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -15,6 +15,7 @@
 #include "spline2/MultiBsplineEval_OMPoffload.hpp"
 #include "QMCWaveFunctions/BsplineFactory/contraction_helper.hpp"
 #include "OMPTarget/OMPTargetMath.hpp"
+#include "Concurrency/OpenMP.h"
 
 namespace qmcplusplus
 {

--- a/src/Sandbox/determinant.hpp
+++ b/src/Sandbox/determinant.hpp
@@ -18,6 +18,7 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "CPU/SIMD/aligned_allocator.hpp"
 #include "Numerics/DeterminantOperators.h"
+#include "Concurrency/OpenMP.h"
 
 namespace qmcplusplus
 {

--- a/src/Sandbox/einspline_spo.cpp
+++ b/src/Sandbox/einspline_spo.cpp
@@ -23,6 +23,7 @@
 #include "Utilities/Timer.h"
 #include "Sandbox/common.hpp"
 #include "einspline_spo.hpp"
+#include "Concurrency/OpenMP.h"
 #include <getopt.h>
 
 using namespace std;

--- a/src/Sandbox/einspline_spo_nested.cpp
+++ b/src/Sandbox/einspline_spo_nested.cpp
@@ -23,6 +23,7 @@
 #include "Utilities/Timer.h"
 #include "Sandbox/common.hpp"
 #include "Sandbox/einspline_spo.hpp"
+#include "Concurrency/OpenMP.h"
 #include <getopt.h>
 
 using namespace std;

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -28,6 +28,7 @@
 #include <getopt.h>
 #include "mpi/collectives.h"
 #include "ParticleBase/ParticleAttribOps.h"
+#include "Concurrency/OpenMP.h"
 
 using namespace std;
 using namespace qmcplusplus;

--- a/src/Utilities/Clock.h
+++ b/src/Utilities/Clock.h
@@ -15,8 +15,6 @@
 #ifndef QMCPLUSPLUS_CLOCK_H
 #define QMCPLUSPLUS_CLOCK_H
 
-#include "Concurrency/OpenMP.h"
-
 #include <stddef.h>
 #include <chrono>
 


### PR DESCRIPTION
After the change to use std::chrono clocks, the include file for OpenMP is no longer needed in Clock.h.  However, several other files depend it being transitively included.  Add those includes where necessary.

Change was suggested #4334

Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
