### PR TITLE
Sycl queue created instead of copy

### DIFF
--- a/src/Platforms/SYCL/SYCLDeviceManager.cpp
+++ b/src/Platforms/SYCL/SYCLDeviceManager.cpp
@@ -132,11 +132,16 @@ SYCLDeviceManager::SYCLDeviceManager(int& default_device_num, int& num_devices, 
   }
 }
 
-sycl::queue& SYCLDeviceManager::getDefaultDeviceQueue()
+sycl::queue& SYCLDeviceManager::getDefaultDeviceDefaultQueue()
 {
   if (!default_device_queue)
     throw std::runtime_error("SYCLDeviceManager::getDefaultDeviceQueue() the global instance not initialized.");
   return *default_device_queue;
+}
+
+sycl::queue SYCLDeviceManager::createQueueDefaultDevice() const
+{
+  return sycl::queue(visible_devices[sycl_default_device_num].get_context(), visible_devices[sycl_default_device_num].get_device());
 }
 
 } // namespace qmcplusplus

--- a/src/Platforms/SYCL/SYCLDeviceManager.h
+++ b/src/Platforms/SYCL/SYCLDeviceManager.h
@@ -62,7 +62,8 @@ public:
    * Restrict the use of it to performance non-critical operations.
    * Note: CUDA has a default queue but all the SYCL queues are explicit.
    */
-  static sycl::queue& getDefaultDeviceQueue();
+  static sycl::queue& getDefaultDeviceDefaultQueue();
+  sycl::queue createQueueDefaultDevice() const;
 };
 } // namespace qmcplusplus
 

--- a/src/Platforms/SYCL/SYCLruntime.cpp
+++ b/src/Platforms/SYCL/SYCLruntime.cpp
@@ -15,5 +15,5 @@
 
 namespace qmcplusplus
 {
-sycl::queue getSYCLDefaultDeviceDefaultQueue() { return SYCLDeviceManager::getDefaultDeviceQueue(); }
+sycl::queue getSYCLDefaultDeviceDefaultQueue() { return SYCLDeviceManager::getDefaultDeviceDefaultQueue(); }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
+++ b/src/QMCWaveFunctions/Fermion/DelayedUpdateSYCL.h
@@ -21,6 +21,7 @@
 #include "DiracMatrix.h"
 #include "PrefetchedRange.h"
 #include "syclSolverInverter.hpp"
+#include "DeviceManager.h"
 
 //#define SYCL_BLOCKING
 
@@ -70,7 +71,7 @@ class DelayedUpdateSYCL
 
 public:
   /// default constructor
-  DelayedUpdateSYCL() : delay_count(0) { m_queue_ = getSYCLDefaultDeviceDefaultQueue(); }
+  DelayedUpdateSYCL() : delay_count(0) { m_queue_ = DeviceManager::getGlobal().getSYCLDM().createQueueDefaultDevice(); }
 
   ~DelayedUpdateSYCL() {}
 


### PR DESCRIPTION
## Proposed changes
SYCL queue copy constructor only does shallow copy. Underlying level 0 objects are shared and caused performance penalty due to undesired entanglement.
Make actual queue creation from device and context instead of copying.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
sunspot

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'