### PR TITLE
Add check for using parallel hdf5 in non-mpi build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,13 +632,9 @@ find_package(LibXml2 REQUIRED)
 #  set up HDF5 library
 #-------------------------------------------------------------------
 if(HAVE_MPI)
-  set(HDF5_PREFER_PARALLEL
-      TRUE
-      CACHE BOOL "Request parallel/serial HDF5 library")
+  option(HDF5_PREFER_PARALLEL "Request parallel/serial HDF5 library" ON)
 else(HAVE_MPI)
-  set(HDF5_PREFER_PARALLEL
-      FALSE
-      CACHE BOOL "Request parallel/serial HDF5 library")
+  option(HDF5_PREFER_PARALLEL "Request parallel/serial HDF5 library" OFF)
   if(HDF5_PREFER_PARALLEL)
     message(FATAL_ERROR "Parallel HDF5 library cannot be selected with QMCPACK non-MPI build. "
                         "Please set HDF5_PREFER_PARALLEL=0.")
@@ -657,8 +653,13 @@ find_package(HDF5 1.10 COMPONENTS C)
 
 if(HDF5_FOUND)
   if(HDF5_IS_PARALLEL)
-    message(STATUS "Parallel HDF5 library found")
-    option(ENABLE_PHDF5 "Enable code paths using parallel HDF5" ON)
+    if(HAVE_MPI)
+      message(STATUS "Parallel HDF5 library found")
+      option(ENABLE_PHDF5 "Enable code paths using parallel HDF5" ON)
+    else(HAVE_MPI)
+      message(FATAL_ERROR "Parallel HDF5 library found but cannot be used with QMCPACK non-MPI build. "
+                          "Please provide serial HDF5 library.")
+    endif(HAVE_MPI)
   else(HDF5_IS_PARALLEL)
     message(STATUS "Serial HDF5 library found")
     option(ENABLE_PHDF5 "Enable code paths using parallel HDF5" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,7 +658,7 @@ if(HDF5_FOUND)
       option(ENABLE_PHDF5 "Enable code paths using parallel HDF5" ON)
     else(HAVE_MPI)
       message(FATAL_ERROR "Parallel HDF5 library found but cannot be used with QMCPACK non-MPI build. "
-                          "Please provide serial HDF5 library.")
+                          "Please provide a serial HDF5 library or switch to building QMCPACK with MPI.")
     endif(HAVE_MPI)
   else(HDF5_IS_PARALLEL)
     message(STATUS "Serial HDF5 library found")


### PR DESCRIPTION
## Proposed changes

Added check for when MPI is disabled but the parallel HDF5 library was found. This results in an error due to incompatibility, since the parallel HDF5 library cannot be used without MPI.
Closes #4370 

## What type(s) of changes does this code introduce?

- Build related changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Ubuntu 22.04

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
