### PR TITLE
Remove unnecessary hdf5 error checking

### DIFF
--- a/src/QMCTools/LCAOHDFParser.cpp
+++ b/src/QMCTools/LCAOHDFParser.cpp
@@ -326,17 +326,9 @@ void LCAOHDFParser::getMO(const std::string& fname)
   char name[72];
   sprintf(name, "%s", "/Super_Twist/eigenset_0");
   setname = name;
-  if (!hin.readEntry(CartMat, setname))
-  {
-    setname = "SPOSet::putFromH5 Missing " + setname + " from HDF5 File.";
-    APP_ABORT(setname.c_str());
-  }
+  hin.read(CartMat, setname);
   sprintf(name, "%s", "/Super_Twist/eigenval_0");
-  if (!hin.readEntry(EigVal_alpha, setname))
-  {
-    setname = "SPOSet::putFromH5 Missing " + setname + " from HDF5 File.";
-    APP_ABORT(setname.c_str());
-  }
+  hin.read(EigVal_alpha, setname);
 
   int cnt = 0;
   for (int i = 0; i < numMO; i++)
@@ -347,17 +339,9 @@ void LCAOHDFParser::getMO(const std::string& fname)
   {
     sprintf(name, "%s", "/Super_Twist/eigenset_1");
     setname = name;
-    if (!hin.readEntry(CartMat, setname))
-    {
-      setname = "SPOSet::putFromH5 Missing " + setname + " from HDF5 File.";
-      APP_ABORT(setname.c_str());
-    }
+    hin.read(CartMat, setname);
     sprintf(name, "%s", "/Super_Twist/eigenval_1");
-    if (!hin.readEntry(EigVal_beta, setname))
-    {
-      setname = "SPOSet::putFromH5 Missing " + setname + " from HDF5 File.";
-      APP_ABORT(setname.c_str());
-    }
+    hin.read(EigVal_beta, setname);
   }
 
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -1150,8 +1150,7 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
       APP_ABORT("Unknown HDF5 CI format");
     }
 
-    if (!hin.readEntry(temps[grp], ds_tag))
-      APP_ABORT("Unknown HDF5 CI format");
+    hin.read(temps[grp], ds_tag);
   }
 
   std::vector<std::string> MyCIs(nGroups);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -1150,7 +1150,8 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
       APP_ABORT("Unknown HDF5 CI format");
     }
 
-    hin.read(temps[grp], ds_tag);
+    if (!hin.readEntry(temps[grp], ds_tag))
+      throw std::runtime_error("Unknown HDF5 CI format");
   }
 
   std::vector<std::string> MyCIs(nGroups);

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.h
@@ -115,8 +115,7 @@ private:
     else
       extVar = "Coeff_" + std::to_string(ext_level);
 
-    if (!hin.readEntry(ci_coeff, extVar))
-      throw std::runtime_error("Could not read CI coefficients from HDF5");
+    hin.read(ci_coeff, extVar);
   }
 
   template<typename VT,
@@ -142,8 +141,7 @@ private:
       extVar = "Coeff_" + std::to_string(ext_level);
 
 
-    if (!hin.readEntry(CIcoeff_real, extVar))
-      throw std::runtime_error("Could not read CI coefficients from HDF5");
+    hin.read(CIcoeff_real, extVar);
 
     extVar = extVar + "_imag";
     if (!hin.readEntry(CIcoeff_imag, extVar))

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -691,11 +691,7 @@ bool LCAOrbitalBuilder::putFromH5(LCAOrbitalSet& spo, xmlNodePtr coeff_ptr)
     {
       sprintf(name, "%s%d", "/KPTS_0/eigenset_", setVal);
       setname = name;
-      if (!hin.readEntry(Ctemp, setname))
-      {
-        setname = "LCAOrbitalBuilder::putFromH5 Missing " + setname + " from HDF5 File.";
-        APP_ABORT(setname.c_str());
-      }
+      hin.read(Ctemp, setname);
     }
     hin.close();
 
@@ -874,11 +870,7 @@ void LCAOrbitalBuilder::readRealMatrixFromH5(hdf_archive& hin,
                                              const std::string& setname,
                                              Matrix<LCAOrbitalBuilder::RealType>& Creal) const
 {
-  if (!hin.readEntry(Creal, setname))
-  {
-    std::string error_msg = "LCAOrbitalBuilder::readRealMatrixFromH5 Missing " + setname + " from HDF5 File.";
-    APP_ABORT(error_msg.c_str());
-  }
+  hin.read(Creal, setname);
 }
 
 void LCAOrbitalBuilder::LoadFullCoefsFromH5(hdf_archive& hin,
@@ -979,8 +971,7 @@ void LCAOrbitalBuilder::EvalPeriodicImagePhaseFactors(PosType SuperTwist,
         APP_ABORT("Could not open H5 file");
       if (!hin.push("Cell"))
         APP_ABORT("Could not open Cell group in H5; Probably Corrupt H5 file; accessed from LCAOrbitalBuilder");
-      if (!hin.readEntry(Lattice, "LatticeVectors"))
-        APP_ABORT("Could not open Lattice vectors in H5; Probably Corrupt H5 file; accessed from LCAOrbitalBuilder");
+      hin.read(Lattice, "LatticeVectors");
       hin.close();
     }
     for (int i = 0; i < 3; i++)

--- a/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
+++ b/src/QMCWaveFunctions/LCAO/RadialOrbitalSetBuilder.h
@@ -182,11 +182,7 @@ bool RadialOrbitalSetBuilder<COT>::addGridH5(hdf_archive& hin)
   std::string gridtype;
   if (myComm->rank() == 0)
   {
-    if (!hin.readEntry(gridtype, "grid_type"))
-    {
-      std::cerr << "Could not read grid_type in H5; Probably Corrupt H5 file" << std::endl;
-      exit(0);
-    }
+    hin.read(gridtype, "grid_type");
   }
   myComm->bcast(gridtype);
 


### PR DESCRIPTION
## Proposed changes
Hdf5 wrapper `read` has built-in error checking which is duplicated in other places if the lower level `readEntry` is used. This PR replaces some `readEntry` with `read`.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
Workstation 

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
