### PR TITLE
Remove the error trap which blocks DMC->any QMC restart in classic drivers

### DIFF
--- a/src/QMCDrivers/SimpleFixedNodeBranch.cpp
+++ b/src/QMCDrivers/SimpleFixedNodeBranch.cpp
@@ -783,11 +783,6 @@ void SimpleFixedNodeBranch::read(const std::string& fname)
     }
   }
 
-  if (BranchMode[B_DMC] && !bmode[B_DMC])
-    throw UniformCommunicateError("SimpleFixedNodeBranch::read legacy drivers cannot make a non-DMC run by restarting "
-                                  "from a previous DMC run. This capability is only supported by the newer batched drivers."
-                                  " Switch to using the batched drivers if this restart was intended.");
-
   app_log().flush();
 }
 


### PR DESCRIPTION
## Proposed changes
Revert #4486 which was doing more than it should.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
bora

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'