### PR TITLE
Split restart_dmc into two tests with and without disable_branching.

### DIFF
--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -140,6 +140,24 @@ run_restart_and_check(
   true)
 
 run_restart_and_check(
+  deterministic-restart_dmc_disable_branching
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_dmc_disable_branching"
+  det_qmc_vmcbatch_dmcbatch_tm
+  8
+  2
+  check.sh
+  false)
+
+run_restart_and_check(
+  deterministic-restart_dmc_disable_branching
+  "${qmcpack_SOURCE_DIR}/tests/io/restart_dmc_disable_branching"
+  det_qmc_vmcbatch_dmcbatch_tm
+  1
+  16
+  check.sh
+  true)
+
+run_restart_and_check(
   deterministic-save_spline_coefs
   "${qmcpack_SOURCE_DIR}/tests/io/save_spline_coefs"
   qmc_short

--- a/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.in.xml
+++ b/tests/io/restart_dmc/det_qmc_vmcbatch_dmcbatch_tm.in.xml
@@ -103,17 +103,14 @@
      <parameter name="steps">   3   </parameter>
      <parameter name="blocks">  3   </parameter>
      <parameter name="nonlocalmoves">  v0 </parameter>
-     <parameter name="debug_disable_branching"> yes </parameter>
    </qmc>
    <qmc method="dmc_batch" move="pbyp" checkpoint="0">
      <estimator name="LocalEnergy" hdf5="yes"/>
-     <parameter name="total_walkers"> 16  </parameter>
      <parameter name="reconfiguration">   no </parameter>
      <parameter name="warmupSteps">  3  </parameter>
      <parameter name="timestep">  0.005 </parameter>
      <parameter name="steps">   3   </parameter>
      <parameter name="blocks">  3   </parameter>
      <parameter name="nonlocalmoves">  v1 </parameter>
-     <parameter name="debug_disable_branching"> yes </parameter>
 </qmc>
 </simulation>

--- a/tests/io/restart_dmc_disable_branching/C.BFD.xml
+++ b/tests/io/restart_dmc_disable_branching/C.BFD.xml
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/C.BFD.xml

--- a/tests/io/restart_dmc_disable_branching/check.sh
+++ b/tests/io/restart_dmc_disable_branching/check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "========================================================================================"
+echo "First run : det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat"
+cat det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat
+
+echo "========================================================================================"
+echo "Restart run : det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat"
+cat det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat
+
+echo "========================================================================================"
+echo "comparing the Kinetic ElecElec IonIon LocalECP up to the 7th digit after the decimal"
+
+sed "/#/d" det_qmc_vmcbatch_dmcbatch_tm.s002.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s002
+sed "/#/d" det_qmc_vmcbatch_dmcbatch_tm.s003.scalar.dat | awk '{printf("%.7e %.7e %.7e %.7e\n",$5,$6,$7,$8)}' > s003
+diff s002 s003

--- a/tests/io/restart_dmc_disable_branching/det_qmc_vmcbatch_dmcbatch_tm.in.xml
+++ b/tests/io/restart_dmc_disable_branching/det_qmc_vmcbatch_dmcbatch_tm.in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <simulation>
-   <project id="det_qmc_vmcbatch_dmcbatch_tm" series="3">
+   <project id="det_qmc_vmcbatch_dmcbatch_tm" series="0">
      <application name="qmcapp" role="molecu" class="serial" version="1.0"/>
      <parameter name="driver_version">batched</parameter>
    </project>
@@ -84,7 +84,27 @@
       </hamiltonian>
    </qmcsystem>
 
-   <mcwalkerset fileroot="det_qmc_vmcbatch_dmcbatch_tm.s001" node="-1" nprocs="1" version="0 4" collected="yes"/>
+   <qmc method="vmc" move="pbyp" checkpoint="-1">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers">    16   </parameter>
+     <parameter name="substeps">  2 </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="steps">  3 </parameter>
+     <parameter name="blocks">  3 </parameter>
+     <parameter name="timestep">  1.0 </parameter>
+     <parameter name="usedrift">   no </parameter>
+   </qmc>
+   <qmc method="dmc_batch" move="pbyp" checkpoint="0">
+     <estimator name="LocalEnergy" hdf5="no"/>
+     <parameter name="total_walkers"> 16  </parameter>
+     <parameter name="reconfiguration">   no </parameter>
+     <parameter name="warmupSteps">  3  </parameter>
+     <parameter name="timestep">  0.005 </parameter>
+     <parameter name="steps">   3   </parameter>
+     <parameter name="blocks">  3   </parameter>
+     <parameter name="nonlocalmoves">  v0 </parameter>
+     <parameter name="debug_disable_branching"> yes </parameter>
+   </qmc>
    <qmc method="dmc_batch" move="pbyp" checkpoint="0">
      <estimator name="LocalEnergy" hdf5="yes"/>
      <parameter name="reconfiguration">   no </parameter>
@@ -93,5 +113,6 @@
      <parameter name="steps">   3   </parameter>
      <parameter name="blocks">  3   </parameter>
      <parameter name="nonlocalmoves">  v1 </parameter>
-   </qmc>
+     <parameter name="debug_disable_branching"> yes </parameter>
+</qmc>
 </simulation>

--- a/tests/io/restart_dmc_disable_branching/det_qmc_vmcbatch_dmcbatch_tm.restart.xml
+++ b/tests/io/restart_dmc_disable_branching/det_qmc_vmcbatch_dmcbatch_tm.restart.xml
@@ -93,5 +93,6 @@
      <parameter name="steps">   3   </parameter>
      <parameter name="blocks">  3   </parameter>
      <parameter name="nonlocalmoves">  v1 </parameter>
+     <parameter name="debug_disable_branching"> yes </parameter>
    </qmc>
 </simulation>

--- a/tests/io/restart_dmc_disable_branching/pwscf.pwscf.h5
+++ b/tests/io/restart_dmc_disable_branching/pwscf.pwscf.h5
@@ -1,0 +1,1 @@
+../../solids/diamondC_1x1x1_pp/pwscf.pwscf.h5


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Removed `debug_disable_branching` and `total_walkers` to create a DMC restart test. Since this test now has all walker weights equal to 1., I renamed our old test with  `debug_disable_branching==yes` to `restart_dmc_disable_branching`.

This fixes #798.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

my laptop, ubuntu 20.04

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes/No. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes/No. Documentation has been added (if appropriate)
