### PR TITLE
Use HDF5 1.10 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,7 +653,7 @@ else()
   set(HDF5_USE_STATIC_LIBRARIES off)
 endif()
 
-find_package(HDF5 COMPONENTS C)
+find_package(HDF5 1.10 COMPONENTS C)
 
 if(HDF5_FOUND)
   if(HDF5_IS_PARALLEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ if(HDF5_FOUND)
 
   add_library(IO::HDF5 INTERFACE IMPORTED)
   target_include_directories(IO::HDF5 INTERFACE "${HDF5_INCLUDE_DIR}")
-  target_compile_definitions(IO::HDF5 INTERFACE "H5_USE_18_API")
+  target_compile_definitions(IO::HDF5 INTERFACE "H5_USE_110_API")
   target_link_libraries(IO::HDF5 INTERFACE "${HDF5_LIBRARIES}")
   if(ENABLE_PHDF5)
     target_compile_definitions(IO::HDF5 INTERFACE "ENABLE_PHDF5")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ if(HDF5_FOUND)
 
   add_library(IO::HDF5 INTERFACE IMPORTED)
   target_include_directories(IO::HDF5 INTERFACE "${HDF5_INCLUDE_DIR}")
-  target_compile_definitions(IO::HDF5 INTERFACE "H5_USE_16_API")
+  target_compile_definitions(IO::HDF5 INTERFACE "H5_USE_18_API")
   target_link_libraries(IO::HDF5 INTERFACE "${HDF5_LIBRARIES}")
   if(ENABLE_PHDF5)
     target_compile_definitions(IO::HDF5 INTERFACE "ENABLE_PHDF5")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ particular emphasis is placed on code quality and reproducibility.
  * CMake v3.17.0 or later, build utility, http://www.cmake.org
  * BLAS/LAPACK, numerical library. Use vendor and platform-optimized libraries.
  * LibXml2, XML parser, http://xmlsoft.org/
- * HDF5, portable I/O library, http://www.hdfgroup.org/HDF5/
+ * HDF5 v1.10.0 or later, portable I/O library, http://www.hdfgroup.org/HDF5/
  * BOOST v1.61.0 or newer, peer-reviewed portable C++ source libraries, http://www.boost.org
  * FFTW, FFT library, http://www.fftw.org/
  * MPI, parallel library. Optional, but a near requirement for production calculations.

--- a/src/QMCHamiltonians/SkEstimator.cpp
+++ b/src/QMCHamiltonians/SkEstimator.cpp
@@ -128,7 +128,8 @@ void SkEstimator::registerCollectables(std::vector<ObservableHelper>& h5desc, hd
     kdims[1]          = OHMMS_DIM;
     std::string kpath = name_ + "/kpoints";
     hid_t k_space     = H5Screate_simple(2, kdims, NULL);
-    hid_t k_set       = H5Dcreate(file.getFileID(), kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT);
+    hid_t k_set =
+        H5Dcreate(file.getFileID(), kpath.c_str(), H5T_NATIVE_DOUBLE, k_space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     hid_t mem_space   = H5Screate_simple(2, kdims, NULL);
     auto* ptr         = &(sourcePtcl->getSimulationCell().getKLists().kpts_cart[0][0]);
     herr_t ret        = H5Dwrite(k_set, H5T_NATIVE_DOUBLE, mem_space, k_space, H5P_DEFAULT, ptr);

--- a/src/QMCWaveFunctions/PlaneWave/PWParameterSet.cpp
+++ b/src/QMCWaveFunctions/PlaneWave/PWParameterSet.cpp
@@ -76,7 +76,7 @@ bool PWParameterSet::getEigVectorType(hid_t h)
       oss << "/" << spinTag << 0;
     oss << "/eigenvector";
     hsize_t dimTot[4];
-    hid_t dataset   = H5Dopen(h, oss.str().c_str());
+    hid_t dataset   = H5Dopen(h, oss.str().c_str(), H5P_DEFAULT);
     hid_t dataspace = H5Dget_space(dataset);
     rank            = H5Sget_simple_extent_ndims(dataspace);
     int status_n    = H5Sget_simple_extent_dims(dataspace, dimTot, NULL);
@@ -184,7 +184,7 @@ void PWParameterSet::checkVersion(hdf_archive& h)
 {
   if (is_manager())
   {
-    hid_t dataset         = H5Dopen(h.getFileID(), "version");
+    hid_t dataset         = H5Dopen(h.getFileID(), "version", H5P_DEFAULT);
     hid_t datatype        = H5Dget_type(dataset);
     H5T_class_t classtype = H5Tget_class(datatype);
     H5Tclose(datatype);

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -317,7 +317,7 @@ public:
     if (Mode[NOIO])
       return;
     hid_t p       = group_id.empty() ? file_id : group_id.top();
-    herr_t status = H5Gunlink(p, aname.c_str());
+    herr_t status = H5Ldelete(p, aname.c_str(), H5P_DEFAULT);
   }
 };
 

--- a/src/io/hdf/hdf_stl.h
+++ b/src/io/hdf/hdf_stl.h
@@ -96,7 +96,7 @@ struct h5data_proxy<std::string>
 
   inline bool read(data_type& ref, hid_t grp, const std::string& aname, hid_t xfer_plist = H5P_DEFAULT)
   {
-    hid_t dataset = H5Dopen(grp, aname.c_str());
+    hid_t dataset = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
     if (dataset > -1)
     {
       hid_t datatype = H5Dget_type(dataset);
@@ -127,11 +127,11 @@ struct h5data_proxy<std::string>
     hsize_t dim = 1;
 
     herr_t ret = -1;
-    hid_t h1   = H5Dopen(grp, aname.c_str());
+    hid_t h1   = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
     if (h1 < 0) // missing create one
     {
       hid_t dataspace = H5Screate_simple(1, &dim, NULL);
-      hid_t dataset   = H5Dcreate(grp, aname.c_str(), str80, dataspace, H5P_DEFAULT);
+      hid_t dataset   = H5Dcreate(grp, aname.c_str(), str80, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       ret             = H5Dwrite(dataset, str80, H5S_ALL, H5S_ALL, xfer_plist, ref.data());
       H5Sclose(dataspace);
       H5Dclose(dataset);
@@ -157,7 +157,7 @@ struct h5data_proxy<std::vector<std::string>>
   {
     hid_t datatype = H5Tcopy(H5T_C_S1);
     H5Tset_size(datatype, H5T_VARIABLE);
-    hid_t dataset = H5Dopen(grp, aname.c_str());
+    hid_t dataset = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
     std::vector<char*> char_list;
     herr_t ret = -1;
     if (dataset > -1)
@@ -198,12 +198,12 @@ struct h5data_proxy<std::vector<std::string>>
     for (int i = 0; i < ref.size(); i++)
       char_list.push_back(ref[i].data());
 
-    hid_t h1   = H5Dopen(grp, aname.c_str());
+    hid_t h1   = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
     herr_t ret = -1;
     if (h1 < 0) // missing create one
     {
       hid_t dataspace = H5Screate_simple(1, &dim, NULL);
-      hid_t dataset   = H5Dcreate(grp, aname.c_str(), datatype, dataspace, H5P_DEFAULT);
+      hid_t dataset   = H5Dcreate(grp, aname.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       ret             = H5Dwrite(dataset, datatype, H5S_ALL, H5S_ALL, xfer_plist, char_list.data());
       H5Sclose(dataspace);
       H5Dclose(dataset);

--- a/src/io/hdf/hdf_wrapper_functions.h
+++ b/src/io/hdf/hdf_wrapper_functions.h
@@ -438,7 +438,7 @@ inline bool h5d_append(hid_t grp,
     start[0] = current;
     end[0]   = start[0] + dims[0];
     //extend the dataset (file)
-    herr_t he = H5Dextend(dataset, end.data());
+    herr_t he = H5Dset_extent(dataset, end.data());
     //get the corresponding dataspace (filespace)
     dataspace = H5Dget_space(dataset);
     //set the extent

--- a/src/io/hdf/hdf_wrapper_functions.h
+++ b/src/io/hdf/hdf_wrapper_functions.h
@@ -47,7 +47,7 @@ inline bool getDataShape(hid_t grp, const std::string& aname, std::vector<IT>& s
   using TSpaceType = h5_space_type<T, 0>;
   TSpaceType TSpace;
 
-  hid_t h1        = H5Dopen(grp, aname.c_str());
+  hid_t h1        = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   hid_t dataspace = H5Dget_space(h1);
   int rank        = H5Sget_simple_extent_ndims(dataspace);
 
@@ -124,7 +124,7 @@ inline bool h5d_read(hid_t grp, const std::string& aname, T* first, hid_t xfer_p
 {
   if (grp < 0)
     return true;
-  hid_t h1 = H5Dopen(grp, aname.c_str());
+  hid_t h1 = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   if (h1 < 0)
     return false;
   hid_t h5d_type_id = get_h5_datatype(*first);
@@ -144,12 +144,12 @@ inline bool h5d_write(hid_t grp,
   if (grp < 0)
     return true;
   hid_t h5d_type_id = get_h5_datatype(*first);
-  hid_t h1          = H5Dopen(grp, aname.c_str());
+  hid_t h1          = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   herr_t ret        = -1;
   if (h1 < 0) //missing create one
   {
     hid_t dataspace = H5Screate_simple(ndims, dims, NULL);
-    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT);
+    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     ret             = H5Dwrite(dataset, h5d_type_id, H5S_ALL, H5S_ALL, xfer_plist, first);
     H5Sclose(dataspace);
     H5Dclose(dataset);
@@ -180,7 +180,7 @@ bool h5d_read(hid_t grp,
 {
   if (grp < 0)
     return true;
-  hid_t h1 = H5Dopen(grp, aname.c_str());
+  hid_t h1 = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   if (h1 < 0)
     return false;
   //herr_t ret = H5Dread(h1, h5d_type_id, H5S_ALL, H5S_ALL, xfer_plist, first);
@@ -223,7 +223,7 @@ inline bool h5d_write(hid_t grp,
   if (grp < 0)
     return true;
   hid_t h5d_type_id = get_h5_datatype(*first);
-  hid_t h1          = H5Dopen(grp, aname.c_str());
+  hid_t h1          = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   hid_t filespace, memspace;
   herr_t ret = -1;
 
@@ -231,7 +231,7 @@ inline bool h5d_write(hid_t grp,
   if (h1 < 0) //missing create one
   {
     hid_t dataspace = H5Screate_simple(ndims, gcounts, NULL);
-    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT);
+    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     hid_t filespace = H5Dget_space(dataset);
     ret             = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offsets, NULL, ones.data(), counts);
@@ -276,7 +276,7 @@ bool h5d_read(hid_t grp,
 {
   if (grp < 0)
     return true;
-  hid_t h1 = H5Dopen(grp, aname.c_str());
+  hid_t h1 = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   if (h1 < 0)
     return false;
 
@@ -320,14 +320,14 @@ inline bool h5d_write(hid_t grp,
             << *(mem_gcounts + 2) << " " << *mem_counts << " " << *(mem_counts + 1) << " " << *(mem_counts + 2) << " "
             << *mem_offsets << " " << *(mem_offsets + 1) << " " << *(mem_offsets + 2) << " " << std::endl;
   hid_t h5d_type_id = get_h5_datatype(*first);
-  hid_t h1          = H5Dopen(grp, aname.c_str());
+  hid_t h1          = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   herr_t ret        = -1;
 
   const std::vector<hsize_t> ones(std::max(ndims, mem_ndims), 1);
   if (h1 < 0) //missing create one
   {
     hid_t dataspace = H5Screate_simple(ndims, gcounts, NULL);
-    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT);
+    hid_t dataset   = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     hid_t filespace = H5Dget_space(dataset);
     ret             = H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offsets, NULL, ones.data(), counts);
@@ -373,7 +373,7 @@ inline bool h5d_append(hid_t grp,
   hid_t h5d_type_id = get_h5_datatype(*first);
   hid_t dataspace;
   hid_t memspace;
-  hid_t dataset = H5Dopen(grp, aname.c_str());
+  hid_t dataset = H5Dopen(grp, aname.c_str(), H5P_DEFAULT);
   std::vector<hsize_t> max_dims(ndims);
   max_dims[0] = H5S_UNLIMITED;
   for (int d = 1; d < ndims; ++d)
@@ -397,7 +397,7 @@ inline bool h5d_append(hid_t grp,
     // set chunk size
     hid_t cs = H5Pset_chunk(p, ndims, chunk_dims.data());
     // create the dataset
-    dataset = H5Dcreate2(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT, p, H5P_DEFAULT);
+    dataset = H5Dcreate(grp, aname.c_str(), h5d_type_id, dataspace, H5P_DEFAULT, p, H5P_DEFAULT);
     // create memory dataspace, size of current buffer
     memspace = H5Screate_simple(ndims, dims, NULL);
     // write the data for the first time


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Move QMCPACK to use the HDF5 1.10 API, released in 2016. 1.10 is available starting in Ubuntu 18.04 and RHEL 8 The 1.8 and 1.12 branches have their final patch releases in January 2023, so 1.10 seems to be the sweet spot.

I think this flag in 1.8 will let us use a [longer `std::string` instead of `std::vector<std::string>` in ObservableHelper](
https://docs.hdfgroup.org/hdf5/v1_12/group___a_l_c_a_p_l.html#ga66c4c5d3f34e5cf65d00e47a5387383c). 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Build related changes

### Does this introduce a breaking change?

- No (might if we use HDF5 1.8+ features in hdf5 output)

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
