### PR TITLE
Remove buildOptVariables from SPOSet

### DIFF
--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -22,6 +22,7 @@
 #include "Numerics/DeterminantOperators.h"
 #include "Numerics/MatrixOperators.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
+#include "QMCWaveFunctions/RotatedSPOs.h"
 
 namespace qmcplusplus
 {
@@ -43,7 +44,14 @@ DiracDeterminant<DU_TYPE>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
   resize(NumPtcls, NumPtcls);
 
   if (isOptimizable())
-    Phi->buildOptVariables(NumPtcls);
+  {
+    RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+    if (rot_spo)
+      rot_spo->buildOptVariables(NumPtcls);
+    else
+      throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
+  }
+
 
   if (Phi->getOrbitalSetSize() < NumPtcls)
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -22,7 +22,9 @@
 #include "Numerics/DeterminantOperators.h"
 #include "Numerics/MatrixOperators.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
+#ifndef QMC_COMPLEX
 #include "QMCWaveFunctions/RotatedSPOs.h"
+#endif
 
 namespace qmcplusplus
 {
@@ -43,9 +45,11 @@ DiracDeterminant<DU_TYPE>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
 {
   resize(NumPtcls, NumPtcls);
 
+#ifndef QMC_COMPLEX
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(NumPtcls);
+#endif
 
   if (Phi->getOrbitalSetSize() < NumPtcls)
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminant.cpp
@@ -43,15 +43,9 @@ DiracDeterminant<DU_TYPE>::DiracDeterminant(std::unique_ptr<SPOSet>&& spos,
 {
   resize(NumPtcls, NumPtcls);
 
-  if (isOptimizable())
-  {
-    RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
-    if (rot_spo)
-      rot_spo->buildOptVariables(NumPtcls);
-    else
-      throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
-  }
-
+  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  if (rot_spo)
+    rot_spo->buildOptVariables(NumPtcls);
 
   if (Phi->getOrbitalSetSize() < NumPtcls)
   {

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -17,6 +17,7 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Numerics/MatrixOperators.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
+#include "QMCWaveFunctions/RotatedSPOs.h"
 #include "CPU/SIMD/simd.hpp"
 #include <cassert>
 
@@ -41,7 +42,13 @@ DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatched(std::unique_ptr<SPO
   static_assert(std::is_same<SPOSet::ValueType, typename DET_ENGINE::Value>::value);
   resize(NumPtcls, NumPtcls);
   if (isOptimizable())
-    Phi->buildOptVariables(NumPtcls);
+  {
+    RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+    if (rot_spo)
+      rot_spo->buildOptVariables(NumPtcls);
+    else
+      throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
+  }
 }
 
 template<typename DET_ENGINE>

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -17,7 +17,9 @@
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Numerics/MatrixOperators.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
+#ifndef QMC_COMPLEX
 #include "QMCWaveFunctions/RotatedSPOs.h"
+#endif
 #include "CPU/SIMD/simd.hpp"
 #include <cassert>
 
@@ -42,9 +44,11 @@ DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatched(std::unique_ptr<SPO
   static_assert(std::is_same<SPOSet::ValueType, typename DET_ENGINE::Value>::value);
   resize(NumPtcls, NumPtcls);
 
+#ifndef QMC_COMPLEX
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(NumPtcls);
+#endif
 }
 
 template<typename DET_ENGINE>

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -41,14 +41,10 @@ DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatched(std::unique_ptr<SPO
 {
   static_assert(std::is_same<SPOSet::ValueType, typename DET_ENGINE::Value>::value);
   resize(NumPtcls, NumPtcls);
-  if (isOptimizable())
-  {
-    RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
-    if (rot_spo)
-      rot_spo->buildOptVariables(NumPtcls);
-    else
-      throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
-  }
+
+  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  if (rot_spo)
+    rot_spo->buildOptVariables(NumPtcls);
 }
 
 template<typename DET_ENGINE>

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -809,8 +809,6 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(m_act_rot_inds);
-  else
-    throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
 }
 
 int MultiDiracDeterminant::build_occ_vec(const OffloadVector<int>& data,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -16,6 +16,7 @@
 
 #include "MultiDiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/ci_configuration2.h"
+#include "QMCWaveFunctions/RotatedSPOs.h"
 #include "Message/Communicate.h"
 #include "Numerics/DeterminantOperators.h"
 #include "CPU/BLAS.hpp"
@@ -805,7 +806,11 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
       }
     }
 
-  Phi->buildOptVariables(m_act_rot_inds);
+  RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
+  if (rot_spo)
+    rot_spo->buildOptVariables(m_act_rot_inds);
+  else
+    throw std::runtime_error("Cast of Phi to RotatedSPOs failed.");
 }
 
 int MultiDiracDeterminant::build_occ_vec(const OffloadVector<int>& data,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -16,7 +16,9 @@
 
 #include "MultiDiracDeterminant.h"
 #include "QMCWaveFunctions/Fermion/ci_configuration2.h"
+#ifndef QMC_COMPLEX
 #include "QMCWaveFunctions/RotatedSPOs.h"
+#endif
 #include "Message/Communicate.h"
 #include "Numerics/DeterminantOperators.h"
 #include "CPU/BLAS.hpp"
@@ -806,9 +808,11 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
       }
     }
 
+#ifndef QMC_COMPLEX
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
   if (rot_spo)
     rot_spo->buildOptVariables(m_act_rot_inds);
+#endif
 }
 
 int MultiDiracDeterminant::build_occ_vec(const OffloadVector<int>& data,

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -91,10 +91,10 @@ public:
 
 
   // Single Slater creation
-  void buildOptVariables(size_t nel) override;
+  void buildOptVariables(size_t nel);
 
   // For the MSD case rotations must be created in MultiSlaterDetTableMethod class
-  void buildOptVariables(const RotationIndices& rotations) override;
+  void buildOptVariables(const RotationIndices& rotations);
 
 
   void evaluateDerivatives(ParticleSet& P,

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -110,11 +110,6 @@ public:
   /// check a few key parameters before putting the SPO into a determinant
   virtual void checkObject() const {}
 
-  /// create optimizable orbital rotation parameters
-  // Single Slater creation
-  virtual void buildOptVariables(const size_t nel) {}
-  // For the MSD case rotations must be created in MultiSlaterDetTableMethod class
-  virtual void buildOptVariables(const std::vector<std::pair<int, int>>& rotations) {}
   /// return true if this SPOSet can be wrappered by RotatedSPO
   virtual bool isRotationSupported() const { return false; }
   /// store parameters before getting destroyed by rotation.


### PR DESCRIPTION
These functions are specific to RotatedSPOs.  Use a dynamic_cast to get the right type and call buildOptVariables.

Requested in https://github.com/QMCPACK/qmcpack/pull/4426#discussion_r1091405773


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
