### PR TITLE
[WIP] Store VP in groups by wavefunction component

### DIFF
--- a/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
+++ b/src/QMCDrivers/WFOpt/QMCCostFunctionBase.cpp
@@ -215,7 +215,13 @@ void QMCCostFunctionBase::reportParameters()
   {
     std::ostringstream vp_filename;
     vp_filename << RootName << ".vp.h5";
-    OptVariables.saveAsHDF(vp_filename.str());
+
+    hdf_archive hout;
+    OptimizableObject::openHDFToSave(vp_filename.str(), hout);
+
+    UniqueOptObjRefs opt_obj_refs = Psi.extractOptimizableObjectRefs();
+    for (auto opt_obj : opt_obj_refs)
+      opt_obj.get().saveVariationalParameters(hout, OptVariables);
 
     char newxml[128];
     sprintf(newxml, "%s.opt.xml", RootName.c_str());

--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(detail)
 
 set(WFBASE_SRCS
     OptimizableFunctorBase.cpp
+    OptimizableObject.cpp
     VariableSet.cpp
     WaveFunctionPool.cpp
     WaveFunctionComponent.cpp

--- a/src/QMCWaveFunctions/OptimizableObject.cpp
+++ b/src/QMCWaveFunctions/OptimizableObject.cpp
@@ -1,0 +1,100 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2023 QMCPACK developers.
+//
+// File developed by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+#include "OptimizableObject.h"
+#include "VariableSet.h"
+#include "io/hdf/hdf_archive.h"
+
+/**@file OptimizableObject.cpp
+ *@brief OptimizableObject implementation
+ */
+
+namespace qmcplusplus
+{
+
+using opt_variables_type = optimize::VariableSet;
+
+void OptimizableObject::openHDFToSave(const std::string& filename, hdf_archive& hout)
+{
+  hout.create(filename);
+  std::vector<int> vp_file_version{2, 0, 0};
+  hout.write(vp_file_version, "version");
+}
+
+int OptimizableObject::openHDFToRead(const std::string& filename, hdf_archive& hin)
+{
+  if (!hin.open(filename, H5F_ACC_RDONLY))
+  {
+    std::ostringstream err_msg;
+    err_msg << "Unable to open VP file: " << filename;
+    throw std::runtime_error(err_msg.str());
+  }
+  std::vector<int> vp_file_version(3);
+  hin.read(vp_file_version, "version");
+  return vp_file_version[0];
+}
+
+void OptimizableObject::saveVariationalParameters(hdf_archive& hout, opt_variables_type& opt_vars)
+{
+  opt_variables_type dummy;
+  checkInVariablesExclusive(dummy);
+  hid_t name_grp = hout.push(name_);
+
+  hid_t grp = hout.push("name_value_lists");
+
+  std::vector<qmcplusplus::QMCTraits::ValueType> param_values;
+  std::vector<std::string> param_names;
+  for (auto pair_it = dummy.begin(); pair_it != dummy.end(); pair_it++)
+  {
+    const std::string& param_name = pair_it->first;
+    param_names.push_back(param_name);
+    //auto opt_it = opt_vars.find(param_name);
+    //if (opt_it == opt_vars.end())
+    //  throw std::runtime_error("Inconsistent parameter " + param_name + " in " + name_);
+    //param_values.push_back(opt_it->second);
+    param_values.push_back(pair_it->second);
+  }
+
+  hout.write(param_names, "parameter_names");
+  hout.write(param_values, "parameter_values");
+  hout.pop(); // name_value_lists
+  hout.pop(); // component name in name_
+}
+
+void OptimizableObject::readVariationalParameters(hdf_archive& hin, opt_variables_type& opt_vars)
+{
+  hid_t name_grp = hin.push(name_);
+  hid_t grp      = hin.push("name_value_lists", false);
+  if (grp < 0)
+  {
+    std::ostringstream err_msg;
+    err_msg << "The group name_value_lists in not present in file";
+    throw std::runtime_error(err_msg.str());
+  }
+
+  std::vector<qmcplusplus::QMCTraits::ValueType> param_values;
+  hin.read(param_values, "parameter_values");
+
+  std::vector<std::string> param_names;
+  hin.read(param_names, "parameter_names");
+
+  for (int i = 0; i < param_names.size(); i++)
+  {
+    std::string& vp_name = param_names[i];
+    // Find and set values by name.
+    // Values that are not present do not get added.
+    opt_vars.insert(vp_name, param_values[i]);
+  }
+  hin.pop(); // name_value_lists_
+  hin.pop(); // compoent name in name_
+}
+} // namespace qmcplusplus

--- a/src/QMCWaveFunctions/OptimizableObject.h
+++ b/src/QMCWaveFunctions/OptimizableObject.h
@@ -21,6 +21,8 @@
  */
 namespace qmcplusplus
 {
+class hdf_archive;
+
 using opt_variables_type = optimize::VariableSet;
 
 class OptimizableObject
@@ -72,6 +74,23 @@ public:
   virtual void reportStatus(std::ostream& os) {}
 
   void setOptimization(bool state) { is_optimized_ = state; }
+
+  /** Open HDF file for saving variational parameters */
+  static void openHDFToSave(const std::string& filename, hdf_archive& hout);
+
+  /** Open HDF file for reading variational parameters.
+   *  Return value is the major version. */
+  static int openHDFToRead(const std::string& filename, hdf_archive& hin);
+
+  /** Save variational parameters.
+   * The hout parameter should be opened by openHDFToSave
+   * The default implementation saves the parameters listed in checkInVariablesExclusive,
+   * The parameter values are taken from opt_vars */
+  virtual void saveVariationalParameters(hdf_archive& hout, opt_variables_type& opt_vars);
+
+  /** Read variational parameters.
+   * The hin parameter should be opened by openHDFToRead */
+  virtual void readVariationalParameters(hdf_archive& hin, opt_variables_type& opt_vars);
 };
 
 class UniqueOptObjRefs : public RefVector<OptimizableObject>

--- a/src/QMCWaveFunctions/WaveFunctionFactory.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionFactory.cpp
@@ -158,7 +158,16 @@ std::unique_ptr<TrialWaveFunction> WaveFunctionFactory::buildTWF(xmlNodePtr cur,
   if (!vp_file_to_load.empty())
   {
     app_log() << "  Reading variational parameters from " << vp_file_to_load << std::endl;
-    dummy.readFromHDF(vp_file_to_load);
+    hdf_archive hin;
+    int major_version = OptimizableObject::openHDFToRead(vp_file_to_load, hin);
+    if (major_version == 1)
+      dummy.readFromHDF(vp_file_to_load);
+    else
+    {
+      UniqueOptObjRefs opt_obj_refs = targetPsi->extractOptimizableObjectRefs();
+      for (auto opt_obj : opt_obj_refs)
+        opt_obj.get().readVariationalParameters(hin, dummy);
+    }
   }
 
   targetPsi->resetParameters(dummy);


### PR DESCRIPTION

Store variational parameters as suggested by Ye in
https://github.com/QMCPACK/qmcpack/pull/4517#issuecomment-1470684859

Each optimizable component handles reading/writing its own parameters.   The default implementation in OptimizableObject operates on the variables returned checkInVariablesExclusive.
Objects that need to need store additional information (like RotatedSPOs) can override {save,read}VariationalParameters.  That will be implemented in a future PR - for now this is a refactor of the existing scheme.

The VP file changes internal organization and the major version is changed to "2".  Each component stores its parameters in a separate group. 
The ability to read version 1 files is still present.

Marked "WIP" because there are no tests yet.




## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
