### PR TITLE
Save walker weights in HDF5 files

### DIFF
--- a/docs/output_overview.rst
+++ b/docs/output_overview.rst
@@ -137,28 +137,28 @@ This file contains stored walker configurations.
 * GROUP "root"
   * GROUP "state_0"
     * DATASET "block"
-      * DATATYPE H5T_STD_I32LE
-      * DATASPACE SCALAR
+      * int
+      * SCALAR
 
     * DATASET "number_of_walkers"
-      * DATATYPE H5T_STD_U64LE
-      * DATASPACE SCALAR
+      * size_t
+      * SCALAR
 
     * DATASET "walker_partition"
-      * DATATYPE H5T_STD_I32LE
-      * DATASPACE SIMPLE
+      * int
+      * ARRAY ( offsets )
 
     * DATASET "walker_weights"
-      * DATATYPE H5T_IEEE_F64LE
-      * DATASPACE SIMPLE
+      * double
+      * ARRAY ( weights )
 
     * DATASET "walkers"
-      * DATATYPE H5T_IEEE_F64LE
-      * DATASPACE SIMPLE
+      * double
+      * ARRAY ( configurations )
 
   * DATASET "version"
-    * DATATYPE H5T_STD_I32LE
-    * DATASPACE SIMPLE
+    * int
+    * ARRAY ( major version number, minor version number )
 
 The .random.h5 file
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/output_overview.rst
+++ b/docs/output_overview.rst
@@ -134,6 +134,32 @@ The .config.h5 file
 
 This file contains stored walker configurations.
 
+* GROUP "root"
+  * GROUP "state_0"
+    * DATASET "block"
+      * DATATYPE H5T_STD_I32LE
+      * DATASPACE SCALAR
+
+    * DATASET "number_of_walkers"
+      * DATATYPE H5T_STD_U64LE
+      * DATASPACE SCALAR
+
+    * DATASET "walker_partition"
+      * DATATYPE H5T_STD_I32LE
+      * DATASPACE SIMPLE
+
+    * DATASET "walker_weights"
+      * DATATYPE H5T_IEEE_F64LE
+      * DATASPACE SIMPLE
+
+    * DATASET "walkers"
+      * DATATYPE H5T_IEEE_F64LE
+      * DATASPACE SIMPLE
+
+  * DATASET "version"
+    * DATATYPE H5T_STD_I32LE
+    * DATASPACE SIMPLE
+
 The .random.h5 file
 ~~~~~~~~~~~~~~~~~~~
 

--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -150,7 +150,7 @@ bool HDFWalkerInput_0_4::read_hdf5(const std::filesystem::path& h5name)
   std::array<size_t, 3> dims{nw_in, num_ptcls_, OHMMS_DIM};
   Buffer_t posin(dims[0] * dims[1] * dims[2]);
   hin.readSlabReshaped(posin, dims, hdf::walkers);
-  std::vector<QMCTraits::FullPrecRealType> weights_in;
+  std::vector<QMCTraits::FullPrecRealType> weights_in(nw_in);
   const bool has_weights = hin.readEntry(weights_in, hdf::walker_weights);
 
   std::vector<int> woffsets;
@@ -220,25 +220,25 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(const std::filesystem::path& h5name)
   using Buffer_t = std::vector<QMCTraits::RealType>;
 
   const int np1 = myComm->size() + 1;
-  std::vector<int> counts(myComm->size()), woffsets(np1, 0);
-  FairDivideLow(nw_in, myComm->size(), woffsets);
+  std::vector<int> woffsets_weights(np1, 0);
+  FairDivideLow(nw_in, myComm->size(), woffsets_weights);
 
-  auto woffsets_w = woffsets;
-  std::vector<int> counts_w(myComm->size());
-  for (int i = 0; i < counts_w.size(); ++i)
-    counts_w[i] = woffsets_w[i + 1] - woffsets_w[i];
+  std::vector<int> counts_weights(myComm->size());
+  for (int i = 0; i < counts_weights.size(); ++i)
+    counts_weights[i] = woffsets_weights[i + 1] - woffsets_weights[i];
 
-  const size_t nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
-
+  // walker counts and offsets for electron coordinates
+  std::vector<int> woffsets(woffsets_weights);
   const int nitems = num_ptcls_ * OHMMS_DIM;
   for (int i = 0; i < woffsets.size(); ++i)
     woffsets[i] *= nitems;
+  std::vector<int> counts(myComm->size());
   for (int i = 0; i < counts.size(); ++i)
     counts[i] = woffsets[i + 1] - woffsets[i];
 
   std::array<size_t, 3> dims{nw_in, num_ptcls_, OHMMS_DIM};
-  Buffer_t posin(nw_in * nitems), posout(counts[myComm->rank()]);
-  std::vector<QMCTraits::FullPrecRealType> weights_in(nw_in), weights_out(counts[myComm->rank()]);
+  Buffer_t posin(nw_in * nitems);
+  std::vector<QMCTraits::FullPrecRealType> weights_in(nw_in);
   bool has_weights{false};
   if (myComm->rank() == 0)
   {
@@ -249,12 +249,15 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(const std::filesystem::path& h5name)
     has_weights = hin.readEntry(weights_in, hdf::walker_weights);
   }
 
+  Buffer_t posout(counts[myComm->rank()]);
+  std::vector<QMCTraits::FullPrecRealType> weights_out(counts[myComm->rank()]);
   mpi::scatterv(*myComm, posin, posout, counts, woffsets);
 
   mpi::bcast(*myComm, has_weights);
   if (has_weights)
-    mpi::scatterv(*myComm, weights_in, weights_out, counts_w, woffsets_w);
+    mpi::scatterv(*myComm, weights_in, weights_out, counts_weights, woffsets_weights);
 
+  const size_t nw_loc = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
   const int curWalker = wc_list_.getActiveWalkers();
   wc_list_.createWalkers(nw_loc, num_ptcls_);
 
@@ -276,7 +279,7 @@ bool HDFWalkerInput_0_4::read_phdf5(const std::filesystem::path& h5name)
 
   { // handle small dataset with master rank
     hdf_archive hin(myComm, false);
-    if (!myComm->rank())
+    if (myComm->rank() == 0)
     {
       success = hin.open(h5name, H5F_ACC_RDONLY);
       //check if hdf and xml versions can work together
@@ -306,7 +309,7 @@ bool HDFWalkerInput_0_4::read_phdf5(const std::filesystem::path& h5name)
 
     // load woffsets by master
     // can not read collectively since the size may differ from Nranks+1.
-    if (!myComm->rank())
+    if (myComm->rank() == 0)
     {
       hin.read(woffsets, "walker_partition");
       woffsets_size = woffsets.size();

--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -228,10 +228,10 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(const std::filesystem::path& h5name)
     counts_weights[i] = woffsets_weights[i + 1] - woffsets_weights[i];
 
   // walker counts and offsets for electron coordinates
-  std::vector<int> woffsets(woffsets_weights);
+  std::vector<int> woffsets(np1, 0);
   const int nitems = num_ptcls_ * OHMMS_DIM;
   for (int i = 0; i < woffsets.size(); ++i)
-    woffsets[i] *= nitems;
+    woffsets[i] = nitems * woffsets_weights[i];
   std::vector<int> counts(myComm->size());
   for (int i = 0; i < counts.size(); ++i)
     counts[i] = woffsets[i + 1] - woffsets[i];

--- a/src/Particle/HDFWalkerInput_0_4.cpp
+++ b/src/Particle/HDFWalkerInput_0_4.cpp
@@ -151,7 +151,7 @@ bool HDFWalkerInput_0_4::read_hdf5(const std::filesystem::path& h5name)
   Buffer_t posin(dims[0] * dims[1] * dims[2]);
   hin.readSlabReshaped(posin, dims, hdf::walkers);
   std::vector<QMCTraits::FullPrecRealType> weights_in;
-  bool has_weights = hin.readEntry(weights_in, hdf::walker_weights);
+  const bool has_weights = hin.readEntry(weights_in, hdf::walker_weights);
 
   std::vector<int> woffsets;
   hin.read(woffsets, "walker_partition");
@@ -172,16 +172,12 @@ bool HDFWalkerInput_0_4::read_hdf5(const std::filesystem::path& h5name)
 
     auto it = posin.begin() + woffsets[myComm->rank()] * nitems;
     for (int i = 0; i < nw_in; ++i, it += nitems)
-    {
       copy(it, it + nitems, get_first_address(wc_list_[i + curWalker]->R));
-    }
     if (has_weights)
     {
       const auto woffset = woffsets[myComm->rank()];
       for (int i = 0; i < nw_in; ++i)
-      {
         wc_list_[i + curWalker]->Weight = weights_in[i + woffset];
-      }
     }
   }
 
@@ -264,16 +260,10 @@ bool HDFWalkerInput_0_4::read_hdf5_scatter(const std::filesystem::path& h5name)
 
   auto it = posout.begin();
   for (int i = 0; i < nw_loc; ++i, it += nitems)
-  {
-    copy(it, it + nitems, get_first_address(wc_list_[i + curWalker]->R));
-  }
+    std::copy(it, it + nitems, get_first_address(wc_list_[i + curWalker]->R));
   if (has_weights)
-  {
     for (int i = 0; i < nw_in; ++i)
-    {
       wc_list_[i + curWalker]->Weight = weights_out[i];
-    }
-  }
   return true;
 }
 
@@ -357,7 +347,7 @@ bool HDFWalkerInput_0_4::read_phdf5(const std::filesystem::path& h5name)
   hin.read(slab, hdf::walkers);
 
   hyperslab_proxy<std::vector<QMCTraits::FullPrecRealType>, 1> slab_w(weights_in, dims_w, counts_w, offsets_w);
-  bool has_weights = hin.readEntry(slab_w, hdf::walker_weights);
+  const bool has_weights = hin.readEntry(slab_w, hdf::walker_weights);
 
   app_log() << " HDFWalkerInput_0_4::put getting " << dims[0] << " walkers " << posin.size() << std::endl;
   nw_in = woffsets[myComm->rank() + 1] - woffsets[myComm->rank()];
@@ -367,16 +357,10 @@ bool HDFWalkerInput_0_4::read_phdf5(const std::filesystem::path& h5name)
     wc_list_.createWalkers(nw_in, num_ptcls_);
     auto it = posin.begin();
     for (int i = 0; i < nw_in; ++i, it += nitems)
-    {
       copy(it, it + nitems, get_first_address(wc_list_[i + curWalker]->R));
-    }
     if (has_weights)
-    {
       for (int i = 0; i < nw_in; ++i)
-      {
         wc_list_[i + curWalker]->Weight = weights_in[i];
-      }
-    }
   }
   return true;
 }

--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -56,20 +56,9 @@ HDFWalkerOutput::HDFWalkerOutput(size_t num_ptcls, const std::string& aroot, Com
       number_of_particles_(num_ptcls),
       myComm(c),
       currentConfigNumber(0),
-      RootName(aroot),
-      RemoteData(2)
-//       , fw_out(myComm)
+      RootName(aroot)
 {
   block = -1;
-  //     //FileName=myComm->getName()+hdf::config_ext;
-  //     //ConfigFileName=myComm->getName()+".storeConfig.h5";
-  //     std::string ConfigFileName=myComm->getName()+".storeConfig.h5";
-  //     HDFVersion cur_version;
-  //     int dim=OHMMS_DIM;
-  //     fw_out.create(ConfigFileName);
-  //     fw_out.write(cur_version.version,hdf::version);
-  //     fw_out.write(number_of_particles_,"NumberElectrons");
-  //     fw_out.write(dim,"DIM");
 }
 
 /** Destructor writes the state of random numbers and close the file */
@@ -120,14 +109,13 @@ void HDFWalkerOutput::write_configuration(const WalkerConfigurations& W, hdf_arc
   if (nblock > block)
   {
     RemoteData[0].resize(wb * W.getActiveWalkers());
-    W.putConfigurations(RemoteData[0].data());
+    RemoteDataW[0].resize(W.getActiveWalkers());
+    W.putConfigurations(RemoteData[0].data(), RemoteDataW[0].data());
     block = nblock;
   }
 
   number_of_walkers_ = W.WalkerOffsets[myComm->size()];
   hout.write(number_of_walkers_, hdf::num_walkers);
-
-  std::array<size_t, 3> gcounts{number_of_walkers_, number_of_particles_, OHMMS_DIM};
 
   if (hout.is_parallel())
   {
@@ -152,10 +140,18 @@ void HDFWalkerOutput::write_configuration(const WalkerConfigurations& W, hdf_arc
       hout.write(slab, "walker_partition");
     }
     { // write walker configuration
+      std::array<size_t, 3> gcounts{number_of_walkers_, number_of_particles_, OHMMS_DIM};
       std::array<size_t, 3> counts{W.getActiveWalkers(), number_of_particles_, OHMMS_DIM};
       std::array<size_t, 3> offsets{static_cast<size_t>(W.WalkerOffsets[myComm->rank()]), 0, 0};
       hyperslab_proxy<BufferType, 3> slab(RemoteData[0], gcounts, counts, offsets);
       hout.write(slab, hdf::walkers);
+    }
+    {
+      std::array<size_t, 1> gcounts{number_of_walkers_};
+      std::array<size_t, 1> counts{W.getActiveWalkers()};
+      std::array<size_t, 1> offsets{static_cast<size_t>(W.WalkerOffsets[myComm->rank()])};
+      hyperslab_proxy<std::vector<QMCTraits::FullPrecRealType>, 1> slab(RemoteDataW[0], gcounts, counts, offsets);
+      hout.write(slab, hdf::walker_weights);
     }
   }
   else
@@ -172,106 +168,25 @@ void HDFWalkerOutput::write_configuration(const WalkerConfigurations& W, hdf_arc
       if (!myComm->rank())
         RemoteData[1].resize(wb * W.WalkerOffsets[myComm->size()]);
       mpi::gatherv(*myComm, RemoteData[0], RemoteData[1], counts, displ);
+      // update counts and displ for gathering walker weights
+      for (int i = 0; i < myComm->size(); ++i)
+      {
+        counts[i] = (W.WalkerOffsets[i + 1] - W.WalkerOffsets[i]);
+        displ[i]  = W.WalkerOffsets[i];
+      }
+      if (!myComm->rank())
+        RemoteDataW[1].resize(W.WalkerOffsets[myComm->size()]);
+      mpi::gatherv(*myComm, RemoteDataW[0], RemoteDataW[1], counts, displ);
     }
     int buffer_id = (myComm->size() > 1) ? 1 : 0;
-    hout.writeSlabReshaped(RemoteData[buffer_id], gcounts, hdf::walkers);
+    {
+      std::array<size_t, 3> gcounts{number_of_walkers_, number_of_particles_, OHMMS_DIM};
+      hout.writeSlabReshaped(RemoteData[buffer_id], gcounts, hdf::walkers);
+    }
+    {
+      std::array<size_t, 1> gcounts{number_of_walkers_};
+      hout.writeSlabReshaped(RemoteDataW[buffer_id], gcounts, hdf::walker_weights);
+    }
   }
 }
-
-/*
-bool HDFWalkerOutput::dump(ForwardWalkingHistoryObject& FWO)
-{
-//     std::string ConfigFileName=myComm->getName()+".storeConfig.h5";
-//     fw_out.open(ConfigFileName);
-//
-//     if (myComm->size()==1)
-//     {
-//       for (int i=0; i<FWO.ForwardWalkingHistory.size(); i++ )
-//       {
-//         int fwdata_size=FWO.ForwardWalkingHistory[i]->size();
-//         std::stringstream sstr;
-//         sstr<<"Block_"<<currentConfigNumber;
-//         fw_out.push(sstr.str());//open the group
-//
-//         std::vector<float> posVecs;
-//         //reserve enough space
-//         std::vector<long> IDs(fwdata_size,0);
-//         std::vector<long> ParentIDs(fwdata_size,0);
-//         std::vector<float>::iterator tend(posVecs.begin());
-//         for (int j=0;j<fwdata_size;j++)
-//         {
-//           const ForwardWalkingData& fwdata(FWO(i,j));
-//           IDs[j]=fwdata.ID;
-//           ParentIDs[j]=fwdata.ParentID;
-//           fwdata.append(posVecs);
-//         }
-//         fw_out.write(posVecs,"Positions");
-//         fw_out.write(IDs,"WalkerID");
-//         fw_out.write(ParentIDs,"ParentID");
-//         fw_out.write(fwdata_size,hdf::num_walkers);
-//
-//         fw_out.pop();//close the group
-//         ++currentConfigNumber;
-//       }
-//     }
-// #if defined(HAVE_MPI)
-//     else
-//     {
-//       const int n3=number_of_particles_*OHMMS_DIM;
-//       for (int i=0; i<FWO.ForwardWalkingHistory.size(); i++ )
-//       {
-//         int fwdata_size=FWO.ForwardWalkingHistory[i]->size();
-//         std::stringstream sstr;
-//         sstr<<"Block_"<<currentConfigNumber;
-//         fw_out.push(sstr.str());//open the group
-//
-//         std::vector<int> counts(myComm->size());
-//         mpi::all_gather(*myComm,fwdata_size,counts);
-//
-//         std::vector<float> posVecs;
-//         //reserve space to minimize the allocation
-//         posVecs.reserve(FWO.number_of_walkers_*n3);
-//         std::vector<long> myIDs(fwdata_size),pIDs(fwdata_size);
-//         std::vector<float>::iterator tend(posVecs.begin());
-//         for (int j=0;j<fwdata_size;j++)
-//         {
-//           const ForwardWalkingData& fwdata(FWO(i,j));
-//           myIDs[j]=fwdata.ID;
-//           pIDs[j]=fwdata.ParentID;
-//           fwdata.append(posVecs);
-//         }
-//         std::vector<int> offsets(myComm->size()+1,0);
-//         for(int i=0; i<myComm->size();++i) offsets[i+1]=offsets[i]+counts[i];
-//         fwdata_size=offsets.back();
-//         fw_out.write(fwdata_size,hdf::num_walkers);
-//
-//         std::vector<long> globalIDs;
-//         if(myComm->rank()==0) globalIDs.resize(fwdata_size);
-//
-//         //collect WalkerID
-//         mpi::gatherv(*myComm, myIDs, globalIDs, counts, offsets);
-//         fw_out.write(globalIDs,"WalkerID");
-//         //collect ParentID
-//         mpi::gatherv(*myComm, pIDs, globalIDs, counts, offsets);
-//         fw_out.write(globalIDs,"ParentID");
-//
-//         for(int i=0; i<counts.size();++i) counts[i]*=n3;
-//         for(int i=0; i<offsets.size();++i) offsets[i]*=n3;
-//         std::vector<float> gpos;
-//         if(myComm->rank()==0) gpos.resize(offsets.back());
-//         mpi::gatherv(*myComm, posVecs, gpos, counts, offsets);
-//
-//         fw_out.write(gpos,"Positions");
-//
-//         fw_out.pop();//close the group
-//         ++currentConfigNumber;
-//       }
-//     }
-// #endif
-//     fw_out.close();
-//     FWO.clearConfigsForForwardWalking();
-//
-    return true;
-}*/
-
 } // namespace qmcplusplus

--- a/src/Particle/HDFWalkerOutput.cpp
+++ b/src/Particle/HDFWalkerOutput.cpp
@@ -40,6 +40,10 @@ namespace qmcplusplus
  * so that subsequent write can utilize existing dataspaces.
  * HDF5 contains
  * - state_0
+ *   -- block
+ *   -- number of walkers
+ *   -- walker_partition
+ *   -- walker_weights
  *   -- walkers
  * - config_collection
  *   -- NumOfConfigurations current count of the configurations
@@ -71,7 +75,7 @@ HDFWalkerOutput::~HDFWalkerOutput() = default;
  * - version
  * - state_0
  *  - block (int)
- *  - number_of_walkes (int)
+ *  - number_of_walkers (int)
  *  - walker_partition (int array)
  *  - walkers (nw,np,3)
  */

--- a/src/Particle/HDFWalkerOutput.h
+++ b/src/Particle/HDFWalkerOutput.h
@@ -61,14 +61,9 @@ private:
   ///PooledData<T> is used to define the shape of multi-dimensional array
   using BufferType = PooledData<OHMMS_PRECISION>;
   std::vector<Communicate::request> myRequest;
-  std::vector<BufferType> RemoteData;
+  std::array<BufferType, 2> RemoteData;
+  std::array<std::vector<QMCTraits::FullPrecRealType>, 2> RemoteDataW;
   int block;
-
-  //     //define some types for the FW collection
-  //     using FWBufferType = std::vector<ForwardWalkingData>;
-  //     std::vector<FWBufferType*> FWData;
-  //     std::vector<std::vector<int> > FWCountData;
-
   void write_configuration(const WalkerConfigurations& W, hdf_archive& hout, int block);
 };
 

--- a/src/Particle/WalkerConfigurations.cpp
+++ b/src/Particle/WalkerConfigurations.cpp
@@ -135,12 +135,14 @@ void WalkerConfigurations::reset()
   }
 }
 
-void WalkerConfigurations::putConfigurations(Walker_t::RealType* target) const
+void WalkerConfigurations::putConfigurations(Walker_t::RealType* target, QMCTraits::FullPrecRealType* weights) const
 {
   for (const auto& walker : WalkerList)
   {
     std::copy(get_first_address(walker->R), get_last_address(walker->R), target);
     target += get_last_address(walker->R) - get_first_address(walker->R);
+    *weights = walker->Weight;
+    ++weights;
   }
 }
 

--- a/src/Particle/WalkerConfigurations.h
+++ b/src/Particle/WalkerConfigurations.h
@@ -187,7 +187,7 @@ public:
   void reset();
 
   ///save the particle positions of all the walkers into target
-  void putConfigurations(Walker_t::RealType* target) const;
+  void putConfigurations(Walker_t::RealType* target, QMCTraits::FullPrecRealType* weights) const;
 
 protected:
   ///number of walkers on a node

--- a/src/io/hdf/HDFVersion.h
+++ b/src/io/hdf/HDFVersion.h
@@ -35,6 +35,7 @@ const char config_group[] = "config_collection";
 const char random[]         = "random_state";
 const char walkers[]        = "walkers";
 const char num_walkers[]    = "number_of_walkers";
+const char walker_weights[] = "walker_weights";
 const char energy_history[] = "energy_history";
 const char norm_history[]   = "norm_history";
 const char qmc_status[]     = "qmc_status";

--- a/tests/io/restart/qmc_short.restart.xml
+++ b/tests/io/restart/qmc_short.restart.xml
@@ -82,7 +82,7 @@
       </hamiltonian>
    </qmcsystem>
 
-   <mcwalkerset fileroot="qmc_short.s000" node="-1" nprocs="4" version="3 0" collected="yes"/>
+   <mcwalkerset fileroot="qmc_short.s000" node="-1" nprocs="4" version="0 4" collected="yes"/>
 
    <qmc method="vmc" move="pbyp" checkpoint="-1">
       <parameter name="walkers">        16              </parameter>

--- a/tests/io/restart_batch/qmc_short_batch.restart.xml
+++ b/tests/io/restart_batch/qmc_short_batch.restart.xml
@@ -82,7 +82,7 @@
       </hamiltonian>
    </qmcsystem>
 
-   <mcwalkerset fileroot="qmc_short_batch.s000" node="-1" nprocs="1" version="3 14" collected="yes"/>
+   <mcwalkerset fileroot="qmc_short_batch.s000" node="-1" nprocs="1" version="0 4" collected="yes"/>
 
    <qmc method="vmc_batch" move="pbyp" checkpoint="-1">
       <parameter name="walkers_per_rank"> 16            </parameter>	   


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Saves the walker weights following the same pattern used to save the particle positions.

This fixes #4157

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
