### PR TITLE
Update hdf_archive push

### DIFF
--- a/src/AFQMC/Drivers/DriverFactory.cpp
+++ b/src/AFQMC/Drivers/DriverFactory.cpp
@@ -144,8 +144,14 @@ bool DriverFactory::executeAFQMCDriver(std::string title, int m_series, xmlNodeP
       if (read.open(hdf_read_restart, H5F_ACC_RDONLY))
       {
         // always write driver data and walkers
-        if (!read.push("AFQMCDriver", false))
+        try
+        {
+          read.push("AFQMCDriver", false);
+        }
+        catch (...)
+        {
           return false;
+        }
 
         std::vector<IndexType> Idata(2);
         std::vector<RealType> Rdata(2);

--- a/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/atomcentered_correlators.hpp
@@ -137,11 +137,9 @@ public:
         app_error() << " Error opening orbitals file for atomcentered_correlators estimator. \n";
         APP_ABORT("");
       }
-      if (!dump.push("AtomicOverlaps", false))
-      {
-        app_error() << " Error in atomcentered_correlators: Group OrbsR not found." << std::endl;
-        APP_ABORT("");
-      }
+
+      dump.push("AtomicOverlaps", false);
+
       if (!dump.readEntry(orbs, "index_of_orbital_per_site"))
       {
         app_error() << " Error in atomcentered_correlators: Problems reading index_of_orbital_per_site. " << std::endl;

--- a/src/AFQMC/Estimators/Observables/full1rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full1rdm.hpp
@@ -126,8 +126,8 @@ public:
       {
         if (!dump.open(rot_file, H5F_ACC_RDONLY))
           APP_ABORT("Error opening orbitals file for n2r estimator.\n");
-        if (!dump.push(path, false))
-          APP_ABORT("Error in full1rdm: path not found.");
+        dump.push(path, false);
+
         stdCMatrix R;
         if (!dump.readEntry(R, "RotationMatrix"))
           APP_ABORT("Error reading RotationMatrix.\n");

--- a/src/AFQMC/Estimators/Observables/full2rdm.hpp
+++ b/src/AFQMC/Estimators/Observables/full2rdm.hpp
@@ -119,8 +119,8 @@ public:
       {
         if (!dump.open(rot_file, H5F_ACC_RDONLY))
           APP_ABORT("Error opening orbitals file for n2r estimator.\n");
-        if (!dump.push(path, false))
-          APP_ABORT("Error in full2rdm: path not found.");
+        dump.push(path, false);
+
         stdCMatrix R;
         if (!dump.readEntry(R, "RotationMatrix"))
           APP_ABORT("Error reading RotationMatrix.\n");

--- a/src/AFQMC/Estimators/Observables/n2r.hpp
+++ b/src/AFQMC/Estimators/Observables/n2r.hpp
@@ -132,11 +132,8 @@ public:
         app_error() << " Error opening orbitals file for n2r estimator. \n";
         APP_ABORT("");
       }
-      if (!dump.push("OrbsR", false))
-      {
-        app_error() << " Error in n2r: Group OrbsR not found." << std::endl;
-        APP_ABORT("");
-      }
+      dump.push("OrbsR", false);
+
       if (!dump.readEntry(grid_dim, "grid_dim"))
       {
         app_error() << " Error in n2r: Problems reading grid_dim. " << std::endl;

--- a/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
+++ b/src/AFQMC/Estimators/Observables/realspace_correlators.hpp
@@ -121,11 +121,8 @@ public:
         app_error() << " Error opening orbitals file for realspace_correlators estimator. \n";
         APP_ABORT("");
       }
-      if (!dump.push("OrbsR", false))
-      {
-        app_error() << " Error in realspace_correlators: Group OrbsR not found." << std::endl;
-        APP_ABORT("");
-      }
+      dump.push("OrbsR", false);
+
       // read one orbital to check size and later corroborate all orbitals have same size
       stdCVector orb(iextensions<1u>{1});
       if (!dump.readEntry(orb, "kp0_b0"))

--- a/src/AFQMC/HamiltonianOperations/HamOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/HamOpsIO.hpp
@@ -48,11 +48,8 @@ HamiltonianOperations loadHamOps(hdf_archive& dump,
   int hops_type = -1;
   if (TGwfn.Global().root())
   {
-    if (!dump.push("HamiltonianOperations", false))
-    {
-      app_error() << " Error in loadHamOps: Group HamiltonianOperations not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("HamiltonianOperations", false);
+
     if (dump.is_group(std::string("THCOps")))
       hops_type = 1;
     else if (dump.is_group(std::string("KP3IndexFactorization")))

--- a/src/AFQMC/HamiltonianOperations/KP3IndexFactorizationIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/KP3IndexFactorizationIO.hpp
@@ -66,16 +66,9 @@ inline HamiltonianOperations loadKP3IndexFactorization(hdf_archive& dump,
   // single reader for now
   if (TGwfn.Global().root())
   {
-    if (!dump.push("HamiltonianOperations", false))
-    {
-      app_error() << " Error in loadKP3IndexFactorization: Group HamiltonianOperations not found. \n";
-      APP_ABORT("");
-    }
-    if (!dump.push("KP3IndexFactorization", false))
-    {
-      app_error() << " Error in loadKP3IndexFactorization: Group KP3IndexFactorization not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("HamiltonianOperations", false);
+    dump.push("KP3IndexFactorization", false);
+
     if (!dump.read(dims, "dims"))
     {
       app_error() << " Error in loadKP3IndexFactorization: Problems reading dataset. \n";
@@ -557,10 +550,9 @@ inline void writeKP3IndexFactorization(hdf_archive& dump,
 
   if (TGwfn.Global().root())
   {
-    if (dump.push("HamiltonianOperations") == hdf_archive::is_closed)
-      APP_ABORT(" Error: hdf_archive::push returned false. \n");
-    if (dump.push("KP3IndexFactorization") == hdf_archive::is_closed)
-      APP_ABORT(" Error: hdf_archive::push returned false. \n");
+    dump.push("HamiltonianOperations");
+    dump.push("KP3IndexFactorization");
+
     std::vector<int> dims{NMO, NAEA, NAEB, int(nopk.size()), type, nsampleQ, gncv};
     dump.write(dims, "dims");
     std::vector<ValueType> et{E0};

--- a/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/SparseTensorIO.hpp
@@ -62,16 +62,9 @@ SparseTensor<T1, T2> loadSparseTensor(hdf_archive& dump,
   int V2_nrows, V2_ncols, Spvn_nrows, Spvn_ncols;
 
   // read from HDF
-  if (!dump.push("HamiltonianOperations", false))
-  {
-    app_error() << " Error in loadSparseTensor: Group HamiltonianOperations not found. \n";
-    APP_ABORT("");
-  }
-  if (!dump.push("SparseTensor", false))
-  {
-    app_error() << " Error in loadSparseTensor: Group SparseTensor not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("HamiltonianOperations", false);
+  dump.push("SparseTensor", false);
+
   if (TGwfn.Global().root())
   {
     if (!dump.readEntry(dims, "dims"))
@@ -155,22 +148,14 @@ SparseTensor<T1, T2> loadSparseTensor(hdf_archive& dump,
   V2.reserve(ndet);
   for (int i = 0; i < ndet; i++)
   {
-    if (!dump.push(std::string("HalfRotatedHijkl_") + std::to_string(i), false))
-    {
-      app_error() << " Error in loadSparseTensor: Group HalfRotatedHijkl_" << i << " not found. \n";
-      APP_ABORT("");
-    }
+    dump.push(std::string("HalfRotatedHijkl_") + std::to_string(i), false);
     V2.emplace_back(
         csr_hdf5::unstructured_distributed_CSR_from_HDF<T1_shm_csr_matrix>(dump, TGwfn, V2_nrows, V2_ncols, cutv2));
     dump.pop();
   }
 
   // read Cholesky matrix
-  if (!dump.push(std::string("SparseCholeskyMatrix"), false))
-  {
-    app_error() << " Error in loadSparseTensor: Group SparseCholeskyMatrix not found. \n";
-    APP_ABORT("");
-  }
+  dump.push(std::string("SparseCholeskyMatrix"), false);
   SpVType_shm_csr_matrix Spvn(
       csr_hdf5::column_distributed_CSR_from_HDF<SpVType_shm_csr_matrix>(dump, TGprop, Spvn_nrows, Spvn_ncols, cutv2));
   dump.pop();

--- a/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
+++ b/src/AFQMC/HamiltonianOperations/THCOpsIO.hpp
@@ -75,16 +75,9 @@ inline THCOps loadTHCOps(hdf_archive& dump,
 
   // read from HDF
 
-  if (!dump.push("HamiltonianOperations", false))
-  {
-    app_error() << " Error in loadTHCOps: Group HamiltonianOperations not found. \n";
-    APP_ABORT("");
-  }
-  if (!dump.push("THCOps", false))
-  {
-    app_error() << " Error in loadTHCOps: Group THCOps not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("HamiltonianOperations", false);
+  dump.push("THCOps", false);
+
   if (TGwfn.Global().root())
   {
     if (!dump.readEntry(dims, "dims"))

--- a/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
+++ b/src/AFQMC/Hamiltonians/HamiltonianFactory.cpp
@@ -99,11 +99,7 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
       app_error() << " Error opening integral file in SparseGeneralHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   HamiltonianTypes htype = UNKNOWN;
@@ -266,11 +262,9 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
   if (htype == KPTHC)
   {
     APP_ABORT(" Error: KPTHC hamiltonian not yet working. \n");
-    if (coreid < nread && !dump.push("KPTHC", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group not KPTHC found. \n";
-      APP_ABORT("");
-    }
+    if (coreid < nread)
+      dump.push("KPTHC", false);
+
     if (coreid < nread)
     {
       dump.pop();
@@ -284,11 +278,9 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
   }
   else if (htype == KPFactorized)
   {
-    if (coreid < nread && !dump.push("KPFactorized", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group not KPFactorized found. \n";
-      APP_ABORT("");
-    }
+    if (coreid < nread)
+      dump.push("KPFactorized", false);
+
     if (coreid < nread)
     {
       dump.pop();
@@ -304,11 +296,9 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
 #else
   if (htype == RealDenseFactorized)
   {
-    if (coreid < nread && !dump.push("DenseFactorized", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group not DenseFactorized found. \n";
-      APP_ABORT("");
-    }
+    if (coreid < nread)
+      dump.push("DenseFactorized", false);
+
     if (coreid < nread)
     {
       dump.pop();
@@ -332,11 +322,9 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
 #endif
       if (htype == THC)
   {
-    if (coreid < nread && !dump.push("THC", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group not THC found. \n";
-      APP_ABORT("");
-    }
+    if (coreid < nread)
+      dump.push("THC", false);
+
     if (coreid < nread)
     {
       dump.pop();
@@ -350,11 +338,8 @@ Hamiltonian HamiltonianFactory::fromHDF5(GlobalTaskGroup& gTG, xmlNodePtr cur)
   }
   else if (htype == Factorized)
   {
-    if (coreid < nread && !dump.push("Factorized", false))
-    {
-      app_error() << " Error in HamiltonianFactory::fromHDF5(): Group Factorized not found. \n";
-      APP_ABORT("");
-    }
+    if (coreid < nread)
+      dump.push("Factorized", false);
 
     if (TG.getNumberOfTGs() > 1)
       APP_ABORT(" Error: Distributed Factorized hamiltonian not yet implemented. \n\n");

--- a/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPFactorizedHamiltonian.cpp
@@ -99,12 +99,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   std::vector<int> Idata(8);
@@ -257,12 +252,8 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_shared(b
       ma::add(ComplexType(1.0), h1, ComplexType(0.0), h1, H1[Q]({0, npol * nmo_per_kp[Q]}, {0, npol * nmo_per_kp[Q]}));
     }
     // read LQ
-    if (!dump.push("KPFactorized", false))
-    {
-      app_error() << " Error in KPFactorizedHamiltonian::getHamiltonianOperations():"
-                  << " Group KPFactorized not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("KPFactorized", false);
+
     for (int Q = 0; Q < nkpts; Q++)
     {
       using ma::conj;
@@ -834,12 +825,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   std::vector<int> Idata(8);
@@ -993,12 +979,7 @@ HamiltonianOperations KPFactorizedHamiltonian::getHamiltonianOperations_batched(
     for (auto& v : LQKikn)
       std::fill_n(to_address(v.origin()), v.num_elements(), SPComplexType(0.0));
     // read LQ
-    if (!dump.push("KPFactorized", false))
-    {
-      app_error() << " Error in KPFactorizedHamiltonian::getHamiltonianOperations():"
-                  << " Group KPFactorized not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("KPFactorized", false);
     // read in compact form and transform to padded
     SpMatrix L_({1, 1});
     for (int Q = 0; Q < nkpts; Q++)

--- a/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/KPTHCHamiltonian.cpp
@@ -72,12 +72,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   std::vector<int> Idata(8);
@@ -228,12 +223,7 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
     }
 
     // read LQ
-    if (!dump.push("KPTHC", false))
-    {
-      app_error() << " Error in KPTHCHamiltonian::getHamiltonianOperations():"
-                  << " Group KPTHC not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("KPTHC", false);
 
     if (!dump.readEntry(Idata, "dims"))
     {
@@ -1056,12 +1046,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump_.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump_.push("Hamiltonian", false);
+
     if (!dump_.readEntry(nchol_per_kp_, "NCholPerKP"))
     {
       app_error() << " Error in KPFactorizedHamiltonian::getHamiltonianOperations():"
@@ -1078,12 +1064,8 @@ HamiltonianOperations KPTHCHamiltonian::getHamiltonianOperations(bool pureSD,
   if (TG.Node().root())
   {
     // read LQ
-    if (!dump_.push("KPFactorized", false))
-    {
-      app_error() << " Error in KPFactorizedHamiltonian::getHamiltonianOperations():"
-                  << " Group KPFactorized not found. \n";
-      APP_ABORT("");
-    }
+    dump_.push("KPFactorized", false);
+
     for (int Q = 0; Q < nkpts; Q++)
     {
       std::cout << " reading: " << Q << std::endl;

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian.cpp
@@ -90,12 +90,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
       app_error() << " Error opening integral file in RealDenseHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in RealDenseHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   std::vector<int> Idata(8);
@@ -158,12 +153,7 @@ HamiltonianOperations RealDenseHamiltonian::getHamiltonianOperations(bool pureSD
   if (distNode.root())
   {
     // read L
-    if (!dump.push("DenseFactorized", false))
-    {
-      app_error() << " Error in RealDenseHamiltonian::getHamiltonianOperations():"
-                  << " Group DenseFactorized not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("DenseFactorized", false);
     SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
     hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
                                             std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),

--- a/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
+++ b/src/AFQMC/Hamiltonians/RealDenseHamiltonian_v2.cpp
@@ -88,12 +88,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
   }
 
   std::vector<int> Idata(8);
@@ -156,12 +151,7 @@ HamiltonianOperations RealDenseHamiltonian_v2::getHamiltonianOperations(bool pur
   if (distNode.root())
   {
     // read L
-    if (!dump.push("DenseFactorized", false))
-    {
-      app_error() << " Error in RealDenseHamiltonian_v2::getHamiltonianOperations():"
-                  << " Group DenseFactorized not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("DenseFactorized", false);
     SpRMatrix_ref L(to_address(Likn.origin()), Likn.extensions());
     hyperslab_proxy<SpRMatrix_ref, 2> hslab(L,
                                             std::array<size_t, 2>{static_cast<size_t>(NMO * NMO),

--- a/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
+++ b/src/AFQMC/Hamiltonians/THCHamiltonian.cpp
@@ -71,18 +71,8 @@ HamiltonianOperations THCHamiltonian::getHamiltonianOperations(bool pureSD,
       app_error() << " Error opening integral file in THCHamiltonian. \n";
       APP_ABORT("");
     }
-    if (!dump.push("Hamiltonian", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not Hamiltonian found. \n";
-      APP_ABORT("");
-    }
-    if (!dump.push("THC", false))
-    {
-      app_error() << " Error in THCHamiltonian::getHamiltonianOperations():"
-                  << " Group not THC found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Hamiltonian", false);
+    dump.push("THC", false);
   }
   if (TG.Global().root())
   {

--- a/src/AFQMC/Utilities/readWfn.cpp
+++ b/src/AFQMC/Utilities/readWfn.cpp
@@ -219,16 +219,8 @@ WALKER_TYPES getWalkerTypeHDF5(std::string filename, std::string type)
     std::cerr << " Error opening wavefunction file in read_info_from_wfn. \n";
     APP_ABORT("");
   }
-  if (!dump.push("Wavefunction", false))
-  {
-    std::cerr << " Error in getWalkerTypeHDF5: Group Wavefunction found. \n";
-    APP_ABORT("");
-  }
-  if (!dump.push(type, false))
-  {
-    std::cerr << " Error in getWalkerTypeHDF5: Group " << type << " not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Wavefunction", false);
+  dump.push(type, false);
 
   std::vector<int> Idata(5);
   if (!dump.readEntry(Idata, "dims"))
@@ -746,30 +738,19 @@ void read_ph_wavefunction_hdf(hdf_archive& dump,
   {
     PsiT.reserve((wfn_type != 1) ? 1 : 2);
 
-    if (!dump.push(std::string("PsiT_") + std::to_string(0), false))
-    {
-      app_error() << " Error in WavefunctionFactory: Group PsiT not found. \n";
-      APP_ABORT("");
-    }
+    dump.push(std::string("PsiT_") + std::to_string(0), false);
+
     PsiT.emplace_back(csr_hdf5::HDF2CSR<PsiT_Matrix, Alloc>(dump, comm));
     dump.pop();
     if (wfn_type == 1)
     {
       if (wtype == CLOSED)
       {
-        if (!dump.push(std::string("PsiT_") + std::to_string(0), false))
-        {
-          app_error() << " Error in WavefunctionFactory: Group PsiT not found. \n";
-          APP_ABORT("");
-        }
+        dump.push(std::string("PsiT_") + std::to_string(0), false);
       }
       else if (wtype == COLLINEAR)
       {
-        if (!dump.push(std::string("PsiT_") + std::to_string(1), false))
-        {
-          app_error() << " Error in WavefunctionFactory: Group PsiT not found. \n";
-          APP_ABORT("");
-        }
+        dump.push(std::string("PsiT_") + std::to_string(1), false);
       }
       PsiT.emplace_back(csr_hdf5::HDF2CSR<PsiT_Matrix, Alloc>(dump, comm));
       dump.pop();

--- a/src/AFQMC/Utilities/test_utils.hpp
+++ b/src/AFQMC/Utilities/test_utils.hpp
@@ -38,11 +38,7 @@ inline std::tuple<int, int, int> read_info_from_hdf(std::string fileName)
     std::cerr << " Error opening integral file in SparseGeneralHamiltonian. \n";
     APP_ABORT("");
   }
-  if (!dump.push("Hamiltonian", false))
-  {
-    std::cerr << " Error in HamiltonianFactory::fromHDF5(): Group not Hamiltonian found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Hamiltonian", false);
 
   std::vector<int> Idata(8);
   if (!dump.readEntry(Idata, "dims"))
@@ -64,16 +60,8 @@ inline std::tuple<int, int, int> read_info_from_wfn(std::string fileName, std::s
     std::cerr << " Error opening wavefunction file in read_info_from_wfn. \n";
     APP_ABORT("");
   }
-  if (!dump.push("Wavefunction", false))
-  {
-    std::cerr << " Error in read_info_from_wfn(): Group not Wavefunction found. \n";
-    APP_ABORT("");
-  }
-  if (!dump.push(type, false))
-  {
-    std::cerr << " Error in read_info_from_wfn(): Group " << type << " not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Wavefunction", false);
+  dump.push(type, false);
 
   std::vector<int> Idata(5);
   if (!dump.readEntry(Idata, "dims"))
@@ -96,11 +84,7 @@ TEST_DATA<T> read_test_results_from_hdf(std::string fileName, std::string wfn_ty
     std::cerr << " Error opening integral file in SparseGeneralHamiltonian. \n";
     APP_ABORT("");
   }
-  if (!dump.push("Hamiltonian", false))
-  {
-    std::cerr << " Error in HamiltonianFactory::fromHDF5(): Group not Hamiltonian found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Hamiltonian", false);
 
   std::vector<int> Idata(8);
   if (!dump.readEntry(Idata, "dims"))
@@ -112,8 +96,9 @@ TEST_DATA<T> read_test_results_from_hdf(std::string fileName, std::string wfn_ty
 
   T E0(0), E1(0), E2(0), Xsum(0), Vsum(0);
 
-  if (dump.push("TEST_RESULTS", false))
+  try
   {
+    dump.push("TEST_RESULTS", false);
     dump.read(E0, wfn_type + "_E0");
     dump.read(E1, wfn_type + "_E1");
     dump.read(E2, wfn_type + "_E2");
@@ -121,6 +106,8 @@ TEST_DATA<T> read_test_results_from_hdf(std::string fileName, std::string wfn_ty
     dump.read(Vsum, wfn_type + "_Vsum");
     dump.pop();
   }
+  catch (...)
+  {}
 
   return TEST_DATA<T>{Idata[3], Idata[4], Idata[5], E0, E1, E2, Xsum, Vsum};
 }

--- a/src/AFQMC/Walkers/WalkerIO.hpp
+++ b/src/AFQMC/Walkers/WalkerIO.hpp
@@ -191,10 +191,8 @@ bool restartFromHDF5(WalkerSet& wset,
       return false;
     }
 
-    if (!read.push("Walkers"))
-      return false;
-    if (!read.push("WalkerSet"))
-      return false;
+    read.push("Walkers");
+    read.push("WalkerSet");
 
     if (!read.readEntry(Idata, "dims"))
       return false;

--- a/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
+++ b/src/AFQMC/Wavefunctions/WavefunctionFactory.cpp
@@ -656,20 +656,13 @@ Wavefunction WavefunctionFactory::fromHDF5(TaskGroup_& TGprop,
     app_error() << " Error hdf5 file in WavefunctionFactory. \n";
     APP_ABORT("");
   }
-  if (!dump.push("Wavefunction", false))
-  {
-    app_error() << " Error in WavefunctionFactory: Group Wavefunction not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Wavefunction", false);
 
   if (type == "msd" || type == "nomsd")
   {
     app_log() << " Wavefunction type: NOMSD" << std::endl;
-    if (!dump.push("NOMSD", false))
-    {
-      app_error() << " Error in WavefunctionFactory: Group NOMSD not found.\n";
-      APP_ABORT("");
-    }
+    dump.push("NOMSD", false);
+
     std::vector<ComplexType> ci;
 
     // Read common trial wavefunction input options.
@@ -690,11 +683,8 @@ Wavefunction WavefunctionFactory::fromHDF5(TaskGroup_& TGprop,
     using Alloc = shared_allocator<ComplexType>;
     for (int i = 0; i < ndread; ++i)
     {
-      if (!dump.push(std::string("PsiT_") + std::to_string(i), false))
-      {
-        app_error() << " Error in WavefunctionFactory: Group PsiT not found. \n";
-        APP_ABORT("");
-      }
+      dump.push(std::string("PsiT_") + std::to_string(i), false);
+
       PsiT.emplace_back(csr_hdf5::HDF2CSR<PsiT_Matrix, Alloc>(dump, TGwfn.Node())); //,Alloc(TGwfn.Node())));
       dump.pop();
       if (walker_type == COLLINEAR and input_wtype == CLOSED)
@@ -702,11 +692,7 @@ Wavefunction WavefunctionFactory::fromHDF5(TaskGroup_& TGprop,
         if (NAEA != NAEB)
           APP_ABORT(" Error: NAEA!=NAEB when initializing collinear wfn from closed shell file.\n");
         // read them again
-        if (!dump.push(std::string("PsiT_") + std::to_string(i), false))
-        {
-          app_error() << " Error in WavefunctionFactory: Group PsiT not found. \n";
-          APP_ABORT("");
-        }
+        dump.push(std::string("PsiT_") + std::to_string(i), false);
         PsiT.emplace_back(csr_hdf5::HDF2CSR<PsiT_Matrix, Alloc>(dump, TGwfn.Node())); //,Alloc(TGwfn.Node())));
         dump.pop();
       }
@@ -795,11 +781,9 @@ Wavefunction WavefunctionFactory::fromHDF5(TaskGroup_& TGprop,
       APP_ABORT("Error: PHMSD requires a COLLINEAR calculation.\n");
     std::vector<PsiT_Matrix> PsiT_MO;
     std::string wfn_type;
-    if (!dump.push("PHMSD", false))
-    {
-      app_error() << " Error in WavefunctionFactory: Group PHMSD not found. \n";
-      APP_ABORT("");
-    }
+
+    dump.push("PHMSD", false);
+
     std::vector<int> occbuff;
     std::vector<ComplexType> coeffs;
     // 1. Read occupancies and coefficients.

--- a/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
+++ b/src/AFQMC/Wavefunctions/tests/test_phmsd.cpp
@@ -85,16 +85,9 @@ void test_read_phmsd(boost::mpi3::communicator& world)
     {
       app_error() << "Error reading wavefunction file.\n";
     }
-    if (!dump.push("Wavefunction", false))
-    {
-      app_error() << " Error in WavefunctionFactory: Group Wavefunction not found. \n";
-      APP_ABORT("");
-    }
-    if (!dump.push("PHMSD", false))
-    {
-      app_error() << " Error in WavefunctionFactory: Group PHMSD not found. \n";
-      APP_ABORT("");
-    }
+    dump.push("Wavefunction", false);
+    dump.push("PHMSD", false);
+
     int ndets_to_read = -1;
     std::string wfn_type;
     WALKER_TYPES walker_type = COLLINEAR;
@@ -150,16 +143,9 @@ void getBasicWavefunction(std::vector<int>& occs, std::vector<ComplexType>& coef
   {
     app_error() << "Error reading wavefunction file.\n";
   }
-  if (!dump.push("Wavefunction", false))
-  {
-    app_error() << " Error in WavefunctionFactory: Group Wavefunction not found. \n";
-    APP_ABORT("");
-  }
-  if (!dump.push("PHMSD", false))
-  {
-    app_error() << " Error in WavefunctionFactory: Group PHMSD not found. \n";
-    APP_ABORT("");
-  }
+  dump.push("Wavefunction", false);
+  dump.push("PHMSD", false);
+
   std::vector<int> Idata(5);
   if (!dump.readEntry(Idata, "dims"))
     APP_ABORT("Errro reading dims array\n");

--- a/src/Estimators/TraceManager.h
+++ b/src/Estimators/TraceManager.h
@@ -1286,7 +1286,8 @@ struct TraceBuffer
     dims[1] = buffer.size(1);
     if (dims[0] > 0)
     {
-      h5d_append(f.push(top), "traces", file_pointer, buffer.dim(), dims, buffer.data());
+      f.push(top);
+      h5d_append(f.top(), "traces", file_pointer, buffer.dim(), dims, buffer.data());
       f.pop();
     }
     f.flush();

--- a/src/QMCHamiltonians/ObservableHelper.cpp
+++ b/src/QMCHamiltonians/ObservableHelper.cpp
@@ -92,8 +92,8 @@ void ObservableHelper::write(const value_type* const first_v, hdf_archive& file)
   hsize_t rank = mydims.size();
   if (rank)
   {
-    hid_t g_id = file.push(group_name, true);
-    h5d_append(g_id, "value", current, rank, mydims.data(), first_v + lower_bound);
+    file.push(group_name, true);
+    h5d_append(file.top(), "value", current, rank, mydims.data(), first_v + lower_bound);
     file.pop();
   }
 }

--- a/src/QMCTools/LCAOHDFParser.cpp
+++ b/src/QMCTools/LCAOHDFParser.cpp
@@ -159,33 +159,27 @@ void LCAOHDFParser::parse(const std::string& fname)
       abort();
     }
 
-    if (!hin.push("MultiDet"))
-    {
-      std::cerr << "Could not open Multidet Group in H5 file" << std::endl;
-      abort();
-    }
-    else
-    {
-      hin.read(ci_size, "NbDet");
-      hin.read(ci_nstates, "nstate");
-      hin.read(nbexcitedstates, "nexcitedstate");
-      CIcoeff.clear();
-      CIalpha.clear();
-      CIbeta.clear();
-      CIcoeff.resize(ci_size);
-      CIalpha.resize(ci_size);
-      CIbeta.resize(ci_size);
+    hin.push("MultiDet");
 
-      int ds  = SpinMultiplicity - 1;
-      int neb = (NumberOfEls - ds) / 2;
-      int nea = NumberOfEls - NumberOfBeta;
-      ci_nea  = NumberOfAlpha;
-      ci_neb  = NumberOfBeta;
-      ci_nca  = nea - ci_nea;
-      ci_ncb  = neb - ci_neb;
-      std::cout << " Done reading CIs!!" << std::endl;
-      hin.close();
-    }
+    hin.read(ci_size, "NbDet");
+    hin.read(ci_nstates, "nstate");
+    hin.read(nbexcitedstates, "nexcitedstate");
+    CIcoeff.clear();
+    CIalpha.clear();
+    CIbeta.clear();
+    CIcoeff.resize(ci_size);
+    CIalpha.resize(ci_size);
+    CIbeta.resize(ci_size);
+
+    int ds  = SpinMultiplicity - 1;
+    int neb = (NumberOfEls - ds) / 2;
+    int nea = NumberOfEls - NumberOfBeta;
+    ci_nea  = NumberOfAlpha;
+    ci_neb  = NumberOfBeta;
+    ci_nca  = nea - ci_nea;
+    ci_ncb  = neb - ci_neb;
+    std::cout << " Done reading CIs!!" << std::endl;
+    hin.close();
   }
 }
 
@@ -290,11 +284,8 @@ void LCAOHDFParser::getSuperTwist(const std::string& fname)
     abort();
   }
 
-  if (!hin.push("Super_Twist"))
-  {
-    std::cerr << "Could not find Super Twist" << std::endl;
-    abort();
-  }
+  hin.push("Super_Twist");
+
   STwist_Coord.resize(3);
 
   hin.read(MyVec, "Coord");

--- a/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
+++ b/src/QMCWaveFunctions/BsplineFactory/HybridRepCenterOrbitals.h
@@ -486,7 +486,14 @@ public:
     bool success = true;
     size_t ncenter;
 
-    success = success && h5f.push("atomic_centers", false);
+    try
+    {
+      h5f.push("atomic_centers", false);
+    }
+    catch (...)
+    {
+      success = false;
+    }
     success = success && h5f.readEntry(ncenter, "number_of_centers");
     if (!success)
       return success;
@@ -497,7 +504,14 @@ public:
     {
       std::ostringstream gname;
       gname << "center_" << ic;
-      success = success && h5f.push(gname.str().c_str(), false);
+      try
+      {
+        h5f.push(gname.str().c_str(), false);
+      }
+      catch (...)
+      {
+        success = false;
+      }
       success = success && AtomicCenters[ic].read_splines(h5f);
       h5f.pop();
     }
@@ -509,14 +523,28 @@ public:
   {
     bool success = true;
     int ncenter  = AtomicCenters.size();
-    success      = success && h5f.push("atomic_centers", true);
-    success      = success && h5f.writeEntry(ncenter, "number_of_centers");
+    try
+    {
+      h5f.push("atomic_centers", true);
+    }
+    catch (...)
+    {
+      success = false;
+    }
+    success = success && h5f.writeEntry(ncenter, "number_of_centers");
     // write splines of each center
     for (int ic = 0; ic < AtomicCenters.size(); ic++)
     {
       std::ostringstream gname;
       gname << "center_" << ic;
-      success = success && h5f.push(gname.str().c_str(), true);
+      try
+      {
+        h5f.push(gname.str().c_str(), true);
+      }
+      catch (...)
+      {
+        success = false;
+      }
       success = success && AtomicCenters[ic].write_splines(h5f);
       h5f.pop();
     }
@@ -569,7 +597,8 @@ public:
   {
     const int center_idx = VP.refSourcePtcl;
     auto& myCenter       = AtomicCenters[Super2Prim[center_idx]];
-    return VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx] < myCenter.getNonOverlappingRadius();
+    return VP.getRefPS().getDistTableAB(myTableID).getDistRow(VP.refPtcl)[center_idx] <
+        myCenter.getNonOverlappingRadius();
   }
 
   // C2C, C2R cases

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -1060,15 +1060,7 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
   }
 
 
-  try
-  {
-    hin.push("MultiDet", false);
-  }
-  catch (...)
-  {
-    std::cerr << "Could not open Multidet Group in H5 file" << std::endl;
-    abort();
-  }
+  hin.push("MultiDet", false);
 
   hin.read(H5_ndets, "NbDet");
   if (ndets != H5_ndets)
@@ -1110,15 +1102,8 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
       abort();
     }
 
-    try
-    {
-      coeffin.push("MultiDet", false);
-    }
-    catch (...)
-    {
-      std::cerr << "Could not open Multidet Group in H5 file" << std::endl;
-      abort();
-    }
+    coeffin.push("MultiDet", false);
+
     coeffin.read(OptCiSize, "NbDet");
     CIcoeffopt.resize(OptCiSize);
 

--- a/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
+++ b/src/QMCWaveFunctions/Fermion/SlaterDetBuilder.cpp
@@ -825,7 +825,7 @@ bool SlaterDetBuilder::readDetList(xmlNodePtr cur,
             }
           } // if(name=="det")
           csf = csf->next;
-        }   // csf loop
+        } // csf loop
         if (DetsPerCSF.back() == 0)
         {
           APP_ABORT("Found empty CSF (no det blocks).");
@@ -1059,7 +1059,12 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
     abort();
   }
 
-  if (!hin.push("MultiDet"))
+
+  try
+  {
+    hin.push("MultiDet", false);
+  }
+  catch (...)
   {
     std::cerr << "Could not open Multidet Group in H5 file" << std::endl;
     abort();
@@ -1105,7 +1110,11 @@ bool SlaterDetBuilder::readDetListH5(xmlNodePtr cur,
       abort();
     }
 
-    if (!coeffin.push("MultiDet"))
+    try
+    {
+      coeffin.push("MultiDet", false);
+    }
+    catch (...)
     {
       std::cerr << "Could not open Multidet Group in H5 file" << std::endl;
       abort();

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalBuilder.cpp
@@ -262,25 +262,14 @@ std::unique_ptr<BasisSet_t> LCAOrbitalBuilder::loadBasisSetFromH5(xmlNodePtr par
   {
     if (!hin.open(h5_path, H5F_ACC_RDONLY))
       PRE.error("Could not open H5 file", true);
-    try
-    {
-      hin.push("basisset", false);
-    }
-    catch (...)
-    {
-      PRE.error("Could not open basisset group in H5; Probably Corrupt H5 file", true);
-    }
+
+    hin.push("basisset", false);
 
     std::string sph;
     std::string ElemID0 = "atomicBasisSet0";
-    try
-    {
-      hin.push(ElemID0.c_str(), false);
-    }
-    catch (...)
-    {
-      PRE.error("Could not open  group Containing atomic Basis set in H5; Probably Corrupt H5 file", true);
-    }
+
+    hin.push(ElemID0.c_str(), false);
+
     if (!hin.readEntry(sph, "angular"))
       PRE.error("Could not find name of  basisset group in H5; Probably Corrupt H5 file", true);
     ylm = (sph == "cartesian") ? 0 : 1;
@@ -402,14 +391,9 @@ LCAOrbitalBuilder::BasisSet_t* LCAOrbitalBuilder::createBasisSetH5()
   {
     if (!hin.open(h5_path, H5F_ACC_RDONLY))
       PRE.error("Could not open H5 file", true);
-    try
-    {
-      hin.push("basisset", false);
-    }
-    catch (...)
-    {
-      PRE.error("Could not open basisset group in H5; Probably Corrupt H5 file", true);
-    }
+
+    hin.push("basisset", false);
+
     hin.read(Nb_Elements, "NbElements");
   }
 
@@ -427,14 +411,8 @@ LCAOrbitalBuilder::BasisSet_t* LCAOrbitalBuilder::createBasisSetH5()
 
     if (myComm->rank() == 0)
     {
-      try
-      {
-        hin.push(ElemType.c_str(), false);
-      }
-      catch (...)
-      {
-        PRE.error("Could not open  group Containing atomic Basis set in H5; Probably Corrupt H5 file", true);
-      }
+      hin.push(ElemType.c_str(), false);
+
       if (!hin.readEntry(basiset_name, "name"))
         PRE.error("Could not find name of  basisset group in H5; Probably Corrupt H5 file", true);
       if (!hin.readEntry(elementType, "elementType"))
@@ -995,14 +973,9 @@ void LCAOrbitalBuilder::EvalPeriodicImagePhaseFactors(PosType SuperTwist,
     {
       if (!hin.open(h5_path, H5F_ACC_RDONLY))
         APP_ABORT("Could not open H5 file");
-      try
-      {
-        hin.push("Cell", false);
-      }
-      catch (...)
-      {
-        APP_ABORT("Could not open Cell group in H5; Probably Corrupt H5 file; accessed from LCAOrbitalBuilder");
-      }
+
+      hin.push("Cell", false);
+
       hin.read(Lattice, "LatticeVectors");
       hin.close();
     }

--- a/src/QMCWaveFunctions/RotatedSPOs.cpp
+++ b/src/QMCWaveFunctions/RotatedSPOs.cpp
@@ -144,7 +144,7 @@ void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
   hout.push("RotatedSPOs");
   if (use_global_rot_)
   {
-    hid_t grp                   = hout.push("rotation_global");
+    hout.push("rotation_global");
     std::string rot_global_name = std::string("rotation_global_") + SPOSet::getName();
 
     int nparam_full = myVarsFull.size();
@@ -157,7 +157,7 @@ void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
   }
   else
   {
-    hid_t grp   = hout.push("rotation_history");
+    hout.push("rotation_history");
     size_t rows = history_params_.size();
     size_t cols = 0;
     if (rows > 0)
@@ -175,7 +175,7 @@ void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
 
   // Save myVars in order to restore object state exactly
   //  The values aren't meaningful, but they need to match those saved in VariableSet
-  hid_t grp                   = hout.push("rotation_params");
+  hout.push("rotation_params");
   std::string rot_params_name = std::string("rotation_params_") + SPOSet::getName();
 
   int nparam = myVars.size();
@@ -191,9 +191,7 @@ void RotatedSPOs::writeVariationalParameters(hdf_archive& hout)
 
 void RotatedSPOs::readVariationalParameters(hdf_archive& hin)
 {
-  hid_t grp_rot = hin.push("RotatedSPOs", false);
-  if (grp_rot < 0)
-    app_warning() << "RotateSPOs not found in VP file";
+  hin.push("RotatedSPOs", false);
 
   bool grp_hist_exists   = hin.is_group("rotation_history");
   bool grp_global_exists = hin.is_group("rotation_global");

--- a/src/QMCWaveFunctions/VariableSet.cpp
+++ b/src/QMCWaveFunctions/VariableSet.cpp
@@ -174,17 +174,17 @@ void VariableSet::getIndex(const VariableSet& selected)
   }
 }
 
-  int VariableSet::getIndex(const std::string& vname) const
+int VariableSet::getIndex(const std::string& vname) const
+{
+  int loc = 0;
+  while (loc != NameAndValue.size())
   {
-    int loc = 0;
-    while (loc != NameAndValue.size())
-    {
-      if (NameAndValue[loc].first == vname)
-        return Index[loc];
-      ++loc;
-    }
-    return -1;
+    if (NameAndValue[loc].first == vname)
+      return Index[loc];
+    ++loc;
   }
+  return -1;
+}
 
 void VariableSet::setIndexDefault()
 {
@@ -257,7 +257,7 @@ void VariableSet::writeToHDF(const std::string& filename, qmcplusplus::hdf_archi
   std::string timestamp(getDateAndTime("%Y-%m-%d %H:%M:%S %Z"));
   hout.write(timestamp, "timestamp");
 
-  hid_t grp = hout.push("name_value_lists");
+  hout.push("name_value_lists");
 
   std::vector<qmcplusplus::QMCTraits::ValueType> param_values;
   std::vector<std::string> param_names;
@@ -281,8 +281,11 @@ void VariableSet::readFromHDF(const std::string& filename, qmcplusplus::hdf_arch
     throw std::runtime_error(err_msg.str());
   }
 
-  hid_t grp = hin.push("name_value_lists", false);
-  if (grp < 0)
+  try
+  {
+    hin.push("name_value_lists", false);
+  }
+  catch (std::runtime_error&)
   {
     std::ostringstream err_msg;
     err_msg << "The group name_value_lists in not present in file: " << filename;

--- a/src/QMCWaveFunctions/tests/test_OptimizableObject.cpp
+++ b/src/QMCWaveFunctions/tests/test_OptimizableObject.cpp
@@ -48,9 +48,7 @@ public:
 
   void readVariationalParameters(hdf_archive& hin) override
   {
-    hid_t group = hin.push("FakeOptimizableObject", false);
-    if (group < 0)
-      throw std::runtime_error("Expected group not present in file");
+    hin.push("FakeOptimizableObject", false);
 
     myVars.clear();
     double tmp_var1;

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -195,9 +195,13 @@ bool hdf_archive::is_group(const std::string& aname)
 void hdf_archive::push(const std::string& gname, bool createit)
 {
   hid_t g = is_closed;
-  if (Mode[NOIO] || file_id == is_closed)
+  if (Mode[NOIO])
+    return;
+
+  if (file_id == is_closed)
     throw std::runtime_error("Failed to open group \"" + gname +
                              "\" because file is not open.  Expected file: " + possible_filename_);
+
   hid_t p = group_id.empty() ? file_id : group_id.top();
 
 #if H5_VERSION_GE(1, 12, 0)

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -42,6 +42,7 @@ void hdf_archive::close()
   }
   if (file_id != is_closed)
     H5Fclose(file_id);
+  filename_.clear();
   file_id = is_closed;
 }
 
@@ -138,6 +139,7 @@ void hdf_archive::set_access_plist(boost::mpi3::communicator& comm, bool request
 
 bool hdf_archive::create(const std::filesystem::path& fname, unsigned flags)
 {
+  assert(filename_.empty());
   filename_ = fname;
   if (Mode[NOIO])
     return true;
@@ -150,6 +152,7 @@ bool hdf_archive::create(const std::filesystem::path& fname, unsigned flags)
 
 bool hdf_archive::open(const std::filesystem::path& fname, unsigned flags)
 {
+  assert(filename_.empty());
   filename_ = fname;
   if (Mode[NOIO])
     return true;
@@ -195,7 +198,7 @@ void hdf_archive::push(const std::string& gname, bool createit)
 {
   hid_t g = is_closed;
   if (Mode[NOIO] || file_id == is_closed)
-    throw std::runtime_error("Failed to open group \"" + gname + "\" because file \"" + filename_ + "\" is not open");
+    throw std::runtime_error("Failed to open group \"" + gname + "\" because file is not open");
   hid_t p = group_id.empty() ? file_id : group_id.top();
 
 #if H5_VERSION_GE(1, 12, 0)

--- a/src/io/hdf/hdf_archive.cpp
+++ b/src/io/hdf/hdf_archive.cpp
@@ -238,7 +238,7 @@ void hdf_archive::push(const std::string& gname, bool createit)
 
 void hdf_archive::push(const hdf_path& gname, bool createit) { push(gname.string(), createit); }
 
-std::string hdf_archive::group_path_as_string()
+std::string hdf_archive::group_path_as_string() const
 {
   std::string group_path;
   for (auto it = group_names.begin(); it != group_names.end(); it++)

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -70,6 +70,8 @@ private:
   hid_t lcpl_id;
   ///FILO to handle H5Group
   std::stack<hid_t> group_id;
+  ///Track group names corresponding to group_id
+  std::vector<std::string> group_names;
 
   /// Name of file
   std::string filename_;
@@ -202,10 +204,15 @@ public:
       return;
     hid_t g = group_id.top();
     group_id.pop();
+    group_names.pop_back();
     herr_t err = H5Gclose(g);
     if (err < 0)
       throw std::runtime_error("H5Gclose failed with error.");
   }
+
+  /** Return a string representation of the current group stack
+   */
+  std::string group_path_as_string();
 
   /** read the shape of multidimensional filespace from the group aname
    * this function can be used to query dataset for preparing containers.

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -71,6 +71,9 @@ private:
   ///FILO to handle H5Group
   std::stack<hid_t> group_id;
 
+  /// Name of file
+  std::string filename_;
+
   ///set the access property
   void set_access_plist(Communicate* comm, bool request_pio);
 #ifdef HAVE_MPI
@@ -189,8 +192,8 @@ public:
    * @param gname name of the group
    * @param createit if true, group is create when missing
    */
-  hid_t push(const std::string& gname, bool createit = true);
-  hid_t push(const hdf_path& gname, bool createit = true);
+  void push(const std::string& gname, bool createit = true);
+  void push(const hdf_path& gname, bool createit = true);
 
 
   inline void pop()

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -73,8 +73,11 @@ private:
   ///Track group names corresponding to group_id
   std::vector<std::string> group_names;
 
-  /// Name of file
-  std::string filename_;
+  /** Name of file that hdf_archive thinks is open.
+   *  This may not correspond to the actual file because the open call failed,
+   *  or the file was closed. This information is useful for debugging.
+   */
+  std::string possible_filename_;
 
   ///set the access property
   void set_access_plist(Communicate* comm, bool request_pio);

--- a/src/io/hdf/hdf_archive.h
+++ b/src/io/hdf/hdf_archive.h
@@ -212,7 +212,7 @@ public:
 
   /** Return a string representation of the current group stack
    */
-  std::string group_path_as_string();
+  std::string group_path_as_string() const;
 
   /** read the shape of multidimensional filespace from the group aname
    * this function can be used to query dataset for preparing containers.

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -216,6 +216,9 @@ TEST_CASE("hdf_archive_group", "[hdf]")
 
   hd.close();
 
+  // Check that opening a group on a closed file throws an exception
+  REQUIRE_THROWS(hd.push("group"));
+
   hdf_archive hd2;
   hd2.open("test_group.hdf");
   bool int_is_group = hd2.is_group("int");
@@ -234,6 +237,8 @@ TEST_CASE("hdf_archive_group", "[hdf]")
   okay = hd2.readEntry(j3, "int2");
   REQUIRE(okay);
   REQUIRE(j3 == j);
+
+  REQUIRE_THROWS(hd2.push("nonexistent_group", false));
 
   hd2.close();
 }

--- a/src/io/hdf/tests/test_hdf_archive.cpp
+++ b/src/io/hdf/tests/test_hdf_archive.cpp
@@ -208,11 +208,18 @@ TEST_CASE("hdf_archive_group", "[hdf]")
   bool okay = hd.writeEntry(i, "int");
   REQUIRE(okay);
 
+  CHECK(hd.group_path_as_string() == "");
+
   hd.push("name1");
+
+  CHECK(hd.group_path_as_string() == "name1");
 
   int j = 3;
   okay  = hd.writeEntry(j, "int2");
   REQUIRE(okay);
+
+  hd.push("name2");
+  CHECK(hd.group_path_as_string() == "name1/name2");
 
   hd.close();
 


### PR DESCRIPTION
Addresses #4547 

Changes to hdf_archive:
* When 'push' is called with the createit flag set to false, and the group does not exist, throw an exception.
* Also throw an exception if the file is not open.
* Remove the return value (use `top` to get the value if it's really needed)
* Store the hdf archive filename so it can be included in the error messages in the exceptions.

In most cases, I added try/catch blocks to preserve the existing error handling flow.  But in a few places I let the underlying exception propagate.

In LCAOrbitalBuilder.cpp, the logic around 'PBC' was updated to match what was described in the commented-out code.

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_


- Refactoring (no functional changes, no api changes)


### Does this introduce a breaking change?


- No

## What systems has this change been tested on?
desktop

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- Yes. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
