### PR TITLE
Fix wrong output size in SplineC2ROMPTarget::mw_evaluateVGLandDetRatioGrads

### DIFF
--- a/src/Platforms/CUDA/cuBLAS_missing_functions.cu
+++ b/src/Platforms/CUDA/cuBLAS_missing_functions.cu
@@ -11,7 +11,6 @@
 
 
 #include "cuBLAS_missing_functions.hpp"
-#include <stdexcept>
 #include "config.h"
 #ifndef QMC_CUDA2HIP
 #include <cuComplex.h>

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2R.h
@@ -36,7 +36,7 @@ namespace qmcplusplus
  * The internal storage of complex spline coefficients uses double sized real arrays of ST type, aligned and padded.
  * The first nComplexBands complex splines produce 2 real orbitals.
  * The rest complex splines produce 1 real orbital.
- * All the output orbitals are real.
+ * All the output orbitals are real (C2R). The maximal number of output orbitals is OrbitalSetSize.
  */
 template<typename ST>
 class SplineC2R : public BsplineSet

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -247,14 +247,14 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
     const size_t ChunkSizePerTeam = 512;
     const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
-    const auto padded_size = myV.size();
-    offload_scratch.resize(padded_size);
+    const auto spline_padded_size = myV.size();
+    offload_scratch.resize(spline_padded_size);
 
     // Ye: need to extract sizes and pointers before entering target region
-    const auto orb_size       = psi.size();
-    const auto* spline_ptr    = SplineInst->getSplinePtr();
-    auto* offload_scratch_ptr = offload_scratch.data();
-    auto* psi_ptr             = psi.data();
+    const auto requested_orb_size = psi.size();
+    const auto* spline_ptr        = SplineInst->getSplinePtr();
+    auto* offload_scratch_ptr     = offload_scratch.data();
+    auto* psi_ptr                 = psi.data();
     const auto x = r[0], y = r[1], z = r[2];
     const auto rux = ru[0], ruy = ru[1], ruz = ru[2];
     const auto myKcart_padded_size   = myKcart->capacity();
@@ -265,11 +265,11 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
     {
       ScopedTimer offload(offload_timer_);
       PRAGMA_OFFLOAD("omp target teams distribute num_teams(NumTeams) \
-                  map(always, from: psi_ptr[0:orb_size])")
+                  map(always, from: psi_ptr[0:requested_orb_size])")
       for (int team_id = 0; team_id < NumTeams; team_id++)
       {
         const size_t first = ChunkSizePerTeam * team_id;
-        const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+        const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
         int ix, iy, iz;
         ST a[4], b[4], c[4];
@@ -280,11 +280,12 @@ void SplineC2ROMPTarget<ST>::evaluateValue(const ParticleSet& P, const int iat, 
           spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_ptr + first, first,
                                              index);
         const size_t first_cplx = first / 2;
-        const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+        const size_t last_cplx  = last / 2;
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(x, y, z, psi_ptr, offload_scratch_ptr, myKcart_ptr, myKcart_padded_size, first_spo_local,
                         nComplexBands_local, index);
+        //FIXME psi should be assigned in a separate stage with requested_orb_size
       }
     }
   }
@@ -319,10 +320,10 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   ratios_private.resize(nVP, NumTeams);
-  const auto padded_size = myV.size();
-  offload_scratch.resize(padded_size * nVP);
-  const auto orb_size = psiinv.size();
-  results_scratch.resize(padded_size * nVP);
+  const auto spline_padded_size = myV.size();
+  const auto sposet_padded_size = getAlignedSize<TT>(OrbitalSetSize);
+  offload_scratch.resize(spline_padded_size * nVP);
+  results_scratch.resize(sposet_padded_size * nVP);
 
   // Ye: need to extract sizes and pointers before entering target region
   const auto* spline_ptr           = SplineInst->getSplinePtr();
@@ -334,6 +335,7 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
   auto* ratios_private_ptr         = ratios_private.data();
   const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
+  const auto requested_orb_size    = psiinv.size();
 
   {
     ScopedTimer offload(offload_timer_);
@@ -344,11 +346,11 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
       for (int team_id = 0; team_id < NumTeams; team_id++)
       {
         const size_t first = ChunkSizePerTeam * team_id;
-        const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+        const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
-        auto* restrict offload_scratch_iat_ptr = offload_scratch_ptr + padded_size * iat;
-        auto* restrict psi_iat_ptr             = results_scratch_ptr + padded_size * iat;
-        auto* restrict pos_scratch             = psiinv_ptr + orb_size;
+        auto* restrict offload_scratch_iat_ptr = offload_scratch_ptr + spline_padded_size * iat;
+        auto* restrict psi_iat_ptr             = results_scratch_ptr + sposet_padded_size * iat;
+        auto* restrict pos_scratch             = psiinv_ptr + requested_orb_size;
 
         int ix, iy, iz;
         ST a[4], b[4], c[4];
@@ -360,7 +362,7 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
           spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_iat_ptr + first, first,
                                              index);
         const size_t first_cplx = first / 2;
-        const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+        const size_t last_cplx  = last / 2;
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
@@ -368,7 +370,8 @@ void SplineC2ROMPTarget<ST>::evaluateDetRatios(const VirtualParticleSet& VP,
                         nComplexBands_local, index);
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
-        const size_t last_real  = last_cplx + omptarget::min(nComplexBands_local, last_cplx);
+        const size_t last_real =
+            omptarget::min(last_cplx + omptarget::min(nComplexBands_local, last_cplx), requested_orb_size);
         TT sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+:sum)")
         for (int i = first_real; i < last_real; i++)
@@ -394,14 +397,14 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
                                                   std::vector<std::vector<ValueType>>& ratios_list) const
 {
   assert(this == &spo_list.getLeader());
-  auto& phi_leader            = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-  auto& mw_mem                = *phi_leader.mw_mem_;
-  auto& det_ratios_buffer_H2D = mw_mem.det_ratios_buffer_H2D;
-  auto& mw_ratios_private     = mw_mem.mw_ratios_private;
-  auto& mw_offload_scratch    = mw_mem.mw_offload_scratch;
-  auto& mw_results_scratch    = mw_mem.mw_results_scratch;
-  const size_t nw             = spo_list.size();
-  const size_t orb_size       = phi_leader.size();
+  auto& phi_leader                = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
+  auto& mw_mem                    = *phi_leader.mw_mem_;
+  auto& det_ratios_buffer_H2D     = mw_mem.det_ratios_buffer_H2D;
+  auto& mw_ratios_private         = mw_mem.mw_ratios_private;
+  auto& mw_offload_scratch        = mw_mem.mw_offload_scratch;
+  auto& mw_results_scratch        = mw_mem.mw_results_scratch;
+  const size_t nw                 = spo_list.size();
+  const size_t requested_orb_size = phi_leader.size();
 
   size_t mw_nVP = 0;
   for (const VirtualParticleSet& VP : vp_list)
@@ -442,9 +445,10 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
   const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   mw_ratios_private.resize(mw_nVP, NumTeams);
-  const auto padded_size = myV.size();
-  mw_offload_scratch.resize(padded_size * mw_nVP);
-  mw_results_scratch.resize(padded_size * mw_nVP);
+  const auto spline_padded_size = myV.size();
+  const auto sposet_padded_size = getAlignedSize<TT>(OrbitalSetSize);
+  mw_offload_scratch.resize(spline_padded_size * mw_nVP);
+  mw_results_scratch.resize(sposet_padded_size * mw_nVP);
 
   // Ye: need to extract sizes and pointers before entering target region
   const auto* spline_ptr           = SplineInst->getSplinePtr();
@@ -466,10 +470,10 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
       for (int team_id = 0; team_id < NumTeams; team_id++)
       {
         const size_t first = ChunkSizePerTeam * team_id;
-        const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+        const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
-        auto* restrict offload_scratch_iat_ptr = offload_scratch_ptr + padded_size * iat;
-        auto* restrict psi_iat_ptr             = results_scratch_ptr + padded_size * iat;
+        auto* restrict offload_scratch_iat_ptr = offload_scratch_ptr + spline_padded_size * iat;
+        auto* restrict psi_iat_ptr             = results_scratch_ptr + sposet_padded_size * iat;
         auto* ref_id_ptr = reinterpret_cast<int*>(buffer_H2D_ptr + nw * sizeof(ValueType*) + mw_nVP * 6 * sizeof(TT));
         auto* restrict psiinv_ptr  = reinterpret_cast<const ValueType**>(buffer_H2D_ptr)[ref_id_ptr[iat]];
         auto* restrict pos_scratch = reinterpret_cast<TT*>(buffer_H2D_ptr + nw * sizeof(ValueType*));
@@ -484,7 +488,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
           spline2offload::evaluate_v_impl_v2(spline_ptr, ix, iy, iz, a, b, c, offload_scratch_iat_ptr + first, first,
                                              index);
         const size_t first_cplx = first / 2;
-        const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+        const size_t last_cplx  = last / 2;
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_v(ST(pos_scratch[iat * 6]), ST(pos_scratch[iat * 6 + 1]), ST(pos_scratch[iat * 6 + 2]),
@@ -492,7 +496,8 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
                         nComplexBands_local, index);
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
-        const size_t last_real  = last_cplx + omptarget::min(nComplexBands_local, last_cplx);
+        const size_t last_real =
+            omptarget::min(last_cplx + omptarget::min(nComplexBands_local, last_cplx), requested_orb_size);
         TT sum(0);
         PRAGMA_OFFLOAD("omp parallel for simd reduction(+:sum)")
         for (int i = first_real; i < last_real; i++)
@@ -648,12 +653,12 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
 
-  const auto padded_size = myV.size();
+  const auto spline_padded_size = myV.size();
+  const auto sposet_padded_size = getAlignedSize<TT>(OrbitalSetSize);
   // for V(1)G(3)H(6) intermediate result
-  offload_scratch.resize(padded_size * 10);
-  const auto orb_size = psi.size();
+  offload_scratch.resize(spline_padded_size * 10);
   // for V(1)G(3)L(1) final result
-  results_scratch.resize(padded_size * 5);
+  results_scratch.resize(sposet_padded_size * 5);
 
   // Ye: need to extract sizes and pointers before entering target region
   const auto* spline_ptr    = SplineInst->getSplinePtr();
@@ -668,15 +673,16 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
   auto* myKcart_ptr                = myKcart->data();
   const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
+  const auto requested_orb_size    = psi.size();
 
   {
     ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute num_teams(NumTeams) \
-                map(always, from: results_scratch_ptr[0:padded_size*5])")
+                map(always, from: results_scratch_ptr[0:sposet_padded_size*5])")
     for (int team_id = 0; team_id < NumTeams; team_id++)
     {
       const size_t first = ChunkSizePerTeam * team_id;
-      const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+      const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
       int ix, iy, iz;
       ST a[4], b[4], c[4], da[4], db[4], dc[4], d2a[4], d2b[4], d2c[4];
@@ -691,24 +697,27 @@ void SplineC2ROMPTarget<ST>::evaluateVGL(const ParticleSet& P,
       PRAGMA_OFFLOAD("omp parallel for")
       for (int index = 0; index < last - first; index++)
         spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                             offload_scratch_ptr + first, offload_scratch_ptr + padded_size + first,
-                                             offload_scratch_ptr + padded_size * 4 + first, padded_size, first, index);
+                                             offload_scratch_ptr + first,
+                                             offload_scratch_ptr + spline_padded_size + first,
+                                             offload_scratch_ptr + spline_padded_size * 4 + first, spline_padded_size,
+                                             first, index);
       const size_t first_cplx = first / 2;
-      const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+      const size_t last_cplx  = last / 2;
       PRAGMA_OFFLOAD("omp parallel for")
       for (int index = first_cplx; index < last_cplx; index++)
-        C2R::assign_vgl(x, y, z, results_scratch_ptr, padded_size, mKK_ptr, offload_scratch_ptr, padded_size, symGGt, G,
-                        myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local, index);
+        C2R::assign_vgl(x, y, z, results_scratch_ptr, sposet_padded_size, mKK_ptr, offload_scratch_ptr,
+                        spline_padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size, first_spo_local,
+                        nComplexBands_local, index);
     }
   }
 
-  for (size_t i = 0; i < orb_size; i++)
+  for (size_t i = 0; i < requested_orb_size; i++)
   {
     psi[i]     = results_scratch[i];
-    dpsi[i][0] = results_scratch[i + padded_size * 1];
-    dpsi[i][1] = results_scratch[i + padded_size * 2];
-    dpsi[i][2] = results_scratch[i + padded_size * 3];
-    d2psi[i]   = results_scratch[i + padded_size * 4];
+    dpsi[i][0] = results_scratch[i + sposet_padded_size * 1];
+    dpsi[i][1] = results_scratch[i + sposet_padded_size * 2];
+    dpsi[i][2] = results_scratch[i + sposet_padded_size * 3];
+    d2psi[i]   = results_scratch[i + sposet_padded_size * 4];
   }
 }
 
@@ -723,12 +732,12 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   const size_t num_pos          = psi_v_list.size();
   const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
-  const auto padded_size        = myV.size();
+  const auto spline_padded_size = myV.size();
+  const auto sposet_padded_size = getAlignedSize<TT>(OrbitalSetSize);
   // for V(1)G(3)H(6) intermediate result
-  offload_scratch.resize(padded_size * num_pos * 10);
-  const auto orb_size = psi_v_list[0].get().size();
+  offload_scratch.resize(spline_padded_size * num_pos * 10);
   // for V(1)G(3)L(1) final result
-  results_scratch.resize(padded_size * num_pos * 5);
+  results_scratch.resize(sposet_padded_size * num_pos * 5);
 
   // Ye: need to extract sizes and pointers before entering target region
   const auto* spline_ptr           = SplineInst->getSplinePtr();
@@ -742,20 +751,21 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
   auto* myKcart_ptr                = myKcart->data();
   const size_t first_spo_local     = first_spo;
   const size_t nComplexBands_local = nComplexBands;
+  const auto requested_orb_size    = psi_v_list[0].get().size();
 
   {
     ScopedTimer offload(offload_timer_);
     PRAGMA_OFFLOAD("omp target teams distribute collapse(2) num_teams(NumTeams*num_pos) \
                     map(always, to: pos_copy_ptr[0:num_pos*6]) \
-                    map(always, from: results_scratch_ptr[0:padded_size*num_pos*5])")
+                    map(always, from: results_scratch_ptr[0:sposet_padded_size*num_pos*5])")
     for (int iw = 0; iw < num_pos; iw++)
       for (int team_id = 0; team_id < NumTeams; team_id++)
       {
         const size_t first = ChunkSizePerTeam * team_id;
-        const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+        const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
-        auto* restrict offload_scratch_iw_ptr = offload_scratch_ptr + padded_size * iw * 10;
-        auto* restrict psi_iw_ptr             = results_scratch_ptr + padded_size * iw * 5;
+        auto* restrict offload_scratch_iw_ptr = offload_scratch_ptr + spline_padded_size * iw * 10;
+        auto* restrict psi_iw_ptr             = results_scratch_ptr + sposet_padded_size * iw * 5;
 
         int ix, iy, iz;
         ST a[4], b[4], c[4], da[4], db[4], dc[4], d2a[4], d2b[4], d2c[4];
@@ -772,32 +782,32 @@ void SplineC2ROMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
         for (int index = 0; index < last - first; index++)
           spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
                                                offload_scratch_iw_ptr + first,
-                                               offload_scratch_iw_ptr + padded_size + first,
-                                               offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
-                                               index);
+                                               offload_scratch_iw_ptr + spline_padded_size + first,
+                                               offload_scratch_iw_ptr + spline_padded_size * 4 + first,
+                                               spline_padded_size, first, index);
         const size_t first_cplx = first / 2;
-        const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+        const size_t last_cplx  = last / 2;
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
           C2R::assign_vgl(pos_copy_ptr[iw * 6], pos_copy_ptr[iw * 6 + 1], pos_copy_ptr[iw * 6 + 2], psi_iw_ptr,
-                          padded_size, mKK_ptr, offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr,
-                          myKcart_padded_size, first_spo_local, nComplexBands_local, index);
+                          sposet_padded_size, mKK_ptr, offload_scratch_iw_ptr, spline_padded_size, symGGt, G,
+                          myKcart_ptr, myKcart_padded_size, first_spo_local, nComplexBands_local, index);
       }
   }
 
   for (int iw = 0; iw < num_pos; ++iw)
   {
-    auto* restrict results_iw_ptr = results_scratch_ptr + padded_size * iw * 5;
+    auto* restrict results_iw_ptr = results_scratch_ptr + sposet_padded_size * iw * 5;
     ValueVector& psi_v(psi_v_list[iw]);
     GradVector& dpsi_v(dpsi_v_list[iw]);
     ValueVector& d2psi_v(d2psi_v_list[iw]);
-    for (size_t i = 0; i < orb_size; i++)
+    for (size_t i = 0; i < requested_orb_size; i++)
     {
       psi_v[i]     = results_iw_ptr[i];
-      dpsi_v[i][0] = results_iw_ptr[i + padded_size];
-      dpsi_v[i][1] = results_iw_ptr[i + padded_size * 2];
-      dpsi_v[i][2] = results_iw_ptr[i + padded_size * 3];
-      d2psi_v[i]   = results_iw_ptr[i + padded_size * 4];
+      dpsi_v[i][0] = results_iw_ptr[i + sposet_padded_size];
+      dpsi_v[i][1] = results_iw_ptr[i + sposet_padded_size * 2];
+      dpsi_v[i][2] = results_iw_ptr[i + sposet_padded_size * 3];
+      d2psi_v[i]   = results_iw_ptr[i + sposet_padded_size * 4];
     }
   }
 }
@@ -882,14 +892,14 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   }
 
   const size_t num_pos          = nwalkers;
-  const auto orb_size           = phi_vgl_v.size(2);
-  const auto padded_size        = myV.size();
+  const auto spline_padded_size = myV.size();
+  const auto sposet_padded_size = getAlignedSize<TT>(OrbitalSetSize);
   const size_t ChunkSizePerTeam = 512;
   const int NumTeams            = (myV.size() + ChunkSizePerTeam - 1) / ChunkSizePerTeam;
   // for V(1)G(3)H(6) intermediate result
-  mw_offload_scratch.resize(padded_size * num_pos * 10);
+  mw_offload_scratch.resize(spline_padded_size * num_pos * 10);
   // for V(1)G(3)L(1) final result
-  mw_results_scratch.resize(padded_size * num_pos * 5);
+  mw_results_scratch.resize(sposet_padded_size * num_pos * 5);
   // per team ratio and grads
   rg_private.resize(num_pos, NumTeams * 4);
 
@@ -907,7 +917,8 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
   auto* rg_private_ptr             = rg_private.data();
   const size_t buffer_H2D_stride   = buffer_H2D.cols();
   const size_t first_spo_local     = first_spo;
-  const size_t phi_vgl_stride      = num_pos * orb_size;
+  const auto requested_orb_size    = phi_vgl_v.size(2);
+  const size_t phi_vgl_stride      = num_pos * requested_orb_size;
   const size_t nComplexBands_local = nComplexBands;
 
   {
@@ -919,10 +930,10 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
       for (int team_id = 0; team_id < NumTeams; team_id++)
       {
         const size_t first = ChunkSizePerTeam * team_id;
-        const size_t last  = omptarget::min(first + ChunkSizePerTeam, padded_size);
+        const size_t last  = omptarget::min(first + ChunkSizePerTeam, spline_padded_size);
 
-        auto* restrict offload_scratch_iw_ptr = offload_scratch_ptr + padded_size * iw * 10;
-        auto* restrict psi_iw_ptr             = results_scratch_ptr + padded_size * iw * 5;
+        auto* restrict offload_scratch_iw_ptr = offload_scratch_ptr + spline_padded_size * iw * 10;
+        auto* restrict psi_iw_ptr             = results_scratch_ptr + sposet_padded_size * iw * 5;
         const auto* restrict pos_iw_ptr       = reinterpret_cast<ST*>(buffer_H2D_ptr + buffer_H2D_stride * iw);
         const auto* restrict invRow_iw_ptr =
             *reinterpret_cast<ValueType**>(buffer_H2D_ptr + buffer_H2D_stride * iw + sizeof(ST) * 6);
@@ -942,31 +953,32 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
         for (int index = 0; index < last - first; index++)
           spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, a, b, c, da, db, dc, d2a, d2b, d2c,
                                                offload_scratch_iw_ptr + first,
-                                               offload_scratch_iw_ptr + padded_size + first,
-                                               offload_scratch_iw_ptr + padded_size * 4 + first, padded_size, first,
-                                               index);
+                                               offload_scratch_iw_ptr + spline_padded_size + first,
+                                               offload_scratch_iw_ptr + spline_padded_size * 4 + first,
+                                               spline_padded_size, first, index);
         const size_t first_cplx = first / 2;
-        const size_t last_cplx  = omptarget::min(last / 2, orb_size);
+        const size_t last_cplx  = last / 2;
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = first_cplx; index < last_cplx; index++)
-          C2R::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, padded_size, mKK_ptr,
-                          offload_scratch_iw_ptr, padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
+          C2R::assign_vgl(pos_iw_ptr[0], pos_iw_ptr[1], pos_iw_ptr[2], psi_iw_ptr, sposet_padded_size, mKK_ptr,
+                          offload_scratch_iw_ptr, spline_padded_size, symGGt, G, myKcart_ptr, myKcart_padded_size,
                           first_spo_local, nComplexBands_local, index);
 
         ValueType* restrict psi    = psi_iw_ptr;
-        ValueType* restrict dpsi_x = psi_iw_ptr + padded_size;
-        ValueType* restrict dpsi_y = psi_iw_ptr + padded_size * 2;
-        ValueType* restrict dpsi_z = psi_iw_ptr + padded_size * 3;
-        ValueType* restrict d2psi  = psi_iw_ptr + padded_size * 4;
+        ValueType* restrict dpsi_x = psi_iw_ptr + sposet_padded_size;
+        ValueType* restrict dpsi_y = psi_iw_ptr + sposet_padded_size * 2;
+        ValueType* restrict dpsi_z = psi_iw_ptr + sposet_padded_size * 3;
+        ValueType* restrict d2psi  = psi_iw_ptr + sposet_padded_size * 4;
 
-        ValueType* restrict out_phi    = phi_vgl_ptr + iw * orb_size;
+        ValueType* restrict out_phi    = phi_vgl_ptr + iw * requested_orb_size;
         ValueType* restrict out_dphi_x = out_phi + phi_vgl_stride;
         ValueType* restrict out_dphi_y = out_dphi_x + phi_vgl_stride;
         ValueType* restrict out_dphi_z = out_dphi_y + phi_vgl_stride;
         ValueType* restrict out_d2phi  = out_dphi_z + phi_vgl_stride;
 
         const size_t first_real = first_cplx + omptarget::min(nComplexBands_local, first_cplx);
-        const size_t last_real  = last_cplx + omptarget::min(nComplexBands_local, last_cplx);
+        const size_t last_real =
+            omptarget::min(last_cplx + omptarget::min(nComplexBands_local, last_cplx), requested_orb_size);
         ValueType ratio(0), grad_x(0), grad_y(0), grad_z(0);
         PRAGMA_OFFLOAD("omp parallel for reduction(+: ratio, grad_x, grad_y, grad_z)")
         for (size_t j = first_real; j < last_real; j++)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -37,7 +37,7 @@ namespace qmcplusplus
  * The internal storage of complex spline coefficients uses double sized real arrays of ST type, aligned and padded.
  * The first nComplexBands complex splines produce 2 real orbitals.
  * The rest complex splines produce 1 real orbital.
- * All the output orbitals are real.
+ * All the output orbitals are real (C2R). The maximal number of output orbitals is OrbitalSetSize.
  */
 template<typename ST>
 class SplineC2ROMPTarget : public BsplineSet

--- a/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
+++ b/src/QMCWaveFunctions/EinsplineSetBuilderESHDF.fft.cpp
@@ -60,7 +60,7 @@ bool EinsplineSetBuilder::ReadOrbitalInfo_ESHDF(bool skipChecks)
            "      %9.6f %9.6f %9.6f ]\n",
            SuperLattice(0, 0), SuperLattice(0, 1), SuperLattice(0, 2), SuperLattice(1, 0), SuperLattice(1, 1),
            SuperLattice(1, 2), SuperLattice(2, 0), SuperLattice(2, 1), SuperLattice(2, 2));
-  app_log() << buff;
+  app_log() << buff << std::endl;
   if (!CheckLattice())
     throw std::runtime_error("CheckLattice failed");
   PrimCell.set(Lattice);

--- a/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
+++ b/src/QMCWaveFunctions/Fermion/MatrixDelayedUpdateCUDA.h
@@ -775,18 +775,25 @@ public:
     delay_count = 0;
   }
 
+/*
   inline void print_Ainv(const RefVector<This_t>& engines)
   {
     for (This_t& engine : engines)
     {
-      std::cout << "debug Ainv host  " << engine.get_psiMinv()[0][0] << " " << engine.get_psiMinv()[0][1] << " "
-                << engine.psiMinv[1][0] << " " << engine.psiMinv[1][1] << std::endl;
-      auto* temp_ptr = engine.psiMinv.data();
+      std::cout << "debug Ainv host  " << engine.get_psiMinv()[0][0] << " " << engine.get_psiMinv()[0][32] << " "
+                << engine.get_psiMinv()[1][0] << " " << engine.get_psiMinv()[1][32] << std::endl;
+      auto* temp_ptr = engine.get_psiMinv().data();
       PRAGMA_OFFLOAD("omp target update from(temp_ptr[:psiMinv_.size()])")
-      std::cout << "debug Ainv devi  " << engine.psiMinv[0][0] << " " << engine.psiMinv[0][1] << " "
-                << engine.psiMinv[1][0] << " " << engine.psiMinv[1][1] << std::endl;
+      std::cout << "debug Ainv devi";
+      for (size_t row = 0; row < psiMinv_.rows(); row++)
+      {
+        for (size_t col = 0; col < psiMinv_.cols(); col++)
+          std::cout << " " << row << " " << col << " " << engine.get_psiMinv()[row][col];
+        std::cout << std::endl;
+      }
     }
   }
+*/
 
   /** return invRow host or device pointers based on on_host request
    * prepare invRow if not already.

--- a/src/QMCWaveFunctions/tests/CMakeLists.txt
+++ b/src/QMCWaveFunctions/tests/CMakeLists.txt
@@ -39,6 +39,24 @@ maybe_symlink(${UTEST_HDF_INPUT9} ${UTEST_DIR}/Bi.orbs.h5)
 maybe_symlink(${UTEST_HDF_INPUT10} ${UTEST_DIR}/lcao_spinor_molecule.h5)
 maybe_symlink(${UTEST_HDF_INPUT11} ${UTEST_DIR}/hcpBe.pwscf.h5)
 
+if(NOT QMC_DATA)
+  message(VERBOSE "QMC_DATA not set. NiO_a16 based tests not added.")
+elseif(NOT EXISTS ${QMC_DATA}/NiO)
+  message("NiO directory under QMC_DATA does not exist. NiO_a16 based tests not added.")
+else()
+
+  set(H5_FILE NiO-fcc-supertwist111-supershift000-S4.h5)
+  set(H5_FULL_PATH "${QMC_DATA}/NiO/${H5_FILE}")
+
+  if(EXISTS ${H5_FULL_PATH})
+    #symlink h5 file
+    maybe_symlink(${H5_FULL_PATH} ${UTEST_DIR}/${H5_FILE})
+    set(NiO_a16_H5_FOUND TRUE)
+  else()
+    message(VERBOSE "NiO_a16 based tests not added because the corresponding h5 file not found: ${H5_FULL_PATH}")
+  endif()
+endif()
+
 set(FILES_TO_COPY
     he_sto3g.wfj.xml
     ne_def2_svp.wfnoj.xml
@@ -80,6 +98,7 @@ set(TRIALWF_SRC
     test_example_he.cpp
     test_lattice_gaussian.cpp
     test_TWFGrads.cpp)
+
 set(SPOSET_SRC
     test_spo_collection_input_spline.cpp
     test_spo_collection_input_LCAO_xml.cpp
@@ -90,6 +109,10 @@ set(SPOSET_SRC
     test_hybridrep.cpp
     test_pw.cpp
     ${MO_SRCS})
+if(NiO_a16_H5_FOUND)
+  set(SPOSET_SRC ${SPOSET_SRC} test_einset_NiO_a16.cpp)
+endif()
+
 set(JASTROW_SRC
     test_counting_jastrow.cpp
     test_polynomial_eeI_jastrow.cpp
@@ -104,6 +127,7 @@ set(JASTROW_SRC
     test_J2_bspline.cpp
     test_J2_derivatives.cpp
     test_2d_jastrow.cpp)
+
 set(DETERMINANT_SRC
     FakeSPO.cpp
     test_DiracDeterminant.cpp

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -34,28 +34,10 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 
   ParticleSet::ParticleLayout lattice;
   // monoO
-  /*
-  lattice.R(0,0) = 5.10509515;
-  lattice.R(0,1) = -3.23993545;
-  lattice.R(0,2) = 0.0;
-  lattice.R(1,0) = 5.10509515;
-  lattice.R(1,1) = 3.23993545;
-  lattice.R(1,2) = 0.0;
-  lattice.R(2,0) = -6.49690625;
-  lattice.R(2,1) = 0.0;
-  lattice.R(2,2) = 7.08268015;
-  */
+  // lattice.R(0,0) = {5.10509515, -3.23993545,  0.0, 5.10509515, 3.23993545, 0.0, -6.49690625, 0.0, 7.08268015};
 
   // diamondC_1x1x1
-  lattice.R(0, 0) = 3.37316115;
-  lattice.R(0, 1) = 3.37316115;
-  lattice.R(0, 2) = 0.0;
-  lattice.R(1, 0) = 0.0;
-  lattice.R(1, 1) = 3.37316115;
-  lattice.R(1, 2) = 3.37316115;
-  lattice.R(2, 0) = 3.37316115;
-  lattice.R(2, 1) = 0.0;
-  lattice.R(2, 2) = 3.37316115;
+  lattice.R = {3.37316115, 3.37316115, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
   ptcl.setSimulationCell(lattice);
@@ -67,23 +49,15 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   ions_.setName("ion");
   ptcl.addParticleSet(std::move(ions_uptr));
   ions_.create({2});
-  ions_.R[0][0] = 0.0;
-  ions_.R[0][1] = 0.0;
-  ions_.R[0][2] = 0.0;
-  ions_.R[1][0] = 1.68658058;
-  ions_.R[1][1] = 1.68658058;
-  ions_.R[1][2] = 1.68658058;
+  ions_.R[0] = {0.0, 0.0, 0.0};
+  ions_.R[1] = {1.68658058, 1.68658058, 1.68658058};
 
 
   elec_.setName("elec");
   ptcl.addParticleSet(std::move(elec_uptr));
   elec_.create({2});
-  elec_.R[0][0] = 0.0;
-  elec_.R[0][1] = 0.0;
-  elec_.R[0][2] = 0.0;
-  elec_.R[1][0] = 0.0;
-  elec_.R[1][1] = 1.0;
-  elec_.R[1][2] = 0.0;
+  elec_.R[0] = {0.0, 0.0, 0.0};
+  elec_.R[1] = {0.0, 1.0, 0.0};
 
   SpeciesSet& tspecies       = elec_.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");
@@ -146,15 +120,15 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   // Catch default is 100*(float epsilson)
   double eps = 2000 * std::numeric_limits<float>::epsilon();
   //hess
-  REQUIRE(std::real(ddpsiV[1](0, 0)) == Approx(-2.3160984034));
-  REQUIRE(std::real(ddpsiV[1](0, 1)) == Approx(1.8089479397));
-  REQUIRE(std::real(ddpsiV[1](0, 2)) == Approx(0.5608575749));
-  REQUIRE(std::real(ddpsiV[1](1, 0)) == Approx(1.8089479397));
-  REQUIRE(std::real(ddpsiV[1](1, 1)) == Approx(-0.07996207476).epsilon(eps));
-  REQUIRE(std::real(ddpsiV[1](1, 2)) == Approx(0.5237969314));
-  REQUIRE(std::real(ddpsiV[1](2, 0)) == Approx(0.5608575749));
-  REQUIRE(std::real(ddpsiV[1](2, 1)) == Approx(0.5237969314));
-  REQUIRE(std::real(ddpsiV[1](2, 2)) == Approx(-2.316497764));
+  CHECK(std::real(ddpsiV[1](0, 0)) == Approx(-2.3160984034));
+  CHECK(std::real(ddpsiV[1](0, 1)) == Approx(1.8089479397));
+  CHECK(std::real(ddpsiV[1](0, 2)) == Approx(0.5608575749));
+  CHECK(std::real(ddpsiV[1](1, 0)) == Approx(1.8089479397));
+  CHECK(std::real(ddpsiV[1](1, 1)) == Approx(-0.07996207476).epsilon(eps));
+  CHECK(std::real(ddpsiV[1](1, 2)) == Approx(0.5237969314));
+  CHECK(std::real(ddpsiV[1](2, 0)) == Approx(0.5608575749));
+  CHECK(std::real(ddpsiV[1](2, 1)) == Approx(0.5237969314));
+  CHECK(std::real(ddpsiV[1](2, 2)) == Approx(-2.316497764));
 
   SPOSet::HessMatrix hesspsiV(elec_.R.size(), psi_size);
   SPOSet::GGGMatrix d3psiV(elec_.R.size(), psi_size);
@@ -186,27 +160,27 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 */
 
 #if 0 //Enable when finite precision issue on Rhea is found.
-  REQUIRE(std::real(d3psiV(1,0)[0][0] ) == Approx(0.0463371276));
-  REQUIRE(std::real(d3psiV(1,0)[0][1] ) == Approx(1.1755813360));
-  REQUIRE(std::real(d3psiV(1,0)[0][2] ) == Approx(0.0660155713));
-  REQUIRE(std::real(d3psiV(1,0)[0][4] ) == Approx(0.0414704382));
-  REQUIRE(std::real(d3psiV(1,0)[0][5] ) == Approx(-0.5167412758));
-  REQUIRE(std::real(d3psiV(1,0)[0][8] ) == Approx(0.0659536421));
-  REQUIRE(std::real(d3psiV(1,0)[1][4] ) == Approx(-4.8771157264));
-  REQUIRE(std::real(d3psiV(1,0)[1][5] ) == Approx(0.0415326356));
-  REQUIRE(std::real(d3psiV(1,0)[1][8] ) == Approx(1.1755810976));
-  REQUIRE(std::real(d3psiV(1,0)[2][8] ) == Approx(0.0463993549));
+  CHECK(std::real(d3psiV(1,0)[0][0] ) == Approx(0.0463371276));
+  CHECK(std::real(d3psiV(1,0)[0][1] ) == Approx(1.1755813360));
+  CHECK(std::real(d3psiV(1,0)[0][2] ) == Approx(0.0660155713));
+  CHECK(std::real(d3psiV(1,0)[0][4] ) == Approx(0.0414704382));
+  CHECK(std::real(d3psiV(1,0)[0][5] ) == Approx(-0.5167412758));
+  CHECK(std::real(d3psiV(1,0)[0][8] ) == Approx(0.0659536421));
+  CHECK(std::real(d3psiV(1,0)[1][4] ) == Approx(-4.8771157264));
+  CHECK(std::real(d3psiV(1,0)[1][5] ) == Approx(0.0415326356));
+  CHECK(std::real(d3psiV(1,0)[1][8] ) == Approx(1.1755810976));
+  CHECK(std::real(d3psiV(1,0)[2][8] ) == Approx(0.0463993549));
 
-  REQUIRE(std::real(d3psiV(1,1)[0][0] ) == Approx(6.7155771255));
-  REQUIRE(std::real(d3psiV(1,1)[0][1] ) == Approx(5.5450510978));
-  REQUIRE(std::real(d3psiV(1,1)[0][2] ) == Approx(0.9829711914));
-  REQUIRE(std::real(d3psiV(1,1)[0][4] ) == Approx(-3.1704092025));
-  REQUIRE(std::real(d3psiV(1,1)[0][5] ) == Approx(-1.9537661075));
-  REQUIRE(std::real(d3psiV(1,1)[0][8] ) == Approx(1.9305641651));
-  REQUIRE(std::real(d3psiV(1,1)[1][4] ) == Approx(3.6051378250));
-  REQUIRE(std::real(d3psiV(1,1)[1][5] ) == Approx(-0.7382576465));
-  REQUIRE(std::real(d3psiV(1,1)[1][8] ) == Approx(5.5741839408));
-  REQUIRE(std::real(d3psiV(1,1)[2][8] ) == Approx(3.1312348842));
+  CHECK(std::real(d3psiV(1,1)[0][0] ) == Approx(6.7155771255));
+  CHECK(std::real(d3psiV(1,1)[0][1] ) == Approx(5.5450510978));
+  CHECK(std::real(d3psiV(1,1)[0][2] ) == Approx(0.9829711914));
+  CHECK(std::real(d3psiV(1,1)[0][4] ) == Approx(-3.1704092025));
+  CHECK(std::real(d3psiV(1,1)[0][5] ) == Approx(-1.9537661075));
+  CHECK(std::real(d3psiV(1,1)[0][8] ) == Approx(1.9305641651));
+  CHECK(std::real(d3psiV(1,1)[1][4] ) == Approx(3.6051378250));
+  CHECK(std::real(d3psiV(1,1)[1][5] ) == Approx(-0.7382576465));
+  CHECK(std::real(d3psiV(1,1)[1][8] ) == Approx(5.5741839408));
+  CHECK(std::real(d3psiV(1,1)[2][8] ) == Approx(3.1312348842));
 #endif
 
   // Test the batched interface
@@ -438,21 +412,13 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
 #endif
 }
 
-TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
+TEST_CASE("Einspline SPO from HDF diamond_2x1x1 5 electrons", "[wavefunction]")
 {
   Communicate* c = OHMMS::Controller;
 
   ParticleSet::ParticleLayout lattice;
   // diamondC_2x1x1
-  lattice.R(0, 0) = 6.7463223;
-  lattice.R(0, 1) = 6.7463223;
-  lattice.R(0, 2) = 0.0;
-  lattice.R(1, 0) = 0.0;
-  lattice.R(1, 1) = 3.37316115;
-  lattice.R(1, 2) = 3.37316115;
-  lattice.R(2, 0) = 3.37316115;
-  lattice.R(2, 1) = 0.0;
-  lattice.R(2, 2) = 3.37316115;
+  lattice.R = {6.7463223, 6.7463223, 0.0, 0.0, 3.37316115, 3.37316115, 3.37316115, 0.0, 3.37316115};
 
   ParticleSetPool ptcl = ParticleSetPool(c);
   ptcl.setSimulationCell(lattice);
@@ -464,29 +430,20 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   ions_.setName("ion");
   ptcl.addParticleSet(std::move(ions_uptr));
   ions_.create({4});
-  ions_.R[0][0] = 0.0;
-  ions_.R[0][1] = 0.0;
-  ions_.R[0][2] = 0.0;
-  ions_.R[1][0] = 1.68658058;
-  ions_.R[1][1] = 1.68658058;
-  ions_.R[1][2] = 1.68658058;
-  ions_.R[2][0] = 3.37316115;
-  ions_.R[2][1] = 3.37316115;
-  ions_.R[2][2] = 0.0;
-  ions_.R[3][0] = 5.05974173;
-  ions_.R[3][1] = 5.05974173;
-  ions_.R[3][2] = 1.68658058;
+  ions_.R[0] = {0.0, 0.0, 0.0};
+  ions_.R[1] = {1.68658058, 1.68658058, 1.68658058};
+  ions_.R[2] = {3.37316115, 3.37316115, 0.0};
+  ions_.R[3] = {5.05974173, 5.05974173, 1.68658058};
 
 
   elec_.setName("elec");
   ptcl.addParticleSet(std::move(elec_uptr));
-  elec_.create({2});
-  elec_.R[0][0] = 0.0;
-  elec_.R[0][1] = 0.0;
-  elec_.R[0][2] = 0.0;
-  elec_.R[1][0] = 0.0;
-  elec_.R[1][1] = 1.0;
-  elec_.R[1][2] = 0.0;
+  elec_.create({5});
+  elec_.R[0] = {0.0, 0.0, 0.0};
+  elec_.R[1] = {0.0, 1.0, 0.0};
+  elec_.R[2] = {0.0, 1.1, 0.0};
+  elec_.R[3] = {0.0, 1.2, 0.0};
+  elec_.R[4] = {0.0, 1.3, 0.0};
 
   SpeciesSet& tspecies       = elec_.getSpeciesSet();
   int upIdx                  = tspecies.addSpecies("u");
@@ -495,7 +452,7 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
 
   //diamondC_2x1x1
   const char* particles = R"(<tmp>
-<determinantset type="einspline" href="diamondC_2x1x1.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="4"/>
+<determinantset type="einspline" href="diamondC_2x1x1.pwscf.h5" tilematrix="2 0 0 0 1 0 0 0 1" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="5"/>
 </tmp>
 )";
 
@@ -522,35 +479,35 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   // due to the different ordering of bands skip the tests on CUDA+Real builds
   // checking evaluations, reference values are not independently generated.
   // value
-  REQUIRE(std::real(psiM[1][0]) == Approx(0.9008999467));
-  REQUIRE(std::real(psiM[1][1]) == Approx(1.2383049726));
+  CHECK(std::real(psiM[1][0]) == Approx(0.9008999467));
+  CHECK(std::real(psiM[1][1]) == Approx(1.2383049726));
   // grad
-  REQUIRE(std::real(dpsiM[1][0][0]) == Approx(0.0025820041));
-  REQUIRE(std::real(dpsiM[1][0][1]) == Approx(-0.1880052537));
-  REQUIRE(std::real(dpsiM[1][0][2]) == Approx(-0.0025404284));
-  REQUIRE(std::real(dpsiM[1][1][0]) == Approx(0.1069662273));
-  REQUIRE(std::real(dpsiM[1][1][1]) == Approx(-0.4364597797));
-  REQUIRE(std::real(dpsiM[1][1][2]) == Approx(-0.106951952));
+  CHECK(std::real(dpsiM[1][0][0]) == Approx(0.0025820041));
+  CHECK(std::real(dpsiM[1][0][1]) == Approx(-0.1880052537));
+  CHECK(std::real(dpsiM[1][0][2]) == Approx(-0.0025404284));
+  CHECK(std::real(dpsiM[1][1][0]) == Approx(0.1069662273));
+  CHECK(std::real(dpsiM[1][1][1]) == Approx(-0.4364597797));
+  CHECK(std::real(dpsiM[1][1][2]) == Approx(-0.106951952));
   // lapl
-  REQUIRE(std::real(d2psiM[1][0]) == Approx(-1.3757134676));
-  REQUIRE(std::real(d2psiM[1][1]) == Approx(-2.4803137779));
+  CHECK(std::real(d2psiM[1][0]) == Approx(-1.3757134676));
+  CHECK(std::real(d2psiM[1][1]) == Approx(-2.4803137779));
 #endif
 
 #if defined(QMC_COMPLEX)
   // imaginary part
   // value
-  REQUIRE(std::imag(psiM[1][0]) == Approx(0.9008999467));
-  REQUIRE(std::imag(psiM[1][1]) == Approx(1.2383049726));
+  CHECK(std::imag(psiM[1][0]) == Approx(0.9008999467));
+  CHECK(std::imag(psiM[1][1]) == Approx(1.2383049726));
   // grad
-  REQUIRE(std::imag(dpsiM[1][0][0]) == Approx(0.0025820041));
-  REQUIRE(std::imag(dpsiM[1][0][1]) == Approx(-0.1880052537));
-  REQUIRE(std::imag(dpsiM[1][0][2]) == Approx(-0.0025404284));
-  REQUIRE(std::imag(dpsiM[1][1][0]) == Approx(0.1069453433));
-  REQUIRE(std::imag(dpsiM[1][1][1]) == Approx(-0.43649593));
-  REQUIRE(std::imag(dpsiM[1][1][2]) == Approx(-0.1069145575));
+  CHECK(std::imag(dpsiM[1][0][0]) == Approx(0.0025820041));
+  CHECK(std::imag(dpsiM[1][0][1]) == Approx(-0.1880052537));
+  CHECK(std::imag(dpsiM[1][0][2]) == Approx(-0.0025404284));
+  CHECK(std::imag(dpsiM[1][1][0]) == Approx(0.1069453433));
+  CHECK(std::imag(dpsiM[1][1][1]) == Approx(-0.43649593));
+  CHECK(std::imag(dpsiM[1][1][2]) == Approx(-0.1069145575));
   // lapl
-  REQUIRE(std::imag(d2psiM[1][0]) == Approx(-1.3757134676));
-  REQUIRE(std::imag(d2psiM[1][1]) == Approx(-2.4919104576));
+  CHECK(std::imag(d2psiM[1][0]) == Approx(-1.3757134676));
+  CHECK(std::imag(d2psiM[1][1]) == Approx(-2.4919104576));
 #endif
 
   // test batched interfaces
@@ -592,35 +549,59 @@ TEST_CASE("Einspline SPO from HDF diamond_2x1x1", "[wavefunction]")
   // due to the different ordering of bands skip the tests on CUDA+Real builds
   // checking evaluations, reference values are not independently generated.
   // value
-  REQUIRE(std::real(psi_v_list[1].get()[0]) == Approx(0.9008999467));
-  REQUIRE(std::real(psi_v_list[1].get()[1]) == Approx(1.2383049726));
+  CHECK(std::real(psi_v_list[1].get()[0]) == Approx(0.9008999467));
+  CHECK(std::real(psi_v_list[1].get()[1]) == Approx(1.2383049726));
   // grad
-  REQUIRE(std::real(dpsi_v_list[1].get()[0][0]) == Approx(0.0025820041));
-  REQUIRE(std::real(dpsi_v_list[1].get()[0][1]) == Approx(-0.1880052537));
-  REQUIRE(std::real(dpsi_v_list[1].get()[0][2]) == Approx(-0.0025404284));
-  REQUIRE(std::real(dpsi_v_list[1].get()[1][0]) == Approx(0.1069662273));
-  REQUIRE(std::real(dpsi_v_list[1].get()[1][1]) == Approx(-0.4364597797));
-  REQUIRE(std::real(dpsi_v_list[1].get()[1][2]) == Approx(-0.106951952));
+  CHECK(std::real(dpsi_v_list[1].get()[0][0]) == Approx(0.0025820041));
+  CHECK(std::real(dpsi_v_list[1].get()[0][1]) == Approx(-0.1880052537));
+  CHECK(std::real(dpsi_v_list[1].get()[0][2]) == Approx(-0.0025404284));
+  CHECK(std::real(dpsi_v_list[1].get()[1][0]) == Approx(0.1069662273));
+  CHECK(std::real(dpsi_v_list[1].get()[1][1]) == Approx(-0.4364597797));
+  CHECK(std::real(dpsi_v_list[1].get()[1][2]) == Approx(-0.106951952));
   // lapl
-  REQUIRE(std::real(d2psi_v_list[1].get()[0]) == Approx(-1.3757134676));
-  REQUIRE(std::real(d2psi_v_list[1].get()[1]) == Approx(-2.4803137779));
+  CHECK(std::real(d2psi_v_list[1].get()[0]) == Approx(-1.3757134676));
+  CHECK(std::real(d2psi_v_list[1].get()[1]) == Approx(-2.4803137779));
 #endif
 
 #if defined(QMC_COMPLEX)
   // imaginary part
   // value
-  REQUIRE(std::imag(psi_v_list[1].get()[0]) == Approx(0.9008999467));
-  REQUIRE(std::imag(psi_v_list[1].get()[1]) == Approx(1.2383049726));
+  CHECK(std::imag(psi_v_list[1].get()[0]) == Approx(0.9008999467));
+  CHECK(std::imag(psi_v_list[1].get()[1]) == Approx(1.2383049726));
   // grad
-  REQUIRE(std::imag(dpsi_v_list[1].get()[0][0]) == Approx(0.0025820041));
-  REQUIRE(std::imag(dpsi_v_list[1].get()[0][1]) == Approx(-0.1880052537));
-  REQUIRE(std::imag(dpsi_v_list[1].get()[0][2]) == Approx(-0.0025404284));
-  REQUIRE(std::imag(dpsi_v_list[1].get()[1][0]) == Approx(0.1069453433));
-  REQUIRE(std::imag(dpsi_v_list[1].get()[1][1]) == Approx(-0.43649593));
-  REQUIRE(std::imag(dpsi_v_list[1].get()[1][2]) == Approx(-0.1069145575));
+  CHECK(std::imag(dpsi_v_list[1].get()[0][0]) == Approx(0.0025820041));
+  CHECK(std::imag(dpsi_v_list[1].get()[0][1]) == Approx(-0.1880052537));
+  CHECK(std::imag(dpsi_v_list[1].get()[0][2]) == Approx(-0.0025404284));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][0]) == Approx(0.1069453433));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][1]) == Approx(-0.43649593));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][2]) == Approx(-0.1069145575));
   // lapl
-  REQUIRE(std::imag(d2psi_v_list[1].get()[0]) == Approx(-1.3757134676));
-  REQUIRE(std::imag(d2psi_v_list[1].get()[1]) == Approx(-2.4919104576));
+  CHECK(std::imag(d2psi_v_list[1].get()[0]) == Approx(-1.3757134676));
+  CHECK(std::imag(d2psi_v_list[1].get()[1]) == Approx(-2.4919104576));
+#endif
+
+  const size_t nw = 2;
+  std::vector<SPOSet::ValueType> ratio_v(nw);
+  std::vector<SPOSet::GradType> grads_v(nw);
+
+  Vector<SPOSet::ValueType, OffloadPinnedAllocator<SPOSet::ValueType>> inv_row(5);
+  inv_row = {0.1, 0.2, 0.3, 0.4, 0.5};
+  inv_row.updateTo();
+
+  std::vector<const SPOSet::ValueType*> inv_row_ptr(nw, inv_row.device_data());
+
+  SPOSet::OffloadMWVGLArray phi_vgl_v;
+  phi_vgl_v.resize(QMCTraits::DIM_VGL, nw, 5);
+  spo->mw_evaluateVGLandDetRatioGrads(spo_list, p_list, 0, inv_row_ptr, phi_vgl_v, ratio_v, grads_v);
+#if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
+  CHECK(std::real(ratio_v[0]) == Approx(0.2365307168));
+  CHECK(std::real(grads_v[0][0]) == Approx(-5.4095164399));
+  CHECK(std::real(grads_v[0][1]) == Approx(14.37990087));
+  CHECK(std::real(grads_v[0][2]) == Approx(16.9374788259));
+  CHECK(std::real(ratio_v[1]) == Approx(1.0560744941));
+  CHECK(std::real(grads_v[1][0]) == Approx(-0.0863436466));
+  CHECK(std::real(grads_v[1][1]) == Approx(-0.7499371447));
+  CHECK(std::real(grads_v[1][2]) == Approx(0.8570534314));
 #endif
 }
 
@@ -643,12 +624,8 @@ TEST_CASE("EinsplineSetBuilder CheckLattice", "[wavefunction]")
   agroup[0] = 1;
   agroup[1] = 1;
   elec.create(agroup);
-  elec.R[0][0] = 0.00;
-  elec.R[0][1] = 0.0;
-  elec.R[0][2] = 0.0;
-  elec.R[1][0] = 0.0;
-  elec.R[1][1] = 1.0;
-  elec.R[1][2] = 0.0;
+  elec.R[0] = {0.0, 0.0, 0.0};
+  elec.R[1] = {0.0, 1.0, 0.0};
 
   EinsplineSetBuilder::PSetMap ptcl_map;
   ptcl_map.emplace(elec_ptr->getName(), std::move(elec_ptr));

--- a/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
@@ -217,6 +217,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   CHECK(std::imag(d2psi_v_list[1].get()[1]) == Approx(-2.6130394936).epsilon(0.0001));
 #endif
 
+#if !defined(QMC_CUDA)
   const size_t nw = 2;
   std::vector<SPOSet::ValueType> ratio_v(nw);
   std::vector<SPOSet::GradType> grads_v(nw);
@@ -235,7 +236,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   phi_vgl_v.resize(QMCTraits::DIM_VGL, nw, 5);
   spo->mw_evaluateVGLandDetRatioGrads(spo_list, p_list, 0, inv_row_ptr, phi_vgl_v, ratio_v, grads_v);
   phi_vgl_v.updateFrom();
-#if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
+#if !defined(QMC_COMPLEX)
   CHECK(std::real(ratio_v[0]) == Approx(-0.4838374162));
   CHECK(std::real(grads_v[0][0]) == Approx(-24.6573209338));
   CHECK(std::real(grads_v[0][1]) == Approx(24.6573187288));
@@ -246,9 +247,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   CHECK(std::real(grads_v[1][1]) == Approx(-2.6037152796));
   CHECK(std::real(grads_v[1][2]) == Approx(-0.0001673779));
   CHECK(std::real(phi_vgl_v(0, 1, 0)) == Approx(-2.6693785191));
-#endif
-
-#if defined(QMC_COMPLEX)
+#else
   CHECK(std::imag(ratio_v[0]) == Approx(0.0005530113));
   CHECK(std::imag(grads_v[0][0]) == Approx(-0.000357729));
   CHECK(std::imag(grads_v[0][1]) == Approx(-0.0005462062));
@@ -259,6 +258,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   CHECK(std::imag(grads_v[1][1]) == Approx(-0.0000331457));
   CHECK(std::imag(grads_v[1][2]) == Approx(0.0000295465));
   CHECK(std::imag(phi_vgl_v(0, 1, 0)) == Approx(2.6693942547));
+#endif
 #endif
 }
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
@@ -1,0 +1,264 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//
+// File created by: Mark Dewing, markdewing@gmail.com, University of Illinois at Urbana-Champaign
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "catch.hpp"
+
+#include "OhmmsData/Libxml2Doc.h"
+#include "OhmmsPETE/OhmmsMatrix.h"
+#include "Particle/ParticleSet.h"
+#include "Particle/ParticleSetPool.h"
+#include "QMCWaveFunctions/WaveFunctionComponent.h"
+#include "QMCWaveFunctions/EinsplineSetBuilder.h"
+#include "QMCWaveFunctions/EinsplineSpinorSetBuilder.h"
+
+#include <stdio.h>
+#include <string>
+#include <limits>
+
+using std::string;
+
+namespace qmcplusplus
+{
+
+TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
+{
+  Communicate* c = OHMMS::Controller;
+
+  ParticleSet::ParticleLayout lattice;
+  lattice.R = {3.94055, 3.94055, 7.8811, 3.94055, 3.94055, -7.8811, -7.8811, 7.8811, 0};
+
+  ParticleSetPool ptcl = ParticleSetPool(c);
+  ptcl.setSimulationCell(lattice);
+  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  ParticleSet& ions_(*ions_uptr);
+  ParticleSet& elec_(*elec_uptr);
+
+  ions_.setName("ion");
+  ptcl.addParticleSet(std::move(ions_uptr));
+  ions_.create({8, 8});
+  ions_.R[0]  = {0.75, 0.25, 0};
+  ions_.R[1]  = {0.75, 0.25, 0.5};
+  ions_.R[2]  = {0.75, 0.75, 0.25};
+  ions_.R[3]  = {0.75, 0.75, 0.75};
+  ions_.R[4]  = {0.25, 0.75, 0};
+  ions_.R[5]  = {0.25, 0.25, 0.25};
+  ions_.R[6]  = {0.25, 0.75, 0.5};
+  ions_.R[7]  = {0.25, 0.25, 0.75};
+  ions_.R[8]  = {0, 0, 0};
+  ions_.R[9]  = {0, 0, 0.5};
+  ions_.R[10] = {0, 0.5, 0.25};
+  ions_.R[11] = {0, 0.5, 0.75};
+  ions_.R[12] = {0.5, 0.5, 0};
+  ions_.R[13] = {0.5, 0, 0.25};
+  ions_.R[14] = {0.5, 0.5, 0.5};
+  ions_.R[15] = {0.5, 0, 0.75};
+
+  // convert to cartesian
+  ions_.R.setUnit(PosUnit::Lattice);
+  ions_.convert2Cart(ions_.R);
+
+  // printout coordinates
+  SpeciesSet& ispecies = ions_.getSpeciesSet();
+  int Oidx             = ispecies.addSpecies("O");
+  int Niidx            = ispecies.addSpecies("Ni");
+  ions_.print(app_log());
+
+  elec_.setName("elec");
+  ptcl.addParticleSet(std::move(elec_uptr));
+  elec_.create({97});
+  elec_.R[0] = {0.0, 0.0, 0.0};
+  elec_.R[1] = {0.0, 1.0, 0.0};
+  elec_.R[2] = {0.0, 1.1, 0.0};
+  elec_.R[3] = {0.0, 1.2, 0.0};
+  elec_.R[4] = {0.0, 1.3, 0.0};
+
+  SpeciesSet& tspecies       = elec_.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  tspecies(chargeIdx, upIdx) = -1;
+
+  //diamondC_2x1x1
+  const char* particles = R"(<tmp>
+<determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S4.h5" tilematrix="1 0 0 0 1 1 0 2 -2" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="97"/>
+</tmp>
+)";
+
+  Libxml2Document doc;
+  bool okay = doc.parseFromString(particles);
+  REQUIRE(okay);
+
+  xmlNodePtr root = doc.getRoot();
+
+  xmlNodePtr ein1 = xmlFirstElementChild(root);
+
+  EinsplineSetBuilder einSet(elec_, ptcl.getPool(), c, ein1);
+  auto spo = einSet.createSPOSetFromXML(ein1);
+  REQUIRE(spo);
+
+  // for vgl
+  SPOSet::ValueMatrix psiM(elec_.R.size(), spo->getOrbitalSetSize());
+  SPOSet::GradMatrix dpsiM(elec_.R.size(), spo->getOrbitalSetSize());
+  SPOSet::ValueMatrix d2psiM(elec_.R.size(), spo->getOrbitalSetSize());
+  spo->evaluate_notranspose(elec_, 0, elec_.R.size(), psiM, dpsiM, d2psiM);
+
+#if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
+  // real part
+  // due to the different ordering of bands skip the tests on CUDA+Real builds
+  // checking evaluations, reference values are not independently generated.
+  // value
+  CHECK(std::real(psiM[1][0]) == Approx(-2.6693785191));
+  CHECK(std::real(psiM[1][1]) == Approx(-2.669519186));
+  // grad
+  CHECK(std::real(dpsiM[1][0][0]) == Approx(-0.0002679008));
+  CHECK(std::real(dpsiM[1][0][1]) == Approx(7.622625351));
+  CHECK(std::real(dpsiM[1][0][2]) == Approx(-0.0003001692));
+  CHECK(std::real(dpsiM[1][1][0]) == Approx(-0.0002825252));
+  CHECK(std::real(dpsiM[1][1][1]) == Approx(7.6229834557));
+  CHECK(std::real(dpsiM[1][1][2]) == Approx(-0.0002339484));
+  // lapl
+  CHECK(std::real(d2psiM[1][0]) == Approx(-2.6130394936));
+  CHECK(std::real(d2psiM[1][1]) == Approx(-2.6067698002));
+#endif
+
+#if defined(QMC_COMPLEX)
+  // imaginary part
+  // value
+  CHECK(std::imag(psiM[1][0]) == Approx(2.6693942547));
+  CHECK(std::imag(psiM[1][1]) == Approx(-2.6693785191));
+  // grad
+  CHECK(std::imag(dpsiM[1][0][0]) == Approx(-0.000179037));
+  CHECK(std::imag(dpsiM[1][0][1]) == Approx(-7.6221408844));
+  CHECK(std::imag(dpsiM[1][0][2]) == Approx(-0.0000232533));
+  CHECK(std::imag(dpsiM[1][1][0]) == Approx(-0.0002679008));
+  CHECK(std::imag(dpsiM[1][1][1]) == Approx(7.622625351));
+  CHECK(std::imag(dpsiM[1][1][2]) == Approx(-0.0003001692));
+  // lapl
+  CHECK(std::imag(d2psiM[1][0]) == Approx(2.6158618927).epsilon(0.0001));
+  CHECK(std::imag(d2psiM[1][1]) == Approx(-2.6130394936).epsilon(0.0001));
+#endif
+
+  // test batched interfaces
+
+  ParticleSet elec_2(elec_);
+  // interchange positions
+  elec_2.R[0] = elec_.R[1];
+  elec_2.R[1] = elec_.R[0];
+  RefVectorWithLeader<ParticleSet> p_list(elec_);
+  p_list.push_back(elec_);
+  p_list.push_back(elec_2);
+
+  std::unique_ptr<SPOSet> spo_2(spo->makeClone());
+  RefVectorWithLeader<SPOSet> spo_list(*spo);
+  spo_list.push_back(*spo);
+  spo_list.push_back(*spo_2);
+
+  SPOSet::ValueVector psi(spo->getOrbitalSetSize());
+  SPOSet::GradVector dpsi(spo->getOrbitalSetSize());
+  SPOSet::ValueVector d2psi(spo->getOrbitalSetSize());
+  SPOSet::ValueVector psi_2(spo->getOrbitalSetSize());
+  SPOSet::GradVector dpsi_2(spo->getOrbitalSetSize());
+  SPOSet::ValueVector d2psi_2(spo->getOrbitalSetSize());
+
+  RefVector<SPOSet::ValueVector> psi_v_list;
+  RefVector<SPOSet::GradVector> dpsi_v_list;
+  RefVector<SPOSet::ValueVector> d2psi_v_list;
+
+  psi_v_list.push_back(psi);
+  psi_v_list.push_back(psi_2);
+  dpsi_v_list.push_back(dpsi);
+  dpsi_v_list.push_back(dpsi_2);
+  d2psi_v_list.push_back(d2psi);
+  d2psi_v_list.push_back(d2psi_2);
+
+  spo->mw_evaluateVGL(spo_list, p_list, 0, psi_v_list, dpsi_v_list, d2psi_v_list);
+#if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
+  // real part
+  // due to the different ordering of bands skip the tests on CUDA+Real builds
+  // checking evaluations, reference values are not independently generated.
+  // value
+  CHECK(std::real(psi_v_list[1].get()[0]) == Approx(-2.6693785191));
+  CHECK(std::real(psi_v_list[1].get()[1]) == Approx(-2.669519186));
+  // grad
+  CHECK(std::real(dpsi_v_list[1].get()[0][0]) == Approx(-0.0002679008));
+  CHECK(std::real(dpsi_v_list[1].get()[0][1]) == Approx(7.622625351));
+  CHECK(std::real(dpsi_v_list[1].get()[0][2]) == Approx(-0.0003001692));
+  CHECK(std::real(dpsi_v_list[1].get()[1][0]) == Approx(-0.0002825252));
+  CHECK(std::real(dpsi_v_list[1].get()[1][1]) == Approx(7.6229834557));
+  CHECK(std::real(dpsi_v_list[1].get()[1][2]) == Approx(-0.0002339484));
+  // lapl
+  CHECK(std::real(d2psi_v_list[1].get()[0]) == Approx(-2.6130394936));
+  CHECK(std::real(d2psi_v_list[1].get()[1]) == Approx(-2.6067698002));
+#endif
+
+#if defined(QMC_COMPLEX)
+  // imaginary part
+  // value
+  CHECK(std::imag(psi_v_list[1].get()[0]) == Approx(2.6693942547));
+  CHECK(std::imag(psi_v_list[1].get()[1]) == Approx(-2.6693785191));
+  // grad
+  CHECK(std::imag(dpsi_v_list[1].get()[0][0]) == Approx(-0.000179037));
+  CHECK(std::imag(dpsi_v_list[1].get()[0][1]) == Approx(-7.6221408844));
+  CHECK(std::imag(dpsi_v_list[1].get()[0][2]) == Approx(-0.0000232533));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][0]) == Approx(-0.0002679008));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][1]) == Approx(7.622625351));
+  CHECK(std::imag(dpsi_v_list[1].get()[1][2]) == Approx(-0.0003001692));
+  // lapl
+  CHECK(std::imag(d2psi_v_list[1].get()[0]) == Approx(2.6158618927).epsilon(0.0001));
+  CHECK(std::imag(d2psi_v_list[1].get()[1]) == Approx(-2.6130394936).epsilon(0.0001));
+#endif
+
+  const size_t nw = 2;
+  std::vector<SPOSet::ValueType> ratio_v(nw);
+  std::vector<SPOSet::GradType> grads_v(nw);
+
+  Vector<SPOSet::ValueType, OffloadPinnedAllocator<SPOSet::ValueType>> inv_row(5);
+  inv_row[0] = 0.1;
+  inv_row[1] = 0.2;
+  inv_row[2] = 0.3;
+  inv_row[3] = 0.4;
+  inv_row[4] = 0.5;
+  inv_row.updateTo();
+
+  std::vector<const SPOSet::ValueType*> inv_row_ptr(nw, inv_row.device_data());
+
+  SPOSet::OffloadMWVGLArray phi_vgl_v;
+  phi_vgl_v.resize(QMCTraits::DIM_VGL, nw, 5);
+  spo->mw_evaluateVGLandDetRatioGrads(spo_list, p_list, 0, inv_row_ptr, phi_vgl_v, ratio_v, grads_v);
+  phi_vgl_v.updateFrom();
+#if !defined(QMC_CUDA) && !defined(QMC_COMPLEX)
+  CHECK(std::real(ratio_v[0]) == Approx(-0.4838374162));
+  CHECK(std::real(grads_v[0][0]) == Approx(-24.6573209338));
+  CHECK(std::real(grads_v[0][1]) == Approx(24.6573187288));
+  CHECK(std::real(grads_v[0][2]) == Approx(-0.0000002709));
+  CHECK(std::real(phi_vgl_v(0, 0, 0)) == Approx(-1.6125482321));
+  CHECK(std::real(ratio_v[1]) == Approx(-2.4885484445));
+  CHECK(std::real(grads_v[1][0]) == Approx(-0.6732621026));
+  CHECK(std::real(grads_v[1][1]) == Approx(-2.6037152796));
+  CHECK(std::real(grads_v[1][2]) == Approx(-0.0001673779));
+  CHECK(std::real(phi_vgl_v(0, 1, 0)) == Approx(-2.6693785191));
+#endif
+
+#if defined(QMC_COMPLEX)
+  CHECK(std::imag(ratio_v[0]) == Approx(0.0005530113));
+  CHECK(std::imag(grads_v[0][0]) == Approx(-0.000357729));
+  CHECK(std::imag(grads_v[0][1]) == Approx(-0.0005462062));
+  CHECK(std::imag(grads_v[0][2]) == Approx(0.0004516766));
+  CHECK(std::imag(phi_vgl_v(0, 0, 0)) == Approx(1.6124026775));
+  CHECK(std::imag(ratio_v[1]) == Approx(0.0009635784));
+  CHECK(std::imag(grads_v[1][0]) == Approx(0.0001453869));
+  CHECK(std::imag(grads_v[1][1]) == Approx(-0.0000331457));
+  CHECK(std::imag(grads_v[1][2]) == Approx(0.0000295465));
+  CHECK(std::imag(phi_vgl_v(0, 1, 0)) == Approx(2.6693942547));
+#endif
+}
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset_NiO_a16.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
 
   //diamondC_2x1x1
   const char* particles = R"(<tmp>
-<determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S4.h5" tilematrix="1 0 0 0 1 1 0 2 -2" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="97"/>
+<determinantset type="einspline" href="NiO-fcc-supertwist111-supershift000-S4.h5" tilematrix="1 0 0 0 1 1 0 2 -2" twistnum="0" source="ion" meshfactor="1.0" precision="float" size="97" gpu="omptarget"/>
 </tmp>
 )";
 
@@ -126,8 +126,8 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   CHECK(std::real(dpsiM[1][1][1]) == Approx(7.6229834557));
   CHECK(std::real(dpsiM[1][1][2]) == Approx(-0.0002339484));
   // lapl
-  CHECK(std::real(d2psiM[1][0]) == Approx(-2.6130394936));
-  CHECK(std::real(d2psiM[1][1]) == Approx(-2.6067698002));
+  CHECK(std::real(d2psiM[1][0]) == Approx(-2.6130394936).epsilon(0.0001));
+  CHECK(std::real(d2psiM[1][1]) == Approx(-2.6067698002).epsilon(0.0001));
 #endif
 
 #if defined(QMC_COMPLEX)
@@ -196,8 +196,8 @@ TEST_CASE("Einspline SPO from HDF NiO a16 97 electrons", "[wavefunction]")
   CHECK(std::real(dpsi_v_list[1].get()[1][1]) == Approx(7.6229834557));
   CHECK(std::real(dpsi_v_list[1].get()[1][2]) == Approx(-0.0002339484));
   // lapl
-  CHECK(std::real(d2psi_v_list[1].get()[0]) == Approx(-2.6130394936));
-  CHECK(std::real(d2psi_v_list[1].get()[1]) == Approx(-2.6067698002));
+  CHECK(std::real(d2psi_v_list[1].get()[0]) == Approx(-2.6130394936).epsilon(0.0001));
+  CHECK(std::real(d2psi_v_list[1].get()[1]) == Approx(-2.6067698002).epsilon(0.0001));
 #endif
 
 #if defined(QMC_COMPLEX)


### PR DESCRIPTION
## Proposed changes
There is bug when using offload real build.
This caused writing to undesired memory locations and wrong numbers (crazy high variance/energy >>1)

## What type(s) of changes does this code introduce?
- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
