### PR TITLE
Refactor ornl sulfur and nitrogen CI

### DIFF
--- a/.github/workflows/ci-github-actions-self-hosted.yaml
+++ b/.github/workflows/ci-github-actions-self-hosted.yaml
@@ -119,9 +119,10 @@ jobs:
             V100-Clang16-MPI-CUDA-AFQMC-Offload-Real,
             V100-Clang16-MPI-CUDA-AFQMC-Offload-Complex-Mixed,
             V100-Clang16-MPI-CUDA-AFQMC-Offload-Complex,
-            V100-OneAPI23-MPI-CUDA-Real-Mixed,
-            V100-OneAPI23-MPI-CUDA-Complex-Mixed,
-            V100-OneAPI23-MPI-CUDA-Real,
+            V100-GCC11-MPI-CUDA-Real-Mixed,
+            V100-GCC11-MPI-CUDA-Real,
+            V100-GCC11-MPI-CUDA-Complex-Mixed,
+            V100-GCC11-MPI-CUDA-Complex,
           ]
 
     steps:
@@ -282,101 +283,6 @@ jobs:
       - name: Test
         if: steps.check.outputs.triggered == 'true'
         run: tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh test
-
-      - name: Report PR status
-        if: always() && steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1.1.6
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "ornl-nitrogen CI ${{matrix.jobname}}"
-          state: ${{job.status}}
-          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-
-  nitrogen-cuda:
-    if: |
-      github.repository_owner == 'QMCPACK' &&
-      github.event.issue.pull_request &&
-      ( startsWith(github.event.comment.body, 'Test this please') || 
-        startsWith(github.event.comment.body, 'Start testing in-house') )
-
-    runs-on: [self-hosted, Linux, X64, ornl-nitrogen-2]
-
-    env:
-      GH_JOBNAME: ${{matrix.jobname}}
-      GH_OS: Linux
-    strategy:
-      fail-fast: false
-      matrix:
-        jobname: [
-            GCC9-MPI-CUDA-AFQMC-Real-Mixed, # auxiliary field, requires MPI
-            GCC9-MPI-CUDA-AFQMC-Complex-Mixed,
-            GCC9-MPI-CUDA-AFQMC-Real,
-            GCC9-MPI-CUDA-AFQMC-Complex,
-          ]
-
-    steps:
-      - name: Verify actor
-        # Only trigger for certain "actors" (those commenting the PR, not the PR originator)
-        # this is in-line with the current workflow
-        env:
-          ACTOR_TOKEN: ${{secrets.TOKENIZER}}${{github.actor}}${{secrets.TOKENIZER}}
-          SECRET_ACTORS: ${{secrets.CI_GPU_ACTORS}}
-        if: contains(env.SECRET_ACTORS, env.ACTOR_TOKEN)
-        id: check
-        run: |
-          echo "::set-output name=triggered::true"
-
-      # Request repo info, required since issue_comment doesn't point at PR commit, but develop
-      - name: GitHub API Request
-        if: steps.check.outputs.triggered == 'true'
-        id: request
-        uses: octokit/request-action@v2.1.7
-        with:
-          route: ${{github.event.issue.pull_request.url}}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      # Create a separate PR status pointing at GitHub Actions tab URL
-      # just like any other third-party service
-      - name: Create PR status
-        if: steps.check.outputs.triggered == 'true'
-        uses: Sibz/github-status-action@v1.1.6
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "ornl-nitrogen CI ${{matrix.jobname}}"
-          state: "pending"
-          sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          target_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-
-      - name: Get PR information
-        if: steps.check.outputs.triggered == 'true'
-        id: pr_data
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
-
-      - name: Checkout PR branch
-        if: steps.check.outputs.triggered == 'true'
-        uses: actions/checkout@v3
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          repository: ${{fromJson(steps.request.outputs.data).head.repo.full_name}}
-          ref: ${{steps.pr_data.outputs.branch}}
-
-      - name: Configure
-        if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh configure
-
-      - name: Build
-        if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh build
-
-      - name: Test
-        if: steps.check.outputs.triggered == 'true'
-        run: tests/test_automation/github-actions/ci/run_step.sh test
 
       - name: Report PR status
         if: always() && steps.check.outputs.triggered == 'true'

--- a/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-sulfur-2.sh
@@ -91,24 +91,17 @@ case "$1" in
               ${GITHUB_WORKSPACE}
       ;;
 
-      *"V100-OneAPI23-MPI-CUDA"*)
-        echo "Configure for building with CUDA and AFQMC  " \
-             "using Intel OneAPI icx compiler" 
-        
-        source /opt/intel/oneapi/setvars.sh
+      *"V100-GCC11-MPI-CUDA"*)
+        echo "Configure for building with CUDA 12.1 and" \
+             "GCC11 system compiler" 
 
         echo "Set PATHs to cuda-12.1"
         export PATH=/usr/local/cuda-12.1/bin:$PATH
         export LD_LIBRARY_PATH=/usr/local/cuda-12.1/bin:$LD_LIBRARY_PATH
-        
-        export OMPI_CC=`which icx`
-        export OMPI_CXX=`which icpx`
 
         # Make current environment variables available to subsequent steps
         echo "PATH=$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "OMPI_CC=$OMPI_CC" >> $GITHUB_ENV
-        echo "OMPI_CXX=$OMPI_CXX" >> $GITHUB_ENV
 
         cmake -GNinja \
               -DCMAKE_C_COMPILER=/usr/lib64/openmpi/bin/mpicc \


### PR DESCRIPTION
## Proposed changes

Current CI using oneAPI is unstable, these changes attempt to move CI to a green (all tests pass) status.
Remove ornl-nitrogen-2 (not used)
Switch oneAPI+CUDA12 (unstable) to GCC11+CUDA12 on ornl-sulfur-2

## What type(s) of changes does this code introduce?

- Refactoring (no functional changes, no api changes)
- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
sulfur, must pass CI

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
