### PR TITLE
Remove raw owning pointers in SampleStack

### DIFF
--- a/src/Particle/MCWalkerConfiguration.cpp
+++ b/src/Particle/MCWalkerConfiguration.cpp
@@ -42,7 +42,7 @@ MCWalkerConfiguration::MCWalkerConfiguration(const MCWalkerConfiguration& mcw)
   samples.clearEnsemble();
   samples.setMaxSamples(mcw.getMaxSamples());
   setWalkerOffsets(mcw.getWalkerOffsets());
-  Properties      = mcw.Properties;
+  Properties = mcw.Properties;
 }
 
 MCWalkerConfiguration::~MCWalkerConfiguration() = default;

--- a/src/Particle/SampleStack.cpp
+++ b/src/Particle/SampleStack.cpp
@@ -24,12 +24,8 @@ void SampleStack::setMaxSamples(size_t n, size_t num_ranks)
 {
   max_samples_        = n;
   global_num_samples_ = n * num_ranks;
-  //do not add anything
-  if (n == 0)
-    return;
-  sample_vector_.reserve(n);
-  size_t nadd = n - sample_vector_.size();
-  sample_vector_.insert(sample_vector_.end(), nadd, MCSample(total_num_));
+  current_sample_count_ = std::min(current_sample_count_, max_samples_);
+  sample_vector_.resize(n, MCSample(0));
 }
 
 const MCSample& SampleStack::getSample(size_t i) const { return sample_vector_[i]; }

--- a/src/Particle/SampleStack.cpp
+++ b/src/Particle/SampleStack.cpp
@@ -20,7 +20,7 @@ namespace qmcplusplus
  * @param n number of samples per rank
  * @param num_ranks number of ranks. Used to set global number of samples.
  */
-void SampleStack::setMaxSamples(int n, int num_ranks)
+void SampleStack::setMaxSamples(size_t n, size_t num_ranks)
 {
   max_samples_        = n;
   global_num_samples_ = n * num_ranks;
@@ -28,12 +28,8 @@ void SampleStack::setMaxSamples(int n, int num_ranks)
   if (n == 0)
     return;
   sample_vector_.reserve(n);
-  int nadd = n - sample_vector_.size();
-  while (nadd > 0)
-  {
-    sample_vector_.emplace_back(total_num_);
-    --nadd;
-  }
+  size_t nadd = n - sample_vector_.size();
+  sample_vector_.insert(sample_vector_.end(), nadd, MCSample(total_num_));
 }
 
 const MCSample& SampleStack::getSample(size_t i) const { return sample_vector_[i]; }

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -31,8 +31,6 @@ class SampleStack
 public:
   using PropertySetType = QMCTraits::PropertySetType;
 
-  void setTotalNum(size_t total_num) { total_num_ = total_num; }
-
   size_t getMaxSamples() const { return max_samples_; }
 
   bool empty() const { return sample_vector_.empty(); }
@@ -57,7 +55,6 @@ public:
   void resetSampleCount();
 
 private:
-  size_t total_num_{0};
   size_t max_samples_{10};
   size_t current_sample_count_{0};
   size_t global_num_samples_{max_samples_};

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -20,19 +20,16 @@
 
 #include <vector>
 #include "Particle/ParticleSet.h"
+#include "Particle/MCSample.h"
 #include "Particle/Walker.h"
 #include "Particle/WalkerConfigurations.h"
 
 namespace qmcplusplus
 {
-struct MCSample;
-
 class SampleStack
 {
 public:
   using PropertySetType = QMCTraits::PropertySetType;
-
-  SampleStack();
 
   void setTotalNum(int total_num) { total_num_ = total_num; }
 
@@ -40,16 +37,14 @@ public:
 
   bool empty() const { return sample_vector_.empty(); }
 
-  MCSample& getSample(unsigned int i) const;
+  const MCSample& getSample(size_t i) const;
 
   //@{save/load/clear function for optimization
   inline int getNumSamples() const { return current_sample_count_; }
   ///set the number of max samples per rank.
   void setMaxSamples(int n, int number_of_ranks = 1);
   /// Global number of samples is number of samples per rank * number of ranks
-  uint64_t getGlobalNumSamples() const { return global_num_samples_; }
-  ///save the position of current walkers
-  void saveEnsemble(std::vector<MCSample>& walker_list);
+  int64_t getGlobalNumSamples() const { return global_num_samples_; }
   /// load a single sample from SampleStack
   void loadSample(ParticleSet& pset, size_t iw) const;
 
@@ -61,15 +56,13 @@ public:
   ///  Set the sample count to zero but preserve the storage
   void resetSampleCount();
 
-  ~SampleStack();
-
 private:
-  int total_num_;
-  int max_samples_;
-  int current_sample_count_;
-  uint64_t global_num_samples_;
+  int total_num_{0};
+  int max_samples_{10};
+  int current_sample_count_{0};
+  int64_t global_num_samples_{max_samples_};
 
-  std::vector<MCSample*> sample_vector_;
+  std::vector<MCSample> sample_vector_;
 };
 
 

--- a/src/Particle/SampleStack.h
+++ b/src/Particle/SampleStack.h
@@ -31,20 +31,20 @@ class SampleStack
 public:
   using PropertySetType = QMCTraits::PropertySetType;
 
-  void setTotalNum(int total_num) { total_num_ = total_num; }
+  void setTotalNum(size_t total_num) { total_num_ = total_num; }
 
-  int getMaxSamples() const { return max_samples_; }
+  size_t getMaxSamples() const { return max_samples_; }
 
   bool empty() const { return sample_vector_.empty(); }
 
   const MCSample& getSample(size_t i) const;
 
   //@{save/load/clear function for optimization
-  inline int getNumSamples() const { return current_sample_count_; }
+  inline size_t getNumSamples() const { return current_sample_count_; }
   ///set the number of max samples per rank.
-  void setMaxSamples(int n, int number_of_ranks = 1);
+  void setMaxSamples(size_t n, size_t number_of_ranks = 1);
   /// Global number of samples is number of samples per rank * number of ranks
-  int64_t getGlobalNumSamples() const { return global_num_samples_; }
+  size_t getGlobalNumSamples() const { return global_num_samples_; }
   /// load a single sample from SampleStack
   void loadSample(ParticleSet& pset, size_t iw) const;
 
@@ -57,10 +57,10 @@ public:
   void resetSampleCount();
 
 private:
-  int total_num_{0};
-  int max_samples_{10};
-  int current_sample_count_{0};
-  int64_t global_num_samples_{max_samples_};
+  size_t total_num_{0};
+  size_t max_samples_{10};
+  size_t current_sample_count_{0};
+  size_t global_num_samples_{max_samples_};
 
   std::vector<MCSample> sample_vector_;
 };

--- a/src/Particle/tests/test_sample_stack.cpp
+++ b/src/Particle/tests/test_sample_stack.cpp
@@ -28,7 +28,6 @@ TEST_CASE("SampleStack", "[particle]")
   SampleStack samples;
 
   const int total_num = 2; // number of particles
-  samples.setTotalNum(total_num);
 
   // reserve storage
   int nranks = 2;

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
@@ -21,11 +21,11 @@
 
 namespace qmcplusplus
 {
-int QMCCostFunction::total_samples()
+int64_t QMCCostFunction::total_samples()
 {
   // for the unfamiliar, the [] starts a lambda function
-  return std::accumulate(wClones.begin(), wClones.begin() + NumThreads, 0,
-                         [](int x, const auto& p) { return x + p->numSamples(); });
+  return std::accumulate(wClones.begin(), wClones.begin() + NumThreads, int64_t{0},
+                         [](int64_t x, const auto& p) { return x + p->numSamples(); });
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ int QMCCostFunction::total_samples()
 QMCCostFunction::Return_rt QMCCostFunction::LMYEngineCost_detail(cqmc::engine::LMYEngine<ValueType>* EngineObj)
 {
   // get total number of samples
-  const int m = this->total_samples();
+  const int64_t m = this->total_samples();
 
   // reset Engine object
   EngineObj->reset();

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunction.cpp
@@ -21,11 +21,11 @@
 
 namespace qmcplusplus
 {
-int64_t QMCCostFunction::total_samples()
+size_t QMCCostFunction::total_samples()
 {
   // for the unfamiliar, the [] starts a lambda function
-  return std::accumulate(wClones.begin(), wClones.begin() + NumThreads, int64_t{0},
-                         [](int64_t x, const auto& p) { return x + p->numSamples(); });
+  return std::accumulate(wClones.begin(), wClones.begin() + NumThreads, size_t{0},
+                         [](size_t x, const auto& p) { return x + p->numSamples(); });
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ int64_t QMCCostFunction::total_samples()
 QMCCostFunction::Return_rt QMCCostFunction::LMYEngineCost_detail(cqmc::engine::LMYEngine<ValueType>* EngineObj)
 {
   // get total number of samples
-  const int64_t m = this->total_samples();
+  const size_t m = this->total_samples();
 
   // reset Engine object
   EngineObj->reset();

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
@@ -19,7 +19,7 @@
 
 namespace qmcplusplus
 {
-int64_t QMCCostFunctionBatched::total_samples() { return samples_.getGlobalNumSamples(); }
+size_t QMCCostFunctionBatched::total_samples() { return samples_.getGlobalNumSamples(); }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  Computes the cost function using the LMYEngine for interfacing with batched driver
@@ -29,7 +29,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::LMYEngineCost_detail(
     cqmc::engine::LMYEngine<Return_t>* EngineObj)
 {
   // get total number of samples
-  const int64_t m = this->total_samples();
+  const size_t m = this->total_samples();
   // reset Engine object
   EngineObj->reset();
 

--- a/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/LMYEngineInterface/LMYE_QMCCostFunctionBatched.cpp
@@ -19,10 +19,7 @@
 
 namespace qmcplusplus
 {
-int QMCCostFunctionBatched::total_samples()
-{
-  return samples_.getGlobalNumSamples();
-}
+int64_t QMCCostFunctionBatched::total_samples() { return samples_.getGlobalNumSamples(); }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief  Computes the cost function using the LMYEngine for interfacing with batched driver
@@ -32,7 +29,7 @@ QMCCostFunctionBatched::Return_rt QMCCostFunctionBatched::LMYEngineCost_detail(
     cqmc::engine::LMYEngine<Return_t>* EngineObj)
 {
   // get total number of samples
-  const int m = this->total_samples();
+  const int64_t m = this->total_samples();
   // reset Engine object
   EngineObj->reset();
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -63,7 +63,7 @@ protected:
   EffectiveWeight correlatedSampling(bool needGrad = true) override;
 
 #ifdef HAVE_LMY_ENGINE
-  int total_samples();
+  int64_t total_samples();
   Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunction.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunction.h
@@ -63,7 +63,7 @@ protected:
   EffectiveWeight correlatedSampling(bool needGrad = true) override;
 
 #ifdef HAVE_LMY_ENGINE
-  int64_t total_samples();
+  size_t total_samples();
   Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -90,7 +90,7 @@ protected:
 
 
 #ifdef HAVE_LMY_ENGINE
-  int64_t total_samples();
+  size_t total_samples();
   Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
 #endif
 

--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBatched.h
@@ -90,7 +90,7 @@ protected:
 
 
 #ifdef HAVE_LMY_ENGINE
-  int total_samples();
+  int64_t total_samples();
   Return_rt LMYEngineCost_detail(cqmc::engine::LMYEngine<Return_t>* EngineObj) override;
 #endif
 

--- a/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
+++ b/src/QMCDrivers/tests/QMCDriverNewTestWrapper.h
@@ -33,7 +33,6 @@ public:
                           QMCDriverInput&& input,
                           WalkerConfigurations& wc,
                           MCPopulation&& population,
-                          SampleStack samples,
                           Communicate* comm)
       : QMCDriverNew(test_project,
                      std::move(input),

--- a/src/QMCDrivers/tests/test_QMCDriverNew.cpp
+++ b/src/QMCDrivers/tests/test_QMCDriverNew.cpp
@@ -44,12 +44,11 @@ TEST_CASE("QMCDriverNew tiny case", "[drivers]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  SampleStack samples;
   WalkerConfigurations walker_confs;
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                    samples, comm);
+                                    comm);
 
   // setStatus must be called before process
   std::string root_name{"Test"};
@@ -97,12 +96,11 @@ TEST_CASE("QMCDriverNew more crowds than threads", "[drivers]")
 
   ProjectData test_project("", ProjectData::DriverVersion::BATCH);
   QMCDriverInput qmcdriver_copy(qmcdriver_input);
-  SampleStack samples;
   WalkerConfigurations walker_confs;
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                      samples, comm);
+                                      comm);
   QMCDriverNewTestWrapper::TestNumCrowdsVsNumThreads<ParallelExecutor<>> testNumCrowds;
   testNumCrowds(9);
   testNumCrowds(8);
@@ -136,12 +134,11 @@ TEST_CASE("QMCDriverNew walker counts", "[drivers]")
 
   ProjectData test_project("", ProjectData::DriverVersion::BATCH);
   QMCDriverInput qmcdriver_copy(qmcdriver_input);
-  SampleStack samples;
   WalkerConfigurations walker_confs;
   QMCDriverNewTestWrapper qmc_batched(test_project, std::move(qmcdriver_copy), walker_confs,
                                       MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                    wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                      samples, comm);
+                                      comm);
 
   qmc_batched.testAdjustGlobalWalkerCount();
 }
@@ -165,12 +162,11 @@ TEST_CASE("QMCDriverNew test driver operations", "[drivers]")
   auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(comm, particle_pool);
 
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  SampleStack samples;
   WalkerConfigurations walker_confs;
   QMCDriverNewTestWrapper qmcdriver(test_project, std::move(qmcdriver_input), walker_confs,
                                     MCPopulation(comm->size(), comm->rank(), particle_pool.getParticleSet("e"),
                                                  wavefunction_pool.getPrimary(), hamiltonian_pool.getPrimary()),
-                                    samples, comm);
+                                    comm);
 
 
   auto tau       = 1.0;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Refactoring SampleStack while working on #4493. I changed `sample_vector_` to hold values instead of pointers and deleted an unused member function. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes/No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
