### PR TITLE
include option to specify a directory for the restart sandbox test

### DIFF
--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -261,11 +261,11 @@ int main(int argc, char** argv)
   elecs[0].destroyWalkers(elecs[0].begin(), elecs[0].end());
 
   // load walkers
-  std::string restart_input_directory = "<tmp> \
-  <mcwalkerset fileroot=\"" + directory + "restart\" node=\"-1\" version=\"3 0\" collected=\"yes\"/> \
-</tmp> \
-";
-  const char* restart_input = restart_input_directory.c_str();
+  std::string restart_input = R"(
+    <tmp>
+      <mcwalkerset fileroot=")" + directory + R"(restart" node="-1" version="3 0" collected="yes"/>
+    </tmp>
+  )";
 
   Libxml2Document doc;
   bool okay               = doc.parseFromString(restart_input);

--- a/src/Sandbox/restart.cpp
+++ b/src/Sandbox/restart.cpp
@@ -54,9 +54,7 @@ int main(int argc, char** argv)
   qmcplusplus::hdf_error_suppression hide_hdf_errors;
 
   Communicate* myComm = OHMMS::Controller;
-  myComm->setName("restart");
-  myComm->barrier();
-
+  
   using RealType    = QMCTraits::RealType;
   using ParticlePos = ParticleSet::ParticlePos;
   using LatticeType = ParticleSet::ParticleLayout;
@@ -73,6 +71,7 @@ int main(int argc, char** argv)
   int nsteps                = 100;
   int iseed                 = 11;
   int AverageWalkersPerNode = 0;
+  string directory          = "";
   int nwtot;
   std::vector<int> wPerNode;
   RealType Rmax(1.7);
@@ -81,7 +80,7 @@ int main(int argc, char** argv)
 
   char* g_opt_arg;
   int opt;
-  while ((opt = getopt(argc, argv, "hg:i:r:")) != -1)
+  while ((opt = getopt(argc, argv, "hg:i:r:s:d:")) != -1)
   {
     switch (opt)
     {
@@ -103,8 +102,17 @@ int main(int argc, char** argv)
     case 'r': //rmax
       Rmax = atof(optarg);
       break;
+    case 'd': //directory
+      directory = optarg;
+      if (directory.back() != '/') {
+        directory += "/";
+      }
+      break;
     }
   }
+
+  myComm->setName(directory + "restart");
+  myComm->barrier();
 
   // set the number of walkers equal to the threads.
   if (!AverageWalkersPerNode)
@@ -184,7 +192,7 @@ int main(int argc, char** argv)
   // dump random seeds
   myComm->barrier();
   h5clock.restart(); //start timer
-  RandomNumberControl::write("restart", myComm);
+  RandomNumberControl::write(directory + "restart", myComm);
   myComm->barrier();
   h5write += h5clock.elapsed(); //store timer
 
@@ -202,7 +210,7 @@ int main(int argc, char** argv)
   // load random seeds
   myComm->barrier();
   h5clock.restart(); //start timer
-  RandomNumberControl::read("restart", myComm);
+  RandomNumberControl::read(directory + "restart", myComm);
   myComm->barrier();
   h5read += h5clock.elapsed(); //store timer
 
@@ -237,7 +245,7 @@ int main(int argc, char** argv)
   }
 
   // dump electron coordinates.
-  HDFWalkerOutput wOut(elecs[0].getTotalNum(), "restart", myComm);
+  HDFWalkerOutput wOut(elecs[0].getTotalNum(), directory + "restart", myComm);
   myComm->barrier();
   h5clock.restart(); //start timer
   wOut.dump(elecs[0], 1);
@@ -253,10 +261,11 @@ int main(int argc, char** argv)
   elecs[0].destroyWalkers(elecs[0].begin(), elecs[0].end());
 
   // load walkers
-  const char* restart_input = "<tmp> \
-  <mcwalkerset fileroot=\"restart\" node=\"-1\" version=\"3 0\" collected=\"yes\"/> \
+  std::string restart_input_directory = "<tmp> \
+  <mcwalkerset fileroot=\"" + directory + "restart\" node=\"-1\" version=\"3 0\" collected=\"yes\"/> \
 </tmp> \
 ";
+  const char* restart_input = restart_input_directory.c_str();
 
   Libxml2Document doc;
   bool okay               = doc.parseFromString(restart_input);


### PR DESCRIPTION
## Proposed changes

We plan to include the restart sandbox example in h5bench. For that, we need to be able to define a directory prefix in which the files are created. This PR includes that option by adding `-d` to the restart code.

## What type(s) of changes does this code introduce?
- Other (please describe): Adds a new optional parameter for the restart sandbox example.

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
MacOS and Linux

## Checklist

- **Yes**/No. This PR is up to date with current the current state of 'develop'
- **Yes**/No. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
