### PR TITLE
Bump icc version to 2021 from oneAPI 2023 on sulfur CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -123,9 +123,9 @@ jobs:
             Clang15-MPI-CUDA-AFQMC-Offload-Real,
             Clang15-MPI-CUDA-AFQMC-Offload-Complex-Mixed,
             Clang15-MPI-CUDA-AFQMC-Offload-Complex,
-            Intel19-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
-            Intel19-MPI-CUDA-AFQMC-Complex-Mixed,
-            Intel19-MPI-CUDA-AFQMC-Real,
+            Intel21-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
+            Intel21-MPI-CUDA-AFQMC-Complex-Mixed,
+            Intel21-MPI-CUDA-AFQMC-Real,
           ]
 
     steps:

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -208,23 +208,27 @@ case "$1" in
               -DQMC_DATA=$QMC_DATA_DIR \
               ${GITHUB_WORKSPACE}
       ;;
-      *"Intel19-MPI-CUDA-AFQMC"*)
+      *"Intel21-MPI-CUDA-AFQMC"*)
         echo "Configure for building with ENABLE_CUDA and AFQMC  " \
-              "with Intel 2019 compiler, need built-from-source OpenBLAS due to bug in rpm"
+             "with Intel classic compiler in OneAPI 2021 (to be deprecated in 2023), " \
+             "need built-from-source OpenBLAS due to bug in rpm"
         
-        source /opt/intel2020/bin/compilervars.sh -arch intel64 -platform linux
+        source /opt/intel/oneapi/setvars.sh
 
-        export OMPI_CC=/opt/intel2020/bin/icc
-        export OMPI_CXX=/opt/intel2020/bin/icpc
+        export OMPI_CC=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icc
+        export OMPI_CXX=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icpc
         
         # Make current environment variables available to subsequent steps
-        echo "OMPI_CC=/opt/intel2020/bin/icc" >> $GITHUB_ENV
-        echo "OMPI_CXX=/opt/intel2020/bin/icpc" >> $GITHUB_ENV
+        echo "OMPI_CC=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icc" >> $GITHUB_ENV
+        echo "OMPI_CXX=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/intel64/icpc" >> $GITHUB_ENV
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \
               -DCMAKE_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx \
               -DMPIEXEC_EXECUTABLE=/usr/lib64/openmpi/bin/mpirun \
+              -DCMAKE_C_FLAGS="-diag-disable=10441" \
+              -DCMAKE_CXX_FLAGS="-diag-disable=10441" \
+              -DCMAKE_CUDA_FLAGS="-diag-disable=10441" \
               -DBUILD_AFQMC=ON \
               -DENABLE_CUDA=ON \
               -DCMAKE_PREFIX_PATH="/opt/OpenBLAS/0.3.18" \
@@ -402,9 +406,9 @@ case "$1" in
        export LD_LIBRARY_PATH=/opt/llvm/15.0.0/lib:/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH}
     fi
 
-    if [[ "${GH_JOBNAME}" =~ (Intel19) ]]
+    if [[ "${GH_JOBNAME}" =~ (Intel21) ]]
     then
-       source /opt/intel2020/bin/compilervars.sh -arch intel64 -platform linux
+       source /opt/intel/oneapi/setvars.sh
     fi
 
     if [[ "${GH_JOBNAME}" =~ (MKL) ]]


### PR DESCRIPTION
## Proposed changes

Uses classic compiler icc inside oneAPI (to be deprecated) on sulfur CI
Related to #4389 , #4326 , #4359 
Move eventually to oneAPI icx compiler


## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur 

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
