### PR TITLE
docs(): correct the wrong .dat filename in the afqmc tutorial

### DIFF
--- a/examples/afqmc/01-neon_atom/README.rst
+++ b/examples/afqmc/01-neon_atom/README.rst
@@ -169,7 +169,7 @@ Hartree--Fock energy you computed earlier from pyscf to within roughly the error
 you specified when generating the Cholesky decomposition. This check is not very
 meaningful if using, say, DFT orbitals.  However if this energy is crazy it's a good sign
 something went wrong with either the wavefunction or integral generation.  Next you should
-inspect the `qmc.scalar.s000.dat` file which contains the mixed estimates for various
+inspect the `qmc.s000.scalar.dat` file which contains the mixed estimates for various
 quantities. This can be plotted using gnuplot.  `EnergyEstim__nume_real` contains the
 block averaged values for the local energy, which should be the 7th column.
 


### PR DESCRIPTION
## Proposed changes

Correct the `.dat` filename in the first AFQMC tutorial from `qmc.scalar.s000.dat` to `qmc.s000.scalar.dat`.

## What type(s) of changes does this code introduce?

- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes. Documentation has been added (if appropriate)
