### PR TITLE
Update codecov configuration to notify after 2 builds

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -21,3 +21,9 @@ ignore:
 # from https://docs.codecov.io/docs/fixing-paths
 fixes:
   - "/__w/::"
+
+# Wait for both real and complex reports
+# from https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
## Proposed changes

Try to avoid coverage failure reports until both real + complex builds have reported. Docs are at https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds

## What type(s) of changes does this code introduce?

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None.

## Checklist

None relevant

