### PR TITLE
Pass RuntimeOptions to TrialWaveFunction

### DIFF
--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -21,7 +21,7 @@
 #include "Particle/tests/MinimalParticlePool.h"
 #include "QMCWaveFunctions/tests/MinimalWaveFunctionPool.h"
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -29,14 +29,13 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
 {
   using namespace testing;
 
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  RuntimeOptions runtime_options;
   Communicate* comm = OHMMS::Controller;
 
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  TrialWaveFunction twf(test_project.getRuntimeOptions());
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  TrialWaveFunction twf(runtime_options);
   WalkerConfigurations walker_confs;
 
   MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), &twf, hamiltonian_pool.getPrimary());
@@ -74,14 +73,13 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
 {
   using namespace testing;
 
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  RuntimeOptions runtime_options;
   Communicate* comm = OHMMS::Controller;
 
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  TrialWaveFunction twf(test_project.getRuntimeOptions());
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  TrialWaveFunction twf(runtime_options);
   WalkerConfigurations walker_confs;
 
   std::vector<MCPopulation> pops;
@@ -141,13 +139,12 @@ TEST_CASE("MCPopulation::redistributeWalkers", "[particle][population]")
 {
   using namespace testing;
 
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  RuntimeOptions runtime_options;
   Communicate* comm = OHMMS::Controller;
 
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
   WalkerConfigurations walker_confs;
   MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), wavefunction_pool.getPrimary(),
                           hamiltonian_pool.getPrimary());

--- a/src/QMCDrivers/tests/test_MCPopulation.cpp
+++ b/src/QMCDrivers/tests/test_MCPopulation.cpp
@@ -36,7 +36,7 @@ TEST_CASE("MCPopulation::createWalkers", "[particle][population]")
   auto wavefunction_pool =
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  TrialWaveFunction twf;
+  TrialWaveFunction twf(test_project.getRuntimeOptions());
   WalkerConfigurations walker_confs;
 
   MCPopulation population(1, comm->rank(), particle_pool.getParticleSet("e"), &twf, hamiltonian_pool.getPrimary());
@@ -81,7 +81,7 @@ TEST_CASE("MCPopulation::createWalkers_walker_ids", "[particle][population]")
   auto wavefunction_pool =
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
-  TrialWaveFunction twf;
+  TrialWaveFunction twf(test_project.getRuntimeOptions());
   WalkerConfigurations walker_confs;
 
   std::vector<MCPopulation> pops;

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
@@ -11,7 +11,7 @@
 
 #include "catch.hpp"
 #include "QMCDrivers/WFOpt/QMCCostFunctionBase.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 
 namespace qmcplusplus
@@ -56,8 +56,8 @@ TEST_CASE("updateXmlNodes", "[drivers]")
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w(simulation_cell);
   QMCHamiltonian h;
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   Communicate* comm = OHMMS::Controller;
 
@@ -92,8 +92,8 @@ TEST_CASE("updateXmlNodes with existing element", "[drivers]")
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w(simulation_cell);
   QMCHamiltonian h;
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   Communicate* comm = OHMMS::Controller;
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBase.cpp
@@ -11,6 +11,7 @@
 
 #include "catch.hpp"
 #include "QMCDrivers/WFOpt/QMCCostFunctionBase.h"
+#include "Utilities/ProjectData.h"
 
 
 namespace qmcplusplus
@@ -55,7 +56,8 @@ TEST_CASE("updateXmlNodes", "[drivers]")
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w(simulation_cell);
   QMCHamiltonian h;
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   Communicate* comm = OHMMS::Controller;
 
@@ -90,7 +92,8 @@ TEST_CASE("updateXmlNodes with existing element", "[drivers]")
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w(simulation_cell);
   QMCHamiltonian h;
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   Communicate* comm = OHMMS::Controller;
 

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -14,6 +14,7 @@
 #include "FillData.h"
 // Input data and gold data for fillFromText test
 #include "diamond_fill_data.h"
+#include "Utilities/ProjectData.h"
 
 
 namespace qmcplusplus
@@ -52,7 +53,8 @@ public:
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w;
   QMCHamiltonian h;
-  TrialWaveFunction psi;
+  ProjectData project_data_;
+  TrialWaveFunction psi = TrialWaveFunction(project_data_.getRuntimeOptions());
   QMCCostFunctionBatched costFn;
 
   LinearMethodTestSupport(const std::vector<int>& walkers_per_crowd, Communicate* comm)

--- a/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
+++ b/src/QMCDrivers/tests/test_QMCCostFunctionBatched.cpp
@@ -14,7 +14,7 @@
 #include "FillData.h"
 // Input data and gold data for fillFromText test
 #include "diamond_fill_data.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 
 namespace qmcplusplus
@@ -53,8 +53,8 @@ public:
   const SimulationCell simulation_cell;
   MCWalkerConfiguration w;
   QMCHamiltonian h;
-  ProjectData project_data_;
-  TrialWaveFunction psi = TrialWaveFunction(project_data_.getRuntimeOptions());
+  RuntimeOptions runtime_options_;
+  TrialWaveFunction psi = TrialWaveFunction(runtime_options_);
   QMCCostFunctionBatched costFn;
 
   LinearMethodTestSupport(const std::vector<int>& walkers_per_crowd, Communicate* comm)

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -16,6 +16,7 @@
 #include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Utilities/RandomGenerator.h"
+#include "Utilities/ProjectData.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
@@ -54,17 +55,18 @@ TEST_CASE("QMCUpdate", "[drivers]")
   elec.create({1});
   elec.createWalkers(1);
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
 
   FakeRandom rg;
 
   QMCHamiltonian h;
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   FakeUpdate update(elec, psi, h, rg);
 
   update.put(NULL);

--- a/src/QMCDrivers/tests/test_clone_manager.cpp
+++ b/src/QMCDrivers/tests/test_clone_manager.cpp
@@ -16,7 +16,7 @@
 #include "Configuration.h"
 #include "Message/Communicate.h"
 #include "Utilities/RandomGenerator.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
@@ -65,8 +65,8 @@ TEST_CASE("QMCUpdate", "[drivers]")
   FakeRandom rg;
 
   QMCHamiltonian h;
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   FakeUpdate update(elec, psi, h, rg);
 
   update.put(NULL);

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -27,6 +27,7 @@
 #include "Estimators/TraceManager.h"
 #include "QMCDrivers/DMC/DMCUpdatePbyP.h"
 #include "QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.h"
+#include "Utilities/ProjectData.h"
 
 
 #include <stdio.h>
@@ -71,8 +72,8 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
   elec.addTable(ions);
   elec.update();
 
-
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   auto orb_uptr = std::make_unique<ConstantOrbital>();
   auto orb      = orb_uptr.get();
   psi.addComponent(std::move(orb_uptr));
@@ -165,8 +166,8 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dm
   elec.addTable(ions);
   elec.update();
 
-
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<LinearOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCDrivers/tests/test_dmc.cpp
+++ b/src/QMCDrivers/tests/test_dmc.cpp
@@ -27,7 +27,7 @@
 #include "Estimators/TraceManager.h"
 #include "QMCDrivers/DMC/DMCUpdatePbyP.h"
 #include "QMCDrivers/GreenFunctionModifiers/DriftModifierUNR.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 
 #include <stdio.h>
@@ -72,8 +72,8 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers ConstantOrbital", "[drivers][
   elec.addTable(ions);
   elec.update();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   auto orb_uptr = std::make_unique<ConstantOrbital>();
   auto orb      = orb_uptr.get();
   psi.addComponent(std::move(orb_uptr));
@@ -166,8 +166,8 @@ TEST_CASE("DMC Particle-by-Particle advanceWalkers LinearOrbital", "[drivers][dm
   elec.addTable(ions);
   elec.update();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   psi.addComponent(std::make_unique<LinearOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCDrivers/tests/test_dmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_dmc_driver.cpp
@@ -78,7 +78,7 @@ TEST_CASE("DMC", "[drivers][dmc]")
 
   CloneManager::clearClones();
 
-  TrialWaveFunction psi;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
@@ -164,7 +164,7 @@ TEST_CASE("SODMC", "[drivers][dmc]")
 
   CloneManager::clearClones();
 
-  TrialWaveFunction psi;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -14,7 +14,7 @@
 
 
 #include "Utilities/RandomGenerator.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
@@ -72,8 +72,8 @@ TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
   elec.addTable(ions);
   elec.update();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCDrivers/tests/test_vmc.cpp
+++ b/src/QMCDrivers/tests/test_vmc.cpp
@@ -14,6 +14,7 @@
 
 
 #include "Utilities/RandomGenerator.h"
+#include "Utilities/ProjectData.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
 #include "Particle/ParticleSet.h"
@@ -71,8 +72,8 @@ TEST_CASE("VMC Particle-by-Particle advanceWalkers", "[drivers][vmc]")
   elec.addTable(ions);
   elec.update();
 
-
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCDrivers/tests/test_vmc_driver.cpp
+++ b/src/QMCDrivers/tests/test_vmc_driver.cpp
@@ -71,7 +71,7 @@ TEST_CASE("VMC", "[drivers][vmc]")
 
   CloneManager::clearClones();
 
-  TrialWaveFunction psi;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
@@ -153,7 +153,7 @@ TEST_CASE("SOVMC", "[drivers][vmc]")
 
   CloneManager::clearClones();
 
-  TrialWaveFunction psi;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();
@@ -240,7 +240,7 @@ TEST_CASE("SOVMC-alle", "[drivers][vmc]")
 
   CloneManager::clearClones();
 
-  TrialWaveFunction psi;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::make_unique<ConstantOrbital>());
   psi.registerData(elec, elec[0]->DataSet);
   elec[0]->DataSet.allocate();

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -18,7 +18,7 @@
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "TestListenerFunction.h"
 #include "Utilities/StlPrettyPrint.hpp"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -119,9 +119,9 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   RefVector<ParticleSet> ptcls{elec, elec2};
   RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
-  TrialWaveFunction psi2(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
+  TrialWaveFunction psi2(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
 
   bool doForces = false;

--- a/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_NonLocalECPotential.cpp
@@ -18,6 +18,7 @@
 #include "QMCHamiltonians/NonLocalECPotential.h"
 #include "TestListenerFunction.h"
 #include "Utilities/StlPrettyPrint.hpp"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -118,7 +119,9 @@ TEST_CASE("NonLocalECPotential", "[hamiltonian]")
   RefVector<ParticleSet> ptcls{elec, elec2};
   RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);
 
-  TrialWaveFunction psi, psi2;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  TrialWaveFunction psi2(project_data.getRuntimeOptions());
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi2});
 
   bool doForces = false;

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -41,7 +41,7 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
       MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
   auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
-  TrialWaveFunction twf;
+  TrialWaveFunction twf(test_project.getRuntimeOptions());
 
   std::vector<QMCHamiltonian> hamiltonians;
   //hamiltonians.emplace_back(*(hamiltonian_pool.getPrimary()));

--- a/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/tests/test_QMCHamiltonian.cpp
@@ -20,7 +20,7 @@
 #include "TestListenerFunction.h"
 #include "Utilities/ResourceCollection.h"
 #include "Utilities/StlPrettyPrint.hpp"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include "Utilities/for_testing/NativeInitializerPrint.hpp"
 
 namespace qmcplusplus
@@ -32,16 +32,15 @@ constexpr bool generate_test_data = false;
 
 TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
 {
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  RuntimeOptions runtime_options;
   Communicate* comm;
   comm = OHMMS::Controller;
 
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto hamiltonian_pool = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::make_hamWithEE(comm, particle_pool, wavefunction_pool);
 
-  TrialWaveFunction twf(test_project.getRuntimeOptions());
+  TrialWaveFunction twf(runtime_options);
 
   std::vector<QMCHamiltonian> hamiltonians;
   //hamiltonians.emplace_back(*(hamiltonian_pool.getPrimary()));
@@ -61,14 +60,13 @@ TEST_CASE("QMCHamiltonian::flex_evaluate", "[hamiltonian]")
  */
 TEST_CASE("integrateListeners", "[hamiltonian]")
 {
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
+  RuntimeOptions runtime_options;
   Communicate* comm = OHMMS::Controller;
 
-  auto particle_pool = MinimalParticlePool::make_diamondC_1x1x1(comm);
-  auto wavefunction_pool =
-      MinimalWaveFunctionPool::make_diamondC_1x1x1(test_project.getRuntimeOptions(), comm, particle_pool);
-  auto hamiltonian_pool = MinimalHamiltonianPool::makeHamWithEEEI(comm, particle_pool, wavefunction_pool);
-  auto& pset_target     = *(particle_pool.getParticleSet("e"));
+  auto particle_pool     = MinimalParticlePool::make_diamondC_1x1x1(comm);
+  auto wavefunction_pool = MinimalWaveFunctionPool::make_diamondC_1x1x1(runtime_options, comm, particle_pool);
+  auto hamiltonian_pool  = MinimalHamiltonianPool::makeHamWithEEEI(comm, particle_pool, wavefunction_pool);
+  auto& pset_target      = *(particle_pool.getParticleSet("e"));
   //auto& species_set        = pset_target.getSpeciesSet();
   //auto& spo_map            = wavefunction_pool.getWaveFunction("wavefunction")->getSPOMap();
   auto& trial_wavefunction = *(wavefunction_pool.getPrimary());

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -21,7 +21,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCHamiltonians/ECPComponentBuilder.h"
 #include "TestListenerFunction.h"
-
+#include "Utilities/ProjectData.h"
 namespace qmcplusplus
 {
 namespace testing
@@ -123,7 +123,8 @@ void doSOECPotentialTest(bool use_VPs)
   ResourceCollection pset_res("test_pset_res");
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   std::vector<Pos> kup, kdn;
   std::vector<Real> k2up, k2dn;

--- a/src/QMCHamiltonians/tests/test_SOECPotential.cpp
+++ b/src/QMCHamiltonians/tests/test_SOECPotential.cpp
@@ -21,7 +21,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCHamiltonians/ECPComponentBuilder.h"
 #include "TestListenerFunction.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 namespace qmcplusplus
 {
 namespace testing
@@ -123,8 +123,8 @@ void doSOECPotentialTest(bool use_VPs)
   ResourceCollection pset_res("test_pset_res");
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_list);
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   std::vector<Pos> kup, kdn;
   std::vector<Real> k2up, k2dn;

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -19,6 +19,7 @@
 #include "QMCHamiltonians/tests/TestListenerFunction.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
+#include "Utilities/ProjectData.h"
 
 #include <functional>
 #include <stdio.h>
@@ -71,7 +72,8 @@ TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
 
   xmlNodePtr h1 = xmlFirstElementChild(root);
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   BareKineticEnergy bare_ke(elec, psi);
   bare_ke.put(h1);
 
@@ -160,7 +162,8 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   elec.resetGroups();
 
   //Cool.  Now to construct a wavefunction with 1 and 2 body jastrow (no determinant)
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   //Add the two body jastrow
   const char* particles = R"(<tmp>
@@ -270,7 +273,7 @@ void testElecCase(double mass_up,
   ParticleSet elec(simulation_cell);
 
   elec.setName("elec");
-  elec.create({1,1});
+  elec.create({1, 1});
   elec.R[0][0] = 0.0;
   elec.R[0][1] = 1.0;
   elec.R[0][2] = 0.0;
@@ -295,7 +298,9 @@ void testElecCase(double mass_up,
   elec2.R[1][2] = 1.0;
   elec2.update();
 
-  TrialWaveFunction psi, psi_clone;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
 
   RefVector<ParticleSet> ptcls{elec, elec2};
   RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);

--- a/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
+++ b/src/QMCHamiltonians/tests/test_bare_kinetic.cpp
@@ -19,7 +19,7 @@
 #include "QMCHamiltonians/tests/TestListenerFunction.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <functional>
 #include <stdio.h>
@@ -72,8 +72,8 @@ TEST_CASE("Bare Kinetic Energy", "[hamiltonian]")
 
   xmlNodePtr h1 = xmlFirstElementChild(root);
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   BareKineticEnergy bare_ke(elec, psi);
   bare_ke.put(h1);
 
@@ -162,8 +162,8 @@ TEST_CASE("Bare KE Pulay PBC", "[hamiltonian]")
   elec.resetGroups();
 
   //Cool.  Now to construct a wavefunction with 1 and 2 body jastrow (no determinant)
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   //Add the two body jastrow
   const char* particles = R"(<tmp>
@@ -298,9 +298,9 @@ void testElecCase(double mass_up,
   elec2.R[1][2] = 1.0;
   elec2.update();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
-  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
+  TrialWaveFunction psi_clone(runtime_options);
 
   RefVector<ParticleSet> ptcls{elec, elec2};
   RefVectorWithLeader<ParticleSet> p_list(elec, ptcls);

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -28,6 +28,7 @@
 #include <ResourceCollection.h>
 #include "TestListenerFunction.h"
 #include <TrialWaveFunction.h>
+#include "Utilities/ProjectData.h"
 
 using std::string;
 
@@ -256,7 +257,9 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   RefVectorWithLeader<OperatorBase> caa_ref_list(caa, {caa, caa_clone});
 
   // dummy psi
-  TrialWaveFunction psi, psi_clone;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
   RefVectorWithLeader<TrialWaveFunction> psi_ref_list(psi, {psi, psi_clone});
 
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
@@ -321,8 +324,9 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   CoulombPBCAA caa(elec, true, false, kind == DynamicCoordinateKind::DC_POS_OFFLOAD);
 
   // mock golden wavefunction, only needed to satisfy APIs
-  TrialWaveFunction psi;
-  
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
+
   // informOfPerParticleListener should be called on the golden instance of this operator if there
   // are listeners present for it.  This would normally be done by QMCHamiltonian but this is a unit test.
   caa.informOfPerParticleListener();
@@ -342,7 +346,7 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   RefVector<OperatorBase> caas{caa, caa2};
   RefVectorWithLeader<OperatorBase> o_list(caa, caas);
 
-  TrialWaveFunction psi_clone;
+  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
 
   // Self-energy correction, no background charge for e-e interaction

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAA.cpp
@@ -28,7 +28,7 @@
 #include <ResourceCollection.h>
 #include "TestListenerFunction.h"
 #include <TrialWaveFunction.h>
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 using std::string;
 
@@ -257,9 +257,9 @@ void test_CoulombPBCAA_3p(DynamicCoordinateKind kind)
   RefVectorWithLeader<OperatorBase> caa_ref_list(caa, {caa, caa_clone});
 
   // dummy psi
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
-  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
+  TrialWaveFunction psi_clone(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> psi_ref_list(psi, {psi, psi_clone});
 
   ResourceCollectionTeamLock<ParticleSet> mw_pset_lock(pset_res, p_ref_list);
@@ -324,8 +324,8 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   CoulombPBCAA caa(elec, true, false, kind == DynamicCoordinateKind::DC_POS_OFFLOAD);
 
   // mock golden wavefunction, only needed to satisfy APIs
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   // informOfPerParticleListener should be called on the golden instance of this operator if there
   // are listeners present for it.  This would normally be done by QMCHamiltonian but this is a unit test.
@@ -346,7 +346,7 @@ TEST_CASE("CoulombAA::mw_evaluatePerParticle", "[hamiltonian]")
   RefVector<OperatorBase> caas{caa, caa2};
   RefVectorWithLeader<OperatorBase> o_list(caa, caas);
 
-  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
+  TrialWaveFunction psi_clone(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
 
   // Self-energy correction, no background charge for e-e interaction

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -21,7 +21,7 @@
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "TestListenerFunction.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -247,9 +247,9 @@ TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
   RefVector<ParticleSet> ion_ptcls{ions, ions2};
   RefVectorWithLeader<ParticleSet> ion_p_list(ions, ion_ptcls);
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
-  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
+  TrialWaveFunction psi_clone(runtime_options);
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
 
   Matrix<Real> local_pots(2);

--- a/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
+++ b/src/QMCHamiltonians/tests/test_coulomb_pbcAB.cpp
@@ -21,6 +21,7 @@
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "TestListenerFunction.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -93,7 +94,7 @@ TEST_CASE("Coulomb PBC A-B", "[hamiltonian]")
   double val_ii = caa_ion.evaluate(ions);
   double sum    = val_ee + val_ii + val_ei;
   CHECK(sum == Approx(-2.741363553)); // Can be validated via Ewald summation elsewhere
-                                        // -2.74136517454081
+                                      // -2.74136517454081
 }
 
 TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
@@ -163,7 +164,7 @@ TEST_CASE("Coulomb PBC A-B BCC H", "[hamiltonian]")
   double val_ii = caa_ion.evaluate(ions);
   double sum    = val_ee + val_ii + val_ei;
   CHECK(sum == Approx(-3.143491064)); // Can be validated via Ewald summation elsewhere
-                                        // -3.14349127313640
+                                      // -3.14349127313640
 }
 
 TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
@@ -246,7 +247,9 @@ TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
   RefVector<ParticleSet> ion_ptcls{ions, ions2};
   RefVectorWithLeader<ParticleSet> ion_p_list(ions, ion_ptcls);
 
-  TrialWaveFunction psi, psi_clone;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  TrialWaveFunction psi_clone(project_data.getRuntimeOptions());
   RefVectorWithLeader<TrialWaveFunction> twf_list(psi, {psi, psi_clone});
 
   Matrix<Real> local_pots(2);
@@ -277,9 +280,8 @@ TEST_CASE("CoulombAB::Listener", "[hamiltonian]")
   CHECK(cab2.getValue() == Approx(-1.7222343352));
   // Check that the sum of the particle energies == the total
   Real elec_ion_sum = std::accumulate(local_pots.begin(), local_pots.begin() + local_pots.cols(), 0.0);
-  CHECK( elec_ion_sum ==
-	 Approx(-1.0562537047));
-  CHECK( elec_ion_sum + std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) ==
+  CHECK(elec_ion_sum == Approx(-1.0562537047));
+  CHECK(elec_ion_sum + std::accumulate(ion_pots.begin(), ion_pots.begin() + ion_pots.cols(), 0.0) ==
         Approx(-2.219665062 + 0.0267892759 * 4));
   elec_ion_sum = std::accumulate(local_pots[1], local_pots[1] + local_pots.cols(), 0.0);
   CHECK(elec_ion_sum == Approx(-0.8611171676));

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -18,6 +18,7 @@
 #include "QMCHamiltonians/ECPComponentBuilder.h"
 #include "QMCHamiltonians/NonLocalECPComponent.h"
 #include "QMCHamiltonians/SOECPComponent.h"
+#include "Utilities/ProjectData.h"
 
 //for wavefunction
 #include "OhmmsData/Libxml2Doc.h"
@@ -219,7 +220,8 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   elec.resetGroups();
 
   //Cool.  Now to construct a wavefunction with 1 and 2 body jastrow (no determinant)
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   //Add the two body jastrow
   const char* particles = R"(<tmp>
@@ -488,7 +490,8 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   ions.resetGroups();
   elec.resetGroups();
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   std::vector<PosType> kup, kdn;
   std::vector<RealType> k2up, k2dn;
@@ -590,17 +593,18 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
 
 
   //Ref Values from soecp_eval_ref.cpp in the print_dlogpsi using finite differences
-  std::vector<RealType> dlogpsi_refs = { -0.2622341567, -0.64168132, -0.09608452334, -2.486899575e-14, -2.486899575e-14};
+  std::vector<RealType> dlogpsi_refs = {-0.2622341567, -0.64168132, -0.09608452334, -2.486899575e-14, -2.486899575e-14};
   //These weren't independently validated in soecp_eval_ref.cpp
   //trusting current values from evaluateDerivatives...which should be correct if the
   //dlogpsi comes out correct
   std::vector<RealType> dkinpsioverpsi_refs = {-3.807451601, 0.1047251267, 3.702726474, 0, 0};
   //These were independently validated in soecp_eval_ref.cpp, includes the contribution
   //from dkinpsioverpsi_refs
-  std::vector<RealType> dhpsioverpsi_refs = { -3.855727438, 0.202618546, 3.653108892, -8.169955304e-14, -8.169955304e-14};
+  std::vector<RealType> dhpsioverpsi_refs = {-3.855727438, 0.202618546, 3.653108892, -8.169955304e-14,
+                                             -8.169955304e-14};
 
 
-  auto test_evaluateValueAndDerivatives     = [&]() {
+  auto test_evaluateValueAndDerivatives = [&]() {
     dlogpsi.resize(NumOptimizables, ValueType(0));
     dhpsioverpsi.resize(NumOptimizables, ValueType(0));
     psi.evaluateDerivatives(elec, optvars, dlogpsi, dhpsioverpsi);
@@ -619,7 +623,7 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
       for (int iat = 0; iat < ions.getTotalNum(); iat++)
         if (sopp != nullptr && dist[iat] < sopp->getRmax())
           Value1 += sopp->evaluateValueAndDerivatives(elec, iat, psi, jel, dist[iat], -displ[iat], optvars, dlogpsi,
-                                                          dhpsioverpsi);
+                                                      dhpsioverpsi);
     }
     REQUIRE(Value1 == Approx(-3.530511241));
 

--- a/src/QMCHamiltonians/tests/test_ecp.cpp
+++ b/src/QMCHamiltonians/tests/test_ecp.cpp
@@ -18,7 +18,7 @@
 #include "QMCHamiltonians/ECPComponentBuilder.h"
 #include "QMCHamiltonians/NonLocalECPComponent.h"
 #include "QMCHamiltonians/SOECPComponent.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 //for wavefunction
 #include "OhmmsData/Libxml2Doc.h"
@@ -220,8 +220,8 @@ TEST_CASE("Evaluate_ecp", "[hamiltonian]")
   elec.resetGroups();
 
   //Cool.  Now to construct a wavefunction with 1 and 2 body jastrow (no determinant)
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   //Add the two body jastrow
   const char* particles = R"(<tmp>
@@ -490,8 +490,8 @@ TEST_CASE("Evaluate_soecp", "[hamiltonian]")
   ions.resetGroups();
   elec.resetGroups();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   std::vector<PosType> kup, kdn;
   std::vector<RealType> k2up, k2dn;

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -23,6 +23,7 @@
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "QMCHamiltonians/CoulombPBCAB.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -244,7 +245,8 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // 2) The species is active
   CoulombPBCAA noElecForce(elec, true, true, false);
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   // Making local copies here in refactoring attempt to disallow modifying
   // ForceBase members directly...
   // Probably fine for a test but if this type of behavior was needed in
@@ -462,7 +464,8 @@ TEST_CASE("AC Force", "[hamiltonian]")
   elec.update();
 
   // defaults
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   QMCHamiltonian qmcHamiltonian;
 
   //This is redundant code, but necessary to avoid adding API's to

--- a/src/QMCHamiltonians/tests/test_force.cpp
+++ b/src/QMCHamiltonians/tests/test_force.cpp
@@ -23,7 +23,7 @@
 #include "QMCHamiltonians/CoulombPBCAA.h"
 #include "QMCHamiltonians/CoulombPBCAB.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -245,8 +245,8 @@ TEST_CASE("Chiesa Force", "[hamiltonian]")
   // 2) The species is active
   CoulombPBCAA noElecForce(elec, true, true, false);
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   // Making local copies here in refactoring attempt to disallow modifying
   // ForceBase members directly...
   // Probably fine for a test but if this type of behavior was needed in
@@ -464,8 +464,8 @@ TEST_CASE("AC Force", "[hamiltonian]")
   elec.update();
 
   // defaults
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   QMCHamiltonian qmcHamiltonian;
 
   //This is redundant code, but necessary to avoid adding API's to

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -20,6 +20,7 @@
 #include "QMCHamiltonians/ForceCeperley.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "LongRange/EwaldHandler3D.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -203,7 +204,8 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCDrivers/CloneManager::makeClones
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).release()));
   clone->evaluate(elec);
   REQUIRE(clone->getAddIonIon() == force.getAddIonIon());

--- a/src/QMCHamiltonians/tests/test_force_ewald.cpp
+++ b/src/QMCHamiltonians/tests/test_force_ewald.cpp
@@ -20,7 +20,7 @@
 #include "QMCHamiltonians/ForceCeperley.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "LongRange/EwaldHandler3D.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -204,8 +204,8 @@ TEST_CASE("fccz sr lr clone", "[hamiltonian]")
   //  QMCDrivers/CloneManager::makeClones
   //  QMCHamiltonian::makeClone
   //  OperatorBase::add2Hamiltonian -> ForceChiesaPBCAA::makeClone
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   std::unique_ptr<ForceChiesaPBCAA> clone(dynamic_cast<ForceChiesaPBCAA*>(force.makeClone(elec, psi).release()));
   clone->evaluate(elec);
   REQUIRE(clone->getAddIonIon() == force.getAddIonIon());

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -17,7 +17,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCHamiltonians/HamiltonianFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -58,9 +58,9 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(project_data.getRuntimeOptions(), "psi0"));
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
@@ -111,9 +111,9 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(project_data.getRuntimeOptions(), "psi0"));
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_factory.cpp
@@ -17,6 +17,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCHamiltonians/HamiltonianFactory.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -57,8 +58,9 @@ TEST_CASE("HamiltonianFactory", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
+  ProjectData project_data;
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting("psi0"));
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(project_data.getRuntimeOptions(), "psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 
@@ -109,8 +111,9 @@ TEST_CASE("HamiltonianFactory pseudopotential", "[hamiltonian]")
   particle_set_map.emplace(ions_ptr->getName(), std::move(ions_ptr));
   particle_set_map.emplace(elec_ptr->getName(), std::move(elec_ptr));
 
+  ProjectData project_data;
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting("psi0"));
+  psi_map.emplace("psi0", WaveFunctionFactory::buildEmptyTWFForTesting(project_data.getRuntimeOptions(), "psi0"));
 
   HamiltonianFactory hf("h0", elec, particle_set_map, psi_map, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -19,7 +19,7 @@
 #include "QMCHamiltonians/HamiltonianPool.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionPool.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -32,7 +32,6 @@ extern std::unique_ptr<ParticleSet> createElectronParticleSet(const SimulationCe
 
 TEST_CASE("HamiltonianPool", "[qmcapp]")
 {
-  ProjectData test_project("test", ProjectData::DriverVersion::BATCH);
   Communicate* c;
   c = OHMMS::Controller;
 
@@ -51,8 +50,9 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
   auto qp = createElectronParticleSet(pp.getSimulationCell());
   pp.addParticleSet(std::move(qp));
 
-  WaveFunctionPool wfp(test_project.getRuntimeOptions(), pp, c);
-  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(test_project.getRuntimeOptions(), "psi0"), true);
+  RuntimeOptions runtime_options;
+  WaveFunctionPool wfp(runtime_options, pp, c);
+  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(runtime_options, "psi0"), true);
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
+++ b/src/QMCHamiltonians/tests/test_hamiltonian_pool.cpp
@@ -52,8 +52,7 @@ TEST_CASE("HamiltonianPool", "[qmcapp]")
   pp.addParticleSet(std::move(qp));
 
   WaveFunctionPool wfp(test_project.getRuntimeOptions(), pp, c);
-
-  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting("psi0"), true);
+  wfp.addFactory(WaveFunctionFactory::buildEmptyTWFForTesting(test_project.getRuntimeOptions(), "psi0"), true);
 
   HamiltonianPool hpool(pp, wfp, c);
 

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -20,7 +20,7 @@
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "Utilities/RandomGenerator.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
 
 namespace qmcplusplus
@@ -139,10 +139,10 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.wfnoj.xml");
   REQUIRE(wfokay);
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -308,10 +308,10 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.wfj.xml");
   REQUIRE(wfokay);
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -476,10 +476,10 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.msd-wfnoj.xml");
   REQUIRE(wfokay);
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -615,10 +615,10 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.msd-wfj.xml");
   REQUIRE(wfokay);
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -758,10 +758,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(root2, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(root2, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -1018,10 +1018,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(root2, project_data.getRuntimeOptions()));
+  psi_map.emplace("psi0", wff.buildTWF(root2, runtime_options));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);

--- a/src/QMCHamiltonians/tests/test_ion_derivs.cpp
+++ b/src/QMCHamiltonians/tests/test_ion_derivs.cpp
@@ -20,6 +20,7 @@
 #include "QMCHamiltonians/tests/MinimalHamiltonianPool.h"
 #include "ParticleIO/XMLParticleIO.h"
 #include "Utilities/RandomGenerator.h"
+#include "Utilities/ProjectData.h"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
 
 namespace qmcplusplus
@@ -138,9 +139,10 @@ TEST_CASE("Eloc_Derivatives:slater_noj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.wfnoj.xml");
   REQUIRE(wfokay);
 
+  ProjectData project_data;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -306,9 +308,10 @@ TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.wfj.xml");
   REQUIRE(wfokay);
 
+  ProjectData project_data;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -473,9 +476,10 @@ TEST_CASE("Eloc_Derivatives:multislater_noj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.msd-wfnoj.xml");
   REQUIRE(wfokay);
 
+  ProjectData project_data;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -611,9 +615,10 @@ TEST_CASE("Eloc_Derivatives:multislater_wj", "[hamiltonian]")
   bool wfokay = wfdoc.parse("cn.msd-wfj.xml");
   REQUIRE(wfokay);
 
+  ProjectData project_data;
   xmlNodePtr wfroot = wfdoc.getRoot();
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(wfroot));
+  psi_map.emplace("psi0", wff.buildTWF(wfroot, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -753,9 +758,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
+  ProjectData project_data;
   WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(root2));
+  psi_map.emplace("psi0", wff.buildTWF(root2, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -775,7 +781,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_noj", "[hamiltonian]")
 
   QMCHamiltonian& ham = create_CN_Hamiltonian(hf);
 
-  //Enum to give human readable indexing into QMCHamiltonian. 
+  //Enum to give human readable indexing into QMCHamiltonian.
   enum observ_id
   {
     KINETIC = 0,
@@ -1012,9 +1018,10 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   particle_set_map.emplace("e", std::move(elec_ptr));
   particle_set_map.emplace("ion0", std::move(ions_ptr));
 
+  ProjectData project_data;
   WaveFunctionFactory wff(elec, particle_set_map, c);
   HamiltonianFactory::PsiPoolType psi_map;
-  psi_map.emplace("psi0", wff.buildTWF(root2));
+  psi_map.emplace("psi0", wff.buildTWF(root2, project_data.getRuntimeOptions()));
 
   TrialWaveFunction* psi = psi_map["psi0"].get();
   REQUIRE(psi != nullptr);
@@ -1241,7 +1248,7 @@ TEST_CASE("Eloc_Derivatives:proto_sd_wj", "[hamiltonian]")
   //This is to test the fast force API in QMCHamiltonian.
   ParticleSet::ParticlePos dedr(ions.getTotalNum());
   ParticleSet::ParticlePos dpsidr(ions.getTotalNum());
-  ham.evaluateIonDerivsDeterministicFast(elec,ions,*psi,twf,dedr,dpsidr);
+  ham.evaluateIonDerivsDeterministicFast(elec, ions, *psi, twf, dedr, dpsidr);
 }
 /*TEST_CASE("Eloc_Derivatives:slater_wj", "[hamiltonian]")
 {

--- a/src/QMCHamiltonians/tests/test_stress.cpp
+++ b/src/QMCHamiltonians/tests/test_stress.cpp
@@ -18,6 +18,7 @@
 #include "LongRange/EwaldHandler3D.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCHamiltonians/StressPBC.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -67,19 +68,20 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
   elec.R[1][2] = 2.02478653;
 
 
-  SpeciesSet& tspecies         = elec.getSpeciesSet();
-  int upIdx                    = tspecies.addSpecies("u");
-  int chargeIdx                = tspecies.addAttribute("charge");
-  int massIdx                  = tspecies.addAttribute("mass");
-  tspecies(chargeIdx, upIdx)   = -1;
-  tspecies(massIdx, upIdx)     = 1.0;
+  SpeciesSet& tspecies       = elec.getSpeciesSet();
+  int upIdx                  = tspecies.addSpecies("u");
+  int chargeIdx              = tspecies.addAttribute("charge");
+  int massIdx                = tspecies.addAttribute("mass");
+  tspecies(chargeIdx, upIdx) = -1;
+  tspecies(massIdx, upIdx)   = 1.0;
 
   // The call to resetGroups is needed transfer the SpeciesSet
   // settings to the ParticleSet
   elec.resetGroups();
   elec.createSK();
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
 
   LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);
@@ -118,4 +120,4 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
 
   LRCoulombSingleton::CoulombDerivHandler.reset(nullptr);
 }
-}
+} // namespace qmcplusplus

--- a/src/QMCHamiltonians/tests/test_stress.cpp
+++ b/src/QMCHamiltonians/tests/test_stress.cpp
@@ -18,7 +18,7 @@
 #include "LongRange/EwaldHandler3D.h"
 #include "QMCWaveFunctions/TrialWaveFunction.h"
 #include "QMCHamiltonians/StressPBC.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -80,8 +80,8 @@ TEST_CASE("Stress BCC H Ewald3D", "[hamiltonian]")
   elec.resetGroups();
   elec.createSK();
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
 
   LRCoulombSingleton::CoulombHandler = std::make_unique<EwaldHandler3D>(ions);
   LRCoulombSingleton::CoulombHandler->initBreakup(ions);

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -42,8 +42,9 @@ typedef enum
 static const std::vector<std::string> suffixes{"V",         "VGL",    "accept", "NLratio",
                                                "recompute", "buffer", "derivs", "preparegroup"};
 
-TrialWaveFunction::TrialWaveFunction(const std::string_view aname, bool tasking)
-    : myNode_(NULL),
+TrialWaveFunction::TrialWaveFunction(const RuntimeOptions& runtime_options, const std::string_view aname, bool tasking)
+    : runtime_options_(runtime_options),
+      myNode_(NULL),
       spomap_(std::make_shared<SPOMap>()),
       myName(aname),
       BufferCursor(0),
@@ -1057,7 +1058,7 @@ bool TrialWaveFunction::put(xmlNodePtr cur) { return true; }
 
 std::unique_ptr<TrialWaveFunction> TrialWaveFunction::makeClone(ParticleSet& tqp) const
 {
-  auto myclone                 = std::make_unique<TrialWaveFunction>(myName, use_tasking_);
+  auto myclone                 = std::make_unique<TrialWaveFunction>(runtime_options_, myName, use_tasking_);
   myclone->BufferCursor        = BufferCursor;
   myclone->BufferCursor_scalar = BufferCursor_scalar;
   for (int i = 0; i < Z.size(); ++i)

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -30,6 +30,7 @@
 #include "Containers/MinimalContainers/RecordArray.hpp"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
 #include "TWFGrads.hpp"
+#include "Utilities/qmc_common.h" // RuntimeOptions
 
 /**@defgroup MBWfs Many-body wave function group
  * @brief Classes to handle many-body trial wave functions
@@ -58,11 +59,11 @@ class TrialWaveFunction
 {
 public:
   // derived types from WaveFunctionComponent
-  using RealType     = WaveFunctionComponent::RealType;
-  using ComplexType  = WaveFunctionComponent::ComplexType;
+  using RealType    = WaveFunctionComponent::RealType;
+  using ComplexType = WaveFunctionComponent::ComplexType;
 
 #ifndef NDEBUG
-  using FullPrecRealType =  WaveFunctionComponent::FullPrecRealType;
+  using FullPrecRealType = WaveFunctionComponent::FullPrecRealType;
 #endif
 
   using ValueType    = WaveFunctionComponent::ValueType;
@@ -89,7 +90,7 @@ public:
   ///differential laplacians
   ParticleSet::ParticleLaplacian L;
 
-  TrialWaveFunction(const std::string_view aname = "psi0", bool tasking = false);
+  TrialWaveFunction(const RuntimeOptions& runtime_options, const std::string_view aname = "psi0", bool tasking = false);
 
   // delete copy constructor
   TrialWaveFunction(const TrialWaveFunction&) = delete;
@@ -502,6 +503,9 @@ public:
 
 private:
   static void debugOnlyCheckBuffer(WFBufferType& buffer);
+
+  /// @brief top-level runtime options from project data information > WaveFunctionPool
+  const RuntimeOptions& runtime_options_;
 
   /** XML input node for a many-body wavefunction. Copied from the original one.
    * WFOpt driver needs to look it up and make its own copies.

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -30,7 +30,7 @@
 #include "Containers/MinimalContainers/RecordArray.hpp"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
 #include "TWFGrads.hpp"
-#include "Utilities/qmc_common.h" // RuntimeOptions
+#include "Utilities/RuntimeOptions.h"
 
 /**@defgroup MBWfs Many-body wave function group
  * @brief Classes to handle many-body trial wave functions

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -34,19 +34,15 @@
 #include "OhmmsData/AttributeSet.h"
 namespace qmcplusplus
 {
-WaveFunctionFactory::WaveFunctionFactory(ParticleSet& qp,
-                                         const PSetMap& pset,
-                                         Communicate* c)
-    : MPIObjectBase(c),
-      targetPtcl(qp),
-      ptclPool(pset)
+WaveFunctionFactory::WaveFunctionFactory(ParticleSet& qp, const PSetMap& pset, Communicate* c)
+    : MPIObjectBase(c), targetPtcl(qp), ptclPool(pset)
 {
   ClassName = "WaveFunctionFactory";
 }
 
 WaveFunctionFactory::~WaveFunctionFactory() = default;
 
-std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur)
+std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur, const RuntimeOptions& runtime_options)
 {
   // YL: how can this happen?
   if (cur == NULL)
@@ -67,14 +63,14 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur)
   app_summary() << "  Name: " << psiName << "   Tasking: " << (tasking == "yes" ? "yes" : "no") << std::endl;
   app_summary() << std::endl;
 
-  auto targetPsi = std::make_unique<TrialWaveFunction>(psiName, tasking == "yes");
+  auto targetPsi = std::make_unique<TrialWaveFunction>(runtime_options, psiName, tasking == "yes");
   targetPsi->setMassTerm(targetPtcl);
   targetPsi->storeXMLNode(cur);
 
   SPOSetBuilderFactory sposet_builder_factory(myComm, targetPtcl, ptclPool);
 
   std::string vp_file_to_load;
-  cur          = cur->children;
+  cur = cur->children;
   while (cur != NULL)
   {
     std::string cname((const char*)(cur->name));

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -23,6 +23,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "Message/MPIObjectBase.h"
+#include "Utilities/qmc_common.h" // RuntimeOptions
 namespace qmcplusplus
 {
 /** Factory class to build a many-body wavefunction
@@ -45,12 +46,13 @@ public:
   ~WaveFunctionFactory();
 
   ///read from xmlNode
-  std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur);
+  std::unique_ptr<TrialWaveFunction> buildTWF(xmlNodePtr cur, const RuntimeOptions& runtime_options);
 
   /// create an empty TrialWaveFunction for testing use.
-  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting(const std::string_view name)
+  std::unique_ptr<TrialWaveFunction> static buildEmptyTWFForTesting(const RuntimeOptions& runtime_options,
+                                                                    const std::string_view name)
   {
-    return std::make_unique<TrialWaveFunction>(name);
+    return std::make_unique<TrialWaveFunction>(runtime_options, name);
   }
 
 private:

--- a/src/QMCWaveFunctions/WaveFunctionFactory.h
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.h
@@ -23,7 +23,7 @@
 #include "QMCWaveFunctions/WaveFunctionComponentBuilder.h"
 #include "QMCWaveFunctions/SPOSetBuilderFactory.h"
 #include "Message/MPIObjectBase.h"
-#include "Utilities/qmc_common.h" // RuntimeOptions
+#include "Utilities/RuntimeOptions.h"
 namespace qmcplusplus
 {
 /** Factory class to build a many-body wavefunction

--- a/src/QMCWaveFunctions/WaveFunctionPool.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionPool.cpp
@@ -49,7 +49,7 @@ bool WaveFunctionPool::put(xmlNodePtr cur)
     myComm->barrier_and_abort("target particle set named '" + target + "' not found");
 
   WaveFunctionFactory psiFactory(*qp, ptcl_pool_.getPool(), myComm);
-  auto psi = psiFactory.buildTWF(cur);
+  auto psi = psiFactory.buildTWF(cur, runtime_options_);
   addFactory(std::move(psi), myPool.empty() || role == "primary");
   return true;
 }

--- a/src/QMCWaveFunctions/WaveFunctionPool.h
+++ b/src/QMCWaveFunctions/WaveFunctionPool.h
@@ -20,7 +20,7 @@
 #include "OhmmsData/OhmmsElementBase.h"
 #include "Message/MPIObjectBase.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/qmc_common.h" // RuntimeOptions
+#include "Utilities/RuntimeOptions.h"
 #include <map>
 #include <string>
 

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -15,7 +15,7 @@
 #include "QMCWaveFunctions/Jastrow/J1OrbitalSoA.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -80,9 +80,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
+  auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
@@ -181,9 +181,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
+  auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
@@ -279,9 +279,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow"
 
   // update all distance tables
   elec_.update();
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
+  auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);

--- a/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1OrbitalSoA.cpp
@@ -15,6 +15,7 @@
 #include "QMCWaveFunctions/Jastrow/J1OrbitalSoA.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -23,8 +24,8 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
   Communicate* c = OHMMS::Controller;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -79,8 +80,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
+  ProjectData project_data;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
@@ -112,10 +114,10 @@ TEST_CASE("J1 evaluate derivatives Jastrow", "[wavefunction]")
 
 TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
 {
-  Communicate* c = OHMMS::Controller;
+  Communicate* c       = OHMMS::Controller;
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -179,8 +181,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
 
   // update all distance tables
   elec_.update();
+  ProjectData project_data;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);
@@ -212,10 +215,10 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species", "[wavefunction]")
 
 TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow", "[wavefunction]")
 {
-  Communicate* c = OHMMS::Controller;
+  Communicate* c       = OHMMS::Controller;
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -276,8 +279,9 @@ TEST_CASE("J1 evaluate derivatives Jastrow with two species one without Jastrow"
 
   // update all distance tables
   elec_.update();
+  ProjectData project_data;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1);
+  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -16,6 +16,7 @@
 #include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -81,7 +82,8 @@ TEST_CASE("J1 spin evaluate derivatives Jastrow", "[wavefunction]")
   REQUIRE(okay);
   xmlNodePtr jas1 = doc.getRoot();
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   auto& twf_component_list = twf.getOrbitals();

--- a/src/QMCWaveFunctions/tests/test_J1Spin.cpp
+++ b/src/QMCWaveFunctions/tests/test_J1Spin.cpp
@@ -16,7 +16,7 @@
 #include "QMCWaveFunctions/Jastrow/BsplineFunctor.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -82,8 +82,8 @@ TEST_CASE("J1 spin evaluate derivatives Jastrow", "[wavefunction]")
   REQUIRE(okay);
   xmlNodePtr jas1 = doc.getRoot();
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   auto& twf_component_list = twf.getOrbitals();

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "TWFGrads.hpp"
+#include "Utilities/ProjectData.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -111,7 +112,8 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::move(slater_det));
 
   const char* jas_input = R"(<tmp>

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction.cpp
@@ -22,7 +22,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "TWFGrads.hpp"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -112,8 +112,8 @@ TEST_CASE("TrialWaveFunction_diamondC_1x1x1", "[wavefunction]")
 
   auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   psi.addComponent(std::move(slater_det));
 
   const char* jas_input = R"(<tmp>

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -22,6 +22,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -106,7 +107,8 @@ std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  auto twf_ptr    = wff.buildTWF(root);
+  ProjectData project_data;
+  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 2);
@@ -253,7 +255,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   ParticleSet elec2b(elec2);
   elec2b.update();
 
-  TrialWaveFunction psi2;
+  ProjectData project_data;
+  TrialWaveFunction psi2(project_data.getRuntimeOptions());
   auto orb1 = psi.getOrbitals()[0]->makeClone(elec2);
   psi2.addComponent(std::move(orb1));
   auto orb2 = psi.getOrbitals()[1]->makeClone(elec2);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_He.cpp
@@ -22,7 +22,7 @@
 #include "QMCWaveFunctions/Fermion/SlaterDet.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -107,8 +107,8 @@ std::unique_ptr<TrialWaveFunction> setup_He_wavefunction(Communicate* c,
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  ProjectData project_data;
-  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wff.buildTWF(root, runtime_options);
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 2);
@@ -255,8 +255,8 @@ TEST_CASE("TrialWaveFunction flex_evaluateDeltaLogSetup", "[wavefunction]")
   ParticleSet elec2b(elec2);
   elec2b.update();
 
-  ProjectData project_data;
-  TrialWaveFunction psi2(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi2(runtime_options);
   auto orb1 = psi.getOrbitals()[0]->makeClone(elec2);
   psi2.addComponent(std::move(orb1));
   auto orb2 = psi.getOrbitals()[1]->makeClone(elec2);

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -25,7 +25,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCHamiltonians/NLPPJob.h"
 #include "TWFGrads.hpp"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -148,8 +148,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
 
-  ProjectData project_data;
-  TrialWaveFunction psi(project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  TrialWaveFunction psi(runtime_options);
   psi.addComponent(std::move(slater_det));
 
   const char* jas_input = R"XML(<tmp>

--- a/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
+++ b/src/QMCWaveFunctions/tests/test_TrialWaveFunction_diamondC_2x1x1.cpp
@@ -25,6 +25,7 @@
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCHamiltonians/NLPPJob.h"
 #include "TWFGrads.hpp"
+#include "Utilities/ProjectData.h"
 #include <ResourceCollection.h>
 
 namespace qmcplusplus
@@ -147,7 +148,8 @@ void testTrialWaveFunction_diamondC_2x1x1(const int ndelay, const OffloadSwitche
 
   auto slater_det = std::make_unique<SlaterDet>(elec_, std::move(dets));
 
-  TrialWaveFunction psi;
+  ProjectData project_data;
+  TrialWaveFunction psi(project_data.getRuntimeOptions());
   psi.addComponent(std::move(slater_det));
 
   const char* jas_input = R"XML(<tmp>

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -18,7 +18,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCWaveFunctions/ExampleHeComponent.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -86,8 +86,8 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  ProjectData project_data;
-  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wff.buildTWF(root, runtime_options);
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 1);

--- a/src/QMCWaveFunctions/tests/test_example_he.cpp
+++ b/src/QMCWaveFunctions/tests/test_example_he.cpp
@@ -18,6 +18,7 @@
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
 #include "QMCWaveFunctions/ExampleHeComponent.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -85,7 +86,8 @@ TEST_CASE("ExampleHe", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  auto twf_ptr = wff.buildTWF(root);
+  ProjectData project_data;
+  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 1);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -19,6 +19,7 @@
 #include "WaveFunctionFactory.h"
 #include "LCAO/LCAOrbitalSet.h"
 #include "TWFGrads.hpp"
+#include "Utilities/ProjectData.h"
 #include <ResourceCollection.h>
 
 #include <stdio.h>
@@ -84,7 +85,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   CHECK(spo.getOrbitalSetSize() == check_spo_size);
@@ -434,8 +436,9 @@ void test_Bi_msd(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
+  ProjectData project_data;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);
   CHECK(spo.getOrbitalSetSize() == check_spo_size);

--- a/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
+++ b/src/QMCWaveFunctions/tests/test_multi_slater_determinant.cpp
@@ -19,7 +19,7 @@
 #include "WaveFunctionFactory.h"
 #include "LCAO/LCAOrbitalSet.h"
 #include "TWFGrads.hpp"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 #include <ResourceCollection.h>
 
 #include <stdio.h>
@@ -85,8 +85,8 @@ void test_LiH_msd(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   CHECK(spo.getOrbitalSetSize() == check_spo_size);
@@ -436,9 +436,9 @@ void test_Bi_msd(const std::string& spo_xml_string,
 
   xmlNodePtr ein_xml = doc.getRoot();
 
-  ProjectData project_data;
+  RuntimeOptions runtime_options;
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   auto& spo = twf_ptr->getSPOSet(check_sponame);
   CHECK(spo.getOrbitalSetSize() == check_spo_size);

--- a/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
@@ -20,6 +20,7 @@
 #include "QMCWaveFunctions/Jastrow/PadeFunctors.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 
 #include <stdio.h>
@@ -183,7 +184,8 @@ TEST_CASE("Pade2 Jastrow", "[wavefunction]")
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(jas1);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);

--- a/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
+++ b/src/QMCWaveFunctions/tests/test_pade_jastrow.cpp
@@ -20,7 +20,7 @@
 #include "QMCWaveFunctions/Jastrow/PadeFunctors.h"
 #include "QMCWaveFunctions/Jastrow/RadialJastrowBuilder.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 
 #include <stdio.h>
@@ -184,8 +184,8 @@ TEST_CASE("Pade2 Jastrow", "[wavefunction]")
   // update all distance tables
   elec_.update();
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(jas1, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(jas1, runtime_options);
   auto& twf(*twf_ptr);
   twf.setMassTerm(elec_);
   twf.evaluateLog(elec_);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -17,6 +17,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -66,7 +67,8 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   std::unique_ptr<SPOSet> sposet(twf_ptr->getSPOSet("spo").makeClone());
 

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_LCAO_xml.cpp
@@ -17,7 +17,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -67,8 +67,8 @@ void test_He_sto3g_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   std::unique_ptr<SPOSet> sposet(twf_ptr->getSPOSet("spo").makeClone());
 

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -18,6 +18,7 @@
 #include "Particle/ParticleSetPool.h"
 #include "WaveFunctionFactory.h"
 #include "LCAO/LCAOrbitalSet.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -35,8 +36,8 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string,
   Communicate* c = OHMMS::Controller;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -71,7 +72,8 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   REQUIRE(spo.getOrbitalSetSize() == check_spo_size);
@@ -197,8 +199,8 @@ void test_LiH_msd_xml_input_with_positron(const std::string& spo_xml_string,
   Communicate* c = OHMMS::Controller;
 
   ParticleSetPool ptcl = ParticleSetPool(c);
-  auto ions_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
-  auto elec_uptr = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto ions_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
+  auto elec_uptr       = std::make_unique<ParticleSet>(ptcl.getSimulationCell());
   ParticleSet& ions_(*ions_uptr);
   ParticleSet& elec_(*elec_uptr);
 
@@ -240,7 +242,8 @@ void test_LiH_msd_xml_input_with_positron(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   REQUIRE(spo.getOrbitalSetSize() == check_spo_size);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_MSD_LCAO_h5.cpp
@@ -18,7 +18,7 @@
 #include "Particle/ParticleSetPool.h"
 #include "WaveFunctionFactory.h"
 #include "LCAO/LCAOrbitalSet.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -72,8 +72,8 @@ void test_LiH_msd_xml_input(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   REQUIRE(spo.getOrbitalSetSize() == check_spo_size);
@@ -242,8 +242,8 @@ void test_LiH_msd_xml_input_with_positron(const std::string& spo_xml_string,
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   auto& spo = dynamic_cast<const LCAOrbitalSet&>(twf_ptr->getSPOSet(check_sponame));
   REQUIRE(spo.getOrbitalSetSize() == check_spo_size);

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -17,7 +17,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 #include <stdio.h>
 #include <string>
@@ -81,8 +81,8 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  ProjectData project_data;
-  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, runtime_options);
 
   std::unique_ptr<SPOSet> spo(twf_ptr->getSPOSet("spo").makeClone());
 

--- a/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
+++ b/src/QMCWaveFunctions/tests/test_spo_collection_input_spline.cpp
@@ -17,6 +17,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/ParticleSetPool.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 #include <stdio.h>
 #include <string>
@@ -80,7 +81,8 @@ void test_diamond_2x1x1_xml_input(const std::string& spo_xml_string)
   xmlNodePtr ein_xml = doc.getRoot();
 
   WaveFunctionFactory wf_factory(elec_, ptcl.getPool(), c);
-  auto twf_ptr = wf_factory.buildTWF(ein_xml);
+  ProjectData project_data;
+  auto twf_ptr = wf_factory.buildTWF(ein_xml, project_data.getRuntimeOptions());
 
   std::unique_ptr<SPOSet> spo(twf_ptr->getSPOSet("spo").makeClone());
 

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -16,6 +16,7 @@
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
+#include "Utilities/ProjectData.h"
 
 namespace qmcplusplus
 {
@@ -60,7 +61,8 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  auto twf_ptr = wff.buildTWF(root);
+  ProjectData project_data;
+  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 1);

--- a/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
+++ b/src/QMCWaveFunctions/tests/test_wavefunction_factory.cpp
@@ -16,7 +16,7 @@
 #include "Message/Communicate.h"
 #include "OhmmsData/Libxml2Doc.h"
 #include "QMCWaveFunctions/WaveFunctionFactory.h"
-#include "Utilities/ProjectData.h"
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {
@@ -61,8 +61,8 @@ TEST_CASE("WaveFunctionFactory", "[wavefunction]")
   REQUIRE(okay);
 
   xmlNodePtr root = doc.getRoot();
-  ProjectData project_data;
-  auto twf_ptr = wff.buildTWF(root, project_data.getRuntimeOptions());
+  RuntimeOptions runtime_options;
+  auto twf_ptr = wff.buildTWF(root, runtime_options);
 
   REQUIRE(twf_ptr != nullptr);
   REQUIRE(twf_ptr->size() == 1);

--- a/src/Utilities/ProjectData.cpp
+++ b/src/Utilities/ProjectData.cpp
@@ -38,19 +38,7 @@ ProjectData::ProjectData(const std::string& atitle, ProjectData::DriverVersion d
       cur_(NULL),
       max_cpu_secs_(360000),
       driver_version_(driver_version),
-      runtime_options_({
-#ifdef QMC_COMPLEX
-          true
-#else
-          false
-#endif
-          ,
-#ifdef QMC_MIXED_PRECISION
-          true
-#else
-          false
-#endif
-      })
+      runtime_options_(RuntimeOptions())
 {
   my_comm_ = OHMMS::Controller;
   if (title_.empty())

--- a/src/Utilities/ProjectData.h
+++ b/src/Utilities/ProjectData.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 #include "OhmmsData/libxmldefs.h"
 #include "Message/Communicate.h"
-#include "Utilities/qmc_common.h" // RuntimeOptions
+#include "Utilities/RuntimeOptions.h"
 
 namespace qmcplusplus
 {

--- a/src/Utilities/RuntimeOptions.h
+++ b/src/Utilities/RuntimeOptions.h
@@ -1,0 +1,48 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2017 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by: William F Godoy, godoywf@ornl.gov, Oak Ridge National Laboratory
+//
+// File created by: William F Godoy, godoywf@ornl.gov, Oak Ridge National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_RUNTIMEOPTIONS_H__
+#define QMCPLUSPLUS_RUNTIMEOPTIONS_H__
+
+namespace qmcplusplus
+{
+
+// Simple struct that tracks (@TODO: future) runtime options for the project:
+// - mixed precision,
+// - complex
+struct RuntimeOptions
+{
+  bool is_complex;
+  bool is_mixed_precision;
+
+  // Default constructor follows current compile-time options
+  // @TODO: remove this at the end of the complex/mixed precision integrations
+  RuntimeOptions()
+      : is_complex(
+#ifdef QMC_COMPLEX
+            true
+#else
+            false
+#endif
+            ),
+        is_mixed_precision(
+#ifdef QMC_MIXED_PRECISION
+            true
+#else
+            false
+#endif
+        )
+  {}
+};
+
+} // namespace qmcplusplus
+
+#endif

--- a/src/Utilities/qmc_common.h
+++ b/src/Utilities/qmc_common.h
@@ -57,14 +57,6 @@ struct QMCState
 ///a unique QMCState during a run
 extern QMCState qmc_common;
 
-
-struct RuntimeOptions
-{
-  bool is_complex;
-  bool is_mixed_precision;
-};
-
-
 } // namespace qmcplusplus
 
 #endif


### PR DESCRIPTION
## Proposed changes

Pass it from WaveFunctionPool to
- `TrialWaveFunction` constructor
- `WaveFunctionFactory::buildTWF`
Modify tests accordingly using ProjectData
Related to #3411 and #4099

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Ubuntu 22

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
