### PR TITLE
Reorder nlpp construction to near beginning

### DIFF
--- a/src/Particle/VirtualParticleSet.cpp
+++ b/src/Particle/VirtualParticleSet.cpp
@@ -37,7 +37,7 @@ struct VPMultiWalkerMem : public Resource
   Resource* makeClone() const override { return new VPMultiWalkerMem(*this); }
 };
 
-VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl) : ParticleSet(p.getSimulationCell())
+VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl, size_t dt_count_limit) : ParticleSet(p.getSimulationCell())
 {
   setName("virtual");
 
@@ -50,7 +50,10 @@ VirtualParticleSet::VirtualParticleSet(const ParticleSet& p, int nptcl) : Partic
   coordinates_->resize(nptcl);
 
   //create distancetables
-  for (int i = 0; i < p.getNumDistTables(); ++i)
+  assert(dt_count_limit <= p.getNumDistTables());
+  if (dt_count_limit == 0)
+    dt_count_limit = p.getNumDistTables();
+  for (int i = 0; i < dt_count_limit; ++i)
     if (p.getDistTable(i).getModes() & DTModes::NEED_VP_FULL_TABLE_ON_HOST)
       addTable(p.getDistTable(i).get_origin());
     else

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -64,8 +64,9 @@ public:
   /** constructor 
      * @param p ParticleSet whose virtual moves are handled by this object
      * @param nptcl number of virtual particles
+     * @param dt_count_limit distance tables corresepond to [0, dt_count_limit) of the reference particle set are created
      */
-  VirtualParticleSet(const ParticleSet& p, int nptcl);
+  VirtualParticleSet(const ParticleSet& p, int nptcl, size_t dt_count_limit = 0);
 
   ~VirtualParticleSet();
 

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -153,8 +153,6 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
 #if OHMMS_DIM == 3
       else if (potType == "MPC" || potType == "mpc")
         addMPCPotential(element);
-      else if (potType == "pseudo")
-        addPseudoPotential(element);
 #endif
     }
     else if (cname == "constant")
@@ -387,6 +385,15 @@ bool HamiltonianFactory::build(xmlNodePtr cur)
       targetH->addOperatorType(potName, potType);
     }
   });
+
+  // Other Hamiltonian elements or estimators may add distance tables in particle sets.
+  // Virtual particle sets must have the same distance table count.
+  // Process pseudopotentials last to avoid size mismatch.
+  processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
+    if (cname == "pairpot" && getXMLAttributeValue(element, "type") == "pseudo")
+      addPseudoPotential(element);
+  });
+
   //add observables with physical and simple estimators
   targetH->addObservables(targetPtcl);
   //do correction

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -135,13 +135,10 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
   // KineticEnergy must be the first element in the hamiltonian array.
   if (defaultKE != "no")
     targetH->addOperator(std::make_unique<BareKineticEnergy>(targetPtcl, *targetPsi), "Kinetic");
-  xmlNodePtr cur_saved(cur);
-  cur = cur->children;
-  while (cur != NULL)
-  {
+
+  processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
     std::string notype = "0";
     std::string noname = "any";
-    std::string cname((const char*)cur->name);
     std::string potType(notype);
     std::string potName(noname);
     std::string potUnit("hartree");
@@ -156,7 +153,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
     attrib.add(potName, "name");
     attrib.add(potUnit, "units");
     attrib.add(estType, "potential");
-    attrib.put(cur);
+    attrib.put(element);
     renameProperty(sourceInp);
     renameProperty(targetInp);
 
@@ -165,41 +162,41 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
     {
       if (potType == "coulomb")
       {
-        addCoulombPotential(cur);
+        addCoulombPotential(element);
       }
 #if !defined(QMC_CUDA)
       else if (potType == "skpot")
       {
         std::unique_ptr<SkPot> hs = std::make_unique<SkPot>(targetPtcl);
-        hs->put(cur);
+        hs->put(element);
         targetH->addOperator(std::move(hs), "SkPot", true);
       }
 #endif
 #if OHMMS_DIM == 3
       else if (potType == "MPC" || potType == "mpc")
-        addMPCPotential(cur);
+        addMPCPotential(element);
       else if (potType == "pseudo")
-        addPseudoPotential(cur);
+        addPseudoPotential(element);
 #endif
     }
     else if (cname == "constant")
     {
       //just to support old input
       if (potType == "coulomb")
-        addCoulombPotential(cur);
+        addCoulombPotential(element);
     }
     else if (cname == "extpot")
     {
       if (potType == "harmonic_ext" || potType == "HarmonicExt")
       {
         std::unique_ptr<HarmonicExternalPotential> hs = std::make_unique<HarmonicExternalPotential>(targetPtcl);
-        hs->put(cur);
+        hs->put(element);
         targetH->addOperator(std::move(hs), "HarmonicExt", true);
       }
       if (potType == "grid")
       {
         std::unique_ptr<GridExternalPotential> hs = std::make_unique<GridExternalPotential>(targetPtcl);
-        hs->put(cur);
+        hs->put(element);
         targetH->addOperator(std::move(hs), "Grid", true);
       }
     }
@@ -212,7 +209,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       else if (potType == "specieskinetic")
       {
         std::unique_ptr<SpeciesKineticEnergy> apot = std::make_unique<SpeciesKineticEnergy>(targetPtcl);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "latticedeviation")
@@ -236,21 +233,21 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         std::string target_group, source_group;
         local_attrib.add(target_group, "tgroup");
         local_attrib.add(source_group, "sgroup");
-        local_attrib.put(cur);
+        local_attrib.put(element);
 
         std::unique_ptr<LatticeDeviationEstimator> apot =
             std::make_unique<LatticeDeviationEstimator>(*pit->second, *spit->second, target_group, source_group);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "Force")
       {
-        addForceHam(cur);
+        addForceHam(element);
       }
       else if (potType == "gofr")
       {
         std::unique_ptr<PairCorrEstimator> apot = std::make_unique<PairCorrEstimator>(targetPtcl, sourceInp);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "density")
@@ -258,7 +255,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         //          if(PBCType)//only if perioidic
         {
           std::unique_ptr<DensityEstimator> apot = std::make_unique<DensityEstimator>(targetPtcl);
-          apot->put(cur);
+          apot->put(element);
           targetH->addOperator(std::move(apot), potName, false);
         }
       }
@@ -266,14 +263,14 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       {
         app_log() << "  Adding SpinDensity" << std::endl;
         std::unique_ptr<SpinDensity> apot = std::make_unique<SpinDensity>(targetPtcl);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "structurefactor")
       {
         app_log() << "  Adding StaticStructureFactor" << std::endl;
         std::unique_ptr<StaticStructureFactor> apot = std::make_unique<StaticStructureFactor>(targetPtcl);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "orbitalimages")
@@ -281,7 +278,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         app_log() << "  Adding OrbitalImages" << std::endl;
         std::unique_ptr<OrbitalImages> apot =
             std::make_unique<OrbitalImages>(targetPtcl, ptclPool, myComm, targetPsi->getSPOMap());
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
 #if !defined(REMOVE_TRACEMANAGER)
@@ -289,7 +286,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
       {
         app_log() << "  Adding EnergyDensityEstimator" << std::endl;
         std::unique_ptr<EnergyDensityEstimator> apot = std::make_unique<EnergyDensityEstimator>(ptclPool, defaultKE);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
       else if (potType == "dm1b")
@@ -298,7 +295,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         std::string source = "";
         OhmmsAttributeSet attrib;
         attrib.add(source, "source");
-        attrib.put(cur);
+        attrib.put(element);
         auto pit(ptclPool.find(source));
         ParticleSet* Pc = nullptr;
         if (source == "")
@@ -310,7 +307,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
           APP_ABORT("Unknown source \"" + source + "\" for DensityMatrices1B");
         }
         std::unique_ptr<DensityMatrices1B> apot = std::make_unique<DensityMatrices1B>(targetPtcl, *targetPsi, Pc);
-        apot->put(cur);
+        apot->put(element);
         targetH->addOperator(std::move(apot), potName, false);
       }
 #endif
@@ -323,7 +320,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
 #else
           std::unique_ptr<SkEstimator> apot = std::make_unique<SkEstimator>(targetPtcl);
 #endif
-          apot->put(cur);
+          apot->put(element);
           targetH->addOperator(std::move(apot), potName, false);
           app_log() << "Adding S(k) estimator" << std::endl;
         }
@@ -336,7 +333,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         OhmmsAttributeSet hAttrib;
         hAttrib.add(PsiName, "psi");
         hAttrib.add(SourceName, "source");
-        hAttrib.put(cur);
+        hAttrib.put(element);
         auto pit(ptclPool.find(SourceName));
         if (pit == ptclPool.end())
         {
@@ -357,7 +354,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         std::string SourceName = "";
         OhmmsAttributeSet attrib;
         attrib.add(SourceName, "source");
-        attrib.put(cur);
+        attrib.put(element);
 
         auto pit(ptclPool.find(SourceName));
         if (pit == ptclPool.end())
@@ -368,7 +365,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         if (PBCType)
         {
           std::unique_ptr<SkAllEstimator> apot = std::make_unique<SkAllEstimator>(*pit->second, targetPtcl);
-          apot->put(cur);
+          apot->put(element);
           targetH->addOperator(std::move(apot), potName, false);
           app_log() << "Adding S(k) ALL estimator" << std::endl;
         }
@@ -380,11 +377,11 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         if (estType == "coulomb")
         {
           std::unique_ptr<Pressure> BP = std::make_unique<Pressure>(targetPtcl);
-          BP->put(cur);
+          BP->put(element);
           targetH->addOperator(std::move(BP), "Pressure", false);
           int nlen(100);
           attrib.add(nlen, "truncateSum");
-          attrib.put(cur);
+          attrib.put(element);
           //             DMCPressureCorr* DMCP = new DMCPressureCorr(targetPtcl,nlen);
           //             targetH->addOperator(DMCP,"PressureSum",false);
         }
@@ -395,7 +392,7 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         std::string PsiName = "psi0";
         OhmmsAttributeSet hAttrib;
         hAttrib.add(PsiName, "wavefunction");
-        hAttrib.put(cur);
+        hAttrib.put(element);
         auto psi_it(psiPool.find(PsiName));
         if (psi_it == psiPool.end())
         {
@@ -403,18 +400,9 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
         }
         std::unique_ptr<MomentumEstimator> ME = std::make_unique<MomentumEstimator>(targetPtcl, *psi_it->second);
         bool rt(myComm->rank() == 0);
-        ME->putSpecial(cur, targetPtcl, rt);
+        ME->putSpecial(element, targetPtcl, rt);
         targetH->addOperator(std::move(ME), "MomentumEstimator", false);
       }
-    }
-    else if (cname == "Kinetic")
-    {
-      std::string TargetName = "e";
-      std::string SourceName = "I";
-      OhmmsAttributeSet hAttrib;
-      hAttrib.add(TargetName, "Dependant");
-      hAttrib.add(SourceName, "Independent");
-      hAttrib.put(cur);
     }
 
     if (nham < targetH->total_size()) //if(cname!="text" && cname !="comment")
@@ -429,48 +417,26 @@ bool HamiltonianFactory::build(xmlNodePtr cur, bool buildtree)
     }
 
     if (attach2Node)
-      xmlAddChild(myNode, xmlCopyNode(cur, 1));
-    cur = cur->next;
-  }
+      xmlAddChild(myNode, xmlCopyNode(element, 1));
+  });
   //add observables with physical and simple estimators
   targetH->addObservables(targetPtcl);
   //do correction
   bool dmc_correction = false;
-  cur                 = cur_saved->children;
-  while (cur != NULL)
-  {
-    std::string cname((const char*)cur->name);
+  processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
     std::string potType("0");
     OhmmsAttributeSet attrib;
     attrib.add(potType, "type");
-    attrib.put(cur);
-    if (cname == "estimator")
+    attrib.put(element);
+    if (cname == "estimator" && potType == "ForwardWalking")
     {
-      if (potType == "ZeroVarObs")
-      {
-        app_log() << "  Not Adding ZeroVarObs Operator" << std::endl;
-        //         ZeroVarObs* FW=new ZeroVarObs();
-        //         FW->put(cur,*targetH,targetPtcl);
-        //         targetH->addOperator(FW,"ZeroVarObs",false);
-      }
-      //         else if(potType == "DMCCorrection")
-      //         {
-      //           TrialDMCCorrection* TE = new TrialDMCCorrection();
-      //           TE->putSpecial(cur,*targetH,targetPtcl);
-      //           targetH->addOperator(TE,"DMC_CORR",false);
-      //           dmc_correction=true;
-      //         }
-      else if (potType == "ForwardWalking")
-      {
-        app_log() << "  Adding Forward Walking Operator" << std::endl;
-        std::unique_ptr<ForwardWalking> FW = std::make_unique<ForwardWalking>();
-        FW->putSpecial(cur, *targetH, targetPtcl);
-        targetH->addOperator(std::move(FW), "ForwardWalking", false);
-        dmc_correction = true;
-      }
+      app_log() << "  Adding Forward Walking Operator" << std::endl;
+      std::unique_ptr<ForwardWalking> FW = std::make_unique<ForwardWalking>();
+      FW->putSpecial(element, *targetH, targetPtcl);
+      targetH->addOperator(std::move(FW), "ForwardWalking", false);
+      dmc_correction = true;
     }
-    cur = cur->next;
-  }
+  });
   //evaluate the observables again
   if (dmc_correction)
     targetH->addObservables(targetPtcl);

--- a/src/QMCHamiltonians/HamiltonianFactory.cpp
+++ b/src/QMCHamiltonians/HamiltonianFactory.cpp
@@ -47,7 +47,6 @@
 #include "QMCHamiltonians/ChiesaCorrection.h"
 #include "QMCHamiltonians/SkAllEstimator.h"
 #endif
-// #include "QMCHamiltonians/ZeroVarObs.h"
 #if !defined(QMC_CUDA)
 #include "QMCHamiltonians/SkPot.h"
 #endif

--- a/src/QMCHamiltonians/HamiltonianFactory.h
+++ b/src/QMCHamiltonians/HamiltonianFactory.h
@@ -60,7 +60,7 @@ public:
 private:
   /** process xmlNode to populate targetPsi
    */
-  bool build(xmlNodePtr cur, bool buildtree);
+  bool build(xmlNodePtr cur);
 
   void addCoulombPotential(xmlNodePtr cur);
   void addForceHam(xmlNodePtr cur);
@@ -77,8 +77,6 @@ private:
   const PSetMap& ptclPool;
   ///reference to the TrialWaveFunction Pool
   const PsiPoolType& psiPool;
-  ///input node for a many-body wavefunction
-  xmlNodePtr myNode;
 
   ///name of the TrialWaveFunction
   std::string psiName;

--- a/src/QMCHamiltonians/NonLocalECPComponent.cpp
+++ b/src/QMCHamiltonians/NonLocalECPComponent.cpp
@@ -32,7 +32,7 @@ NonLocalECPComponent::NonLocalECPComponent(const NonLocalECPComponent& nl_ecpc, 
   for (int i = 0; i < nl_ecpc.nlpp_m.size(); ++i)
     nlpp_m[i] = nl_ecpc.nlpp_m[i]->makeClone();
   if (nl_ecpc.VP)
-    VP = new VirtualParticleSet(pset, nknot);
+    VP = new VirtualParticleSet(pset, nknot, nl_ecpc.VP->getNumDistTables());
 }
 
 NonLocalECPComponent::~NonLocalECPComponent()

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -165,10 +165,10 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.6170527168e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.9015560571e+01));
@@ -333,10 +333,10 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.77926812569e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.9015560571e+01));
@@ -500,10 +500,10 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.59769057565e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.90155605707e+01));
@@ -639,10 +639,10 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.75211124679e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.90155605707e+01));
@@ -779,10 +779,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
 
   using ValueMatrix = SPOSet::ValueMatrix;
@@ -1038,10 +1038,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
 
   using ValueMatrix = SPOSet::ValueMatrix;
@@ -1314,10 +1314,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.77926812569e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.9015560571e+01));
@@ -1499,10 +1499,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.59769057565e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.90155605707e+01));
@@ -1655,10 +1655,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   enum observ_id
   {
     KINETIC = 0,
-    ELECELEC,
-    IONION,
     LOCALECP,
-    NONLOCALECP
+    NONLOCALECP,
+    ELECELEC,
+    IONION
   };
   REQUIRE(eloc == Approx(-1.75211124679e+01));
   REQUIRE(ham.getObservable(ELECELEC) == Approx(1.90155605707e+01));

--- a/tests/molecules/FeCO6_b3lyp_pyscf/det_vmcbatch_noj.in.xml
+++ b/tests/molecules/FeCO6_b3lyp_pyscf/det_vmcbatch_noj.in.xml
@@ -7,13 +7,13 @@
   <include href="FeCO6.wfnoj.xml"/>
   <random seed="17"/>
   <hamiltonian name="h0" type="generic" target="e">
-    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
-    <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
     <pairpot name="PseudoPot" type="pseudo" source="ion0" wavefunction="psi0" format="xml">
       <pseudo elementType="C" href="C.BFD.xml"/>
       <pseudo elementType="Fe" href="Fe.BFD.xml"/>
       <pseudo elementType="O" href="O.BFD.xml"/>
     </pairpot>
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e" physical="true"/>
+    <pairpot name="IonIon" type="coulomb" source="ion0" target="ion0"/>
   </hamiltonian>
   <qmc method="vmc" move="pbyp">
       <parameter name="total_walkers"       >    1              </parameter>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
The modified [tests/molecules/FeCO6_b3lyp_pyscf/det_vmcbatch_noj.in.xml](https://github.com/QMCPACK/qmcpack/compare/develop...ye-luo:reorder-nlpp-construction?expand=1#diff-885d05f95457a4ab71dc3836cc4ac4f995423d4c4a9fb88a7167f1a8565b03f5)
triggers a bug caused by mismatch distance table counts in the gold VPset and cloned VPsets.
When NLPP gets constructed, VP has only 1 DT based on the particle set at that moment.
However Coulomb adds e-e DT and the table counts is 2 and thus the cloned ones have two DTs based on later state of the particle set. This triggers shared resource issue.

This PR changes to create VP based only a subset of DTs of the particleset. In NLPP, clones are created with the same size as the original VP set. To minimize the needed DTs in VP, NLPP parsing is moved right after KE when parsing Hamiltonian.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed