### PR TITLE
Update reference ParticleSet handling in VirtualParticleSet

### DIFF
--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -166,18 +166,19 @@ void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleS
   for (int iw = 0; iw < vp_list.size(); iw++)
   {
     VirtualParticleSet& vp(vp_list[iw]);
-    vp.refPS = refp_list[iw];
     const std::vector<PosType>& deltaV(deltaV_list[iw]);
     const NLPPJob<RealType>& job(joblist[iw]);
 
     vp.onSphere      = sphere;
+    vp.refPS         = refp_list[iw];
     vp.refPtcl       = job.electron_id;
     vp.refSourcePtcl = job.ion_id;
     assert(vp.R.size() == deltaV.size());
     for (size_t k = 0; k < vp.R.size(); k++, ivp++)
     {
-      vp.R[k] = job.elec_pos + deltaV[k];
-      //FIXME need to hand spinor ref from job //no spin deltas in this API
+      vp.R[k] = refp_list[iw].R[vp.refPtcl] + deltaV[k];
+      if (vp_leader.isSpinor())
+        vp.spins[k] = refp_list[iw].spins[vp.refPtcl]; //no spin deltas in this API
       mw_refPctls[ivp] = vp.refPtcl;
     }
     p_list.push_back(vp);

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -108,7 +108,7 @@ void VirtualParticleSet::makeMoves(const ParticleSet& refp,
     throw std::runtime_error(
         "VirtualParticleSet::makeMoves is invoked incorrectly, the flag sphere=true requires iat specified!");
   onSphere      = sphere;
-  refPS         = std::make_unique<std::reference_wrapper<const ParticleSet>>(refp);
+  refPS         = refp;
   refPtcl       = jel;
   refSourcePtcl = iat;
   assert(R.size() == deltaV.size());
@@ -133,7 +133,7 @@ void VirtualParticleSet::makeMovesWithSpin(const ParticleSet& refp,
     throw std::runtime_error(
         "VirtualParticleSet::makeMovesWithSpin is invoked incorrectly, the flag sphere=true requires iat specified!");
   onSphere      = sphere;
-  refPS         = std::make_unique<std::reference_wrapper<const ParticleSet>>(refp);
+  refPS         = refp;
   refPtcl       = jel;
   refSourcePtcl = iat;
   assert(R.size() == deltaV.size());
@@ -166,7 +166,7 @@ void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleS
   for (int iw = 0; iw < vp_list.size(); iw++)
   {
     VirtualParticleSet& vp(vp_list[iw]);
-    vp.refPS = std::make_unique<std::reference_wrapper<const ParticleSet>>(refp_list[iw]);
+    vp.refPS = refp_list[iw];
     const std::vector<PosType>& deltaV(deltaV_list[iw]);
     const NLPPJob<RealType>& job(joblist[iw]);
 

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -99,8 +99,6 @@ void VirtualParticleSet::releaseResource(ResourceCollection& collection,
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMoves(int jel,
-                                   const PosType& ref_pos,
-                                   const RealType ref_spin,
                                    const std::vector<PosType>& deltaV,
                                    bool sphere,
                                    int iat)
@@ -113,22 +111,21 @@ void VirtualParticleSet::makeMoves(int jel,
   refSourcePtcl = iat;
   assert(R.size() == deltaV.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
-  {
-    R[ivp]     = ref_pos + deltaV[ivp];
-    spins[ivp] = ref_spin; //no spin deltas in this API
-  }
+    R[ivp]     = refPS.R[jel] + deltaV[ivp];
+  if (refPS.isSpinor())
+    for (size_t ivp = 0; ivp < R.size(); ivp++)
+      spins[ivp] = refPS.spins[jel]; //no spin deltas in this API
   update();
 }
 
 /// move virtual particles to new postions and update distance tables
 void VirtualParticleSet::makeMovesWithSpin(int jel,
-                                           const PosType& ref_pos,
-                                           const RealType ref_spin,
                                            const std::vector<PosType>& deltaV,
                                            const std::vector<RealType>& deltaS,
                                            bool sphere,
                                            int iat)
 {
+  assert(refPS.isSpinor());
   if (sphere && iat < 0)
     throw std::runtime_error(
         "VirtualParticleSet::makeMovesWithSpin is invoked incorrectly, the flag sphere=true requires iat specified!");
@@ -139,8 +136,8 @@ void VirtualParticleSet::makeMovesWithSpin(int jel,
   assert(spins.size() == deltaS.size());
   for (size_t ivp = 0; ivp < R.size(); ivp++)
   {
-    R[ivp]     = ref_pos + deltaV[ivp];
-    spins[ivp] = ref_spin + deltaS[ivp];
+    R[ivp]     = refPS.R[jel] + deltaV[ivp];
+    spins[ivp] = refPS.spins[jel] + deltaS[ivp];
   }
   update();
 }
@@ -174,6 +171,7 @@ void VirtualParticleSet::mw_makeMoves(const RefVectorWithLeader<VirtualParticleS
     for (size_t k = 0; k < vp.R.size(); k++, ivp++)
     {
       vp.R[k]          = job.elec_pos + deltaV[k];
+      //FIXME need to hand spinor ref from job //no spin deltas in this API
       mw_refPctls[ivp] = vp.refPtcl;
     }
     p_list.push_back(vp);

--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -45,7 +45,8 @@ VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl) : Partic
   setSpinor(p.isSpinor());
   TotalNum = nptcl;
   R.resize(nptcl);
-  spins.resize(nptcl);
+  if (isSpinor())
+    spins.resize(nptcl);
   coordinates_->resize(nptcl);
 
   //create distancetables

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -75,31 +75,23 @@ public:
 
   /** move virtual particles to new postions and update distance tables
      * @param jel reference particle that all the VP moves from
-     * @param ref_pos reference particle position
-     * @param ref_spin reference particle spin
      * @param deltaV Position delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
   void makeMoves(int jel,
-                 const PosType& ref_pos,
-                 const RealType ref_spin,
                  const std::vector<PosType>& deltaV,
                  bool sphere = false,
                  int iat     = -1);
 
   /** move virtual particles to new postions and update distance tables
      * @param jel reference particle that all the VP moves from
-     * @param ref_pos reference particle position
-     * @param ref_spin reference particle spin
      * @param deltaV Position delta for virtual moves.
      * @param deltaS Spin delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
   void makeMovesWithSpin(int jel,
-                         const PosType& ref_pos,
-                         const RealType ref_spin,
                          const std::vector<PosType>& deltaV,
                          const std::vector<RealType>& deltaS,
                          bool sphere = false,

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -34,7 +34,6 @@ struct VPMultiWalkerMem;
  * VirtualParticleSet is introduced to avoid changing any internal states of the physical ParticleSet.
  * For this reason, the physical ParticleSet is always marked const.
  * It is heavily used by non-local PP evaluations.
- *
  */
 class VirtualParticleSet : public ParticleSet
 {

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -41,6 +41,9 @@ private:
 
   Vector<int, OffloadPinnedAllocator<int>>& getMultiWalkerRefPctls();
 
+  /// ParticleSet this object refers to after makeMoves
+  std::unique_ptr<std::reference_wrapper<const ParticleSet>> refPS;
+
 public:
   /// Reference particle
   int refPtcl;
@@ -48,7 +51,7 @@ public:
   int refSourcePtcl;
 
   /// ParticleSet this object refers to
-  const ParticleSet& refPS;
+  const ParticleSet& getRefPS() const { return *refPS; }
 
   inline bool isOnSphere() const { return onSphere; }
 
@@ -74,30 +77,31 @@ public:
   static void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<VirtualParticleSet>& vp_list);
 
   /** move virtual particles to new postions and update distance tables
+     * @param refp reference particle set
      * @param jel reference particle that all the VP moves from
      * @param deltaV Position delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
-  void makeMoves(int jel,
-                 const std::vector<PosType>& deltaV,
-                 bool sphere = false,
-                 int iat     = -1);
+  void makeMoves(const ParticleSet& refp, int jel, const std::vector<PosType>& deltaV, bool sphere = false, int iat = -1);
 
   /** move virtual particles to new postions and update distance tables
+     * @param refp reference particle set
      * @param jel reference particle that all the VP moves from
      * @param deltaV Position delta for virtual moves.
      * @param deltaS Spin delta for virtual moves.
      * @param sphere set true if VP are on a sphere around the reference source particle
      * @param iat reference source particle
      */
-  void makeMovesWithSpin(int jel,
+  void makeMovesWithSpin(const ParticleSet& refp,
+                         int jel,
                          const std::vector<PosType>& deltaV,
                          const std::vector<RealType>& deltaS,
                          bool sphere = false,
                          int iat     = -1);
 
   static void mw_makeMoves(const RefVectorWithLeader<VirtualParticleSet>& vp_list,
+                           const RefVectorWithLeader<ParticleSet>& p_list,
                            const RefVector<const std::vector<PosType>>& deltaV_list,
                            const RefVector<const NLPPJob<RealType>>& joblist,
                            bool sphere);

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -29,8 +29,13 @@ template<typename T>
 struct NLPPJob;
 struct VPMultiWalkerMem;
 
-/** Introduced to handle virtual moves and ratio computations, e.g. for non-local PP evaluations.
-   */
+/** A ParticleSet that handles virtual moves of a selected particle of a given physical ParticleSet
+ * Virtual moves are defined as moves being proposed but will never be accepted.
+ * VirtualParticleSet is introduced to avoid changing any internal states of the physical ParticleSet.
+ * For this reason, the physical ParticleSet is always marked const.
+ * It is heavily used by non-local PP evaluations.
+ *
+ */
 class VirtualParticleSet : public ParticleSet
 {
 private:
@@ -42,7 +47,7 @@ private:
   Vector<int, OffloadPinnedAllocator<int>>& getMultiWalkerRefPctls();
 
   /// ParticleSet this object refers to after makeMoves
-  std::unique_ptr<std::reference_wrapper<const ParticleSet>> refPS;
+  std::optional<std::reference_wrapper<const ParticleSet>> refPS;
 
 public:
   /// Reference particle
@@ -51,7 +56,7 @@ public:
   int refSourcePtcl;
 
   /// ParticleSet this object refers to
-  const ParticleSet& getRefPS() const { return *refPS; }
+  const ParticleSet& getRefPS() const { return refPS.value(); }
 
   inline bool isOnSphere() const { return onSphere; }
 

--- a/src/QMCHamiltonians/NLPPJob.h
+++ b/src/QMCHamiltonians/NLPPJob.h
@@ -29,7 +29,6 @@ struct NLPPJob
   using PosType  = TinyVector<RealType, 3>;
   const int ion_id;
   const int electron_id;
-  const PosType elec_pos;
   const RealType ion_elec_dist;
   const PosType ion_elec_displ;
 
@@ -39,12 +38,10 @@ struct NLPPJob
    */
   NLPPJob(const int ion_id_in,
           const int electron_id_in,
-          const PosType& elec_pos_in,
           const RealType ion_elec_dist_in,
           const PosType& ion_elec_displ_in)
       : ion_id(ion_id_in),
         electron_id(electron_id_in),
-        elec_pos(elec_pos_in),
         ion_elec_dist(ion_elec_dist_in),
         ion_elec_displ(ion_elec_displ_in)
   {}

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -135,7 +135,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, deltaV, true, iat);
+    VP->makeMoves(W, iel, deltaV, true, iat);
     if (use_DLA)
       psi.evaluateRatios(*VP, psiratio, TrialWaveFunction::ComputeType::FERMIONIC);
     else
@@ -232,7 +232,7 @@ void NonLocalECPComponent::mw_evaluateOne(const RefVectorWithLeader<NonLocalECPC
 
     ResourceCollectionTeamLock<VirtualParticleSet> vp_res_lock(collection, vp_list);
 
-    VirtualParticleSet::mw_makeMoves(vp_list, deltaV_list, joblist, true);
+    VirtualParticleSet::mw_makeMoves(vp_list, p_list, deltaV_list, joblist, true);
 
     if (use_DLA)
       TrialWaveFunction::mw_evaluateRatios(psi_list, const_vp_list, psiratios_list,
@@ -310,7 +310,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, deltaV, true, iat);
+    VP->makeMoves(W, iel, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else
@@ -460,7 +460,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, deltaV, true, iat);
+    VP->makeMoves(W, iel, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -135,7 +135,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOne(ParticleSet& W,
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
+    VP->makeMoves(iel, deltaV, true, iat);
     if (use_DLA)
       psi.evaluateRatios(*VP, psiratio, TrialWaveFunction::ComputeType::FERMIONIC);
     else
@@ -310,7 +310,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
+    VP->makeMoves(iel, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else
@@ -460,7 +460,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateOneWithForces(Parti
   {
     APP_ABORT("NonLocalECPComponent::evaluateOneWithForces(...): Forces not implemented with virtual particle moves\n");
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
+    VP->makeMoves(iel, deltaV, true, iat);
     psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -325,7 +325,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
           {
             NeighborIons.push_back(iat);
             O.IonNeighborElecs.getNeighborList(iat).push_back(jel);
-            joblist.emplace_back(iat, jel, P.R[jel], dist[iat], -displ[iat]);
+            joblist.emplace_back(iat, jel, dist[iat], -displ[iat]);
           }
       }
     }

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -81,7 +81,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, deltaV, true, iat);
+    VP->makeMoves(W, iel, deltaV, true, iat);
     psi.evaluateDerivRatios(*VP, optvars, psiratio, dratio);
   }
   else

--- a/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.deriv.cpp
@@ -81,7 +81,7 @@ NonLocalECPComponent::RealType NonLocalECPComponent::evaluateValueAndDerivatives
   if (VP)
   {
     // Compute ratios with VP
-    VP->makeMoves(iel, W.R[iel], W.spins[iel], deltaV, true, iat);
+    VP->makeMoves(iel, deltaV, true, iat);
     psi.evaluateDerivRatios(*VP, optvars, psiratio, dratio);
   }
   else

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -135,7 +135,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
 
   if (VP)
   {
-    VP->makeMovesWithSpin(iel, deltaV, deltaS, true, iat);
+    VP->makeMovesWithSpin(W, iel, deltaV, deltaS, true, iat);
     Psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/SOECPComponent.cpp
+++ b/src/QMCHamiltonians/SOECPComponent.cpp
@@ -135,7 +135,7 @@ SOECPComponent::ComplexType SOECPComponent::getAngularIntegral(RealType sold,
 
   if (VP)
   {
-    VP->makeMovesWithSpin(iel, W.R[iel], W.spins[iel], deltaV, deltaS, true, iat);
+    VP->makeMovesWithSpin(iel, deltaV, deltaS, true, iat);
     Psi.evaluateRatios(*VP, psiratio);
   }
   else

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -472,6 +472,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
 
 
   elec.setName("e");
+  elec.setSpinor(true);
   elec.create({1});
   elec.R[0][0]  = 0.138;
   elec.R[0][1]  = -0.24;

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -569,7 +569,7 @@ public:
   {
     const int center_idx = VP.refSourcePtcl;
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
-    return VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx] < myCenter.getNonOverlappingRadius();
+    return VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx] < myCenter.getNonOverlappingRadius();
   }
 
   // C2C, C2R cases
@@ -577,7 +577,7 @@ public:
   inline RealType evaluateValuesC2X(const VirtualParticleSet& VP, VM& multi_myV)
   {
     const int center_idx = VP.refSourcePtcl;
-    dist_r               = VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
+    dist_r               = VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
     if (dist_r < myCenter.getCutoff())
     {
@@ -596,7 +596,7 @@ public:
                                     SV& bc_signs)
   {
     const int center_idx = VP.refSourcePtcl;
-    dist_r               = VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
+    dist_r               = VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx];
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
     if (dist_r < myCenter.getCutoff())
     {

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -588,7 +588,7 @@ public:
       const size_t ns = d_table.sources();
       const size_t nt = VP.getTotalNum();
 
-      const auto& dist_ref = VP.refPS.getDistTableAB(myTableID).getDistRow(VP.refPtcl);
+      const auto& dist_ref = VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl);
 
       for (size_t i = 0; i < ns; ++i)
       {

--- a/src/QMCWaveFunctions/Jastrow/J1Spin.h
+++ b/src/QMCWaveFunctions/Jastrow/J1Spin.h
@@ -232,7 +232,7 @@ struct J1Spin : public WaveFunctionComponent
   {
     for (int k = 0; k < ratios.size(); ++k)
       ratios[k] =
-          std::exp(Vat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTableAB(myTableID).getDistRow(k)));
+          std::exp(Vat[VP.refPtcl] - computeU(VP.getRefPS(), VP.refPtcl, VP.getDistTableAB(myTableID).getDistRow(k)));
   }
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -399,7 +399,7 @@ public:
     assert(VP.getTotalNum() == ratios.size());
     for (int k = 0; k < ratios.size(); ++k)
       ratios[k] = std::exp(Uat[VP.refPtcl] -
-                           computeU(VP.refPS, VP.refPtcl, VP.refPS.GroupID[VP.refPtcl],
+                           computeU(VP.getRefPS(), VP.refPtcl, VP.getRefPS().GroupID[VP.refPtcl],
                                     VP.getDistTableAB(ei_Table_ID_).getDistRow(k),
                                     VP.getDistTableAB(ee_Table_ID_).getDistRow(k), ions_nearby_old));
   }
@@ -969,7 +969,7 @@ public:
     {
       constexpr valT czero(0);
 
-      const auto& refPS    = VP.refPS;
+      const auto& refPS    = VP.getRefPS();
       const auto& ee_dists = refPS.getDistTableAA(ee_Table_ID_).getDistances();
       const auto& ei_dists = refPS.getDistTableAB(ei_Table_ID_).getDistances();
 

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.cpp
@@ -173,7 +173,7 @@ void TwoBodyJastrow<FT>::evaluateRatios(const VirtualParticleSet& VP, std::vecto
 {
   for (int k = 0; k < ratios.size(); ++k)
     ratios[k] =
-        std::exp(Uat[VP.refPtcl] - computeU(VP.refPS, VP.refPtcl, VP.getDistTableAB(my_table_ID_).getDistRow(k)));
+        std::exp(Uat[VP.refPtcl] - computeU(VP.getRefPS(), VP.refPtcl, VP.getDistTableAB(my_table_ID_).getDistRow(k)));
 }
 
 template<typename FT>
@@ -201,7 +201,7 @@ void TwoBodyJastrow<FT>::mw_evaluateRatios(const RefVectorWithLeader<WaveFunctio
 
   // need to access the spin group of refPtcl. vp_leader doesn't necessary be a member of the list.
   // for this reason, refPtcl must be access from [0].
-  const int igt = vp_leader.refPS.getGroupID(vp_list[0].refPtcl);
+  const int igt = vp_leader.getRefPS().getGroupID(vp_list[0].refPtcl);
   const auto& dt_leader(vp_leader.getDistTableAB(wfc_leader.my_table_ID_));
 
   FT::mw_evaluateV(NumGroups, F.data() + igt * NumGroups, wfc_leader.N, grp_ids.data(), nVPs, mw_refPctls.data(),
@@ -1019,11 +1019,11 @@ void TwoBodyJastrow<FT>::evaluateDerivRatios(const VirtualParticleSet& VP,
     {
       if (i == VP.refPtcl)
         continue;
-      const size_t ptype = VP.refPS.GroupID[i] * VP.refPS.groups() + VP.refPS.GroupID[VP.refPtcl];
+      const size_t ptype = VP.getRefPS().GroupID[i] * VP.getRefPS().groups() + VP.getRefPS().GroupID[VP.refPtcl];
       if (!RecalcSwitch[ptype])
         continue;
-      const auto dist_ref = i < VP.refPtcl ? VP.refPS.getDistTableAA(my_table_ID_).getDistRow(VP.refPtcl)[i]
-                                           : VP.refPS.getDistTableAA(my_table_ID_).getDistRow(i)[VP.refPtcl];
+      const auto dist_ref = i < VP.refPtcl ? VP.getRefPS().getDistTableAA(my_table_ID_).getDistRow(VP.refPtcl)[i]
+                                           : VP.getRefPS().getDistTableAA(my_table_ID_).getDistRow(i)[VP.refPtcl];
       //first calculate the old derivatives VP.refPtcl.
       std::fill(derivs_ref.begin(), derivs_ref.end(), 0.0);
       F[ptype]->evaluateDerivatives(dist_ref, derivs_ref);

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -123,7 +123,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec.R[1], elec.spins[1], newpos2);
+  VP.makeMoves(1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminant.cpp
@@ -123,7 +123,7 @@ void test_DiracDeterminant_first(const DetMatInvertor inverter_kind)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, newpos2);
+  VP.makeMoves(elec, 1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -109,7 +109,7 @@ void test_DiracDeterminantBatched_first()
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, elec.R[1], elec.spins[1], newpos2);
+  VP.makeMoves(1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/tests/test_DiracDeterminantBatched.cpp
@@ -109,7 +109,7 @@ void test_DiracDeterminantBatched_first()
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec.R[1];
-  VP.makeMoves(1, newpos2);
+  VP.makeMoves(elec, 1, newpos2);
   ddb.evaluateRatios(VP, ratios2);
 
   CHECK(std::real(ratios2[0]) == Approx(0.4880285278));

--- a/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
@@ -427,7 +427,7 @@ void test_J1_spline(const DynamicCoordinateKind kind_selected)
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};
 
-  VirtualParticleSet::mw_makeMoves(vp_list, {deltaV1, deltaV2}, {job1, job2}, false);
+  VirtualParticleSet::mw_makeMoves(vp_list, p_ref_list, {deltaV1, deltaV2}, {job1, job2}, false);
 
   std::vector<std::vector<ValueType>> nlpp_ratios(2);
   nlpp_ratios[0].resize(nknot);

--- a/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1_bspline.cpp
@@ -419,10 +419,10 @@ void test_J1_spline(const DynamicCoordinateKind kind_selected)
   const int ei_table_index = elec_.addTable(ions_);
   const auto& ei_table1    = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, elec_.R[0], ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, elec_clone.R[1], ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -239,7 +239,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, newpos2);
+  VP.makeMoves(elec_, 1, newpos2);
   j2->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(0.9871985577));

--- a/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
+++ b/src/QMCWaveFunctions/tests/test_J2_bspline.cpp
@@ -239,7 +239,7 @@ TEST_CASE("BSpline builder Jastrow J2", "[wavefunction]")
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
+  VP.makeMoves(1, newpos2);
   j2->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(0.9871985577));

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -263,7 +263,7 @@ void test_Ne(bool transform)
     std::vector<SPOSet::ValueType> ratios2(2);
     newpos2[0] = disp;
     newpos2[1] = -disp;
-    VP.makeMoves(0, newpos2);
+    VP.makeMoves(elec, 0, newpos2);
     sposet->evaluateDetRatios(VP, phi, phiinv, ratios2);
     CHECK(ratios2[0] == Approx(-0.504163137)); // values[0] * phiinv[0]
     CHECK(ratios2[1] == Approx(-0.504163137)); // symmetric move

--- a/src/QMCWaveFunctions/tests/test_MO.cpp
+++ b/src/QMCWaveFunctions/tests/test_MO.cpp
@@ -263,7 +263,7 @@ void test_Ne(bool transform)
     std::vector<SPOSet::ValueType> ratios2(2);
     newpos2[0] = disp;
     newpos2[1] = -disp;
-    VP.makeMoves(0, elec.R[0], elec.spins[0], newpos2);
+    VP.makeMoves(0, newpos2);
     sposet->evaluateDetRatios(VP, phi, phiinv, ratios2);
     CHECK(ratios2[0] == Approx(-0.504163137)); // values[0] * phiinv[0]
     CHECK(ratios2[1] == Approx(-0.504163137)); // symmetric move

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -557,10 +557,10 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   const auto& ei_table1 = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, elec_.R[0], ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, elec_clone.R[1], ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -565,7 +565,7 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};
 
-  VirtualParticleSet::mw_makeMoves(vp_list, {deltaV1, deltaV2}, {job1, job2}, false);
+  VirtualParticleSet::mw_makeMoves(vp_list, p_ref_list, {deltaV1, deltaV2}, {job1, job2}, false);
 
   std::vector<ValueType> nlpp1_ratios(nknot), nlpp2_ratios(nknot);
   TrialWaveFunction::mw_evaluateRatios(wf_ref_list, RefVectorWithLeader<const VirtualParticleSet>(vp, {vp, vp_clone}),

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -174,7 +174,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     std::vector<ValueType> ratios2(2);
     newpos2[0] = newpos - elec_.R[1];
     newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-    VP.makeMoves(1, newpos2);
+    VP.makeMoves(elec_, 1, newpos2);
     twf.evaluateRatios(VP, ratios2);
 
     CHECK(std::real(ratios2[0]) == Approx(-0.8544310407));

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -174,7 +174,7 @@ void test_LiH_msd(const std::string& spo_xml_string,
     std::vector<ValueType> ratios2(2);
     newpos2[0] = newpos - elec_.R[1];
     newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-    VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
+    VP.makeMoves(1, newpos2);
     twf.evaluateRatios(VP, ratios2);
 
     CHECK(std::real(ratios2[0]) == Approx(-0.8544310407));

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -188,7 +188,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, newpos2);
+  VP.makeMoves(elec_, 1, newpos2);
   j3->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(1.0357541137));
@@ -243,7 +243,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};
 
-  VirtualParticleSet::mw_makeMoves(vp_list, {deltaV1, deltaV2}, {job1, job2}, false);
+  VirtualParticleSet::mw_makeMoves(vp_list, p_ref_list, {deltaV1, deltaV2}, {job1, job2}, false);
 
   std::vector<std::vector<ValueType>> nlpp_ratios(2);
   nlpp_ratios[0].resize(nknot);

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -235,10 +235,10 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   const int ei_table_index = elec_.addTable(ions_);
   const auto& ei_table1    = elec_.getDistTableAB(ei_table_index);
   // make virtual move of elec 0, reference ion 1
-  NLPPJob<RealType> job1(1, 0, elec_.R[0], ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
+  NLPPJob<RealType> job1(1, 0, ei_table1.getDistances()[0][1], -ei_table1.getDisplacements()[0][1]);
   const auto& ei_table2 = elec_clone.getDistTableAB(ei_table_index);
   // make virtual move of elec 1, reference ion 3
-  NLPPJob<RealType> job2(3, 1, elec_clone.R[1], ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
+  NLPPJob<RealType> job2(3, 1, ei_table2.getDistances()[1][3], -ei_table2.getDisplacements()[1][3]);
 
   std::vector<PosType> deltaV1{{0.1, 0.2, 0.3}, {0.1, 0.3, 0.2}, {0.2, 0.1, 0.3}};
   std::vector<PosType> deltaV2{{0.02, 0.01, 0.03}, {0.02, 0.03, 0.01}, {0.03, 0.01, 0.02}};

--- a/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_polynomial_eeI_jastrow.cpp
@@ -188,7 +188,7 @@ void test_J3_polynomial3D(const DynamicCoordinateKind kind_selected)
   std::vector<ValueType> ratios2(2);
   newpos2[0] = newpos - elec_.R[1];
   newpos2[1] = PosType(0.2, 0.5, 0.3) - elec_.R[1];
-  VP.makeMoves(1, elec_.R[1], elec_.spins[1], newpos2);
+  VP.makeMoves(1, newpos2);
   j3->evaluateRatios(VP, ratios2);
 
   REQUIRE(std::real(ratios2[0]) == Approx(1.0357541137));


### PR DESCRIPTION
## Proposed changes
It is better to update the reference ParticleSet whenever makeMoves happen.

## What type(s) of changes does this code introduce?
- Refactoring

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted