### PR TITLE
Add restart_dmc test with nontrivial walker weights.

### DIFF
--- a/src/Particle/MCSample.h
+++ b/src/Particle/MCSample.h
@@ -31,6 +31,7 @@ struct MCSample
   using Walker_t = ParticleSet::Walker_t;
 
   ParticleSet::ParticlePos R;
+  ParticleSet::FullPrecRealType Weight;
   ParticleSet::ParticleScalar spins;
   ParticleSet::ParticleGradient G;
   ParticleSet::ParticleLaplacian L;
@@ -39,7 +40,7 @@ struct MCSample
   inline MCSample(const ParticleSet& pset) : R(pset.R), spins(pset.spins) {}
 
   /// deprecated. Beyond w.R and w.spins, others are used perhaps somewhere but intended not to.
-  inline MCSample(const Walker_t& w) : R(w.R), spins(w.spins), G(w.G), L(w.L)
+  inline MCSample(const Walker_t& w) : R(w.R), Weight(w.Weight), spins(w.spins), G(w.G), L(w.L)
   {
     LogPsi = w.Properties(WP::LOGPSI);
     Sign   = w.Properties(WP::SIGN);
@@ -60,6 +61,7 @@ struct MCSample
   inline void convertToWalker(Walker_t& w) const
   {
     w.R                              = R;
+    w.Weight                         = Weight;
     w.spins                          = spins;
     w.G                              = G;
     w.L                              = L;

--- a/src/QMCDrivers/MCPopulation.cpp
+++ b/src/QMCDrivers/MCPopulation.cpp
@@ -292,6 +292,9 @@ void MCPopulation::saveWalkerConfigurations(WalkerConfigurations& walker_configs
 {
   walker_configs.resize(walker_elec_particle_sets_.size(), elec_particle_set_->getTotalNum());
   for (int iw = 0; iw < walker_elec_particle_sets_.size(); iw++)
+  {
     walker_elec_particle_sets_[iw]->saveWalker(*walker_configs[iw]);
+    walker_configs[iw]->Weight = walkers_[iw]->Weight;
+  }
 }
 } // namespace qmcplusplus

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -122,6 +122,24 @@ run_restart_and_check(
   true)
 
 run_restart_and_check(
+  deterministic-restart_dmc
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_dmc"
+  det_qmc_vmcbatch_dmcbatch_tm
+  8
+  2
+  check.sh
+  false)
+
+run_restart_and_check(
+  deterministic-restart_dmc
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_dmc"
+  det_qmc_vmcbatch_dmcbatch_tm
+  1
+  16
+  check.sh
+  true)
+
+run_restart_and_check(
   deterministic-save_spline_coefs
   "${qmcpack_SOURCE_DIR}/tests/io/save_spline_coefs"
   qmc_short

--- a/tests/io/restart_dmc/C.BFD.xml
+++ b/tests/io/restart_dmc/C.BFD.xml
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/C.BFD.xml

--- a/tests/io/restart_dmc/check.sh
+++ b/tests/io/restart_dmc/check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "========================================================================================"
+echo "First run : det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat"
+cat det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat
+
+echo "========================================================================================"
+echo "Restart run : det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat"
+cat det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat
+
+echo "========================================================================================"
+echo "comparing the Kinetic ElecElec IonIon LocalECP up to the 7th digit after the decimal"
+
+sed "/#/d" det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s002
+sed "/#/d" det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s003
+diff s002 s003

--- a/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.in.xml
+++ b/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.in.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_vmcbatch_dmcbatch_tm" series="0">
+     <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+     <parameter name="driver_version">batched</parameter>
+   </project>
+   <random seed="36"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <slaterdeterminant>
+               <determinant id="updet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <qmc method="vmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers">    16   </parameter>
+     <parameter name="substeps">  2 </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="steps">  3 </parameter>
+     <parameter name="blocks">  3 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc_batch" move="pbyp" checkpoint="0">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers"> 16  </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   3   </parameter>
+     <parameter name="blocks">  3   </parameter>
+     <parameter name="nonlocalmoves">  v0 </parameter>
+     <parameter name="debug_disable_branching"> yes </parameter>
+   </qmc>
+   <qmc method="dmc_batch" move="pbyp" checkpoint="0">
+     <estimator name="LocalEnergy" hdf5="yes"/>
+     <parameter name="total_walkers"> 16  </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   3   </parameter>
+     <parameter name="blocks">  3   </parameter>
+     <parameter name="nonlocalmoves">  v1 </parameter>
+     <parameter name="debug_disable_branching"> yes </parameter>
+</qmc>
+</simulation>

--- a/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.restart.xml
+++ b/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.restart.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<simulation>
+   <project id="det_qmc_vmcbatch_dmcbatch_tm" series="3">
+     <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
+     <parameter name="driver_version">batched</parameter>
+   </project>
+   <random seed="36"/>
+   <qmcsystem>
+      <simulationcell>
+         <parameter name="lattice" units="bohr">
+                  3.37316115        3.37316115        0.00000000
+                  0.00000000        3.37316115        3.37316115
+                  3.37316115        0.00000000        3.37316115
+         </parameter>
+         <parameter name="bconds">
+            p p p
+         </parameter>
+         <parameter name="LR_dim_cutoff"       >    15                 </parameter>
+      </simulationcell>
+      <particleset name="e" random="yes">
+         <group name="u" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+         <group name="d" size="4" mass="1.0">
+            <parameter name="charge"              >    -1                    </parameter>
+            <parameter name="mass"                >    1.0                   </parameter>
+         </group>
+      </particleset>
+      <particleset name="ion0">
+         <group name="C" size="2" mass="21894.7135906">
+            <parameter name="charge"              >    4                     </parameter>
+            <parameter name="valence"             >    4                     </parameter>
+            <parameter name="atomicnumber"        >    6                     </parameter>
+            <parameter name="mass"                >    21894.7135906            </parameter>
+            <attrib name="position" datatype="posArray" condition="0">
+                     0.00000000        0.00000000        0.00000000
+                     1.68658058        1.68658058        1.68658058
+            </attrib>
+         </group>
+      </particleset>
+      <wavefunction name="psi0" target="e">
+         <determinantset type="einspline" href="pwscf.pwscf.h5" tilematrix="1 0 0 0 1 0 0 0 1" twistnum="0" source="ion0" meshfactor="1.0" precision="double">
+            <slaterdeterminant>
+               <determinant id="updet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+               <determinant id="downdet" size="4">
+                  <occupation mode="ground" spindataset="0"/>
+               </determinant>
+            </slaterdeterminant>
+         </determinantset>
+         <jastrow type="One-Body" name="J1" function="bspline" source="ion0" print="yes">
+            <correlation elementType="C" size="8" cusp="0.0">
+               <coefficients id="eC" type="Array">                  
+-0.2032153051 -0.1625595974 -0.143124599 -0.1216434956 -0.09919771951 -0.07111729038 
+-0.04445345869 -0.02135082917
+               </coefficients>
+            </correlation>
+         </jastrow>
+         <jastrow type="Two-Body" name="J2" function="bspline" print="yes">
+            <correlation speciesA="u" speciesB="u" size="8">
+               <coefficients id="uu" type="Array">                  
+0.2797730287 0.2172604155 0.1656172964 0.1216984261 0.083995349 0.05302065936 
+0.02915953995 0.0122402581
+               </coefficients>
+            </correlation>
+            <correlation speciesA="u" speciesB="d" size="8">
+               <coefficients id="ud" type="Array">                  
+0.4631099906 0.356399124 0.2587895287 0.1829298509 0.1233653291 0.07714708174 
+0.04145899033 0.01690645936
+               </coefficients>
+            </correlation>
+         </jastrow>
+      </wavefunction>
+      <hamiltonian name="h0" type="generic" target="e">
+         <pairpot type="coulomb" name="ElecElec" source="e" target="e"/>
+         <pairpot type="coulomb" name="IonIon" source="ion0" target="ion0"/>
+         <pairpot type="pseudo" name="PseudoPot" source="ion0" wavefunction="psi0" format="xml">
+            <pseudo elementType="C" href="C.BFD.xml"/>
+         </pairpot>
+         <pairpot name="MPC" type="MPC" source="e" target="e" ecut="60.0" physical="false"/>
+         <!-- <estimator type="flux" name="Flux"/> -->
+      </hamiltonian>
+   </qmcsystem>
+
+   <mcwalkerset fileroot="det_qmc_vmcbatch_dmcbatch_tm.s001" node="-1" nprocs="1" version="0 4" collected="yes"/>
+   <qmc method="dmc_batch" move="pbyp" checkpoint="0">
+     <estimator name="LocalEnergy" hdf5="yes"/>
+     <parameter name="total_walkers"> 16  </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   3   </parameter>
+     <parameter name="blocks">  3   </parameter>
+     <parameter name="nonlocalmoves">  v1 </parameter>
+     <parameter name="debug_disable_branching"> yes </parameter>
+   </qmc>
+</simulation>

--- a/tests/io/restart_dmc/pwscf.pwscf.h5
+++ b/tests/io/restart_dmc/pwscf.pwscf.h5
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/pwscf.pwscf.h5


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This fixes #4493.

This add a dmc_batched restart test. "debug_disable_branching" is set to yes so that the walker weights are not all equal to 1.

To get this working, `weight` needed to be added to MCSample. In `MCPopulation::saveWalkerConfigurations(...)` I worked around `ParticleSet` not containing weights, but using both `walker_elec_particle_sets_` and `walkers_` looks like a code smell.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
