### PR TITLE
Add single thread offload NiO performance tests

### DIFF
--- a/tests/performance/NiO/CMakeLists.txt
+++ b/tests/performance/NiO/CMakeLists.txt
@@ -209,6 +209,19 @@ else()
         ${INPUT_FILE}
         ${H5_FILE}
         "${ADJUST_INPUT} -w ${WALKER_COUNT} -d ${NDELAY} -u --detbatched")
+      # To help analyze multithread offload implementations, add a single threaded batched test with same total workload as 4 thread case
+      if(ENABLE_OFFLOAD)
+        add_nio_test(
+          ${PERF_TEST}
+          1
+          1
+          ${TEST_DIR}
+          ${TEST_SOURCE_DIR}
+          ${INPUT_FILE}
+          ${H5_FILE}
+          "${ADJUST_INPUT} -w ${WALKER_COUNT} -d ${NDELAY} -u --detbatched")
+      endif(ENABLE_OFFLOAD)
+
     else()
       message(
         "NiO-a${ATOM_COUNT}-e${ELECTRON_COUNT} performance test not added because the corresponding h5 file not found: ${H5_FULL_PATH}"


### PR DESCRIPTION
## Proposed changes

Add a single threaded version of the current 4 thread NiO performance tests when offload enabled. Help debug and monitor performance of mulithread offload compilers and runtimes.

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

nitrogen2, amdclang, rocm 5.4.2

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
