### PR TITLE
Store copy of bspline coefficients for orbital rotation

### DIFF
--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -51,6 +51,16 @@ bool SplineR2R<ST>::write_splines(hdf_archive& h5f)
   return h5f.writeEntry(bigtable, o.str().c_str()); //"spline_0");
 }
 
+template<typename ST>
+void SplineR2R<ST>::storeParamsBeforeRotation()
+{
+  const auto spline_ptr     = SplineInst->getSplinePtr();
+  const auto coefs_tot_size = spline_ptr->coefs_size;
+  coef_copy_                = std::make_shared<std::vector<RealType>>(coefs_tot_size);
+
+  std::copy_n(spline_ptr->coefs, coefs_tot_size, coef_copy_->begin());
+}
+
 /*
   ~~ Notes for rotation ~~
   spl_coefs      = Raw pointer of spline coefficients
@@ -87,6 +97,9 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
   const auto TrueNOrbs      = rot_mat.size1(); // == Nsplines - padding
   assert(OrbitalSetSize >= TrueNOrbs);
 
+  if (!use_stored_copy)
+    std::copy_n(spl_coefs, coefs_tot_size, coef_copy_->begin());
+
   // Fill top left corner of tmpU with rot_mat
   ValueMatrix tmpU;
   tmpU.resize(Nsplines, Nsplines);
@@ -110,14 +123,11 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
       for (auto k = 0; k < Nsplines; k++)
       {
         const auto index = i * Nsplines + k;
-        newval += *(spl_coefs + index) * tmpU[k][j];
+        newval += (*coef_copy_)[index] * tmpU[k][j];
       }
-      new_coefs[cur_elem] = newval;
+      spl_coefs[cur_elem] = newval;
     }
   }
-
-  // Update the coefs
-  std::copy(new_coefs.begin(), new_coefs.end(), spl_coefs);
 
   /*
     // Here is my attempt to use gemm but it doesn't work...

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.cpp
@@ -113,7 +113,6 @@ void SplineR2R<ST>::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
   }
 
   // Apply rotation the dumb way b/c I can't get BLAS::gemm to work...
-  std::vector<RealType> new_coefs(coefs_tot_size, 0);
   for (auto i = 0; i < BasisSetSize; i++)
   {
     for (auto j = 0; j < Nsplines; j++)

--- a/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineR2R.h
@@ -58,6 +58,9 @@ private:
   ///multi bspline set
   std::shared_ptr<MultiBspline<ST>> SplineInst;
 
+  ///Copy of original splines for orbital rotation
+  std::shared_ptr<std::vector<RealType>> coef_copy_;
+
   ///thread private ratios for reduction when using nested threading, numVP x numThread
   Matrix<TT> ratios_private;
 
@@ -82,6 +85,9 @@ public:
   bool isRotationSupported() const override { return true; }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineR2R>(*this); }
+
+  /// Store an original copy of the spline coefficients for orbital rotation
+  void storeParamsBeforeRotation() override;
 
   /* 
      Implements orbital rotations via [1,2]. 

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -119,6 +119,7 @@ TEST_CASE("RotatedSPOs via SplineR2R", "[wavefunction]")
   // SplineR2R only for the moment, so skip if QMC_COMPLEX is set
 #if !defined(QMC_COMPLEX)
 
+  spo->storeParamsBeforeRotation();
   // 1.) Make a RotatedSPOs object so that we can use the rotation routines
   auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
 
@@ -557,6 +558,7 @@ TEST_CASE("RotatedSPOs hcpBe", "[wavefunction]")
   auto spo = einSet.createSPOSetFromXML(sposet_ptr);
   REQUIRE(spo);
 
+  spo->storeParamsBeforeRotation();
   auto rot_spo = std::make_unique<RotatedSPOs>("one_rotated_set", std::move(spo));
 
   // Sanity check for orbs. Expect 1 electron, 2 orbitals

--- a/src/QMCWaveFunctions/tests/test_einset.cpp
+++ b/src/QMCWaveFunctions/tests/test_einset.cpp
@@ -333,8 +333,10 @@ TEST_CASE("Einspline SPO from HDF diamond_1x1x1", "[wavefunction]")
   rot_mat[7][6] = -0.00647;
   rot_mat[7][7] = 0.99273;
 
-  // Apply the rotation
-  spo->applyRotation(rot_mat, false);
+  spo->storeParamsBeforeRotation();
+  // Apply the rotation (use_stored_copy is set to true just
+  // to test a different code path from other calls to applyRotation elsewhere)
+  spo->applyRotation(rot_mat, true);
 
   // Get data for rotated orbitals
   SPOSet::ValueMatrix psiM_rot(elec_.R.size(), orbitalsetsize);


### PR DESCRIPTION
This is the bspline version of #4468.

Bsplines did not previously keep a copy of the coefficients.   The copy of the coefficients performs two functions. First it allocates storage for the matrix multiplication in applyRotation (it replaces `new_coefs` for this purpose). Second, it allows using the global rotation method with bsplines.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
