### PR TITLE
Bump github actions versions

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -52,7 +52,7 @@ jobs:
       # just like any other third-party service
       - name: Create PR status
         if: steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-sulfur CI ${{ matrix.jobname }}"
@@ -91,7 +91,7 @@ jobs:
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-sulfur CI ${{matrix.jobname}}"
@@ -144,7 +144,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -154,7 +154,7 @@ jobs:
       # just like any other third-party service
       - name: Create PR status
         if: steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-sulfur CI ${{ matrix.jobname }}"
@@ -193,7 +193,7 @@ jobs:
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-sulfur CI ${{matrix.jobname}}"
@@ -244,7 +244,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -254,7 +254,7 @@ jobs:
       # just like any other third-party service
       - name: Create PR status
         if: steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-nitrogen CI ${{matrix.jobname}}"
@@ -293,7 +293,7 @@ jobs:
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-nitrogen CI ${{matrix.jobname}}"
@@ -339,7 +339,7 @@ jobs:
       - name: GitHub API Request
         if: steps.check.outputs.triggered == 'true'
         id: request
-        uses: octokit/request-action@v2.1.0
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{github.event.issue.pull_request.url}}
         env:
@@ -349,7 +349,7 @@ jobs:
       # just like any other third-party service
       - name: Create PR status
         if: steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-nitrogen CI ${{matrix.jobname}}"
@@ -388,7 +388,7 @@ jobs:
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1
+        uses: Sibz/github-status-action@v1.1.6
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: "ornl-nitrogen CI ${{matrix.jobname}}"


### PR DESCRIPTION
## Proposed changes

Node.js 12 actions [will be deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
Moving to the latest available versions
github-status-action might still need a new release

## What type(s) of changes does this code introduce?
CI actions

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Must be merged and tested on sulfur/nitrogen CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
