### PR TITLE
bugfix for MSD with spins and add mw_ tests

### DIFF
--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -388,6 +388,8 @@ WaveFunctionComponent::GradType MultiSlaterDetTableMethod::evalGradWithSpin(Part
   else
     evalGradWithSpin_impl_no_precompute(P, iat, false, grad_iat, spingrad_iat);
 
+  spingrad += spingrad_iat;
+
   return grad_iat;
 }
 

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -461,6 +461,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
   CHECK(grad_old[0] == ComplexApprox(ValueType(0.060932, -0.285244)).epsilon(1e-4));
   CHECK(grad_old[1] == ComplexApprox(ValueType(-0.401769, 0.180544)).epsilon(1e-4));
   CHECK(grad_old[2] == ComplexApprox(ValueType(0.174010, 0.140642)).epsilon(1e-4));
+  CHECK(spingrad_old == ComplexApprox(ValueType(0.6766137,-0.8366186)).epsilon(1e-4));
 
   PosType delta(0.464586, 0.75017, 1.184383);
   double ds = 0.12;
@@ -474,6 +475,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
   CHECK(grad_new[0] == ComplexApprox(ValueType(-0.631184, -0.136918)).epsilon(1e-4));
   CHECK(grad_new[1] == ComplexApprox(ValueType(0.074214, -0.080204)).epsilon(1e-4));
   CHECK(grad_new[2] == ComplexApprox(ValueType(-0.073180, -0.133539)).epsilon(1e-4));
+  CHECK(spingrad_new == ComplexApprox(ValueType(-0.135438, -0.6085006)).epsilon(1e-4));
 
   ratio = twf.calcRatio(elec_, 0);
   app_log() << "twf.calcRatio ratio " << ratio << std::endl;
@@ -507,13 +509,14 @@ void test_Bi_msd(const std::string& spo_xml_string,
   TrialWaveFunction::mw_prepareGroup(twf_list, p_list, 0);
 
   int moved_elec_id = 1;
-  TWFGrads<CoordsType::POS> grads_old(num_walkers);
+  TWFGrads<CoordsType::POS_SPIN> grads_old(num_walkers);
   TrialWaveFunction::mw_evalGrad(twf_list, p_list, moved_elec_id, grads_old);
   for (int iw = 0; iw < num_walkers; iw++)
   {
     CHECK(grads_old.grads_positions[iw][0] == ComplexApprox(ValueType(0.060932, -0.285244)).epsilon(1e-4));
     CHECK(grads_old.grads_positions[iw][1] == ComplexApprox(ValueType(-0.401769, 0.180544)).epsilon(1e-4));
     CHECK(grads_old.grads_positions[iw][2] == ComplexApprox(ValueType(0.174010, 0.140642)).epsilon(1e-4));
+    CHECK(grads_old.grads_spins[iw] == ComplexApprox(ValueType(0.6766137,-0.8366186)).epsilon(1e-4));
   }
 
   moved_elec_id = 0;
@@ -536,6 +539,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
     CHECK(grads_new.grads_positions[iw][0] == ComplexApprox(ValueType(-0.631184, -0.136918)).epsilon(1e-4));
     CHECK(grads_new.grads_positions[iw][1] == ComplexApprox(ValueType(0.074214, -0.080204)).epsilon(1e-4));
     CHECK(grads_new.grads_positions[iw][2] == ComplexApprox(ValueType(-0.073180, -0.133539)).epsilon(1e-4));
+    CHECK(grads_new.grads_spins[iw] == ComplexApprox(ValueType(-0.135438, -0.6085006)).epsilon(1e-4));
   }
 }
 

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -461,7 +461,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
   CHECK(grad_old[0] == ComplexApprox(ValueType(0.060932, -0.285244)).epsilon(1e-4));
   CHECK(grad_old[1] == ComplexApprox(ValueType(-0.401769, 0.180544)).epsilon(1e-4));
   CHECK(grad_old[2] == ComplexApprox(ValueType(0.174010, 0.140642)).epsilon(1e-4));
-  CHECK(spingrad_old == ComplexApprox(ValueType(0.6766137,-0.8366186)).epsilon(1e-4));
+  CHECK(spingrad_old == ComplexApprox(ValueType(0.6766137, -0.8366186)).epsilon(1e-4));
 
   PosType delta(0.464586, 0.75017, 1.184383);
   double ds = 0.12;
@@ -516,7 +516,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
     CHECK(grads_old.grads_positions[iw][0] == ComplexApprox(ValueType(0.060932, -0.285244)).epsilon(1e-4));
     CHECK(grads_old.grads_positions[iw][1] == ComplexApprox(ValueType(-0.401769, 0.180544)).epsilon(1e-4));
     CHECK(grads_old.grads_positions[iw][2] == ComplexApprox(ValueType(0.174010, 0.140642)).epsilon(1e-4));
-    CHECK(grads_old.grads_spins[iw] == ComplexApprox(ValueType(0.6766137,-0.8366186)).epsilon(1e-4));
+    CHECK(grads_old.grads_spins[iw] == ComplexApprox(ValueType(0.6766137, -0.8366186)).epsilon(1e-4));
   }
 
   moved_elec_id = 0;
@@ -525,7 +525,7 @@ void test_Bi_msd(const std::string& spo_xml_string,
   displs.spins     = {ds, ds};
   ParticleSet::mw_makeMove(p_list, moved_elec_id, displs);
 
-  std::vector<ValueType> ratios(num_walkers);
+  std::vector<PsiValueType> ratios(num_walkers);
   TrialWaveFunction::mw_calcRatio(twf_list, p_list, moved_elec_id, ratios);
   for (int iw = 0; iw < num_walkers; iw++)
     CHECK(ValueType(std::abs(ratios[iw])) == ValueApprox(0.991503).epsilon(1e-4));


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

This PR fixes a bug I noticed as I was implementing the mw_XXXWithSpin APIs for MSD wave functions. It looks like when I initially did the unit tests for MultiSlaterDetFast, I forgot to add reference values for the spin gradients. Later on, there was renaming/refactoring from MultiSlaterDetFast into MultiSlaterDetTableMethod which introduced a bug into evalGradWithSpin (essentially returning 0 for the spin gradient). This bug was not caught by the unit tests because I seemingly overlooked adding the reference values for the spin gradient. 

This PR adds the correct values into the test for the spin gradient (coming from an independent code QWalk) and fixes the bug. 

Also, I went ahead and introduced the mw_XXXWithSpin APIs into the unit test using those same reference values. These tests will pass since it currently falls back to the single walker implementation...will add mw implementation in a future PR. 

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
M1 mac

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
