### PR TITLE
Orbital rotation part 1

### DIFF
--- a/src/Numerics/GaussianTimesRN.h
+++ b/src/Numerics/GaussianTimesRN.h
@@ -124,7 +124,7 @@ struct GaussianTimesRN : public OptimizableFunctorBase
 
   void checkInVariablesExclusive(opt_variables_type& active) override {}
   void checkOutVariables(const opt_variables_type& active) override {}
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     ///DO NOTHING FOR NOW
   }

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.cpp
@@ -509,9 +509,10 @@ void QMCCostFunction::resetPsi(bool final_reset)
   //OptVariablesForPsi.print(std::cout);
   //cout << "-------------------------------------- " << std::endl;
 
-  resetOptimizableObjects(Psi, OptVariablesForPsi);
-  for (int i = 0; i < psiClones.size(); ++i)
-    resetOptimizableObjects(*psiClones[i], OptVariablesForPsi);
+  resetOptimizableObjects(Psi, OptVariablesForPsi, true);
+  // Assume that Psi is psiClones[0]
+  for (int i = 1; i < psiClones.size(); ++i)
+    resetOptimizableObjects(*psiClones[i], OptVariablesForPsi, false);
 }
 
 QMCCostFunction::EffectiveWeight QMCCostFunction::correlatedSampling(bool needGrad)

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -1086,12 +1086,12 @@ UniqueOptObjRefs QMCCostFunctionBase::extractOptimizableObjects(TrialWaveFunctio
   return opt_obj_refs;
 }
 
-void QMCCostFunctionBase::resetOptimizableObjects(TrialWaveFunction& psi, const opt_variables_type& opt_variables) const
+void QMCCostFunctionBase::resetOptimizableObjects(TrialWaveFunction& psi, const opt_variables_type& opt_variables, bool isPrimaryObject) const
 {
   const auto opt_obj_refs = extractOptimizableObjects(psi);
   for (OptimizableObject& obj : opt_obj_refs)
     if (obj.isOptimized())
-      obj.resetParametersExclusive(opt_variables);
+      obj.resetParametersExclusive(opt_variables, isPrimaryObject);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.h
@@ -320,7 +320,7 @@ protected:
   /// survey all the optimizable objects
   UniqueOptObjRefs extractOptimizableObjects(TrialWaveFunction& psi) const;
 
-  void resetOptimizableObjects(TrialWaveFunction& psi, const opt_variables_type& opt_variables) const;
+  void resetOptimizableObjects(TrialWaveFunction& psi, const opt_variables_type& opt_variables, bool isPrimaryObject) const;
 
 #ifdef HAVE_LMY_ENGINE
   virtual Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj)

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.cpp
@@ -438,10 +438,10 @@ void QMCCostFunctionBatched::resetPsi(bool final_reset)
   //cout << "######### QMCCostFunctionBatched::resetPsi " << std::endl;
   //OptVariablesForPsi.print(std::cout);
   //cout << "-------------------------------------- " << std::endl;
-  resetOptimizableObjects(Psi, OptVariablesForPsi);
+  resetOptimizableObjects(Psi, OptVariablesForPsi, true);
   for (int i = 0; i < opt_eval_.size(); i++)
     for (int j = 0; j < opt_eval_[i]->get_wf_ptr_list().size(); j++)
-      resetOptimizableObjects(*opt_eval_[i]->get_wf_ptr_list()[j], OptVariablesForPsi);
+      resetOptimizableObjects(*opt_eval_[i]->get_wf_ptr_list()[j], OptVariablesForPsi, false);
 }
 
 QMCCostFunctionBatched::EffectiveWeight QMCCostFunctionBatched::correlatedSampling(bool needGrad)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -58,7 +58,7 @@ void SplineR2R<ST>::storeParamsBeforeRotation()
   const auto coefs_tot_size = spline_ptr->coefs_size;
   coef_copy_                = std::make_shared<std::vector<RealType>>(coefs_tot_size);
 
-  std::copy_n(spline_ptr->coefs, coefs_tot_size, coef_copy_);
+  std::copy_n(spline_ptr->coefs, coefs_tot_size, coef_copy_->begin());
 }
 
 /*
@@ -101,7 +101,7 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
   {
     if (!coef_copy_)
       coef_copy_ = std::make_shared<std::vector<RealType>>(coefs_tot_size);
-    std::copy_n(spl_coefs, coefs_tot_size, coef_copy_);
+    std::copy_n(spl_coefs, coefs_tot_size, coef_copy_->begin());
   }
 
   // Fill top left corner of tmpU with rot_mat

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -58,6 +58,9 @@ private:
   ///multi bspline set
   std::shared_ptr<MultiBspline<ST>> SplineInst;
 
+  ///Copy of original splines for orbital rotation
+  std::shared_ptr<std::vector<RealType>> coef_copy_;
+
   ///thread private ratios for reduction when using nested threading, numVP x numThread
   Matrix<TT> ratios_private;
 
@@ -82,6 +85,9 @@ public:
   bool isRotationSupported() const override { return true; }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineR2R>(*this); }
+
+  /// Store an original copy of the spline coefficients for orbital rotation
+  void storeParamsBeforeRotation() override;
 
   /* 
      Implements orbital rotations via [1,2]. 

--- a/src/QMCWaveFunctions/ExampleHeComponent.cpp
+++ b/src/QMCWaveFunctions/ExampleHeComponent.cpp
@@ -209,7 +209,7 @@ std::unique_ptr<WaveFunctionComponent> ExampleHeComponent::makeClone(ParticleSet
   return std::make_unique<ExampleHeComponent>(*this);
 }
 
-void ExampleHeComponent::resetParametersExclusive(const OptVariablesType& active)
+void ExampleHeComponent::resetParametersExclusive(const OptVariablesType& active, bool isPrimaryObject)
 {
   if (my_vars_.size())
   {

--- a/src/QMCWaveFunctions/ExampleHeComponent.h
+++ b/src/QMCWaveFunctions/ExampleHeComponent.h
@@ -40,7 +40,7 @@ public:
   bool isOptimizable() const override { return true; }
   void checkInVariablesExclusive(OptVariablesType& active) override { active.insertFrom(my_vars_); }
   void checkOutVariables(const OptVariablesType& active) override { my_vars_.getIndex(active); }
-  void resetParametersExclusive(const OptVariablesType& active) override;
+  void resetParametersExclusive(const OptVariablesType& active, bool isPrimaryObject=false) override;
 
   LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient& G,

--- a/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
+++ b/src/QMCWaveFunctions/Fermion/BackflowTransformation.h
@@ -166,7 +166,7 @@ public:
   // it is exposed as a whole to the opitmizer. Thus the underlying OptimizableObject are not explosed.
   // Simply redirect existing implentation.
   void checkInVariablesExclusive(opt_variables_type& active) final { checkInVariables(active); }
-  void resetParametersExclusive(const opt_variables_type& active) final { resetParameters(active); }
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) final { resetParameters(active); }
 
   void registerData(ParticleSet& P, WFBufferType& buf);
 

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -787,6 +787,7 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
 
   // create active rotation parameter indices
   std::vector<std::pair<int, int>> m_act_rot_inds;
+  std::vector<std::pair<int, int>> other_rot_inds;
 
   for (int i = 0; i < nmo; i++)
     for (int j = i + 1; j < nmo; j++)
@@ -803,9 +804,20 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
                 int>(i,
                      j)); // orbital rotation parameter accepted as long as rotation isn't core-core or virtual-virtual
       }
+      else
+      {
+        other_rot_inds.push_back(std::pair<int, int>(i, j));
+      }
     }
 
-  Phi->buildOptVariables(m_act_rot_inds);
+  std::vector<std::pair<int, int>> full_rot_inds;
+
+  // Copy the adjustable rotations first
+  full_rot_inds = m_act_rot_inds;
+  // Add the other rotations at the end
+  full_rot_inds.insert(full_rot_inds.end(), other_rot_inds.begin(), other_rot_inds.end());
+
+  Phi->buildOptVariables(m_act_rot_inds, full_rot_inds);
 }
 
 int MultiDiracDeterminant::build_occ_vec(const OffloadVector<int>& data,

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -720,7 +720,7 @@ void MultiSlaterDetTableMethod::checkOutVariables(const opt_variables_type& acti
       Dets[id]->checkOutVariables(active);
 }
 
-void MultiSlaterDetTableMethod::resetParametersExclusive(const opt_variables_type& active)
+void MultiSlaterDetTableMethod::resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject)
 {
   if (CI_Optimizable)
   {

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -101,7 +101,7 @@ public:
   void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) override;
   void checkOutVariables(const opt_variables_type& active) override;
   void checkInVariablesExclusive(opt_variables_type& active) override;
-  void resetParametersExclusive(const opt_variables_type& active) override;
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override;
 
   //builds orbital rotation parameters using MultiSlater member variables
   void buildOptVariables();

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -686,7 +686,7 @@ struct BsplineFunctor : public OptimizableFunctorBase
     active.insertFrom(myVars);
   }
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (notOpt)
       return;

--- a/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/CountingJastrow.h
@@ -120,7 +120,7 @@ public:
   }
 
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     int ia, IJ, JI;
     std::string id;

--- a/src/QMCWaveFunctions/Jastrow/FakeFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/FakeFunctor.h
@@ -135,7 +135,7 @@ struct FakeFunctor : public OptimizableFunctorBase
 
   void checkOutVariables(const opt_variables_type& active) override {}
 
-  void resetParametersExclusive(const opt_variables_type& active) override {}
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override {}
 
 
   std::vector<TinyVector<real_type, 3>> derivs_;

--- a/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
+++ b/src/QMCWaveFunctions/Jastrow/LRBreakupUtilities.h
@@ -478,7 +478,7 @@ struct ShortRangePartAdapter : OptimizableFunctorBase
   inline real_type df(real_type r) override { return myHandler->srDf(r, 1.0 / r); }
   void checkInVariablesExclusive(opt_variables_type& active) override {}
   void checkOutVariables(const opt_variables_type& active) override {}
-  void resetParametersExclusive(const opt_variables_type& optVariables) override {}
+  void resetParametersExclusive(const opt_variables_type& optVariables, bool isPrimaryObject=false) override {}
   bool put(xmlNodePtr cur) override { return true; }
   real_type Uconst;
   HandlerType* myHandler;

--- a/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
+++ b/src/QMCWaveFunctions/Jastrow/PadeFunctors.h
@@ -297,7 +297,7 @@ struct PadeFunctor : public OptimizableFunctorBase
     myVars.getIndex(active);
   }
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (myVars.size())
     {
@@ -591,7 +591,7 @@ struct Pade2ndOrderFunctor : public OptimizableFunctorBase
   void checkInVariablesExclusive(opt_variables_type& active) override { active.insertFrom(myVars); }
 
   void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     int i = 0;
     if (ID_A != "0")
@@ -916,7 +916,7 @@ struct PadeTwo2ndOrderFunctor : public OptimizableFunctorBase
   void checkInVariablesExclusive(opt_variables_type& active) override { active.insertFrom(myVars); }
 
   void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (myVars.size() == 0)
       return;
@@ -1020,7 +1020,7 @@ struct ScaledPadeFunctor : public OptimizableFunctorBase
 
   void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
 
-  inline void resetParametersExclusive(const opt_variables_type& active) override
+  inline void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     OneOverC = 1.0 / C;
     B2       = 2.0 * B;

--- a/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
+++ b/src/QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h
@@ -1050,7 +1050,7 @@ struct PolynomialFunctor3D : public OptimizableFunctorBase
     return true;
   }
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (notOpt)
       return;

--- a/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/ShortRangeCuspFunctor.h
@@ -643,7 +643,7 @@ struct ShortRangeCuspFunctor : public OptimizableFunctorBase
     myVars.getIndex(active);
   }
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (myVars.size())
     {

--- a/src/QMCWaveFunctions/Jastrow/SplineFunctors.h
+++ b/src/QMCWaveFunctions/Jastrow/SplineFunctors.h
@@ -184,7 +184,7 @@ struct CubicSplineSingle : public OptimizableFunctorBase
   }
 
   ///reset the input/output function
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (InFunc)
     {
@@ -257,7 +257,7 @@ struct CubicSplineBasisSet : public OptimizableFunctorBase
   ///set the output numerical function
   void setOutFunc(FNOUT* out_) { OutFunc = out_; }
   ///reset the input/output function
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (!InFunc)
       APP_ABORT("CubicSplineBasisSet::resetParameters failed due to null input function ");

--- a/src/QMCWaveFunctions/Jastrow/UserFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/UserFunctor.h
@@ -314,7 +314,7 @@ struct UserFunctor : public OptimizableFunctorBase
     myVars.getIndex(active);
   }
 
-  void resetParametersExclusive(const opt_variables_type& active) override
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override
   {
     if (myVars.size())
     {

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.cpp
@@ -702,7 +702,7 @@ void kSpaceJastrow::checkInVariablesExclusive(opt_variables_type& active)
 
 void kSpaceJastrow::checkOutVariables(const opt_variables_type& active) { myVars.getIndex(active); }
 
-void kSpaceJastrow::resetParametersExclusive(const opt_variables_type& active)
+void kSpaceJastrow::resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject)
 {
   int ii = 0;
 

--- a/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/kSpaceJastrow.h
@@ -163,7 +163,7 @@ public:
   void extractOptimizableObjectRefs(UniqueOptObjRefs& opt_obj_refs) override { opt_obj_refs.push_back(*this); }
 
   void checkInVariablesExclusive(opt_variables_type& active) final;
-  void resetParametersExclusive(const opt_variables_type& active) final;
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) final;
 
   LogValueType evaluateLog(const ParticleSet& P,
                            ParticleSet::ParticleGradient& G,

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -779,9 +779,9 @@ void LCAOrbitalSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last
 void LCAOrbitalSet::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
 {
   if (!use_stored_copy)
-    C_copy = *C;
+    *C_copy = *C;
   //gemm is out-of-place
-  BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy.data(), BasisSetSize,
+  BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy->data(), BasisSetSize,
              rot_mat.data(), OrbitalSetSize, RealType(0.0), C->data(), BasisSetSize);
 
   /* debugging code

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -55,7 +55,7 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override;
 
-  void storeParamsBeforeRotation() override { C_copy = *C; }
+  void storeParamsBeforeRotation() override { C_copy = std::make_unique<ValueMatrix>(*C); }
 
   void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
 
@@ -211,7 +211,7 @@ protected:
   ///number of Single-particle orbitals
   const IndexType BasisSetSize;
   /// a copy of the original C before orbital rotation is applied;
-  ValueMatrix C_copy;
+  std::shared_ptr<ValueMatrix> C_copy;
 
   ///true if C is an identity matrix
   bool Identity;

--- a/src/QMCWaveFunctions/OptimizableObject.h
+++ b/src/QMCWaveFunctions/OptimizableObject.h
@@ -66,7 +66,7 @@ public:
 
   /** reset the parameters during optimizations. Exclusive, see checkInVariablesExclusive
    */
-  virtual void resetParametersExclusive(const opt_variables_type& active) = 0;
+  virtual void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) = 0;
 
   /** print the state, e.g., optimizables */
   virtual void reportStatus(std::ostream& os) {}

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -92,7 +92,7 @@ void RotatedSPOs::extractParamsFromAntiSymmetricMatrix(const RotationIndices& ro
   }
 }
 
-void RotatedSPOs::resetParametersExclusive(const opt_variables_type& active)
+void RotatedSPOs::resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject)
 {
   std::vector<RealType> delta_param(m_act_rot_inds.size());
 
@@ -119,7 +119,7 @@ void RotatedSPOs::resetParametersExclusive(const opt_variables_type& active)
     for (int i = 0; i < m_full_rot_inds.size(); i++)
       old_param[i] = myVarsFull[i];
 
-    if (use_this_copy_to_apply_rotation_)
+    if (isPrimaryObject)
       applyDeltaRotation(delta_param, old_param, new_param);
 
     // Save the the params
@@ -128,7 +128,7 @@ void RotatedSPOs::resetParametersExclusive(const opt_variables_type& active)
   }
   else
   {
-    if (use_this_copy_to_apply_rotation_)
+    if (isPrimaryObject)
       apply_rotation(delta_param, false);
 
     // Save the parameters in the history list
@@ -1409,8 +1409,6 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   myclone->myVarsFull      = this->myVarsFull;
   myclone->history_params_ = this->history_params_;
   myclone->use_global_rot_ = this->use_global_rot_;
-
-  // use_this_copy_to_apply_rotation_ is deliberately not copied
 
   return myclone;
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -172,14 +172,16 @@ void RotatedSPOs::buildOptVariables(const size_t nel)
 #endif
 }
 
-void RotatedSPOs::buildOptVariables(const RotationIndices& rotations)
+void RotatedSPOs::buildOptVariables(const RotationIndices& rotations, const RotationIndices& full_rotations)
 {
 #if !defined(QMC_COMPLEX)
   const size_t nmo = Phi->getOrbitalSetSize();
 
   // create active rotations
   m_act_rot_inds  = rotations;
-  m_full_rot_inds = full_rotations;
+
+  if (use_global_rot_)
+    m_full_rot_inds = full_rotations;
 
   if (use_global_rot_)
   {
@@ -280,6 +282,39 @@ void RotatedSPOs::apply_rotation(const std::vector<RealType>& param, bool use_st
   exponentiate_antisym_matrix(rot_mat);
   Phi->applyRotation(rot_mat, use_stored_copy);
 }
+
+void RotatedSPOs::apply_delta_rotation(const std::vector<RealType>& delta_param,
+                                       const std::vector<RealType>& old_param,
+                                       std::vector<RealType>& new_param)
+{
+  assert(delta_param.size() == m_act_rot_inds.size());
+  assert(old_param.size() == m_full_rot_inds.size());
+  assert(new_param.size() == m_full_rot_inds.size());
+
+  const size_t nmo = Phi->getOrbitalSetSize();
+  ValueMatrix old_rot_mat(nmo, nmo);
+  old_rot_mat = ValueType(0);
+
+  constructAntiSymmetricMatrix(m_full_rot_inds, old_param, old_rot_mat);
+  exponentiate_antisym_matrix(old_rot_mat);
+
+  ValueMatrix delta_rot_mat(nmo, nmo);
+  delta_rot_mat = ValueType(0);
+
+  constructAntiSymmetricMatrix(m_act_rot_inds, delta_param, delta_rot_mat);
+  exponentiate_antisym_matrix(delta_rot_mat);
+
+  // Apply delta rotation to old rotation.
+  ValueMatrix new_rot_mat(nmo, nmo);
+  BLAS::gemm('N', 'N', nmo, nmo, nmo, 1.0, delta_rot_mat.data(), nmo, old_rot_mat.data(), nmo, 0.0, new_rot_mat.data(),
+             nmo);
+
+  Phi->applyRotation(new_rot_mat, true);
+
+  log_antisym_matrix(new_rot_mat);
+  extractParamsFromAntiSymmetricMatrix(m_full_rot_inds, new_rot_mat, new_param);
+}
+
 
 
 // compute exponential of a real, antisymmetric matrix by diagonalizing and exponentiating eigenvalues

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -331,7 +331,7 @@ void RotatedSPOs::evaluateDerivRatios(const VirtualParticleSet& VP,
   d2psiM_all = 0;
 
   const ParticleSet& P = VP.getRefPS();
-  int iel = VP.refPtcl;
+  int iel              = VP.refPtcl;
 
   Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_all, dpsiM_all, d2psiM_all);
 
@@ -377,10 +377,10 @@ void RotatedSPOs::evaluateDerivRatios(const VirtualParticleSet& VP,
 
     for (int i = 0; i < m_act_rot_inds.size(); i++)
     {
-      int kk           = myVars.where(i);
-      const int p      = m_act_rot_inds.at(i).first;
-      const int q      = m_act_rot_inds.at(i).second;
-      dratios(iat, kk) = T(p, q) - T_orig(p, q); // dratio size is (nknot, num_vars)
+      int kk      = myVars.where(i);
+      const int p = m_act_rot_inds.at(i).first;
+      const int q = m_act_rot_inds.at(i).second;
+      dratios(iat, kk) += T(p, q) - T_orig(p, q); // dratio size is (nknot, num_vars)
     }
   }
 }
@@ -427,7 +427,7 @@ void RotatedSPOs::evaluateDerivativesWF(ParticleSet& P,
     int kk      = myVars.where(i);
     const int p = m_act_rot_inds.at(i).first;
     const int q = m_act_rot_inds.at(i).second;
-    dlogpsi[kk] = T(p, q);
+    dlogpsi[kk] += T(p, q);
   }
 }
 
@@ -526,11 +526,11 @@ void RotatedSPOs::evaluateDerivatives(ParticleSet& P,
 
   for (int i = 0; i < m_act_rot_inds.size(); i++)
   {
-    int kk           = myVars.where(i);
-    const int p      = m_act_rot_inds.at(i).first;
-    const int q      = m_act_rot_inds.at(i).second;
-    dlogpsi[kk]      = T(p, q);
-    dhpsioverpsi[kk] = ValueType(-0.5) * Y4(p, q);
+    int kk      = myVars.where(i);
+    const int p = m_act_rot_inds.at(i).first;
+    const int q = m_act_rot_inds.at(i).second;
+    dlogpsi[kk] += T(p, q);
+    dhpsioverpsi[kk] += ValueType(-0.5) * Y4(p, q);
   }
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -19,13 +19,7 @@
 namespace qmcplusplus
 {
 RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos)
-    : SPOSet(my_name),
-      OptimizableObject(my_name),
-      Phi(std::move(spos)),
-      nel_major_(0),
-      params_supplied(false),
-      use_this_copy_to_apply_rotation_(false),
-      use_global_rot_(true)
+    : SPOSet(my_name), OptimizableObject(my_name), Phi(std::move(spos)), nel_major_(0)
 {
   OrbitalSetSize = Phi->getOrbitalSetSize();
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -184,13 +184,9 @@ void RotatedSPOs::buildOptVariables(const RotationIndices& rotations, const Rota
     m_full_rot_inds = full_rotations;
 
   if (use_global_rot_)
-  {
     app_log() << "Orbital rotation using global rotation" << std::endl;
-  }
   else
-  {
     app_log() << "Orbital rotation using history" << std::endl;
-  }
 
 
   // This will add the orbital rotation parameters to myVars
@@ -216,13 +212,9 @@ void RotatedSPOs::buildOptVariables(const RotationIndices& rotations, const Rota
 
     // If the user input parameters, use those. Otherwise, initialize the parameters to zero
     if (params_supplied)
-    {
       myVars.insert(sstr.str(), params[i]);
-    }
     else
-    {
       myVars.insert(sstr.str(), 0.0);
-    }
   }
 
   if (use_global_rot_)
@@ -237,13 +229,9 @@ void RotatedSPOs::buildOptVariables(const RotationIndices& rotations, const Rota
            << "_" << (q < 10 ? "0" : "") << (q < 100 ? "0" : "") << (q < 1000 ? "0" : "") << q;
 
       if (params_supplied && i < m_act_rot_inds.size())
-      {
         myVarsFull.insert(sstr.str(), params[i]);
-      }
       else
-      {
         myVarsFull.insert(sstr.str(), 0.0);
-      }
     }
   }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -19,7 +19,13 @@
 namespace qmcplusplus
 {
 RotatedSPOs::RotatedSPOs(const std::string& my_name, std::unique_ptr<SPOSet>&& spos)
-    : SPOSet(my_name), OptimizableObject(my_name), Phi(std::move(spos)), nel_major_(0), params_supplied(false)
+    : SPOSet(my_name),
+      OptimizableObject(my_name),
+      Phi(std::move(spos)),
+      nel_major_(0),
+      params_supplied(false),
+      use_this_copy_to_apply_rotation_(false),
+      use_global_rot_(true)
 {
   OrbitalSetSize = Phi->getOrbitalSetSize();
 }
@@ -1265,6 +1271,9 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   myclone->params_supplied = this->params_supplied;
   myclone->m_act_rot_inds  = this->m_act_rot_inds;
   myclone->myVars          = this->myVars;
+
+  // use_this_copy_to_apply_rotation_ is deliberately not copied
+
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -226,7 +226,6 @@ public:
 
   void checkInVariablesExclusive(opt_variables_type& active) override
   {
-    use_this_copy_to_apply_rotation_ = true;
     if (myVars.size())
       active.insertFrom(myVars);
   }
@@ -234,7 +233,7 @@ public:
   void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
 
   ///reset
-  void resetParametersExclusive(const opt_variables_type& active) override;
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override;
 
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions
@@ -358,9 +357,6 @@ private:
   bool params_supplied = false;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
-
-  /// Flag to ensure rotation is applied to shared coefficients only on one thread
-  bool use_this_copy_to_apply_rotation_ = false;
 
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -355,12 +355,12 @@ public:
 
 private:
   /// true if SPO parameters (orbital rotation parameters) have been supplied by input
-  bool params_supplied;
+  bool params_supplied = false;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
 
   /// Flag to ensure rotation is applied to shared coefficients only on one thread
-  bool use_this_copy_to_apply_rotation_;
+  bool use_this_copy_to_apply_rotation_ = false;
 
   /// List of previously applied parameters
   std::vector<std::vector<RealType>> history_params_;
@@ -369,7 +369,7 @@ private:
   opt_variables_type myVarsFull;
 
   /// Use global rotation or history list
-  bool use_global_rot_;
+  bool use_global_rot_ = true;
 };
 
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -38,7 +38,7 @@ public:
   RotationIndices m_act_rot_inds;
 
   // Full set of rotation values for global rotation
-  RotationIndicies m_full_rot_inds;
+  RotationIndices m_full_rot_inds;
 
   // Construct a list of the matrix indices for non-zero rotation parameters.
   // (The structure for a sparse representation of the matrix)

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -203,13 +203,9 @@ public:
 
   void checkInVariablesExclusive(opt_variables_type& active) override
   {
-    //reset parameters to zero after coefficient matrix has been updated
-    for (int k = 0; k < myVars.size(); ++k)
-      myVars[k] = 0.0;
-
+    use_this_copy_to_apply_rotation_ = true;
     if (myVars.size())
       active.insertFrom(myVars);
-    Phi->storeParamsBeforeRotation();
   }
 
   void checkOutVariables(const opt_variables_type& active) override { myVars.getIndex(active); }
@@ -340,11 +336,26 @@ public:
   //  void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
   //  {Phi->evaluateThridDeriv(P, first, last, grad_grad_grad_logdet); }
 
+  /// Use history list (false) or global rotation (true)
+  void set_use_global_rotation(bool use_global_rotation) { use_global_rot_ = use_global_rotation; }
+
 private:
   /// true if SPO parameters (orbital rotation parameters) have been supplied by input
   bool params_supplied;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
+
+  /// Flag to ensure rotation is applied to shared coefficients only on one thread
+  bool use_this_copy_to_apply_rotation_;
+
+  /// List of previously applied parameters
+  std::vector<std::vector<RealType>> history_params_;
+
+  /// Full set of rotation matrix parameters for use in global rotation method
+  opt_variables_type myVarsFull;
+
+  /// Use global rotation or history list
+  bool use_global_rot_;
 };
 
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -67,9 +67,19 @@ public:
   // For global rotation, inputs are the old parameters and the delta parameters.
   // The corresponding rotation matrices are constructed, multiplied together,
   // and the new parameters extracted.
-  void apply_delta_rotation(const std::vector<RealType>& delta_param,
-                            const std::vector<RealType>& old_param,
-                            std::vector<RealType>& new_param);
+  // The new rotation is applied to the underlying SPO coefficients
+  void applyDeltaRotation(const std::vector<RealType>& delta_param,
+                          const std::vector<RealType>& old_param,
+                          std::vector<RealType>& new_param);
+
+  // Perform the construction of matrices and extraction of parameters in apply_delta_rotation.
+  // Split out and made static for testing.
+  static void constructDeltaRotation(const std::vector<RealType>& delta_param,
+                                     const std::vector<RealType>& old_param,
+                                     const RotationIndices& act_rot_inds,
+                                     const RotationIndices& full_rot_inds,
+                                     std::vector<RealType>& new_param,
+                                     ValueMatrix& new_rot_mat);
 
   // Compute matrix exponential of an antisymmetric matrix (result is rotation matrix)
   static void exponentiate_antisym_matrix(ValueMatrix& mat);

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -117,7 +117,9 @@ public:
   // Single Slater creation
   virtual void buildOptVariables(const size_t nel) {}
   // For the MSD case rotations must be created in MultiSlaterDetTableMethod class
-  virtual void buildOptVariables(const std::vector<std::pair<int, int>>& rotations) {}
+  virtual void buildOptVariables(const std::vector<std::pair<int, int>>& rotations,
+                                 const std::vector<std::pair<int, int>>& full_rotations)
+  {}
   /// return true if this SPOSet can be wrappered by RotatedSPO
   virtual bool isRotationSupported() const { return false; }
   /// store parameters before getting destroyed by rotation.

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -117,6 +117,9 @@ public:
   // Single Slater creation
   virtual void buildOptVariables(const size_t nel) {}
   // For the MSD case rotations must be created in MultiSlaterDetTableMethod class
+  // The rotations parameter contains only the occupied-unoccupied rotations
+  // The full_rotations parameter contains all the rotations (occupied-unoccupied, occupied-occupied, unoccupied-unoccupied)
+  //  It is needed for the global rotation method
   virtual void buildOptVariables(const std::vector<std::pair<int, int>>& rotations,
                                  const std::vector<std::pair<int, int>>& full_rotations)
   {}

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
   if (!sposet)
     myComm->barrier_and_abort("SPOSetBuilder::createSPOSet sposet creation failed");
 
-  if (optimize == "rotation" || optimize == "yes" || optimize == "history")
+  if (optimize == "rotation" || optimize == "yes" || optimize == "history" || optimize == "global")
   {
 #ifdef QMC_COMPLEX
     app_error() << "Orbital optimization via rotation doesn't support complex wavefunction yet.\n";

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -887,7 +887,7 @@ void TrialWaveFunction::resetParameters(const opt_variables_type& active)
 {
   auto opt_obj_refs = extractOptimizableObjectRefs();
   for (OptimizableObject& obj : opt_obj_refs)
-    obj.resetParametersExclusive(active);
+    obj.resetParametersExclusive(active, true);
 }
 
 void TrialWaveFunction::reportStatus(std::ostream& os)

--- a/src/QMCWaveFunctions/tests/gen_matrix_ops.py
+++ b/src/QMCWaveFunctions/tests/gen_matrix_ops.py
@@ -2,6 +2,8 @@
 # Output used in test_RotatedSPOs.cpp
 
 from sympy import *
+import scipy.linalg
+import numpy as np
 
 # Create 2x2 skew symmetric matrix
 def create2x2_matrix(k1):
@@ -17,6 +19,44 @@ def create3x3_matrix(k1, k2, k3):
                    [k1,  0.0, -k3],
                    [k2,   k3, 0.0]])
 
+def extract3x3parameters(m3):
+    k1 = m3[1,0]
+    k2 = m3[2,0]
+    k3 = m3[1,2]
+
+    # Test that it is really an antisymmetric matrix
+    tol = 1e-12
+    for i in range(3):
+        assert(abs(m3[i,i]) < tol)
+
+    for (i,j) in [(1,0), (2,0), (1,2)]:
+        assert(abs(m3[i,j] + m3[j,i]) < tol)
+
+    return k1, k2, k3
+
+def create4x4_matrix(k1, k2, k3, k4, k5, k6):
+    return np.array([[0.0, -k1, -k2, -k3],
+                     [k1,  0.0, -k4, -k5],
+                     [k2,   k4, 0.0, -k6],
+                     [k3,   k5,  k6, 0.0]])
+
+def extract4x4parameters(m4):
+    k1 = m4[1,0]
+    k2 = m4[2,0]
+    k3 = m4[3,0]
+    k4 = m4[2,1]
+    k5 = m4[3,1]
+    k6 = m4[3,2]
+
+    # Test that it is really an antisymmetric matrix
+    tol = 1e-12
+    for i in range(4):
+        assert(abs(m4[i,i]) < tol)
+
+    for (i,j) in [(1,0), (2,0), (3,0), (1,2), (1,3), (2,3)]:
+        assert(abs(m4[i,j] + m4[j,i]) < tol)
+
+    return k1, k2, k3, k4, k5, k6
 
 # Print a check for each matrix entry
 def print_matrix_for_check(m, matrix_name):
@@ -27,16 +67,26 @@ def print_matrix_for_check(m, matrix_name):
 
 
 # Print matrix as initializer list (for use in checkMatrix)
-def print_matrix_as_intializer_list(m):
+# The entries are printed nicely to appear as a matrix, but form a single list in row-major ordering, which is the same as used by OhmmsMatrix.
+def print_matrix_as_initializer_list(m):
+    try:
+        # Sympy matrices
+        rows = m.rows
+        cols = m.cols
+    except AttributeError:
+        # Numpy arrays
+        rows = m.shape[0]
+        cols = m.shape[1]
+
     print("{", end="")
     comma = ","
-    for i in range(m.rows):
-        for j in range(m.cols):
+    for i in range(rows):
+        for j in range(cols):
             # Skip comma after the last entry
-            if i == m.rows-1 and j == m.cols-1:
+            if i == rows-1 and j == cols-1:
                 comma = ""
-            print(" {:>18.15g}{comma}".format(m[i,j], comma=comma), end="")
-        if i == m.rows-1:
+            print(" {:>18.15g}{comma}".format(float(m[i,j]), comma=comma), end="")
+        if i == rows-1:
             print(" };")
         else:
             print()
@@ -56,9 +106,9 @@ m2 = create2x2_matrix(0.1)
 m2exp = exp(m2)
 
 print("Input")
-print_matrix_as_intializer_list(m2)
+print_matrix_as_initializer_list(m2)
 print("\nExp(Input)")
-print_matrix_as_intializer_list(m2exp)
+print_matrix_as_initializer_list(m2exp)
 print()
 
 print("3x3 matrix")
@@ -66,6 +116,58 @@ m3 = create3x3_matrix(0.3, 0.1, 0.2)
 m3exp = exp(m3)
 
 print("Input")
-print_matrix_as_intializer_list(m3)
+print_matrix_as_initializer_list(m3)
 print("\nExp(Input)")
-print_matrix_as_intializer_list(m3exp)
+print_matrix_as_initializer_list(m3exp)
+
+
+# Application of rotation matrix in the test "RotatedSPOs construct delta matrix" in test_RotatedSPOs.cpp
+# Sympy operations are very slow for a 4x4 matrix, and it doesn't have a matrix log.
+# Use the Scipy versions instead.
+print()
+print("4x4 rotation matrix in 'RotatedSPOs construct delta matrix' test")
+print()
+# Be aware of the order of the indices when comparing with qmcpack.
+# This system has 2 electrons and 4 orbitals.
+# The 0,1 (core->core) and 2,3 (unoccupied->unoccupied) are parameters k1 and k6, respectively,
+#  and are put at the end of the full rotation indices list.
+m4old = create4x4_matrix(-1.1, 1.5, 0.2, -0.15, 0.03, 0.05)
+m4delta = create4x4_matrix(0.0, 0.1, 0.3, 0.2, -0.1, 0.0)
+
+# Why is the order reversed compared with constructDeltaRotations?
+#  Probably has to do with the data ordering of the matrices?
+m4new = np.dot(scipy.linalg.expm(m4old), scipy.linalg.expm(m4delta))
+print("New rotation matrix")
+print_matrix_as_initializer_list(m4new)
+
+param4 = scipy.linalg.logm(m4new)
+print("Corresponding antisymmetric matrix")
+print(param4)
+ks = extract4x4parameters(param4)
+print('Extracted parameters (Reminder: ordering differs from QMCPACK)')
+print(ks)
+
+
+# Application of rotation matrix in test_RotatedSPOs_LCAO.cpp "Rotated LCAO global rotation consistency"
+print()
+print("3x3 rotation matrix in 'Rotated LCAO global rotation consistency' test")
+print()
+
+# For this test, nel = 1 nmo = 3
+# The core-unoccupied rotations come first (0,1),(0,2) followed by the unoccupied-unoccupied rotations (1,2)
+# In this case they fall in the natural order for k1, k2, and k3.
+m3old = np.array(create3x3_matrix(0.1, 0.2, 0.0))
+m3next = np.array(create3x3_matrix(0.3, 0.15, 0.0))
+
+print('Original rotation matrix')
+print_matrix_as_initializer_list(scipy.linalg.expm(m3old).T)
+
+m3new = np.dot(scipy.linalg.expm(m3next).T, scipy.linalg.expm(m3old).T)
+print('After second rotation')
+print_matrix_as_initializer_list(m3new)
+
+param3 = scipy.linalg.logm(m3new)
+
+ks3 = extract3x3parameters(param3.T)
+print('Extracted parameters after second rotation')
+print(ks3)

--- a/src/QMCWaveFunctions/tests/test_OptimizableObject.cpp
+++ b/src/QMCWaveFunctions/tests/test_OptimizableObject.cpp
@@ -22,7 +22,7 @@ class FakeOptimizableObject : public OptimizableObject
 public:
   FakeOptimizableObject(const std::string& my_name) : OptimizableObject(my_name) {}
   void checkInVariablesExclusive(opt_variables_type& active) override {}
-  void resetParametersExclusive(const opt_variables_type& active) override {}
+  void resetParametersExclusive(const opt_variables_type& active, bool isPrimaryObject=false) override {}
 };
 
 TEST_CASE("Test OptimizableObject", "[wavefunction]")

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -539,6 +539,8 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   auto spo = einSet.createSPOSetFromXML(ein1);
   REQUIRE(spo);
 
+  spo->storeParamsBeforeRotation();
+
   auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
 
   // Sanity check for orbs. Expect 1 electron, 2 orbitals
@@ -587,6 +589,13 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   rot_spo->evaluateDerivatives(elec, opt_vars, dlogpsi, dhpsioverpsi, 0, 1);
   CHECK(dlogpsi[0] == ValueApprox(-0.10034901119468914));
   CHECK(dhpsioverpsi[0] == ValueApprox(32.96939041498753));
+
+  std::vector<ValueType> new_params(1);
+  std::vector<ValueType> old_params   = {0.2};
+  std::vector<ValueType> delta_params = {0.3};
+  rot_spo->apply_delta_rotation(delta_params, old_params, new_params);
+  // 2x2 rotation matrix so the angles can be added
+  CHECK(new_params[0] == Approx(0.5));
 }
 
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -523,9 +523,8 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
 
   // Reminder: Ordering!
   std::vector<ValueType> expected_new_param = {1.6813965019790489, 0.3623564254653294, -0.05486544454559908, -0.20574472941408453, -0.9542513302873077, 0.27497788909911774};
-  for (int i = 0; i < new_params.size(); i++) {
+  for (int i = 0; i < new_params.size(); i++)
     CHECK(new_params[i] == Approx(expected_new_param[i]));
-  }
 
 
   // Rotated back to original position
@@ -533,9 +532,8 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
   std::vector<ValueType> new_params2(6);
   std::vector<ValueType> reverse_delta_params = {-0.1, -0.3, -0.2, 0.1};
   RotatedSPOs::constructDeltaRotation(reverse_delta_params, new_params, rot_ind, full_rot_ind, new_params2, rot_m4);
-  for (int i = 0; i < new_params2.size(); i++) {
+  for (int i = 0; i < new_params2.size(); i++)
     CHECK(new_params2[i] == Approx(old_params[i]));
-  }
 }
 
 TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -480,6 +480,64 @@ TEST_CASE("RotatedSPOs exp-log matrix", "[wavefunction]")
   }
 }
 
+// Test construction of delta rotation
+TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
+{
+  using ValueType   = SPOSet::ValueType;
+  using ValueMatrix = SPOSet::ValueMatrix;
+
+  int nel = 2;
+  int nmo = 4;
+  RotatedSPOs::RotationIndices rot_ind;
+  RotatedSPOs::createRotationIndices(nel, nmo, rot_ind);
+  RotatedSPOs::RotationIndices full_rot_ind;
+  RotatedSPOs::createRotationIndicesFull(nel, nmo, full_rot_ind);
+  // rot_ind size is 4 and full rot_ind size is 6
+
+  ValueMatrix rot_m4(nmo, nmo);
+  rot_m4 = ValueType(0);
+
+  // When comparing with gen_matrix_ops.py, be aware of the order of indices
+  // in full_rot
+  // rot_ind is (0,2) (0,3) (1,2) (1,3)
+  // full_rot_ind is (0,2) (0,3) (1,2) (1,3) (0,1) (2,3)
+  // The extra indices go at the back
+  std::vector<ValueType> old_params   = {1.5, 0.2, -0.15, 0.03, -1.1, 0.05};
+  std::vector<ValueType> delta_params = {0.1, 0.3, 0.2, -0.1};
+  std::vector<ValueType> new_params(6);
+
+  RotatedSPOs::constructDeltaRotation(delta_params, old_params, rot_ind, full_rot_ind, new_params, rot_m4);
+
+  // clang-format off
+  std::vector<ValueType> rot_data4 =
+    { -0.371126931484737,  0.491586564957393,   -0.784780958819798,   0.0687480658200083,
+      -0.373372784561548,  0.66111547793048,     0.610450337985578,   0.225542620014052,
+       0.751270334458895,  0.566737323353515,   -0.0297901110611425, -0.336918744155143,
+       0.398058348785074,  0.00881931472604944, -0.102867783149713,   0.911531672428406 };
+  // clang-format on
+
+  ValueMatrix new_rot_m4(rot_data4.data(), 4, 4);
+
+  CheckMatrixResult check_matrix_result4 = checkMatrix(rot_m4, new_rot_m4, true);
+  CHECKED_ELSE(check_matrix_result4.result) { FAIL(check_matrix_result4.result_message); }
+
+  // Reminder: Ordering!
+  std::vector<ValueType> expected_new_param = {1.6813965019790489, 0.3623564254653294, -0.05486544454559908, -0.20574472941408453, -0.9542513302873077, 0.27497788909911774};
+  for (int i = 0; i < new_params.size(); i++) {
+    CHECK(new_params[i] == Approx(expected_new_param[i]));
+  }
+
+
+  // Rotated back to original position
+
+  std::vector<ValueType> new_params2(6);
+  std::vector<ValueType> reverse_delta_params = {-0.1, -0.3, -0.2, 0.1};
+  RotatedSPOs::constructDeltaRotation(reverse_delta_params, new_params, rot_ind, full_rot_ind, new_params2, rot_m4);
+  for (int i = 0; i < new_params2.size(); i++) {
+    CHECK(new_params2[i] == Approx(old_params[i]));
+  }
+}
+
 TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
 {
   using RealType = QMCTraits::RealType;
@@ -593,8 +651,8 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   std::vector<ValueType> new_params(1);
   std::vector<ValueType> old_params   = {0.2};
   std::vector<ValueType> delta_params = {0.3};
-  rot_spo->apply_delta_rotation(delta_params, old_params, new_params);
-  // 2x2 rotation matrix so the angles can be added
+  rot_spo->applyDeltaRotation(delta_params, old_params, new_params);
+  // Angles can be simply added with a 2x2 rotation matrix
   CHECK(new_params[0] == Approx(0.5));
 }
 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -657,8 +657,6 @@ TEST_CASE("Rotated LCAO global rotation consistency", "[qmcapp]")
   // Need to flip the sign on the first two entries to match the output from gen_matrix_ops.py
   std::vector<ValueType> expected_param = {0.3998099017676912, 0.34924318065960236, -0.02261313113492491};
   for (int i = 0; i < expected_param.size(); i++)
-  {
     CHECK(new_params2[i] == Approx(expected_param[i]));
-  }
 }
 } // namespace qmcplusplus


### PR DESCRIPTION
Partially supersedes #4351.  This PR doesn't have the VP file save/restore code, but that will be in a subsequent PR.

Changes:
* The LCAO coefficient copy uses a shared pointer to reduce storage.  The rotation must be performed by only one thread.
* The bpsline coefficients are saved in order to enable the global rotation method.  The multiplication was changed slightly to copy the old spline coefficients to temporary storage first, then store the results of the multiplication in the actual spline storage.
* The global rotation method was made the default when optimize="yes" is specified in the input (versus #4351 where the history list method was the default.)
* The single-determinant derivatives were updated to enable Restricted Hartree-Fock wavefunctions (where the same orbitals are used for up and down electrons)
* Some tests for the global rotation code

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
