### PR TITLE
Bump nitrogen OpenBLAS CI to 0.3.23

### DIFF
--- a/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
+++ b/tests/test_automation/github-actions/ci/run_step_ornl-nitrogen-1.sh
@@ -54,6 +54,7 @@ case "$1" in
     cmake -GNinja \
           -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
           -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+          -DCMAKE_PREFIX_PATH=$HOME/opt/OpenBLAS/0.3.23 \
           -DQMC_MPI=0 \
           -DENABLE_CUDA=ON \
           -DQMC_CUDA2HIP=ON \


### PR DESCRIPTION
## Proposed changes
Replace RHEL9 system OpenBLAS 0.3.15 on CI
Related to #4450

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Testing changes (e.g. new unit/integration/performance tests)

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
nitrogen, must pass CI

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- No. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
