### PR TITLE
[WIP] Remove Observable Helper

### DIFF
--- a/src/Estimators/EstimatorManagerNew.cpp
+++ b/src/Estimators/EstimatorManagerNew.cpp
@@ -55,7 +55,7 @@ bool EstimatorManagerNew::areThereListeners() const
   return std::any_of(operator_ests_.begin(), operator_ests_.end(),
                      [](auto& oper_est) { return oper_est->isListenerRequired(); });
 }
-  
+
 template<class EstInputType, typename... Args>
 bool EstimatorManagerNew::createEstimator(EstimatorInput& input, Args&&... args)
 {
@@ -373,7 +373,7 @@ void EstimatorManagerNew::reduceOperatorEstimators()
     {
       operator_data_sizes[iop] = operator_ests_[iop]->get_data().size();
     }
-    // 1 larger because we put the weight in to avoid dependence of the Scalar estimators being reduced firt.
+    // 1 larger because we put the weight in to avoid dependence of the Scalar estimators being reduced first.
     size_t nops = *(std::max_element(operator_data_sizes.begin(), operator_data_sizes.end())) + 1;
     std::vector<RealType> operator_send_buffer;
     std::vector<RealType> operator_recv_buffer;

--- a/src/Estimators/InputSection.h
+++ b/src/Estimators/InputSection.h
@@ -18,7 +18,6 @@
 #include <unordered_map>
 
 #include "Configuration.h"
-#include "OhmmsData/ParameterSet.h"
 #include "Containers/OhmmsPETE/TinyVector.h"
 
 #include "Message/UniformCommunicateError.h"
@@ -44,12 +43,12 @@ protected:
   // Becuase it hurts to read all the trailing _ in the constructors of input section subtypes
   // NOLINTBEGIN(readability-indentifier-naming)
 
-  std::string section_name; // name of the input section
+  std::string section_name;                      // name of the input section
 
-  std::unordered_set<std::string> attributes; // list of attribute variables
-  std::unordered_set<std::string> parameters; // list of parameter variables
-  std::unordered_set<std::string> delegates;  // input nodes delegate to next level of input parsing.
-  std::unordered_set<std::string> required;   // list of required variables
+  std::unordered_set<std::string> attributes;    // list of attribute variables
+  std::unordered_set<std::string> parameters;    // list of parameter variables
+  std::unordered_set<std::string> delegates;     // input nodes delegate to next level of input parsing.
+  std::unordered_set<std::string> required;      // list of required variables
 
   std::unordered_set<std::string> strings;       // list of string variables that can have one value
   std::unordered_set<std::string> multi_strings; // list of string variables that can one or more values
@@ -146,8 +145,7 @@ protected:
    *   \param[in]   tag                parmater name or node ename delgation is controlled by
    *   \param[in]   delegate_handler   factory function for delegated input function.
    */
-  void registerDelegate(const std::string& tag,
-                        DelegateHandler delegate_handler);
+  void registerDelegate(const std::string& tag, DelegateHandler delegate_handler);
 
   /** Do validation for a particular subtype of InputSection
    *  Called by check_valid.
@@ -176,7 +174,9 @@ protected:
   /** Derived class can overrides this to do custom parsing of the element values for Custom elements
    *  These can have a name attribute only.
    */
-  [[noreturn]] virtual void setFromStreamCustom(const std::string& ename, const std::string& name, std::istringstream& svalue)
+  [[noreturn]] virtual void setFromStreamCustom(const std::string& ename,
+                                                const std::string& name,
+                                                std::istringstream& svalue)
   {
     throw std::runtime_error("derived class must provide handleCustom method if custom parameters are used");
   }

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -103,10 +103,12 @@ public:
 
   /** Write to previously registered observable_helper hdf5 wrapper.
    *
+   *  You need to override this if your estimator does anything more than just write its data to a single h5 descriptor.
+   *
    *  if you haven't registered Operator Estimator 
-   *  this will do nothing.
+   *  this will/should do nothing.
    */
-  void write(hdf_archive& file);
+  virtual void write(hdf_archive& file);
 
   /** zero data appropriately for the DataLocality
    */

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -231,5 +231,31 @@ void SpinDensityNew::registerOperatorEstimator(hdf_archive& file)
   }
 }
 
+void SpinDensityNew::write(hdf_archive& file)
+{
+  if (h5desc_.empty())
+    return;
+
+  auto writeFullPrecData = [&](auto& fp_data) {
+    std::size_t offset = 0;
+    for (auto& h5d : h5desc_)
+    {
+      h5d.write(fp_data.data() + offset, file);
+      offset += derived_parameters_.npoints;
+    }
+  };
+
+#ifdef MIXED_PRECISION
+  std::vector<QMCT::FullPrecRealType> expanded_data(data_.size(), 0.0);
+  std::copy_n(data_.begin(), data_.size(), expanded_data.begin());
+  assert(!data_.empty());
+  writeFullPrecData(expanded_data);
+  // auto total = std::accumulate(data_->begin(), data_->end(), 0.0);
+  // std::cout << "data size: " << data_->size() << " : " << total << '\n';
+
+#else
+  writeFullPrecData(data_);
+#endif
+}
 
 } // namespace qmcplusplus

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -247,12 +247,12 @@ void SpinDensityNew::write(hdf_archive& file)
     for (int s = 0; s < species_.size(); ++s)
     {
       data.attachReference(fp_data.data() + offset, derived_parameters_.npoints);
-      file.push(species_.speciesName[s]);
-      //file.write(data, "value");
-      file.writeSlabReshaped(data, ng, "value");
+      hid_t g_id = file.push(species_.speciesName[s], true);
+      file.append(data, "value", append_index_);
       offset += derived_parameters_.npoints;
       file.pop();
     }
+    ++append_index_;
     file.pop();
   };
 

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -143,6 +143,9 @@ private:
   SpinDensityInput::DerivedParameters derived_parameters_;
   /**}@*/
 
+  /// current index for h5d_append
+  hsize_t append_index_ = 0;
+
   friend class testing::SpinDensityNewTests;
 };
 

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -122,7 +122,8 @@ private:
   size_t getFullDataSize();
   void accumulateToData(size_t point, QMCT::RealType weight);
   void reset();
-  void report(const std::string& pad);
+  void report(const std::string& pad) const;
+  void report(const std::string& pad, std::ostream& out) const;
 
   //data members
   const SpinDensityInput input_;

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -109,6 +109,10 @@ public:
    */
   void registerOperatorEstimator(hdf_archive& file) override;
 
+  /** Custom write method since spin density new has its own hdf5 format
+   */
+  void write(hdf_archive& file) override;
+
 private:
   SpinDensityNew(const SpinDensityNew& sdn) = default;
 

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -21,6 +21,7 @@
 #include "ParticleSet.h"
 #include "TrialWaveFunction.h"
 #include "EstimatorTesting.h"
+#include "NativeInitializerPrint.hpp"
 
 #include "OhmmsData/Libxml2Doc.h"
 
@@ -36,7 +37,7 @@ using FullPrecReal = QMCTraits::FullPrecRealType;
 
 namespace testing
 {
-/** class to preserve access control in MomentumDistribution
+/** class to preserve access control in SpinDensityNew
  */
 class SpinDensityNewTests
 {
@@ -50,6 +51,11 @@ public:
   }
 
   const std::string& getName(const SpinDensityNew& sdn) { return sdn.my_name_; }
+  const SpinDensityInput::DerivedParameters& getDerivedParameters(const SpinDensityNew& sdn)
+  {
+    return sdn.derived_parameters_;
+  }
+  static void report(const std::string& padding, const SpinDensityNew& sdn) { sdn.report(padding, std::cout); }
 };
 } // namespace testing
 
@@ -57,9 +63,14 @@ void accumulateFromPsets(int n_crowds,
                          int n_walkers,
                          SpinDensityNew& sdn,
                          UPtrVector<OperatorEstBase>& crowd_sdns,
-                         int n_electrons = 2)
+                         int n_electrons,
+                         PosUnit pos_unit = PosUnit::Lattice)
 {
-  const SimulationCell simulation_cell;
+  // aka PtclOnLatticeTraits::ParticleLayout CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>
+  CrystalLattice<FullPrecReal, 3> lattice;
+  lattice.set(Tensor<FullPrecReal, 3>(3.37316115, 3.37316115, 0.00000000, 0.00000000, 3.37316115, 3.37316115,
+                                      3.37316115, 0.00000000, 3.37316115));
+  const SimulationCell simulation_cell(lattice);
   for (int iops = 0; iops < n_crowds; ++iops)
   {
     std::vector<OperatorEstBase::MCPWalker> walkers;
@@ -76,9 +87,29 @@ void accumulateFromPsets(int n_crowds,
       psets.emplace_back(simulation_cell);
       ParticleSet& pset = psets.back();
       pset.create({n_electrons});
-      Real inv_ne = 1 / n_electrons;
+      pset.R.setUnit(pos_unit);
+      Real inv_ne         = 1 / static_cast<Real>(n_electrons);
+      const auto& lattice = simulation_cell.getLattice();
+      std::cout << "inv_ne: " << inv_ne << '\n';
+      // There is a strong assumption that the electron coordinates will only be from -0.5 to 0.5 in lattice coords
       for (int ie = 0; ie < n_electrons; ++ie)
-        pset.R[ie] = ParticleSet::PosType(ie * inv_ne, ie * inv_ne, ie * inv_ne);
+      {
+        ParticleSet::SingleParticlePos pos(ie * inv_ne, ie * inv_ne, ie * inv_ne);
+        std::cout << "position" << pos[0] << " " << pos[1] << " " << pos[2] << '\n';
+        ParticleSet::SingleParticlePos corner{-0.5, -0.5, -0.5};
+        ParticleSet::SingleParticlePos adjusted_pos = pos - corner;
+        switch (pos_unit)
+        {
+        case PosUnit::Lattice:
+          pset.R[ie] = adjusted_pos;
+          break;
+        case PosUnit::Cartesian:
+          std::cout << "Cartesian R: " << lattice.R << '\n';
+          pset.R[ie] = lattice.toCart(adjusted_pos);
+          std::cout << "cart position:" << pset.R[ie][0] << " " << pset.R[ie][1] << " " << pset.R[ie][2] << '\n';
+          break;
+        }
+      }
     }
 
     std::vector<TrialWaveFunction> wfns;
@@ -95,10 +126,15 @@ void accumulateFromPsets(int n_crowds,
 
 void randomUpdateAccumulate(int n_walkers,
                             testing::RandomForTest<QMCT::RealType>& rft,
-                            UPtrVector<OperatorEstBase>& crowd_sdns)
+                            UPtrVector<OperatorEstBase>& crowd_sdns,
+                            int n_elecs)
 {
-  int n_elecs = 2;
-  const SimulationCell simulation_cell;
+  // aka PtclOnLatticeTraits::ParticleLayout CrystalLattice<OHMMS_PRECISION, OHMMS_DIM>
+  CrystalLattice<FullPrecReal, 3> lattice;
+  lattice.set(Tensor<FullPrecReal, 3>(3.37316115, 3.37316115, 0.00000000, 0.00000000, 3.37316115, 3.37316115,
+                                      3.37316115, 0.00000000, 3.37316115));
+
+  const SimulationCell simulation_cell(lattice);
   for (auto& uptr_crowd_sdn : crowd_sdns)
   {
     std::vector<OperatorEstBase::MCPWalker> walkers;
@@ -117,8 +153,8 @@ void randomUpdateAccumulate(int n_walkers,
       psets.emplace_back(simulation_cell);
       ParticleSet& pset = psets.back();
       pset.create({n_elecs});
-      pset.R[0] = ParticleSet::PosType(*it_rng_reals++, *it_rng_reals++, *it_rng_reals++);
-      pset.R[1] = ParticleSet::PosType(*it_rng_reals++, *it_rng_reals++, *it_rng_reals++);
+      for (int i = 0; i < n_elecs; ++i)
+        pset.R[i] = ParticleSet::PosType(*it_rng_reals++, *it_rng_reals++, *it_rng_reals++);
     }
 
     std::vector<TrialWaveFunction> wfns;
@@ -265,7 +301,7 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::crowd)", "[estimators]")
     int n_crowds  = 2;
     int n_walkers = 4;
 
-    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns);
+    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns, n_elec);
 
     RefVector<OperatorEstBase> crowd_oeb_refs = convertUPtrToRefVector(crowd_sdns);
     sdn.collect(crowd_oeb_refs);
@@ -291,10 +327,10 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::crowd)", "[estimators]")
 
 TEST_CASE("SpinDensityNew::collect(DataLocality::rank)", "[estimators]")
 {
-  {
-    using MCPWalker = OperatorEstBase::MCPWalker;
-    using QMCT      = QMCTraits;
+  using MCPWalker = OperatorEstBase::MCPWalker;
+  using QMCT      = QMCTraits;
 
+  auto checkCollectAtPoint = [](int n_elec, PosUnit pos_unit) {
     Libxml2Document doc;
     bool okay = doc.parseFromString(testing::valid_spin_density_input_sections[0]);
     REQUIRE(okay);
@@ -304,11 +340,18 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::rank)", "[estimators]")
     int ispecies = species_set.addSpecies("u");
     ispecies     = species_set.addSpecies("d");
     CHECK(ispecies == 1);
-    int iattribute             = species_set.addAttribute("membersize");
-    species_set(iattribute, 0) = 1;
-    species_set(iattribute, 1) = 1;
+    int i_msize = species_set.addAttribute("membersize");
+    std::vector<int> species_size(species_set.size());
+    species_size[0]         = n_elec / 2 + n_elec % 2;
+    species_size[1]         = n_elec / 2;
+    species_set(i_msize, 0) = species_size[0];
+    species_set(i_msize, 1) = species_size[1];
+
 
     SpinDensityNew sdn(std::move(sdi), species_set, DataLocality::rank);
+
+    testing::SpinDensityNewTests sdnt;
+    const auto& derived_parameters = sdnt.getDerivedParameters(sdn);
 
     auto lattice = testing::makeTestLattice();
 
@@ -316,7 +359,7 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::rank)", "[estimators]")
     int n_crowds  = 2;
     int n_walkers = 4;
 
-    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns);
+    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns, n_elec, pos_unit);
 
     RefVector<OperatorEstBase> crowd_oeb_refs = convertUPtrToRefVector(crowd_sdns);
     sdn.collect(crowd_oeb_refs);
@@ -325,9 +368,37 @@ TEST_CASE("SpinDensityNew::collect(DataLocality::rank)", "[estimators]")
     // There should be a check that the discretization of particle locations expressed in lattice coords
     // is correct.  This just checks it hasn't changed from how it was in SpinDensity which lacked testing.
     //
-    CHECK(data_ref[555] == n_walkers * n_crowds);
-    CHECK(data_ref[1555] == n_walkers * n_crowds);
-  }
+    INFO("n_elec: " << n_elec);
+    CHECK(data_ref.size() == 2000);
+    sdnt.report("", sdn);
+    std::cout << NativePrint(data_ref) << '\n';
+
+
+    size_t offset = 0;
+    int p         = 0;
+    Real inv_ne   = 1 / static_cast<Real>(n_elec);
+    for (int s = 0; s < species_set.size(); ++s, offset += derived_parameters.npoints)
+      for (int ps = 0; ps < species_size[s]; ++ps, ++p)
+      {
+        //QMCT::PosType u = lattice_.toUnit(pset.R[p] - dp_.corner);
+        ParticleSet::SingleParticlePos pos(p * inv_ne, p * inv_ne, p * inv_ne);
+        std::cout << "position" << pos[0] << " " << pos[1] << " " << pos[2] << '\n';
+        //pos = lattice.toCart(pos);
+        //std::cout << "position" << pos[0] << " " << pos[1] << " " << pos[2] <<'\n';
+
+        //pset.R[ie] = pos;
+        size_t point = offset;
+        for (int d = 0; d < QMCT::DIM; ++d)
+          point += derived_parameters.gdims[d] *
+              ((int)(derived_parameters.grid[d] * (pos[d] - std::floor(pos[d])))); //periodic only
+        INFO("species:" << s << " ps: " << ps << " point:" << point);
+        CHECK(data_ref[point] == n_walkers * n_crowds);
+      }
+  };
+  checkCollectAtPoint(2, PosUnit::Lattice);
+  checkCollectAtPoint(3, PosUnit::Lattice);
+  checkCollectAtPoint(2, PosUnit::Cartesian);
+  checkCollectAtPoint(3, PosUnit::Cartesian);
 }
 
 TEST_CASE("SpinDensityNew algorithm comparison", "[estimators]")
@@ -335,64 +406,69 @@ TEST_CASE("SpinDensityNew algorithm comparison", "[estimators]")
   using MCPWalker = OperatorEstBase::MCPWalker;
   using QMCT      = QMCTraits;
 
-  Libxml2Document doc;
-  bool okay = doc.parseFromString(testing::valid_spin_density_input_sections[0]);
-  REQUIRE(okay);
-  xmlNodePtr node = doc.getRoot();
-  SpinDensityInput sdi(node);
-  SpeciesSet species_set;
-  int ispecies = species_set.addSpecies("u");
-  ispecies     = species_set.addSpecies("d");
-  CHECK(ispecies == 1);
-  int i_msize             = species_set.addAttribute("membersize");
-  species_set(i_msize, 0) = 1;
-  species_set(i_msize, 1) = 1;
+  auto checkAlgorithmsForNParticles = [](int n_elec) {
+    Libxml2Document doc;
+    bool okay = doc.parseFromString(testing::valid_spin_density_input_sections[0]);
+    REQUIRE(okay);
+    xmlNodePtr node = doc.getRoot();
+    SpinDensityInput sdi(node);
+    SpeciesSet species_set;
+    int ispecies = species_set.addSpecies("u");
+    ispecies     = species_set.addSpecies("d");
+    CHECK(ispecies == 1);
+    int i_msize             = species_set.addAttribute("membersize");
+    species_set(i_msize, 0) = n_elec / 2 + n_elec % 2;
+    species_set(i_msize, 1) = n_elec / 2;
 
-  SpinDensityInput sdi_copy = sdi;
+    SpinDensityInput sdi_copy = sdi;
 
-  int n_crowds  = 3;
-  int n_walkers = 4;
-  int nsteps    = 4;
+    int n_crowds  = 3;
+    int n_walkers = 4;
+    int nsteps    = 4;
 
-  SpinDensityNew sdn_rank(std::move(sdi), species_set, DataLocality::rank);
-  UPtrVector<OperatorEstBase> crowd_sdns_rank;
-  accumulateFromPsets(n_crowds, n_walkers, sdn_rank, crowd_sdns_rank);
-  testing::RandomForTest<QMCT::RealType> rng_for_test_rank;
-  for (int i = 0; i < nsteps; ++i)
-    randomUpdateAccumulate(n_walkers, rng_for_test_rank, crowd_sdns_rank);
-  RefVector<OperatorEstBase> crowd_oeb_refs_rank = convertUPtrToRefVector(crowd_sdns_rank);
-  sdn_rank.collect(crowd_oeb_refs_rank);
-  std::vector<QMCT::RealType>& data_ref_rank = sdn_rank.get_data();
-  SpinDensityNew sdn_crowd(std::move(sdi), species_set, DataLocality::crowd);
-  UPtrVector<OperatorEstBase> crowd_sdns_crowd;
-  accumulateFromPsets(n_crowds, n_walkers, sdn_crowd, crowd_sdns_crowd);
-  testing::RandomForTest<QMCT::RealType> rng_for_test_crowd;
-  for (int i = 0; i < nsteps; ++i)
-    randomUpdateAccumulate(n_walkers, rng_for_test_crowd, crowd_sdns_crowd);
-  RefVector<OperatorEstBase> crowd_oeb_refs_crowd = convertUPtrToRefVector(crowd_sdns_crowd);
-  sdn_crowd.collect(crowd_oeb_refs_crowd);
-  std::vector<QMCT::RealType>& data_ref_crowd = sdn_crowd.get_data();
+    SpinDensityNew sdn_rank(std::move(sdi), species_set, DataLocality::rank);
+    UPtrVector<OperatorEstBase> crowd_sdns_rank;
+    accumulateFromPsets(n_crowds, n_walkers, sdn_rank, crowd_sdns_rank, n_elec);
+    testing::RandomForTest<QMCT::RealType> rng_for_test_rank;
+    for (int i = 0; i < nsteps; ++i)
+      randomUpdateAccumulate(n_walkers, rng_for_test_rank, crowd_sdns_rank, n_elec);
+    RefVector<OperatorEstBase> crowd_oeb_refs_rank = convertUPtrToRefVector(crowd_sdns_rank);
+    sdn_rank.collect(crowd_oeb_refs_rank);
+    std::vector<QMCT::RealType>& data_ref_rank = sdn_rank.get_data();
+    SpinDensityNew sdn_crowd(std::move(sdi), species_set, DataLocality::crowd);
+    UPtrVector<OperatorEstBase> crowd_sdns_crowd;
+    accumulateFromPsets(n_crowds, n_walkers, sdn_crowd, crowd_sdns_crowd, n_elec);
+    testing::RandomForTest<QMCT::RealType> rng_for_test_crowd;
+    for (int i = 0; i < nsteps; ++i)
+      randomUpdateAccumulate(n_walkers, rng_for_test_crowd, crowd_sdns_crowd, n_elec);
+    RefVector<OperatorEstBase> crowd_oeb_refs_crowd = convertUPtrToRefVector(crowd_sdns_crowd);
+    sdn_crowd.collect(crowd_oeb_refs_crowd);
+    std::vector<QMCT::RealType>& data_ref_crowd = sdn_crowd.get_data();
 
-  for (size_t i = 0; i < data_ref_rank.size(); ++i)
-  {
-    if (data_ref_crowd[i] != data_ref_rank[i])
-      FAIL_CHECK("crowd local " << data_ref_crowd[i] << " != rank local " << data_ref_rank[i] << " at index " << i);
-    break;
-  }
+    for (size_t i = 0; i < data_ref_rank.size(); ++i)
+    {
+      if (data_ref_crowd[i] != data_ref_rank[i])
+        FAIL_CHECK("crowd local " << data_ref_crowd[i] << " != rank local " << data_ref_rank[i] << " at index " << i);
+      break;
+    }
 
-  auto sumAndCheck = [i_msize, nsteps, n_crowds, n_walkers, &species_set](const auto& data_ref) {
-    Real up_sum{0};
-    Real dn_sum{0};
-    for (int i = 0; i < 1000; ++i)
-      up_sum += data_ref[i];
-    for (int i = 0; i < 1000; ++i)
-      dn_sum += data_ref[i + 1000];
-    // +1 is for the accumulateFromPsets
-    CHECK(up_sum == (nsteps + 1) * n_crowds * n_walkers * species_set(i_msize, 0));
-    CHECK(dn_sum == (nsteps + 1) * n_crowds * n_walkers * species_set(i_msize, 1));
+    auto sumAndCheck = [i_msize, nsteps, n_crowds, n_walkers, &species_set](const auto& data_ref) {
+      Real up_sum{0};
+      Real dn_sum{0};
+      for (int i = 0; i < 1000; ++i)
+        up_sum += data_ref[i];
+      for (int i = 0; i < 1000; ++i)
+        dn_sum += data_ref[i + 1000];
+      // +1 is for the accumulateFromPsets
+      CHECK(up_sum == (nsteps + 1) * n_crowds * n_walkers * species_set(i_msize, 0));
+      CHECK(dn_sum == (nsteps + 1) * n_crowds * n_walkers * species_set(i_msize, 1));
+    };
+    sumAndCheck(data_ref_rank);
+    sumAndCheck(data_ref_crowd);
   };
-  sumAndCheck(data_ref_rank);
-  sumAndCheck(data_ref_crowd);
+
+  checkAlgorithmsForNParticles(2);
+  checkAlgorithmsForNParticles(3);
 }
 
 TEST_CASE("SpinDensityNew::registerAndWrite", "[estimators]")
@@ -420,7 +496,7 @@ TEST_CASE("SpinDensityNew::registerAndWrite", "[estimators]")
     int n_crowds  = 2;
     int n_walkers = 4;
 
-    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns);
+    accumulateFromPsets(n_crowds, n_walkers, sdn, crowd_sdns, n_elec);
 
     RefVector<OperatorEstBase> crowd_oeb_refs = convertUPtrToRefVector(crowd_sdns);
     sdn.collect(crowd_oeb_refs);
@@ -443,22 +519,25 @@ TEST_CASE("SpinDensityNew::registerAndWrite", "[estimators]")
     testing::SpinDensityNewTests sdnt;
     hdf_path sdn_name_up{sdnt.getName(sdn)};
 
-    sdn_name_up /= "u";
+    sdn_name_up /= "u/value";
     std::cout << sdn_name_up.string() << '\n';
-    read_hd.read(up_data, "SpinDensity/u"); //sdn_name_up.string());
+    read_hd.read(up_data, sdn_name_up.string()); //sdn_name_up.string());
     CHECK(up_data.size() == 1000);
     hdf_path sdn_name_dn{sdnt.getName(sdn)};
-    sdn_name_dn /= "d";
+    sdn_name_dn /= "d/value";
     std::cout << sdn_name_dn.string() << '\n';
     read_hd.read(dn_data, sdn_name_dn.string());
+    CHECK(up_data.size() == 1000);
 
-    auto sumAndCheckData = [i_msize, n_crowds, n_walkers](const auto& data, int num_particles) {
-      FullPrecReal sum;
-      for (int i = 0; i < data.size(); ++i)
-        sum += data[i];
+    auto sumAndCheckData = [n_crowds, n_walkers](const auto& data, int num_particles) {
+      FullPrecReal sum = std::accumulate(data.begin(), data.end(), 0.0);
       // +1 is for the accumulateFromPsets
+      INFO("num_particles: " << num_particles);
       CHECK(sum == n_crowds * n_walkers * num_particles);
     };
+
+    std::cout << NativePrint(up_data);
+    std::cout << NativePrint(dn_data);
 
     sumAndCheckData(up_data, species_set(i_msize, 0));
     sumAndCheckData(dn_data, species_set(i_msize, 1));

--- a/src/Estimators/tests/test_SpinDensityNew.cpp
+++ b/src/Estimators/tests/test_SpinDensityNew.cpp
@@ -521,12 +521,13 @@ TEST_CASE("SpinDensityNew::registerAndWrite", "[estimators]")
 
     sdn_name_up /= "u/value";
     std::cout << sdn_name_up.string() << '\n';
-    read_hd.read(up_data, sdn_name_up.string()); //sdn_name_up.string());
+    std::array<int, 2> select_one_grid{0, -1};
+    read_hd.readSlabSelection(up_data, select_one_grid, sdn_name_up.string()); //sdn_name_up.string());
     CHECK(up_data.size() == 1000);
     hdf_path sdn_name_dn{sdnt.getName(sdn)};
     sdn_name_dn /= "d/value";
     std::cout << sdn_name_dn.string() << '\n';
-    read_hd.read(dn_data, sdn_name_dn.string());
+    read_hd.readSlabSelection(dn_data, select_one_grid, sdn_name_dn.string());
     CHECK(up_data.size() == 1000);
 
     auto sumAndCheckData = [n_crowds, n_walkers](const auto& data, int num_particles) {
@@ -542,7 +543,7 @@ TEST_CASE("SpinDensityNew::registerAndWrite", "[estimators]")
     sumAndCheckData(up_data, species_set(i_msize, 0));
     sumAndCheckData(dn_data, species_set(i_msize, 1));
   };
-
+  checkWriteForNParticles(2);
   checkWriteForNParticles(3);
 }
 

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -72,7 +72,13 @@ public:
   quantum_domains quantum_domain;
 
   //@{ public data members
-  ///Species ID
+  /** Species ID
+   *  This forms a redundant and unchecked for consistency pair with the species_set_ membersize attribute.
+   *  This can result in out of bounds access depending on which the client of ParticleSet trusts.!
+   *  Group id is more widely used but implementation specific and a per particle value.
+   *  the membersize attribute is a per group value and allows code to process by group.
+   *  \todo Fix this mess.
+   */
   ParticleIndex GroupID;
   ///Position
   ParticlePos R;

--- a/src/io/hdf/hdf_dataproxy.h
+++ b/src/io/hdf/hdf_dataproxy.h
@@ -48,6 +48,16 @@ struct h5data_proxy : public h5_space_type<T, 0>
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(&ref), xfer_plist);
   }
+
+  inline bool append(const data_type& ref, hid_t grp, const std::string& aname, hsize_t& current_leading_index, hid_t xfer_plist = H5P_DEFAULT) const
+  {
+    std::vector<hsize_t> my_dims;
+    hsize_t rank = dims.size() + 1;
+    my_dims.resize(rank, 1);
+    copy(dims.begin(), dims.end(), my_dims.begin() + 1);
+    return h5d_append(grp, aname.c_str(), current_leading_index, FileSpace::rank, my_dims.data(), get_address(&ref), xfer_plist);
+  }
+
 };
 
 /** specialization for bool, convert to int

--- a/src/io/hdf/hdf_pete.h
+++ b/src/io/hdf/hdf_pete.h
@@ -45,6 +45,12 @@ struct h5data_proxy<Vector<T>> : public h5_space_type<T, 1>
   {
     return h5d_write(grp, aname.c_str(), FileSpace::rank, dims, get_address(ref.data()), xfer_plist);
   }
+
+  inline bool append(const data_type& ref, hid_t grp, const std::string& aname, hsize_t& current_append_index, hid_t xfer_plist = H5P_DEFAULT)
+  {
+    std::array<hsize_t,2> my_dims{1,dims[0]};
+    return h5d_append(grp, aname.c_str(), current_append_index, 2, my_dims.data(), get_address(ref.data()), 1, xfer_plist);
+  }
 };
 
 

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -199,6 +199,41 @@ TEST_CASE("hdf_archive_vector", "[hdf]")
     CHECK(v_const[i] == v2_for_const[i]);
 }
 
+TEST_CASE("hdf_archive_append_pete", "[hdf]")
+{
+  using qmcplusplus::Vector;
+  hdf_archive hd;
+  hd.create("test_append_pete.hdf");
+
+  Vector<double> v1{2.3, 3.4, 5.6};
+  hsize_t append_index = 0;
+
+  std::string name = "pete_vector_series";
+  hd.append(v1, name, append_index);
+
+  Vector<double> v2{4.0, 5.0, 6.0};
+
+  hd.append(v2, name, append_index);
+  hd.close();
+
+  hdf_archive read_hd;
+  bool okay = read_hd.open("test_append_pete.hdf");
+  REQUIRE(okay);
+
+  Vector<double> v_read;
+  std::array<int, 2> select_one_vector{0, -1};
+  read_hd.readSlabSelection(v_read, select_one_vector, name);
+
+  CHECK(v_read.size() == 3);
+  CHECK(v1 == v_read);
+
+  select_one_vector = {1, -1};
+  read_hd.readSlabSelection(v_read, select_one_vector, name);
+
+  CHECK(v_read.size() == 3);
+  CHECK(v2 == v_read);
+}
+
 TEST_CASE("hdf_archive_group", "[hdf]")
 {
   hdf_archive hd;


### PR DESCRIPTION
## Proposed changes

Make  `OperatorEstBase::write` virtual and override for estimators that do not simply write their data block to hdf5 actually implemented.  Integration test added.

My only explanation here is that we had inadequate testing, and there is plenty more "corner" cases like this totally uncovered to be found.

This is a draft because for whatever reason I have not put together code to successfully use hdfarchive to read a previous written dataset.  Anyone who can point out my issue please do so.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Bugfix
- New feature
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

Mac laptop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes/No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- Yes Documentation has been added (if appropriate)
