### PR TITLE
Drop special case constructor from Observable Helper

### DIFF
--- a/src/Estimators/LocalEnergyEstimator.cpp
+++ b/src/Estimators/LocalEnergyEstimator.cpp
@@ -41,9 +41,9 @@ void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5
     return;
   int loc = h5desc.size();
   //add LocalEnergy and LocalPotential
-  h5desc.emplace_back("LocalEnergy");
-  h5desc.emplace_back("LocalEnergy_sq");
-  h5desc.emplace_back("LocalPotential");
+  h5desc.push_back({{"LocalEnergy"}});
+  h5desc.push_back({{"LocalEnergy_sq"}});
+  h5desc.push_back({{"LocalPotential"}});
   std::vector<int> onedim(1, 1);
   h5desc[loc++].set_dimensions(onedim, FirstIndex);
   h5desc[loc++].set_dimensions(onedim, FirstIndex + 1);

--- a/src/Estimators/LocalEnergyEstimator.cpp
+++ b/src/Estimators/LocalEnergyEstimator.cpp
@@ -25,14 +25,15 @@ LocalEnergyEstimator::LocalEnergyEstimator(const QMCHamiltonian& h, bool use_hdf
   scalars_saved.resize(SizeOfHamiltonians + LE_MAX);
 }
 
-LocalEnergyEstimator::LocalEnergyEstimator(LocalEnergyInput&& input, const QMCHamiltonian& h) : UseHDF5(input.get_use_hdf5()), refH(h), input_(input)
+LocalEnergyEstimator::LocalEnergyEstimator(LocalEnergyInput&& input, const QMCHamiltonian& h)
+    : UseHDF5(input.get_use_hdf5()), refH(h), input_(input)
 {
   SizeOfHamiltonians = h.sizeOfObservables();
   FirstHamiltonian   = h.startIndex();
   scalars.resize(SizeOfHamiltonians + LE_MAX);
   scalars_saved.resize(SizeOfHamiltonians + LE_MAX);
 }
- 
+
 LocalEnergyEstimator* LocalEnergyEstimator::clone() { return new LocalEnergyEstimator(*this); }
 
 void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5desc, hdf_archive& file)
@@ -41,9 +42,10 @@ void LocalEnergyEstimator::registerObservables(std::vector<ObservableHelper>& h5
     return;
   int loc = h5desc.size();
   //add LocalEnergy and LocalPotential
-  h5desc.push_back({{"LocalEnergy"}});
-  h5desc.push_back({{"LocalEnergy_sq"}});
-  h5desc.push_back({{"LocalPotential"}});
+  using namespace std::string_literals;
+  h5desc.push_back({{"LocalEnergy"s}});
+  h5desc.push_back({{"LocalEnergy_sq"s}});
+  h5desc.push_back({{"LocalPotential"s}});
   std::vector<int> onedim(1, 1);
   h5desc[loc++].set_dimensions(onedim, FirstIndex);
   h5desc[loc++].set_dimensions(onedim, FirstIndex + 1);

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -319,12 +319,12 @@ void MomentumDistribution::registerOperatorEstimator(hdf_archive& file)
   std::vector<int> ng(1);
   //add nofk
   ng[0] = nofK.size();
-  h5desc_.push_back(std::make_unique<ObservableHelper>("nofk"));
+  h5desc_.push_back({{"nofk"}});
   auto& h5o = h5desc_.back();
   //h5o.set_dimensions(ng, my_index_);
-  h5o->set_dimensions(ng, 0); // JTK: doesn't seem right
-  h5o->addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints", file);
-  h5o->addProperty(const_cast<std::vector<int>&>(kWeights), "kweights", file);
+  h5o.set_dimensions(ng, 0); // JTK: doesn't seem right
+  h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints", file);
+  h5o.addProperty(const_cast<std::vector<int>&>(kWeights), "kweights", file);
 }
 
 

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -42,7 +42,7 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
   //length of reciprocal lattice vector
   for (int i = 0; i < OHMMS_DIM; i++)
     vec_length[i] = 2.0 * M_PI * std::sqrt(dot(Lattice.Gv[i], Lattice.Gv[i]));
-  RealType kmax = input_.get_kmax();
+  RealType kmax      = input_.get_kmax();
   PosType kmaxs      = {input_.get_kmax0(), input_.get_kmax1(), input_.get_kmax2()};
   RealType sum_kmaxs = kmaxs[0] + kmaxs[1] + kmaxs[2];
   RealType sphere_kmax;
@@ -123,8 +123,8 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
       sums[1] += kcount1[i];
       sums[2] += kcount2[i];
     }
-    app_log() << "    Using all k-space points within cut-offs " << input_.get_kmax0() << ", " << input_.get_kmax1() << ", " << input_.get_kmax2()
-              << " for Momentum Distribution." << std::endl;
+    app_log() << "    Using all k-space points within cut-offs " << input_.get_kmax0() << ", " << input_.get_kmax1()
+              << ", " << input_.get_kmax2() << " for Momentum Distribution." << std::endl;
     app_log() << "    Total number of k-points for Momentum Distribution: " << kPoints.size() << std::endl;
     app_log() << "      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
     app_log() << "      Number of grid points in kmax1 direction: " << sums[1] << std::endl;
@@ -143,8 +143,8 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
       sums[2] += kcount2[i];
     }
     app_log() << "    Using all k-space points with (kx^2+ky^2+kz^2)^0.5 < " << sphere_kmax << ", and" << std::endl;
-    app_log() << "    within the cut-offs " << input_.get_kmax0() << ", " << input_.get_kmax1() << ", " << input_.get_kmax2() << " for Momentum Distribution."
-              << std::endl;
+    app_log() << "    within the cut-offs " << input_.get_kmax0() << ", " << input_.get_kmax1() << ", "
+              << input_.get_kmax2() << " for Momentum Distribution." << std::endl;
     app_log() << "    Total number of k-points for Momentum Distribution is " << kPoints.size() << std::endl;
     app_log() << "    The number of k-points within the cut-off region: " << sums[0] * sums[1] * sums[2] << std::endl;
     app_log() << "      Number of grid points in kmax0 direction: " << sums[0] << std::endl;
@@ -170,20 +170,21 @@ MomentumDistribution::MomentumDistribution(MomentumDistributionInput&& mdi,
   data_.resize(data_size, 0.0);
 }
 
-MomentumDistribution::MomentumDistribution(const MomentumDistribution& md, DataLocality dl): MomentumDistribution(md) {
+MomentumDistribution::MomentumDistribution(const MomentumDistribution& md, DataLocality dl) : MomentumDistribution(md)
+{
   data_locality_ = dl;
 }
- 
+
 std::unique_ptr<OperatorEstBase> MomentumDistribution::spawnCrowdClone() const
 {
-  std::size_t data_size = data_.size();
+  std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;
 
   if (data_locality_ == DataLocality::rank)
   {
     // This is just a stub until a memory saving optimization is deemed necessary
     spawn_data_locality = DataLocality::queue;
-    data_size = 0;
+    data_size           = 0;
     throw std::runtime_error("There is no memory savings implementation for MomentumDistribution");
   }
 
@@ -295,7 +296,6 @@ void MomentumDistribution::accumulate(const RefVector<MCPWalker>& walkers,
     // accumulate data
     for (int ik = 0; ik < nofK.size(); ++ik)
       data_[ik] += weight * nofK[ik] * norm_nofK;
-
   }
 }
 
@@ -315,11 +315,12 @@ void MomentumDistribution::collect(const RefVector<OperatorEstBase>& type_erased
 
 void MomentumDistribution::registerOperatorEstimator(hdf_archive& file)
 {
+  using namespace std::string_literals;
   //descriptor for the data, 1-D data
   std::vector<int> ng(1);
   //add nofk
   ng[0] = nofK.size();
-  h5desc_.push_back({{"nofk"}});
+  h5desc_.push_back({{"nofk"s}});
   auto& h5o = h5desc_.back();
   //h5o.set_dimensions(ng, my_index_);
   h5o.set_dimensions(ng, 0); // JTK: doesn't seem right

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -611,10 +611,9 @@ void OneBodyDensityMatrices::registerOperatorEstimator(hdf_archive& file)
   using namespace std::string_literals;
   for (int s = 0; s < species_.size(); ++s)
   {
-    h5desc_.push_back(std::make_unique<ObservableHelper>(
-        std::vector<std::string>{my_name_, "number_matrix"s, species_.speciesName[s]}));
+    h5desc_.push_back({{my_name_, "number_matrix"s, species_.speciesName[s]}});
     auto& oh = h5desc_.back();
-    oh->set_dimensions(my_indexes, 0);
+    oh.set_dimensions(my_indexes, 0);
   }
 }
 

--- a/src/Estimators/OperatorEstBase.cpp
+++ b/src/Estimators/OperatorEstBase.cpp
@@ -53,10 +53,10 @@ void OperatorEstBase::write(hdf_archive& file)
   // auto total = std::accumulate(data_->begin(), data_->end(), 0.0);
   // std::cout << "data size: " << data_->size() << " : " << total << '\n';
   for (auto& h5d : h5desc_)
-    h5d->write(expanded_data.data(), file);
+    h5d.write(expanded_data.data(), file);
 #else
   for (auto& h5d : h5desc_)
-    h5d->write(data_.data(), file);
+    h5d.write(data_.data(), file);
 #endif
   file.pop();
 }

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -140,7 +140,7 @@ protected:
   QMCT::FullPrecRealType walkers_weight_;
 
   // convenient Descriptors hdf5 for Operator Estimators only populated for rank scope OperatorEstimator
-  UPtrVector<ObservableHelper> h5desc_;
+  std::vector<ObservableHelper> h5desc_;
 
   Data data_;
 

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -224,9 +224,9 @@ void SpinDensityNew::registerOperatorEstimator(hdf_archive& file)
 
   for (int s = 0; s < species_.size(); ++s)
   {
-    h5desc_.push_back(std::make_unique<ObservableHelper>(std::vector<std::string>{my_name_, species_.speciesName[s]}));
+    h5desc_.push_back({{my_name_, species_.speciesName[s]}});
     auto& oh = h5desc_.back();
-    oh->set_dimensions(ng, 0);
+    oh.set_dimensions(ng, 0);
   }
 }
 

--- a/src/QMCHamiltonians/DensityEstimator.cpp
+++ b/src/QMCHamiltonians/DensityEstimator.cpp
@@ -124,7 +124,7 @@ void DensityEstimator::registerCollectables(std::vector<ObservableHelper>& h5des
   std::vector<int> ng(OHMMS_DIM);
   for (int i = 0; i < OHMMS_DIM; ++i)
     ng[i] = NumGrids[i];
-  h5desc.emplace_back(name_);
+  h5desc.push_back({{name_}});
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ng, my_index_);
 }

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -541,7 +541,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   using namespace std::string_literals;
   for (int s = 0; s < nspecies; ++s)
   {
-    h5desc.emplace_back(std::vector<std::string>{name_, "number_matrix"s, species_name[s]});
+    h5desc.push_back({{name_, "number_matrix"s, species_name[s]}});
     auto& oh = h5desc.back();
     oh.set_dimensions(ng, nindex + s * nentries);
   }
@@ -550,7 +550,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   {
     for (int s = 0; s < nspecies; ++s)
     {
-      h5desc.emplace_back(std::vector<std::string>{name_, "energy_matrix", species_name[s]});
+      h5desc.push_back({{name_, "energy_matrix", species_name[s]}});
       auto& oh = h5desc.back();
       oh.set_dimensions(ng, eindex + s * nentries);
     }

--- a/src/QMCHamiltonians/DensityMatrices1B.cpp
+++ b/src/QMCHamiltonians/DensityMatrices1B.cpp
@@ -550,7 +550,7 @@ void DensityMatrices1B::registerCollectables(std::vector<ObservableHelper>& h5de
   {
     for (int s = 0; s < nspecies; ++s)
     {
-      h5desc.push_back({{name_, "energy_matrix", species_name[s]}});
+      h5desc.push_back({{name_, "energy_matrix"s, species_name[s]}});
       auto& oh = h5desc.back();
       oh.set_dimensions(ng, eindex + s * nentries);
     }

--- a/src/QMCHamiltonians/EnergyDensityEstimator.cpp
+++ b/src/QMCHamiltonians/EnergyDensityEstimator.cpp
@@ -481,7 +481,7 @@ void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>&
 {
   using namespace std::string_literals;
 
-  h5desc.emplace_back(std::vector<std::string>{name_, "variables"s});
+  h5desc.push_back({{name_, "variables"s}});
   auto& oh = h5desc.back();
   oh.addProperty(const_cast<int&>(nparticles), "nparticles", file);
   int nspacegrids = spacegrids.size();
@@ -495,7 +495,7 @@ void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>&
 
   ref.save(h5desc, file);
 
-  h5desc.emplace_back(std::vector<std::string>{name_, "outside"s});
+  h5desc.push_back({{name_, "outside"s}});
   auto& ohOutside = h5desc.back();
   std::vector<int> ng(1);
   ng[0] = (int)nEDValues;
@@ -511,7 +511,7 @@ void EnergyDensityEstimator::registerCollectables(std::vector<ObservableHelper>&
     ng2[0] = nions;
     ng2[1] = (int)nEDValues;
 
-    h5desc.emplace_back(std::vector<std::string>{name_, "ions"s});
+    h5desc.push_back({{name_, "ions"s}});
     auto& ohIons = h5desc.back();
     ohIons.set_dimensions(ng2, ion_buffer_offset);
   }

--- a/src/QMCHamiltonians/ForceBase.cpp
+++ b/src/QMCHamiltonians/ForceBase.cpp
@@ -76,7 +76,7 @@ void ForceBase::registerObservablesF(std::vector<ObservableHelper>& h5list, hdf_
   ndim[0] = Nnuc;
   ndim[1] = OHMMS_DIM;
 
-  h5list.emplace_back(prefix);
+  h5list.push_back({{prefix}});
   auto& h5o = h5list.back();
   h5o.set_dimensions(ndim, FirstForceIndex);
 }

--- a/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
+++ b/src/QMCHamiltonians/LatticeDeviationEstimator.cpp
@@ -239,7 +239,7 @@ void LatticeDeviationEstimator::registerCollectables(std::vector<ObservableHelpe
   }
 
   // open hdf5 entry and resize
-  h5desc.emplace_back(name_);
+  h5desc.push_back({{name_}});
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ndim, h5_index);
 }

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -14,6 +14,10 @@
 
 
 #include "MomentumEstimator.h"
+
+#include <set>
+#include <string>
+
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "CPU/e2iphi.h"
 #include "CPU/BLAS.hpp"
@@ -21,7 +25,6 @@
 #include "Utilities/SimpleParser.h"
 #include "Particle/DistanceTable.h"
 #include "Numerics/DeterminantOperators.h"
-#include <set>
 
 namespace qmcplusplus
 {
@@ -101,8 +104,8 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     //descriptor for the data, 1-D data
     std::vector<int> ng(1);
     //add nofk
-    ng[0] = nofK.size();
-    h5desc.push_back({{"nofk"}});
+    using namespace std::string_literals;
+    h5desc.push_back({{"nofk"s}});
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ng, my_index_);
     h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints", file);

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -102,7 +102,7 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     std::vector<int> ng(1);
     //add nofk
     ng[0] = nofK.size();
-    h5desc.emplace_back("nofk");
+    h5desc.push_back({{"nofk"}});
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ng, my_index_);
     h5o.addProperty(const_cast<std::vector<PosType>&>(kPoints), "kpoints", file);

--- a/src/QMCHamiltonians/MomentumEstimator.cpp
+++ b/src/QMCHamiltonians/MomentumEstimator.cpp
@@ -104,6 +104,7 @@ void MomentumEstimator::registerCollectables(std::vector<ObservableHelper>& h5de
     //descriptor for the data, 1-D data
     std::vector<int> ng(1);
     //add nofk
+    ng[0] = nofK.size();
     using namespace std::string_literals;
     h5desc.push_back({{"nofk"s}});
     auto& h5o = h5desc.back();

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -823,13 +823,15 @@ void NonLocalECPotential::addObservables(PropertySetType& plist, BufferType& col
 
 void NonLocalECPotential::registerObservables(std::vector<ObservableHelper>& h5list, hdf_archive& file) const
 {
+  using namespace std::string_literals;
+
   OperatorBase::registerObservables(h5list, file);
   if (ComputeForces)
   {
     std::vector<int> ndim(2);
     ndim[0] = Nnuc;
     ndim[1] = OHMMS_DIM;
-    h5list.push_back({{"FNL"}});
+    h5list.push_back({{"FNL"s}});
     auto& h5o1 = h5list.back();
     h5o1.set_dimensions(ndim, FirstForceIndex);
   }

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -829,7 +829,7 @@ void NonLocalECPotential::registerObservables(std::vector<ObservableHelper>& h5l
     std::vector<int> ndim(2);
     ndim[0] = Nnuc;
     ndim[1] = OHMMS_DIM;
-    h5list.emplace_back("FNL");
+    h5list.push_back({{"FNL"}});
     auto& h5o1 = h5list.back();
     h5o1.set_dimensions(ndim, FirstForceIndex);
   }

--- a/src/QMCHamiltonians/ObservableHelper.cpp
+++ b/src/QMCHamiltonians/ObservableHelper.cpp
@@ -20,7 +20,6 @@
 
 namespace qmcplusplus
 {
-ObservableHelper::ObservableHelper(const std::string& title) : group_name{title} {}
 ObservableHelper::ObservableHelper(std::vector<std::string> title) : group_name(std::move(title)) {}
 
 ObservableHelper::~ObservableHelper() = default;

--- a/src/QMCHamiltonians/ObservableHelper.h
+++ b/src/QMCHamiltonians/ObservableHelper.h
@@ -2,7 +2,7 @@
 // This file is distributed under the University of Illinois/NCSA Open Source License.
 // See LICENSE file in top directory for details.
 //
-// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+// Copyright (c) 2022 QMCPACK developers.
 //
 // File developed by: Jeongnim Kim, jeongnim.kim@gmail.com, University of Illinois at Urbana-Champaign
 //                    Jeremy McMinnis, jmcminis@gmail.com, University of Illinois at Urbana-Champaign
@@ -35,7 +35,6 @@ using value_type = QMCTraits::FullPrecRealType;
 class ObservableHelper
 {
 public:
-  ObservableHelper() = delete;
   /**
    * Favored constructor
    * \param[in] title         is the ordered hdf5 group path elements of the observable

--- a/src/QMCHamiltonians/ObservableHelper.h
+++ b/src/QMCHamiltonians/ObservableHelper.h
@@ -45,14 +45,14 @@ public:
   /**
    * delete copy constructor as hdf5 handlers must have unique owners
    */
-  ObservableHelper(const ObservableHelper&) = delete;
+  ObservableHelper(const ObservableHelper&)            = delete;
   ObservableHelper& operator=(const ObservableHelper&) = delete;
 
   /**
    * Move constructor.
    * @param in input object to be moved to this
    */
-  ObservableHelper(ObservableHelper&&) noexcept = default;
+  ObservableHelper(ObservableHelper&&) noexcept            = default;
   ObservableHelper& operator=(ObservableHelper&&) noexcept = default;
 
   /**
@@ -92,6 +92,7 @@ public:
 
   ///starting index
   hsize_t lower_bound = 0;
+
 private:
   /// "file pointer" for h5d_append
   hsize_t current = 0;

--- a/src/QMCHamiltonians/ObservableHelper.h
+++ b/src/QMCHamiltonians/ObservableHelper.h
@@ -35,10 +35,11 @@ using value_type = QMCTraits::FullPrecRealType;
 class ObservableHelper
 {
 public:
+  ObservableHelper() = delete;
   /**
-   * default constructor
+   * Favored constructor
+   * \param[in] title         is the ordered hdf5 group path elements of the observable
    */
-  ObservableHelper(const std::string& title = "dummy");
   ObservableHelper(std::vector<std::string> title);
 
   /**

--- a/src/QMCHamiltonians/OperatorBase.cpp
+++ b/src/QMCHamiltonians/OperatorBase.cpp
@@ -61,7 +61,7 @@ void OperatorBase::registerObservables(std::vector<ObservableHelper>& h5desc, hd
   //exclude collectables
   if (!collect)
   {
-    h5desc.emplace_back(name_);
+    h5desc.push_back({{name_}});
     auto& oh = h5desc.back();
     std::vector<int> onedim(1, 1);
     oh.set_dimensions(onedim, my_index_);

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -164,7 +164,7 @@ void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5li
   int offset = my_index_;
   for (int i = 0; i < gof_r_prefix.size(); ++i)
   {
-    h5list.emplace_back(gof_r_prefix[i]);
+    h5list.push_back({{name_, gof_r_prefix[i]}});
     auto& h5o = h5list.back();
     h5o.set_dimensions(onedim, offset);
     h5o.addProperty(const_cast<RealType&>(Delta), "delta", file);

--- a/src/QMCHamiltonians/PairCorrEstimator.cpp
+++ b/src/QMCHamiltonians/PairCorrEstimator.cpp
@@ -164,7 +164,7 @@ void PairCorrEstimator::registerCollectables(std::vector<ObservableHelper>& h5li
   int offset = my_index_;
   for (int i = 0; i < gof_r_prefix.size(); ++i)
   {
-    h5list.push_back({{name_, gof_r_prefix[i]}});
+    h5list.push_back({{gof_r_prefix[i]}});
     auto& h5o = h5list.back();
     h5o.set_dimensions(onedim, offset);
     h5o.addProperty(const_cast<RealType&>(Delta), "delta", file);

--- a/src/QMCHamiltonians/ReferencePoints.cpp
+++ b/src/QMCHamiltonians/ReferencePoints.cpp
@@ -133,7 +133,7 @@ void ReferencePoints::write_description(std::ostream& os, std::string& indent)
 
 void ReferencePoints::save(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  h5desc.emplace_back("reference_points");
+  h5desc.push_back({{"reference_points"}});
   auto& oh = h5desc.back();
   std::map<std::string, Point>::const_iterator it;
   for (it = points.begin(); it != points.end(); ++it)

--- a/src/QMCHamiltonians/ReferencePoints.cpp
+++ b/src/QMCHamiltonians/ReferencePoints.cpp
@@ -133,7 +133,8 @@ void ReferencePoints::write_description(std::ostream& os, std::string& indent)
 
 void ReferencePoints::save(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  h5desc.push_back({{"reference_points"}});
+  using namespace std::string_literals;
+  h5desc.push_back({{"reference_points"s}});
   auto& oh = h5desc.back();
   std::map<std::string, Point>::const_iterator it;
   for (it = points.begin(); it != points.end(); ++it)

--- a/src/QMCHamiltonians/SkAllEstimator.cpp
+++ b/src/QMCHamiltonians/SkAllEstimator.cpp
@@ -228,7 +228,7 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
 
   using namespace std::string_literals;
   // Add k-point information
-  h5desc.emplace_back(std::vector<std::string>{name_, "kpoints"s});
+  h5desc.push_back({{name_, "kpoints"s}});
   auto& ohKPoints = h5desc.back();
   ohKPoints.addProperty(const_cast<std::vector<PosType>&>(ions->getSimulationCell().getKLists().kpts_cart), "value",
                         file);
@@ -237,15 +237,15 @@ void SkAllEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc,
   std::vector<int> ng(1);
   ng[0] = NumK;
   //  modulus
-  h5desc.emplace_back(std::vector<std::string>{name_, "rhok_e_e"s});
+  h5desc.push_back({{name_, "rhok_e_e"s}});
   auto& ohRhoKEE = h5desc.back();
   ohRhoKEE.set_dimensions(ng, my_index_);
   //  real part
-  h5desc.emplace_back(std::vector<std::string>{name_, "rhok_e_r"s});
+  h5desc.push_back({{name_, "rhok_e_r"s}});
   auto& ohRhoKER = h5desc.back();
   ohRhoKER.set_dimensions(ng, my_index_ + NumK);
   //  imaginary part
-  h5desc.emplace_back(std::vector<std::string>{name_, "rhok_e_i"s});
+  h5desc.push_back({{name_, "rhok_e_i"s}});
   auto& ohRhoKEI = h5desc.back();
   ohRhoKEI.set_dimensions(ng, my_index_ + 2 * NumK);
 }

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -119,7 +119,7 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hd
   if (hdf5_out)
   {
     std::vector<int> ndim(1, NumK);
-    h5desc.emplace_back(name_);
+    h5desc.push_back({{name_}});
     auto& h5o = h5desc.back();
     h5o.set_dimensions(ndim, my_index_);
 

--- a/src/QMCHamiltonians/SpaceGrid.cpp
+++ b/src/QMCHamiltonians/SpaceGrid.cpp
@@ -710,7 +710,7 @@ void SpaceGrid::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_
   std::stringstream ss;
   ss << grid_index + cshift;
   std::string name = "spacegrid" + ss.str();
-  h5desc.emplace_back(name);
+  h5desc.push_back({{name}});
   auto& oh = h5desc.back();
   if (!chempot)
     ng[0] = nvalues_per_domain * ndomains;

--- a/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
+++ b/src/QMCHamiltonians/SpeciesKineticEnergy.cpp
@@ -85,7 +85,7 @@ void SpeciesKineticEnergy::registerCollectables(std::vector<ObservableHelper>& h
     return;
 
   std::vector<int> ndim(1, num_species);
-  h5desc.emplace_back(name_);
+  h5desc.push_back({{name_}});
   auto& h5o = h5desc.back();
   h5o.set_dimensions(ndim, h5_index);
 }

--- a/src/QMCHamiltonians/SpinDensity.cpp
+++ b/src/QMCHamiltonians/SpinDensity.cpp
@@ -194,7 +194,7 @@ void SpinDensity::registerCollectables(std::vector<ObservableHelper>& h5desc, hd
 
   for (int s = 0; s < nspecies; ++s)
   {
-    h5desc.emplace_back(std::vector<std::string>{name_, species_name[s]});
+    h5desc.push_back({{name_, species_name[s]}});
     auto& oh = h5desc.back();
     oh.set_dimensions(ng, my_index_ + s * npoints);
   }

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -106,7 +106,8 @@ void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& c
 
 void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  h5desc.push_back({{name_, "kpoints"}});
+  using namespace std::string_literals;
+  h5desc.push_back({{name_, "kpoints"s}});
   auto& oh = h5desc.back();
   oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.getSimulationCell().getKLists().kpts_cart), "value", file);
 

--- a/src/QMCHamiltonians/StaticStructureFactor.cpp
+++ b/src/QMCHamiltonians/StaticStructureFactor.cpp
@@ -106,7 +106,7 @@ void StaticStructureFactor::addObservables(PropertySetType& plist, BufferType& c
 
 void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& h5desc, hdf_archive& file) const
 {
-  h5desc.emplace_back(std::vector<std::string>{name_, "kpoints"});
+  h5desc.push_back({{name_, "kpoints"}});
   auto& oh = h5desc.back();
   oh.addProperty(const_cast<std::vector<PosType>&>(Pinit.getSimulationCell().getKLists().kpts_cart), "value", file);
 
@@ -115,7 +115,7 @@ void StaticStructureFactor::registerCollectables(std::vector<ObservableHelper>& 
   ng[1] = nkpoints;
   for (int s = 0; s < nspecies; ++s)
   {
-    h5desc.emplace_back(species_name[s]);
+    h5desc.push_back({{species_name[s]}});
     auto& ohSpeciesName = h5desc.back();
     ohSpeciesName.set_dimensions(ng, my_index_ + s * 2 * nkpoints);
   }

--- a/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
+++ b/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
@@ -25,16 +25,17 @@
 namespace qmcplusplus
 {
 
+using namespace std::string_literals;
+
 TEST_CASE("ObservableHelper::ObservableHelper(std::vector<std::string>)", "[hamiltonian]")
 {
-  using namespace std::string_literals;
   ObservableHelper oh({"u"s, "v"s});
   CHECK(oh.lower_bound == 0);
 }
 
 TEST_CASE("ObservableHelper::set_dimensions", "[hamiltonian]")
 {
-  ObservableHelper oh{{"u"}};
+  ObservableHelper oh{{"u"s}};
 
   std::vector<int> dims = {10, 10};
   oh.set_dimensions(dims, 1);
@@ -48,7 +49,7 @@ TEST_CASE("ObservableHelper::ObservableHelper()", "[hamiltonian]")
   hdf_archive hFile;
   hFile.create(filename);
 
-  ObservableHelper oh{{"u"}};
+  ObservableHelper oh{{"u"s}};
   std::vector<int> dims = {10, 10};
   float propertyFloat   = 10.f;
   oh.addProperty(propertyFloat, "propertyFloat", hFile);

--- a/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
+++ b/src/QMCHamiltonians/tests/test_ObservableHelper.cpp
@@ -24,11 +24,6 @@
 
 namespace qmcplusplus
 {
-TEST_CASE("ObservableHelper::ObservableHelper(const std::string&)", "[hamiltonian]")
-{
-  ObservableHelper oh("u");
-  CHECK(oh.lower_bound == 0);
-}
 
 TEST_CASE("ObservableHelper::ObservableHelper(std::vector<std::string>)", "[hamiltonian]")
 {
@@ -39,7 +34,7 @@ TEST_CASE("ObservableHelper::ObservableHelper(std::vector<std::string>)", "[hami
 
 TEST_CASE("ObservableHelper::set_dimensions", "[hamiltonian]")
 {
-  ObservableHelper oh("u");
+  ObservableHelper oh{{"u"}};
 
   std::vector<int> dims = {10, 10};
   oh.set_dimensions(dims, 1);
@@ -53,7 +48,7 @@ TEST_CASE("ObservableHelper::ObservableHelper()", "[hamiltonian]")
   hdf_archive hFile;
   hFile.create(filename);
 
-  ObservableHelper oh("u");
+  ObservableHelper oh{{"u"}};
   std::vector<int> dims = {10, 10};
   float propertyFloat   = 10.f;
   oh.addProperty(propertyFloat, "propertyFloat", hFile);


### PR DESCRIPTION
## Proposed changes
Following on from some experimenting to review #4332 which got merged prior to my review. OperatorHelper is looking better but it would be nice to remove some ugly.

Remove single group path term convenience constructor. Remove unnecessary and potentially problematic default constructor. Remove need for a bunch of explicit construction of temporary `std::vector<std::string>`

Stop using unique pointer vectors in a unnecessary way in `OperatorEstBase` simplify things further.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)  Well at least not much.
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
