### PR TITLE
Read and write orbital rotation parameters

### DIFF
--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -147,9 +147,9 @@ void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
     hid_t grp                   = hout.push("rotation_global");
     std::string rot_global_name = std::string("rotation_global_") + SPOSet::getName();
 
-    int nparam = myVarsFull.size();
-    std::vector<RealType> full_params(nparam);
-    for (int i = 0; i < nparam; i++)
+    int nparam_full = myVarsFull.size();
+    std::vector<RealType> full_params(nparam_full);
+    for (int i = 0; i < nparam_full; i++)
       full_params[i] = myVarsFull[i];
 
     hout.write(full_params, rot_global_name);
@@ -210,19 +210,19 @@ void RotatedSPOs::readVariationalParameters(hdf_archive& hin)
     if (!hin.getShape<RealType>(rot_global_name, sizes))
       throw std::runtime_error("Failed to read rotation_global in VP file");
 
-    int nparam_actual = sizes[0];
-    int nparam        = myVarsFull.size();
+    int nparam_full_actual = sizes[0];
+    int nparam_full        = myVarsFull.size();
 
-    if (nparam != nparam_actual)
+    if (nparam_full != nparam_full_actual)
     {
       std::ostringstream tmp_err;
-      tmp_err << "Expected number of full rotation parameters (" << nparam << ") does not match number in file ("
-              << nparam_actual << ")";
+      tmp_err << "Expected number of full rotation parameters (" << nparam_full << ") does not match number in file ("
+              << nparam_full_actual << ")";
       throw std::runtime_error(tmp_err.str());
     }
-    std::vector<RealType> full_params(nparam);
+    std::vector<RealType> full_params(nparam_full);
     hin.read(full_params, rot_global_name);
-    for (int i = 0; i < nparam; i++)
+    for (int i = 0; i < nparam_full; i++)
       myVarsFull[i] = full_params[i];
 
     hin.pop();

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -14,6 +14,7 @@
 #include "Numerics/MatrixOperators.h"
 #include "Numerics/DeterminantOperators.h"
 #include "CPU/BLAS.hpp"
+#include "io/hdf/hdf_archive.h"
 
 
 namespace qmcplusplus
@@ -136,6 +137,148 @@ void RotatedSPOs::resetParametersExclusive(const opt_variables_type& active)
     // Save the parameters in the history list
     history_params_.push_back(delta_param);
   }
+}
+
+void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
+{
+  hout.push("RotatedSPOs");
+  if (use_global_rot_)
+  {
+    hid_t grp                   = hout.push("rotation_global");
+    std::string rot_global_name = std::string("rotation_global_") + SPOSet::getName();
+
+    int nparam = myVarsFull.size();
+    std::vector<RealType> full_params(nparam);
+    for (int i = 0; i < nparam; i++)
+      full_params[i] = myVarsFull[i];
+
+    hout.write(full_params, rot_global_name);
+    hout.pop();
+  }
+  else
+  {
+    hid_t grp   = hout.push("rotation_history");
+    size_t rows = history_params_.size();
+    size_t cols = 0;
+    if (rows > 0)
+      cols = history_params_[0].size();
+
+    Matrix<RealType> tmp(rows, cols);
+    for (size_t i = 0; i < rows; i++)
+      for (size_t j = 0; j < cols; j++)
+        tmp(i, j) = history_params_[i][j];
+
+    std::string rot_hist_name = std::string("rotation_history_") + SPOSet::getName();
+    hout.write(tmp, rot_hist_name);
+    hout.pop();
+  }
+
+  // Save myVars in order to restore object state exactly
+  //  The values aren't meaningful, but they need to match those saved in VariableSet
+  hid_t grp                   = hout.push("rotation_params");
+  std::string rot_params_name = std::string("rotation_params_") + SPOSet::getName();
+
+  int nparam = myVars.size();
+  std::vector<RealType> params(nparam);
+  for (int i = 0; i < nparam; i++)
+    params[i] = myVars[i];
+
+  hout.write(params, rot_params_name);
+  hout.pop();
+
+  hout.pop();
+}
+
+void RotatedSPOs::readVariationalParameters(hdf_archive& hin)
+{
+  hid_t grp_rot = hin.push("RotatedSPOs", false);
+  if (grp_rot < 0)
+    app_warning() << "RotateSPOs not found in VP file";
+
+  bool grp_hist_exists   = hin.is_group("rotation_history");
+  bool grp_global_exists = hin.is_group("rotation_global");
+  if (!grp_hist_exists && !grp_global_exists)
+    app_warning() << "Rotation parameters not found in VP file";
+
+
+  if (grp_global_exists)
+  {
+    hin.push("rotation_global", false);
+    std::string rot_global_name = std::string("rotation_global_") + SPOSet::getName();
+
+    std::vector<int> sizes(1);
+    if (!hin.getShape<RealType>(rot_global_name, sizes))
+      throw std::runtime_error("Failed to read rotation_global in VP file");
+
+    int nparam_actual = sizes[0];
+    int nparam        = myVarsFull.size();
+
+    if (nparam != nparam_actual)
+    {
+      std::ostringstream tmp_err;
+      tmp_err << "Expected number of full rotation parameters (" << nparam << ") does not match number in file ("
+              << nparam_actual << ")";
+      throw std::runtime_error(tmp_err.str());
+    }
+    std::vector<RealType> full_params(nparam);
+    hin.read(full_params, rot_global_name);
+    for (int i = 0; i < nparam; i++)
+      myVarsFull[i] = full_params[i];
+
+    hin.pop();
+
+    applyFullRotation(full_params, true);
+  }
+  else if (grp_hist_exists)
+  {
+    hin.push("rotation_history", false);
+    std::string rot_hist_name = std::string("rotation_history_") + SPOSet::getName();
+    std::vector<int> sizes(2);
+    if (!hin.getShape<RealType>(rot_hist_name, sizes))
+      throw std::runtime_error("Failed to read rotation history in VP file");
+
+    int rows = sizes[0];
+    int cols = sizes[1];
+    history_params_.resize(rows);
+    Matrix<RealType> tmp(rows, cols);
+    hin.read(tmp, rot_hist_name);
+    for (size_t i = 0; i < rows; i++)
+    {
+      history_params_[i].resize(cols);
+      for (size_t j = 0; j < cols; j++)
+        history_params_[i][j] = tmp(i, j);
+    }
+
+    hin.pop();
+
+    applyRotationHistory();
+  }
+
+  hin.push("rotation_params", false);
+  std::string rot_param_name = std::string("rotation_params_") + SPOSet::getName();
+
+  std::vector<int> sizes(1);
+  if (!hin.getShape<RealType>(rot_param_name, sizes))
+    throw std::runtime_error("Failed to read rotation_params in VP file");
+
+  int nparam_actual = sizes[0];
+  int nparam        = myVars.size();
+  if (nparam != nparam_actual)
+  {
+    std::ostringstream tmp_err;
+    tmp_err << "Expected number of rotation parameters (" << nparam << ") does not match number in file ("
+            << nparam_actual << ")";
+    throw std::runtime_error(tmp_err.str());
+  }
+
+  std::vector<RealType> params(nparam);
+  hin.read(params, rot_param_name);
+  for (int i = 0; i < nparam; i++)
+    myVars[i] = params[i];
+
+  hin.pop();
+
+  hin.pop();
 }
 
 void RotatedSPOs::buildOptVariables(const size_t nel)
@@ -312,6 +455,33 @@ void RotatedSPOs::constructDeltaRotation(const std::vector<RealType>& delta_para
   ValueMatrix log_rot_mat(nmo, nmo);
   log_antisym_matrix(new_rot_mat, log_rot_mat);
   extractParamsFromAntiSymmetricMatrix(full_rot_inds, log_rot_mat, new_param);
+}
+
+void RotatedSPOs::applyFullRotation(const std::vector<RealType>& full_param, bool use_stored_copy)
+{
+  assert(full_param.size() == m_full_rot_inds.size());
+
+  const size_t nmo = Phi->getOrbitalSetSize();
+  ValueMatrix rot_mat(nmo, nmo);
+  rot_mat = ValueType(0);
+
+  constructAntiSymmetricMatrix(m_full_rot_inds, full_param, rot_mat);
+
+  /*
+    rot_mat is now an anti-hermitian matrix. Now we convert
+    it into a unitary matrix via rot_mat = exp(-rot_mat).
+    Finally, apply unitary matrix to orbs.
+  */
+  exponentiate_antisym_matrix(rot_mat);
+  Phi->applyRotation(rot_mat, use_stored_copy);
+}
+
+void RotatedSPOs::applyRotationHistory()
+{
+  for (auto delta_param : history_params_)
+  {
+    apply_rotation(delta_param, false);
+  }
 }
 
 // compute exponential of a real, antisymmetric matrix by diagonalizing and exponentiating eigenvalues

--- a/src/QMCWaveFunctions/RotatedSPOs.h
+++ b/src/QMCWaveFunctions/RotatedSPOs.h
@@ -18,6 +18,13 @@
 
 namespace qmcplusplus
 {
+class RotatedSPOs;
+namespace testing
+{
+opt_variables_type& getMyVarsFull(RotatedSPOs& rot);
+std::vector<std::vector<QMCTraits::RealType>>& getHistoryParams(RotatedSPOs& rot);
+} // namespace testing
+
 class RotatedSPOs : public SPOSet, public OptimizableObject
 {
 public:
@@ -80,6 +87,14 @@ public:
                                      const RotationIndices& full_rot_inds,
                                      std::vector<RealType>& new_param,
                                      ValueMatrix& new_rot_mat);
+
+  // When initializing the rotation from VP files
+  // This function applies the rotation history
+  void applyRotationHistory();
+
+  // This function applies the global rotation (similar to apply_rotation, but for the full
+  // set of rotation parameters)
+  void applyFullRotation(const std::vector<RealType>& full_param, bool use_stored_copy);
 
   // Compute matrix exponential of an antisymmetric matrix (result is rotation matrix)
   static void exponentiate_antisym_matrix(ValueMatrix& mat);
@@ -235,6 +250,10 @@ public:
   ///reset
   void resetParametersExclusive(const opt_variables_type& active) override;
 
+  void writeVariationalParameters(hdf_archive& hout) override;
+
+  void readVariationalParameters(hdf_archive& hin) override;
+
   //*********************************************************************************
   //the following functions simply call Phi's corresponding functions
   void setOrbitalSetSize(int norbs) override { Phi->setOrbitalSetSize(norbs); }
@@ -366,6 +385,9 @@ private:
 
   /// Use global rotation or history list
   bool use_global_rot_ = true;
+
+  friend opt_variables_type& testing::getMyVarsFull(RotatedSPOs& rot);
+  friend std::vector<std::vector<RealType>>& testing::getHistoryParams(RotatedSPOs& rot);
 };
 
 } //namespace qmcplusplus

--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -32,6 +32,13 @@ namespace qmcplusplus
 {
 class ResourceCollection;
 
+class SPOSet;
+namespace testing
+{
+opt_variables_type& getMyVars(SPOSet& spo);
+}
+
+
 /** base class for Single-particle orbital sets
  *
  * SPOSet stands for S(ingle)P(article)O(rbital)Set which contains
@@ -546,6 +553,8 @@ protected:
   IndexType OrbitalSetSize;
   /// Optimizable variables
   opt_variables_type myVars;
+
+  friend opt_variables_type& testing::getMyVars(SPOSet& spo);
 };
 
 using SPOSetPtr = SPOSet*;

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -662,7 +662,7 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
   vs[0] = 0.1;
   vs[1] = 0.15;
   vs[2] = 0.2;
-  vs[4] = 0.25;
+  vs[3] = 0.25;
   rot.resetParametersExclusive(vs);
 
   hdf_archive hout;
@@ -715,7 +715,7 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   vs[0] = 0.1;
   vs[1] = 0.15;
   vs[2] = 0.2;
-  vs[4] = 0.25;
+  vs[3] = 0.25;
   rot.resetParametersExclusive(vs);
 
   hdf_archive hout;

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -665,12 +665,12 @@ TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
   vs[3] = 0.25;
   rot.resetParametersExclusive(vs);
 
-  hdf_archive hout;
-  vs.writeToHDF("rot_vp.h5", hout);
+  {
+    hdf_archive hout;
+    vs.writeToHDF("rot_vp.h5", hout);
 
-  rot.writeVariationalParameters(hout);
-
-  hout.close();
+    rot.writeVariationalParameters(hout);
+  }
 
   auto fake_spo2 = std::make_unique<FakeSPO>();
   fake_spo2->setOrbitalSetSize(4);
@@ -718,11 +718,12 @@ TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
   vs[3] = 0.25;
   rot.resetParametersExclusive(vs);
 
-  hdf_archive hout;
-  vs.writeToHDF("rot_vp_hist.h5", hout);
+  {
+    hdf_archive hout;
+    vs.writeToHDF("rot_vp_hist.h5", hout);
 
-  rot.writeVariationalParameters(hout);
-  hout.close();
+    rot.writeVariationalParameters(hout);
+  }
 
   auto fake_spo2 = std::make_unique<FakeSPO>();
   fake_spo2->setOrbitalSetSize(4);

--- a/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/tests/test_RotatedSPOs.cpp
@@ -21,6 +21,7 @@
 #include "QMCWaveFunctions/EinsplineSetBuilder.h"
 #include "QMCWaveFunctions/RotatedSPOs.h"
 #include "checkMatrix.hpp"
+#include "FakeSPO.h"
 
 #include <stdio.h>
 #include <string>
@@ -638,6 +639,113 @@ TEST_CASE("RotatedSPOs construct delta matrix", "[wavefunction]")
   RotatedSPOs::constructDeltaRotation(reverse_delta_params, new_params, rot_ind, full_rot_ind, new_params2, rot_m4);
   for (int i = 0; i < new_params2.size(); i++)
     CHECK(new_params2[i] == Approx(old_params[i]));
+}
+
+namespace testing
+{
+opt_variables_type& getMyVars(SPOSet& rot) { return rot.myVars; }
+opt_variables_type& getMyVarsFull(RotatedSPOs& rot) { return rot.myVarsFull; }
+std::vector<std::vector<QMCTraits::RealType>>& getHistoryParams(RotatedSPOs& rot) { return rot.history_params_; }
+} // namespace testing
+
+// Test using global rotation
+TEST_CASE("RotatedSPOs read and write parameters", "[wavefunction]")
+{
+  auto fake_spo = std::make_unique<FakeSPO>();
+  fake_spo->setOrbitalSetSize(4);
+  RotatedSPOs rot("fake_rot", std::move(fake_spo));
+  int nel = 2;
+  rot.buildOptVariables(nel);
+
+  optimize::VariableSet vs;
+  rot.checkInVariablesExclusive(vs);
+  vs[0] = 0.1;
+  vs[1] = 0.15;
+  vs[2] = 0.2;
+  vs[4] = 0.25;
+  rot.resetParametersExclusive(vs);
+
+  hdf_archive hout;
+  vs.writeToHDF("rot_vp.h5", hout);
+
+  rot.writeVariationalParameters(hout);
+
+  hout.close();
+
+  auto fake_spo2 = std::make_unique<FakeSPO>();
+  fake_spo2->setOrbitalSetSize(4);
+
+  RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
+  rot2.buildOptVariables(nel);
+
+  optimize::VariableSet vs2;
+  rot2.checkInVariablesExclusive(vs2);
+
+  hdf_archive hin;
+  vs2.readFromHDF("rot_vp.h5", hin);
+  rot2.readVariationalParameters(hin);
+
+  opt_variables_type& var = testing::getMyVars(rot2);
+  CHECK(var[0] == Approx(vs[0]));
+  CHECK(var[1] == Approx(vs[1]));
+  CHECK(var[2] == Approx(vs[2]));
+  CHECK(var[3] == Approx(vs[3]));
+
+  opt_variables_type& full_var = testing::getMyVarsFull(rot2);
+  CHECK(full_var[0] == Approx(vs[0]));
+  CHECK(full_var[1] == Approx(vs[1]));
+  CHECK(full_var[2] == Approx(vs[2]));
+  CHECK(full_var[3] == Approx(vs[3]));
+  CHECK(full_var[4] == Approx(0.0));
+  CHECK(full_var[5] == Approx(0.0));
+}
+
+// Test using history list.
+TEST_CASE("RotatedSPOs read and write parameters history", "[wavefunction]")
+{
+  auto fake_spo = std::make_unique<FakeSPO>();
+  fake_spo->setOrbitalSetSize(4);
+  RotatedSPOs rot("fake_rot", std::move(fake_spo));
+  rot.set_use_global_rotation(false);
+  int nel = 2;
+  rot.buildOptVariables(nel);
+
+  optimize::VariableSet vs;
+  rot.checkInVariablesExclusive(vs);
+  vs[0] = 0.1;
+  vs[1] = 0.15;
+  vs[2] = 0.2;
+  vs[4] = 0.25;
+  rot.resetParametersExclusive(vs);
+
+  hdf_archive hout;
+  vs.writeToHDF("rot_vp_hist.h5", hout);
+
+  rot.writeVariationalParameters(hout);
+  hout.close();
+
+  auto fake_spo2 = std::make_unique<FakeSPO>();
+  fake_spo2->setOrbitalSetSize(4);
+
+  RotatedSPOs rot2("fake_rot", std::move(fake_spo2));
+  rot2.buildOptVariables(nel);
+
+  optimize::VariableSet vs2;
+  rot2.checkInVariablesExclusive(vs2);
+
+  hdf_archive hin;
+  vs2.readFromHDF("rot_vp_hist.h5", hin);
+  rot2.readVariationalParameters(hin);
+
+  opt_variables_type& var = testing::getMyVars(rot2);
+  CHECK(var[0] == Approx(vs[0]));
+  CHECK(var[1] == Approx(vs[1]));
+  CHECK(var[2] == Approx(vs[2]));
+  CHECK(var[3] == Approx(vs[3]));
+
+  auto hist = testing::getHistoryParams(rot2);
+  REQUIRE(hist.size() == 1);
+  REQUIRE(hist[0].size() == 4);
 }
 
 } // namespace qmcplusplus


### PR DESCRIPTION
Implement write/readVariationalParameters for orbital rotation.

The parameters associated with either global rotation or a history list are stored to the VP HDF file.

The parameters in myVars are also saved so the first call to resetParameters works correctly.  The first call occurs in WaveFunctionFactory::buildTWF after the VP file is read.   By "works correctly" , I mean the parameters set in myVars and the parameters in read into VariableSet match, so the change in parameters in RotatedSPOs::resetParametersExclusive is zero, and that causes no change to the carefully restored rotation matrices.

There are unit tests that do minimal testing of the code paths.  There will need to be more complete tests of this functionality.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
