### PR TITLE
Update resource handling

### DIFF
--- a/src/Particle/LongRange/LRHandlerBase.h
+++ b/src/Particle/LongRange/LRHandlerBase.h
@@ -21,6 +21,7 @@
 
 #include "coulomb_types.h"
 #include "LongRange/StructFact.h"
+#include "Particle/ParticleSet.h"
 
 namespace qmcplusplus
 {

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -14,15 +14,20 @@
 #ifndef QMCPLUSPLUS_STRUCTFACT_H
 #define QMCPLUSPLUS_STRUCTFACT_H
 
-#include "ParticleSet.h"
-#include "DynamicCoordinates.h"
 #include "OhmmsPETE/OhmmsVector.h"
 #include "OhmmsPETE/OhmmsMatrix.h"
-#include "Resource.h"
+#include "Configuration.h"
+#include <Resource.h>
+#include <NewTimer.h>
+#include <OMPTarget/OffloadAlignedAllocators.hpp>
+#include <type_traits/template_types.hpp>
 
 namespace qmcplusplus
 {
+class ParticleSet;
 class KContainer;
+struct SKMultiWalkerMem;
+
 /** @ingroup longrange
  *\brief Calculates the structure-factor for a particle set
  *
@@ -108,7 +113,7 @@ struct SKMultiWalkerMem : public Resource
   using RealType = StructFact::RealType;
 
   ///dist displ for temporary and old pairs
-  Matrix<RealType, OMPallocator<RealType, PinnedAlignedAllocator<RealType>>> nw_rhok;
+  Matrix<RealType, OffloadPinnedAllocator<RealType>> nw_rhok;
 
   SKMultiWalkerMem() : Resource("SKMultiWalkerMem") {}
 

--- a/src/Particle/LongRange/StructFact.h
+++ b/src/Particle/LongRange/StructFact.h
@@ -114,7 +114,7 @@ struct SKMultiWalkerMem : public Resource
 
   SKMultiWalkerMem(const SKMultiWalkerMem&) : SKMultiWalkerMem() {}
 
-  Resource* makeClone() const override { return new SKMultiWalkerMem(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<SKMultiWalkerMem>(*this); }
 };
 
 } // namespace qmcplusplus

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -791,7 +791,7 @@ void ParticleSet::mw_donePbyP(const RefVectorWithLeader<ParticleSet>& p_list, bo
   if (!skipSK && p_leader.structure_factor_)
   {
     auto sk_list = extractSKRefList(p_list);
-    StructFact::mw_updateAllPart(sk_list, p_list, *p_leader.mw_structure_factor_data_);
+    StructFact::mw_updateAllPart(sk_list, p_list, p_leader.mw_structure_factor_data_handle_);
   }
 
   auto& dts = p_leader.DistTables;
@@ -958,12 +958,7 @@ void ParticleSet::acquireResource(ResourceCollection& collection, const RefVecto
     ps_leader.DistTables[i]->acquireResource(collection, extractDTRefList(p_list, i));
 
   if (ps_leader.structure_factor_)
-  {
-    auto res_ptr = dynamic_cast<SKMultiWalkerMem*>(collection.lendResource().release());
-    if (!res_ptr)
-      throw std::runtime_error("ParticleSet::acquireResource SKMultiWalkerMem dynamic_cast failed");
-    p_list.getLeader().mw_structure_factor_data_.reset(res_ptr);
-  }
+    p_list.getLeader().mw_structure_factor_data_handle_ = collection.lendResource<SKMultiWalkerMem>();
 }
 
 void ParticleSet::releaseResource(ResourceCollection& collection, const RefVectorWithLeader<ParticleSet>& p_list)
@@ -974,7 +969,7 @@ void ParticleSet::releaseResource(ResourceCollection& collection, const RefVecto
     ps_leader.DistTables[i]->releaseResource(collection, extractDTRefList(p_list, i));
 
   if (ps_leader.structure_factor_)
-    collection.takebackResource(std::move(p_list.getLeader().mw_structure_factor_data_));
+    collection.takebackResource(p_list.getLeader().mw_structure_factor_data_handle_);
 }
 
 RefVectorWithLeader<DistanceTable> ParticleSet::extractDTRefList(const RefVectorWithLeader<ParticleSet>& p_list, int id)

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -24,6 +24,7 @@
 #include "ParticleTags.h"
 #include "DynamicCoordinates.h"
 #include "Walker.h"
+#include "ResourceHandle.h"
 #include "SpeciesSet.h"
 #include "Pools/PooledData.h"
 #include "OhmmsPETE/OhmmsArray.h"
@@ -616,7 +617,7 @@ protected:
   std::unique_ptr<StructFact> structure_factor_;
 
   ///multi walker structure factor data
-  std::unique_ptr<SKMultiWalkerMem> mw_structure_factor_data_;
+  ResourceHandle<SKMultiWalkerMem> mw_structure_factor_data_handle_;
 
   /** map to handle distance tables
    *

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -89,8 +89,6 @@ public:
   {
     assert(this == &coords_list.getLeader());
     auto& coords_leader = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
-    // multi walker resource must have been acquired
-    assert(coords_leader.mw_mem_handle_);
 
     const auto nw    = coords_list.size();
     auto& mw_new_pos = coords_leader.mw_mem_handle_.getResource().mw_new_pos;

--- a/src/Particle/RealSpacePositionsOMPTarget.h
+++ b/src/Particle/RealSpacePositionsOMPTarget.h
@@ -90,10 +90,10 @@ public:
     assert(this == &coords_list.getLeader());
     auto& coords_leader = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
     // multi walker resource must have been acquired
-    assert(coords_leader.mw_mem_);
+    assert(coords_leader.mw_mem_handle_);
 
     const auto nw    = coords_list.size();
-    auto& mw_new_pos = coords_leader.mw_mem_->mw_new_pos;
+    auto& mw_new_pos = coords_leader.mw_mem_handle_.getResource().mw_new_pos;
     mw_new_pos.resize(nw);
 
     for (int iw = 0; iw < nw; iw++)
@@ -111,11 +111,12 @@ public:
                             const std::vector<bool>& isAccepted) const override
   {
     assert(this == &coords_list.getLeader());
-    auto& coords_leader     = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
-    auto& mw_new_pos        = coords_leader.mw_mem_->mw_new_pos;
-    auto& mw_rsoa_ptrs      = coords_leader.mw_mem_->mw_rsoa_ptrs;
-    auto& mw_accept_indices = coords_leader.mw_mem_->mw_accept_indices;
     const size_t nw         = coords_list.size();
+    auto& coords_leader     = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>();
+    MultiWalkerMem& mw_mem  = coords_leader.mw_mem_handle_;
+    auto& mw_new_pos        = mw_mem.mw_new_pos;
+    auto& mw_rsoa_ptrs      = mw_mem.mw_rsoa_ptrs;
+    auto& mw_accept_indices = mw_mem.mw_accept_indices;
 
     if (!is_nw_new_pos_prepared)
     {
@@ -175,7 +176,7 @@ public:
 
   const RealType* getDevicePtr() const { return RSoA.device_data(); }
 
-  const auto& getFusedNewPosBuffer() const { return mw_mem_->mw_new_pos; }
+  const auto& getFusedNewPosBuffer() const { return mw_mem_handle_.getResource().mw_new_pos; }
 
   void createResource(ResourceCollection& collection) const override
   {
@@ -185,13 +186,10 @@ public:
   void acquireResource(ResourceCollection& collection,
                        const RefVectorWithLeader<DynamicCoordinates>& coords_list) const override
   {
-    auto res_ptr = dynamic_cast<MultiWalkerMem*>(collection.lendResource().release());
-    if (!res_ptr)
-      throw std::runtime_error("RealSpacePositionsOMPTarget::acquireResource dynamic_cast failed");
-    auto& mw_mem = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_;
-    mw_mem.reset(res_ptr);
+    MultiWalkerMem& mw_mem = coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_handle_ =
+        collection.lendResource<MultiWalkerMem>();
 
-    auto& mw_rsoa_ptrs(mw_mem->mw_rsoa_ptrs);
+    auto& mw_rsoa_ptrs(mw_mem.mw_rsoa_ptrs);
     const auto nw = coords_list.size();
     mw_rsoa_ptrs.resize(nw);
     for (int iw = 0; iw < nw; iw++)
@@ -205,10 +203,10 @@ public:
   void releaseResource(ResourceCollection& collection,
                        const RefVectorWithLeader<DynamicCoordinates>& coords_list) const override
   {
-    collection.takebackResource(std::move(coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_));
+    collection.takebackResource(coords_list.getCastedLeader<RealSpacePositionsOMPTarget>().mw_mem_handle_);
   }
 
-  const auto& getMultiWalkerRSoADevicePtrs() const { return mw_mem_->mw_rsoa_ptrs; }
+  const auto& getMultiWalkerRSoADevicePtrs() const { return mw_mem_handle_.getResource().mw_rsoa_ptrs; }
 
 private:
   ///particle positions in SoA layout
@@ -230,10 +228,10 @@ private:
 
     MultiWalkerMem(const MultiWalkerMem&) : MultiWalkerMem() {}
 
-    Resource* makeClone() const override { return new MultiWalkerMem(*this); }
+    std::unique_ptr<Resource> makeClone() const override { return std::make_unique<MultiWalkerMem>(*this); }
   };
 
-  std::unique_ptr<MultiWalkerMem> mw_mem_;
+  ResourceHandle<MultiWalkerMem> mw_mem_handle_;
 
   ///host view of RSoA
   PosVectorSoa RSoA_hostview;

--- a/src/Particle/VirtualParticleSet.h
+++ b/src/Particle/VirtualParticleSet.h
@@ -19,6 +19,7 @@
 
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
+#include <ResourceHandle.h>
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
 
 namespace qmcplusplus
@@ -41,7 +42,7 @@ private:
   /// true, if virtual particles are on a sphere for NLPP
   bool onSphere;
   /// multi walker resource
-  std::unique_ptr<VPMultiWalkerMem> mw_mem_;
+  ResourceHandle<VPMultiWalkerMem> mw_mem_handle_;
 
   Vector<int, OffloadPinnedAllocator<int>>& getMultiWalkerRefPctls();
 

--- a/src/Platforms/CUDA/CUDALinearAlgebraHandles.h
+++ b/src/Platforms/CUDA/CUDALinearAlgebraHandles.h
@@ -39,7 +39,7 @@ struct CUDALinearAlgebraHandles : public Resource
     cudaErrorCheck(cudaStreamDestroy(hstream), "cudaStreamDestroy failed!");
   }
 
-  Resource* makeClone() const override { return new CUDALinearAlgebraHandles(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<CUDALinearAlgebraHandles>(*this); }
 };
 }
 #endif

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -28,6 +28,16 @@ namespace qmcplusplus
 using WP       = WalkerProperties::Indexes;
 using Return_t = BareKineticEnergy::Return_t;
 
+struct BareKineticEnergy::MultiWalkerResource : public Resource
+{
+  MultiWalkerResource() : Resource("BareKineticEnergy") {}
+
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<MultiWalkerResource>(*this); }
+
+  Vector<RealType> t_samples;
+  Vector<std::complex<RealType>> tcmp_samples;
+};
+
 /** constructor with particleset
    * @param target particleset
    *

--- a/src/QMCHamiltonians/BareKineticEnergy.cpp
+++ b/src/QMCHamiltonians/BareKineticEnergy.cpp
@@ -436,18 +436,15 @@ void BareKineticEnergy::createResource(ResourceCollection& collection) const
 void BareKineticEnergy::acquireResource(ResourceCollection& collection,
                                         const RefVectorWithLeader<OperatorBase>& o_list) const
 {
-  auto& O_leader = o_list.getCastedLeader<BareKineticEnergy>();
-  auto res_ptr   = dynamic_cast<MultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("BareKineticEnergy::acquireResource dynamic_cast failed");
-  O_leader.mw_res_.reset(res_ptr);
+  auto& O_leader   = o_list.getCastedLeader<BareKineticEnergy>();
+  O_leader.mw_res_ = collection.lendResource<MultiWalkerResource>();
 }
 
 void BareKineticEnergy::releaseResource(ResourceCollection& collection,
                                         const RefVectorWithLeader<OperatorBase>& o_list) const
 {
   auto& O_leader = o_list.getCastedLeader<BareKineticEnergy>();
-  collection.takebackResource(std::move(O_leader.mw_res_));
+  collection.takebackResource(O_leader.mw_res_);
 }
 
 void BareKineticEnergy::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase>& o_list,
@@ -462,8 +459,8 @@ void BareKineticEnergy::mw_evaluatePerParticle(const RefVectorWithLeader<Operato
 
   auto num_particles                        = p_leader.getTotalNum();
   auto& name                                = o_leader.name_;
-  Vector<RealType>& t_samp                  = o_leader.mw_res_->t_samples;
-  Vector<std::complex<RealType>>& tcmp_samp = o_leader.mw_res_->tcmp_samples;
+  Vector<RealType>& t_samp                  = o_leader.mw_res_.getResource().t_samples;
+  Vector<std::complex<RealType>>& tcmp_samp = o_leader.mw_res_.getResource().tcmp_samples;
 
   auto num_species = p_leader.getSpeciesSet().getTotalNum();
   t_samp.resize(num_particles);

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -161,7 +161,7 @@ private:
   {
     MultiWalkerResource() : Resource("BareKineticEnergy") {}
 
-    Resource* makeClone() const override { return new MultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override { return std::make_unique<MultiWalkerResource>(*this); }
 
     Vector<RealType> t_samples;
     Vector<std::complex<RealType>> tcmp_samples;

--- a/src/QMCHamiltonians/BareKineticEnergy.h
+++ b/src/QMCHamiltonians/BareKineticEnergy.h
@@ -157,16 +157,6 @@ public:
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<OperatorBase>& o_list) const override;
 
 private:
-  struct MultiWalkerResource : public Resource
-  {
-    MultiWalkerResource() : Resource("BareKineticEnergy") {}
-
-    std::unique_ptr<Resource> makeClone() const override { return std::make_unique<MultiWalkerResource>(*this); }
-
-    Vector<RealType> t_samples;
-    Vector<std::complex<RealType>> tcmp_samples;
-  };
-
   ///true, if all the species have the same mass
   bool same_mass_;
 
@@ -186,6 +176,7 @@ private:
 
   ParticleSet& ps_;
 
+  struct MultiWalkerResource;
   ResourceHandle<MultiWalkerResource> mw_res_;
 
   TrialWaveFunction& psi_;

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -25,6 +25,24 @@
 
 namespace qmcplusplus
 {
+struct CoulombPBCAA::CoulombPBCAAMultiWalkerResource : public Resource
+{
+  CoulombPBCAAMultiWalkerResource() : Resource("CoulombPBCAA") {}
+
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<CoulombPBCAAMultiWalkerResource>(*this);
+  }
+
+  Vector<CoulombPBCAA::Return_t, OffloadPinnedAllocator<CoulombPBCAA::Return_t>> values_offload;
+
+  /// a walkers worth of per particle coulomb AA potential values
+  Vector<RealType> v_sample;
+
+  /// constant values per particle for coulomb AA potential
+  Vector<RealType> pp_consts;
+};
+
 CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces, bool use_offload)
     : ForceBase(ref, ref),
       is_active(active),

--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -128,8 +128,8 @@ void CoulombPBCAA::updateSource(ParticleSet& s)
   if (ComputeForces)
   {
     forces_ = 0.0;
-    eS     = evalSRwithForces(s);
-    eL     = evalLRwithForces(s);
+    eS      = evalSRwithForces(s);
+    eL      = evalLRwithForces(s);
   }
   else
   {
@@ -236,8 +236,8 @@ void CoulombPBCAA::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
 
   auto num_centers = p_leader.getTotalNum();
   auto name(o_leader.getName());
-  Vector<RealType>& v_sample = o_leader.mw_res_->v_sample;
-  const auto& pp_consts      = o_leader.mw_res_->pp_consts;
+  Vector<RealType>& v_sample = o_leader.mw_res_handle_.getResource().v_sample;
+  const auto& pp_consts      = o_leader.mw_res_handle_.getResource().pp_consts;
   auto num_species           = p_leader.getSpeciesSet().getTotalNum();
   v_sample.resize(num_centers);
   // This lambda is mostly about getting a handle on what is being touched by the per particle evaluation.
@@ -653,7 +653,7 @@ std::vector<CoulombPBCAA::Return_t> CoulombPBCAA::mw_evalSR_offload(const RefVec
   if (chunk_size == 0)
     throw std::runtime_error("bug dtaa_leader.get_num_particls_stored() == 0");
 
-  auto& values_offload        = caa_leader.mw_res_->values_offload;
+  auto& values_offload        = caa_leader.mw_res_handle_.getResource().values_offload;
   const size_t total_num      = p_leader.getTotalNum();
   const size_t total_num_half = (total_num + 1) / 2;
   const size_t num_padded     = getAlignedSize<RealType>(total_num);
@@ -795,18 +795,15 @@ void CoulombPBCAA::createResource(ResourceCollection& collection) const
 void CoulombPBCAA::acquireResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {
-  auto& o_leader = o_list.getCastedLeader<CoulombPBCAA>();
-  auto res_ptr   = dynamic_cast<CoulombPBCAAMultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("CoulombPBCAA::acquireResource dynamic_cast failed");
-  o_leader.mw_res_.reset(res_ptr);
+  auto& o_leader          = o_list.getCastedLeader<CoulombPBCAA>();
+  o_leader.mw_res_handle_ = collection.lendResource<CoulombPBCAAMultiWalkerResource>();
 }
 
 void CoulombPBCAA::releaseResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {
   auto& o_leader = o_list.getCastedLeader<CoulombPBCAA>();
-  collection.takebackResource(std::move(o_leader.mw_res_));
+  collection.takebackResource(o_leader.mw_res_handle_);
 }
 
 std::unique_ptr<OperatorBase> CoulombPBCAA::makeClone(ParticleSet& qp, TrialWaveFunction& psi)

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -201,7 +201,10 @@ private:
   {
     CoulombPBCAAMultiWalkerResource() : Resource("CoulombPBCAA") {}
 
-    Resource* makeClone() const override { return new CoulombPBCAAMultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override
+    {
+      return std::make_unique<CoulombPBCAAMultiWalkerResource>(*this);
+    }
 
     Vector<CoulombPBCAA::Return_t, OffloadPinnedAllocator<CoulombPBCAA::Return_t>> values_offload;
 
@@ -213,7 +216,7 @@ private:
   };
 
   /// multiwalker shared resource
-  ResourceHandle<CoulombPBCAAMultiWalkerResource> mw_res_;
+  ResourceHandle<CoulombPBCAAMultiWalkerResource> mw_res_handle_;
 
   /** constructor code factored out
    */

--- a/src/QMCHamiltonians/CoulombPBCAA.h
+++ b/src/QMCHamiltonians/CoulombPBCAA.h
@@ -197,25 +197,8 @@ private:
   /// Timer for offload part
   NewTimer& offload_timer_;
 
-  struct CoulombPBCAAMultiWalkerResource : public Resource
-  {
-    CoulombPBCAAMultiWalkerResource() : Resource("CoulombPBCAA") {}
-
-    std::unique_ptr<Resource> makeClone() const override
-    {
-      return std::make_unique<CoulombPBCAAMultiWalkerResource>(*this);
-    }
-
-    Vector<CoulombPBCAA::Return_t, OffloadPinnedAllocator<CoulombPBCAA::Return_t>> values_offload;
-
-    /// a walkers worth of per particle coulomb AA potential values
-    Vector<RealType> v_sample;
-
-    /// constant values per particle for coulomb AA potential
-    Vector<RealType> pp_consts;
-  };
-
   /// multiwalker shared resource
+  struct CoulombPBCAAMultiWalkerResource;
   ResourceHandle<CoulombPBCAAMultiWalkerResource> mw_res_handle_;
 
   /** constructor code factored out

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -22,6 +22,24 @@
 
 namespace qmcplusplus
 {
+struct CoulombPBCAB::CoulombPBCABMultiWalkerResource : public Resource
+{
+  CoulombPBCABMultiWalkerResource() : Resource("CoulombPBCAB") {}
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<CoulombPBCABMultiWalkerResource>(*this);
+  }
+
+  /// a walkers worth of per ion AB potential values
+  Vector<RealType> pp_samples_src;
+  /// a walkers worth of per electron AB potential values
+  Vector<RealType> pp_samples_trg;
+  /// constant values for the source particles aka ions aka A
+  Vector<RealType> pp_consts_src;
+  /// constant values for the target particles aka electrons aka B
+  Vector<RealType> pp_consts_trg;
+};
+
 CoulombPBCAB::CoulombPBCAB(ParticleSet& ions, ParticleSet& elns, bool computeForces)
     : ForceBase(ions, elns),
       myTableIndex(elns.addTable(ions)),

--- a/src/QMCHamiltonians/CoulombPBCAB.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAB.cpp
@@ -265,10 +265,11 @@ void CoulombPBCAB::mw_evaluatePerParticle(const RefVectorWithLeader<OperatorBase
 
   auto num_centers            = p_leader.getTotalNum();
   auto& name                  = o_leader.name_;
-  Vector<RealType>& ve_sample = o_leader.mw_res_->pp_samples_trg;
-  Vector<RealType>& vi_sample = o_leader.mw_res_->pp_samples_src;
-  const auto& ve_consts       = o_leader.mw_res_->pp_consts_trg;
-  const auto& vi_consts       = o_leader.mw_res_->pp_consts_src;
+  auto& mw_res                = o_leader.mw_res_handle_.getResource();
+  Vector<RealType>& ve_sample = mw_res.pp_samples_trg;
+  Vector<RealType>& vi_sample = mw_res.pp_samples_src;
+  const auto& ve_consts       = mw_res.pp_consts_trg;
+  const auto& vi_consts       = mw_res.pp_consts_src;
   auto num_species            = p_leader.getSpeciesSet().getTotalNum();
   ve_sample.resize(NptclB);
   vi_sample.resize(NptclA);
@@ -730,18 +731,15 @@ void CoulombPBCAB::createResource(ResourceCollection& collection) const
 void CoulombPBCAB::acquireResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {
-  auto& o_leader = o_list.getCastedLeader<CoulombPBCAB>();
-  auto res_ptr   = dynamic_cast<CoulombPBCABMultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("CoulombPBCAA::acquireResource dynamic_cast failed");
-  o_leader.mw_res_.reset(res_ptr);
+  auto& o_leader          = o_list.getCastedLeader<CoulombPBCAB>();
+  o_leader.mw_res_handle_ = collection.lendResource<CoulombPBCABMultiWalkerResource>();
 }
 
 void CoulombPBCAB::releaseResource(ResourceCollection& collection,
                                    const RefVectorWithLeader<OperatorBase>& o_list) const
 {
   auto& o_leader = o_list.getCastedLeader<CoulombPBCAB>();
-  collection.takebackResource(std::move(o_leader.mw_res_));
+  collection.takebackResource(o_leader.mw_res_handle_);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -232,24 +232,7 @@ private:
   ///source particle set
   ParticleSet& pset_ions_;
 
-  struct CoulombPBCABMultiWalkerResource : public Resource
-  {
-    CoulombPBCABMultiWalkerResource() : Resource("CoulombPBCAB") {}
-    std::unique_ptr<Resource> makeClone() const override
-    {
-      return std::make_unique<CoulombPBCABMultiWalkerResource>(*this);
-    }
-
-    /// a walkers worth of per ion AB potential values
-    Vector<RealType> pp_samples_src;
-    /// a walkers worth of per electron AB potential values
-    Vector<RealType> pp_samples_trg;
-    /// constant values for the source particles aka ions aka A
-    Vector<RealType> pp_consts_src;
-    /// constant values for the target particles aka electrons aka B
-    Vector<RealType> pp_consts_trg;
-  };
-
+  struct CoulombPBCABMultiWalkerResource;
   ResourceHandle<CoulombPBCABMultiWalkerResource> mw_res_handle_;
 
   /** Compute the const part of the per particle coulomb AB potential.

--- a/src/QMCHamiltonians/CoulombPBCAB.h
+++ b/src/QMCHamiltonians/CoulombPBCAB.h
@@ -235,7 +235,10 @@ private:
   struct CoulombPBCABMultiWalkerResource : public Resource
   {
     CoulombPBCABMultiWalkerResource() : Resource("CoulombPBCAB") {}
-    Resource* makeClone() const override { return new CoulombPBCABMultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override
+    {
+      return std::make_unique<CoulombPBCABMultiWalkerResource>(*this);
+    }
 
     /// a walkers worth of per ion AB potential values
     Vector<RealType> pp_samples_src;
@@ -247,7 +250,7 @@ private:
     Vector<RealType> pp_consts_trg;
   };
 
-  ResourceHandle<CoulombPBCABMultiWalkerResource> mw_res_;
+  ResourceHandle<CoulombPBCABMultiWalkerResource> mw_res_handle_;
 
   /** Compute the const part of the per particle coulomb AB potential.
    *  \param[out]  pp_consts_src   constant values for the source particles aka ions aka A   

--- a/src/QMCHamiltonians/NonLocalECPotential.cpp
+++ b/src/QMCHamiltonians/NonLocalECPotential.cpp
@@ -32,7 +32,11 @@ struct NonLocalECPotential::NonLocalECPotentialMultiWalkerResource : public Reso
 {
   NonLocalECPotentialMultiWalkerResource() : Resource("NonLocalECPotential") {}
 
-  Resource* makeClone() const override;
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<NonLocalECPotentialMultiWalkerResource>(*this);
+  }
+
 
   ResourceCollection collection{"NLPPcollection"};
   /// a crowds worth of per particle nonlocal ecp potential values
@@ -336,8 +340,8 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
 
   if (listeners)
   {
-    auto& ve_samples = O_leader.mw_res_->ve_samples;
-    auto& vi_samples = O_leader.mw_res_->vi_samples;
+    auto& ve_samples = O_leader.mw_res_handle_.getResource().ve_samples;
+    auto& vi_samples = O_leader.mw_res_handle_.getResource().vi_samples;
     ve_samples.resize(nw, pset_leader.getTotalNum());
     vi_samples.resize(nw, O_leader.IonConfig.getTotalNum());
   }
@@ -397,7 +401,7 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
       }
 
       NonLocalECPComponent::mw_evaluateOne(ecp_component_list, pset_list, psi_list, batch_list, pairpots,
-                                           O_leader.mw_res_->collection, O_leader.use_DLA);
+                                           O_leader.mw_res_handle_.getResource().collection, O_leader.use_DLA);
 
       // Right now this is just over walker but could and probably should be over a set
       // larger than the walker count.  The easiest way to not complicate the per particle
@@ -410,8 +414,8 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
 
         if (listeners)
         {
-          auto& ve_samples = O_leader.mw_res_->ve_samples;
-          auto& vi_samples = O_leader.mw_res_->vi_samples;
+          auto& ve_samples = O_leader.mw_res_handle_.getResource().ve_samples;
+          auto& vi_samples = O_leader.mw_res_handle_.getResource().vi_samples;
           // CAUTION! This may not be so simple in the future
           int iw = j;
           ve_samples(iw, batch_list[j].get().electron_id) += pairpots[j];
@@ -435,8 +439,8 @@ void NonLocalECPotential::mw_evaluateImpl(const RefVectorWithLeader<OperatorBase
   {
     // Motivation for this repeated definition is to make factoring this listener code out easy
     // and making it ignorable when reading this function.
-    auto& ve_samples  = O_leader.mw_res_->ve_samples;
-    auto& vi_samples  = O_leader.mw_res_->vi_samples;
+    auto& ve_samples  = O_leader.mw_res_handle_.getResource().ve_samples;
+    auto& vi_samples  = O_leader.mw_res_handle_.getResource().vi_samples;
     int num_electrons = pset_leader.getTotalNum();
     for (int iw = 0; iw < nw; ++iw)
     {
@@ -777,18 +781,15 @@ void NonLocalECPotential::createResource(ResourceCollection& collection) const
 void NonLocalECPotential::acquireResource(ResourceCollection& collection,
                                           const RefVectorWithLeader<OperatorBase>& o_list) const
 {
-  auto& O_leader = o_list.getCastedLeader<NonLocalECPotential>();
-  auto res_ptr   = dynamic_cast<NonLocalECPotentialMultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("NonLocalECPotential::acquireResource dynamic_cast failed");
-  O_leader.mw_res_.reset(res_ptr);
+  auto& O_leader          = o_list.getCastedLeader<NonLocalECPotential>();
+  O_leader.mw_res_handle_ = collection.lendResource<NonLocalECPotentialMultiWalkerResource>();
 }
 
 void NonLocalECPotential::releaseResource(ResourceCollection& collection,
                                           const RefVectorWithLeader<OperatorBase>& o_list) const
 {
   auto& O_leader = o_list.getCastedLeader<NonLocalECPotential>();
-  collection.takebackResource(std::move(O_leader.mw_res_));
+  collection.takebackResource(O_leader.mw_res_handle_);
 }
 
 std::unique_ptr<OperatorBase> NonLocalECPotential::makeClone(ParticleSet& qp, TrialWaveFunction& psi)
@@ -873,11 +874,6 @@ void NonLocalECPotential::setParticlePropertyList(QMCTraits::PropertySetType& pl
       }
     }
   }
-}
-
-Resource* NonLocalECPotential::NonLocalECPotentialMultiWalkerResource::makeClone() const
-{
-  return new NonLocalECPotentialMultiWalkerResource(*this);
 }
 
 } // namespace qmcplusplus

--- a/src/QMCHamiltonians/NonLocalECPotential.h
+++ b/src/QMCHamiltonians/NonLocalECPotential.h
@@ -227,7 +227,7 @@ private:
   ///NLPP job list of ion-electron pairs by spin group
   std::vector<std::vector<NLPPJob<Real>>> nlpp_jobs;
   /// mult walker shared resource
-  std::unique_ptr<NonLocalECPotentialMultiWalkerResource> mw_res_;
+  ResourceHandle<NonLocalECPotentialMultiWalkerResource> mw_res_handle_;
 
   /** the actual implementation, used by evaluate and evaluateWithToperator
    * @param P particle set

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -146,10 +146,10 @@ public:
   /** Listener Registration
    *  This must be called on a QMCHamiltonian that has acquired multiwalker resources
    */
-  static void mw_registerKineticListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
-  static void mw_registerLocalEnergyListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
-  static void mw_registerLocalPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
-  static void mw_registerLocalIonPotentialListener(const QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerKineticListener(QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalEnergyListener(QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalPotentialListener(QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
+  static void mw_registerLocalIonPotentialListener(QMCHamiltonian& ham_leader, ListenerVector<RealType> listener);
 
   /** Some Hamiltonian components need to be informed that they are in a per particle reporting
    *  situation so additional state can be added either to them or the objects they are strongly coupled with.
@@ -488,20 +488,9 @@ private:
   Array<TraceReal, 2>* position_sample;
 #endif
 
-  struct QMCHamiltonianMultiWalkerResource : public Resource
-  {
-    QMCHamiltonianMultiWalkerResource() : Resource("QMCHamiltonian") {}
-    // the listeners represet the connection of a particular crowds estimators to the crowds lead QMCHamiltonian.
-    // So you can not clone them.
-    Resource* makeClone() const override { return new QMCHamiltonianMultiWalkerResource(*this); }
-    std::vector<ListenerVector<RealType>> kinetic_listeners_;
-    std::vector<ListenerVector<RealType>> potential_listeners_;
-    std::vector<ListenerVector<RealType>> ion_kinetic_listeners_;
-    std::vector<ListenerVector<RealType>> ion_potential_listeners_;
-  };
-
   /// multiwalker shared resource
-  ResourceHandle<QMCHamiltonianMultiWalkerResource> mw_res_;
+  struct QMCHamiltonianMultiWalkerResource;
+  ResourceHandle<QMCHamiltonianMultiWalkerResource> mw_res_handle_;
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCHamiltonians/SOECPotential.h
+++ b/src/QMCHamiltonians/SOECPotential.h
@@ -105,7 +105,7 @@ private:
   //job list for evaluation
   std::vector<std::vector<NLPPJob<RealType>>> sopp_jobs_;
   //multi walker resource
-  std::unique_ptr<SOECPotentialMultiWalkerResource> mw_res_;
+  ResourceHandle<SOECPotentialMultiWalkerResource> mw_res_handle_;
 
   void evaluateImpl(ParticleSet& elec, bool keep_grid = false);
 

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -195,7 +195,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
 {
   assert(this == &spo_list.getLeader());
   auto& phi_leader            = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-  auto& mw_mem                = *phi_leader.mw_mem_;
+  auto& mw_mem                = phi_leader.mw_mem_handle_.getResource();
   auto& det_ratios_buffer_H2D = mw_mem.det_ratios_buffer_H2D;
   auto& mw_ratios_private     = mw_mem.mw_ratios_private;
   auto& mw_offload_scratch    = mw_mem.mw_offload_scratch;
@@ -518,8 +518,8 @@ void SplineC2COMPTarget<ST>::evaluateVGLMultiPos(const Vector<ST, OffloadPinnedA
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = 0; index < last - first; index++)
         {
-          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, first + index, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                               offload_scratch_iw_ptr + first + index, padded_size);
+          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, first + index, a, b, c, da, db, dc, d2a, d2b,
+                                               d2c, offload_scratch_iw_ptr + first + index, padded_size);
           const int output_index = first + index;
           offload_scratch_iw_ptr[padded_size * SoAFields3D::LAPL + output_index] =
               SymTrace(offload_scratch_iw_ptr[padded_size * SoAFields3D::HESS00 + output_index],
@@ -567,8 +567,8 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
 {
   assert(this == &sa_list.getLeader());
   auto& phi_leader = sa_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-  assert(phi_leader.mw_mem_);
-  auto& mw_mem             = *phi_leader.mw_mem_;
+  assert(phi_leader.mw_mem_handle_);
+  auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;
   auto& mw_results_scratch = mw_mem.mw_results_scratch;
@@ -603,7 +603,7 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
 {
   assert(this == &spo_list.getLeader());
   auto& phi_leader         = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-  auto& mw_mem             = *phi_leader.mw_mem_;
+  auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& buffer_H2D         = mw_mem.buffer_H2D;
   auto& rg_private         = mw_mem.rg_private;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;
@@ -687,8 +687,8 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
         PRAGMA_OFFLOAD("omp parallel for")
         for (int index = 0; index < last - first; index++)
         {
-          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, first + index, a, b, c, da, db, dc, d2a, d2b, d2c,
-                                               offload_scratch_iw_ptr + first + index, padded_size);
+          spline2offload::evaluate_vgh_impl_v2(spline_ptr, ix, iy, iz, first + index, a, b, c, da, db, dc, d2a, d2b,
+                                               d2c, offload_scratch_iw_ptr + first + index, padded_size);
           const int output_index = first + index;
           offload_scratch_iw_ptr[padded_size * SoAFields3D::LAPL + output_index] =
               SymTrace(offload_scratch_iw_ptr[padded_size * SoAFields3D::HESS00 + output_index],

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.cpp
@@ -567,7 +567,6 @@ void SplineC2COMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
 {
   assert(this == &sa_list.getLeader());
   auto& phi_leader = sa_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-  assert(phi_leader.mw_mem_handle_);
   auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2COMPTarget.h
@@ -78,7 +78,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, ComplexT>> mw_mem_;
+  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, ComplexT>> mw_mem_handle_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<ComplexT, OffloadPinnedAllocator<ComplexT>> ratios_private;
@@ -129,18 +129,15 @@ public:
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
     assert(this == &spo_list.getLeader());
-    auto& phi_leader = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-    auto res_ptr     = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, ComplexT>*>(collection.lendResource().release());
-    if (!res_ptr)
-      throw std::runtime_error("SplineC2COMPTarget::acquireResource dynamic_cast failed");
-    phi_leader.mw_mem_.reset(res_ptr);
+    auto& phi_leader          = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
+    phi_leader.mw_mem_handle_ = collection.lendResource<SplineOMPTargetMultiWalkerMem<ST, ComplexT>>();
   }
 
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
     assert(this == &spo_list.getLeader());
     auto& phi_leader = spo_list.getCastedLeader<SplineC2COMPTarget<ST>>();
-    collection.takebackResource(std::move(phi_leader.mw_mem_));
+    collection.takebackResource(phi_leader.mw_mem_handle_);
   }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2COMPTarget>(*this); }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -708,7 +708,6 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
 {
   assert(this == &sa_list.getLeader());
   auto& phi_leader = sa_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-  assert(phi_leader.mw_mem_handle_);
   auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.cpp
@@ -270,7 +270,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateDetRatios(const RefVectorWithLeader<SPOS
 {
   assert(this == &spo_list.getLeader());
   auto& phi_leader                = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-  auto& mw_mem                    = *phi_leader.mw_mem_;
+  auto& mw_mem                    = phi_leader.mw_mem_handle_.getResource();
   auto& det_ratios_buffer_H2D     = mw_mem.det_ratios_buffer_H2D;
   auto& mw_ratios_private         = mw_mem.mw_ratios_private;
   auto& mw_offload_scratch        = mw_mem.mw_offload_scratch;
@@ -708,8 +708,8 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGL(const RefVectorWithLeader<SPOSet>& s
 {
   assert(this == &sa_list.getLeader());
   auto& phi_leader = sa_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-  assert(phi_leader.mw_mem_);
-  auto& mw_mem             = *phi_leader.mw_mem_;
+  assert(phi_leader.mw_mem_handle_);
+  auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& mw_pos_copy        = mw_mem.mw_pos_copy;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;
   auto& mw_results_scratch = mw_mem.mw_results_scratch;
@@ -744,7 +744,7 @@ void SplineC2ROMPTarget<ST>::mw_evaluateVGLandDetRatioGrads(const RefVectorWithL
 {
   assert(this == &spo_list.getLeader());
   auto& phi_leader         = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-  auto& mw_mem             = *phi_leader.mw_mem_;
+  auto& mw_mem             = phi_leader.mw_mem_handle_.getResource();
   auto& buffer_H2D         = mw_mem.buffer_H2D;
   auto& rg_private         = mw_mem.rg_private;
   auto& mw_offload_scratch = mw_mem.mw_offload_scratch;

--- a/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineC2ROMPTarget.h
@@ -82,7 +82,7 @@ private:
   std::shared_ptr<OffloadVector<ST>> GGt_offload;
   std::shared_ptr<OffloadVector<ST>> PrimLattice_G_offload;
 
-  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, TT>> mw_mem_;
+  ResourceHandle<SplineOMPTargetMultiWalkerMem<ST, TT>> mw_mem_handle_;
 
   ///team private ratios for reduction, numVP x numTeams
   Matrix<TT, OffloadPinnedAllocator<TT>> ratios_private;
@@ -134,18 +134,15 @@ public:
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
     assert(this == &spo_list.getLeader());
-    auto& phi_leader = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-    auto res_ptr     = dynamic_cast<SplineOMPTargetMultiWalkerMem<ST, TT>*>(collection.lendResource().release());
-    if (!res_ptr)
-      throw std::runtime_error("SplineC2ROMPTarget::acquireResource dynamic_cast failed");
-    phi_leader.mw_mem_.reset(res_ptr);
+    auto& phi_leader          = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
+    phi_leader.mw_mem_handle_ = collection.lendResource<SplineOMPTargetMultiWalkerMem<ST, TT>>();
   }
 
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override
   {
     assert(this == &spo_list.getLeader());
     auto& phi_leader = spo_list.getCastedLeader<SplineC2ROMPTarget<ST>>();
-    collection.takebackResource(std::move(phi_leader.mw_mem_));
+    collection.takebackResource(phi_leader.mw_mem_handle_);
   }
 
   std::unique_ptr<SPOSet> makeClone() const override { return std::make_unique<SplineC2ROMPTarget>(*this); }

--- a/src/QMCWaveFunctions/BsplineFactory/SplineOMPTargetMultiWalkerMem.h
+++ b/src/QMCWaveFunctions/BsplineFactory/SplineOMPTargetMultiWalkerMem.h
@@ -41,7 +41,10 @@ struct SplineOMPTargetMultiWalkerMem : public Resource
 
   SplineOMPTargetMultiWalkerMem(const SplineOMPTargetMultiWalkerMem&) : SplineOMPTargetMultiWalkerMem() {}
 
-  Resource* makeClone() const override { return new SplineOMPTargetMultiWalkerMem(*this); }
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<SplineOMPTargetMultiWalkerMem>(*this);
+  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.cpp
@@ -25,6 +25,31 @@
 
 namespace qmcplusplus
 {
+template<typename DET_ENGINE>
+struct DiracDeterminantBatched<DET_ENGINE>::DiracDeterminantBatchedMultiWalkerResource : public Resource
+{
+  DiracDeterminantBatchedMultiWalkerResource() : Resource("DiracDeterminantBatched") {}
+  DiracDeterminantBatchedMultiWalkerResource(const DiracDeterminantBatchedMultiWalkerResource&)
+      : DiracDeterminantBatchedMultiWalkerResource()
+  {}
+
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<DiracDeterminantBatchedMultiWalkerResource>(*this);
+  }
+  DualVector<LogValue> log_values;
+  /// value, grads, laplacian of single-particle orbital for particle-by-particle update and multi walker [5][nw][norb]
+  OffloadMWVGLArray phi_vgl_v;
+  // multi walker of ratio
+  std::vector<Value> ratios_local;
+  // multi walker of grads
+  std::vector<Grad> grad_new_local;
+  // multi walker of spingrads
+  std::vector<Value> spingrad_new_local;
+  // mw spin gradients of orbitals, matrix is [nw][norb]
+  OffloadMatrix<ComplexType> mw_dspin;
+};
+
 /** constructor
  *@param spos the single-particle orbital set
  *@param first index of the first particle

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -59,30 +59,6 @@ public:
 
   using OffloadMWVGLArray = typename SPOSet::OffloadMWVGLArray;
 
-  struct DiracDeterminantBatchedMultiWalkerResource : public Resource
-  {
-    DiracDeterminantBatchedMultiWalkerResource() : Resource("DiracDeterminantBatched") {}
-    DiracDeterminantBatchedMultiWalkerResource(const DiracDeterminantBatchedMultiWalkerResource&)
-        : DiracDeterminantBatchedMultiWalkerResource()
-    {}
-
-    std::unique_ptr<Resource> makeClone() const override
-    {
-      return std::make_unique<DiracDeterminantBatchedMultiWalkerResource>(*this);
-    }
-    DualVector<LogValue> log_values;
-    /// value, grads, laplacian of single-particle orbital for particle-by-particle update and multi walker [5][nw][norb]
-    OffloadMWVGLArray phi_vgl_v;
-    // multi walker of ratio
-    std::vector<Value> ratios_local;
-    // multi walker of grads
-    std::vector<Grad> grad_new_local;
-    // multi walker of spingrads
-    std::vector<Value> spingrad_new_local;
-    // mw spin gradients of orbitals, matrix is [nw][norb]
-    OffloadMatrix<ComplexType> mw_dspin;
-  };
-
   /** constructor
    *@param spos the single-particle orbital set
    *@param first index of the first particle
@@ -307,6 +283,7 @@ public:
   PsiValue curRatio;
   /**@}*/
 
+  struct DiracDeterminantBatchedMultiWalkerResource;
   ResourceHandle<DiracDeterminantBatchedMultiWalkerResource> mw_res_handle_;
 
 private:

--- a/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
+++ b/src/QMCWaveFunctions/Fermion/DiracDeterminantBatched.h
@@ -52,7 +52,7 @@ public:
   template<typename DT>
   using DualVector = Vector<DT, PinnedDualAllocator<DT>>;
   template<typename DT>
-  using DualMatrix    = Matrix<DT, PinnedDualAllocator<DT>>;
+  using DualMatrix = Matrix<DT, PinnedDualAllocator<DT>>;
   template<typename DT>
   using OffloadMatrix = Matrix<DT, OffloadPinnedAllocator<DT>>;
   using DualVGLVector = VectorSoaContainer<Value, DIM + 2, PinnedDualAllocator<Value>>;
@@ -66,7 +66,10 @@ public:
         : DiracDeterminantBatchedMultiWalkerResource()
     {}
 
-    Resource* makeClone() const override { return new DiracDeterminantBatchedMultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override
+    {
+      return std::make_unique<DiracDeterminantBatchedMultiWalkerResource>(*this);
+    }
     DualVector<LogValue> log_values;
     /// value, grads, laplacian of single-particle orbital for particle-by-particle update and multi walker [5][nw][norb]
     OffloadMWVGLArray phi_vgl_v;
@@ -103,9 +106,7 @@ public:
                            Vector<Value>& dlogpsi,
                            Vector<Value>& dhpsioverpsi) override;
 
-  void evaluateDerivativesWF(ParticleSet& P,
-                             const opt_variables_type& optvars,
-                             Vector<ValueType>& dlogpsi) override;
+  void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, Vector<ValueType>& dlogpsi) override;
 
   void registerData(ParticleSet& P, WFBufferType& buf) override;
 
@@ -306,7 +307,7 @@ public:
   PsiValue curRatio;
   /**@}*/
 
-  std::unique_ptr<DiracDeterminantBatchedMultiWalkerResource> mw_res_;
+  ResourceHandle<DiracDeterminantBatchedMultiWalkerResource> mw_res_handle_;
 
 private:
   ///reset the size: with the number of particles and number of orbtials
@@ -319,7 +320,7 @@ private:
   DiracMatrix<FullPrecValue> host_inverter_;
 
   /// matrix inversion engine this a crowd scope resource and only the leader engine gets it
-  std::unique_ptr<typename DET_ENGINE::DetInverter> accel_inverter_;
+  ResourceHandle<typename DET_ENGINE::DetInverter> accel_inverter_;
 
   /// compute G and L assuming psiMinv, dpsiM, d2psiM are ready for use
   void computeGL(ParticleSet::ParticleGradient& G, ParticleSet::ParticleLaplacian& L) const;
@@ -341,19 +342,6 @@ private:
   static void mw_invertPsiM(const RefVectorWithLeader<WaveFunctionComponent>& wfc_list,
                             const RefVector<const DualMatrix<Value>>& logdetT_list,
                             const RefVector<DualMatrix<Value>>& a_inv_lis);
-
-  // make this class unit tests friendly without the need of setup resources.
-  void guardMultiWalkerRes()
-  {
-    if (!mw_res_)
-    {
-      std::cerr
-          << "WARNING DiracDeterminantBatched : This message should not be seen in production (performance bug) runs "
-             "but only unit tests (expected)."
-          << std::endl;
-      mw_res_ = std::make_unique<DiracDeterminantBatchedMultiWalkerResource>();
-    }
-  }
 
   /// Resize all temporary arrays required for force computation.
   void resizeScratchObjectsForIonDerivs();

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeCUDA.hpp
@@ -215,7 +215,7 @@ public:
 
   DiracMatrixComputeCUDA(const DiracMatrixComputeCUDA& other) : Resource(other.getName()) {}
 
-  Resource* makeClone() const override { return new DiracMatrixComputeCUDA(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<DiracMatrixComputeCUDA>(*this); }
 
   /** Given a_mat returns inverted amit and log determinant of a_matches.
    *  \param [in] a_mat a matrix input

--- a/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
+++ b/src/QMCWaveFunctions/Fermion/DiracMatrixComputeOMPTarget.hpp
@@ -161,7 +161,7 @@ private:
 public:
   DiracMatrixComputeOMPTarget() : Resource("DiracMatrixComputeOMPTarget"), lwork_(0) {}
 
-  Resource* makeClone() const override { return new DiracMatrixComputeOMPTarget(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<DiracMatrixComputeOMPTarget>(*this); }
 
   /** compute the inverse of the transpose of matrix A and its determinant value in log
    * when VALUE_FP and TMAT are the same

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.2.cpp
@@ -408,20 +408,21 @@ void MultiDiracDeterminant::mw_evaluateDetsForPtclMove(const RefVectorWithLeader
   const auto NumOrbitals  = det_leader.NumOrbitals;
   const auto& confgList   = *det_leader.ciConfigList;
 
-  auto* psiV_list_devptr   = det_leader.mw_res_->psiV_deviceptr_list.device_data();
-  auto* psiV_temp_list_ptr = det_leader.mw_res_->psiV_temp_deviceptr_list.data();
+  auto& mw_res             = det_leader.mw_res_handle_.getResource();
+  auto* psiV_list_devptr   = mw_res.psiV_deviceptr_list.device_data();
+  auto* psiV_temp_list_ptr = mw_res.psiV_temp_deviceptr_list.data();
 
-  auto* psiMinv_list_devptr      = det_leader.mw_res_->psiMinv_deviceptr_list.device_data();
-  auto* psiMinv_temp_list_devptr = det_leader.mw_res_->psiMinv_temp_deviceptr_list.device_data();
+  auto* psiMinv_list_devptr      = mw_res.psiMinv_deviceptr_list.device_data();
+  auto* psiMinv_temp_list_devptr = mw_res.psiMinv_temp_deviceptr_list.device_data();
 
-  auto* TpsiM_list_devptr = det_leader.mw_res_->TpsiM_deviceptr_list.device_data();
-  auto* psiM_list_ptr     = det_leader.mw_res_->psiM_deviceptr_list.data();
+  auto* TpsiM_list_devptr = mw_res.TpsiM_deviceptr_list.device_data();
+  auto* psiM_list_ptr     = mw_res.psiM_deviceptr_list.data();
 
-  auto& curRatio_list = det_leader.mw_res_->curRatio_list;
+  auto& curRatio_list = mw_res.curRatio_list;
   curRatio_list.resize(nw);
   auto* curRatio_list_ptr = curRatio_list.data();
 
-  auto& inv_curRatio_list = det_leader.mw_res_->inv_curRatio_list;
+  auto& inv_curRatio_list = mw_res.inv_curRatio_list;
   inv_curRatio_list.resize(nw);
   auto* inv_curRatio_list_ptr = inv_curRatio_list.data();
 
@@ -455,9 +456,9 @@ void MultiDiracDeterminant::mw_evaluateDetsForPtclMove(const RefVectorWithLeader
       inv_curRatio_list_ptr[iw] = ValueType(1) / c_ratio;
     }
 
-    det_leader.mw_InverseUpdateByColumn(*det_leader.mw_res_, WorkingIndex, inv_curRatio_list,
-                                        det_leader.mw_res_->psiV_temp_deviceptr_list,
-                                        det_leader.mw_res_->psiMinv_temp_deviceptr_list, psiMinv_rows);
+    det_leader.mw_InverseUpdateByColumn(det_leader.mw_res_handle_, WorkingIndex, inv_curRatio_list,
+                                        mw_res.psiV_temp_deviceptr_list, mw_res.psiMinv_temp_deviceptr_list,
+                                        psiMinv_rows);
     ///This is needed by acceptMove. Eventually acceptMove will need to become mw_acceptMove.
     {
       ScopedTimer local_timer(det_leader.transferD2H_timer);
@@ -465,9 +466,9 @@ void MultiDiracDeterminant::mw_evaluateDetsForPtclMove(const RefVectorWithLeader
         psiMinv_temp_list[iw].get().updateFrom();
     }
 
-    auto& det0_list = det_leader.mw_res_->cone_vec;
-    det_leader.mw_buildTableMatrix_calculateRatios(*det_leader.mw_res_, det_leader.ReferenceDeterminant, det0_list,
-                                                   psiMinv_temp_list, TpsiM_list, *det_leader.detData,
+    auto& det0_list = mw_res.cone_vec;
+    det_leader.mw_buildTableMatrix_calculateRatios(det_leader.mw_res_handle_, det_leader.ReferenceDeterminant,
+                                                   det0_list, psiMinv_temp_list, TpsiM_list, *det_leader.detData,
                                                    *det_leader.uniquePairs, *det_leader.DetSigns, table_matrix_list,
                                                    new_ratios_to_ref_list);
 
@@ -696,8 +697,9 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
   dpsiMinv_list.reserve(nw);
   WorkSpace_list.reserve(nw);
 
-  auto& ratioGradRef_list = det_leader.mw_res_->ratioGradRef_list;
-  auto& det0_grad_list    = det_leader.mw_res_->det0_grad_list;
+  auto& mw_res            = det_leader.mw_res_handle_.getResource();
+  auto& ratioGradRef_list = mw_res.ratioGradRef_list;
+  auto& det0_grad_list    = mw_res.det0_grad_list;
   ratioGradRef_list.resize(nw);
   det0_grad_list.resize(nw);
 
@@ -747,26 +749,26 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
   const auto psiM_num_cols  = psiM_list[0].get().cols();
   const auto& confgList     = *det_leader.ciConfigList;
 
-  auto* psiV_list_devptr         = det_leader.mw_res_->psiV_deviceptr_list.device_data();
-  auto* psiV_temp_list_ptr       = det_leader.mw_res_->psiV_temp_deviceptr_list.data();
-  auto* TpsiM_list_devptr        = det_leader.mw_res_->TpsiM_deviceptr_list.device_data();
-  auto* psiM_list_ptr            = det_leader.mw_res_->psiM_deviceptr_list.data();
-  auto* psiMinv_list_devptr      = det_leader.mw_res_->psiMinv_deviceptr_list.device_data();
-  auto* dpsiMinv_list_devptr     = det_leader.mw_res_->dpsiMinv_deviceptr_list.device_data();
-  auto* psiMinv_temp_list_devptr = det_leader.mw_res_->psiMinv_temp_deviceptr_list.device_data();
+  auto* psiV_list_devptr         = mw_res.psiV_deviceptr_list.device_data();
+  auto* psiV_temp_list_ptr       = mw_res.psiV_temp_deviceptr_list.data();
+  auto* TpsiM_list_devptr        = mw_res.TpsiM_deviceptr_list.device_data();
+  auto* psiM_list_ptr            = mw_res.psiM_deviceptr_list.data();
+  auto* psiMinv_list_devptr      = mw_res.psiMinv_deviceptr_list.device_data();
+  auto* dpsiMinv_list_devptr     = mw_res.dpsiMinv_deviceptr_list.device_data();
+  auto* psiMinv_temp_list_devptr = mw_res.psiMinv_temp_deviceptr_list.device_data();
 
-  auto& curRatio_list = det_leader.mw_res_->curRatio_list;
+  auto& curRatio_list = mw_res.curRatio_list;
   curRatio_list.resize(nw);
   auto* curRatio_list_ptr = curRatio_list.data();
 
-  auto& inv_curRatio_list = det_leader.mw_res_->inv_curRatio_list;
+  auto& inv_curRatio_list = mw_res.inv_curRatio_list;
   inv_curRatio_list.resize(nw);
   auto* inv_curRatio_list_ptr = inv_curRatio_list.data();
 
   auto* det0_grad_list_ptr = det0_grad_list.data();
   auto* confgListOccup_ptr = det_leader.refdet_occup->data();
 
-  auto* dpsiV_list_ptr        = det_leader.mw_res_->dpsiV_deviceptr_list.data();
+  auto* dpsiV_list_ptr        = mw_res.dpsiV_deviceptr_list.data();
   auto* ratioGradRef_list_ptr = ratioGradRef_list.data();
 
   {
@@ -807,9 +809,9 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
       throw std::runtime_error("In MultiDiracDeterminant ompBLAS::copy_batched_offset failed.");
 
 
-    det_leader.mw_InverseUpdateByColumn(*det_leader.mw_res_, WorkingIndex, inv_curRatio_list,
-                                        det_leader.mw_res_->psiV_temp_deviceptr_list,
-                                        det_leader.mw_res_->psiMinv_temp_deviceptr_list, psiMinv_rows);
+    det_leader.mw_InverseUpdateByColumn(det_leader.mw_res_handle_, WorkingIndex, inv_curRatio_list,
+                                        mw_res.psiV_temp_deviceptr_list, mw_res.psiMinv_temp_deviceptr_list,
+                                        psiMinv_rows);
 
     ///This is needed by Host in acceptMove. Eventually acceptMove will need to become mw_acceptMove.
     {
@@ -818,9 +820,9 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
         psiMinv_temp_list[iw].get().updateFrom();
     }
 
-    auto& det0_list = det_leader.mw_res_->cone_vec;
-    det_leader.mw_buildTableMatrix_calculateRatios(*det_leader.mw_res_, det_leader.ReferenceDeterminant, det0_list,
-                                                   psiMinv_temp_list, TpsiM_list, *det_leader.detData,
+    auto& det0_list = mw_res.cone_vec;
+    det_leader.mw_buildTableMatrix_calculateRatios(det_leader.mw_res_handle_, det_leader.ReferenceDeterminant,
+                                                   det0_list, psiMinv_temp_list, TpsiM_list, *det_leader.detData,
                                                    *det_leader.uniquePairs, *det_leader.DetSigns, table_matrix_list,
                                                    new_ratios_to_ref_list);
 
@@ -843,9 +845,9 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
         }
       }
 
-      det_leader.mw_InverseUpdateByColumn(*det_leader.mw_res_, WorkingIndex, inv_curRatio_list,
-                                          det_leader.mw_res_->psiV_temp_deviceptr_list,
-                                          det_leader.mw_res_->dpsiMinv_deviceptr_list, psiMinv_rows);
+      det_leader.mw_InverseUpdateByColumn(det_leader.mw_res_handle_, WorkingIndex, inv_curRatio_list,
+                                          mw_res.psiV_temp_deviceptr_list, mw_res.dpsiMinv_deviceptr_list,
+                                          psiMinv_rows);
 
       PRAGMA_OFFLOAD("omp target teams distribute map(to:dpsiV_list_ptr[:nw], curRatio_list_ptr[:nw]) \
 		                       map(always,from:det0_grad_list_ptr[:nw]) \
@@ -857,7 +859,7 @@ void MultiDiracDeterminant::mw_evaluateDetsAndGradsForPtclMove(
           TpsiM_list_devptr[iw][i * TpsiM_num_cols + WorkingIndex] = dpsiV_list_ptr[iw][i][idim];
       }
 
-      det_leader.mw_buildTableMatrix_calculateGradRatios(*det_leader.mw_res_, det_leader.ReferenceDeterminant,
+      det_leader.mw_buildTableMatrix_calculateGradRatios(det_leader.mw_res_handle_, det_leader.ReferenceDeterminant,
                                                          WorkingIndex, idim, det_leader.getNumDets(), det0_grad_list,
                                                          dpsiMinv_list, TpsiM_list, *det_leader.detData,
                                                          *det_leader.uniquePairs, *det_leader.DetSigns, WorkSpace_list,
@@ -1008,20 +1010,21 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
   const auto dpsiM_rows   = dpsiM_list[0].get().rows();
   const auto& confgList   = *det_leader.ciConfigList;
 
-  auto& ratioG_list = det_leader.mw_res_->curRatio_list;
+  auto& mw_res      = det_leader.mw_res_handle_.getResource();
+  auto& ratioG_list = mw_res.curRatio_list;
   ratioG_list.resize(nw);
   auto* ratioG_list_ptr = ratioG_list.data();
 
-  auto& inv_ratioG_list = det_leader.mw_res_->inv_curRatio_list;
+  auto& inv_ratioG_list = mw_res.inv_curRatio_list;
   inv_ratioG_list.resize(nw);
   auto* inv_ratioG_list_ptr = inv_ratioG_list.data();
 
-  auto* psiMinv_list_devptr  = det_leader.mw_res_->psiMinv_deviceptr_list.device_data();
-  auto* dpsiMinv_list_devptr = det_leader.mw_res_->dpsiMinv_deviceptr_list.device_data();
-  auto* TpsiM_list_devptr    = det_leader.mw_res_->TpsiM_deviceptr_list.data();
-  auto* psiM_list_ptr        = det_leader.mw_res_->psiM_deviceptr_list.data();
-  auto* psiV_temp_list_ptr   = det_leader.mw_res_->psiV_temp_deviceptr_list.data();
-  auto* dpsiM_list_ptr       = det_leader.mw_res_->dpsiM_deviceptr_list.data();
+  auto* psiMinv_list_devptr  = mw_res.psiMinv_deviceptr_list.device_data();
+  auto* dpsiMinv_list_devptr = mw_res.dpsiMinv_deviceptr_list.device_data();
+  auto* TpsiM_list_devptr    = mw_res.TpsiM_deviceptr_list.data();
+  auto* psiM_list_ptr        = mw_res.psiM_deviceptr_list.data();
+  auto* psiV_temp_list_ptr   = mw_res.psiV_temp_deviceptr_list.data();
+  auto* dpsiM_list_ptr       = mw_res.dpsiM_deviceptr_list.data();
   auto* confgListOccup_ptr   = det_leader.refdet_occup->data();
 
   {
@@ -1057,9 +1060,9 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
         inv_ratioG_list_ptr[iw] = ValueType(1) / ratioG_local;
       }
 
-      det_leader.mw_InverseUpdateByColumn(*det_leader.mw_res_, WorkingIndex, inv_ratioG_list,
-                                          det_leader.mw_res_->psiV_temp_deviceptr_list,
-                                          det_leader.mw_res_->dpsiMinv_deviceptr_list, psiMinv_rows);
+      det_leader.mw_InverseUpdateByColumn(det_leader.mw_res_handle_, WorkingIndex, inv_ratioG_list,
+                                          mw_res.psiV_temp_deviceptr_list, mw_res.dpsiMinv_deviceptr_list,
+                                          psiMinv_rows);
 
       PRAGMA_OFFLOAD("omp target teams distribute parallel for collapse(2) map(to:dpsiM_list_ptr[:nw]) \
 		                                              map(always, to: TpsiM_list_devptr[:nw])")
@@ -1069,7 +1072,7 @@ void MultiDiracDeterminant::mw_evaluateGrads(const RefVectorWithLeader<MultiDira
               dpsiM_list_ptr[iw][dpsiM_cols * WorkingIndex + i][idim];
 
 
-      det_leader.mw_buildTableMatrix_calculateGradRatios(*det_leader.mw_res_, det_leader.ReferenceDeterminant,
+      det_leader.mw_buildTableMatrix_calculateGradRatios(det_leader.mw_res_handle_, det_leader.ReferenceDeterminant,
                                                          WorkingIndex, idim, det_leader.getNumDets(), ratioG_list,
                                                          dpsiMinv_list, TpsiM_list, *det_leader.detData,
                                                          *det_leader.uniquePairs, *det_leader.DetSigns, WorkSpace_list,

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.cpp
@@ -650,27 +650,25 @@ void MultiDiracDeterminant::createResource(ResourceCollection& collection) const
 void MultiDiracDeterminant::acquireResource(ResourceCollection& collection,
                                             const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list) const
 {
-  auto& wfc_leader = wfc_list.getCastedLeader<MultiDiracDeterminant>();
-  auto res_ptr     = dynamic_cast<MultiDiracDetMultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("MultiDiracDeterminant::acquireResource dynamic_cast failed");
-  wfc_leader.mw_res_.reset(res_ptr);
+  auto& wfc_leader          = wfc_list.getCastedLeader<MultiDiracDeterminant>();
+  wfc_leader.mw_res_handle_ = collection.lendResource<MultiDiracDetMultiWalkerResource>();
+  auto& mw_res              = wfc_leader.mw_res_handle_.getResource();
 
   const size_t nw = wfc_list.size();
-  wfc_leader.mw_res_->resizeConstants(nw);
+  mw_res.resizeConstants(nw);
 
-  auto& psiV_temp_deviceptr_list    = wfc_leader.mw_res_->psiV_temp_deviceptr_list;
-  auto& psiMinv_temp_deviceptr_list = wfc_leader.mw_res_->psiMinv_temp_deviceptr_list;
-  auto& dpsiMinv_deviceptr_list     = wfc_leader.mw_res_->dpsiMinv_deviceptr_list;
-  auto& workV1_deviceptr_list       = wfc_leader.mw_res_->workV1_deviceptr_list;
-  auto& workV2_deviceptr_list       = wfc_leader.mw_res_->workV2_deviceptr_list;
+  auto& psiV_temp_deviceptr_list    = mw_res.psiV_temp_deviceptr_list;
+  auto& psiMinv_temp_deviceptr_list = mw_res.psiMinv_temp_deviceptr_list;
+  auto& dpsiMinv_deviceptr_list     = mw_res.dpsiMinv_deviceptr_list;
+  auto& workV1_deviceptr_list       = mw_res.workV1_deviceptr_list;
+  auto& workV2_deviceptr_list       = mw_res.workV2_deviceptr_list;
 
-  auto& psiV_deviceptr_list    = wfc_leader.mw_res_->psiV_deviceptr_list;
-  auto& dpsiV_deviceptr_list   = wfc_leader.mw_res_->dpsiV_deviceptr_list;
-  auto& TpsiM_deviceptr_list   = wfc_leader.mw_res_->TpsiM_deviceptr_list;
-  auto& psiM_deviceptr_list    = wfc_leader.mw_res_->psiM_deviceptr_list;
-  auto& psiMinv_deviceptr_list = wfc_leader.mw_res_->psiMinv_deviceptr_list;
-  auto& dpsiM_deviceptr_list   = wfc_leader.mw_res_->dpsiM_deviceptr_list;
+  auto& psiV_deviceptr_list    = mw_res.psiV_deviceptr_list;
+  auto& dpsiV_deviceptr_list   = mw_res.dpsiV_deviceptr_list;
+  auto& TpsiM_deviceptr_list   = mw_res.TpsiM_deviceptr_list;
+  auto& psiM_deviceptr_list    = mw_res.psiM_deviceptr_list;
+  auto& psiMinv_deviceptr_list = mw_res.psiMinv_deviceptr_list;
+  auto& dpsiM_deviceptr_list   = mw_res.dpsiM_deviceptr_list;
 
   psiV_temp_deviceptr_list.resize(nw);
   psiMinv_temp_deviceptr_list.resize(nw);
@@ -720,7 +718,7 @@ void MultiDiracDeterminant::releaseResource(ResourceCollection& collection,
                                             const RefVectorWithLeader<MultiDiracDeterminant>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<MultiDiracDeterminant>();
-  collection.takebackResource(std::move(wfc_leader.mw_res_));
+  collection.takebackResource(wfc_leader.mw_res_handle_);
 }
 
 ///reset the size: with the number of particles and number of orbtials

--- a/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
+++ b/src/QMCWaveFunctions/Fermion/MultiDiracDeterminant.h
@@ -59,7 +59,10 @@ public:
     MultiDiracDetMultiWalkerResource() : Resource("MultiDiracDeterminant") {}
     MultiDiracDetMultiWalkerResource(const MultiDiracDetMultiWalkerResource&) : MultiDiracDetMultiWalkerResource() {}
 
-    Resource* makeClone() const override { return new MultiDiracDetMultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override
+    {
+      return std::make_unique<MultiDiracDetMultiWalkerResource>(*this);
+    }
 
     void resizeConstants(size_t nw)
     {
@@ -597,7 +600,7 @@ private:
   /// for matrices with leading dimensions <= MaxSmallDet, compute determinant with direct expansion.
   static constexpr size_t MaxSmallDet = 5;
 
-  std::unique_ptr<MultiDiracDetMultiWalkerResource> mw_res_;
+  ResourceHandle<MultiDiracDetMultiWalkerResource> mw_res_handle_;
 };
 
 

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -233,14 +233,15 @@ void MultiSlaterDetTableMethod::mw_evalGrad_impl(const RefVectorWithLeader<WaveF
     det_list.push_back(*det.Dets[det_id]);
   }
 
-  auto& mw_grads = det_leader.mw_res_->mw_grads;
+  auto& mw_res   = det_leader.mw_res_handle_.getResource();
+  auto& mw_grads = mw_res.mw_grads;
   mw_grads.resize(3 * nw, ndets);
   if (newpos)
     det_leader.Dets[det_id]->mw_evaluateDetsAndGradsForPtclMove(det_list, P_list, iat, mw_grads);
   else
     det_leader.Dets[det_id]->mw_evaluateGrads(det_list, P_list, iat, mw_grads);
 
-  auto& det_value_ptr_list = det_leader.mw_res_->det_value_ptr_list;
+  auto& det_value_ptr_list = mw_res.det_value_ptr_list;
   det_value_ptr_list.resize(nw);
   for (size_t iw = 0; iw < nw; iw++)
   {
@@ -253,7 +254,7 @@ void MultiSlaterDetTableMethod::mw_evalGrad_impl(const RefVectorWithLeader<WaveF
   auto* grad_now_list_ptr      = grad_now_list.data();
   auto* mw_grads_ptr           = mw_grads.data();
   auto* psi_list_ptr           = psi_list.data();
-  auto* C_otherDs_ptr_list_ptr = det_leader.mw_res_->C_otherDs_ptr_list.data();
+  auto* C_otherDs_ptr_list_ptr = mw_res.C_otherDs_ptr_list.data();
   auto* det_value_ptr_list_ptr = det_value_ptr_list.data();
   {
     ScopedTimer local_timer(det_leader.offload_timer);
@@ -561,7 +562,8 @@ void MultiSlaterDetTableMethod::mw_calcRatio(const RefVectorWithLeader<WaveFunct
 
   det_leader.Dets[det_id]->mw_evaluateDetsForPtclMove(det_list, P_list, iat);
 
-  auto& det_value_ptr_list = det_leader.mw_res_->det_value_ptr_list;
+  auto& mw_res             = det_leader.mw_res_handle_.getResource();
+  auto& det_value_ptr_list = mw_res.det_value_ptr_list;
   det_value_ptr_list.resize(nw);
   for (size_t iw = 0; iw < nw; iw++)
   {
@@ -573,7 +575,7 @@ void MultiSlaterDetTableMethod::mw_calcRatio(const RefVectorWithLeader<WaveFunct
 
   std::vector<PsiValueType> psi_list(nw, 0);
   auto* psi_list_ptr           = psi_list.data();
-  auto* C_otherDs_ptr_list_ptr = det_leader.mw_res_->C_otherDs_ptr_list.data();
+  auto* C_otherDs_ptr_list_ptr = mw_res.C_otherDs_ptr_list.data();
   auto* det_value_ptr_list_ptr = det_value_ptr_list.data();
   {
     ScopedTimer local_timer(det_leader.offload_timer);
@@ -1121,7 +1123,7 @@ void MultiSlaterDetTableMethod::mw_prepareGroup(const RefVectorWithLeader<WaveFu
   const size_t nw  = wfc_list.size();
   assert(this == &det_leader);
 
-  auto& C_otherDs_ptr_list = det_leader.mw_res_->C_otherDs_ptr_list;
+  auto& C_otherDs_ptr_list = det_leader.mw_res_handle_.getResource().C_otherDs_ptr_list;
   C_otherDs_ptr_list.resize(nw);
   for (int iw = 0; iw < nw; iw++)
   {
@@ -1174,11 +1176,8 @@ void MultiSlaterDetTableMethod::createResource(ResourceCollection& collection) c
 void MultiSlaterDetTableMethod::acquireResource(ResourceCollection& collection,
                                                 const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  auto& wfc_leader = wfc_list.getCastedLeader<MultiSlaterDetTableMethod>();
-  auto res_ptr     = dynamic_cast<MultiSlaterDetTableMethodMultiWalkerResource*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("MultiSlaterDetTableMethod::acquireResource dynamic_cast failed");
-  wfc_leader.mw_res_.reset(res_ptr);
+  auto& wfc_leader          = wfc_list.getCastedLeader<MultiSlaterDetTableMethod>();
+  wfc_leader.mw_res_handle_ = collection.lendResource<MultiSlaterDetTableMethodMultiWalkerResource>();
   for (int idet = 0; idet < Dets.size(); idet++)
   {
     const auto det_list(extract_DetRef_list(wfc_list, idet));
@@ -1190,7 +1189,7 @@ void MultiSlaterDetTableMethod::releaseResource(ResourceCollection& collection,
                                                 const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<MultiSlaterDetTableMethod>();
-  collection.takebackResource(std::move(wfc_leader.mw_res_));
+  collection.takebackResource(wfc_leader.mw_res_handle_);
   for (int idet = 0; idet < Dets.size(); idet++)
   {
     const auto det_list(extract_DetRef_list(wfc_list, idet));

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.cpp
@@ -20,6 +20,25 @@
 
 namespace qmcplusplus
 {
+struct MultiSlaterDetTableMethod::MultiSlaterDetTableMethodMultiWalkerResource : public Resource
+{
+  MultiSlaterDetTableMethodMultiWalkerResource() : Resource("MultiSlaterDetTableMethod") {}
+  MultiSlaterDetTableMethodMultiWalkerResource(const MultiSlaterDetTableMethodMultiWalkerResource&)
+      : MultiSlaterDetTableMethodMultiWalkerResource()
+  {}
+
+  std::unique_ptr<Resource> makeClone() const override
+  {
+    return std::make_unique<MultiSlaterDetTableMethodMultiWalkerResource>(*this);
+  }
+
+  /// grads of each unique determinants for multiple walkers
+  Matrix<ValueType, OffloadAllocator<ValueType>> mw_grads;
+  /// a collection of device pointers of multiple walkers fused for fast H2D transfer.
+  OffloadVector<const ValueType*> C_otherDs_ptr_list;
+  OffloadVector<const ValueType*> det_value_ptr_list;
+};
+
 MultiSlaterDetTableMethod::MultiSlaterDetTableMethod(ParticleSet& targetPtcl,
                                                      std::vector<std::unique_ptr<MultiDiracDeterminant>>&& dets,
                                                      bool use_pre_computing)

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -184,9 +184,7 @@ public:
                            Vector<ValueType>& dlogpsi,
                            Vector<ValueType>& dhpsioverpsi) override;
 
-  void evaluateDerivativesWF(ParticleSet& P,
-                             const opt_variables_type& optvars,
-                             Vector<ValueType>& dlogpsi) override;
+  void evaluateDerivativesWF(ParticleSet& P, const opt_variables_type& optvars, Vector<ValueType>& dlogpsi) override;
 
   void evaluateDerivRatios(const VirtualParticleSet& VP,
                            const opt_variables_type& optvars,
@@ -265,9 +263,7 @@ private:
    * @param dlogpsi saved derivatives
    * @param det_id provide this argument to affect determinant group id for virtual moves
    */
-  void evaluateDerivativesMSD(const PsiValueType& multi_det_to_ref,
-                              Vector<ValueType>& dlogpsi,
-                              int det_id = -1) const;
+  void evaluateDerivativesMSD(const PsiValueType& multi_det_to_ref, Vector<ValueType>& dlogpsi, int det_id = -1) const;
 
   /// determinant collection
   std::vector<std::unique_ptr<MultiDiracDeterminant>> Dets;
@@ -319,7 +315,10 @@ private:
         : MultiSlaterDetTableMethodMultiWalkerResource()
     {}
 
-    Resource* makeClone() const override { return new MultiSlaterDetTableMethodMultiWalkerResource(*this); }
+    std::unique_ptr<Resource> makeClone() const override
+    {
+      return std::make_unique<MultiSlaterDetTableMethodMultiWalkerResource>(*this);
+    }
 
     /// grads of each unique determinants for multiple walkers
     Matrix<ValueType, OffloadAllocator<ValueType>> mw_grads;
@@ -328,7 +327,7 @@ private:
     OffloadVector<const ValueType*> det_value_ptr_list;
   };
 
-  std::unique_ptr<MultiSlaterDetTableMethodMultiWalkerResource> mw_res_;
+  ResourceHandle<MultiSlaterDetTableMethodMultiWalkerResource> mw_res_handle_;
 
   // helper function for extracting a list of WaveFunctionComponent from a list of TrialWaveFunction
   RefVectorWithLeader<MultiDiracDeterminant> extract_DetRef_list(

--- a/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
+++ b/src/QMCWaveFunctions/Fermion/MultiSlaterDetTableMethod.h
@@ -308,25 +308,7 @@ private:
   std::vector<Matrix<RealType>> dpsia, dLa;
   std::vector<Array<GradType, OHMMS_DIM>> dGa;
 
-  struct MultiSlaterDetTableMethodMultiWalkerResource : public Resource
-  {
-    MultiSlaterDetTableMethodMultiWalkerResource() : Resource("MultiSlaterDetTableMethod") {}
-    MultiSlaterDetTableMethodMultiWalkerResource(const MultiSlaterDetTableMethodMultiWalkerResource&)
-        : MultiSlaterDetTableMethodMultiWalkerResource()
-    {}
-
-    std::unique_ptr<Resource> makeClone() const override
-    {
-      return std::make_unique<MultiSlaterDetTableMethodMultiWalkerResource>(*this);
-    }
-
-    /// grads of each unique determinants for multiple walkers
-    Matrix<ValueType, OffloadAllocator<ValueType>> mw_grads;
-    /// a collection of device pointers of multiple walkers fused for fast H2D transfer.
-    OffloadVector<const ValueType*> C_otherDs_ptr_list;
-    OffloadVector<const ValueType*> det_value_ptr_list;
-  };
-
+  struct MultiSlaterDetTableMethodMultiWalkerResource;
   ResourceHandle<MultiSlaterDetTableMethodMultiWalkerResource> mw_res_handle_;
 
   // helper function for extracting a list of WaveFunctionComponent from a list of TrialWaveFunction

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.cpp
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.cpp
@@ -41,7 +41,7 @@ struct J1OrbitalSoAMultiWalkerMem : public Resource
 
   J1OrbitalSoAMultiWalkerMem(const J1OrbitalSoAMultiWalkerMem&) : J1OrbitalSoAMultiWalkerMem() {}
 
-  Resource* makeClone() const override { return new J1OrbitalSoAMultiWalkerMem(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<J1OrbitalSoAMultiWalkerMem>(*this); }
 };
 
 template<typename FT>
@@ -94,11 +94,8 @@ template<typename FT>
 void J1OrbitalSoA<FT>::acquireResource(ResourceCollection& collection,
                                        const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  auto& wfc_leader = wfc_list.getCastedLeader<J1OrbitalSoA<FT>>();
-  auto res_ptr     = dynamic_cast<J1OrbitalSoAMultiWalkerMem<RealType>*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("VirtualParticleSet::acquireResource dynamic_cast failed");
-  wfc_leader.mw_mem_.reset(res_ptr);
+  auto& wfc_leader          = wfc_list.getCastedLeader<J1OrbitalSoA<FT>>();
+  wfc_leader.mw_mem_handle_ = collection.lendResource<J1OrbitalSoAMultiWalkerMem<RealType>>();
 }
 
 template<typename FT>
@@ -106,7 +103,7 @@ void J1OrbitalSoA<FT>::releaseResource(ResourceCollection& collection,
                                        const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
   auto& wfc_leader = wfc_list.getCastedLeader<J1OrbitalSoA<FT>>();
-  collection.takebackResource(std::move(wfc_leader.mw_mem_));
+  collection.takebackResource(wfc_leader.mw_mem_handle_);
 }
 
 template<typename FT>
@@ -126,19 +123,20 @@ void J1OrbitalSoA<FT>::mw_evaluateRatios(const RefVectorWithLeader<WaveFunctionC
   auto& wfc_leader        = wfc_list.getCastedLeader<J1OrbitalSoA<FT>>();
   auto& vp_leader         = vp_list.getLeader();
   const auto& mw_refPctls = vp_leader.getMultiWalkerRefPctls();
-  auto& mw_vals           = wfc_leader.mw_mem_->mw_vals;
-  auto& mw_minus_one      = wfc_leader.mw_mem_->mw_minus_one;
+  auto& mw_mem            = wfc_leader.mw_mem_handle_.getResource();
+  auto& mw_vals           = mw_mem.mw_vals;
+  auto& mw_minus_one      = mw_mem.mw_minus_one;
   const int nw            = wfc_list.size();
 
   const size_t nVPs = mw_refPctls.size();
   mw_vals.resize(nVPs);
-  wfc_leader.mw_mem_->resize_minus_one(nVPs);
+  mw_mem.resize_minus_one(nVPs);
 
   const auto& dt_leader(vp_leader.getDistTableAB(wfc_leader.myTableID));
 
   FT::mw_evaluateV(NumGroups, GroupFunctors.data(), wfc_leader.Nions, grp_ids.data(), nVPs, mw_minus_one.data(),
                    dt_leader.getMultiWalkerDataPtr(), dt_leader.getPerTargetPctlStrideSize(), mw_vals.data(),
-                   wfc_leader.mw_mem_->transfer_buffer);
+                   mw_mem.transfer_buffer);
 
   size_t ivp = 0;
   for (int iw = 0; iw < nw; ++iw)

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <numeric>
 #include "Configuration.h"
+#include <ResourceHandle.h>
 #include "Particle/DistanceTable.h"
 #include "ParticleBase/ParticleAttribOps.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
@@ -101,7 +102,7 @@ class J1OrbitalSoA : public WaveFunctionComponent
   std::vector<GradDerivVec> gradLogPsi;
   std::vector<ValueDerivVec> lapLogPsi;
 
-  std::unique_ptr<J1OrbitalSoAMultiWalkerMem<RealType>> mw_mem_;
+  ResourceHandle<J1OrbitalSoAMultiWalkerMem<RealType>> mw_mem_handle_;
 
   void resizeWFOptVectors()
   {

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.cpp
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.cpp
@@ -44,7 +44,7 @@ struct TwoBodyJastrowMultiWalkerMem : public Resource
 
   TwoBodyJastrowMultiWalkerMem(const TwoBodyJastrowMultiWalkerMem&) : TwoBodyJastrowMultiWalkerMem() {}
 
-  Resource* makeClone() const override { return new TwoBodyJastrowMultiWalkerMem(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<TwoBodyJastrowMultiWalkerMem>(*this); }
 };
 
 template<typename FT>
@@ -57,13 +57,10 @@ template<typename FT>
 void TwoBodyJastrow<FT>::acquireResource(ResourceCollection& collection,
                                          const RefVectorWithLeader<WaveFunctionComponent>& wfc_list) const
 {
-  auto& wfc_leader = wfc_list.getCastedLeader<TwoBodyJastrow<FT>>();
-  auto res_ptr     = dynamic_cast<TwoBodyJastrowMultiWalkerMem<RealType>*>(collection.lendResource().release());
-  if (!res_ptr)
-    throw std::runtime_error("VirtualParticleSet::acquireResource dynamic_cast failed");
-  wfc_leader.mw_mem_.reset(res_ptr);
-  const size_t nw = wfc_list.size();
-  auto& mw_allUat = wfc_leader.mw_mem_->mw_allUat;
+  auto& wfc_leader          = wfc_list.getCastedLeader<TwoBodyJastrow<FT>>();
+  wfc_leader.mw_mem_handle_ = collection.lendResource<TwoBodyJastrowMultiWalkerMem<RealType>>();
+  const size_t nw           = wfc_list.size();
+  auto& mw_allUat           = wfc_leader.mw_mem_handle_.getResource().mw_allUat;
   mw_allUat.resize(N_padded * (DIM + 2) * nw);
   for (size_t iw = 0; iw < nw; iw++)
   {
@@ -87,7 +84,7 @@ void TwoBodyJastrow<FT>::acquireResource(ResourceCollection& collection,
     wfc.d2Uat.free();
     wfc.d2Uat.attachReference(mw_allUat.data() + nw * N_padded * (DIM + 1) + iw * N_padded, N);
   }
-  wfc_leader.mw_mem_->mw_cur_allu.resize(N_padded * 3 * nw);
+  wfc_leader.mw_mem_handle_.getResource().mw_cur_allu.resize(N_padded * 3 * nw);
 }
 
 template<typename FT>
@@ -96,7 +93,7 @@ void TwoBodyJastrow<FT>::releaseResource(ResourceCollection& collection,
 {
   auto& wfc_leader = wfc_list.getCastedLeader<TwoBodyJastrow<FT>>();
   const size_t nw  = wfc_list.size();
-  auto& mw_allUat  = wfc_leader.mw_mem_->mw_allUat;
+  auto& mw_allUat  = wfc_leader.mw_mem_handle_.getResource().mw_allUat;
   for (size_t iw = 0; iw < nw; iw++)
   {
     // detach buffer and copy per walker Uat, dUat, d2Uat from shared buffer
@@ -119,7 +116,7 @@ void TwoBodyJastrow<FT>::releaseResource(ResourceCollection& collection,
     wfc.d2Uat.resize(N);
     wfc.d2Uat = d2Uat_view;
   }
-  collection.takebackResource(std::move(wfc_leader.mw_mem_));
+  collection.takebackResource(wfc_leader.mw_mem_handle_);
 }
 
 template<typename FT>
@@ -193,7 +190,7 @@ void TwoBodyJastrow<FT>::mw_evaluateRatios(const RefVectorWithLeader<WaveFunctio
   auto& wfc_leader        = wfc_list.getCastedLeader<TwoBodyJastrow<FT>>();
   auto& vp_leader         = vp_list.getLeader();
   const auto& mw_refPctls = vp_leader.getMultiWalkerRefPctls();
-  auto& mw_vals           = wfc_leader.mw_mem_->mw_vals;
+  auto& mw_vals           = wfc_leader.mw_mem_handle_.getResource().mw_vals;
   const int nw            = wfc_list.size();
 
   const size_t nVPs = mw_refPctls.size();
@@ -206,7 +203,7 @@ void TwoBodyJastrow<FT>::mw_evaluateRatios(const RefVectorWithLeader<WaveFunctio
 
   FT::mw_evaluateV(NumGroups, F.data() + igt * NumGroups, wfc_leader.N, grp_ids.data(), nVPs, mw_refPctls.data(),
                    dt_leader.getMultiWalkerDataPtr(), dt_leader.getPerTargetPctlStrideSize(), mw_vals.data(),
-                   wfc_leader.mw_mem_->transfer_buffer);
+                   wfc_leader.mw_mem_handle_.getResource().transfer_buffer);
 
   size_t ivp = 0;
   for (int iw = 0; iw < nw; ++iw)
@@ -478,15 +475,15 @@ void TwoBodyJastrow<FT>::mw_calcRatio(const RefVectorWithLeader<WaveFunctionComp
   const auto& dt_leader = p_leader.getDistTableAA(my_table_ID_);
   const int nw          = wfc_list.size();
 
-  auto& mw_vgl = wfc_leader.mw_mem_->mw_vgl;
+  auto& mw_vgl = wfc_leader.mw_mem_handle_.getResource().mw_vgl;
   mw_vgl.resize(nw, DIM + 2);
 
-  auto& mw_allUat   = wfc_leader.mw_mem_->mw_allUat;
-  auto& mw_cur_allu = wfc_leader.mw_mem_->mw_cur_allu;
+  auto& mw_allUat   = wfc_leader.mw_mem_handle_.getResource().mw_allUat;
+  auto& mw_cur_allu = wfc_leader.mw_mem_handle_.getResource().mw_cur_allu;
 
   FT::mw_evaluateVGL(iat, NumGroups, F.data() + p_leader.GroupID[iat] * NumGroups, wfc_leader.N, grp_ids.data(), nw,
                      mw_vgl.data(), N_padded, dt_leader.getMultiWalkerTempDataPtr(), mw_cur_allu.data(),
-                     wfc_leader.mw_mem_->mw_ratiograd_buffer);
+                     wfc_leader.mw_mem_handle_.getResource().mw_ratiograd_buffer);
 
   for (int iw = 0; iw < nw; iw++)
   {
@@ -562,15 +559,15 @@ void TwoBodyJastrow<FT>::mw_ratioGrad(const RefVectorWithLeader<WaveFunctionComp
   const auto& dt_leader = p_leader.getDistTableAA(my_table_ID_);
   const int nw          = wfc_list.size();
 
-  auto& mw_vgl = wfc_leader.mw_mem_->mw_vgl;
+  auto& mw_vgl = wfc_leader.mw_mem_handle_.getResource().mw_vgl;
   mw_vgl.resize(nw, DIM + 2);
 
-  auto& mw_allUat   = wfc_leader.mw_mem_->mw_allUat;
-  auto& mw_cur_allu = wfc_leader.mw_mem_->mw_cur_allu;
+  auto& mw_allUat   = wfc_leader.mw_mem_handle_.getResource().mw_allUat;
+  auto& mw_cur_allu = wfc_leader.mw_mem_handle_.getResource().mw_cur_allu;
 
   FT::mw_evaluateVGL(iat, NumGroups, F.data() + p_leader.GroupID[iat] * NumGroups, wfc_leader.N, grp_ids.data(), nw,
                      mw_vgl.data(), N_padded, dt_leader.getMultiWalkerTempDataPtr(), mw_cur_allu.data(),
-                     wfc_leader.mw_mem_->mw_ratiograd_buffer);
+                     wfc_leader.mw_mem_handle_.getResource().mw_ratiograd_buffer);
 
   for (int iw = 0; iw < nw; iw++)
   {
@@ -651,10 +648,10 @@ void TwoBodyJastrow<FT>::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunc
   const auto& dt_leader = p_leader.getDistTableAA(my_table_ID_);
   const int nw          = wfc_list.size();
 
-  auto& mw_vgl = wfc_leader.mw_mem_->mw_vgl;
+  auto& mw_vgl = wfc_leader.mw_mem_handle_.getResource().mw_vgl;
 
-  auto& mw_allUat   = wfc_leader.mw_mem_->mw_allUat;
-  auto& mw_cur_allu = wfc_leader.mw_mem_->mw_cur_allu;
+  auto& mw_allUat   = wfc_leader.mw_mem_handle_.getResource().mw_allUat;
+  auto& mw_cur_allu = wfc_leader.mw_mem_handle_.getResource().mw_cur_allu;
 
   for (int iw = 0; iw < nw; iw++)
   {
@@ -665,7 +662,7 @@ void TwoBodyJastrow<FT>::mw_accept_rejectMove(const RefVectorWithLeader<WaveFunc
   // this call may go asynchronous, then need to wait at mw_calcRatio mw_ratioGrad and mw_completeUpdates
   FT::mw_updateVGL(iat, isAccepted, NumGroups, F.data() + p_leader.GroupID[iat] * NumGroups, wfc_leader.N,
                    grp_ids.data(), nw, mw_vgl.data(), N_padded, dt_leader.getMultiWalkerTempDataPtr(), mw_allUat.data(),
-                   mw_cur_allu.data(), wfc_leader.mw_mem_->mw_update_buffer);
+                   mw_cur_allu.data(), wfc_leader.mw_mem_handle_.getResource().mw_update_buffer);
 }
 
 template<typename FT>
@@ -733,7 +730,7 @@ void TwoBodyJastrow<FT>::mw_recompute(const RefVectorWithLeader<WaveFunctionComp
   for (int iw = 0; iw < wfc_list.size(); iw++)
     if (recompute[iw])
       wfc_list[iw].recompute(p_list[iw]);
-  wfc_leader.mw_mem_->mw_allUat.updateTo();
+  wfc_leader.mw_mem_handle_.getResource().mw_allUat.updateTo();
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -20,6 +20,7 @@
 #if !defined(QMC_BUILD_SANDBOX_ONLY)
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
 #endif
+#include <ResourceHandle.h>
 #include "Particle/DistanceTable.h"
 #include "LongRange/StructFact.h"
 #include "OMPTarget/OffloadAlignedAllocators.hpp"
@@ -120,7 +121,7 @@ private:
   std::vector<GradDerivVec> gradLogPsi;
   std::vector<ValueDerivVec> lapLogPsi;
 
-  std::unique_ptr<TwoBodyJastrowMultiWalkerMem<RealType>> mw_mem_;
+  ResourceHandle<TwoBodyJastrowMultiWalkerMem<RealType>> mw_mem_handle_;
 
   void resizeWFOptVectors()
   {

--- a/src/QMCWaveFunctions/SpinorSet.h
+++ b/src/QMCWaveFunctions/SpinorSet.h
@@ -14,6 +14,7 @@
 #define QMCPLUSPLUS_SPINORSET_H
 
 #include "QMCWaveFunctions/SPOSet.h"
+#include <ResourceHandle.h>
 
 namespace qmcplusplus
 {
@@ -175,11 +176,11 @@ public:
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<SPOSet>& spo_list) const override;
 
   /// check if the multi walker resource is owned. For testing only.
-  bool isResourceOwned() const { return bool(mw_res_); }
+  bool isResourceOwned() const { return bool(mw_res_handle_); }
 
 private:
   struct SpinorSetMultiWalkerResource;
-  std::unique_ptr<SpinorSetMultiWalkerResource> mw_res_;
+  ResourceHandle<SpinorSetMultiWalkerResource> mw_res_handle_;
 
   std::pair<RefVectorWithLeader<SPOSet>, RefVectorWithLeader<SPOSet>> extractSpinComponentRefList(
       const RefVectorWithLeader<SPOSet>& spo_list) const;

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -13,6 +13,7 @@
 #define QMCPLUSPLUS_RESOURCE_H
 
 #include <string>
+#include <memory>
 
 namespace qmcplusplus
 {

--- a/src/Utilities/Resource.h
+++ b/src/Utilities/Resource.h
@@ -20,8 +20,8 @@ class Resource
 {
 public:
   Resource(const std::string& name) : name_(name) {}
-  virtual ~Resource()                 = default;
-  virtual Resource* makeClone() const = 0;
+  virtual ~Resource()                                 = default;
+  virtual std::unique_ptr<Resource> makeClone() const = 0;
   const std::string& getName() const { return name_; }
 
 private:
@@ -37,7 +37,7 @@ class DummyResource : public Resource
 public:
   DummyResource() : Resource("Dummy") {}
   DummyResource(const std::string& name) : Resource(name) {}
-  DummyResource* makeClone() const override { return new DummyResource(); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<DummyResource>(*this); }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Utilities/ResourceCollection.h
+++ b/src/Utilities/ResourceCollection.h
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <vector>
 #include "Resource.h"
+#include "ResourceHandle.h"
 #include "type_traits/RefVectorWithLeader.h"
 
 namespace qmcplusplus
@@ -26,19 +27,26 @@ class ResourceCollection
 public:
   ResourceCollection(const std::string& name);
   ResourceCollection(const ResourceCollection&);
+
   const std::string& getName() const { return name_; }
+
   size_t size() const { return collection_.size(); }
-  void printResources() const;
-
-  size_t addResource(std::unique_ptr<Resource>&& res, bool noprint = false);
-  std::unique_ptr<Resource> lendResource();
-  void takebackResource(std::unique_ptr<Resource>&& res);
-
-  void rewind(size_t cursor = 0) { cursor_index_ = cursor; }
-
   bool empty() const { return collection_.size() == 0; }
 
+  size_t addResource(std::unique_ptr<Resource>&& res, bool noprint = false);
+  void printResources() const;
+
+  template<class RS>
+  ResourceHandle<RS> lendResource() { return dynamic_cast<RS&>(lendResourceImpl()); }
+
+  template<class RS>
+  void takebackResource(ResourceHandle<RS>& res_handle) { takebackResourceImpl(res_handle.release()); }
+
+  void rewind(size_t cursor = 0) { cursor_index_ = cursor; }
 private:
+  Resource& lendResourceImpl();
+  void takebackResourceImpl(Resource& res);
+
   const std::string name_;
   size_t cursor_index_;
   std::vector<std::unique_ptr<Resource>> collection_;

--- a/src/Utilities/ResourceHandle.h
+++ b/src/Utilities/ResourceHandle.h
@@ -12,27 +12,38 @@
 #ifndef QMCPLUSPLUS_RESOURCHANDLE_H
 #define QMCPLUSPLUS_RESOURCHANDLE_H
 
-#include <memory>
+#include <functional>
+#include <optional>
 
 namespace qmcplusplus
 {
-/** ResourceHandle manages the temporary owned resource obtained from a collection
- *
- * Resource copy should be handled at the collection. Individual handle cannot be copied.
- * However, directly using unique_ptr prevents compiler generated copy constructor.
- * For this reason, the ResourceHandle class adds a copy constructor as no-op to facilitate
- * compiler generated copy constructor in classes owning ResourceHandle objects.
+/** ResourceHandle manages the temporary resource referenced from a collection
  */
 template<class RS>
-class ResourceHandle : public std::unique_ptr<RS>
+class ResourceHandle : private std::optional<std::reference_wrapper<RS>>
 {
 public:
   ResourceHandle() = default;
-  ResourceHandle(const ResourceHandle&) {}
-  ResourceHandle(ResourceHandle&&) = default;
-  ResourceHandle& operator=(const ResourceHandle&) {};
-  ResourceHandle& operator=(ResourceHandle&&) = default;
-  using std::unique_ptr<RS>::operator=;
+  ResourceHandle(RS& res) { this->emplace(res); }
+  ResourceHandle& operator=(RS& res)
+  {
+    this->emplace(res);
+    return *this;
+  }
+  bool hasResource() const { return this->has_value(); }
+
+  RS& getResource() { return this->value(); }
+  const RS& getResource() const { return this->value(); }
+
+  operator RS&() { return this->value(); }
+  operator const RS&() const { return this->value(); }
+
+  RS& release()
+  {
+    RS& res = this->value();
+    this->reset();
+    return res;
+  }
 };
 
 } // namespace qmcplusplus

--- a/src/Utilities/ResourceHandle.h
+++ b/src/Utilities/ResourceHandle.h
@@ -23,25 +23,28 @@ template<class RS>
 class ResourceHandle : private std::optional<std::reference_wrapper<RS>>
 {
 public:
+  using Base = std::optional<std::reference_wrapper<RS>>;
+
   ResourceHandle() = default;
-  ResourceHandle(RS& res) { this->emplace(res); }
+  ResourceHandle(RS& res) { Base::emplace(res); }
   ResourceHandle& operator=(RS& res)
   {
-    this->emplace(res);
+    Base::emplace(res);
     return *this;
   }
-  bool hasResource() const { return this->has_value(); }
+  bool hasResource() const { return Base::has_value(); }
+  operator bool() const { return Base::has_value(); }
 
-  RS& getResource() { return this->value(); }
-  const RS& getResource() const { return this->value(); }
+  RS& getResource() { return Base::value(); }
+  const RS& getResource() const { return Base::value(); }
 
   operator RS&() { return this->value(); }
-  operator const RS&() const { return this->value(); }
+  operator const RS&() const { return Base::value(); }
 
   RS& release()
   {
-    RS& res = this->value();
-    this->reset();
+    RS& res = Base::value();
+    Base::reset();
     return res;
   }
 };

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -19,7 +19,7 @@ class MemoryResource : public Resource
 public:
   MemoryResource(const std::string& name) : Resource(name) {}
 
-  MemoryResource* makeClone() const override { return new MemoryResource(*this); }
+  std::unique_ptr<Resource> makeClone() const override { return std::make_unique<MemoryResource>(*this); }
 
   std::vector<int> data;
 };
@@ -29,15 +29,16 @@ TEST_CASE("Resource", "[utilities]")
   auto mem_res = std::make_unique<MemoryResource>("test_res");
   mem_res->data.resize(5);
 
-  std::unique_ptr<MemoryResource> res_copy(mem_res->makeClone());
-  REQUIRE(res_copy->data.size() == 5);
+  auto res_copy      = mem_res->makeClone();
+  auto& res_copy_ref = dynamic_cast<MemoryResource&>(*res_copy);
+  REQUIRE(res_copy_ref.data.size() == 5);
 }
 
 TEST_CASE("DummyResource", "[utilities]")
 {
   DummyResource dummy;
-  std::unique_ptr<DummyResource> dummy2(dummy.makeClone());
-  REQUIRE(dummy.getName() == "Dummy");
+  auto dummy2 = dummy.makeClone();
+  REQUIRE(dummy2->getName() == "Dummy");
   DummyResource dummy_alt("dummy_alt_name");
   REQUIRE(dummy_alt.getName() == "dummy_alt_name");
 }
@@ -47,48 +48,50 @@ class WFCResourceConsumer
 public:
   void createResource(ResourceCollection& collection)
   {
-    external_memory_handle = std::make_unique<MemoryResource>("test_res");
-    external_memory_handle->data.resize(5);
-    collection.addResource(std::move(external_memory_handle));
+    auto memory_handle = std::make_unique<MemoryResource>("test_res");
+    memory_handle->data.resize(5);
+    collection.addResource(std::move(memory_handle));
   }
 
   void acquireResource(ResourceCollection& collection, const RefVectorWithLeader<WFCResourceConsumer>& wfcrc_list)
   {
-    auto res_ptr = dynamic_cast<MemoryResource*>(collection.lendResource().release());
-    if (!res_ptr)
-      throw std::runtime_error("WFCResourceConsumer::acquireResource dynamic_cast failed");
-    external_memory_handle.reset(res_ptr);
+    external_memory_handle = collection.lendResource<MemoryResource>();
   }
 
   void releaseResource(ResourceCollection& collection, const RefVectorWithLeader<WFCResourceConsumer>& wfcrc_list)
   {
-    collection.takebackResource(std::move(external_memory_handle));
+    collection.takebackResource(external_memory_handle);
   }
 
-  MemoryResource* getPtr() const { return external_memory_handle.get(); }
+  auto& getResourceHandle() { return external_memory_handle; }
 
 private:
-  std::unique_ptr<MemoryResource> external_memory_handle;
+  ResourceHandle<MemoryResource> external_memory_handle;
 };
 
 TEST_CASE("ResourceCollection", "[utilities]")
 {
   ResourceCollection res_collection("abc");
   WFCResourceConsumer wfc, wfc1, wfc2;
-  REQUIRE(wfc.getPtr() == nullptr);
+  REQUIRE(wfc.getResourceHandle().hasResource() == false);
 
   wfc.createResource(res_collection);
-  REQUIRE(wfc.getPtr() == nullptr);
+  REQUIRE(wfc.getResourceHandle().hasResource() == false);
 
   RefVectorWithLeader wfc_list(wfc, {wfc, wfc1, wfc2});
 
   {
     ResourceCollectionTeamLock lock(res_collection, wfc_list);
-    REQUIRE(wfc.getPtr() != nullptr);
-    CHECK(wfc.getPtr()->data.size() == 5);
+    auto& res_handle = wfc.getResourceHandle();
+    REQUIRE(res_handle.hasResource() == true);
+
+    MemoryResource& mem_res             = res_handle;
+    const MemoryResource& const_mem_res = res_handle;
+    CHECK(mem_res.data.size() == 5);
+    CHECK(const_mem_res.data.size() == 5);
   }
 
-  REQUIRE(wfc.getPtr() == nullptr);
+  REQUIRE(wfc.getResourceHandle().hasResource() == false);
 }
 
 } // namespace qmcplusplus

--- a/src/Utilities/tests/test_ResourceCollection.cpp
+++ b/src/Utilities/tests/test_ResourceCollection.cpp
@@ -83,7 +83,7 @@ TEST_CASE("ResourceCollection", "[utilities]")
   {
     ResourceCollectionTeamLock lock(res_collection, wfc_list);
     auto& res_handle = wfc.getResourceHandle();
-    REQUIRE(res_handle.hasResource() == true);
+    REQUIRE(res_handle);
 
     MemoryResource& mem_res             = res_handle;
     const MemoryResource& const_mem_res = res_handle;


### PR DESCRIPTION
## Proposed changes
Change ResourceHandle implementation from `std::unique_ptr` to `std::optional<std::reference_wrapper>`.
 `std::optional` has built-in presence check and should be more robust.
There is no more moving of resource between ResourceCollection and a Resource consumer.
Consumers reference into ResourceCollection.

Reviewers: please first review ResourceCollection.h/cpp Resource.h ResourceHandle.h and their tests at test_ResourceCollection.cpp

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'