### PR TITLE
Enable orbital rotation

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -790,6 +790,7 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
 
   // create active rotation parameter indices
   std::vector<std::pair<int, int>> m_act_rot_inds;
+  std::vector<std::pair<int, int>> other_rot_inds;
 
   for (int i = 0; i < nmo; i++)
     for (int j = i + 1; j < nmo; j++)
@@ -806,12 +807,24 @@ void MultiDiracDeterminant::buildOptVariables(std::vector<size_t>& C2node)
                 int>(i,
                      j)); // orbital rotation parameter accepted as long as rotation isn't core-core or virtual-virtual
       }
+      else
+      {
+        other_rot_inds.push_back(std::pair<int, int>(i, j));
+      }
     }
+
+  std::vector<std::pair<int, int>> full_rot_inds;
+
+  // Copy the adjustable rotations first
+  full_rot_inds = m_act_rot_inds;
+  // Add the other rotations at the end
+  full_rot_inds.insert(full_rot_inds.end(), other_rot_inds.begin(), other_rot_inds.end());
+
 
 #ifndef QMC_COMPLEX
   RotatedSPOs* rot_spo = dynamic_cast<RotatedSPOs*>(Phi.get());
   if (rot_spo)
-    rot_spo->buildOptVariables(m_act_rot_inds);
+    rot_spo->buildOptVariables(m_act_rot_inds, full_rot_inds);
 #endif
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1405,8 +1405,10 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   myclone->params          = this->params;
   myclone->params_supplied = this->params_supplied;
   myclone->m_act_rot_inds  = this->m_act_rot_inds;
+  myclone->m_full_rot_inds = this->m_full_rot_inds;
   myclone->myVars          = this->myVars;
   myclone->myVarsFull      = this->myVarsFull;
+  myclone->history_params_ = this->history_params_;
   myclone->use_global_rot_ = this->use_global_rot_;
   return myclone;
 }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -1319,6 +1319,7 @@ std::unique_ptr<SPOSet> RotatedSPOs::makeClone() const
   myclone->params_supplied = this->params_supplied;
   myclone->m_act_rot_inds  = this->m_act_rot_inds;
   myclone->myVars          = this->myVars;
+  myclone->use_global_rot_ = this->use_global_rot_;
   return myclone;
 }
 

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -352,11 +352,17 @@ public:
   //  void evaluateThirdDeriv(const ParticleSet& P, int first, int last, GGGMatrix& grad_grad_grad_logdet)
   //  {Phi->evaluateThridDeriv(P, first, last, grad_grad_grad_logdet); }
 
+  /// Use history list (false) or global rotation (true)
+  void set_use_global_rotation(bool use_global_rotation) { use_global_rot_ = use_global_rotation; }
+
 private:
   /// true if SPO parameters (orbital rotation parameters) have been supplied by input
   bool params_supplied;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
+
+  /// Use global rotation or history list
+  bool use_global_rot_ = true;
 };
 
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -37,6 +37,9 @@ public:
   // Active orbital rotation parameter indices
   RotationIndices m_act_rot_inds;
 
+  // Full set of rotation values for global rotation
+  RotationIndices m_full_rot_inds;
+
   // Construct a list of the matrix indices for non-zero rotation parameters.
   // (The structure for a sparse representation of the matrix)
   // Only core->active rotations are created.
@@ -106,7 +109,7 @@ public:
   void buildOptVariables(size_t nel);
 
   // For the MSD case rotations must be created in MultiSlaterDetTableMethod class
-  void buildOptVariables(const RotationIndices& rotations);
+  void buildOptVariables(const RotationIndices& rotations, const RotationIndices& full_rotations);
 
 
   void evaluateDerivatives(ParticleSet& P,
@@ -360,6 +363,9 @@ private:
   bool params_supplied;
   /// list of supplied orbital rotation parameters
   std::vector<RealType> params;
+
+  /// Full set of rotation matrix parameters for use in global rotation method
+  opt_variables_type myVarsFull;
 
   /// Use global rotation or history list
   bool use_global_rot_ = true;

--- a/src/QMCWaveFunctions/SPOSetBuilder.cpp
+++ b/src/QMCWaveFunctions/SPOSetBuilder.cpp
@@ -135,8 +135,10 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createSPOSet(xmlNodePtr cur)
 std::unique_ptr<SPOSet> SPOSetBuilder::createRotatedSPOSet(xmlNodePtr cur)
 {
   std::string spo_object_name;
+  std::string method;
   OhmmsAttributeSet attrib;
   attrib.add(spo_object_name, "name");
+  attrib.add(method, "method", {"global", "history"});
   attrib.put(cur);
 
 
@@ -161,6 +163,9 @@ std::unique_ptr<SPOSet> SPOSetBuilder::createRotatedSPOSet(xmlNodePtr cur)
 
   sposet->storeParamsBeforeRotation();
   auto rot_spo = std::make_unique<RotatedSPOs>(spo_object_name, std::move(sposet));
+
+  if (method == "history")
+    rot_spo->set_use_global_rotation(false);
 
   processChildren(cur, [&](const std::string& cname, const xmlNodePtr element) {
     if (cname == "opt_vars")

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -242,7 +242,7 @@ TEST_CASE("Rotated LCAO WF0 zero angle", "[qmcapp]")
   CHECK(dhpsi_over_psi_list[0][1] == ValueApprox(7.84119772047731));
 }
 
-// No Jastrow, rotation angle theta1=0.1 and theta2=0.2 from idenity coefficients
+// No Jastrow, rotation angle theta1=0.1 and theta2=0.2 from identity coefficients
 TEST_CASE("Rotated LCAO WF1", "[qmcapp]")
 {
   Communicate* c;
@@ -327,7 +327,7 @@ TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
         </atomicBasisSet>
       </basisset>
       <rotated_sposet name="rot-spo-up">
-        <sposet basisset="LCAOBSet" name="spo-up">
+        <sposet basisset="LCAOBSet" name="spo-up" method="history">
           <coefficient id="updetC" type="Array" size="2">
             1.0 0.0
             0.0 1.0
@@ -335,7 +335,7 @@ TEST_CASE("Rotated LCAO WF2 with jastrow", "[qmcapp]")
         </sposet>
       </rotated_sposet>
       <rotated_sposet name="rot-spo-down">
-        <sposet basisset="LCAOBSet" name="spo-down">
+        <sposet basisset="LCAOBSet" name="spo-down" method="history">
           <coefficient id="updetC" type="Array" size="2">
             1.0 0.0
             0.0 1.0

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs_LCAO.cpp
@@ -530,6 +530,7 @@ TEST_CASE("Rotated LCAO WF1 MO coeff rotated, half angle", "[qmcapp]")
 }
 
 // Test rotation using stored coefficients
+//  and test consistency between history list and global rotation
 TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
 {
   using RealType    = QMCTraits::RealType;
@@ -644,6 +645,36 @@ TEST_CASE("Rotated LCAO rotation consistency", "[qmcapp]")
 
   CheckMatrixResult check_matrix_result0 = checkMatrix(*lcao_global->C, new_rot_m0, true);
   CHECKED_ELSE(check_matrix_result0.result) { FAIL(check_matrix_result0.result_message); }
+
+  std::vector<RealType> old_params = {0.0, 0.0, 0.0};
+  std::vector<RealType> new_params(3);
+  global_rot_spo->applyDeltaRotation(params1, old_params, new_params);
+
+  std::vector<RealType> params2 = {0.3, 0.15};
+  rot_spo->apply_rotation(params2, false);
+
+  std::vector<RealType> new_params2(3);
+  global_rot_spo->applyDeltaRotation(params2, new_params, new_params2);
+  CheckMatrixResult check_matrix_result2 = checkMatrix(*lcao1->C, *lcao_global->C, true);
+  CHECKED_ELSE(check_matrix_result2.result) { FAIL(check_matrix_result2.result_message); }
+
+  // Value after two rotations, computed from gen_matrix_ops.py
+  // clang-format off
+  std::vector<ValueType> rot_data3 =
+    {  0.862374825309137,  0.38511734273482,   0.328624851461217,
+      -0.377403929117215,  0.921689108007811, -0.0897522281988318,
+      -0.337455085840952, -0.046624248032951,  0.940186281826872 };
+  // clang-format on
+
+  ValueMatrix new_rot_m3(rot_data3.data(), 3, 3);
+
+  CheckMatrixResult check_matrix_result3 = checkMatrix(*lcao1->C, new_rot_m3, true);
+  CHECKED_ELSE(check_matrix_result3.result) { FAIL(check_matrix_result3.result_message); }
+
+  // Need to flip the sign on the first two entries to match the output from gen_matrix_ops.py
+  std::vector<ValueType> expected_param = {0.3998099017676912, 0.34924318065960236, -0.02261313113492491};
+  for (int i = 0; i < expected_param.size(); i++)
+    CHECK(new_params2[i] == Approx(expected_param[i]));
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
Change how rotation interacts with the optimizer to enable orbital rotation.

The method for tracking the rotation - history list versus global rotation - uses the "method" attribute on the "rotated_spo" tag.  The choices are "global" and "history", and the default is "global".

Note that the history method with the legacy driver and more than one thread does not work.  I couldn't figure out how to easily get all the information in one place to make the check and throw an error.  Given the default method is global rotation, and that does work with the legacy driver and multiple threads, this is going to take some effort to encounter.
* Batched driver
   * With the changes in #4440, the batched driver only ever operates on one copy.
* Legacy driver
   * global rotation - the state is kept in the RotatedSPOs, so applying resetParametersExclusive multiple times results in the same rotated coefficients.
   * history list - the state is kept in the coefficients of the underlying SPOSet, so the rotation gets applied once per-thread.

The rationale for keeping both methods around:
 * The history list is conceptually simpler and is more likely to be correct (though it might have numerical issues if the spline coefficients are kept as floats)
 * The matrix exponential uses an N^3 eigenvalue decomposition.  I expect this to be one of the first performance issues encountered when scaling up the number of rotation parameters.  The matrix log also uses an eigenvalue decomposition.  So the history list method uses one eigenvalue decomposition per applied rotation, where the global method uses two. 
 * The global rotation method is convenient because there is always just one set of rotation parameters to describe the state.
 * I suspect one future option for performance (or numerics) is to use the history method during the optimization run, but maintain the rotation matrix separate from the coefficients.  Then the matrix log can be performed once at the end to recover a single set of rotation parameters.


The previous code in checkInVariablesExclusive and resetParametersExclusive computed the delta rotation by setting the parameters to 0 in checkInVariablesExclusive.  Then when the driver calls resetParametersExclusive, the passed parameters represent the change in rotation.  The problem is the code is not guaranteed to pair every call to resetParametersExclusive with a previous call to checkInVariablesExclusive.  For instance, when computing the gradient, or when using multiple threads.

The new code tracks the current values of the parameters in myVars and computes the difference on entry to resetParameters.  As long as the parameters in myVars in RotatedSPOs match the values the optimizer has in currentParameters, the change in rotation will be computed correctly.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
