### PR TITLE
Used shared pointer for LCAO coefficient matrix copy

### DIFF
--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -779,9 +779,9 @@ void LCAOrbitalSet::evaluateThirdDeriv(const ParticleSet& P, int first, int last
 void LCAOrbitalSet::applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy)
 {
   if (!use_stored_copy)
-    C_copy = *C;
+    *C_copy = *C;
   //gemm is out-of-place
-  BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy.data(), BasisSetSize,
+  BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy->data(), BasisSetSize,
              rot_mat.data(), OrbitalSetSize, RealType(0.0), C->data(), BasisSetSize);
 
   /* debugging code

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h
@@ -55,7 +55,7 @@ public:
 
   std::unique_ptr<SPOSet> makeClone() const override;
 
-  void storeParamsBeforeRotation() override { C_copy = *C; }
+  void storeParamsBeforeRotation() override { C_copy = std::make_shared<ValueMatrix>(*C); }
 
   void applyRotation(const ValueMatrix& rot_mat, bool use_stored_copy) override;
 
@@ -211,7 +211,7 @@ protected:
   ///number of Single-particle orbitals
   const IndexType BasisSetSize;
   /// a copy of the original C before orbital rotation is applied;
-  ValueMatrix C_copy;
+  std::shared_ptr<ValueMatrix> C_copy;
 
   ///true if C is an identity matrix
   bool Identity;

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -98,6 +98,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
     app_warning() << "Specifying orbital rotation via optimize tag is deprecated. Use the rotated_spo element instead"
                   << std::endl;
 
+    sposet->storeParamsBeforeRotation();
     // create sposet with rotation
     auto& sposet_ref = *sposet;
     app_log() << "  SPOSet " << sposet_ref.getName() << " is optimizable\n";
@@ -158,6 +159,7 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createRotatedSPOSet(xmlNodePtr cur)
     myComm->barrier_and_abort("Orbital rotation not supported with '" + sposet->getName() + "' of type '" +
                               sposet->getClassName() + "'.");
 
+  sposet->storeParamsBeforeRotation();
   auto rot_spo = std::make_unique<RotatedSPOs>(spo_object_name, std::move(sposet));
 
   processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {


### PR DESCRIPTION
A copy of the coefficient matrix is used for orbital rotation.
Change the copy to use a shared pointer.  This means the rotation only needs to be performed on one thread (and should be performed only on one thread).

The storage for the coefficient copy is used regardless of the setting of `use_stored_copy`. That means `storeParamsBeforeRotation` needs to be called once sometime before `applyRotation` is called.

The `use_stored_copy` flag changes which values get used - true uses the values in the copy and false uses the values in the existing coefficients.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- New feature


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
