### PR TITLE
Print coordinates when NaN is detected

### DIFF
--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -272,8 +272,7 @@ void ParticleSet::randomizeFromSource(ParticleSet& src)
   }
 }
 
-///write to a std::ostream
-bool ParticleSet::get(std::ostream& os) const
+void ParticleSet::print(std::ostream& os, const size_t maxParticlesToPrint) const
 {
   os << "  ParticleSet '" << getName() << "' contains " << TotalNum << " particles : ";
   if (auto& group_offsets(*group_offsets_); group_offsets.size() > 0)
@@ -281,8 +280,7 @@ bool ParticleSet::get(std::ostream& os) const
       os << " " << my_species_.speciesName[i] << "(" << group_offsets[i + 1] - group_offsets[i] << ")";
   os << std::endl << std::endl;
 
-  const size_t maxParticlesToPrint = 10;
-  size_t numToPrint                = std::min(TotalNum, maxParticlesToPrint);
+  const size_t numToPrint = maxParticlesToPrint == 0 ? TotalNum : std::min(TotalNum, maxParticlesToPrint);
 
   for (int i = 0; i < numToPrint; i++)
   {
@@ -297,13 +295,10 @@ bool ParticleSet::get(std::ostream& os) const
   for (const std::string& description : distTableDescriptions)
     os << description;
   os << std::endl;
-  return true;
 }
 
-///read from std::istream
+bool ParticleSet::get(std::ostream& is) const { return true; }
 bool ParticleSet::put(std::istream& is) { return true; }
-
-///reset member data
 void ParticleSet::reset() { app_log() << "<<<< going to set properties >>>> " << std::endl; }
 
 ///read the particleset

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -146,13 +146,17 @@ public:
    */
   void create(const std::vector<int>& agroup);
 
-  ///write to a std::ostream
-  bool get(std::ostream&) const override;
+  /** print particle coordinates to a std::ostream
+   * @param os output stream
+   * @param maxParticlesToPrint maximal number of particles to print. Pass 0 to print all.
+   */
+  void print(std::ostream& os, const size_t maxParticlesToPrint = 0) const;
 
-  ///read from std::istream
+  ///dummy. For satisfying OhmmsElementBase.
+  bool get(std::ostream& os) const override;
+  ///dummy. For satisfying OhmmsElementBase.
   bool put(std::istream&) override;
-
-  ///reset member data
+  ///dummy. For satisfying OhmmsElementBase.
   void reset() override;
 
   ///initialize ParticleSet from xmlNode

--- a/src/Particle/ParticleSetPool.cpp
+++ b/src/Particle/ParticleSetPool.cpp
@@ -207,12 +207,11 @@ bool ParticleSetPool::get(std::ostream& os) const
   os << "ParticleSetPool has: " << std::endl << std::endl;
   os.setf(std::ios::scientific, std::ios::floatfield);
   os.precision(14);
-  PoolType::const_iterator it(myPool.begin()), it_end(myPool.end());
-  while (it != it_end)
-  {
-    (*it).second->get(os);
-    ++it;
-  }
+  for (const auto& [name, pset] : myPool)
+    if (outputManager.isDebugActive())
+      pset->print(os, 0);
+    else
+      pset->print(os, 10 /* maxParticlesToPrint */);
   return true;
 }
 

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -535,7 +535,12 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluate(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluate component " + H[i]->getName() + " returns NaN\n");
+    {
+      std::ostringstream msg;
+      msg << "QMCHamiltonian::evaluate component " <<  H[i]->getName() << " returns NaN." << std::endl;
+      P.print(msg);
+      throw std::runtime_error(msg.str());
+    }
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -559,7 +564,12 @@ QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateDeterministic(ParticleS
     ScopedTimer h_timer(my_timers_[i]);
     const auto LocalEnergyComponent = H[i]->evaluateDeterministic(P);
     if (std::isnan(LocalEnergyComponent))
-      APP_ABORT("QMCHamiltonian::evaluateDeterministic component " + H[i]->getName() + " returns NaN\n");
+    {
+      std::ostringstream msg;
+      msg << "QMCHamiltonian::evaluateDeterministic component " <<  H[i]->getName() << " returns NaN." << std::endl;
+      P.print(msg);
+      throw std::runtime_error(msg.str());
+    }
     LocalEnergy += LocalEnergyComponent;
     H[i]->setObservables(Observables);
 #if !defined(REMOVE_TRACEMANAGER)
@@ -577,7 +587,12 @@ void QMCHamiltonian::updateNonKinetic(OperatorBase& op, QMCHamiltonian& ham, Par
 {
   // It's much better to be able to see where this is coming from.  It is caught just fine.
   if (std::isnan(op.getValue()))
-    throw std::runtime_error("QMCHamiltonian::updateNonKinetic component " + op.getName() + " returns NaN\n");
+  {
+    std::ostringstream msg;
+    msg << "QMCHamiltonian::updateNonKinetic component " <<  op.getName() << " returns NaN." << std::endl;
+    pset.print(msg);
+    throw std::runtime_error(msg.str());
+  }
   // The following is a ridiculous breach of encapsulation.
   ham.LocalEnergy += op.getValue();
   op.setObservables(ham.Observables);


### PR DESCRIPTION
# Proposed changes
Rename expand ParticleSet::get to print and support particle count limit.
When NaN is detected, print all particle coordinates.
Also `--verbosity=debug` now prints all particle coordinates.

## What type(s) of changes does this code introduce?
- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'