### PR TITLE
Remove versions from requirements.txt to fix rtd builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
 # Specify exact versions for reproducible builds, e.g. in readthedocs
-sphinx==3.2.0
-sphinx_rtd_theme==0.5.2
-sphinxcontrib-bibtex==2.2.0
+sphinx
+sphinx_rtd_theme
+sphinxcontrib-bibtex
+#sphinx==3.2.0
+#sphinx_rtd_theme==0.5.2
+#sphinxcontrib-bibtex==2.2.0
 
 


### PR DESCRIPTION
## Proposed changes

Theory: too old versions in current file are source of rtd build failures. Will need to restore specific versions that are supported by spack for reproducibility and local testing.

## What type(s) of changes does this code introduce?

- Bugfix
- Testing changes (e.g. new unit/integration/performance tests)
- Documentation changes

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

None. CI needs to run. Unsure if merge required for rtd to see config change.

## Checklist

- Yes. This PR is up to date with current the current state of 'develop'
- NA. Code added or changed in the PR has been clang-formatted
- NA. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- NA. Documentation has been added (if appropriate)
