### PR TITLE
Rename QMCAppBase and QMCMain members and one ifdef QMC_COMPLEX

### DIFF
--- a/src/QMCApp/QMCAppBase.cpp
+++ b/src/QMCApp/QMCAppBase.cpp
@@ -21,7 +21,7 @@ QMCAppBase::QMCAppBase() = default;
 
 QMCAppBase::~QMCAppBase()
 {
-  while (!XmlDocStack.empty())
+  while (!xml_doc_stack_.empty())
   {
     popDocument();
   }
@@ -33,7 +33,7 @@ bool QMCAppBase::pushDocument(const std::string& infile)
   bool success          = adoc->parse(infile);
   if (success)
   {
-    XmlDocStack.push(adoc);
+    xml_doc_stack_.push(adoc);
   }
   else
   {
@@ -45,12 +45,12 @@ bool QMCAppBase::pushDocument(const std::string& infile)
 
 void QMCAppBase::popDocument()
 {
-  if (!XmlDocStack.empty())
+  if (!xml_doc_stack_.empty())
   //Check if the stack is empty
   {
-    Libxml2Document* adoc = XmlDocStack.top();
+    Libxml2Document* adoc = xml_doc_stack_.top();
     delete adoc;
-    XmlDocStack.pop();
+    xml_doc_stack_.pop();
   }
 }
 
@@ -69,15 +69,15 @@ bool QMCAppBase::parse(const std::string& infile)
 
 void QMCAppBase::saveXml()
 {
-  if (!XmlDocStack.empty())
+  if (!xml_doc_stack_.empty())
   {
-    std::string newxml(myProject.currentMainRoot());
+    std::string newxml(my_project_.currentMainRoot());
     newxml.append(".cont.xml");
     app_log() << "\n========================================================="
               << "\n  A new xml input file : " << newxml << std::endl;
-    XmlDocStack.top()->dump(newxml);
+    xml_doc_stack_.top()->dump(newxml);
   }
 }
 
-const std::string& QMCAppBase::getTitle() const { return myProject.getTitle(); }
+const std::string& QMCAppBase::getTitle() const { return my_project_.getTitle(); }
 } // namespace qmcplusplus

--- a/src/QMCApp/QMCAppBase.h
+++ b/src/QMCApp/QMCAppBase.h
@@ -61,13 +61,13 @@ public:
 
 protected:
   ///stack of xml document
-  std::stack<Libxml2Document*> XmlDocStack;
+  std::stack<Libxml2Document*> xml_doc_stack_;
 
   ///project description
-  ProjectData myProject;
+  ProjectData my_project_;
 
   ///random number controller
-  RandomNumberControl myRandomControl;
+  RandomNumberControl my_random_control_;
 
   ///open a new document
   bool pushDocument(const std::string& infile);

--- a/src/QMCApp/QMCMain.cpp
+++ b/src/QMCApp/QMCMain.cpp
@@ -191,9 +191,9 @@ bool QMCMain::execute()
               << "/*************************************************\n"
               << " ********  This is an AFQMC calculation   ********\n"
               << " *************************************************" << std::endl;
-    xmlNodePtr cur = XmlDocStack.top()->getRoot();
+    xmlNodePtr cur = xml_doc_stack_.top()->getRoot();
 
-    xmlXPathContextPtr m_context = XmlDocStack.top()->getXPathContext();
+    xmlXPathContextPtr m_context = xml_doc_stack_.top()->getXPathContext();
     //initialize the random number generator
     xmlNodePtr rptr = my_random_control_.initialize(m_context);
 
@@ -204,7 +204,7 @@ bool QMCMain::execute()
       app_log() << " Error in AFQMCFactory::parse() ." << std::endl;
       return false;
     }
-    cur = XmlDocStack.top()->getRoot();
+    cur = xml_doc_stack_.top()->getRoot();
     return afqmc_fac.execute(cur);
   }
 #else

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -55,6 +55,9 @@ private:
   /// last branch engine used by legacy drivers
   std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver_;
 
+  /// Suppress HDF5 warning and error messages.
+  hdf_error_suppression hide_hdf_errors;
+
   ///xml mcwalkerset elements for output
   std::vector<xmlNodePtr> walker_set_;
 

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -47,24 +47,29 @@ public:
 
 private:
   ///flag to indicate that a qmc is the first QMC
-  bool FirstQMC;
-  /// the last driver object. Should be in a loop only.
-  std::unique_ptr<QMCDriverInterface> last_driver;
-  /// last branch engine used by legacy drivers
-  std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver;
+  bool first_qmc_;
 
-  /// Suppress HDF5 warning and error messages.
-  hdf_error_suppression hide_hdf_errors;
+  /// the last driver object. Should be in a loop only.
+  std::unique_ptr<QMCDriverInterface> last_driver_;
+
+  /// last branch engine used by legacy drivers
+  std::unique_ptr<SimpleFixedNodeBranch> last_branch_engine_legacy_driver_;
+
   ///xml mcwalkerset elements for output
-  std::vector<xmlNodePtr> m_walkerset;
+  std::vector<xmlNodePtr> walker_set_;
+
   ///xml mcwalkerset read-in elements
-  std::vector<xmlNodePtr> m_walkerset_in;
+  std::vector<xmlNodePtr> walker_set_in_;
+
   ///traces xml
   xmlNodePtr traces_xml;
+
   ///qmc sections
-  std::vector<std::pair<xmlNodePtr, bool>> m_qmcaction;
+  std::vector<std::pair<xmlNodePtr, bool>> qmc_action_;
+
   ///pointer to the last node of the main inputfile
-  xmlNodePtr lastInputNode;
+  xmlNodePtr last_input_node_;
+
   /** execute <qmc/> element
    * @param cur qmc xml node
    * @param reuse if true, reuse the driver built from the last QMC section. This should be used by loop only.
@@ -84,14 +89,17 @@ private:
 
   /** execute loop **/
   void executeLoop(xmlNodePtr cur);
+
   /** execute qmc
    * @param cur qmc xml node
    * @param reuse if true, reuse the driver built from the last QMC section. This should be used by loop only.
    * @return true, if a section is successfully executed.
    */
   bool executeQMCSection(xmlNodePtr cur, bool reuse = false);
+
   ///execute <cmc/> element
   bool executeCMCSection(xmlNodePtr cur);
+
   ///execute <debug/> element
   bool executeDebugSection(xmlNodePtr cur);
 };

--- a/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
+++ b/src/QMCTools/QMCFiniteSize/QMCFiniteSize.cpp
@@ -58,8 +58,8 @@ void QMCFiniteSize::build_spherical_grid(IndexType mtheta, IndexType mphi)
 
 bool QMCFiniteSize::validateXML()
 {
-  xmlXPathContextPtr m_context = XmlDocStack.top()->getXPathContext();
-  xmlNodePtr cur               = XmlDocStack.top()->getRoot()->children;
+  xmlXPathContextPtr m_context = xml_doc_stack_.top()->getXPathContext();
+  xmlNodePtr cur               = xml_doc_stack_.top()->getRoot()->children;
 
   while (cur != NULL)
   {
@@ -79,7 +79,7 @@ bool QMCFiniteSize::validateXML()
       if (a)
       {
         pushDocument((const char*)a);
-        processPWH(XmlDocStack.top()->getRoot());
+        processPWH(xml_doc_stack_.top()->getRoot());
         popDocument();
       }
     }
@@ -87,8 +87,7 @@ bool QMCFiniteSize::validateXML()
     {
       processPWH(cur);
     }
-    else
-    {}
+    else {}
     cur = cur->next;
   }
 
@@ -511,7 +510,7 @@ void QMCFiniteSize::calcPotentialCorrection()
     for (int j = 0; j < SK_raw.size(); j++)
     {
       FullPrecRealType chi;
-      chi = rng();
+      chi          = rng();
       newSK_raw[j] = SK_raw[j] + SKerr_raw[j] * chi;
     }
     vsums[i] = calcPotentialDiscrete(newSK_raw);
@@ -520,7 +519,7 @@ void QMCFiniteSize::calcPotentialCorrection()
     for (int j = 0; j < SK.size(); j++)
     {
       FullPrecRealType chi;
-      chi = rng();
+      chi      = rng();
       newSK[j] = SK[j] + SKerr[j] * chi;
     }
     vints[i] = calcPotentialInt(newSK);
@@ -548,7 +547,7 @@ void QMCFiniteSize::calcLeadingOrderCorrections()
     for (int j = 0; j < SK.size(); j++)
     {
       FullPrecRealType chi;
-      chi = rng();
+      chi      = rng();
       newSK[j] = SK[j] + SKerr[j] * chi;
     }
     UBspline_3d_d* spline = getSkSpline(newSK);


### PR DESCRIPTION
## Proposed changes

Rename protected and private members
Eliminate one #ifdef QMC_COMPLEX in QMCMain class
Clean unused member in QMCMain
Related to #3411 #4099

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
Ubuntu 22, must pass CI variants

## Checklist


- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
