### PR TITLE
update runtime env to fix read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.8"
 
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt  


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes

https://github.com/urllib3/urllib3/issues/2168#issuecomment-1536456946

It looks like a dependency finally reached EOL, comment in the thread suggests adding this config should resolve the readthedocs builds failing.


## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

Bugfix #4587 

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?

-- needs to be tested on readthedocs build server --

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- Yes. This PR is up to date with current the current state of 'develop'
- N/A. Code added or changed in the PR has been clang-formatted
- N/A. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- N/A. Documentation has been added (if appropriate)
