### PR TITLE
Fix clang warning about non-virtual destructor

### DIFF
--- a/src/QMCApp/QMCAppBase.h
+++ b/src/QMCApp/QMCAppBase.h
@@ -38,7 +38,7 @@ public:
   QMCAppBase();
 
   ///destructor
-  ~QMCAppBase();
+  virtual ~QMCAppBase();
 
   /** parse an input file
    * @param infile file to be parsed.

--- a/src/QMCApp/QMCMain.h
+++ b/src/QMCApp/QMCMain.h
@@ -38,7 +38,7 @@ class QMCMain : public MPIObjectBase, public QMCAppBase
 public:
   QMCMain(Communicate* c);
 
-  ~QMCMain();
+  ~QMCMain() override;
 
   bool validateXML() override;
   bool execute() override;


### PR DESCRIPTION
## Proposed changes
clang 15 complains.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'