### PR TITLE
Change coulomb safeguard printout to uniform error

### DIFF
--- a/src/QMCHamiltonians/CoulombPBCAA.cpp
+++ b/src/QMCHamiltonians/CoulombPBCAA.cpp
@@ -21,6 +21,7 @@
 #include "Particle/DistanceTable.h"
 #include "Utilities/ProgressReportEngine.h"
 #include <ResourceCollection.h>
+#include <Message/UniformCommunicateError.h>
 #include "Numerics/OneDimCubicSplineLinearGrid.h"
 
 namespace qmcplusplus
@@ -116,7 +117,7 @@ CoulombPBCAA::CoulombPBCAA(ParticleSet& ref, bool active, bool computeForces, bo
       msg << "differences to ensure this error is controlled for your application." << std::endl;
       msg << std::endl;
 
-      throw std::runtime_error(msg.str());
+      throw UniformCommunicateError(msg.str());
     }
     else
     {


### PR DESCRIPTION
## Proposed changes
Fixes #4546.

## What type(s) of changes does this code introduce?
- Bugfix

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
epyc-server

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
