### PR TITLE
Construct crowd data before each use in the batch optimizer

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -84,8 +84,6 @@ protected:
   // Number of walkers per crowd. Size of vector is number of crowds.
   std::vector<int> walkers_per_crowd_;
 
-  std::vector<std::unique_ptr<CostFunctionCrowdData>> opt_eval_;
-
   NewTimer& check_config_timer_;
   NewTimer& corr_sampling_timer_;
   NewTimer& fill_timer_;


### PR DESCRIPTION
For batched optimization, construct the crowd data in correlatedSampling in addition to checkConfigurations. The previous code would construct it in checkConfigurations and reuse the crowd data in correlatedSampling.
This simplifies changes to the variational parameters in the wavefunction, as the reset parameters call only needs to be performed on the gold copy.

Suggested in https://github.com/QMCPACK/qmcpack/pull/4426#discussion_r1095028360


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
