### PR TITLE
Reinstate ornl-nitrogen-1 CI ROCm jobs

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -214,10 +214,10 @@ jobs:
       matrix:
         jobname:
           [
-            ROCm-Clang13-NoMPI-CUDA2HIP-Real-Mixed,
-            ROCm-Clang13-NoMPI-CUDA2HIP-Real,
-            ROCm-Clang13-NoMPI-CUDA2HIP-Complex-Mixed,
-            ROCm-Clang13-NoMPI-CUDA2HIP-Complex,
+            ROCm-Clang15-NoMPI-CUDA2HIP-Real-Mixed,
+            ROCm-Clang15-NoMPI-CUDA2HIP-Real,
+            ROCm-Clang15-NoMPI-CUDA2HIP-Complex-Mixed,
+            ROCm-Clang15-NoMPI-CUDA2HIP-Complex,
           ]
 
     steps:
@@ -273,15 +273,15 @@ jobs:
 
       - name: Configure
         if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh configure
+        run: tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh configure
 
       - name: Build
         if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh build
+        run: tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh build
 
       - name: Test
         if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh test
+        run: tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh test
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'

--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -214,10 +214,10 @@ jobs:
       matrix:
         jobname:
           [
-            ROCm-Clang15-NoMPI-CUDA2HIP-Real-Mixed,
-            ROCm-Clang15-NoMPI-CUDA2HIP-Real,
-            ROCm-Clang15-NoMPI-CUDA2HIP-Complex-Mixed,
-            ROCm-Clang15-NoMPI-CUDA2HIP-Complex,
+            RadeonVII-ROCm-NoMPI-CUDA2HIP-Real-Mixed,
+            RadeonVII-ROCm-NoMPI-CUDA2HIP-Real,
+            RadeonVII-ROCm-NoMPI-CUDA2HIP-Complex-Mixed,
+            RadeonVII-ROCm-NoMPI-CUDA2HIP-Complex,
           ]
 
     steps:

--- a/tests/test_automation/github-actions/ci/config_ornl-nitrogen.sh
+++ b/tests/test_automation/github-actions/ci/config_ornl-nitrogen.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script is used to configure the ORNL nitrogen cluster for CI testing
+# of the github-actions/ci workflow.
+# Run manually to reproduce installation of dependencies in $PREFIX
+# $SOFT_TMP keeps sources, installers, etc. Can be removed.
+
+# create directories, change PREFIX and SOFT_TMP to a location of your choice
+PREFIX=$HOME/opt
+SOFT_TMP=$HOME/software
+mkdir -p $PREFIX
+mkdir -p $SOFT_TMP
+
+# Recent CMake and LLVM are required to build the latest version of QMCPACK
+# CMake installer
+cd $PREFIX && mkdir -p cmake
+cd $SOFT_TMP
+CMAKE_VERSION=3.24.3
+wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.sh
+sh cmake-$CMAKE_VERSION-linux-x86_64.sh --skip-license --prefix=$PREFIX/cmake/$CMAKE_VERSION
+export PATH=$PREFIX/cmake/$CMAKE_VERSION/bin:$PATH
+
+# LLVM 
+cd $SOFT_TMP
+LLVM_VERSION=15.0.7
+LLVM_TAG=llvmorg-$LLVM_VERSION
+git clone --depth=1 --branch $LLVM_TAG https://github.com/llvm/llvm-project.git
+cd llvm-project
+
+cmake -S llvm -B build -G Ninja \
+      -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" \
+      -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;openmp" \
+      -DCLANG_OPENMP_NVPTX_DEFAULT_ARCH=sm_70 \
+      -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=37,60,70 \
+      -DCMAKE_INSTALL_PREFIX=$HOME/opt/llvm/$LLVM_VERSION \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER=/usr/bin/gcc \
+      -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+      -DGCC_INSTALL_PREFIX=/usr 
+
+cd build && ninja && ninja install

--- a/tests/test_automation/github-actions/ci/config_ornl-nitrogen.sh
+++ b/tests/test_automation/github-actions/ci/config_ornl-nitrogen.sh
@@ -11,7 +11,7 @@ SOFT_TMP=$HOME/software
 mkdir -p $PREFIX
 mkdir -p $SOFT_TMP
 
-# Recent CMake and LLVM are required to build the latest version of QMCPACK
+# A recent CMake ( > 3.21) is required to build the latest version of QMCPACK
 # CMake installer
 cd $PREFIX && mkdir -p cmake
 cd $SOFT_TMP
@@ -19,23 +19,3 @@ CMAKE_VERSION=3.24.3
 wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.sh
 sh cmake-$CMAKE_VERSION-linux-x86_64.sh --skip-license --prefix=$PREFIX/cmake/$CMAKE_VERSION
 export PATH=$PREFIX/cmake/$CMAKE_VERSION/bin:$PATH
-
-# LLVM 
-cd $SOFT_TMP
-LLVM_VERSION=15.0.7
-LLVM_TAG=llvmorg-$LLVM_VERSION
-git clone --depth=1 --branch $LLVM_TAG https://github.com/llvm/llvm-project.git
-cd llvm-project
-
-cmake -S llvm -B build -G Ninja \
-      -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" \
-      -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;openmp" \
-      -DCLANG_OPENMP_NVPTX_DEFAULT_ARCH=sm_70 \
-      -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=37,60,70 \
-      -DCMAKE_INSTALL_PREFIX=$HOME/opt/llvm/$LLVM_VERSION \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_C_COMPILER=/usr/bin/gcc \
-      -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
-      -DGCC_INSTALL_PREFIX=/usr 
-
-cd build && ninja && ninja install

--- a/tests/test_automation/github-actions/ci/run_step.sh
+++ b/tests/test_automation/github-actions/ci/run_step.sh
@@ -238,26 +238,6 @@ case "$1" in
               -DQMC_DATA=$QMC_DATA_DIR \
               ${GITHUB_WORKSPACE}
       ;;
-      *"ROCm-Clang13-NoMPI-CUDA2HIP"*)
-        echo 'Configure for building CUDA2HIP with clang compilers shipped with ROCM on AMD hardware'
-        export ROCM_PATH=/opt/rocm
-
-        # Make current environment variables available to subsequent steps
-        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-
-        cmake -GNinja \
-              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
-              -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
-              -DQMC_MPI=0 \
-              -DENABLE_CUDA=ON \
-              -DQMC_CUDA2HIP=ON \
-              -DCMAKE_PREFIX_PATH="/opt/OpenBLAS/0.3.18" \
-              -DQMC_COMPLEX=$IS_COMPLEX \
-              -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-              -DQMC_DATA=$QMC_DATA_DIR \
-              ${GITHUB_WORKSPACE}
-      ;;
       *"GCC9-MPI-CUDA-AFQMC"*)
         echo 'Configure for building with ENABLE_CUDA and AFQMC, need built-from-source OpenBLAS due to bug in rpm'
         cmake -GNinja \

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Executes pipeline steps for the nitrogen-1 CI jobs
+
+set -x
+HOST_NAME=$(hostname -s)
+
+case "$1" in 
+
+  configure)
+
+    echo "Use recent cmake v3.24.3"
+    export PATH=/opt/cmake/3.24.3/bin:$PATH
+    # Make current environment variables available to subsequent steps, ctest
+    echo "PATH=$PATH" >> $GITHUB_ENV
+
+    QMC_DATA_DIR=/scratch/ci/QMC_DATA_FULL
+
+    if [ -d ${GITHUB_WORKSPACE}/../qmcpack-build ]
+    then
+      echo "Found existing out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build, removing"
+      rm -fr ${GITHUB_WORKSPACE}/../qmcpack-build
+    fi
+
+    echo "Creating new out-of-source build directory ${GITHUB_WORKSPACE}/../qmcpack-build"
+    cd ${GITHUB_WORKSPACE}/.. && mkdir qmcpack-build && cd qmcpack-build
+
+    # Build variants
+    # Real or Complex configuration
+    case "${GH_JOBNAME}" in
+      *"Real"*)
+        echo 'Configure for real build -DQMC_COMPLEX=0'
+        IS_COMPLEX=0
+      ;;
+      *"Complex"*)
+        echo 'Configure for complex build -DQMC_COMPLEX=1'
+        IS_COMPLEX=1
+      ;; 
+    esac
+
+    # Mixed or Non-Mixed (default, full) precision, used with GPU code
+    case "${GH_JOBNAME}" in
+      *"Mixed"*)
+        echo 'Configure for mixed precision build -DQMC_MIXED_PRECISION=1'
+        IS_MIXED_PRECISION=1
+      ;; 
+      *)
+        IS_MIXED_PRECISION=0
+      ;;
+    esac
+    
+    case "${GH_JOBNAME}" in
+      *"ROCm-Clang15-NoMPI-CUDA2HIP"*)
+        echo 'Configure for building CUDA2HIP with clang compilers shipped with ROCM on AMD hardware'
+
+        cmake -GNinja \
+              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+              -DQMC_MPI=0 \
+              -DENABLE_CUDA=ON \
+              -DQMC_CUDA2HIP=ON \
+              -DQMC_COMPLEX=$IS_COMPLEX \
+              -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DQMC_DATA=$QMC_DATA_DIR \
+              ${GITHUB_WORKSPACE}
+      ;;
+    esac
+    ;;
+  
+  build)
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    ninja
+    ;;
+   
+  test)
+    echo "Running deterministic tests"
+    cd ${GITHUB_WORKSPACE}/../qmcpack-build
+    ctest --output-on-failure -L deterministic -j 32
+    ;;
+    
+esac

--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -9,8 +9,8 @@ case "$1" in
 
   configure)
 
-    echo "Use recent cmake v3.24.3"
-    export PATH=/opt/cmake/3.24.3/bin:$PATH
+    echo "Use recent CMake v3.24.3"
+    export PATH=$HOME/opt/cmake/3.24.3/bin:$PATH
     # Make current environment variables available to subsequent steps, ctest
     echo "PATH=$PATH" >> $GITHUB_ENV
 
@@ -48,24 +48,21 @@ case "$1" in
         IS_MIXED_PRECISION=0
       ;;
     esac
-    
-    case "${GH_JOBNAME}" in
-      *"ROCm-Clang15-NoMPI-CUDA2HIP"*)
-        echo 'Configure for building CUDA2HIP with clang compilers shipped with ROCM on AMD hardware'
+       
+    echo 'Configure for building CUDA2HIP with ROCM clang compilers'
 
-        cmake -GNinja \
-              -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
-              -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
-              -DQMC_MPI=0 \
-              -DENABLE_CUDA=ON \
-              -DQMC_CUDA2HIP=ON \
-              -DQMC_COMPLEX=$IS_COMPLEX \
-              -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-              -DQMC_DATA=$QMC_DATA_DIR \
-              ${GITHUB_WORKSPACE}
-      ;;
-    esac
+    cmake -GNinja \
+          -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+          -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+          -DQMC_MPI=0 \
+          -DENABLE_CUDA=ON \
+          -DQMC_CUDA2HIP=ON \
+          -DQMC_COMPLEX=$IS_COMPLEX \
+          -DQMC_MIXED_PRECISION=$IS_MIXED_PRECISION \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DQMC_DATA=$QMC_DATA_DIR \
+          ${GITHUB_WORKSPACE}
+          
     ;;
   
   build)


### PR DESCRIPTION
## Proposed changes

After system upgrades on nitrogen this PR reinstates ROCm jobs to CI
Starts refactoring CI for a cleaner separation of runner workflow steps
Move steps from run_step.sh to run_step_ornl-nitrogen-1.sh Update from Clang13 to Clang15
Add configuration file for LLVM and CMake deps
Tested locally

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
ornl-nitrogen, must pass GitHub Actions workflows CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
