### PR TITLE
Fix orbital rotation RHF parameter derivatives

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -331,7 +331,7 @@ void RotatedSPOs::evaluateDerivRatios(const VirtualParticleSet& VP,
   d2psiM_all = 0;
 
   const ParticleSet& P = VP.getRefPS();
-  int iel = VP.refPtcl;
+  int iel              = VP.refPtcl;
 
   Phi->evaluate_notranspose(P, FirstIndex, LastIndex, psiM_all, dpsiM_all, d2psiM_all);
 
@@ -526,11 +526,11 @@ void RotatedSPOs::evaluateDerivatives(ParticleSet& P,
 
   for (int i = 0; i < m_act_rot_inds.size(); i++)
   {
-    int kk           = myVars.where(i);
-    const int p      = m_act_rot_inds.at(i).first;
-    const int q      = m_act_rot_inds.at(i).second;
-    dlogpsi[kk]      = T(p, q);
-    dhpsioverpsi[kk] = ValueType(-0.5) * Y4(p, q);
+    int kk      = myVars.where(i);
+    const int p = m_act_rot_inds.at(i).first;
+    const int q = m_act_rot_inds.at(i).second;
+    dlogpsi[kk] += T(p, q);
+    dhpsioverpsi[kk] += ValueType(-0.5) * Y4(p, q);
   }
 }
 

--- a/tests/molecules/He_param/CMakeLists.txt
+++ b/tests/molecules/He_param/CMakeLists.txt
@@ -158,6 +158,25 @@ if(NOT QMC_CUDA)
       SCALAR_VALUES
       HE_ORB_ROT_PARAM)
 
+    list(APPEND HE_ORB_ROT_RHF_PARAM spo-up_orb_rot_0000_0001  -0.766  0.01) # scalar name, value, error
+    qmc_run_and_check_custom_scalar(
+      BASE_NAME
+      short-He_orb_rot_param_grad_rhf
+      BASE_DIR
+      "${qmcpack_SOURCE_DIR}/tests/molecules/He_param"
+      PREFIX
+      He_orb_rot_param_grad_rhf.param
+      INPUT_FILE
+      He_orb_rot_param_grad_rhf.xml
+      PROCS
+      1
+      THREADS
+      16
+      SERIES
+      0
+      SCALAR_VALUES
+      HE_ORB_ROT_RHF_PARAM)
+
     # Two atomic orbitals, with jastrow
 
     list(APPEND HE_ORB_ROT_JASTROW_PARAM spo-up_orb_rot_0000_0001    0.078  0.02)  # scalar name, value, error

--- a/tests/molecules/He_param/He_orb_rot_param_grad_rhf.xml
+++ b/tests/molecules/He_param/He_orb_rot_param_grad_rhf.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<simulation>
+  <project id="He_orb_rot_param_grad_rhf" series="0">
+         <parameter name="driver_version">batch</parameter>
+  </project>
+
+  <!-- Location of atoms -->
+
+  <particleset name="ion0" size="1">
+    <group name="He">
+      <parameter name="charge">2</parameter>
+    </group>
+    <attrib name="position" datatype="posArray">
+      0.0 0.0 0.0
+    </attrib>
+  </particleset>
+
+  <!-- Randomly create electrons around the atomic position -->
+
+  <particleset name="e" random="yes" randomsrc="ion0">
+    <group name="u" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+    <group name="d" size="1">
+      <parameter name="charge">-1</parameter>
+    </group>
+  </particleset>
+
+  <!-- Trial wavefunction - use Slater determinant multiplied by a Jastrow factor -->
+
+  <wavefunction name="psi0" target="e">
+    <sposet_collection type="MolecularOrbital">
+      <!-- Use a single Slater Type Orbital (STO) for the basis. Cusp condition is correct. -->
+      <basisset keyword="STO" transform="no">
+        <atomicBasisSet type="STO" elementType="He" normalized="no">
+          <basisGroup rid="R0" l="0" m="0" type="Slater">
+             <radfunc n="1" exponent="2.0"/>
+          </basisGroup>
+          <basisGroup rid="R1" l="0" m="0" type="Slater">
+             <radfunc n="2" exponent="1.0"/>
+          </basisGroup>
+        </atomicBasisSet>
+      </basisset>
+      <sposet basisset="LCAOBSet" name="spo-up" size="2" optimize="yes">
+          <coefficient id="updetC" type="Array" size="2">
+            1.0 0.0
+            0.0 1.0
+          </coefficient>
+      </sposet>
+    </sposet_collection>
+    <determinantset type="MO" key="STO" transform="no" source="ion0">
+      <slaterdeterminant>
+        <determinant id="spo-up" spin="1" size="2"/>
+        <determinant id="spo-up" spin="-1" size="2"/>
+      </slaterdeterminant>
+    </determinantset>
+
+
+  </wavefunction>
+
+  <!-- Hamiltonian - the energy of interactions between particles -->
+
+  <hamiltonian name="h0" type="generic" target="e">
+    <!-- Electon-electron -->
+    <pairpot name="ElecElec" type="coulomb" source="e" target="e"/>
+    <!-- Electon-ion -->
+    <pairpot name="Coulomb" type="coulomb" source="ion0" target="e"/>
+    <!-- Ion-ion (not needed for a single atom) -->
+    <!--<constant name="IonIon" type="coulomb" source="ion0" target="ion0"/>-->
+  </hamiltonian>
+
+  <!-- QMC method(s) to run -->
+
+  <loop max="10">
+    <qmc method="linear" move="pbyp" checkpoint="-1" gpu="no">
+      <optimize method="gradient_test">
+        <parameter name="output_param_file">yes</parameter>
+      </optimize>
+      <parameter name="blocks">     100  </parameter>
+      <parameter name="warmupsteps"> 25 </parameter>
+      <parameter name="steps"> 10 </parameter>
+      <parameter name="substeps"> 20 </parameter>
+      <parameter name="timestep"> 0.5 </parameter>
+      <cost name="energy">                   1.0 </cost>
+      <cost name="reweightedvariance">       0.00 </cost>
+    </qmc>
+  </loop>
+
+
+</simulation>


### PR DESCRIPTION
Accumulate the derivatives in the case where multiple wavefunction pieces are controlled by the same variational parameter.

The fixes the single determinant case.  The multi-determinant case should work as it uses accumulation already.

The input file has no initial rotation (no "opt_vars" elements).  These don't work correctly in the RHF case, as the rotation ends up being applied twice.  (I don't think there's an easy way to fix this, and it doesn't seem like an important case to fix.  For normal usage, initial rotations will be read in from a VP file.)

Some of the other single-determinant derivative functions related to ECP's aren't changed, and I don't know if they need to be - will need to look into that separately.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
