### PR TITLE
Compile script for Perlmutter CPU

### DIFF
--- a/config/build_nersc_perlmutter.sh
+++ b/config/build_nersc_perlmutter.sh
@@ -16,16 +16,15 @@ spack install libxml2
 spack load libxml2
 # Load the required modules
 module load cpu
-module load PrgEnv-cray
 module load cray-hdf5-parallel
 module load cray-fftw
 module list
 
 # On the above date, the loaded modules were:
 #Currently Loaded Modules:
-#  1) craype-x86-milan     4) xpmem/2.5.2-2.4_3.18__gd0f7936.shasta   7) xalt/2.10.2    10) cpu/1.0        13) cray-dsmml/0.2.2       16) PrgEnv-cray/8.3.3
-#  2) libfabric/1.15.2.0   5) perftools-base/22.09.0                  8) darshan/3.4.0  11) cce/15.0.0     14) cray-mpich/8.1.22      17) cray-hdf5-parallel/1.12.2.1
-#  3) craype-network-ofi   6) cpe/22.11                               9) e4s/22.05      12) craype/2.7.19  15) cray-libsci/22.11.1.2  18) cray-fftw/3.3.10.2
+#  1) craype-x86-milan     4) xpmem/2.5.2-2.4_3.18__gd0f7936.shasta   7) cray-libsci/22.11.1.2  10) gcc/11.2.0              13) xalt/2.10.2    16) cpu/1.0
+#  2) libfabric/1.15.2.0   5) PrgEnv-gnu/8.3.3                        8) cray-mpich/8.1.22      11) perftools-base/22.09.0  14) darshan/3.4.0  17) cray-hdf5-parallel/1.12.2.1
+#  3) craype-network-ofi   6) cray-dsmml/0.2.2                        9) craype/2.7.19          12) cpe/22.11               15) e4s/22.05      18) cray-fftw/3.3.10.2
 
 mkdir build_cpu_real
 cd build_cpu_real

--- a/config/build_nersc_perlmutter.sh
+++ b/config/build_nersc_perlmutter.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+################################################################
+## * This script builds CPU versions of QMCPACK               ##
+##   on NERSC Perlmutter.                                     ##
+##                                                            ##
+## * Execute this script from qmcpack directory as:           ##
+##   ./config/build_nersc_perlmutter.sh                       ##
+##                                                            ##
+## * Last verified: 2023/01/13                                ##
+################################################################
+
+# Make LibXml2 available to QMCPACK on PATH
+module load e4s
+spack install libxml2
+spack load libxml2
+# Load the required modules
+module load cpu
+module load PrgEnv-cray
+module load cray-hdf5-parallel
+module load cray-fftw
+module list
+
+# On the above date, the loaded modules were:
+#Currently Loaded Modules:
+#  1) craype-x86-milan     4) xpmem/2.5.2-2.4_3.18__gd0f7936.shasta   7) xalt/2.10.2    10) cpu/1.0        13) cray-dsmml/0.2.2       16) PrgEnv-cray/8.3.3
+#  2) libfabric/1.15.2.0   5) perftools-base/22.09.0                  8) darshan/3.4.0  11) cce/15.0.0     14) cray-mpich/8.1.22      17) cray-hdf5-parallel/1.12.2.1
+#  3) craype-network-ofi   6) cpe/22.11                               9) e4s/22.05      12) craype/2.7.19  15) cray-libsci/22.11.1.2  18) cray-fftw/3.3.10.2
+
+mkdir build_cpu_real
+cd build_cpu_real
+cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++ -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DQMC_COMPLEX=0 ..
+nice make -j 16
+ls -l bin/qmcpack
+cd ..
+
+mkdir build_cpu_cplx
+cd build_cpu_cplx
+cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++ -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DQMC_COMPLEX=1 ..
+nice make -j 16
+ls -l bin/qmcpack_complex
+cd ..

--- a/config/build_nersc_perlmutter.sh
+++ b/config/build_nersc_perlmutter.sh
@@ -1,41 +1,89 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash                                                                                                                                                                                                
 
-################################################################
-## * This script builds CPU versions of QMCPACK               ##
-##   on NERSC Perlmutter.                                     ##
-##                                                            ##
-## * Execute this script from qmcpack directory as:           ##
-##   ./config/build_nersc_perlmutter.sh                       ##
-##                                                            ##
-## * Last verified: 2023/01/13                                ##
-################################################################
+# This recipe is intended for NERSC Perlmutter https://docs.nersc.gov/systems/perlmutter/
+# It builds the CPU varaints of QMCPACK in the current directory
+# Last revision: 2023/01/13
+#
+# How to invoke this script?
+# build_nersc_perlmutter.sh # build all the variants assuming the current directory is the source directory
+# build_nersc_perlmutter.sh <source_dir> # build all the variants with a given source directory <source_dir>
+# build_nersc_perlmutter.sh <source_dir> <install_dir> # build all the variants with a given source directory <source_dir> and install to <install_dir>
 
-# Make LibXml2 available to QMCPACK on PATH
-module load e4s
-spack install libxml2
-spack load libxml2
 # Load the required modules
 module load cpu
+module load PrgEnv-gnu
 module load cray-hdf5-parallel
 module load cray-fftw
+module load cmake
 module list
 
-# On the above date, the loaded modules were:
+# Make LibXml2 available to QMCPACK
+export CMAKE_PREFIX_PATH=/global/common/software/spackecp/perlmutter/e4s-22.05/78535/spack/opt/spack/cray-sles15-zen3/gcc-11.2.0/libxml2-2.9.13-u2ai4xjq2lmljvej4p3ly7qd6hfbrz7h:$CMAKE_PREFIX_PATH
+
+# On the date above, the loaded modules were:
 #Currently Loaded Modules:
-#  1) craype-x86-milan     4) xpmem/2.5.2-2.4_3.18__gd0f7936.shasta   7) cray-libsci/22.11.1.2  10) gcc/11.2.0              13) xalt/2.10.2    16) cpu/1.0
-#  2) libfabric/1.15.2.0   5) PrgEnv-gnu/8.3.3                        8) cray-mpich/8.1.22      11) perftools-base/22.09.0  14) darshan/3.4.0  17) cray-hdf5-parallel/1.12.2.1
-#  3) craype-network-ofi   6) cray-dsmml/0.2.2                        9) craype/2.7.19          12) cpe/22.11               15) e4s/22.05      18) cray-fftw/3.3.10.2
+#  1) craype-x86-milan     4) xpmem/2.5.2-2.4_3.18__gd0f7936.shasta   7) cpe/22.11      10) cpu/1.0           13) cray-mpich/8.1.22      16) cray-hdf5-parallel/1.12.2.1
+#  2) libfabric/1.15.2.0   5) gcc/11.2.0                              8) xalt/2.10.2    11) craype/2.7.19     14) cray-libsci/22.11.1.2  17) cray-fftw/3.3.10.2
+#  3) craype-network-ofi   6) perftools-base/22.09.0                  9) darshan/3.4.0  12) cray-dsmml/0.2.2  15) PrgEnv-gnu/8.3.3       18) cmake/3.24.3
 
-mkdir build_cpu_real
-cd build_cpu_real
-cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++ -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DQMC_COMPLEX=0 ..
-nice make -j 16
-ls -l bin/qmcpack
+TYPE=Release
+Machine=perlmutter
+Compiler=GNU
+
+if [[ $# -eq 0 ]]; then
+  source_folder=`pwd`
+elif [[ $# -eq 1 ]]; then
+  source_folder=$1
+else
+  source_folder=$1
+  install_folder=$2
+fi
+
+if [[ -f $source_folder/CMakeLists.txt ]]; then
+  echo Using QMCPACK source directory $source_folder
+else
+  echo "Source directory $source_folder doesn't contain CMakeLists.txt. Pass QMCPACK source directory as the first argument."
+  exit
+fi
+
+for name in cpu_real_MP cpu_real cpu_cplx_MP cpu_cplx
+do
+
+CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=$TYPE"
+
+if [[ $name == *"cplx"* ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_COMPLEX=ON"
+fi
+
+if [[ $name == *"_MP"* ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -DQMC_MIXED_PRECISION=ON"
+fi
+
+folder=build_${Machine}_${Compiler}_${name}
+
+if [[ -v install_folder ]]; then
+  CMAKE_FLAGS="$CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=$install_folder/$folder"
+fi
+
+echo "**********************************"
+echo "$folder"
+echo "$CMAKE_FLAGS"
+echo "**********************************"
+
+mkdir $folder
+cd $folder
+
+if [ ! -f CMakeCache.txt ] ; then
+cmake $CMAKE_FLAGS -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=CC -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment $source_folder
+fi
+
+if [[ -v install_folder ]]; then
+  make -j16 install && chmod -R -w $install_folder/$folder
+else
+  make -j16
+fi
+
 cd ..
 
-mkdir build_cpu_cplx
-cd build_cpu_cplx
-cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpic++ -DCMAKE_SYSTEM_NAME=CrayLinuxEnvironment -DQMC_COMPLEX=1 ..
-nice make -j 16
-ls -l bin/qmcpack_complex
-cd ..
+echo
+done


### PR DESCRIPTION
## Proposed changes

I've been looking at compiling the CPU version on Perlmutter since Cori will be retired soon. The added script compiles the real and complex versions for CPU-only nodes. Some dependencies, such as LibXml2, are handled via spack as this is not provided by default.

I didn't have luck with GNU compilers and/or the `cc`, `CC` wrappers provided by NERSC. However, the `mpicc`, `mpic++` MPI wrappers with cray compile without problems.

For the real build, all unit tests pass. 99% of deterministic tests pass, and there are 5 fails related to HEG (see attached).

For the complex build, 2 unit tests are failing. For the deterministic case, 84% is passing. The fails are related to HEG + Gaussian basis bulk systems (see attached).

I didn't explore the GPU build yet.

## What type(s) of changes does this code introduce?

- Build script changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

NERSC/Perlmutter-CPU

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'

[cplx_tests.txt](https://github.com/QMCPACK/qmcpack/files/10414073/cplx_tests.txt)
[real_tests.txt](https://github.com/QMCPACK/qmcpack/files/10414074/real_tests.txt)
