### PR TITLE
Extending modern string utils to include split and strip

### DIFF
--- a/src/Utilities/ModernStringUtils.cpp
+++ b/src/Utilities/ModernStringUtils.cpp
@@ -15,6 +15,9 @@
 
 namespace qmcplusplus
 {
+using std::size_t;
+using std::string_view;
+
 
 std::string lowerCase(const std::string_view s)
 {
@@ -23,5 +26,41 @@ std::string lowerCase(const std::string_view s)
                  [](unsigned char c) { return std::tolower(c); });
   return lower_str;
 }
+
+namespace modernstrutil
+{
+std::vector<std::string_view> split(const string_view s, const string_view delimiters)
+{
+  std::vector<std::string_view> tokens;
+  size_t right = 0;
+  size_t left  = 0;
+  while (true)
+  {
+    left = s.find_first_not_of(delimiters, right);
+    if (left == s.npos)
+      break;
+    else
+      right = s.find_first_of(delimiters, left);
+    if (right == s.npos)
+      right = s.size();
+    size_t count = right - left;
+    tokens.push_back(s.substr(left, count));
+  }
+  return tokens;
+}
+
+std::string_view strip(const string_view s)
+{
+  std::string_view delimiters = " \t\n\0";
+  size_t left                 = s.find_first_not_of(delimiters, 0);
+  if (left != s.npos) {
+    size_t right = s.find_last_not_of(delimiters, s.npos);
+    return s.substr(left, right - left + 1);
+  }
+  else
+    return std::string_view{};
+}
+} // namespace modernstrutil
+
 
 } // namespace qmcplusplus

--- a/src/Utilities/ModernStringUtils.hpp
+++ b/src/Utilities/ModernStringUtils.hpp
@@ -12,8 +12,12 @@
 #ifndef QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
 #define QMCPLUSPLUS_MODERNSTRINGUTILS_HPP
 
+#include <charconv>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <vector>
 
 namespace qmcplusplus
 {
@@ -30,6 +34,36 @@ namespace qmcplusplus
  *  *  For other XML derived text this should never be used since we should assume that to be UTF-8 encoded.
  */
 std::string lowerCase(const std::string_view s);
+
+/** prevent clash with string_utils.h */
+namespace modernstrutil {
+  /** return string_view tokens */
+  std::vector<std::string_view> split(const std::string_view s, const std::string_view delimiters);
+  /** remove white space from each beginning and end of string_view */
+  std::string_view strip(const std::string_view s);
+}
+
+/** alternate to string2real
+ *  calls c++ string to real conversion based on T's precision template<typename T>
+ */
+template<typename T>
+inline T string2Real(const std::string_view svalue) {
+  static_assert(std::is_floating_point_v<T>);
+      T result;
+// full support for floating point from char not present until stdlibc++ aligned with gcc11
+// there is still not from_char for floats as of libc++ 15
+#if _GLIBCXX_RELEASE > 10
+  auto [prt, ec] = std::from_chars(svalue.data(), svalue.data() + svalue.size(), result, std::chars_format::general);
+  if (ec != std::errc())
+    throw std::runtime_error("Could not convert from string to real value");
+#else
+  // atof must be given a null terminated string, string_view is not guaranteed to have a null terminator.
+  std::string str_value(svalue);
+  result = static_cast<T>(atof(str_value.c_str()));
+#endif
+  return result;
+}
+  
 /** @} */
 
 } // namespace qmcplusplus

--- a/src/Utilities/for_testing/NativeInitializerPrint.hpp
+++ b/src/Utilities/for_testing/NativeInitializerPrint.hpp
@@ -39,4 +39,16 @@ std::ostream& operator<<(std::ostream& out, const NativePrint<std::vector<T>>& n
   return out;
 }
 
+template<class T>
+std::ostream& operator<<(std::ostream& out, const NativePrint<Vector<T>>& np_vec)
+{
+  out << "{ ";
+  auto vec = np_vec.get_obj();
+  for(T& t : vec)
+    out << std::setprecision(10) << t << ", ";
+  out << " }";
+  return out;
+}
+
+  
 } // namespace qmcplusplus

--- a/src/Utilities/for_testing/NativeInitializerPrint.hpp
+++ b/src/Utilities/for_testing/NativeInitializerPrint.hpp
@@ -1,3 +1,24 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2022 QMCPACK developers.
+//
+// File developed by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//
+// File created by: Peter Doak, doakpw@ornl.gov, Oak Ridge National Lab
+//////////////////////////////////////////////////////////////////////////////////////
+
+/** \file
+ *  The operator<< functions provide output for data structures that can be
+ *  used to directly initialize them in test code.
+ *
+ *  Usage is present in future test code and provides the "coverage" of these
+ *  functions.
+ */
+
+#ifndef QMCPLUSPLUS_NATIVE_INTITIALIZER_PRINT_HPP
+#define QMCPLUSPLUS_NATIVE_INTITIALIZER_PRINT_HPP
 
 #include <iostream>
 
@@ -13,6 +34,7 @@ public:
   using type_t = OBJECT;
   NativePrint(const OBJECT& obj) : obj_(obj) {}
   const OBJECT& get_obj() const { return obj_; }
+
 private:
   OBJECT obj_;
 };
@@ -22,7 +44,7 @@ std::ostream& operator<<(std::ostream& out, const NativePrint<TinyVector<T, D>>&
 {
   out << "{ ";
   auto vec = np_vec.get_obj();
-  for(int i = 0 ; i < D - 1; ++i)
+  for (int i = 0; i < D - 1; ++i)
     out << std::setw(12) << std::setprecision(10) << vec[i] << ", ";
   out << std::setw(12) << std::setprecision(10) << vec[D - 1] << " }";
   return out;
@@ -33,7 +55,7 @@ std::ostream& operator<<(std::ostream& out, const NativePrint<std::vector<T>>& n
 {
   out << "{ ";
   auto vec = np_vec.get_obj();
-  for(T& t : vec)
+  for (T& t : vec)
     out << std::setprecision(10) << t << ", ";
   out << " }";
   return out;
@@ -44,11 +66,13 @@ std::ostream& operator<<(std::ostream& out, const NativePrint<Vector<T>>& np_vec
 {
   out << "{ ";
   auto vec = np_vec.get_obj();
-  for(T& t : vec)
+  for (T& t : vec)
     out << std::setprecision(10) << t << ", ";
   out << " }";
   return out;
 }
 
-  
+
 } // namespace qmcplusplus
+
+#endif

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -31,4 +31,61 @@ TEST_CASE("ModernStringUtils_strToLower", "[utilities]")
         "\xab"
         "not_just_ascii");
 }
+
+TEST_CASE("ModernStringUtils_split", "[utilities]")
+{
+  using modernstrutil::split;
+  std::string test_line{"hi there 101, random line"};
+  auto tokens = split(test_line, " ");
+  CHECK(tokens[0].size() == 2);
+  CHECK(tokens[4].size() == 4);
+  CHECK(tokens[3] == "random");
+
+  std::string test_lines{R"(
+this is a multi
+line
+token test
+)"};
+  auto tokens_lines = split(test_lines, "\n");
+  CHECK(tokens_lines[0] == "this is a multi");
+  CHECK(tokens_lines[1] == "line");
+  CHECK(tokens_lines[2] == "token test");
+
+  std::string test_multidel{"this \t is a multidelimiter  \n   \n token test"};
+  auto tokens_multidel = split(test_multidel, "\t \n");
+  CHECK(tokens_multidel[0] == "this");
+  CHECK(tokens_multidel[1] == "is");
+  CHECK(tokens_multidel[4] == "token");
+}
+
+TEST_CASE("ModernStringUtils_string2Real", "[utilities]")
+{
+  std::string_view svalue{"101.52326626"};
+  double value = string2Real<double>(svalue);
+  CHECK(value == Approx(101.52326626));
 } // namespace qmcplusplus
+
+TEST_CASE("ModernStringUtils_strip", "[utilities]")
+{
+  std::string test_lines{R"(
+    r1 1 0 0
+    r2 0 1 0
+    r3 0 0 1
+)"};
+
+  using modernstrutil::strip;
+  std::string_view stripped_lines = strip(test_lines);
+
+  std::string_view ref_stripped{"r1 1 0 0\n    r2 0 1 0\n    r3 0 0 1"};
+  CHECK(ref_stripped == stripped_lines);
+
+  std::string_view another{"r1 1 0 0\n    r2 0 1 0\n    r3 0 0 1\n  \0"};
+  std::string_view another_stripped = strip(another);
+  CHECK(another_stripped == "r1 1 0 0\n    r2 0 1 0\n    r3 0 0 1");
+
+  std::string_view unneeded{"this needs no stripping"};
+  std::string_view unneeded_stripped = strip(unneeded);
+  CHECK(unneeded_stripped == unneeded);
+}
+  
+}

--- a/src/Utilities/tests/test_ModernStringUtils.cpp
+++ b/src/Utilities/tests/test_ModernStringUtils.cpp
@@ -35,12 +35,33 @@ TEST_CASE("ModernStringUtils_strToLower", "[utilities]")
 TEST_CASE("ModernStringUtils_split", "[utilities]")
 {
   using modernstrutil::split;
+
+  std::string nothing;
+  auto no_tokens = split(nothing, " ");
+  CHECK(no_tokens.empty());
+  no_tokens = split(nothing, "");
+  CHECK(no_tokens.empty());
+
+  std::string white_space{"             "};
+  auto tokens = split(white_space, ".");
+  CHECK(tokens.size() == 1);
+  CHECK(tokens[0] == "             ");
+
+  tokens = split(white_space, " ");
+  CHECK(tokens.empty());
+  
   std::string test_line{"hi there 101, random line"};
-  auto tokens = split(test_line, " ");
+  tokens = split(test_line, " ");
   CHECK(tokens[0].size() == 2);
   CHECK(tokens[4].size() == 4);
   CHECK(tokens[3] == "random");
 
+  tokens = split(test_line, "");
+  CHECK(tokens.size() == 1);
+
+  tokens = split(test_line, ";");
+  CHECK(tokens.size() == 1);
+  
   std::string test_lines{R"(
 this is a multi
 line
@@ -67,13 +88,22 @@ TEST_CASE("ModernStringUtils_string2Real", "[utilities]")
 
 TEST_CASE("ModernStringUtils_strip", "[utilities]")
 {
+  using modernstrutil::strip;
+
+  std::string nothing;
+  auto stripped_nothing = strip(nothing);
+  CHECK(stripped_nothing.empty());
+
+  std::string white_space{"           "};
+  auto stripped_white_space = strip(white_space);
+  CHECK(stripped_white_space.empty());
+
   std::string test_lines{R"(
     r1 1 0 0
     r2 0 1 0
     r3 0 0 1
 )"};
 
-  using modernstrutil::strip;
   std::string_view stripped_lines = strip(test_lines);
 
   std::string_view ref_stripped{"r1 1 0 0\n    r2 0 1 0\n    r3 0 0 1"};


### PR DESCRIPTION
## Proposed changes

Adds a strip and split function that support `string-view`
Existing code does not use this but it is required for #4299 

## What type(s) of changes does this code introduce?
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Leconte

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes This PR is up to date with current the current state of 'develop'
- Yes Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
