### PR TITLE
Make one definition of SPOMap

### DIFF
--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -40,7 +40,7 @@
 namespace qmcplusplus
 {
 
-using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+using SPOMap = SPOSet::SPOMap;
 
 EstimatorManagerNew::EstimatorManagerNew(const QMCHamiltonian& ham, Communicate* c)
     : RecordCount(0), my_comm_(c), max4ascii(8), FieldWidth(20)

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -55,7 +55,7 @@ public:
 
   using Evaluator  = OneBodyDensityMatricesInput::Evaluator;
   using Integrator = OneBodyDensityMatricesInput::Integrator;
-  using SPOMap     = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+  using SPOMap     = SPOSet::SPOMap;
 
   enum class Sampling
   {

--- a/src/QMCHamiltonians/OperatorBase.h
+++ b/src/QMCHamiltonians/OperatorBase.h
@@ -81,7 +81,7 @@ public:
   using ParticleScalar = ParticleSet::Scalar_t;
 
   ///typedef for SPOMap
-  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+  using SPOMap = SPOSet::SPOMap;
 
   ///enum to denote energy domain of operators
   enum EnergyDomains

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -54,7 +54,7 @@ public:
   using GGGMatrix   = OrbitalSetTraits<ValueType>::GradHessMatrix;
   using VGLVector   = OrbitalSetTraits<ValueType>::VGLVector;
   using Walker_t    = ParticleSet::Walker_t;
-  using SPOPool_t   = std::map<std::string, SPOSet*>;
+  using SPOMap      = std::map<std::string, const std::unique_ptr<const SPOSet>>;
 
   using OffloadMWVGLArray = Array<ValueType, 3, OffloadPinnedAllocator<ValueType>>; // [VGL, walker, Orbs]
   template<typename DT>

--- a/src/QMCWaveFunctions/SPOSetBuilder.h
+++ b/src/QMCWaveFunctions/SPOSetBuilder.h
@@ -47,7 +47,6 @@ namespace qmcplusplus
 class SPOSetBuilder : public QMCTraits, public MPIObjectBase
 {
 public:
-  using SPOPool_t  = std::map<std::string, SPOSet*>;
   using indices_t  = std::vector<int>;
   using energies_t = std::vector<RealType>;
 

--- a/src/QMCWaveFunctions/SPOSetBuilderFactory.h
+++ b/src/QMCWaveFunctions/SPOSetBuilderFactory.h
@@ -25,7 +25,7 @@ namespace qmcplusplus
 class SPOSetBuilderFactory : public MPIObjectBase
 {
 public:
-  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+  using SPOMap = SPOSet::SPOMap;
   using PSetMap = std::map<std::string, const std::unique_ptr<ParticleSet>>;
 
   /** constructor

--- a/src/QMCWaveFunctions/SPOSetScanner.h
+++ b/src/QMCWaveFunctions/SPOSetScanner.h
@@ -26,7 +26,7 @@ class SPOSetScanner
 {
 public:
   using PtclPool    = std::map<std::string, const std::unique_ptr<ParticleSet>>;
-  using SPOSetMap   = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+  using SPOSetMap   = SPOSet::SPOMap;
   using RealType    = QMCTraits::RealType;
   using ValueType   = QMCTraits::ValueType;
   using ValueVector = OrbitalSetTraits<ValueType>::ValueVector;

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -71,7 +71,7 @@ public:
   using LogValueType     = WaveFunctionComponent::LogValueType;
   using PsiValueType     = WaveFunctionComponent::PsiValueType;
 
-  using SPOMap = std::map<std::string, const std::unique_ptr<const SPOSet>>;
+  using SPOMap = SPOSet::SPOMap;
 
   /// enum type for computing partial WaveFunctionComponents
   enum class ComputeType


### PR DESCRIPTION
While working on #4428, I got annoyed that SPOMap was defined all over the place if it needed changing.  While I don't think the definition will need to ultimately change, I wanted to consolidate all the definitions.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A Documentation has been added (if appropriate)
