### PR TITLE
Add VPs to SOECP

### DIFF
--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -116,6 +116,31 @@ void VirtualParticleSet::makeMoves(int jel,
   update();
 }
 
+/// move virtual particles to new postions and update distance tables
+void VirtualParticleSet::makeMovesWithSpin(int jel,
+                                           const PosType& ref_pos,
+                                           const std::vector<PosType>& deltaV,
+                                           const RealType& ref_spin,
+                                           const std::vector<RealType>& deltaS,
+                                           bool sphere,
+                                           int iat)
+{
+  if (sphere && iat < 0)
+    throw std::runtime_error(
+        "VirtualParticleSet::makeMoves is invoked incorrectly, the flag sphere=true requires iat specified!");
+  onSphere      = sphere;
+  refPtcl       = jel;
+  refSourcePtcl = iat;
+  assert(R.size() == deltaV.size());
+  assert(spins.size() == deltaS.size());
+  for (size_t ivp = 0; ivp < R.size(); ivp++)
+  {
+    R[ivp]     = ref_pos + deltaV[ivp];
+    spins[ivp] = ref_spin + deltaS[ivp];
+  }
+  update();
+}
+
 void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
                                       const RefVector<const std::vector<PosType>>& deltaV_list,
                                       const RefVector<const NLPPJob<RealType>>& joblist,

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -99,7 +99,7 @@ void VirtualParticleSet::releaseResource(ResourceCollection& collection,
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMoves(int jel,
-                                   const PosType& ref_pos,
+                                   const ParticleSet& p,
                                    const std::vector<PosType>& deltaV,
                                    bool sphere,
                                    int iat)
@@ -112,15 +112,17 @@ void VirtualParticleSet::makeMoves(int jel,
   refSourcePtcl = iat;
   assert(R.size() == deltaV.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
-    R[ivp] = ref_pos + deltaV[ivp];
+  {
+    R[ivp]     = p.R[jel] + deltaV[ivp];
+    spins[ivp] = p.spins[jel]; //no spin deltas in this API
+  }
   update();
 }
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMovesWithSpin(int jel,
-                                           const PosType& ref_pos,
+                                           const ParticleSet& p,
                                            const std::vector<PosType>& deltaV,
-                                           const RealType& ref_spin,
                                            const std::vector<RealType>& deltaS,
                                            bool sphere,
                                            int iat)
@@ -135,8 +137,8 @@ void VirtualParticleSet::makeMovesWithSpin(int jel,
   assert(spins.size() == deltaS.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
   {
-    R[ivp]     = ref_pos + deltaV[ivp];
-    spins[ivp] = ref_spin + deltaS[ivp];
+    R[ivp]     = p.R[jel] + deltaV[ivp];
+    spins[ivp] = p.spins[jel] + deltaS[ivp];
   }
   update();
 }

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -99,7 +99,8 @@ void VirtualParticleSet::releaseResource(ResourceCollection& collection,
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMoves(int jel,
-                                   const ParticleSet& p,
+                                   const PosType& ref_pos,
+                                   const RealType ref_spin,
                                    const std::vector<PosType>& deltaV,
                                    bool sphere,
                                    int iat)
@@ -113,15 +114,16 @@ void VirtualParticleSet::makeMoves(int jel,
   assert(R.size() == deltaV.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
   {
-    R[ivp]     = p.R[jel] + deltaV[ivp];
-    spins[ivp] = p.spins[jel]; //no spin deltas in this API
+    R[ivp]     = ref_pos + deltaV[ivp];
+    spins[ivp] = ref_spin; //no spin deltas in this API
   }
   update();
 }
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMovesWithSpin(int jel,
-                                           const ParticleSet& p,
+                                           const PosType& ref_pos,
+                                           const RealType ref_spin,
                                            const std::vector<PosType>& deltaV,
                                            const std::vector<RealType>& deltaS,
                                            bool sphere,
@@ -137,8 +139,8 @@ void VirtualParticleSet::makeMovesWithSpin(int jel,
   assert(spins.size() == deltaS.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
   {
-    R[ivp]     = p.R[jel] + deltaV[ivp];
-    spins[ivp] = p.spins[jel] + deltaS[ivp];
+    R[ivp]     = ref_pos + deltaV[ivp];
+    spins[ivp] = ref_spin + deltaS[ivp];
   }
   update();
 }

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -129,7 +129,7 @@ void VirtualParticleSet::makeMovesWithSpin(int jel,
 {
   if (sphere && iat < 0)
     throw std::runtime_error(
-        "VirtualParticleSet::makeMoves is invoked incorrectly, the flag sphere=true requires iat specified!");
+        "VirtualParticleSet::makeMovesWithSpin is invoked incorrectly, the flag sphere=true requires iat specified!");
   onSphere      = sphere;
   refPtcl       = jel;
   refSourcePtcl = iat;

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -75,15 +75,31 @@ public:
 
   /** move virtual particles to new postions and update distance tables
      * @param jel reference particle that all the VP moves from
-     * @param p reference particle set
+     * @param ref_pos reference particle position
+     * @param ref_spin reference particle spin
      * @param deltaV Position delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
-  void makeMoves(int jel, const ParticleSet& p, const std::vector<PosType>& deltaV, bool sphere = false, int iat = -1);
+  void makeMoves(int jel,
+                 const PosType& ref_pos,
+                 const RealType ref_spin,
+                 const std::vector<PosType>& deltaV,
+                 bool sphere = false,
+                 int iat     = -1);
 
+  /** move virtual particles to new postions and update distance tables
+     * @param jel reference particle that all the VP moves from
+     * @param ref_pos reference particle position
+     * @param ref_spin reference particle spin
+     * @param deltaV Position delta for virtual moves.
+     * @param deltaS Spin delta for virtual moves.
+     * @param sphere set true if VP are on a sphere around the reference source particle
+     * @param iat reference source particle
+     */
   void makeMovesWithSpin(int jel,
-                         const ParticleSet& p,
+                         const PosType& ref_pos,
+                         const RealType ref_spin,
                          const std::vector<PosType>& deltaV,
                          const std::vector<RealType>& deltaS,
                          bool sphere = false,

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -86,6 +86,14 @@ public:
                  bool sphere = false,
                  int iat     = -1);
 
+  void makeMovesWithSpin(int jel,
+                         const PosType& ref_pos,
+                         const std::vector<PosType>& deltaV,
+                         const RealType& ref_spin,
+                         const std::vector<RealType>& deltaS,
+                         bool sphere = false,
+                         int iat     = -1);
+
   static void mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
                            const RefVector<const std::vector<PosType>>& deltaV_list,
                            const RefVector<const NLPPJob<RealType>>& joblist,

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -75,21 +75,16 @@ public:
 
   /** move virtual particles to new postions and update distance tables
      * @param jel reference particle that all the VP moves from
-     * @param ref_pos reference particle position
+     * @param p reference particle set
      * @param deltaV Position delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
-  void makeMoves(int jel,
-                 const PosType& ref_pos,
-                 const std::vector<PosType>& deltaV,
-                 bool sphere = false,
-                 int iat     = -1);
+  void makeMoves(int jel, const ParticleSet& p, const std::vector<PosType>& deltaV, bool sphere = false, int iat = -1);
 
   void makeMovesWithSpin(int jel,
-                         const PosType& ref_pos,
+                         const ParticleSet& p,
                          const std::vector<PosType>& deltaV,
-                         const RealType& ref_spin,
                          const std::vector<RealType>& deltaS,
                          bool sphere = false,
                          int iat     = -1);

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -144,12 +144,7 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
       {
         nknot_max = std::max(nknot_max, nonLocalPot[i]->getNknot());
         if (NLPP_algo == "batched")
-        {
-          if( !targetPtcl.isSpinor())
-            nonLocalPot[i]->initVirtualParticle(targetPtcl);
-          else
-            throw std::runtime_error("Batched NLPP evaluation not validated with spinors.  Use algorithm=\"non-batched\" in pseudopotential block."); 
-        } 
+          nonLocalPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(nonLocalPot[i]));
       }
     }
@@ -181,12 +176,16 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
       {
         nknot_max = std::max(nknot_max, soPot[i]->getNknot());
         sknot_max = std::max(sknot_max, soPot[i]->getSknot());
+        if (NLPP_algo == "batched")
+          soPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(soPot[i]));
       }
     }
     app_log() << "\n  Using SOECP potential \n"
               << "    Maximum grid on a sphere for SOECPotential: " << nknot_max << std::endl;
     app_log() << "    Maximum grid for Simpson's rule for spin integral: " << sknot_max << std::endl;
+    if (NLPP_algo == "batched")
+      app_log() << "    Using batched ratio computing in SOECP potential" << std::endl;
 
     if (physicalSO == "yes")
       targetH.addOperator(std::move(apot), "SOECP"); //default is physical operator
@@ -218,7 +217,7 @@ void ECPotentialBuilder::useXmlFormat(xmlNodePtr cur)
       std::string href("none");
       std::string ionName("none");
       std::string format("xml");
-      int nrule = -1;
+      int nrule  = -1;
       int llocal = -1;
       //RealType rc(2.0);//use 2 Bohr
       OhmmsAttributeSet hAttrib;

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -176,8 +176,8 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
       {
         nknot_max = std::max(nknot_max, soPot[i]->getNknot());
         sknot_max = std::max(sknot_max, soPot[i]->getSknot());
-        //if (NLPP_algo == "batched")
-        //  soPot[i]->initVirtualParticle(targetPtcl);
+        if (NLPP_algo == "batched")
+          soPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(soPot[i]));
       }
     }

--- a/src/QMCHamiltonians/ECPotentialBuilder.cpp
+++ b/src/QMCHamiltonians/ECPotentialBuilder.cpp
@@ -176,8 +176,8 @@ bool ECPotentialBuilder::put(xmlNodePtr cur)
       {
         nknot_max = std::max(nknot_max, soPot[i]->getNknot());
         sknot_max = std::max(sknot_max, soPot[i]->getSknot());
-        if (NLPP_algo == "batched")
-          soPot[i]->initVirtualParticle(targetPtcl);
+        //if (NLPP_algo == "batched")
+        //  soPot[i]->initVirtualParticle(targetPtcl);
         apot->addComponent(i, std::move(soPot[i]));
       }
     }

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -135,7 +135,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W, deltaV, true, iat);
+    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
     if (use_DLA)
       psi.evaluateRatios(*VP, psiratio, TrialWaveFunction::ComputeType::FERMIONIC);
     else
@@ -310,7 +310,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W, deltaV, true, iat);
+    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else
@@ -460,7 +460,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W, deltaV, true, iat);
+    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -135,7 +135,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], deltaV, true, iat);
+    VP->makeMoves(iel, W, deltaV, true, iat);
     if (use_DLA)
       psi.evaluateRatios(*VP, psiratio, TrialWaveFunction::ComputeType::FERMIONIC);
     else
@@ -310,7 +310,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], deltaV, true, iat);
+    VP->makeMoves(iel, W, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else
@@ -460,7 +460,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], deltaV, true, iat);
+    VP->makeMoves(iel, W, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else
@@ -802,7 +802,6 @@ void NonLocalECPComponent::evaluateOneBodyOpMatrixdRContribution(ParticleSet& W,
 
   for (int j = 0; j < nknot; j++)
   {
-
     RealType zz        = dot(dr, rrotsgrid_m[j]) * rinv;
     PosType uminusrvec = rrotsgrid_m[j] - zz * dr * rinv;
 

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -81,7 +81,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], deltaV, true, iat);
+    VP->makeMoves(iel, W, deltaV, true, iat);
     psi.evaluateDerivRatios(*VP, optvars, psiratio, dratio);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -81,7 +81,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W, deltaV, true, iat);
+    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
     psi.evaluateDerivRatios(*VP, optvars, psiratio, dratio);
   }
   else

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -55,6 +55,8 @@ SOECPComponent* SOECPComponent::makeClone(const ParticleSet& qp)
   SOECPComponent* myclone = new SOECPComponent(*this);
   for (int i = 0; i < sopp_m.size(); i++)
     myclone->sopp_m[i] = sopp_m[i]->makeClone();
+  if (VP)
+    myclone->VP = new VirtualParticleSet(qp, nknot);
   return myclone;
 }
 

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -152,7 +152,10 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
 
   //Need to add appropriate weight to psiratio
   std::transform(psiratio.begin(), psiratio.end(), sgridweight_m.begin(), psiratio.begin(),
-                 [](auto& psi, auto& weight) { return psi * weight * 2.0 * TWOPI; });
+                 [](auto& psi, auto& weight) {
+                   RealType fourpi = 2.0 * TWOPI;
+                   return psi * weight * fourpi;
+                 });
 
   ComplexType angint(0.0);
   for (int j = 0; j < nknot; j++)

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -135,7 +135,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
 
   if (VP)
   {
-    VP->makeMovesWithSpin(iel, W, deltaV, deltaS, true, iat);
+    VP->makeMovesWithSpin(iel, W.R[iel], W.spins[iel], deltaV, deltaS, true, iat);
     Psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -17,15 +17,32 @@
 
 namespace qmcplusplus
 {
-SOECPComponent::SOECPComponent() : lmax(0), nchannel(0), nknot(0), sknot(0), Rmax(-1) {}
+SOECPComponent::SOECPComponent() : lmax(0), nchannel(0), nknot(0), sknot(0), Rmax(-1), VP(nullptr) {}
 
 SOECPComponent::~SOECPComponent()
 {
   for (int i = 0; i < sopp_m.size(); i++)
     delete sopp_m[i];
+  if (VP)
+    delete VP;
 }
 
 void SOECPComponent::print(std::ostream& os) {}
+
+void SOECPComponent::initVirtualParticle(const ParticleSet& qp)
+{
+  assert(VP == nullptr);
+  outputManager.pause();
+  VP = new VirtualParticleSet(qp, nknot);
+  outputManager.resume();
+}
+
+void SOECPComponent::deleteVirtualParticle()
+{
+  if (VP)
+    delete VP;
+  VP = nullptr;
+}
 
 void SOECPComponent::add(int l, RadialPotentialType* pp)
 {

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -133,7 +133,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
 
   if (VP)
   {
-    VP->makeMovesWithSpin(iel, W.R[iel], deltaV, W.spins[iel], deltaS, true, iat);
+    VP->makeMovesWithSpin(iel, W, deltaV, deltaS, true, iat);
     Psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -69,6 +69,7 @@ private:
   std::vector<ValueType> vrad;
   std::vector<RealType> sgridweight_m;
 
+  VirtualParticleSet* VP;
 
 public:
   SOECPComponent();
@@ -116,7 +117,8 @@ public:
 
   void print(std::ostream& os);
 
-  //void initVirtualParticle(const ParticleSet& qp){};
+  void initVirtualParticle(const ParticleSet& qp);
+  void deleteVirtualParticle();
 
   inline void setRmax(int rmax) { Rmax = rmax; }
   inline RealType getRmax() const { return Rmax; }

--- a/src/QMCHamiltonians/SOECPComponent.h
+++ b/src/QMCHamiltonians/SOECPComponent.h
@@ -60,9 +60,11 @@ private:
                                  TrialWaveFunction& Psi,
                                  int iel,
                                  RealType r,
-                                 const PosType& dr);
+                                 const PosType& dr,
+                                 int iat);
 
   std::vector<PosType> deltaV;
+  std::vector<RealType> deltaS;
   SpherGridType sgridxyz_m;
   SpherGridType rrotsgrid_m;
   std::vector<ValueType> psiratio;
@@ -70,6 +72,12 @@ private:
   std::vector<RealType> sgridweight_m;
 
   VirtualParticleSet* VP;
+
+  void buildQuadraturePointDeltas(RealType r,
+                                  const PosType& dr,
+                                  std::vector<PosType>& deltaV,
+                                  RealType ds,
+                                  std::vector<RealType>& deltaS) const;
 
 public:
   SOECPComponent();

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -544,12 +544,8 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
       const auto& dist  = myTable.getDistRow(jel);
       const auto& displ = myTable.getDisplRow(jel);
       for (int iat = 0; iat < ions.getTotalNum(); iat++)
-      {
         if (sopp != nullptr && dist[iat] < sopp->getRmax())
-        {
           Value1 += sopp->evaluateOne(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat]);
-        }
-      }
     }
     REQUIRE(Value1 == Approx(-0.3214176962));
   };

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -536,21 +536,32 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   //Need to set up temporary data for this configuration in trial wavefunction.  Needed for ratios.
   double logpsi = psi.evaluateLog(elec);
 
-  RealType Value1(0.0);
 
-  for (int jel = 0; jel < elec.getTotalNum(); jel++)
-  {
-    const auto& dist  = myTable.getDistRow(jel);
-    const auto& displ = myTable.getDisplRow(jel);
-    for (int iat = 0; iat < ions.getTotalNum(); iat++)
+  auto test_evaluateOne = [&]() {
+    RealType Value1(0.0);
+    for (int jel = 0; jel < elec.getTotalNum(); jel++)
     {
-      if (sopp != nullptr && dist[iat] < sopp->getRmax())
+      const auto& dist  = myTable.getDistRow(jel);
+      const auto& displ = myTable.getDisplRow(jel);
+      for (int iat = 0; iat < ions.getTotalNum(); iat++)
       {
-        Value1 += sopp->evaluateOne(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat]);
+        if (sopp != nullptr && dist[iat] < sopp->getRmax())
+        {
+          Value1 += sopp->evaluateOne(elec, iat, psi, jel, dist[iat], RealType(-1) * displ[iat]);
+        }
       }
     }
+    REQUIRE(Value1 == Approx(-0.3214176962));
+  };
+
+  {
+    //test with VPs
+    sopp->initVirtualParticle(elec);
+    test_evaluateOne();
+    sopp->deleteVirtualParticle();
+    //test without VPs
+    test_evaluateOne();
   }
-  REQUIRE(Value1 == Approx(-0.3214176962));
 }
 #endif
 

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -123,7 +123,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec.R[1], newpos2);
+  VP.makeMoves(1, elec, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -123,7 +123,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec, newpos2);
+  VP.makeMoves(1, elec.R[1], elec.spins[1], newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -109,7 +109,7 @@ void test_DiracDeterminantBatched_first()
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec.R[1], newpos2);
+  VP.makeMoves(1, elec, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));
@@ -817,7 +817,7 @@ void test_DiracDeterminantBatched_spinor_update(const int delay_rank, DetMatInve
 
 TEST_CASE("DiracDeterminantBatched_spinor_update", "[wavefunction][fermion]")
 {
-/* Uncomment when MatrixDelayedUpdateCUDA::mw_evalGradWithSpin is implemented
+  /* Uncomment when MatrixDelayedUpdateCUDA::mw_evalGradWithSpin is implemented
 #if defined(ENABLE_OFFLOAD) && defined(ENABLE_CUDA)
   test_DiracDeterminantBatched_spinor_update<
       MatrixDelayedUpdateCUDA<ValueType, QMCTraits::QTFull::ValueType>>(1, DetMatInvertor::ACCEL);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -109,7 +109,7 @@ void test_DiracDeterminantBatched_first()
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec, newpos2);
+  VP.makeMoves(1, elec.R[1], elec.spins[1], newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -239,7 +239,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_.R[1], newpos2);
+  VP.makeMoves(1, elec_, newpos2);
   j2->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(0.9871985577));

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -239,7 +239,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_, newpos2);
+  VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
   j2->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(0.9871985577));

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -263,7 +263,7 @@ void test_Ne(bool transform)
     std::vector<SPOSet::ValueType> ratios2(2);
     newpos2[0] = disp;
     newpos2[1] = -disp;
-    VP.makeMoves(0, elec.R[0], newpos2);
+    VP.makeMoves(0, elec, newpos2);
     sposet->evaluateDetRatios(VP, phi, phiinv, ratios2);
     CHECK(ratios2[0] == Approx(-0.504163137)); // values[0] * phiinv[0]
     CHECK(ratios2[1] == Approx(-0.504163137)); // symmetric move

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -263,7 +263,7 @@ void test_Ne(bool transform)
     std::vector<SPOSet::ValueType> ratios2(2);
     newpos2[0] = disp;
     newpos2[1] = -disp;
-    VP.makeMoves(0, elec, newpos2);
+    VP.makeMoves(0, elec.R[0], elec.spins[0], newpos2);
     sposet->evaluateDetRatios(VP, phi, phiinv, ratios2);
     CHECK(ratios2[0] == Approx(-0.504163137)); // values[0] * phiinv[0]
     CHECK(ratios2[1] == Approx(-0.504163137)); // symmetric move

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -174,7 +174,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     std::vector<ValueType> ratios2(2);
     newpos2[0] = newpos - elec_.R[1];
     newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-    VP.makeMoves(1, elec_, newpos2);
+    VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
     twf.evaluateRatios(VP, ratios2);
 
     CHECK(std::real(ratios2[0]) == Approx(-0.8544310407));

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -98,7 +98,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
   twf.evaluateLog(elec_);
 
   app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-             << std::endl;
+            << std::endl;
   CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
         LogComplexApprox(std::complex<double>(-7.646027846242066, 3.141592653589793)));
   CHECK(elec_.G[0][0] == ValueApprox(-2.181896934));
@@ -174,7 +174,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     std::vector<ValueType> ratios2(2);
     newpos2[0] = newpos - elec_.R[1];
     newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-    VP.makeMoves(1, elec_.R[1], newpos2);
+    VP.makeMoves(1, elec_, newpos2);
     twf.evaluateRatios(VP, ratios2);
 
     CHECK(std::real(ratios2[0]) == Approx(-0.8544310407));
@@ -205,7 +205,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     twf.evaluateLog(elec_);
 
     app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-               << std::endl;
+              << std::endl;
     CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
           LogComplexApprox(std::complex<double>(-7.803347327300154, 0.0)));
     CHECK(elec_.G[0][0] == ValueApprox(1.63020975849953));
@@ -244,9 +244,9 @@ void test_LiH_msd(const std::string& spo_xml_string,
     ParticleSet::mw_update(p_ref_list);
     TrialWaveFunction::mw_evaluateLog(wf_ref_list, p_ref_list);
     app_log() << "before YYY [0] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[0].getLogPsi() << " "
-               << wf_ref_list[0].getPhase() << std::endl;
+              << wf_ref_list[0].getPhase() << std::endl;
     app_log() << "before YYY [1] getLogPsi getPhase " << std::setprecision(16) << wf_ref_list[1].getLogPsi() << " "
-               << wf_ref_list[1].getPhase() << std::endl;
+              << wf_ref_list[1].getPhase() << std::endl;
     CHECK(std::complex<RealType>(wf_ref_list[0].getLogPsi(), wf_ref_list[0].getPhase()) ==
           LogComplexApprox(std::complex<RealType>(-7.803347327300153, 0.0)));
     CHECK(std::complex<RealType>(wf_ref_list[1].getLogPsi(), wf_ref_list[1].getPhase()) ==
@@ -450,7 +450,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
   //Reference values from QWalk with SOC
 
   app_log() << "twf.evaluateLog logpsi " << std::setprecision(16) << twf.getLogPsi() << " " << twf.getPhase()
-             << std::endl;
+            << std::endl;
   CHECK(std::complex<double>(twf.getLogPsi(), twf.getPhase()) ==
         LogComplexApprox(std::complex<double>(-9.653087, 3.311467)));
 

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -188,7 +188,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_.R[1], newpos2);
+  VP.makeMoves(1, elec_, newpos2);
   j3->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(1.0357541137));

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -188,7 +188,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_, newpos2);
+  VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
   j3->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(1.0357541137));

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-long.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-long.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-long.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-long.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-short.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-short.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-short.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-dmc-short.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-long.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-long.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-long.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-long.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-short.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-short.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-short.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/Mo-vmc-short.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc-dmc.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc-dmc.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc-dmc.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc-dmc.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="non-batched">
+    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>

--- a/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc.in.xml
+++ b/tests/solids/bccMo_2x1x1_SOREP/det_Mo-vmc.in.xml
@@ -58,7 +58,7 @@
     </jastrow>    
   </wavefunction>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes" algorithm="batched">
+      <pairpot type="pseudo" name="PseudoPot" source="i" wavefunction="psi0" format="xml" physicalSO="yes">
       <pseudo elementType="Mo" href="Mo.ccECP.xml"/>
     </pairpot>
     <constant name="IonIon" type="coulomb" source="i" target="i"/>


### PR DESCRIPTION
## Proposed changes

This PR adds VirtualParticleSets to SOECPs. This essentially makes it so that we no longer have to add an additional keyword to run with SOECPs since it can now use the default batched path with virtual particles. 

Note that while this is only implemented in the legacy APIs, this actually enables SOECPs to be used in the batched code since the default behavior of OperatorBase is to fallback to a loop over single walker APIs. So effectively, we have a path to run using the batched code, although it won't be as efficient as the mw implementation (coming soon). 

I did a little refactoring in SOECP, and had to change the makeMoves API in VirtualParticleSet so that we also store the current electron spin...otherwise the NonLocalECP part was failing when spinors were enabled. 

I also updated the short/long/determinanistic tests for bccMo to remove the algorithm=non-batched so that it uses the batched by default.

Also, I'm trying to make it so that I don't use raw pointers for the VirtualParticleSet (that's how it is still done in NonLocalECPComponent as well) and use smart pointers, but I ran into some hiccups as I was trying to change that and other things to use smart pointers. I'm still playing with that, but I wanted to go ahead and get this up so the rest of the code could be looked at. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_
- New feature
- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
my mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
